### PR TITLE
fix(web-fetch): detect multi-dimensional CSS scale(0,0) and scale3d(0,0,0) as hidden

### DIFF
--- a/src/agents/tools/web-fetch-visibility.test.ts
+++ b/src/agents/tools/web-fetch-visibility.test.ts
@@ -65,6 +65,24 @@ describe("sanitizeHtml", () => {
     expect(result).not.toContain("Scaled");
   });
 
+  it("strips transform:scale(0, 0) multi-dimensional elements", async () => {
+    const html = '<p>Show</p><div style="transform:scale(0, 0)">Scaled2d</div>';
+    const result = await sanitizeHtml(html);
+    expect(result).not.toContain("Scaled2d");
+  });
+
+  it("strips transform:scale3d(0, 0, 0) elements", async () => {
+    const html = '<p>Show</p><div style="transform:scale3d(0, 0, 0)">Scaled3d</div>';
+    const result = await sanitizeHtml(html);
+    expect(result).not.toContain("Scaled3d");
+  });
+
+  it("preserves transform:scale(1, 0) non-zero-axis elements", async () => {
+    const html = '<p>Show</p><div style="transform:scale(1, 0)">Partial</div>';
+    const result = await sanitizeHtml(html);
+    expect(result).toContain("Partial");
+  });
+
   it("strips transform:translateX far-offscreen elements", async () => {
     const html = '<p>Show</p><div style="transform:translateX(-9999px)">Translated</div>';
     const result = await sanitizeHtml(html);

--- a/src/agents/tools/web-fetch-visibility.ts
+++ b/src/agents/tools/web-fetch-visibility.ts
@@ -75,7 +75,11 @@ function isStyleHidden(style: string): boolean {
   const transform = style.match(/(?:^|;)\s*transform\s*:\s*([^;]+)/i);
   const transformValue = transform?.at(1);
   if (transformValue) {
-    if (/scale(?:3d)?\s*\(\s*0(?:\.0+)?(?:\s*,\s*0(?:\.0+)?)+\s*\)|\bscale\s*\(\s*0(?:\.0+)?\s*\)/i.test(transformValue)) {
+    if (
+      /scale(?:3d)?\s*\(\s*0(?:\.0+)?(?:\s*,\s*0(?:\.0+)?)+\s*\)|\bscale\s*\(\s*0(?:\.0+)?\s*\)/i.test(
+        transformValue,
+      )
+    ) {
       return true;
     }
     if (/translateX\s*\(\s*-\d{4,}px\s*\)/i.test(transformValue)) {

--- a/src/agents/tools/web-fetch-visibility.ts
+++ b/src/agents/tools/web-fetch-visibility.ts
@@ -71,11 +71,11 @@ function isStyleHidden(style: string): boolean {
     }
   }
 
-  // transform: scale(0)
+  // transform: scale(0) / scale(0, 0) / scale3d(0, 0, 0)
   const transform = style.match(/(?:^|;)\s*transform\s*:\s*([^;]+)/i);
   const transformValue = transform?.at(1);
   if (transformValue) {
-    if (/scale\s*\(\s*0\s*\)/i.test(transformValue)) {
+    if (/scale(?:3d)?\s*\(\s*0(?:\.0+)?(?:\s*,\s*0(?:\.0+)?)+\s*\)|\bscale\s*\(\s*0(?:\.0+)?\s*\)/i.test(transformValue)) {
       return true;
     }
     if (/translateX\s*\(\s*-\d{4,}px\s*\)/i.test(transformValue)) {


### PR DESCRIPTION
## What Problem This Solves

The CSS transform scale detection in `isStyleHidden` only matched `scale(0)` (single zero value). Multi-dimensional scales like `scale(0, 0)` (2D) and `scale3d(0, 0, 0)` (3D) were not detected, leaving elements with these styles visible in scraped pages when they should be treated as hidden.

## Why This Change Was Made

The regex was `scale\s*\(\s*0\s*\)` which only matches `scale(0)`. Updated to:
- `scale(0)` — single value (existing)
- `scale(0, 0)` — 2D zero scale (new)
- `scale(0, 0, 0)` — also matches (new)
- `scale3d(0, 0, 0)` — 3D zero scale (new)
- `scale(1, 0)` — NOT matched, only matches when ALL values are zero (correct)

## User Impact

More accurate hidden element detection during web_fetch. Elements hidden via multi-dimensional or 3D zero scaling will now be properly stripped before text extraction.

## Evidence

### New test cases added
- `scale(0, 0)` is stripped (multi-dimensional zero scale)
- `scale3d(0, 0, 0)` is stripped (3D zero scale)
- `scale(1, 0)` is preserved (non-zero X axis)

All 46 tests pass (43 existing + 3 new).

```
 Test Files  1 passed (1)
      Tests  46 passed (46)
```

## Risk checklist
- [x] No breaking config changes
- [x] No user-visible behavior change for normal cases
- [x] No security impact
- [x] All-zero detection is strictly additive; existing `scale(0)` matching unchanged

Closes #105438

Co-Authored-By: Claude <noreply@anthropic.com>