### PR TITLE
refactor(cli): share precomputed help dispatch

### DIFF
--- a/src/cli/precomputed-help.ts
+++ b/src/cli/precomputed-help.ts
@@ -1,4 +1,6 @@
 import { consumeRootOptionToken } from "../infra/cli-root-options.js";
+import { getCommandPathWithRootOptions, hasFlag } from "./argv.js";
+import type { RootHelpRenderOptions } from "./program/root-help.js";
 
 export type PrecomputedSubcommandHelpName =
   | "doctor"
@@ -7,6 +9,20 @@ export type PrecomputedSubcommandHelpName =
   | "plugins"
   | "sessions"
   | "tasks";
+
+type PrecomputedCommandHelpName = "browser" | "secrets" | "nodes";
+type OutputPrecomputedHelpText = () => boolean;
+
+export type PrecomputedCommandHelpDeps = {
+  outputPrecomputedBrowserHelpText?: OutputPrecomputedHelpText;
+  outputPrecomputedSecretsHelpText?: OutputPrecomputedHelpText;
+  outputPrecomputedNodesHelpText?: OutputPrecomputedHelpText;
+  outputPrecomputedSubcommandHelpText?: (commandName: PrecomputedSubcommandHelpName) => boolean;
+  loadRootHelpRenderOptionsForConfigSensitivePlugins?: (
+    env?: NodeJS.ProcessEnv,
+  ) => Promise<RootHelpRenderOptions | null>;
+  env?: NodeJS.ProcessEnv;
+};
 
 const PRECOMPUTED_SUBCOMMAND_HELP_COMMANDS = new Set<PrecomputedSubcommandHelpName>([
   "doctor",
@@ -18,6 +34,9 @@ const PRECOMPUTED_SUBCOMMAND_HELP_COMMANDS = new Set<PrecomputedSubcommandHelpNa
 ]);
 const HELP_FLAGS = new Set(["-h", "--help"]);
 const VERSION_FLAGS = new Set(["-V", "--version"]);
+
+const loadRootHelpLiveConfigModule = async () => await import("./root-help-live-config.js");
+const loadRootHelpMetadataModule = async () => await import("./root-help-metadata.js");
 
 function isPrecomputedSubcommandHelpName(value: string): value is PrecomputedSubcommandHelpName {
   return PRECOMPUTED_SUBCOMMAND_HELP_COMMANDS.has(value as PrecomputedSubcommandHelpName);
@@ -58,4 +77,66 @@ export function resolvePrecomputedSubcommandHelpCommand(
   }
 
   return commandName && sawHelp ? commandName : null;
+}
+
+function resolvePrecomputedCommandHelpName(argv: string[]): PrecomputedCommandHelpName | null {
+  if (!hasFlag(argv, "--help") && !hasFlag(argv, "-h")) {
+    return null;
+  }
+  const commandPath = getCommandPathWithRootOptions(argv, 2);
+  if (commandPath.length !== 1) {
+    return null;
+  }
+  const [commandName] = commandPath;
+  return commandName === "browser" || commandName === "secrets" || commandName === "nodes"
+    ? commandName
+    : null;
+}
+
+export async function tryOutputPrecomputedCommandHelp(
+  argv: string[],
+  deps: PrecomputedCommandHelpDeps = {},
+): Promise<boolean> {
+  const env = deps.env ?? process.env;
+  if (env.OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH === "1") {
+    return false;
+  }
+
+  const commandName = resolvePrecomputedCommandHelpName(argv);
+  const subcommandName = commandName ? null : resolvePrecomputedSubcommandHelpCommand(argv);
+  if (subcommandName) {
+    const outputPrecomputedSubcommandHelpText =
+      deps.outputPrecomputedSubcommandHelpText ??
+      (await loadRootHelpMetadataModule()).outputPrecomputedSubcommandHelpText;
+    return outputPrecomputedSubcommandHelpText(subcommandName);
+  }
+  if (!commandName) {
+    return false;
+  }
+
+  if (commandName === "nodes") {
+    const loadRootHelpRenderOptionsForConfigSensitivePlugins =
+      deps.loadRootHelpRenderOptionsForConfigSensitivePlugins ??
+      (await loadRootHelpLiveConfigModule()).loadRootHelpRenderOptionsForConfigSensitivePlugins;
+    if (await loadRootHelpRenderOptionsForConfigSensitivePlugins(env)) {
+      return false;
+    }
+  }
+
+  if (commandName === "browser") {
+    const outputPrecomputedBrowserHelpText =
+      deps.outputPrecomputedBrowserHelpText ??
+      (await loadRootHelpMetadataModule()).outputPrecomputedBrowserHelpText;
+    return outputPrecomputedBrowserHelpText();
+  }
+  if (commandName === "secrets") {
+    const outputPrecomputedSecretsHelpText =
+      deps.outputPrecomputedSecretsHelpText ??
+      (await loadRootHelpMetadataModule()).outputPrecomputedSecretsHelpText;
+    return outputPrecomputedSecretsHelpText();
+  }
+  const outputPrecomputedNodesHelpText =
+    deps.outputPrecomputedNodesHelpText ??
+    (await loadRootHelpMetadataModule()).outputPrecomputedNodesHelpText;
+  return outputPrecomputedNodesHelpText();
 }

