### PR TITLE
fix(plugins): show upgrade command for stale official plugin pins

### DIFF
--- a/src/plugins/official-external-install-records.ts
+++ b/src/plugins/official-external-install-records.ts
@@ -12,6 +12,11 @@ function resolveNpmSpecPackageName(spec: string | undefined): string | undefined
   return spec ? parseRegistryNpmSpec(spec)?.name : undefined;
 }
 
+/** Official catalog npm specs without an exact version follow the OpenClaw release line. */
+export function isOfficialNpmSpecVersionLockstep(spec: string | undefined): boolean {
+  return Boolean(spec && parseRegistryNpmSpec(spec)?.selectorKind !== "exact-version");
+}
+
 function resolveClawHubSpecPackageName(spec: string | undefined): string | undefined {
   return spec ? parseClawHubPluginSpec(spec)?.name : undefined;
 }

--- a/src/plugins/plugin-version-drift.ts
+++ b/src/plugins/plugin-version-drift.ts
@@ -5,6 +5,7 @@ import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
 import { parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
 import {
+  isOfficialNpmSpecVersionLockstep,
   resolveTrustedSourceLinkedOfficialClawHubInstall,
   resolveTrustedSourceLinkedOfficialNpmSpec,
 } from "./official-external-install-records.js";
@@ -71,7 +72,7 @@ function shouldCompareOfficialInstallToGateway(params: {
 }): boolean {
   const officialNpmSpec = resolveTrustedSourceLinkedOfficialNpmSpec(params);
   if (officialNpmSpec) {
-    return parseRegistryNpmSpec(officialNpmSpec)?.selectorKind !== "exact-version";
+    return isOfficialNpmSpecVersionLockstep(officialNpmSpec);
   }
   const officialClawHubInstall = resolveTrustedSourceLinkedOfficialClawHubInstall(params);
   if (officialClawHubInstall) {

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -1594,6 +1594,49 @@ describe("updateNpmInstalledPlugins", () => {
     ]);
   });
 
+  it("reports official core-version drift when an exact npm pin is unchanged", async () => {
+    const installPath = createInstalledPackageDir({
+      name: "@openclaw/codex",
+      version: "2026.6.11",
+      peerDependencies: { openclaw: ">=2026.6.11" },
+    });
+    fs.mkdirSync(path.join(installPath, "node_modules", "openclaw"), { recursive: true });
+    mockNpmViewMetadata({
+      name: "@openclaw/codex",
+      version: "2026.6.11",
+      integrity: "sha512-same",
+      shasum: "same",
+    });
+    installPluginFromNpmSpecMock.mockRejectedValue(new Error("installer should not run"));
+
+    const result = await updateNpmInstalledPlugins({
+      config: createNpmInstallConfig({
+        pluginId: "codex",
+        spec: "@openclaw/codex@2026.6.11",
+        installPath,
+        resolvedName: "@openclaw/codex",
+        resolvedVersion: "2026.6.11",
+        resolvedSpec: "@openclaw/codex@2026.6.11",
+        integrity: "sha512-same",
+        shasum: "same",
+      }),
+      pluginIds: ["codex"],
+      coreVersion: "2026.7.1-beta.5",
+    });
+
+    expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
+    expect(result.outcomes).toEqual([
+      {
+        pluginId: "codex",
+        status: "unchanged",
+        currentVersion: "2026.6.11",
+        nextVersion: "2026.6.11",
+        message:
+          "codex is pinned to @openclaw/codex@2026.6.11 (installed 2026.6.11), which differs from OpenClaw 2026.7.1-beta.5. Pass `openclaw plugins update @openclaw/codex@2026.7.1-beta.5` to match this OpenClaw version.",
+      },
+    ]);
+  });
+
   it("repairs openclaw peer links after batch npm updates prune earlier plugin links", async () => {
     const plugins = [
       { pluginId: "brave", packageName: "@openclaw/brave-plugin" },
@@ -2304,6 +2347,49 @@ describe("updateNpmInstalledPlugins", () => {
       status: "unchanged",
       currentVersion: "2026.5.28",
       nextVersion: "2026.5.28",
+    });
+  });
+
+  it("reports official core-version drift for exact pinned npm dry-runs", async () => {
+    const installPath = createInstalledPackageDir({
+      name: "@openclaw/codex",
+      version: "2026.6.11",
+    });
+    installPluginFromNpmSpecMock.mockResolvedValue(
+      createSuccessfulNpmUpdateResult({
+        pluginId: "codex",
+        targetDir: installPath,
+        version: "2026.6.11",
+        npmResolution: {
+          name: "@openclaw/codex",
+          version: "2026.6.11",
+          resolvedSpec: "@openclaw/codex@2026.6.11",
+        },
+      }),
+    );
+
+    const result = await updateNpmInstalledPlugins({
+      config: createNpmInstallConfig({
+        pluginId: "codex",
+        spec: "@openclaw/codex@2026.6.11",
+        installPath,
+        resolvedName: "@openclaw/codex",
+        resolvedSpec: "@openclaw/codex@2026.6.11",
+        resolvedVersion: "2026.6.11",
+      }),
+      pluginIds: ["codex"],
+      dryRun: true,
+      coreVersion: "2026.7.1-beta.5",
+    });
+
+    expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+    expectRecordFields(result.outcomes[0], {
+      pluginId: "codex",
+      status: "unchanged",
+      currentVersion: "2026.6.11",
+      nextVersion: "2026.6.11",
+      message:
+        "codex is pinned to @openclaw/codex@2026.6.11 (installed 2026.6.11), which differs from OpenClaw 2026.7.1-beta.5. Pass `openclaw plugins update @openclaw/codex@2026.7.1-beta.5` to match this OpenClaw version.",
     });
   });
 

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -1637,6 +1637,62 @@ describe("updateNpmInstalledPlugins", () => {
     ]);
   });
 
