### PR TITLE
fix(update): preserve ClawHub plugins after cutover

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -990,6 +990,7 @@ describe("update-cli", () => {
       config: baseConfig,
       summary: {
         switchedToBundled: [],
+        switchedToClawHub: [],
         switchedToNpm: [],
         warnings: [],
         errors: [],
@@ -2037,6 +2038,7 @@ describe("update-cli", () => {
       config: baseConfig,
       summary: {
         switchedToBundled: [],
+        switchedToClawHub: [],
         switchedToNpm: [],
         warnings: [trustWarning],
         errors: [
@@ -2070,6 +2072,7 @@ describe("update-cli", () => {
           config: params.config,
           summary: {
             switchedToBundled: [],
+            switchedToClawHub: [],
             switchedToNpm: [],
             warnings: [trustWarning],
             errors: [
@@ -2155,6 +2158,7 @@ describe("update-cli", () => {
       config,
       summary: {
         switchedToBundled: [],
+        switchedToClawHub: [],
         switchedToNpm: [],
         warnings: [],
         errors: [],
@@ -5484,6 +5488,7 @@ describe("update-cli", () => {
       config,
       summary: {
         switchedToBundled: [],
+        switchedToClawHub: [],
         switchedToNpm: [],
         warnings: [],
         errors: [],
@@ -5535,6 +5540,7 @@ describe("update-cli", () => {
       },
       summary: {
         switchedToBundled: [],
+        switchedToClawHub: [],
         switchedToNpm: [],
         warnings: [],
         errors: [],
@@ -5596,6 +5602,7 @@ describe("update-cli", () => {
       config,
       summary: {
         switchedToBundled: [],
+        switchedToClawHub: [],
         switchedToNpm: [],
         warnings: [],
         errors: [],
@@ -5687,6 +5694,7 @@ describe("update-cli", () => {
       config,
       summary: {
         switchedToBundled: [],
+        switchedToClawHub: [],
         switchedToNpm: [],
         warnings: [],
         errors: [],
@@ -5774,6 +5782,7 @@ describe("update-cli", () => {
       config,
       summary: {
         switchedToBundled: [],
+        switchedToClawHub: [],
         switchedToNpm: [],
         warnings: [],
         errors: [],
@@ -5840,6 +5849,7 @@ describe("update-cli", () => {
       config,
       summary: {
         switchedToBundled: [],
+        switchedToClawHub: [],
         switchedToNpm: [],
         warnings: [],
         errors: [],
@@ -5898,6 +5908,7 @@ describe("update-cli", () => {
       config,
       summary: {
         switchedToBundled: [],
+        switchedToClawHub: [],
         switchedToNpm: [],
         warnings: [],
         errors: [],
@@ -5979,6 +5990,7 @@ describe("update-cli", () => {
       config,
       summary: {
         switchedToBundled: [],
+        switchedToClawHub: [],
         switchedToNpm: [],
         warnings: [],
         errors: [],
@@ -6057,6 +6069,7 @@ describe("update-cli", () => {
       config,
       summary: {
         switchedToBundled: [],
+        switchedToClawHub: [],
         switchedToNpm: [],
         warnings: [],
         errors: [],
@@ -6129,6 +6142,7 @@ describe("update-cli", () => {
       config,
       summary: {
         switchedToBundled: [],
+        switchedToClawHub: [],
         switchedToNpm: [],
         warnings: [],
         errors: [],
@@ -6196,6 +6210,7 @@ describe("update-cli", () => {
       config,
       summary: {
         switchedToBundled: [],
+        switchedToClawHub: [],
         switchedToNpm: [],
         warnings: [],
         errors: [],
@@ -6258,6 +6273,7 @@ describe("update-cli", () => {
       config: sourceConfig,
       summary: {
         switchedToBundled: [],
+        switchedToClawHub: [],
         switchedToNpm: [],
         warnings: [],
         errors: [],
@@ -6518,6 +6534,7 @@ describe("update-cli", () => {
       config,
       summary: {
         switchedToBundled: [],
+        switchedToClawHub: [],
         switchedToNpm: [],
         warnings: [],
         errors: [],
@@ -7498,6 +7515,7 @@ describe("update-cli", () => {
         config: params.config ?? baseConfig,
         summary: {
           switchedToBundled: [],
+          switchedToClawHub: [],
           switchedToNpm: [],
           warnings: [],
           errors: [],

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -18,6 +18,7 @@ import {
   resolvePostCoreUpdateChildStdio,
   resolvePostUpdateServiceStateReadEnv,
   resolvePostInstallDoctorEnv,
+  resolvePostSyncPluginUpdateSkipIds,
   shouldPrepareUpdatedInstallRestart,
   resolveUpdatedGatewayRestartPort,
   shouldUseLegacyProcessRestartAfterUpdate,
@@ -538,6 +539,18 @@ describe("collectMissingPluginInstallPayloads", () => {
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("resolvePostSyncPluginUpdateSkipIds", () => {
+  it("skips plugins already switched through ClawHub or npm and repaired payloads", () => {
+    expect(
+      resolvePostSyncPluginUpdateSkipIds({
+        switchedToClawHub: ["whatsapp"],
+        switchedToNpm: ["voice-call"],
+        repairedMissingPayloadIds: new Set(["telegram"]),
+      }),
+    ).toStrictEqual(new Set(["whatsapp", "voice-call", "telegram"]));
   });
 });
 

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -264,6 +264,18 @@ type MissingPluginInstallPayload = {
 
 type PostUpdatePluginWarning = NonNullable<PostCorePluginUpdateResult["warnings"]>[number];
 
+export function resolvePostSyncPluginUpdateSkipIds(params: {
+  switchedToClawHub: readonly string[];
+  switchedToNpm: readonly string[];
+  repairedMissingPayloadIds: ReadonlySet<string>;
+}): Set<string> {
+  return new Set([
+    ...params.switchedToClawHub,
+    ...params.switchedToNpm,
+    ...params.repairedMissingPayloadIds,
+  ]);
+}
+
 function isClawHubTrustNotice(message: string): boolean {
   const trimmed = stripAnsi(message).trimStart();
   return (
@@ -2324,7 +2336,11 @@ export async function updatePluginsAfterCoreUpdate(params: {
     timeoutMs: params.timeoutMs,
     updateChannel: pluginUpdateChannel,
     coreVersion: coreVersion ?? undefined,
-    skipIds: new Set([...syncResult.summary.switchedToNpm, ...missingPayloadIdSet]),
+    skipIds: resolvePostSyncPluginUpdateSkipIds({
+      switchedToClawHub: syncResult.summary.switchedToClawHub,
+      switchedToNpm: syncResult.summary.switchedToNpm,
+      repairedMissingPayloadIds: missingPayloadIdSet,
+    }),
     skipDisabledPlugins: true,
     syncOfficialPluginInstalls: true,
     disableOnFailure: true,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a plugin switched from a bundled payload to ClawHub during `openclaw update` could be processed a second time immediately afterward. If that redundant update failed, the updater disabled the freshly installed plugin and removed it from `plugins.allow`.

## Why This Change Was Made

The post-sync update pass now skips plugins already switched through either ClawHub or npm, along with plugins repaired for missing payloads. A focused regression test covers the complete skip set.

## User Impact

Externalized channel plugins such as WhatsApp remain enabled after a successful ClawHub cutover, even if a later redundant network request would have failed.

## Evidence

- Release validation exposed the failure in `update-restart-auth`: https://github.com/openclaw/openclaw/actions/runs/29193333289
- Rebased exact head: `dc351fa93bb421c21aaf9e6838d76378589704b4`
- Blacksmith Testbox `tbx_01kxbajx1fkf3a70mmpam1w8qt`: 222/222 focused updater tests passed.
- Earlier Testbox `pnpm check:changed` passed before the rebase; final hosted exact-head CI is authoritative for the rebased stack.
- Rebased-head autoreview: no findings, patch correct, confidence `0.95`.
- `git diff --check` passed.
