### PR TITLE
fix(slack): guard matchesSlackDeliveryMetadataSignature against UTF-8/UTF-16 length mismatch

### DIFF
--- a/extensions/slack/src/send.reconcile.test.ts
+++ b/extensions/slack/src/send.reconcile.test.ts
@@ -602,30 +602,32 @@ describe("reconcileSlackUnknownSend", () => {
     });
   });
 
-  it("does not throw when the stored signature contains multi-byte UTF-8 characters", async () => {
+  it("skips a malformed multi-byte signature and finds the valid delivery marker", async () => {
     const client = createSlackReconcileTestClient();
     const metadata = await postWithDeliveryMetadata({ client });
-    // Tamper the signature with a multi-byte payload whose UTF-16 length
-    // happens to match the original base64url signature length, but whose
-    // UTF-8 byte length differs — this exercises the Buffer-length guard.
     const signature = metadata.event_payload.openclaw_delivery_signature as string;
+    const malformedSignature = "é".repeat(signature.length);
+    expect(malformedSignature).toHaveLength(signature.length);
+    expect(Buffer.byteLength(malformedSignature)).not.toBe(Buffer.byteLength(signature));
     const tampered: MessageMetadata = {
       ...metadata,
       event_payload: {
         ...metadata.event_payload,
-        openclaw_delivery_signature: "\u{1f600}".repeat(signature.length),
+        openclaw_delivery_signature: malformedSignature,
       },
     };
     client.conversations.history.mockResolvedValueOnce({
-      messages: [{ ts: "1782584647.000002", metadata: tampered }],
+      messages: [
+        { ts: "1782584648.000003", metadata: tampered },
+        { ts: "1782584647.000002", metadata },
+      ],
     });
 
-    await expect(
-      reconcileSlackUnknownSend(createUnknownSendContext(), { client }),
-    ).resolves.toEqual({
-      status: "unresolved",
-      error: "Slack history contains no exact durable delivery marker",
-      retryable: true,
-    });
+    const reconciled = await reconcileSlackUnknownSend(createUnknownSendContext(), { client });
+
+    expect(reconciled.status).toBe("sent");
+    if (reconciled.status === "sent") {
+      expect(reconciled.messageId).toBe("1782584647.000002");
+    }
   });
 });

--- a/extensions/slack/src/send.reconcile.test.ts
+++ b/extensions/slack/src/send.reconcile.test.ts
@@ -601,4 +601,31 @@ describe("reconcileSlackUnknownSend", () => {
       retryable: true,
     });
   });
