### PR TITLE
refactor(scripts): remove benchmark testing aliases

### DIFF
--- a/scripts/bench-gateway-restart.ts
+++ b/scripts/bench-gateway-restart.ts
@@ -1695,4 +1695,3 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
     process.exitCode = 1;
   });
 }
-export { testing as __testing };

--- a/scripts/bench-gateway-startup.ts
+++ b/scripts/bench-gateway-startup.ts
@@ -1033,4 +1033,3 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
     process.exitCode = 1;
   });
 }
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

The gateway startup and restart benchmark scripts still exported legacy `__testing` aliases after their tests migrated to the canonical `testing` exports. The aliases have no repository consumers and unnecessarily enlarge the scripts' module API.

## Why This Change Was Made

Remove the two redundant aliases while keeping the canonical `testing` exports and all benchmark behavior unchanged. Both files share the same scripts-owned benchmark boundary, so the cleanup lands as one focused batch.

## User Impact

None. These benchmark scripts are internal repository tooling and are not part of the published package exports.

## Evidence

- Full open-PR file audit plus a live refresh of 147 recently updated open PRs found no overlap on either changed file.
- Codebase-memory graph: 305,294 nodes and 1,263,049 edges; traced benchmark runtime paths do not depend on either alias.
- Testbox `tbx_01kxbf2jp1425pqq6wkjdrmjev`: 56 focused benchmark tests passed before and after the change.
- Testbox `tbx_01kxbf2jp1425pqq6wkjdrmjev`: `pnpm check:changed -- scripts/bench-gateway-startup.ts scripts/bench-gateway-restart.ts` passed.
- Fresh autoreview: `gpt-5.6-sol`, medium reasoning, clean with no accepted/actionable findings (0.93).
- `git diff --check` passed; production diff is 0 additions and 2 deletions.

No changelog entry: internal dead-export cleanup with no user-visible behavior change.
