### PR TITLE
fix(sessions): estimate file content size before Buffer allocation

### DIFF
--- a/src/gateway/server-methods/sessions-files.test.ts
+++ b/src/gateway/server-methods/sessions-files.test.ts
@@ -957,22 +957,29 @@ describe("sessions.files RPC handlers", () => {
     expect(fs.existsSync(path.join(workspaceRoot, "missing.txt"))).toBe(false);
   });
 
-  it("rejects replacement content over the workspace preview limit", async () => {
-    const error = expectError(
-      await invokeSessionFilesHandler("sessions.files.set", {
-        sessionKey: "agent:main:main",
-        path: "ui/vite.config.ts",
-        content: "x".repeat(256 * 1024 + 1),
-        expectedHash: hashContent("export default {};\n"),
-      }),
-    );
+  it("rejects oversized replacement content before allocating an encoded Buffer", async () => {
+    const content = "é".repeat(128 * 1024 + 1);
+    const bufferFrom = vi.spyOn(Buffer, "from");
+    try {
+      const error = expectError(
+        await invokeSessionFilesHandler("sessions.files.set", {
+          sessionKey: "agent:main:main",
+          path: "ui/vite.config.ts",
+          content,
+          expectedHash: hashContent("export default {};\n"),
+        }),
+      );
 
-    expect(error.details).toMatchObject({
-      maxPreviewBytes: 256 * 1024,
-      path: "ui/vite.config.ts",
-      size: 256 * 1024 + 1,
-      type: "session_file_too_large",
-    });
+      expect(error.details).toMatchObject({
+        maxPreviewBytes: 256 * 1024,
+        path: "ui/vite.config.ts",
+        size: 256 * 1024 + 2,
+        type: "session_file_too_large",
+      });
+      expect(bufferFrom).not.toHaveBeenCalled();
+    } finally {
+      bufferFrom.mockRestore();
+    }
   });
 
   it("round-trips a UTF-8 BOM through get and set", async () => {

--- a/src/gateway/server-methods/sessions-files.ts
+++ b/src/gateway/server-methods/sessions-files.ts
@@ -698,24 +698,26 @@ export const sessionsFilesHandlers: GatewayRequestHandlers = {
       respondSessionFileUnsafe(respond, params.path);
       return;
     }
-    const contentBuffer = Buffer.from(params.content, "utf8");
-    // Node replaces lone UTF-16 surrogates while encoding. Reject them instead
-    // of reporting a hash for bytes that no longer match the submitted text.
-    if (contentBuffer.toString("utf8") !== params.content) {
-      respondSessionFileUnsafe(respond, params.path);
-      return;
-    }
-    const contentSize = contentBuffer.byteLength;
-    if (contentSize > MAX_PREVIEW_BYTES) {
+    // Estimate the UTF-8 byte size before allocating a Buffer so oversized
+    // content is rejected without first materialising the full encoded payload.
+    const estimatedBytes = Buffer.byteLength(params.content, "utf8");
+    if (estimatedBytes > MAX_PREVIEW_BYTES) {
       respond(
         false,
         undefined,
         sessionFilesError("session_file_too_large", "session file content is too large", {
           maxPreviewBytes: MAX_PREVIEW_BYTES,
           path: params.path,
-          size: contentSize,
+          size: estimatedBytes,
         }),
       );
+      return;
+    }
+    const contentBuffer = Buffer.from(params.content, "utf8");
+    // Node replaces lone UTF-16 surrogates while encoding. Reject them instead
+    // of reporting a hash for bytes that no longer match the submitted text.
+    if (contentBuffer.toString("utf8") !== params.content) {
+      respondSessionFileUnsafe(respond, params.path);
       return;
     }
     const loaded = loadSessionFileRoot(params);

--- a/src/gateway/server-methods/sessions-files.ts
+++ b/src/gateway/server-methods/sessions-files.ts
@@ -698,17 +698,15 @@ export const sessionsFilesHandlers: GatewayRequestHandlers = {
       respondSessionFileUnsafe(respond, params.path);
       return;
     }
-    // Estimate the UTF-8 byte size before allocating a Buffer so oversized
-    // content is rejected without first materialising the full encoded payload.
-    const estimatedBytes = Buffer.byteLength(params.content, "utf8");
-    if (estimatedBytes > MAX_PREVIEW_BYTES) {
+    const contentSize = Buffer.byteLength(params.content, "utf8");
+    if (contentSize > MAX_PREVIEW_BYTES) {
       respond(
         false,
         undefined,
         sessionFilesError("session_file_too_large", "session file content is too large", {
           maxPreviewBytes: MAX_PREVIEW_BYTES,
           path: params.path,
-          size: estimatedBytes,
+          size: contentSize,
         }),
       );
       return;


### PR DESCRIPTION
## What Problem This Solves

The `sessions.files.set` handler allocated `Buffer.from(params.content, "utf8")` before checking the 256 KiB preview limit. An oversized request therefore materialized its complete encoded payload only to reject it immediately.

## Why This Change Was Made

The handler now obtains the exact UTF-8 byte count with `Buffer.byteLength` first. Only accepted content is encoded into a Buffer for the existing strict round-trip safety check. The protocol schema intentionally stays byte-limit agnostic: a character-count limit would not enforce this UTF-8 byte contract.

Maintainer follow-up tightened the regression test: multibyte input proves byte accounting, and a `Buffer.from` spy proves rejection happens before encoded-buffer allocation.

## User Impact

No behavior or API change. Oversized session-file writes still return `session_file_too_large` with the exact byte size, but avoid the redundant allocation.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-methods/sessions-files.test.ts` — 35 tests passed.
- `node scripts/check-changed.mjs -- src/gateway/server-methods/sessions-files.ts src/gateway/server-methods/sessions-files.test.ts` — full delegated changed gate passed on Testbox `tbx_01kxs6pvcm7fh6818wcms5rzb3`: https://github.com/openclaw/openclaw/actions/runs/29620897495
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, confidence 0.98.
- `git diff --check` — passed.
