### PR TITLE
refactor(tencent): localize preview model reference

### DIFF
--- a/extensions/tencent/onboard.ts
+++ b/extensions/tencent/onboard.ts
@@ -18,7 +18,7 @@ import {
 // ---------- TokenHub ----------
 
 export const TOKENHUB_DEFAULT_MODEL_REF = `${TOKENHUB_PROVIDER_ID}/hy3`;
-export const TOKENHUB_PREVIEW_MODEL_REF = `${TOKENHUB_PROVIDER_ID}/hy3-preview`;
+const TOKENHUB_PREVIEW_MODEL_REF = `${TOKENHUB_PROVIDER_ID}/hy3-preview`;
 
 function applyTokenHubProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
   const models = { ...cfg.agents?.defaults?.models };


### PR DESCRIPTION
## What Problem This Solves

`TOKENHUB_PREVIEW_MODEL_REF` was emitted as a named export from Tencent's private `onboard.ts` module even though it is used only by the same file and is not promoted through the plugin's public `api.ts`, runtime entrypoint, or setup entrypoint.

## Why This Change Was Made

Keep the preview model alias/config behavior unchanged while removing an accidental implementation export.

The compatibility audit included the published `2026.7.1-beta.5` npm tarball. It physically contains `dist/onboard.js`, but the symbol has no declaration file, docs, public-barrel exposure, setup-entry exposure, repository consumer, or public GitHub consumer. Scoped plugin policy explicitly treats `onboard.ts` as private unless promoted through `api.ts`; the introducing commit updated `api.ts` without adding this symbol.

The audit checked the full open-PR file set plus PRs updated during the work and found no overlap on `extensions/tencent/onboard.ts`.

## User Impact

None for supported plugin usage. TokenHub onboarding still adds both `hy3` and `hy3-preview` aliases and keeps `hy3` as the default.

An undocumented deep import from `@openclaw/tencent-provider/dist/onboard.js` would no longer expose this one constant. That path is not a supported plugin API.

No changelog entry: this removes a private implementation leak without changing supported behavior.

## Evidence

- repository search: four references, all inside `extensions/tencent/onboard.ts`
- public surfaces: `api.ts`, `setup-api.ts`, and `index.ts` do not expose or consume the preview constant
- public GitHub code search: no deep-import consumer found
- codebase-memory graph: 305,286 nodes / 1,263,733 edges; onboarding callers and config behavior mapped
- before: `pnpm test:serial extensions/tencent/index.test.ts extensions/tencent/config-compat.test.ts` - 16/16 passed in Testbox `tbx_01kxbcys0pxgsp55dp3jvdbx8d`
- after: same focused command - 16/16 passed in the same Testbox
- publishable plugin build: `node scripts/lib/plugin-npm-runtime-build.mjs extensions/tencent` passed; emitted `dist/onboard.js` retains the supported onboarding exports and omits only `TOKENHUB_PREVIEW_MODEL_REF`
- `pnpm check:changed -- extensions/tencent/onboard.ts` - passed in the same Testbox
- fresh autoreview: `gpt-5.6-sol`, medium reasoning, no accepted/actionable findings, 0.93 confidence
