### PR TITLE
refactor(outbound): internalize audit helpers

### DIFF
--- a/src/infra/outbound/outbound-audit.ts
+++ b/src/infra/outbound/outbound-audit.ts
@@ -38,7 +38,7 @@ type OutboundAuditDeliveryContext = {
   mirror?: DeliveryMirror;
 };
 
-export type OutboundAuditTerminal =
+type OutboundAuditTerminal =
   | {
       outcome: "sent";
       results: readonly OutboundDeliveryResult[];
@@ -63,12 +63,12 @@ export type OutboundAuditTerminal =
       sentBeforeError?: boolean;
     };
 
-export type IndexedOutboundAuditTerminal = {
+type IndexedOutboundAuditTerminal = {
   payloadIndex: number;
   terminal: OutboundAuditTerminal;
 };
 
-export function outboundQueueAuditSourceId(queueId: string, payloadIndex: number): string {
+function outboundQueueAuditSourceId(queueId: string, payloadIndex: number): string {
   return `message:outbound:queue:${queueId}:payload:${payloadIndex}`;
 }
 


### PR DESCRIPTION
## What Problem This Solves

The outbound audit module exported two structural types and one queue source-id helper that have no consumers outside the module. Those exports made private audit implementation details look reusable.

## Why This Change Was Made

Keep the audit projection and emission behavior unchanged while making the terminal types and queue source-id formatter module-private. The delivery-facing audit functions remain exported.

## User Impact

None. This only narrows unconsumed internal exports.

## Evidence

- Repository-wide search found no references outside `src/infra/outbound/outbound-audit.ts`.
- Codebase-memory call graph shows `outboundQueueAuditSourceId` is called only by `emitOutboundAuditTerminals` in the same module.
- Testbox `tbx_01kxbn3ckehgvj12frmwbya7re`: `pnpm test:serial src/infra/outbound/outbound-audit.test.ts` passed, 10 tests.
- Testbox changed gate passed conflict, changelog, re-export, duplicate, dependency, and formatting checks, then stopped only on the pre-existing Plugin SDK API baseline hash drift. The touched file is not a Plugin SDK entrypoint.
- Fresh autoreview: `gpt-5.6-sol`, medium reasoning, no findings, 0.94 confidence.
