### PR TITLE
refactor(agents): simplify apply patch matching

### DIFF
--- a/src/agents/apply-patch-update.ts
+++ b/src/agents/apply-patch-update.ts
@@ -6,6 +6,11 @@
 import fs from "node:fs/promises";
 import { formatErrorMessage } from "../infra/errors.js";
 
+const DASH_PUNCTUATION = /[\u2010-\u2015\u2212]/g;
+const SINGLE_QUOTE_PUNCTUATION = /[\u2018-\u201B]/g;
+const DOUBLE_QUOTE_PUNCTUATION = /[\u201C-\u201F]/g;
+const SPACE_PUNCTUATION = /[\u00A0\u2002-\u200A\u202F\u205F\u3000]/g;
+
 type UpdateFileChunk = {
   changeContext?: string;
   oldLines: string[];
@@ -137,27 +142,20 @@ function seekSequence(
     return null;
   }
 
-  for (let i = searchStart; i <= maxStart; i += 1) {
-    if (linesMatch(lines, pattern, i, (value) => value)) {
-      return i;
-    }
-  }
   // Fall back through increasingly tolerant comparisons. This preserves normal
   // exact matching while accepting whitespace/punctuation differences common in
   // generated patch text.
-  for (let i = searchStart; i <= maxStart; i += 1) {
-    if (linesMatch(lines, pattern, i, (value) => value.trimEnd())) {
-      return i;
-    }
-  }
-  for (let i = searchStart; i <= maxStart; i += 1) {
-    if (linesMatch(lines, pattern, i, (value) => value.trim())) {
-      return i;
-    }
-  }
-  for (let i = searchStart; i <= maxStart; i += 1) {
-    if (linesMatch(lines, pattern, i, (value) => normalizePunctuation(value.trim()))) {
-      return i;
+  const normalizers = [
+    (value: string) => value,
+    (value: string) => value.trimEnd(),
+    (value: string) => value.trim(),
+    (value: string) => normalizePunctuation(value.trim()),
+  ];
+  for (const normalize of normalizers) {
+    for (let i = searchStart; i <= maxStart; i += 1) {
+      if (linesMatch(lines, pattern, i, normalize)) {
+        return i;
+      }
     }
   }
 
@@ -181,44 +179,9 @@ function linesMatch(
 }
 
 function normalizePunctuation(value: string): string {
-  return Array.from(value)
-    .map((char) => {
-      switch (char) {
-        case "\u2010":
-        case "\u2011":
-        case "\u2012":
-        case "\u2013":
-        case "\u2014":
-        case "\u2015":
-        case "\u2212":
-          return "-";
-        case "\u2018":
-        case "\u2019":
-        case "\u201A":
-        case "\u201B":
-          return "'";
-        case "\u201C":
-        case "\u201D":
-        case "\u201E":
-        case "\u201F":
-          return '"';
-        case "\u00A0":
-        case "\u2002":
-        case "\u2003":
-        case "\u2004":
-        case "\u2005":
-        case "\u2006":
-        case "\u2007":
-        case "\u2008":
-        case "\u2009":
-        case "\u200A":
-        case "\u202F":
-        case "\u205F":
-        case "\u3000":
-          return " ";
-        default:
-          return char;
-      }
-    })
-    .join("");
+  return value
+    .replace(DASH_PUNCTUATION, "-")
+    .replace(SINGLE_QUOTE_PUNCTUATION, "'")
+    .replace(DOUBLE_QUOTE_PUNCTUATION, '"')
+    .replace(SPACE_PUNCTUATION, " ");
 }

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -269,6 +269,34 @@ describe("applyPatch", () => {
     expect(memory.files.get("/sandbox/source.txt")).toBe("a\nafter-a\nb\nafter-b\nc\n");
   });
 
+  it("normalizes supported punctuation while matching update hunks", async () => {
+    const cases = [
+      ["a\u2010\u2011\u2012\u2013\u2014\u2015\u2212b", "a-------b"],
+      ["a\u2018\u2019\u201A\u201Bb", "a''''b"],
+      ["a\u201C\u201D\u201E\u201Fb", 'a""""b'],
+      [
+        "a\u00A0\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000b",
+        "a             b",
+      ],
+    ] as const;
+
+    for (const [sourceLine, patchLine] of cases) {
+      const memory = createMemoryPatchSandbox({
+        "source.txt": `${sourceLine}\n`,
+      });
+      const patch = `*** Begin Patch
+*** Update File: source.txt
+@@
+-${patchLine}
++updated
+*** End Patch`;
+
+      await applyPatch(patch, memory.options);
+
+      expect(memory.files.get("/sandbox/source.txt")).toBe("updated\n");
+    }
+  });
+
   it("supports end-of-file inserts", async () => {
     const memory = createMemoryPatchSandbox({
       "end.txt": "line1\n",


### PR DESCRIPTION
Related: #105392

## What Problem This Solves

The apply-patch update matcher repeated the same file scan four times and normalized supported Unicode punctuation through a large character switch. That made a small, stable matching policy expensive to inspect and modify safely.

## Why This Change Was Made

This keeps the existing exact-to-tolerant matching order while running it through one ordered normalization pipeline. Supported dash, quote, and space variants now use four explicit regex classes instead of a per-character switch. AI-assisted implementation under the maintainer-requested complexity sweep in #105392.

## User Impact

No user-visible behavior changes. Generated patches retain the same whitespace and punctuation tolerance with less branching in the matcher.

## Evidence

- `pnpm test:serial src/agents/apply-patch.test.ts` on Blacksmith Testbox `tbx_01kxb7wds08bdqcnx48rn702w8`: 26 tests passed
- `pnpm check:changed` on the same Testbox: passed for core and coreTests lanes
- fresh autoreview against the local diff: clean, no accepted/actionable findings
- production code delta: `src/agents/apply-patch-update.ts` +21/-58 (net -37 LOC)
- added public-path coverage for every preserved Unicode punctuation class
