### PR TITLE
fix(test): bound agents-core full-suite processes

### DIFF
--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -291,6 +291,7 @@ const BROAD_TOOLING_SCRIPT_TEST_PATTERNS = new Set([
   "test/scripts/*.test.ts",
 ]);
 const BROAD_TOOLING_SCRIPT_TEST_TARGET_CHUNK_SIZE = 60;
+const FULL_SUITE_AGENTS_CORE_TEST_TARGET_CHUNK_COUNT = 6;
 const FULL_SUITE_TOOLING_TEST_TARGET_CHUNK_SIZE = 2;
 const FULL_SUITE_UNIT_FAST_TEST_TARGET_CHUNK_SIZE = 70;
 const TUI_VITEST_CONFIG = "test/vitest/vitest.tui.config.ts";
@@ -2515,6 +2516,18 @@ function listUnitFastFullSuiteTestTargets() {
   return getUnitFastTestFiles().filter((file) => !timerTargets.has(file));
 }
 
+function listAgentsCoreFullSuiteTestTargets(cwd) {
+  const agentsDir = path.join(cwd, "src/agents");
+  if (!fs.existsSync(agentsDir)) {
+    return [];
+  }
+  return fs
+    .readdirSync(agentsDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".test.ts"))
+    .map((entry) => `src/agents/${entry.name}`)
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
 function createBroadToolingScriptPlans({ config, forwardedArgs, includePatterns, watchMode, cwd }) {
   if (watchMode || config !== TOOLING_VITEST_CONFIG || !includePatterns) {
     return null;
@@ -4232,7 +4245,14 @@ export function buildFullSuiteVitestRunPlans(args, cwd = process.cwd()) {
     return configs.flatMap((config) => {
       if (expandShard && targetArgs.length === 0) {
         let chunks = [];
-        if (config === UNIT_FAST_VITEST_CONFIG) {
+        if (config === AGENTS_CORE_VITEST_CONFIG) {
+          // A single non-isolated agents-core process grows until its worker can
+          // exit under the full-suite memory load. Bound each process lifetime.
+          chunks = splitTargetChunks(
+            listAgentsCoreFullSuiteTestTargets(cwd),
+            FULL_SUITE_AGENTS_CORE_TEST_TARGET_CHUNK_COUNT,
+          );
+        } else if (config === UNIT_FAST_VITEST_CONFIG) {
           const targets = listUnitFastFullSuiteTestTargets();
           const chunkCount = Math.ceil(
             targets.length / FULL_SUITE_UNIT_FAST_TEST_TARGET_CHUNK_SIZE,

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -4323,9 +4323,11 @@ describe("scripts/test-projects full-suite sharding", () => {
 
   it("can expand full-suite shards to project configs for perf experiments", () => {
     const gatewayServerConfig = "test/vitest/vitest.gateway-server.config.ts";
+    const agentsCoreConfig = "test/vitest/vitest.agents-core.config.ts";
     const toolingConfig = "test/vitest/vitest.tooling.config.ts";
     const unitFastConfig = "test/vitest/vitest.unit-fast.config.ts";
     const plans = leafShardPlans;
+    const agentsCorePlans = plans.filter((plan) => plan.config === agentsCoreConfig);
     const toolingPlans = plans.filter((plan) => plan.config === toolingConfig);
     const unitFastPlans = plans.filter((plan) => plan.config === unitFastConfig);
 
@@ -4375,7 +4377,7 @@ describe("scripts/test-projects full-suite sharding", () => {
       "test/vitest/vitest.cli.config.ts",
       "test/vitest/vitest.commands-light.config.ts",
       "test/vitest/vitest.commands.config.ts",
-      "test/vitest/vitest.agents-core.config.ts",
+      ...agentsCorePlans.map(() => agentsCoreConfig),
       "test/vitest/vitest.agents-embedded-agent.config.ts",
       "test/vitest/vitest.agents-support.config.ts",
       "test/vitest/vitest.agents-tools.config.ts",
@@ -4432,6 +4434,18 @@ describe("scripts/test-projects full-suite sharding", () => {
     expect(gatewayTargets).toContain("src/gateway/server-network-runtime.e2e.test.ts");
     expect(gatewayTargets).not.toContain("src/gateway/gateway.test.ts");
     expect(Math.max(...gatewayChunkSizes) - Math.min(...gatewayChunkSizes)).toBeLessThanOrEqual(1);
+    const agentsCoreTargets = agentsCorePlans.flatMap((plan) => plan.forwardedArgs);
+    const agentsCoreChunkSizes = agentsCorePlans.map((plan) => plan.forwardedArgs.length);
+    expect(agentsCorePlans).toHaveLength(6);
+    expect(agentsCoreTargets.length).toBeGreaterThan(500);
+    expect(new Set(agentsCoreTargets).size).toBe(agentsCoreTargets.length);
+    expect(agentsCoreTargets).toContain("src/agents/agent-command.live-model-switch.test.ts");
+    expect(agentsCoreTargets).not.toContain(
+      "src/agents/embedded-agent-runner/run.incomplete-turn.test.ts",
+    );
+    expect(
+      Math.max(...agentsCoreChunkSizes) - Math.min(...agentsCoreChunkSizes),
+    ).toBeLessThanOrEqual(1);
     const unitFastTargets = unitFastPlans.flatMap((plan) => plan.forwardedArgs);
     expect(unitFastPlans.length).toBeGreaterThan(10);
     expect(unitFastPlans.every((plan) => plan.forwardedArgs.length <= 70)).toBe(true);
@@ -4451,6 +4465,7 @@ describe("scripts/test-projects full-suite sharding", () => {
       plans.filter(
         (plan) =>
           plan.config !== gatewayServerConfig &&
+          plan.config !== agentsCoreConfig &&
           plan.config !== toolingConfig &&
           plan.config !== unitFastConfig,
       ),
@@ -4459,6 +4474,7 @@ describe("scripts/test-projects full-suite sharding", () => {
         .filter(
           (plan) =>
             plan.config !== gatewayServerConfig &&
+            plan.config !== agentsCoreConfig &&
             plan.config !== toolingConfig &&
             plan.config !== unitFastConfig,
         )


### PR DESCRIPTION
## What Problem This Solves

The expanded full test suite runs all 532 top-level `src/agents/*.test.ts` files in one non-isolated Vitest process. On a 32-vCPU Testbox that process repeatedly lost its worker after roughly four minutes, including from a clean archive of current `main`, so unrelated PRs could not obtain a green native prepare gate.

## Why This Change Was Made

Reuse the existing full-suite target chunking seam and divide agents-core into six balanced, deterministic processes. This bounds each worker lifetime while preserving the same file ownership boundary, explicit focused config behavior, and serial full-suite scheduling.

## User Impact

No runtime behavior changes. Maintainer full-suite validation no longer depends on one unbounded agents-core worker.

## Evidence

- `test/scripts/test-projects.test.ts`: 191/191 passed on Testbox `tbx_01kxb6em9gvswd06g1bwx5tk1p` ([run](https://github.com/openclaw/openclaw/actions/runs/29193534523)).
- All six generated agents-core chunks passed end-to-end on Testbox `tbx_01kxb6h2qyytsmh2grhjhfmcqp` ([run](https://github.com/openclaw/openclaw/actions/runs/29193571947)).
- Clean `origin/main` reproduced the pre-fix worker exit on Testbox `tbx_01kxb5pa4tgyramsjmwhzs0svw` ([run](https://github.com/openclaw/openclaw/actions/runs/29193147633)).
- Fresh autoreview: clean, no actionable findings (confidence 0.91).
