### PR TITLE
refactor(android): remove unused benchmark coordinate

### DIFF
--- a/apps/android/scripts/perf-online-benchmark.sh
+++ b/apps/android/scripts/perf-online-benchmark.sh
@@ -165,7 +165,6 @@ pct_of() {
   awk -v total="$total" -v pct="$pct" 'BEGIN { printf "%d", total * pct }'
 }
 
-tab_connect_x="$(pct_of "$display_width" "0.11")"
 tab_chat_x="$(pct_of "$display_width" "0.31")"
 tab_screen_x="$(pct_of "$display_width" "0.69")"
 tab_y="$(pct_of "$display_height" "0.93")"


### PR DESCRIPTION
## What Problem This Solves

The Android online benchmark calculated a Connect-tab X coordinate that no benchmark path ever reads. Every run paid for an unnecessary `awk` subprocess while the value remained dead.

## Why This Change Was Made

Remove the unread assignment. The adjacent Chat and Screen coordinates remain intact and continue to drive every tab interaction in the benchmark.

## User Impact

No behavior change. Benchmark startup performs one fewer unused coordinate calculation.

## Evidence

- Exhaustive repository search finds no remaining `tab_connect_x` reference; history shows the assignment was never consumed after introduction.
- Full, delta, and final live open-PR overlap checks returned zero matches for the file.
- Testbox `tbx_01kxbhn5xbgsay0ptvhmdpq912`: `bash -n apps/android/scripts/perf-online-benchmark.sh` passed before and after the deletion.
- Testbox changed-file gate passed for `apps/android/scripts/perf-online-benchmark.sh`.
- Fresh autoreview: `gpt-5.6-sol`, medium reasoning, no actionable findings, 0.99 confidence.
- Refreshed codebase-memory graph dropped one node; `git diff --check` passed.
