### PR TITLE
refactor(audit): remove unused recorder reset

### DIFF
--- a/src/audit/audit-recorder.ts
+++ b/src/audit/audit-recorder.ts
@@ -59,7 +59,3 @@ export function createAuditEventRecorder(options: {
     },
   };
 }
-
-export function resetAuditEventRecorderForTest(): void {
-  persistenceFailureWarned = false;
-}


### PR DESCRIPTION
## What Problem This Solves

Removes an unused test-only audit recorder reset that exposed module state without any caller or test coverage.

## Why This Change Was Made

The reset was introduced with the recorder, has never been referenced, is absent from public barrels, and is not part of a tagged release. The active recorder factory, gateway subscription path, and the two genuinely used audit test resets remain unchanged.

## User Impact

No user-visible behavior changes. This reduces dead internal API surface in the audit subsystem.

## Evidence

- Codebase graph and repository-wide exact-symbol search found zero callers.
- Focused Testbox proof: `pnpm test:serial src/audit/audit-recorder.test.ts src/gateway/server-runtime-subscriptions.test.ts` passed all 17 assertions across the unit and gateway projects.
- Testbox `tbx_01kxbakyeajsxyc8sbv3kx4q8r`: `pnpm check:changed -- src/audit/audit-recorder.ts` passed.
- Fresh autoreview: `gpt-5.6-sol`, medium reasoning, clean with 0.93 confidence.
