### PR TITLE
fix(clawhub): bound promotions feed refresh latency

### DIFF
--- a/scripts/lib/plugin-clawhub-release.ts
+++ b/scripts/lib/plugin-clawhub-release.ts
@@ -215,7 +215,7 @@ async function buildClawHubQueryError(
   request: Awaited<ReturnType<typeof fetchClawHubRequest>>,
 ): Promise<Error> {
   const { response } = request;
-  let body = "";
+  let body: string;
   try {
     body = (
       await readBoundedResponseText(response, message, CLAWHUB_ERROR_BODY_MAX_BYTES, {

--- a/src/infra/clawhub.promotions.test.ts
+++ b/src/infra/clawhub.promotions.test.ts
@@ -190,4 +190,12 @@ describe("fetchClawHubPromotionsFeed", () => {
     const init = fetchImpl.mock.calls[0]?.[1] as RequestInit;
     expect(new Headers(init?.headers).get("if-none-match")).toBe('"seq-3"');
   });
+
+  it("does not extend the interactive feed timeout with transient retries", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("offline"));
+
+    await expect(fetchClawHubPromotionsFeed({ fetchImpl })).rejects.toThrow("offline");
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -424,6 +424,7 @@ type ClawHubRequestParams = {
   search?: Record<string, string | undefined>;
   fetchImpl?: FetchLike;
   skipAuth?: boolean;
+  retryTransientReads?: boolean;
   headers?: Record<string, string>;
 };
 
@@ -729,7 +730,7 @@ async function clawhubRequest(
 
   // A write may have committed before its response failed, so only replay
   // idempotent reads across transient ClawHub transport failures.
-  if ((params.method ?? "GET") !== "GET") {
+  if ((params.method ?? "GET") !== "GET" || params.retryTransientReads === false) {
     return await request();
   }
   return await retryClawHubRead(request, {
@@ -1967,6 +1968,9 @@ export async function fetchClawHubPromotionsFeed(
     path: "/api/v1/feeds/promotions",
     timeoutMs: params.timeoutMs,
     fetchImpl: params.fetchImpl,
+    // This passive refresh runs inline from interactive commands. Its cache
+    // cadence owns retries; shared backoff would turn the 2.5s cap into ~24s.
+    retryTransientReads: false,
     // Public CDN-served snapshot; an Authorization header would only
     // fragment edge caches.
     skipAuth: true,


### PR DESCRIPTION
## What Problem This Solves

ClawHub transient-read retries added by #105388 also applied to the passive promotions feed. That feed refresh runs inline from interactive commands and has a deliberate 2.5-second timeout, but the shared retry schedule could extend an offline refresh to roughly 24 seconds. The stale single-failure test setup exposed this as repeated `expected fetch 2, got 3` failures across current-main CI.

The same current-main stack also introduced a script lint failure in `plugin-clawhub-release.ts`. The canonical one-line correction from #105411 is stacked as a separate commit so one exact-head run can prove both mutually blocking fixes.

## Why This Change Was Made

Keep shared retry behavior for normal idempotent ClawHub reads, while giving the internal request helper a narrow opt-out for the passive promotions feed. Its existing daily/expiry cache cadence remains the retry owner, so failed refreshes stay fail-silent and interactive commands retain their bounded latency.

The lint commit removes only an initializer overwritten in both the `try` and `catch` branches; runtime error behavior is unchanged.

## User Impact

Offline or unavailable ClawHub promotions no longer make interactive model-list commands wait through the shared retry backoff. Package, skill, install, and release reads retain transient recovery.

## Evidence

- Blacksmith Testbox `tbx_01kxb8rrvz5wkb3xtcqn2k5j31`: 29/29 focused promotion tests passed.
- Previous Blacksmith Testbox run: https://github.com/openclaw/openclaw/actions/runs/29194972006
- Focused promotion, retry, and cache tests passed before the lint prerequisite was stacked.
- Independent autoreview: promotion fix clean at 0.97 confidence; lint fix clean at 0.98 confidence.
- `git diff --check` passed for the combined two-commit stack.
- Exact-head hosted CI is running on `13e349cb8fa52e828cea356af55b69a4e81def76`.
