### PR TITLE
fix(qa): align mock catalog with selected models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,7 @@ Skills own workflows; root owns hard policy and routing.
 - zsh: quote `gh api` endpoints containing `?` or brackets; otherwise glob expansion corrupts the invocation.
 - GitHub Actions: resolve workflow files from `.github/workflows` or API; never infer filenames from display names.
 - zsh: quote command globs; unmatched patterns abort before the tool runs.
+- zsh: don't use `path` as a variable; it rewrites `$PATH`.
 - `scripts/pr` artifacts: preserve template enum values; validate before prepare.
 - `scripts/pr` subcommands require a PR number; no subcommand `--help` placeholder.
 - `scripts/pr` review: checkout main baseline, then PR, before artifact validation.

--- a/extensions/qa-lab/src/live-transports/shared/live-gateway.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-gateway.runtime.test.ts
@@ -89,12 +89,14 @@ describe("startQaLiveLaneGateway", () => {
       transport: createStubTransport(),
       transportBaseUrl: "http://127.0.0.1:43123",
       providerMode: "mock-openai",
-      primaryModel: "mock-openai/gpt-5.6-luna",
-      alternateModel: "mock-openai/gpt-5.6-luna-alt",
+      primaryModel: "mock-openai/gpt-5.5",
+      alternateModel: "mock-openai/gpt-5.5-alt",
       controlUiEnabled: false,
     });
 
-    expect(startQaProviderServer).toHaveBeenCalledWith("mock-openai");
+    expect(startQaProviderServer).toHaveBeenCalledWith("mock-openai", {
+      modelRefs: ["mock-openai/gpt-5.5", "mock-openai/gpt-5.5-alt"],
+    });
     const gatewayOptions = firstGatewayOptions();
     expect(gatewayOptions?.transportBaseUrl).toBe("http://127.0.0.1:43123");
     expect(gatewayOptions?.providerBaseUrl).toBe("http://127.0.0.1:44080/v1");
@@ -198,7 +200,9 @@ describe("startQaLiveLaneGateway", () => {
       controlUiEnabled: false,
     });
 
-    expect(startQaProviderServer).toHaveBeenCalledWith("live-frontier");
+    expect(startQaProviderServer).toHaveBeenCalledWith("live-frontier", {
+      modelRefs: ["openai/gpt-5.6-luna", "openai/gpt-5.6-luna"],
+    });
     const gatewayOptions = firstGatewayOptions();
     expect(gatewayOptions?.transportBaseUrl).toBe("http://127.0.0.1:43123");
     expect(gatewayOptions?.providerBaseUrl).toBeUndefined();

