### PR TITLE
fix(openai): preserve image provider base URL without a model catalog

### DIFF
--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -1,5 +1,5 @@
 // Openai tests cover image generation provider plugin behavior.
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildOpenAIImageGenerationProvider } from "./image-generation-provider.js";
 

--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -1,4 +1,5 @@
 // Openai tests cover image generation provider plugin behavior.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildOpenAIImageGenerationProvider } from "./image-generation-provider.js";
 
@@ -726,6 +727,33 @@ describe("openai image generation provider", () => {
     expect(body.model).toBe("gpt-image-1");
     expect(body.size).toBe("2048x1152");
     expect(result.metadata).toBeUndefined();
+  });
+
+  it("falls back to the provider baseUrl when the model catalog is omitted", async () => {
+    mockGeneratedPngResponse();
+
+    const provider = buildOpenAIImageGenerationProvider();
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://openai-compatible.example.com/v1",
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const result = await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Create an image through a provider overlay",
+      cfg,
+    });
+
+    expect(httpConfigCall().baseUrl).toBe("https://openai-compatible.example.com/v1");
+    expect(jsonRequestCall().url).toBe(
+      "https://openai-compatible.example.com/v1/images/generations",
+    );
+    expect(result.images).toHaveLength(1);
   });
 
   it("forwards output and OpenAI-only options on direct generations", async () => {

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -268,7 +268,7 @@ function resolveNativeOpenAIImageSizesForModel(model: string): readonly string[]
 function resolveConfiguredOpenAIImageBaseUrl(cfg: OpenClawConfig | undefined, model: string) {
   const modelId = model.trim().replace(/^openai\//u, "");
   const modelBaseUrl = cfg?.models?.providers?.openai?.models
-    .find((candidate) => candidate.id.trim().replace(/^openai\//u, "") === modelId)
+    ?.find((candidate) => candidate.id.trim().replace(/^openai\//u, "") === modelId)
     ?.baseUrl?.trim();
   return modelBaseUrl || resolveConfiguredOpenAIBaseUrl(cfg);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenAI-compatible image generation could crash when the provider configuration supplied a base URL but intentionally omitted a model catalog.

## Why This Change Was Made

The model-specific image route now treats the provider model list as optional and falls back to the existing provider-level base URL. The regression test covers the valid overlay shape without changing model-specific routing behavior.

## User Impact

OpenAI-compatible image providers configured only with a provider-level base URL continue generating images instead of failing before the request is built.

## Evidence

- Blacksmith Testbox `tbx_01kxbfrhm7vwsrdv72t2nafwqm`
- Actions run `29198630020`
- `extensions/openai/image-generation-provider.test.ts`: 69/69 passed
- Fresh autoreview: clean, correctness 0.98
- Scoped changed gate passed formatting and guards; the remaining Plugin SDK baseline hash drift is unrelated current-main state and this patch does not touch SDK exports or generated metadata.

AI-assisted maintenance change; implementation and test behavior were manually reviewed.
