### PR TITLE
fix(ci): capture live Telegram model proof

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1493,6 +1493,69 @@ jobs:
               pgrep -u "$SUT_UID" >/dev/null 2>&1
           }
 
+          capture_live_model_config() {
+            local config_path="${1:?}"
+            local config_id diagnostics_dir diagnostics_real proof_bytes proof_path proof_tmp
+            umask 077
+            config_id="$(printf '%s' "$config_path" | sha256sum | awk '{print $1}')"
+            diagnostics_dir="${EVIDENCE_ROOT}/trusted-runtime-diagnostics"
+            install -d -o "$RUNNER_UID" -g "$RUNNER_GID" -m 0700 "$diagnostics_dir"
+            [[ ! -L "$diagnostics_dir" ]]
+            diagnostics_real="$(realpath -e "$diagnostics_dir")"
+            [[ "$diagnostics_real" == "$diagnostics_dir" ]]
+            proof_path="${diagnostics_dir}/gateway-model-config-${config_id}.json"
+            proof_tmp="${RUNTIME_ROOT}/gateway-model-config-${BASHPID}.json"
+
+            # Capture only bounded routing identifiers before the QA suite removes its temp config.
+            jq -c '
+              def bounded_text:
+                if type == "string" then .[0:256] else null end;
+              def bounded_texts:
+                if type == "array" then
+                  [.[:64][] | bounded_text | select(. != null)]
+                else
+                  []
+                end;
+              {
+                agentDefaultModel: (
+                  if (.agents.defaults.model | type) == "string" then
+                    {
+                      primary: (.agents.defaults.model | bounded_text),
+                      fallbacks: []
+                    }
+                  elif (.agents.defaults.model | type) == "object" then
+                    {
+                      primary: (.agents.defaults.model.primary | bounded_text),
+                      fallbacks: (.agents.defaults.model.fallbacks | bounded_texts)
+                    }
+                  else
+                    {primary: null, fallbacks: []}
+                  end
+                ),
+                agentModelRefs: (
+                  ((.agents.defaults.models // {}) | keys | sort)[:128] |
+                  map(bounded_text | select(. != null))
+                ),
+                providers: (
+                  (.models.providers // {}) |
+                  to_entries |
+                  sort_by(.key) |
+                  .[:32] |
+                  map({
+                    id: (.key | bounded_text),
+                    api: (.value.api | bounded_text),
+                    modelIds: ([.value.models[]?.id][:128] | map(bounded_text | select(. != null)))
+                  })
+                )
+              }
+            ' "$config_path" >"$proof_tmp"
+            proof_bytes="$(stat -c '%s' "$proof_tmp")"
+            ((proof_bytes > 0 && proof_bytes <= 65536))
+            chown "$RUNNER_UID:$RUNNER_GID" "$proof_tmp"
+            chmod 0600 "$proof_tmp"
+            mv -f "$proof_tmp" "$proof_path"
+          }
+
           terminate_sut_uid() {
             pkill -TERM -U "$SUT_UID" >/dev/null 2>&1 || true
             pkill -TERM -u "$SUT_UID" >/dev/null 2>&1 || true
@@ -1642,6 +1705,7 @@ jobs:
           config_path="${temp_root}/openclaw.json"
           [[ -f "$config_path" && ! -L "$config_path" ]]
           [[ "$(realpath -e "$config_path")" == "$config_path" ]]
+          capture_live_model_config "$config_path"
 
           export OPENCLAW_QA_TEMP_ROOT="$temp_root"
           export HOME="${temp_root}/home"
@@ -2288,33 +2352,25 @@ jobs:
             sudo cat "$log_path" | node --import tsx "$redactor_script" "$output_path"
           done
 
-          mapfile -t gateway_configs < <(
-            sudo find "$RUNTIME_ROOT/tmp" -xdev -type f -name openclaw.json -print | sort
+          mapfile -t model_config_proofs < <(
+            find "$diagnostics_dir" -maxdepth 1 -type f -name 'gateway-model-config-*.json' -print |
+              sort
           )
-          ((${#gateway_configs[@]} > 0 && ${#gateway_configs[@]} <= 8))
-          for index in "${!gateway_configs[@]}"; do
-            config_path="$(sudo realpath -e "${gateway_configs[$index]}")"
-            case "$config_path" in
-              "$RUNTIME_ROOT"/tmp/*) ;;
-              *) echo "Telegram gateway config escaped the isolated runtime root." >&2; exit 1 ;;
-            esac
-            proof_path="${diagnostics_dir}/gateway-model-config-$((index + 1)).json"
-            sudo jq -e '
-              {
-                agentDefaultModel: .agents.defaults.model,
-                agentModelRefs: ((.agents.defaults.models // {}) | keys),
-                providers: (
-                  (.models.providers // {}) |
-                  to_entries |
-                  map({
-                    id: .key,
-                    api: .value.api,
-                    modelIds: [.value.models[]?.id]
-                  })
-                )
-              }
-            ' "$config_path" >"$proof_path"
-            chmod 0600 "$proof_path"
+          ((${#model_config_proofs[@]} > 0 && ${#model_config_proofs[@]} <= 8))
+          for proof_path in "${model_config_proofs[@]}"; do
+            [[ "$(stat -c '%F:%a' "$proof_path")" == "regular file:600" ]]
+            proof_bytes="$(stat -c '%s' "$proof_path")"
+            ((proof_bytes > 0 && proof_bytes <= 65536))
+            jq -e '
+              (keys | sort) == ["agentDefaultModel", "agentModelRefs", "providers"] and
+              (.agentDefaultModel | keys | sort) == ["fallbacks", "primary"] and
+              ([.agentDefaultModel.primary, .agentDefaultModel.fallbacks[], .agentModelRefs[]] |
+                all(. == null or type == "string")) and
+              (.providers | all(
+                (keys | sort) == ["api", "id", "modelIds"] and
+                ([.id, .api, .modelIds[]] | all(. == null or type == "string"))
+              ))
+            ' "$proof_path" >/dev/null
           done
 
       - name: Finalize trusted Telegram process-boundary evidence

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -581,8 +581,9 @@ describe("release Telegram QA workflow", () => {
     expect(captureStep?.run).not.toContain("readline.createInterface");
     expect(captureStep?.run).toContain("while (retained.length > 0");
     expect(captureStep?.run).toContain("redactQaGatewayDebugText");
-    expect(captureStep?.run).toContain("agentDefaultModel: .agents.defaults.model");
-    expect(captureStep?.run).toContain("modelIds: [.value.models[]?.id]");
+    expect(captureStep?.run).toContain("model_config_proofs");
+    expect(captureStep?.run).toContain("proof_bytes > 0 && proof_bytes <= 65536");
+    expect(captureStep?.run).not.toContain("-name openclaw.json");
     expect(
       job?.steps?.findIndex(
         (step) => step.name === "Capture isolated Telegram runtime diagnostics",
@@ -676,6 +677,13 @@ describe("release Telegram QA workflow", () => {
     expect(source).toContain('export HOME="${temp_root}/home"');
     expect(source).toContain('export XDG_CONFIG_HOME="${temp_root}/xdg-config"');
     expect(source).toContain('if [[ "${1:-}" == "--root-terminate-uid" ]]');
+    expect(source).toContain("capture_live_model_config() {");
+    expect(source).toContain('capture_live_model_config "$config_path"');
+    expect(source).toContain('proof_tmp="${RUNTIME_ROOT}/gateway-model-config-${BASHPID}.json"');
+    expect(source).toContain("proof_bytes > 0 && proof_bytes <= 65536");
+    expect(source).toContain("before the QA suite removes its temp config");
+    expect(source).toContain("agentDefaultModel:");
+    expect(source).toContain("modelIds: ([.value.models[]?.id][:128]");
   });
 
   it("keeps the generated SUT launcher valid bash", () => {
@@ -694,6 +702,82 @@ describe("release Telegram QA workflow", () => {
     });
     expect(result.status, result.stderr).toBe(0);
   });
+
+  it.runIf(process.platform === "linux")(
+    "captures only bounded model routing facts before candidate launch",
+    () => {
+      const createSutStep = workflowStep(
+        workflowJob("run_telegram"),
+        "Create isolated Telegram SUT identity and launcher",
+      );
+      const launcherSource = createSutStep.run?.match(
+        /<<'LAUNCHER'\n([\s\S]*?)\nLAUNCHER(?:\n|$)/u,
+      )?.[1];
+      const captureSource = launcherSource?.match(
+        /^capture_live_model_config\(\) \{[\s\S]*?^\}/mu,
+      )?.[0];
+      expect(captureSource).toBeTruthy();
+
+      const workdir = tempDirs.make("openclaw-telegram-model-proof-");
+      const runtimeRoot = join(workdir, "runtime");
+      const evidenceRoot = join(workdir, "evidence");
+      const configPath = join(workdir, "openclaw.json");
+      mkdirSync(runtimeRoot);
+      mkdirSync(evidenceRoot);
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          agents: {
+            defaults: {
+              model: { primary: "mock-openai/gpt-5.5", fallbacks: ["mock-openai/fallback"] },
+              models: { "mock-openai/gpt-5.5": {}, "mock-openai/fallback": {} },
+            },
+          },
+          models: {
+            providers: {
+              "mock-openai": {
+                api: "openai-responses",
+                endpoint: "https://example.invalid",
+                ignoredField: "not-exported",
+                models: [{ id: "gpt-5.5", ignoredField: "not-exported" }],
+              },
+            },
+          },
+        }),
+      );
+      const result = spawnSync(
+        "bash",
+        [
+          "-c",
+          `set -euo pipefail\n${captureSource}\ncapture_live_model_config "$CONFIG_PATH"\nfind "$EVIDENCE_ROOT/trusted-runtime-diagnostics" -type f -name 'gateway-model-config-*.json' -print`,
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            CONFIG_PATH: configPath,
+            EVIDENCE_ROOT: evidenceRoot,
+            RUNTIME_ROOT: runtimeRoot,
+            RUNNER_GID: String(process.getgid?.() ?? 0),
+            RUNNER_UID: String(process.getuid?.() ?? 0),
+          },
+        },
+      );
+      expect(result.status, result.stderr).toBe(0);
+      const proofPath = result.stdout.trim();
+      const proofText = readFileSync(proofPath, "utf8");
+      expect(JSON.parse(proofText)).toEqual({
+        agentDefaultModel: {
+          primary: "mock-openai/gpt-5.5",
+          fallbacks: ["mock-openai/fallback"],
+        },
+        agentModelRefs: ["mock-openai/fallback", "mock-openai/gpt-5.5"],
+        providers: [{ id: "mock-openai", api: "openai-responses", modelIds: ["gpt-5.5"] }],
+      });
+      expect(proofText).not.toContain("not-exported");
+      expect(proofText).not.toContain("example.invalid");
+    },
+  );
 
   it("arms the boundary preload only in the gateway main thread", () => {
     const createSutStep = workflowStep(


### PR DESCRIPTION
## What Problem This Solves

Failed Telegram release QA runs lose their ephemeral `openclaw.json` before post-run diagnostics, so the retained artifact cannot prove which model and provider routing facts the candidate actually received.

## Why This Change Was Made

Capture a bounded safe projection from the already-verified config inside the trusted launcher, immediately before candidate launch. Post-quiescence diagnostics validate the retained projection instead of searching for a config that suite cleanup has already removed.

## User Impact

No product behavior change. Failed release checks retain model/provider identifiers needed to diagnose candidate routing without retaining raw config, endpoints, or credentials.

## Evidence

- `actionlint .github/workflows/openclaw-release-telegram-qa.yml`
- generated launcher `bash -n`
- Blacksmith Testbox `tbx_01kxbezetv4qgewzqq98b3k45w`: focused workflow test, 19/19 passed
- Blacksmith Testbox `tbx_01kxbezetv4qgewzqq98b3k45w`: `pnpm check:changed`, passed
- fresh autoreview: clean