--- a/extensions/qa-lab/src/live-transports/shared/live-gateway.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-gateway.runtime.ts
@@ -108,7 +108,9 @@ export async function startQaLiveLaneGateway(params: {
   mockAuthAgentIds?: readonly string[];
   mutateConfig?: (cfg: OpenClawConfig) => OpenClawConfig;
 }) {
-  const mock = await startQaProviderServer(params.providerMode);
+  const mock = await startQaProviderServer(params.providerMode, {
+    modelRefs: [params.primaryModel, params.alternateModel],
+  });
   try {
     const gateway = await startQaGatewayChild({
       repoRoot: params.repoRoot,

--- a/extensions/qa-lab/src/manual-lane.runtime.test.ts
+++ b/extensions/qa-lab/src/manual-lane.runtime.test.ts
@@ -85,14 +85,16 @@ describe("runQaManualLane", () => {
     const result = await runQaManualLane({
       repoRoot: "/tmp/openclaw-repo",
       providerMode: "mock-openai",
-      primaryModel: "mock-openai/gpt-5.6-luna",
-      alternateModel: "mock-openai/gpt-5.6-luna-alt",
+      primaryModel: "mock-openai/gpt-5.5",
+      alternateModel: "mock-openai/gpt-5.5-alt",
       message: "check the kickoff file",
       timeoutMs: 5_000,
       replySettleMs: 0,
     });
 
-    expect(startQaProviderServer).toHaveBeenCalledWith("mock-openai");
+    expect(startQaProviderServer).toHaveBeenCalledWith("mock-openai", {
+      modelRefs: ["mock-openai/gpt-5.5", "mock-openai/gpt-5.5-alt"],
+    });
     const [gatewayOptions] = startQaGatewayChild.mock.calls[0] ?? [];
     expect(gatewayOptions?.repoRoot).toBe("/tmp/openclaw-repo");
     expect(gatewayOptions?.providerMode).toBe("mock-openai");
@@ -118,7 +120,9 @@ describe("runQaManualLane", () => {
       replySettleMs: 0,
     });
 
-    expect(startQaProviderServer).toHaveBeenCalledWith("live-frontier");
+    expect(startQaProviderServer).toHaveBeenCalledWith("live-frontier", {
+      modelRefs: ["openai/gpt-5.6-luna", "openai/gpt-5.6-luna"],
+    });
     expect(startQaLabServer).toHaveBeenCalledWith({
       repoRoot: "/tmp/openclaw-repo",
       embeddedGateway: "disabled",

--- a/extensions/qa-lab/src/manual-lane.runtime.ts
+++ b/extensions/qa-lab/src/manual-lane.runtime.ts
@@ -95,7 +95,9 @@ export async function runQaManualLane(params: QaManualLaneParams) {
     });
     const transport = transportFactoryResult.adapter;
     transportCleanup = transportFactoryResult.cleanup;
-    mock = await startQaProviderServer(params.providerMode);
+    mock = await startQaProviderServer(params.providerMode, {
+      modelRefs: [params.primaryModel, params.alternateModel],
+    });
     gateway = await startQaGatewayChild({
       repoRoot: params.repoRoot,
       providerBaseUrl: mock ? `${mock.baseUrl}/v1` : undefined,

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -4846,6 +4846,24 @@ describe("qa mock openai server", () => {
     expect(ids).toContain("gpt-4o-transcribe");
   });
 
+  it("advertises selected target-era models on /v1/models", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+      modelRefs: ["mock-openai/gpt-5.5", "mock-openai/gpt-5.5-alt"],
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/models`);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { data: Array<{ id: string }> };
+    expect(body.data.map((entry) => entry.id)).toEqual(
+      expect.arrayContaining(["gpt-5.5", "gpt-5.5-alt", "gpt-image-1"]),
+    );
+  });
+
   it("serves deterministic OpenAI-compatible audio transcription responses", async () => {
     const server = await startQaMockOpenAiServer({
       host: "127.0.0.1",

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -8,6 +8,7 @@ import { closeQaHttpServer } from "../../bus-server.js";
 import { QA_LAB_WEB_SEARCH_DENIED_INPUT_QUERY } from "../../qa-web-search-provider.js";
 import { parseQaDebugRequestCursor } from "../shared/debug-request-cursor.js";
 import { writeJson } from "../shared/http-json.js";
+import { listMockOpenAiServerModelIds } from "../shared/mock-model-config.js";
 
 type ResponsesInputItem = Record<string, unknown>;
 
@@ -3765,6 +3766,7 @@ export async function startQaMockOpenAiServer(params?: {
   host?: string;
   port?: number;
   finalOnlyMarkerPauseMs?: number;
+  modelRefs?: readonly string[];
 }) {
   const host = params?.host ?? "127.0.0.1";
   const finalOnlyMarkerPauseMs = params?.finalOnlyMarkerPauseMs ?? 1_500;
@@ -3797,15 +3799,10 @@ export async function startQaMockOpenAiServer(params?: {
       }
       if (req.method === "GET" && url.pathname === "/v1/models") {
         writeJson(res, 200, {
-          data: [
-            { id: "gpt-5.6-luna", object: "model" },
-            { id: "gpt-5.6-luna-alt", object: "model" },
-            { id: "gpt-image-1", object: "model" },
-            { id: "gpt-4o-transcribe", object: "model" },
-            { id: "text-embedding-3-small", object: "model" },
-            { id: "claude-opus-4-8", object: "model" },
-            { id: "claude-sonnet-4-6", object: "model" },
-          ],
+          data: listMockOpenAiServerModelIds(params?.modelRefs).map((id) => ({
+            id,
+            object: "model",
+          })),
         });
         return;
       }

--- a/extensions/qa-lab/src/providers/server-runtime.ts
+++ b/extensions/qa-lab/src/providers/server-runtime.ts
@@ -4,6 +4,7 @@ import { getQaProvider, type QaMockProviderServer, type QaProviderModeInput } fr
 type QaProviderServerParams = {
   host: string;
   port: number;
+  modelRefs?: readonly string[];
 };
 
 async function startMockOpenAiProviderServer(params: QaProviderServerParams) {
@@ -18,12 +19,13 @@ async function startAimockProviderServer(params: QaProviderServerParams) {
 
 export async function startQaProviderServer(
   input: QaProviderModeInput,
-  params?: { host?: string; port?: number },
+  params?: { host?: string; port?: number; modelRefs?: readonly string[] },
 ): Promise<QaMockProviderServer | null> {
   const provider = getQaProvider(input);
   const serverParams = {
     host: params?.host ?? "127.0.0.1",
     port: params?.port ?? 0,
+    modelRefs: params?.modelRefs,
   };
   switch (provider.mode) {
     case "mock-openai":

--- a/extensions/qa-lab/src/providers/shared/mock-model-config.ts
+++ b/extensions/qa-lab/src/providers/shared/mock-model-config.ts
@@ -19,7 +19,42 @@ function trimTrailingApiV1(baseUrl: string) {
   return baseUrl.replace(/\/v1\/?$/i, "");
 }
 
-function createMockOpenAiResponsesProvider(baseUrl: string): ModelProviderConfig {
+const DEFAULT_OPENAI_MODEL_IDS = ["gpt-5.6-luna", "gpt-5.6-luna-alt"] as const;
+
+function selectedOpenAiModelIds(
+  primaryProviderId: string,
+  selectedModelRefs: readonly (string | undefined)[],
+) {
+  const selected = selectedModelRefs.flatMap((modelRef) => {
+    const slash = modelRef?.indexOf("/") ?? -1;
+    if (!modelRef || slash <= 0 || slash === modelRef.length - 1) {
+      return [];
+    }
+    const providerId = modelRef.slice(0, slash);
+    return providerId === primaryProviderId || providerId === "openai"
+      ? [modelRef.slice(slash + 1)]
+      : [];
+  });
+  return selected.length > 0 ? [...new Set(selected)] : [...DEFAULT_OPENAI_MODEL_IDS];
+}
+
+function createMockOpenAiTextModel(id: string): ModelProviderConfig["models"][number] {
+  return {
+    id,
+    name: id,
+    api: "openai-responses",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: ZERO_COST,
+    contextWindow: 128_000,
+    maxTokens: 4096,
+  };
+}
+
+function createMockOpenAiResponsesProvider(
+  baseUrl: string,
+  modelIds: readonly string[],
+): ModelProviderConfig {
   return {
     baseUrl,
     apiKey: "test",
@@ -28,26 +63,7 @@ function createMockOpenAiResponsesProvider(baseUrl: string): ModelProviderConfig
       allowPrivateNetwork: true,
     },
     models: [
-      {
-        id: "gpt-5.6-luna",
-        name: "gpt-5.6-luna",
-        api: "openai-responses",
-        reasoning: true,
-        input: ["text", "image"],
-        cost: ZERO_COST,
-        contextWindow: 128_000,
-        maxTokens: 4096,
-      },
-      {
-        id: "gpt-5.6-luna-alt",
-        name: "gpt-5.6-luna-alt",
-        api: "openai-responses",
-        reasoning: true,
-        input: ["text", "image"],
-        cost: ZERO_COST,
-        contextWindow: 128_000,
-        maxTokens: 4096,
-      },
+      ...modelIds.map(createMockOpenAiTextModel),
       {
         id: "gpt-image-1",
         name: "gpt-image-1",
@@ -95,11 +111,29 @@ function createMockAnthropicMessagesProvider(baseUrl: string): ModelProviderConf
   };
 }
 
-export function createMockProviderMap(primaryProviderId: string, providerBaseUrl: string) {
-  const primaryProvider = createMockOpenAiResponsesProvider(providerBaseUrl);
+export function createMockProviderMap(
+  primaryProviderId: string,
+  providerBaseUrl: string,
+  selectedModelRefs: readonly (string | undefined)[] = [],
+) {
+  const primaryProvider = createMockOpenAiResponsesProvider(
+    providerBaseUrl,
+    selectedOpenAiModelIds(primaryProviderId, selectedModelRefs),
+  );
   return {
     [primaryProviderId]: primaryProvider,
     openai: cloneProvider(primaryProvider),
     anthropic: createMockAnthropicMessagesProvider(providerBaseUrl),
   };
+}
+
+export function listMockOpenAiServerModelIds(selectedModelRefs: readonly string[] = []) {
+  return [
+    ...selectedOpenAiModelIds("mock-openai", selectedModelRefs),
+    "gpt-image-1",
+    "gpt-4o-transcribe",
+    "text-embedding-3-small",
+    "claude-opus-4-8",
+    "claude-sonnet-4-6",
+  ];
 }

--- a/extensions/qa-lab/src/providers/shared/mock-provider-definition.ts
+++ b/extensions/qa-lab/src/providers/shared/mock-provider-definition.ts
@@ -35,9 +35,12 @@ export function createMockQaProviderDefinition(
       openaiWsWarmup: false,
     }),
     resolveTurnTimeoutMs: ({ fallbackMs }) => fallbackMs,
-    buildGatewayModels: ({ providerBaseUrl }) => ({
+    buildGatewayModels: ({ providerBaseUrl, primaryModel, alternateModel }) => ({
       mode: "replace",
-      providers: createMockProviderMap(params.mode, providerBaseUrl),
+      providers: createMockProviderMap(params.mode, providerBaseUrl, [
+        primaryModel,
+        alternateModel,
+      ]),
     }),
     mockAuthProviders: params.mockAuthProviders,
     usesModelProviderPlugins: false,

--- a/extensions/qa-lab/src/providers/shared/types.ts
+++ b/extensions/qa-lab/src/providers/shared/types.ts
@@ -18,6 +18,8 @@ type QaProviderModelParamsInput = {
 
 type QaProviderGatewayModelsInput = {
   providerBaseUrl: string;
+  primaryModel?: string;
+  alternateModel?: string;
   liveProviderConfigs?: Record<string, ModelProviderConfig>;
 };
 

--- a/extensions/qa-lab/src/qa-gateway-config.test.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.test.ts
@@ -112,6 +112,27 @@ describe("buildQaGatewayConfig", () => {
     expect(cfg.messages?.groupChat?.visibleReplies).toBe("automatic");
   });
 
+  it("adds selected target-era models to the mock provider catalog", () => {
+    const cfg = buildQaGatewayConfig({
+      bind: "loopback",
+      gatewayPort: 18789,
+      gatewayToken: "token",
+      providerBaseUrl: "http://127.0.0.1:44080/v1",
+      workspaceDir: "/tmp/qa-workspace",
+      providerMode: "mock-openai",
+      primaryModel: "mock-openai/gpt-5.5",
+      alternateModel: "mock-openai/gpt-5.5-alt",
+    });
+
+    expect(getPrimaryModel(cfg.agents?.defaults?.model)).toBe("mock-openai/gpt-5.5");
+    expect(cfg.models?.providers?.["mock-openai"]?.models.map((model) => model.id)).toEqual([
+      "gpt-5.5",
+      "gpt-5.5-alt",
+      "gpt-image-1",
+    ]);
+    expect(cfg.models?.providers?.openai?.models.map((model) => model.id)).toContain("gpt-5.5");
+  });
+
   it("maps provider-qualified openai and anthropic refs through the mock provider lane", () => {
     const cfg = buildQaGatewayConfig({
       bind: "loopback",

--- a/extensions/qa-lab/src/qa-gateway-config.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.ts
@@ -139,6 +139,8 @@ export function buildQaGatewayConfig(params: {
   const allowedOrigins = mergeQaControlUiAllowedOrigins(params.controlUiAllowedOrigins);
   const gatewayModels = provider.buildGatewayModels({
     providerBaseUrl,
+    primaryModel,
+    alternateModel,
     liveProviderConfigs: params.liveProviderConfigs,
   });
 

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -1758,7 +1758,9 @@ export async function runQaFlowSuite(params?: QaSuiteRunParams): Promise<QaSuite
   let runError: unknown;
   try {
     writeQaSuiteProgress(progressEnabled, `provider start: ${providerMode}`);
-    const activeMock = await startQaProviderServer(providerMode);
+    const activeMock = await startQaProviderServer(providerMode, {
+      modelRefs: [primaryModel, alternateModel],
+    });
     mock = activeMock;
     writeQaSuiteProgress(
       progressEnabled,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the trusted Telegram release lane could select a target-era mock model such as `mock-openai/gpt-5.5` while the generated gateway catalog still exposed only current mock model IDs. The exact LTS canary then accepted Telegram ingress but never reached a provider completion.

## Why This Change Was Made

The QA provider contract now receives the normalized primary and alternate model refs. Mock gateway configuration and `/v1/models` advertise those selected refs, while preserving the existing default catalog when no refs are supplied. The canonical `channel-canary` scenario and current-candidate behavior remain unchanged.

## User Impact

Release maintainers can validate older compatible release candidates with the trusted current Telegram harness without weakening the normal-message canary or backporting target-specific scenario logic.

## Evidence

- Retained failing exact-target evidence: https://github.com/openclaw/openclaw/actions/runs/29193908030 (`a62bede54bbb6e66f624812ade28b70f3f0aa57c` reached Telegram ingress with `mock-openai/gpt-5.5`, then timed out before provider completion).
- Blacksmith Testbox focused proof: https://github.com/openclaw/openclaw/actions/runs/29194484164 — 142 tests passed across `qa-gateway-config.test.ts` and `providers/mock-openai/server.test.ts`.
- Blacksmith Testbox `check:changed`: extension production/test typechecks, lint, format, API baseline, and runtime guards passed on the same kept lease.
- Fresh autoreview: clean, no accepted/actionable findings.
