### PR TITLE
fix(openai): preserve image routing before catalog load

### DIFF
--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -1,5 +1,5 @@
 // Openai tests cover image generation provider plugin behavior.
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildOpenAIImageGenerationProvider } from "./image-generation-provider.js";
 

--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -733,6 +733,8 @@ describe("openai image generation provider", () => {
     mockGeneratedPngResponse();
 
     const provider = buildOpenAIImageGenerationProvider();
+    // Plugin-scoped runtime snapshots can carry a built-in provider overlay
+    // before its model catalog is present.
     const cfg = {
       models: {
         providers: {
@@ -741,7 +743,7 @@ describe("openai image generation provider", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
     const result = await provider.generateImage({
       provider: "openai",
       model: "gpt-image-2",

--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -1,4 +1,5 @@
 // Openai tests cover image generation provider plugin behavior.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildOpenAIImageGenerationProvider } from "./image-generation-provider.js";
 
@@ -726,6 +727,33 @@ describe("openai image generation provider", () => {
     expect(body.model).toBe("gpt-image-1");
     expect(body.size).toBe("2048x1152");
     expect(result.metadata).toBeUndefined();
+  });
+
+  it("falls back to the provider baseUrl when the model catalog is omitted", async () => {
+    mockGeneratedPngResponse();
+
+    const provider = buildOpenAIImageGenerationProvider();
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://openai-compatible.example.com/v1",
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const result = await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Create an image through a provider overlay",
+      cfg,
+    });
+
+    expect(httpConfigCall().baseUrl).toBe("https://openai-compatible.example.com/v1");
+    expect(jsonRequestCall().url).toBe(
+      "https://openai-compatible.example.com/v1/images/generations",
+    );
+    expect(result.images).toHaveLength(1);
   });
 
   it("forwards output and OpenAI-only options on direct generations", async () => {

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -268,7 +268,7 @@ function resolveNativeOpenAIImageSizesForModel(model: string): readonly string[]
 function resolveConfiguredOpenAIImageBaseUrl(cfg: OpenClawConfig | undefined, model: string) {
   const modelId = model.trim().replace(/^openai\//u, "");
   const modelBaseUrl = cfg?.models?.providers?.openai?.models
-    .find((candidate) => candidate.id.trim().replace(/^openai\//u, "") === modelId)
+    ?.find((candidate) => candidate.id.trim().replace(/^openai\//u, "") === modelId)
     ?.baseUrl?.trim();
   return modelBaseUrl || resolveConfiguredOpenAIBaseUrl(cfg);
 }


### PR DESCRIPTION
## What Problem This Solves

OpenAI image generation and reference-image editing crash when a plugin-scoped provider overlay supplies credentials or `baseUrl` before its model catalog is present.

Exact beta6 release proof: OpenClaw Release Checks run `29199550952`, job `86668750490`, failed both live image paths with `TypeError: Cannot read properties of undefined (reading 'find')` in `resolveConfiguredOpenAIImageBaseUrl()`.

Supersedes the closed investigation in #105501 after the live release gate proved the pre-catalog runtime shape is reachable.

## Why This Change Was Made

Treat the provider model catalog as optional at the lookup boundary. Model-specific routing remains unchanged when a catalog exists; provider-level `baseUrl` fallback remains available before catalog materialization.

## User Impact

OpenAI image generation and image editing no longer crash when the active provider overlay has no loaded model catalog yet.

## Evidence

- Blacksmith Testbox `tbx_01kxbfrhm7vwsrdv72t2nafwqm`, Actions run `29198630020`: focused OpenAI image provider suite passed 69/69 before the fixture typing correction.
- Beta6 Release Checks run `29199550952`, job `86668750490`: exact before-fix live reproduction in both image generation and editing.
- `node scripts/check-plugin-sdk-subpath-exports.mjs`
- `git diff --check`
- Fresh autoreview: no accepted or actionable findings.

## Changelog

Release-owned. Beta6 finalization will render this original main PR after backport.