--- a/src/cli/run-main-policy.ts
+++ b/src/cli/run-main-policy.ts
@@ -12,13 +12,11 @@ import {
   type PluginManifestToolOwnerRecord,
 } from "../plugins/manifest-command-aliases.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
-import { hasFlag } from "./argv.js";
 import {
   resolveCliCommandPathPolicy,
   resolveCliNetworkProxyPolicy,
 } from "./command-path-policy.js";
 import { isReservedNonPluginCommandRoot } from "./command-registration-policy.js";
-import { resolvePrecomputedSubcommandHelpCommand } from "./precomputed-help.js";
 import { getCoreCliParentDefaultHelpCommands } from "./program/core-command-descriptors.js";
 import { getSubCliParentDefaultHelpCommands } from "./program/subcli-descriptors.js";
 
@@ -28,10 +26,6 @@ const BARE_PARENT_DEFAULT_HELP_COMMANDS = new Set([
   ...getCoreCliParentDefaultHelpCommands(),
   ...getSubCliParentDefaultHelpCommands(),
 ]);
-
-function hasHelpFlag(argv: string[]): boolean {
-  return hasFlag(argv, "-h") || hasFlag(argv, "--help");
-}
 
 function isBareParentDefaultHelpArgv(argv: string[]): boolean {
   const invocation = resolveCliArgvInvocation(argv);
@@ -82,51 +76,6 @@ export function shouldUseRootHelpFastPath(
   );
 }
 
