### PR TITLE
fix: agent turns ignore inactive web search SecretRefs

### DIFF
--- a/src/plugins/config-contracts.ts
+++ b/src/plugins/config-contracts.ts
@@ -4,7 +4,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { findBundledPluginMetadataById } from "./bundled-plugin-metadata.js";
 import { discoverOpenClawPlugins, type PluginDiscoveryResult } from "./discovery.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
-import type { PluginManifestConfigContracts } from "./manifest.js";
+import type { PluginManifestConfigContracts, PluginManifestContracts } from "./manifest.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
 import { loadPluginManifestRegistryForPluginRegistry } from "./plugin-registry.js";
 export { collectPluginConfigContractMatches } from "./config-contract-matches.js";
@@ -12,6 +12,8 @@ export { collectPluginConfigContractMatches } from "./config-contract-matches.js
 type PluginConfigContractMetadata = {
   /** Runtime origin that supplied the contract metadata. */
   origin: PluginOrigin;
+  /** Capability contracts that determine runtime ownership of config subtrees. */
+  contracts?: PluginManifestContracts;
   /** Manifest-declared config contract paths used by secret/security/config scanners. */
   configContracts: PluginManifestConfigContracts;
 };
@@ -36,6 +38,7 @@ export function resolvePluginConfigContractsById(params: {
     normalizeSortedUniqueStringEntries(params.fallbackBundledPluginIds),
   );
   const bundledContractFallbacks = new Map<string, PluginManifestConfigContracts | undefined>();
+  const bundledCapabilityContractFallbacks = new Map<string, PluginManifestContracts | undefined>();
   const findBundledConfigContracts = (
     pluginId: string,
   ): PluginManifestConfigContracts | undefined => {
@@ -57,6 +60,7 @@ export function resolvePluginConfigContractsById(params: {
     });
     for (const plugin of registry.plugins) {
       bundledContractFallbacks.set(plugin.id, plugin.configContracts);
+      bundledCapabilityContractFallbacks.set(plugin.id, plugin.contracts);
     }
     if (bundledContractFallbacks.get(pluginId) === undefined) {
       const bundledMetadata = findBundledPluginMetadataById(pluginId, {
@@ -66,11 +70,22 @@ export function resolvePluginConfigContractsById(params: {
       if (bundledMetadata?.manifest.configContracts) {
         bundledContractFallbacks.set(pluginId, bundledMetadata.manifest.configContracts);
       }
+      if (bundledMetadata?.manifest.contracts) {
+        bundledCapabilityContractFallbacks.set(pluginId, bundledMetadata.manifest.contracts);
+      }
     }
     if (!bundledContractFallbacks.has(pluginId)) {
       bundledContractFallbacks.set(pluginId, undefined);
     }
     return bundledContractFallbacks.get(pluginId);
+  };
+  const findBundledCapabilityContracts = (
+    pluginId: string,
+  ): PluginManifestContracts | undefined => {
+    if (!bundledCapabilityContractFallbacks.has(pluginId)) {
+      findBundledConfigContracts(pluginId);
+    }
+    return bundledCapabilityContractFallbacks.get(pluginId);
   };
 
   const resolvedPluginOrigins = new Map<string, PluginOrigin>();
@@ -90,6 +105,7 @@ export function resolvePluginConfigContractsById(params: {
     }
     matches.set(plugin.id, {
       origin: plugin.origin,
+      ...(plugin.contracts ? { contracts: plugin.contracts } : {}),
       configContracts: plugin.configContracts,
     });
   }
@@ -103,11 +119,15 @@ export function resolvePluginConfigContractsById(params: {
           fallbackBundledPluginIds.has(pluginId));
       if (shouldHydrateBundledMatch) {
         const bundledConfigContracts = findBundledConfigContracts(pluginId);
+        const bundledCapabilityContracts = findBundledCapabilityContracts(pluginId);
         if (bundledConfigContracts) {
           // Bundled metadata can carry richer contract declarations than installed registry entries;
           // installed declarations still win except for bundled secret input coverage.
           matches.set(pluginId, {
             origin: fallbackBundledPluginIds.has(pluginId) ? "bundled" : existing.origin,
+            ...(existing.contracts || bundledCapabilityContracts
+              ? { contracts: existing.contracts ?? bundledCapabilityContracts }
+              : {}),
             configContracts: {
               ...bundledConfigContracts,
               ...existing.configContracts,
@@ -131,11 +151,13 @@ export function resolvePluginConfigContractsById(params: {
         continue;
       }
       const bundledConfigContracts = findBundledConfigContracts(pluginId);
+      const bundledCapabilityContracts = findBundledCapabilityContracts(pluginId);
       if (!bundledConfigContracts) {
         continue;
       }
       matches.set(pluginId, {
         origin: "bundled",
+        ...(bundledCapabilityContracts ? { contracts: bundledCapabilityContracts } : {}),
         configContracts: bundledConfigContracts,
       });
     }

--- a/src/plugins/config-contracts.ts
+++ b/src/plugins/config-contracts.ts
@@ -12,7 +12,7 @@ export { collectPluginConfigContractMatches } from "./config-contract-matches.js
 type PluginConfigContractMetadata = {
   /** Runtime origin that supplied the contract metadata. */
   origin: PluginOrigin;
-  /** Capability contracts that determine runtime ownership of config subtrees. */
+  /** Capability contracts that determine runtime ownership of exact secret paths. */
   contracts?: PluginManifestContracts;
   /** Manifest-declared config contract paths used by secret/security/config scanners. */
   configContracts: PluginManifestConfigContracts;

--- a/src/secrets/runtime-config-collectors-plugins.test.ts
+++ b/src/secrets/runtime-config-collectors-plugins.test.ts
@@ -570,4 +570,54 @@ describe("collectPluginConfigAssignments", () => {
       "plugins.entries.other.config.service.tokens.secondary",
     ]);
   });
+
+  it("defers only the exact web-search credential path for active provider plugins", () => {
+    loadPluginManifestRegistryForPluginRegistryMock.mockReturnValue({
+      plugins: [
+        {
+          id: "custom-search",
+          origin: "config",
+          providers: [],
+          legacyPluginIds: [],
+          contracts: { webSearchProviders: ["custom"] },
+          configContracts: {
+            secretInputs: {
+              paths: [
+                { path: "webSearch.apiKey", expected: "string" },
+                { path: "webSearch.headers.authorization", expected: "string" },
+              ],
+            },
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+    const config = asConfig({
+      plugins: {
+        entries: {
+          "custom-search": {
+            enabled: true,
+            config: {
+              webSearch: {
+                apiKey: envRef("A"),
+                headers: { authorization: envRef("B") },
+              },
+            },
+          },
+        },
+      },
+    });
+    const context = makeContext(config);
+
+    collectPluginConfigAssignments({
+      config,
+      defaults: undefined,
+      context,
+      loadablePluginOrigins: loadablePluginOrigins([["custom-search", "config"]]),
+    });
+
+    expect(context.assignments.map((assignment) => assignment.path)).toEqual([
+      "plugins.entries.custom-search.config.webSearch.headers.authorization",
+    ]);
+  });
 });

--- a/src/secrets/runtime-config-collectors-plugins.ts
+++ b/src/secrets/runtime-config-collectors-plugins.ts
@@ -76,6 +76,7 @@ export function collectPluginConfigAssignments(params: {
           pluginId,
           {
             origin: metadata.origin,
+            contracts: metadata.contracts,
             bundledDefaultEnabled: secretInputs.bundledDefaultEnabled,
             paths: secretInputs.paths,
           },
@@ -123,6 +124,9 @@ export function collectPluginConfigAssignments(params: {
       pluginConfig,
       secretPaths: secretInputs.paths,
       active: enableState.enabled,
+      runtimeOwnedPathPrefixes: secretInputs.contracts?.webSearchProviders?.length
+        ? ["webSearch."]
+        : [],
       inactiveReason: enableState.reason ?? "plugin is disabled.",
       defaults: params.defaults,
       context: params.context,
@@ -135,12 +139,21 @@ function collectConfiguredPluginSecretAssignments(params: {
   pluginConfig: Record<string, unknown>;
   secretPaths: ReadonlyArray<{ path: string; expected?: "string" }>;
   active: boolean;
+  runtimeOwnedPathPrefixes?: readonly string[];
   inactiveReason: string;
   defaults: SecretDefaults | undefined;
   context: ResolverContext;
 }): void {
   const seenPaths = new Set<string>();
   for (const secretPath of params.secretPaths) {
+    if (
+      params.active &&
+      params.runtimeOwnedPathPrefixes?.some((prefix) => secretPath.path.startsWith(prefix))
+    ) {
+      // Web provider selection owns these credentials. Resolving them here would make an
+      // inactive or non-selected provider block the whole runtime snapshot.
+      continue;
+    }
     for (const match of collectPluginConfigContractMatches({
       root: params.pluginConfig,
       pathPattern: secretPath.path,

--- a/src/secrets/runtime-config-collectors-plugins.ts
+++ b/src/secrets/runtime-config-collectors-plugins.ts
@@ -15,6 +15,7 @@ import {
   type SecretDefaults,
 } from "./runtime-shared.js";
 import { isRecord } from "./shared.js";
+import { listWebProviderSecretConfigPaths } from "./web-provider-secret-configs.js";
 
 function parsePluginConfigArrayIndex(segment: string): number | undefined {
   return parseConfigPathArrayIndex(segment);
@@ -124,9 +125,10 @@ export function collectPluginConfigAssignments(params: {
       pluginConfig,
       secretPaths: secretInputs.paths,
       active: enableState.enabled,
-      runtimeOwnedPathPrefixes: secretInputs.contracts?.webSearchProviders?.length
-        ? ["webSearch."]
-        : [],
+      runtimeOwnedPaths: listWebProviderSecretConfigPaths({
+        contracts: secretInputs.contracts,
+        contract: "webSearchProviders",
+      }),
       inactiveReason: enableState.reason ?? "plugin is disabled.",
       defaults: params.defaults,
       context: params.context,
@@ -139,17 +141,14 @@ function collectConfiguredPluginSecretAssignments(params: {
   pluginConfig: Record<string, unknown>;
   secretPaths: ReadonlyArray<{ path: string; expected?: "string" }>;
   active: boolean;
-  runtimeOwnedPathPrefixes?: readonly string[];
+  runtimeOwnedPaths?: readonly string[];
   inactiveReason: string;
   defaults: SecretDefaults | undefined;
   context: ResolverContext;
 }): void {
   const seenPaths = new Set<string>();
   for (const secretPath of params.secretPaths) {
-    if (
-      params.active &&
-      params.runtimeOwnedPathPrefixes?.some((prefix) => secretPath.path.startsWith(prefix))
-    ) {
+    if (params.active && params.runtimeOwnedPaths?.includes(secretPath.path)) {
       // Web provider selection owns these credentials. Resolving them here would make an
       // inactive or non-selected provider block the whole runtime snapshot.
       continue;

--- a/src/secrets/runtime-core-snapshots.test.ts
+++ b/src/secrets/runtime-core-snapshots.test.ts
@@ -6,6 +6,7 @@ import {
   clearConfigCache,
   clearRuntimeConfigSnapshot,
 } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
@@ -42,6 +43,13 @@ const OPENAI_ENV_KEY_REF = {
 } as const;
 
 type SecretsRuntimeEnvSnapshot = ReturnType<typeof captureEnv>;
+
+function readPluginWebSearchApiKey(config: OpenClawConfig, pluginId: string): unknown {
+  const pluginConfig = config.plugins?.entries?.[pluginId]?.config as
+    | { webSearch?: { apiKey?: unknown } }
+    | undefined;
+  return pluginConfig?.webSearch?.apiKey;
+}
 
 function beginSecretsRuntimeIsolationForTest(): SecretsRuntimeEnvSnapshot {
   const envSnapshot = captureEnv([
@@ -272,6 +280,101 @@ describe("secrets runtime snapshot core lanes", () => {
       provider: "default",
       id: "OPENAI_API_KEY",
     });
+  });
+
+  it("does not resolve a disabled web-search provider SecretRef", async () => {
+    const missingRef = {
+      source: "env",
+      provider: "default",
+      id: "MISSING_GEMINI_WEB_SEARCH_KEY",
+    } as const;
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        tools: { web: { search: { enabled: false, provider: "gemini" } } },
+        plugins: {
+          entries: {
+            google: { enabled: true, config: { webSearch: { apiKey: missingRef } } },
+          },
+        },
+      }),
+      env: {},
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: new Map([["google", "bundled"]]),
+    });
+
+    expect(readPluginWebSearchApiKey(snapshot.config, "google")).toEqual(missingRef);
+    expect(snapshot.webTools.search.selectedProvider).toBeUndefined();
+    expect(snapshot.warnings).toContainEqual(
+      expect.objectContaining({
+        code: "SECRETS_REF_IGNORED_INACTIVE_SURFACE",
+        path: "plugins.entries.google.config.webSearch.apiKey",
+      }),
+    );
+  });
+
+  it("resolves only the selected web-search provider SecretRef", async () => {
+    const missingRef = {
+      source: "env",
+      provider: "default",
+      id: "MISSING_GEMINI_WEB_SEARCH_KEY",
+    } as const;
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        tools: { web: { search: { provider: "brave" } } },
+        plugins: {
+          entries: {
+            brave: {
+              enabled: true,
+              config: {
+                webSearch: {
+                  apiKey: { source: "env", provider: "default", id: "BRAVE_WEB_SEARCH_KEY" },
+                },
+              },
+            },
+            google: { enabled: true, config: { webSearch: { apiKey: missingRef } } },
+          },
+        },
+      }),
+      env: { BRAVE_WEB_SEARCH_KEY: "brave-runtime-key" },
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: new Map([
+        ["brave", "bundled"],
+        ["google", "bundled"],
+      ]),
+    });
+
+    expect(readPluginWebSearchApiKey(snapshot.config, "brave")).toBe("brave-runtime-key");
+    expect(readPluginWebSearchApiKey(snapshot.config, "google")).toEqual(missingRef);
+    expect(snapshot.webTools.search.selectedProvider).toBe("brave");
+  });
+
+  it("still rejects an unresolved SecretRef for the selected web-search provider", async () => {
+    await expect(
+      prepareSecretsRuntimeSnapshot({
+        config: asConfig({
+          tools: { web: { search: { provider: "gemini" } } },
+          plugins: {
+            entries: {
+              google: {
+                enabled: true,
+                config: {
+                  webSearch: {
+                    apiKey: {
+                      source: "env",
+                      provider: "default",
+                      id: "MISSING_GEMINI_WEB_SEARCH_KEY",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }),
+        env: {},
+        includeAuthStoreRefs: false,
+        loadablePluginOrigins: new Map([["google", "bundled"]]),
+      }),
+    ).rejects.toThrow("[WEB_SEARCH_KEY_UNRESOLVED_NO_FALLBACK]");
   });
 
   it("activates runtime snapshots for loadConfig", async () => {

--- a/src/secrets/target-registry-data.ts
+++ b/src/secrets/target-registry-data.ts
@@ -4,16 +4,13 @@ import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { loadChannelSecretContractApiForRecord } from "./channel-contract-api.js";
 import type { SecretTargetRegistryEntry } from "./target-registry-types.js";
+import {
+  WEB_PROVIDER_SECRET_CONFIGS,
+  type WebProviderSecretConfig,
+} from "./web-provider-secret-configs.js";
 
 const SECRET_INPUT_SHAPE = "secret_input"; // pragma: allowlist secret
 const SIBLING_REF_SHAPE = "sibling_ref"; // pragma: allowlist secret
-
-const WEB_PROVIDER_SECRET_CONFIGS = [
-  { contract: "webSearchProviders", configPath: "webSearch.apiKey" },
-  { contract: "webFetchProviders", configPath: "webFetch.apiKey" },
-] as const;
-
-type WebProviderSecretConfig = (typeof WEB_PROVIDER_SECRET_CONFIGS)[number];
 
 function createPluginOpenClawConfigSecretTargetEntry(
   pluginId: string,

--- a/src/secrets/web-provider-secret-configs.ts
+++ b/src/secrets/web-provider-secret-configs.ts
@@ -1,0 +1,21 @@
+import type { PluginManifestContracts } from "../plugins/manifest.js";
+
+export const WEB_PROVIDER_SECRET_CONFIGS = [
+  { contract: "webSearchProviders", configPath: "webSearch.apiKey" },
+  { contract: "webFetchProviders", configPath: "webFetch.apiKey" },
+] as const;
+
+export type WebProviderSecretConfig = (typeof WEB_PROVIDER_SECRET_CONFIGS)[number];
+
+/** Lists exact provider-owned config paths without loading provider runtime. */
+export function listWebProviderSecretConfigPaths(params: {
+  contracts: PluginManifestContracts | undefined;
+  contract: WebProviderSecretConfig["contract"];
+}): string[] {
+  if ((params.contracts?.[params.contract]?.length ?? 0) === 0) {
+    return [];
+  }
+  return WEB_PROVIDER_SECRET_CONFIGS.filter((config) => config.contract === params.contract).map(
+    (config) => config.configPath,
+  );
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ordinary agent turns could fail during secrets runtime preparation when a disabled or non-selected web-search provider had an unresolved `SecretRef` configured.

## Why This Change Was Made

Plugin capability contracts now travel with config-contract metadata. A lightweight shared mapping identifies the exact provider-owned credential path (`webSearch.apiKey`), so the generic plugin collector still resolves every other declared SecretInput while provider selection resolves only the enabled, selected provider API key. This preserves strict failures for the provider that is actually selected while inactive provider credentials remain unresolved until needed.

This change is AI-assisted. The implementation and focused proof were reviewed with the repository's structured autoreview workflow.

## User Impact

Users can keep credentials configured for alternate or disabled web-search providers without those inactive references blocking unrelated agent turns. A missing credential for the enabled, selected provider still fails explicitly.

## Evidence

- `pnpm test src/plugins/config-contracts.test.ts src/secrets/runtime-config-collectors-plugins.test.ts src/secrets/runtime-core-snapshots.test.ts src/secrets/runtime-command-secrets.test.ts src/secrets/target-registry.test.ts`
  - 5 files, 45 tests passed across 2 Vitest shards, including the active non-owned sibling SecretInput regression.
- `pnpm check:test-types`
  - Passed for core, extensions, and root test projects.
- `node scripts/run-oxlint.mjs <six touched files>`
  - 0 warnings and 0 errors.
- `node_modules/.bin/oxfmt --check <six touched files>`
  - All files use the correct format.
- `git diff --check`
  - Passed.
- Dependency-file scan against `origin/main`
  - No dependency graph files changed.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`
  - Clean: no accepted/actionable findings; correctness confidence 0.96.

### Real behavior proof

- **Behavior addressed:** an unresolved SecretRef for a disabled or non-selected web-search provider no longer blocks ordinary agent-turn preparation; an unresolved ref for the selected provider still fails. A separate active SecretInput under `webSearch.*` remains owned by the generic strict resolver.
- **Real environment tested:** direct GCP Crabbox on Compute Engine, project `abs-crabbox`, zone `us-central1-a`, `e2-standard-8`, provider `gcp`, lease `cbx_874b1d4cba22` (`swift-crayfish`). The run used a fresh checkout of exact PR head `6459b7b360eeae440851a5f1efc515ea24627610`, public networking, no Tailscale, no Actions hydration, an isolated temporary OpenClaw state directory, and a deterministic local mock OpenAI server.
- **Exact steps or command run after this patch:**
  - The five-file focused test command above.
  - `pnpm check:test-types` and the six-file lint/format checks above.
  - `pnpm openclaw agent --local --agent main --session-id <isolated-session> --message <redacted-prompt> --thinking off --timeout 60 --json` for disabled, non-selected, and selected-provider configurations.
- **Evidence after fix:** 45 focused tests passed; the exact-path sibling regression passed; test types and static checks passed; disabled-provider and non-selected-provider CLI agent turns emitted the expected mock response; the selected-provider turn exited nonzero during active secret resolution; the mock model received exactly 2 requests, proving the selected-provider failure did not reach model execution.
- **Observed result after fix:** `AGENT_TURN_DISABLED=PASS`, `AGENT_TURN_NONSELECTED=PASS`, `ACTIVE_SELECTED_PROVIDER_FAILURE=PRESERVED`, `MOCK_MODEL_REQUESTS=2`, and `GCP_REVIEW_FIX_EVIDENCE=PASS`.
- **What was not tested:** live third-party web-search API authentication/network calls, production gateway mutation, and non-Linux platforms.

The exact-head GCP run exited 0 in 11m55.830s. Cleanup completed automatically (`leaseStopped=true`), and the provider-native inventory reports zero Crabbox-labeled instances with no instance for `cbx_874b1d4cba22`.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":9,"user":4,"assistant":4,"toolCalls":16,"toolOutputsDropped":16,"web":0,"redactions":4,"omittedUnsafe":0,"rawEntries":22}

[user]
[instructions recap omitted; policy/config text, not task dialogue]

[assistant]
I’m taking this through trace, fix, remote proof, fresh autoreview, and commit. I’m using the repository’s `openclaw-testing` skill for the validation lane and `autoreview` for the mandatory pre-commit review; I’ll first confirm the task branch/worktree and warm the trusted remote test backend while I inspect the failure path.

The delegated Blacksmith backend is unavailable because this host is not authenticated to the OpenClaw org. Per the testing runbook, I’m switching the same trusted maintainer checkout to the coordinator-backed AWS lane and will report that backend explicitly; no local test fallback is being used.

The trace has isolated the ownership bug: `prepareSecretsRuntimeSnapshot` sends enabled plugin config SecretRefs through the generic plugin collector before `resolveRuntimeWebTools` can decide whether web search is disabled or which provider wins. The web resolver already has the correct selection semantics and active-provider failure behavior; the fix is to stop the generic collector from pre-resolving web-provider credential subtrees for plugins that actually declare web search/fetch contracts, leaving those refs exclusively to the web runtime resolver.

The direct AWS fallback is also unavailable: this host has neither broker authentication nor AWS credentials/instance role. The runbook permits a narrow, explicitly reported local fallback when Testbox is unavailable, so I’ll use the repository’s linked-worktree Node test harness only for the focused files and keep broader static proof lightweight.

The focused harness found this task checkout has no `node_modules`. The repository’s missing-dependency rule requires one frozen install and one retry, so I’m doing that in the task checkout; if installation fails, I’ll preserve the first actionable error rather than weakening the proof.

The focused regression now passes: disabled and non-selected provider refs remain unresolved without blocking snapshot preparation, while the selected provider’s unresolved ref still throws the existing `WEB_SEARCH_KEY_UNRESOLVED_NO_FALLBACK` error. I’m tightening the diff now, then I’ll run targeted lint/static checks and the mandatory fresh autoreview before committing.

The mandatory autoreview is still active and inspecting the collector-to-provider handoff; its live interim assessment has no findings so far, but I’m waiting for the helper’s validated final result before treating the review gate as clean.

Autoreview found one valid scope regression: I had generalized the exemption to `webFetch`, whose disabled path short-circuits before producing the same diagnostics. That surface is outside this bug and has different control flow, so I’m narrowing the fix to declared `webSearchProviders` only, then rerunning focused proof and autoreview.

The narrowed patch is clean on the second autoreview: no accepted/actionable findings. Focused tests, targeted lint, formatting, and `git diff --check` are green; I’m committing exactly the three task files now, without pushing or opening a PR.

Implemented and committed the fix on `abs/inactive-web-secretref-command`.

Root cause: the generic plugin SecretRef collector resolved enabled plugin credentials before web-search provider selection. Thus disabled or non-selected provider refs could abort snapshot preparation. Web-search credential paths now remain owned by the web runtime resolver, which resolves only the enabled, selected provider.

Changed:

- `src/plugins/config-contracts.ts:15` — propagates capability contracts with config metadata.
- `src/secrets/runtime-config-collectors-plugins.ts:127` — defers declared `webSearch` provider credentials to provider selection.
- `src/secrets/runtime-core-snapshots.test.ts:285` — regressions for disabled, non-selected, and actively selected providers.

Validation:

- Focused Vitest: 4 files, 36 tests passed.
- Targeted `oxfmt` and `oxlint`: passed.
- `git diff --check`: passed.
- Final autoreview: clean, no actionable findings.
- Remote Testbox/AWS proof was unavailable because this host lacks Blacksmith org authentication, Crabbox broker authentication, and AWS credentials. The documented narrow local fallback was used after `pnpm install --frozen-lockfile`.

Commit: `7efa9c9123b59ce47ca287b6e4d56efd4577be87`  
Working tree is clean and one commit ahead of `origin/main`. Nothing pushed; no PR opened.

::git-stage{cwd="[LOCAL_PATH]"}
::git-commit{cwd="[LOCAL_PATH]"}

[user]
[$autoreview]([LOCAL_PATH])

[assistant]
I’m using the requested `autoreview` skill against the committed task change, so the target will be commit `HEAD` rather than an empty local-worktree review. I’ll report the structured findings exactly and won’t mutate the branch unless a verified in-scope blocker appears.

The commit review is still healthy and actively reading downstream provider-resolution paths. Its interim structured state has no findings; I’m waiting for the helper’s final validated exit rather than treating the preliminary output as complete.

Autoreview passed cleanly for commit `7efa9c9123b59ce47ca287b6e4d56efd4577be87`.

- Command: `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --stream-engine-output`
- Result: no accepted/actionable findings
- Correctness: patch is correct, confidence `0.88`
- Prior proof: 36 focused tests passed, targeted lint/format and `git diff --check` passed
- No changes made; branch remains unpushed and one commit ahead of `origin/main`

[user]
open pr

[assistant]
I’ll publish the committed task branch and open a takeover-ready PR with the repository template and exact proof. I’m using the required `agent-transcript` skill first to determine whether a sanitized Codex transcript should be offered or attached; then I’ll verify live GitHub state, push, and create the PR without adding unsolicited labels.

A high-confidence local Codex session was found for this fix. The skill requires your consent before any sanitized transcript is included; I can still prepare the remote branch now while leaving the PR body undecided.

Branch pushed. Include a redacted agent transcript in the PR? It helps reviewers and prioritization; I can preview it locally first if you prefer.

::git-push{cwd="[LOCAL_PATH]" branch="abs/inactive-web-secretref-command"}

[user]
OK, include a redacted transcript

[assistant]
I’m applying the `agent-transcript` skill now: rendering the selected local session through its redaction filter, checking the sanitized output for task-only scope, and appending it to the completed PR template before creation. Raw logs will not be uploaded.

[tool summary]
16 other; raw tool outputs dropped: 16
````

</details>
<!-- agent-transcript:end -->