### PR TITLE
fix(qa): preserve Codex mock routing

### DIFF
--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -897,6 +897,44 @@ describe("openai image generation provider", () => {
     expect(result.images).toHaveLength(1);
   });
 
+  it("uses a model-specific QA image endpoint without changing the text provider route", async () => {
+    mockGeneratedPngResponse();
+    vi.stubEnv("OPENCLAW_QA_ALLOW_LOCAL_IMAGE_PROVIDER", "1");
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-1",
+      prompt: "Draw a QA lighthouse",
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              models: [
+                {
+                  id: "gpt-image-1",
+                  name: "gpt-image-1",
+                  api: "openai-responses",
+                  baseUrl: "http://127.0.0.1:44080/v1",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128_000,
+                  maxTokens: 4096,
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    expect(httpConfigCall().baseUrl).toBe("http://127.0.0.1:44080/v1");
+    expect(jsonRequestCall().url).toBe("http://127.0.0.1:44080/v1/images/generations");
+    expect(jsonRequestCall().allowPrivateNetwork).toBe(true);
+  });
+
   it("forwards edit count, custom size, and multiple input images", async () => {
     mockGeneratedPngResponse();
 

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -265,6 +265,14 @@ function resolveNativeOpenAIImageSizesForModel(model: string): readonly string[]
   }
 }
 
+function resolveConfiguredOpenAIImageBaseUrl(cfg: OpenClawConfig | undefined, model: string) {
+  const modelId = model.trim().replace(/^openai\//u, "");
+  const modelBaseUrl = cfg?.models?.providers?.openai?.models
+    .find((candidate) => candidate.id.trim().replace(/^openai\//u, "") === modelId)
+    ?.baseUrl?.trim();
+  return modelBaseUrl || resolveConfiguredOpenAIBaseUrl(cfg);
+}
+
 function resolveOpenAIImageRequestSize(params: {
   model: string;
   requestedSize?: string;
@@ -297,6 +305,7 @@ function resolveOpenAIImageRequestSize(params: {
 
 function shouldAllowPrivateImageEndpoint(req: {
   provider: string;
+  model: string;
   cfg: OpenClawConfig | undefined;
 }) {
   if (req.provider === MOCK_OPENAI_PROVIDER_ID) {
@@ -305,7 +314,7 @@ function shouldAllowPrivateImageEndpoint(req: {
   if (isPrivateNetworkOptInEnabled(req.cfg?.browser?.ssrfPolicy)) {
     return true;
   }
-  const baseUrl = resolveConfiguredOpenAIBaseUrl(req.cfg);
+  const baseUrl = resolveConfiguredOpenAIImageBaseUrl(req.cfg, req.model);
   if (!baseUrl.startsWith("http://127.0.0.1:") && !baseUrl.startsWith("http://localhost:")) {
     return false;
   }
@@ -860,7 +869,7 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
     async generateImage(req) {
       const inputImages = req.inputImages ?? [];
       const isEdit = inputImages.length > 0;
-      const rawBaseUrl = resolveConfiguredOpenAIBaseUrl(req.cfg);
+      const rawBaseUrl = resolveConfiguredOpenAIImageBaseUrl(req.cfg, req.model);
       const publicOpenAIBaseUrl = isPublicOpenAIImageBaseUrl(rawBaseUrl);
       const chatGPTBaseUrl = isOpenAICodexBaseUrl(rawBaseUrl);
       const codexResponsesConfigured =

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -8,6 +8,7 @@ import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   testing,
+  buildQaForcedRuntimeEnvPatch,
   buildQaRuntimeEnv,
   resolveQaControlUiRoot,
   startQaGatewayChild,
@@ -97,6 +98,34 @@ function requireAuthProfile(
   }
   return profile;
 }
+
+describe("forced runtime environment", () => {
+  it("pins forced Codex mock runs to the managed provider endpoint", () => {
+    expect(
+      buildQaForcedRuntimeEnvPatch({
+        forcedRuntime: "codex",
+        providerMode: "mock-openai",
+        providerBaseUrl: "http://127.0.0.1:44080/v1/",
+      }),
+    ).toEqual({
+      OPENCLAW_BUILD_PRIVATE_QA: "1",
+      OPENCLAW_QA_FORCE_RUNTIME: "codex",
+      OPENCLAW_CODEX_APP_SERVER_ARGS:
+        "app-server -c openai_base_url=http://127.0.0.1:44080/v1 --listen stdio://",
+      OPENAI_API_KEY: ["qa", "mock", "openai", "key"].join("-"),
+      CODEX_API_KEY: ["qa", "mock", "openai", "key"].join("-"),
+    });
+  });
+
+  it("fails closed when a forced Codex mock run lacks its managed endpoint", () => {
+    expect(() =>
+      buildQaForcedRuntimeEnvPatch({
+        forcedRuntime: "codex",
+        providerMode: "mock-openai",
+      }),
+    ).toThrow("forced Codex mock QA requires the managed mock provider URL");
+  });
+});
 
 function requireSsrFetchCall(index = 0): SsrFetchCall {
   const call = fetchWithSsrFGuardMock.mock.calls[index];

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -71,6 +71,7 @@ const QA_GATEWAY_CHILD_STARTUP_MAX_ATTEMPTS = 5;
 const QA_GATEWAY_CHILD_RPC_STARTUP_TIMEOUT_MS = 30_000;
 const QA_GATEWAY_CHILD_RPC_RETRY_HEALTH_TIMEOUT_MS = 60_000;
 const QA_GATEWAY_CHILD_RESTART_BOUNDARY_TIMEOUT_MS = 90_000;
+const QA_MOCK_OPENAI_API_KEY = ["qa", "mock", "openai", "key"].join("-");
 const QA_GATEWAY_CHILD_BLOCKED_SECRET_ENV_VARS = Object.freeze([
   "OPENCLAW_QA_CONVEX_SECRET_CI",
   "OPENCLAW_QA_CONVEX_SECRET_MAINTAINER",
@@ -397,6 +398,31 @@ export function buildQaRuntimeEnv(params: {
   delete normalizedEnv[QA_LIVE_ANTHROPIC_SETUP_TOKEN_ENV];
   delete normalizedEnv[QA_LIVE_SETUP_TOKEN_VALUE_ENV];
   return scrubQaGatewayChildSecretEnv(normalizedEnv);
+}
+
+export function buildQaForcedRuntimeEnvPatch(params: {
+  forcedRuntime?: RuntimeId;
+  providerMode: QaProviderMode;
+  providerBaseUrl?: string;
+}): NodeJS.ProcessEnv | undefined {
+  if (!params.forcedRuntime) {
+    return undefined;
+  }
+  const patch: NodeJS.ProcessEnv = {
+    OPENCLAW_BUILD_PRIVATE_QA: "1",
+    OPENCLAW_QA_FORCE_RUNTIME: params.forcedRuntime,
+  };
+  if (params.forcedRuntime !== "codex" || params.providerMode !== "mock-openai") {
+    return patch;
+  }
+  const providerBaseUrl = params.providerBaseUrl?.trim().replace(/\/+$/u, "");
+  if (!providerBaseUrl) {
+    throw new Error("forced Codex mock QA requires the managed mock provider URL");
+  }
+  patch.OPENCLAW_CODEX_APP_SERVER_ARGS = `app-server -c openai_base_url=${providerBaseUrl} --listen stdio://`;
+  patch.OPENAI_API_KEY = String(QA_MOCK_OPENAI_API_KEY);
+  patch.CODEX_API_KEY = String(QA_MOCK_OPENAI_API_KEY);
+  return patch;
 }
 
 function isRetryableGatewayCallError(details: string): boolean {
@@ -1171,7 +1197,14 @@ export async function startQaGatewayChild(params: {
           stagedBundledPluginsRoot,
           compatibilityHostVersion: stagedPluginRuntime.runtimeHostVersion,
           providerMode,
-          runtimeEnvPatch: params.runtimeEnvPatch,
+          runtimeEnvPatch: {
+            ...params.runtimeEnvPatch,
+            ...buildQaForcedRuntimeEnvPatch({
+              forcedRuntime: params.forcedRuntime,
+              providerMode,
+              providerBaseUrl: params.providerBaseUrl,
+            }),
+          },
           forwardHostHomeForClaudeCli: liveProviderIds.includes("claude-cli"),
           claudeCliAuthMode: params.claudeCliAuthMode,
         });

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -420,8 +420,8 @@ export function buildQaForcedRuntimeEnvPatch(params: {
     throw new Error("forced Codex mock QA requires the managed mock provider URL");
   }
   patch.OPENCLAW_CODEX_APP_SERVER_ARGS = `app-server -c openai_base_url=${providerBaseUrl} --listen stdio://`;
-  patch.OPENAI_API_KEY = String(QA_MOCK_OPENAI_API_KEY);
-  patch.CODEX_API_KEY = String(QA_MOCK_OPENAI_API_KEY);
+  patch.OPENAI_API_KEY = QA_MOCK_OPENAI_API_KEY;
+  patch.CODEX_API_KEY = QA_MOCK_OPENAI_API_KEY;
   return patch;
 }
 

--- a/extensions/qa-lab/src/providers/image-generation.test.ts
+++ b/extensions/qa-lab/src/providers/image-generation.test.ts
@@ -33,6 +33,28 @@ describe("QA provider image generation config", () => {
       "qa-channel",
     ]);
   });
+
+  it("keeps forced Codex text routing reproducible while images use the mock", () => {
+    const patch = buildQaImageGenerationConfigPatch({
+      providerMode: "mock-openai",
+      providerBaseUrl: "http://127.0.0.1:44080/v1",
+      requiredPluginIds: ["qa-channel"],
+      existingPluginIds: ["codex", "openai"],
+      forcedRuntime: "codex",
+    });
+
+    expect(patch.models?.mode).toBe("merge");
+    expect(patch.models?.providers["mock-openai"]).toBeUndefined();
+    expect(patch.models?.providers.openai?.baseUrl).toBe("https://api.openai.com/v1");
+    expect(patch.models?.providers.openai?.request).toBeUndefined();
+    expect(
+      patch.models?.providers.openai?.models.find((model) => model.id === "gpt-5.6-luna-alt")
+        ?.baseUrl,
+    ).toBeUndefined();
+    expect(
+      patch.models?.providers.openai?.models.find((model) => model.id === "gpt-image-1")?.baseUrl,
+    ).toBe("http://127.0.0.1:44080/v1");
+  });
   it("routes AIMock image generation through the OpenAI image provider", () => {
     const patch = buildQaImageGenerationConfigPatch({
       providerMode: "aimock",

--- a/extensions/qa-lab/src/providers/image-generation.ts
+++ b/extensions/qa-lab/src/providers/image-generation.ts
@@ -3,7 +3,11 @@ import {
   normalizeTrimmedStringList,
   uniqueStrings,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { QA_BASE_RUNTIME_PLUGIN_IDS } from "../qa-gateway-config.js";
+import {
+  QA_BASE_RUNTIME_PLUGIN_IDS,
+  QA_CODEX_OPENAI_CATALOG_BASE_URL,
+} from "../qa-gateway-config.js";
+import type { RuntimeId } from "../runtime-parity.js";
 import type { QaProviderMode } from "./index.js";
 import { getQaProvider } from "./index.js";
 
@@ -12,6 +16,7 @@ type QaImageGenerationPatchInput = {
   providerBaseUrl?: string;
   requiredPluginIds: readonly string[];
   existingPluginIds?: readonly string[];
+  forcedRuntime?: RuntimeId;
 };
 
 function splitModelProviderId(modelRef: string) {
@@ -44,9 +49,29 @@ export function buildQaImageGenerationConfigPatch(input: QaImageGenerationPatchI
     if (!input.providerBaseUrl) {
       throw new Error(`QA provider "${input.providerMode}" requires a mock provider URL`);
     }
-    return provider.buildGatewayModels({
+    const gatewayModels = provider.buildGatewayModels({
       providerBaseUrl: input.providerBaseUrl,
     });
+    if (input.forcedRuntime !== "codex" || input.providerMode !== "mock-openai") {
+      return gatewayModels;
+    }
+    const openAiCatalog = gatewayModels?.providers.openai;
+    if (!openAiCatalog) {
+      throw new Error("forced Codex mock image QA requires the OpenAI mock catalog");
+    }
+    return {
+      mode: "merge" as const,
+      providers: {
+        openai: {
+          ...openAiCatalog,
+          baseUrl: QA_CODEX_OPENAI_CATALOG_BASE_URL,
+          request: undefined,
+          models: openAiCatalog.models.map((model) =>
+            model.id === "gpt-image-1" ? { ...model, baseUrl: input.providerBaseUrl } : model,
+          ),
+        },
+      },
+    };
   })();
   const providerPluginIds = imageProviderId ? [imageProviderId] : [];
   const enabledPluginIds = uniqueNonEmpty(providerPluginIds);

--- a/extensions/qa-lab/src/providers/image-generation.ts
+++ b/extensions/qa-lab/src/providers/image-generation.ts
@@ -67,7 +67,9 @@ export function buildQaImageGenerationConfigPatch(input: QaImageGenerationPatchI
           baseUrl: QA_CODEX_OPENAI_CATALOG_BASE_URL,
           request: undefined,
           models: openAiCatalog.models.map((model) =>
-            model.id === "gpt-image-1" ? { ...model, baseUrl: input.providerBaseUrl } : model,
+            model.id === "gpt-image-1"
+              ? Object.assign({}, model, { baseUrl: input.providerBaseUrl })
+              : model,
           ),
         },
       },

--- a/extensions/qa-lab/src/qa-gateway-config.test.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.test.ts
@@ -259,6 +259,45 @@ describe("buildQaGatewayConfig", () => {
     expect(cfg.agents?.list?.[0]?.fastModeDefault).toBe(true);
   });
 
+  it("routes forced Codex mock cells through the app-server OpenAI provider", () => {
+    const cfg = buildQaGatewayConfig({
+      bind: "loopback",
+      gatewayPort: 18789,
+      gatewayToken: "token",
+      providerBaseUrl: "http://127.0.0.1:44080/v1",
+      workspaceDir: "/tmp/qa-workspace",
+      providerMode: "mock-openai",
+      forcedRuntime: "codex",
+      primaryModel: "mock-openai/gpt-5.6-luna",
+      alternateModel: "mock-openai/gpt-5.6-luna-alt",
+      enabledPluginIds: ["codex"],
+      ...createQaChannelTransportParams(),
+    });
+
+    expect(getPrimaryModel(cfg.agents?.defaults?.model)).toBe("openai/gpt-5.6-luna");
+    expect(getModelFallbacks(cfg.agents?.defaults?.model)).toEqual(["openai/gpt-5.6-luna-alt"]);
+    expect(cfg.models?.mode).toBe("merge");
+    expect(cfg.models?.providers?.openai?.baseUrl).toBe("https://api.openai.com/v1");
+    expect(cfg.models?.providers?.openai?.request).toBeUndefined();
+    expect(cfg.models?.providers?.openai?.models.map((model) => model.id)).toContain(
+      "gpt-5.6-luna-alt",
+    );
+    expect(cfg.plugins?.allow).toEqual([
+      "acpx",
+      "memory-core",
+      "qa-lab",
+      "codex",
+      "openai",
+      "qa-channel",
+    ]);
+    expect(cfg.plugins?.entries?.codex).toEqual({ enabled: true });
+    expect(cfg.plugins?.entries?.openai).toEqual({ enabled: true });
+    expect(cfg.agents?.defaults?.models).toEqual({
+      "openai/gpt-5.6-luna": {},
+      "openai/gpt-5.6-luna-alt": {},
+    });
+  });
+
   it("does not force OpenAI when the frontier lane only needs Anthropic and Google", () => {
     const cfg = buildQaGatewayConfig({
       bind: "loopback",

--- a/extensions/qa-lab/src/qa-gateway-config.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.ts
@@ -24,6 +24,7 @@ export const DEFAULT_QA_CONTROL_UI_ALLOWED_ORIGINS = Object.freeze([
 ]);
 
 export const QA_BASE_RUNTIME_PLUGIN_IDS = Object.freeze(["acpx", "memory-core"]);
+export const QA_CODEX_OPENAI_CATALOG_BASE_URL = "https://api.openai.com/v1";
 const QA_LAB_PLUGIN_ID = "qa-lab";
 
 export function mergeQaControlUiAllowedOrigins(extraOrigins?: string[]) {
@@ -36,6 +37,11 @@ export function mergeQaControlUiAllowedOrigins(extraOrigins?: string[]) {
 function normalizeQaGatewayModelRef(input: string | undefined, fallback: string) {
   const model = input?.trim();
   return model && model.length > 0 ? model : fallback;
+}
+
+function remapQaMockModelRefForCodex(modelRef: string) {
+  const split = splitQaModelRef(modelRef);
+  return split?.provider === "mock-openai" ? `openai/${split.model}` : modelRef;
 }
 
 function buildQaModelSelection(primaryModel: string, alternateModel: string) {
@@ -68,14 +74,21 @@ export function buildQaGatewayConfig(params: {
   const providerBaseUrl = params.providerBaseUrl ?? "http://127.0.0.1:44080/v1";
   const providerMode = normalizeQaProviderMode(params.providerMode ?? DEFAULT_QA_PROVIDER_MODE);
   const provider = getQaProvider(providerMode);
-  const primaryModel = normalizeQaGatewayModelRef(
+  const usesCodexMockAppServer = params.forcedRuntime === "codex" && providerMode === "mock-openai";
+  const normalizedPrimaryModel = normalizeQaGatewayModelRef(
     params.primaryModel,
     defaultQaModelForMode(providerMode),
   );
-  const alternateModel = normalizeQaGatewayModelRef(
+  const normalizedAlternateModel = normalizeQaGatewayModelRef(
     params.alternateModel,
     defaultQaModelForMode(providerMode, { alternate: true }),
   );
+  const primaryModel = usesCodexMockAppServer
+    ? remapQaMockModelRefForCodex(normalizedPrimaryModel)
+    : normalizedPrimaryModel;
+  const alternateModel = usesCodexMockAppServer
+    ? remapQaMockModelRefForCodex(normalizedAlternateModel)
+    : normalizedAlternateModel;
   const modelProviderIds = [primaryModel, alternateModel]
     .map((ref) => splitQaModelRef(ref)?.provider)
     .filter((providerValue): providerValue is string => Boolean(providerValue));
@@ -83,28 +96,30 @@ export function buildQaGatewayConfig(params: {
     params.imageGenerationModel !== undefined
       ? params.imageGenerationModel
       : provider.defaultImageGenerationModel({ modelProviderIds });
-  const selectedProviderIds = provider.usesModelProviderPlugins
-    ? [
-        ...new Set(
-          [...(params.enabledProviderIds ?? []), ...modelProviderIds, imageGenerationModelRef]
-            .map((value) =>
-              typeof value === "string" ? (splitQaModelRef(value)?.provider ?? value) : null,
-            )
-            .filter((providerLocal): providerLocal is string => Boolean(providerLocal)),
-        ),
-      ]
-    : [];
-  const selectedPluginIds = provider.usesModelProviderPlugins
-    ? uniqueStrings(
-        (params.enabledPluginIds?.length ?? 0) > 0
-          ? (params.enabledPluginIds ?? [])
-          : selectedProviderIds,
-      )
-    : uniqueStrings(
-        (params.enabledPluginIds ?? [])
-          .map((pluginId) => pluginId.trim())
-          .filter((pluginId) => pluginId.length > 0),
-      );
+  const selectedProviderIds =
+    provider.usesModelProviderPlugins || usesCodexMockAppServer
+      ? [
+          ...new Set(
+            [...(params.enabledProviderIds ?? []), ...modelProviderIds, imageGenerationModelRef]
+              .map((value) =>
+                typeof value === "string" ? (splitQaModelRef(value)?.provider ?? value) : null,
+              )
+              .filter((providerLocal): providerLocal is string => Boolean(providerLocal)),
+          ),
+        ]
+      : [];
+  const configuredPluginIds = uniqueStrings(
+    (params.enabledPluginIds ?? [])
+      .map((pluginId) => pluginId.trim())
+      .filter((pluginId) => pluginId.length > 0),
+  );
+  const selectedPluginIds = usesCodexMockAppServer
+    ? uniqueStrings([...configuredPluginIds, ...selectedProviderIds])
+    : provider.usesModelProviderPlugins
+      ? uniqueStrings(
+          (params.enabledPluginIds?.length ?? 0) > 0 ? configuredPluginIds : selectedProviderIds,
+        )
+      : configuredPluginIds;
   const transportPluginIds = uniqueStrings(params.transportPluginIds ?? [])
     .map((pluginId) => pluginId.trim())
     .filter((pluginId) => pluginId.length > 0);
@@ -137,10 +152,26 @@ export function buildQaGatewayConfig(params: {
     };
   };
   const allowedOrigins = mergeQaControlUiAllowedOrigins(params.controlUiAllowedOrigins);
-  const gatewayModels = provider.buildGatewayModels({
+  const providerGatewayModels = provider.buildGatewayModels({
     providerBaseUrl,
     liveProviderConfigs: params.liveProviderConfigs,
   });
+  const codexMockOpenAiCatalog = providerGatewayModels?.providers.openai;
+  const gatewayModels =
+    usesCodexMockAppServer && codexMockOpenAiCatalog
+      ? {
+          mode: "merge" as const,
+          providers: {
+            openai: {
+              ...codexMockOpenAiCatalog,
+              // Keep synthetic QA model ids registered without authoring the
+              // private mock route that the Codex harness cannot reproduce.
+              baseUrl: QA_CODEX_OPENAI_CATALOG_BASE_URL,
+              request: undefined,
+            },
+          },
+        }
+      : providerGatewayModels;
 
   return {
     plugins: {

--- a/extensions/qa-lab/src/suite-runtime-agent-media.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-media.ts
@@ -151,6 +151,8 @@ async function ensureImageGenerationConfigured(env: QaSuiteRuntimeEnv) {
       providerBaseUrl: env.mock ? `${env.mock.baseUrl}/v1` : undefined,
       requiredPluginIds: env.transport.requiredPluginIds,
       existingPluginIds: readPluginAllow(snapshot.config),
+      forcedRuntime:
+        env.gateway?.runtimeEnv?.OPENCLAW_QA_FORCE_RUNTIME === "codex" ? "codex" : undefined,
     }),
   });
   await waitForGatewayHealthy(env);


### PR DESCRIPTION
## Summary

- keep forced Codex mock cells on the managed app-server endpoint without authoring private Gateway request overrides
- preserve synthetic alternate-model registration and merge derived provider plugins with caller-selected plugins
- support model-specific OpenAI image endpoints so QA images stay local without changing the text provider route

## Root cause

Runtime parity remapped mock model refs onto `openai/*`, but the generated Gateway config retained the loopback provider request override. The Codex harness correctly rejected that authored route. Removing the provider wholesale was also insufficient because the synthetic alternate model still needs catalog registration, and image QA needs an independently scoped local endpoint.

## Validation

- `node scripts/test-projects.mjs extensions/openai/image-generation-provider.test.ts extensions/qa-lab/src/qa-gateway-config.test.ts extensions/qa-lab/src/gateway-child.test.ts extensions/qa-lab/src/providers/image-generation.test.ts extensions/qa-lab/src/suite-runtime-agent-media.test.ts extensions/qa-lab/src/suite.test.ts`
- 68 OpenAI image-provider tests passed
- 135 QA configuration/runtime tests passed
- structured Codex autoreview: clean
- isolated private-QA runtime pair with landed #105390: `model-switch-tool-continuity` passed in both OpenClaw and Codex cells with drift `none`
