### PR TITLE
refactor(scripts): remove Telegram runner testing alias

### DIFF
--- a/scripts/e2e/npm-telegram-live-runner.ts
+++ b/scripts/e2e/npm-telegram-live-runner.ts
@@ -184,4 +184,3 @@ export const testing = {
   resolveTrustedOpenClawCommand,
   shouldFailPackageTelegramRun,
 };
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

The npm Telegram live runner still exported a legacy `__testing` alias after its tooling tests migrated to the canonical `testing` export. The alias has no repository consumers and unnecessarily enlarges the script module API.

## Why This Change Was Made

Remove the redundant alias directly while retaining the canonical `testing` object and every executable runner path. The alias was introduced as lint-migration compatibility, but the same migration updated the only consumer.

## User Impact

None. The live runner behavior, Docker entrypoint, and test helpers are unchanged; this script is repository tooling and is not a published package export.

## Evidence

- Full open-PR file audit, reusable 1,862-path delta, and live refresh of 14 newer open PRs found no overlap on the changed file.
- Codebase-memory graph: 305,342 nodes and 1,263,657 edges; canonical helpers trace into the runner `main` path and no `__testing` consumer exists.
- Testbox `tbx_01kxbg0w1m9bc689w45gbhbxxg`: `pnpm test:serial test/scripts/npm-telegram-live.test.ts` passed 21/21 tests before and after.
- Testbox `tbx_01kxbg0w1m9bc689w45gbhbxxg`: `pnpm check:changed -- scripts/e2e/npm-telegram-live-runner.ts` passed.
- Fresh autoreview: `gpt-5.6-sol`, medium reasoning, clean with no accepted/actionable findings (0.93).
- `git diff --check` passed; production diff is 0 additions and 1 deletion.

No changelog entry: internal dead-export cleanup with no user-visible behavior change.
