### PR TITLE
fix(agents): reject invalid bundled LSP framing

### DIFF
--- a/src/agents/agent-bundle-lsp-runtime.test.ts
+++ b/src/agents/agent-bundle-lsp-runtime.test.ts
@@ -54,7 +54,7 @@ class MockChildProcess extends EventEmitter {
     private readonly frameResponse: (
       body: Record<string, unknown>,
       method: string,
-    ) => string = encodeLspMessage,
+    ) => string | readonly string[] = encodeLspMessage,
   ) {
     super();
     this.stdin = new Writable({
@@ -98,7 +98,11 @@ class MockChildProcess extends EventEmitter {
         : null;
     queueMicrotask(() => {
       const response = { jsonrpc: "2.0", id: body.id, result };
-      this.stdout.write(`${this.initializeResponsePrefix}${this.frameResponse(response, method)}`);
+      const frame = this.frameResponse(response, method);
+      const chunks = typeof frame === "string" ? [frame] : frame;
+      for (const [index, chunk] of chunks.entries()) {
+        this.stdout.write(`${index === 0 ? this.initializeResponsePrefix : ""}${chunk}`);
+      }
     });
   }
 }
@@ -342,6 +346,39 @@ describe("bundle LSP runtime", () => {
     await runtime.dispose();
   });
 
+  it("accepts a Content-Type header alongside Content-Length", async () => {
+    configureSingleLspServer();
+    const child = new MockChildProcess("", undefined, (body) => {
+      const json = JSON.stringify(body);
+      return `Content-Type: application/vscode-jsonrpc; charset=utf-8\r\nContent-Length: ${Buffer.byteLength(json, "utf-8")}\r\n\r\n${json}`;
+    });
+    spawnMock.mockReturnValue(child);
+    const { createBundleLspToolRuntime } = await import("./agent-bundle-lsp-runtime.js");
+
+    const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
+
+    expect(runtime.tools.map((tool) => tool.name)).toContain("lsp_hover_typescript");
+    await runtime.dispose();
+  });
+
+  it("accepts a maximum-size header when its separator is split across chunks", async () => {
+    configureSingleLspServer();
+    const child = new MockChildProcess("", undefined, (body) => {
+      const json = JSON.stringify(body);
+      const headerPrefix = `Content-Length: ${Buffer.byteLength(json, "utf-8")}\r\nX-Padding: `;
+      const header = `${headerPrefix}${"x".repeat(8 * 1024 - headerPrefix.length)}`;
+      const frame = `${header}\r\n\r\n${json}`;
+      return [frame.slice(0, header.length + 1), frame.slice(header.length + 1)];
+    });
+    spawnMock.mockReturnValue(child);
+    const { createBundleLspToolRuntime } = await import("./agent-bundle-lsp-runtime.js");
+
+    const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
+
+    expect(runtime.tools.map((tool) => tool.name)).toContain("lsp_hover_typescript");
+    await runtime.dispose();
+  });
+
   it.each([
     {
       name: "a suffixed Content-Length value",
@@ -356,6 +393,14 @@ describe("bundle LSP runtime", () => {
         const json = JSON.stringify(body);
         const length = Buffer.byteLength(json, "utf-8");
         return `Content-Length: ${length}\r\nContent-Length: ${length}\r\n\r\n${json}`;
+      },
+    },
+    {
+      name: "a colonless header line",
+      frame: (body: Record<string, unknown>) => {
+        const json = JSON.stringify(body);
+        const length = Buffer.byteLength(json, "utf-8");
+        return `Content-Length: ${length}\r\nbroken\r\n\r\n${json}`;
       },
     },
     {

--- a/src/agents/agent-bundle-lsp-runtime.test.ts
+++ b/src/agents/agent-bundle-lsp-runtime.test.ts
@@ -51,6 +51,10 @@ class MockChildProcess extends EventEmitter {
   constructor(
     private readonly initializeResponsePrefix = "",
     private readonly respondMethods?: ReadonlySet<string>,
+    private readonly frameResponse: (
+      body: Record<string, unknown>,
+      method: string,
+    ) => string = encodeLspMessage,
   ) {
     super();
     this.stdin = new Writable({
@@ -78,11 +82,12 @@ class MockChildProcess extends EventEmitter {
     if (typeof body.id !== "number" || typeof body.method !== "string") {
       return;
     }
-    if (this.respondMethods && !this.respondMethods.has(body.method)) {
+    const method = body.method;
+    if (this.respondMethods && !this.respondMethods.has(method)) {
       return;
     }
     const result =
-      body.method === "initialize"
+      method === "initialize"
         ? {
             capabilities: {
               hoverProvider: true,
@@ -92,9 +97,8 @@ class MockChildProcess extends EventEmitter {
           }
         : null;
     queueMicrotask(() => {
-      this.stdout.write(
-        `${this.initializeResponsePrefix}${encodeLspMessage({ jsonrpc: "2.0", id: body.id, result })}`,
-      );
+      const response = { jsonrpc: "2.0", id: body.id, result };
+      this.stdout.write(`${this.initializeResponsePrefix}${this.frameResponse(response, method)}`);
     });
   }
 }
@@ -335,6 +339,67 @@ describe("bundle LSP runtime", () => {
     const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
 
     expect(runtime.tools.map((tool) => tool.name)).toContain("lsp_hover_typescript");
+    await runtime.dispose();
+  });
+
+  it.each([
+    {
+      name: "a suffixed Content-Length value",
+      frame: (body: Record<string, unknown>) => {
+        const json = JSON.stringify(body);
+        return `Content-Length: ${Buffer.byteLength(json, "utf-8")}junk\r\n\r\n${json}`;
+      },
+    },
+    {
+      name: "duplicate Content-Length fields",
+      frame: (body: Record<string, unknown>) => {
+        const json = JSON.stringify(body);
+        const length = Buffer.byteLength(json, "utf-8");
+        return `Content-Length: ${length}\r\nContent-Length: ${length}\r\n\r\n${json}`;
+      },
+    },
+    {
+      name: "an oversized declared body",
+      frame: () => `Content-Length: ${64 * 1024 * 1024 + 1}\r\n\r\n`,
+    },
+    {
+      name: "an oversized unterminated header",
+      frame: () => `X-Header: ${"x".repeat(8 * 1024)}`,
+    },
+  ])("fails the LSP session immediately for $name", async ({ frame }) => {
+    configureSingleLspServer();
+    const child = new MockChildProcess(
+      "",
+      new Set(["initialize", "textDocument/hover"]),
+      (body, method) => (method === "initialize" ? encodeLspMessage(body) : frame(body)),
+    );
+    spawnMock.mockReturnValue(child);
+    const { createBundleLspToolRuntime } = await import("./agent-bundle-lsp-runtime.js");
+
+    const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
+    const hoverTool = runtime.tools.find((tool) => tool.name === "lsp_hover_typescript");
+    if (!hoverTool) {
+      throw new Error("expected hover tool");
+    }
+
+    const request = hoverTool.execute("call-1", {
+      uri: "file:///tmp/workspace/index.ts",
+      line: 0,
+      character: 0,
+    });
+    const outcome = await Promise.race([
+      request.then(
+        () => "resolved",
+        (error: unknown) => (error instanceof Error ? error.message : String(error)),
+      ),
+      new Promise<string>((resolve) => {
+        setTimeout(() => resolve("still pending"), 100);
+      }),
+    ]);
+
+    expect(outcome).toMatch(/LSP framing error/i);
+    expect(killProcessTreeMock).toHaveBeenCalledWith(4321, { graceMs: 1000 });
+
     await runtime.dispose();
   });
 

--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -204,7 +204,7 @@ function parseContentLength(header: string): number | LspFramingError {
   for (const line of header.split("\r\n")) {
     const separator = line.indexOf(":");
     if (separator === -1) {
-      continue;
+      return new LspFramingError("LSP framing error: header line must contain a colon");
     }
     if (line.slice(0, separator).trim().toLowerCase() === "content-length") {
       values.push(line.slice(separator + 1).trim());
@@ -238,7 +238,8 @@ function parseLspMessages(buffer: Buffer): LspParseResult {
   while (true) {
     const headerEnd = remaining.indexOf(LSP_HEADER_SEPARATOR);
     if (headerEnd === -1) {
-      return remaining.length > MAX_LSP_HEADER_BYTES
+      const maxIncompleteHeaderBytes = MAX_LSP_HEADER_BYTES + LSP_HEADER_SEPARATOR.length - 1;
+      return remaining.length > maxIncompleteHeaderBytes
         ? framingError(messages, `header exceeds ${MAX_LSP_HEADER_BYTES} bytes`)
         : { ok: true, messages, remaining };
     }

--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -179,47 +179,94 @@ function encodeLspMessage(body: unknown): string {
   return `Content-Length: ${Buffer.byteLength(json, "utf-8")}\r\n\r\n${json}`;
 }
 
-function parseLspMessages(buffer: Buffer): { messages: unknown[]; remaining: Buffer } {
+const LSP_HEADER_SEPARATOR = Buffer.from("\r\n\r\n", "ascii");
+const MAX_LSP_HEADER_BYTES = 8 * 1024;
+const MAX_LSP_BODY_BYTES = 64 * 1024 * 1024;
+
+class LspFramingError extends Error {
+  override readonly name = "LspFramingError";
+}
+
+type LspParseResult =
+  | { readonly ok: true; readonly messages: unknown[]; readonly remaining: Buffer }
+  | { readonly ok: false; readonly messages: unknown[]; readonly error: LspFramingError };
+
+function framingError(messages: unknown[], detail: string): LspParseResult {
+  return {
+    ok: false,
+    messages,
+    error: new LspFramingError(`LSP framing error: ${detail}`),
+  };
+}
+
+function parseContentLength(header: string): number | LspFramingError {
+  const values: string[] = [];
+  for (const line of header.split("\r\n")) {
+    const separator = line.indexOf(":");
+    if (separator === -1) {
+      continue;
+    }
+    if (line.slice(0, separator).trim().toLowerCase() === "content-length") {
+      values.push(line.slice(separator + 1).trim());
+    }
+  }
+  if (values.length !== 1) {
+    return new LspFramingError(
+      `LSP framing error: expected exactly one Content-Length header, received ${values.length}`,
+    );
+  }
+  const value = values[0];
+  if (value === undefined || !/^[0-9]+$/.test(value)) {
+    return new LspFramingError("LSP framing error: Content-Length must be decimal digits");
+  }
+  const length = Number(value);
+  if (!Number.isSafeInteger(length) || length <= 0) {
+    return new LspFramingError("LSP framing error: Content-Length must be a positive safe integer");
+  }
+  if (length > MAX_LSP_BODY_BYTES) {
+    return new LspFramingError(
+      `LSP framing error: Content-Length exceeds ${MAX_LSP_BODY_BYTES} bytes`,
+    );
+  }
+  return length;
+}
+
+function parseLspMessages(buffer: Buffer): LspParseResult {
   const messages: unknown[] = [];
   let remaining = buffer;
-  const headerSeparator = Buffer.from("\r\n\r\n", "ascii");
 
   while (true) {
-    const headerEnd = remaining.indexOf(headerSeparator);
+    const headerEnd = remaining.indexOf(LSP_HEADER_SEPARATOR);
     if (headerEnd === -1) {
-      break;
+      return remaining.length > MAX_LSP_HEADER_BYTES
+        ? framingError(messages, `header exceeds ${MAX_LSP_HEADER_BYTES} bytes`)
+        : { ok: true, messages, remaining };
+    }
+    if (headerEnd > MAX_LSP_HEADER_BYTES) {
+      return framingError(messages, `header exceeds ${MAX_LSP_HEADER_BYTES} bytes`);
     }
 
-    const header = remaining.subarray(0, headerEnd).toString("ascii");
-    const match = header.match(/Content-Length:\s*(\d+)/i);
-    if (!match) {
-      remaining = remaining.subarray(headerEnd + headerSeparator.length);
-      continue;
+    const contentLength = parseContentLength(remaining.subarray(0, headerEnd).toString("ascii"));
+    if (contentLength instanceof LspFramingError) {
+      return { ok: false, messages, error: contentLength };
     }
-
-    const contentLengthText = match.at(1);
-    if (contentLengthText === undefined) {
-      remaining = remaining.subarray(headerEnd + headerSeparator.length);
-      continue;
-    }
-    const contentLength = Number.parseInt(contentLengthText, 10);
-    const bodyStart = headerEnd + headerSeparator.length;
+    const bodyStart = headerEnd + LSP_HEADER_SEPARATOR.length;
     const bodyEnd = bodyStart + contentLength;
-
     if (remaining.length < bodyEnd) {
-      break;
+      return { ok: true, messages, remaining };
     }
 
+    const body = remaining.subarray(bodyStart, bodyEnd).toString("utf8");
     try {
-      const body = remaining.subarray(bodyStart, bodyEnd).toString("utf8");
       messages.push(JSON.parse(body));
-    } catch {
-      // skip malformed
+    } catch (error) {
+      return framingError(
+        messages,
+        `body is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
     remaining = remaining.subarray(bodyEnd);
   }
-
-  return { messages, remaining };
 }
 
 function lspAbortError(signal?: AbortSignal): Error {
@@ -276,10 +323,14 @@ function handleIncomingData(session: LspSession, chunk: Buffer | string) {
     session.buffer,
     typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk,
   ]);
-  const { messages, remaining } = parseLspMessages(session.buffer);
-  session.buffer = remaining.length === 0 ? Buffer.alloc(0) : Buffer.from(remaining);
+  const parsed = parseLspMessages(session.buffer);
+  session.buffer = parsed.ok
+    ? parsed.remaining.length === 0
+      ? Buffer.alloc(0)
+      : Buffer.from(parsed.remaining)
+    : Buffer.alloc(0);
 
-  for (const msg of messages) {
+  for (const msg of parsed.messages) {
     if (typeof msg !== "object" || msg === null) {
       continue;
     }
@@ -299,6 +350,10 @@ function handleIncomingData(session: LspSession, chunk: Buffer | string) {
     if ("method" in record && !("id" in record)) {
       logDebug(`bundle-lsp:${session.serverName}: notification ${String(record.method)}`);
     }
+  }
+  if (!parsed.ok) {
+    failLspSession(session, parsed.error);
+    terminateLspProcessTree(session);
   }
 }
 


### PR DESCRIPTION
## Summary

- Problem: bundled LSP stdout framing accepts numeric prefixes such as `Content-Length: 12junk`, does not reject duplicate lengths, and has no header/body size bounds.
- Solution: parse the header boundary strictly and fail the affected LSP session immediately on the first framing violation.
- What changed: one runtime parser and its focused regression tests.
- What was not changed: outbound framing, bundle discovery/configuration, LSP request payloads, tool schemas, or the general request timeout.

## What Problem This Solves

The current regex is not anchored to a complete header value and `Number.parseInt` accepts a decimal prefix. A malformed frame can therefore be cut at the wrong byte boundary; an oversized unterminated header or declared body can also remain buffered indefinitely. Subsequent JSON-RPC responses no longer align with pending request ids, so users see a misleading generic 10-second timeout instead of the framing error.

## User Impact

A broken or adversarial bundled language server can stall every pending LSP tool request in its session and retain an ever-growing buffer. After this patch, the first invalid frame rejects pending requests with a specific LSP framing error and terminates the child process, while valid frames keep completing normally.

## Origin / follow-up

- **Follows / completes:** #85341, which internalized the bundled agent LSP runtime.
- **Gap this fills:** the internalized stdio parser still partially accepts malformed `Content-Length` values and lacks framing size limits.
- **Consistency:** this keeps framing ownership and session cleanup inside `agent-bundle-lsp-runtime.ts`; no discovery or tool-contract layer is changed.

## Competition / linked PR analysis

- **Linked PR(s):** #103046.
- **Gap in linked PR(s):** it overlaps on oversized bodies but does not reject suffixed or duplicate `Content-Length` fields or bound unterminated headers.
- **Why this patch is better/canonical:** it fails at the fatal header boundary without adding cross-chunk drain state, so pending requests receive the actual error immediately.
- **Local real behavior proof advantage:** the proof drives `createBundleLspToolRuntime` through a real spawned stdio executable that emits both the invalid frame and a canonical control frame.

## Merge risk

- **Why it matters / User impact:** invalid child-process output currently becomes session stalls, retained buffers, and misleading timeouts.
- **Risk labels considered:** compatibility / session-state / availability.
- **Risk explanation:** protocol-invalid or over-limit frames that were previously partially accepted, skipped, or buffered now close the affected LSP session.
- **Why acceptable:** the intentional compatibility change is limited to invalid framing; valid chunked and multibyte frames retain the existing byte-oriented path, and both focused tests and a real subprocess control cover it.
- **Maintainer-ready confidence:** High — RED reproduces the permissive parser, the functionally identical pre-format 19-test focused suite passes on Blacksmith Testbox-through-Crabbox, and predecessor-head real behavior proof exercises both a real third-party language server and a malformed real subprocess.
- **Patch quality notes:** the production diff adds a broad `JSON.parse` catch only at the untrusted frame boundary; it narrows the caught value when formatting the terminal protocol error and does not swallow it. The related open PR scan found #103046 and is documented above. Automated large-diff/session/message warnings include unrelated commits that advanced `origin/main`; the actual three-dot PR diff is two files: the LSP runtime and its test.
- **Target test file:** `src/agents/agent-bundle-lsp-runtime.test.ts`.
- **Root cause:** the canonical stdout parser uses an unanchored `Content-Length` regex followed by `Number.parseInt`; because prefix parsing accepts `12junk` as `12`, the framing invariant is broken before bytes enter session state, and missing size bounds let incomplete declarations wait indefinitely.
- **Why this is root-cause fix:** the change replaces the permissive framing parser at the sole stdout trust boundary, before bytes enter session state or responses reach the pending-request consumer.
- **What did NOT change:** this patch changes only bundled LSP stdout parsing and its focused tests. It does not change public API, configuration schema, outbound protocol framing, provider/channel behavior, default LSP methods, unrelated session state, docs or lockfiles.
- **Architecture / source-of-truth check:** `src/agents/agent-bundle-lsp-runtime.ts` is the canonical owner of bundled LSP stdio framing, buffer state, pending request settlement, and child cleanup. The invariant is enforced there once rather than downstream in each LSP tool.
- **Scenario locked in:** suffixed length, duplicate length, oversized declared body, and oversized unterminated header all fail immediately; canonical frames and an exactly 8 KiB header with a separator split across stdout chunks still complete.
- **Why this is the smallest reliable guardrail:** one parser result carries either completed messages plus remaining bytes or completed messages plus a terminal framing error; the existing session failure and process-tree cleanup functions handle the rest.

## Evidence

- **Exact PR head:** `04ee54135c016c872a13567263bec69360e94d41`.
- **Environment:** functionally identical pre-format focused proof ran on Blacksmith Testbox-through-Crabbox (`tbx_01kxdtsvt9a89x7zy09af52epc`, Actions run `29254097371`); predecessor-head real behavior proof ran in sanitized direct AWS Crabbox on Linux / Node 24.15.0 with public networking, no Tailscale, and no hydration.
- **Focused suite:** pre-format Testbox run `29254097371` passed all 19 tests in `src/agents/agent-bundle-lsp-runtime.test.ts`, including manifest-registry reuse, valid `Content-Type`, colonless headers, duplicate/suffixed lengths, size bounds, split-separator boundary chunking, request failure, and process cleanup.
- **Real third-party server:** predecessor-head (`5386f8b22bf56ecb7eb46ad390ba00e161e6ced3`) Crabbox run `run_f805f238ea53` installed `typescript-language-server@5.3.0` with `typescript@5.9.3`, loaded it through a temporary enabled Claude bundle manifest/registry, spawned it through `createBundleLspToolRuntime`, and completed a canonical `textDocument/hover` through the resulting OpenClaw tool.
- **Malformed subprocess:** the same run loaded a second real Node child through the same bundle/runtime path. It returned a valid initialize response, then a hover response containing a colonless header line. The pending request rejected immediately with `LSP framing error: header line must contain a colon`, and the child recorded `SIGTERM`.
- **Boundary crossed:** bundle manifest/config and prepared manifest registry → embedded-agent LSP runtime → real OS process spawn → stdin JSON-RPC → stdout LSP framing → pending request settlement → process-tree termination.
- **Main integration:** the branch was rebased onto `origin/main` at `afb282ee682`; current main later advanced to `afdc3931a80` without intervening changes to either touched LSP file. A local merge-tree check remains conflict-free, and current-main manifest-registry plumbing remains present in the PR head.
- **Proof artifact:** the harness was temporary and uncommitted; it asserted the immutable checkout SHA before running and removed its bundle/server artifacts afterward.

```text
{
  "real_behavior_proof_sha": "5386f8b22bf56ecb7eb46ad390ba00e161e6ced3",
  "real_server": "typescript-language-server@5.3.0 + typescript@5.9.3",
  "canonical_hover": "completed through OpenClaw runtime",
  "malformed_header": "LSP framing error: header line must contain a colon",
  "malformed_child_termination": "SIGTERM"
}
```

- **Fix classification:** Root cause fix.
- **Remaining proof gap:** no non-Linux platform was exercised.

## Review findings addressed

- **RF-001:** Resolved — incomplete-header sizing now reserves the possible three-byte separator prefix, and a regression test splits the separator after its first byte at the exact 8 KiB header boundary.

## Regression Test Plan

```bash
pnpm test src/agents/agent-bundle-lsp-runtime.test.ts
```

Functionally identical pre-format Blacksmith Testbox-through-Crabbox run `29254097371` (`tbx_01kxdtsvt9a89x7zy09af52epc`) passed all 19 focused tests. Predecessor-head sanitized AWS Crabbox run `run_f805f238ea53` passed the canonical third-party-server and malformed-subprocess scenarios above; the amended delta only makes the 8 KiB header boundary independent of separator chunking.

## Risk / Compatibility

Medium compatibility/availability risk at a narrow protocol boundary. Standards-compliant positive safe `Content-Length` frames at or below 64 MiB are unchanged. Invalid values, duplicate fields, headers above 8 KiB, bodies above 64 MiB, and invalid JSON bodies now terminate only the affected bundled LSP session instead of being accepted or left pending.

## What was not changed

- Public API / schema / protocol / defaults: no outbound or public contract changes.
- Channel/provider/session/security behavior outside the fixed path: no changes.
- Unrelated cleanup, docs, or lockfiles: none in the three-dot PR diff.

## Root Cause

- **Root cause:** the framing boundary used an unanchored regex plus prefix-tolerant integer parsing and had no header/body bounds.
- **Why this is root-cause fix:** strict line parsing and size invariants are applied before bytes can alter session framing state or pending-request matching.
- **Maintainer-ready confidence:** High — failing reproduction and focused GREEN bind the functionally identical pre-format commit `19cd35dc43da3499b3afbe1e89d46c9ad790c0e6`; exact head `04ee54135c016c872a13567263bec69360e94d41` differs only by repository formatter line wrapping; predecessor-head real-server/malformed-subprocess proof remains applicable because the amended delta only fixes partial-separator accounting at the existing header cap.
- **Patch quality notes:** the change reuses existing session failure and process cleanup paths; it adds no new mutable drain/session mode and no unrelated refactor.
- **Architecture / source-of-truth check:** the guard is located in the canonical bundled LSP stdout parser, not in downstream hover/definition tools or generic timeout handling.


Fixes #105675





