### PR TITLE
fix(matrix): preserve UTF-8 bootstrap output tails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **SQLite maintenance schema validation:** reject current-version global and agent databases with missing or drifted canonical tables, constraints, indexes, triggers, or table options before compaction, while accepting supported additive-migration layouts.
+- **Matrix bootstrap diagnostics:** preserve complete UTF-8 code points in bounded stdout and stderr tails so crypto dependency failures do not show replacement characters at retention boundaries. (#105475) Thanks @qingminlong.
 - **iOS Watch relay commands:** allow paired iPhone nodes to advertise and invoke `watch.status` and `watch.notify` through the default Gateway policy while preserving the direct watchOS node's fixed minimal command surface.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.

--- a/extensions/matrix/src/matrix/deps.test.ts
+++ b/extensions/matrix/src/matrix/deps.test.ts
@@ -253,6 +253,37 @@ describe("runFixedCommandWithTimeout", () => {
     expect(result.stderr).toBe("b".repeat(MATRIX_COMMAND_OUTPUT_TAIL_BYTES));
   });
 
+  it("keeps bounded stdout and stderr tails on UTF-8 character boundaries", async () => {
+    const suffix = "z".repeat(MATRIX_COMMAND_OUTPUT_TAIL_BYTES - 2);
+    const result = await runFixedCommandWithTimeout({
+      argv: [
+        process.execPath,
+        "-e",
+        [
+          'const prefix = "a".repeat(10);',
+          `const suffix = "z".repeat(${MATRIX_COMMAND_OUTPUT_TAIL_BYTES - 2});`,
+          "const payload = `${prefix}🙂${suffix}`;",
+          "process.stdout.write(payload);",
+          "process.stderr.write(payload);",
+        ].join(""),
+      ],
+      cwd: process.cwd(),
+      timeoutMs: 10_000,
+    });
+
+    expect(result.code).toBe(0);
+    expect(Buffer.byteLength(result.stdout, "utf8")).toBeLessThanOrEqual(
+      MATRIX_COMMAND_OUTPUT_TAIL_BYTES,
+    );
+    expect(Buffer.byteLength(result.stderr, "utf8")).toBeLessThanOrEqual(
+      MATRIX_COMMAND_OUTPUT_TAIL_BYTES,
+    );
+    expect(result.stdout).toBe(suffix);
+    expect(result.stderr).toBe(suffix);
+    expect(result.stdout).not.toContain("\uFFFD");
+    expect(result.stderr).not.toContain("\uFFFD");
+  });
+
   it("settles real child stream errors after child close and terminates once", async () => {
     const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
 

--- a/extensions/matrix/src/matrix/deps.ts
+++ b/extensions/matrix/src/matrix/deps.ts
@@ -52,25 +52,30 @@ type CommandResult = {
 
 let defaultMatrixCryptoRuntimeEnsurePromise: Promise<void> | null = null;
 
-function appendBoundedOutputTail(current: string, chunk: Buffer | string): string {
+function sliceUtf8OutputTail(buffer: Buffer): Buffer {
+  let start = Math.max(0, buffer.byteLength - MATRIX_COMMAND_OUTPUT_TAIL_BYTES);
+  while (start < buffer.byteLength && (buffer[start] & 0xc0) === 0x80) {
+    start++;
+  }
+  return buffer.subarray(start);
+}
+
+function appendBoundedOutputTail(current: Buffer, chunk: Buffer | string): Buffer {
   const chunkBuffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
   if (chunkBuffer.byteLength >= MATRIX_COMMAND_OUTPUT_TAIL_BYTES) {
-    return chunkBuffer
-      .subarray(chunkBuffer.byteLength - MATRIX_COMMAND_OUTPUT_TAIL_BYTES)
-      .toString("utf8");
+    return sliceUtf8OutputTail(chunkBuffer);
   }
 
-  const currentBuffer = Buffer.from(current);
-  const nextBytes = currentBuffer.byteLength + chunkBuffer.byteLength;
+  const nextBytes = current.byteLength + chunkBuffer.byteLength;
   if (nextBytes <= MATRIX_COMMAND_OUTPUT_TAIL_BYTES) {
-    return `${current}${chunkBuffer.toString("utf8")}`;
+    return Buffer.concat([current, chunkBuffer], nextBytes);
   }
 
-  const currentTailBytes = MATRIX_COMMAND_OUTPUT_TAIL_BYTES - chunkBuffer.byteLength;
-  const currentTail = currentBuffer.subarray(currentBuffer.byteLength - currentTailBytes);
-  return Buffer.concat([currentTail, chunkBuffer], MATRIX_COMMAND_OUTPUT_TAIL_BYTES).toString(
-    "utf8",
-  );
+  return sliceUtf8OutputTail(Buffer.concat([current, chunkBuffer], nextBytes));
+}
+
+function decodeOutputTail(output: Buffer): string {
+  return sliceUtf8OutputTail(output).toString("utf8");
 }
 
 export async function runFixedCommandWithTimeout(params: {
@@ -96,8 +101,8 @@ export async function runFixedCommandWithTimeout(params: {
       stdio: ["ignore", "pipe", "pipe"],
     });
 
-    let stdout = "";
-    let stderr = "";
+    let stdout = Buffer.alloc(0);
+    let stderr = Buffer.alloc(0);
     let settled = false;
     let timer: NodeJS.Timeout | null = null;
     let streamKillTimer: NodeJS.Timeout | null = null;
@@ -155,8 +160,8 @@ export async function runFixedCommandWithTimeout(params: {
       }
       finalize({
         code: 124,
-        stdout,
-        stderr: stderr || `command timed out after ${params.timeoutMs}ms`,
+        stdout: decodeOutputTail(stdout),
+        stderr: decodeOutputTail(stderr) || `command timed out after ${params.timeoutMs}ms`,
       });
     }, params.timeoutMs);
 
@@ -166,21 +171,21 @@ export async function runFixedCommandWithTimeout(params: {
       }
       finalize({
         code: 1,
-        stdout,
+        stdout: decodeOutputTail(stdout),
         stderr: err.message,
       });
     });
 
     proc.on("close", (code) => {
       const streamErrorStderr = streamErrorMessage
-        ? stderr
+        ? stderr.byteLength > 0
           ? appendBoundedOutputTail(stderr, `\n${streamErrorMessage}`)
-          : streamErrorMessage
+          : Buffer.from(streamErrorMessage)
         : stderr;
       finalize({
         code: streamErrorMessage ? 1 : (code ?? 1),
-        stdout,
-        stderr: streamErrorStderr,
+        stdout: decodeOutputTail(stdout),
+        stderr: decodeOutputTail(streamErrorStderr),
       });
     });
   });

--- a/extensions/matrix/src/matrix/deps.ts
+++ b/extensions/matrix/src/matrix/deps.ts
@@ -54,7 +54,11 @@ let defaultMatrixCryptoRuntimeEnsurePromise: Promise<void> | null = null;
 
 function sliceUtf8OutputTail(buffer: Buffer): Buffer {
   let start = Math.max(0, buffer.byteLength - MATRIX_COMMAND_OUTPUT_TAIL_BYTES);
-  while (start < buffer.byteLength && (buffer[start] & 0xc0) === 0x80) {
+  while (start < buffer.byteLength) {
+    const byte = buffer[start];
+    if (byte === undefined || (byte & 0xc0) !== 0x80) {
+      break;
+    }
     start++;
   }
   return buffer.subarray(start);
@@ -101,8 +105,8 @@ export async function runFixedCommandWithTimeout(params: {
       stdio: ["ignore", "pipe", "pipe"],
     });
 
-    let stdout = Buffer.alloc(0);
-    let stderr = Buffer.alloc(0);
+    let stdout: Buffer = Buffer.alloc(0);
+    let stderr: Buffer = Buffer.alloc(0);
     let settled = false;
     let timer: NodeJS.Timeout | null = null;
     let streamKillTimer: NodeJS.Timeout | null = null;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Matrix crypto bootstrap diagnostics could show replacement characters when a noisy bootstrap command output tail was truncated across a multibyte UTF-8 character.

## Why This Change Was Made

The Matrix dependency command runner now retains stdout and stderr tails as bytes and decodes them only after trimming the retained window to a UTF-8 character boundary. This stays inside the Matrix dependency bootstrap boundary used by `ensureMatrixCryptoRuntime`, covers the shared stdout/stderr output-tail invariant, and does not change config, provider behavior, package selection, or successful bootstrap behavior.

## User Impact

Matrix users and operators get cleaner bootstrap failure diagnostics: retained stdout and stderr tails stay byte-bounded while avoiding invalid UTF-8 replacement characters from a truncated multibyte character.

## Evidence

- Claim proved: Matrix crypto bootstrap command stdout and stderr retained tails preserve valid UTF-8 while staying under `MATRIX_COMMAND_OUTPUT_TAIL_BYTES`.
- Current-head proof at `89852551fdc8552b4f3d53a6642d519d04dbae4c`: `node scripts/run-vitest.mjs extensions/matrix/src/matrix/deps.test.ts --testNamePattern "keeps bounded stdout and stderr tails|retains bounded tails"` passed with 1 file passing, 2 tests passing, and 9 skipped.
- Type-check repair: the current head narrows the retained-tail byte read and keeps stdout/stderr typed as `Buffer`, addressing the `TS2532` and `TS2322` diagnostics reported by `check-prod-types`, `check-test-types`, and `check-additional-extension-package-boundary`.
- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Observed result: the focused regression writes stdout and stderr payloads whose retained windows begin inside a multibyte emoji; both outputs omit `\uFFFD`, remain within the byte cap, and keep the expected valid UTF-8 suffix.