### PR TITLE
feat(sqlite): add verified snapshot repository

### DIFF
--- a/src/infra/sqlite-snapshot.test.ts
+++ b/src/infra/sqlite-snapshot.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -129,7 +130,143 @@ describe("createVerifiedSqliteSnapshot", () => {
     await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("racer");
   });
 
-  it("preserves a target replaced after hard-link publication", async () => {
+  it("rejects staged bytes changed after validation", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const sqlite = requireNodeSqlite();
+    new sqlite.DatabaseSync(sourcePath).close();
+    const originalOpen = fs.open.bind(fs);
+    let stagedReadCount = 0;
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      const resolvedPath = path.resolve(String(filePath));
+      if (
+        flags === "r" &&
+        path.basename(resolvedPath) === "database.sqlite" &&
+        path.basename(path.dirname(resolvedPath)).startsWith(".sqlite-snapshot-")
+      ) {
+        stagedReadCount += 1;
+        if (stagedReadCount === 2) {
+          await fs.appendFile(resolvedPath, "changed-after-validation");
+        }
+      }
+      return await originalOpen(filePath, flags, mode);
+    });
+
+    try {
+      await expect(createVerifiedSqliteSnapshot({ sourcePath, targetPath })).rejects.toThrow(
+        /size mismatch|hash mismatch/u,
+      );
+      await expect(fs.access(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
+  it("runs the final caller guard before publishing the target", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const sqlite = requireNodeSqlite();
+    new sqlite.DatabaseSync(sourcePath).close();
+    let guarded = false;
+
+    await expect(
+      createVerifiedSqliteSnapshot({
+        sourcePath,
+        targetPath,
+        beforePublish: () => {
+          guarded = true;
+          throw new Error("publication refused");
+        },
+      }),
+    ).rejects.toThrow(/publication refused/u);
+    expect(guarded).toBe(true);
+    await expect(fs.access(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("removes its published target when the caller rejects it", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const sqlite = requireNodeSqlite();
+    new sqlite.DatabaseSync(sourcePath).close();
+    let guarded = false;
+
+    await expect(
+      createVerifiedSqliteSnapshot({
+        sourcePath,
+        targetPath,
+        afterPublish: () => {
+          guarded = true;
+          throw new Error("published target refused");
+        },
+      }),
+    ).rejects.toThrow(/published target refused/u);
+    expect(guarded).toBe(true);
+    await expect(fs.access(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects an asynchronous after-publication guard", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const sqlite = requireNodeSqlite();
+    new sqlite.DatabaseSync(sourcePath).close();
+    const asynchronousGuard = (async () => {}) as unknown as () => void;
+
+    await expect(
+      createVerifiedSqliteSnapshot({
+        sourcePath,
+        targetPath,
+        afterPublish: asynchronousGuard,
+      }),
+    ).rejects.toThrow(/after-publication guard must be synchronous/u);
+    await expect(fs.access(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects an asynchronous final publication check", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const sqlite = requireNodeSqlite();
+    new sqlite.DatabaseSync(sourcePath).close();
+    const asynchronousFinalCheck = (async () => {}) as unknown as () => void;
+
+    await expect(
+      createVerifiedSqliteSnapshot({
+        sourcePath,
+        targetPath,
+        afterPublish: (guard) => {
+          guard.assertTargetUnchanged(asynchronousFinalCheck);
+        },
+      }),
+    ).rejects.toThrow(/publication final check must be synchronous/u);
+    await expect(fs.access(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("preserves a target replaced by the caller after publication", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const sqlite = requireNodeSqlite();
+    new sqlite.DatabaseSync(sourcePath).close();
+
+    await expect(
+      createVerifiedSqliteSnapshot({
+        sourcePath,
+        targetPath,
+        afterPublish: (guard) => {
+          fsSync.unlinkSync(targetPath);
+          fsSync.writeFileSync(targetPath, "racer");
+          guard.assertTargetUnchanged();
+        },
+      }),
+    ).rejects.toThrow(/snapshot file changed|hash mismatch|size mismatch/u);
+    await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("racer");
+  });
+
+  it("rejects a target replaced after atomic publication", async () => {
     const tempDir = await createTempDir();
     const sourcePath = path.join(tempDir, "source.sqlite");
     const targetPath = path.join(tempDir, "snapshot.sqlite");
@@ -138,13 +275,15 @@ describe("createVerifiedSqliteSnapshot", () => {
     const originalLink = fs.link.bind(fs);
     const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (source, target) => {
       await originalLink(source, target);
-      await fs.unlink(target);
-      await fs.writeFile(target, "racer");
+      if (path.resolve(String(target)) === targetPath) {
+        await fs.unlink(targetPath);
+        await fs.writeFile(targetPath, "racer");
+      }
     });
 
     try {
       await expect(createVerifiedSqliteSnapshot({ sourcePath, targetPath })).rejects.toThrow(
-        /target changed during publication/u,
+        /target changed during publication|staging path changed|snapshot file changed/u,
       );
       await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("racer");
     } finally {
@@ -152,43 +291,72 @@ describe("createVerifiedSqliteSnapshot", () => {
     }
   });
 
-  it("rejects a target replaced after exclusive-copy publication", async () => {
+  it.runIf(process.platform !== "win32")(
+    "removes target bytes linked from a replaced staging pathname",
+    async () => {
+      const tempDir = await createTempDir();
+      const sourcePath = path.join(tempDir, "source.sqlite");
+      const targetPath = path.join(tempDir, "snapshot.sqlite");
+      const sqlite = requireNodeSqlite();
+      new sqlite.DatabaseSync(sourcePath).close();
+      const originalLink = fs.link.bind(fs);
+      const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (source, target) => {
+        if (path.resolve(String(target)) === targetPath) {
+          await fs.unlink(source);
+          const replacement = new sqlite.DatabaseSync(String(source));
+          replacement.exec("CREATE TABLE replacement (value TEXT NOT NULL);");
+          replacement.close();
+        }
+        await originalLink(source, target);
+      });
+
+      try {
+        await expect(createVerifiedSqliteSnapshot({ sourcePath, targetPath })).rejects.toThrow(
+          /staging file changed during publication|size mismatch|hash mismatch/u,
+        );
+        await expect(fs.access(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        linkSpy.mockRestore();
+      }
+    },
+  );
+
+  it("removes its target when inspection fails after atomic publication", async () => {
     const tempDir = await createTempDir();
     const sourcePath = path.join(tempDir, "source.sqlite");
     const targetPath = path.join(tempDir, "snapshot.sqlite");
     const sqlite = requireNodeSqlite();
     new sqlite.DatabaseSync(sourcePath).close();
-    const originalOpen = fs.open.bind(fs);
-    const linkSpy = vi.spyOn(fs, "link").mockRejectedValue(
-      Object.assign(new Error("hard links unsupported"), {
-        code: "EPERM",
-      }),
-    );
-    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-      const handle = await originalOpen(filePath, flags, mode);
-      if (path.resolve(String(filePath)) === targetPath && flags === "wx+") {
-        const originalSync = handle.sync.bind(handle);
-        vi.spyOn(handle, "sync").mockImplementationOnce(async () => {
-          await originalSync();
-          await fs.unlink(targetPath);
-          await fs.writeFile(targetPath, "racer");
-        });
+    const originalLink = fs.link.bind(fs);
+    const originalLstat = fs.lstat.bind(fs);
+    let linked = false;
+    let failedInspection = false;
+    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (source, target) => {
+      await originalLink(source, target);
+      if (path.resolve(String(target)) === targetPath) {
+        linked = true;
       }
-      return handle;
+    });
+    const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (filePath) => {
+      if (linked && !failedInspection && path.resolve(String(filePath)) === targetPath) {
+        failedInspection = true;
+        throw Object.assign(new Error("target inspection failed"), { code: "EIO" });
+      }
+      return await originalLstat(filePath);
     });
 
     try {
       await expect(createVerifiedSqliteSnapshot({ sourcePath, targetPath })).rejects.toThrow(
-        /target changed during publication/u,
+        /target inspection failed/u,
       );
-      await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("racer");
+      await expect(fs.access(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
     } finally {
-      openSpy.mockRestore();
+      lstatSpy.mockRestore();
       linkSpy.mockRestore();
     }
   });
 
-  it("syncs fallback copies before reporting success", async () => {
+  it("uses a private sibling staging file for atomic publication", async () => {
     const tempDir = await createTempDir();
     const sourcePath = path.join(tempDir, "source.sqlite");
     const targetPath = path.join(tempDir, "snapshot.sqlite");
@@ -196,20 +364,122 @@ describe("createVerifiedSqliteSnapshot", () => {
     new sqlite.DatabaseSync(sourcePath).close();
     const originalOpen = fs.open.bind(fs);
     const openSpy = vi.spyOn(fs, "open").mockImplementation(originalOpen);
-    const linkSpy = vi.spyOn(fs, "link").mockRejectedValue(
-      Object.assign(new Error("hard links unsupported"), {
-        code: "EPERM",
-      }),
-    );
 
     try {
       await createVerifiedSqliteSnapshot({ sourcePath, targetPath });
       expect(
-        openSpy.mock.calls.some(([filePath]) => path.resolve(String(filePath)) === targetPath),
+        openSpy.mock.calls.some(
+          ([filePath, flags]) =>
+            flags === "wx+" &&
+            path.basename(path.dirname(String(filePath))).startsWith(".sqlite-publish-"),
+        ),
       ).toBe(true);
     } finally {
-      linkSpy.mockRestore();
       openSpy.mockRestore();
+    }
+  });
+
+  it("falls back to an exclusive copy when hard links are unavailable", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const sqlite = requireNodeSqlite();
+    new sqlite.DatabaseSync(sourcePath).close();
+    const linkSpy = vi
+      .spyOn(fs, "link")
+      .mockRejectedValue(Object.assign(new Error("hard links unsupported"), { code: "ENOTSUP" }));
+
+    try {
+      await expect(createVerifiedSqliteSnapshot({ sourcePath, targetPath })).resolves.toEqual({
+        path: targetPath,
+        userVersion: 0,
+      });
+      const restored = new sqlite.DatabaseSync(targetPath, { readOnly: true });
+      restored.close();
+    } finally {
+      linkSpy.mockRestore();
+    }
+  });
+
+  it("removes a fallback target whose copied bytes fail verification", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const sqlite = requireNodeSqlite();
+    new sqlite.DatabaseSync(sourcePath).close();
+    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (source, target) => {
+      if (path.resolve(String(target)) === targetPath) {
+        await fs.appendFile(source, "changed-before-fallback");
+      }
+      throw Object.assign(new Error("hard links unsupported"), { code: "ENOTSUP" });
+    });
+
+    try {
+      await expect(createVerifiedSqliteSnapshot({ sourcePath, targetPath })).rejects.toThrow(
+        /size mismatch|hash mismatch/u,
+      );
+      await expect(fs.access(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      linkSpy.mockRestore();
+    }
+  });
+
+  it("removes its hard link when opening the published target fails", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const sqlite = requireNodeSqlite();
+    new sqlite.DatabaseSync(sourcePath).close();
+    const originalLink = fs.link.bind(fs);
+    const originalOpen = fs.open.bind(fs);
+    let linked = false;
+    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (source, target) => {
+      await originalLink(source, target);
+      if (path.resolve(String(target)) === targetPath) {
+        linked = true;
+      }
+    });
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      if (linked && path.resolve(String(filePath)) === targetPath && flags === "r") {
+        throw Object.assign(new Error("target open failed"), { code: "EIO" });
+      }
+      return await originalOpen(filePath, flags, mode);
+    });
+
+    try {
+      await expect(createVerifiedSqliteSnapshot({ sourcePath, targetPath })).rejects.toThrow(
+        /target open failed/u,
+      );
+      await expect(fs.access(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      openSpy.mockRestore();
+      linkSpy.mockRestore();
+    }
+  });
+
+  it("cleans publication staging when initialization fails", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const sqlite = requireNodeSqlite();
+    new sqlite.DatabaseSync(sourcePath).close();
+    const originalChmod = fs.chmod.bind(fs);
+    const chmodSpy = vi.spyOn(fs, "chmod").mockImplementation(async (filePath, mode) => {
+      if (path.basename(String(filePath)).startsWith(".sqlite-publish-")) {
+        throw Object.assign(new Error("chmod refused"), { code: "EACCES" });
+      }
+      await originalChmod(filePath, mode);
+    });
+
+    try {
+      await expect(createVerifiedSqliteSnapshot({ sourcePath, targetPath })).rejects.toThrow(
+        /chmod refused/u,
+      );
+      expect(
+        (await fs.readdir(tempDir)).every((name) => !name.startsWith(".sqlite-publish-")),
+      ).toBe(true);
+    } finally {
+      chmodSpy.mockRestore();
     }
   });
 
@@ -259,7 +529,7 @@ describe("createVerifiedSqliteSnapshot", () => {
       validate: (_database, label) => labels.push(label),
     });
 
-    expect(labels).toEqual([sourcePath, targetPath]);
+    expect(labels).toEqual([sourcePath, targetPath, targetPath]);
     expect((await fs.readFile(targetPath)).includes(removedValue)).toBe(false);
     const snapshot = new sqlite.DatabaseSync(targetPath, { readOnly: true });
     try {

--- a/src/infra/sqlite-snapshot.ts
+++ b/src/infra/sqlite-snapshot.ts
@@ -1,6 +1,8 @@
 // Creates compact SQLite snapshots only after verifying both source and output.
-import type { Stats } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import fsSync, { type BigIntStats, type Stats } from "node:fs";
 import fs from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { loadSqliteVecExtension } from "../../packages/memory-host-sdk/src/engine-storage.js";
@@ -15,8 +17,33 @@ export type SqliteSnapshotValidator = (database: DatabaseSync, databaseLabel: st
 export type CreateVerifiedSqliteSnapshotOptions = {
   sourcePath: string;
   targetPath: string;
+  /** Final caller checks around publication; failures remove only this helper's target. */
+  afterPublish?: (guard: PublishedSqliteFileGuard) => void;
+  beforePublish?: () => void | Promise<void>;
   transform?: (database: DatabaseSync) => void | Promise<void>;
   validate?: SqliteSnapshotValidator;
+};
+
+export type SqliteFileContent = {
+  sha256: string;
+  sizeBytes: number;
+};
+
+export type PublishedSqliteFileGuard = {
+  assertTargetMatchesExpectedContent: (finalCheck?: () => void) => void;
+  assertTargetUnchanged: (finalCheck?: () => void) => void;
+};
+
+export type PublishVerifiedSqliteFileOptions = {
+  sourceIdentity: Stats;
+  sourcePath: string;
+  targetPath: string;
+  expectedContent: SqliteFileContent;
+  requireAtomicPublication?: boolean;
+  beforePublish?: () => void | Promise<void>;
+  validatePublished?: (publishedPath: string) => void | Promise<void>;
+  /** Runs last. Call the supplied guard after any caller-specific checks. */
+  afterPublish?: (guard: PublishedSqliteFileGuard) => void;
 };
 
 export type VerifiedSqliteSnapshot = {
@@ -43,47 +70,25 @@ async function assertTargetAbsent(targetPath: string): Promise<void> {
   throw new Error(`SQLite snapshot target already exists: ${targetPath}`);
 }
 
-function isLinkFallbackError(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException).code;
-  return (
-    code === "EPERM" ||
-    code === "EXDEV" ||
-    code === "ENOTSUP" ||
-    code === "EOPNOTSUPP" ||
-    code === "ENOSYS"
-  );
-}
-
-async function publishSnapshotNoOverwrite(
-  stagedPath: string,
+async function copyFileExclusive(
+  source: FileHandle,
   targetPath: string,
-  stagedIdentity: Stats,
-): Promise<Stats> {
-  try {
-    await fs.link(stagedPath, targetPath);
-    return stagedIdentity;
-  } catch (error) {
-    if (!isLinkFallbackError(error)) {
-      throw error;
-    }
-    return await copyFileExclusive(stagedPath, targetPath);
-  }
-}
-
-async function copyFileExclusive(sourcePath: string, targetPath: string): Promise<Stats> {
-  const source = await fs.open(sourcePath, "r");
+): Promise<{ content: SqliteFileContent; identity: Stats }> {
+  const sourceFingerprint = await readMutationFingerprint(source);
   let target: Awaited<ReturnType<typeof fs.open>> | undefined;
   let targetIdentity: Stats | undefined;
   try {
     target = await fs.open(targetPath, "wx+", 0o600);
     targetIdentity = await target.stat();
     const buffer = Buffer.allocUnsafe(1024 * 1024);
+    const hash = createHash("sha256");
     let offset = 0;
     while (true) {
       const { bytesRead } = await source.read(buffer, 0, buffer.length, offset);
       if (bytesRead === 0) {
         break;
       }
+      hash.update(buffer.subarray(0, bytesRead));
       let bytesWritten = 0;
       while (bytesWritten < bytesRead) {
         const result = await target.write(
@@ -99,19 +104,75 @@ async function copyFileExclusive(sourcePath: string, targetPath: string): Promis
       }
       offset += bytesRead;
     }
+    await assertMutationFingerprintUnchanged(source, sourceFingerprint, targetPath);
     await target.sync();
-    return targetIdentity;
+    const currentIdentity = await fs.lstat(targetPath);
+    if (!sameFileIdentity(targetIdentity, currentIdentity)) {
+      throw new Error(`SQLite snapshot target changed during publication: ${targetPath}`);
+    }
+    return {
+      content: { sha256: hash.digest("hex"), sizeBytes: offset },
+      identity: currentIdentity,
+    };
   } catch (error) {
     if (targetIdentity) {
       await target?.close().catch(() => undefined);
       target = undefined;
-      await removePublishedTargetIfOwned(targetPath, targetIdentity);
+      removePublishedTargetIfOwned(targetPath, targetIdentity);
     }
     throw error;
   } finally {
     await target?.close().catch(() => undefined);
-    await source.close().catch(() => undefined);
   }
+}
+
+type FileMutationFingerprint = Pick<
+  BigIntStats,
+  "birthtimeNs" | "ctimeNs" | "dev" | "ino" | "mtimeNs" | "size"
+>;
+
+async function readMutationFingerprint(handle: FileHandle): Promise<FileMutationFingerprint> {
+  const stat = await handle.stat({ bigint: true });
+  return {
+    birthtimeNs: stat.birthtimeNs,
+    ctimeNs: stat.ctimeNs,
+    dev: stat.dev,
+    ino: stat.ino,
+    mtimeNs: stat.mtimeNs,
+    size: stat.size,
+  };
+}
+
+async function assertMutationFingerprintUnchanged(
+  handle: FileHandle,
+  expected: FileMutationFingerprint,
+  filePath: string,
+): Promise<void> {
+  const current = await readMutationFingerprint(handle);
+  if (
+    current.birthtimeNs !== expected.birthtimeNs ||
+    current.ctimeNs !== expected.ctimeNs ||
+    current.dev !== expected.dev ||
+    current.ino !== expected.ino ||
+    current.mtimeNs !== expected.mtimeNs ||
+    current.size !== expected.size
+  ) {
+    throw new Error(`SQLite snapshot file changed while reading: ${filePath}`);
+  }
+}
+
+function sameMutationFingerprint(
+  left: FileMutationFingerprint,
+  right: FileMutationFingerprint,
+): boolean {
+  return (
+    left.birthtimeNs === right.birthtimeNs &&
+    left.ctimeNs === right.ctimeNs &&
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mtimeNs === right.mtimeNs &&
+    left.size === right.size
+  );
 }
 
 async function syncFile(filePath: string): Promise<void> {
@@ -123,30 +184,187 @@ async function syncFile(filePath: string): Promise<void> {
   }
 }
 
-async function syncPublishedFile(filePath: string, expectedIdentity: Stats): Promise<void> {
-  const handle = await fs.open(filePath, "r+");
+async function assertOpenFileIdentity(
+  handle: FileHandle,
+  filePath: string,
+  expectedIdentity: Stats,
+): Promise<void> {
+  const openedIdentity = await handle.stat();
+  const currentIdentity = await fs.lstat(filePath);
+  if (
+    !openedIdentity.isFile() ||
+    !currentIdentity.isFile() ||
+    !sameFileIdentity(expectedIdentity, openedIdentity) ||
+    !sameFileIdentity(expectedIdentity, currentIdentity)
+  ) {
+    throw new Error(`SQLite snapshot file changed: ${filePath}`);
+  }
+}
+
+async function hashPublishedFile(
+  filePath: string,
+  expectedIdentity: Stats,
+): Promise<SqliteFileContent> {
+  const handle = await fs.open(filePath, "r");
   try {
-    const openedIdentity = await handle.stat();
-    if (!sameFileIdentity(expectedIdentity, openedIdentity)) {
-      throw new Error(`SQLite snapshot target changed before sync: ${filePath}`);
-    }
-    await handle.sync();
-    const currentIdentity = await fs.lstat(filePath);
-    if (!sameFileIdentity(expectedIdentity, currentIdentity)) {
-      throw new Error(`SQLite snapshot target changed during sync: ${filePath}`);
-    }
+    return await hashOpenPublishedFile(handle, filePath, expectedIdentity);
   } finally {
     await handle.close();
   }
 }
 
-async function removePublishedTargetIfOwned(
+async function hashOpenPublishedFile(
+  handle: FileHandle,
   filePath: string,
   expectedIdentity: Stats,
-): Promise<void> {
-  const currentIdentity = await fs.lstat(filePath).catch(() => undefined);
-  if (currentIdentity && sameFileIdentity(expectedIdentity, currentIdentity)) {
-    await fs.unlink(filePath).catch(() => undefined);
+): Promise<SqliteFileContent> {
+  await assertOpenFileIdentity(handle, filePath, expectedIdentity);
+  const fingerprint = await readMutationFingerprint(handle);
+  const buffer = Buffer.allocUnsafe(1024 * 1024);
+  const hash = createHash("sha256");
+  let offset = 0;
+  while (true) {
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, offset);
+    if (bytesRead === 0) {
+      break;
+    }
+    hash.update(buffer.subarray(0, bytesRead));
+    offset += bytesRead;
+  }
+  await assertMutationFingerprintUnchanged(handle, fingerprint, filePath);
+  await assertOpenFileIdentity(handle, filePath, expectedIdentity);
+  return { sha256: hash.digest("hex"), sizeBytes: offset };
+}
+
+function assertPublishedFileIdentitySync(filePath: string, expectedIdentity: Stats): void {
+  const currentIdentity = fsSync.lstatSync(filePath);
+  if (
+    !currentIdentity.isFile() ||
+    !sameFileIdentity(expectedIdentity, currentIdentity) ||
+    expectedIdentity.size !== currentIdentity.size ||
+    expectedIdentity.mtimeMs !== currentIdentity.mtimeMs ||
+    expectedIdentity.ctimeMs !== currentIdentity.ctimeMs ||
+    expectedIdentity.birthtimeMs !== currentIdentity.birthtimeMs
+  ) {
+    throw new Error(`SQLite snapshot file changed: ${filePath}`);
+  }
+}
+
+function assertOpenFileIdentitySync(
+  fileDescriptor: number,
+  filePath: string,
+  expectedIdentity: Stats,
+): void {
+  const openedIdentity = fsSync.fstatSync(fileDescriptor);
+  const currentIdentity = fsSync.lstatSync(filePath);
+  if (
+    !openedIdentity.isFile() ||
+    !currentIdentity.isFile() ||
+    !sameFileIdentity(expectedIdentity, openedIdentity) ||
+    !sameFileIdentity(expectedIdentity, currentIdentity)
+  ) {
+    throw new Error(`SQLite snapshot file changed: ${filePath}`);
+  }
+}
+
+function hashPublishedFileSync(filePath: string, expectedIdentity: Stats): SqliteFileContent {
+  const fileDescriptor = fsSync.openSync(filePath, "r");
+  try {
+    assertOpenFileIdentitySync(fileDescriptor, filePath, expectedIdentity);
+    const initialStat = fsSync.fstatSync(fileDescriptor, { bigint: true });
+    const initialFingerprint: FileMutationFingerprint = {
+      birthtimeNs: initialStat.birthtimeNs,
+      ctimeNs: initialStat.ctimeNs,
+      dev: initialStat.dev,
+      ino: initialStat.ino,
+      mtimeNs: initialStat.mtimeNs,
+      size: initialStat.size,
+    };
+    const hash = createHash("sha256");
+    const buffer = Buffer.allocUnsafe(1024 * 1024);
+    let offset = 0;
+    while (true) {
+      const bytesRead = fsSync.readSync(fileDescriptor, buffer, 0, buffer.length, offset);
+      if (bytesRead === 0) {
+        break;
+      }
+      hash.update(buffer.subarray(0, bytesRead));
+      offset += bytesRead;
+    }
+    const finalStat = fsSync.fstatSync(fileDescriptor, { bigint: true });
+    const finalFingerprint: FileMutationFingerprint = {
+      birthtimeNs: finalStat.birthtimeNs,
+      ctimeNs: finalStat.ctimeNs,
+      dev: finalStat.dev,
+      ino: finalStat.ino,
+      mtimeNs: finalStat.mtimeNs,
+      size: finalStat.size,
+    };
+    if (!sameMutationFingerprint(initialFingerprint, finalFingerprint)) {
+      throw new Error(`SQLite snapshot file changed while reading: ${filePath}`);
+    }
+    assertOpenFileIdentitySync(fileDescriptor, filePath, expectedIdentity);
+    return { sha256: hash.digest("hex"), sizeBytes: offset };
+  } finally {
+    fsSync.closeSync(fileDescriptor);
+  }
+}
+
+function assertExpectedContent(
+  actual: SqliteFileContent,
+  expected: SqliteFileContent,
+  filePath: string,
+): void {
+  if (actual.sizeBytes !== expected.sizeBytes) {
+    throw new Error(
+      `SQLite snapshot size mismatch for ${filePath}: expected ${expected.sizeBytes}, got ${actual.sizeBytes}`,
+    );
+  }
+  if (actual.sha256 !== expected.sha256) {
+    throw new Error(
+      `SQLite snapshot hash mismatch for ${filePath}: expected ${expected.sha256}, got ${actual.sha256}`,
+    );
+  }
+}
+
+function removePublishedTargetIfOwned(
+  filePath: string,
+  expectedIdentity: Stats,
+  requireFingerprint = false,
+): boolean {
+  let currentIdentity: Stats;
+  try {
+    currentIdentity = fsSync.lstatSync(filePath);
+  } catch {
+    return false;
+  }
+  const fingerprintMatches =
+    !requireFingerprint ||
+    (expectedIdentity.size === currentIdentity.size &&
+      expectedIdentity.mtimeMs === currentIdentity.mtimeMs &&
+      expectedIdentity.ctimeMs === currentIdentity.ctimeMs &&
+      expectedIdentity.birthtimeMs === currentIdentity.birthtimeMs);
+  if (!sameFileIdentity(expectedIdentity, currentIdentity) || !fingerprintMatches) {
+    return false;
+  }
+  // Node has no cross-platform unlink-by-inode primitive. Keep the ownership
+  // check and unlink synchronous so no in-process task can replace the path.
+  try {
+    fsSync.unlinkSync(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function assertSynchronousCallbackResult(result: unknown, label: string): void {
+  if (
+    result &&
+    (typeof result === "object" || typeof result === "function") &&
+    typeof (result as { then?: unknown }).then === "function"
+  ) {
+    void Promise.resolve(result).catch(() => undefined);
+    throw new Error(`${label} must be synchronous.`);
   }
 }
 
@@ -160,7 +378,7 @@ function isUnsupportedDirectorySyncError(error: unknown): boolean {
   );
 }
 
-async function syncDirectoryBestEffort(directoryPath: string): Promise<void> {
+export async function syncDirectoryBestEffort(directoryPath: string): Promise<void> {
   const handle = await fs.open(directoryPath, "r").catch((error: unknown) => {
     if (isUnsupportedDirectorySyncError(error)) {
       return undefined;
@@ -179,6 +397,241 @@ async function syncDirectoryBestEffort(directoryPath: string): Promise<void> {
   } finally {
     await handle.close();
   }
+}
+
+function isLinkFallbackError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return (
+    code === "EPERM" ||
+    code === "EXDEV" ||
+    code === "ENOTSUP" ||
+    code === "EOPNOTSUPP" ||
+    code === "ENOSYS"
+  );
+}
+
+/**
+ * Publish the exact bytes of one already-verified SQLite file without reopening
+ * its pathname during the copy. The target is always created exclusively.
+ */
+export async function publishVerifiedSqliteFile(
+  options: PublishVerifiedSqliteFileOptions,
+): Promise<void> {
+  await assertTargetAbsent(options.targetPath);
+  const targetDirectory = path.dirname(options.targetPath);
+  const stagingDir = await fs.mkdtemp(
+    path.join(targetDirectory, `.sqlite-publish-${randomUUID()}-`),
+  );
+  const stagedPath = path.join(stagingDir, "database.sqlite");
+  let stagingIdentity: Stats | undefined;
+  let source: FileHandle | undefined;
+  let target: FileHandle | undefined;
+  let targetPinFileDescriptor: number | undefined;
+  let verifiedStagedIdentity: Stats | undefined;
+  let linkedCandidateIdentity: Stats | undefined;
+  let publishedIdentity: Stats | undefined;
+  let ownershipPinned = false;
+  let hardLinkCreated = false;
+  try {
+    stagingIdentity = await fs.lstat(stagingDir);
+    await fs.chmod(stagingDir, 0o700);
+    source = await fs.open(options.sourcePath, "r");
+    await assertOpenFileIdentity(source, options.sourcePath, options.sourceIdentity);
+    const staged = await copyFileExclusive(source, stagedPath);
+    verifiedStagedIdentity = staged.identity;
+    const expectedContent = options.expectedContent;
+    assertExpectedContent(staged.content, expectedContent, options.targetPath);
+    await source.close();
+    source = undefined;
+
+    await options.validatePublished?.(stagedPath);
+    const validatedContent = await hashPublishedFile(stagedPath, staged.identity);
+    assertExpectedContent(validatedContent, expectedContent, options.targetPath);
+    await options.beforePublish?.();
+    await assertTargetAbsent(options.targetPath);
+    let usedHardLink = false;
+    try {
+      await fs.link(stagedPath, options.targetPath);
+      usedHardLink = true;
+      hardLinkCreated = true;
+    } catch (error) {
+      if (!isLinkFallbackError(error)) {
+        throw error;
+      }
+      if (options.requireAtomicPublication) {
+        throw new Error(
+          `Atomic SQLite publication requires hard-link support in ${targetDirectory}.`,
+          { cause: error },
+        );
+      }
+      const stagedSource = await fs.open(stagedPath, "r");
+      try {
+        const copied = await copyFileExclusive(stagedSource, options.targetPath);
+        publishedIdentity = copied.identity;
+        assertExpectedContent(copied.content, expectedContent, options.targetPath);
+      } finally {
+        await stagedSource.close();
+      }
+    }
+    if (usedHardLink) {
+      target = await fs.open(options.targetPath, "r");
+      const linkedIdentity = await target.stat();
+      linkedCandidateIdentity = linkedIdentity;
+      const currentTargetIdentity = await fs.lstat(options.targetPath);
+      const currentStagedIdentity = await fs.lstat(stagedPath);
+      if (!sameFileIdentity(linkedIdentity, currentTargetIdentity)) {
+        throw new Error(`SQLite snapshot target changed during publication: ${options.targetPath}`);
+      }
+      const matchesVerifiedStaging = sameFileIdentity(staged.identity, linkedIdentity);
+      const matchesCurrentStaging = sameFileIdentity(currentStagedIdentity, linkedIdentity);
+      if (matchesVerifiedStaging || matchesCurrentStaging) {
+        // The target handle pins exactly what link() published for ownership-safe cleanup.
+        publishedIdentity = linkedIdentity;
+        ownershipPinned = true;
+      }
+      if (!matchesCurrentStaging) {
+        throw new Error(`SQLite snapshot staging path changed after publication: ${stagedPath}`);
+      }
+      if (!matchesVerifiedStaging) {
+        throw new Error(
+          `SQLite snapshot staging file changed during publication: ${options.targetPath}`,
+        );
+      }
+    }
+    if (!publishedIdentity) {
+      throw new Error(`SQLite snapshot target was not published: ${options.targetPath}`);
+    }
+    const initialPublishedIdentity = publishedIdentity;
+    target ??= await fs.open(options.targetPath, "r");
+    await assertOpenFileIdentity(target, options.targetPath, initialPublishedIdentity);
+    ownershipPinned = true;
+    await syncDirectoryBestEffort(targetDirectory);
+    await fs.unlink(stagedPath);
+    const expectedIdentity = await target.stat();
+    publishedIdentity = expectedIdentity;
+    await fs.rmdir(stagingDir);
+    await syncDirectoryBestEffort(targetDirectory);
+    const linkedContent = await hashOpenPublishedFile(target, options.targetPath, expectedIdentity);
+    assertExpectedContent(linkedContent, expectedContent, options.targetPath);
+    await target.close();
+    target = undefined;
+    ownershipPinned = false;
+    targetPinFileDescriptor = fsSync.openSync(options.targetPath, "r");
+    assertOpenFileIdentitySync(targetPinFileDescriptor, options.targetPath, expectedIdentity);
+    ownershipPinned = true;
+
+    const guard: PublishedSqliteFileGuard = {
+      assertTargetMatchesExpectedContent: (finalCheck) => {
+        const content = hashPublishedFileSync(options.targetPath, expectedIdentity);
+        assertExpectedContent(content, expectedContent, options.targetPath);
+        assertSynchronousCallbackResult(finalCheck?.(), "SQLite publication final check");
+        assertPublishedFileIdentitySync(options.targetPath, expectedIdentity);
+      },
+      assertTargetUnchanged: (finalCheck) => {
+        assertPublishedFileIdentitySync(options.targetPath, expectedIdentity);
+        assertSynchronousCallbackResult(finalCheck?.(), "SQLite publication final check");
+        assertPublishedFileIdentitySync(options.targetPath, expectedIdentity);
+      },
+    };
+    if (options.afterPublish) {
+      assertSynchronousCallbackResult(
+        options.afterPublish(guard),
+        "SQLite after-publication guard",
+      );
+    } else {
+      guard.assertTargetUnchanged();
+    }
+    fsSync.closeSync(targetPinFileDescriptor);
+    targetPinFileDescriptor = undefined;
+    ownershipPinned = false;
+  } catch (error) {
+    if (!publishedIdentity && hardLinkCreated && verifiedStagedIdentity) {
+      const currentTargetIdentity = await fs.lstat(options.targetPath).catch(() => undefined);
+      const currentStagedIdentity = await fs.lstat(stagedPath).catch(() => undefined);
+      const targetMatchesStaging =
+        currentTargetIdentity &&
+        currentStagedIdentity &&
+        sameFileIdentity(currentTargetIdentity, currentStagedIdentity);
+      const targetMatchesVerified =
+        currentTargetIdentity && sameFileIdentity(currentTargetIdentity, verifiedStagedIdentity);
+      if (targetMatchesStaging || targetMatchesVerified) {
+        publishedIdentity = currentTargetIdentity;
+        ownershipPinned = Boolean(targetMatchesStaging);
+      }
+    }
+    if (!publishedIdentity && target && linkedCandidateIdentity && verifiedStagedIdentity) {
+      const currentTargetIdentity = await fs.lstat(options.targetPath).catch(() => undefined);
+      const currentStagedIdentity = await fs.lstat(stagedPath).catch(() => undefined);
+      const targetStillMatches =
+        currentTargetIdentity && sameFileIdentity(currentTargetIdentity, linkedCandidateIdentity);
+      const targetCameFromStaging =
+        (currentStagedIdentity &&
+          sameFileIdentity(currentStagedIdentity, linkedCandidateIdentity)) ||
+        sameFileIdentity(verifiedStagedIdentity, linkedCandidateIdentity);
+      if (targetStillMatches && targetCameFromStaging) {
+        publishedIdentity = linkedCandidateIdentity;
+        ownershipPinned = true;
+      }
+    }
+    if (target && publishedIdentity) {
+      const openedIdentity = await target.stat().catch(() => undefined);
+      if (openedIdentity && sameFileIdentity(openedIdentity, publishedIdentity)) {
+        publishedIdentity = openedIdentity;
+        ownershipPinned = true;
+      }
+    }
+    if (publishedIdentity) {
+      const removed = removePublishedTargetIfOwned(
+        options.targetPath,
+        publishedIdentity,
+        !ownershipPinned,
+      );
+      if (removed) {
+        await syncDirectoryBestEffort(targetDirectory).catch(() => undefined);
+      }
+    }
+    if (stagingIdentity) {
+      await removePublicationStagingDirectory(stagingDir, stagingIdentity).catch(() => undefined);
+    } else {
+      await fs.rmdir(stagingDir).catch(() => undefined);
+    }
+    throw error;
+  } finally {
+    if (targetPinFileDescriptor !== undefined) {
+      fsSync.closeSync(targetPinFileDescriptor);
+    }
+    if (target) {
+      await target.close().catch(() => undefined);
+    }
+    if (source) {
+      await source.close().catch(() => undefined);
+    }
+  }
+}
+
+async function removePublicationStagingDirectory(
+  stagingDir: string,
+  expectedIdentity: Stats,
+): Promise<void> {
+  const currentIdentity = await fs.lstat(stagingDir).catch(() => undefined);
+  if (!currentIdentity) {
+    return;
+  }
+  if (!currentIdentity.isDirectory() || !sameFileIdentity(expectedIdentity, currentIdentity)) {
+    throw new Error(`SQLite publication staging directory changed: ${stagingDir}`);
+  }
+  const entries = await fs.readdir(stagingDir, { withFileTypes: true });
+  if (
+    entries.length > 1 ||
+    entries.some((entry) => entry.name !== "database.sqlite" || !entry.isFile())
+  ) {
+    throw new Error(`SQLite publication staging directory has unexpected contents: ${stagingDir}`);
+  }
+  const stagedEntry = entries[0];
+  if (stagedEntry) {
+    await fs.unlink(path.join(stagingDir, stagedEntry.name));
+  }
+  await fs.rmdir(stagingDir);
 }
 
 /**
@@ -200,7 +653,6 @@ export async function createVerifiedSqliteSnapshot(
   const stagedPath = path.join(stagingDir, "database.sqlite");
   const sqlite = requireNodeSqlite();
   let stagedIdentity: Stats | undefined;
-  let publishedIdentity: Stats | undefined;
   try {
     const source = new sqlite.DatabaseSync(options.sourcePath, {
       allowExtension: true,
@@ -233,20 +685,35 @@ export async function createVerifiedSqliteSnapshot(
       snapshot.close();
       await syncFile(stagedPath);
       stagedIdentity = await fs.lstat(stagedPath);
-      publishedIdentity = await publishSnapshotNoOverwrite(
-        stagedPath,
-        options.targetPath,
-        stagedIdentity,
-      );
-      const currentIdentity = await fs.lstat(options.targetPath);
-      if (!currentIdentity.isFile()) {
-        throw new Error(`SQLite snapshot target is not a regular file: ${options.targetPath}`);
-      }
-      if (!sameFileIdentity(publishedIdentity, currentIdentity)) {
-        throw new Error(`SQLite snapshot target changed during publication: ${options.targetPath}`);
-      }
-      await syncPublishedFile(options.targetPath, publishedIdentity);
-      await syncDirectoryBestEffort(path.dirname(options.targetPath));
+      const expectedContent = await hashPublishedFile(stagedPath, stagedIdentity);
+      await publishVerifiedSqliteFile({
+        sourceIdentity: stagedIdentity,
+        sourcePath: stagedPath,
+        targetPath: options.targetPath,
+        expectedContent,
+        beforePublish: options.beforePublish,
+        afterPublish: options.afterPublish,
+        validatePublished: async (publishedPath) => {
+          const published = new sqlite.DatabaseSync(publishedPath, {
+            allowExtension: true,
+            readOnly: true,
+          });
+          try {
+            published.exec("PRAGMA busy_timeout = 30000; PRAGMA trusted_schema = OFF;");
+            await loadSqliteVecExtension({ db: published });
+            assertSqliteIntegrity(published, options.targetPath);
+            options.validate?.(published, options.targetPath);
+            const publishedUserVersion = readSqliteUserVersion(published);
+            if (publishedUserVersion !== userVersion) {
+              throw new Error(
+                `SQLite snapshot user_version changed during publication: expected ${userVersion}, got ${publishedUserVersion}`,
+              );
+            }
+          } finally {
+            published.close();
+          }
+        },
+      });
       return { path: options.targetPath, userVersion };
     } finally {
       if (snapshot.isOpen) {
@@ -254,10 +721,6 @@ export async function createVerifiedSqliteSnapshot(
       }
     }
   } catch (error) {
-    const ownedIdentity = publishedIdentity ?? stagedIdentity;
-    if (ownedIdentity) {
-      await removePublishedTargetIfOwned(options.targetPath, ownedIdentity);
-    }
     throw new Error(
       `SQLite database cannot be snapshotted safely: ${options.sourcePath}. ${formatErrorMessage(error)}`,
       { cause: error },

--- a/src/snapshot/local-repository.test.ts
+++ b/src/snapshot/local-repository.test.ts
@@ -1,0 +1,958 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db.js";
+import { createLocalSqliteSnapshotProvider } from "./local-repository.js";
+import { hashSnapshotArtifact, parseSnapshotManifest, readSnapshotManifest } from "./manifest.js";
+import {
+  SNAPSHOT_MANIFEST_FILENAME,
+  SNAPSHOT_SQLITE_FILENAME,
+  type SnapshotManifest,
+  type SnapshotResult,
+} from "./snapshot-provider.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-snapshot-repository-"));
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((tempDir) => fs.rm(tempDir, { recursive: true })));
+});
+
+function createGenericDatabase(
+  databasePath: string,
+  options: { userVersion?: number; values?: string[]; wal?: boolean } = {},
+): void {
+  const sqlite = requireNodeSqlite();
+  const database = new sqlite.DatabaseSync(databasePath);
+  try {
+    database.exec(`
+      ${options.wal ? "PRAGMA journal_mode = WAL; PRAGMA wal_autocheckpoint = 0;" : ""}
+      PRAGMA user_version = ${options.userVersion ?? 7};
+      CREATE TABLE entries (
+        id INTEGER PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+    `);
+    const insert = database.prepare("INSERT INTO entries (value) VALUES (?)");
+    for (const value of options.values ?? ["one"]) {
+      insert.run(value);
+    }
+  } finally {
+    database.close();
+  }
+}
+
+function createGlobalDatabase(databasePath: string): void {
+  const sqlite = requireNodeSqlite();
+  const database = new sqlite.DatabaseSync(databasePath);
+  try {
+    database.exec(`
+      PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION};
+      CREATE TABLE schema_meta (
+        meta_key TEXT PRIMARY KEY,
+        role TEXT NOT NULL,
+        schema_version INTEGER NOT NULL
+      );
+      INSERT INTO schema_meta VALUES ('primary', 'global', ${OPENCLAW_STATE_SCHEMA_VERSION});
+      CREATE TABLE delivery_queue_entries (
+        id TEXT PRIMARY KEY,
+        payload TEXT NOT NULL
+      );
+      INSERT INTO delivery_queue_entries VALUES ('queued', 'do-not-restore');
+    `);
+  } finally {
+    database.close();
+  }
+}
+
+function createAgentDatabase(databasePath: string, agentId: string): void {
+  const sqlite = requireNodeSqlite();
+  const database = new sqlite.DatabaseSync(databasePath);
+  try {
+    database.exec(`
+      PRAGMA user_version = ${OPENCLAW_AGENT_SCHEMA_VERSION};
+      CREATE TABLE schema_meta (
+        meta_key TEXT PRIMARY KEY,
+        role TEXT NOT NULL,
+        schema_version INTEGER NOT NULL,
+        agent_id TEXT
+      );
+    `);
+    database
+      .prepare("INSERT INTO schema_meta VALUES ('primary', 'agent', ?, ?)")
+      .run(OPENCLAW_AGENT_SCHEMA_VERSION, agentId);
+  } finally {
+    database.close();
+  }
+}
+
+function createUnsafeIndexDrift(databasePath: string): void {
+  const sqlite = requireNodeSqlite();
+  const database = new sqlite.DatabaseSync(databasePath);
+  try {
+    database.exec(`
+      CREATE TABLE records (
+        id INTEGER PRIMARY KEY,
+        indexed_value TEXT NOT NULL,
+        alternate_value TEXT NOT NULL
+      );
+      CREATE INDEX records_value ON records(indexed_value);
+      INSERT INTO records (indexed_value, alternate_value)
+      VALUES ('alpha', 'zeta'), ('beta', 'eta'), ('gamma', 'theta');
+      PRAGMA writable_schema = ON;
+    `);
+    database
+      .prepare(
+        "UPDATE sqlite_schema SET sql = 'CREATE INDEX records_value ON records(alternate_value)' WHERE name = 'records_value'",
+      )
+      .run();
+    const schemaVersion = Number(
+      Object.values(database.prepare("PRAGMA schema_version").get() as Record<string, unknown>)[0],
+    );
+    database.exec(`PRAGMA writable_schema = OFF; PRAGMA schema_version = ${schemaVersion + 1};`);
+  } finally {
+    database.close();
+  }
+}
+
+async function rewriteManifest(
+  result: SnapshotResult,
+  mutate: (manifest: SnapshotManifest) => SnapshotManifest,
+): Promise<void> {
+  const manifestPath = path.join(result.ref.path, SNAPSHOT_MANIFEST_FILENAME);
+  const manifest = await readSnapshotManifest(result.ref.path);
+  await fs.writeFile(manifestPath, `${JSON.stringify(mutate(manifest), null, 2)}\n`);
+}
+
+async function refreshArtifactManifest(result: SnapshotResult): Promise<void> {
+  const digest = await hashSnapshotArtifact(result.ref.path);
+  await rewriteManifest(result, (manifest) => ({
+    ...manifest,
+    artifact: {
+      ...manifest.artifact,
+      sha256: digest.sha256,
+      sizeBytes: digest.sizeBytes,
+    },
+  }));
+}
+
+describe("local SQLite snapshot repository", () => {
+  it("creates, lists, verifies, and fresh-restores committed WAL state", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    const restorePath = path.join(tempDir, "restore", "source.sqlite");
+    const sqlite = requireNodeSqlite();
+    const source = new sqlite.DatabaseSync(sourcePath);
+    try {
+      source.exec(`
+        PRAGMA journal_mode = WAL;
+        PRAGMA wal_autocheckpoint = 0;
+        PRAGMA user_version = 42;
+        CREATE TABLE entries (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+        INSERT INTO entries (value) VALUES ('checkpointed');
+        PRAGMA wal_checkpoint(TRUNCATE);
+        INSERT INTO entries (value) VALUES ('committed-in-wal');
+      `);
+      const provider = createLocalSqliteSnapshotProvider({
+        repositoryPath,
+        now: () => new Date("2026-07-12T14:00:00.000Z"),
+      });
+      const snapshot = await provider.create({
+        path: sourcePath,
+        identity: { role: "generic", id: "test-database" },
+      });
+
+      expect(snapshot.manifest).toMatchObject({
+        schemaVersion: 1,
+        createdAt: "2026-07-12T14:00:00.000Z",
+        database: {
+          role: "generic",
+          id: "test-database",
+          basename: "source.sqlite",
+          userVersion: 42,
+        },
+        artifact: {
+          path: SNAPSHOT_SQLITE_FILENAME,
+        },
+      });
+      expect(snapshot.manifest.artifact.sha256).toMatch(/^[a-f0-9]{64}$/u);
+      await expect(provider.verify(snapshot.ref)).resolves.toEqual({
+        ok: true,
+        manifest: snapshot.manifest,
+      });
+      await expect(provider.list()).resolves.toEqual([snapshot]);
+      await expect(provider.restoreFresh(snapshot.ref, restorePath)).resolves.toEqual({
+        ok: true,
+        manifest: snapshot.manifest,
+      });
+      await expect(fs.readFile(restorePath)).resolves.toEqual(
+        await fs.readFile(path.join(snapshot.ref.path, SNAPSHOT_SQLITE_FILENAME)),
+      );
+      expect((await fs.readdir(repositoryPath)).every((name) => !name.startsWith(".tmp-"))).toBe(
+        true,
+      );
+      await expect(fs.readdir(path.dirname(restorePath))).resolves.toEqual(["source.sqlite"]);
+    } finally {
+      source.close();
+    }
+
+    const restored = new sqlite.DatabaseSync(restorePath, { readOnly: true });
+    try {
+      expect(restored.prepare("SELECT value FROM entries ORDER BY id").all()).toEqual([
+        { value: "checkpointed" },
+        { value: "committed-in-wal" },
+      ]);
+      expect(restored.prepare("PRAGMA user_version").get()).toEqual({ user_version: 42 });
+    } finally {
+      restored.close();
+    }
+    if (process.platform !== "win32") {
+      expect((await fs.stat(repositoryPath)).mode & 0o777).toBe(0o700);
+      expect((await fs.stat(restorePath)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("sorts snapshots newest first and ignores incomplete staging directories", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    createGenericDatabase(sourcePath);
+    const dates = [new Date("2026-07-12T14:00:00.000Z"), new Date("2026-07-12T14:01:00.000Z")];
+    const provider = createLocalSqliteSnapshotProvider({
+      repositoryPath,
+      now: () => dates.shift() ?? new Date("invalid"),
+    });
+    const first = await provider.create({
+      path: sourcePath,
+      identity: { role: "generic", id: "test-database" },
+    });
+    const second = await provider.create({
+      path: sourcePath,
+      identity: { role: "generic", id: "test-database" },
+    });
+    await fs.mkdir(path.join(repositoryPath, ".tmp-interrupted"));
+    await fs.mkdir(path.join(repositoryPath, "interrupted-final"));
+    await fs.writeFile(path.join(repositoryPath, "interrupted-final", ".pending"), "");
+    await fs.mkdir(path.join(repositoryPath, "empty-final"));
+
+    await expect(provider.list()).resolves.toEqual([second, first]);
+  });
+
+  it("never replaces a snapshot directory raced into place", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    createGenericDatabase(sourcePath);
+    const provider = createLocalSqliteSnapshotProvider({
+      repositoryPath,
+      now: () => new Date("2026-07-12T14:00:00.000Z"),
+    });
+    const originalMkdir = fs.mkdir.bind(fs);
+    let racedPath: string | undefined;
+    const mkdirSpy = vi.spyOn(fs, "mkdir").mockImplementation(async (directoryPath, options) => {
+      const resolvedPath = path.resolve(String(directoryPath));
+      if (
+        path.dirname(resolvedPath) === repositoryPath &&
+        !path.basename(resolvedPath).startsWith(".tmp-")
+      ) {
+        racedPath = resolvedPath;
+        await originalMkdir(resolvedPath, options);
+        await fs.writeFile(path.join(resolvedPath, "keep"), "racer");
+      }
+      return await originalMkdir(directoryPath, options);
+    });
+
+    try {
+      await expect(
+        provider.create({
+          path: sourcePath,
+          identity: { role: "generic", id: "directory-race" },
+        }),
+      ).rejects.toThrow(/directory already exists/u);
+    } finally {
+      mkdirSpy.mockRestore();
+    }
+    expect(racedPath).toBeDefined();
+    await expect(fs.readFile(path.join(racedPath!, "keep"), "utf8")).resolves.toBe("racer");
+  });
+
+  it("rejects an artifact changed after entering the final directory", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    createGenericDatabase(sourcePath);
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+    const originalLink = fs.link.bind(fs);
+    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (source, target) => {
+      await originalLink(source, target);
+      if (
+        path.basename(String(target)) === SNAPSHOT_MANIFEST_FILENAME &&
+        !path.basename(path.dirname(String(target))).startsWith(".tmp-")
+      ) {
+        await fs.appendFile(
+          path.join(path.dirname(String(target)), SNAPSHOT_SQLITE_FILENAME),
+          "changed-after-final-move",
+        );
+      }
+    });
+
+    try {
+      await expect(
+        provider.create({
+          path: sourcePath,
+          identity: { role: "generic", id: "final-directory-race" },
+        }),
+      ).rejects.toThrow(/size mismatch/u);
+      await expect(provider.list()).resolves.toEqual([]);
+    } finally {
+      linkSpy.mockRestore();
+    }
+  });
+
+  it("cleans a linked entry when post-link inspection fails", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    createGenericDatabase(sourcePath);
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+    const originalLink = fs.link.bind(fs);
+    const originalLstat = fs.lstat.bind(fs);
+    let linkedArtifactPath: string | undefined;
+    let failedInspection = false;
+    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (source, target) => {
+      await originalLink(source, target);
+      if (
+        path.basename(String(target)) === SNAPSHOT_SQLITE_FILENAME &&
+        !path.basename(path.dirname(String(target))).startsWith(".tmp-")
+      ) {
+        linkedArtifactPath = path.resolve(String(target));
+      }
+    });
+    const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (filePath) => {
+      if (
+        linkedArtifactPath &&
+        !failedInspection &&
+        path.resolve(String(filePath)) === linkedArtifactPath
+      ) {
+        failedInspection = true;
+        throw Object.assign(new Error("post-link inspection failed"), { code: "EIO" });
+      }
+      return await originalLstat(filePath);
+    });
+
+    try {
+      await expect(
+        provider.create({
+          path: sourcePath,
+          identity: { role: "generic", id: "post-link-inspection" },
+        }),
+      ).rejects.toThrow(/post-link inspection failed/u);
+      await expect(provider.list()).resolves.toEqual([]);
+      await expect(fs.readdir(repositoryPath)).resolves.toEqual([]);
+    } finally {
+      lstatSpy.mockRestore();
+      linkSpy.mockRestore();
+    }
+  });
+
+  it("never overwrites a file raced into the final snapshot directory", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    createGenericDatabase(sourcePath);
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+    const originalLink = fs.link.bind(fs);
+    let racedPath: string | undefined;
+    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (source, target) => {
+      const targetPath = path.resolve(String(target));
+      if (
+        path.basename(targetPath) === SNAPSHOT_SQLITE_FILENAME &&
+        path.dirname(targetPath) !== repositoryPath &&
+        !path.basename(path.dirname(targetPath)).startsWith(".tmp-")
+      ) {
+        racedPath = targetPath;
+        await fs.writeFile(targetPath, "racer", { flag: "wx" });
+      }
+      await originalLink(source, target);
+    });
+
+    try {
+      await expect(
+        provider.create({
+          path: sourcePath,
+          identity: { role: "generic", id: "entry-race" },
+        }),
+      ).rejects.toThrow(/EEXIST/u);
+    } finally {
+      linkSpy.mockRestore();
+    }
+    expect(racedPath).toBeDefined();
+    await expect(fs.readFile(racedPath!, "utf8")).resolves.toBe("racer");
+  });
+
+  it("sanitizes transient global delivery rows and enforces the global owner", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "openclaw.sqlite");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    createGlobalDatabase(sourcePath);
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+    const snapshot = await provider.create({
+      path: sourcePath,
+      identity: { role: "global" },
+    });
+    const artifactPath = path.join(snapshot.ref.path, SNAPSHOT_SQLITE_FILENAME);
+    expect((await fs.readFile(artifactPath)).includes("do-not-restore")).toBe(false);
+    const sqlite = requireNodeSqlite();
+    const artifact = new sqlite.DatabaseSync(artifactPath, { readOnly: true });
+    try {
+      expect(
+        artifact.prepare("SELECT COUNT(*) AS count FROM delivery_queue_entries").get(),
+      ).toEqual({ count: 0 });
+    } finally {
+      artifact.close();
+    }
+
+    const wrongRolePath = path.join(tempDir, "wrong-role.sqlite");
+    createAgentDatabase(wrongRolePath, "main");
+    const wrongRole = new sqlite.DatabaseSync(wrongRolePath);
+    wrongRole.exec(`PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION};`);
+    wrongRole.close();
+    await expect(
+      provider.create({ path: wrongRolePath, identity: { role: "global" } }),
+    ).rejects.toThrow(/expected global/u);
+  });
+
+  it("enforces the exact agent owner and canonical agent id", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "openclaw-agent.sqlite");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    createAgentDatabase(sourcePath, "worker-1");
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+
+    await expect(
+      provider.create({
+        path: sourcePath,
+        identity: { role: "agent", agentId: "worker-2" },
+      }),
+    ).rejects.toThrow(/belongs to agent worker-1/u);
+    await expect(
+      provider.create({
+        path: sourcePath,
+        identity: { role: "agent", agentId: "Worker-1" },
+      }),
+    ).rejects.toThrow(/must be canonical/u);
+    await expect(
+      provider.create({
+        path: sourcePath,
+        identity: { role: "agent", agentId: "worker-1" },
+      }),
+    ).resolves.toMatchObject({
+      manifest: {
+        database: {
+          role: "agent",
+          agentId: "worker-1",
+          userVersion: OPENCLAW_AGENT_SCHEMA_VERSION,
+        },
+      },
+    });
+  });
+
+  it("rejects foreign-key violations and unsafe index definitions at creation", async () => {
+    const tempDir = await createTempDir();
+    const repositoryPath = path.join(tempDir, "snapshots");
+    const foreignKeyPath = path.join(tempDir, "foreign-key.sqlite");
+    const sqlite = requireNodeSqlite();
+    const foreignKeyDatabase = new sqlite.DatabaseSync(foreignKeyPath);
+    try {
+      foreignKeyDatabase.exec(`
+        PRAGMA foreign_keys = OFF;
+        CREATE TABLE parents (id INTEGER PRIMARY KEY);
+        CREATE TABLE children (
+          id INTEGER PRIMARY KEY,
+          parent_id INTEGER REFERENCES parents(id)
+        );
+        INSERT INTO children VALUES (1, 99);
+      `);
+    } finally {
+      foreignKeyDatabase.close();
+    }
+    const unsafeIndexPath = path.join(tempDir, "unsafe-index.sqlite");
+    createUnsafeIndexDrift(unsafeIndexPath);
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+
+    await expect(
+      provider.create({
+        path: foreignKeyPath,
+        identity: { role: "generic", id: "foreign-key" },
+      }),
+    ).rejects.toThrow(/foreign_key_check failed/u);
+    await expect(
+      provider.create({
+        path: unsafeIndexPath,
+        identity: { role: "generic", id: "unsafe-index" },
+      }),
+    ).rejects.toThrow(/integrity_check failed|malformed database schema/iu);
+    await expect(provider.list()).resolves.toEqual([]);
+  });
+
+  it("detects artifact hash, user_version, and unsafe-index drift after creation", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    createGenericDatabase(sourcePath);
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+
+    const hashSnapshot = await provider.create({
+      path: sourcePath,
+      identity: { role: "generic", id: "hash" },
+    });
+    await fs.appendFile(path.join(hashSnapshot.ref.path, SNAPSHOT_SQLITE_FILENAME), "tamper");
+    await expect(provider.verify(hashSnapshot.ref)).rejects.toThrow(/size mismatch/u);
+
+    const versionSnapshot = await provider.create({
+      path: sourcePath,
+      identity: { role: "generic", id: "version" },
+    });
+    const sqlite = requireNodeSqlite();
+    const versionDatabase = new sqlite.DatabaseSync(
+      path.join(versionSnapshot.ref.path, SNAPSHOT_SQLITE_FILENAME),
+    );
+    versionDatabase.exec("PRAGMA user_version = 99;");
+    versionDatabase.close();
+    await refreshArtifactManifest(versionSnapshot);
+    await expect(provider.verify(versionSnapshot.ref)).rejects.toThrow(/user_version mismatch/u);
+
+    const unsafeSnapshot = await provider.create({
+      path: sourcePath,
+      identity: { role: "generic", id: "unsafe" },
+    });
+    const unsafePath = path.join(unsafeSnapshot.ref.path, SNAPSHOT_SQLITE_FILENAME);
+    const unsafeDatabase = new sqlite.DatabaseSync(unsafePath);
+    try {
+      unsafeDatabase.exec(`
+        CREATE TABLE indexed_records (
+          id INTEGER PRIMARY KEY,
+          indexed_value TEXT NOT NULL,
+          alternate_value TEXT NOT NULL
+        );
+        CREATE INDEX indexed_records_value ON indexed_records(indexed_value);
+        INSERT INTO indexed_records (indexed_value, alternate_value)
+        VALUES ('alpha', 'zeta'), ('beta', 'eta');
+        PRAGMA writable_schema = ON;
+      `);
+      unsafeDatabase
+        .prepare(
+          "UPDATE sqlite_schema SET sql = 'CREATE INDEX indexed_records_value ON indexed_records(alternate_value)' WHERE name = 'indexed_records_value'",
+        )
+        .run();
+      const schemaVersion = Number(
+        Object.values(
+          unsafeDatabase.prepare("PRAGMA schema_version").get() as Record<string, unknown>,
+        )[0],
+      );
+      unsafeDatabase.exec(
+        `PRAGMA writable_schema = OFF; PRAGMA schema_version = ${schemaVersion + 1};`,
+      );
+    } finally {
+      unsafeDatabase.close();
+    }
+    await refreshArtifactManifest(unsafeSnapshot);
+    await expect(provider.verify(unsafeSnapshot.ref)).rejects.toThrow(
+      /integrity_check failed|malformed database schema/iu,
+    );
+  });
+
+  it("never overwrites an existing target or orphan SQLite sidecar", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    const restorePath = path.join(tempDir, "restore", "source.sqlite");
+    createGenericDatabase(sourcePath);
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+    const snapshot = await provider.create({
+      path: sourcePath,
+      identity: { role: "generic", id: "restore" },
+    });
+    await fs.mkdir(path.dirname(restorePath), { recursive: true });
+    await fs.writeFile(restorePath, "keep");
+
+    await expect(provider.restoreFresh(snapshot.ref, restorePath)).rejects.toThrow(
+      /restore path already exists/u,
+    );
+    await expect(fs.readFile(restorePath, "utf8")).resolves.toBe("keep");
+
+    await fs.unlink(restorePath);
+    await fs.writeFile(`${restorePath}-wal`, "keep-wal");
+    await expect(provider.restoreFresh(snapshot.ref, restorePath)).rejects.toThrow(
+      /restore path already exists/u,
+    );
+    await expect(fs.readFile(`${restorePath}-wal`, "utf8")).resolves.toBe("keep-wal");
+    await expect(fs.access(restorePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("fails closed when fresh restore cannot publish atomically", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    const restorePath = path.join(tempDir, "restore", "source.sqlite");
+    createGenericDatabase(sourcePath);
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+    const snapshot = await provider.create({
+      path: sourcePath,
+      identity: { role: "generic", id: "atomic-restore" },
+    });
+    const linkSpy = vi
+      .spyOn(fs, "link")
+      .mockRejectedValue(Object.assign(new Error("hard links unsupported"), { code: "ENOTSUP" }));
+
+    try {
+      await expect(provider.restoreFresh(snapshot.ref, restorePath)).rejects.toThrow(
+        /requires hard-link support/u,
+      );
+      await expect(fs.access(restorePath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      linkSpy.mockRestore();
+    }
+  });
+
+  it("rejects restore targets inside the snapshot repository", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    createGenericDatabase(sourcePath);
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+    const snapshot = await provider.create({
+      path: sourcePath,
+      identity: { role: "generic", id: "repository-boundary" },
+    });
+
+    await expect(
+      provider.restoreFresh(snapshot.ref, path.join(repositoryPath, "restored.sqlite")),
+    ).rejects.toThrow(/outside snapshot repository/u);
+    await expect(
+      provider.restoreFresh(snapshot.ref, path.join(snapshot.ref.path, "restored.sqlite")),
+    ).rejects.toThrow(/outside snapshot repository/u);
+    await expect(provider.verify(snapshot.ref)).resolves.toMatchObject({ ok: true });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "binds restore to the exact artifact bytes recorded by the manifest",
+    async () => {
+      const tempDir = await createTempDir();
+      const sourcePath = path.join(tempDir, "source.sqlite");
+      const repositoryPath = path.join(tempDir, "snapshots");
+      const restorePath = path.join(tempDir, "restore", "source.sqlite");
+      createGenericDatabase(sourcePath);
+      const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+      const snapshot = await provider.create({
+        path: sourcePath,
+        identity: { role: "generic", id: "verified-bytes" },
+      });
+      const artifactPath = path.join(snapshot.ref.path, SNAPSHOT_SQLITE_FILENAME);
+      const originalOpen = fs.open.bind(fs);
+      const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+        const handle = await originalOpen(filePath, flags, mode);
+        if (
+          flags === "wx+" &&
+          path.basename(String(filePath)) === SNAPSHOT_SQLITE_FILENAME &&
+          path.basename(path.dirname(String(filePath))).startsWith(".tmp-restore-")
+        ) {
+          const sqlite = requireNodeSqlite();
+          const database = new sqlite.DatabaseSync(artifactPath);
+          database.prepare("INSERT INTO entries (value) VALUES (?)").run("raced");
+          database.close();
+        }
+        return handle;
+      });
+
+      try {
+        await expect(provider.restoreFresh(snapshot.ref, restorePath)).rejects.toThrow(
+          /hash mismatch|size mismatch/u,
+        );
+        await expect(fs.access(restorePath)).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        openSpy.mockRestore();
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "never publishes replacement bytes when the pinned staging pathname changes",
+    async () => {
+      const tempDir = await createTempDir();
+      const sourcePath = path.join(tempDir, "source.sqlite");
+      const repositoryPath = path.join(tempDir, "snapshots");
+      const restorePath = path.join(tempDir, "restore", "source.sqlite");
+      createGenericDatabase(sourcePath, { values: ["original"] });
+      const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+      const snapshot = await provider.create({
+        path: sourcePath,
+        identity: { role: "generic", id: "pinned-staging" },
+      });
+      const originalOpen = fs.open.bind(fs);
+      const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+        if (
+          flags === "wx+" &&
+          path.basename(path.dirname(String(filePath))).startsWith(".sqlite-publish-")
+        ) {
+          const stagingEntry = (await fs.readdir(repositoryPath)).find((entry) =>
+            entry.startsWith(".tmp-restore-"),
+          );
+          if (!stagingEntry) {
+            throw new Error("restore staging directory was not created");
+          }
+          const stagedPath = path.join(repositoryPath, stagingEntry, SNAPSHOT_SQLITE_FILENAME);
+          await fs.unlink(stagedPath);
+          createGenericDatabase(stagedPath, { values: ["replacement"] });
+        }
+        return await originalOpen(filePath, flags, mode);
+      });
+
+      let restored = false;
+      try {
+        await provider.restoreFresh(snapshot.ref, restorePath);
+        restored = true;
+      } catch (error) {
+        expect(String(error)).toMatch(/file changed while reading/u);
+      } finally {
+        openSpy.mockRestore();
+      }
+      if (!restored) {
+        await expect(fs.access(restorePath)).rejects.toMatchObject({ code: "ENOENT" });
+        return;
+      }
+      const sqlite = requireNodeSqlite();
+      const database = new sqlite.DatabaseSync(restorePath, { readOnly: true });
+      try {
+        expect(database.prepare("SELECT value FROM entries").all()).toEqual([
+          { value: "original" },
+        ]);
+      } finally {
+        database.close();
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "removes only its restored target when a sidecar races publication",
+    async () => {
+      const tempDir = await createTempDir();
+      const sourcePath = path.join(tempDir, "source.sqlite");
+      const repositoryPath = path.join(tempDir, "snapshots");
+      const restorePath = path.join(tempDir, "restore", "source.sqlite");
+      createGenericDatabase(sourcePath);
+      const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+      const snapshot = await provider.create({
+        path: sourcePath,
+        identity: { role: "generic", id: "restore-race" },
+      });
+      const originalLink = fs.link.bind(fs);
+      const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (source, target) => {
+        await originalLink(source, target);
+        if (path.resolve(String(target)) === restorePath) {
+          await fs.writeFile(`${restorePath}-wal`, "racer");
+        }
+      });
+
+      try {
+        await expect(provider.restoreFresh(snapshot.ref, restorePath)).rejects.toThrow(
+          /unexpected sidecar/u,
+        );
+        await expect(fs.access(restorePath)).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(fs.readFile(`${restorePath}-wal`, "utf8")).resolves.toBe("racer");
+      } finally {
+        linkSpy.mockRestore();
+      }
+    },
+  );
+
+  it("rejects snapshots outside the configured repository and unexpected contents", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    createGenericDatabase(sourcePath);
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+    const snapshot = await provider.create({
+      path: sourcePath,
+      identity: { role: "generic", id: "boundary" },
+    });
+
+    await expect(provider.verify({ path: tempDir })).rejects.toThrow(/immediate child/u);
+    await fs.writeFile(path.join(snapshot.ref.path, `${SNAPSHOT_SQLITE_FILENAME}-wal`), "orphan");
+    await expect(provider.verify(snapshot.ref)).rejects.toThrow(/unexpected entry/u);
+    await expect(provider.list()).rejects.toThrow(/unexpected entry/u);
+  });
+
+  it("bounds manifest reads before parsing untrusted snapshot metadata", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    createGenericDatabase(sourcePath);
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+    const snapshot = await provider.create({
+      path: sourcePath,
+      identity: { role: "generic", id: "bounded-manifest" },
+    });
+    await fs.writeFile(
+      path.join(snapshot.ref.path, SNAPSHOT_MANIFEST_FILENAME),
+      Buffer.alloc(1024 * 1024 + 1, 0x20),
+    );
+
+    await expect(provider.verify(snapshot.ref)).rejects.toThrow(/1048576 bytes/u);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects symlinked repositories, snapshot files, restore parents, and hardlinked artifacts",
+    async () => {
+      const tempDir = await createTempDir();
+      const sourcePath = path.join(tempDir, "source.sqlite");
+      const realRepositoryPath = path.join(tempDir, "real-snapshots");
+      const repositoryLink = path.join(tempDir, "snapshot-link");
+      createGenericDatabase(sourcePath);
+      await fs.mkdir(realRepositoryPath);
+      await fs.symlink(realRepositoryPath, repositoryLink);
+      const linkedProvider = createLocalSqliteSnapshotProvider({
+        repositoryPath: repositoryLink,
+      });
+      await expect(
+        linkedProvider.create({
+          path: sourcePath,
+          identity: { role: "generic", id: "symlink-repository" },
+        }),
+      ).rejects.toThrow(/symlink|Invalid path/iu);
+
+      const provider = createLocalSqliteSnapshotProvider({
+        repositoryPath: realRepositoryPath,
+      });
+      const snapshot = await provider.create({
+        path: sourcePath,
+        identity: { role: "generic", id: "links" },
+      });
+      const artifactPath = path.join(snapshot.ref.path, SNAPSHOT_SQLITE_FILENAME);
+      const externalArtifact = path.join(tempDir, "external.sqlite");
+      await fs.link(artifactPath, externalArtifact);
+      await expect(provider.verify(snapshot.ref)).rejects.toThrow(/hardlink/iu);
+      await fs.unlink(externalArtifact);
+
+      const manifestPath = path.join(snapshot.ref.path, SNAPSHOT_MANIFEST_FILENAME);
+      const realManifest = path.join(tempDir, "manifest.json");
+      await fs.rename(manifestPath, realManifest);
+      await fs.symlink(realManifest, manifestPath);
+      await expect(provider.verify(snapshot.ref)).rejects.toThrow(/regular file|symlink/iu);
+
+      await fs.unlink(manifestPath);
+      await fs.rename(realManifest, manifestPath);
+      const realRestoreParent = path.join(tempDir, "real-restore");
+      const restoreParentLink = path.join(tempDir, "restore-link");
+      await fs.mkdir(realRestoreParent);
+      await fs.symlink(realRestoreParent, restoreParentLink);
+      await expect(
+        provider.restoreFresh(snapshot.ref, path.join(restoreParentLink, "restored.sqlite")),
+      ).rejects.toThrow(/symlink|Invalid path/iu);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects repository restore targets reached through another filesystem spelling",
+    async () => {
+      const tempDir = await createTempDir();
+      const sourcePath = path.join(tempDir, "source.sqlite");
+      const repositoryPath = path.join(tempDir, "snapshots");
+      createGenericDatabase(sourcePath);
+      const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+      const snapshot = await provider.create({
+        path: sourcePath,
+        identity: { role: "generic", id: "canonical-boundary" },
+      });
+      const aliasRoot = path.join(tempDir, "alias");
+      await fs.symlink(tempDir, aliasRoot);
+      const aliasRepositoryPath = path.join(aliasRoot, "snapshots");
+      const aliasProvider = createLocalSqliteSnapshotProvider({
+        repositoryPath: aliasRepositoryPath,
+      });
+      const aliasSnapshot = {
+        path: path.join(aliasRepositoryPath, path.basename(snapshot.ref.path)),
+      };
+
+      await expect(
+        aliasProvider.restoreFresh(aliasSnapshot, path.join(repositoryPath, "restored.sqlite")),
+      ).rejects.toThrow(/outside snapshot repository/u);
+      await expect(provider.verify(snapshot.ref)).resolves.toMatchObject({ ok: true });
+    },
+  );
+});
+
+describe("snapshot manifest parser", () => {
+  const manifestPath = "/snapshots/snapshot/manifest.json";
+  const snapshotId = "snapshot";
+  const validManifest: SnapshotManifest = {
+    schemaVersion: 1,
+    snapshotId,
+    createdAt: "2026-07-12T14:00:00.000Z",
+    database: {
+      role: "agent",
+      agentId: "worker-1",
+      basename: "openclaw-agent.sqlite",
+      userVersion: OPENCLAW_AGENT_SCHEMA_VERSION,
+    },
+    artifact: {
+      path: SNAPSHOT_SQLITE_FILENAME,
+      sha256: "a".repeat(64),
+      sizeBytes: 4096,
+    },
+  };
+
+  it.each([
+    ["unknown top-level field", { ...validManifest, extra: true }, /fields must be exactly/u],
+    ["wrong directory id", validManifest, /does not match directory/u, "other"],
+    [
+      "noncanonical timestamp",
+      { ...validManifest, createdAt: "2026-07-12T14:00:00Z" },
+      /not canonical/u,
+    ],
+    [
+      "artifact path traversal",
+      { ...validManifest, artifact: { ...validManifest.artifact, path: "../database.sqlite" } },
+      /artifact\.path must be database\.sqlite/u,
+    ],
+    [
+      "prefixed digest",
+      {
+        ...validManifest,
+        artifact: { ...validManifest.artifact, sha256: `sha256:${"a".repeat(64)}` },
+      },
+      /sha256 is invalid/u,
+    ],
+    [
+      "noncanonical agent id",
+      { ...validManifest, database: { ...validManifest.database, agentId: "Worker-1" } },
+      /agentId is invalid/u,
+    ],
+    [
+      "unsafe basename",
+      { ...validManifest, database: { ...validManifest.database, basename: "../db.sqlite" } },
+      /basename is invalid/u,
+    ],
+    [
+      "out-of-range user version",
+      { ...validManifest, database: { ...validManifest.database, userVersion: 2 ** 31 } },
+      /userVersion is invalid/u,
+    ],
+    [
+      "zero-byte artifact",
+      { ...validManifest, artifact: { ...validManifest.artifact, sizeBytes: 0 } },
+      /sizeBytes is invalid/u,
+    ],
+  ])("rejects %s", (_name, value, error, expectedId = snapshotId) => {
+    expect(() => parseSnapshotManifest(value, manifestPath, expectedId)).toThrow(error);
+  });
+});

--- a/src/snapshot/local-repository.ts
+++ b/src/snapshot/local-repository.ts
@@ -1,0 +1,863 @@
+import { randomUUID } from "node:crypto";
+import fsSync, { type Stats } from "node:fs";
+import fs from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { isDeepStrictEqual } from "node:util";
+import { loadSqliteVecExtension } from "../../packages/memory-host-sdk/src/engine-storage.js";
+import { sameFileIdentity } from "../infra/fs-safe-advanced.js";
+import {
+  canonicalPathFromExistingAncestor,
+  ensureAbsoluteDirectory,
+  isPathInside,
+} from "../infra/fs-safe.js";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { applyPrivateModeSync } from "../infra/private-mode.js";
+import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
+import {
+  createVerifiedSqliteSnapshot,
+  publishVerifiedSqliteFile,
+  syncDirectoryBestEffort,
+  type SqliteSnapshotValidator,
+} from "../infra/sqlite-snapshot.js";
+import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
+import { isValidAgentId, normalizeAgentId } from "../routing/session-key.js";
+import { assertOpenClawAgentDatabaseForMaintenance } from "../state/openclaw-agent-db.js";
+import { assertOpenClawStateDatabaseForMaintenance } from "../state/openclaw-state-db.js";
+import {
+  containsAsciiControlCharacter,
+  copySnapshotArtifact,
+  hashSnapshotArtifact,
+  readSnapshotManifest,
+  type SnapshotArtifactDigest,
+  writeSnapshotManifest,
+} from "./manifest.js";
+import {
+  SNAPSHOT_MANIFEST_FILENAME,
+  SNAPSHOT_SQLITE_FILENAME,
+  type SnapshotDatabaseIdentity,
+  type SnapshotDatabaseManifest,
+  type SnapshotDatabaseRef,
+  type SnapshotManifest,
+  type SnapshotRef,
+  type SnapshotResult,
+  type SnapshotSummary,
+  type SnapshotVerificationResult,
+  type SqliteSnapshotProvider,
+} from "./snapshot-provider.js";
+
+const SNAPSHOT_DIRECTORY_MODE = 0o700;
+const SNAPSHOT_FILE_MODE = 0o600;
+const SNAPSHOT_ID_BASENAME_MAX_LENGTH = 80;
+const SNAPSHOT_PENDING_FILENAME = ".pending";
+const SQLITE_SIDECAR_SUFFIXES = ["-wal", "-shm", "-journal"] as const;
+const SNAPSHOT_ARTIFACT_ENTRIES = new Set([
+  SNAPSHOT_MANIFEST_FILENAME,
+  SNAPSHOT_PENDING_FILENAME,
+  SNAPSHOT_SQLITE_FILENAME,
+]);
+const RESTORE_STAGING_ENTRIES = new Set([SNAPSHOT_SQLITE_FILENAME]);
+
+export type LocalSqliteSnapshotProviderOptions = {
+  readonly repositoryPath: string;
+  readonly now?: () => Date;
+};
+
+export function createLocalSqliteSnapshotProvider(
+  options: LocalSqliteSnapshotProviderOptions,
+): SqliteSnapshotProvider {
+  return new LocalSqliteSnapshotProvider(options);
+}
+
+class LocalSqliteSnapshotProvider implements SqliteSnapshotProvider {
+  readonly #repositoryPath: string;
+  readonly #now: () => Date;
+
+  constructor(options: LocalSqliteSnapshotProviderOptions) {
+    this.#repositoryPath = path.resolve(options.repositoryPath);
+    this.#now = options.now ?? (() => new Date());
+  }
+
+  async create(database: SnapshotDatabaseRef): Promise<SnapshotResult> {
+    await ensurePrivateDirectory(this.#repositoryPath, "SQLite snapshot repository");
+    const sourcePath = path.resolve(database.path);
+    const identity = normalizeSnapshotIdentity(database.identity);
+    const now = this.#now();
+    if (!Number.isFinite(now.getTime())) {
+      throw new Error("SQLite snapshot timestamp is invalid.");
+    }
+    const snapshotId = buildSnapshotId(now, sourcePath);
+    const snapshotDir = path.join(this.#repositoryPath, snapshotId);
+    const stagingDir = path.join(this.#repositoryPath, `.tmp-${snapshotId}-${randomUUID()}`);
+    const artifactPath = path.join(stagingDir, SNAPSHOT_SQLITE_FILENAME);
+    await fs.mkdir(stagingDir, { mode: SNAPSHOT_DIRECTORY_MODE });
+
+    let stagingIdentity: Stats | undefined;
+    let publishedDirectory: FileHandle | undefined;
+    let publishedIdentity: Stats | undefined;
+    const publishedEntries = new Map<string, Stats>();
+    let snapshotDirectoryCreated = false;
+    try {
+      stagingIdentity = await fs.lstat(stagingDir);
+      applyPrivateModeSync(stagingDir, SNAPSHOT_DIRECTORY_MODE);
+      const result = await createVerifiedSqliteSnapshot({
+        sourcePath,
+        targetPath: artifactPath,
+        transform: identity.role === "global" ? sanitizeGlobalStateSnapshot : undefined,
+        validate: buildDatabaseValidator(identity),
+      });
+      applyPrivateModeSync(artifactPath, SNAPSHOT_FILE_MODE);
+      const artifact = await hashSnapshotArtifact(stagingDir);
+      const manifest: SnapshotManifest = {
+        schemaVersion: 1,
+        snapshotId,
+        createdAt: now.toISOString(),
+        database: buildDatabaseManifest(identity, sourcePath, result.userVersion),
+        artifact: {
+          path: SNAPSHOT_SQLITE_FILENAME,
+          sha256: artifact.sha256,
+          sizeBytes: artifact.sizeBytes,
+        },
+      };
+      await writeSnapshotManifest(stagingDir, manifest);
+      applyPrivateModeSync(path.join(stagingDir, SNAPSHOT_MANIFEST_FILENAME), SNAPSHOT_FILE_MODE);
+      await readSnapshotManifest(stagingDir, snapshotId);
+      await syncDirectoryBestEffort(stagingDir);
+
+      try {
+        await fs.mkdir(snapshotDir, { mode: SNAPSHOT_DIRECTORY_MODE });
+        snapshotDirectoryCreated = true;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+          throw new Error(`SQLite snapshot directory already exists: ${snapshotDir}`, {
+            cause: error,
+          });
+        }
+        throw error;
+      }
+      publishedIdentity = await fs.lstat(snapshotDir);
+      applyPrivateModeSync(snapshotDir, SNAPSHOT_DIRECTORY_MODE);
+      publishedDirectory = await fs.open(snapshotDir, "r");
+      await assertOpenDirectoryIdentity(publishedDirectory, snapshotDir, publishedIdentity);
+      const pendingPath = path.join(snapshotDir, SNAPSHOT_PENDING_FILENAME);
+      await fs.writeFile(pendingPath, "", {
+        flag: "wx",
+        mode: SNAPSHOT_FILE_MODE,
+      });
+      publishedEntries.set(SNAPSHOT_PENDING_FILENAME, await fs.lstat(pendingPath));
+      await assertOpenDirectoryIdentity(publishedDirectory, snapshotDir, publishedIdentity);
+      await publishSnapshotEntryNoOverwrite(
+        path.join(stagingDir, SNAPSHOT_SQLITE_FILENAME),
+        path.join(snapshotDir, SNAPSHOT_SQLITE_FILENAME),
+        SNAPSHOT_SQLITE_FILENAME,
+        publishedEntries,
+      );
+      await assertOpenDirectoryIdentity(publishedDirectory, snapshotDir, publishedIdentity);
+      await publishSnapshotEntryNoOverwrite(
+        path.join(stagingDir, SNAPSHOT_MANIFEST_FILENAME),
+        path.join(snapshotDir, SNAPSHOT_MANIFEST_FILENAME),
+        SNAPSHOT_MANIFEST_FILENAME,
+        publishedEntries,
+      );
+      await assertOpenDirectoryIdentity(publishedDirectory, snapshotDir, publishedIdentity);
+      await syncDirectoryBestEffort(snapshotDir);
+      await assertPendingSnapshotContents(snapshotDir);
+      const publishedManifest = await readSnapshotManifest(snapshotDir, snapshotId);
+      if (!isDeepStrictEqual(publishedManifest, manifest)) {
+        throw new Error(`SQLite snapshot manifest changed during publication: ${snapshotDir}`);
+      }
+      const publishedArtifact = await hashSnapshotArtifact(snapshotDir);
+      const publishedArtifactPath = path.join(snapshotDir, SNAPSHOT_SQLITE_FILENAME);
+      assertArtifactMatchesManifest(publishedArtifactPath, publishedArtifact, publishedManifest);
+      await verifySnapshotDatabaseFile(
+        publishedArtifactPath,
+        publishedArtifact.stat,
+        publishedManifest,
+      );
+      const expectedPendingIdentity = publishedEntries.get(SNAPSHOT_PENDING_FILENAME);
+      const currentPendingIdentity = fsSync.lstatSync(pendingPath);
+      if (
+        !expectedPendingIdentity ||
+        !sameFileIdentity(expectedPendingIdentity, currentPendingIdentity)
+      ) {
+        throw new Error(`SQLite snapshot pending marker changed: ${pendingPath}`);
+      }
+      fsSync.unlinkSync(pendingPath);
+      publishedEntries.delete(SNAPSHOT_PENDING_FILENAME);
+      await syncDirectoryBestEffort(snapshotDir);
+      await publishedDirectory.close();
+      publishedDirectory = undefined;
+      const committedManifest = await readSnapshotManifest(snapshotDir, snapshotId);
+      if (!isDeepStrictEqual(committedManifest, manifest)) {
+        throw new Error(`SQLite snapshot manifest changed after commit: ${snapshotDir}`);
+      }
+      const committedArtifact = await hashSnapshotArtifact(snapshotDir);
+      assertArtifactMatchesManifest(
+        path.join(snapshotDir, SNAPSHOT_SQLITE_FILENAME),
+        committedArtifact,
+        committedManifest,
+      );
+      const currentIdentity = await fs.lstat(snapshotDir);
+      if (!sameFileIdentity(publishedIdentity, currentIdentity)) {
+        throw new Error(`SQLite snapshot directory changed during publication: ${snapshotDir}`);
+      }
+      await assertExactSnapshotContents(snapshotDir);
+      await syncDirectoryBestEffort(this.#repositoryPath);
+      return { ref: { path: snapshotDir }, manifest };
+    } catch (error) {
+      await publishedDirectory?.close().catch(() => undefined);
+      publishedDirectory = undefined;
+      if (snapshotDirectoryCreated) {
+        publishedIdentity ??= await fs.lstat(snapshotDir).catch(() => undefined);
+      }
+      if (publishedIdentity) {
+        const removed = await removePublishedSnapshotDirectoryIfOwned(
+          snapshotDir,
+          publishedIdentity,
+          publishedEntries,
+        );
+        if (removed) {
+          await syncDirectoryBestEffort(this.#repositoryPath);
+        }
+      }
+      throw error;
+    } finally {
+      const removed = stagingIdentity
+        ? await removePrivateDirectoryIfOwned(
+            stagingDir,
+            stagingIdentity,
+            SNAPSHOT_ARTIFACT_ENTRIES,
+          ).catch(() => false)
+        : await fs
+            .rmdir(stagingDir)
+            .then(() => true)
+            .catch(() => false);
+      if (removed) {
+        await syncDirectoryBestEffort(this.#repositoryPath).catch(() => undefined);
+      }
+    }
+  }
+
+  async verify(snapshot: SnapshotRef): Promise<SnapshotVerificationResult> {
+    const snapshotDir = await this.#resolveSnapshotDirectory(snapshot);
+    const manifest = await readVerifiedSnapshotManifest(snapshotDir);
+    const artifact = await hashSnapshotArtifact(snapshotDir);
+    const artifactPath = path.join(snapshotDir, SNAPSHOT_SQLITE_FILENAME);
+    assertArtifactMatchesManifest(artifactPath, artifact, manifest);
+    await verifySnapshotDatabaseFile(artifactPath, artifact.stat, manifest);
+    await assertExactSnapshotContents(snapshotDir);
+    return { ok: true, manifest };
+  }
+
+  async restoreFresh(
+    snapshot: SnapshotRef,
+    targetPath: string,
+  ): Promise<SnapshotVerificationResult> {
+    const snapshotDir = await this.#resolveSnapshotDirectory(snapshot);
+    const manifest = await readVerifiedSnapshotManifest(snapshotDir);
+    const resolvedTargetPath = path.resolve(targetPath);
+    const canonicalRepositoryPath = await fs.realpath(this.#repositoryPath);
+    const canonicalTargetPath = await canonicalPathFromExistingAncestor(resolvedTargetPath);
+    if (isPathInside(canonicalRepositoryPath, canonicalTargetPath)) {
+      throw new Error(
+        `SQLite restore target must be outside snapshot repository ${this.#repositoryPath}: ${resolvedTargetPath}`,
+      );
+    }
+    const restoreParentPath = path.dirname(resolvedTargetPath);
+    await ensureRestoreParentDirectory(restoreParentPath);
+    const restoreParentIdentity = await fs.lstat(restoreParentPath);
+    applyPrivateModeSync(this.#repositoryPath, SNAPSHOT_DIRECTORY_MODE);
+    // Existing databases need a crash-recoverable main/WAL/SHM swap protocol.
+    // This path is deliberately fresh-only and refuses every preexisting sidecar.
+    await assertFreshRestorePathsAbsent(resolvedTargetPath);
+
+    const stagingDir = await fs.mkdtemp(path.join(this.#repositoryPath, ".tmp-restore-"));
+    const stagedSourcePath = path.join(stagingDir, SNAPSHOT_SQLITE_FILENAME);
+    let stagingIdentity: Stats | undefined;
+    try {
+      stagingIdentity = await fs.lstat(stagingDir);
+      applyPrivateModeSync(stagingDir, SNAPSHOT_DIRECTORY_MODE);
+      const stagedArtifact = await copySnapshotArtifact(snapshotDir, stagedSourcePath);
+      await assertDirectoryIdentity(stagingDir, stagingIdentity);
+      assertArtifactMatchesManifest(stagedSourcePath, stagedArtifact, manifest);
+      await assertExactSnapshotContents(snapshotDir);
+      await verifySnapshotDatabaseFile(stagedSourcePath, stagedArtifact.stat, manifest);
+      await publishVerifiedSqliteFile({
+        sourceIdentity: stagedArtifact.stat,
+        sourcePath: stagedSourcePath,
+        targetPath: resolvedTargetPath,
+        expectedContent: manifest.artifact,
+        requireAtomicPublication: true,
+        beforePublish: async () => {
+          await assertDirectoryIdentity(restoreParentPath, restoreParentIdentity);
+          await assertFreshRestorePathsAbsent(resolvedTargetPath);
+        },
+        afterPublish: (guard) => {
+          guard.assertTargetMatchesExpectedContent(() => {
+            assertDirectoryIdentitySync(restoreParentPath, restoreParentIdentity);
+            assertNoSqliteSidecarsSync(resolvedTargetPath);
+          });
+        },
+      });
+      return { ok: true, manifest };
+    } finally {
+      const removed = stagingIdentity
+        ? await removePrivateDirectoryIfOwned(
+            stagingDir,
+            stagingIdentity,
+            RESTORE_STAGING_ENTRIES,
+          ).catch(() => false)
+        : await fs
+            .rmdir(stagingDir)
+            .then(() => true)
+            .catch(() => false);
+      if (removed) {
+        await syncDirectoryBestEffort(this.#repositoryPath).catch(() => undefined);
+      }
+    }
+  }
+
+  async list(): Promise<SnapshotSummary[]> {
+    const repositoryStat = await lstatIfExists(this.#repositoryPath);
+    if (!repositoryStat) {
+      return [];
+    }
+    assertDirectory(repositoryStat, this.#repositoryPath, "SQLite snapshot repository");
+    applyPrivateModeSync(this.#repositoryPath, SNAPSHOT_DIRECTORY_MODE);
+
+    const entries = await fs.readdir(this.#repositoryPath, { withFileTypes: true });
+    const snapshots: SnapshotSummary[] = [];
+    for (const entry of entries) {
+      if (entry.name.startsWith(".tmp-")) {
+        if (entry.isSymbolicLink() || !entry.isDirectory()) {
+          throw new Error(
+            `SQLite snapshot repository contains unsafe staging entry: ${path.join(this.#repositoryPath, entry.name)}`,
+          );
+        }
+        continue;
+      }
+      if (entry.isSymbolicLink() || !entry.isDirectory()) {
+        throw new Error(
+          `SQLite snapshot repository contains unexpected entry: ${path.join(this.#repositoryPath, entry.name)}`,
+        );
+      }
+      const snapshotPath = path.join(this.#repositoryPath, entry.name);
+      if (await isIncompleteSnapshotDirectory(snapshotPath)) {
+        continue;
+      }
+      await assertExactSnapshotContents(snapshotPath);
+      snapshots.push({
+        ref: { path: snapshotPath },
+        manifest: await readSnapshotManifest(snapshotPath),
+      });
+    }
+    return snapshots.toSorted(
+      (left, right) =>
+        right.manifest.createdAt.localeCompare(left.manifest.createdAt) ||
+        right.manifest.snapshotId.localeCompare(left.manifest.snapshotId),
+    );
+  }
+
+  async #resolveSnapshotDirectory(snapshot: SnapshotRef): Promise<string> {
+    const snapshotDir = path.resolve(snapshot.path);
+    if (path.dirname(snapshotDir) !== this.#repositoryPath) {
+      throw new Error(
+        `SQLite snapshot must be an immediate child of repository ${this.#repositoryPath}: ${snapshotDir}`,
+      );
+    }
+    const repositoryStat = await fs.lstat(this.#repositoryPath);
+    assertDirectory(repositoryStat, this.#repositoryPath, "SQLite snapshot repository");
+    const snapshotStat = await fs.lstat(snapshotDir);
+    assertDirectory(snapshotStat, snapshotDir, "SQLite snapshot");
+    return snapshotDir;
+  }
+}
+
+async function readVerifiedSnapshotManifest(snapshotDir: string): Promise<SnapshotManifest> {
+  await assertExactSnapshotContents(snapshotDir);
+  return await readSnapshotManifest(snapshotDir);
+}
+
+function assertArtifactMatchesManifest(
+  artifactPath: string,
+  artifact: SnapshotArtifactDigest,
+  manifest: SnapshotManifest,
+): void {
+  if (artifact.sizeBytes !== manifest.artifact.sizeBytes) {
+    throw new Error(
+      `Snapshot artifact size mismatch for ${artifactPath}: expected ${manifest.artifact.sizeBytes}, got ${artifact.sizeBytes}`,
+    );
+  }
+  if (artifact.sha256 !== manifest.artifact.sha256) {
+    throw new Error(
+      `Snapshot artifact hash mismatch for ${artifactPath}: expected ${manifest.artifact.sha256}, got ${artifact.sha256}`,
+    );
+  }
+}
+
+async function verifySnapshotDatabaseFile(
+  artifactPath: string,
+  expectedIdentity: Stats,
+  manifest: SnapshotManifest,
+): Promise<void> {
+  const beforeOpen = await fs.lstat(artifactPath);
+  if (
+    beforeOpen.isSymbolicLink() ||
+    !beforeOpen.isFile() ||
+    beforeOpen.nlink > 1 ||
+    !sameFileIdentity(expectedIdentity, beforeOpen)
+  ) {
+    throw new Error(`Snapshot artifact changed before SQLite verification: ${artifactPath}`);
+  }
+
+  const validationDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-snapshot-verify-"));
+  const validationPath = path.join(validationDir, SNAPSHOT_SQLITE_FILENAME);
+  try {
+    await fs.chmod(validationDir, SNAPSHOT_DIRECTORY_MODE);
+    const validationArtifact = await copySnapshotArtifact(
+      path.dirname(artifactPath),
+      validationPath,
+    );
+    assertArtifactMatchesManifest(validationPath, validationArtifact, manifest);
+    const sqlite = requireNodeSqlite();
+    const database = new sqlite.DatabaseSync(validationPath, {
+      allowExtension: true,
+      readOnly: true,
+    });
+    try {
+      database.exec("PRAGMA busy_timeout = 30000; PRAGMA trusted_schema = OFF;");
+      await loadSqliteVecExtension({ db: database });
+      assertSqliteIntegrity(database, artifactPath);
+      buildManifestDatabaseValidator(manifest.database)(database, artifactPath);
+    } finally {
+      database.close();
+    }
+    const validatedArtifact = await hashSnapshotArtifact(validationDir);
+    if (!sameFileIdentity(validationArtifact.stat, validatedArtifact.stat)) {
+      throw new Error(`Snapshot validation copy changed: ${validationPath}`);
+    }
+    assertArtifactMatchesManifest(validationPath, validatedArtifact, manifest);
+  } finally {
+    await fs.unlink(validationPath).catch(() => undefined);
+    await fs.rmdir(validationDir).catch(() => undefined);
+  }
+  const afterOpen = await fs.lstat(artifactPath);
+  if (
+    afterOpen.isSymbolicLink() ||
+    !afterOpen.isFile() ||
+    afterOpen.nlink > 1 ||
+    !sameFileIdentity(expectedIdentity, afterOpen)
+  ) {
+    throw new Error(`Snapshot artifact changed during SQLite verification: ${artifactPath}`);
+  }
+  const verifiedArtifact = await hashSnapshotArtifact(path.dirname(artifactPath));
+  if (!sameFileIdentity(expectedIdentity, verifiedArtifact.stat)) {
+    throw new Error(`Snapshot artifact changed after SQLite verification: ${artifactPath}`);
+  }
+  assertArtifactMatchesManifest(artifactPath, verifiedArtifact, manifest);
+}
+
+function normalizeSnapshotIdentity(identity: SnapshotDatabaseIdentity): SnapshotDatabaseIdentity {
+  if (identity.role === "global") {
+    return identity;
+  }
+  if (identity.role === "agent") {
+    const agentId = normalizeAgentId(identity.agentId);
+    if (!isValidAgentId(identity.agentId) || agentId !== identity.agentId) {
+      throw new Error(`SQLite snapshot agent id must be canonical: ${identity.agentId}`);
+    }
+    return { role: "agent", agentId };
+  }
+  const id = identity.id.trim();
+  if (!id || id !== identity.id || id.length > 256 || containsAsciiControlCharacter(id)) {
+    throw new Error("SQLite snapshot generic database id is invalid.");
+  }
+  return { role: "generic", id };
+}
+
+function buildDatabaseManifest(
+  identity: SnapshotDatabaseIdentity,
+  sourcePath: string,
+  userVersion: number,
+): SnapshotDatabaseManifest {
+  const basename = path.basename(sourcePath);
+  if (identity.role === "global") {
+    return { role: "global", basename, userVersion };
+  }
+  if (identity.role === "agent") {
+    return { role: "agent", agentId: identity.agentId, basename, userVersion };
+  }
+  return { role: "generic", id: identity.id, basename, userVersion };
+}
+
+function buildDatabaseValidator(
+  identity: SnapshotDatabaseIdentity | SnapshotDatabaseManifest,
+): SqliteSnapshotValidator {
+  if (identity.role === "global") {
+    return (database, pathname) =>
+      assertOpenClawStateDatabaseForMaintenance(database, { pathname });
+  }
+  if (identity.role === "agent") {
+    return (database, pathname) =>
+      assertOpenClawAgentDatabaseForMaintenance(database, {
+        agentId: identity.agentId,
+        pathname,
+      });
+  }
+  return () => undefined;
+}
+
+function buildManifestDatabaseValidator(
+  manifest: SnapshotDatabaseManifest,
+): SqliteSnapshotValidator {
+  const validateOwner = buildDatabaseValidator(manifest);
+  return (database, pathname) => {
+    validateOwner(database, pathname);
+    const userVersion = readSqliteUserVersion(database);
+    if (userVersion !== manifest.userVersion) {
+      throw new Error(
+        `Snapshot database user_version mismatch for ${pathname}: expected ${manifest.userVersion}, got ${userVersion}`,
+      );
+    }
+  };
+}
+
+function sanitizeGlobalStateSnapshot(database: DatabaseSync): void {
+  database.prepare("DELETE FROM delivery_queue_entries").run();
+}
+
+function buildSnapshotId(now: Date, sourcePath: string): string {
+  const timestamp = now.toISOString().replaceAll(/[:.]/g, "-");
+  const basename =
+    path
+      .basename(sourcePath)
+      .replaceAll(/[^a-zA-Z0-9._-]/g, "-")
+      .slice(0, SNAPSHOT_ID_BASENAME_MAX_LENGTH) || "database.sqlite";
+  return `${timestamp}-${basename}-${randomUUID()}`;
+}
+
+async function ensurePrivateDirectory(directoryPath: string, scopeLabel: string): Promise<void> {
+  const result = await ensureAbsoluteDirectory(directoryPath, {
+    mode: SNAPSHOT_DIRECTORY_MODE,
+    scopeLabel,
+  });
+  if (!result.ok) {
+    throw result.error;
+  }
+  applyPrivateModeSync(result.path, SNAPSHOT_DIRECTORY_MODE);
+}
+
+async function ensureRestoreParentDirectory(directoryPath: string): Promise<void> {
+  const result = await ensureAbsoluteDirectory(directoryPath, {
+    mode: SNAPSHOT_DIRECTORY_MODE,
+    scopeLabel: "SQLite restore target",
+  });
+  if (!result.ok) {
+    throw result.error;
+  }
+}
+
+function assertDirectory(stat: Stats, pathname: string, label: string): void {
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new Error(`${label} must be a real directory: ${pathname}`);
+  }
+}
+
+async function assertDirectoryIdentity(
+  directoryPath: string,
+  expectedIdentity: Stats,
+): Promise<void> {
+  const currentIdentity = await fs.lstat(directoryPath);
+  assertDirectory(currentIdentity, directoryPath, "SQLite restore target directory");
+  if (!sameFileIdentity(currentIdentity, expectedIdentity)) {
+    throw new Error(`SQLite restore target directory changed during restore: ${directoryPath}`);
+  }
+}
+
+async function assertOpenDirectoryIdentity(
+  handle: FileHandle,
+  directoryPath: string,
+  expectedIdentity: Stats,
+): Promise<void> {
+  const openedIdentity = await handle.stat();
+  const currentIdentity = await fs.lstat(directoryPath);
+  assertDirectory(openedIdentity, directoryPath, "SQLite snapshot directory");
+  assertDirectory(currentIdentity, directoryPath, "SQLite snapshot directory");
+  if (
+    !sameFileIdentity(openedIdentity, expectedIdentity) ||
+    !sameFileIdentity(currentIdentity, expectedIdentity)
+  ) {
+    throw new Error(`SQLite snapshot directory changed during publication: ${directoryPath}`);
+  }
+}
+
+function assertDirectoryIdentitySync(directoryPath: string, expectedIdentity: Stats): void {
+  const currentIdentity = fsSync.lstatSync(directoryPath);
+  assertDirectory(currentIdentity, directoryPath, "SQLite restore target directory");
+  if (!sameFileIdentity(currentIdentity, expectedIdentity)) {
+    throw new Error(`SQLite restore target directory changed during restore: ${directoryPath}`);
+  }
+}
+
+function isSnapshotEntryLinkFallbackError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return (
+    code === "EPERM" ||
+    code === "EXDEV" ||
+    code === "ENOTSUP" ||
+    code === "EOPNOTSUPP" ||
+    code === "ENOSYS"
+  );
+}
+
+async function publishSnapshotEntryNoOverwrite(
+  sourcePath: string,
+  targetPath: string,
+  entryName: string,
+  publishedEntries: Map<string, Stats>,
+): Promise<void> {
+  let linked = false;
+  let linkedSourceIdentity: Stats | undefined;
+  try {
+    linkedSourceIdentity = await fs.lstat(sourcePath);
+    await fs.link(sourcePath, targetPath);
+    publishedEntries.set(entryName, linkedSourceIdentity);
+    linked = true;
+  } catch (error) {
+    if (!isSnapshotEntryLinkFallbackError(error)) {
+      throw error;
+    }
+    const copiedIdentity = await copySnapshotEntryExclusive(sourcePath, targetPath);
+    publishedEntries.set(entryName, copiedIdentity);
+  }
+  const expectedTargetIdentity = publishedEntries.get(entryName);
+  const initialTargetIdentity = await fs.lstat(targetPath);
+  if (!expectedTargetIdentity || !sameFileIdentity(expectedTargetIdentity, initialTargetIdentity)) {
+    throw new Error(`SQLite snapshot entry changed during publication: ${targetPath}`);
+  }
+  if (linked) {
+    if (!linkedSourceIdentity || !sameFileIdentity(linkedSourceIdentity, initialTargetIdentity)) {
+      throw new Error(`SQLite snapshot entry changed during publication: ${targetPath}`);
+    }
+    const sourceIdentity = await fs.lstat(sourcePath);
+    if (!sameFileIdentity(sourceIdentity, initialTargetIdentity)) {
+      throw new Error(`SQLite snapshot entry changed during publication: ${targetPath}`);
+    }
+  }
+  await fs.unlink(sourcePath);
+  const finalTargetIdentity = await fs.lstat(targetPath);
+  if (!sameFileIdentity(initialTargetIdentity, finalTargetIdentity)) {
+    throw new Error(`SQLite snapshot entry changed after publication: ${targetPath}`);
+  }
+  publishedEntries.set(entryName, finalTargetIdentity);
+}
+
+async function copySnapshotEntryExclusive(sourcePath: string, targetPath: string): Promise<Stats> {
+  const source = await fs.open(sourcePath, "r");
+  let target: FileHandle | undefined;
+  let targetIdentity: Stats | undefined;
+  try {
+    target = await fs.open(targetPath, "wx+", SNAPSHOT_FILE_MODE);
+    targetIdentity = await target.stat();
+    const buffer = Buffer.allocUnsafe(1024 * 1024);
+    let offset = 0;
+    while (true) {
+      const { bytesRead } = await source.read(buffer, 0, buffer.length, offset);
+      if (bytesRead === 0) {
+        break;
+      }
+      let bytesWritten = 0;
+      while (bytesWritten < bytesRead) {
+        const result = await target.write(
+          buffer,
+          bytesWritten,
+          bytesRead - bytesWritten,
+          offset + bytesWritten,
+        );
+        if (result.bytesWritten === 0) {
+          throw new Error(`SQLite snapshot entry copy made no progress: ${targetPath}`);
+        }
+        bytesWritten += result.bytesWritten;
+      }
+      offset += bytesRead;
+    }
+    await target.sync();
+    const finalIdentity = await target.stat();
+    const currentIdentity = await fs.lstat(targetPath);
+    if (
+      !sameFileIdentity(targetIdentity, finalIdentity) ||
+      !sameFileIdentity(targetIdentity, currentIdentity)
+    ) {
+      throw new Error(`SQLite snapshot entry changed during copy: ${targetPath}`);
+    }
+    return finalIdentity;
+  } catch (error) {
+    if (targetIdentity) {
+      const currentIdentity = await fs.lstat(targetPath).catch(() => undefined);
+      if (currentIdentity && sameFileIdentity(currentIdentity, targetIdentity)) {
+        await fs.unlink(targetPath).catch(() => undefined);
+      }
+    }
+    throw error;
+  } finally {
+    await target?.close().catch(() => undefined);
+    await source.close().catch(() => undefined);
+  }
+}
+
+async function assertExactSnapshotContents(snapshotDir: string): Promise<void> {
+  await assertSnapshotContents(
+    snapshotDir,
+    new Set([SNAPSHOT_MANIFEST_FILENAME, SNAPSHOT_SQLITE_FILENAME]),
+  );
+}
+
+async function assertPendingSnapshotContents(snapshotDir: string): Promise<void> {
+  await assertSnapshotContents(
+    snapshotDir,
+    new Set([SNAPSHOT_MANIFEST_FILENAME, SNAPSHOT_PENDING_FILENAME, SNAPSHOT_SQLITE_FILENAME]),
+  );
+}
+
+async function assertSnapshotContents(snapshotDir: string, expected: Set<string>): Promise<void> {
+  const entries = await fs.readdir(snapshotDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!expected.delete(entry.name)) {
+      throw new Error(
+        `SQLite snapshot contains unexpected entry: ${path.join(snapshotDir, entry.name)}`,
+      );
+    }
+    if (entry.isSymbolicLink() || !entry.isFile()) {
+      throw new Error(
+        `SQLite snapshot entry must be a regular file: ${path.join(snapshotDir, entry.name)}`,
+      );
+    }
+    const stat = await fs.lstat(path.join(snapshotDir, entry.name));
+    if (stat.nlink > 1) {
+      throw new Error(
+        `SQLite snapshot entry must not be hardlinked: ${path.join(snapshotDir, entry.name)}`,
+      );
+    }
+  }
+  if (expected.size > 0) {
+    throw new Error(`SQLite snapshot is missing ${[...expected].join(", ")}: ${snapshotDir}`);
+  }
+}
+
+async function isIncompleteSnapshotDirectory(snapshotDir: string): Promise<boolean> {
+  const entries = await fs.readdir(snapshotDir, { withFileTypes: true });
+  const names = new Set(entries.map((entry) => entry.name));
+  if (names.has(SNAPSHOT_PENDING_FILENAME)) {
+    return true;
+  }
+  if (names.has(SNAPSHOT_MANIFEST_FILENAME)) {
+    return false;
+  }
+  return entries.length === 0;
+}
+
+async function assertFreshRestorePathsAbsent(databasePath: string): Promise<void> {
+  for (const candidate of [
+    databasePath,
+    ...SQLITE_SIDECAR_SUFFIXES.map((suffix) => `${databasePath}${suffix}`),
+  ]) {
+    if (await lstatIfExists(candidate)) {
+      throw new Error(`Fresh SQLite restore path already exists: ${candidate}`);
+    }
+  }
+}
+
+function assertNoSqliteSidecarsSync(databasePath: string): void {
+  for (const suffix of SQLITE_SIDECAR_SUFFIXES) {
+    const sidecarPath = `${databasePath}${suffix}`;
+    try {
+      fsSync.lstatSync(sidecarPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+    throw new Error(`Restored SQLite database has unexpected sidecar: ${sidecarPath}`);
+  }
+}
+
+async function lstatIfExists(pathname: string): Promise<Stats | undefined> {
+  try {
+    return await fs.lstat(pathname);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function removePrivateDirectoryIfOwned(
+  directoryPath: string,
+  expectedIdentity: Stats,
+  allowedEntries: ReadonlySet<string>,
+): Promise<boolean> {
+  const currentIdentity = await lstatIfExists(directoryPath);
+  if (!currentIdentity) {
+    return false;
+  }
+  if (
+    currentIdentity.isSymbolicLink() ||
+    !currentIdentity.isDirectory() ||
+    !sameFileIdentity(currentIdentity, expectedIdentity)
+  ) {
+    throw new Error(`Private SQLite staging directory changed before cleanup: ${directoryPath}`);
+  }
+  const entries = await fs.readdir(directoryPath, { withFileTypes: true });
+  const verifiedPaths: string[] = [];
+  for (const entry of entries) {
+    const entryPath = path.join(directoryPath, entry.name);
+    if (!allowedEntries.has(entry.name) || entry.isSymbolicLink() || !entry.isFile()) {
+      throw new Error(`Private SQLite staging directory has unexpected entry: ${entryPath}`);
+    }
+    const stat = await fs.lstat(entryPath);
+    if (stat.nlink > 1) {
+      throw new Error(`Private SQLite staging file must not be hardlinked: ${entryPath}`);
+    }
+    verifiedPaths.push(entryPath);
+  }
+  await Promise.all(verifiedPaths.map(async (entryPath) => await fs.unlink(entryPath)));
+  await fs.rmdir(directoryPath);
+  return true;
+}
+
+async function removePublishedSnapshotDirectoryIfOwned(
+  directoryPath: string,
+  expectedIdentity: Stats,
+  publishedEntries: ReadonlyMap<string, Stats>,
+): Promise<boolean> {
+  const currentIdentity = await lstatIfExists(directoryPath);
+  if (
+    !currentIdentity ||
+    currentIdentity.isSymbolicLink() ||
+    !currentIdentity.isDirectory() ||
+    !sameFileIdentity(currentIdentity, expectedIdentity)
+  ) {
+    return false;
+  }
+  const entries = await fs.readdir(directoryPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const expectedEntryIdentity = publishedEntries.get(entry.name);
+    if (!expectedEntryIdentity || entry.isSymbolicLink() || !entry.isFile()) {
+      continue;
+    }
+    const entryPath = path.join(directoryPath, entry.name);
+    const currentEntryIdentity = await fs.lstat(entryPath);
+    if (sameFileIdentity(currentEntryIdentity, expectedEntryIdentity)) {
+      await fs.unlink(entryPath);
+    }
+  }
+  if ((await fs.readdir(directoryPath)).length > 0) {
+    return false;
+  }
+  await fs.rmdir(directoryPath);
+  return true;
+}

--- a/src/snapshot/manifest.ts
+++ b/src/snapshot/manifest.ts
@@ -1,0 +1,316 @@
+import { createHash } from "node:crypto";
+import type { BigIntStats, Stats } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { sameFileIdentity } from "../infra/fs-safe-advanced.js";
+import { root } from "../infra/fs-safe.js";
+import { isValidAgentId, normalizeAgentId } from "../routing/session-key.js";
+import {
+  SNAPSHOT_MANIFEST_FILENAME,
+  SNAPSHOT_SQLITE_FILENAME,
+  type SnapshotDatabaseManifest,
+  type SnapshotManifest,
+} from "./snapshot-provider.js";
+
+const MAX_MANIFEST_BYTES = 1024 * 1024;
+const MAX_SQLITE_USER_VERSION = 2_147_483_647;
+const MIN_SQLITE_USER_VERSION = -2_147_483_648;
+const SNAPSHOT_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,254}$/;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+
+export type SnapshotArtifactDigest = {
+  sha256: string;
+  sizeBytes: number;
+  stat: Stats;
+};
+
+type OpenFileHandle = Awaited<ReturnType<typeof fs.open>>;
+
+export function containsAsciiControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export async function hashSnapshotArtifact(snapshotDir: string): Promise<SnapshotArtifactDigest> {
+  const snapshotRoot = await root(snapshotDir);
+  const opened = await snapshotRoot.open(SNAPSHOT_SQLITE_FILENAME, {
+    hardlinks: "reject",
+    symlinks: "reject",
+  });
+  try {
+    return { ...(await hashFileHandle(opened.handle)), stat: opened.stat };
+  } finally {
+    await opened.handle.close();
+  }
+}
+
+export async function copySnapshotArtifact(
+  snapshotDir: string,
+  targetPath: string,
+): Promise<SnapshotArtifactDigest> {
+  const snapshotRoot = await root(snapshotDir);
+  const source = await snapshotRoot.open(SNAPSHOT_SQLITE_FILENAME, {
+    hardlinks: "reject",
+    symlinks: "reject",
+  });
+  let target: OpenFileHandle | undefined;
+  let targetIdentity: Stats | undefined;
+  try {
+    target = await fs.open(targetPath, "wx+", 0o600);
+    targetIdentity = await target.stat();
+    const digest = await hashFileHandle(source.handle, target);
+    await target.sync();
+    const finalIdentity = await target.stat();
+    const currentIdentity = await fs.lstat(targetPath);
+    if (
+      !sameFileIdentity(targetIdentity, finalIdentity) ||
+      !sameFileIdentity(targetIdentity, currentIdentity)
+    ) {
+      throw new Error(`Snapshot restore staging file changed during copy: ${targetPath}`);
+    }
+    return { ...digest, stat: finalIdentity };
+  } catch (error) {
+    await target?.close().catch(() => undefined);
+    target = undefined;
+    if (targetIdentity) {
+      const currentIdentity = await fs.lstat(targetPath).catch(() => undefined);
+      if (currentIdentity && sameFileIdentity(targetIdentity, currentIdentity)) {
+        await fs.unlink(targetPath).catch(() => undefined);
+      }
+    }
+    throw error;
+  } finally {
+    await target?.close().catch(() => undefined);
+    await source.handle.close().catch(() => undefined);
+  }
+}
+
+async function hashFileHandle(
+  source: OpenFileHandle,
+  target?: OpenFileHandle,
+): Promise<Omit<SnapshotArtifactDigest, "stat">> {
+  const initialStat = await source.stat({ bigint: true });
+  const hash = createHash("sha256");
+  const buffer = Buffer.allocUnsafe(1024 * 1024);
+  let sizeBytes = 0;
+  while (true) {
+    const { bytesRead } = await source.read(buffer, 0, buffer.length, sizeBytes);
+    if (bytesRead === 0) {
+      break;
+    }
+    hash.update(buffer.subarray(0, bytesRead));
+    let bytesWritten = 0;
+    if (target) {
+      while (bytesWritten < bytesRead) {
+        const result = await target.write(
+          buffer,
+          bytesWritten,
+          bytesRead - bytesWritten,
+          sizeBytes + bytesWritten,
+        );
+        if (result.bytesWritten === 0) {
+          throw new Error("Snapshot restore staging copy made no progress.");
+        }
+        bytesWritten += result.bytesWritten;
+      }
+    }
+    sizeBytes += bytesRead;
+  }
+  const finalStat = await source.stat({ bigint: true });
+  if (!sameMutationFingerprint(initialStat, finalStat)) {
+    throw new Error("Snapshot artifact changed while being read.");
+  }
+  return { sha256: hash.digest("hex"), sizeBytes };
+}
+
+function sameMutationFingerprint(left: BigIntStats, right: BigIntStats): boolean {
+  return (
+    left.birthtimeNs === right.birthtimeNs &&
+    left.ctimeNs === right.ctimeNs &&
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mtimeNs === right.mtimeNs &&
+    left.size === right.size
+  );
+}
+
+export async function writeSnapshotManifest(
+  snapshotDir: string,
+  manifest: SnapshotManifest,
+): Promise<void> {
+  const manifestPath = path.join(snapshotDir, SNAPSHOT_MANIFEST_FILENAME);
+  const handle = await fs.open(manifestPath, "wx+", 0o600);
+  try {
+    await handle.writeFile(`${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function readSnapshotManifest(
+  snapshotDir: string,
+  expectedSnapshotId = path.basename(snapshotDir),
+): Promise<SnapshotManifest> {
+  const snapshotRoot = await root(snapshotDir);
+  const manifestPath = path.join(snapshotDir, SNAPSHOT_MANIFEST_FILENAME);
+  const result = await snapshotRoot.read(SNAPSHOT_MANIFEST_FILENAME, {
+    hardlinks: "reject",
+    maxBytes: MAX_MANIFEST_BYTES,
+    symlinks: "reject",
+  });
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result.buffer.toString("utf8")) as unknown;
+  } catch (error) {
+    throw new Error(`Snapshot manifest is not valid JSON: ${manifestPath}`, { cause: error });
+  }
+  return parseSnapshotManifest(parsed, manifestPath, expectedSnapshotId);
+}
+
+export function parseSnapshotManifest(
+  value: unknown,
+  manifestPath: string,
+  expectedSnapshotId: string,
+): SnapshotManifest {
+  const record = requireRecord(value, "manifest", manifestPath);
+  requireExactKeys(record, ["schemaVersion", "snapshotId", "createdAt", "database", "artifact"]);
+  if (record.schemaVersion !== 1) {
+    throw new Error(
+      `Unsupported snapshot manifest schemaVersion ${String(record.schemaVersion)}: ${manifestPath}`,
+    );
+  }
+  const snapshotId = requireSnapshotId(record.snapshotId, manifestPath);
+  if (snapshotId !== expectedSnapshotId) {
+    throw new Error(
+      `Snapshot manifest id ${snapshotId} does not match directory ${expectedSnapshotId}: ${manifestPath}`,
+    );
+  }
+  const createdAt = requireCanonicalTimestamp(record.createdAt, manifestPath);
+  const database = parseSnapshotDatabase(record.database, manifestPath);
+  const artifactRecord = requireRecord(record.artifact, "artifact", manifestPath);
+  requireExactKeys(artifactRecord, ["path", "sha256", "sizeBytes"]);
+  if (artifactRecord.path !== SNAPSHOT_SQLITE_FILENAME) {
+    throw new Error(
+      `Snapshot manifest artifact.path must be ${SNAPSHOT_SQLITE_FILENAME}: ${manifestPath}`,
+    );
+  }
+  if (typeof artifactRecord.sha256 !== "string" || !SHA256_PATTERN.test(artifactRecord.sha256)) {
+    throw new Error(`Snapshot manifest artifact.sha256 is invalid: ${manifestPath}`);
+  }
+  if (!Number.isSafeInteger(artifactRecord.sizeBytes) || Number(artifactRecord.sizeBytes) <= 0) {
+    throw new Error(`Snapshot manifest artifact.sizeBytes is invalid: ${manifestPath}`);
+  }
+  return {
+    schemaVersion: 1,
+    snapshotId,
+    createdAt,
+    database,
+    artifact: {
+      path: SNAPSHOT_SQLITE_FILENAME,
+      sha256: artifactRecord.sha256,
+      sizeBytes: Number(artifactRecord.sizeBytes),
+    },
+  };
+}
+
+function parseSnapshotDatabase(value: unknown, manifestPath: string): SnapshotDatabaseManifest {
+  const database = requireRecord(value, "database", manifestPath);
+  const role = database.role;
+  const basename = requireSafeText(database.basename, "database.basename", manifestPath, 255);
+  if (path.basename(basename) !== basename || basename === "." || basename === "..") {
+    throw new Error(`Snapshot manifest database.basename is invalid: ${manifestPath}`);
+  }
+  const userVersion = requireSqliteUserVersion(database.userVersion, manifestPath);
+  if (role === "global") {
+    requireExactKeys(database, ["role", "basename", "userVersion"]);
+    return { role, basename, userVersion };
+  }
+  if (role === "agent") {
+    requireExactKeys(database, ["role", "agentId", "basename", "userVersion"]);
+    const agentId = requireSafeText(database.agentId, "database.agentId", manifestPath, 64);
+    if (!isValidAgentId(agentId) || normalizeAgentId(agentId) !== agentId) {
+      throw new Error(`Snapshot manifest database.agentId is invalid: ${manifestPath}`);
+    }
+    return { role, agentId, basename, userVersion };
+  }
+  if (role === "generic") {
+    requireExactKeys(database, ["role", "id", "basename", "userVersion"]);
+    const id = requireSafeText(database.id, "database.id", manifestPath, 256);
+    return { role, id, basename, userVersion };
+  }
+  throw new Error(`Snapshot manifest database.role is invalid: ${manifestPath}`);
+}
+
+function requireRecord(
+  value: unknown,
+  field: string,
+  manifestPath: string,
+): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Snapshot manifest ${field} must be an object: ${manifestPath}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireExactKeys(record: Record<string, unknown>, expectedKeys: readonly string[]): void {
+  const actual = Object.keys(record).toSorted();
+  const expected = [...expectedKeys].toSorted();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new Error(
+      `Snapshot manifest fields must be exactly ${expectedKeys.join(", ")}; got ${actual.join(", ")}`,
+    );
+  }
+}
+
+function requireSnapshotId(value: unknown, manifestPath: string): string {
+  if (typeof value !== "string" || !SNAPSHOT_ID_PATTERN.test(value)) {
+    throw new Error(`Snapshot manifest snapshotId is invalid: ${manifestPath}`);
+  }
+  return value;
+}
+
+function requireCanonicalTimestamp(value: unknown, manifestPath: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`Snapshot manifest createdAt is invalid: ${manifestPath}`);
+  }
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.getTime()) || parsed.toISOString() !== value) {
+    throw new Error(`Snapshot manifest createdAt is not canonical ISO 8601: ${manifestPath}`);
+  }
+  return value;
+}
+
+function requireSafeText(
+  value: unknown,
+  field: string,
+  manifestPath: string,
+  maxLength: number,
+): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maxLength ||
+    value.trim() !== value ||
+    containsAsciiControlCharacter(value)
+  ) {
+    throw new Error(`Snapshot manifest ${field} is invalid: ${manifestPath}`);
+  }
+  return value;
+}
+
+function requireSqliteUserVersion(value: unknown, manifestPath: string): number {
+  if (
+    !Number.isSafeInteger(value) ||
+    Number(value) < MIN_SQLITE_USER_VERSION ||
+    Number(value) > MAX_SQLITE_USER_VERSION
+  ) {
+    throw new Error(`Snapshot manifest database.userVersion is invalid: ${manifestPath}`);
+  }
+  return Number(value);
+}

--- a/src/snapshot/snapshot-provider.ts
+++ b/src/snapshot/snapshot-provider.ts
@@ -1,0 +1,66 @@
+export const SNAPSHOT_MANIFEST_FILENAME = "manifest.json";
+export const SNAPSHOT_SQLITE_FILENAME = "database.sqlite";
+
+export type SnapshotDatabaseIdentity =
+  | { readonly role: "global" }
+  | { readonly role: "agent"; readonly agentId: string }
+  | { readonly role: "generic"; readonly id: string };
+
+export type SnapshotDatabaseRef = {
+  readonly path: string;
+  readonly identity: SnapshotDatabaseIdentity;
+};
+
+export type SnapshotDatabaseManifest =
+  | {
+      readonly role: "global";
+      readonly basename: string;
+      readonly userVersion: number;
+    }
+  | {
+      readonly role: "agent";
+      readonly agentId: string;
+      readonly basename: string;
+      readonly userVersion: number;
+    }
+  | {
+      readonly role: "generic";
+      readonly id: string;
+      readonly basename: string;
+      readonly userVersion: number;
+    };
+
+export type SnapshotManifest = {
+  readonly schemaVersion: 1;
+  readonly snapshotId: string;
+  readonly createdAt: string;
+  readonly database: SnapshotDatabaseManifest;
+  readonly artifact: {
+    readonly path: typeof SNAPSHOT_SQLITE_FILENAME;
+    readonly sha256: string;
+    readonly sizeBytes: number;
+  };
+};
+
+export type SnapshotRef = {
+  readonly path: string;
+};
+
+export type SnapshotResult = {
+  readonly ref: SnapshotRef;
+  readonly manifest: SnapshotManifest;
+};
+
+export type SnapshotVerificationResult = {
+  readonly ok: true;
+  readonly manifest: SnapshotManifest;
+};
+
+export type SnapshotSummary = SnapshotResult;
+
+export type SqliteSnapshotProvider = {
+  create(database: SnapshotDatabaseRef): Promise<SnapshotResult>;
+  list(): Promise<SnapshotSummary[]>;
+  restoreFresh(snapshot: SnapshotRef, targetPath: string): Promise<SnapshotVerificationResult>;
+  verify(snapshot: SnapshotRef): Promise<SnapshotVerificationResult>;
+};


### PR DESCRIPTION
Related: #94805

## What Problem This Solves

OpenClaw's SQLite state had no reusable snapshot repository that could prove a snapshot is structurally valid, belongs to the expected database owner, captures committed WAL state, and can be restored without overwriting or mixing with existing database files.

## Why This Change Was Made

This adds a local SQLite snapshot provider with strict versioned manifests, verified `VACUUM INTO` artifacts, owner/schema/user-version checks, unsafe-index and foreign-key validation, transient global delivery-row sanitization, private file modes, and fresh-only restore. Publication is exclusive and race-aware: incomplete snapshots remain hidden, committed entries are revalidated, and cleanup removes only files created by the current operation.

PR #94805 supplied the original direction. Its branch is conflicted and cannot be edited by maintainers, so this direct implementation carries Gio Della-Libera's co-author credit while adding the stricter manifest, ownership, restore-boundary, and publication guarantees needed for landing.

## User Impact

This is an internal reliability foundation with no new CLI surface yet. Follow-up work can expose snapshot/list/verify/restore operations without inventing a second storage or validation path.

## Evidence

- `49/49` focused snapshot and repository tests passed on Blacksmith Testbox-through-Crabbox `tbx_01kxbjfbvh388qb65wgkzjfm81` (`harbor-hermit`), Actions run `29200160000`.
- Exact-path `check:changed` passed on the same lease: core and core-test typechecks, targeted lint, database-first storage guard, package/format guards, import cycles, and auth/webhook guards.
- Clean `origin/main` at `46848ee4f6` independently reproduced the pre-existing Plugin SDK API baseline drift. The disposable Testbox regenerated that unrelated baseline before the branch changed gate; this PR does not touch Plugin SDK exports or generated baseline files.
- Fresh structured autoreview completed with no accepted or actionable findings after the final code changes.
