### PR TITLE
refactor(cli): remove config guard testing alias

### DIFF
--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -354,4 +354,3 @@ export async function ensureConfigReady(params: {
 export const testApi = {
   resetConfigGuardStateForTests,
 };
-export { testApi as __test__ };


### PR DESCRIPTION
## What Problem This Solves

`src/cli/program/config-guard.ts` still exported the legacy `__test__` alias even though tests and mocks use the canonical `testApi` export directly. The redundant name expands an internal test surface with no surviving consumer.

## Why This Change Was Made

The alias was introduced during a lint migration and is not part of runtime CLI behavior. Removing it keeps the active reset hook available through `testApi` while deleting the unused compatibility name.

## User Impact

None. Runtime config validation and the canonical test reset API are unchanged.

## Evidence

- Full 2,816-open-PR audit, 153-PR delta audit, and final complete 26-PR live tail found no overlap on the touched file.
- Full code graph indexed 305,350 nodes / 1,264,659 edges after the patch; the production `ensureConfigReady` path still reaches command bootstrap, execution startup, pre-actions, and routing.
- `src/cli/program/config-guard.test.ts`: 46/46 passed before and after in Testbox `tbx_01kxbgvwvdrcs6hgeajc20z3cb`.
- `pnpm check:changed -- src/cli/program/config-guard.ts`: conflict, attribution, wildcard-export, duplicate-coverage, dependency-pin, and format lanes passed. The run then hit the unrelated current-`main` Plugin SDK baseline hash drift.
- Patched and clean-base API regeneration produced byte-identical outputs (`4d48d018...` JSON, `72bad044...` JSONL), proving this CLI deletion does not affect that failed baseline.
- Fresh `gpt-5.6-sol` medium autoreview: no actionable findings, confidence 0.96.
- `git diff --check` passed; 0 additions / 1 deletion.
- No docs or changelog entry required for an internal test-alias cleanup.
