### PR TITLE
refactor(ui): simplify usage query filters

### DIFF
--- a/ui/src/pages/usage/helpers.node.test.ts
+++ b/ui/src/pages/usage/helpers.node.test.ts
@@ -27,10 +27,57 @@ describe("usage-helpers", () => {
   });
 
   it("supports numeric filters like minTokens/maxTokens", () => {
-    const a = { key: "a", label: "a", usage: { totalTokens: 100, totalCost: 0 } };
-    const b = { key: "b", label: "b", usage: { totalTokens: 5, totalCost: 0 } };
-    expect(filterSessionsByQuery([a, b], "minTokens:10").sessions).toEqual([a]);
-    expect(filterSessionsByQuery([a, b], "maxTokens:10").sessions).toEqual([b]);
+    const a = {
+      key: "a",
+      usage: { totalTokens: 100, totalCost: 20, messageCounts: { total: 30 } },
+    };
+    const b = {
+      key: "b",
+      usage: { totalTokens: 5, totalCost: 2, messageCounts: { total: 3 } },
+    };
+    const filters = [
+      "minTokens:10",
+      "minCost:10",
+      "minMessages:10",
+      "maxTokens:10",
+      "maxCost:10",
+      "maxMessages:10",
+    ];
+
+    for (const filter of filters.slice(0, 3)) {
+      const result = filterSessionsByQuery([a, b], filter);
+      expect(result.sessions).toEqual([a]);
+      expect(result.warnings).toEqual([]);
+    }
+    for (const filter of filters.slice(3)) {
+      const result = filterSessionsByQuery([a, b], filter);
+      expect(result.sessions).toEqual([b]);
+      expect(result.warnings).toEqual([]);
+    }
+  });
+
+  it("supports every has predicate and warns on unknown values", () => {
+    const populated = {
+      key: "populated",
+      contextWeight: 1,
+      modelProvider: "openai",
+      model: "gpt-5.2",
+      usage: {
+        messageCounts: { errors: 1 },
+        toolUsage: { totalCalls: 1 },
+      },
+    };
+    const empty = { key: "empty", usage: null };
+
+    for (const value of ["tools", "errors", "context", "usage", "model", "provider"]) {
+      const result = filterSessionsByQuery([populated, empty], `has:${value}`);
+      expect(result.sessions).toEqual([populated]);
+      expect(result.warnings).toEqual([]);
+    }
+    expect(filterSessionsByQuery([populated, empty], "has:__proto__")).toEqual({
+      sessions: [populated, empty],
+      warnings: ["Unknown has:__proto__"],
+    });
   });
 
   it("rejects non-decimal numeric filter values", () => {
@@ -50,8 +97,8 @@ describe("usage-helpers", () => {
 
   it("warns on unknown keys and invalid numbers", () => {
     const session = { key: "a", usage: { totalTokens: 10, totalCost: 0 } };
-    const res = filterSessionsByQuery([session], "wat:1 minTokens:wat");
-    expect(res.warnings).toEqual(["Unknown filter: wat", "Invalid number for minTokens"]);
+    const res = filterSessionsByQuery([session], "__proto__:1 minTokens:wat");
+    expect(res.warnings).toEqual(["Unknown filter: __proto__", "Invalid number for minTokens"]);
   });
 
   it("parses tool summaries from compact session logs", () => {

--- a/ui/src/pages/usage/helpers.ts
+++ b/ui/src/pages/usage/helpers.ts
@@ -85,26 +85,6 @@ export function selectUsageSessionKeys(
   return selected.length === 1 && selected[0] === key ? [] : [key];
 }
 
-const QUERY_KEYS = new Set([
-  "agent",
-  "channel",
-  "chat",
-  "provider",
-  "model",
-  "tool",
-  "label",
-  "key",
-  "session",
-  "id",
-  "has",
-  "mintokens",
-  "maxtokens",
-  "mincost",
-  "maxcost",
-  "minmessages",
-  "maxmessages",
-]);
-
 const normalizeQueryText = (value: string): string => normalizeLowercaseStringOrEmpty(value);
 
 const globToRegex = (pattern: string): RegExp => {
@@ -199,6 +179,48 @@ const getSessionModels = (session: UsageSessionQueryTarget): string[] => {
 const getSessionTools = (session: UsageSessionQueryTarget): string[] =>
   (session.usage?.toolUsage?.tools ?? []).map((tool) => normalizeLowercaseStringOrEmpty(tool.name));
 
+type UsageQueryPredicate = (session: UsageSessionQueryTarget) => boolean;
+
+const HAS_PREDICATES: Readonly<Record<string, UsageQueryPredicate>> = {
+  tools: (session) => (session.usage?.toolUsage?.totalCalls ?? 0) > 0,
+  errors: (session) => (session.usage?.messageCounts?.errors ?? 0) > 0,
+  context: (session) => Boolean(session.contextWeight),
+  usage: (session) => Boolean(session.usage),
+  model: (session) => getSessionModels(session).length > 0,
+  provider: (session) => getSessionProviders(session).length > 0,
+};
+
+type NumericQuerySpec = readonly [
+  value: (session: UsageSessionQueryTarget) => number,
+  matches: (value: number, threshold: number) => boolean,
+];
+
+const atLeast = (value: number, threshold: number): boolean => value >= threshold;
+const atMost = (value: number, threshold: number): boolean => value <= threshold;
+const NUMERIC_QUERY_SPECS: Readonly<Record<string, NumericQuerySpec>> = {
+  mintokens: [(session) => session.usage?.totalTokens ?? 0, atLeast],
+  maxtokens: [(session) => session.usage?.totalTokens ?? 0, atMost],
+  mincost: [(session) => session.usage?.totalCost ?? 0, atLeast],
+  maxcost: [(session) => session.usage?.totalCost ?? 0, atMost],
+  minmessages: [(session) => session.usage?.messageCounts?.total ?? 0, atLeast],
+  maxmessages: [(session) => session.usage?.messageCounts?.total ?? 0, atMost],
+};
+
+const QUERY_KEYS = new Set([
+  "agent",
+  "channel",
+  "chat",
+  "provider",
+  "model",
+  "tool",
+  "label",
+  "key",
+  "session",
+  "id",
+  "has",
+  ...Object.keys(NUMERIC_QUERY_SPECS),
+]);
+
 const matchesUsageQuery = (session: UsageSessionQueryTarget, term: UsageQueryTerm): boolean => {
   const value = normalizeQueryText(term.value ?? "");
   if (!value) {
@@ -237,68 +259,21 @@ const matchesUsageQuery = (session: UsageSessionQueryTarget, term: UsageQueryTer
         normalizeLowercaseStringOrEmpty(session.key).includes(value) ||
         normalizeLowercaseStringOrEmpty(session.sessionId).includes(value)
       );
-    case "has":
-      switch (value) {
-        case "tools":
-          return (session.usage?.toolUsage?.totalCalls ?? 0) > 0;
-        case "errors":
-          return (session.usage?.messageCounts?.errors ?? 0) > 0;
-        case "context":
-          return Boolean(session.contextWeight);
-        case "usage":
-          return Boolean(session.usage);
-        case "model":
-          return getSessionModels(session).length > 0;
-        case "provider":
-          return getSessionProviders(session).length > 0;
-        default:
-          return true;
-      }
-    case "mintokens": {
-      const threshold = parseQueryNumber(value);
-      if (threshold === null) {
-        return true;
-      }
-      return (session.usage?.totalTokens ?? 0) >= threshold;
+    case "has": {
+      const predicate = Object.hasOwn(HAS_PREDICATES, value) ? HAS_PREDICATES[value] : undefined;
+      return predicate?.(session) ?? true;
     }
-    case "maxtokens": {
-      const threshold = parseQueryNumber(value);
-      if (threshold === null) {
-        return true;
-      }
-      return (session.usage?.totalTokens ?? 0) <= threshold;
-    }
-    case "mincost": {
-      const threshold = parseQueryNumber(value);
-      if (threshold === null) {
-        return true;
-      }
-      return (session.usage?.totalCost ?? 0) >= threshold;
-    }
-    case "maxcost": {
-      const threshold = parseQueryNumber(value);
-      if (threshold === null) {
-        return true;
-      }
-      return (session.usage?.totalCost ?? 0) <= threshold;
-    }
-    case "minmessages": {
-      const threshold = parseQueryNumber(value);
-      if (threshold === null) {
-        return true;
-      }
-      return (session.usage?.messageCounts?.total ?? 0) >= threshold;
-    }
-    case "maxmessages": {
-      const threshold = parseQueryNumber(value);
-      if (threshold === null) {
-        return true;
-      }
-      return (session.usage?.messageCounts?.total ?? 0) <= threshold;
-    }
-    default:
-      return true;
   }
+
+  const numericSpec = Object.hasOwn(NUMERIC_QUERY_SPECS, key)
+    ? NUMERIC_QUERY_SPECS[key]
+    : undefined;
+  if (!numericSpec) {
+    return true;
+  }
+  const threshold = parseQueryNumber(value);
+  const [getValue, matches] = numericSpec;
+  return threshold === null || matches(getValue(session), threshold);
 };
 
 export const filterSessionsByQuery = <TSession extends UsageSessionQueryTarget>(
@@ -323,20 +298,19 @@ export const filterSessionsByQuery = <TSession extends UsageSessionQueryTarget>(
     if (term.value === "") {
       warnings.push(`Missing value for ${term.key}`);
     }
-    if (normalizedKey === "has") {
-      const allowed = new Set(["tools", "errors", "context", "usage", "model", "provider"]);
-      if (term.value && !allowed.has(normalizeQueryText(term.value))) {
-        warnings.push(`Unknown has:${term.value}`);
-      }
+    if (
+      normalizedKey === "has" &&
+      term.value &&
+      !Object.hasOwn(HAS_PREDICATES, normalizeQueryText(term.value))
+    ) {
+      warnings.push(`Unknown has:${term.value}`);
     }
     if (
-      ["mintokens", "maxtokens", "mincost", "maxcost", "minmessages", "maxmessages"].includes(
-        normalizedKey,
-      )
+      Object.hasOwn(NUMERIC_QUERY_SPECS, normalizedKey) &&
+      term.value &&
+      parseQueryNumber(term.value) === null
     ) {
-      if (term.value && parseQueryNumber(term.value) === null) {
-        warnings.push(`Invalid number for ${term.key}`);
-      }
+      warnings.push(`Invalid number for ${term.key}`);
     }
   }
 


### PR DESCRIPTION
Related: #105392

## What Problem This Solves

The usage query helper repeated six numeric filter branches and a nested `has:` switch, then separately duplicated those accepted values during warning validation. That made adding or reviewing filters require changes across multiple decision surfaces.

## Why This Change Was Made

This centralizes `has:` predicates and numeric getter/comparator specs while leaving text and glob matching explicit. The same registries now drive matching and validation, with own-property checks protecting prototype-derived query keys. AI-assisted implementation under the maintainer-requested complexity sweep in #105392.

## User Impact

No user-visible behavior changes. Existing usage filters and warnings retain their current semantics with fewer duplicated branches.

## Evidence

- `pnpm test:serial ui/src/pages/usage/helpers.node.test.ts` on Blacksmith Testbox `tbx_01kxb8pjqpesr6yjkr7bvr5py6`: 7 tests passed
- sparse-aware `pnpm check:changed` on the same Testbox: coreTests and ui lanes passed
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29194714232
- fresh branch autoreview: clean, no accepted/actionable findings
- production delta: `ui/src/pages/usage/helpers.ts` +65/-91 (net -26 LOC)
- tests cover all numeric filters, every supported `has:` predicate, and prototype-derived keys
