### PR TITLE
fix(config): key agentDir collisions by volume case sensitivity

### DIFF
--- a/src/config/agent-dirs.test.ts
+++ b/src/config/agent-dirs.test.ts
@@ -3,35 +3,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { pathCaseInsensitive } from "../infra/path-case-sensitivity.js";
 import { findDuplicateAgentDirs } from "./agent-dirs.js";
 import type { OpenClawConfig } from "./types.js";
 
 afterEach(() => {
   vi.unstubAllEnvs();
 });
-
-function probePathCaseInsensitive(dir: string): boolean {
-  const marker = path.join(dir, `case-probe-${process.pid}`);
-  fs.writeFileSync(marker, "x", "utf8");
-  try {
-    const swapped = marker.replace(/[A-Za-z]/g, (char) => {
-      const lower = char.toLowerCase();
-      return char === lower ? char.toUpperCase() : lower;
-    });
-    if (swapped === marker) {
-      return process.platform === "win32";
-    }
-    try {
-      const a = fs.statSync(marker);
-      const b = fs.statSync(swapped);
-      return a.dev === b.dev && a.ino === b.ino;
-    } catch {
-      return false;
-    }
-  } finally {
-    fs.rmSync(marker, { force: true });
-  }
-}
 
 describe("resolveEffectiveAgentDir via findDuplicateAgentDirs", () => {
   it("uses OPENCLAW_HOME for default agent dir resolution", () => {
@@ -90,9 +68,10 @@ describe("resolveEffectiveAgentDir via findDuplicateAgentDirs", () => {
   it("keys agentDir collision identity to the target volume case semantics", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agentdir-case-"));
     try {
-      const caseInsensitive = probePathCaseInsensitive(root);
+      const caseInsensitive = pathCaseInsensitive(root);
       const upper = path.join(root, "AgentState");
       const lower = path.join(root, "agentstate");
+      // Leave paths absent so collision keys use closest-parent child probes.
       const cfg: OpenClawConfig = {
         agents: {
           list: [
@@ -108,6 +87,32 @@ describe("resolveEffectiveAgentDir via findDuplicateAgentDirs", () => {
         expect(dupes[0]?.agentIds).toEqual(["a", "b"]);
       } else {
         // Case-sensitive volume: distinct case paths are valid distinct agent dirs.
+        expect(dupes).toHaveLength(0);
+      }
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keys absent nested agentDir paths using parent volume child semantics", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agentdir-absent-"));
+    try {
+      const caseInsensitive = pathCaseInsensitive(root);
+      const upper = path.join(root, "Nested", "AgentState");
+      const lower = path.join(root, "Nested", "agentstate");
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            { id: "a", agentDir: upper },
+            { id: "b", agentDir: lower },
+          ],
+        },
+      };
+      const dupes = findDuplicateAgentDirs(cfg);
+      if (caseInsensitive) {
+        expect(dupes).toHaveLength(1);
+        expect(dupes[0]?.agentIds).toEqual(["a", "b"]);
+      } else {
         expect(dupes).toHaveLength(0);
       }
     } finally {

--- a/src/config/agent-dirs.test.ts
+++ b/src/config/agent-dirs.test.ts
@@ -3,7 +3,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { pathCaseInsensitive } from "../infra/path-case-sensitivity.js";
+import {
+  canonicalizePathIdentity,
+  pathCaseInsensitive,
+  type PathChildCaseProbe,
+} from "../infra/path-case-sensitivity.js";
 import { findDuplicateAgentDirs } from "./agent-dirs.js";
 import type { OpenClawConfig } from "./types.js";
 
@@ -115,6 +119,35 @@ describe("resolveEffectiveAgentDir via findDuplicateAgentDirs", () => {
       } else {
         expect(dupes).toHaveLength(0);
       }
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps case-distinct agentDirs distinct across a case-sensitive ancestor", () => {
+    // Component-aware identity: mixed CS ancestor must not collapse Foo/foo
+    // even when a leaf would fold under whole-path semantics.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agentdir-mixed-"));
+    try {
+      const rootResolved = path.resolve(root);
+      const probe: PathChildCaseProbe = (dir) => {
+        const rel = path.relative(rootResolved, path.resolve(dir));
+        if (rel.startsWith("..") || path.isAbsolute(rel)) {
+          return null;
+        }
+        const parts = rel.split(path.sep).filter((part) => part.length > 0);
+        return parts.includes("CI");
+      };
+      const upper = path.join(root, "Foo", "CI", "agent");
+      const lower = path.join(root, "foo", "CI", "agent");
+      // Mixed mounts: validate via canonicalizePathIdentity injection (same helper
+      // production canonicalizeAgentDir uses).
+      expect(canonicalizePathIdentity(upper, { probeChildCaseInsensitive: probe })).not.toBe(
+        canonicalizePathIdentity(lower, { probeChildCaseInsensitive: probe }),
+      );
+      expect(canonicalizePathIdentity(upper, { probeChildCaseInsensitive: probe })).toBe(
+        canonicalizePathIdentity(upper, { probeChildCaseInsensitive: probe }),
+      );
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }

--- a/src/config/agent-dirs.test.ts
+++ b/src/config/agent-dirs.test.ts
@@ -1,4 +1,7 @@
 // Covers agent directory resolution across config and environment overrides.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { findDuplicateAgentDirs } from "./agent-dirs.js";
 import type { OpenClawConfig } from "./types.js";
@@ -6,6 +9,29 @@ import type { OpenClawConfig } from "./types.js";
 afterEach(() => {
   vi.unstubAllEnvs();
 });
+
+function probePathCaseInsensitive(dir: string): boolean {
+  const marker = path.join(dir, `case-probe-${process.pid}`);
+  fs.writeFileSync(marker, "x", "utf8");
+  try {
+    const swapped = marker.replace(/[A-Za-z]/g, (char) => {
+      const lower = char.toLowerCase();
+      return char === lower ? char.toUpperCase() : lower;
+    });
+    if (swapped === marker) {
+      return process.platform === "win32";
+    }
+    try {
+      const a = fs.statSync(marker);
+      const b = fs.statSync(swapped);
+      return a.dev === b.dev && a.ino === b.ino;
+    } catch {
+      return false;
+    }
+  } finally {
+    fs.rmSync(marker, { force: true });
+  }
+}
 
 describe("resolveEffectiveAgentDir via findDuplicateAgentDirs", () => {
   it("uses OPENCLAW_HOME for default agent dir resolution", () => {
@@ -44,5 +70,48 @@ describe("resolveEffectiveAgentDir via findDuplicateAgentDirs", () => {
     // No duplicates for a single default agent
     const dupes = findDuplicateAgentDirs(cfg, { env });
     expect(dupes).toHaveLength(0);
+  });
+
+  it("still rejects identical agentDir paths", () => {
+    const shared = path.join(os.tmpdir(), `openclaw-agentdir-shared-${process.pid}`);
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          { id: "a", agentDir: shared },
+          { id: "b", agentDir: shared },
+        ],
+      },
+    };
+    const dupes = findDuplicateAgentDirs(cfg);
+    expect(dupes).toHaveLength(1);
+    expect(dupes[0]?.agentIds).toEqual(["a", "b"]);
+  });
+
+  it("keys agentDir collision identity to the target volume case semantics", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agentdir-case-"));
+    try {
+      const caseInsensitive = probePathCaseInsensitive(root);
+      const upper = path.join(root, "AgentState");
+      const lower = path.join(root, "agentstate");
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            { id: "a", agentDir: upper },
+            { id: "b", agentDir: lower },
+          ],
+        },
+      };
+      const dupes = findDuplicateAgentDirs(cfg);
+      if (caseInsensitive) {
+        // Common macOS/Windows volumes: case variants are one directory identity.
+        expect(dupes).toHaveLength(1);
+        expect(dupes[0]?.agentIds).toEqual(["a", "b"]);
+      } else {
+        // Case-sensitive volume: distinct case paths are valid distinct agent dirs.
+        expect(dupes).toHaveLength(0);
+      }
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/src/config/agent-dirs.ts
+++ b/src/config/agent-dirs.ts
@@ -1,9 +1,9 @@
 // Resolves agent-specific config and workspace directories.
-import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
+import { pathCaseInsensitive } from "../infra/path-case-sensitivity.js";
 import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveStateDir } from "./paths.js";
@@ -25,55 +25,13 @@ export class DuplicateAgentDirError extends Error {
   }
 }
 
-function swapAsciiCase(value: string): string {
-  return value.replace(/[A-Za-z]/g, (char) => {
-    const lower = char.toLowerCase();
-    return char === lower ? char.toUpperCase() : lower;
-  });
-}
-
-function sameFsObject(a: fs.Stats, b: fs.Stats): boolean {
-  return a.dev === b.dev && a.ino === b.ino;
-}
-
-/**
- * Probe whether `value` lives on a case-insensitive volume.
- * Walks to the closest existing parent so configured agentDirs need not exist yet.
- * Mirrors the trusted-bin path probe so collision identity matches real FS semantics.
- */
-function pathCaseInsensitive(value: string): boolean {
-  let candidate = value;
-  for (;;) {
-    const swapped = swapAsciiCase(candidate);
-    if (swapped !== candidate) {
-      try {
-        const original = fs.statSync(candidate);
-        try {
-          const alternate = fs.statSync(swapped);
-          return sameFsObject(original, alternate);
-        } catch {
-          // Alternate case path missing while original exists → case-sensitive volume.
-          return false;
-        }
-      } catch {
-        // Path may not exist yet; probe the closest existing parent.
-      }
-    }
-
-    const parent = path.dirname(candidate);
-    if (parent === candidate) {
-      // Unknown root: Windows volumes are case-insensitive by default; POSIX is not.
-      return process.platform === "win32";
-    }
-    candidate = parent;
-  }
-}
-
 /**
  * Collision key for agentDir identity.
  * Case-insensitive volumes (common macOS APFS / Windows NTFS) fold case so
  * AgentA and agenta cannot share auth state under different spellings.
  * Case-sensitive volumes keep distinct case paths as distinct agent dirs.
+ * Uses shared child-lookup probes so absent paths and mount boundaries match
+ * real filesystem identity (not parent-name case swaps).
  */
 function canonicalizeAgentDir(agentDir: string): string {
   const resolved = path.resolve(agentDir);

--- a/src/config/agent-dirs.ts
+++ b/src/config/agent-dirs.ts
@@ -1,9 +1,8 @@
 // Resolves agent-specific config and workspace directories.
 import os from "node:os";
 import path from "node:path";
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
-import { pathCaseInsensitive } from "../infra/path-case-sensitivity.js";
+import { canonicalizePathIdentity } from "../infra/path-case-sensitivity.js";
 import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveStateDir } from "./paths.js";
@@ -27,18 +26,12 @@ export class DuplicateAgentDirError extends Error {
 
 /**
  * Collision key for agentDir identity.
- * Case-insensitive volumes (common macOS APFS / Windows NTFS) fold case so
- * AgentA and agenta cannot share auth state under different spellings.
- * Case-sensitive volumes keep distinct case paths as distinct agent dirs.
- * Uses shared child-lookup probes so absent paths and mount boundaries match
- * real filesystem identity (not parent-name case swaps).
+ * Component-aware: fold only segments whose parent resolves children
+ * case-insensitively. Case-sensitive ancestors keep Foo/foo distinct even when
+ * a descendant is case-insensitive (mixed mount / per-dir semantics).
  */
 function canonicalizeAgentDir(agentDir: string): string {
-  const resolved = path.resolve(agentDir);
-  if (pathCaseInsensitive(resolved)) {
-    return normalizeLowercaseStringOrEmpty(resolved);
-  }
-  return resolved;
+  return canonicalizePathIdentity(agentDir);
 }
 
 function collectReferencedAgentIds(cfg: OpenClawConfig): string[] {

--- a/src/config/agent-dirs.ts
+++ b/src/config/agent-dirs.ts
@@ -1,4 +1,5 @@
 // Resolves agent-specific config and workspace directories.
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
@@ -24,10 +25,59 @@ export class DuplicateAgentDirError extends Error {
   }
 }
 
+function swapAsciiCase(value: string): string {
+  return value.replace(/[A-Za-z]/g, (char) => {
+    const lower = char.toLowerCase();
+    return char === lower ? char.toUpperCase() : lower;
+  });
+}
+
+function sameFsObject(a: fs.Stats, b: fs.Stats): boolean {
+  return a.dev === b.dev && a.ino === b.ino;
+}
+
+/**
+ * Probe whether `value` lives on a case-insensitive volume.
+ * Walks to the closest existing parent so configured agentDirs need not exist yet.
+ * Mirrors the trusted-bin path probe so collision identity matches real FS semantics.
+ */
+function pathCaseInsensitive(value: string): boolean {
+  let candidate = value;
+  for (;;) {
+    const swapped = swapAsciiCase(candidate);
+    if (swapped !== candidate) {
+      try {
+        const original = fs.statSync(candidate);
+        try {
+          const alternate = fs.statSync(swapped);
+          return sameFsObject(original, alternate);
+        } catch {
+          // Alternate case path missing while original exists → case-sensitive volume.
+          return false;
+        }
+      } catch {
+        // Path may not exist yet; probe the closest existing parent.
+      }
+    }
+
+    const parent = path.dirname(candidate);
+    if (parent === candidate) {
+      // Unknown root: Windows volumes are case-insensitive by default; POSIX is not.
+      return process.platform === "win32";
+    }
+    candidate = parent;
+  }
+}
+
+/**
+ * Collision key for agentDir identity.
+ * Case-insensitive volumes (common macOS APFS / Windows NTFS) fold case so
+ * AgentA and agenta cannot share auth state under different spellings.
+ * Case-sensitive volumes keep distinct case paths as distinct agent dirs.
+ */
 function canonicalizeAgentDir(agentDir: string): string {
   const resolved = path.resolve(agentDir);
-  if (process.platform === "darwin" || process.platform === "win32") {
-    // Agent dirs collide case-insensitively on the common macOS/Windows filesystems.
+  if (pathCaseInsensitive(resolved)) {
     return normalizeLowercaseStringOrEmpty(resolved);
   }
   return resolved;

--- a/src/infra/exec-safe-bin-trust.ts
+++ b/src/infra/exec-safe-bin-trust.ts
@@ -6,6 +6,7 @@ import {
   sortUniqueStrings,
   uniqueStrings,
 } from "@openclaw/normalization-core/string-normalization";
+import { pathCaseInsensitive } from "./path-case-sensitivity.js";
 
 // Keep defaults to OS-managed immutable bins only.
 // User/package-manager bins must be opted in via tools.exec.safeBinTrustedDirs.
@@ -29,45 +30,9 @@ export type WritableTrustedSafeBinDir = {
 
 let trustedSafeBinCache: TrustedSafeBinCache | null = null;
 
-function swapAsciiCase(value: string): string {
-  return value.replace(/[A-Za-z]/g, (char) => {
-    const lower = char.toLowerCase();
-    return char === lower ? char.toUpperCase() : lower;
-  });
-}
-
-function sameFsObject(a: fs.Stats, b: fs.Stats): boolean {
-  return a.dev === b.dev && a.ino === b.ino;
-}
-
-function pathCaseInsensitive(value: string): boolean {
-  let candidate = value;
-  for (;;) {
-    const swapped = swapAsciiCase(candidate);
-    if (swapped !== candidate) {
-      try {
-        const original = fs.statSync(candidate);
-        try {
-          const alternate = fs.statSync(swapped);
-          return sameFsObject(original, alternate);
-        } catch {
-          return false;
-        }
-      } catch {
-        // The compared path may not exist yet; probe the closest existing parent.
-      }
-    }
-
-    const parent = path.dirname(candidate);
-    if (parent === candidate) {
-      return process.platform === "win32";
-    }
-    candidate = parent;
-  }
-}
-
 function normalizeTrustComparisonPath(value: string): string {
   const resolved = path.resolve(value);
+  // Shared child-lookup probe: fold only when the target volume is case-insensitive.
   return pathCaseInsensitive(resolved) ? resolved.toLowerCase() : resolved;
 }
 

--- a/src/infra/exec-safe-bin-trust.ts
+++ b/src/infra/exec-safe-bin-trust.ts
@@ -6,7 +6,7 @@ import {
   sortUniqueStrings,
   uniqueStrings,
 } from "@openclaw/normalization-core/string-normalization";
-import { pathCaseInsensitive } from "./path-case-sensitivity.js";
+import { canonicalizePathIdentity } from "./path-case-sensitivity.js";
 
 // Keep defaults to OS-managed immutable bins only.
 // User/package-manager bins must be opted in via tools.exec.safeBinTrustedDirs.
@@ -31,9 +31,9 @@ export type WritableTrustedSafeBinDir = {
 let trustedSafeBinCache: TrustedSafeBinCache | null = null;
 
 function normalizeTrustComparisonPath(value: string): string {
-  const resolved = path.resolve(value);
-  // Shared child-lookup probe: fold only when the target volume is case-insensitive.
-  return pathCaseInsensitive(resolved) ? resolved.toLowerCase() : resolved;
+  // Component-aware identity (fail-closed on unknown probes): do not fold
+  // case-sensitive ancestor components when a descendant mount is CI.
+  return canonicalizePathIdentity(value);
 }
 
 function normalizeTrustedDir(value: string, forComparison = true): string | null {

--- a/src/infra/path-case-sensitivity.test.ts
+++ b/src/infra/path-case-sensitivity.test.ts
@@ -1,0 +1,77 @@
+// Covers filesystem case-sensitivity child probes for path identity keys.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { pathCaseInsensitive } from "./path-case-sensitivity.js";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function makeTempRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-path-case-"));
+  tempRoots.push(root);
+  return root;
+}
+
+function probeChildCaseInsensitive(dir: string): boolean {
+  const marker = path.join(dir, `caseProbeChild-${process.pid}`);
+  fs.writeFileSync(marker, "x", "utf8");
+  try {
+    const swapped = marker.replace(/[A-Za-z]/g, (char) => {
+      const lower = char.toLowerCase();
+      return char === lower ? char.toUpperCase() : lower;
+    });
+    if (swapped === marker) {
+      return process.platform === "win32";
+    }
+    try {
+      const a = fs.statSync(marker);
+      const b = fs.statSync(swapped);
+      return a.dev === b.dev && a.ino === b.ino;
+    } catch {
+      return false;
+    }
+  } finally {
+    fs.rmSync(marker, { force: true });
+  }
+}
+
+describe("pathCaseInsensitive", () => {
+  it("matches child lookup semantics on the host temp volume", () => {
+    const root = makeTempRoot();
+    const expected = probeChildCaseInsensitive(root);
+    expect(pathCaseInsensitive(root)).toBe(expected);
+  });
+
+  it("uses closest existing parent for absent nested paths", () => {
+    const root = makeTempRoot();
+    const absent = path.join(root, "AgentState", "nested", "missing");
+    const expected = probeChildCaseInsensitive(root);
+    expect(pathCaseInsensitive(absent)).toBe(expected);
+  });
+
+  it("probes an existing empty directory via temporary child marker", () => {
+    const root = makeTempRoot();
+    const empty = path.join(root, "emptyDir");
+    fs.mkdirSync(empty);
+    const expected = probeChildCaseInsensitive(empty);
+    expect(pathCaseInsensitive(empty)).toBe(expected);
+  });
+
+  it("probes via an existing lettered child without leaving a marker", () => {
+    const root = makeTempRoot();
+    const child = path.join(root, "LetterEntry");
+    fs.writeFileSync(child, "x", "utf8");
+    const before = new Set(fs.readdirSync(root));
+    const result = pathCaseInsensitive(path.join(root, "does-not-exist-yet"));
+    const after = new Set(fs.readdirSync(root));
+    expect(result).toBe(probeChildCaseInsensitive(root));
+    expect(after).toEqual(before);
+  });
+});

--- a/src/infra/path-case-sensitivity.test.ts
+++ b/src/infra/path-case-sensitivity.test.ts
@@ -1,9 +1,13 @@
-// Covers filesystem case-sensitivity child probes for path identity keys.
+// Covers filesystem case-sensitivity probes and component-aware path identity.
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { pathCaseInsensitive } from "./path-case-sensitivity.js";
+import {
+  canonicalizePathIdentity,
+  pathCaseInsensitive,
+  type PathChildCaseProbe,
+} from "./path-case-sensitivity.js";
 
 const tempRoots: string[] = [];
 
@@ -42,6 +46,18 @@ function probeChildCaseInsensitive(dir: string): boolean {
   }
 }
 
+/**
+ * Simulate mixed case-sensitivity without host volume side effects:
+ * only parents that already contain a `CI` path segment fold children.
+ * All other parents (including `/` and temp ancestors) are case-sensitive.
+ */
+function mixedBoundaryProbe(): PathChildCaseProbe {
+  return (dir: string) => {
+    // Match a CI segment as built so far (before leaf folding rewrites it).
+    return /(^|[\\/])CI([\\/]|$)/.test(path.resolve(dir));
+  };
+}
+
 describe("pathCaseInsensitive", () => {
   it("matches child lookup semantics on the host temp volume", () => {
     const root = makeTempRoot();
@@ -73,5 +89,91 @@ describe("pathCaseInsensitive", () => {
     const after = new Set(fs.readdirSync(root));
     expect(result).toBe(probeChildCaseInsensitive(root));
     expect(after).toEqual(before);
+  });
+});
+
+describe("canonicalizePathIdentity", () => {
+  it("folds whole path when every parent is case-insensitive", () => {
+    const root = makeTempRoot();
+    if (!probeChildCaseInsensitive(root)) {
+      return;
+    }
+    const upper = path.join(root, "AgentState", "Nested");
+    const lower = path.join(root, "agentstate", "nested");
+    const key = canonicalizePathIdentity(upper);
+    expect(key).toBe(canonicalizePathIdentity(lower));
+    // Folded identity ends with lowercased leaf segments (ancestor temp dirs may also fold).
+    expect(key.endsWith(`${path.sep}agentstate${path.sep}nested`)).toBe(true);
+  });
+
+  it("preserves case when every parent is case-sensitive", () => {
+    const root = makeTempRoot();
+    // Host temp is usually CI on macOS; force CS via injected probe.
+    const probe: PathChildCaseProbe = () => false;
+    const upper = path.join(root, "AgentState");
+    const lower = path.join(root, "agentstate");
+    expect(canonicalizePathIdentity(upper, { probeChildCaseInsensitive: probe })).toBe(
+      path.resolve(upper),
+    );
+    expect(canonicalizePathIdentity(lower, { probeChildCaseInsensitive: probe })).toBe(
+      path.resolve(lower),
+    );
+    expect(canonicalizePathIdentity(upper, { probeChildCaseInsensitive: probe })).not.toBe(
+      canonicalizePathIdentity(lower, { probeChildCaseInsensitive: probe }),
+    );
+  });
+
+  it("preserves case-sensitive ancestor components under mixed boundaries", () => {
+    // CS ancestor + CI descendant: whole-path fold would collapse Foo/foo.
+    const root = makeTempRoot();
+    const probe = mixedBoundaryProbe();
+
+    const a = path.join(root, "CS", "Foo", "CI", "Agent");
+    const b = path.join(root, "CS", "foo", "CI", "Agent");
+    const keyA = canonicalizePathIdentity(a, { probeChildCaseInsensitive: probe });
+    const keyB = canonicalizePathIdentity(b, { probeChildCaseInsensitive: probe });
+
+    expect(keyA).not.toBe(keyB);
+    // Ancestor Foo/foo stays distinct; only CI-parented segments fold.
+    expect(keyA).toContain(`${path.sep}Foo${path.sep}`);
+    expect(keyB).toContain(`${path.sep}foo${path.sep}`);
+    expect(keyA.endsWith(`${path.sep}agent`)).toBe(true);
+    expect(keyB.endsWith(`${path.sep}agent`)).toBe(true);
+  });
+
+  it("folds only CI-parented segments on a mixed boundary path", () => {
+    const root = makeTempRoot();
+    const probe = mixedBoundaryProbe();
+
+    const mixed = path.join(root, "CS", "KeepCase", "CI", "AgentState");
+    const key = canonicalizePathIdentity(mixed, { probeChildCaseInsensitive: probe });
+    // KeepCase under CS parent stays; AgentState under CI parent folds.
+    expect(key).toContain(`${path.sep}KeepCase${path.sep}`);
+    expect(key.endsWith(`${path.sep}agentstate`)).toBe(true);
+    expect(key).not.toContain("AgentState");
+  });
+
+  it("fails closed when probe returns null (does not fold)", () => {
+    const root = makeTempRoot();
+    const probe: PathChildCaseProbe = () => null;
+    const upper = path.join(root, "TrustedBin");
+    const lower = path.join(root, "trustedbin");
+    expect(canonicalizePathIdentity(upper, { probeChildCaseInsensitive: probe })).toBe(
+      path.resolve(upper),
+    );
+    expect(canonicalizePathIdentity(upper, { probeChildCaseInsensitive: probe })).not.toBe(
+      canonicalizePathIdentity(lower, { probeChildCaseInsensitive: probe }),
+    );
+  });
+
+  it("does not conflate distinct dirs across a case-sensitive ancestor (safe-bin shape)", () => {
+    // Security: trusted /CS/Trusted/bin must not match /CS/trusted/bin when ancestor is CS.
+    const root = makeTempRoot();
+    const probe = mixedBoundaryProbe();
+    const trusted = path.join(root, "CS", "Trusted", "bin");
+    const alias = path.join(root, "CS", "trusted", "bin");
+    expect(canonicalizePathIdentity(trusted, { probeChildCaseInsensitive: probe })).not.toBe(
+      canonicalizePathIdentity(alias, { probeChildCaseInsensitive: probe }),
+    );
   });
 });

--- a/src/infra/path-case-sensitivity.ts
+++ b/src/infra/path-case-sensitivity.ts
@@ -1,0 +1,117 @@
+// Path case-sensitivity probes for identity keys (agentDir, trusted bins, …).
+// Measures *child* lookup semantics on the target filesystem so mount boundaries
+// are not misclassified by case-swapping a parent path name.
+import fs from "node:fs";
+import path from "node:path";
+
+function swapAsciiCase(value: string): string {
+  return value.replace(/[A-Za-z]/g, (char) => {
+    const lower = char.toLowerCase();
+    return char === lower ? char.toUpperCase() : lower;
+  });
+}
+
+function sameFsObject(a: fs.Stats, b: fs.Stats): boolean {
+  return a.dev === b.dev && a.ino === b.ino;
+}
+
+function hasAsciiLetters(value: string): boolean {
+  return /[A-Za-z]/.test(value);
+}
+
+/**
+ * Probe whether children of `dir` are resolved case-insensitively.
+ * Prefer an existing lettered entry (works on read-only system dirs);
+ * otherwise create a temporary marker and remove it.
+ * Returns null when the directory cannot be probed.
+ */
+function probeDirectoryChildCaseInsensitive(dir: string): boolean | null {
+  try {
+    const entries = fs.readdirSync(dir);
+    for (const entry of entries) {
+      if (!hasAsciiLetters(entry)) {
+        continue;
+      }
+      const swapped = swapAsciiCase(entry);
+      if (swapped === entry) {
+        continue;
+      }
+      const originalPath = path.join(dir, entry);
+      const alternatePath = path.join(dir, swapped);
+      try {
+        const original = fs.statSync(originalPath);
+        try {
+          const alternate = fs.statSync(alternatePath);
+          return sameFsObject(original, alternate);
+        } catch {
+          // Original child exists, alternate spelling does not → case-sensitive.
+          return false;
+        }
+      } catch {
+        // Entry disappeared between readdir and stat; try another.
+      }
+    }
+  } catch {
+    // Not readable; fall through to a write probe when possible.
+  }
+
+  // No usable existing entry: create a short-lived child marker.
+  // Child probe (not parent-name swap) is required at mount boundaries.
+  const markerName = `.openclawCaseProbe-${process.pid}-${Date.now().toString(36)}`;
+  const markerPath = path.join(dir, markerName);
+  const swappedPath = swapAsciiCase(markerPath);
+  if (swappedPath === markerPath) {
+    return process.platform === "win32";
+  }
+
+  try {
+    fs.writeFileSync(markerPath, "x", { flag: "wx" });
+  } catch {
+    return null;
+  }
+
+  try {
+    const original = fs.statSync(markerPath);
+    try {
+      const alternate = fs.statSync(swappedPath);
+      return sameFsObject(original, alternate);
+    } catch {
+      return false;
+    }
+  } finally {
+    fs.rmSync(markerPath, { force: true });
+  }
+}
+
+/**
+ * True when `value` lives on a volume where child path lookups fold case.
+ * Walks to the closest existing directory so configured paths need not exist yet.
+ * Probes child lookup semantics on that directory (mount-boundary safe).
+ */
+export function pathCaseInsensitive(value: string): boolean {
+  let candidate = path.resolve(value);
+  for (;;) {
+    try {
+      const stats = fs.statSync(candidate);
+      if (stats.isDirectory()) {
+        const probed = probeDirectoryChildCaseInsensitive(candidate);
+        if (probed !== null) {
+          return probed;
+        }
+        // Directory exists but is unreadable/unwritable: do not walk past a
+        // mount boundary by case-swapping the parent name. Fall back to OS default.
+        return process.platform === "win32";
+      }
+      // Existing non-directory: children of the containing dir share its volume.
+    } catch {
+      // Path may not exist yet; walk to the closest existing parent directory.
+    }
+
+    const parent = path.dirname(candidate);
+    if (parent === candidate) {
+      // Unknown root: Windows volumes are case-insensitive by default; POSIX is not.
+      return process.platform === "win32";
+    }
+    candidate = parent;
+  }
+}

--- a/src/infra/path-case-sensitivity.ts
+++ b/src/infra/path-case-sensitivity.ts
@@ -1,8 +1,14 @@
-// Path case-sensitivity probes for identity keys (agentDir, trusted bins, …).
-// Measures *child* lookup semantics on the target filesystem so mount boundaries
-// are not misclassified by case-swapping a parent path name.
+// Path case-sensitivity probes and component-aware identity keys
+// (agentDir collisions, trusted safe-bin dirs, …).
+//
+// Whole-path folding is unsafe across mixed mount / per-directory case
+// semantics: one boolean must not lowercase every component. Identity walks
+// components and folds only where the parent resolves children case-insensitively.
 import fs from "node:fs";
 import path from "node:path";
+
+/** Probe whether `dir` resolves children case-insensitively. null = unknown. */
+export type PathChildCaseProbe = (dir: string) => boolean | null;
 
 function swapAsciiCase(value: string): string {
   return value.replace(/[A-Za-z]/g, (char) => {
@@ -25,7 +31,7 @@ function hasAsciiLetters(value: string): boolean {
  * otherwise create a temporary marker and remove it.
  * Returns null when the directory cannot be probed.
  */
-function probeDirectoryChildCaseInsensitive(dir: string): boolean | null {
+export function probeDirectoryChildCaseInsensitive(dir: string): boolean | null {
   try {
     const entries = fs.readdirSync(dir);
     for (const entry of entries) {
@@ -84,34 +90,98 @@ function probeDirectoryChildCaseInsensitive(dir: string): boolean | null {
 }
 
 /**
- * True when `value` lives on a volume where child path lookups fold case.
+ * True when `value` lives under a directory whose *child* lookups fold case.
  * Walks to the closest existing directory so configured paths need not exist yet.
- * Probes child lookup semantics on that directory (mount-boundary safe).
+ * Prefer {@link canonicalizePathIdentity} for multi-component identity keys.
  */
 export function pathCaseInsensitive(value: string): boolean {
-  let candidate = path.resolve(value);
+  return childLookupFoldsCase(path.resolve(value), probeDirectoryChildCaseInsensitive);
+}
+
+/**
+ * Whether children of `parent` fold case.
+ * Tries the logical parent first (injected probes / existing dirs), then walks
+ * to the closest existing ancestor for production probes on absent paths.
+ * Unknown / unreadable → false (fail-closed: do not invent equality).
+ */
+function childLookupFoldsCase(parent: string, probe: PathChildCaseProbe): boolean {
+  let candidate = parent;
   for (;;) {
+    const probed = probe(candidate);
+    if (probed === true) {
+      return true;
+    }
+    if (probed === false) {
+      return false;
+    }
+    // null: probe could not answer (missing / unreadable). Prefer an existing
+    // ancestor so production child markers still work for absent leaf paths.
     try {
       const stats = fs.statSync(candidate);
       if (stats.isDirectory()) {
-        const probed = probeDirectoryChildCaseInsensitive(candidate);
-        if (probed !== null) {
-          return probed;
-        }
-        // Directory exists but is unreadable/unwritable: do not walk past a
-        // mount boundary by case-swapping the parent name. Fall back to OS default.
-        return process.platform === "win32";
+        // Existing dir answered null → fail-closed (do not fold).
+        return false;
       }
-      // Existing non-directory: children of the containing dir share its volume.
     } catch {
-      // Path may not exist yet; walk to the closest existing parent directory.
+      // Missing path: walk up.
     }
 
-    const parent = path.dirname(candidate);
-    if (parent === candidate) {
+    const up = path.dirname(candidate);
+    if (up === candidate) {
       // Unknown root: Windows volumes are case-insensitive by default; POSIX is not.
+      // Fail-closed on POSIX (preserve case) matches safe-bin trust needs.
       return process.platform === "win32";
     }
-    candidate = parent;
+    candidate = up;
   }
+}
+
+export type CanonicalizePathIdentityOptions = {
+  /**
+   * Optional probe for unit tests / mixed-boundary simulation.
+   * Receives the logical parent path built so far (may not exist yet).
+   * Production default probes the closest existing directory.
+   */
+  probeChildCaseInsensitive?: PathChildCaseProbe;
+};
+
+/**
+ * Component-aware path identity key.
+ *
+ * Walks absolute path components left-to-right. Folds a component to lowercase
+ * only when that component's parent resolves children case-insensitively.
+ * Case-sensitive ancestors keep distinct spellings (`Foo` vs `foo`) even when a
+ * descendant mount is case-insensitive — fixing whole-path folding false aliases.
+ *
+ * Fail-closed: unknown parent probes do not fold (safe for trusted-bin compare).
+ */
+export function canonicalizePathIdentity(
+  value: string,
+  options?: CanonicalizePathIdentityOptions,
+): string {
+  const resolved = path.resolve(value);
+  const probe = options?.probeChildCaseInsensitive ?? probeDirectoryChildCaseInsensitive;
+  const parsed = path.parse(resolved);
+  // Root (/, C:\, \\server\share\) has no parent component to fold.
+  let built = parsed.root;
+  const relative = resolved.slice(parsed.root.length);
+  if (!relative) {
+    return built;
+  }
+  const parts = relative.split(path.sep).filter((part) => part.length > 0);
+  const foldsCache = new Map<string, boolean>();
+
+  for (const part of parts) {
+    let folds = foldsCache.get(built);
+    if (folds === undefined) {
+      // Injected probes answer for the logical parent (tests); production
+      // probes walk to the closest existing directory inside childLookupFoldsCase.
+      folds = childLookupFoldsCase(built, probe);
+      foldsCache.set(built, folds);
+    }
+    const segment = folds ? part.toLowerCase() : part;
+    built =
+      built.endsWith(path.sep) || built === "" ? `${built}${segment}` : path.join(built, segment);
+  }
+  return built;
 }


### PR DESCRIPTION
Closes #105194

## What Problem This Solves

Fixes an issue where users with case-sensitive macOS APFS or Windows NTFS volumes would hit a false `DuplicateAgentDirError` startup rejection when two agents used distinct `agentDir` paths that differed only by case, even though the filesystem treats those paths as separate directories.

## Why This Change Was Made

`canonicalizeAgentDir` no longer lowercases all darwin/win32 paths unconditionally. Collision identity uses a **shared component-aware** filesystem helper (`src/infra/path-case-sensitivity.ts` → `canonicalizePathIdentity`) that:

1. Probes **child lookup semantics** on each parent component (existing lettered entry first, temporary marker otherwise)
2. Folds a path segment to lowercase **only when that segment's parent** resolves children case-insensitively
3. Preserves case on case-sensitive ancestors so mixed mount / per-directory boundaries cannot collapse `Foo` vs `foo`

Trusted safe-bin path normalization uses the same helper (fail-closed on unknown probes) so identity rules cannot diverge.

This addresses ClawSweeper review on #105442 (P1 whole-path folding / security-boundary finding): the previous shared helper still applied one boolean to the entire absolute path.

## User Impact

Operators on case-sensitive volumes can configure case-distinct agent directories without a false startup collision. Common case-insensitive macOS/Windows volumes still reject case-only spelling variants that would share auth/session state. Mixed case-sensitivity boundaries no longer invent aliases across case-sensitive ancestors (including trusted safe-bin directories).

## Evidence

Verification host: local macOS (Crabbox bypass)

Focused tests:
```text
node scripts/run-vitest.mjs \
  src/infra/path-case-sensitivity.test.ts \
  src/config/agent-dirs.test.ts \
  src/infra/exec-safe-bin-trust.test.ts \
  src/config/config.multi-agent-agentdir-validation.test.ts
# Test Files  4 passed (4)
# Tests  26 passed (26)
```

Path-scoped static:
```text
pnpm exec oxfmt --check <touched>  # pass
pnpm exec oxlint <touched>  # 0 warnings / 0 errors
git diff --check  # pass
```

## Real behavior proof

- Behavior addressed: case-distinct `agentDir` paths on a case-sensitive volume no longer raise a false duplicate-agentDir collision for **absent** nested paths and existing paths; identical paths still collide; **mixed-boundary** component-aware identity keeps case-sensitive ancestors distinct (agentDir + safe-bin shape).
- Environment: local macOS arm64, branch `fix/105194-agent-dir-case-sensitive-collisions` (`cb63a98d4`), Case-sensitive APFS sparseimage mounted at `/Volumes/OC105442Proof`.
- Current-main contrast: unconditional darwin/win32 lowercasing maps case-distinct paths onto one collision key even when the volume stores them as distinct. Prior PR head used whole-path folding from one child-probe boolean.
- Exact steps or command run after this patch:
  1. `hdiutil create -size 32m -type SPARSE -fs "Case-sensitive APFS" -volname OC105442Proof … && hdiutil attach …`
  2. Call production `findDuplicateAgentDirs` + `pathCaseInsensitive` + `canonicalizePathIdentity` via `tsx`
  3. Absent case-distinct dirs, true shared path control, existing case-distinct dirs
  4. Mixed-boundary injected probe (`CI` segment folds children only) for `CS/Foo/CI/Agent` vs `CS/foo/CI/Agent` and safe-bin `CS/Trusted/bin` vs `CS/trusted/bin`
- Evidence after fix:
  ```text
  volume_child_case_insensitive false
  after_fix_absent_case_distinct_dupes 0
  after_fix_true_dupes 1 ["a","b"]
  after_fix_existing_case_distinct_dupes 0
  mixed_boundary_keys_distinct true
  safe_bin_cs_ancestor_distinct true
  keyA …/CS/Foo/CI/agent
  keyB …/CS/foo/CI/agent
  PROOF_OK
  ```
- Control check: identical `agentDir` strings still report one conflict for agents `a` and `b`.
- Observed result after fix: false collision gone on case-sensitive volume; true duplicates still rejected; mixed CS ancestor components stay distinct under component-aware identity; host temp case folding covered by unit tests via shared helper.
- What was not tested: live Windows case-sensitive volume (same shared probe; not exercised on a Windows host here); real bind-mount mixed lab (unit + injected-probe coverage for component algorithm; CS APFS covers single-volume production probe).

## AI disclosure

This fix was authored with AI assistance (Grok). Human operator ran the auto find→fix pipeline and CS review follow-up; verification commands and Real behavior proof were executed on the local macOS host.
