### PR TITLE
fix(media): preserve remote filename prefixes with encoded separators

### DIFF
--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -1033,6 +1033,35 @@ describe("readRemoteMediaBuffer", () => {
     },
   );
 
+  it.each([
+    [`attachment; filename*=UTF-8''reports%2FQ1.pdf`, "reports_Q1.pdf"],
+    [`attachment; filename*=UTF-8''reports%5CQ1.pdf`, "reports_Q1.pdf"],
+    [`attachment; filename*=UTF-8''reports%2F%2FQ1.pdf`, "reports__Q1.pdf"],
+  ])(
+    "keeps decoded content-disposition filename* separators inside the selected filename",
+    async (contentDisposition, fileName) => {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(makeStream([new Uint8Array([1, 2, 3])]), {
+            status: 200,
+            headers: {
+              "content-disposition": contentDisposition,
+              "content-type": "application/pdf",
+            },
+          }),
+      );
+
+      const saved = await saveRemoteMedia({
+        url: "https://example.com/download",
+        fetchImpl,
+        lookupFn: makeLookupFn(),
+        maxBytes: 8,
+      });
+
+      expect(saved.fileName).toBe(fileName);
+    },
+  );
+
   it("saves bodyless successful responses without unbounded buffering", async () => {
     const saved = await saveResponseMedia(new Response(null, { status: 204 }), {
       sourceUrl: "https://example.com/empty",

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -129,6 +129,14 @@ function stripQuotes(value: string): string {
   return value.replace(/^["']|["']$/g, "");
 }
 
+function decodeRemoteFileNameComponent(value: string): string {
+  try {
+    return decodeURIComponent(value).replace(/[\\/]/g, "_");
+  } catch {
+    return value;
+  }
+}
+
 function parseContentDispositionFileName(header?: string | null): string | undefined {
   if (!header) {
     return undefined;
@@ -137,11 +145,7 @@ function parseContentDispositionFileName(header?: string | null): string | undef
   if (starMatch?.[1]) {
     const cleaned = stripQuotes(starMatch[1].trim());
     const encoded = cleaned.split("''").slice(1).join("''") || cleaned;
-    try {
-      return basenameFromAnyPath(decodeURIComponent(encoded));
-    } catch {
-      return basenameFromAnyPath(encoded);
-    }
+    return basenameFromAnyPath(decodeRemoteFileNameComponent(encoded));
   }
   const match = /filename\s*=\s*([^;]+)/i.exec(header);
   if (match?.[1]) {
@@ -155,11 +159,7 @@ function basenameFromUrlPathname(pathname: string): string {
   if (!base) {
     return "";
   }
-  try {
-    return decodeURIComponent(base).replace(/[\\/]/g, "_");
-  } catch {
-    return base;
-  }
+  return decodeRemoteFileNameComponent(base);
 }
 
 async function readErrorBodySnippet(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where remote media downloads could drop the prefix of a `Content-Disposition: filename*=` filename when the header percent-encoded `/` or `\` inside the selected filename.

## Why This Change Was Made

Remote media filename resolution now uses the same decoded-separator normalization for `filename*` header values that URL-path fallback filenames already use. The change stays inside the remote media filename boundary, preserves malformed percent-encoding handling, and does not change media fetching, storage, config, schema, provider, or channel delivery policy.

## User Impact

Users and channel integrations keep clearer remote attachment filenames such as `reports_Q1.pdf` instead of seeing the prefix truncated to `Q1.pdf` when a server encodes separators in `filename*`.

## Evidence

- Claim proved: remote media filename resolution preserves decoded forward-slash, backslash, and repeated separator prefixes in `Content-Disposition: filename*=` values while preserving the existing URL-path filename behavior.
- Current head: `66384814824f43a69daff6da12ef58dd145c511e`.
- Real HTTP runtime proof: `node --import tsx --input-type=module -` with an inline script that started a local HTTP server, served real `Content-Disposition: filename*=` responses, and called `saveRemoteMedia` through the guarded remote download path.

```text
PR: #105547
HEAD: 66384814824f43a69daff6da12ef58dd145c511e
/slash: header=attachment; filename*=UTF-8''reports%2FQ1.pdf -> fileName=reports_Q1.pdf; expected=reports_Q1.pdf; bytes=36; payloadMatch=true; PASS
/backslash: header=attachment; filename*=UTF-8''reports%5CQ1.pdf -> fileName=reports_Q1.pdf; expected=reports_Q1.pdf; bytes=36; payloadMatch=true; PASS
/repeated: header=attachment; filename*=UTF-8''reports%2F%2FQ1.pdf -> fileName=reports__Q1.pdf; expected=reports__Q1.pdf; bytes=36; payloadMatch=true; PASS
server requests: GET /slash, GET /backslash, GET /repeated
result: PASS
```

- Focused regression proof at `66384814824f43a69daff6da12ef58dd145c511e`: `node scripts/run-vitest.mjs src/media/fetch.test.ts` passed with 1 file and 42 tests.
- Diff hygiene at `66384814824f43a69daff6da12ef58dd145c511e`: `git diff --check HEAD~1..HEAD` passed.
- Review proof: autoreview commit mode passed with no accepted/actionable findings.
- Observed result: real remote downloads now return `reports_Q1.pdf` and `reports__Q1.pdf` from encoded `filename*` header separators instead of truncating the prefix.
