### PR TITLE
fix(secrets): avoid redundant toString round-trip in exec provider output tracking

### DIFF
--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -541,8 +541,9 @@ async function runExecResolver(params: {
     };
 
     const append = (chunk: Buffer | string, target: "stdout" | "stderr") => {
+      outputBytes +=
+        typeof chunk === "string" ? Buffer.byteLength(chunk, "utf8") : chunk.byteLength;
       const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
-      outputBytes += Buffer.byteLength(text, "utf8");
       if (outputBytes > params.maxOutputBytes) {
         forceKillChildProcessTree(child);
         if (!settled) {


### PR DESCRIPTION
## What Problem This Solves

In `runExecResolver`, the `append()` callback measures output byte count by first converting every chunk to a UTF-8 string (`toString("utf8")`) and then measuring the string's byte length (`Buffer.byteLength(text, "utf8")`). This is a decode-then-re-encode round-trip that is both wasteful and marginally less precise:

1. **Wasteful**: For Buffer chunks (always the case with Node.js stream data events), `chunk.byteLength` already holds the raw byte count — no conversion needed.
2. **Less precise**: `toString("utf8")` replaces incomplete multi-byte sequences at chunk boundaries with U+FFFD (3 bytes), causing the tracked `outputBytes` to drift slightly from actual pipe consumption.

## Why This Change Was Made

Move `outputBytes` tracking before the `toString()` conversion and measure directly from the chunk. This avoids an unnecessary string allocation per data event and tracks the byte count that `maxOutputBytes` is meant to limit — the raw bytes consumed from the pipe.

## User Impact

No user-visible behavior change. The exec provider output limit (`maxOutputBytes`, default 1 MB) is enforced identically. The only difference is that `outputBytes` now reflects raw pipe bytes instead of a decode-re-encode round-trip value.

## Evidence

- The `append` callback is called from `child.stdout.on("data", ...)` and `child.stderr.on("data", ...)`. Node.js stream data events deliver `Buffer` instances unless `setEncoding()` was called — which it is not in this code path.
- Existing test at `src/secrets/resolve.test.ts:753` ("runExecResolver stream error handling") covers the exec provider output path and passes unchanged.