-export function shouldUseBrowserHelpFastPath(
-  argv: string[],
-  env: NodeJS.ProcessEnv = process.env,
-): boolean {
-  if (env.OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH === "1") {
-    return false;
-  }
-  const invocation = resolveCliArgvInvocation(argv);
-  return (
-    invocation.commandPath.length === 1 &&
-    invocation.commandPath[0] === "browser" &&
-    hasHelpFlag(argv)
-  );
-}
-
-export function shouldUseSecretsHelpFastPath(
-  argv: string[],
-  env: NodeJS.ProcessEnv = process.env,
-): boolean {
-  if (env.OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH === "1") {
-    return false;
-  }
-  const invocation = resolveCliArgvInvocation(argv);
-  return (
-    invocation.commandPath.length === 1 &&
-    invocation.commandPath[0] === "secrets" &&
-    hasHelpFlag(argv)
-  );
-}
-
-export function shouldUseNodesHelpFastPath(
-  argv: string[],
-  env: NodeJS.ProcessEnv = process.env,
-): boolean {
-  if (env.OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH === "1") {
-    return false;
-  }
-  const invocation = resolveCliArgvInvocation(argv);
-  return (
-    invocation.commandPath.length === 1 &&
-    invocation.commandPath[0] === "nodes" &&
-    hasHelpFlag(argv)
-  );
-}
-
 export function shouldUseSetupOnboardConfigureHelpFastPath(
   argv: string[],
   env: NodeJS.ProcessEnv = process.env,
@@ -140,16 +89,6 @@ export function shouldUseSetupOnboardConfigureHelpFastPath(
     SETUP_ONBOARD_CONFIGURE_HELP_COMMANDS.has(invocation.commandPath[0] ?? "") &&
     invocation.hasHelpOrVersion
   );
-}
-
-export function resolvePrecomputedSubcommandHelpFastPath(
-  argv: string[],
-  env: NodeJS.ProcessEnv = process.env,
-): string | null {
-  if (env.OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH === "1") {
-    return null;
-  }
-  return resolvePrecomputedSubcommandHelpCommand(argv);
 }
 
 export function shouldHandleBareRoot(argv: string[]): boolean {

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -2029,6 +2029,26 @@ describe("runCli exit behavior", () => {
     expect(closeActiveMemorySearchManagersMock).not.toHaveBeenCalled();
   });
 
+  it("propagates precomputed help metadata failures", async () => {
+    outputPrecomputedSecretsHelpTextMock.mockImplementationOnce(() => {
+      throw new Error("startup metadata failed");
+    });
+
+    await expect(runCli(["node", "openclaw", "secrets", "--help"])).rejects.toThrow(
+      "startup metadata failed",
+    );
+  });
+
+  it("propagates nodes live-config probe failures", async () => {
+    loadRootHelpRenderOptionsForConfigSensitivePluginsMock.mockRejectedValueOnce(
+      new Error("live config failed"),
+    );
+
+    await expect(runCli(["node", "openclaw", "nodes", "--help"])).rejects.toThrow(
+      "live config failed",
+    );
+  });
+
   it("keeps root help on the precomputed path without proxy bootstrap", async () => {
     outputPrecomputedRootHelpTextMock.mockReturnValueOnce(true);
 

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -2,17 +2,14 @@
 import { describe, expect, it } from "vitest";
 import type { PluginManifestCommandAliasRegistry } from "../plugins/manifest-command-aliases.js";
 import { resolveGatewayRunPreBootstrapOptions } from "./gateway-run-argv.js";
+import { resolvePrecomputedSubcommandHelpCommand } from "./precomputed-help.js";
 import {
-  resolvePrecomputedSubcommandHelpFastPath,
   rewriteUpdateFlagArgv,
   resolveMissingPluginCommandMessage,
   shouldHandleBareRoot,
   shouldEnsureCliPath,
   shouldStartProxyForCli,
-  shouldUseBrowserHelpFastPath,
-  shouldUseNodesHelpFastPath,
   shouldUseRootHelpFastPath,
-  shouldUseSecretsHelpFastPath,
   shouldUseSetupOnboardConfigureHelpFastPath,
 } from "./run-main-policy.js";
 import { isGatewayRunFastPathArgv } from "./run-main.js";
@@ -207,40 +204,6 @@ describe("shouldUseRootHelpFastPath", () => {
   });
 });
 
-describe("shouldUseBrowserHelpFastPath", () => {
-  it("uses the fast path for browser command help only", () => {
-    expect(shouldUseBrowserHelpFastPath(["node", "openclaw", "browser", "--help"])).toBe(true);
-    expect(shouldUseBrowserHelpFastPath(["node", "openclaw", "browser", "-h"])).toBe(true);
-    expect(
-      shouldUseBrowserHelpFastPath(["node", "openclaw", "--profile", "work", "browser", "-h"]),
-    ).toBe(true);
-    expect(shouldUseBrowserHelpFastPath(["node", "openclaw", "browser", "status", "--help"])).toBe(
-      false,
-    );
-    expect(shouldUseBrowserHelpFastPath(["node", "openclaw", "browser", "--version"])).toBe(false);
-    expect(shouldUseBrowserHelpFastPath(["node", "openclaw", "status", "--help"])).toBe(false);
-    expect(shouldUseBrowserHelpFastPath(["node", "openclaw", "browser", "--version"])).toBe(false);
-  });
-});
-
-describe("parent command help fast paths", () => {
-  it("use fast paths for secrets and nodes parent help only", () => {
-    expect(shouldUseSecretsHelpFastPath(["node", "openclaw", "secrets", "--help"])).toBe(true);
-    expect(shouldUseSecretsHelpFastPath(["node", "openclaw", "secrets", "-h"])).toBe(true);
-    expect(shouldUseSecretsHelpFastPath(["node", "openclaw", "secrets", "--version"])).toBe(false);
-    expect(shouldUseSecretsHelpFastPath(["node", "openclaw", "secrets", "audit", "--help"])).toBe(
-      false,
-    );
-
-    expect(shouldUseNodesHelpFastPath(["node", "openclaw", "nodes", "--help"])).toBe(true);
-    expect(shouldUseNodesHelpFastPath(["node", "openclaw", "nodes", "-h"])).toBe(true);
-    expect(shouldUseNodesHelpFastPath(["node", "openclaw", "nodes", "--version"])).toBe(false);
-    expect(shouldUseNodesHelpFastPath(["node", "openclaw", "nodes", "invoke", "--help"])).toBe(
-      false,
-    );
-  });
-});
-
 describe("shouldUseSetupOnboardConfigureHelpFastPath", () => {
   it("uses the fast path only for setup, onboard, and configure help", () => {
     expect(
@@ -274,16 +237,16 @@ describe("shouldUseSetupOnboardConfigureHelpFastPath", () => {
   });
 });
 
-describe("resolvePrecomputedSubcommandHelpFastPath", () => {
-  it("uses the fast path only for allowlisted parent command help", () => {
-    expect(resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "doctor", "--help"])).toBe(
+describe("resolvePrecomputedSubcommandHelpCommand", () => {
+  it("matches only strict allowlisted parent command help", () => {
+    expect(resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "doctor", "--help"])).toBe(
       "doctor",
     );
-    expect(resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "gateway", "-h"])).toBe(
+    expect(resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "gateway", "-h"])).toBe(
       "gateway",
     );
     expect(
-      resolvePrecomputedSubcommandHelpFastPath([
+      resolvePrecomputedSubcommandHelpCommand([
         "node",
         "openclaw",
         "--profile",
@@ -293,23 +256,23 @@ describe("resolvePrecomputedSubcommandHelpFastPath", () => {
         "-h",
       ]),
     ).toBe("models");
+    expect(resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "plugins", "--help"])).toBe(
+      "plugins",
+    );
     expect(
-      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "plugins", "--help"]),
-    ).toBe("plugins");
-    expect(
-      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "sessions", "--help"]),
+      resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "sessions", "--help"]),
     ).toBe("sessions");
-    expect(resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "tasks", "-h"])).toBe(
+    expect(resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "tasks", "-h"])).toBe(
       "tasks",
     );
     expect(
-      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "doctor", "--version"]),
+      resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "doctor", "--version"]),
     ).toBeNull();
     expect(
-      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "gateway", "-V"]),
+      resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "gateway", "-V"]),
     ).toBeNull();
     expect(
-      resolvePrecomputedSubcommandHelpFastPath([
+      resolvePrecomputedSubcommandHelpCommand([
         "node",
         "openclaw",
         "doctor",
@@ -318,27 +281,22 @@ describe("resolvePrecomputedSubcommandHelpFastPath", () => {
       ]),
     ).toBeNull();
     expect(
-      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "doctor", "--version", "-h"]),
+      resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "doctor", "--version", "-h"]),
     ).toBeNull();
     expect(
-      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "--bogus", "doctor", "--help"]),
+      resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "--bogus", "doctor", "--help"]),
     ).toBeNull();
     expect(
-      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "doctor", "--help", "--bogus"]),
+      resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "doctor", "--help", "--bogus"]),
     ).toBeNull();
     expect(
-      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "doctor", "--help", "extra"]),
+      resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "doctor", "--help", "extra"]),
     ).toBeNull();
     expect(
-      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "gateway", "status", "--help"]),
+      resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "gateway", "status", "--help"]),
     ).toBeNull();
     expect(
-      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "status", "--help"]),
-    ).toBeNull();
-    expect(
-      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "doctor", "--help"], {
-        OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH: "1",
-      }),
+      resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "status", "--help"]),
     ).toBeNull();
   });
 });

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -35,21 +35,18 @@ import {
 } from "./gateway-run-argv.js";
 import { hasJsonOutputFlag, withConsoleLogsRoutedToStderrForJson } from "./json-output-mode.js";
 import { flushExitAfterOneShotOutput } from "./one-shot-exit.js";
