### PR TITLE
fix(discord): omit invalid component accent colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Discord component accent colors:** omit negative, fractional, and out-of-range numeric container colors before Discord serialization while preserving valid RGB boundary values. (#105387) Thanks @qingminlong.
 - **Provider network retries:** align provider read/poll/download and agent-wait recovery for transient connection errors, retry bounded provider `ENOTFOUND` failures while leaving gateway `ENOTFOUND` and non-idempotent create operations fail-fast. (#101496) Thanks @xialonglee.
 - **Session retry classification:** stop permanent provider errors whose identifiers or payload details merely contain 429/5xx digit sequences from re-sending full context, and share bounded rate-limit-window parsing across retry paths. (#105258) Thanks @destire-mio.
 - **LINE directive templates:** suppress confirms and buttons with blank required fields or unlabeled actions while preserving valid titleless buttons and surrounding reply text. (#105520) Thanks @edenfunf.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Discord component accent colors:** omit negative, fractional, and out-of-range numeric container colors before Discord serialization while preserving valid RGB boundary values. (#105387) Thanks @qingminlong.
 - **Provider network retries:** align provider read/poll/download and agent-wait recovery for transient connection errors, retry bounded provider `ENOTFOUND` failures while leaving gateway `ENOTFOUND` and non-idempotent create operations fail-fast. (#101496) Thanks @xialonglee.
 - **Session retry classification:** stop permanent provider errors whose identifiers or payload details merely contain 429/5xx digit sequences from re-sending full context, and share bounded rate-limit-window parsing across retry paths. (#105258) Thanks @destire-mio.
 - **LINE directive templates:** suppress confirms and buttons with blank required fields or unlabeled actions while preserving valid titleless buttons and surrounding reply text. (#105520) Thanks @edenfunf.

--- a/extensions/discord/src/components.test.ts
+++ b/extensions/discord/src/components.test.ts
@@ -115,32 +115,30 @@ describe("discord components", () => {
     expect(result.modals[0]?.allowedUsers).toEqual(["discord:user-1"]);
   });
 
-  it("omits invalid numeric container accent colors", () => {
-    const validSpec = readDiscordComponentSpec({
-      text: "Status",
-      container: { accentColor: 0 },
-    });
-    if (!validSpec) {
-      throw new Error("Expected valid component spec to be parsed");
-    }
-    const validResult = buildDiscordComponentMessage({ spec: validSpec });
-    const validSerialized = validResult.components[0]?.serialize() as
-      | { accent_color?: unknown }
-      | undefined;
-    expect(validSerialized?.accent_color).toBe(0);
-
+  it.each([
+    { label: "minimum", accentColor: 0, expected: 0 },
+    { label: "maximum", accentColor: 0xffffff, expected: 0xffffff },
+    { label: "negative", accentColor: -1, expected: undefined },
+    { label: "fractional", accentColor: 1.5, expected: undefined },
+    { label: "above maximum", accentColor: 0x1000000, expected: undefined },
+  ])("serializes $label numeric container accent colors safely", ({ accentColor, expected }) => {
     const spec = readDiscordComponentSpec({
       text: "Status",
-      container: { accentColor: 0x1000000 },
+      container: { accentColor },
     });
     if (!spec) {
       throw new Error("Expected component spec to be parsed");
     }
 
-    const result = buildDiscordComponentMessage({ spec });
-    const serialized = result.components[0]?.serialize() as { accent_color?: unknown } | undefined;
+    const serialized = buildDiscordComponentMessage({ spec }).components[0]?.serialize() as
+      | { accent_color?: unknown }
+      | undefined;
 
-    expect(serialized).not.toHaveProperty("accent_color");
+    if (expected === undefined) {
+      expect(serialized).not.toHaveProperty("accent_color");
+    } else {
+      expect(serialized?.accent_color).toBe(expected);
+    }
   });
 
   it("serializes disabled link buttons", () => {

--- a/extensions/discord/src/components.test.ts
+++ b/extensions/discord/src/components.test.ts
@@ -115,6 +115,34 @@ describe("discord components", () => {
     expect(result.modals[0]?.allowedUsers).toEqual(["discord:user-1"]);
   });
 
+  it("omits invalid numeric container accent colors", () => {
+    const validSpec = readDiscordComponentSpec({
+      text: "Status",
+      container: { accentColor: 0 },
+    });
+    if (!validSpec) {
+      throw new Error("Expected valid component spec to be parsed");
+    }
+    const validResult = buildDiscordComponentMessage({ spec: validSpec });
+    const validSerialized = validResult.components[0]?.serialize() as
+      | { accent_color?: unknown }
+      | undefined;
+    expect(validSerialized?.accent_color).toBe(0);
+
+    const spec = readDiscordComponentSpec({
+      text: "Status",
+      container: { accentColor: 0x1000000 },
+    });
+    if (!spec) {
+      throw new Error("Expected component spec to be parsed");
+    }
+
+    const result = buildDiscordComponentMessage({ spec });
+    const serialized = result.components[0]?.serialize() as { accent_color?: unknown } | undefined;
+
+    expect(serialized).not.toHaveProperty("accent_color");
+  });
+
   it("serializes disabled link buttons", () => {
     const spec = readDiscordComponentSpec({
       blocks: [

--- a/extensions/discord/src/internal/components.base.ts
+++ b/extensions/discord/src/internal/components.base.ts
@@ -41,7 +41,7 @@ export function clean<T extends Record<string, unknown>>(value: T): T {
 
 export function colorToNumber(value: string | number | undefined): number | undefined {
   if (typeof value === "number") {
-    return value;
+    return Number.isInteger(value) && value >= 0 && value <= 0xffffff ? value : undefined;
   }
   if (typeof value === "string" && /^#?[0-9a-f]{6}$/i.test(value)) {
     return Number.parseInt(value.replace(/^#/, ""), 16);


### PR DESCRIPTION
## What Problem This Solves

Discord component messages could serialize negative, fractional, or greater-than-24-bit numeric container accent colors, producing payloads outside Discord's documented RGB contract.

## Why This Change Was Made

The Discord serializer now emits numeric `accent_color` only for integers from `0x000000` through `0xFFFFFF`. Invalid optional styling is omitted while the message and its components remain deliverable; valid hex strings and numeric boundaries are unchanged.

## User Impact

Malformed numeric accent styling no longer causes otherwise valid Discord component messages to be rejected.

Release-note context: **Discord component accent colors:** omit negative, fractional, and out-of-range numeric container colors before Discord serialization while preserving valid RGB boundary values. Thanks @qingminlong.

## Evidence

- Official Discord component contract: https://docs.discord.com/developers/components/reference#container
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29214933453
- `pnpm test extensions/discord/src/components.test.ts` — 22 tests passed.
- `pnpm check:changed` — passed, including Plugin SDK baseline, extension tsgo/lint, import-cycle, and boundary guards.
- Parameterized coverage includes minimum, maximum, negative, fractional, and above-maximum numeric values.
- Fresh autoreview — clean, no actionable findings.
- Live private-guild REST oracle: AWS Crabbox `cbx_671f0ee1e838`, run `run_bfe70ce55e60`.
  - valid raw `0xFFFFFF` container accent: HTTP 200
  - raw out-of-range `0x1000000`: HTTP 400
  - production-serialized out-of-range input: invalid accent omitted, HTTP 200
  - both proof messages deleted: HTTP 204/204; Convex credential lease released
