### PR TITLE
refactor(google-meet): remove obsolete Chrome testing alias

### DIFF
--- a/extensions/google-meet/src/transports/chrome.ts
+++ b/extensions/google-meet/src/transports/chrome.ts
@@ -1727,4 +1727,3 @@ export async function launchChromeMeetOnNode(params: {
     tab: browserControl.tab,
   };
 }
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

The Google Meet Chrome transport retained an obsolete `__testing` export after its test helpers moved to the canonical `testing` name. The duplicate internal surface had no repository consumer and made the transport's test boundary needlessly ambiguous.

## Why This Change Was Made

Remove only the unreferenced transport-level alias while keeping the canonical `testing` object and all runtime exports unchanged. The separately deprecated alias on the plugin entrypoint is intentionally untouched.

## User Impact

No user-visible or runtime behavior changes. This reduces dead internal API surface in the Google Meet plugin.

## Evidence

- Codebase-memory graph: 305,236 nodes / 1,263,652 edges. `testing.setDepsForTest` resolves as the active test seam; the transport `__testing` alias has no graph node or repository consumer.
- History: the alias was introduced by the May 18, 2026 lint rename in `4f4d108639`, not as a documented compatibility contract.
- Before and after on Testbox `tbx_01kxb94nqqctn9a5pydp1cxffh`: `corepack pnpm test:serial extensions/google-meet/src/transports/chrome.test.ts extensions/google-meet/index.test.ts` (147/147 tests passed both times).
- `corepack pnpm check:changed -- extensions/google-meet/src/transports/chrome.ts` passed on the same Testbox.
- Fresh `gpt-5.6-sol` medium autoreview: clean, no findings, patch correct (0.93 confidence).
- Live overlap delta: 78 open PRs updated since the earlier full sweep were checked; none touch `extensions/google-meet/src/transports/chrome.ts`.
