### PR TITLE
refactor(sessions): route updates through patch path

### DIFF
--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -64,7 +64,6 @@ import {
   replaceSqliteTranscriptEvents,
   restoreSqliteCompactionCheckpointSession,
   sqliteTranscriptExists,
-  updateSqliteSessionEntry,
   upsertSqliteSessionEntry,
 } from "./session-accessor.sqlite.js";
 import { parseSqliteSessionFileMarker } from "./sqlite-marker.js";
@@ -201,7 +200,7 @@ const sqliteAdapter: AccessorAdapter = {
   upsertSessionEntry: upsertSqliteSessionEntry,
   replaceSessionEntry: replaceSqliteSessionEntry,
   patchSessionEntry: patchSqliteSessionEntry,
-  updateSessionEntry: updateSqliteSessionEntry,
+  updateSessionEntry: patchSqliteSessionEntry,
   cleanupSessionLifecycleArtifacts: cleanupSqliteSessionLifecycleArtifacts,
   loadTranscriptEvents: loadSqliteTranscriptEvents,
   appendTranscriptEvent: appendSqliteTranscriptEvent,
@@ -735,7 +734,7 @@ describe.each([publicAccessorAdapter, sqliteAdapter])(
       });
     });
 
-    it("serializes concurrent SQLite entry patches and updates", async () => {
+    it("serializes concurrent SQLite entry patches", async () => {
       const scope = sqliteAdapter.entryScope(paths);
 
       await upsertSqliteSessionEntry(scope, {
@@ -766,30 +765,6 @@ describe.each([publicAccessorAdapter, sqliteAdapter])(
       expect(loadSqliteSessionEntry(scope)).toMatchObject({
         model: "first",
         providerOverride: "openai",
-      });
-
-      let firstUpdate!: Promise<SessionEntry | null>;
-      let releaseUpdate!: () => void;
-      const updateStarted = new Promise<void>((resolve) => {
-        const blockedUpdate = new Promise<void>((release) => {
-          releaseUpdate = release;
-        });
-        firstUpdate = updateSqliteSessionEntry(scope, async () => {
-          resolve();
-          await blockedUpdate;
-          return { model: "updated" };
-        });
-      });
-      await updateStarted;
-      const secondUpdate = updateSqliteSessionEntry(scope, () => ({
-        providerOverride: "anthropic",
-      }));
-      releaseUpdate();
-      await Promise.all([firstUpdate, secondUpdate]);
-
-      expect(loadSqliteSessionEntry(scope)).toMatchObject({
-        model: "updated",
-        providerOverride: "anthropic",
       });
     });
 
@@ -1507,7 +1482,7 @@ describe("sqlite session normalization", () => {
       staleTranscriptEvent,
     );
 
-    await updateSqliteSessionEntry(scopeFor("agent:main:active"), () => ({ model: "gpt-5.5" }), {
+    await patchSqliteSessionEntry(scopeFor("agent:main:active"), () => ({ model: "gpt-5.5" }), {
       skipMaintenance: true,
     });
     await expect(
@@ -1528,7 +1503,7 @@ describe("sqlite session normalization", () => {
 
     const notify = vi.fn();
     const unsubscribe = onSessionIdentityMutation(notify);
-    await updateSqliteSessionEntry(scopeFor("agent:main:active"), () => ({
+    await patchSqliteSessionEntry(scopeFor("agent:main:active"), () => ({
       providerOverride: "openai",
     }));
     unsubscribe();
@@ -1666,7 +1641,7 @@ describe("sqlite session normalization", () => {
       },
     );
 
-    await updateSqliteSessionEntry(scopeFor("agent:main:active-budget"), () => ({
+    await patchSqliteSessionEntry(scopeFor("agent:main:active-budget"), () => ({
       modelOverride: "gpt-5.5",
     }));
 

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -82,7 +82,6 @@ import type {
   SessionEntryTargetPatchScope,
   SessionLifecycleArtifactCleanupParams,
   SessionLifecycleArtifactCleanupResult,
-  SessionEntryUpdateOptions,
   SessionTranscriptAccessScope,
   SessionTranscriptReadScope,
   SessionTranscriptStats,
@@ -841,71 +840,6 @@ async function persistSqliteParentForkSkipPatch(params: {
   emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
   finalizeSqliteSessionEntryMaintenancePlansBestEffort(params.resolved, maintenancePlans);
   return cloneSessionEntry(next);
-}
-
-/** Updates an existing entry in the additive SQLite session store. */
-export async function updateSqliteSessionEntry(
-  scope: SessionAccessScope,
-  update: (
-    entry: SessionEntry,
-  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
-  options: SessionEntryUpdateOptions = {},
-): Promise<SessionEntry | null> {
-  const resolved = resolveSqliteScope(scope);
-  return await runExclusiveSqliteSessionWrite(resolved, async () => {
-    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-    const prepared = readSqliteSessionEntrySelectionSnapshot(database, resolved.sessionKey, false);
-    const writeBase = prepared.selected?.entry;
-    if (!writeBase) {
-      return null;
-    }
-    const patch = await update(cloneSessionEntry(writeBase));
-    const maintenancePlans: SqliteSessionEntryMaintenancePlan[] = [];
-    let result: SessionEntry | null = null;
-    let previousIdentity = new Map<string, SessionEntry>();
-    let currentIdentity = new Map<string, SessionEntry>();
-    runOpenClawAgentWriteTransaction((writeDatabase) => {
-      const fresh = readSqliteSessionEntrySelectionSnapshot(
-        writeDatabase,
-        resolved.sessionKey,
-        false,
-      );
-      assertSqliteSessionEntrySelectionUnchanged(prepared, fresh, "session-entry.update");
-      if (!patch) {
-        result = cloneSessionEntry(writeBase);
-        return;
-      }
-      const identityKeys = [
-        resolved.sessionKey,
-        ...fresh.selectedRows.map((row) => row.sessionKey),
-      ];
-      previousIdentity = createSqliteSessionIdentitySnapshot(fresh.selectedRows);
-      const merged = mergeSessionEntry(writeBase, patch);
-      const next = preserveSqliteSameKeySessionRolloverLineage({
-        next: merged,
-        previous: writeBase,
-        sessionKey: resolved.sessionKey,
-      });
-      writeSessionEntry(writeDatabase, resolved.sessionKey, next);
-      deleteLegacySessionEntryRows(
-        writeDatabase,
-        fresh.selected?.legacyKeys ?? [],
-        resolved.sessionKey,
-      );
-      maintenancePlans.push(
-        applySqliteSessionEntryMaintenance(writeDatabase, {
-          activeSessionKey: resolved.sessionKey,
-          archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
-          skipMaintenance: options.skipMaintenance,
-        }),
-      );
-      currentIdentity = readSqliteSessionIdentitySnapshot(writeDatabase, identityKeys);
-      result = cloneSessionEntry(next);
-    }, toDatabaseOptions(resolved));
-    emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
-    finalizeSqliteSessionEntryMaintenancePlansBestEffort(resolved, maintenancePlans);
-    return result;
-  });
 }
 
 /** Cleans scoped session lifecycle rows and associated SQLite transcript state. */

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -67,7 +67,6 @@ import {
   rollbackSqliteAgentHarnessSessionEntryLifecycle,
   rollbackSqlitePluginOwnedSessionEntryLifecycle,
   resetSqliteSessionEntryLifecycle,
-  updateSqliteSessionEntry,
   upsertSqliteSessionEntry,
   withSqliteTranscriptWriteLock,
   withSqliteTranscriptWriteTransaction,
@@ -1513,7 +1512,7 @@ export async function updateSessionEntry(
   ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
   options: SessionEntryUpdateOptions = {},
 ): Promise<SessionEntry | null> {
-  return await updateSqliteSessionEntry(scope, update, options);
+  return await patchSqliteSessionEntry(scope, update, options);
 }
 
 export type RecordInboundSessionMetaParams = {


### PR DESCRIPTION
## What Problem This Solves

`updateSqliteSessionEntry` duplicated the canonical SQLite session patch transaction, including selection validation, merge, rollover lineage, alias cleanup, maintenance, and identity publication. Keeping two mutation paths made a heavily used session API harder to reason about and easier to drift.

Fixes #105463

## Why This Change Was Made

`patchSqliteSessionEntry` already has the same absent-entry, async-updater, null-skip, merge, serialization, and post-commit semantics. `updateSessionEntry` now delegates to that owner directly, and the duplicate implementation and duplicate conformance branch are removed.

## User Impact

No intended behavior change. Session updates retain their existing API contract while the SQLite implementation has one canonical mutation path. Production code shrinks by 67 lines.

## Evidence

- `pnpm test:serial src/config/sessions/session-accessor.conformance.test.ts src/config/sessions/session-accessor.test.ts src/config/sessions/session-accessor.reply-init-concurrency.test.ts` in Testbox `tbx_01kxbbvbjhr5p44xd2cx96asv8`: 118 tests passed
- `pnpm check:changed` in the same Testbox: passed
- fresh branch autoreview with `gpt-5.6-sol` high reasoning: clean, correctness 0.94
- `git diff --check`: passed
