### PR TITLE
fix: run ts-topology entrypoint on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1963,7 +1963,7 @@
     "test:unit:fast:audit": "node scripts/test-unit-fast-audit.mjs",
     "test:voicecall:closedloop": "node scripts/test-voicecall-closedloop.mjs",
     "test:watch": "node scripts/test-projects.mjs --watch",
-    "test:windows:ci": "node scripts/test-projects.mjs src/shared/runtime-import.test.ts src/process/exec.windows.test.ts src/process/windows-command.test.ts src/infra/backup-create.windows.test.ts src/infra/windows-install-roots.test.ts src/node-host/invoke-system-run-allowlist.test.ts src/daemon/schtasks.startup-fallback.test.ts extensions/lobster/src/lobster-runner.test.ts test/scripts/format-generated-module.test.ts test/scripts/npm-runner.test.ts test/scripts/openclaw-cross-os-release-workflow.test.ts test/scripts/pnpm-runner.test.ts test/scripts/run-with-env.test.ts test/scripts/ui.test.ts test/scripts/vitest-process-group.test.ts",
+    "test:windows:ci": "node scripts/test-projects.mjs src/shared/runtime-import.test.ts src/process/exec.windows.test.ts src/process/windows-command.test.ts src/infra/backup-create.windows.test.ts src/infra/windows-install-roots.test.ts src/node-host/invoke-system-run-allowlist.test.ts src/daemon/schtasks.startup-fallback.test.ts extensions/lobster/src/lobster-runner.test.ts test/scripts/format-generated-module.test.ts test/scripts/npm-runner.test.ts test/scripts/openclaw-cross-os-release-workflow.test.ts test/scripts/pnpm-runner.test.ts test/scripts/run-with-env.test.ts test/scripts/ts-topology.test.ts test/scripts/ui.test.ts test/scripts/vitest-process-group.test.ts",
     "tool-display:check": "node --import tsx scripts/tool-display.ts --check",
     "tool-display:write": "node --import tsx scripts/tool-display.ts --write",
     "ts-topology": "node --import tsx scripts/ts-topology.ts",

