### PR TITLE
fix(ui): serialize agent file tab selection

### DIFF
--- a/ui/src/pages/agents/panels-status-files.ts
+++ b/ui/src/pages/agents/panels-status-files.ts
@@ -505,11 +505,14 @@ export function renderAgentFiles(params: {
                 ${files.map((file) => {
                   const isActive = active === file.name;
                   const label = file.name.replace(/\.md$/i, "");
+                  // File reads are serialized; changing the active tab mid-read would
+                  // expose an editor whose content request was never accepted.
                   return html`
                     <button
                       class="agent-tab ${isActive ? "active" : ""} ${file.missing
                         ? "agent-tab--missing"
                         : ""}"
+                      ?disabled=${params.agentFilesLoading}
                       @click=${() => params.onSelectFile(file.name)}
                     >
                       ${label}${file.missing

--- a/ui/src/pages/agents/view.test.ts
+++ b/ui/src/pages/agents/view.test.ts
@@ -437,6 +437,50 @@ describe("renderAgents", () => {
 });
 
 describe("renderAgentFiles", () => {
+  it("does not accept another file selection while a file request is loading", () => {
+    const container = document.createElement("div");
+    const onSelectFile = vi.fn();
+
+    render(
+      renderAgentFiles({
+        agentId: "alpha",
+        agentFilesList: {
+          agentId: "alpha",
+          workspace: "/tmp/workspace",
+          files: [
+            {
+              name: "AGENTS.md",
+              path: "/tmp/workspace/AGENTS.md",
+              missing: false,
+            },
+            {
+              name: "HEARTBEAT.md",
+              path: "/tmp/workspace/HEARTBEAT.md",
+              missing: false,
+            },
+          ],
+        },
+        agentFilesLoading: true,
+        agentFilesError: null,
+        agentFileActive: "AGENTS.md",
+        agentFileContents: { "AGENTS.md": "# Instructions" },
+        agentFileDrafts: { "AGENTS.md": "# Instructions" },
+        agentFileSaving: false,
+        onLoadFiles: () => undefined,
+        onSelectFile,
+        onFileDraftChange: () => undefined,
+        onFileReset: () => undefined,
+        onFileSave: () => undefined,
+      }),
+      container,
+    );
+
+    const heartbeatTab = expectAgentTab(container, "HEARTBEAT");
+    expect(heartbeatTab.disabled).toBe(true);
+    heartbeatTab.click();
+    expect(onSelectFile).not.toHaveBeenCalled();
+  });
+
   it("renders the upgraded markdown preview structure with file metadata", () => {
     const container = document.createElement("div");
 


### PR DESCRIPTION
## What Problem This Solves

Closes #105364.

Agent Files uses one serialized loading state, but its file tabs remained interactive. A second click changed the active editor even though the controller rejected that file read, leaving a persistent blank editor for an existing non-empty file.

## Why This Change Was Made

Keep file tabs disabled while the shared file operation is loading. The view now matches the controller's acceptance contract: active state cannot advance unless the corresponding file request can start. Once the pending operation finishes, tabs become selectable normally.

The focused regression test verifies both the disabled state and suppression of the selection callback. The inline invariant comment records why the tabs must follow the shared loading state.

## User Impact

Rapidly switching Agent Files tabs no longer exposes a blank or mismatched editor. Users can select the next file as soon as the current read or list refresh completes, and the selected editor then reflects the real Gateway response.

## Evidence

- Current-main live before-proof against the real Gateway: only `AGENTS.md` was requested; active state switched to `HEARTBEAT.md`; the editor stayed blank after settlement while a separate real read confirmed non-empty server content; exact match was false; no browser/page error.
- Live after-proof, repeated in two fresh Playwright browser contexts: HEARTBEAT disabled while AGENTS was held; AGENTS stayed active before and after settlement; the enabled follow-up selection requested HEARTBEAT; the non-empty editor exactly matched a separate real Gateway read; no browser/page error.
- Source-blind behavior contract: 5/5 clauses passed, including request-order and exact-content anti-cheat probes.
- Testbox `corepack pnpm test ui/src/pages/agents/view.test.ts`: 11/11 passed on `tbx_01kxb50qjz0s2a2z66q1f0rapm`.
- Exact Testbox changed gate for `ui/src/pages/agents/panels-status-files.ts` and `ui/src/pages/agents/view.test.ts`: passed with 0 warnings and 0 errors.
- `OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/ui.js build`: passed.
- Fresh autoreview: no accepted/actionable findings; confidence 0.98.
- `git diff --check`: passed.
- Changelog intentionally omitted; native prepare owns release-note generation.

No screenshots or transcript artifacts uploaded.
