### PR TITLE
fix(whatsapp): preserve disconnect diagnostics

### DIFF
--- a/extensions/whatsapp/src/session.test.ts
+++ b/extensions/whatsapp/src/session.test.ts
@@ -597,6 +597,24 @@ describe("web session", () => {
     await expect(promise).rejects.toBeInstanceOf(Error);
   });
 
+  it("preserves the underlying Baileys disconnect error", async () => {
+    const ev = new EventEmitter();
+    const promise = waitForWaConnection(
+      { ev } as unknown as ReturnType<typeof baileys.makeWASocket>,
+      { timeout: "none" },
+    );
+    const disconnectError = Object.assign(new Error("logged out"), {
+      output: { statusCode: 401 },
+    });
+    ev.emit("connection.update", {
+      connection: "close",
+      lastDisconnect: { date: new Date(), error: disconnectError },
+    });
+    const error = await promise.catch((caught: unknown) => caught);
+    expect(error).toBe(disconnectError);
+    expect(error).toMatchObject({ message: "logged out", output: { statusCode: 401 } });
+  });
+
   it("rejects after timeout with no connection event", async () => {
     vi.useFakeTimers();
     const ev = new EventEmitter();

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -513,9 +513,10 @@ export async function waitForWaConnection(
       }
       if (update.connection === "close") {
         cleanup();
+        const disconnectError = update.lastDisconnect?.error ?? update.lastDisconnect;
         reject(
           toLintErrorObject(
-            update.lastDisconnect ?? new Error("Connection closed"),
+            disconnectError ?? new Error("Connection closed"),
             "Non-Error rejection",
           ),
         );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where WhatsApp connection failures lost the underlying Baileys disconnect message and status, leaving QA and operator logs with `Non-Error rejection` instead of the real logged-out or transport reason.

## Why This Change Was Made

Baileys exposes the causal `Boom | Error` at `ConnectionState.lastDisconnect.error`. Reject with that error before applying the existing non-Error normalization, while retaining the fallback for missing or legacy-shaped disconnect data. This changes diagnostics only; it does not alter reconnect policy or repair expired credentials.

## User Impact

Operators and QA failures retain actionable WhatsApp disconnect messages and status codes such as `401`, making logged-out sessions distinguishable from transient transport failures.

## Evidence

- Blacksmith Testbox `tbx_01kxb8c3j4zc9c2q4n9qt5rd20`: `pnpm test extensions/whatsapp/src/session.test.ts` — 39/39 passed.
- Fresh autoreview: no accepted/actionable findings; confidence 0.98.
- Regression test verifies the original error identity, `logged out` message, and status `401` survive `waitForWaConnection`.

Known boundary: the existing expired Convex WhatsApp QA credential still requires operator relinking; this PR does not mutate or bypass credentials.
