### PR TITLE
fix(clawhub): retry transient package reads

### DIFF
--- a/scripts/lib/plugin-clawhub-release.ts
+++ b/scripts/lib/plugin-clawhub-release.ts
@@ -2,6 +2,7 @@
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { validateExternalCodePluginPackageJson } from "../../packages/plugin-package-contract/src/index.ts";
+import { retryClawHubRead } from "../../src/infra/clawhub-retry.js";
 import { readBoundedResponseText } from "./bounded-response.ts";
 import {
   assertPluginReleaseDependencyFreshness,
@@ -98,8 +99,8 @@ type ClawHubPublishablePluginPackageFilters = {
 const CLAWHUB_DEFAULT_REGISTRY = "https://clawhub.ai";
 const CLAWHUB_REQUEST_TIMEOUT_MS = 30_000;
 const CLAWHUB_RESPONSE_BODY_MAX_BYTES = 64 * 1024;
-const CLAWHUB_RATE_LIMIT_RETRY_DELAYS_MS = [1_000, 3_000, 10_000] as const;
-const CLAWHUB_MAX_RETRY_AFTER_MS = 60_000;
+const CLAWHUB_ERROR_BODY_MAX_BYTES = 8 * 1024;
+const CLAWHUB_ERROR_BODY_MAX_CHARS = 400;
 const OPENCLAW_PLUGIN_CLAWHUB_REPOSITORY = "openclaw/openclaw";
 const OPENCLAW_PLUGIN_CLAWHUB_WORKFLOW_FILENAME = "plugin-clawhub-release.yml";
 const SAFE_EXTENSION_ID_RE = /^[a-z0-9][a-z0-9._-]*$/;
@@ -186,6 +187,63 @@ async function fetchClawHubRequest(
 
 async function cancelClawHubResponseBody(response: Response): Promise<void> {
   await response.body?.cancel().catch(() => undefined);
+}
+
+async function fetchClawHubRead(
+  url: URL,
+  options: ClawHubRetryOptions = {},
+): Promise<Awaited<ReturnType<typeof fetchClawHubRequest>>> {
+  return await retryClawHubRead(
+    () =>
+      fetchClawHubRequest(url, {
+        fetchImpl: options.fetchImpl,
+        requestTimeoutMs: options.requestTimeoutMs,
+      }),
+    {
+      disposeRetry: async (request) => {
+        await cancelClawHubResponseBody(request.response);
+        request.clearTimeout();
+      },
+      retryRateLimit: true,
+      sleep: options.sleep,
+    },
+  );
+}
+
+async function buildClawHubQueryError(
+  message: string,
+  request: Awaited<ReturnType<typeof fetchClawHubRequest>>,
+): Promise<Error> {
+  const { response } = request;
+  let body = "";
+  try {
+    body = (
+      await readBoundedResponseText(response, message, CLAWHUB_ERROR_BODY_MAX_BYTES, {
+        signal: request.signal,
+        timeoutPromise: request.timeoutPromise,
+      })
+    )
+      .replace(/\s+/gu, " ")
+      .trim();
+  } catch {
+    body = "";
+  }
+  if (body.length > CLAWHUB_ERROR_BODY_MAX_CHARS) {
+    body = `${body.slice(0, CLAWHUB_ERROR_BODY_MAX_CHARS)}...`;
+  }
+  const diagnosticHeaders = ["retry-after", "x-request-id", "x-vercel-id", "cf-ray"]
+    .map((name) => {
+      const value = response.headers.get(name)?.trim();
+      return value ? `${name}=${value}` : undefined;
+    })
+    .filter((value): value is string => Boolean(value));
+  const detail = [
+    body || response.statusText || `HTTP ${response.status}`,
+    diagnosticHeaders.length > 0 ? `[${diagnosticHeaders.join("; ")}]` : undefined,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" ");
+  return new Error(`${message}: ${response.status} ${detail}`);
 }
 
 function formatClawHubPackageArtifactName(
@@ -419,19 +477,16 @@ export function collectClawHubVersionGateErrors(params: {
 async function isPluginVersionPublishedOnClawHub(
   packageName: string,
   version: string,
-  options: {
-    fetchImpl?: typeof fetch;
-    registryBaseUrl?: string;
-    requestTimeoutMs?: number;
-  } = {},
+  options: ClawHubRetryOptions & { registryBaseUrl?: string } = {},
 ): Promise<boolean> {
   const url = new URL(
     `/api/v1/packages/${encodeURIComponent(packageName)}/versions/${encodeURIComponent(version)}`,
     getRegistryBaseUrl(options.registryBaseUrl),
   );
-  const request = await fetchClawHubRequest(url, {
+  const request = await fetchClawHubRead(url, {
     fetchImpl: options.fetchImpl,
     requestTimeoutMs: options.requestTimeoutMs,
+    sleep: options.sleep,
   });
   const { response } = request;
 
@@ -443,8 +498,9 @@ async function isPluginVersionPublishedOnClawHub(
       return true;
     }
 
-    throw new Error(
-      `Failed to query ClawHub for ${packageName}@${version}: ${response.status} ${response.statusText}`,
+    throw await buildClawHubQueryError(
+      `Failed to query ClawHub for ${packageName}@${version}`,
+      request,
     );
   } finally {
     await cancelClawHubResponseBody(response);
@@ -454,19 +510,16 @@ async function isPluginVersionPublishedOnClawHub(
 
 async function doesClawHubPackageExist(
   packageName: string,
-  options: {
-    fetchImpl?: typeof fetch;
-    registryBaseUrl?: string;
-    requestTimeoutMs?: number;
-  } = {},
+  options: ClawHubRetryOptions & { registryBaseUrl?: string } = {},
 ): Promise<boolean> {
   const url = new URL(
     `/api/v1/packages/${encodeURIComponent(packageName)}`,
     getRegistryBaseUrl(options.registryBaseUrl),
   );
-  const request = await fetchClawHubRequest(url, {
+  const request = await fetchClawHubRead(url, {
     fetchImpl: options.fetchImpl,
     requestTimeoutMs: options.requestTimeoutMs,
+    sleep: options.sleep,
   });
   const { response } = request;
 
@@ -475,9 +528,7 @@ async function doesClawHubPackageExist(
       return false;
     }
     if (!response.ok) {
-      throw new Error(
-        `Failed to query ClawHub package ${packageName}: ${response.status} ${response.statusText}`,
-      );
+      throw await buildClawHubQueryError(`Failed to query ClawHub package ${packageName}`, request);
     }
 
     return true;
@@ -497,77 +548,38 @@ async function hasClawHubTrustedPublisher(
     `/api/v1/packages/${encodeURIComponent(packageName)}/trusted-publisher`,
     getRegistryBaseUrl(options.registryBaseUrl),
   );
-  for (let attempt = 0; ; attempt += 1) {
-    const request = await fetchClawHubRequest(url, {
-      fetchImpl: options.fetchImpl,
-      requestTimeoutMs: options.requestTimeoutMs,
-    });
-    const { response } = request;
+  const request = await fetchClawHubRead(url, options);
+  const { response } = request;
+  try {
+    if (!response.ok) {
+      throw await buildClawHubQueryError(
+        `Failed to query ClawHub trusted publisher for ${packageName}`,
+        request,
+      );
+    }
 
-    const retryRateLimit =
-      response.status === 429 && attempt < CLAWHUB_RATE_LIMIT_RETRY_DELAYS_MS.length;
+    let trustedPublisherDetail: ClawHubTrustedPublisherDetail;
+    const text = await readBoundedResponseText(
+      response,
+      `ClawHub trusted publisher ${packageName}`,
+      CLAWHUB_RESPONSE_BODY_MAX_BYTES,
+      {
+        signal: request.signal,
+        timeoutPromise: request.timeoutPromise,
+      },
+    );
     try {
-      if (!retryRateLimit) {
-        if (!response.ok) {
-          throw new Error(
-            `Failed to query ClawHub trusted publisher for ${packageName}: ${response.status} ${response.statusText}`,
-          );
-        }
-
-        let trustedPublisherDetail: ClawHubTrustedPublisherDetail;
-        const text = await readBoundedResponseText(
-          response,
-          `ClawHub trusted publisher ${packageName}`,
-          CLAWHUB_RESPONSE_BODY_MAX_BYTES,
-          {
-            signal: request.signal,
-            timeoutPromise: request.timeoutPromise,
-          },
-        );
-        try {
-          trustedPublisherDetail = JSON.parse(text) as ClawHubTrustedPublisherDetail;
-        } catch (error) {
-          throw new Error(`Failed to parse ClawHub trusted publisher ${packageName} response.`, {
-            cause: error,
-          });
-        }
-
-        return isOpenClawPluginTrustedPublisher(trustedPublisherDetail.trustedPublisher);
-      }
-    } finally {
-      request.clearTimeout();
+      trustedPublisherDetail = JSON.parse(text) as ClawHubTrustedPublisherDetail;
+    } catch (error) {
+      throw new Error(`Failed to parse ClawHub trusted publisher ${packageName} response.`, {
+        cause: error,
+      });
     }
 
-    await response.body?.cancel().catch(() => undefined);
-    await (options.sleep ?? delay)(clawHubRetryDelayMs(response, attempt));
+    return isOpenClawPluginTrustedPublisher(trustedPublisherDetail.trustedPublisher);
+  } finally {
+    request.clearTimeout();
   }
-}
-
-function clawHubRetryDelayMs(response: Response, attempt: number): number {
-  const retryAfter = response.headers.get("retry-after")?.trim();
-  if (retryAfter) {
-    const retryAfterSeconds = Number(retryAfter);
-    if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
-      const retryAfterMs = Math.round(retryAfterSeconds * 1_000);
-      if (retryAfterMs <= CLAWHUB_MAX_RETRY_AFTER_MS) {
-        return retryAfterMs;
-      }
-    }
-    const retryAfterAt = Date.parse(retryAfter);
-    if (Number.isFinite(retryAfterAt)) {
-      const retryAfterMs = Math.max(0, retryAfterAt - Date.now());
-      if (retryAfterMs <= CLAWHUB_MAX_RETRY_AFTER_MS) {
-        return retryAfterMs;
-      }
-    }
-  }
-  return CLAWHUB_RATE_LIMIT_RETRY_DELAYS_MS[attempt] ?? 0;
-}
-
-async function delay(ms: number): Promise<void> {
-  await new Promise<void>((resolveDelay) => {
-    setTimeout(resolveDelay, ms);
-  });
 }
 
 function isOpenClawPluginTrustedPublisher(value: unknown): boolean {
@@ -645,6 +657,7 @@ export async function collectPluginClawHubReleasePlan(params?: {
       registryBaseUrl: params?.registryBaseUrl,
       fetchImpl: params?.fetchImpl,
       requestTimeoutMs: params?.requestTimeoutMs,
+      sleep: params?.sleep,
     });
     const hasTrustedPublisher = packageExists
       ? await hasClawHubTrustedPublisher(plugin.packageName, {
@@ -659,6 +672,7 @@ export async function collectPluginClawHubReleasePlan(params?: {
           registryBaseUrl: params?.registryBaseUrl,
           fetchImpl: params?.fetchImpl,
           requestTimeoutMs: params?.requestTimeoutMs,
+          sleep: params?.sleep,
         })
       : false;
 

--- a/src/infra/clawhub-retry.test.ts
+++ b/src/infra/clawhub-retry.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import { retryClawHubRead } from "./clawhub-retry.js";
+
+describe("retryClawHubRead", () => {
+  it("honors Retry-After and cancels the discarded response", async () => {
+    const cancel = vi.fn();
+    const delays: number[] = [];
+    let attempts = 0;
+
+    const result = await retryClawHubRead(
+      async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          return {
+            response: new Response(
+              new ReadableStream<Uint8Array>({
+                cancel() {
+                  cancel();
+                },
+              }),
+              {
+                status: 503,
+                headers: { "Retry-After": "1" },
+              },
+            ),
+          };
+        }
+        return { response: new Response("ok") };
+      },
+      {
+        disposeRetry: async ({ response }) => {
+          await response.body?.cancel();
+        },
+        sleep: async (ms) => {
+          delays.push(ms);
+        },
+      },
+    );
+
+    expect(await result.response.text()).toBe("ok");
+    expect(attempts).toBe(2);
+    expect(delays).toEqual([1_000]);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries transport failures with the bounded schedule", async () => {
+    const delays: number[] = [];
+    let attempts = 0;
+
+    const result = await retryClawHubRead(
+      async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new TypeError("fetch failed");
+        }
+        return { response: new Response("ok") };
+      },
+      {
+        disposeRetry: async () => {},
+        sleep: async (ms) => {
+          delays.push(ms);
+        },
+      },
+    );
+
+    expect(await result.response.text()).toBe("ok");
+    expect(attempts).toBe(2);
+    expect(delays).toEqual([1_000]);
+  });
+
+  it("does not retry 429 unless the caller enables rate-limit retries", async () => {
+    let defaultAttempts = 0;
+    const defaultResult = await retryClawHubRead(
+      async () => {
+        defaultAttempts += 1;
+        return { response: new Response("limited", { status: 429 }) };
+      },
+      {
+        disposeRetry: async () => {},
+        sleep: async () => {},
+      },
+    );
+
+    let optedInAttempts = 0;
+    const optedInResult = await retryClawHubRead(
+      async () => {
+        optedInAttempts += 1;
+        return {
+          response: new Response(optedInAttempts === 1 ? "limited" : "ok", {
+            status: optedInAttempts === 1 ? 429 : 200,
+          }),
+        };
+      },
+      {
+        disposeRetry: async ({ response }) => {
+          await response.body?.cancel();
+        },
+        retryRateLimit: true,
+        sleep: async () => {},
+      },
+    );
+
+    expect(defaultResult.response.status).toBe(429);
+    expect(defaultAttempts).toBe(1);
+    expect(await optedInResult.response.text()).toBe("ok");
+    expect(optedInAttempts).toBe(2);
+  });
+});

--- a/src/infra/clawhub-retry.ts
+++ b/src/infra/clawhub-retry.ts
@@ -1,0 +1,82 @@
+// Defines the bounded retry contract shared by ClawHub runtime and release reads.
+const CLAWHUB_RETRY_DELAYS_MS = [1_000, 3_000, 10_000] as const;
+const CLAWHUB_MAX_RETRY_AFTER_MS = 60_000;
+
+type ClawHubResponseHandle = {
+  response: Response;
+};
+
+type ClawHubRetryOptions<T extends ClawHubResponseHandle> = {
+  disposeRetry: (result: T) => Promise<void>;
+  retryRateLimit?: boolean;
+  sleep?: (ms: number) => Promise<void>;
+};
+
+function isRetryableClawHubStatus(status: number, retryRateLimit: boolean): boolean {
+  return (retryRateLimit && status === 429) || status === 502 || status === 503 || status === 504;
+}
+
+function parseRetryAfterMs(headers: Headers): number | undefined {
+  const retryAfter = headers.get("retry-after")?.trim();
+  if (!retryAfter) {
+    return undefined;
+  }
+  const seconds = Number(retryAfter);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    const delayMs = Math.round(seconds * 1_000);
+    return delayMs <= CLAWHUB_MAX_RETRY_AFTER_MS ? delayMs : undefined;
+  }
+  const retryAt = Date.parse(retryAfter);
+  if (!Number.isFinite(retryAt)) {
+    return undefined;
+  }
+  const delayMs = Math.max(0, retryAt - Date.now());
+  return delayMs <= CLAWHUB_MAX_RETRY_AFTER_MS ? delayMs : undefined;
+}
+
+function retryDelayMs(response: Response | undefined, attempt: number): number {
+  return (
+    (response ? parseRetryAfterMs(response.headers) : undefined) ??
+    CLAWHUB_RETRY_DELAYS_MS[attempt] ??
+    0
+  );
+}
+
+async function defaultSleep(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * Retries idempotent ClawHub reads on transient HTTP and transport failures.
+ * Callers retain the final response so their existing body limits and errors apply.
+ */
+export async function retryClawHubRead<T extends ClawHubResponseHandle>(
+  request: () => Promise<T>,
+  options: ClawHubRetryOptions<T>,
+): Promise<T> {
+  for (let attempt = 0; ; attempt += 1) {
+    let result: T;
+    try {
+      result = await request();
+    } catch (error) {
+      if (attempt >= CLAWHUB_RETRY_DELAYS_MS.length) {
+        throw error;
+      }
+      await (options.sleep ?? defaultSleep)(retryDelayMs(undefined, attempt));
+      continue;
+    }
+
+    if (
+      !isRetryableClawHubStatus(result.response.status, options.retryRateLimit === true) ||
+      attempt >= CLAWHUB_RETRY_DELAYS_MS.length
+    ) {
+      return result;
+    }
+
+    const delayMs = retryDelayMs(result.response, attempt);
+    await options.disposeRetry(result);
+    await (options.sleep ?? defaultSleep)(delayMs);
+  }
+}

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -995,6 +995,72 @@ describe("clawhub helpers", () => {
     ).rejects.toThrow(/Rate limit exceeded Sign in for higher rate limits\.$/);
   });
 
+  it("retries transient ClawHub reads and honors Retry-After", async () => {
+    const cancel = vi.fn();
+    let attempts = 0;
+    await expect(
+      searchClawHubSkills({
+        query: "calendar",
+        fetchImpl: async () => {
+          attempts += 1;
+          if (attempts === 1) {
+            return new Response(
+              new ReadableStream<Uint8Array>({
+                cancel() {
+                  cancel();
+                },
+              }),
+              {
+                status: 503,
+                headers: { "Retry-After": "0" },
+              },
+            );
+          }
+          return new Response(JSON.stringify({ results: [] }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      }),
+    ).resolves.toStrictEqual([]);
+
+    expect(attempts).toBe(2);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the final ClawHub error body after transient retries are exhausted", async () => {
+    let attempts = 0;
+    await expect(
+      searchClawHubSkills({
+        query: "calendar",
+        fetchImpl: async () => {
+          attempts += 1;
+          return new Response("Rate limit temporarily unavailable", {
+            status: 503,
+            headers: { "Retry-After": "0" },
+          });
+        },
+      }),
+    ).rejects.toThrow("ClawHub /api/v1/search failed (503): Rate limit temporarily unavailable");
+
+    expect(attempts).toBe(4);
+  });
+
+  it("does not retry non-idempotent ClawHub requests", async () => {
+    let attempts = 0;
+    await expect(
+      fetchClawHubSkillSecurityVerdicts({
+        items: [],
+        skipAuth: true,
+        fetchImpl: async () => {
+          attempts += 1;
+          return new Response("temporarily unavailable", { status: 503 });
+        },
+      }),
+    ).rejects.toThrow("ClawHub /api/v1/skills/-/security-verdicts failed (503)");
+    expect(attempts).toBe(1);
+  });
+
   it("wraps malformed successful ClawHub JSON responses", async () => {
     await expect(
       searchClawHubSkills({

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -9,6 +9,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { retryClawHubRead } from "./clawhub-retry.js";
 import { sha256Base64, sha256Hex as digestSha256Hex } from "./crypto-digest.js";
 import { readResponseTextSnippet, readResponseWithLimit } from "./http-body.js";
 import { parseRegistryNpmSpec } from "./npm-registry-spec.js";
@@ -697,12 +698,12 @@ async function clawhubRequest(
     ? undefined
     : normalizeOptionalString(params.token) || (await resolveClawHubAuthToken());
   const timeoutMs = resolveClawHubRequestTimeoutMs(params.timeoutMs);
-  const controller = new AbortController();
-  const timeout = setTimeout(
-    () => controller.abort(new Error(`ClawHub request timed out after ${timeoutMs}ms`)),
-    timeoutMs,
-  );
-  try {
+  const request = async () => {
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(new Error(`ClawHub request timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
     const headers = {
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
       ...(params.json === undefined ? {} : { "Content-Type": "application/json" }),
@@ -718,11 +719,24 @@ async function clawhubRequest(
     if (params.json !== undefined) {
       init.body = JSON.stringify(params.json);
     }
-    const response = await (params.fetchImpl ?? fetch)(url, init);
-    return { response, url, hasToken: Boolean(token) };
-  } finally {
-    clearTimeout(timeout);
+    try {
+      const response = await (params.fetchImpl ?? fetch)(url, init);
+      return { response, url, hasToken: Boolean(token) };
+    } finally {
+      clearTimeout(timeout);
+    }
+  };
+
+  // A write may have committed before its response failed, so only replay
+  // idempotent reads across transient ClawHub transport failures.
+  if ((params.method ?? "GET") !== "GET") {
+    return await request();
   }
+  return await retryClawHubRead(request, {
+    disposeRetry: async ({ response }) => {
+      await response.body?.cancel().catch(() => undefined);
+    },
+  });
 }
 
 async function readErrorBody(response: Response, timeoutMs?: number): Promise<string> {

--- a/test/plugin-clawhub-release.test.ts
+++ b/test/plugin-clawhub-release.test.ts
@@ -662,6 +662,138 @@ describe("collectPluginClawHubReleasePlan", () => {
     expect(plan.candidates.map((plugin) => plugin.packageName)).toEqual(["@openclaw/demo-plugin"]);
   });
 
+  it("retries a transient package lookup and cancels the discarded response", async () => {
+    const repoDir = createTempPluginRepo();
+    let packageRequests = 0;
+    let transientBodyCanceled = false;
+    const retryDelays: number[] = [];
+    const fetchImpl: typeof fetch = async (input) => {
+      const requestUrl =
+        typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      const pathname = new URL(requestUrl).pathname;
+      if (pathname === "/api/v1/packages/%40openclaw%2Fdemo-plugin") {
+        packageRequests += 1;
+        if (packageRequests === 1) {
+          return new Response(
+            new ReadableStream({
+              cancel() {
+                transientBodyCanceled = true;
+              },
+            }),
+            {
+              status: 503,
+              headers: { "retry-after": "1" },
+            },
+          );
+        }
+        return new Response("{}", { status: 200 });
+      }
+      if (pathname === "/api/v1/packages/%40openclaw%2Fdemo-plugin/trusted-publisher") {
+        return new Response(
+          JSON.stringify({
+            trustedPublisher: {
+              repository: "openclaw/openclaw",
+              workflowFilename: "plugin-clawhub-release.yml",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      if (pathname === "/api/v1/packages/%40openclaw%2Fdemo-plugin/versions/2026.4.1") {
+        return new Response("", { status: 404 });
+      }
+      throw new Error(`Unexpected ClawHub request to ${pathname}`);
+    };
+
+    const plan = await collectPluginClawHubReleasePlan({
+      rootDir: repoDir,
+      selection: ["@openclaw/demo-plugin"],
+      fetchImpl,
+      registryBaseUrl: "https://clawhub.ai",
+      sleep: async (ms) => {
+        retryDelays.push(ms);
+      },
+    });
+
+    expect(packageRequests).toBe(2);
+    expect(transientBodyCanceled).toBe(true);
+    expect(retryDelays).toEqual([1_000]);
+    expect(plan.candidates.map((plugin) => plugin.packageName)).toEqual(["@openclaw/demo-plugin"]);
+  });
+
+  it("retries a transient transport failure during version lookup", async () => {
+    const repoDir = createTempPluginRepo();
+    let versionRequests = 0;
+    const retryDelays: number[] = [];
+    const fetchImpl: typeof fetch = async (input) => {
+      const requestUrl =
+        typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      const pathname = new URL(requestUrl).pathname;
+      if (pathname === "/api/v1/packages/%40openclaw%2Fdemo-plugin") {
+        return new Response("{}", { status: 200 });
+      }
+      if (pathname === "/api/v1/packages/%40openclaw%2Fdemo-plugin/trusted-publisher") {
+        return new Response(
+          JSON.stringify({
+            trustedPublisher: {
+              repository: "openclaw/openclaw",
+              workflowFilename: "plugin-clawhub-release.yml",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      if (pathname === "/api/v1/packages/%40openclaw%2Fdemo-plugin/versions/2026.4.1") {
+        versionRequests += 1;
+        if (versionRequests === 1) {
+          throw new TypeError("fetch failed");
+        }
+        return new Response("", { status: 404 });
+      }
+      throw new Error(`Unexpected ClawHub request to ${pathname}`);
+    };
+
+    const plan = await collectPluginClawHubReleasePlan({
+      rootDir: repoDir,
+      selection: ["@openclaw/demo-plugin"],
+      fetchImpl,
+      registryBaseUrl: "https://clawhub.ai",
+      sleep: async (ms) => {
+        retryDelays.push(ms);
+      },
+    });
+
+    expect(versionRequests).toBe(2);
+    expect(retryDelays).toEqual([1_000]);
+    expect(plan.candidates.map((plugin) => plugin.packageName)).toEqual(["@openclaw/demo-plugin"]);
+  });
+
+  it("preserves ClawHub response details after package retries are exhausted", async () => {
+    const repoDir = createTempPluginRepo();
+    let packageRequests = 0;
+    await expect(
+      collectPluginClawHubReleasePlan({
+        rootDir: repoDir,
+        selection: ["@openclaw/demo-plugin"],
+        registryBaseUrl: "https://clawhub.ai",
+        fetchImpl: async () => {
+          packageRequests += 1;
+          return new Response("Rate limit temporarily unavailable", {
+            status: 503,
+            headers: {
+              "Retry-After": "1",
+              "x-request-id": "request-123",
+            },
+          });
+        },
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow(
+      "Failed to query ClawHub package @openclaw/demo-plugin: 503 Rate limit temporarily unavailable [retry-after=1; x-request-id=request-123]",
+    );
+    expect(packageRequests).toBe(4);
+  });
+
   it("honors an HTTP-date Retry-After header", async () => {
     const repoDir = createTempPluginRepo();
     const retryAfter = "Wed, 21 Oct 2030 07:28:00 GMT";


### PR DESCRIPTION
Fixes #105383

## What Problem This Solves

Fixes an issue where plugin release, install, and doctor workflows would fail
immediately when a ClawHub package or skill read encountered a transient 502,
503, 504, or transport error.

## Why This Change Was Made

ClawHub reads now use one shared bounded retry policy that honors a safe
`Retry-After` value and retains final response diagnostics. Mutating requests
remain single-attempt because a failed response cannot prove the remote write
did not commit.

## User Impact

Operators can expect transient ClawHub read failures to recover automatically
instead of aborting a release or package workflow on the first failed request.
Persistent failures still terminate with bounded, correlation-friendly
diagnostics.

## Evidence

- Blacksmith Testbox focused serial tests: 125 passed, 2 skipped across
  `src/infra/clawhub-retry.test.ts`, `src/infra/clawhub.test.ts`, and
  `test/plugin-clawhub-release.test.ts`.
- Scoped `pnpm check:changed` passed all available format, core typecheck,
  dependency, plugin SDK, changelog-attribution, and repository guard lanes.
- `git diff --check` passed.
- Exact-head branch autoreview completed with no actionable findings
  (`overall_correctness: patch is correct`, confidence `0.9`).
