### PR TITLE
fix(clawhub): keep promotions refresh single-attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **ClawHub promotions refresh:** keep passive promotion checks single-attempt so offline or degraded feeds do not inherit package-read backoff, while preserving transient retries for package and skill reads. (#105420)
 - **iOS Watch relay commands:** allow paired iPhone nodes to advertise and invoke `watch.status` and `watch.notify` through the default Gateway policy while preserving the direct watchOS node's fixed minimal command surface.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **ClawHub promotions refresh:** keep passive promotion checks single-attempt so offline or degraded feeds do not inherit package-read backoff, while preserving transient retries for package and skill reads. (#105420)
 - **iOS Watch relay commands:** allow paired iPhone nodes to advertise and invoke `watch.status` and `watch.notify` through the default Gateway policy while preserving the direct watchOS node's fixed minimal command surface.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.

--- a/extensions/browser/src/browser/routes/agent.existing-session.test.ts
+++ b/extensions/browser/src/browser/routes/agent.existing-session.test.ts
@@ -10,6 +10,7 @@ import { createBrowserRouteApp, createBrowserRouteResponse } from "./test-helper
 const routeState = existingSessionRouteState;
 
 const chromeMcpMocks = vi.hoisted(() => ({
+  ChromeMcpDocumentUnavailableError: class ChromeMcpDocumentUnavailableError extends Error {},
   clickChromeMcpCoords: vi.fn(async () => {}),
   clickChromeMcpElement: vi.fn(async () => {}),
   evaluateChromeMcpScript: vi.fn(
@@ -24,6 +25,10 @@ const chromeMcpMocks = vi.hoisted(() => ({
     name: "Example",
     children: [{ id: "btn-1", role: "button", name: "Continue" }],
   })),
+  withChromeMcpDocument: vi.fn(
+    async (_params: unknown, task: (document: { evaluate: (fn: string) => unknown }) => unknown) =>
+      await task({ evaluate: async () => "https://example.com/" }),
+  ),
 }));
 
 const navigationGuardMocks = vi.hoisted(() => ({
@@ -33,6 +38,7 @@ const navigationGuardMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../chrome-mcp.js", () => ({
+  ChromeMcpDocumentUnavailableError: chromeMcpMocks.ChromeMcpDocumentUnavailableError,
   clickChromeMcpCoords: chromeMcpMocks.clickChromeMcpCoords,
   clickChromeMcpElement: chromeMcpMocks.clickChromeMcpElement,
   closeChromeMcpTab: vi.fn(async () => {}),
@@ -46,6 +52,7 @@ vi.mock("../chrome-mcp.js", () => ({
   resizeChromeMcpPage: vi.fn(async () => {}),
   takeChromeMcpScreenshot: chromeMcpMocks.takeChromeMcpScreenshot,
   takeChromeMcpSnapshot: chromeMcpMocks.takeChromeMcpSnapshot,
+  withChromeMcpDocument: chromeMcpMocks.withChromeMcpDocument,
 }));
 
 vi.mock("../cdp.js", () => ({
@@ -153,6 +160,7 @@ describe("existing-session browser routes", () => {
     chromeMcpMocks.navigateChromeMcpPage.mockClear();
     chromeMcpMocks.takeChromeMcpScreenshot.mockClear();
     chromeMcpMocks.takeChromeMcpSnapshot.mockClear();
+    chromeMcpMocks.withChromeMcpDocument.mockClear();
     navigationGuardMocks.assertBrowserNavigationAllowed.mockClear();
     navigationGuardMocks.assertBrowserNavigationResultAllowed.mockClear();
     navigationGuardMocks.withBrowserNavigationPolicy.mockClear();
@@ -454,10 +462,9 @@ describe("existing-session browser routes", () => {
   });
 
   it("supports glob URL waits for existing-session profiles", async () => {
-    chromeMcpMocks.evaluateChromeMcpScript.mockReset();
-    chromeMcpMocks.evaluateChromeMcpScript.mockImplementation(
-      async ({ fn }: { fn: string }) =>
-        (fn === "() => window.location.href" ? "https://example.com/" : true) as never,
+    const evaluate = vi.fn(async (_fn: string) => "https://example.com/");
+    chromeMcpMocks.withChromeMcpDocument.mockImplementationOnce(
+      async (_params, task) => await task({ evaluate }),
     );
 
     const handler = getActPostHandler();
@@ -475,15 +482,16 @@ describe("existing-session browser routes", () => {
     const body = requireRecord(response.body, "response body");
     expect(body.ok).toBe(true);
     expect(body.targetId).toBe("7");
-    const evaluateParams = requireRecord(
-      callArg(chromeMcpMocks.evaluateChromeMcpScript, 0, 0, "evaluate params"),
-      "evaluate params",
+    const documentParams = requireRecord(
+      callArg(chromeMcpMocks.withChromeMcpDocument, 0, 0, "document params"),
+      "document params",
     );
-    expect(evaluateParams.profileName).toBe("chrome-live");
-    expectExistingSessionProfile(evaluateParams.profile);
-    expect(evaluateParams.userDataDir).toBeUndefined();
-    expect(evaluateParams.targetId).toBe("7");
-    expect(evaluateParams.fn).toBe("() => window.location.href");
+    expect(documentParams.profileName).toBe("chrome-live");
+    expectExistingSessionProfile(documentParams.profile);
+    expect(documentParams.userDataDir).toBeUndefined();
+    expect(documentParams.targetId).toBe("7");
+    expect(evaluate).toHaveBeenCalledOnce();
+    expect(String(evaluate.mock.calls[0]?.[0])).toContain("globalThis.location.href");
   });
 
   it("forwards click timeoutMs to the existing-session click executor", async () => {

--- a/extensions/google-meet/src/transports/chrome.ts
+++ b/extensions/google-meet/src/transports/chrome.ts
@@ -1727,4 +1727,3 @@ export async function launchChromeMeetOnNode(params: {
     tab: browserControl.tab,
   };
 }
-export { testing as __testing };

--- a/src/infra/clawhub.promotions.test.ts
+++ b/src/infra/clawhub.promotions.test.ts
@@ -190,4 +190,13 @@ describe("fetchClawHubPromotionsFeed", () => {
     const init = fetchImpl.mock.calls[0]?.[1] as RequestInit;
     expect(new Headers(init?.headers).get("if-none-match")).toBe('"seq-3"');
   });
+
+  it("leaves transport retry cadence to the passive feed cache", async () => {
+    const fetchImpl = vi.fn(async (..._args: unknown[]) => {
+      throw new Error("offline");
+    });
+
+    await expect(fetchClawHubPromotionsFeed({ fetchImpl })).rejects.toThrow("offline");
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
 });

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -424,6 +424,7 @@ type ClawHubRequestParams = {
   search?: Record<string, string | undefined>;
   fetchImpl?: FetchLike;
   skipAuth?: boolean;
+  retry?: boolean;
   headers?: Record<string, string>;
 };
 
@@ -729,7 +730,7 @@ async function clawhubRequest(
 
   // A write may have committed before its response failed, so only replay
   // idempotent reads across transient ClawHub transport failures.
-  if ((params.method ?? "GET") !== "GET") {
+  if ((params.method ?? "GET") !== "GET" || params.retry === false) {
     return await request();
   }
   return await retryClawHubRead(request, {
@@ -1970,6 +1971,8 @@ export async function fetchClawHubPromotionsFeed(
     // Public CDN-served snapshot; an Authorization header would only
     // fragment edge caches.
     skipAuth: true,
+    // Passive checks run inline; caller cadence owns retries so commands never inherit package-read backoff.
+    retry: false,
     ...(params.etag ? { headers: { "If-None-Match": params.etag } } : {}),
   });
   if (response.status === 304) {


### PR DESCRIPTION
## What Problem This Solves

The new shared ClawHub GET retry policy also reached the passive promotions feed. Its refresh runs inline from interactive commands and already has a cache-owned daily/expiry cadence plus a 2.5-second request deadline; inheriting package-read backoffs repeats failed requests and can stall the command path. The existing focused regression now fails because one expiry refresh performs three transport calls.

## Why This Change Was Made

Keep retries enabled by default for idempotent ClawHub package reads, while allowing the internal request owner to opt out. The promotions feed uses that opt-out so its cache remains the sole retry owner. A direct fetch test locks the single-attempt contract, while the cache test proves a failed expiry refresh remains hidden and cadence-gated.

The same landing head also repairs the independent browser existing-session test baseline that blocked the full suite after evaluation moved behind the document owner. The test now supplies `withChromeMcpDocument` and a typed evaluator mock through the production-owned seam; browser production behavior is unchanged. This consolidates the two mutually blocking current-main gate repairs into one exact-head landing.

## User Impact

Offline or degraded ClawHub promotion checks fail silently after one bounded attempt instead of inheriting package-read backoff. Plugin/package reads retain their bounded transient retries.

## Evidence

- Current `main` reproduction: Testbox `tbx_01kxb9bpbeg4x2120x0zpvkejz`, Actions 29195063769; `promotions-feed.test.ts` failed because one expiry refresh made three fetch calls.
- Fixed Testbox `tbx_01kxb9gh936x0zh9grh7fp6cx0`, Actions 29195150082: 32/32 passed across `promotions-feed.test.ts`, `clawhub.promotions.test.ts`, and `clawhub-retry.test.ts`.
- Browser Testbox `tbx_01kxb8aadn58x7vtgqdpv32qep`, Actions 29194501382: 44/44 existing-session tests passed.
- Browser changed-file Testbox `tbx_01kxb8y8gyfext77nftr4e2wq0`, Actions 29194842577: format, extension test typecheck, and lint passed.
- `oxfmt --check src/infra/clawhub.ts src/infra/clawhub.promotions.test.ts`
- `git diff --check`
- Fresh combined-branch autoreview: clean, 0.98 confidence; no accepted/actionable findings.
