### PR TITLE
fix(cron): throttle session reaper after persistence errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Cron session reaper backoff:** throttle failed session-store sweep attempts per store so frequent timer ticks cannot repeatedly hammer broken or inaccessible persistence. (#105188, #105386) Thanks @ZOOWH.
 - **Provider network retries:** align provider read/poll/download and agent-wait recovery for transient connection errors, retry bounded provider `ENOTFOUND` failures while leaving gateway `ENOTFOUND` and non-idempotent create operations fail-fast. (#101496) Thanks @xialonglee.
 - **Session retry classification:** stop permanent provider errors whose identifiers or payload details merely contain 429/5xx digit sequences from re-sending full context, and share bounded rate-limit-window parsing across retry paths. (#105258) Thanks @destire-mio.
 - **LINE directive templates:** suppress confirms and buttons with blank required fields or unlabeled actions while preserving valid titleless buttons and surrounding reply text. (#105520) Thanks @edenfunf.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Cron session reaper backoff:** throttle failed session-store sweep attempts per store so frequent timer ticks cannot repeatedly hammer broken or inaccessible persistence. (#105188, #105386) Thanks @ZOOWH.
 - **Provider network retries:** align provider read/poll/download and agent-wait recovery for transient connection errors, retry bounded provider `ENOTFOUND` failures while leaving gateway `ENOTFOUND` and non-idempotent create operations fail-fast. (#101496) Thanks @xialonglee.
 - **Session retry classification:** stop permanent provider errors whose identifiers or payload details merely contain 429/5xx digit sequences from re-sending full context, and share bounded rate-limit-window parsing across retry paths. (#105258) Thanks @destire-mio.
 - **LINE directive templates:** suppress confirms and buttons with blank required fields or unlabeled actions while preserving valid titleless buttons and surrounding reply text. (#105520) Thanks @edenfunf.

--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -3,17 +3,15 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  listSessionEntries,
-  patchSessionEntry,
-  replaceSessionEntry,
-} from "../config/sessions/session-accessor.js";
+import * as sessionAccessor from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import { beginSessionWorkAdmission } from "../sessions/session-lifecycle-admission.js";
 import { createDeferred } from "../test-utils/deferred.js";
 import type { Logger } from "./service/state.js";
 import { sweepCronRunSessions, resolveRetentionMs, resetReaperThrottle } from "./session-reaper.js";
+
+const { listSessionEntries, patchSessionEntry, replaceSessionEntry } = sessionAccessor;
 
 const taskStatusMocks = vi.hoisted(() => ({ hasPendingGeneratedMediaTask: vi.fn() }));
 
@@ -405,5 +403,52 @@ describe("sweepCronRunSessions", () => {
       log,
     });
     expect(r3.swept).toBe(false);
+  });
+
+  it("updates throttle after persistence errors so the next tick does not thrash (#105188)", async () => {
+    const now = Date.now();
+    const warn = vi.fn();
+    const failingLog: Logger = { ...log, warn };
+    const eacces = Object.assign(new Error("EACCES: permission denied, open 'sessions.json'"), {
+      code: "EACCES",
+    });
+    const listSpy = vi.spyOn(sessionAccessor, "listSessionEntries").mockImplementation(() => {
+      throw eacces;
+    });
+
+    try {
+      const first = await sweepCronRunSessions({
+        sessionStorePath: storePath,
+        nowMs: now,
+        log: failingLog,
+      });
+      expect(first).toEqual({ swept: false, pruned: 0 });
+      expect(warn).toHaveBeenCalledWith(
+        { err: String(eacces) },
+        "cron-reaper: failed to sweep session store",
+      );
+      expect(listSpy).toHaveBeenCalledTimes(1);
+
+      warn.mockClear();
+      const immediateRetry = await sweepCronRunSessions({
+        sessionStorePath: storePath,
+        nowMs: now + 1_000,
+        log: failingLog,
+      });
+      expect(immediateRetry).toEqual({ swept: false, pruned: 0 });
+      expect(warn).not.toHaveBeenCalled();
+      expect(listSpy).toHaveBeenCalledTimes(1);
+
+      const afterCooldown = await sweepCronRunSessions({
+        sessionStorePath: storePath,
+        nowMs: now + 5 * 60_000,
+        log: failingLog,
+      });
+      expect(afterCooldown).toEqual({ swept: false, pruned: 0 });
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(listSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      listSpy.mockRestore();
+    }
   });
 });

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -65,15 +65,17 @@ export async function sweepCronRunSessions(params: {
     return { swept: false, pruned: 0 };
   }
 
+  // Throttle attempts, not only successful sweeps. A broken session store must
+  // not turn frequent timer ticks into an unbounded persistence-error loop.
+  lastSweepAtMsByStore.set(storePath, now);
+
   const retentionMs = resolveRetentionMs(params.cronConfig);
   if (retentionMs === null) {
-    lastSweepAtMsByStore.set(storePath, now);
     return { swept: false, pruned: 0 };
   }
 
   let pruned = 0;
   let transcriptCleanupError: unknown;
-  let swept = false;
   try {
     const cutoff = now - retentionMs;
     const removals: SessionEntryLifecycleRemoval[] = [];
@@ -123,16 +125,8 @@ export async function sweepCronRunSessions(params: {
       pruned = result.removedEntries;
       transcriptCleanupError = result.artifactCleanupError;
     }
-    swept = true;
   } catch (err) {
     params.log.warn({ err: String(err) }, "cron-reaper: failed to sweep session store");
-  } finally {
-    // Always arm the per-store cooldown — including after persistence errors —
-    // so timer ticks cannot immediately re-enter and thrash disk I/O (#105188).
-    lastSweepAtMsByStore.set(storePath, now);
-  }
-
-  if (!swept) {
     return { swept: false, pruned: 0 };
   }
 

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -73,6 +73,7 @@ export async function sweepCronRunSessions(params: {
 
   let pruned = 0;
   let transcriptCleanupError: unknown;
+  let swept = false;
   try {
     const cutoff = now - retentionMs;
     const removals: SessionEntryLifecycleRemoval[] = [];
@@ -122,12 +123,18 @@ export async function sweepCronRunSessions(params: {
       pruned = result.removedEntries;
       transcriptCleanupError = result.artifactCleanupError;
     }
+    swept = true;
   } catch (err) {
     params.log.warn({ err: String(err) }, "cron-reaper: failed to sweep session store");
-    return { swept: false, pruned: 0 };
+  } finally {
+    // Always arm the per-store cooldown — including after persistence errors —
+    // so timer ticks cannot immediately re-enter and thrash disk I/O (#105188).
+    lastSweepAtMsByStore.set(storePath, now);
   }
 
-  lastSweepAtMsByStore.set(storePath, now);
+  if (!swept) {
+    return { swept: false, pruned: 0 };
+  }
 
   if (transcriptCleanupError) {
     params.log.warn(


### PR DESCRIPTION
Closes #105188

## What Problem This Solves

Persistence failures in the cron session reaper returned before updating the per-store throttle timestamp. Frequent timer ticks could therefore retry an inaccessible or broken store continuously instead of respecting the existing cooldown.

## Why This Change Was Made

The final implementation records each admitted sweep attempt immediately after the throttle guard and before fallible persistence work. This directly models the invariant without an extra success flag or `finally` control flow, while preserving disabled-retention, success, warning, and result behavior.

## User Impact

Transient session-store failures back off for the existing five-minute interval instead of repeatedly hammering disk and logs.

Release-note context: **Cron session reaper backoff:** throttle failed session-store sweep attempts per store so frequent timer ticks cannot repeatedly hammer broken or inaccessible persistence. Thanks @ZOOWH.

## Evidence

- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29214579361
- `pnpm test src/cron/session-reaper.test.ts` — 20 tests passed.
- `pnpm check:changed` — passed, including Plugin SDK baseline, tsgo, lint, import-cycle, and boundary guards.
- Regression covers first failure, suppressed retry after one second, and a new attempt at the five-minute boundary.
- Fresh autoreview — clean, no actionable findings.
