### PR TITLE
fix(clawhub): restore bounded promotions refresh and lint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,7 @@ Skills own workflows; root owns hard policy and routing.
 - Base/head changed: stop and rewarm Testbox; never override stale lease checks.
 - Compound Testbox commands: `bash -lc`, never `sh -lc`; job env uses Bash `declare`.
 - Testbox cleanup: `blacksmith testbox stop --id <tbx_id>`; id is not positional.
+- Delegated Testbox runs reject `--stop-after`; lifecycle is workflow-owned.
 - PR review artifacts: keep template enum values; put evidence detail in summaries.
 - Crabbox request means real scenario proof: install/update/call/repro user path; not just copy tests and run them remotely.
 - Visual proof: use Crabbox, set up like a user, then screenshot-verify. No harness/bypass/shortcut unless explicitly asked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ Skills own workflows; root owns hard policy and routing.
 - Base/head changed: stop and rewarm Testbox; never override stale lease checks.
 - Compound Testbox commands: `bash -lc`, never `sh -lc`; job env uses Bash `declare`.
 - Testbox cleanup: `blacksmith testbox stop --id <tbx_id>`; id is not positional.
-- Delegated Testbox runs reject `--stop-after`; lifecycle is workflow-owned.
+- Delegated Testbox rejects `--fresh-pr` and `--stop-after`; sync current checkout, workflow owns lifecycle.
 - PR review artifacts: keep template enum values; put evidence detail in summaries.
 - Crabbox request means real scenario proof: install/update/call/repro user path; not just copy tests and run them remotely.
 - Visual proof: use Crabbox, set up like a user, then screenshot-verify. No harness/bypass/shortcut unless explicitly asked.

--- a/scripts/lib/plugin-clawhub-release.ts
+++ b/scripts/lib/plugin-clawhub-release.ts
@@ -215,7 +215,7 @@ async function buildClawHubQueryError(
   request: Awaited<ReturnType<typeof fetchClawHubRequest>>,
 ): Promise<Error> {
   const { response } = request;
-  let body = "";
+  let body: string;
   try {
     body = (
       await readBoundedResponseText(response, message, CLAWHUB_ERROR_BODY_MAX_BYTES, {

--- a/src/infra/clawhub.promotions.test.ts
+++ b/src/infra/clawhub.promotions.test.ts
@@ -190,4 +190,12 @@ describe("fetchClawHubPromotionsFeed", () => {
     const init = fetchImpl.mock.calls[0]?.[1] as RequestInit;
     expect(new Headers(init?.headers).get("if-none-match")).toBe('"seq-3"');
   });
+
+  it("does not extend the interactive feed timeout with transient retries", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("offline"));
+
+    await expect(fetchClawHubPromotionsFeed({ fetchImpl })).rejects.toThrow("offline");
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -424,6 +424,7 @@ type ClawHubRequestParams = {
   search?: Record<string, string | undefined>;
   fetchImpl?: FetchLike;
   skipAuth?: boolean;
+  retryTransientReads?: boolean;
   headers?: Record<string, string>;
 };
 
@@ -729,7 +730,7 @@ async function clawhubRequest(
 
   // A write may have committed before its response failed, so only replay
   // idempotent reads across transient ClawHub transport failures.
-  if ((params.method ?? "GET") !== "GET") {
+  if ((params.method ?? "GET") !== "GET" || params.retryTransientReads === false) {
     return await request();
   }
   return await retryClawHubRead(request, {
@@ -1967,6 +1968,9 @@ export async function fetchClawHubPromotionsFeed(
     path: "/api/v1/feeds/promotions",
     timeoutMs: params.timeoutMs,
     fetchImpl: params.fetchImpl,
+    // This passive refresh runs inline from interactive commands. Its cache
+    // cadence owns retries; shared backoff would turn the 2.5s cap into ~24s.
+    retryTransientReads: false,
     // Public CDN-served snapshot; an Authorization header would only
     // fragment edge caches.
     skipAuth: true,


### PR DESCRIPTION
## What Problem This Solves

Current `main` has two deterministic gate failures introduced by the same ClawHub retry change:

1. `pnpm lint` rejects an overwritten query-error body initializer.
2. The promotions feed's interactive 2.5-second request cap is multiplied by shared transient retries, causing an extra fetch and compact-shard failure.

This PR combines the two already-proven fixes to break their circular exact-head CI dependency. It supersedes #105417 while preserving that commit's history.

## Why This Change Was Made

- Declare the query-error `body` without a useless initializer; both control-flow branches assign before use.
- Add a request-level `retryTransientReads` choice and disable shared retries only for the passive promotions feed. Its cache cadence remains the retry owner, preserving bounded interactive latency.
- Record the delegated Testbox invocation contract discovered during proof: it syncs the current checkout and rejects `--fresh-pr`/`--stop-after`.

## User Impact

Promotions refresh failures return within the existing interactive timeout instead of expanding to roughly 24 seconds through shared backoff. Other idempotent ClawHub reads retain transient retries. Release-prep lint and compact test gates are restored.

## Evidence

- Original lint failure: https://github.com/openclaw/openclaw/actions/runs/29194644458/job/86655376935
- Lint Testbox `tbx_01kxb9azkznpw2dbsj6a456kwk`: targeted oxlint passed with 0 warnings/errors; https://github.com/openclaw/openclaw/actions/runs/29195052529
- Promotions Testbox: 32/32 focused tests green; https://github.com/openclaw/openclaw/actions/runs/29194972006
- Promotions exact compact shard green on #105417: https://github.com/openclaw/openclaw/actions/runs/29195180764/job/86656811613
- Fresh combined-diff autoreview: clean; no accepted/actionable findings.
- Combined exact-head CI will be required before `scripts/pr` landing.
