### PR TITLE
fix(ui): prevent cron edits from being lost during save

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,7 @@ Skills own workflows; root owns hard policy and routing.
 - Base/head changed: stop and rewarm Testbox; never override stale lease checks.
 - Compound Testbox commands: `bash -lc`, never `sh -lc`; job env uses Bash `declare`.
 - Testbox cleanup: `blacksmith testbox stop --id <tbx_id>`; id is not positional.
+- Delegated Testbox rejects `--fresh-pr` and `--stop-after`; sync current checkout, workflow owns lifecycle.
 - PR review artifacts: keep template enum values; put evidence detail in summaries.
 - Crabbox request means real scenario proof: install/update/call/repro user path; not just copy tests and run them remotely.
 - Visual proof: use Crabbox, set up like a user, then screenshot-verify. No harness/bypass/shortcut unless explicitly asked.

--- a/extensions/elevenlabs/realtime-transcription-provider.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.ts
@@ -296,4 +296,3 @@ export const testing = {
   normalizeProviderConfig,
   toElevenLabsRealtimeWsUrl,
 };
-export { testing as __testing };

--- a/extensions/google-meet/src/transports/chrome.ts
+++ b/extensions/google-meet/src/transports/chrome.ts
@@ -1727,4 +1727,3 @@ export async function launchChromeMeetOnNode(params: {
     tab: browserControl.tab,
   };
 }
-export { testing as __testing };

--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -152,4 +152,3 @@ export const testing = {
   resolveGeminiModel,
   withGoogleModelProviderFallbacks,
 } as const;
-export { testing as __testing };

--- a/extensions/meta/stream.ts
+++ b/extensions/meta/stream.ts
@@ -18,7 +18,7 @@ function ensureMetaResponsesReplayFields(payloadObj: Record<string, unknown>): v
   payloadObj.store = false;
 }
 
