### PR TITLE
fix(ci): pass Telegram target ref to identity gate

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -72,6 +72,7 @@ jobs:
           CALLER_WORKFLOW_SHA: ${{ github.workflow_sha }}
           EXPECTED_TRUSTED_WORKFLOW_SHA: ${{ inputs.expected_trusted_workflow_sha }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          TARGET_REF: ${{ inputs.target_ref }}
           TARGET_SHA: ${{ inputs.target_sha }}
           WORKFLOW_REF: ${{ github.workflow_ref }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -348,6 +348,11 @@ describe("release Telegram QA workflow", () => {
   });
 
   it("binds dispatched and legacy reusable OIDC identity to the resolved main SHA", () => {
+    expect(
+      workflowStep(workflowJob("trusted_identity"), "Verify dispatched-main identity").env
+        ?.TARGET_REF,
+    ).toBe("${{ inputs.target_ref }}");
+
     const trustedSha = "b".repeat(40);
     const success = runIdentityVerification({
       expectedTrustedWorkflowSha: trustedSha,


### PR DESCRIPTION
## What Problem This Solves

The trusted Telegram release workflow references `TARGET_REF` under `set -u` but did not pass the workflow input into the identity step environment. Every direct dispatch therefore failed before candidate validation.

## Why This Change Was Made

Pass the existing required `target_ref` input into the identity gate and pin that wiring in the workflow contract test.

## User Impact

No product behavior change. Trusted Telegram release validation can reach the candidate build and live lane again.

## Evidence

- Failure: https://github.com/openclaw/openclaw/actions/runs/29192414311
- `actionlint .github/workflows/openclaw-release-telegram-qa.yml`
- `git diff --check`
- Focused workflow env contract assertion
