### PR TITLE
refactor(skills): remove obsolete testing aliases

### DIFF
--- a/src/skills/discovery/chat-commands.ts
+++ b/src/skills/discovery/chat-commands.ts
@@ -140,4 +140,3 @@ export function listSkillCommandsForAgents(params: {
 export const testing = {
   dedupeBySkillName,
 };
-export { testing as __testing };

--- a/src/skills/lifecycle/install.ts
+++ b/src/skills/lifecycle/install.ts
@@ -828,4 +828,3 @@ export const testing = {
     };
   },
 };
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

Removes stale duplicate internal test exports from skill command discovery and skill installation. Tests already use the canonical `testing` exports, so the aliases add dead API surface without serving a caller.

## Why This Change Was Made

Both skill-owned modules retain their canonical test hooks and all production exports. Only the unused `__testing` aliases are removed.

The changed files have zero exact-path overlap across the current open pull requests. `src/skills/loading/workspace.ts` was explicitly excluded because ten active PRs touch it.

## User Impact

No user-visible behavior changes. Skill command discovery, SDK entry points, onboarding, Gateway installation, install policy checks, and dependency injection remain unchanged.

## Evidence

- `blacksmith testbox run --id tbx_01kxb3zrm64yhczfagbz6w70yw "pnpm test:serial src/skills/discovery/chat-commands.test.ts src/skills/lifecycle/install.test.ts src/skills/lifecycle/install-fallback.test.ts"`: 57 tests passed
- Path-scoped `pnpm check:changed` in the same Testbox: passed
- Full codebase-memory graph: 304,993 nodes / 1,261,630 edges; no `__testing` consumers
- Fresh `gpt-5.6-sol` medium autoreview: clean, no actionable findings
- `git diff --check`: passed

AI-assisted; implementation and validation were reviewed before submission. No session transcript is attached.