-export function createMetaResponsesWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+function createMetaResponsesWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) =>
     streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {

--- a/extensions/mistral/realtime-transcription-provider.ts
+++ b/extensions/mistral/realtime-transcription-provider.ts
@@ -276,4 +276,3 @@ export const testing = {
   normalizeProviderConfig,
   toMistralRealtimeWsUrl,
 };
-export { testing as __testing };

--- a/scripts/lib/plugin-clawhub-release.ts
+++ b/scripts/lib/plugin-clawhub-release.ts
@@ -215,7 +215,7 @@ async function buildClawHubQueryError(
   request: Awaited<ReturnType<typeof fetchClawHubRequest>>,
 ): Promise<Error> {
   const { response } = request;
-  let body = "";
+  let body: string;
   try {
     body = (
       await readBoundedResponseText(response, message, CLAWHUB_ERROR_BODY_MAX_BYTES, {

--- a/src/commands/doctor-session-sqlite-migration-run.ts
+++ b/src/commands/doctor-session-sqlite-migration-run.ts
@@ -803,7 +803,7 @@ function hasUnsupportedV1DirectorySymlink(manifest: SessionSqliteMigrationManife
   });
 }
 
-function canonicalMigrationFilePath(filePath: string): string {
+export function canonicalMigrationFilePath(filePath: string): string {
   const resolvedPath = path.resolve(filePath);
   const fileName = path.basename(resolvedPath);
   const directoryPath = path.dirname(resolvedPath);

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -47,6 +47,9 @@ const previousEnv = {
 const lexicalTempDir = path.resolve(os.tmpdir());
 const realTempDir = fs.realpathSync.native(os.tmpdir());
 const hasPlatformTempAlias = lexicalTempDir !== realTempDir;
+const lexicalRootTempDir = path.resolve("/tmp");
+const realRootTempDir = canonicalTestPath(lexicalRootTempDir);
+const hasPlatformRootTempAlias = lexicalRootTempDir !== realRootTempDir;
 
 beforeEach(() => {
   closeOpenClawAgentDatabasesForTest();
@@ -1002,7 +1005,7 @@ describe("runDoctorSessionSqlite", () => {
       const outsideDir = path.join(store.tempDir, "outside", "nested");
       const outsideArchivePath = path.join(path.dirname(outsideDir), "payload.jsonl");
       const traversalArchivePath = path.join(archiveDir, "escape", "..", "payload.jsonl");
-      const sourcePath = path.join(store.sessionDir, "payload.jsonl");
+      const sourcePath = path.join(canonicalTestPath(store.sessionDir), "payload.jsonl");
       fs.mkdirSync(outsideDir, { recursive: true });
       fs.symlinkSync(outsideDir, path.join(archiveDir, "escape"));
       fs.writeFileSync(outsideArchivePath, '{"type":"outside"}\n', { mode: 0o600 });
@@ -1064,6 +1067,30 @@ describe("runDoctorSessionSqlite", () => {
       expect(restore.conflicts).toEqual([]);
       expect(restore.restoredFiles).toContain(canonicalTestPath(store.transcriptPath));
       expect(fs.existsSync(store.transcriptPath)).toBe(true);
+    },
+  );
+
+  it.skipIf(!hasPlatformRootTempAlias)(
+    "imports a legacy store written through a platform root alias",
+    async () => {
+      const store = createLegacyStore({ tempRoot: lexicalRootTempDir });
+
+      const report = await runDoctorSessionSqlite({
+        env: store.env,
+        mode: "import",
+        store: store.storePath,
+      });
+
+      expect(report.totals).toMatchObject({ importedEntries: 1, issues: 0 });
+      const manifest = readMigrationManifest(report.migrationRun?.manifestPath);
+      expect(manifest.targets[0]?.storePath).toBe(
+        path.join(realRootTempDir, path.relative(lexicalRootTempDir, store.storePath)),
+      );
+      expect(
+        manifest.targets[0]?.completedMoves.every((move) =>
+          move.sourcePath.startsWith(realRootTempDir + path.sep),
+        ),
+      ).toBe(true);
     },
   );
 
@@ -2288,10 +2315,13 @@ function createLegacyStore(
     agentDirName?: string;
     customStore?: boolean;
     entryOverrides?: Record<string, unknown>;
+    tempRoot?: string;
     transcriptLines?: string[];
   } = {},
 ): TestStore {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-session-sqlite-"));
+  const tempDir = fs.mkdtempSync(
+    path.join(params.tempRoot ?? os.tmpdir(), "openclaw-doctor-session-sqlite-"),
+  );
   const stateDir = path.join(tempDir, "state");
   const configPath = path.join(tempDir, "openclaw.json");
   const sessionDir = params.customStore

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -28,6 +28,7 @@ import { compactDoctorSessionSqliteTarget } from "./doctor-session-sqlite-compac
 import {
   assertSafeSessionSqliteMigrationDirectory,
   assertSafeSessionSqliteMigrationMove,
+  canonicalMigrationFilePath,
   createSessionSqliteMigrationRun,
   recordCompletedMigrationMove,
   recordCompletedMigrationMoves,
@@ -1173,8 +1174,8 @@ function canonicalFilePath(filePath: string): string {
 function createMigrationTargetInput(target: SessionStoreTarget): SessionSqliteMigrationTargetInput {
   return {
     agentId: target.agentId,
-    sqlitePath: resolveTargetSqlitePath(target),
-    storePath: target.storePath,
+    sqlitePath: canonicalMigrationFilePath(resolveTargetSqlitePath(target)),
+    storePath: canonicalMigrationFilePath(target.storePath),
   };
 }
 

--- a/src/commands/doctor-state-sqlite-compact.ts
+++ b/src/commands/doctor-state-sqlite-compact.ts
@@ -1,14 +1,9 @@
 /** Explicit doctor maintenance for the canonical shared state SQLite database. */
 import fs from "node:fs";
-import type { DatabaseSync } from "node:sqlite";
 import {
-  createNewerSqliteSchemaVersionError,
-  readSqliteUserVersion,
-} from "../infra/sqlite-user-version.js";
-import {
+  assertOpenClawStateDatabaseForMaintenance,
   ensureOpenClawStatePermissions,
   isOpenClawStateDatabaseOpen,
-  OPENCLAW_STATE_SCHEMA_VERSION,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import {
@@ -65,7 +60,8 @@ export function runDoctorStateSqliteCompact(
   const compact = compactDoctorSqliteFile({
     afterMutation: () => ensureOpenClawStatePermissions(sqlitePath, env),
     sqlitePath,
-    validateBeforeMutation: (database) => validateCanonicalStateDatabase(database, sqlitePath),
+    validateBeforeMutation: (database) =>
+      assertOpenClawStateDatabaseForMaintenance(database, { pathname: sqlitePath }),
   });
   return {
     ...compact,
@@ -83,39 +79,5 @@ function readCanonicalStateDatabaseStat(sqlitePath: string): fs.Stats | undefine
       return undefined;
     }
     throw error;
-  }
-}
-
-function validateCanonicalStateDatabase(database: DatabaseSync, sqlitePath: string): void {
-  const userVersion = readSqliteUserVersion(database);
-  if (userVersion > OPENCLAW_STATE_SCHEMA_VERSION) {
-    throw createNewerSqliteSchemaVersionError(
-      "OpenClaw state database",
-      sqlitePath,
-      userVersion,
-      OPENCLAW_STATE_SCHEMA_VERSION,
-    );
-  }
-  if (userVersion !== OPENCLAW_STATE_SCHEMA_VERSION) {
-    throw new Error(
-      `OpenClaw state database ${sqlitePath} uses schema version ${userVersion}; run openclaw doctor --fix before compacting it.`,
-    );
-  }
-
-  const metadata = database
-    .prepare("SELECT role, schema_version FROM schema_meta WHERE meta_key = 'primary' LIMIT 1")
-    .get() as { role?: unknown; schema_version?: unknown } | undefined;
-  if (metadata?.role !== "global") {
-    const role = typeof metadata?.role === "string" ? metadata.role : "missing";
-    throw new Error(
-      `OpenClaw state database ${sqlitePath} has schema role ${role}; expected global.`,
-    );
-  }
-  if (metadata.schema_version !== OPENCLAW_STATE_SCHEMA_VERSION) {
-    const schemaVersion =
-      typeof metadata.schema_version === "number" ? metadata.schema_version : "invalid";
-    throw new Error(
-      `OpenClaw state database ${sqlitePath} metadata schema version ${schemaVersion} does not match ${OPENCLAW_STATE_SCHEMA_VERSION}; run openclaw doctor --fix before compacting it.`,
-    );
   }
 }

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -7,7 +7,6 @@ import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { pipeline } from "node:stream/promises";
 import { resolveDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
-import { loadSqliteVecExtension } from "../../packages/memory-host-sdk/src/engine-storage.js";
 import {
   buildBackupArchiveBasename,
   buildBackupArchivePath,
@@ -24,8 +23,7 @@ import { resolveRuntimeServiceVersion } from "../version.js";
 import { isVolatileBackupPath } from "./backup-volatile-filter.js";
 import { formatErrorMessage } from "./errors.js";
 import { writeJson } from "./json-files.js";
-import { requireNodeSqlite } from "./node-sqlite.js";
-import { assertSqliteIntegrity } from "./sqlite-integrity.js";
+import { createVerifiedSqliteSnapshot } from "./sqlite-snapshot.js";
 
 const loadTarRuntime = createLazyRuntimeModule(() => import("tar"));
 
@@ -631,7 +629,6 @@ function tableExistsSql(db: DatabaseSync, tableName: string): boolean {
 function sanitizeGlobalStateSqliteSnapshot(db: DatabaseSync): void {
   if (tableExistsSql(db, "delivery_queue_entries")) {
     db.prepare("DELETE FROM delivery_queue_entries").run();
-    db.exec("VACUUM;");
   }
 }
 
@@ -738,7 +735,6 @@ async function createStateSqliteBackupPlan(params: {
     stateDir: params.stateDir,
     globalStateSqlitePath,
   });
-  const sqlite = requireNodeSqlite();
   const snapshots: SqliteBackupAsset[] = [];
   for (const archiveSourcePath of discovery.snapshotPaths) {
     // A discovered *.sqlite file that SQLite cannot snapshot aborts backup.
@@ -749,44 +745,21 @@ async function createStateSqliteBackupPlan(params: {
       path.resolve(archiveSourcePath) === globalStateSqlitePath
         ? await fs.realpath(archiveSourcePath)
         : archiveSourcePath;
-    const source = new sqlite.DatabaseSync(sourceDatabasePath, {
-      allowExtension: true,
-      readOnly: true,
-    });
     const sourcePath = path.join(params.tempDir, `openclaw-state-db-${snapshots.length}.sqlite`);
     try {
-      source.exec("PRAGMA busy_timeout = 30000;");
-      try {
-        // VACUUM INTO removes deleted-page remnants before the snapshot enters
-        // the archive. Load known bundled extensions, but fail closed when an
-        // owner schema needs capabilities core cannot safely reproduce.
-        await loadSqliteVecExtension({ db: source });
-        assertSqliteIntegrity(source, archiveSourcePath);
-        source.prepare("VACUUM INTO ?").run(sourcePath);
-      } catch (err) {
-        throw new Error(
-          `SQLite database cannot be compacted safely for backup: ${archiveSourcePath}. ${formatErrorMessage(err)}. The source must pass full integrity checks and VACUUM INTO with its required SQLite capabilities; raw page backup was refused because it can retain deleted data.`,
-          { cause: err },
-        );
-      }
-    } finally {
-      source.close();
-    }
-    await fs.chmod(sourcePath, 0o600);
-    const snapshot = new sqlite.DatabaseSync(sourcePath, { allowExtension: true });
-    try {
-      await loadSqliteVecExtension({ db: snapshot });
-      if (path.resolve(archiveSourcePath) === globalStateSqlitePath) {
-        sanitizeGlobalStateSqliteSnapshot(snapshot);
-      }
-      assertSqliteIntegrity(snapshot, sourcePath);
+      await createVerifiedSqliteSnapshot({
+        sourcePath: sourceDatabasePath,
+        targetPath: sourcePath,
+        transform:
+          path.resolve(archiveSourcePath) === globalStateSqlitePath
+            ? sanitizeGlobalStateSqliteSnapshot
+            : undefined,
+      });
     } catch (err) {
       throw new Error(
-        `SQLite backup snapshot failed verification for ${archiveSourcePath}: ${formatErrorMessage(err)}`,
+        `SQLite database cannot be compacted safely for backup: ${archiveSourcePath}. ${formatErrorMessage(err)}. The source must pass full integrity checks and VACUUM INTO with its required SQLite capabilities; raw page backup was refused because it can retain deleted data.`,
         { cause: err },
       );
-    } finally {
-      snapshot.close();
     }
     snapshots.push({
       sourcePath,

--- a/src/infra/clawhub.promotions.test.ts
+++ b/src/infra/clawhub.promotions.test.ts
@@ -190,4 +190,12 @@ describe("fetchClawHubPromotionsFeed", () => {
     const init = fetchImpl.mock.calls[0]?.[1] as RequestInit;
     expect(new Headers(init?.headers).get("if-none-match")).toBe('"seq-3"');
   });
+
+  it("does not extend the interactive feed timeout with transient retries", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("offline"));
+
+    await expect(fetchClawHubPromotionsFeed({ fetchImpl })).rejects.toThrow("offline");
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -424,6 +424,7 @@ type ClawHubRequestParams = {
   search?: Record<string, string | undefined>;
   fetchImpl?: FetchLike;
   skipAuth?: boolean;
+  retryTransientReads?: boolean;
   headers?: Record<string, string>;
 };
 
@@ -729,7 +730,7 @@ async function clawhubRequest(
 
   // A write may have committed before its response failed, so only replay
   // idempotent reads across transient ClawHub transport failures.
-  if ((params.method ?? "GET") !== "GET") {
+  if ((params.method ?? "GET") !== "GET" || params.retryTransientReads === false) {
     return await request();
   }
   return await retryClawHubRead(request, {
@@ -1967,6 +1968,9 @@ export async function fetchClawHubPromotionsFeed(
     path: "/api/v1/feeds/promotions",
     timeoutMs: params.timeoutMs,
     fetchImpl: params.fetchImpl,
+    // This passive refresh runs inline from interactive commands. Its cache
+    // cadence owns retries; shared backoff would turn the 2.5s cap into ~24s.
+    retryTransientReads: false,
     // Public CDN-served snapshot; an Authorization header would only
     // fragment edge caches.
     skipAuth: true,

--- a/src/infra/sqlite-snapshot.test.ts
+++ b/src/infra/sqlite-snapshot.test.ts
@@ -1,0 +1,271 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { requireNodeSqlite } from "./node-sqlite.js";
+import { createVerifiedSqliteSnapshot } from "./sqlite-snapshot.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sqlite-snapshot-"));
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((tempDir) => fs.rm(tempDir, { recursive: true })));
+});
+
+function createUnsafeIndexDrift(sqlitePath: string): void {
+  const sqlite = requireNodeSqlite();
+  const database = new sqlite.DatabaseSync(sqlitePath);
+  try {
+    database.exec(`
+      CREATE TABLE records (
+        id INTEGER PRIMARY KEY,
+        indexed_value TEXT NOT NULL,
+        alternate_value TEXT NOT NULL
+      );
+      CREATE INDEX records_value ON records(indexed_value);
+      INSERT INTO records (indexed_value, alternate_value)
+      VALUES ('alpha', 'zeta'), ('beta', 'eta'), ('gamma', 'theta');
+    `);
+    database.enableDefensive?.(false);
+    database.exec("PRAGMA writable_schema = ON;");
+    database
+      .prepare(
+        "UPDATE sqlite_schema SET sql = 'CREATE INDEX records_value ON records(alternate_value)' WHERE name = 'records_value'",
+      )
+      .run();
+    const schemaVersion = Number(
+      Object.values(database.prepare("PRAGMA schema_version;").get() as Record<string, unknown>)[0],
+    );
+    database.exec(`PRAGMA writable_schema = OFF; PRAGMA schema_version = ${schemaVersion + 1};`);
+  } finally {
+    database.close();
+  }
+}
+
+describe("createVerifiedSqliteSnapshot", () => {
+  it("captures committed WAL state and removes deleted page contents", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const deletedValue = `deleted-secret-${"x".repeat(256)}`;
+    const sqlite = requireNodeSqlite();
+    const source = new sqlite.DatabaseSync(sourcePath);
+    try {
+      source.exec(`
+        PRAGMA journal_mode = WAL;
+        PRAGMA wal_autocheckpoint = 0;
+        PRAGMA secure_delete = OFF;
+        CREATE TABLE records (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+        PRAGMA wal_checkpoint(TRUNCATE);
+      `);
+      source.prepare("INSERT INTO records (value) VALUES (?)").run("survivor");
+      source.prepare("INSERT INTO records (value) VALUES (?)").run(deletedValue);
+      source.prepare("DELETE FROM records WHERE value = ?").run(deletedValue);
+
+      const result = await createVerifiedSqliteSnapshot({ sourcePath, targetPath });
+      expect(result).toEqual({ path: targetPath, userVersion: 0 });
+      expect((await fs.readFile(targetPath)).includes(deletedValue)).toBe(false);
+
+      const snapshot = new sqlite.DatabaseSync(targetPath, { readOnly: true });
+      try {
+        expect(snapshot.prepare("SELECT value FROM records").all()).toEqual([
+          { value: "survivor" },
+        ]);
+      } finally {
+        snapshot.close();
+      }
+    } finally {
+      source.close();
+    }
+  });
+
+  it("rejects unsafe index drift and removes the failed target", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    createUnsafeIndexDrift(sourcePath);
+
+    await expect(createVerifiedSqliteSnapshot({ sourcePath, targetPath })).rejects.toThrow(
+      /integrity_check failed|malformed database schema/iu,
+    );
+    await expect(fs.access(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects an existing target without modifying it", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const sqlite = requireNodeSqlite();
+    new sqlite.DatabaseSync(sourcePath).close();
+    await fs.writeFile(targetPath, "keep");
+
+    await expect(createVerifiedSqliteSnapshot({ sourcePath, targetPath })).rejects.toThrow(
+      /target already exists/u,
+    );
+    await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("keep");
+  });
+
+  it("preserves a target created while the snapshot is being prepared", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const sqlite = requireNodeSqlite();
+    new sqlite.DatabaseSync(sourcePath).close();
+
+    await expect(
+      createVerifiedSqliteSnapshot({
+        sourcePath,
+        targetPath,
+        transform: async () => {
+          await fs.writeFile(targetPath, "racer");
+        },
+      }),
+    ).rejects.toThrow(/EEXIST|already exists/iu);
+    await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("racer");
+  });
+
+  it("preserves a target replaced after hard-link publication", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const sqlite = requireNodeSqlite();
+    new sqlite.DatabaseSync(sourcePath).close();
+    const originalLink = fs.link.bind(fs);
+    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (source, target) => {
+      await originalLink(source, target);
+      await fs.unlink(target);
+      await fs.writeFile(target, "racer");
+    });
+
+    try {
+      await expect(createVerifiedSqliteSnapshot({ sourcePath, targetPath })).rejects.toThrow(
+        /target changed during publication/u,
+      );
+      await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("racer");
+    } finally {
+      linkSpy.mockRestore();
+    }
+  });
+
+  it("rejects a target replaced after exclusive-copy publication", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const sqlite = requireNodeSqlite();
+    new sqlite.DatabaseSync(sourcePath).close();
+    const originalOpen = fs.open.bind(fs);
+    const linkSpy = vi.spyOn(fs, "link").mockRejectedValue(
+      Object.assign(new Error("hard links unsupported"), {
+        code: "EPERM",
+      }),
+    );
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      const handle = await originalOpen(filePath, flags, mode);
+      if (path.resolve(String(filePath)) === targetPath && flags === "wx+") {
+        const originalSync = handle.sync.bind(handle);
+        vi.spyOn(handle, "sync").mockImplementationOnce(async () => {
+          await originalSync();
+          await fs.unlink(targetPath);
+          await fs.writeFile(targetPath, "racer");
+        });
+      }
+      return handle;
+    });
+
+    try {
+      await expect(createVerifiedSqliteSnapshot({ sourcePath, targetPath })).rejects.toThrow(
+        /target changed during publication/u,
+      );
+      await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("racer");
+    } finally {
+      openSpy.mockRestore();
+      linkSpy.mockRestore();
+    }
+  });
+
+  it("syncs fallback copies before reporting success", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const sqlite = requireNodeSqlite();
+    new sqlite.DatabaseSync(sourcePath).close();
+    const originalOpen = fs.open.bind(fs);
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(originalOpen);
+    const linkSpy = vi.spyOn(fs, "link").mockRejectedValue(
+      Object.assign(new Error("hard links unsupported"), {
+        code: "EPERM",
+      }),
+    );
+
+    try {
+      await createVerifiedSqliteSnapshot({ sourcePath, targetPath });
+      expect(
+        openSpy.mock.calls.some(([filePath]) => path.resolve(String(filePath)) === targetPath),
+      ).toBe(true);
+    } finally {
+      linkSpy.mockRestore();
+      openSpy.mockRestore();
+    }
+  });
+
+  it("removes its published target when final directory sync fails", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const sqlite = requireNodeSqlite();
+    new sqlite.DatabaseSync(sourcePath).close();
+    const originalOpen = fs.open.bind(fs);
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      if (path.resolve(String(filePath)) === tempDir) {
+        throw Object.assign(new Error("directory sync failed"), { code: "EIO" });
+      }
+      return await originalOpen(filePath, flags, mode);
+    });
+
+    try {
+      await expect(createVerifiedSqliteSnapshot({ sourcePath, targetPath })).rejects.toThrow(
+        /directory sync failed/u,
+      );
+      await expect(fs.access(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
+  it("validates both the source and transformed snapshot", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const removedValue = `removed-secret-${"x".repeat(256)}`;
+    const sqlite = requireNodeSqlite();
+    const source = new sqlite.DatabaseSync(sourcePath);
+    source.exec("PRAGMA secure_delete = OFF; CREATE TABLE records (value TEXT NOT NULL);");
+    source.prepare("INSERT INTO records VALUES (?)").run(removedValue);
+    source.close();
+    const labels: string[] = [];
+
+    await createVerifiedSqliteSnapshot({
+      sourcePath,
+      targetPath,
+      transform: (database) => {
+        database.exec("DELETE FROM records;");
+        database.prepare("INSERT INTO records VALUES (?)").run("new");
+      },
+      validate: (_database, label) => labels.push(label),
+    });
+
+    expect(labels).toEqual([sourcePath, targetPath]);
+    expect((await fs.readFile(targetPath)).includes(removedValue)).toBe(false);
+    const snapshot = new sqlite.DatabaseSync(targetPath, { readOnly: true });
+    try {
+      expect(snapshot.prepare("SELECT value FROM records").get()).toEqual({ value: "new" });
+    } finally {
+      snapshot.close();
+    }
+  });
+});

--- a/src/infra/sqlite-snapshot.ts
+++ b/src/infra/sqlite-snapshot.ts
@@ -1,0 +1,268 @@
+// Creates compact SQLite snapshots only after verifying both source and output.
+import type { Stats } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { loadSqliteVecExtension } from "../../packages/memory-host-sdk/src/engine-storage.js";
+import { formatErrorMessage } from "./errors.js";
+import { sameFileIdentity } from "./fs-safe-advanced.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+import { assertSqliteIntegrity } from "./sqlite-integrity.js";
+import { readSqliteUserVersion } from "./sqlite-user-version.js";
+
+export type SqliteSnapshotValidator = (database: DatabaseSync, databaseLabel: string) => void;
+
+export type CreateVerifiedSqliteSnapshotOptions = {
+  sourcePath: string;
+  targetPath: string;
+  transform?: (database: DatabaseSync) => void | Promise<void>;
+  validate?: SqliteSnapshotValidator;
+};
+
+export type VerifiedSqliteSnapshot = {
+  path: string;
+  userVersion: number;
+};
+
+async function assertRegularSourceFile(sourcePath: string): Promise<void> {
+  const stat = await fs.lstat(sourcePath);
+  if (!stat.isFile()) {
+    throw new Error(`SQLite snapshot source must be a regular file: ${sourcePath}`);
+  }
+}
+
+async function assertTargetAbsent(targetPath: string): Promise<void> {
+  try {
+    await fs.lstat(targetPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+  throw new Error(`SQLite snapshot target already exists: ${targetPath}`);
+}
+
+function isLinkFallbackError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return (
+    code === "EPERM" ||
+    code === "EXDEV" ||
+    code === "ENOTSUP" ||
+    code === "EOPNOTSUPP" ||
+    code === "ENOSYS"
+  );
+}
+
+async function publishSnapshotNoOverwrite(
+  stagedPath: string,
+  targetPath: string,
+  stagedIdentity: Stats,
+): Promise<Stats> {
+  try {
+    await fs.link(stagedPath, targetPath);
+    return stagedIdentity;
+  } catch (error) {
+    if (!isLinkFallbackError(error)) {
+      throw error;
+    }
+    return await copyFileExclusive(stagedPath, targetPath);
+  }
+}
+
+async function copyFileExclusive(sourcePath: string, targetPath: string): Promise<Stats> {
+  const source = await fs.open(sourcePath, "r");
+  let target: Awaited<ReturnType<typeof fs.open>> | undefined;
+  let targetIdentity: Stats | undefined;
+  try {
+    target = await fs.open(targetPath, "wx+", 0o600);
+    targetIdentity = await target.stat();
+    const buffer = Buffer.allocUnsafe(1024 * 1024);
+    let offset = 0;
+    while (true) {
+      const { bytesRead } = await source.read(buffer, 0, buffer.length, offset);
+      if (bytesRead === 0) {
+        break;
+      }
+      let bytesWritten = 0;
+      while (bytesWritten < bytesRead) {
+        const result = await target.write(
+          buffer,
+          bytesWritten,
+          bytesRead - bytesWritten,
+          offset + bytesWritten,
+        );
+        if (result.bytesWritten === 0) {
+          throw new Error(`SQLite snapshot copy made no progress: ${targetPath}`);
+        }
+        bytesWritten += result.bytesWritten;
+      }
+      offset += bytesRead;
+    }
+    await target.sync();
+    return targetIdentity;
+  } catch (error) {
+    if (targetIdentity) {
+      await target?.close().catch(() => undefined);
+      target = undefined;
+      await removePublishedTargetIfOwned(targetPath, targetIdentity);
+    }
+    throw error;
+  } finally {
+    await target?.close().catch(() => undefined);
+    await source.close().catch(() => undefined);
+  }
+}
+
+async function syncFile(filePath: string): Promise<void> {
+  const handle = await fs.open(filePath, "r+");
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function syncPublishedFile(filePath: string, expectedIdentity: Stats): Promise<void> {
+  const handle = await fs.open(filePath, "r+");
+  try {
+    const openedIdentity = await handle.stat();
+    if (!sameFileIdentity(expectedIdentity, openedIdentity)) {
+      throw new Error(`SQLite snapshot target changed before sync: ${filePath}`);
+    }
+    await handle.sync();
+    const currentIdentity = await fs.lstat(filePath);
+    if (!sameFileIdentity(expectedIdentity, currentIdentity)) {
+      throw new Error(`SQLite snapshot target changed during sync: ${filePath}`);
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
+async function removePublishedTargetIfOwned(
+  filePath: string,
+  expectedIdentity: Stats,
+): Promise<void> {
+  const currentIdentity = await fs.lstat(filePath).catch(() => undefined);
+  if (currentIdentity && sameFileIdentity(expectedIdentity, currentIdentity)) {
+    await fs.unlink(filePath).catch(() => undefined);
+  }
+}
+
+function isUnsupportedDirectorySyncError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return (
+    code === "EINVAL" ||
+    code === "ENOTSUP" ||
+    code === "ENOSYS" ||
+    (process.platform === "win32" && (code === "EISDIR" || code === "EPERM" || code === "EACCES"))
+  );
+}
+
+async function syncDirectoryBestEffort(directoryPath: string): Promise<void> {
+  const handle = await fs.open(directoryPath, "r").catch((error: unknown) => {
+    if (isUnsupportedDirectorySyncError(error)) {
+      return undefined;
+    }
+    throw error;
+  });
+  if (!handle) {
+    return;
+  }
+  try {
+    await handle.sync();
+  } catch (error) {
+    if (!isUnsupportedDirectorySyncError(error)) {
+      throw error;
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Compact one SQLite database into a fresh private file and verify the result.
+ *
+ * The source and output both receive full structural, index, and foreign-key
+ * checks. Only a fully verified, synced snapshot is published to the target.
+ */
+export async function createVerifiedSqliteSnapshot(
+  options: CreateVerifiedSqliteSnapshotOptions,
+): Promise<VerifiedSqliteSnapshot> {
+  await assertRegularSourceFile(options.sourcePath);
+  await assertTargetAbsent(options.targetPath);
+
+  const stagingDir = await fs.mkdtemp(
+    path.join(path.dirname(options.targetPath), ".sqlite-snapshot-"),
+  );
+  await fs.chmod(stagingDir, 0o700);
+  const stagedPath = path.join(stagingDir, "database.sqlite");
+  const sqlite = requireNodeSqlite();
+  let stagedIdentity: Stats | undefined;
+  let publishedIdentity: Stats | undefined;
+  try {
+    const source = new sqlite.DatabaseSync(options.sourcePath, {
+      allowExtension: true,
+      readOnly: true,
+    });
+    try {
+      source.exec("PRAGMA busy_timeout = 30000; PRAGMA trusted_schema = OFF;");
+      await loadSqliteVecExtension({ db: source });
+      assertSqliteIntegrity(source, options.sourcePath);
+      options.validate?.(source, options.sourcePath);
+      source.prepare("VACUUM INTO ?").run(stagedPath);
+    } finally {
+      source.close();
+    }
+
+    await fs.chmod(stagedPath, 0o600);
+    const snapshot = new sqlite.DatabaseSync(stagedPath, { allowExtension: true });
+    try {
+      snapshot.exec("PRAGMA busy_timeout = 30000; PRAGMA trusted_schema = OFF;");
+      await loadSqliteVecExtension({ db: snapshot });
+      if (options.transform) {
+        await options.transform(snapshot);
+        // A transform may delete sensitive rows. Compact again so the
+        // published artifact cannot retain their bytes in free pages.
+        snapshot.exec("VACUUM;");
+      }
+      assertSqliteIntegrity(snapshot, options.targetPath);
+      options.validate?.(snapshot, options.targetPath);
+      const userVersion = readSqliteUserVersion(snapshot);
+      snapshot.close();
+      await syncFile(stagedPath);
+      stagedIdentity = await fs.lstat(stagedPath);
+      publishedIdentity = await publishSnapshotNoOverwrite(
+        stagedPath,
+        options.targetPath,
+        stagedIdentity,
+      );
+      const currentIdentity = await fs.lstat(options.targetPath);
+      if (!currentIdentity.isFile()) {
+        throw new Error(`SQLite snapshot target is not a regular file: ${options.targetPath}`);
+      }
+      if (!sameFileIdentity(publishedIdentity, currentIdentity)) {
+        throw new Error(`SQLite snapshot target changed during publication: ${options.targetPath}`);
+      }
+      await syncPublishedFile(options.targetPath, publishedIdentity);
+      await syncDirectoryBestEffort(path.dirname(options.targetPath));
+      return { path: options.targetPath, userVersion };
+    } finally {
+      if (snapshot.isOpen) {
+        snapshot.close();
+      }
+    }
+  } catch (error) {
+    const ownedIdentity = publishedIdentity ?? stagedIdentity;
+    if (ownedIdentity) {
+      await removePublishedTargetIfOwned(options.targetPath, ownedIdentity);
+    }
+    throw new Error(
+      `SQLite database cannot be snapshotted safely: ${options.sourcePath}. ${formatErrorMessage(error)}`,
+      { cause: error },
+    );
+  } finally {
+    await fs.rm(stagingDir, { force: true, recursive: true }).catch(() => undefined);
+  }
+}

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -99,6 +99,44 @@ function assertSupportedSchemaVersion(db: DatabaseSync, pathname: string): void 
   }
 }
 
+/** Require the canonical shared-state owner and schema before offline file maintenance. */
+export function assertOpenClawStateDatabaseForMaintenance(
+  database: DatabaseSync,
+  options: { pathname: string },
+): void {
+  const userVersion = readSqliteUserVersion(database);
+  if (userVersion > OPENCLAW_STATE_SCHEMA_VERSION) {
+    throw createNewerSqliteSchemaVersionError(
+      "OpenClaw state database",
+      options.pathname,
+      userVersion,
+      OPENCLAW_STATE_SCHEMA_VERSION,
+    );
+  }
+  if (userVersion !== OPENCLAW_STATE_SCHEMA_VERSION) {
+    throw new Error(
+      `OpenClaw state database ${options.pathname} uses schema version ${userVersion}; run openclaw doctor --fix before compacting it.`,
+    );
+  }
+
+  const metadata = database
+    .prepare("SELECT role, schema_version FROM schema_meta WHERE meta_key = 'primary' LIMIT 1")
+    .get() as { role?: unknown; schema_version?: unknown } | undefined;
+  if (metadata?.role !== "global") {
+    const role = typeof metadata?.role === "string" ? metadata.role : "missing";
+    throw new Error(
+      `OpenClaw state database ${options.pathname} has schema role ${role}; expected global.`,
+    );
+  }
+  if (metadata.schema_version !== OPENCLAW_STATE_SCHEMA_VERSION) {
+    const schemaVersion =
+      typeof metadata.schema_version === "number" ? metadata.schema_version : "invalid";
+    throw new Error(
+      `OpenClaw state database ${options.pathname} metadata schema version ${schemaVersion} does not match ${OPENCLAW_STATE_SCHEMA_VERSION}; run openclaw doctor --fix before compacting it.`,
+    );
+  }
+}
+
 const stateDbLog = createSubsystemLogger("state/db");
 
 /** Targets already warned about, so chmod-less filesystems warn once per path. */

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -594,6 +594,23 @@ describe("cron view editor", () => {
     expect(onDetailTabChange).toHaveBeenCalledWith("history");
   });
 
+  it("locks the editor and back navigation while a save is pending", () => {
+    const job = createJob("job-1", { name: "Nightly digest" });
+    const container = renderView({ jobs: [job], editingJobId: "job-1", busy: true });
+
+    const editor = getElement(container, ".cron-editor", HTMLFieldSetElement);
+    const name = getElement(container, "#cron-name", HTMLInputElement);
+    const back = getElement(container, '[data-test-id="cron-back"]', HTMLButtonElement);
+    const submit = getElement(container, '[data-test-id="cron-submit"]', HTMLButtonElement);
+
+    expect(editor.disabled).toBe(true);
+    expect(editor.getAttribute("aria-busy")).toBe("true");
+    expect(name.matches(":disabled")).toBe(true);
+    expect(back.disabled).toBe(true);
+    expect(submit.disabled).toBe(true);
+    expect(submit.textContent).toContain("Saving");
+  });
+
   it("shows run history instead of the editor on the history tab", () => {
     const job = createJob("job-1", { name: "Nightly digest" });
     const container = renderView({

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -868,6 +868,7 @@ function renderDetailView(props: CronProps, mode: CronPanelMode) {
           type="button"
           class="cron-back"
           data-test-id="cron-back"
+          ?disabled=${props.busy}
           @click=${props.onClosePanel}
         >
           ${icon("arrowLeft")} ${t("cron.detail.back")}
@@ -988,7 +989,7 @@ function renderEditor(props: CronProps, mode: CronPanelMode) {
         : t("cron.form.fixFieldsPlural", { count: String(blockingFields.length) })
       : "";
   return html`
-    <div class="cron-editor">
+    <fieldset class="cron-editor" ?disabled=${props.busy} aria-busy=${String(props.busy)}>
       ${renderPromptCard(props, { payloadLocked, isAgentTurn })}
       <div class="cron-editor-grid">
         ${renderGeneralCard(props)} ${renderScheduleCard(props)}
@@ -1054,7 +1055,7 @@ function renderEditor(props: CronProps, mode: CronPanelMode) {
           ? html` <div class="cron-submit-reason" aria-live="polite">${submitDisabledReason}</div> `
           : nothing}
       </div>
-    </div>
+    </fieldset>
   `;
 }
 

--- a/ui/src/styles/cron.css
+++ b/ui/src/styles/cron.css
@@ -656,6 +656,10 @@
   flex-direction: column;
   gap: 14px;
   max-width: 1060px;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
 }
 
 .cron-history,


### PR DESCRIPTION
Closes #105404

## What Problem This Solves

Fixes an issue where users editing a cron task during a pending Save could have the Control UI accept their later changes and then silently discard them when the older save completed.

## Why This Change Was Made

The Cron editor now uses one native disabled fieldset for all editable controls while a mutation is pending, and Back participates in the same atomic save lock. Fieldset browser defaults are reset so the existing layout remains unchanged.

## User Impact

Cron saves no longer accept edits or navigation that cannot be preserved. The editor re-enables normally after settlement, so subsequent changes can be saved without losing work.

## Evidence

- Live Playwright + real Gateway before: during a held real `cron.update`, Name and Back remained enabled; a later Name was accepted, then replaced by the older submitted value; the disabled fixture was removed; zero browser errors.
- Live Playwright + real Gateway after: Name and Back were disabled for the full held response; late field input and Back navigation were blocked; both controls re-enabled after settlement; a second unheld save persisted in the refreshed UI and Gateway inventory; fixture cleanup succeeded; zero browser errors.
- Source-blind behavior contract: 4/4 checks passed, 4 anti-cheat probes passed, 0 blockers.
- Blacksmith Testbox `tbx_01kxb8t6qyy707gpmgvbp9mxtj`: `corepack pnpm test ui/src/pages/cron/view.test.ts` — 28/28 passed.
- Blacksmith Testbox `tbx_01kxb8t6qyy707gpmgvbp9mxtj`: remote `corepack pnpm check:changed` — format, Core/UI typechecks, exhaustive lint, and repository guards passed.
- Production Control UI build: `OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/ui.js build`.
- Fresh autoreview: clean, no accepted/actionable findings (0.96 confidence).