+
+  it("does not throw when the stored signature contains multi-byte UTF-8 characters", async () => {
+    const client = createSlackReconcileTestClient();
+    const metadata = await postWithDeliveryMetadata({ client });
+    // Tamper the signature with a multi-byte payload whose UTF-16 length
+    // happens to match the original base64url signature length, but whose
+    // UTF-8 byte length differs — this exercises the Buffer-length guard.
+    const signature = metadata.event_payload.openclaw_delivery_signature as string;
+    const tampered: MessageMetadata = {
+      ...metadata,
+      event_payload: {
+        ...metadata.event_payload,
+        openclaw_delivery_signature: "\u{1f600}".repeat(signature.length),
+      },
+    };
+    client.conversations.history.mockResolvedValueOnce({
+      messages: [{ ts: "1782584647.000002", metadata: tampered }],
+    });
+
+    await expect(
+      reconcileSlackUnknownSend(createUnknownSendContext(), { client }),
+    ).resolves.toEqual({
+      status: "unresolved",
+      error: "Slack history contains no exact durable delivery marker",
+      retryable: true,
+    });
+  });
 });

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -569,10 +569,18 @@ function createSlackDeliveryMetadataSignature(params: {
 }
 
 function matchesSlackDeliveryMetadataSignature(actual: unknown, expected: string): boolean {
-  if (typeof actual !== "string" || actual.length !== expected.length) {
+  if (typeof actual !== "string") {
     return false;
   }
-  return timingSafeEqual(Buffer.from(actual), Buffer.from(expected));
+  const actualBuf = Buffer.from(actual);
+  const expectedBuf = Buffer.from(expected);
+  // Compare Buffer byte lengths, not JS string lengths (UTF-16), so multi-byte
+  // characters in `actual` never produce mismatched Buffer sizes that would
+  // cause timingSafeEqual to throw TypeError.
+  if (actualBuf.length !== expectedBuf.length) {
+    return false;
+  }
+  return timingSafeEqual(actualBuf, expectedBuf);
 }
 
 function withSlackDeliveryMetadata(

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -572,15 +572,10 @@ function matchesSlackDeliveryMetadataSignature(actual: unknown, expected: string
   if (typeof actual !== "string") {
     return false;
   }
-  const actualBuf = Buffer.from(actual);
-  const expectedBuf = Buffer.from(expected);
-  // Compare Buffer byte lengths, not JS string lengths (UTF-16), so multi-byte
-  // characters in `actual` never produce mismatched Buffer sizes that would
-  // cause timingSafeEqual to throw TypeError.
-  if (actualBuf.length !== expectedBuf.length) {
-    return false;
-  }
-  return timingSafeEqual(actualBuf, expectedBuf);
+  const actualBytes = Buffer.from(actual);
+  const expectedBytes = Buffer.from(expected);
+  // timingSafeEqual throws on byte-length mismatch; string lengths are UTF-16.
+  return actualBytes.length === expectedBytes.length && timingSafeEqual(actualBytes, expectedBytes);
 }
 
 function withSlackDeliveryMetadata(


### PR DESCRIPTION
## What Problem This Solves

Slack durable-send reconciliation compared JavaScript UTF-16 string lengths before passing UTF-8 buffers to `crypto.timingSafeEqual`. A malformed metadata signature can therefore have the expected string length but a different byte length. Node throws `ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH`; OpenClaw catches that at the outer reconciliation boundary, but the exception aborts the history scan and can hide a valid delivery marker later in the same response.

Fixes #105436.

## Why This Change Was Made

The helper now encodes both signatures once, compares their byte lengths, and only then calls `timingSafeEqual`. This follows Node's documented requirement that both inputs have the same byte length and keeps malformed provider metadata as a non-match instead of an exception.

The regression uses a same-UTF-16-length, different-UTF-8-length signature followed by a valid marker. It proves reconciliation continues scanning and returns the already-sent message. The contributor's original emoji-only assertion was replaced because it did not reach the vulnerable branch or distinguish caught failure from successful scanning.

Best-fix verdict: byte-length validation at the private Slack signature boundary is the narrow root-cause fix. Catching the error higher would still abort the scan; importing a core secret-comparison helper would violate plugin ownership for a fixed-length, provider-visible marker.

## User Impact

Malformed or third-party Slack message metadata can no longer interrupt durable delivery reconciliation and obscure a valid OpenClaw marker, reducing false unresolved sends and duplicate-replay risk.

## Evidence

- Before fix, Blacksmith Testbox `tbx_01kxcaj8a9aggs92e0j7frnsdv`: `pnpm test extensions/slack/src/send.reconcile.test.ts` failed the new case with `expected 'unresolved' to be 'sent'` (16 passed, 1 failed).
- After fix, refreshed exact head: `pnpm test extensions/slack/src/send.reconcile.test.ts` — 17/17 passed.
- Blacksmith Testbox `tbx_01kxcav27z2b3mry9d3akh1r7a`: exact-head focused test plus `pnpm check:changed` passed extension prod/test typechecks, formatting, lint, Plugin SDK baseline, and architecture guards.
- Structured Codex autoreview on `origin/main...HEAD`: clean; no accepted/actionable findings, confidence 0.99.
- Node contract: https://nodejs.org/api/crypto.html#cryptotimingsafeequala-b

Live Slack metadata injection was not used: the regression exercises the full Slack reconciliation scanner with the exact provider response shape and distinguishes the pre-fix failure from the repaired result.

## Provenance

Clear: the affected helper was authored by @joeyfrasier in #97480 (`7e0d530e07d6`, 2026-07-05) and merged/co-authored by @steipete. Current PR authored by @evan-YM; regression and evidence strengthened by @steipete.
