### PR TITLE
refactor(memory): remove unused size classifier

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -6,7 +6,6 @@ import {
   isRetryableMemoryEmbeddingTransportError,
   isRetryableMemoryEmbeddingError,
   isSplittableMemoryEmbeddingTransportError,
-  isStructuredInputTooLargeMemoryEmbeddingError,
   resolveMemoryEmbeddingRetryDelay,
   runMemoryEmbeddingBatchRetryWithSplit,
   runMemoryEmbeddingRetryLoop,
@@ -269,16 +268,6 @@ describe("memory embedding policy", () => {
       }),
     ).rejects.toThrow("ECONNREFUSED");
     expect(run).toHaveBeenCalledTimes(2);
-  });
-
-  it("classifies oversized structured-input errors", () => {
-    expect(isStructuredInputTooLargeMemoryEmbeddingError("payload too large")).toBe(true);
-    expect(
-      isStructuredInputTooLargeMemoryEmbeddingError(
-        "gemini embeddings failed: request size exceeded input limit",
-      ),
-    ).toBe(true);
-    expect(isStructuredInputTooLargeMemoryEmbeddingError("connection reset by peer")).toBe(false);
   });
 
   it("caps retry jittered delays", () => {

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -105,12 +105,6 @@ export function isRetryableMemoryEmbeddingError(message: string): boolean {
   );
 }
 
-export function isStructuredInputTooLargeMemoryEmbeddingError(message: string): boolean {
-  return /(413|payload too large|request too large|input too large|too many tokens|input limit|request size)/i.test(
-    message,
-  );
-}
-
 export function resolveMemoryEmbeddingRetryDelay(
   delayMs: number,
   randomValue: number,


### PR DESCRIPTION
## What Problem This Solves

Memory Core exported a structured-input size classifier that no production path, plugin barrel, or package entrypoint uses. Its only consumer was a dedicated unit test for the dead helper itself.

## Why This Change Was Made

Remove the unused classifier and its self-referential test. The live embedding operations continue to use the retained retry and split classifiers, leaving one smaller policy surface without inventing a compatibility contract for private code.

## User Impact

No user-visible behavior changes. This removes 17 lines of unreachable implementation and test code.

## Evidence

- Exhaustive repository search found no production caller; codebase-memory trace returned `callers: []`.
- Refreshed graph returns zero results for `isStructuredInputTooLargeMemoryEmbeddingError` and dropped one node.
- Full, delta, and final live open-PR overlap checks returned zero matches for both touched files.
- Testbox `tbx_01kxbhn5xbgsay0ptvhmdpq912`: focused policy suite passed 14/14 before and 13/13 after deletion.
- `pnpm check:changed` passed all reached relevant lanes and stopped only on the repository's unrelated Plugin SDK baseline hash drift.
- Fresh autoreview: `gpt-5.6-sol`, medium reasoning, no actionable findings, 0.93 confidence.
- `git diff --check` passed.
