### PR TITLE
refactor(clawdock): remove unused color helper

### DIFF
--- a/scripts/clawdock/clawdock-helpers.sh
+++ b/scripts/clawdock/clawdock-helpers.sh
@@ -23,11 +23,6 @@ _CLR_MAGENTA='\033[0;35m'
 _CLR_CYAN='\033[0;36m'
 _CLR_RED='\033[0;31m'
 
-# Styled command output (green + bold)
-_clr_cmd() {
-  echo -e "${_CLR_GREEN}${_CLR_BOLD}$1${_CLR_RESET}"
-}
-
 # Inline command for use in sentences
 _cmd() {
   echo "${_CLR_GREEN}${_CLR_BOLD}$1${_CLR_RESET}"


### PR DESCRIPTION
## What Problem This Solves

The user-sourced ClawDock helper script defined `_clr_cmd`, but no command, test, doc, or package surface has ever called it. Sourcing the script carried a dead private function.

## Why This Change Was Made

Remove the unused helper and its comment. The active `_cmd` inline formatter and every user-facing ClawDock command remain unchanged.

## User Impact

No behavior change. The sourced helper script is five lines smaller.

## Evidence

- Exhaustive repository search found only the definition; codebase-memory trace returned `callers: []` and `callees: []`.
- History shows the helper has been unused since introduction.
- Refreshed graph returns zero results for `_clr_cmd` and dropped one node.
- Full, delta, and final live open-PR overlap checks returned zero matches for the file.
- Testbox `tbx_01kxbkxkbst0aj1amvnr0d7c66`: ClawDock helper suite passed 3 tests with 1 platform skip; `bash -n` passed.
- Testbox changed-file gate passed, including lint across 774 script files.
- Fresh autoreview: `gpt-5.6-sol`, medium reasoning, no actionable findings, 0.93 confidence.
- `git diff --check` passed.