+import { tryOutputPrecomputedCommandHelp } from "./precomputed-help.js";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./profile.js";
 import { formatCliCommandSuggestions } from "./program/command-suggestions.js";
 import { getCoreCliCommandNames } from "./program/core-command-descriptors.js";
 import { getSubCliEntries } from "./program/subcli-descriptors.js";
 import {
-  resolvePrecomputedSubcommandHelpFastPath,
   resolveMissingPluginCommandMessage as resolveMissingPluginCommandMessageFromPolicy,
   rewriteUpdateFlagArgv,
   shouldHandleBareRoot,
   shouldEnsureCliPath,
   shouldStartProxyForCli,
-  shouldUseBrowserHelpFastPath,
-  shouldUseNodesHelpFastPath,
   shouldUseRootHelpFastPath,
-  shouldUseSecretsHelpFastPath,
   shouldUseSetupOnboardConfigureHelpFastPath,
 } from "./run-main-policy.js";
 import { registerSignalExitBarrier, waitForSignalExitBarriers } from "./signal-exit-barrier.js";
@@ -57,15 +54,11 @@ import { createGatewayStartupTrace } from "./startup-trace.js";
 import { normalizeWindowsArgv } from "./windows-argv.js";
 
 export {
-  resolvePrecomputedSubcommandHelpFastPath,
   rewriteUpdateFlagArgv,
   shouldHandleBareRoot,
   shouldEnsureCliPath,
   shouldStartProxyForCli,
-  shouldUseBrowserHelpFastPath,
-  shouldUseNodesHelpFastPath,
   shouldUseRootHelpFastPath,
-  shouldUseSecretsHelpFastPath,
   shouldUseSetupOnboardConfigureHelpFastPath,
 } from "./run-main-policy.js";
 
