### PR TITLE
refactor(doctor): localize database bloat collector

### DIFF
--- a/src/commands/doctor-db-bloat.ts
+++ b/src/commands/doctor-db-bloat.ts
@@ -80,7 +80,7 @@ function describeBloat(label: string, stats: SqliteBloatStats): string | null {
   return null;
 }
 
-export function collectSqliteBloatWarnings(deps?: { env?: NodeJS.ProcessEnv }): string[] {
+function collectSqliteBloatWarnings(deps?: { env?: NodeJS.ProcessEnv }): string[] {
   const env = deps?.env ?? process.env;
   const warnings: string[] = [];
   const statePath = resolveOpenClawStateSqlitePath(env);


### PR DESCRIPTION
## What Problem This Solves

Removes an unused export from the internal Doctor SQLite bloat contribution.

## Why This Change Was Made

`collectSqliteBloatWarnings` is called only by `noteSqliteDatabaseBloat` in the same module. Unlike structured `collect*HealthFindings` APIs, no Doctor health-check contract, test, package entrypoint, or plugin SDK barrel consumes this collector.

## User Impact

No user-visible behavior changes. Doctor continues to inspect state and agent SQLite databases and emit the same size and reclaimable-page warnings.

## Evidence

- Exact tracked-file search on the branch and `origin/main` found no imports; graph traversal found only the same-file note-function caller.
- The helper was introduced on July 11, 2026 and is absent from release tags.
- Full overlap audit covered all 2,816 open PRs, with a current update delta recheck; none touch `src/commands/doctor-db-bloat.ts`.
- Testbox `tbx_01kxbbj9smy76dy1pz142bewnr`: `pnpm test:serial src/flows/doctor-health-contributions.test.ts` passed all 91 tests before and after the change.
- Same Testbox: `pnpm check:changed -- src/commands/doctor-db-bloat.ts` passed.
- Fresh `gpt-5.6-sol` medium autoreview raised one claim that existing tests import the helper. That finding was rejected as factually false: `git grep` found zero test or external consumers, the graph found one same-file caller, and core-test typecheck passed.
