### PR TITLE
refactor(brave): remove obsolete testing alias

### DIFF
--- a/extensions/brave/test-api.ts
+++ b/extensions/brave/test-api.ts
@@ -16,4 +16,3 @@ export const testing = {
   resolveBraveMode,
   mapBraveLlmContextResults,
 } as const;
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

Brave's private `test-api.ts` exports the same helper object under both `testing` and legacy `__testing` names, but every current consumer uses `testing`.

## Why This Change Was Made

Remove the dead alias while retaining the canonical test-only surface and all helper coverage.

The historical audit found that `__testing` originally bridged core web-search tests. That coverage moved into the Brave extension, and the surviving test now imports `testing`. Private `test-api.js` artifacts were removed from published plugin packages starting in May 2026; current stable and beta Brave packages do not contain that file.

The audit checked the full open-PR file set plus PRs updated during the work and found no overlap on `extensions/brave/test-api.ts`.

## User Impact

None. Runtime Brave behavior and the current test surface are unchanged. The removed name was available only in source/private QA contexts and has no consumer.

No changelog entry: this is test-only dead compatibility cleanup.

## Evidence

- repository search: no Brave `__testing` consumer; the sole test imports `testing`
- package/build audit: `test-api.ts` is excluded from plugin runtime build entries and normal loader aliases
- npm artifact audit: current packages contain no `dist/test-api.js`; historical accidental exposure was already retired
- codebase-memory graph: 305,287 nodes / 1,262,823 edges
- before: Brave tests passed 29/29 in Testbox `tbx_01kxbdrwwgpeq3bkzvac4jj4r0`
- after: 157 assertions passed across Brave tests, loader aliases, package-build rules, and plugin contract guards in the same Testbox
- publishable plugin build: `node scripts/lib/plugin-npm-runtime-build.mjs extensions/brave` passed and produced no `dist/test-api.js`
- `pnpm check:changed -- extensions/brave/test-api.ts` - passed in the same Testbox
- fresh autoreview: `gpt-5.6-sol`, medium reasoning, no accepted/actionable findings, 0.93 confidence
