### PR TITLE
fix(ci): prevent session concurrency test timeout

### DIFF
--- a/src/config/sessions/session-accessor.reply-init-concurrency.test.ts
+++ b/src/config/sessions/session-accessor.reply-init-concurrency.test.ts
@@ -266,12 +266,17 @@ async function waitForChild(child: ReturnType<typeof spawn>, label: string): Pro
     childStderr += String(chunk);
   });
 
-  const childExit = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
-    (resolve, reject) => {
-      child.once("error", reject);
-      child.once("exit", (code, signal) => resolve({ code, signal }));
-    },
-  );
+  // The file handshake can complete immediately before this waiter attaches.
+  // Honor an already-observed exit or the test will wait forever for a spent event.
+  const childExit =
+    child.exitCode !== null || child.signalCode !== null
+      ? { code: child.exitCode, signal: child.signalCode }
+      : await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+          (resolve, reject) => {
+            child.once("error", reject);
+            child.once("exit", (code, signal) => resolve({ code, signal }));
+          },
+        );
   if (childExit.code !== 0) {
     throw new Error(
       `${label} child failed code=${String(childExit.code)} signal=${String(childExit.signal)}\nstdout:\n${childStdout}\nstderr:\n${childStderr}`,
@@ -280,6 +285,18 @@ async function waitForChild(child: ReturnType<typeof spawn>, label: string): Pro
 }
 
 describe("session accessor cross-process concurrency", () => {
+  it("observes a child that exited before the waiter attached", async () => {
+    const child = spawn(process.execPath, ["--eval", ""], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    await new Promise<void>((resolve, reject) => {
+      child.once("error", reject);
+      child.once("exit", () => resolve());
+    });
+
+    await waitForChild(child, "already exited");
+  });
+
   it("commits after same-session activity from another process", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reply-init-"));
     const sessionAccessorUrl = pathToFileURL(


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI flake where the session accessor cross-process concurrency suite could time out after its child process had already completed successfully.

## Why This Change Was Made

The file handshake can finish just before the parent attaches its child `exit` listener. The waiter now accepts Node's recorded `exitCode` or `signalCode` when that one-shot event has already fired, while preserving the existing listener path for a running child. A deterministic regression covers the already-exited ordering.

## User Impact

No runtime behavior change. Session concurrency CI remains strict while avoiding a spent-event timeout.

## Evidence

- Exact failure: https://github.com/openclaw/openclaw/actions/runs/29199479248/job/86668265440 (`5 tests`, one 15-second timeout at the cross-process rewrite case)
- Blacksmith Testbox `tbx_01kxbhky2n2gy7zbkq6e3zjr0q`: focused suite 6/6 green
- Same Testbox: 20 consecutive focused-suite runs green (120 test executions)
- Same Testbox: `pnpm check:changed` green (format, core-test typecheck, lint)
- Fresh autoreview: clean, no accepted/actionable findings
