### PR TITLE
fix(infra): use UTF-16 safe truncation for restart handoff intent ID

### DIFF
--- a/src/infra/restart-handoff.ts
+++ b/src/infra/restart-handoff.ts
@@ -243,7 +243,7 @@ function normalizeGatewayRestartHandoffRow(row: {
   return {
     kind: GATEWAY_SUPERVISOR_RESTART_HANDOFF_KIND,
     version: 1,
-    intentId: row.intent_id.trim().slice(0, MAX_INTENT_ID_LENGTH),
+    intentId: truncateUtf16Safe(row.intent_id.trim(), MAX_INTENT_ID_LENGTH),
     pid: row.pid,
     ...(processInstanceId ? { processInstanceId } : {}),
     createdAt: Math.floor(row.created_at),


### PR DESCRIPTION
## What Problem This Solves

`normalizeGatewayRestartHandoffRow` in `src/infra/restart-handoff.ts` truncates the `intent_id` field with `String.prototype.slice(0, MAX_INTENT_ID_LENGTH)`, which can split surrogate pairs. The file already imports `truncateUtf16Safe` and uses it in the `normalizeText` helper — this single `slice` call was missed.

## Why This Change Was Made

Replaces `row.intent_id.trim().slice(0, MAX_INTENT_ID_LENGTH)` with `truncateUtf16Safe(row.intent_id.trim(), MAX_INTENT_ID_LENGTH)`, using the already-imported helper to match the pattern used by `normalizeText` in the same file.

## User Impact

- Restart handoff intent IDs containing emoji/Unicode are now truncated without surrogate pair corruption
- No change for ASCII IDs
- Same `MAX_INTENT_ID_LENGTH = 120` limit preserved

## Evidence

```
$ npx vitest run src/infra/restart-handoff.test.ts --reporter=verbose

 ✓  infra  restart-handoff.test.ts > gateway restart handoff > writes a supervisor handoff
 ✓  infra  restart-handoff.test.ts > gateway restart handoff > keeps truncated restart reasons free of lone surrogates
 ✓  infra  restart-handoff.test.ts > gateway restart handoff > persists restart trace timing
 ✓  infra  restart-handoff.test.ts > gateway restart handoff > keeps restart trace timing for slow but valid drains
 ✓  infra  restart-handoff.test.ts > gateway restart handoff > rejects malformed handoff payloads
 ✓  infra  restart-handoff.test.ts > gateway restart handoff > rejects expired handoff rows
 ✓  infra  restart-handoff.test.ts > gateway restart handoff > rejects persisted handoffs with too-long TTL
 ✓  infra  restart-handoff.test.ts > gateway restart handoff > overwrites the previous pending handoff row
 ✓  infra  restart-handoff.test.ts > gateway restart handoff > formats a concise diagnostic line
 ✓  infra  restart-handoff.test.ts > gateway restart handoff > formats restart reasons as a single diagnostic line

 Test Files  1 passed (1)
      Tests  10 passed (10)
```