### PR TITLE
refactor(channels): remove obsolete testing alias

### DIFF
--- a/src/channels/plugins/message-action-discovery.ts
+++ b/src/channels/plugins/message-action-discovery.ts
@@ -453,4 +453,3 @@ export const testing = {
     loggedMessageActionErrors.clear();
   },
 };
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

Removes an unused legacy test export from channel message-action discovery. Keeping both `testing` and `__testing` exposed the same internal reset helper under two names even though current tests use only the canonical `testing` export.

## Why This Change Was Made

Delete only the unconsumed `__testing` alias. The canonical test helper, message-tool discovery functions, plugin contract surface, and runtime behavior remain unchanged.

## User Impact

No user-visible behavior changes. This narrows an internal channel module surface and removes redundant code.

## Evidence

- Exhaustive live open-PR file overlap audit found no PR touching `src/channels/plugins/message-action-discovery.ts`, including every oversized PR with more than 100 changed files.
- Dedicated full codebase-memory graph: 305,200 nodes / 1,261,832 edges. Runtime callers and the canonical reset helper resolve, with no module-local `__testing` consumer.
- Before and after: `pnpm test:serial src/channels/plugins/message-actions.test.ts` passed 11/11 tests in Testbox `tbx_01kxb74mazfzkhzm7460rgqate`.
- `pnpm check:changed -- src/channels/plugins/message-action-discovery.ts` passed in the same Testbox, including core, extension, test, lint, cycle, and storage guard lanes.
- Fresh `gpt-5.6-sol` autoreview at medium reasoning: clean, patch correct, confidence 0.86.
- AI-assisted; transcript omitted.
