### PR TITLE
fix: prevent stale Worktrees state during refreshes

### DIFF
--- a/ui/src/pages/worktrees/worktrees-page.test.ts
+++ b/ui/src/pages/worktrees/worktrees-page.test.ts
@@ -16,6 +16,7 @@ type WorktreesPageTestElement = HTMLElement & {
   createBranches: string[];
   updateComplete: Promise<boolean>;
   requestUpdate: () => void;
+  load: () => Promise<void>;
   loadCreateBranches: () => void;
   createWorktree: () => Promise<void>;
   removeWorktree: (record: WorktreeRecord) => Promise<void>;
@@ -106,6 +107,56 @@ afterEach(() => {
 });
 
 describe("WorktreesPage lifecycle", () => {
+  it("serializes list refreshes and row mutations", async () => {
+    const record = worktree();
+    const removedRecord = {
+      ...record,
+      removedAt: 2,
+      snapshotRef: "refs/openclaw/worktree-snapshots/test",
+    };
+    const pendingList = deferred<{ worktrees: WorktreeRecord[] }>();
+    let listRequests = 0;
+    const request = vi.fn((method: string) => {
+      if (method === "worktrees.list") {
+        listRequests += 1;
+        if (listRequests === 1) {
+          return Promise.resolve({ worktrees: [record] });
+        }
+        return listRequests === 2
+          ? pendingList.promise
+          : Promise.resolve({ worktrees: [removedRecord] });
+      }
+      return Promise.resolve({ removed: true });
+    });
+    const page = document.createElement("openclaw-worktrees-page") as WorktreesPageTestElement;
+    page.context = contextWithGateway(
+      gatewayWithClient({ request } as unknown as GatewayBrowserClient),
+    );
+    document.body.append(page);
+    await vi.waitFor(() => expect(page.records).toEqual([record]));
+    await vi.waitFor(() => expect(page.loading).toBe(false));
+
+    const refreshing = page.load();
+    await vi.waitFor(() => expect(listRequests).toBe(2));
+    await page.updateComplete;
+
+    const deleteButton = page.querySelector<HTMLButtonElement>("button.danger");
+    expect(deleteButton?.disabled).toBe(true);
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    await page.removeWorktree(record);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(request).not.toHaveBeenCalledWith("worktrees.remove", { id: record.id });
+
+    pendingList.resolve({ worktrees: [record] });
+    await refreshing;
+
+    await page.removeWorktree(record);
+    expect(confirm).toHaveBeenCalledOnce();
+    expect(request).toHaveBeenCalledWith("worktrees.remove", { id: record.id });
+    expect(listRequests).toBe(3);
+    expect(page.records).toEqual([removedRecord]);
+  });
+
   it("clears stale records when a null-client gateway source is replaced", async () => {
     const page = document.createElement("openclaw-worktrees-page") as WorktreesPageTestElement;
     page.records = [

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -138,9 +138,15 @@ class WorktreesPage extends OpenClawLightDomElement {
     );
   }
 
+  // Reads and writes share one page-level lane. Otherwise a stale list can
+  // overwrite a completed mutation, while busyId can only represent one row.
+  private get operationPending(): boolean {
+    return this.loading || this.busyId !== null || this.creating;
+  }
+
   private async load() {
     const client = this.client;
-    if (!client || !this.gatewayConnected || this.loading) {
+    if (!client || !this.gatewayConnected || this.operationPending) {
       return;
     }
     const generation = ++this.loadGeneration;
@@ -164,7 +170,11 @@ class WorktreesPage extends OpenClawLightDomElement {
 
   private async removeWorktree(record: WorktreeRecord) {
     const scope = this.captureOperationScope();
-    if (!scope || !window.confirm(t("worktrees.confirmDelete", { name: record.name }))) {
+    if (
+      !scope ||
+      this.operationPending ||
+      !window.confirm(t("worktrees.confirmDelete", { name: record.name }))
+    ) {
       return;
     }
     // Both attempts belong to one Gateway epoch. A force retry must never jump
@@ -209,7 +219,7 @@ class WorktreesPage extends OpenClawLightDomElement {
 
   private async restore(record: WorktreeRecord) {
     const scope = this.captureOperationScope();
-    if (!scope) {
+    if (!scope || this.operationPending) {
       return;
     }
     this.busyId = record.id;
@@ -230,7 +240,7 @@ class WorktreesPage extends OpenClawLightDomElement {
 
   private async gc() {
     const scope = this.captureOperationScope();
-    if (!scope) {
+    if (!scope || this.operationPending) {
       return;
     }
     this.loading = true;
@@ -288,7 +298,7 @@ class WorktreesPage extends OpenClawLightDomElement {
   private async createWorktree() {
     const scope = this.captureOperationScope();
     const repoRoot = this.createRepoRoot.trim();
-    if (!scope || !repoRoot || this.creating) {
+    if (!scope || !repoRoot || this.operationPending) {
       return;
     }
     this.creating = true;
@@ -371,7 +381,7 @@ class WorktreesPage extends OpenClawLightDomElement {
         </label>
         <button
           class="btn btn--sm"
-          ?disabled=${this.creating || !this.createRepoRoot.trim()}
+          ?disabled=${this.operationPending || !this.createRepoRoot.trim()}
           @click=${() => void this.createWorktree()}
         >
           ${this.creating ? t("common.loading") : t("common.create")}
@@ -392,7 +402,7 @@ class WorktreesPage extends OpenClawLightDomElement {
             <button class="btn" @click=${() => this.toggleCreate()}>
               ${t("worktrees.newWorktree")}
             </button>
-            <button class="btn" ?disabled=${this.loading} @click=${() => void this.gc()}>
+            <button class="btn" ?disabled=${this.operationPending} @click=${() => void this.gc()}>
               ${this.loading ? t("common.loading") : t("worktrees.cleanNow")}
             </button>
           </div>
@@ -426,14 +436,14 @@ class WorktreesPage extends OpenClawLightDomElement {
                       ${record.removedAt
                         ? html`<button
                             class="btn btn--sm"
-                            ?disabled=${this.busyId === record.id}
+                            ?disabled=${this.operationPending}
                             @click=${() => void this.restore(record)}
                           >
                             ${t("worktrees.restore")}
                           </button>`
                         : html`<button
                             class="btn btn--sm danger"
-                            ?disabled=${this.busyId === record.id}
+                            ?disabled=${this.operationPending}
                             @click=${() => void this.removeWorktree(record)}
                           >
                             ${t("common.delete")}


### PR DESCRIPTION
Closes #105373

## What Problem This Solves

Fixes an issue where users deleting a managed worktree while the Worktrees inventory was refreshing could see the deleted worktree remain Active with a Delete action.

## Why This Change Was Made

The Worktrees page now serializes inventory reads and state-changing operations through one pending-operation guard. Visible controls and controller methods enforce the same boundary, while each completed mutation still refreshes after its own pending flag clears.

## User Impact

Worktrees no longer presents stale actions after overlapping cleanup, create, delete, or restore activity. Users get one coherent operation at a time and the visible row state remains aligned with Gateway state.

## Evidence

- Live Playwright + real Gateway before: Delete stayed enabled during a held real inventory response; after deletion, UI showed Active/Delete while Gateway reported the same ID restorable.
- Live Playwright + real Gateway after: Delete was disabled during the held response; after it settled, a real delete produced Restorable/Restore in both UI and Gateway; the fixture restored successfully; zero browser errors.
- Source-blind behavior contract: 5/5 checks passed, 3 anti-cheat probes passed, 0 blockers.
- Blacksmith Testbox `tbx_01kxb6a17gv9dsn3ak8kge2mq3`: `corepack pnpm test ui/src/pages/worktrees/worktrees-page.test.ts` — 9/9 passed.
- Blacksmith Testbox `tbx_01kxb6a17gv9dsn3ak8kge2mq3`: remote `corepack pnpm check:changed` — format, typecheck, lint, and guards passed.
- Production Control UI build: `OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/ui.js build`.
