### PR TITLE
refactor(cloudflare-ai-gateway): remove obsolete testing alias

### DIFF
--- a/extensions/cloudflare-ai-gateway/stream-wrappers.ts
+++ b/extensions/cloudflare-ai-gateway/stream-wrappers.ts
@@ -41,4 +41,3 @@ export function wrapCloudflareAiGatewayProviderStream(
 
 /** Test-only access to wrapper decisions and logger injection points. */
 export const testing = { log, shouldPatchAnthropicMessagesPayload };
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

Removes a stale test-only export alias from the Cloudflare AI Gateway provider. The alias has no consumers, duplicates the canonical `testing` export, and adds an unnecessary compatibility surface inside the plugin.

## Why This Change Was Made

The May underscore-lint migration renamed `__testing` to `testing` but retained the old name as an alias. Current tests import `testing`, the plugin entry imports only the runtime stream wrapper, and the package exposes no barrel that publishes this module.

## User Impact

No user-visible behavior changes. This only removes unused internal code.

## Evidence

- Exhaustive open-PR file audit found no overlap for `extensions/cloudflare-ai-gateway/stream-wrappers.ts`.
- Code graph: 305,213 nodes / 1,262,239 edges; runtime tracing retained the wrapper path and found no `__testing` consumer.
- Focused Testbox proof before and after: `extensions/cloudflare-ai-gateway/stream-wrappers.test.ts` passed 7/7.
- Testbox `pnpm check:changed -- extensions/cloudflare-ai-gateway/stream-wrappers.ts` passed.
- Fresh `gpt-5.6-sol` autoreview at medium reasoning: clean, patch correct (0.93).
