### PR TITLE
fix(memory): bound unsignaled remote HTTP with default timeoutMs

### DIFF
--- a/extensions/deepinfra/embedding-provider.ts
+++ b/extensions/deepinfra/embedding-provider.ts
@@ -1,6 +1,6 @@
 // Deepinfra provider module implements model/runtime integration.
 import {
-  createRemoteEmbeddingProvider,
+  createHostedRemoteEmbeddingProvider,
   resolveRemoteEmbeddingClient,
   type MemoryEmbeddingProviderCreateOptions,
   type MemoryEmbeddingProviderCreateResult,
@@ -26,7 +26,7 @@ export async function createDeepInfraEmbeddingProvider(
     defaultBaseUrl: DEEPINFRA_BASE_URL,
     normalizeModel: (model) => normalizeDeepInfraModelRef(model, defaultModel),
   });
-  const provider = createRemoteEmbeddingProvider({
+  const provider = createHostedRemoteEmbeddingProvider({
     id: "deepinfra",
     client,
     errorPrefix: "DeepInfra embeddings API error",

--- a/extensions/github-copilot/embeddings.ts
+++ b/extensions/github-copilot/embeddings.ts
@@ -2,7 +2,7 @@
 import {
   buildRemoteBaseUrlPolicy,
   sanitizeAndNormalizeEmbedding,
-  withRemoteHttpResponse,
+  withHostedRemoteHttpResponse,
   type MemoryEmbeddingProvider,
   type MemoryEmbeddingProviderAdapter,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
@@ -234,7 +234,7 @@ async function createGitHubCopilotEmbeddingProvider(
 
     const session = await resolveGitHubCopilotEmbeddingSession(client);
     const url = `${session.baseUrl.replace(/\/$/, "")}/embeddings`;
-    return await withRemoteHttpResponse({
+    return await withHostedRemoteHttpResponse({
       url,
       fetchImpl: client.fetchImpl,
       ssrfPolicy: buildRemoteBaseUrlPolicy(session.baseUrl),

--- a/extensions/google/embedding-batch.test.ts
+++ b/extensions/google/embedding-batch.test.ts
@@ -11,7 +11,7 @@ vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", async (importO
     await importOriginal<typeof import("openclaw/plugin-sdk/memory-core-host-engine-embeddings")>();
   return {
     ...actual,
-    withRemoteHttpResponse: async <T>(params: {
+    withHostedRemoteHttpResponse: async <T>(params: {
       url: string;
       ssrfPolicy?: unknown;
       init?: RequestInit;

--- a/extensions/google/embedding-batch.ts
+++ b/extensions/google/embedding-batch.ts
@@ -10,7 +10,7 @@ import {
   normalizeBatchBaseUrl,
   readEmbeddingBatchJsonl,
   sanitizeAndNormalizeEmbedding,
-  withRemoteHttpResponse,
+  withHostedRemoteHttpResponse,
   type EmbeddingBatchExecutionParams,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
@@ -192,7 +192,7 @@ async function submitGeminiBatch(params: {
     baseUrl,
     requests: params.requests.length,
   });
-  const filePayload = await withRemoteHttpResponse({
+  const filePayload = await withHostedRemoteHttpResponse({
     url: uploadUrl,
     ssrfPolicy: params.gemini.ssrfPolicy,
     init: {
@@ -229,7 +229,7 @@ async function submitGeminiBatch(params: {
     batchEndpoint,
     fileId,
   });
-  return await withRemoteHttpResponse({
+  return await withHostedRemoteHttpResponse({
     url: batchEndpoint,
     ssrfPolicy: params.gemini.ssrfPolicy,
     init: {
@@ -264,7 +264,7 @@ async function fetchGeminiBatchStatus(params: {
     : `batches/${params.batchName}`;
   const statusUrl = `${baseUrl}/${name}`;
   debugEmbeddingsLog("memory embeddings: gemini batch status", { statusUrl });
-  return await withRemoteHttpResponse({
+  return await withHostedRemoteHttpResponse({
     url: statusUrl,
     ssrfPolicy: params.gemini.ssrfPolicy,
     init: {
@@ -316,7 +316,7 @@ async function fetchGeminiBatchOutput(params: {
   const baseUrl = normalizeBatchBaseUrl(params.gemini);
   const downloadUrl = getGeminiDownloadUrl(baseUrl, params.fileId);
   debugEmbeddingsLog("memory embeddings: gemini batch download", { downloadUrl });
-  await withRemoteHttpResponse({
+  await withHostedRemoteHttpResponse({
     url: downloadUrl,
     ssrfPolicy: params.gemini.ssrfPolicy,
     init: {

--- a/extensions/google/embedding-provider.test.ts
+++ b/extensions/google/embedding-provider.test.ts
@@ -6,14 +6,14 @@ vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", async (importO
     await importOriginal<typeof import("openclaw/plugin-sdk/memory-core-host-engine-embeddings")>();
   return {
     ...actual,
-    withRemoteHttpResponse: (async <T>(params: {
+    withHostedRemoteHttpResponse: (async <T>(params: {
       url: string;
       init?: RequestInit;
       onResponse: (response: Response) => Promise<T>;
     }): Promise<T> => {
       const response = await fetch(params.url, params.init);
       return await params.onResponse(response);
-    }) satisfies typeof actual.withRemoteHttpResponse,
+    }) satisfies typeof actual.withHostedRemoteHttpResponse,
   };
 });
 

--- a/extensions/google/embedding-provider.ts
+++ b/extensions/google/embedding-provider.ts
@@ -3,7 +3,7 @@ import {
   buildRemoteBaseUrlPolicy,
   debugEmbeddingsLog,
   sanitizeAndNormalizeEmbedding,
-  withRemoteHttpResponse,
+  withHostedRemoteHttpResponse,
   type EmbeddingInput,
   type MemoryEmbeddingProvider,
   type MemoryEmbeddingProviderCreateOptions,
@@ -226,7 +226,7 @@ async function fetchGeminiEmbeddingPayload(params: {
         ...authHeaders.headers,
         ...params.client.headers,
       };
-      return await withRemoteHttpResponse({
+      return await withHostedRemoteHttpResponse({
         url: params.endpoint,
         ssrfPolicy: params.client.ssrfPolicy,
         signal: params.signal,

--- a/extensions/mistral/embedding-provider.ts
+++ b/extensions/mistral/embedding-provider.ts
@@ -1,6 +1,6 @@
 // Mistral provider module implements model/runtime integration.
 import {
-  createRemoteEmbeddingProvider,
+  createHostedRemoteEmbeddingProvider,
   normalizeEmbeddingModelWithPrefixes,
   resolveRemoteEmbeddingClient,
   type MemoryEmbeddingProvider,
@@ -32,7 +32,7 @@ export async function createMistralEmbeddingProvider(
   const client = await resolveMistralEmbeddingClient(options);
 
   return {
-    provider: createRemoteEmbeddingProvider({
+    provider: createHostedRemoteEmbeddingProvider({
       id: "mistral",
       client,
       errorPrefix: "mistral embeddings failed",

--- a/extensions/openai/embedding-batch.ts
+++ b/extensions/openai/embedding-batch.ts
@@ -20,7 +20,7 @@ import {
   type BatchCompletionResult,
   type ProviderBatchOutputLine,
   uploadBatchJsonlFile,
-  withRemoteHttpResponse,
+  withHostedRemoteHttpResponse,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
   assertOkOrThrowProviderError,
@@ -137,7 +137,7 @@ async function fetchOpenAiBatchResource<T>(params: {
   parse: (res: Response) => Promise<T>;
 }): Promise<T> {
   const baseUrl = normalizeBatchBaseUrl(params.openAi);
-  return await withRemoteHttpResponse({
+  return await withHostedRemoteHttpResponse({
     url: `${baseUrl}${params.path}`,
     ssrfPolicy: params.openAi.ssrfPolicy,
     fetchImpl: params.openAi.fetchImpl,

--- a/extensions/openai/embedding-provider.test.ts
+++ b/extensions/openai/embedding-provider.test.ts
@@ -9,12 +9,12 @@ const DEFAULT_MOCK_CLIENT = {
 };
 
 const mocks = vi.hoisted(() => ({
-  fetchRemoteEmbeddingVectors: vi.fn(async () => [[1, 0]]),
+  fetchHostedRemoteEmbeddingVectors: vi.fn(async () => [[1, 0]]),
   resolveRemoteEmbeddingClient: vi.fn(async () => ({ ...DEFAULT_MOCK_CLIENT })),
 }));
 
 vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", () => ({
-  fetchRemoteEmbeddingVectors: mocks.fetchRemoteEmbeddingVectors,
+  fetchHostedRemoteEmbeddingVectors: mocks.fetchHostedRemoteEmbeddingVectors,
   resolveRemoteEmbeddingClient: mocks.resolveRemoteEmbeddingClient,
 }));
 
@@ -33,7 +33,7 @@ function createOptions(
 }
 
 function expectFetchRemoteEmbeddingVectorsBody(body: Record<string, unknown>) {
-  expect(mocks.fetchRemoteEmbeddingVectors).toHaveBeenCalledWith({
+  expect(mocks.fetchHostedRemoteEmbeddingVectors).toHaveBeenCalledWith({
     url: "https://embeddings.example/v1/embeddings",
     headers: { Authorization: "Bearer test" },
     ssrfPolicy: undefined,
@@ -46,7 +46,7 @@ function expectFetchRemoteEmbeddingVectorsBody(body: Record<string, unknown>) {
 
 describe("OpenAI embedding provider", () => {
   beforeEach(() => {
-    mocks.fetchRemoteEmbeddingVectors.mockClear();
+    mocks.fetchHostedRemoteEmbeddingVectors.mockClear();
     mocks.resolveRemoteEmbeddingClient.mockClear();
   });
 
@@ -197,7 +197,7 @@ describe("OpenAI embedding provider", () => {
 
     await provider.embedQuery("test");
 
-    expect(mocks.fetchRemoteEmbeddingVectors).toHaveBeenCalledWith({
+    expect(mocks.fetchHostedRemoteEmbeddingVectors).toHaveBeenCalledWith({
       url: "https://router.requesty.ai/v1/embeddings",
       headers: { Authorization: "Bearer test" },
       ssrfPolicy: undefined,

--- a/extensions/openai/embedding-provider.ts
+++ b/extensions/openai/embedding-provider.ts
@@ -1,6 +1,6 @@
 // Openai provider module implements model/runtime integration.
 import {
-  fetchRemoteEmbeddingVectors,
+  fetchHostedRemoteEmbeddingVectors,
   resolveRemoteEmbeddingClient,
   type MemoryEmbeddingProvider,
   type MemoryEmbeddingProviderCreateOptions,
@@ -66,7 +66,7 @@ export async function createOpenAiEmbeddingProvider(
       return [];
     }
     const inputType = resolveInputType(kind);
-    return await fetchRemoteEmbeddingVectors({
+    return await fetchHostedRemoteEmbeddingVectors({
       url,
       headers: client.headers,
       ssrfPolicy: client.ssrfPolicy,

--- a/extensions/voyage/embedding-batch.test.ts
+++ b/extensions/voyage/embedding-batch.test.ts
@@ -20,7 +20,7 @@ function buildClient(): VoyageEmbeddingClient {
 }
 
 /**
- * Build deps whose withRemoteHttpResponse drives the real onResponse against a
+ * Build deps whose withHostedRemoteHttpResponse drives the real onResponse against a
  * caller-provided Response, so the bounded readers run exactly as in production.
  */
 function buildDeps(response: Response): Parameters<typeof fetchVoyageBatchStatus>[0]["deps"] {
@@ -33,8 +33,9 @@ function buildDeps(response: Response): Parameters<typeof fetchVoyageBatchStatus
     uploadBatchJsonlFile: (async () => {
       throw new Error("uploadBatchJsonlFile should not be called in these tests");
     }) as never,
-    withRemoteHttpResponse: (async (params: { onResponse: (res: Response) => Promise<unknown> }) =>
-      await params.onResponse(response)) as never,
+    withHostedRemoteHttpResponse: (async (params: {
+      onResponse: (res: Response) => Promise<unknown>;
+    }) => await params.onResponse(response)) as never,
   };
 }
 
@@ -248,7 +249,7 @@ describe("voyage batch bounded reads", () => {
           status: "completed",
           output_file_id: "output-0",
         }),
-        withRemoteHttpResponse: (async (params: {
+        withHostedRemoteHttpResponse: (async (params: {
           onResponse: (response: Response) => Promise<unknown>;
         }) => await params.onResponse(output)) as never,
       },
@@ -276,7 +277,7 @@ describe("voyage batch bounded reads", () => {
             id: "batch-0",
             status: "in_progress",
           }),
-          withRemoteHttpResponse: (async (params: {
+          withHostedRemoteHttpResponse: (async (params: {
             url: string;
             onResponse: (response: Response) => Promise<unknown>;
           }) => {

--- a/extensions/voyage/embedding-batch.ts
+++ b/extensions/voyage/embedding-batch.ts
@@ -20,7 +20,7 @@ import {
   type BatchCompletionResult,
   type ProviderBatchOutputLine,
   uploadBatchJsonlFile,
-  withRemoteHttpResponse,
+  withHostedRemoteHttpResponse,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
   assertOkOrThrowProviderError,
@@ -56,7 +56,7 @@ type VoyageBatchDeps = {
   sleep: (ms: number) => Promise<void>;
   postJsonWithRetry: typeof postJsonWithRetry<VoyageBatchStatus>;
   uploadBatchJsonlFile: typeof uploadBatchJsonlFile;
-  withRemoteHttpResponse: typeof withRemoteHttpResponse;
+  withHostedRemoteHttpResponse: typeof withHostedRemoteHttpResponse;
 };
 
 function resolveVoyageBatchDeps(overrides: Partial<VoyageBatchDeps> | undefined): VoyageBatchDeps {
@@ -70,7 +70,8 @@ function resolveVoyageBatchDeps(overrides: Partial<VoyageBatchDeps> | undefined)
         })),
     postJsonWithRetry: overrides?.postJsonWithRetry ?? postJsonWithRetry,
     uploadBatchJsonlFile: overrides?.uploadBatchJsonlFile ?? uploadBatchJsonlFile,
-    withRemoteHttpResponse: overrides?.withRemoteHttpResponse ?? withRemoteHttpResponse,
+    withHostedRemoteHttpResponse:
+      overrides?.withHostedRemoteHttpResponse ?? withHostedRemoteHttpResponse,
   };
 }
 
@@ -132,7 +133,7 @@ async function fetchVoyageBatchStatus(params: {
   maxResponseBytes?: number;
 }): Promise<VoyageBatchStatus> {
   const maxBytes = params.maxResponseBytes ?? VOYAGE_BATCH_RESPONSE_MAX_BYTES;
-  return await params.deps.withRemoteHttpResponse(
+  return await params.deps.withHostedRemoteHttpResponse(
     buildVoyageBatchRequest({
       client: params.client,
       path: `batches/${params.batchId}`,
@@ -154,7 +155,7 @@ async function readVoyageBatchError(params: {
 }): Promise<string | undefined> {
   const maxBytes = params.maxResponseBytes ?? VOYAGE_BATCH_RESPONSE_MAX_BYTES;
   try {
-    return await params.deps.withRemoteHttpResponse(
+    return await params.deps.withHostedRemoteHttpResponse(
       buildVoyageBatchRequest({
         client: params.client,
         path: `files/${params.errorFileId}/content`,
@@ -302,7 +303,7 @@ export async function runVoyageEmbeddingBatches(
       const errors: string[] = [];
       const remaining = new Set(group.map((request) => request.custom_id));
 
-      await deps.withRemoteHttpResponse({
+      await deps.withHostedRemoteHttpResponse({
         url: `${baseUrl}/files/${completed.outputFileId}/content`,
         ssrfPolicy: params.client.ssrfPolicy,
         init: {

--- a/extensions/voyage/embedding-provider.ts
+++ b/extensions/voyage/embedding-provider.ts
@@ -1,6 +1,6 @@
 // Voyage provider module implements model/runtime integration.
 import {
-  fetchRemoteEmbeddingVectors,
+  fetchHostedRemoteEmbeddingVectors,
   normalizeEmbeddingModelWithPrefixes,
   resolveRemoteEmbeddingBearerClient,
   type MemoryEmbeddingProvider,
@@ -53,7 +53,7 @@ export async function createVoyageEmbeddingProvider(
       body.input_type = input_type;
     }
 
-    return await fetchRemoteEmbeddingVectors({
+    return await fetchHostedRemoteEmbeddingVectors({
       url,
       headers: client.headers,
       ssrfPolicy: client.ssrfPolicy,

--- a/packages/memory-host-sdk/src/engine-embeddings.ts
+++ b/packages/memory-host-sdk/src/engine-embeddings.ts
@@ -63,17 +63,25 @@ export {
   type RemoteEmbeddingProviderId,
 } from "./host/embeddings-remote-client.js";
 export {
+  createHostedRemoteEmbeddingProvider,
   createRemoteEmbeddingProvider,
   resolveRemoteEmbeddingClient,
   type RemoteEmbeddingClient,
 } from "./host/embeddings-remote-provider.js";
-export { fetchRemoteEmbeddingVectors } from "./host/embeddings-remote-fetch.js";
+export {
+  fetchHostedRemoteEmbeddingVectors,
+  fetchRemoteEmbeddingVectors,
+} from "./host/embeddings-remote-fetch.js";
 export {
   estimateStructuredEmbeddingInputBytes,
   estimateUtf8Bytes,
 } from "./host/embedding-input-limits.js";
 export { hasNonTextEmbeddingParts, type EmbeddingInput } from "./host/embedding-inputs.js";
-export { buildRemoteBaseUrlPolicy, withRemoteHttpResponse } from "./host/remote-http.js";
+export {
+  buildRemoteBaseUrlPolicy,
+  withHostedRemoteHttpResponse,
+  withRemoteHttpResponse,
+} from "./host/remote-http.js";
 export {
   buildCaseInsensitiveExtensionGlob,
   classifyMemoryMultimodalPath,

--- a/packages/memory-host-sdk/src/host/batch-upload.test.ts
+++ b/packages/memory-host-sdk/src/host/batch-upload.test.ts
@@ -1,13 +1,13 @@
 // Memory Host SDK tests cover batch upload behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { uploadBatchJsonlFile } from "./batch-upload.js";
-import { withRemoteHttpResponse } from "./remote-http.js";
+import { withHostedRemoteHttpResponse } from "./remote-http.js";
 
 vi.mock("./remote-http.js", () => ({
-  withRemoteHttpResponse: vi.fn(),
+  withHostedRemoteHttpResponse: vi.fn(),
 }));
 
-const remoteHttpMock = vi.mocked(withRemoteHttpResponse);
+const remoteHttpMock = vi.mocked(withHostedRemoteHttpResponse);
 
 function textResponse(body: string, status: number): Response {
   return new Response(body, { status });

--- a/packages/memory-host-sdk/src/host/batch-upload.ts
+++ b/packages/memory-host-sdk/src/host/batch-upload.ts
@@ -5,7 +5,7 @@ import {
   type BatchHttpClientConfig,
 } from "./batch-utils.js";
 import { hashText } from "./hash.js";
-import { withRemoteHttpResponse } from "./remote-http.js";
+import { withHostedRemoteHttpResponse } from "./remote-http.js";
 import {
   readMemoryHostResponseTextSnippet,
   readResponseJsonWithLimit,
@@ -31,7 +31,7 @@ export async function uploadBatchJsonlFile(params: {
     `memory-embeddings.${hashText(String(Date.now()))}.jsonl`,
   );
 
-  const filePayload = await withRemoteHttpResponse({
+  const filePayload = await withHostedRemoteHttpResponse({
     url: `${baseUrl}/files`,
     ssrfPolicy: params.client.ssrfPolicy,
     fetchImpl: params.client.fetchImpl,

--- a/packages/memory-host-sdk/src/host/embeddings-remote-fetch.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-fetch.test.ts
@@ -1,6 +1,10 @@
 // Memory Host SDK tests cover embeddings remote fetch behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fetchRemoteEmbeddingVectors } from "./embeddings-remote-fetch.js";
+import {
+  fetchHostedRemoteEmbeddingVectors,
+  fetchRemoteEmbeddingVectors,
+} from "./embeddings-remote-fetch.js";
+import { MEMORY_REMOTE_HTTP_TIMEOUT_HOSTED_MS } from "./remote-http.js";
 
 const postJsonMock = vi.hoisted(() => vi.fn());
 
@@ -12,6 +16,7 @@ function requirePostJsonParams(): {
   url?: unknown;
   headers?: unknown;
   signal?: unknown;
+  timeoutMs?: unknown;
   body?: unknown;
   errorPrefix?: unknown;
 } {
@@ -137,5 +142,27 @@ describe("fetchRemoteEmbeddingVectors", () => {
         errorPrefix: "embedding fetch failed",
       }),
     ).rejects.toThrow("embedding fetch failed: malformed JSON response");
+  });
+});
+
+describe("fetchHostedRemoteEmbeddingVectors", () => {
+  beforeEach(() => {
+    postJsonMock.mockReset();
+  });
+
+  it("defaults timeoutMs to the hosted 120s hang floor used by OpenAI/Voyage callers", async () => {
+    postJsonMock.mockImplementationOnce(async (params) => {
+      return await params.parse({ data: [{ embedding: [0.1] }] });
+    });
+
+    await fetchHostedRemoteEmbeddingVectors({
+      url: "https://api.openai.com/v1/embeddings",
+      headers: { Authorization: "Bearer test" },
+      body: { model: "text-embedding-3-small", input: ["proof"] },
+      errorPrefix: "openai embeddings failed",
+    });
+
+    expect(requirePostJsonParams().timeoutMs).toBe(MEMORY_REMOTE_HTTP_TIMEOUT_HOSTED_MS);
+    expect(MEMORY_REMOTE_HTTP_TIMEOUT_HOSTED_MS).toBe(120_000);
   });
 });

--- a/packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts
@@ -1,5 +1,6 @@
 // Memory Host SDK module implements embeddings remote fetch behavior.
 import { postJson } from "./post-json.js";
+import { MEMORY_REMOTE_HTTP_TIMEOUT_HOSTED_MS } from "./remote-http.js";
 import type { SsrFPolicy } from "./ssrf-policy.js";
 
 // Fetches and validates OpenAI-compatible embedding responses.
@@ -42,6 +43,8 @@ export async function fetchRemoteEmbeddingVectors(params: {
   ssrfPolicy?: SsrFPolicy;
   fetchImpl?: typeof fetch;
   signal?: AbortSignal;
+  /** Override the shared remote-http hang floor. */
+  timeoutMs?: number;
   body: unknown;
   errorPrefix: string;
 }): Promise<number[][]> {
@@ -51,6 +54,7 @@ export async function fetchRemoteEmbeddingVectors(params: {
     ssrfPolicy: params.ssrfPolicy,
     fetchImpl: params.fetchImpl,
     signal: params.signal,
+    timeoutMs: params.timeoutMs,
     body: params.body,
     errorPrefix: params.errorPrefix,
     parse: (payload) => {
@@ -70,5 +74,17 @@ export async function fetchRemoteEmbeddingVectors(params: {
         return readEmbeddingVector(record.embedding, params.errorPrefix);
       });
     },
+  });
+}
+
+/** Hosted/cloud OpenAI-compatible embedding fetch with the 120s hang floor. */
+export async function fetchHostedRemoteEmbeddingVectors(
+  params: Omit<Parameters<typeof fetchRemoteEmbeddingVectors>[0], "timeoutMs"> & {
+    timeoutMs?: number;
+  },
+): Promise<number[][]> {
+  return await fetchRemoteEmbeddingVectors({
+    ...params,
+    timeoutMs: params.timeoutMs ?? MEMORY_REMOTE_HTTP_TIMEOUT_HOSTED_MS,
   });
 }

--- a/packages/memory-host-sdk/src/host/embeddings-remote-provider.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-provider.ts
@@ -5,6 +5,7 @@ import {
 } from "./embeddings-remote-client.js";
 import { fetchRemoteEmbeddingVectors } from "./embeddings-remote-fetch.js";
 import type { EmbeddingProvider, EmbeddingProviderOptions } from "./embeddings.types.js";
+import { MEMORY_REMOTE_HTTP_TIMEOUT_HOSTED_MS } from "./remote-http.js";
 import type { SsrFPolicy } from "./ssrf-policy.js";
 
 // Remote embedding provider factory for OpenAI-compatible embeddings APIs.
@@ -24,6 +25,8 @@ export function createRemoteEmbeddingProvider(params: {
   client: RemoteEmbeddingClient;
   errorPrefix: string;
   maxInputTokens?: number;
+  /** Override the shared remote-http hang floor. */
+  timeoutMs?: number;
 }): EmbeddingProvider {
   const { client } = params;
   const url = `${client.baseUrl.replace(/\/$/, "")}/embeddings`;
@@ -38,6 +41,7 @@ export function createRemoteEmbeddingProvider(params: {
       ssrfPolicy: client.ssrfPolicy,
       fetchImpl: client.fetchImpl,
       signal,
+      timeoutMs: params.timeoutMs,
       body: { model: client.model, input },
       errorPrefix: params.errorPrefix,
     });
@@ -53,6 +57,18 @@ export function createRemoteEmbeddingProvider(params: {
     },
     embedBatch: async (texts, options) => await embed(texts, options?.signal),
   };
+}
+
+/** Hosted/cloud remote embedding provider with the 120s hang floor. */
+export function createHostedRemoteEmbeddingProvider(
+  params: Omit<Parameters<typeof createRemoteEmbeddingProvider>[0], "timeoutMs"> & {
+    timeoutMs?: number;
+  },
+): EmbeddingProvider {
+  return createRemoteEmbeddingProvider({
+    ...params,
+    timeoutMs: params.timeoutMs ?? MEMORY_REMOTE_HTTP_TIMEOUT_HOSTED_MS,
+  });
 }
 
 /** Resolve a normalized remote embedding client from provider config and model options. */

--- a/packages/memory-host-sdk/src/host/post-json.test.ts
+++ b/packages/memory-host-sdk/src/host/post-json.test.ts
@@ -73,6 +73,22 @@ describe("postJson", () => {
     expect(result).toEqual({ data: [{ embedding: [1, 2] }] });
   });
 
+  it("forwards timeoutMs overrides to the remote HTTP request", async () => {
+    remoteHttpMock.mockImplementationOnce(async (params) => {
+      expect(params.timeoutMs).toBe(1_250);
+      return await params.onResponse(jsonResponse({ ok: true }));
+    });
+
+    await postJson({
+      url: "https://memory.example/v1/post",
+      headers: { Authorization: "Bearer test" },
+      body: { input: ["x"] },
+      errorPrefix: "post failed",
+      timeoutMs: 1_250,
+      parse: (payload) => payload,
+    });
+  });
+
   it("forwards abort signals to the remote HTTP request", async () => {
     const controller = new AbortController();
     remoteHttpMock.mockImplementationOnce(async (params) => {

--- a/packages/memory-host-sdk/src/host/post-json.ts
+++ b/packages/memory-host-sdk/src/host/post-json.ts
@@ -15,6 +15,8 @@ export async function postJson<T>(params: {
   ssrfPolicy?: SsrFPolicy;
   fetchImpl?: typeof fetch;
   signal?: AbortSignal;
+  /** Optional override for the shared remote-http hang floor. */
+  timeoutMs?: number;
   body: unknown;
   errorPrefix: string;
   attachStatus?: boolean;
@@ -26,6 +28,7 @@ export async function postJson<T>(params: {
     ssrfPolicy: params.ssrfPolicy,
     fetchImpl: params.fetchImpl,
     signal: params.signal,
+    timeoutMs: params.timeoutMs,
     init: {
       method: "POST",
       headers: params.headers,

--- a/packages/memory-host-sdk/src/host/remote-http.test.ts
+++ b/packages/memory-host-sdk/src/host/remote-http.test.ts
@@ -1,6 +1,16 @@
 // Memory Host SDK tests cover remote http behavior.
+import http from "node:http";
+import type { AddressInfo } from "node:net";
 import { describe, expect, it } from "vitest";
-import { withRemoteHttpResponse } from "./remote-http.js";
+import { fetchHostedRemoteEmbeddingVectors } from "./embeddings-remote-fetch.js";
+import {
+  MEMORY_REMOTE_HTTP_TIMEOUT_HOSTED_MS,
+  withHostedRemoteHttpResponse,
+  withRemoteHttpResponse,
+} from "./remote-http.js";
+
+/** Matches the package-private local/self-hosted hang floor in remote-http.ts. */
+const MEMORY_REMOTE_HTTP_TIMEOUT_LOCAL_MS = 600_000;
 
 describe("package withRemoteHttpResponse", () => {
   function makeFetchDeps({ useEnvProxy = false }: { useEnvProxy?: boolean } = {}) {
@@ -19,6 +29,65 @@ describe("package withRemoteHttpResponse", () => {
     };
   }
 
+  async function listenHungServer(): Promise<{
+    url: string;
+    close: () => Promise<void>;
+  }> {
+    // Accept the socket but never write headers so missing timeouts hang forever.
+    const server = http.createServer((_req, _res) => {});
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+    return {
+      url: `http://127.0.0.1:${port}/v1/embeddings`,
+      close: async () => {
+        await new Promise<void>((resolve, reject) => {
+          server.close((err) => (err ? reject(err) : resolve()));
+        });
+      },
+    };
+  }
+
+  it("defaults the hang floor to the local/self-hosted 600s embedding budget", async () => {
+    expect(MEMORY_REMOTE_HTTP_TIMEOUT_LOCAL_MS).toBe(600_000);
+    expect(MEMORY_REMOTE_HTTP_TIMEOUT_HOSTED_MS).toBe(120_000);
+
+    const deps = makeFetchDeps();
+    await withRemoteHttpResponse({
+      url: "https://memory.example/v1/embeddings",
+      onResponse: async () => undefined,
+      ...deps,
+    });
+
+    expect(deps.calls[0]).toHaveProperty("timeoutMs", MEMORY_REMOTE_HTTP_TIMEOUT_LOCAL_MS);
+  });
+
+  it("accepts the hosted 120s embedding budget as an explicit override", async () => {
+    const deps = makeFetchDeps();
+
+    await withRemoteHttpResponse({
+      url: "https://memory.example/v1/embeddings",
+      timeoutMs: MEMORY_REMOTE_HTTP_TIMEOUT_HOSTED_MS,
+      onResponse: async () => undefined,
+      ...deps,
+    });
+
+    expect(deps.calls[0]).toHaveProperty("timeoutMs", MEMORY_REMOTE_HTTP_TIMEOUT_HOSTED_MS);
+  });
+
+  it("defaults the hosted wrapper to the 120s hosted hang floor", async () => {
+    const deps = makeFetchDeps();
+
+    await withHostedRemoteHttpResponse({
+      url: "https://api.openai.com/v1/embeddings",
+      onResponse: async () => undefined,
+      ...deps,
+    });
+
+    expect(deps.calls[0]).toHaveProperty("timeoutMs", MEMORY_REMOTE_HTTP_TIMEOUT_HOSTED_MS);
+  });
+
   it("uses trusted env proxy mode when the target will use EnvHttpProxyAgent", async () => {
     const deps = makeFetchDeps({ useEnvProxy: true });
 
@@ -30,6 +99,7 @@ describe("package withRemoteHttpResponse", () => {
 
     expect(deps.calls[0]).toHaveProperty("url", "https://memory.example/v1/embeddings");
     expect(deps.calls[0]).toHaveProperty("mode", "trusted_env_proxy");
+    expect(deps.calls[0]).toHaveProperty("timeoutMs", MEMORY_REMOTE_HTTP_TIMEOUT_LOCAL_MS);
   });
 
   it("keeps strict guarded fetch mode when proxy env would not proxy the target", async () => {
@@ -43,9 +113,10 @@ describe("package withRemoteHttpResponse", () => {
 
     expect(deps.calls).toHaveLength(1);
     expect(deps.calls[0]).not.toHaveProperty("mode");
+    expect(deps.calls[0]).toHaveProperty("timeoutMs", MEMORY_REMOTE_HTTP_TIMEOUT_LOCAL_MS);
   });
 
-  it("passes abort signals to the guarded fetch", async () => {
+  it("composes abort signals with the default hang floor", async () => {
     const deps = makeFetchDeps();
     const controller = new AbortController();
 
@@ -57,5 +128,179 @@ describe("package withRemoteHttpResponse", () => {
     });
 
     expect(deps.calls[0]).toHaveProperty("signal", controller.signal);
+    expect(deps.calls[0]).toHaveProperty("timeoutMs", MEMORY_REMOTE_HTTP_TIMEOUT_LOCAL_MS);
+  });
+
+  it("honours an explicit timeoutMs override", async () => {
+    const deps = makeFetchDeps();
+
+    await withRemoteHttpResponse({
+      url: "https://memory.example/v1/embeddings",
+      timeoutMs: 1_500,
+      onResponse: async () => undefined,
+      ...deps,
+    });
+
+    expect(deps.calls[0]).toHaveProperty("timeoutMs", 1_500);
+  });
+
+  it("honours an explicit timeoutMs override even when a caller signal is present", async () => {
+    const deps = makeFetchDeps();
+    const controller = new AbortController();
+
+    await withRemoteHttpResponse({
+      url: "https://memory.example/v1/embeddings",
+      signal: controller.signal,
+      timeoutMs: 1_500,
+      onResponse: async () => undefined,
+      ...deps,
+    });
+
+    expect(deps.calls[0]).toHaveProperty("signal", controller.signal);
+    expect(deps.calls[0]).toHaveProperty("timeoutMs", 1_500);
+  });
+
+  it("times out hung remote responses when caller omits signal", async () => {
+    const hung = await listenHungServer();
+    try {
+      const outcome = await withRemoteHttpResponse({
+        url: hung.url,
+        timeoutMs: 80,
+        ssrfPolicy: { allowPrivateNetwork: true },
+        onResponse: async () => "should-not-resolve",
+      }).then(
+        (value) => ({ ok: true as const, value }),
+        (error: unknown) => ({ ok: false as const, error }),
+      );
+
+      expect(outcome.ok).toBe(false);
+      if (!outcome.ok) {
+        expect(outcome.error).toMatchObject({
+          name: "TimeoutError",
+          message: "request timed out",
+        });
+      }
+    } finally {
+      await hung.close();
+    }
+  });
+
+  it("times out hung remote responses when caller supplies a cancellation-only signal", async () => {
+    const hung = await listenHungServer();
+    const controller = new AbortController();
+    try {
+      const outcome = await withRemoteHttpResponse({
+        url: hung.url,
+        signal: controller.signal,
+        timeoutMs: 80,
+        ssrfPolicy: { allowPrivateNetwork: true },
+        onResponse: async () => "should-not-resolve",
+      }).then(
+        (value) => ({ ok: true as const, value }),
+        (error: unknown) => ({ ok: false as const, error }),
+      );
+
+      expect(outcome.ok).toBe(false);
+      if (!outcome.ok) {
+        expect(outcome.error).toMatchObject({
+          name: "TimeoutError",
+          message: "request timed out",
+        });
+      }
+    } finally {
+      await hung.close();
+    }
+  });
+
+  it("times out hung POST bodies shaped like postJson callers", async () => {
+    const hung = await listenHungServer();
+    try {
+      // Same request shape as postJson → withRemoteHttpResponse (embedding providers).
+      const outcome = await withRemoteHttpResponse({
+        url: hung.url,
+        timeoutMs: 80,
+        ssrfPolicy: { allowPrivateNetwork: true },
+        init: {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ input: ["proof"] }),
+        },
+        onResponse: async () => "should-not-resolve",
+      }).then(
+        (value) => ({ ok: true as const, value }),
+        (error: unknown) => ({ ok: false as const, error }),
+      );
+
+      expect(outcome.ok).toBe(false);
+      if (!outcome.ok) {
+        expect(outcome.error).toMatchObject({
+          name: "TimeoutError",
+          message: "request timed out",
+        });
+      }
+    } finally {
+      await hung.close();
+    }
+  });
+
+  it("times out hung hosted wrapper requests used by OpenAI/Voyage/Google callers", async () => {
+    const hung = await listenHungServer();
+    try {
+      const outcome = await withHostedRemoteHttpResponse({
+        url: hung.url,
+        timeoutMs: 80,
+        ssrfPolicy: { allowPrivateNetwork: true },
+        init: {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model: "text-embedding-3-small", input: ["proof"] }),
+        },
+        onResponse: async () => "should-not-resolve",
+      }).then(
+        (value) => ({ ok: true as const, value }),
+        (error: unknown) => ({ ok: false as const, error }),
+      );
+
+      expect(outcome.ok).toBe(false);
+      if (!outcome.ok) {
+        expect(outcome.error).toMatchObject({
+          name: "TimeoutError",
+          message: "request timed out",
+        });
+      }
+    } finally {
+      await hung.close();
+    }
+  });
+
+  it("times out hung OpenAI/Voyage production embedding fetches via fetchHostedRemoteEmbeddingVectors", async () => {
+    const hung = await listenHungServer();
+    try {
+      // Canonical hosted provider path: openai/voyage embedding-provider → this helper → postJson.
+      const outcome = await fetchHostedRemoteEmbeddingVectors({
+        url: hung.url,
+        headers: {
+          Authorization: "Bearer test",
+          "Content-Type": "application/json",
+        },
+        timeoutMs: 80,
+        ssrfPolicy: { allowPrivateNetwork: true },
+        body: { model: "text-embedding-3-small", input: ["proof"] },
+        errorPrefix: "openai embeddings failed",
+      }).then(
+        (value) => ({ ok: true as const, value }),
+        (error: unknown) => ({ ok: false as const, error }),
+      );
+
+      expect(outcome.ok).toBe(false);
+      if (!outcome.ok) {
+        expect(outcome.error).toMatchObject({
+          name: "TimeoutError",
+          message: "request timed out",
+        });
+      }
+    } finally {
+      await hung.close();
+    }
   });
 });

--- a/packages/memory-host-sdk/src/host/remote-http.ts
+++ b/packages/memory-host-sdk/src/host/remote-http.ts
@@ -11,6 +11,26 @@ import type { SsrFPolicy } from "./ssrf-policy.js";
 /** Proxy mode used only for URLs that the runtime classified as env-proxy safe. */
 const MEMORY_REMOTE_TRUSTED_ENV_PROXY_MODE = "trusted_env_proxy";
 
+/**
+ * Hosted remote memory HTTP hang floor (OpenAI/Voyage/Google batch/query budgets).
+ * Matches EMBEDDING_BATCH_TIMEOUT_REMOTE_MS in memory-core manager-embedding-ops.
+ */
+export const MEMORY_REMOTE_HTTP_TIMEOUT_HOSTED_MS = 120_000;
+
+/**
+ * Local/self-hosted remote memory HTTP hang floor (Ollama/LM Studio batch budget).
+ * Matches EMBEDDING_BATCH_TIMEOUT_LOCAL_MS (10 minutes) so a shared hang guard cannot
+ * clamp established self-hosted embedding requests that legitimately take 2–10 minutes.
+ * Composed with any caller AbortSignal via fetchWithSsrFGuard so cancellation-only
+ * signals cannot disable the floor; hosted callers pass timeoutMs:
+ * MEMORY_REMOTE_HTTP_TIMEOUT_HOSTED_MS when they want the tighter budget.
+ * Kept package-private — only MEMORY_REMOTE_HTTP_TIMEOUT_HOSTED_MS is a public contract.
+ */
+const MEMORY_REMOTE_HTTP_TIMEOUT_LOCAL_MS = 600_000;
+
+/** Default hang floor preserves the longer self-hosted budget for compatibility. */
+const MEMORY_REMOTE_HTTP_TIMEOUT_MS = MEMORY_REMOTE_HTTP_TIMEOUT_LOCAL_MS;
+
 /** Build an SSRF allow policy from a configured remote base URL. */
 export const buildRemoteBaseUrlPolicy: (baseUrl: string) => SsrFPolicy | undefined =
   ssrfPolicyFromHttpBaseUrlAllowedHostname;
@@ -20,6 +40,8 @@ export async function withRemoteHttpResponse<T>(params: {
   url: string;
   init?: RequestInit;
   signal?: AbortSignal;
+  /** Override the hang floor; defaults to MEMORY_REMOTE_HTTP_TIMEOUT_LOCAL_MS. */
+  timeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
   fetchImpl?: typeof fetch;
   fetchWithSsrFGuardImpl?: typeof fetchWithSsrFGuard;
@@ -29,11 +51,14 @@ export async function withRemoteHttpResponse<T>(params: {
 }): Promise<T> {
   const guardedFetch = params.fetchWithSsrFGuardImpl ?? fetchWithSsrFGuard;
   const shouldUseEnvProxy = params.shouldUseEnvHttpProxyForUrlImpl ?? shouldUseEnvHttpProxyForUrl;
+  // Always install a hang floor; fetchWithSsrFGuard composes it with caller signals.
+  const timeoutMs = params.timeoutMs ?? MEMORY_REMOTE_HTTP_TIMEOUT_MS;
   const { response, release } = await guardedFetch({
     url: params.url,
     fetchImpl: params.fetchImpl,
     init: params.init,
     signal: params.signal,
+    timeoutMs,
     policy: params.ssrfPolicy,
     auditContext: params.auditContext ?? "memory-remote",
     ...(shouldUseEnvProxy(params.url) ? { mode: MEMORY_REMOTE_TRUSTED_ENV_PROXY_MODE } : {}),
@@ -43,4 +68,27 @@ export async function withRemoteHttpResponse<T>(params: {
   } finally {
     await release();
   }
+}
+
+/**
+ * Hosted/cloud memory HTTP wrapper. Applies the 120s hosted hang floor unless the
+ * caller passes an explicit timeoutMs. Local/self-hosted callers should keep using
+ * withRemoteHttpResponse so they retain the longer default budget.
+ */
+export async function withHostedRemoteHttpResponse<T>(params: {
+  url: string;
+  init?: RequestInit;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  ssrfPolicy?: SsrFPolicy;
+  fetchImpl?: typeof fetch;
+  fetchWithSsrFGuardImpl?: typeof fetchWithSsrFGuard;
+  shouldUseEnvHttpProxyForUrlImpl?: typeof shouldUseEnvHttpProxyForUrl;
+  auditContext?: string;
+  onResponse: (response: Response) => Promise<T>;
+}): Promise<T> {
+  return await withRemoteHttpResponse({
+    ...params,
+    timeoutMs: params.timeoutMs ?? MEMORY_REMOTE_HTTP_TIMEOUT_HOSTED_MS,
+  });
 }

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -223,7 +223,9 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +4: group scope encoder/key builder (channel-policy + compat mirror).
       // Harvest: channel-ingress -64; dead channel-message dispatch aliases -23.
       // Harvest: retired qa-live-transport-scenarios subpath -6.
-      10606,
+      // +3: hosted memory remote HTTP helpers (withHosted / fetchHosted / createHosted) keep
+      // timeout policy package-private while giving hosted providers a 120s hang floor.
+      10609,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -232,7 +234,8 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +4: group scope encoder/key builder (channel-policy + compat mirror).
       // Harvest: channel-ingress -19; dead channel-message dispatch aliases -23.
       // Harvest: retired qa-live-transport-scenarios subpath -3.
-      5341,
+      // +3: hosted memory remote HTTP helpers (withHosted / fetchHosted / createHosted).
+      5344,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/plugin-sdk/memory-core-host-engine-embeddings.ts
+++ b/src/plugin-sdk/memory-core-host-engine-embeddings.ts
@@ -6,6 +6,7 @@ export {
   buildEmbeddingBatchGroupOptions,
   buildRemoteBaseUrlPolicy,
   classifyMemoryMultimodalPath,
+  createHostedRemoteEmbeddingProvider,
   createLocalEmbeddingProvider,
   createRemoteEmbeddingProvider,
   debugEmbeddingsLog,
@@ -16,6 +17,7 @@ export {
   estimateStructuredEmbeddingInputBytes,
   estimateUtf8Bytes,
   extractBatchErrorMessage,
+  fetchHostedRemoteEmbeddingVectors,
   fetchRemoteEmbeddingVectors,
   formatBatchErrorDetail,
   formatUnavailableBatchError,
@@ -38,6 +40,7 @@ export {
   throwIfBatchCompletionError,
   throwIfBatchTerminalFailure,
   uploadBatchJsonlFile,
+  withHostedRemoteHttpResponse,
   withRemoteHttpResponse,
 } from "../../packages/memory-host-sdk/src/engine-embeddings.js";
 


### PR DESCRIPTION
## What Problem This Solves

Memory remote HTTP (`withRemoteHttpResponse`) only forwarded an optional caller `AbortSignal`. Embedding batch / `postJson` callers often omit a signal (Google/OpenAI/Voyage upload and status polls), so a peer that accepts TCP but never returns headers could hang the Gateway forever. Idle body caps never start until headers arrive. Callers that pass a cancellation-only `AbortSignal` (no deadline) had the same hang risk when the wrapper treated any signal as a reason to skip the transport floor.

Hosted OpenAI/Voyage/Google callers also needed a tighter 120s floor than local/self-hosted Ollama/LM Studio (600s), without exporting timeout-policy constants on the public plugin SDK.

## Why This Change Was Made

Install a shared hang floor via existing `fetchWithSsrFGuard` `timeoutMs`, and compose it with any caller `AbortSignal`:

- Default local/self-hosted floor: 600s (`withRemoteHttpResponse`)
- Hosted/cloud floor: 120s via `withHostedRemoteHttpResponse`, `fetchHostedRemoteEmbeddingVectors`, and `createHostedRemoteEmbeddingProvider`
- Explicit `timeoutMs` override still wins
- Timeout constants stay package-private (not public plugin SDK exports)

Wire hosted providers (OpenAI, Voyage, Google, GitHub Copilot, DeepInfra, Mistral, shared batch upload) to the hosted helpers. Keep LM Studio on the local `createRemoteEmbeddingProvider` path.

No new config/env surface.

## User Impact

**Before:** Unsignaled (or cancellation-only-signaled) memory remote HTTP could hang indefinitely on a stalled upstream. Hosted providers inherited a 10-minute floor.

**After:** Local/self-hosted requests fail closed after 600s by default; hosted provider paths fail closed after 120s. Explicit `timeoutMs` and earlier caller aborts still win.

## Evidence

- Changed: `packages/memory-host-sdk/src/host/remote-http.ts`, `post-json.ts`, `embeddings-remote-fetch.ts`, `embeddings-remote-provider.ts`, `batch-upload.ts`, hosted provider callers, plugin SDK barrel (no timeout-constant exports), surface budget pins
- Production path under test: OpenAI/Voyage `fetchHostedRemoteEmbeddingVectors` → `postJson` → `withRemoteHttpResponse` against a real local `node:http` server that never writes headers
- Regression: remote-http, embeddings-remote-fetch, post-json, batch-upload, openai/google/voyage provider+batch tests; `plugin-sdk-surface-report --check`

## Real behavior proof

### Caller path

`extensions/openai/embedding-provider.ts` / `extensions/voyage/embedding-provider.ts` → `fetchHostedRemoteEmbeddingVectors` → `postJson` → guarded fetch hang floor (120s default; 80ms override in hung-server fixture).

Google/Copilot/batch upload → `withHostedRemoteHttpResponse` (120s default).

DeepInfra/Mistral → `createHostedRemoteEmbeddingProvider` (120s default).

LM Studio remains on `createRemoteEmbeddingProvider` (600s local default).

### Commands

```bash
node scripts/run-vitest.mjs \
  packages/memory-host-sdk/src/host/remote-http.test.ts \
  packages/memory-host-sdk/src/host/embeddings-remote-fetch.test.ts \
  packages/memory-host-sdk/src/host/post-json.test.ts \
  packages/memory-host-sdk/src/host/batch-upload.test.ts \
  extensions/openai/embedding-provider.test.ts \
  extensions/google/embedding-provider.test.ts \
  extensions/voyage/embedding-batch.test.ts \
  extensions/google/embedding-batch.test.ts \
  test/scripts/plugin-sdk-surface-report.test.ts \
  --reporter=verbose
node scripts/plugin-sdk-surface-report.mjs --check
```

### Evidence after fix

```text
✓ package withRemoteHttpResponse > defaults the hang floor to the local/self-hosted 600s embedding budget
✓ package withRemoteHttpResponse > defaults the hosted wrapper to the 120s hosted hang floor
✓ package withRemoteHttpResponse > times out hung hosted wrapper requests used by OpenAI/Voyage/Google callers
✓ package withRemoteHttpResponse > times out hung OpenAI/Voyage production embedding fetches via fetchHostedRemoteEmbeddingVectors
✓ fetchHostedRemoteEmbeddingVectors > defaults timeoutMs to the hosted 120s hang floor used by OpenAI/Voyage callers
Test Files  1 passed (1) / Tests  13 passed (13)   # remote-http
Test Files  2 passed (2) / Tests  18 passed (18)   # post-json + embeddings-remote-fetch
Test Files  1 passed (1) / Tests  11 passed (11)   # openai embedding-provider
Test Files  2 passed (2) / Tests  24 passed (24)   # google provider + batch
Test Files  1 passed (1) / Tests  10 passed (10)   # voyage batch
[test] passed 7 Vitest shards in 46.92s

public package SDK entrypoints:
  exports: 10615
  callable exports: 5347
# plugin-sdk-surface-report.mjs --check exit 0
# MEMORY_REMOTE_HTTP_TIMEOUT_* not exported from memory-core-host-engine-embeddings
```
