### PR TITLE
refactor(sessions): internalize private helpers

### DIFF
--- a/src/config/sessions/session-sqlite-target.ts
+++ b/src/config/sessions/session-sqlite-target.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../routing/session-key.js";
 
 /** SQLite database target resolved from a legacy session store path. */
-export type ResolvedSqliteStoreTarget = {
+type ResolvedSqliteStoreTarget = {
   agentId?: string;
   path?: string;
 };
@@ -72,7 +72,7 @@ export function resolveSqliteTargetFromSessionStorePath(
 }
 
 /** Extracts the agent id from the canonical per-agent SQLite database path. */
-export function resolveAgentIdFromSqliteDatabasePath(databasePath: string): string | undefined {
+function resolveAgentIdFromSqliteDatabasePath(databasePath: string): string | undefined {
   if (path.basename(databasePath) !== "openclaw-agent.sqlite") {
     return undefined;
   }

--- a/src/config/sessions/session-transcript-index.ts
+++ b/src/config/sessions/session-transcript-index.ts
@@ -29,7 +29,7 @@ type TranscriptIndexDatabase = Pick<
   "session_transcript_fts" | "session_transcript_index_state" | "transcript_events"
 >;
 
-export type TranscriptIndexEntry = {
+type TranscriptIndexEntry = {
   messageId: string;
   role: "assistant" | "user";
   text: string;

--- a/src/config/sessions/session-transcript-search.ts
+++ b/src/config/sessions/session-transcript-search.ts
@@ -21,7 +21,7 @@ const SEARCH_SNIPPET_MAX_CHARS = 500;
 const SEARCH_LIMIT_MAX = 25;
 const SEARCH_QUERY_MAX_CHARS = 4096;
 
-export type SessionTranscriptSearchHit = {
+type SessionTranscriptSearchHit = {
   sessionKey: string;
   sessionId: string;
   messageId: string;
@@ -31,7 +31,7 @@ export type SessionTranscriptSearchHit = {
   score: number;
 };
 
-export type SessionTranscriptSearchResult = {
+type SessionTranscriptSearchResult = {
   hits: SessionTranscriptSearchHit[];
   indexing: boolean;
   truncated: boolean;
@@ -44,7 +44,7 @@ const runningReconciles = new Map<string, Promise<void>>();
  * sweeps orphaned index rows. One write transaction per session keeps the
  * agent DB responsive to live appends between rebuilds.
  */
-export async function reconcileSessionTranscriptIndex(params: {
+async function reconcileSessionTranscriptIndex(params: {
   agentId: string;
   env?: NodeJS.ProcessEnv;
 }): Promise<void> {


### PR DESCRIPTION
## What Problem This Solves

Six session implementation details were exported despite having no consumers outside their defining modules. That inflated the apparent module API and made private helpers look reusable.

## Why This Change Was Made

Keep the runtime code unchanged while making the following declarations module-private:

- SQLite target result type and canonical-path agent-id helper.
- Transcript index entry type.
- Transcript search hit/result types and reconcile implementation.

Test-only hooks and cross-module transcript index functions remain exported.

## User Impact

None. This only narrows unconsumed internal exports; runtime behavior is unchanged.

## Evidence

- Repository-wide symbol search found no imports or public re-exports for the six narrowed declarations.
- Codebase-memory call graphs show the two functions are called only from their defining modules.
- Testbox `tbx_01kxbkxkbst0aj1amvnr0d7c66`: `pnpm test:serial src/config/sessions/session-sqlite-target.test.ts src/config/sessions/session-transcript-search.test.ts` passed, 16 tests.
- Testbox changed gate passed conflict, changelog, re-export, duplicate, dependency, and formatting checks, then stopped only on the pre-existing Plugin SDK API baseline hash drift. The touched declarations are not referenced by any Plugin SDK entrypoint.
- Fresh autoreview: `gpt-5.6-sol`, medium reasoning, no findings, 0.88 confidence.
