### PR TITLE
fix(telegram): strip unsupported HTML header tags to prevent Bot API parse errors

### DIFF
--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -619,7 +619,11 @@ function preserveSupportedTelegramHtmlTags(
       preDepth = isClosing ? Math.max(0, preDepth - 1) : preDepth + 1;
     }
 
-    result += html.slice(tagStart, tagEnd);
+    // Strip unsupported tags outside code/pre so Telegram API does not reject
+    // the message with a Bad Request parse error.
+    if (codeDepth > 0 || preDepth > 0 || isSupportedTelegramHtmlTag(match[0], support)) {
+      result += html.slice(tagStart, tagEnd);
+    }
     lastIndex = tagEnd;
   }
 


### PR DESCRIPTION
## What Problem This Solves

When Telegram receives messages containing unsupported HTML header tags (like h1, h2, etc.) via the legacy HTML parse mode, the Bot API rejects them with `Bad Request: can't parse input` errors, blocking message delivery.

## Why This Change Was Made

The `preserveSupportedTelegramHtmlTags` function was appending ALL HTML tags to the output without checking whether they are in the Telegram-supported tag set. For the legacy HTML mode, heading tags like h1-h6 are not supported but were passed through as-is, causing Telegram API rejections.

The fix adds a guard: when not inside code or pre blocks, only append the tag if `isSupportedTelegramHtmlTag` returns true for the current support mode. Unsupported tags are silently stripped.

## User Impact

Fixes message delivery failures when the markdown-to-HTML renderer produces or preserves h1/h2/etc. tags. Users will no longer see silent message failures or partial deliveries.

## Evidence

### Test results
```
Test Files  14 passed (14)
     Tests  337 passed (337)
```
All existing tests continue to pass, confirming no regression to supported HTML rendering.

## Tests and validation
```
pnpm test "extensions/telegram/src/format*" "extensions/telegram/src/send*" "extensions/telegram/src/telegram-outbound*"
```
All 337 tests pass.

## Risk checklist
- [x] No breaking config changes
- [x] No user-visible behavior change for supported tags
- [x] No security impact
- [x] Per Telegram docs: legacy HTML mode supports b, strong, i, em, u, ins, s, strike, del, code, pre, tg-spoiler, a, blockquote

Closes #105432

Co-Authored-By: Claude <noreply@anthropic.com>