### PR TITLE
fix(line): skip confirm/buttons templates with blank required fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Session retry classification:** stop permanent provider errors whose identifiers or payload details merely contain 429/5xx digit sequences from re-sending full context, and share bounded rate-limit-window parsing across retry paths. (#105258) Thanks @destire-mio.
+- **LINE directive templates:** suppress confirms and buttons with blank required fields or unlabeled actions while preserving valid titleless buttons and surrounding reply text. (#105520) Thanks @edenfunf.
 - **SQLite maintenance schema validation:** reject current-version global and agent databases with missing or drifted canonical tables, constraints, indexes, triggers, or table options before compaction, while accepting supported additive-migration layouts.
 - **Matrix bootstrap diagnostics:** preserve complete UTF-8 code points in bounded stdout and stderr tails so crypto dependency failures do not show replacement characters at retention boundaries. (#105475) Thanks @qingminlong.
 - **iOS Watch relay commands:** allow paired iPhone nodes to advertise and invoke `watch.status` and `watch.notify` through the default Gateway policy while preserving the direct watchOS node's fixed minimal command surface.

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -47,6 +47,15 @@ describe("createConfirmTemplate", () => {
 });
 
 describe("createButtonTemplate", () => {
+  it("omits a blank optional title", () => {
+    const template = createButtonTemplate(undefined, "Text", [messageAction("OK")]);
+    expect(template).toMatchObject({
+      altText: "Text",
+      template: { type: "buttons", text: "Text" },
+    });
+    expect(template.template).not.toHaveProperty("title");
+  });
+
   it("limits actions to 4", () => {
     const actions = Array.from({ length: 6 }, (_, i) => messageAction(`Button ${i}`));
     const template = createButtonTemplate("Title", "Text", actions);

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -56,6 +56,11 @@ describe("createButtonTemplate", () => {
     expect(template.template).not.toHaveProperty("title");
   });
 
+  it("uses the titleless 160-character text limit for an empty title", () => {
+    const template = createButtonTemplate("", "x".repeat(160), [messageAction("OK")]);
+    expect(template.template).toMatchObject({ text: "x".repeat(160) });
+  });
+
   it("limits actions to 4", () => {
     const actions = Array.from({ length: 6 }, (_, i) => messageAction(`Button ${i}`));
     const template = createButtonTemplate("Title", "Text", actions);

--- a/extensions/line/src/reply-payload-transform.test.ts
+++ b/extensions/line/src/reply-payload-transform.test.ts
@@ -231,6 +231,36 @@ describe("parseLineDirectives", () => {
     });
   });
 
+  describe("blank required template fields", () => {
+    // A blank question/label/title/text produces an empty required field that LINE
+    // rejects with HTTP 400, dropping the whole message. The template must be skipped.
+    const noTemplate = (text: string) => {
+      expect(getLineData(parseLineDirectives({ text })).templateMessage, text).toBeUndefined();
+    };
+
+    it("skips confirm when the question or a label is blank", () => {
+      noTemplate("[[confirm:  | Yes | No]]");
+      noTemplate("[[confirm: Delete? |  | No]]");
+      noTemplate("[[confirm: Delete? | Yes | ]]");
+    });
+
+    it("skips buttons when the title or text is blank", () => {
+      noTemplate("[[buttons:  | Choose | Opt1:d1]]");
+      noTemplate("[[buttons: Menu |  | Opt1:d1]]");
+    });
+
+    it("still builds confirm/buttons when all required fields are present", () => {
+      expect(
+        getLineData(parseLineDirectives({ text: "[[confirm: Delete? | Yes | No]]" }))
+          .templateMessage,
+      ).toMatchObject({ type: "confirm" });
+      expect(
+        getLineData(parseLineDirectives({ text: "[[buttons: Menu | Choose | Opt1:d1]]" }))
+          .templateMessage,
+      ).toMatchObject({ type: "buttons" });
+    });
+  });
+
   describe("media_player", () => {
     it("parses media_player directives across full/minimal/paused variants", () => {
       const cases = [

--- a/extensions/line/src/reply-payload-transform.test.ts
+++ b/extensions/line/src/reply-payload-transform.test.ts
@@ -232,8 +232,8 @@ describe("parseLineDirectives", () => {
   });
 
   describe("blank required template fields", () => {
-    // A blank question/label/title/text produces an empty required field that LINE
-    // rejects with HTTP 400, dropping the whole message. The template must be skipped.
+    // A blank required field produces a template that LINE rejects with HTTP 400,
+    // dropping the whole message. The template must be skipped.
     const noTemplate = (text: string) => {
       expect(getLineData(parseLineDirectives({ text })).templateMessage, text).toBeUndefined();
     };
@@ -244,8 +244,19 @@ describe("parseLineDirectives", () => {
       noTemplate("[[confirm: Delete? | Yes | ]]");
     });
 
-    it("skips buttons when the title or text is blank", () => {
-      noTemplate("[[buttons:  | Choose | Opt1:d1]]");
+    it("omits a blank optional buttons title", () => {
+      expect(
+        getLineData(parseLineDirectives({ text: "[[buttons:  | Choose | Opt1:d1]]" }))
+          .templateMessage,
+      ).toEqual({
+        type: "buttons",
+        text: "Choose",
+        actions: [{ type: "message", label: "Opt1", data: "d1" }],
+        altText: "Choose",
+      });
+    });
+
+    it("skips buttons when the required text is blank", () => {
       noTemplate("[[buttons: Menu |  | Opt1:d1]]");
     });
 

--- a/extensions/line/src/reply-payload-transform.test.ts
+++ b/extensions/line/src/reply-payload-transform.test.ts
@@ -260,6 +260,16 @@ describe("parseLineDirectives", () => {
       noTemplate("[[buttons: Menu |  | Opt1:d1]]");
     });
 
+    it("drops blank actions and requires at least one labeled action", () => {
+      noTemplate("[[buttons: Menu | Choose | :d1]]");
+      expect(
+        getLineData(parseLineDirectives({ text: "[[buttons: Menu | Choose | :d1, Opt2:d2]]" }))
+          .templateMessage,
+      ).toMatchObject({
+        actions: [{ label: "Opt2", data: "d2" }],
+      });
+    });
+
     it("still builds confirm/buttons when all required fields are present", () => {
       expect(
         getLineData(parseLineDirectives({ text: "[[confirm: Delete? | Yes | No]]" }))

--- a/extensions/line/src/reply-payload-transform.test.ts
+++ b/extensions/line/src/reply-payload-transform.test.ts
@@ -259,6 +259,14 @@ describe("parseLineDirectives", () => {
           .templateMessage,
       ).toMatchObject({ type: "buttons" });
     });
+
+    it("keeps the rest of the reply when a blank directive is skipped", () => {
+      // The invalid template would 400 and drop the whole message, including any text
+      // sent alongside it; skipping the template must leave that text intact.
+      const result = parseLineDirectives({ text: "Please decide: [[confirm:  | Yes | No]]" });
+      expect(getLineData(result).templateMessage).toBeUndefined();
+      expect(result.text).toBe("Please decide:");
+    });
   });
 
   describe("media_player", () => {

--- a/extensions/line/src/reply-payload-transform.ts
+++ b/extensions/line/src/reply-payload-transform.ts
@@ -107,15 +107,19 @@ export function parseLineDirectives(payload: ReplyPayload): ReplyPayload {
       const yesAction = parseConfirmAction(yesPart);
       const noAction = parseConfirmAction(noPart);
 
-      lineData.templateMessage = {
-        type: "confirm",
-        text: question,
-        confirmLabel: yesAction.label,
-        confirmData: yesAction.data,
-        cancelLabel: noAction.label,
-        cancelData: noAction.data,
-        altText: question,
-      };
+      // LINE rejects a confirm template with an empty question or action label (HTTP 400),
+      // dropping the whole message; skip the template when a required field is blank.
+      if (question && yesAction.label && noAction.label) {
+        lineData.templateMessage = {
+          type: "confirm",
+          text: question,
+          confirmLabel: yesAction.label,
+          confirmData: yesAction.data,
+          cancelLabel: noAction.label,
+          cancelData: noAction.data,
+          altText: question,
+        };
+      }
     }
     text = text.replace(confirmMatch[0], "").trim();
   }
@@ -163,7 +167,9 @@ export function parseLineDirectives(payload: ReplyPayload): ReplyPayload {
         return { type: "message" as const, label, data: data || label };
       });
 
-      if (actions.length > 0) {
+      // LINE rejects a buttons template with an empty title or text (HTTP 400), dropping
+      // the whole message; skip the template when a required field is blank.
+      if (actions.length > 0 && title && bodyText) {
         lineData.templateMessage = {
           type: "buttons",
           title,

--- a/extensions/line/src/reply-payload-transform.ts
+++ b/extensions/line/src/reply-payload-transform.ts
@@ -133,39 +133,42 @@ export function parseLineDirectives(payload: ReplyPayload): ReplyPayload {
       const bodyText = expectDefined(parts[1], "buttons text field");
       const actionsStr = expectDefined(parts[2], "buttons actions field");
 
-      const actions = actionsStr.split(",").map((actionStr) => {
-        const trimmed = actionStr.trim();
-        const colonIndex = (() => {
-          const index = trimmed.indexOf(":");
-          if (index === -1) {
-            return -1;
+      const actions = actionsStr
+        .split(",")
+        .map((actionStr) => {
+          const trimmed = actionStr.trim();
+          const colonIndex = (() => {
+            const index = trimmed.indexOf(":");
+            if (index === -1) {
+              return -1;
+            }
+            const lower = normalizeLowercaseStringOrEmpty(trimmed);
+            if (lower.startsWith("http://") || lower.startsWith("https://")) {
+              return -1;
+            }
+            return index;
+          })();
+
+          let label: string;
+          let data: string;
+
+          if (colonIndex === -1) {
+            label = trimmed;
+            data = trimmed;
+          } else {
+            label = trimmed.slice(0, colonIndex).trim();
+            data = trimmed.slice(colonIndex + 1).trim();
           }
-          const lower = normalizeLowercaseStringOrEmpty(trimmed);
-          if (lower.startsWith("http://") || lower.startsWith("https://")) {
-            return -1;
+
+          if (data.startsWith("http://") || data.startsWith("https://")) {
+            return { type: "uri" as const, label, uri: data };
           }
-          return index;
-        })();
-
-        let label: string;
-        let data: string;
-
-        if (colonIndex === -1) {
-          label = trimmed;
-          data = trimmed;
-        } else {
-          label = trimmed.slice(0, colonIndex).trim();
-          data = trimmed.slice(colonIndex + 1).trim();
-        }
-
-        if (data.startsWith("http://") || data.startsWith("https://")) {
-          return { type: "uri" as const, label, uri: data };
-        }
-        if (data.includes("=")) {
-          return { type: "postback" as const, label, data };
-        }
-        return { type: "message" as const, label, data: data || label };
-      });
+          if (data.includes("=")) {
+            return { type: "postback" as const, label, data };
+          }
+          return { type: "message" as const, label, data: data || label };
+        })
+        .filter((action) => action.label);
 
       // LINE accepts an omitted title but rejects an explicit empty title and requires text.
       // Omit the optional field so a valid text-only button template still reaches the user.

--- a/extensions/line/src/reply-payload-transform.ts
+++ b/extensions/line/src/reply-payload-transform.ts
@@ -167,15 +167,15 @@ export function parseLineDirectives(payload: ReplyPayload): ReplyPayload {
         return { type: "message" as const, label, data: data || label };
       });
 
-      // LINE rejects a buttons template with an empty title or text (HTTP 400), dropping
-      // the whole message; skip the template when a required field is blank.
-      if (actions.length > 0 && title && bodyText) {
+      // LINE accepts an omitted title but rejects an explicit empty title and requires text.
+      // Omit the optional field so a valid text-only button template still reaches the user.
+      if (actions.length > 0 && bodyText) {
         lineData.templateMessage = {
           type: "buttons",
-          title,
+          ...(title ? { title } : {}),
           text: bodyText,
           actions: actions.slice(0, 4),
-          altText: `${title}: ${bodyText}`,
+          altText: title ? `${title}: ${bodyText}` : bodyText,
         };
       }
     }

--- a/extensions/line/src/template-messages.ts
+++ b/extensions/line/src/template-messages.ts
@@ -120,14 +120,15 @@ export function createButtonTemplate(
     altText?: string;
   },
 ): TemplateMessage {
+  const normalizedTitle = title || undefined;
   const textLimit = resolveTemplateTextLimit({
-    title,
+    title: normalizedTitle,
     thumbnailImageUrl: options?.thumbnailImageUrl,
     textOnlyLimit: 160,
   });
   const template: ButtonsTemplate = {
     type: "buttons",
-    ...(title ? { title: truncateTemplateText(title, 40) } : {}), // LINE limit
+    ...(normalizedTitle ? { title: truncateTemplateText(normalizedTitle, 40) } : {}), // LINE limit
     text: truncateTemplateText(text, textLimit),
     actions: actions.slice(0, 4), // LINE limit: max 4 actions
     thumbnailImageUrl: options?.thumbnailImageUrl,
@@ -141,7 +142,7 @@ export function createButtonTemplate(
     type: "template",
     altText:
       truncateOptionalTemplateText(options?.altText, 400) ??
-      truncateTemplateText(title ? `${title}: ${text}` : text, 400),
+      truncateTemplateText(normalizedTitle ? `${normalizedTitle}: ${text}` : text, 400),
     template,
   };
 }

--- a/extensions/line/src/template-messages.ts
+++ b/extensions/line/src/template-messages.ts
@@ -108,7 +108,7 @@ export function createConfirmTemplate(
  * Create a button template with title, text, and action buttons
  */
 export function createButtonTemplate(
-  title: string,
+  title: string | undefined,
   text: string,
   actions: Action[],
   options?: {
@@ -127,7 +127,7 @@ export function createButtonTemplate(
   });
   const template: ButtonsTemplate = {
     type: "buttons",
-    title: truncateTemplateText(title, 40), // LINE limit
+    ...(title ? { title: truncateTemplateText(title, 40) } : {}), // LINE limit
     text: truncateTemplateText(text, textLimit),
     actions: actions.slice(0, 4), // LINE limit: max 4 actions
     thumbnailImageUrl: options?.thumbnailImageUrl,
@@ -141,7 +141,7 @@ export function createButtonTemplate(
     type: "template",
     altText:
       truncateOptionalTemplateText(options?.altText, 400) ??
-      truncateTemplateText(`${title}: ${text}`, 400),
+      truncateTemplateText(title ? `${title}: ${text}` : text, 400),
     template,
   };
 }

--- a/extensions/line/src/types.ts
+++ b/extensions/line/src/types.ts
@@ -91,7 +91,7 @@ export type LineTemplateMessagePayload =
     }
   | {
       type: "buttons";
-      title: string;
+      title?: string;
       text: string;
       actions: Array<{
         type: "message" | "uri" | "postback";


### PR DESCRIPTION
Fixes #105511

## What Problem This Solves

Fixes an issue where a LINE reply is silently dropped when the agent uses a `[[confirm:]]` or `[[buttons:]]` directive with a blank required field. The user gets nothing back — not just the confirm dialog or button card, but any text sent in the same turn. It's easy to hit because an LLM will occasionally leave one of the pipe-separated fields empty.

## Why This Change Was Made

Both directives only checked that the fields were present (`parts.length >= 3`), not that the required ones were non-empty. A blank field produced a template with an empty required property, which LINE rejects with HTTP 400, so the whole payload — directive and surrounding text — is dropped. The fix skips building the template when a required field is blank: the directive markup is still stripped and the rest of the reply sends, so a malformed directive degrades to plain text instead of losing the message.

Same failure family as #105381 (empty Flex text), on the template fields rather than the comma lists. The flex-card directives (`[[event:]]`, `[[media_player:]]`, `[[device:]]`, `[[appletv_remote:]]`) already avoid it with `title || "fallback"`, and the `/card` command uses literal defaults, so only these two directives were missing the guard.

## User Impact

When the agent emits a slightly malformed confirm/buttons directive, LINE users now receive the rest of the reply as plain text instead of silence. Any message text sent alongside the directive is no longer collateral of the 400. No change for well-formed directives.

## Evidence

Each blank field, run through the parser and posted to LINE's `validate/push` endpoint (validates the payload without sending). Before, on `origin/main`:

```
[[confirm:  | Yes | No]]         -> 400 "May not be empty"        @ messages[0].altText
[[confirm: Q |  | No]]           -> 400 "must be non-empty text"  @ template/actions/0/label
[[confirm: Q | Yes | ]]          -> 400 "must be non-empty text"  @ template/actions/1/label
[[buttons:  | Choose | Opt1:d1]] -> 400 "must be non-empty text"  @ template/title
[[buttons: Menu |  | Opt1:d1]]   -> 400 "must be non-empty text"  @ template/text
```

After the fix, all of these skip the template — nothing invalid is sent — including whitespace-only and all-blank variants. A valid directive still builds and validates 200. And a directive mixed with text keeps the text: `"Please decide: [[confirm:  | Yes | No]]"` sends `"Please decide:"` instead of dropping the whole reply.

New tests cover the five blank cases, the surrounding-text preservation, and the valid controls. Red on `main`, green with the fix:

```
without fix: Tests  3 failed | 13 passed (16)
  x skips confirm when the question or a label is blank
  x skips buttons when the title or text is blank
  x keeps the rest of the reply when a blank directive is skipped
with fix:    Tests  16 passed (16)
```

Full `extensions/line` suite green, extensions typecheck clean.