--- a/scripts/ts-topology.ts
+++ b/scripts/ts-topology.ts
@@ -168,7 +168,8 @@ export async function main(argv: string[], io: IoLike = process): Promise<number
   }
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+const entrypointPath = process.argv[1];
+if (entrypointPath && import.meta.url === pathToFileURL(entrypointPath).href) {
   const exitCode = await main(process.argv.slice(2));
   if (exitCode !== 0) {
     process.exit(exitCode);

--- a/scripts/ts-topology.ts
+++ b/scripts/ts-topology.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // Ts Topology script supports OpenClaw repository automation.
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import { formatErrorMessage } from "../src/infra/errors.ts";
 import { parsePositiveInt } from "./lib/numeric-options.mjs";
@@ -167,7 +168,7 @@ export async function main(argv: string[], io: IoLike = process): Promise<number
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   const exitCode = await main(process.argv.slice(2));
   if (exitCode !== 0) {
     process.exit(exitCode);

--- a/test/package-scripts.test.ts
+++ b/test/package-scripts.test.ts
@@ -174,4 +174,10 @@ describe("package scripts", () => {
       "test/scripts/run-with-env.test.ts",
     );
   });
+
+  it("runs ts-topology entrypoint coverage in Windows CI", () => {
+    expect(readPackageJson().scripts["test:windows:ci"]).toContain(
+      "test/scripts/ts-topology.test.ts",
+    );
+  });
 });

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -349,8 +349,6 @@ describe("cross-OS release checks workflow", () => {
     expect(packageJson.scripts["test:windows:ci"]).toContain(
       "test/scripts/openclaw-cross-os-release-workflow.test.ts",
     );
-    expect(packageJson.scripts["test:windows:ci"]).toContain("test/scripts/ts-topology.test.ts");
-
     const result = spawnSync(
       BASH_BIN,
       [

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -349,6 +349,7 @@ describe("cross-OS release checks workflow", () => {
     expect(packageJson.scripts["test:windows:ci"]).toContain(
       "test/scripts/openclaw-cross-os-release-workflow.test.ts",
     );
+    expect(packageJson.scripts["test:windows:ci"]).toContain("test/scripts/ts-topology.test.ts");
 
     const result = spawnSync(
       BASH_BIN,

--- a/test/scripts/ts-topology.test.ts
+++ b/test/scripts/ts-topology.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 // Ts Topology tests cover ts topology script behavior.
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -46,6 +47,17 @@ function requireRecordByExport(exportName: string) {
 }
 
 describe("ts-topology", () => {
+  it("runs the CLI entrypoint when invoked from a filesystem path", () => {
+    const scriptPath = path.resolve("scripts/ts-topology.ts");
+    const result = spawnSync(process.execPath, ["--import", "tsx", scriptPath, "--help"], {
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Usage: ts-topology");
+  });
+
   it("collapses canonical symbols exported by multiple public subpaths", () => {
     const sharedThing = requireRecordByExport("sharedThing");
 

--- a/test/scripts/ts-topology.test.ts
+++ b/test/scripts/ts-topology.test.ts
@@ -1,5 +1,5 @@
-import { spawnSync } from "node:child_process";
 // Ts Topology tests cover ts topology script behavior.
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { analyzeTopology, filterRecordsForReport } from "../../scripts/lib/ts-topology/analyze.js";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows developers running the `ts-topology` package script directly could get a silent no-op because the ESM direct-run guard compared `import.meta.url` against a manually concatenated `file://` path that does not match Windows file URL formatting.

## Why This Change Was Made

The direct-run guard now converts `process.argv[1]` with Node's `pathToFileURL(...)` before comparing it to `import.meta.url`, matching Node's cross-platform path-to-file-URL boundary instead of manually concatenating a file URL. This keeps the behavior change scoped to the `ts-topology` entrypoint and does not change topology analysis logic.

The regression test is also included in `test:windows:ci`, so the Windows-only entrypoint behavior is covered by the Windows CI selection rather than only by POSIX-friendly unit-fast runs.

## User Impact

Developers and automation can run `pnpm ts-topology` or `node --import tsx scripts/ts-topology.ts ...` on Windows and have the CLI execute instead of exiting successfully with no output.

Imported usage through `main(...)` is unchanged.

## Evidence

Before on Windows, the direct script invocation skipped the CLI entrypoint and exited silently:

```powershell
node --import tsx scripts/ts-topology.ts --help
```

Observed before:

```text
exit=0
stdout:
stderr:
```

After on Windows, the same entrypoint reaches the CLI parser and prints usage:

```powershell
node --import tsx D:\ZXY\Github\openclaw\scripts\ts-topology.ts --help
```

Observed after:

```text
exit=1
stdout:
stderr:
Usage: ts-topology [analyze] [options]
```

Call chain / sibling surfaces checked:

```text
pnpm ts-topology
  -> package.json scripts.ts-topology
  -> node --import tsx scripts/ts-topology.ts
  -> import.meta.url direct-run guard
  -> main(process.argv.slice(2))
```

The PR affects only direct CLI execution. The imported `main(...)` test path and topology analysis/reporting helpers remain unchanged.

Validation:

```powershell
node scripts/test-projects.mjs test/scripts/ts-topology.test.ts test/package-scripts.test.ts
pnpm format:check --no-error-on-unmatched-pattern -- scripts/ts-topology.ts test/scripts/ts-topology.test.ts package.json test/package-scripts.test.ts test/scripts/openclaw-cross-os-release-workflow.test.ts
pnpm tsgo:scripts
pnpm tsgo:test:root
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/ts-topology.ts
node scripts/check-changed.mjs --dry-run -- scripts/ts-topology.ts test/scripts/ts-topology.test.ts package.json test/package-scripts.test.ts test/scripts/openclaw-cross-os-release-workflow.test.ts
node --import tsx scripts/ts-topology.ts --help
git diff --check
```

Local limitation: `pnpm test:windows:ci` reaches the updated `test:windows:ci` selection locally, but this Windows machine's WSL harness path currently emits `node is required to run cross-OS release checks` from `test/scripts/openclaw-cross-os-release-workflow.test.ts`; the failure occurs in the pre-existing release-harness execution path and is unrelated to the `ts-topology` code path changed here.