### PR TITLE
refactor(commands): remove obsolete testing aliases

### DIFF
--- a/src/cli/command-secret-gateway.ts
+++ b/src/cli/command-secret-gateway.ts
@@ -1180,4 +1180,3 @@ export async function resolveCommandSecretRefsViaGateway(params: {
     hadUnresolvedTargets: Object.values(targetStatesByPath).includes("unresolved"),
   };
 }
-export { testing as __testing };

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -509,4 +509,3 @@ export const testing = {
   copyPortableAuthProfiles,
   formatSkippedOAuthProfilesMessage,
 };
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

Removes two obsolete internal testing aliases left behind after command tests migrated to the canonical `testing` exports. Keeping both names expands the command modules' symbol surface without serving a tracked consumer.

## Why This Change Was Made

This maintainer-directed dead-code sweep deletes only the mechanical `__testing` re-exports from the command secret resolver and agent-add command. The canonical `testing` objects, their members, production APIs, and package-facing exports remain unchanged.

## User Impact

No user-visible behavior changes. Internal command test APIs now have one canonical name.

## Evidence

- Exact diff: two production-line deletions, no additions or test changes.
- Full code graph: 305,029 nodes and 1,261,333 edges; consumer inspection found no tracked `__testing` import for either changed module.
- Exhaustive live overlap audit: zero open PRs touch either changed file, including PRs with more than 100 changed files.
- Blacksmith Testbox `tbx_01kxb56y1dpezwm6yrv6h9kz8n`:
  - Baseline: 46/46 focused tests passed.
  - After change: 46/46 focused tests passed.
  - Path-scoped `pnpm check:changed` passed, including format, lint, core/core-test tsgo, dependency, SDK-baseline, import-cycle, database-first, sidecar, webhook, and pairing guards.
- Fresh `gpt-5.6-sol` autoreview at medium reasoning: no accepted/actionable findings; patch correct with 0.99 confidence.
- `git diff --check` passed.

AI-assisted. The maintainer reviewed the implementation, consumer map, history, and validation evidence. No agent transcript is included.
