### PR TITLE
refactor(clawrouter): localize default base URL

### DIFF
--- a/extensions/clawrouter/provider-catalog.ts
+++ b/extensions/clawrouter/provider-catalog.ts
@@ -9,7 +9,7 @@ import type {
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
 
-export const CLAWROUTER_DEFAULT_BASE_URL = "https://clawrouter.openclaw.ai";
+const CLAWROUTER_DEFAULT_BASE_URL = "https://clawrouter.openclaw.ai";
 
 const PROVIDER_ID = "clawrouter";
 const CATALOG_CACHE_TTL_MS = 60_000;


### PR DESCRIPTION
## What Problem This Solves

`CLAWROUTER_DEFAULT_BASE_URL` was exported from a private provider-catalog module even though it has no consumer outside that file and is not part of the ClawRouter plugin entrypoint, package metadata, or a public API barrel.

## Why This Change Was Made

Keep the shipped default URL behavior unchanged while removing an accidental module export. The constant remains the fallback used by `normalizeClawRouterRootUrl`; only its visibility changes.

The audit checked the full open-PR file set plus PRs updated during the work and found no overlap on `extensions/clawrouter/provider-catalog.ts`.

## User Impact

None. Runtime URL normalization, model discovery, dynamic-model resolution, and usage fetching are unchanged.

No changelog entry: this is an internal visibility cleanup with no user-visible behavior change.

## Evidence

- `git grep -n 'CLAWROUTER_DEFAULT_BASE_URL'`: definition plus one same-file reference only
- codebase-memory graph: 305,295 nodes / 1,263,621 edges; normalization callers cover plugin registration, catalog discovery, and usage fetching
- before: `pnpm test:serial extensions/clawrouter/provider-catalog.test.ts extensions/clawrouter/index.test.ts extensions/clawrouter/usage.test.ts` - 20/20 passed in Testbox `tbx_01kxbc4yj9sg03r3cambeshwpv`
- after: same focused command - 20/20 passed in the same Testbox
- `pnpm check:changed -- extensions/clawrouter/provider-catalog.ts` - passed in the same Testbox
- fresh autoreview: `gpt-5.6-sol`, medium reasoning, no accepted/actionable findings, 0.98 confidence
