### PR TITLE
refactor(logging): remove dead diagnostic testing export

### DIFF
--- a/src/logging/diagnostic-session-context.ts
+++ b/src/logging/diagnostic-session-context.ts
@@ -198,8 +198,3 @@ export function formatStoppedCronSessionDiagnosticFields(context: CronSessionCon
   }
   return fields.join(" ");
 }
-
-export const testing = {
-  quoteLogField,
-};
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

`src/logging/diagnostic-session-context.ts` still exported a `testing` object and legacy `__testing` alias even though no source, test, dynamic import, or public barrel consumes either name. The extra surface obscures the module's real runtime contract.

## Why This Change Was Made

The private `quoteLogField` helper is exercised through the public formatting functions that own its behavior. Removing the unused test facade keeps that helper private and deletes a lint-migration alias with no surviving caller.

## User Impact

None. Runtime diagnostic formatting and all production exports remain unchanged.

## Evidence

- Full 2,816-open-PR audit, 153-PR delta audit, and final complete 23-PR live tail found no overlap on the touched file.
- Full code graph indexed 305,344 nodes / 1,269,598 edges after the patch; `quoteLogField` traces only to the two production formatting functions and their diagnostic/recovery callers.
- `src/logging/diagnostic-session-context.test.ts`: 5/5 passed before and after in Testbox `tbx_01kxbgeaj92rh4wc8h5mdha7em`.
- `pnpm check:changed -- src/logging/diagnostic-session-context.ts`: conflict, attribution, wildcard-export, duplicate-coverage, dependency-pin, and format lanes passed. The run then hit the unrelated current-`main` Plugin SDK baseline hash drift.
- Patched and clean-base API regeneration produced byte-identical outputs (`4d48d018...` JSON, `72bad044...` JSONL), proving this logging deletion does not affect that failed baseline.
- Fresh `gpt-5.6-sol` medium autoreview: no actionable findings, confidence 0.87.
- `git diff --check` passed; 0 additions / 5 deletions.
- No docs or changelog entry required for an internal dead-export cleanup.
