### PR TITLE
fix(qa): read runtime parity transcripts from sqlite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,7 @@ Skills own workflows; root owns hard policy and routing.
 - `scripts/pr` artifacts: preserve template enum values; validate before prepare.
 - `scripts/pr` subcommands require a PR number; no subcommand `--help` placeholder.
 - `scripts/pr` review: checkout main baseline, then PR, before artifact validation.
+- PR head changed: rerun `scripts/pr review-init`; checkout alone leaves stale guard SHA.
 - `rg`: options before `--`; use `--` before patterns starting with `-`.
 - `gh --jq` is not standalone `jq`; pipe JSON to `jq` for variables or `--arg`.
 - Actions checkout refs: use full 40-char SHAs; short SHAs resolve as branches/tags.

--- a/extensions/qa-lab/src/runtime-parity.test.ts
+++ b/extensions/qa-lab/src/runtime-parity.test.ts
@@ -1,5 +1,14 @@
 // Qa Lab tests cover runtime parity classification behavior.
-import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  formatSqliteSessionFileMarker,
+  resolveStorePath,
+  upsertSessionEntry,
+} from "openclaw/plugin-sdk/session-store-runtime";
+import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   __testing,
   captureRuntimeParityCell,
@@ -10,6 +19,52 @@ import {
   type RuntimeParityCell,
   type RuntimeParityToolCall,
 } from "./runtime-parity.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((tempRoot) => fs.rm(tempRoot, { force: true, recursive: true })),
