### PR TITLE
fix(ci): retain safe Telegram trace milestones

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1255,6 +1255,7 @@ jobs:
             OPENCLAW_EMBEDDED_ABORT_SETTLE_TIMEOUT_MS
             OPENCLAW_GATEWAY_TOKEN
             OPENCLAW_HOME
+            OPENCLAW_LOG_LEVEL
             OPENCLAW_NO_RESPAWN
             OPENCLAW_OAUTH_DIR
             OPENCLAW_QA_ALLOW_LOCAL_IMAGE_PROVIDER
@@ -2097,6 +2098,7 @@ jobs:
           OPENCLAW_QA_TELEGRAM_SUT_PROCESS_BOUNDARY_DIR: ${{ steps.create_sut.outputs.boundary_evidence_dir }}
           OPENCLAW_QA_TELEGRAM_SUT_RUNTIME_EXECUTABLE: ${{ steps.create_sut.outputs.runtime_executable }}
           OPENCLAW_QA_TELEGRAM_SUT_UID: ${{ steps.create_sut.outputs.uid }}
+          OPENCLAW_LOG_LEVEL: trace
           SUT_RUNTIME_ROOT: ${{ steps.create_sut.outputs.runtime_root }}
           SUT_UID: ${{ steps.create_sut.outputs.uid }}
           TARGET_REF: ${{ inputs.target_ref }}
@@ -2258,8 +2260,53 @@ jobs:
           const maxInputRecordBytes = 1_048_576;
           const oversizedMarker = "[truncated oversized gateway log record] ";
           const omittedMarker = "[omitted oversized gateway log record]\n";
+          const safeVerboseMessagePrefixes = [
+            "embedded run start:",
+            "[trace:embedded-run] prep stages:",
+            "[trace:embedded-run] core-plugin-tool stages:",
+            "embedded run prompt start:",
+            "[context-diag] pre-prompt:",
+            "model.call.started",
+            "model_call_started",
+            "embedded run prompt end:",
+            "run cleanup:",
+          ];
           const retained = [];
           let retainedBytes = 0;
+
+          function extractLogTapeMessage(record) {
+            if (!record || typeof record !== "object" || Array.isArray(record)) {
+              return undefined;
+            }
+            const numericKeys = Object.keys(record)
+              .filter((key) => /^\d+$/u.test(key))
+              .sort((left, right) => Number(left) - Number(right));
+            for (let index = numericKeys.length - 1; index >= 0; index -= 1) {
+              const value = record[numericKeys[index]];
+              if (typeof value === "string") {
+                return value;
+              }
+            }
+            return undefined;
+          }
+
+          function shouldRetainRecord(line) {
+            let record;
+            try {
+              record = JSON.parse(line);
+            } catch {
+              return false;
+            }
+            const level = record?._meta?.logLevelName;
+            if (level !== "DEBUG" && level !== "TRACE") {
+              return true;
+            }
+            const message = extractLogTapeMessage(record);
+            return (
+              typeof message === "string" &&
+              safeVerboseMessagePrefixes.some((prefix) => message.startsWith(prefix))
+            );
+          }
 
           function boundRedactedLine(line) {
             const redactedLine = `${redactQaGatewayDebugText(line)}\n`;
@@ -2309,7 +2356,9 @@ jobs:
               retainLine(omittedMarker);
             } else {
               const line = Buffer.concat(recordParts, recordBytes).toString("utf8").replace(/\r$/u, "");
-              retainLine(boundRedactedLine(line));
+              if (shouldRetainRecord(line)) {
+                retainLine(boundRedactedLine(line));
+              }
             }
             recordParts = [];
             recordBytes = 0;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,11 @@ Skills own workflows; root owns hard policy and routing.
 - PR head changed: rerun `scripts/pr review-init`; checkout alone leaves stale guard SHA.
 - `rg`: options before `--`; use `--` before patterns starting with `-`.
 - `gh --jq` is not standalone `jq`; pipe JSON to `jq` for variables or `--arg`.
