### PR TITLE
fix(discovery): find tailnet gateways when tailscale output is noisy

### DIFF
--- a/src/infra/bonjour-discovery.test.ts
+++ b/src/infra/bonjour-discovery.test.ts
@@ -257,12 +257,12 @@ describe("bonjour-discovery", () => {
 
       if (cmd === "tailscale" && argv[1] === "status" && argv[2] === "--json") {
         return {
-          stdout: JSON.stringify({
+          stdout: `warning: stale state {"Self":{},"Peer":{}}\n${JSON.stringify({
             Self: { TailscaleIPs: ["100.69.232.64"] },
             Peer: {
               "peer-1": { TailscaleIPs: ["100.123.224.76"] },
             },
-          }),
+          })}\nwarning: ignored {"after":true}\n`,
           stderr: "",
           code: 0,
           signal: null,

--- a/src/infra/bonjour-discovery.ts
+++ b/src/infra/bonjour-discovery.ts
@@ -6,6 +6,7 @@ import {
   uniqueStrings,
 } from "@openclaw/normalization-core/string-normalization";
 import { runCommandWithTimeout } from "../process/exec.js";
+import { parsePossiblyNoisyJsonObject } from "./noisy-json.js";
 import { parseStrictInteger } from "./parse-finite-number.js";
 import { isTailnetIPv4 } from "./tailnet.js";
 import { resolveWideAreaDiscoveryDomain } from "./widearea-dns.js";
@@ -163,7 +164,7 @@ function parseDigSrv(stdout: string): { host: string; port: number } | null {
 }
 
 function parseTailscaleStatusIPv4s(stdout: string): string[] {
-  const parsed = stdout ? (JSON.parse(stdout) as Record<string, unknown>) : {};
+  const parsed = stdout ? parsePossiblyNoisyJsonObject(stdout, isTailscaleStatusPayload) : {};
   const out: string[] = [];
 
   const addIps = (value: unknown) => {
@@ -195,6 +196,25 @@ function parseTailscaleStatusIPv4s(stdout: string): string[] {
   }
 
   return uniqueStrings(out);
+}
+
+function isTailscaleStatusPayload(payload: Record<string, unknown>): boolean {
+  if (hasTailnetIpList(payload.Self)) {
+    return true;
+  }
+  const peer = payload.Peer;
+  if (!peer || typeof peer !== "object") {
+    return false;
+  }
+  return Object.values(peer as Record<string, unknown>).some((value) => hasTailnetIpList(value));
+}
+
+function hasTailnetIpList(value: unknown): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const ips = (value as { TailscaleIPs?: unknown }).TailscaleIPs;
+  return Array.isArray(ips) && ips.some((ip) => typeof ip === "string" && isTailnetIPv4(ip.trim()));
 }
 
 function parsePortOrUndefined(value: string | undefined): number | undefined {

--- a/src/infra/noisy-json.ts
+++ b/src/infra/noisy-json.ts
@@ -1,0 +1,65 @@
+// Parses command output that may include warnings before or after a JSON object.
+export function parsePossiblyNoisyJsonObject(
+  stdout: string,
+  matchesPayload?: (payload: Record<string, unknown>) => boolean,
+): Record<string, unknown> {
+  const trimmed = stdout.trim();
+  for (let i = 0; i < trimmed.length; i += 1) {
+    if (trimmed[i] !== "{") {
+      continue;
+    }
+    const end = findJsonObjectEnd(trimmed, i);
+    if (end === undefined) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(trimmed.slice(i, end + 1)) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        const payload = parsed as Record<string, unknown>;
+        if (!matchesPayload || matchesPayload(payload) || (i === 0 && end === trimmed.length - 1)) {
+          return payload;
+        }
+      }
+    } catch {
+      // Keep looking: diagnostics can contain brace pairs before the real JSON.
+    }
+  }
+  return JSON.parse(trimmed) as Record<string, unknown>;
+}
+
+function findJsonObjectEnd(value: string, start: number): number | undefined {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < value.length; i += 1) {
+    const ch = value[i] ?? "";
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "{") {
+      depth += 1;
+      continue;
+    }
+    if (ch !== "}") {
+      continue;
+    }
+    depth -= 1;
+    if (depth === 0) {
+      return i;
+    }
+  }
+  return undefined;
+}

--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -71,7 +71,7 @@ describe("tailscale helpers", () => {
   it("parses noisy JSON output from tailscale status", async () => {
     const exec = vi.fn().mockResolvedValue({
       stdout:
-        'warning: stale state\n{"Self":{"DNSName":"noisy.tailnet.ts.net.","TailscaleIPs":["100.9.9.9"]}}\n',
+        'warning: stale state {"Self":{},"Peer":{}}\n{"Self":{"DNSName":"noisy.tailnet.ts.net.","TailscaleIPs":["100.9.9.9"]}}\nwarning: ignored {"after":true}\n',
     });
     const host = await getTailnetHostname(exec);
     expect(host).toBe("noisy.tailnet.ts.net");
@@ -80,7 +80,7 @@ describe("tailscale helpers", () => {
   it("parses noisy JSON output from tailscale whois", async () => {
     const exec = vi.fn().mockResolvedValue({
       stdout:
-        'warning: stale state\n{"UserProfile":{"LoginName":"operator@example.com","DisplayName":"Operator"}}\n',
+        'warning: stale state {"UserProfile":{}}\n{"UserProfile":{"LoginName":"operator@example.com","DisplayName":"Operator"}}\nwarning: ignored {"after":true}\n',
     });
 
     await expect(readTailscaleWhoisIdentity("100.64.0.11", exec)).resolves.toEqual({
@@ -257,7 +257,7 @@ describe("tailscale helpers", () => {
   it("hasTailscaleFunnelRouteForPort accepts noisy JSON status output", async () => {
     const exec = vi.fn().mockResolvedValue({
       stdout:
-        'warning: stale state\n{"AllowFunnel":{"device.tailnet.ts.net:443":true},"Web":{"device.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:18789"}}}}}\n',
+        'warning: stale state {"AllowFunnel":{},"Web":{}}\n{"AllowFunnel":{"device.tailnet.ts.net:443":true},"Web":{"device.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:18789"}}}}}\nwarning: ignored {"after":true}\n',
     });
 
     await expect(hasTailscaleFunnelRouteForPort(18789, exec)).resolves.toBe(true);

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -12,16 +12,7 @@ import {
 import { logVerbose } from "../globals.js";
 import { runExec } from "../process/exec.js";
 import { toErrorObject } from "./errors.js";
-
-function parsePossiblyNoisyJsonObject(stdout: string): Record<string, unknown> {
-  const trimmed = stdout.trim();
-  const start = trimmed.indexOf("{");
-  const end = trimmed.lastIndexOf("}");
-  if (start >= 0 && end > start) {
-    return JSON.parse(trimmed.slice(start, end + 1)) as Record<string, unknown>;
-  }
-  return JSON.parse(trimmed) as Record<string, unknown>;
-}
+import { parsePossiblyNoisyJsonObject } from "./noisy-json.js";
 
 /**
  * Locate Tailscale binary using multiple strategies:
@@ -134,7 +125,7 @@ export async function getTailnetHostname(exec: typeof runExec = runExec, detecte
         timeoutMs: 5000,
         maxBuffer: 400_000,
       });
-      const parsed = stdout ? parsePossiblyNoisyJsonObject(stdout) : {};
+      const parsed = stdout ? parsePossiblyNoisyJsonObject(stdout, isTailscaleStatusPayload) : {};
       const self =
         typeof parsed.Self === "object" && parsed.Self !== null
           ? (parsed.Self as Record<string, unknown>)
@@ -160,6 +151,32 @@ export async function getTailnetHostname(exec: typeof runExec = runExec, detecte
     lastError ?? new Error("Could not determine Tailscale DNS or IP"),
     "Non-Error thrown",
   );
+}
+
+function isTailscaleStatusPayload(payload: Record<string, unknown>): boolean {
+  const self =
+    typeof payload.Self === "object" && payload.Self !== null
+      ? (payload.Self as Record<string, unknown>)
+      : undefined;
+  if (typeof self?.DNSName === "string" && self.DNSName.trim()) {
+    return true;
+  }
+  if (hasTailnetIpList(self)) {
+    return true;
+  }
+  const peer = payload.Peer;
+  if (!peer || typeof peer !== "object") {
+    return false;
+  }
+  return Object.values(peer as Record<string, unknown>).some((value) => hasTailnetIpList(value));
+}
+
+function hasTailnetIpList(value: unknown): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const ips = (value as { TailscaleIPs?: unknown }).TailscaleIPs;
+  return Array.isArray(ips) && ips.some((ip) => typeof ip === "string" && ip.trim());
 }
 
 /**
@@ -300,8 +317,23 @@ export async function hasTailscaleFunnelRouteForPort(
   } catch {
     return false;
   }
-  const parsed = stdout ? parsePossiblyNoisyJsonObject(stdout) : {};
+  const parsed = stdout ? parsePossiblyNoisyJsonObject(stdout, isTailscaleFunnelPayload) : {};
   return tailscaleFunnelStatusCoversPort(parsed, port);
+}
+
+function isTailscaleFunnelPayload(payload: Record<string, unknown>): boolean {
+  const allowFunnel = readRecord(payload.AllowFunnel);
+  const web = readRecord(payload.Web);
+  if (allowFunnel && Object.values(allowFunnel).some((value) => value === true)) {
+    return true;
+  }
+  if (!web) {
+    return false;
+  }
+  return Object.values(web).some((hostEntry) => {
+    const handlers = readRecord(readRecord(hostEntry)?.Handlers);
+    return Boolean(handlers && Object.keys(handlers).length > 0);
+  });
 }
 
 const TAILSCALE_LOOPBACK_PROXY_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]", "::1"]);
@@ -475,7 +507,9 @@ export async function readTailscaleWhoisIdentity(
       timeoutMs: opts?.timeoutMs ?? 5_000,
       maxBuffer: 200_000,
     });
-    const parsed = result.stdout ? parsePossiblyNoisyJsonObject(result.stdout) : {};
+    const parsed = result.stdout
+      ? parsePossiblyNoisyJsonObject(result.stdout, isTailscaleWhoisPayload)
+      : {};
     const identity = parseWhoisIdentity(parsed);
     writeCachedWhois(normalized, identity, cacheTtlMs);
     return identity;
@@ -483,4 +517,8 @@ export async function readTailscaleWhoisIdentity(
     writeCachedWhois(normalized, null, errorTtlMs);
     return null;
   }
+}
+
+function isTailscaleWhoisPayload(payload: Record<string, unknown>): boolean {
+  return parseWhoisIdentity(payload) !== null;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users discovering OpenClaw gateways over a tailnet could miss wide-area Bonjour gateways when the Tailscale CLI printed diagnostic text around its JSON status output.

## Why This Change Was Made

Tailscale command JSON parsing now scans noisy command output for a balanced JSON object and lets each caller require the payload shape it actually consumes. This keeps the fix inside the infra/Tailscale discovery boundary, covers Bonjour wide-area discovery plus the existing Tailscale status, whois, and funnel helpers, and does not change config, provider routing, networking policy, or valid clean JSON behavior.

## User Impact

Gateway discovery and Tailscale helpers keep working when Tailscale emits warning or diagnostic JSON before or around the command response, while unrelated diagnostic objects are skipped instead of being mistaken for the payload.

## Evidence

- Claim proved: Bonjour wide-area discovery and Tailscale status, whois, and funnel helpers skip noisy diagnostic JSON objects and parse the intended Tailscale command payload.
- Current-head proof at `4344f22b1be0c3c42684b273a640fdecf765a6af`: `node scripts/run-vitest.mjs src/infra/bonjour-discovery.test.ts src/infra/tailscale.test.ts` passed with 2 test files and 35 tests.
- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode commit --commit HEAD --no-web-search` passed with no accepted/actionable findings.
- Observed result: the focused regressions feed diagnostic JSON objects using the same top-level markers as Tailscale responses, and the discovery/status/whois/funnel paths still select the real payload.