### PR TITLE
fix(matrix): parse JSON response types with mixed casing

### DIFF
--- a/extensions/matrix/src/matrix/sdk/http-client.test.ts
+++ b/extensions/matrix/src/matrix/sdk/http-client.test.ts
@@ -66,6 +66,29 @@ describe("MatrixAuthedHttpClient", () => {
     });
   });
 
+  it("parses JSON responses when the media type casing differs", async () => {
+    performMatrixRequestMock.mockResolvedValue({
+      response: new Response('{"ok":true}', {
+        status: 200,
+        headers: { "content-type": "Application/JSON; charset=utf-8" },
+      }),
+      text: '{"ok":true}',
+      buffer: Buffer.from('{"ok":true}', "utf8"),
+    });
+
+    const client = new MatrixAuthedHttpClient({
+      homeserver: "https://matrix.example.org",
+      accessToken: "token",
+    });
+    const result = await client.requestJson({
+      method: "GET",
+      endpoint: "/_matrix/client/v3/account/whoami",
+      timeoutMs: 5000,
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
   it("returns plain text when response is not JSON", async () => {
     performMatrixRequestMock.mockResolvedValue({
       response: new Response("pong", {

--- a/extensions/matrix/src/matrix/sdk/http-client.test.ts
+++ b/extensions/matrix/src/matrix/sdk/http-client.test.ts
@@ -89,6 +89,32 @@ describe("MatrixAuthedHttpClient", () => {
     expect(result).toEqual({ ok: true });
   });
 
+  it.each(["application/json-seq", 'text/plain; profile="application/json"'])(
+    "does not parse a non-JSON media type containing application/json (%s)",
+    async (contentType) => {
+      performMatrixRequestMock.mockResolvedValue({
+        response: new Response('{"ok":true}', {
+          status: 200,
+          headers: { "content-type": contentType },
+        }),
+        text: '{"ok":true}',
+        buffer: Buffer.from('{"ok":true}', "utf8"),
+      });
+
+      const client = new MatrixAuthedHttpClient({
+        homeserver: "https://matrix.example.org",
+        accessToken: "token",
+      });
+      const result = await client.requestJson({
+        method: "GET",
+        endpoint: "/_matrix/client/v3/account/whoami",
+        timeoutMs: 5000,
+      });
+
+      expect(result).toBe('{"ok":true}');
+    },
+  );
+
   it("returns plain text when response is not JSON", async () => {
     performMatrixRequestMock.mockResolvedValue({
       response: new Response("pong", {

--- a/extensions/matrix/src/matrix/sdk/http-client.ts
+++ b/extensions/matrix/src/matrix/sdk/http-client.ts
@@ -48,7 +48,7 @@ export class MatrixAuthedHttpClient {
       throw buildHttpError(response.status, text);
     }
     const contentType = response.headers.get("content-type") ?? "";
-    if (contentType.includes("application/json")) {
+    if (contentType.toLowerCase().includes("application/json")) {
       if (!text.trim()) {
         return {};
       }

--- a/extensions/matrix/src/matrix/sdk/http-client.ts
+++ b/extensions/matrix/src/matrix/sdk/http-client.ts
@@ -48,7 +48,8 @@ export class MatrixAuthedHttpClient {
       throw buildHttpError(response.status, text);
     }
     const contentType = response.headers.get("content-type") ?? "";
-    if (contentType.toLowerCase().includes("application/json")) {
+    const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase();
+    if (mediaType === "application/json") {
       if (!text.trim()) {
         return {};
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Matrix users could receive plain text instead of parsed JSON when a homeserver returned a valid JSON `Content-Type` with different media-type casing, such as `Application/JSON; charset=utf-8`.

## Why This Change Was Made

The Matrix authed HTTP client now normalizes the response `Content-Type` before applying its JSON response classification. This stays inside the Matrix SDK HTTP response boundary used by directory lookup, `doRequest`, and receipt calls, while leaving raw media downloads, config, auth, protocol behavior, and non-JSON responses unchanged.

## User Impact

Matrix homeserver control-plane responses are parsed consistently when they use valid JSON media types with casing differences, so Matrix callers continue receiving structured response objects.

## Evidence

- Claim proved: Matrix `requestJson` parses valid JSON responses whose `Content-Type` media type uses different casing and still returns text for non-JSON responses.
- Current-head proof at `e3c3b02b63d635c2537a81c1175cf44d12f19c07`: `node scripts/run-vitest.mjs extensions/matrix/src/matrix/sdk/http-client.test.ts` passed with 1 file and 6 tests passing in `openclaw-lane-p`.
- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Review proof: `python .agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --model gpt-5.6-terra --thinking low --no-web-search` passed with no accepted/actionable findings.
- Observed result: the focused regression returns `{ ok: true }` for `Application/JSON; charset=utf-8` while preserving the existing plain-text response behavior for `text/plain`.