### PR TITLE
fix(mac): silence presence reporter unused capture warning

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodePresenceReporter.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodePresenceReporter.swift
@@ -30,8 +30,7 @@ final class MacNodePresenceReporter {
 
     func start(sender: @escaping Sender) {
         self.stop()
-        self.task = Task { [weak self] in
-            guard let self else { return }
+        self.task = Task {
             var delivery: DeliveryState?
             while !Task.isCancelled {
                 if let sample = Self.currentIdleSample(),


### PR DESCRIPTION
## What Problem This Solves

Resolves a macOS build warning emitted repeatedly while compiling the presence reporter because its task closure captured `self` without using the instance.

## Why This Change Was Made

The task only calls static helpers and the injected sender, so it no longer captures or unwraps `self`. Cancellation and reporting behavior are unchanged.

## User Impact

No product behavior change. Maintainer Mac builds are quieter and avoid a warning that can become stricter in future toolchains.

## Evidence

- `swift build --package-path apps/macos --product OpenClaw`
- `swift test --package-path apps/macos --filter MacNodePresenceReporterTests` (3 tests passed)
- `autoreview --mode local` (clean; no actionable findings)
