### PR TITLE
refactor(workspaces): remove unused migration helper

### DIFF
--- a/extensions/workspaces/src/schema.ts
+++ b/extensions/workspaces/src/schema.ts
@@ -456,18 +456,3 @@ export function validateWorkspaceDoc(value: unknown): WorkspaceDoc {
     prefs: validatePrefs(record.prefs, tabSlugs),
   };
 }
-
-export function migrateWorkspaceDoc(value: unknown): { doc: WorkspaceDoc; changed: boolean } {
-  const record = assertRecord(value, "workspaces");
-  const schemaVersion = record.schemaVersion;
-  if (typeof schemaVersion !== "number" || !Number.isInteger(schemaVersion)) {
-    throw new Error("schemaVersion must be an integer");
-  }
-  if (schemaVersion > CURRENT_WORKSPACE_SCHEMA_VERSION) {
-    throw new Error(`unsupported future workspace schemaVersion: ${schemaVersion}`);
-  }
-  if (schemaVersion < CURRENT_WORKSPACE_SCHEMA_VERSION) {
-    throw new Error(`unsupported old workspace schemaVersion: ${schemaVersion}`);
-  }
-  return { doc: validateWorkspaceDoc(record), changed: false };
-}


### PR DESCRIPTION
## What Problem This Solves

The workspaces schema exported a migration helper that has never had a caller. The plugin's store explicitly treats the current schema as its first shipped format and validates it directly, so the helper represented an unreachable alternate path.

## Why This Change Was Made

Remove the dead helper instead of preserving a migration contract that never shipped. The canonical read path remains `validateWorkspaceDoc`, matching the store's existing ownership and schema policy.

## User Impact

No user-visible behavior changes. This removes 15 lines of unreachable internal code.

## Evidence

- Codebase-memory graph: zero callers before deletion; refreshed graph returns zero results for `migrateWorkspaceDoc`.
- Testbox `tbx_01kxbhn5xbgsay0ptvhmdpq912`: `pnpm test:serial extensions/workspaces/src/schema.test.ts extensions/workspaces/src/store.test.ts` passed 24/24 tests.
- `pnpm check:changed -- extensions/workspaces/src/schema.ts` passed conflict, attribution, re-export, duplicate, dependency, and formatting lanes; it stopped only on the repository's unrelated Plugin SDK baseline hash drift.
- Fresh autoreview: `gpt-5.6-sol`, medium reasoning, no actionable findings, 0.93 confidence.
- `git diff --check` passed.
