### PR TITLE
refactor(google): remove obsolete Gemini testing alias

### DIFF
--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -152,4 +152,3 @@ export const testing = {
   resolveGeminiModel,
   withGoogleModelProviderFallbacks,
 } as const;
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

Removes a stale test-only export alias from the Google Gemini web-search provider. The alias has no consumers, duplicates the canonical `testing` export, and adds an unnecessary private compatibility surface.

## Why This Change Was Made

The May underscore-lint migration renamed `__testing` to `testing` but retained the old name as an alias. Current web-search and image-generation tests import `testing`, runtime registration imports only `createGeminiWebSearchProvider`, and the public Google barrels do not expose the alias.

## User Impact

No user-visible behavior changes. This only removes unused internal code.

## Evidence

- Exhaustive open-PR audit plus two live delta scans found no overlap for `extensions/google/src/gemini-web-search-provider.ts`.
- Code graph: 305,233 nodes / 1,268,806 edges; runtime tracing retained the provider registration path and found no `__testing` consumer.
- Focused Testbox proof before and after: Google web-search and image-generation suites passed 43/43.
- Testbox `pnpm check:changed -- extensions/google/src/gemini-web-search-provider.ts` passed.
- Fresh `gpt-5.6-sol` autoreview at medium reasoning: clean, patch correct (0.91).
