### PR TITLE
chore(msteams): align stream failure delivery trace

### DIFF
--- a/extensions/msteams/src/__traces__/stream-failure-redeliver-full.trace.jsonl
+++ b/extensions/msteams/src/__traces__/stream-failure-redeliver-full.trace.jsonl
@@ -6,8 +6,8 @@
 {"seq":6,"at":300,"dir":"out","kind":"stream.emit","data":{"payload":{"text":" build is green."},"result":{"error":"stream write failed"}}}
 {"seq":7,"at":600,"dir":"in","kind":"block-final","data":{"text":"Deploy status: build is green."}}
 {"seq":8,"at":600,"dir":"in","kind":"partial","data":{"text":"Rolling out to production now."}}
-{"seq":9,"at":600,"dir":"out","kind":"stream.emit","data":{"payload":{"text":" production now."},"result":{"error":"stream write failed"}}}
-{"seq":10,"at":900,"dir":"in","kind":"final","data":{"text":"Deploy status: build is green.\n\nRolling out to production now."}}
-{"seq":11,"at":900,"dir":"in","kind":"idle"}
-{"seq":12,"at":900,"dir":"out","kind":"context.sendActivity","data":{"payload":{"channelData":{"feedbackLoopEnabled":true},"entities":[{"@id":"","@type":"Message","additionalType":["AIGeneratedContent"],"type":"https://schema.org/Message"}],"text":"Deploy status: build is green.","type":"message"},"result":{"id":"activity-2"},"target":"a:1dm-trace-conversation"}}
-{"seq":13,"at":900,"dir":"out","kind":"context.sendActivity","data":{"payload":{"channelData":{"feedbackLoopEnabled":true},"entities":[{"@id":"","@type":"Message","additionalType":["AIGeneratedContent"],"type":"https://schema.org/Message"}],"text":"Deploy status: build is green.\n\nRolling out to production now.","type":"message"},"result":{"id":"activity-3"},"target":"a:1dm-trace-conversation"}}
+{"seq":9,"at":900,"dir":"in","kind":"final","data":{"text":"Deploy status: build is green.\n\nRolling out to production now."}}
+{"seq":10,"at":900,"dir":"in","kind":"idle"}
+{"seq":11,"at":900,"dir":"out","kind":"context.sendActivity","data":{"payload":{"channelData":{"feedbackLoopEnabled":true},"entities":[{"@id":"","@type":"Message","additionalType":["AIGeneratedContent"],"type":"https://schema.org/Message"}],"text":"Deploy status: build is green.","type":"message"},"result":{"id":"activity-2"},"target":"a:1dm-trace-conversation"}}
+{"seq":12,"at":900,"dir":"out","kind":"context.sendActivity","data":{"payload":{"channelData":{"feedbackLoopEnabled":true},"entities":[{"@id":"","@type":"Message","additionalType":["AIGeneratedContent"],"type":"https://schema.org/Message"}],"text":"Deploy status: build is green.\n\nRolling out to production now.","type":"message"},"result":{"id":"activity-3"},"target":"a:1dm-trace-conversation"}}
+{"seq":13,"at":900,"dir":"out","kind":"stream.emit","data":{"payload":{"channelData":{"feedbackLoopEnabled":true},"entities":[{"@context":"https://schema.org","@id":"","@type":"Message","additionalType":["AIGeneratedContent"],"type":"https://schema.org/Message"}],"type":"message"},"result":{"error":"stream write failed"}}}

--- a/extensions/msteams/src/delivery-trace.test.ts
+++ b/extensions/msteams/src/delivery-trace.test.ts
@@ -216,8 +216,10 @@ const MSTEAMS_TRACE_CASES: readonly MSTeamsTraceCase[] = [
   },
   {
     // Mid-stream non-cancel write failure latches streamFailed: the streamed
-    // prefix stays visible AND the full reply re-delivers as blocks. The
-    // duplication is the contract (truncation is the worse outcome).
+    // prefix stays visible AND the full reply re-delivers as blocks. A later
+    // segment rewrites the stale stream buffer, then finalize attempts the
+    // closing metadata write after fallback delivery. The duplication is the
+    // contract (truncation is the worse outcome).
     golden: "stream-failure-redeliver-full",
     scenario: "streaming-happy",
     conversationType: "personal",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Plugin Prerelease validation failed after the Microsoft Teams streaming controller intentionally changed non-whitespace rewrite recovery, because the committed failure-path wire trace still described the previous write sequence.

## Why This Change Was Made

Refreshes the exact delivery trace to preserve the new contract: block fallback delivery completes before the controller attempts the closing metadata write. The scenario comment now documents that ordering and why duplicate fallback delivery remains preferable to truncation.

## User Impact

No product behavior change. Release validation once again checks the current Microsoft Teams stream-failure recovery contract instead of rejecting it as drift.

## Evidence

- Failing exact run: https://github.com/openclaw/openclaw/actions/runs/29198974321/job/86666916545
- Blacksmith Testbox `tbx_01kxbgwfg22pefeethryjpmxrq`: focused delivery/controller tests, 43/43 passed.
- Same Testbox: complete Microsoft Teams extension suite, 1106/1106 passed with retries disabled.
- `git diff --check`
- Fresh autoreview: clean, no accepted/actionable findings.
