### PR TITLE
refactor(infra): remove JSONL socket testing alias

### DIFF
--- a/src/infra/jsonl-socket.ts
+++ b/src/infra/jsonl-socket.ts
@@ -117,4 +117,3 @@ export const testApi = {
   requestJsonlSocketWithMaxLineBytes,
   resolveJsonlSocketTimeoutMs,
 };
-export { testApi as __test__ };


### PR DESCRIPTION
## What Problem This Solves

`src/infra/jsonl-socket.ts` exports the same test facade under both `testApi` and `__test__`, but every current test uses `testApi` and no caller imports `__test__`. The duplicate alias expands the module surface without serving a compatibility contract.

## Why This Change Was Made

Remove only the unused `__test__` re-export. The runtime entry point and canonical `testApi` facade remain unchanged.

The alias was introduced alongside `testApi`; the introducing commit already used `testApi` in the module test, so `__test__` has no shipped-use history. A complete open-PR file audit plus a live tail found no overlapping PR for this file.

## User Impact

None. This is an internal dead-export cleanup with no runtime behavior change.

## Evidence

- Testbox: `tbx_01kxbh6w92nnnn55x74d4j7ncb`
- Before: `corepack pnpm test:serial src/infra/jsonl-socket.test.ts` - 7/7 passed
- After: `corepack pnpm test:serial src/infra/jsonl-socket.test.ts` - 7/7 passed
- `corepack pnpm check:changed -- src/infra/jsonl-socket.ts` - conflict, attribution, wildcard-export, duplicate-coverage, dependency-pin, and formatting lanes passed; stopped only on the pre-existing stale Plugin SDK API baseline
- Patched and clean-base Plugin SDK regeneration produced byte-identical JSON, JSONL, and hash artifacts, proving the baseline drift is unrelated
- `git diff --check` - passed
- Fresh `gpt-5.6-sol` medium autoreview - clean, 0.96 confidence
- Diff: one deletion, zero production additions

No changelog entry: pure internal refactor.
