### PR TITLE
fix(qa): keep mock memory embeddings offline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,7 @@ Skills own workflows; root owns hard policy and routing.
 - Use `$openclaw-testing` for test/CI choice and `$crabbox` for remote/full/E2E proof.
 - At task start, if code changes, tests, builds, typechecks, lint fan-out, Docker, packaging, E2E, or live proof are likely, classify source trust and immediately pre-warm the safe Crabbox backend in a background command session. Trusted maintainer code defaults to Blacksmith Testbox; untrusted contributor/fork code uses secretless fork CI or sanitized direct AWS Crabbox under the rule above. Continue inspection/editing while it hydrates; sync the current checkout for every run, reuse the lease, then stop it before handoff.
 - Warm Testbox from the task checkout; ownership is checkout-path scoped; `--reclaim` only for intentional transfer.
+- One Testbox lease, one active command; never sync/reclaim during a run.
 - Testbox `--reclaim` does not retarget the remote checkout; never cross repos.
 - Base/head changed: stop and rewarm Testbox; never override stale lease checks.
 - Compound Testbox commands: `bash -lc`, never `sh -lc`; job env uses Bash `declare`.

--- a/extensions/qa-lab/src/qa-gateway-config.test.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.test.ts
@@ -88,6 +88,14 @@ describe("buildQaGatewayConfig", () => {
     expect(cfg.models?.providers?.openai?.request).toEqual({ allowPrivateNetwork: true });
     expect(cfg.models?.providers?.anthropic?.baseUrl).toBe("http://127.0.0.1:44080");
     expect(cfg.models?.providers?.anthropic?.request).toEqual({ allowPrivateNetwork: true });
+    expect(cfg.agents?.defaults?.memorySearch).toMatchObject({
+      provider: "openai",
+      model: "text-embedding-3-small",
+      remote: {
+        baseUrl: "http://127.0.0.1:44080/v1",
+        apiKey: "test",
+      },
+    });
     expect(cfg.plugins?.allow).toEqual(["acpx", "memory-core", "qa-lab", "qa-channel"]);
     expectQaLabPluginEnabled(cfg);
     expect(cfg.plugins?.slots?.memory).toBe("memory-core");
@@ -254,6 +262,7 @@ describe("buildQaGatewayConfig", () => {
     expect(getModelFallbacks(cfg.agents?.defaults?.model)).toBeUndefined();
     expect(getModelFallbacks(cfg.agents?.list?.[0]?.model)).toBeUndefined();
     expect(cfg.models).toBeUndefined();
+    expect(cfg.agents?.defaults?.memorySearch?.remote).toBeUndefined();
     expect(cfg.plugins?.allow).toEqual(["acpx", "memory-core", "qa-lab", "openai", "qa-channel"]);
     expect(cfg.plugins?.entries?.openai).toEqual({ enabled: true });
     expect(cfg.agents?.defaults?.models?.["openai/gpt-5.6-luna"]).toEqual({
@@ -300,6 +309,10 @@ describe("buildQaGatewayConfig", () => {
     expect(cfg.models?.mode).toBe("merge");
     expect(cfg.models?.providers?.openai?.baseUrl).toBe("https://api.openai.com/v1");
     expect(cfg.models?.providers?.openai?.request).toBeUndefined();
+    expect(cfg.agents?.defaults?.memorySearch?.remote).toEqual({
+      baseUrl: "http://127.0.0.1:44080/v1",
+      apiKey: "test",
+    });
     expect(cfg.models?.providers?.openai?.models.map((model) => model.id)).toContain(
       "gpt-5.6-luna-alt",
     );

--- a/extensions/qa-lab/src/qa-gateway-config.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.ts
@@ -174,6 +174,19 @@ export function buildQaGatewayConfig(params: {
           },
         }
       : providerGatewayModels;
+  const mockMemorySearch =
+    provider.kind === "mock"
+      ? {
+          provider: "openai",
+          model: "text-embedding-3-small",
+          remote: {
+            // Memory embeddings bypass the model runtime, so bind them to the
+            // mock explicitly or a forced runtime can fall through to a live API.
+            baseUrl: providerBaseUrl,
+            apiKey: "test",
+          },
+        }
+      : {};
 
   return {
     plugins: {
@@ -212,6 +225,7 @@ export function buildQaGatewayConfig(params: {
           : {}),
         ...(params.thinkingDefault ? { thinkingDefault: params.thinkingDefault } : {}),
         memorySearch: {
+          ...mockMemorySearch,
           sync: {
             watch: true,
             watchDebounceMs: 25,


### PR DESCRIPTION
## What Problem This Solves

The `thread-memory-isolation` Codex parity cell sent the QA mock credential to the real OpenAI embeddings endpoint and failed with 401. Forced Codex mock cells intentionally keep the OpenAI model catalog on its canonical URL, but memory embeddings bypass the Codex app-server route and inherited that live URL.

## Why This Change Was Made

Mock provider modes now configure memory search explicitly with the local mock embeddings URL, deterministic embedding model, and inert test credential. Live provider modes remain unchanged and continue to resolve real embedding authentication normally.

The Testbox operating note also records the discovered lease invariant: do not sync or reclaim a lease while another command is active.

## User Impact

No production behavior change. Mock QA runtime parity remains offline and cannot accidentally contact a live embeddings API.

## Evidence

- Original failure: https://github.com/openclaw/openclaw/actions/runs/29196372976
- Blacksmith Testbox `tbx_01kxbdzskab5rr3cvsceg8c77b`: QA config + gateway tests, 96/96 passed.
- Same Testbox: private QA runtime build and exact paired `thread-memory-isolation` scenario, OpenClaw + Codex both passed.
- Focused formatting check passed.
- Fresh autoreview: clean, no actionable findings.