@@ -1136,11 +1129,8 @@ export async function runCli(argv: string[] = process.argv) {
       return;
     }
 
-    if (shouldUseBrowserHelpFastPath(normalizedArgv)) {
-      const { outputPrecomputedBrowserHelpText } = await loadRootHelpMetadataModule();
-      if (outputPrecomputedBrowserHelpText()) {
-        return;
-      }
+    if (await tryOutputPrecomputedCommandHelp(normalizedArgv)) {
+      return;
     }
 
     if (shouldUseSetupOnboardConfigureHelpFastPath(normalizedArgv)) {
@@ -1148,35 +1138,6 @@ export async function runCli(argv: string[] = process.argv) {
         await import("./setup-onboard-configure-help-fast-path.js");
       if (await tryOutputSetupOnboardConfigureHelp(normalizedArgv)) {
         return;
-      }
-    }
-
-    if (shouldUseSecretsHelpFastPath(normalizedArgv)) {
-      const { outputPrecomputedSecretsHelpText } = await loadRootHelpMetadataModule();
-      if (outputPrecomputedSecretsHelpText()) {
-        return;
-      }
-    }
-
-    const precomputedSubcommandHelp = resolvePrecomputedSubcommandHelpFastPath(normalizedArgv);
-    if (precomputedSubcommandHelp) {
-      const { outputPrecomputedSubcommandHelpText } = await loadRootHelpMetadataModule();
-      if (outputPrecomputedSubcommandHelpText(precomputedSubcommandHelp)) {
-        return;
-      }
-    }
-
-    if (shouldUseNodesHelpFastPath(normalizedArgv)) {
-      const { loadRootHelpRenderOptionsForConfigSensitivePlugins } =
-        await loadRootHelpLiveConfigModule();
-      const liveRootHelpOptions = await loadRootHelpRenderOptionsForConfigSensitivePlugins(
-        process.env,
-      );
-      if (!liveRootHelpOptions) {
-        const { outputPrecomputedNodesHelpText } = await loadRootHelpMetadataModule();
-        if (outputPrecomputedNodesHelpText()) {
-          return;
-        }
       }
     }
 

--- a/src/entry.test.ts
+++ b/src/entry.test.ts
@@ -253,6 +253,34 @@ describe("entry precomputed command help fast path", () => {
     expect(handled).toBe(false);
   });
 
+  it("falls through when startup metadata loading fails", async () => {
+    const handled = await tryHandlePrecomputedCommandHelpFastPath(
+      ["node", "openclaw", "secrets", "--help"],
+      {
+        env: {},
+        outputPrecomputedSecretsHelpText: () => {
+          throw new Error("startup metadata failed");
+        },
+      },
+    );
+
+    expect(handled).toBe(false);
+  });
+
+  it("falls through when the nodes live-config probe fails", async () => {
+    const handled = await tryHandlePrecomputedCommandHelpFastPath(
+      ["node", "openclaw", "nodes", "--help"],
+      {
+        env: {},
+        loadRootHelpRenderOptionsForConfigSensitivePlugins: async () => {
+          throw new Error("live config failed");
+        },
+      },
+    );
+
+    expect(handled).toBe(false);
+  });
+
   it("ignores nested subcommand help invocations", async () => {
     let outputPrecomputedNodesHelpTextCalls = 0;
 

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -3,11 +3,11 @@
 // CLI process entrypoint for OpenClaw command execution.
 import process from "node:process";
 import { fileURLToPath } from "node:url";
-import { getCommandPathWithRootOptions, hasFlag, isRootHelpInvocation } from "./cli/argv.js";
+import { isRootHelpInvocation } from "./cli/argv.js";
 import { parseCliContainerArgs, resolveCliContainerTarget } from "./cli/container-target.js";
 import {
-  resolvePrecomputedSubcommandHelpCommand,
-  type PrecomputedSubcommandHelpName,
+  tryOutputPrecomputedCommandHelp,
+  type PrecomputedCommandHelpDeps,
 } from "./cli/precomputed-help.js";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./cli/profile.js";
 import type { RootHelpRenderOptions } from "./cli/program/root-help.js";
@@ -29,9 +29,6 @@ const ENTRY_WRAPPER_PAIRS = [
   { wrapperBasename: "openclaw.mjs", entryBasename: "entry.js" },
   { wrapperBasename: "openclaw.js", entryBasename: "entry.js" },
 ] as const;
-
-type PrecomputedCommandHelpName = "browser" | "secrets" | "nodes";
-type OutputPrecomputedHelpText = () => boolean;
 
 const loadRootHelpLiveConfigModule = async () => await import("./cli/root-help-live-config.js");
 const loadRootHelpMetadataModule = async () => await import("./cli/root-help-metadata.js");
@@ -184,85 +181,17 @@ export async function tryHandleRootHelpFastPath(
   }
 }
 
-function resolvePrecomputedCommandHelpName(argv: string[]): PrecomputedCommandHelpName | null {
-  if (!hasFlag(argv, "--help") && !hasFlag(argv, "-h")) {
-    return null;
-  }
-  const commandPath = getCommandPathWithRootOptions(argv, 2);
-  if (commandPath.length !== 1) {
-    return null;
-  }
-  const [commandName] = commandPath;
-  if (commandName === "browser" || commandName === "secrets" || commandName === "nodes") {
-    return commandName;
-  }
-  return null;
-}
-
-function resolvePrecomputedSubcommandHelpName(
-  argv: string[],
-): PrecomputedSubcommandHelpName | null {
-  return resolvePrecomputedSubcommandHelpCommand(argv);
-}
-
 export async function tryHandlePrecomputedCommandHelpFastPath(
   argv: string[],
-  deps: {
-    outputPrecomputedBrowserHelpText?: OutputPrecomputedHelpText;
-    outputPrecomputedSecretsHelpText?: OutputPrecomputedHelpText;
-    outputPrecomputedNodesHelpText?: OutputPrecomputedHelpText;
-    outputPrecomputedSubcommandHelpText?: (commandName: string) => boolean;
-    loadRootHelpRenderOptionsForConfigSensitivePlugins?: (
-      env?: NodeJS.ProcessEnv,
-    ) => Promise<RootHelpRenderOptions | null>;
-    env?: NodeJS.ProcessEnv;
-  } = {},
+  deps: PrecomputedCommandHelpDeps = {},
 ): Promise<boolean> {
   const env = deps.env ?? process.env;
-  if (env.OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH === "1") {
-    return false;
-  }
   if (resolveCliContainerTarget(argv, env)) {
-    return false;
-  }
-  const commandName = resolvePrecomputedCommandHelpName(argv);
-  const subcommandName = commandName ? null : resolvePrecomputedSubcommandHelpName(argv);
-  if (!commandName && !subcommandName) {
     return false;
   }
 
   try {
-    if (subcommandName) {
-      const outputPrecomputedSubcommandHelpText =
-        deps.outputPrecomputedSubcommandHelpText ??
-        (await loadRootHelpMetadataModule()).outputPrecomputedSubcommandHelpText;
-      return outputPrecomputedSubcommandHelpText(subcommandName);
-    }
-    if (commandName === "nodes") {
-      const loadRootHelpRenderOptionsForConfigSensitivePlugins =
-        deps.loadRootHelpRenderOptionsForConfigSensitivePlugins ??
-        (await loadRootHelpLiveConfigModule()).loadRootHelpRenderOptionsForConfigSensitivePlugins;
-      const liveRootHelpOptions = await loadRootHelpRenderOptionsForConfigSensitivePlugins(env);
-      if (liveRootHelpOptions) {
-        return false;
-      }
-    }
-    if (commandName === "browser") {
-      const outputPrecomputedBrowserHelpText =
-        deps.outputPrecomputedBrowserHelpText ??
-        (await loadRootHelpMetadataModule()).outputPrecomputedBrowserHelpText;
-      return outputPrecomputedBrowserHelpText();
-    }
-    if (commandName === "secrets") {
-      const outputPrecomputedSecretsHelpText =
-        deps.outputPrecomputedSecretsHelpText ??
-        (await loadRootHelpMetadataModule()).outputPrecomputedSecretsHelpText;
-      return outputPrecomputedSecretsHelpText();
-    }
-    const outputPrecomputedNodesHelpText =
-      deps.outputPrecomputedNodesHelpText ??
-      (await loadRootHelpMetadataModule()).outputPrecomputedNodesHelpText;
-    return outputPrecomputedNodesHelpText();
+    return await tryOutputPrecomputedCommandHelp(argv, { ...deps, env });
   } catch {
     return false;
   }


### PR DESCRIPTION
Related: #105392

## What Problem This Solves

CLI startup duplicated precomputed browser, secrets, nodes, and subcommand help dispatch across the lightweight process entry and the full `runCli` path. Policy and error semantics therefore had to be maintained in several helpers and two callers.

## Why This Change Was Made

This moves only the shared precomputed dispatch into `precomputed-help.ts`. Entry retains its container guard and fail-open fallback; `runCli` retains error propagation; nodes still defers when live plugin config changes command metadata; root and setup/onboard/configure help remain separate. AI-assisted implementation under the maintainer-requested complexity sweep in #105392.

## User Impact

No user-visible behavior changes. CLI help startup follows the same fast paths and fallback rules with one canonical command dispatch path.

## Evidence

- focused entry/run-main tests on Blacksmith Testbox `tbx_01kxb8pxczp7feeb2kswe4absp`: 224 tests passed across 3 files
- sparse-aware `pnpm check:changed` on the same Testbox: core and coreTests lanes passed
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29194720088
- fresh branch autoreview: clean, no accepted/actionable findings
- production delta: +89/-179 (net -90 LOC); total diff +157/-241 (net -84 LOC)
