### PR TITLE
test(qa): model Codex compaction in parity mock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,8 @@ Skills own workflows; root owns hard policy and routing.
 - Crabbox wrapper `stop` has no `--timing-json`; use `node scripts/crabbox-wrapper.mjs stop --provider <provider> --id <id>`.
 - Repo-native PR worktree may omit `node_modules`; prove remotely, then use `git commit --no-verify`, not `scripts/committer`.
 - Parallel agents share the checkout; never switch its branch while sibling work runs.
+- Testbox status: `blacksmith testbox status --id <tbx_id>`; no `--json` flag.
+- QA CLI `--output-dir` must be repo-relative.
 - Full suites, changed gates, builds, typechecks, lint fan-out, Docker/package/E2E/live/cross-OS proof, or anything computationally intensive: Crabbox/Testbox.
 - If an allowed local fallback fans out or becomes expensive, stop it and move the work to the pre-warmed remote box.
 - Before handoff/push: prove touched surface. Before landing to `main`: issue proof plus appropriate full/broad proof unless scope is clearly narrow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,7 @@ Skills own workflows; root owns hard policy and routing.
 - Use `$openclaw-pr-maintainer` immediately for maintainer-side OpenClaw issue/PR review, triage, duplicates, labels, comments, close, land, or evidence. Contributor PR creation/refresh follows the requested contributor workflow; linked refs alone do not require maintainer archive tooling.
 - Issue/PR start: `git status -sb`; if clean, `git pull --ff-only`; if dirty, yell before pull/rebase.
 - PR refs: `gh pr view/diff` or `gh api`, not web search. Prefer `gitcrawl` for maintainer discovery; missing/stale `gitcrawl` falls through to live `gh`, not contributor setup. Verify live with `gh` before mutation.
+- `gh pr view` takes the branch positionally; no `--head` flag.
 - zsh: quote `gh api` endpoints containing `?` or brackets; otherwise glob expansion corrupts the invocation.
 - GitHub Actions: resolve workflow files from `.github/workflows` or API; never infer filenames from display names.
 - zsh: quote command globs; unmatched patterns abort before the tool runs.

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -4795,6 +4795,43 @@ describe("qa mock openai server", () => {
     expect(outputText(await response.json())).toContain("model switch handoff confirmed");
   });
 
+  it("returns the Codex remote-compaction-v2 response shape", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        stream: true,
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: "Retained context." }],
+          },
+          { type: "compaction_trigger" },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain('"type":"response.output_item.done"');
+    expect(body).toContain('"type":"compaction"');
+    expect(body).toContain('"encrypted_content":"QA_MOCK_REMOTE_COMPACTION_SUMMARY"');
+    expect(body).toContain('"type":"response.completed"');
+    const debugResponse = await fetch(`${server.baseUrl}/debug/requests`);
+    expect(debugResponse.status).toBe(200);
+    expect(await debugResponse.json()).toEqual([]);
+  });
+
   it("returns NO_REPLY for unmentioned group chatter", async () => {
     const server = await startQaMockOpenAiServer({
       host: "127.0.0.1",

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -329,6 +329,34 @@ function writeSse(res: ServerResponse, events: StreamEvent[]) {
   res.end(body);
 }
 
+function isRemoteCompactionV2Request(input: ResponsesInputItem[]) {
+  // Codex sends compaction through /responses with a trigger item. Keep it
+  // outside scenario dispatch so maintenance calls never become tool evidence.
+  return input.some((item) => item.type === "compaction_trigger");
+}
+
+function buildRemoteCompactionV2Events(): [
+  Extract<StreamEvent, { type: "response.output_item.done" }>,
+  Extract<StreamEvent, { type: "response.completed" }>,
+] {
+  const item = {
+    type: "compaction",
+    encrypted_content: "QA_MOCK_REMOTE_COMPACTION_SUMMARY",
+  };
+  return [
+    { type: "response.output_item.done", item },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_mock_compaction_1",
+        status: "completed",
+        output: [item],
+        usage: { input_tokens: 64, output_tokens: 16, total_tokens: 80 },
+      },
+    },
+  ];
+}
+
 async function writeSseWithPreviewPause(
   res: ServerResponse,
   events: StreamEvent[],
@@ -3921,6 +3949,15 @@ export async function startQaMockOpenAiServer(params?: {
           return;
         }
         const input = Array.isArray(body.input) ? (body.input as ResponsesInputItem[]) : [];
+        if (isRemoteCompactionV2Request(input)) {
+          const events = buildRemoteCompactionV2Events();
+          if (body.stream === false) {
+            writeJson(res, 200, events[1].response);
+          } else {
+            writeSse(res, events);
+          }
+          return;
+        }
         const prompt = extractLastUserText(input);
         const allInputText = extractAllRequestTexts(input, body);
         const inflightRequestId = nextInflightRequestId++;


### PR DESCRIPTION
## What Problem This Solves

Codex runtime parity failed during the model-switch tool-continuity scenario. Codex correctly requested pre-turn remote compaction after the model compatibility hash changed, but the QA OpenAI mock returned an ordinary assistant message instead of the required compaction item.

## Why This Change Was Made

The mock now recognizes the Codex Responses v2 `compaction_trigger` input and returns exactly one `compaction` output item followed by `response.completed`. Compaction maintenance requests bypass scenario dispatch and debug tool evidence, so they cannot appear as unknown scenario tool calls.

## User Impact

Release runtime parity can exercise a real Codex model switch and preserve tool continuity instead of failing in the test harness.

## Evidence

- Blacksmith Testbox: QA mock server tests, 127/127 passed.
- Blacksmith Testbox: exact `model-switch-tool-continuity` runtime pair passed for OpenClaw and Codex.
- Blacksmith Testbox: targeted oxfmt check passed.
- Fresh autoreview: clean.

Upstream Codex contract checked:

- `codex-rs/core/src/session/turn.rs:826` — model compatibility-hash changes trigger pre-turn compaction.
- `codex-rs/core/src/compact_remote_v2.rs:386` — the stream must contain exactly one compaction output item plus completion.
