### PR TITLE
fix(clawhub): ignore malformed retry-after headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 - **iOS Watch relay commands:** allow paired iPhone nodes to advertise and invoke `watch.status` and `watch.notify` through the default Gateway policy while preserving the direct watchOS node's fixed minimal command surface.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.
+- **ClawHub retry timing:** reject fractional delay-seconds and calendar-normalized invalid Retry-After dates so runtime and release reads stay on their bounded fallback schedule. (#105479) Thanks @qingminlong.
 - **Gateway command SecretRefs:** preserve authoritative active-snapshot values when another command secret remains unresolved, falling back locally only for missing paths instead of emitting a per-turn `secrets.resolve` failure. (#96661) Thanks @SunnyShu0925.
 - **Cron delivery status:** keep successful isolated agent turns at `status=ok` when downstream delivery fails, while preserving the send failure separately in delivery state and run logs. (#95419) Thanks @Alix-007.
 - **Channel ingress recovery:** tombstone and scrub malformed durable ingress payloads without letting corrupt rows hide or starve later valid messages. (#98402) Thanks @Pick-cat.

--- a/src/infra/clawhub-retry.test.ts
+++ b/src/infra/clawhub-retry.test.ts
@@ -43,6 +43,72 @@ describe("retryClawHubRead", () => {
     expect(cancel).toHaveBeenCalledTimes(1);
   });
 
+  it.each(["0.5", "1.5"])(
+    "ignores fractional Retry-After delay-seconds values: %s",
+    async (retryAfter) => {
+      const delays: number[] = [];
+      let attempts = 0;
+
+      const result = await retryClawHubRead(
+        async () => {
+          attempts += 1;
+          return {
+            response: new Response(attempts === 1 ? "limited" : "ok", {
+              status: attempts === 1 ? 503 : 200,
+              headers: attempts === 1 ? { "Retry-After": retryAfter } : undefined,
+            }),
+          };
+        },
+        {
+          disposeRetry: async ({ response }) => {
+            await response.body?.cancel();
+          },
+          sleep: async (ms) => {
+            delays.push(ms);
+          },
+        },
+      );
+
+      expect(await result.response.text()).toBe("ok");
+      expect(delays).toEqual([1_000]);
+    },
+  );
+
+  it("ignores Retry-After HTTP dates that Date.parse would normalize", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2027-03-02T23:59:30.000Z"));
+    try {
+      const delays: number[] = [];
+      let attempts = 0;
+
+      const result = await retryClawHubRead(
+        async () => {
+          attempts += 1;
+          return {
+            response: new Response(attempts === 1 ? "limited" : "ok", {
+              status: attempts === 1 ? 503 : 200,
+              headers:
+                attempts === 1 ? { "Retry-After": "Sun, 31 Feb 2027 00:00:00 GMT" } : undefined,
+            }),
+          };
+        },
+        {
+          disposeRetry: async ({ response }) => {
+            await response.body?.cancel();
+          },
+          sleep: async (ms) => {
+            delays.push(ms);
+          },
+        },
+      );
+
+      expect(await result.response.text()).toBe("ok");
+      expect(delays).toEqual([1_000]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("retries transport failures with the bounded schedule", async () => {
     const delays: number[] = [];
     let attempts = 0;

--- a/src/infra/clawhub-retry.ts
+++ b/src/infra/clawhub-retry.ts
@@ -1,4 +1,6 @@
 // Defines the bounded retry contract shared by ClawHub runtime and release reads.
+import { parseRetryAfterHttpDateMs } from "@openclaw/ai/internal/retry-after";
+
 const CLAWHUB_RETRY_DELAYS_MS = [1_000, 3_000, 10_000] as const;
 const CLAWHUB_MAX_RETRY_AFTER_MS = 60_000;
 
@@ -21,13 +23,13 @@ function parseRetryAfterMs(headers: Headers): number | undefined {
   if (!retryAfter) {
     return undefined;
   }
-  const seconds = Number(retryAfter);
-  if (Number.isFinite(seconds) && seconds >= 0) {
+  if (/^\d+$/.test(retryAfter)) {
+    const seconds = Number(retryAfter);
     const delayMs = Math.round(seconds * 1_000);
     return delayMs <= CLAWHUB_MAX_RETRY_AFTER_MS ? delayMs : undefined;
   }
-  const retryAt = Date.parse(retryAfter);
-  if (!Number.isFinite(retryAt)) {
+  const retryAt = parseRetryAfterHttpDateMs(retryAfter);
+  if (retryAt === undefined) {
     return undefined;
   }
   const delayMs = Math.max(0, retryAt - Date.now());

--- a/src/infra/clawhub-retry.ts
+++ b/src/infra/clawhub-retry.ts
@@ -1,5 +1,5 @@
 // Defines the bounded retry contract shared by ClawHub runtime and release reads.
-import { parseRetryAfterHttpDateMs } from "@openclaw/ai/internal/retry-after";
+import { parseRetryAfterHttpDateMs } from "../../packages/ai/src/internal/retry-after.js";
 
 const CLAWHUB_RETRY_DELAYS_MS = [1_000, 3_000, 10_000] as const;
 const CLAWHUB_MAX_RETRY_AFTER_MS = 60_000;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ClawHub package and skill reads could honor malformed `Retry-After` timing when a transient response returned fractional delay-seconds or an invalid HTTP-date.

## Why This Change Was Made

ClawHub now accepts only integer delay-seconds and uses the existing strict HTTP-date parser before honoring `Retry-After`. Malformed values fall back to the existing bounded schedule, and the release planning path resolves the shared retry helper from source when it runs against an old release target cwd.

## User Impact

ClawHub reads keep recovering on the intended bounded schedule when an upstream response sends malformed timing, instead of sleeping on a non-contract header value.

## Evidence

- Claim proved: ClawHub read backoff ignores fractional delay-seconds and invalid normalized HTTP-date `Retry-After` values while preserving the existing valid retry behavior covered by the focused tests.
- Current-head proof at `fc5ef492cfc0b784b34de4c25ef211c737ee7f66`: old-target release plan smoke passed with `EXIT=0`, exercising `scripts/openclaw-release-clawhub-plan.ts` through `scripts/lib/plugin-clawhub-release.ts` into `src/infra/clawhub-retry.ts` from an old release target cwd.
- Current-head retry smoke passed: fractional delay-seconds and invalid HTTP-date headers fall back to the first bounded delay (`1000ms`) instead of overriding it.
- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Observed result: malformed `Retry-After` values fall back to the bounded retry schedule, and the release wrapper old-target planning path no longer exits from retry-helper module resolution.