### PR TITLE
fix(sqlite): canonicalize migration target aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS session SQLite migration:** canonicalize trusted migration targets before archive safety checks so `/tmp` and `/private/tmp` root aliases do not block Gateway startup in isolated QA and temporary state directories.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.
 - **Gateway command SecretRefs:** preserve authoritative active-snapshot values when another command secret remains unresolved, falling back locally only for missing paths instead of emitting a per-turn `secrets.resolve` failure. (#96661) Thanks @SunnyShu0925.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS session SQLite migration:** canonicalize trusted migration targets before archive safety checks so `/tmp` and `/private/tmp` root aliases do not block Gateway startup in isolated QA and temporary state directories.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.
 - **Gateway command SecretRefs:** preserve authoritative active-snapshot values when another command secret remains unresolved, falling back locally only for missing paths instead of emitting a per-turn `secrets.resolve` failure. (#96661) Thanks @SunnyShu0925.

--- a/src/commands/doctor-session-sqlite-migration-run.ts
+++ b/src/commands/doctor-session-sqlite-migration-run.ts
@@ -803,7 +803,7 @@ function hasUnsupportedV1DirectorySymlink(manifest: SessionSqliteMigrationManife
   });
 }
 
-function canonicalMigrationFilePath(filePath: string): string {
+export function canonicalMigrationFilePath(filePath: string): string {
   const resolvedPath = path.resolve(filePath);
   const fileName = path.basename(resolvedPath);
   const directoryPath = path.dirname(resolvedPath);

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -40,6 +40,9 @@ const previousEnv = {
 const lexicalTempDir = path.resolve(os.tmpdir());
 const realTempDir = fs.realpathSync.native(os.tmpdir());
 const hasPlatformTempAlias = lexicalTempDir !== realTempDir;
+const lexicalRootTempDir = path.resolve("/tmp");
+const realRootTempDir = canonicalTestPath(lexicalRootTempDir);
+const hasPlatformRootTempAlias = lexicalRootTempDir !== realRootTempDir;
 
 beforeEach(() => {
   closeOpenClawAgentDatabasesForTest();
@@ -816,7 +819,7 @@ describe("runDoctorSessionSqlite", () => {
       const outsideDir = path.join(store.tempDir, "outside", "nested");
       const outsideArchivePath = path.join(path.dirname(outsideDir), "payload.jsonl");
       const traversalArchivePath = path.join(archiveDir, "escape", "..", "payload.jsonl");
-      const sourcePath = path.join(store.sessionDir, "payload.jsonl");
+      const sourcePath = path.join(canonicalTestPath(store.sessionDir), "payload.jsonl");
       fs.mkdirSync(outsideDir, { recursive: true });
       fs.symlinkSync(outsideDir, path.join(archiveDir, "escape"));
       fs.writeFileSync(outsideArchivePath, '{"type":"outside"}\n', { mode: 0o600 });
@@ -878,6 +881,30 @@ describe("runDoctorSessionSqlite", () => {
       expect(restore.conflicts).toEqual([]);
       expect(restore.restoredFiles).toContain(canonicalTestPath(store.transcriptPath));
       expect(fs.existsSync(store.transcriptPath)).toBe(true);
+    },
+  );
+
+  it.skipIf(!hasPlatformRootTempAlias)(
+    "imports a legacy store written through a platform root alias",
+    async () => {
+      const store = createLegacyStore({ tempRoot: lexicalRootTempDir });
+
+      const report = await runDoctorSessionSqlite({
+        env: store.env,
+        mode: "import",
+        store: store.storePath,
+      });
+
+      expect(report.totals).toMatchObject({ importedEntries: 1, issues: 0 });
+      const manifest = readMigrationManifest(report.migrationRun?.manifestPath);
+      expect(manifest.targets[0]?.storePath).toBe(
+        path.join(realRootTempDir, path.relative(lexicalRootTempDir, store.storePath)),
+      );
+      expect(
+        manifest.targets[0]?.completedMoves.every((move) =>
+          move.sourcePath.startsWith(realRootTempDir + path.sep),
+        ),
+      ).toBe(true);
     },
   );
 
@@ -1871,10 +1898,13 @@ function createLegacyStore(
     agentDirName?: string;
     customStore?: boolean;
     entryOverrides?: Record<string, unknown>;
+    tempRoot?: string;
     transcriptLines?: string[];
   } = {},
 ): TestStore {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-session-sqlite-"));
+  const tempDir = fs.mkdtempSync(
+    path.join(params.tempRoot ?? os.tmpdir(), "openclaw-doctor-session-sqlite-"),
+  );
   const stateDir = path.join(tempDir, "state");
   const configPath = path.join(tempDir, "openclaw.json");
   const sessionDir = params.customStore

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -27,6 +27,7 @@ import { compactDoctorSessionSqliteTarget } from "./doctor-session-sqlite-compac
 import {
   assertSafeSessionSqliteMigrationDirectory,
   assertSafeSessionSqliteMigrationMove,
+  canonicalMigrationFilePath,
   createSessionSqliteMigrationRun,
   recordCompletedMigrationMove,
   recordCompletedMigrationMoves,
@@ -1168,8 +1169,8 @@ function canonicalFilePath(filePath: string): string {
 function createMigrationTargetInput(target: SessionStoreTarget): SessionSqliteMigrationTargetInput {
   return {
     agentId: target.agentId,
-    sqlitePath: resolveTargetSqlitePath(target),
-    storePath: target.storePath,
+    sqlitePath: canonicalMigrationFilePath(resolveTargetSqlitePath(target)),
+    storePath: canonicalMigrationFilePath(target.storePath),
   };
 }
 


### PR DESCRIPTION
## Summary

- canonicalize trusted session SQLite migration target paths before archive safety checks
- preserve symlink rejection while accepting macOS root aliases such as `/tmp` to `/private/tmp`
- add a macOS regression test and changelog entry

## Root cause

Planned archive moves were canonicalized, but repeated target inputs remained lexical. On macOS isolated QA state rooted under `/tmp`, the source path became `/private/tmp` while the target stayed `/tmp`, so Gateway startup falsely rejected its own legacy store as outside the sessions directory.

## Validation

- `node scripts/test-projects.mjs src/commands/doctor-session-sqlite.test.ts`
- 52/52 tests passed
- structured Codex autoreview: clean
- isolated private QA Gateway advanced past session SQLite migration