+  it.each([
+    {
+      caseName: "independently versioned official catalog plugins",
+      pluginId: "openclaw-plugin-yuanbao",
+      packageName: "openclaw-plugin-yuanbao",
+      version: "2.15.0",
+      coreVersion: "2026.7.1-beta.5",
+    },
+    {
+      caseName: "newer lockstep exact pins",
+      pluginId: "codex",
+      packageName: "@openclaw/codex",
+      version: "2026.8.1",
+      coreVersion: "2026.7.1-beta.5",
+    },
+  ])("keeps the normal up-to-date message for $caseName", async (fixture) => {
+    const installPath = createInstalledPackageDir({
+      name: fixture.packageName,
+      version: fixture.version,
+    });
+    fs.mkdirSync(path.join(installPath, "node_modules", "openclaw"), { recursive: true });
+    mockNpmViewMetadata({
+      name: fixture.packageName,
+      version: fixture.version,
+      integrity: "sha512-same",
+      shasum: "same",
+    });
+    installPluginFromNpmSpecMock.mockRejectedValue(new Error("installer should not run"));
+
+    const result = await updateNpmInstalledPlugins({
+      config: createNpmInstallConfig({
+        pluginId: fixture.pluginId,
+        spec: `${fixture.packageName}@${fixture.version}`,
+        installPath,
+        resolvedName: fixture.packageName,
+        resolvedVersion: fixture.version,
+        resolvedSpec: `${fixture.packageName}@${fixture.version}`,
+        integrity: "sha512-same",
+        shasum: "same",
+      }),
+      pluginIds: [fixture.pluginId],
+      coreVersion: fixture.coreVersion,
+    });
+
+    expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
+    expect(result.outcomes).toEqual([
+      {
+        pluginId: fixture.pluginId,
+        status: "unchanged",
+        currentVersion: fixture.version,
+        nextVersion: fixture.version,
+        message: `${fixture.pluginId} is up to date (${fixture.version}).`,
+      },
+    ]);
+  });
+
   it("repairs openclaw peer links after batch npm updates prune earlier plugin links", async () => {
     const plugins = [
       { pluginId: "brave", packageName: "@openclaw/brave-plugin" },
@@ -2390,6 +2446,63 @@ describe("updateNpmInstalledPlugins", () => {
       nextVersion: "2026.6.11",
       message:
         "codex is pinned to @openclaw/codex@2026.6.11 (installed 2026.6.11), which differs from OpenClaw 2026.7.1-beta.5. Pass `openclaw plugins update @openclaw/codex@2026.7.1-beta.5` to match this OpenClaw version.",
+    });
+  });
+
+  it.each([
+    {
+      caseName: "independently versioned official catalog plugins",
+      pluginId: "openclaw-plugin-yuanbao",
+      packageName: "openclaw-plugin-yuanbao",
+      version: "2.15.0",
+      coreVersion: "2026.7.1-beta.5",
+    },
+    {
+      caseName: "newer lockstep exact pins",
+      pluginId: "codex",
+      packageName: "@openclaw/codex",
+      version: "2026.8.1",
+      coreVersion: "2026.7.1-beta.5",
+    },
+  ])("keeps the dry-run up-to-date message for $caseName", async (fixture) => {
+    const installPath = createInstalledPackageDir({
+      name: fixture.packageName,
+      version: fixture.version,
+    });
+    installPluginFromNpmSpecMock.mockResolvedValue(
+      createSuccessfulNpmUpdateResult({
+        pluginId: fixture.pluginId,
+        targetDir: installPath,
+        version: fixture.version,
+        npmResolution: {
+          name: fixture.packageName,
+          version: fixture.version,
+          resolvedSpec: `${fixture.packageName}@${fixture.version}`,
+        },
+      }),
+    );
+
+    const result = await updateNpmInstalledPlugins({
+      config: createNpmInstallConfig({
+        pluginId: fixture.pluginId,
+        spec: `${fixture.packageName}@${fixture.version}`,
+        installPath,
+        resolvedName: fixture.packageName,
+        resolvedSpec: `${fixture.packageName}@${fixture.version}`,
+        resolvedVersion: fixture.version,
+      }),
+      pluginIds: [fixture.pluginId],
+      dryRun: true,
+      coreVersion: fixture.coreVersion,
+    });
+
+    expect(runCommandWithTimeoutMock).toHaveBeenCalledTimes(1);
+    expectRecordFields(result.outcomes[0], {
+      pluginId: fixture.pluginId,
+      status: "unchanged",
+      currentVersion: fixture.version,
+      nextVersion: fixture.version,
+      message: `${fixture.pluginId} is up to date (${fixture.version}).`,
     });
   });
 

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -60,6 +60,7 @@ import {
 import { installPluginFromMarketplace } from "./marketplace.js";
 import { checkMinHostVersion } from "./min-host-version.js";
 import {
+  isOfficialNpmSpecVersionLockstep,
   resolveTrustedSourceLinkedOfficialClawHubSpec,
   resolveTrustedSourceLinkedOfficialNpmSpec,
 } from "./official-external-install-records.js";
@@ -437,7 +438,7 @@ function resolveOfficialCoreVersionDriftMessage(params: {
   currentVersion: string | undefined;
   coreVersion: string | undefined;
   record: PluginInstallRecord;
-  officialPackageName: string | undefined;
+  trustedOfficialNpmSpec: string | undefined;
   specOverride: string | undefined;
   syncOfficialPluginInstalls: boolean | undefined;
 }): string | undefined {
@@ -445,20 +446,28 @@ function resolveOfficialCoreVersionDriftMessage(params: {
     params.record.source !== "npm" ||
     params.specOverride ||
     params.syncOfficialPluginInstalls ||
-    !params.officialPackageName
+    !isOfficialNpmSpecVersionLockstep(params.trustedOfficialNpmSpec)
   ) {
     return undefined;
   }
+  const officialPackageName = resolveNpmSpecPackageName(params.trustedOfficialNpmSpec);
   const pinnedVersion = resolveExactNpmSpecVersion(params.record.spec);
   const currentVersion = normalizeExactNpmVersion(params.currentVersion);
   const coreVersion = normalizeExactNpmVersion(params.coreVersion);
-  if (!pinnedVersion || !currentVersion || !coreVersion || currentVersion === coreVersion) {
+  if (
+    !officialPackageName ||
+    !pinnedVersion ||
+    !currentVersion ||
+    !coreVersion ||
+    pinnedVersion !== currentVersion ||
+    compareNpmSemverForUpdate(pinnedVersion, coreVersion) >= 0
+  ) {
     return undefined;
   }
-  if (resolveNpmSpecPackageName(params.record.spec) !== params.officialPackageName) {
+  if (resolveNpmSpecPackageName(params.record.spec) !== officialPackageName) {
     return undefined;
   }
-  const exactTarget = `${params.officialPackageName}@${coreVersion}`;
+  const exactTarget = `${officialPackageName}@${coreVersion}`;
   if (parseRegistryNpmSpec(exactTarget)?.selectorKind !== "exact-version") {
     return undefined;
   }
@@ -1702,7 +1711,7 @@ export async function updateNpmInstalledPlugins(params: {
       currentVersion,
       coreVersion: params.coreVersion,
       record,
-      officialPackageName: officialNpmPackageName,
+      trustedOfficialNpmSpec,
       specOverride: params.specOverrides?.[pluginId],
       syncOfficialPluginInstalls: params.syncOfficialPluginInstalls,
     });

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -432,6 +432,43 @@ async function resolveNewerExactPinnedNpmDefaultLine(params: {
     : undefined;
 }
 
+function resolveOfficialCoreVersionDriftMessage(params: {
+  pluginId: string;
+  currentVersion: string | undefined;
+  coreVersion: string | undefined;
+  record: PluginInstallRecord;
+  officialPackageName: string | undefined;
+  specOverride: string | undefined;
+  syncOfficialPluginInstalls: boolean | undefined;
+}): string | undefined {
+  if (
+    params.record.source !== "npm" ||
+    params.specOverride ||
+    params.syncOfficialPluginInstalls ||
+    !params.officialPackageName
+  ) {
+    return undefined;
+  }
+  const pinnedVersion = resolveExactNpmSpecVersion(params.record.spec);
+  const currentVersion = normalizeExactNpmVersion(params.currentVersion);
+  const coreVersion = normalizeExactNpmVersion(params.coreVersion);
+  if (!pinnedVersion || !currentVersion || !coreVersion || currentVersion === coreVersion) {
+    return undefined;
+  }
+  if (resolveNpmSpecPackageName(params.record.spec) !== params.officialPackageName) {
+    return undefined;
+  }
+  const exactTarget = `${params.officialPackageName}@${coreVersion}`;
+  if (parseRegistryNpmSpec(exactTarget)?.selectorKind !== "exact-version") {
+    return undefined;
+  }
+  return (
+    `${params.pluginId} is pinned to ${params.record.spec} (installed ${params.currentVersion}), ` +
+    `which differs from OpenClaw ${coreVersion}. ` +
+    `Pass \`openclaw plugins update ${exactTarget}\` to match this OpenClaw version.`
+  );
+}
+
 async function loadNpmPackageVersionsForUpdate(params: {
   packageName: string;
   timeoutMs?: number;
@@ -1660,6 +1697,15 @@ export async function updateNpmInstalledPlugins(params: {
       );
       continue;
     }
+    const officialCoreVersionDriftMessage = resolveOfficialCoreVersionDriftMessage({
+      pluginId,
+      currentVersion,
+      coreVersion: params.coreVersion,
+      record,
+      officialPackageName: officialNpmPackageName,
+      specOverride: params.specOverrides?.[pluginId],
+      syncOfficialPluginInstalls: params.syncOfficialPluginInstalls,
+    });
     const extensionsDir = resolveRecordedExtensionsDir({
       pluginId,
       installPath,
@@ -1749,7 +1795,8 @@ export async function updateNpmInstalledPlugins(params: {
             status: "unchanged",
             currentVersion,
             nextVersion: metadataResult.metadata.version,
-            message: `${pluginId} is up to date (${currentVersion}).`,
+            message:
+              officialCoreVersionDriftMessage ?? `${pluginId} is up to date (${currentVersion}).`,
           });
           continue;
         }
@@ -2033,6 +2080,7 @@ export async function updateNpmInstalledPlugins(params: {
             );
       const newerExactPinnedDefaultLine =
         unchanged &&
+        !officialCoreVersionDriftMessage &&
         record.source === "npm" &&
         !params.specOverrides?.[pluginId] &&
         !officialNpmSpec
@@ -2044,8 +2092,9 @@ export async function updateNpmInstalledPlugins(params: {
             })
           : undefined;
       if (unchanged) {
-        const message =
-          newerExactPinnedDefaultLine && effectiveSpec
+        const message = officialCoreVersionDriftMessage
+          ? officialCoreVersionDriftMessage + channelFallbackSuffix
+          : newerExactPinnedDefaultLine && effectiveSpec
             ? `${pluginId} is pinned to ${effectiveSpec} (installed ${currentLabel}); ` +
               `registry default resolves to ${newerExactPinnedDefaultLine.version}. ` +
               `Pass \`openclaw plugins update ${newerExactPinnedDefaultLine.packageName}@latest\` to follow the registry default line.` +


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running an older exact-pinned lockstep official plugin would be told that the plugin was "up to date" even when its installed version lagged behind the current OpenClaw release line.

This is especially confusing when a newer core exposes a model or capability that requires the matching official plugin runtime. In the motivating case, OpenClaw `2026.7.1-beta.5` listed `openai/gpt-5.6-sol` as available while the exact-pinned `@openclaw/codex@2026.6.11` runtime rejected the request with a 400 error requiring a newer Codex version. `openclaw plugins update codex --dry-run` still reported the old pin as up to date.

## Why This Change Was Made

Exact pins remain exact and are never updated implicitly. When an unchanged exact pin is older than the current OpenClaw version, the update path now prints the exact opt-in alignment command only if the trusted official catalog declares that package as lockstep-versioned.

The implementation reuses the catalog contract already used by plugin version-drift detection:

- Official catalog npm specs without an exact catalog version are lockstep.
- Official catalog npm specs with an exact catalog version are independently versioned and keep the existing message.
- Matching and newer exact pins keep the existing message, so this change never recommends a downgrade.
- Explicit spec overrides, official synchronization flows, third-party plugins, tags, and ranges keep their existing behavior.

## User Impact

Operators with a stale lockstep pin can distinguish an intentionally unchanged pin from a healthy version match and receive an actionable command such as:

```text
openclaw plugins update @openclaw/deepseek-provider@2026.7.1-beta.5
```

This does not change model defaults, provider routing, fallback order, dependency versions, or automatic update policy.

## Evidence

Focused coverage now exercises both normal and dry-run paths for:

- stale lockstep exact pins: emits the alignment command;
- independently versioned official catalog pins: keeps the normal up-to-date message;
- newer lockstep exact pins: keeps the normal up-to-date message and does not suggest a downgrade.

## Real behavior proof

The current PR head was built from a clean checkout, copied into an isolated runtime, and run with isolated `HOME`, `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`. No auth profiles, provider credentials, user config, or Gateway state were copied.

Current `main` identifies itself as development version `2026.7.2`, for which matching official plugin packages are not yet published. For the executable proof only, the isolated runtime's package metadata was set to the published lockstep version `2026.7.1-beta.5`; the executable code and build stamp remained the exact PR head:

```text
$ openclaw --version
OpenClaw 2026.7.1-beta.5 (446ce98)
```

Installed a real older lockstep official package into the isolated state:

```text
$ openclaw plugins install npm:@openclaw/deepseek-provider@2026.6.11 --force --pin
Pinned npm install record to @openclaw/deepseek-provider@2026.6.11.
Installed plugin: deepseek
```

The current branch generated the new dry-run diagnostic:

```text
$ openclaw plugins update deepseek --dry-run
deepseek is pinned to @openclaw/deepseek-provider@2026.6.11 (installed 2026.6.11), which differs from OpenClaw 2026.7.1-beta.5. Pass `openclaw plugins update @openclaw/deepseek-provider@2026.7.1-beta.5` to match this OpenClaw version.
```

Executed the exact command printed by that diagnostic:

```text
$ openclaw plugins update @openclaw/deepseek-provider@2026.7.1-beta.5
Updated deepseek: 2026.6.11 -> 2026.7.1-beta.5.
```

The same dry-run then confirmed convergence:

```text
$ openclaw plugins update deepseek --dry-run
deepseek is up to date (2026.7.1-beta.5).
```

All four commands exited `0`. This proof exercises real npm package installation and replacement through the current branch's production CLI; it does not exercise model inference or use provider credentials.

### End-to-end motivating-case verification

The original `gpt-5.6-sol` incident was also re-verified after aligning OpenClaw core and `@openclaw/codex` at `2026.7.1-beta.5`:

- the Control UI model picker displayed both `GPT-5.5` and `GPT-5.6 Sol`;
- selecting `GPT-5.5` in the UI and sending a turn without a CLI model override produced `provider=openai`, `model=gpt-5.5`, and `agentHarnessId=codex`;
- selecting `GPT-5.6 Sol` in the same UI and sending another turn without a CLI model override produced `provider=openai`, `model=gpt-5.6-sol`, and `agentHarnessId=codex`;
- restarting the Gateway preserved the selection, and a guard smoke turn again used `openai/gpt-5.6-sol` through the Codex harness.

The released beta also exposed a separate legacy model-catalog availability issue that could mark the working Codex-routed `gpt-5.6-sol` entry unavailable in `chat.metadata`. The target `main` branch already contains the route-aware catalog implementation that evaluates both the platform and ChatGPT subscription routes, so this PR does not duplicate that already-landed fix. The UI/inference transcript is included here as end-to-end validation of the motivating stale-plugin scenario, not as an additional code surface in this patch.

No credential values, auth database contents, account identifiers, or Gateway tokens were captured in this verification.

### Current-head verification

```text
node scripts/run-vitest.mjs run src/plugins/update.test.ts src/plugins/plugin-version-drift.test.ts
  2 files passed, 144 tests passed

pnpm check
  passed (typecheck, lint, formatting, policy guards)

pnpm build
  passed, exit 0

git diff --check origin/main...HEAD
  passed
```

The branch was rebased onto current `origin/main` before the verification above. The focused tests, full repository checks, build, and isolated production CLI proof were all rerun against the rebased head.
