### PR TITLE
perf(agents): avoid intermediate array allocation in subagent registry queries

### DIFF
--- a/src/agents/subagent-registry-queries.ts
+++ b/src/agents/subagent-registry-queries.ts
@@ -40,18 +40,20 @@ export function listRunsForRequesterFromRuns(
   const lowerBound = requesterRunMatchesScope?.startedAt ?? requesterRunMatchesScope?.createdAt;
   const upperBound = requesterRunMatchesScope?.endedAt;
 
-  return [...runs.values()].filter((entry) => {
+  const results: SubagentRunRecord[] = [];
+  for (const entry of runs.values()) {
     if (entry.requesterSessionKey !== key) {
-      return false;
+      continue;
     }
     if (typeof lowerBound === "number" && entry.createdAt < lowerBound) {
-      return false;
+      continue;
     }
     if (typeof upperBound === "number" && entry.createdAt > upperBound) {
-      return false;
+      continue;
     }
-    return true;
-  });
+    results.push(entry);
+  }
+  return results;
 }
 
 /** Lists runs controlled by the normalized controller session key. */
@@ -63,7 +65,13 @@ export function listRunsForControllerFromRuns(
   if (!key) {
     return [];
   }
-  return [...runs.values()].filter((entry) => resolveControllerSessionKey(entry) === key);
+  const results: SubagentRunRecord[] = [];
+  for (const entry of runs.values()) {
+    if (resolveControllerSessionKey(entry) === key) {
+      results.push(entry);
+    }
+  }
+  return results;
 }
 
 type LatestRunPair = {


### PR DESCRIPTION
## What Problem This Solves

Both `listRunsForRequesterFromRuns` and `listRunsForControllerFromRuns` spread the full `Map.values()` into an intermediate array before filtering. For registries with thousands of records, this allocates a full-size intermediate array that is immediately discarded.

## Why This Change Was Made

The `[...runs.values()].filter(...)` pattern creates two allocations: the spread array holding all records, then the filtered result. Replacing with a direct `for...of` loop + conditional `push()` eliminates the intermediate array entirely.

This is a **narrow in-memory allocation cleanup** on the existing full-snapshot scan path. It does **not** implement scoped/indexed SQLite reads from #105423.

## User Impact

- Fewer peak allocations when listing requester/controller runs against a large in-memory registry snapshot
- Same matched results and ordering semantics
- Does not change persistence load scope (full snapshot + linear scan remain)

## Evidence

**Head SHA:** `63e77f22d8a68da77ec0c11659806dd2c7795821`

### Rank-up P1 — representative before/after seconds + RSS (production helpers)

Ran against **production** `listRunsForRequesterFromRuns` / `listRunsForControllerFromRuns` from this head, vs the pre-PR `[...runs.values()].filter(...)` shape, on an in-memory registry of **20,000** runs (~500 matches). 50 iterations per case. No credentials / private paths.

```
$ node --expose-gc --import tsx scripts/repro/subagent-registry-query-alloc-proof.mjs

{
  "proof": "production listRunsForRequesterFromRuns / listRunsForControllerFromRuns vs pre-PR [...values].filter",
  "setup": {
    "registrySize": 20000,
    "keepEvery": 40,
    "iterationsPerCase": 50,
    "paths": "none (in-memory Map; no credentials)"
  },
  "requester": {
    "before": {
      "label": "BEFORE requester spread+filter",
      "iterations": 50,
      "matched": 500,
      "totalSeconds": "0.048611",
      "avgMs": 0.972,
      "rssDeltaMb": 8.008,
      "heapDeltaMb": 8.199,
      "rssAfterMb": 90.285,
      "heapAfterMb": 23.028
    },
    "after": {
      "label": "AFTER requester for...of (production)",
      "iterations": 50,
      "matched": 500,
      "totalSeconds": "0.022418",
      "avgMs": 0.448,
      "rssDeltaMb": 1.305,
      "heapDeltaMb": 2.851,
      "rssAfterMb": 83.637,
      "heapAfterMb": 17.673
    }
  },
  "controller": {
    "before": {
      "label": "BEFORE controller spread+filter",
      "iterations": 50,
      "matched": 500,
      "totalSeconds": "0.072905",
      "avgMs": 1.458,
      "rssDeltaMb": 8.012,
      "heapDeltaMb": 8.203,
      "rssAfterMb": 91.836,
      "heapAfterMb": 23.03
    },
    "after": {
      "label": "AFTER controller for...of (production)",
      "iterations": 50,
      "matched": 500,
      "totalSeconds": "0.054688",
      "avgMs": 1.094,
      "rssDeltaMb": 0.758,
      "heapDeltaMb": 3.615,
      "rssAfterMb": 84.598,
      "heapAfterMb": 18.449
    }
  },
  "equivalence": {
    "requesterMatchedEqual": true,
    "controllerMatchedEqual": true
  }
}
```

| Path | Before total s (50×) | After total s (50×) | Before RSS Δ Mb | After RSS Δ Mb | Matched |
|---|---:|---:|---:|---:|---:|
| requester | 0.048611 | 0.022418 | 8.008 | 1.305 | 500 |
| controller | 0.072905 | 0.054688 | 8.012 | 0.758 | 500 |

Process footprint for the proof harness (`/usr/bin/time -l`):

```
1:        0.75 real         0.94 user         0.15 sys
2:            95756288  maximum resident set size
18:            63717376  peak memory footprint
```

Matched counts are equal before/after for both helpers (`equivalence.requesterMatchedEqual` / `controllerMatchedEqual` = true).

### Static / unit gates

```
$ npx oxlint -c .oxlintrc.json src/agents/subagent-registry-queries.ts
✅ No errors

$ npx oxfmt --check src/agents/subagent-registry-queries.ts
✅ All matched files use the correct format.

$ node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts

 Test Files  1 passed (1)
      Tests  97 passed (97)
```

### Before / After call shape

```typescript
// Before — Allocates full intermediate array before filter
[...runs.values()].filter((entry) => entry.requesterSessionKey === key);

// After — Single pass, no intermediate array
const results: SubagentRunRecord[] = [];
for (const entry of runs.values()) {
  if (entry.requesterSessionKey === key) results.push(entry);
}
return results;
```

## What Changed

- `src/agents/subagent-registry-queries.ts`: +15/-7 (both query functions)

## Scope vs #105423

**Related to #105423** — partial overlap only. This PR removes the avoidable intermediate array inside the in-memory scan helpers; it does **not** close #105423 (full SQLite load + linear scan + indexed store reads remain follow-up work).

## AI Assistance 🤖
- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding**: Yes