### PR TITLE
refactor(infra): localize APNS response body limit

### DIFF
--- a/src/infra/push-apns-http2.ts
+++ b/src/infra/push-apns-http2.ts
@@ -20,7 +20,7 @@ const APNS_AUTHORITIES = new Set([
 type ApnsAuthority = "https://api.push.apple.com" | "https://api.sandbox.push.apple.com";
 
 export const APNS_HTTP2_CANCEL_CODE = http2.constants.NGHTTP2_CANCEL;
-export const APNS_RESPONSE_BODY_MAX_BYTES = 8192;
+const APNS_RESPONSE_BODY_MAX_BYTES = 8192;
 const APNS_HTTP2_MIN_TIMEOUT_MS = 1000;
 
 export type ApnsResponseBodyCapture = {


### PR DESCRIPTION
## What Problem This Solves

Removes an unnecessary exported symbol from the internal APNS HTTP/2 transport while preserving the response-body safety limit.

## Why This Change Was Made

`APNS_RESPONSE_BODY_MAX_BYTES` is used only as a same-file default parameter. The package export map, root entrypoint, and curated plugin SDK barrels expose no APNS module path, so the export modifier creates dead internal API surface without serving a supported consumer.

## User Impact

No user-visible behavior changes. APNS responses remain capped at 8192 bytes in direct sends and managed-proxy reachability probes.

## Evidence

- Exact-symbol search and codebase graph inspection found only the declaration and same-file default use.
- Full overlap audit covered all 2,816 open PRs, including separately paginated PRs with more than 100 files; none touch `src/infra/push-apns-http2.ts`.
- Testbox `tbx_01kxbb37seq4zfejr47m37w5y2`: `pnpm test:serial src/infra/push-apns-http2.test.ts src/infra/push-apns.test.ts` passed all 24 tests before and after the change.
- Same Testbox: `pnpm check:changed -- src/infra/push-apns-http2.ts` passed.
- Fresh `gpt-5.6-sol` medium autoreview returned no actionable findings at 0.92 confidence.
