### PR TITLE
refactor(channels): remove unused bootstrap list

### DIFF
--- a/src/channels/plugins/bootstrap-registry.ts
+++ b/src/channels/plugins/bootstrap-registry.ts
@@ -4,8 +4,6 @@
  * Provides channel plugin metadata before the full runtime registry is installed.
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { listBundledChannelPluginIdsForRoot } from "./bundled-ids.js";
-import { resolveBundledChannelRootScope } from "./bundled-root.js";
 import {
   getBundledChannelPlugin,
   getBundledChannelSecrets,
@@ -64,14 +62,6 @@ function mergeBootstrapPlugin(
     actions: mergePluginSection(runtimePlugin.actions, setupPlugin.actions),
     secrets: mergePluginSection(runtimePlugin.secrets, setupPlugin.secrets),
   } as ChannelPlugin;
-}
-
-/**
- * Lists bundled channel ids visible to bootstrap for the current root scope.
- */
-export function listBootstrapChannelPluginIds(): readonly string[] {
-  const rootScope = resolveBundledChannelRootScope();
-  return listBundledChannelPluginIdsForRoot(rootScope.cacheKey);
 }
 
 /**

--- a/src/channels/plugins/bundled-root-caches.test.ts
+++ b/src/channels/plugins/bundled-root-caches.test.ts
@@ -51,7 +51,6 @@ afterEach(() => {
   vi.resetModules();
   vi.doUnmock("../../plugins/channel-catalog-registry.js");
   vi.doUnmock("./bundled.js");
-  vi.doUnmock("./bundled-ids.js");
 });
 
 describe("bundled root-aware plugin lookups", () => {
@@ -89,18 +88,6 @@ describe("bundled root-aware plugin lookups", () => {
   it("reads bootstrap plugins from the active bundled root without re-importing", async () => {
     const rootA = makeBundledRoot("openclaw-bootstrap-a-");
     const rootB = makeBundledRoot("openclaw-bootstrap-b-");
-
-    vi.doMock("./bundled-ids.js", () => ({
-      listBundledChannelPluginIdsForRoot: () => {
-        if (process.env.OPENCLAW_BUNDLED_PLUGINS_DIR === rootA.pluginsDir) {
-          return ["alpha"];
-        }
-        if (process.env.OPENCLAW_BUNDLED_PLUGINS_DIR === rootB.pluginsDir) {
-          return ["beta"];
-        }
-        return [];
-      },
-    }));
 
     vi.doMock("./bundled.js", () => ({
       getBundledChannelPlugin: (id: string) => ({
@@ -143,14 +130,12 @@ describe("bundled root-aware plugin lookups", () => {
     );
 
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = rootA.pluginsDir;
-    expect(bootstrapRegistry.listBootstrapChannelPluginIds()).toEqual(["alpha"]);
     expect(bootstrapRegistry.getBootstrapChannelPlugin("alpha")?.meta.label).toBe("setup-A");
     expect(
       bootstrapRegistry.getBootstrapChannelSecrets("alpha")?.secretTargetRegistryEntries?.[0]?.id,
     ).toBe("setup-alpha-A");
 
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = rootB.pluginsDir;
-    expect(bootstrapRegistry.listBootstrapChannelPluginIds()).toEqual(["beta"]);
     expect(bootstrapRegistry.getBootstrapChannelPlugin("beta")?.meta.label).toBe("setup-B");
     expect(
       bootstrapRegistry.getBootstrapChannelSecrets("beta")?.secretTargetRegistryEntries?.[0]?.id,
@@ -158,13 +143,6 @@ describe("bundled root-aware plugin lookups", () => {
   });
 
   it("retries bootstrap plugin loading after an error", async () => {
-    const root = makeBundledRoot("openclaw-bootstrap-plugin-throw-");
-
-    vi.doMock("./bundled-ids.js", () => ({
-      listBundledChannelPluginIdsForRoot: () =>
-        process.env.OPENCLAW_BUNDLED_PLUGINS_DIR === root.pluginsDir ? ["alpha"] : [],
-    }));
-
     const getBundledChannelPluginMock = vi.fn(() => {
       throw new Error("Cannot find module 'nostr-tools'");
     });
@@ -184,8 +162,6 @@ describe("bundled root-aware plugin lookups", () => {
       "./bootstrap-registry.js?scope=bootstrap-plugin-load-guard",
     );
 
-    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = root.pluginsDir;
-    expect(bootstrapRegistry.listBootstrapChannelPluginIds()).toEqual(["alpha"]);
     expect(bootstrapRegistry.getBootstrapChannelPlugin("alpha")).toBeUndefined();
     expect(bootstrapRegistry.getBootstrapChannelPlugin("alpha")).toBeUndefined();
     expect(bootstrapRegistry.getBootstrapChannelSecrets("alpha")).toBeUndefined();
@@ -194,13 +170,6 @@ describe("bundled root-aware plugin lookups", () => {
   });
 
   it("keeps plugin loading independent from bootstrap secrets loading errors", async () => {
-    const root = makeBundledRoot("openclaw-bootstrap-secrets-throw-");
-
-    vi.doMock("./bundled-ids.js", () => ({
-      listBundledChannelPluginIdsForRoot: () =>
-        process.env.OPENCLAW_BUNDLED_PLUGINS_DIR === root.pluginsDir ? ["alpha"] : [],
-    }));
-
     const getBundledChannelSecretsMock = vi.fn(() => {
       throw new Error("Cannot find module '@larksuiteoapi/node-sdk'");
     });
@@ -223,7 +192,6 @@ describe("bundled root-aware plugin lookups", () => {
       "./bootstrap-registry.js?scope=bootstrap-secrets-load-guard",
     );
 
-    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = root.pluginsDir;
     expect(bootstrapRegistry.getBootstrapChannelSecrets("alpha")).toBeUndefined();
     expect(bootstrapRegistry.getBootstrapChannelSecrets("alpha")).toBeUndefined();
     expect(bootstrapRegistry.getBootstrapChannelPlugin("alpha")).toEqual({


### PR DESCRIPTION
## What Problem This Solves

The channel bootstrap registry retained an ID-listing wrapper after its only production iterator was removed. The wrapper had zero callers; three test assertions and their mocks were the only remaining references.

## Why This Change Was Made

Remove the dead wrapper and only the test scaffolding specific to it. Bootstrap plugin loading, setup merging, secret loading, root switching, and failure isolation remain covered by the existing tests.

## User Impact

No user-visible behavior changes. This removes 42 lines of unreachable code and obsolete test setup.

## Evidence

- Codebase-memory trace returned `callers: []`; repository search found only the definition and three test assertions.
- History shows the wrapper's production iterator was removed in `7cc66b5175`.
- Refreshed graph returns zero results for `listBootstrapChannelPluginIds` and dropped one node.
- Full, delta, and final live open-PR overlap checks returned zero matches for both touched files.
- Testbox `tbx_01kxbhn5xbgsay0ptvhmdpq912`: focused channel suite passed 4/4 before and after deletion.
- `pnpm check:changed` passed all reached relevant lanes and stopped only on the repository's unrelated Plugin SDK baseline hash drift.
- Fresh autoreview: `gpt-5.6-sol`, medium reasoning, no actionable findings, 0.93 confidence.
- `git diff --check` passed.
