### PR TITLE
refactor(meta): remove unused stream helper export

### DIFF
--- a/extensions/meta/stream.ts
+++ b/extensions/meta/stream.ts
@@ -18,7 +18,7 @@ function ensureMetaResponsesReplayFields(payloadObj: Record<string, unknown>): v
   payloadObj.store = false;
 }
 
-export function createMetaResponsesWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+function createMetaResponsesWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) =>
     streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {


### PR DESCRIPTION
## What Problem This Solves

The Meta provider exported `createMetaResponsesWrapper` even though it is only an implementation detail used by the plugin's real `wrapMetaProviderStream` hook. The unnecessary export widened the plugin's private stream surface without a repository or documented consumer.

## Why This Change Was Made

Keep the helper file-local while preserving its implementation, its same-file caller, and the registered provider stream hook. The public `api.ts` surface and plugin entrypoint remain unchanged.

## User Impact

No user-visible or runtime behavior changes. This narrows dead internal API surface in the Meta provider plugin.

## Evidence

- Codebase-memory graph: 305,259 nodes / 1,263,816 edges. `createMetaResponsesWrapper` has exactly one caller, `wrapMetaProviderStream`, in the same file.
- Exhaustive repository search found no other import or reference; `extensions/meta/api.ts` and the package entrypoint do not expose the helper.
- The helper was exported during the July 9, 2026 provider publish move in `266ca5b3a2e` / #103070. That commit is not contained by a release tag.
- Direct SDK contract inspection confirmed `streamWithPayloadPatch` behavior is unchanged.
- Before and after on Testbox `tbx_01kxba30erz1pr4ckjrzcwsbfz`: `corepack pnpm test:serial extensions/meta/index.test.ts extensions/meta/meta.live.test.ts` passed 3/3 runnable tests both times; live-only tests remained skipped without credentials.
- `corepack pnpm check:changed -- extensions/meta/stream.ts` passed on the same Testbox.
- Fresh `gpt-5.6-sol` medium autoreview: clean, no findings, patch correct (0.96 confidence).
- Live overlap delta: 53 recently updated open PRs were checked; none touch `extensions/meta/stream.ts`.