+- `gh api --paginate '<endpoint>' | jq -s ...`; gh `--slurp` may emit nothing and forbids `--jq`/`--template`.
+- Main-bound workflow dispatch: resolve server `main` SHA immediately before dispatch; retry if identity fails after `main` advances.
+- `gh run view --json` uses `attempt`, not `attemptNumber`.
+- Crabbox stop: no `--timing-json`; use `node scripts/crabbox-wrapper.mjs stop --provider <provider> --id <id>`.
+- macOS `find` has no `-printf`; use `-print0` plus `stat`.
 - Actions checkout refs: use full 40-char SHAs; short SHAs resolve as branches/tags.
 - zsh Git object paths: use `${sha}:path`; `$sha:path` invokes parameter modifiers.
 - Bare issue/PR URL/number: inspect live and take the efficient maintainer path; switch branches/refs when useful.

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -530,6 +530,7 @@ describe("release Telegram QA workflow", () => {
     const runStep = job?.steps?.find((step) => step.name === "Run Telegram live lane");
     expect(runStep?.env?.OPENCLAW_QA_CREDENTIAL_ACQUIRE_TIMEOUT_MS).toBe("60000");
     expect(runStep?.env?.OPENCLAW_QA_CREDENTIAL_LEASE_TTL_MS).toBe("7200000");
+    expect(runStep?.env?.OPENCLAW_LOG_LEVEL).toBe("trace");
     expect(runStep?.env?.OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS).toBe("60000");
     expect(runStep?.run).toContain("trap terminate_sut_uid_on_exit EXIT");
     expect(runStep?.run).toContain('"$OPENCLAW_QA_TELEGRAM_SUT_OPENCLAW_COMMAND" --terminate-uid');
@@ -575,6 +576,11 @@ describe("release Telegram QA workflow", () => {
     expect(captureStep?.run).toContain("const redactedLine =");
     expect(captureStep?.run).toContain("const limitBytes = 131_072");
     expect(captureStep?.run).toContain("const maxInputRecordBytes = 1_048_576");
+    expect(captureStep?.run).toContain("safeVerboseMessagePrefixes");
+    expect(captureStep?.run).toContain("shouldRetainRecord");
+    expect(captureStep?.run).toContain('"[trace:embedded-run] prep stages:"');
+    expect(captureStep?.run).toContain('"[context-diag] pre-prompt:"');
+    expect(captureStep?.run).toContain('"model.call.started"');
     expect(captureStep?.run).toContain("[truncated oversized gateway log record]");
     expect(captureStep?.run).toContain("[omitted oversized gateway log record]");
     expect(captureStep?.run).toContain("chunk.indexOf(0x0a, offset)");
@@ -609,6 +615,65 @@ describe("release Telegram QA workflow", () => {
       /run_qa_attempt\(\) \(\n\s+set -euo pipefail\n\s+exec 2>&1\n\s+output_name=/u,
     );
     expect(runStep?.run).toContain("::stop-commands::%s");
+  });
+
+  it("retains only allowlisted verbose runtime diagnostics", () => {
+    const captureStep = workflowStep(
+      workflowJob("run_telegram"),
+      "Capture isolated Telegram runtime diagnostics",
+    );
+    const redactorSource = captureStep.run?.match(
+      /cat >"\$redactor_script" <<'NODE'\n([\s\S]*?)\nNODE/u,
+    )?.[1];
+    expect(redactorSource).toBeTruthy();
+
+    const workdir = tempDirs.make("openclaw-telegram-log-filter-");
+    const scriptPath = join(workdir, "redact-gateway-tail.mts");
+    const outputPath = join(workdir, "gateway.log");
+    writeFileSync(scriptPath, redactorSource ?? "");
+    const inputRecords = [
+      { 0: '{"subsystem":"gateway"}', 1: "ordinary info", _meta: { logLevelName: "INFO" } },
+      {
+        0: '{"subsystem":"agents/embedded"}',
+        1: "embedded run start: safe milestone",
+        _meta: { logLevelName: "DEBUG" },
+      },
+      {
+        0: '{"subsystem":"agents/embedded","details":"embedded run start: marker outside message"}',
+        1: { details: "[context-diag] pre-prompt: structured marker outside message" },
+        2: "verbose payload must drop",
+        _meta: { logLevelName: "DEBUG" },
+      },
+      {
+        0: '{"subsystem":"agents/embedded"}',
+        1: "[context-diag] pre-prompt: safe counts",
+        _meta: { logLevelName: "TRACE" },
+      },
+      {
+        0: '{"subsystem":"agents/embedded"}',
+        1: "trace payload must drop",
+        message: "embedded run prompt end: convenience field must not authorize",
+        _meta: { logLevelName: "TRACE" },
+      },
+    ]
+      .map((record) => JSON.stringify(record))
+      .join("\n");
+    const input = `${inputRecords}\n{"0":"truncated verbose payload must drop"`;
+    const result = spawnSync(process.execPath, ["--import", "tsx", scriptPath, outputPath], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      input,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    const output = readFileSync(outputPath, "utf8");
+    expect(output).toContain("ordinary info");
+    expect(output).toContain("embedded run start: safe milestone");
+    expect(output).toContain("[context-diag] pre-prompt: safe counts");
+    expect(output).not.toContain("verbose payload must drop");
+    expect(output).not.toContain("marker outside message");
+    expect(output).not.toContain("convenience field must not authorize");
+    expect(output).not.toContain("truncated verbose payload must drop");
+    expect(output).not.toContain("trace payload must drop");
   });
 
   it("derives SUT-writable paths from the verified runtime root after sudo", () => {
@@ -677,6 +742,7 @@ describe("release Telegram QA workflow", () => {
     expect(source).toContain('export HOME="${temp_root}/home"');
     expect(source).toContain('export XDG_CONFIG_HOME="${temp_root}/xdg-config"');
     expect(source).toContain('if [[ "${1:-}" == "--root-terminate-uid" ]]');
+    expect(source).toContain("OPENCLAW_LOG_LEVEL");
     expect(source).toContain("capture_live_model_config() {");
     expect(source).toContain('capture_live_model_config "$config_path"');
     expect(source).toContain('proof_tmp="${RUNTIME_ROOT}/gateway-model-config-${BASHPID}.json"');


### PR DESCRIPTION
## What Problem This Solves

The frozen LTS Telegram canary reaches inbound handling and tool-policy evaluation but emits no provider request. INFO logs cannot distinguish a pre-prompt preparation stall from a prompt/provider stall.

## Why This Change Was Made

Forward trace logging only inside the isolated Telegram SUT, then retain only an allowlist of structured lifecycle messages from canonical numeric LogTape arguments. Malformed, oversized, unrelated verbose, and marker-spoofed records fail closed; existing streaming redaction and artifact byte caps remain in force.

The root agent guide also records the bounded invocation mistakes encountered during this release diagnosis.

## User Impact

No product behavior, scenario, or timeout change. Failed hosted Telegram release checks retain bounded stage milestones needed to locate the frozen-candidate stall without retaining verbose payloads.

## Evidence

- exact LTS evidence before this patch: https://github.com/openclaw/openclaw/actions/runs/29198951950
- Blacksmith Testbox `tbx_01kxbh9s7em2c3drmbg7hwq6ew`: focused workflow tests, 20/20 passed
- Blacksmith Testbox `tbx_01kxbh9s7em2c3drmbg7hwq6ew`: `pnpm check:changed`, passed
- `actionlint` and generated launcher `bash -n`, passed
- fresh autoreview: clean after fail-closed structured-log hardening
