### PR TITLE
refactor(transcription): remove obsolete testing aliases

### DIFF
--- a/extensions/elevenlabs/realtime-transcription-provider.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.ts
@@ -296,4 +296,3 @@ export const testing = {
   normalizeProviderConfig,
   toElevenLabsRealtimeWsUrl,
 };
-export { testing as __testing };

--- a/extensions/mistral/realtime-transcription-provider.ts
+++ b/extensions/mistral/realtime-transcription-provider.ts
@@ -276,4 +276,3 @@ export const testing = {
   normalizeProviderConfig,
   toMistralRealtimeWsUrl,
 };
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

Removes stale test-only export aliases from the ElevenLabs and Mistral realtime transcription providers. Both aliases have no consumers, duplicate the canonical `testing` exports, and add unnecessary private compatibility surfaces.

## Why This Change Was Made

The May underscore-lint migration renamed each provider's `__testing` object to `testing` but retained the old names as aliases. Current focused tests import `testing`, runtime/plugin entrypoints import only the provider builders, and the package test barrels expose only those builders.

## User Impact

No user-visible behavior changes. This only removes unused internal code.

## Evidence

- Exhaustive open-PR audit plus live delta scans found no overlap for either provider file.
- Code graph: 305,239 nodes / 1,268,588 edges; runtime tracing retained both provider registration paths and found no `__testing` consumers.
- Focused Testbox proof before and after: ElevenLabs and Mistral realtime transcription suites passed 8/8.
- Testbox `pnpm check:changed -- extensions/elevenlabs/realtime-transcription-provider.ts extensions/mistral/realtime-transcription-provider.ts` passed.
- Fresh `gpt-5.6-sol` autoreview at medium reasoning: clean, patch correct (0.96).
