### PR TITLE
fix(ui): preserve agent file edits during save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI agent files:** preserve edits typed while an earlier file save is pending instead of silently replacing the newer draft when that save completes.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.
 - **Gateway command SecretRefs:** preserve authoritative active-snapshot values when another command secret remains unresolved, falling back locally only for missing paths instead of emitting a per-turn `secrets.resolve` failure. (#96661) Thanks @SunnyShu0925.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI agent files:** preserve edits typed while an earlier file save is pending instead of silently replacing the newer draft when that save completes.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.
 - **Gateway command SecretRefs:** preserve authoritative active-snapshot values when another command secret remains unresolved, falling back locally only for missing paths instead of emitting a per-turn `secrets.resolve` failure. (#96661) Thanks @SunnyShu0925.

--- a/ui/src/pages/agents/files.test.ts
+++ b/ui/src/pages/agents/files.test.ts
@@ -89,4 +89,43 @@ describe("agent file requests", () => {
     expect(state.agentFileContents).toEqual({});
     expect(state.agentFileSaving).toBe(false);
   });
+
+  it("commits the submitted draft when it stays current", async () => {
+    const client = {
+      request: vi.fn().mockResolvedValue({ ok: true, ...fileResult("submitted") }),
+    } as unknown as GatewayBrowserClient;
+    const state = createState(client);
+    state.agentFileContents = { "AGENTS.md": "original" };
+    state.agentFileDrafts = { "AGENTS.md": "submitted" };
+
+    await saveAgentFile(state, "main", "AGENTS.md", "submitted");
+
+    expect(state.agentFileContents).toEqual({ "AGENTS.md": "submitted" });
+    expect(state.agentFileDrafts).toEqual({ "AGENTS.md": "submitted" });
+    expect(state.agentFileSaving).toBe(false);
+  });
+
+  it("preserves edits made while a save is pending", async () => {
+    let resolveSave!: (value: AgentsFilesSetResult) => void;
+    const client = {
+      request: vi.fn(
+        () =>
+          new Promise<AgentsFilesSetResult>((resolve) => {
+            resolveSave = resolve;
+          }),
+      ),
+    } as unknown as GatewayBrowserClient;
+    const state = createState(client);
+    state.agentFileContents = { "AGENTS.md": "original" };
+    state.agentFileDrafts = { "AGENTS.md": "submitted" };
+
+    const save = saveAgentFile(state, "main", "AGENTS.md", "submitted");
+    state.agentFileDrafts = { "AGENTS.md": "typed while saving" };
+    resolveSave({ ok: true, ...fileResult("submitted") });
+    await save;
+
+    expect(state.agentFileContents).toEqual({ "AGENTS.md": "submitted" });
+    expect(state.agentFileDrafts).toEqual({ "AGENTS.md": "typed while saving" });
+    expect(state.agentFileSaving).toBe(false);
+  });
 });

--- a/ui/src/pages/agents/files.ts
+++ b/ui/src/pages/agents/files.ts
@@ -110,7 +110,11 @@ export async function saveAgentFile(
     if (res?.file && isCurrent()) {
       state.agentFilesList = mergeFileEntry(state.agentFilesList, res.file);
       state.agentFileContents = { ...state.agentFileContents, [name]: content };
-      state.agentFileDrafts = { ...state.agentFileDrafts, [name]: content };
+      // The response establishes the saved base, but must not discard text
+      // entered after this save started.
+      if (!Object.hasOwn(state.agentFileDrafts, name) || state.agentFileDrafts[name] === content) {
+        state.agentFileDrafts = { ...state.agentFileDrafts, [name]: content };
+      }
     }
   } catch (err) {
     if (isCurrent()) {


### PR DESCRIPTION
## What Problem This Solves

The Agents > Files editor silently discarded text entered while an earlier save was in flight. The textarea remained writable, but the successful `agents.files.set` response replaced the newer draft with the older submitted content.

Fixes #105354.

## Why This Change Was Made

Treat the save response as a new persisted base without assuming the draft is still unchanged. The draft synchronizes to the saved content only when it still matches the submitted text; a later edit remains visible and dirty.

## User Impact

Users can keep editing agent notes, identity, persona, and tool-guidance files while Save is pending without losing the newer text. Ordinary saves still mark an unchanged submitted draft as current.

## Evidence

- Exact current-main before-proof: newer marker present before settlement, absent afterward; no visible/browser error; file restored and verified.
- Real Gateway after-proof: newer marker present both before and after settlement; original file restored and verified; no visible/browser error.
- Testbox focused controller suite: 4 passed, covering stale clients, unchanged drafts, and concurrent edits.
- Testbox changed gates: passed.
- Production Control UI build: passed.
- Source-blind behavior contract: 6/6 clauses passed.
- Direct Gateway contract check: `agents.files.set` writes and returns the exact submitted content.
- Fresh autoreview: no accepted/actionable findings; confidence 0.97.

No screenshots or transcript artifacts uploaded.
