### PR TITLE
fix(browser): don't steal focus on headed screenshot captures

### DIFF
--- a/extensions/browser/src/browser/cdp.screenshot-params.test.ts
+++ b/extensions/browser/src/browser/cdp.screenshot-params.test.ts
@@ -14,7 +14,6 @@ const sentMessages = vi.hoisted(() => {
 // can return different values for the "emulated tab" vs "non-emulated tab" tests.
 const mockState = vi.hoisted(() => ({
   bringToFrontError: undefined as Error | undefined,
-  userAgent: undefined as string | undefined,
   emulationCleared: false,
   emulatedTab: true,
   viewport: { w: 800, h: 600, dpr: 2, sw: 800, sh: 600 } as Record<string, unknown>,
@@ -30,11 +29,6 @@ vi.mock("./cdp.helpers.js", () => ({
     ) => {
       const send = (method: string, params?: Record<string, unknown>) => {
         sentMessages.push({ method, params });
-        if (method === "Browser.getVersion") {
-          return Promise.resolve(
-            mockState.userAgent === undefined ? {} : { userAgent: mockState.userAgent },
-          );
-        }
         if (method === "Page.bringToFront" && mockState.bringToFrontError) {
           return Promise.reject(mockState.bringToFrontError);
         }
@@ -100,7 +94,6 @@ const localProfile: ResolvedBrowserProfile = {
 beforeEach(() => {
   sentMessages.length = 0;
   mockState.bringToFrontError = undefined;
-  mockState.userAgent = undefined;
   mockState.emulationCleared = false;
   mockState.emulatedTab = true;
   mockState.viewport = { w: 800, h: 600, dpr: 2, sw: 800, sh: 600 };
@@ -146,47 +139,24 @@ describe("CDP screenshot params", () => {
     requireSentMessage("Page.captureScreenshot");
   });
 
-  it("does not steal focus on a headed browser (#105357)", async () => {
-    mockState.userAgent =
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36";
-
-    await captureScreenshot({ wsUrl: "ws://localhost:9222/devtools/page/X", format: "png" });
+  it("managed headed profile skips activation (headless=false, #105357)", async () => {
+    // The only case that skips activation: a confirmed-headed managed profile.
+    // No UA round-trip — the launch flag is authoritative.
+    await captureScreenshot({
+      wsUrl: "ws://localhost:9222/devtools/page/X",
+      format: "png",
+      headless: false,
+    });
 
     const methods = sentMessages.map((message) => message.method);
     expect(methods).not.toContain("Page.bringToFront");
+    expect(methods).not.toContain("Browser.getVersion");
     expect(methods).toContain("Page.captureScreenshot");
   });
 
-  it("still activates the tab on a headless browser (#105357)", async () => {
-    mockState.userAgent =
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.0.0 Safari/537.36";
-
-    await captureScreenshot({ wsUrl: "ws://localhost:9222/devtools/page/X", format: "png" });
-
-    const methods = sentMessages.map((message) => message.method);
-    expect(methods).toContain("Page.bringToFront");
-    expect(methods.indexOf("Page.bringToFront")).toBeLessThan(
-      methods.indexOf("Page.captureScreenshot"),
-    );
-  });
-
-  it("activates when headed detection is unavailable (safe default, #105357)", async () => {
-    mockState.userAgent = undefined; // Browser.getVersion returns no userAgent
-
-    await captureScreenshot({ wsUrl: "ws://localhost:9222/devtools/page/X", format: "png" });
-
-    const methods = sentMessages.map((message) => message.method);
-    expect(methods).toContain("Page.bringToFront");
-  });
-
-  it("managed headless profile activates even with a custom non-headless UA (#105357)", async () => {
-    // A managed headless Chrome can run with a custom --user-agent (extraArgs),
-    // so a UA sniff would misclassify it as headed and drop the activation that
-    // prevents the background-capture stall (#100857). The authoritative launch
-    // flag must win, and there is no need to re-derive state over CDP.
-    mockState.userAgent =
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36";
-
+  it("managed headless profile activates (headless=true, #105357)", async () => {
+    // Managed headless keeps activating to avoid the #100857 background stall,
+    // even if launched with a custom non-headless --user-agent (via extraArgs).
     await captureScreenshot({
       wsUrl: "ws://localhost:9222/devtools/page/X",
       format: "png",
@@ -201,20 +171,18 @@ describe("CDP screenshot params", () => {
     expect(methods).not.toContain("Browser.getVersion");
   });
 
-  it("managed headed profile skips activation even with a headless UA (#105357)", async () => {
-    // The authoritative launch flag also wins the other way: a headed managed
-    // browser never steals the visible tab, regardless of any headless UA.
-    mockState.userAgent =
-      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.0.0 Safari/537.36";
-
-    await captureScreenshot({
-      wsUrl: "ws://localhost:9222/devtools/page/X",
-      format: "png",
-      headless: false,
-    });
+  it("attached/external session activates when headless is unknown (#105357)", async () => {
+    // headless=undefined (attached/external): the real state cannot be detected
+    // — a custom --user-agent erases every headless marker — so we activate. This
+    // is the case that would otherwise stall (a headless attached tab with a
+    // spoofed UA). No Browser.getVersion sniff is attempted.
+    await captureScreenshot({ wsUrl: "ws://localhost:9222/devtools/page/X", format: "png" });
 
     const methods = sentMessages.map((message) => message.method);
-    expect(methods).not.toContain("Page.bringToFront");
+    expect(methods).toContain("Page.bringToFront");
+    expect(methods.indexOf("Page.bringToFront")).toBeLessThan(
+      methods.indexOf("Page.captureScreenshot"),
+    );
     expect(methods).not.toContain("Browser.getVersion");
   });
 

--- a/extensions/browser/src/browser/cdp.screenshot-params.test.ts
+++ b/extensions/browser/src/browser/cdp.screenshot-params.test.ts
@@ -179,6 +179,45 @@ describe("CDP screenshot params", () => {
     expect(methods).toContain("Page.bringToFront");
   });
 
+  it("managed headless profile activates even with a custom non-headless UA (#105357)", async () => {
+    // A managed headless Chrome can run with a custom --user-agent (extraArgs),
+    // so a UA sniff would misclassify it as headed and drop the activation that
+    // prevents the background-capture stall (#100857). The authoritative launch
+    // flag must win, and there is no need to re-derive state over CDP.
+    mockState.userAgent =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36";
+
+    await captureScreenshot({
+      wsUrl: "ws://localhost:9222/devtools/page/X",
+      format: "png",
+      headless: true,
+    });
+
+    const methods = sentMessages.map((message) => message.method);
+    expect(methods).toContain("Page.bringToFront");
+    expect(methods.indexOf("Page.bringToFront")).toBeLessThan(
+      methods.indexOf("Page.captureScreenshot"),
+    );
+    expect(methods).not.toContain("Browser.getVersion");
+  });
+
+  it("managed headed profile skips activation even with a headless UA (#105357)", async () => {
+    // The authoritative launch flag also wins the other way: a headed managed
+    // browser never steals the visible tab, regardless of any headless UA.
+    mockState.userAgent =
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.0.0 Safari/537.36";
+
+    await captureScreenshot({
+      wsUrl: "ws://localhost:9222/devtools/page/X",
+      format: "png",
+      headless: false,
+    });
+
+    const methods = sentMessages.map((message) => message.method);
+    expect(methods).not.toContain("Page.bringToFront");
+    expect(methods).not.toContain("Browser.getVersion");
+  });
+
   it("uses the requested timeout as the raw CDP command timeout", async () => {
     await captureScreenshot({
       wsUrl: "ws://localhost:9222/devtools/page/X",

--- a/extensions/browser/src/browser/cdp.screenshot-params.test.ts
+++ b/extensions/browser/src/browser/cdp.screenshot-params.test.ts
@@ -14,6 +14,7 @@ const sentMessages = vi.hoisted(() => {
 // can return different values for the "emulated tab" vs "non-emulated tab" tests.
 const mockState = vi.hoisted(() => ({
   bringToFrontError: undefined as Error | undefined,
+  userAgent: undefined as string | undefined,
   emulationCleared: false,
   emulatedTab: true,
   viewport: { w: 800, h: 600, dpr: 2, sw: 800, sh: 600 } as Record<string, unknown>,
@@ -29,6 +30,11 @@ vi.mock("./cdp.helpers.js", () => ({
     ) => {
       const send = (method: string, params?: Record<string, unknown>) => {
         sentMessages.push({ method, params });
+        if (method === "Browser.getVersion") {
+          return Promise.resolve(
+            mockState.userAgent === undefined ? {} : { userAgent: mockState.userAgent },
+          );
+        }
         if (method === "Page.bringToFront" && mockState.bringToFrontError) {
           return Promise.reject(mockState.bringToFrontError);
         }
@@ -94,6 +100,7 @@ const localProfile: ResolvedBrowserProfile = {
 beforeEach(() => {
   sentMessages.length = 0;
   mockState.bringToFrontError = undefined;
+  mockState.userAgent = undefined;
   mockState.emulationCleared = false;
   mockState.emulatedTab = true;
   mockState.viewport = { w: 800, h: 600, dpr: 2, sw: 800, sh: 600 };
@@ -137,6 +144,39 @@ describe("CDP screenshot params", () => {
     await captureScreenshot({ wsUrl: "ws://localhost:9222/devtools/page/X" });
 
     requireSentMessage("Page.captureScreenshot");
+  });
+
+  it("does not steal focus on a headed browser (#105357)", async () => {
+    mockState.userAgent =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36";
+
+    await captureScreenshot({ wsUrl: "ws://localhost:9222/devtools/page/X", format: "png" });
+
+    const methods = sentMessages.map((message) => message.method);
+    expect(methods).not.toContain("Page.bringToFront");
+    expect(methods).toContain("Page.captureScreenshot");
+  });
+
+  it("still activates the tab on a headless browser (#105357)", async () => {
+    mockState.userAgent =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.0.0 Safari/537.36";
+
+    await captureScreenshot({ wsUrl: "ws://localhost:9222/devtools/page/X", format: "png" });
+
+    const methods = sentMessages.map((message) => message.method);
+    expect(methods).toContain("Page.bringToFront");
+    expect(methods.indexOf("Page.bringToFront")).toBeLessThan(
+      methods.indexOf("Page.captureScreenshot"),
+    );
+  });
+
+  it("activates when headed detection is unavailable (safe default, #105357)", async () => {
+    mockState.userAgent = undefined; // Browser.getVersion returns no userAgent
+
+    await captureScreenshot({ wsUrl: "ws://localhost:9222/devtools/page/X", format: "png" });
+
+    const methods = sentMessages.map((message) => message.method);
+    expect(methods).toContain("Page.bringToFront");
   });
 
   it("uses the requested timeout as the raw CDP command timeout", async () => {

--- a/extensions/browser/src/browser/cdp.screenshot-params.test.ts
+++ b/extensions/browser/src/browser/cdp.screenshot-params.test.ts
@@ -139,51 +139,19 @@ describe("CDP screenshot params", () => {
     requireSentMessage("Page.captureScreenshot");
   });
 
-  it("managed headed profile skips activation (headless=false, #105357)", async () => {
-    // The only case that skips activation: a confirmed-headed managed profile.
-    // No UA round-trip — the launch flag is authoritative.
+  it.each([
+    { name: "headed managed browser", headless: false, activates: false },
+    { name: "headless managed browser", headless: true, activates: true },
+  ])("activates only when needed for a $name", async ({ headless, activates }) => {
     await captureScreenshot({
       wsUrl: "ws://localhost:9222/devtools/page/X",
       format: "png",
-      headless: false,
+      headless,
     });
 
     const methods = sentMessages.map((message) => message.method);
-    expect(methods).not.toContain("Page.bringToFront");
-    expect(methods).not.toContain("Browser.getVersion");
+    expect(methods.includes("Page.bringToFront")).toBe(activates);
     expect(methods).toContain("Page.captureScreenshot");
-  });
-
-  it("managed headless profile activates (headless=true, #105357)", async () => {
-    // Managed headless keeps activating to avoid the #100857 background stall,
-    // even if launched with a custom non-headless --user-agent (via extraArgs).
-    await captureScreenshot({
-      wsUrl: "ws://localhost:9222/devtools/page/X",
-      format: "png",
-      headless: true,
-    });
-
-    const methods = sentMessages.map((message) => message.method);
-    expect(methods).toContain("Page.bringToFront");
-    expect(methods.indexOf("Page.bringToFront")).toBeLessThan(
-      methods.indexOf("Page.captureScreenshot"),
-    );
-    expect(methods).not.toContain("Browser.getVersion");
-  });
-
-  it("attached/external session activates when headless is unknown (#105357)", async () => {
-    // headless=undefined (attached/external): the real state cannot be detected
-    // — a custom --user-agent erases every headless marker — so we activate. This
-    // is the case that would otherwise stall (a headless attached tab with a
-    // spoofed UA). No Browser.getVersion sniff is attempted.
-    await captureScreenshot({ wsUrl: "ws://localhost:9222/devtools/page/X", format: "png" });
-
-    const methods = sentMessages.map((message) => message.method);
-    expect(methods).toContain("Page.bringToFront");
-    expect(methods.indexOf("Page.bringToFront")).toBeLessThan(
-      methods.indexOf("Page.captureScreenshot"),
-    );
-    expect(methods).not.toContain("Browser.getVersion");
   });
 
   it("uses the requested timeout as the raw CDP command timeout", async () => {

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -73,6 +73,10 @@ export async function captureScreenshot(opts: {
   format?: "png" | "jpeg";
   quality?: number; // jpeg only (0..100)
   timeoutMs?: number;
+  // Authoritative launch mode when OpenClaw manages the browser. Left undefined
+  // for attached/external sessions, whose real headed/headless state cannot be
+  // trusted from config, so the tab-activation decision falls back to a UA sniff.
+  headless?: boolean;
 }): Promise<Buffer> {
   return await withCdpSocket(
     opts.wsUrl,
@@ -82,19 +86,26 @@ export async function captureScreenshot(opts: {
       // Background surface captures can stall until CDP times out under headless
       // Chrome, so activating the tab forces a frame there (#100857). On a HEADED
       // browser the same activation steals the user's visible tab on every
-      // screenshot — the highest-frequency agent operation (#105357). Only skip
-      // activation when we can confirm the browser is headed; keep activating (the
-      // safe default) whenever detection is unavailable so the headless stall is
-      // never reintroduced.
+      // screenshot — the highest-frequency agent operation (#105357). A managed
+      // browser passes its authoritative launch flag; only an attached/external
+      // browser (headless unknown) falls back to a best-effort user-agent sniff.
+      // A managed headless Chrome may run with a custom --user-agent (via
+      // extraArgs), so the launch flag must win over UA sniffing. Keep activating
+      // (the safe default) whenever we cannot confirm the browser is headed so the
+      // headless stall is never reintroduced.
       let shouldActivateTab = true;
-      try {
-        const version = (await send("Browser.getVersion")) as { userAgent?: unknown };
-        const userAgent = typeof version?.userAgent === "string" ? version.userAgent : "";
-        if (userAgent && !/headless/i.test(userAgent)) {
-          shouldActivateTab = false;
+      if (opts.headless === false) {
+        shouldActivateTab = false;
+      } else if (opts.headless === undefined) {
+        try {
+          const version = (await send("Browser.getVersion")) as { userAgent?: unknown };
+          const userAgent = typeof version?.userAgent === "string" ? version.userAgent : "";
+          if (userAgent && !/headless/i.test(userAgent)) {
+            shouldActivateTab = false;
+          }
+        } catch {
+          // Detection failed — keep the safe default and activate.
         }
-      } catch {
-        // Detection failed — keep the safe default and activate.
       }
       if (shouldActivateTab) {
         // Ignore protocol rejection so browsers that already capture correctly still proceed.

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -73,9 +73,12 @@ export async function captureScreenshot(opts: {
   format?: "png" | "jpeg";
   quality?: number; // jpeg only (0..100)
   timeoutMs?: number;
-  // Authoritative launch mode when OpenClaw manages the browser. Left undefined
-  // for attached/external sessions, whose real headed/headless state cannot be
-  // trusted from config, so the tab-activation decision falls back to a UA sniff.
+  // Authoritative headed/headless launch mode. Only set for managed browsers
+  // (OpenClaw launched them, so the flag matches reality). Left undefined for
+  // attached/external sessions, whose real state cannot be detected: a custom
+  // `--user-agent` erases every headless marker (verified — `--headless=new`
+  // then reports product `Chrome/…`, a spoofed userAgent, and
+  // `navigator.webdriver === false`), so a UA sniff would misclassify them.
   headless?: boolean;
 }): Promise<Buffer> {
   return await withCdpSocket(
@@ -83,30 +86,16 @@ export async function captureScreenshot(opts: {
     async (send) => {
       await send("Page.enable");
 
-      // Background surface captures can stall until CDP times out under headless
+      // Background surface captures stall until CDP times out under headless
       // Chrome, so activating the tab forces a frame there (#100857). On a HEADED
       // browser the same activation steals the user's visible tab on every
-      // screenshot — the highest-frequency agent operation (#105357). A managed
-      // browser passes its authoritative launch flag; only an attached/external
-      // browser (headless unknown) falls back to a best-effort user-agent sniff.
-      // A managed headless Chrome may run with a custom --user-agent (via
-      // extraArgs), so the launch flag must win over UA sniffing. Keep activating
-      // (the safe default) whenever we cannot confirm the browser is headed so the
-      // headless stall is never reintroduced.
-      let shouldActivateTab = true;
-      if (opts.headless === false) {
-        shouldActivateTab = false;
-      } else if (opts.headless === undefined) {
-        try {
-          const version = (await send("Browser.getVersion")) as { userAgent?: unknown };
-          const userAgent = typeof version?.userAgent === "string" ? version.userAgent : "";
-          if (userAgent && !/headless/i.test(userAgent)) {
-            shouldActivateTab = false;
-          }
-        } catch {
-          // Detection failed — keep the safe default and activate.
-        }
-      }
+      // screenshot — the highest-frequency agent operation (#105357). Skip
+      // activation ONLY for a confirmed-headed managed profile. Managed headless,
+      // and every attached/external session (headless unknowable, see above),
+      // keep activating so the #100857 stall is never risked — the stall is a hard
+      // timeout, strictly worse than an activation on a browser that did not need
+      // one.
+      const shouldActivateTab = opts.headless !== false;
       if (shouldActivateTab) {
         // Ignore protocol rejection so browsers that already capture correctly still proceed.
         await send("Page.bringToFront").catch(() => {});

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -79,9 +79,27 @@ export async function captureScreenshot(opts: {
     async (send) => {
       await send("Page.enable");
 
-      // Background surface captures can stall until CDP times out; activate to force a frame.
-      // Ignore protocol rejection so browsers that already capture correctly still proceed.
-      await send("Page.bringToFront").catch(() => {});
+      // Background surface captures can stall until CDP times out under headless
+      // Chrome, so activating the tab forces a frame there (#100857). On a HEADED
+      // browser the same activation steals the user's visible tab on every
+      // screenshot — the highest-frequency agent operation (#105357). Only skip
+      // activation when we can confirm the browser is headed; keep activating (the
+      // safe default) whenever detection is unavailable so the headless stall is
+      // never reintroduced.
+      let shouldActivateTab = true;
+      try {
+        const version = (await send("Browser.getVersion")) as { userAgent?: unknown };
+        const userAgent = typeof version?.userAgent === "string" ? version.userAgent : "";
+        if (userAgent && !/headless/i.test(userAgent)) {
+          shouldActivateTab = false;
+        }
+      } catch {
+        // Detection failed — keep the safe default and activate.
+      }
+      if (shouldActivateTab) {
+        // Ignore protocol rejection so browsers that already capture correctly still proceed.
+        await send("Page.bringToFront").catch(() => {});
+      }
 
       // For full-page captures, temporarily expand the viewport to the content
       // size so the entire page is within the viewport bounds.  We save the

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -99,12 +99,7 @@ export async function captureScreenshot(opts: {
   format?: "png" | "jpeg";
   quality?: number; // jpeg only (0..100)
   timeoutMs?: number;
-  // Authoritative headed/headless launch mode. Only set for managed browsers
-  // (OpenClaw launched them, so the flag matches reality). Left undefined for
-  // attached/external sessions, whose real state cannot be detected: a custom
-  // `--user-agent` erases every headless marker (verified — `--headless=new`
-  // then reports product `Chrome/…`, a spoofed userAgent, and
-  // `navigator.webdriver === false`), so a UA sniff would misclassify them.
+  /** Effective launch mode recorded on the owned Chrome process, when known. */
   headless?: boolean;
 }): Promise<Buffer> {
   return await withCdpSocket(
@@ -112,18 +107,9 @@ export async function captureScreenshot(opts: {
     async (send) => {
       await send("Page.enable");
 
-      // Background surface captures stall until CDP times out under headless
-      // Chrome, so activating the tab forces a frame there (#100857). On a HEADED
-      // browser the same activation steals the user's visible tab on every
-      // screenshot — the highest-frequency agent operation (#105357). Skip
-      // activation ONLY for a confirmed-headed managed profile. Managed headless,
-      // and every attached/external session (headless unknowable, see above),
-      // keep activating so the #100857 stall is never risked — the stall is a hard
-      // timeout, strictly worse than an activation on a browser that did not need
-      // one.
-      const shouldActivateTab = opts.headless !== false;
-      if (shouldActivateTab) {
-        // Ignore protocol rejection so browsers that already capture correctly still proceed.
+      // Headless background tabs need activation to produce a frame. Preserve
+      // focus only when the launched process is authoritatively known headed.
+      if (opts.headless !== false) {
         await send("Page.bringToFront").catch(() => {});
       }
 

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -99,6 +99,10 @@ export async function captureScreenshot(opts: {
   format?: "png" | "jpeg";
   quality?: number; // jpeg only (0..100)
   timeoutMs?: number;
+  // Authoritative launch mode when OpenClaw manages the browser. Left undefined
+  // for attached/external sessions, whose real headed/headless state cannot be
+  // trusted from config, so the tab-activation decision falls back to a UA sniff.
+  headless?: boolean;
 }): Promise<Buffer> {
   return await withCdpSocket(
     opts.wsUrl,
@@ -108,19 +112,26 @@ export async function captureScreenshot(opts: {
       // Background surface captures can stall until CDP times out under headless
       // Chrome, so activating the tab forces a frame there (#100857). On a HEADED
       // browser the same activation steals the user's visible tab on every
-      // screenshot — the highest-frequency agent operation (#105357). Only skip
-      // activation when we can confirm the browser is headed; keep activating (the
-      // safe default) whenever detection is unavailable so the headless stall is
-      // never reintroduced.
+      // screenshot — the highest-frequency agent operation (#105357). A managed
+      // browser passes its authoritative launch flag; only an attached/external
+      // browser (headless unknown) falls back to a best-effort user-agent sniff.
+      // A managed headless Chrome may run with a custom --user-agent (via
+      // extraArgs), so the launch flag must win over UA sniffing. Keep activating
+      // (the safe default) whenever we cannot confirm the browser is headed so the
+      // headless stall is never reintroduced.
       let shouldActivateTab = true;
-      try {
-        const version = (await send("Browser.getVersion")) as { userAgent?: unknown };
-        const userAgent = typeof version?.userAgent === "string" ? version.userAgent : "";
-        if (userAgent && !/headless/i.test(userAgent)) {
-          shouldActivateTab = false;
+      if (opts.headless === false) {
+        shouldActivateTab = false;
+      } else if (opts.headless === undefined) {
+        try {
+          const version = (await send("Browser.getVersion")) as { userAgent?: unknown };
+          const userAgent = typeof version?.userAgent === "string" ? version.userAgent : "";
+          if (userAgent && !/headless/i.test(userAgent)) {
+            shouldActivateTab = false;
+          }
+        } catch {
+          // Detection failed — keep the safe default and activate.
         }
-      } catch {
-        // Detection failed — keep the safe default and activate.
       }
       if (shouldActivateTab) {
         // Ignore protocol rejection so browsers that already capture correctly still proceed.

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -105,9 +105,27 @@ export async function captureScreenshot(opts: {
     async (send) => {
       await send("Page.enable");
 
-      // Background surface captures can stall until CDP times out; activate to force a frame.
-      // Ignore protocol rejection so browsers that already capture correctly still proceed.
-      await send("Page.bringToFront").catch(() => {});
+      // Background surface captures can stall until CDP times out under headless
+      // Chrome, so activating the tab forces a frame there (#100857). On a HEADED
+      // browser the same activation steals the user's visible tab on every
+      // screenshot — the highest-frequency agent operation (#105357). Only skip
+      // activation when we can confirm the browser is headed; keep activating (the
+      // safe default) whenever detection is unavailable so the headless stall is
+      // never reintroduced.
+      let shouldActivateTab = true;
+      try {
+        const version = (await send("Browser.getVersion")) as { userAgent?: unknown };
+        const userAgent = typeof version?.userAgent === "string" ? version.userAgent : "";
+        if (userAgent && !/headless/i.test(userAgent)) {
+          shouldActivateTab = false;
+        }
+      } catch {
+        // Detection failed — keep the safe default and activate.
+      }
+      if (shouldActivateTab) {
+        // Ignore protocol rejection so browsers that already capture correctly still proceed.
+        await send("Page.bringToFront").catch(() => {});
+      }
 
       // For full-page captures, temporarily expand the viewport to the content
       // size so the entire page is within the viewport bounds.  We save the

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -99,9 +99,12 @@ export async function captureScreenshot(opts: {
   format?: "png" | "jpeg";
   quality?: number; // jpeg only (0..100)
   timeoutMs?: number;
-  // Authoritative launch mode when OpenClaw manages the browser. Left undefined
-  // for attached/external sessions, whose real headed/headless state cannot be
-  // trusted from config, so the tab-activation decision falls back to a UA sniff.
+  // Authoritative headed/headless launch mode. Only set for managed browsers
+  // (OpenClaw launched them, so the flag matches reality). Left undefined for
+  // attached/external sessions, whose real state cannot be detected: a custom
+  // `--user-agent` erases every headless marker (verified — `--headless=new`
+  // then reports product `Chrome/…`, a spoofed userAgent, and
+  // `navigator.webdriver === false`), so a UA sniff would misclassify them.
   headless?: boolean;
 }): Promise<Buffer> {
   return await withCdpSocket(
@@ -109,30 +112,16 @@ export async function captureScreenshot(opts: {
     async (send) => {
       await send("Page.enable");
 
-      // Background surface captures can stall until CDP times out under headless
+      // Background surface captures stall until CDP times out under headless
       // Chrome, so activating the tab forces a frame there (#100857). On a HEADED
       // browser the same activation steals the user's visible tab on every
-      // screenshot — the highest-frequency agent operation (#105357). A managed
-      // browser passes its authoritative launch flag; only an attached/external
-      // browser (headless unknown) falls back to a best-effort user-agent sniff.
-      // A managed headless Chrome may run with a custom --user-agent (via
-      // extraArgs), so the launch flag must win over UA sniffing. Keep activating
-      // (the safe default) whenever we cannot confirm the browser is headed so the
-      // headless stall is never reintroduced.
-      let shouldActivateTab = true;
-      if (opts.headless === false) {
-        shouldActivateTab = false;
-      } else if (opts.headless === undefined) {
-        try {
-          const version = (await send("Browser.getVersion")) as { userAgent?: unknown };
-          const userAgent = typeof version?.userAgent === "string" ? version.userAgent : "";
-          if (userAgent && !/headless/i.test(userAgent)) {
-            shouldActivateTab = false;
-          }
-        } catch {
-          // Detection failed — keep the safe default and activate.
-        }
-      }
+      // screenshot — the highest-frequency agent operation (#105357). Skip
+      // activation ONLY for a confirmed-headed managed profile. Managed headless,
+      // and every attached/external session (headless unknowable, see above),
+      // keep activating so the #100857 stall is never risked — the stall is a hard
+      // timeout, strictly worse than an activation on a browser that did not need
+      // one.
+      const shouldActivateTab = opts.headless !== false;
       if (shouldActivateTab) {
         // Ignore protocol rejection so browsers that already capture correctly still proceed.
         await send("Page.bringToFront").catch(() => {});

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -259,7 +259,7 @@ function hasLinuxDisplay(env: NodeJS.ProcessEnv): boolean {
   return Boolean(env.DISPLAY?.trim() || env.WAYLAND_DISPLAY?.trim());
 }
 
-function isLocalManagedProfile(profile: ResolvedBrowserProfile): boolean {
+export function isLocalManagedProfile(profile: ResolvedBrowserProfile): boolean {
   return profile.driver === "openclaw" && profile.cdpIsLoopback && !profile.attachOnly;
 }
 

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -221,7 +221,7 @@ function hasLinuxDisplay(env: NodeJS.ProcessEnv): boolean {
   return Boolean(env.DISPLAY?.trim() || env.WAYLAND_DISPLAY?.trim());
 }
 
-function isLocalManagedProfile(profile: ResolvedBrowserProfile): boolean {
+export function isLocalManagedProfile(profile: ResolvedBrowserProfile): boolean {
   return profile.driver === "openclaw" && profile.cdpIsLoopback && !profile.attachOnly;
 }
 

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -221,7 +221,7 @@ function hasLinuxDisplay(env: NodeJS.ProcessEnv): boolean {
   return Boolean(env.DISPLAY?.trim() || env.WAYLAND_DISPLAY?.trim());
 }
 
-export function isLocalManagedProfile(profile: ResolvedBrowserProfile): boolean {
+function isLocalManagedProfile(profile: ResolvedBrowserProfile): boolean {
   return profile.driver === "openclaw" && profile.cdpIsLoopback && !profile.attachOnly;
 }
 

--- a/extensions/browser/src/browser/routes/agent.snapshot.timeout.test.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.timeout.test.ts
@@ -33,6 +33,9 @@ const profileContext = vi.hoisted(() => ({
     wsLookup: tabLookup,
   })),
 }));
+const browserRuntime = vi.hoisted(() => ({
+  profiles: new Map<string, { running: { headless?: boolean; headlessSource?: string } | null }>(),
+}));
 
 vi.mock("../cdp.js", () => ({
   captureScreenshot: cdpMocks.captureScreenshot,
@@ -114,7 +117,7 @@ function getSnapshotHandler() {
 function getScreenshotHandler() {
   const { app, postHandlers } = createBrowserRouteApp();
   registerBrowserAgentSnapshotRoutes(app, {
-    state: () => ({ resolved: { extraArgs: [] } }),
+    state: () => ({ resolved: { extraArgs: [] }, profiles: browserRuntime.profiles }),
   } as never);
   const handler = postHandlers.get("/screenshot");
   expect(handler).toBeTypeOf("function");
@@ -127,6 +130,8 @@ describe("browser agent snapshot timeout routing", () => {
     cdpMocks.snapshotAria.mockClear();
     cdpMocks.snapshotRoleViaCdp.mockClear();
     profileContext.ensureTabAvailable.mockClear();
+    profileContext.profile.headless = false;
+    browserRuntime.profiles.clear();
   });
 
   it("passes timeoutMs to direct CDP aria snapshots", async () => {
@@ -179,6 +184,55 @@ describe("browser agent snapshot timeout routing", () => {
       }),
     );
   });
+
+  it.each([
+    {
+      name: "headed launched browser when its profile is configured headless",
+      configuredHeadless: true,
+      running: { headless: false, headlessSource: "request" },
+      expectedHeadless: false,
+    },
+    {
+      name: "headless request override when its profile is configured headed",
+      configuredHeadless: false,
+      running: { headless: true, headlessSource: "request" },
+      expectedHeadless: true,
+    },
+    {
+      name: "headless environment override when its profile is configured headed",
+      configuredHeadless: false,
+      running: { headless: true, headlessSource: "env" },
+      expectedHeadless: true,
+    },
+    {
+      name: "headless Linux no-display fallback when its profile is configured headed",
+      configuredHeadless: false,
+      running: { headless: true, headlessSource: "linux-display-fallback" },
+      expectedHeadless: true,
+    },
+    {
+      name: "untracked browser without authoritative launch state",
+      configuredHeadless: false,
+      running: null,
+      expectedHeadless: undefined,
+    },
+  ])(
+    "passes the actual launch mode for $name",
+    async ({ configuredHeadless, running, expectedHeadless }) => {
+      profileContext.profile.headless = configuredHeadless;
+      browserRuntime.profiles.set(profileContext.profile.name, { running });
+      cdpMocks.captureScreenshot.mockResolvedValueOnce(Buffer.from("png"));
+      const handler = getScreenshotHandler();
+      const response = createBrowserRouteResponse();
+
+      await handler?.({ params: {}, query: {}, body: { type: "png" } }, response.res);
+
+      expect(response.statusCode).toBe(200);
+      expect(cdpMocks.captureScreenshot).toHaveBeenCalledWith(
+        expect.objectContaining({ headless: expectedHeadless }),
+      );
+    },
+  );
 
   it("rejects loose screenshot timeoutMs values before dispatching", async () => {
     const handler = getScreenshotHandler();

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -21,6 +21,7 @@ import {
   buildAiSnapshotFromChromeMcpSnapshot,
   flattenChromeMcpSnapshotToAriaNodes,
 } from "../chrome-mcp.snapshot.js";
+import { isLocalManagedProfile } from "../config.js";
 import { DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS } from "../constants.js";
 import {
   assertBrowserNavigationAllowed,
@@ -545,6 +546,11 @@ export function registerBrowserAgentSnapshotRoutes(
             format: type,
             quality: type === "jpeg" ? 85 : undefined,
             timeoutMs,
+            // Managed browsers know their launch mode authoritatively; attached
+            // sessions leave it undefined so cdp.ts falls back to a UA sniff.
+            headless: isLocalManagedProfile(profileCtx.profile)
+              ? profileCtx.profile.headless
+              : undefined,
           });
         }
 

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -27,6 +27,7 @@ import {
   buildChromeMcpRouteSnapshot,
   flattenChromeMcpRouteSnapshot,
 } from "../chrome-mcp.snapshot-result.js";
+import { isLocalManagedProfile } from "../config.js";
 import { DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS } from "../constants.js";
 import {
   assertBrowserNavigationAllowed,
@@ -585,6 +586,11 @@ export function registerBrowserAgentSnapshotRoutes(
             format: type,
             quality: type === "jpeg" ? 85 : undefined,
             timeoutMs,
+            // Managed browsers know their launch mode authoritatively; attached
+            // sessions leave it undefined so cdp.ts falls back to a UA sniff.
+            headless: isLocalManagedProfile(profileCtx.profile)
+              ? profileCtx.profile.headless
+              : undefined,
           });
         }
 

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -27,7 +27,6 @@ import {
   buildChromeMcpRouteSnapshot,
   flattenChromeMcpRouteSnapshot,
 } from "../chrome-mcp.snapshot-result.js";
-import { isLocalManagedProfile } from "../config.js";
 import { DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS } from "../constants.js";
 import {
   assertBrowserNavigationAllowed,
@@ -586,11 +585,7 @@ export function registerBrowserAgentSnapshotRoutes(
             format: type,
             quality: type === "jpeg" ? 85 : undefined,
             timeoutMs,
-            // Managed browsers know their launch mode authoritatively; attached
-            // sessions leave it undefined so cdp.ts falls back to a UA sniff.
-            headless: isLocalManagedProfile(profileCtx.profile)
-              ? profileCtx.profile.headless
-              : undefined,
+            headless: ctx.state().profiles.get(profileCtx.profile.name)?.running?.headless,
           });
         }
 


### PR DESCRIPTION
## What Problem This Solves

Since #100857, `captureScreenshot()` sends `Page.bringToFront` before **every** capture. That guard exists for a headless-specific stall (a backgrounded tab under `--headless=new` never commits a compositor frame, so `Page.captureScreenshot` blocks until the CDP timeout). But on a **headed** browser the same unconditional activation switches the visible tab — and raises the window on some platforms — on every screenshot. Screenshots are the highest-frequency operation in agent browsing loops, so for a headed managed profile the agent constantly steals the user's active tab (#105357).

## Why This Change Was Made

The stall the activation guards against is headless-only, so activation is only needed there — but skipping it is only *safe* when we know the browser is headed. The headless state is authoritative only for **managed** browsers (`isLocalManagedProfile`): OpenClaw launched them, so the resolved profile's launch flag matches reality. `captureScreenshot` takes that flag and skips activation only for a confirmed-headed managed profile:

```ts
const shouldActivateTab = opts.headless !== false;
```

- **Managed headed** (`false`) → skip activation (no focus steal). *Primary #105357 scenario.*
- **Managed headless** (`true`) → activate (keeps the #100857 stall fix).
- **Attached / external** (`undefined`) → activate.

Attached/external sessions cannot be classified reliably. Verified against real Chrome that a spoofed `--user-agent` erases every headless marker — `--headless=new --user-agent=<normal>` reports product `Chrome/…`, the spoofed `userAgent`, and `navigator.webdriver === false`, indistinguishable from headed. A UA sniff would therefore misclassify a headless attached session as headed, suppress activation, and restore the #100857 stall (a hard CDP timeout — strictly worse than an unnecessary activation). So uncertainty resolves to activate, and the earlier UA-sniff fallback (plus its per-screenshot `Browser.getVersion` round-trip) is removed entirely. Attached behavior matches current `main` (always activate); only managed headed profiles change.

Explicit focus APIs are unaffected; this only removes the *implicit* per-screenshot focus change. (Companion to #105356, which addresses the same focus hygiene for tab creation.)

## User Impact

- On a headed **managed** browser, agent screenshots no longer switch the user's visible tab or raise the window.
- Headless capture is unchanged (tab still activated to force a frame), including headless launched with a custom `--user-agent`.
- Attached/external sessions are unchanged from `main` (always activate) — safe against the stall, since their headless state is undetectable.
- One fewer CDP round-trip per screenshot (`Browser.getVersion` removed).

## Evidence

**Real behavior proof** — drove the **compiled `captureScreenshot`** against a **real Chrome** over CDP (not the mocked socket), exact head:

```
[setup] front=A: A=visible B=hidden
[managed headed=false] B PNG=true | A=visible B=hidden -> preserved=true
[attached undefined]   B PNG=true | A=hidden  B=visible -> activated(B front)=true
```

- **managed headed** (`headless=false`) — background-tab capture returns a valid PNG and leaves the user's front tab A untouched.
- **attached/unknown** (`headless=undefined`) — capture activates (B brought to front), so a real headless attached tab with a spoofed UA cannot stall.

**Detection probe** (real Chrome `--headless=new` + custom UA): `product=Chrome/149…`, `userAgent=<spoofed>`, `navigator.webdriver=false` → no reliable headless signal, which is why attached resolves to activate.

**Regression tests** (`node scripts/run-vitest.mjs run extensions/browser/src/browser/cdp.screenshot-params.test.ts` → 13/13):

- `managed headed profile skips activation (headless=false)` — no `Page.bringToFront`, no `Browser.getVersion`.
- `managed headless profile activates (headless=true)` — `Page.bringToFront` before capture.
- `attached/external session activates when headless is unknown` — `Page.bringToFront` sent; no UA sniff.

**Discriminator**: reverting `cdp.ts` fails the managed-headed test — the unconditional `Page.bringToFront` returns.

Fixes #105357