+  );
+});
+
+async function seedRuntimeParityTranscript(params: {
+  messages: Array<Record<string, unknown>>;
+  sessionId: string;
+  sessionKey: string;
+}) {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-qa-runtime-parity-"));
+  tempRoots.push(tempRoot);
+  const env = { ...process.env, OPENCLAW_STATE_DIR: path.join(tempRoot, "state") };
+  const storePath = resolveStorePath(undefined, { agentId: "qa", env });
+  await upsertSessionEntry({
+    agentId: "qa",
+    env,
+    sessionKey: params.sessionKey,
+    storePath,
+    entry: {
+      sessionId: params.sessionId,
+      sessionFile: formatSqliteSessionFileMarker({
+        agentId: "qa",
+        sessionId: params.sessionId,
+        storePath,
+      }),
+      updatedAt: 100,
+    },
+  });
+  for (const [index, message] of params.messages.entries()) {
+    await appendSessionTranscriptMessageByIdentity({
+      agentId: "qa",
+      env,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      storePath,
+      now: index + 1,
+      message: message as never,
+    });
+  }
+  return tempRoot;
+}
 
 function makeRuntimeParityCell(
   runtime: RuntimeId,
@@ -31,6 +86,48 @@ function makeRuntimeParityCell(
 }
 
 describe("runtime parity", () => {
+  it("captures tool results from the canonical SQLite session transcript", async () => {
+    const tempRoot = await seedRuntimeParityTranscript({
+      sessionId: "capability-flip",
+      sessionKey: "agent:qa:capability-flip",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Capability flip image check" }],
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-image-1",
+              name: "image_generate",
+              arguments: { prompt: "QA lighthouse" },
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call-image-1",
+          toolName: "image_generate",
+          content: [{ type: "text", text: "Image generation started" }],
+        },
+      ],
+    });
+
+    const cell = await captureRuntimeParityCell({
+      runtime: "openclaw",
+      gateway: { tempRoot },
+      scenarioResult: { status: "pass" },
+      wallClockMs: 10,
+    });
+
+    expect(cell.transcriptBytes).toContain('"role":"toolResult"');
+    expect(cell.toolCalls).toHaveLength(1);
+    expect(cell.toolCalls[0]).toMatchObject({ tool: "image_generate" });
+    expect(cell.toolCalls[0]?.errorClass).toBeUndefined();
+  });
+
   it("keeps a retry pass diagnostic from failing the captured cell", async () => {
     const cell = await captureRuntimeParityCell({
       runtime: "openclaw",

--- a/extensions/qa-lab/src/runtime-parity.test.ts
+++ b/extensions/qa-lab/src/runtime-parity.test.ts
@@ -1,6 +1,4 @@
 // Qa Lab tests cover runtime parity classification behavior.
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import {
   formatSqliteSessionFileMarker,
@@ -19,13 +17,12 @@ import {
   type RuntimeParityCell,
   type RuntimeParityToolCall,
 } from "./runtime-parity.js";
+import { createTempDirHarness } from "./temp-dir.test-helper.js";
 
-const tempRoots: string[] = [];
+const tempDirs = createTempDirHarness();
 
 afterEach(async () => {
-  await Promise.all(
-    tempRoots.splice(0).map((tempRoot) => fs.rm(tempRoot, { force: true, recursive: true })),
-  );
+  await tempDirs.cleanup();
 });
 
 async function seedRuntimeParityTranscript(params: {
@@ -33,8 +30,7 @@ async function seedRuntimeParityTranscript(params: {
   sessionId: string;
   sessionKey: string;
 }) {
-  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-qa-runtime-parity-"));
-  tempRoots.push(tempRoot);
+  const tempRoot = await tempDirs.makeTempDir("openclaw-qa-runtime-parity-");
   const env = { ...process.env, OPENCLAW_STATE_DIR: path.join(tempRoot, "state") };
   const storePath = resolveStorePath(undefined, { agentId: "qa", env });
   await upsertSessionEntry({

--- a/extensions/qa-lab/src/runtime-parity.ts
+++ b/extensions/qa-lab/src/runtime-parity.ts
@@ -1,6 +1,8 @@
+import {
+  listSessionEntries,
+  loadTranscriptEventsSync,
+} from "openclaw/plugin-sdk/session-store-runtime";
 // Qa Lab plugin module implements runtime parity behavior.
-import fs from "node:fs/promises";
-import path from "node:path";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   asFiniteNumber as readFiniteNumber,
@@ -133,6 +135,11 @@ type RuntimeParitySessionEntry = {
   parentSessionKey?: string;
   spawnDepth?: number;
   subagentRole?: string;
+};
+
+type RuntimeParitySessionCandidate = {
+  entry: RuntimeParitySessionEntry;
+  sessionKey: string;
 };
 
 type RuntimeParityTranscriptRecord = {
@@ -907,22 +914,6 @@ function classifyRuntimeParityCells(params: {
   return { drift: "text-only", driftDetails: "final text differs after whitespace normalization" };
 }
 
-function resolveSessionTranscriptFile(params: {
-  sessionsDir: string;
-  sessionId: string;
-  sessionEntry?: RuntimeParitySessionEntry;
-}): string | undefined {
-  const explicitSessionFile = readNonEmptyString(params.sessionEntry?.sessionFile);
-  if (explicitSessionFile) {
-    const candidate = path.isAbsolute(explicitSessionFile)
-      ? explicitSessionFile
-      : path.join(params.sessionsDir, explicitSessionFile);
-    return candidate;
-  }
-  const baseName = `${params.sessionId}.jsonl`;
-  return path.join(params.sessionsDir, baseName);
-}
-
 function isRuntimeParityRootSession(entry: RuntimeParitySessionEntry) {
   if (readNonEmptyString(entry.spawnedBy) || readNonEmptyString(entry.parentSessionKey)) {
     return false;
@@ -936,24 +927,29 @@ function isRuntimeParityRootSession(entry: RuntimeParitySessionEntry) {
   return true;
 }
 
-async function readRuntimeParitySessionEntries(params: {
+function runtimeParitySessionEnv(stateDir: string): NodeJS.ProcessEnv {
+  return { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+}
+
+function readRuntimeParitySessionEntries(params: {
   stateDir: string;
   agentId: string;
-}): Promise<Array<RuntimeParitySessionEntry>> {
-  const storePath = path.join(
-    params.stateDir,
-    "agents",
-    params.agentId,
-    "sessions",
-    "sessions.json",
-  );
+}): RuntimeParitySessionCandidate[] {
   try {
-    const raw = await fs.readFile(storePath, "utf8");
-    const parsed = JSON.parse(raw) as Record<string, RuntimeParitySessionEntry>;
-    const entries = Object.values(parsed).filter((entry) => readNonEmptyString(entry?.sessionId));
-    const rootEntries = entries.filter(isRuntimeParityRootSession);
+    const entries = listSessionEntries({
+      agentId: params.agentId,
+      env: runtimeParitySessionEnv(params.stateDir),
+    })
+      .filter(({ entry }) => readNonEmptyString(entry.sessionId))
+      .map(({ entry, sessionKey }) => ({
+        entry: entry as RuntimeParitySessionEntry,
+        sessionKey,
+      }));
+    const rootEntries = entries.filter(({ entry }) => isRuntimeParityRootSession(entry));
     const candidates = rootEntries.length > 0 ? rootEntries : entries;
-    return candidates.toSorted((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
+    return candidates.toSorted(
+      (left, right) => (right.entry.updatedAt ?? 0) - (left.entry.updatedAt ?? 0),
+    );
   } catch {
     return [];
   }
@@ -963,33 +959,25 @@ async function loadRuntimeParityTranscripts(params: {
   gateway: QaGatewayLike;
   agentId: string;
 }): Promise<string> {
-  const sessionsDir = path.join(
-    params.gateway.tempRoot,
-    "state",
-    "agents",
-    params.agentId,
-    "sessions",
-  );
-  const sessionEntries = await readRuntimeParitySessionEntries({
-    stateDir: path.join(params.gateway.tempRoot, "state"),
+  const stateDir = `${params.gateway.tempRoot}/state`;
+  const sessionEntries = readRuntimeParitySessionEntries({
+    stateDir,
     agentId: params.agentId,
   });
   const transcripts: string[] = [];
-  for (const sessionEntry of sessionEntries) {
-    const sessionId = readNonEmptyString(sessionEntry.sessionId);
+  for (const { entry, sessionKey } of sessionEntries) {
+    const sessionId = readNonEmptyString(entry.sessionId);
     if (!sessionId) {
       continue;
     }
-    const sessionFile = resolveSessionTranscriptFile({
-      sessionsDir,
-      sessionId,
-      sessionEntry,
-    });
-    if (!sessionFile) {
-      continue;
-    }
     try {
-      const transcript = await fs.readFile(sessionFile, "utf8");
+      const events = loadTranscriptEventsSync({
+        agentId: params.agentId,
+        env: runtimeParitySessionEnv(stateDir),
+        sessionId,
+        sessionKey,
+      });
+      const transcript = events.map((event) => JSON.stringify(event)).join("\n");
       if (transcript.trim().length > 0 && !isHeartbeatOnlyRuntimeTranscript(transcript)) {
         transcripts.push(transcript.trimEnd());
         break;


### PR DESCRIPTION
## What Problem This Solves

Runtime parity still read retired `sessions.json` and transcript JSONL paths after QA session storage moved to SQLite. That left both runtime transcripts empty; OpenClaw's successful async `image_generate` turn then looked like a planned tool call with no result.

## Why This Change Was Made

Read session entries and transcript events through the public SQLite-backed Plugin SDK surfaces. Preserve root-session selection, recency ordering, heartbeat exclusion, and the existing transcript-over-mock fallback.

## User Impact

Release runtime parity no longer reports a false failure for successful async image generation after a capability-changing gateway restart.

## Evidence

- Blacksmith Testbox `pnpm test extensions/qa-lab/src/runtime-parity.test.ts`: 12/12 passed.
- Blacksmith Testbox focused `config-restart-capability-flip` runtime pair: OpenClaw pass, Codex pass, runtime-pair pass.
- Blacksmith Testbox changed gate: format, production/test tsgo, lint, database-first guard, and import-cycle check passed.
- Fresh autoreview: no accepted or actionable findings.
- Codex dynamic-tool contract inspected in `codex-rs/app-server/README.md`, `src/bespoke_event_handling.rs`, and `tests/suite/v2/dynamic_tools.rs`: client tool responses complete the dynamic item and are returned to the model.
