### PR TITLE
refactor(wizard): remove obsolete testing alias

### DIFF
--- a/src/wizard/setup.official-plugins.ts
+++ b/src/wizard/setup.official-plugins.ts
@@ -136,4 +136,3 @@ export async function setupOfficialPluginInstalls(params: {
   }
   return next;
 }
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

Removes an unused legacy test export from the official plugin onboarding helper. Keeping both `testing` and `__testing` exposed the same internal object under two names even though all current tests use the canonical `testing` export.

## Why This Change Was Made

Delete only the unconsumed `__testing` alias. The canonical `testing` object, runtime entry point, and onboarding behavior remain unchanged.

## User Impact

No user-visible behavior changes. This narrows an internal wizard module surface and removes redundant code.

## Evidence

- Exhaustive live open-PR file overlap audit found no PR touching `src/wizard/setup.official-plugins.ts`, including oversized PRs with more than 100 changed files.
- Dedicated full codebase-memory graph: 305,200 nodes / 1,261,949 edges. The graph resolves the runtime caller chain and canonical test helper, with no module-local `__testing` symbol consumer.
- Before and after: `pnpm test:serial src/wizard/setup.official-plugins.test.ts` passed 6/6 tests in Testbox `tbx_01kxb6951kp92t0kpc1tx8ftrg`.
- `pnpm check:changed -- src/wizard/setup.official-plugins.ts` passed in the same Testbox.
- Fresh `gpt-5.6-sol` autoreview at medium reasoning: clean, patch correct, confidence 0.82.
- AI-assisted; transcript omitted.
