### PR TITLE
fix(ci): retain failed Telegram QA evidence

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -2170,6 +2170,7 @@ jobs:
         env:
           BOUNDARY_EVIDENCE_DIR: ${{ steps.create_sut.outputs.boundary_evidence_dir }}
           OUTPUT_DIR: ${{ steps.run_lane.outputs.output_dir }}
+          RUN_LANE_OUTCOME: ${{ steps.run_lane.outcome }}
         shell: bash
         run: |
           set -euo pipefail
@@ -2213,6 +2214,7 @@ jobs:
               (.candidateArtifact.version | length > 0)
             ' "$context_path" >/dev/null
           jq -e \
+            --arg runLaneOutcome "$RUN_LANE_OUTCOME" \
             '
               .version == 1 and
               .kind == "qa-gateway-process-boundary" and
@@ -2243,7 +2245,10 @@ jobs:
                   )
                 )
               ) and
-              ([.launches[] | select(.terminalState == "ready-exited")] | length >= 2)
+              (
+                [.launches[] | select(.terminalState == "ready-exited")] | length >=
+                  (if $runLaneOutcome == "success" then 2 else 1 end)
+              )
             ' "$runtime_path" >/dev/null
 
           while IFS=$'\t' read -r relative_path expected_sha256; do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,7 @@ Skills own workflows; root owns hard policy and routing.
 - `scripts/pr` subcommands require a PR number; no subcommand `--help` placeholder.
 - `scripts/pr` review: checkout main baseline, then PR, before artifact validation.
 - `rg`: options before `--`; use `--` before patterns starting with `-`.
+- `gh --jq` is not standalone `jq`; pipe JSON to `jq` for variables or `--arg`.
 - Bare issue/PR URL/number: inspect live and take the efficient maintainer path; switch branches/refs when useful.
 - No unsolicited PR labels/retitles/rebases/fixups/landing. Comments/reviews ok only for reviewable findings, pre-merge proof, or close/duplicate reason after explicit close/sweep/landing request.
 - Maintainer decision closes the cluster: if deciding reported behavior/proposed fix is not planned, comment+close all directly associated open issues/PRs unless explicitly told to keep one open. Associated means linked PRs/issues, duplicates, companion workaround PRs, and the canonical issue for the rejected behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,7 @@ Skills own workflows; root owns hard policy and routing.
 - `rg`: options before `--`; use `--` before patterns starting with `-`.
 - `gh --jq` is not standalone `jq`; pipe JSON to `jq` for variables or `--arg`.
 - Actions checkout refs: use full 40-char SHAs; short SHAs resolve as branches/tags.
+- zsh Git object paths: use `${sha}:path`; `$sha:path` invokes parameter modifiers.
 - Bare issue/PR URL/number: inspect live and take the efficient maintainer path; switch branches/refs when useful.
 - No unsolicited PR labels/retitles/rebases/fixups/landing. Comments/reviews ok only for reviewable findings, pre-merge proof, or close/duplicate reason after explicit close/sweep/landing request.
 - Maintainer decision closes the cluster: if deciding reported behavior/proposed fix is not planned, comment+close all directly associated open issues/PRs unless explicitly told to keep one open. Associated means linked PRs/issues, duplicates, companion workaround PRs, and the canonical issue for the rejected behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,7 @@ Skills own workflows; root owns hard policy and routing.
 - `scripts/pr` review: checkout main baseline, then PR, before artifact validation.
 - `rg`: options before `--`; use `--` before patterns starting with `-`.
 - `gh --jq` is not standalone `jq`; pipe JSON to `jq` for variables or `--arg`.
+- Actions checkout refs: use full 40-char SHAs; short SHAs resolve as branches/tags.
 - Bare issue/PR URL/number: inspect live and take the efficient maintainer path; switch branches/refs when useful.
 - No unsolicited PR labels/retitles/rebases/fixups/landing. Comments/reviews ok only for reviewable findings, pre-merge proof, or close/duplicate reason after explicit close/sweep/landing request.
 - Maintainer decision closes the cluster: if deciding reported behavior/proposed fix is not planned, comment+close all directly associated open issues/PRs unless explicitly told to keep one open. Associated means linked PRs/issues, duplicates, companion workaround PRs, and the canonical issue for the rejected behavior.

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -550,6 +550,13 @@ describe("release Telegram QA workflow", () => {
     expect(
       runStep?.run?.indexOf("run_qa_attempt preflight --scenario channel-canary"),
     ).toBeLessThan(runStep?.run?.indexOf("for attempt in 1 2") ?? -1);
+
+    const finalizeStep = job?.steps?.find(
+      (step) => step.name === "Finalize trusted Telegram process-boundary evidence",
+    );
+    expect(finalizeStep?.env?.RUN_LANE_OUTCOME).toBe("${{ steps.run_lane.outcome }}");
+    expect(finalizeStep?.run).toContain('--arg runLaneOutcome "$RUN_LANE_OUTCOME"');
+    expect(finalizeStep?.run).toContain('if $runLaneOutcome == "success" then 2 else 1 end');
   });
 
   it("serializes stderr behind the workflow-command pause", () => {


### PR DESCRIPTION
## What Problem This Solves

A failed Telegram channel canary launches and cleanly quiesces one verified gateway, but the evidence finalizer required two successful launches. That secondary assertion discarded the canonical QA report and gateway evidence needed to diagnose the actual release blocker.

## Why This Change Was Made

Keep the existing two-launch requirement for successful full lanes. For a failed lane, require at least one fully verified `ready-exited` launch so fail-closed boundary validation still completes and uploads the failure evidence.

## User Impact

No product behavior or canary acceptance change. Failed Telegram release checks retain actionable, attested evidence instead of losing it during finalization.

## Evidence

- Failure with hidden evidence: https://github.com/openclaw/openclaw/actions/runs/29192820469
- `actionlint .github/workflows/openclaw-release-telegram-qa.yml`
- `git diff --check`
- Workflow contract test pins success=2, failure=1 launch threshold
