### PR TITLE
improve(agents): reduce warm model resolution latency

### DIFF
--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const manifestMocks = vi.hoisted(() => ({
+  getCurrentPluginMetadataSnapshot: vi.fn(),
   listOpenClawPluginManifestMetadata: vi.fn(),
   loadPluginManifest: vi.fn(),
   loadPluginManifestRegistry: vi.fn(),
@@ -17,6 +18,10 @@ const providerMocks = vi.hoisted(() => ({
 
 vi.mock("../../plugins/manifest-metadata-scan.js", () => ({
   listOpenClawPluginManifestMetadata: manifestMocks.listOpenClawPluginManifestMetadata,
+}));
+
+vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
+  getCurrentPluginMetadataSnapshot: manifestMocks.getCurrentPluginMetadataSnapshot,
 }));
 
 vi.mock("../../plugins/manifest.js", async (importOriginal) => ({
@@ -117,6 +122,7 @@ function createMistralManifestPlugin(overrides?: {
 }
 
 beforeEach(() => {
+  manifestMocks.getCurrentPluginMetadataSnapshot.mockReset();
   manifestMocks.listOpenClawPluginManifestMetadata.mockReset();
   manifestMocks.loadPluginManifest.mockReset();
   manifestMocks.loadPluginManifestRegistry.mockReset();
@@ -127,6 +133,7 @@ beforeEach(() => {
   providerMocks.resolveRuntimePluginDiscoveryProviders.mockReset();
   providerMocks.runProviderStaticCatalog.mockReset();
   setManifestPlugins([]);
+  manifestMocks.getCurrentPluginMetadataSnapshot.mockReturnValue(undefined);
   manifestMocks.loadPluginManifestRegistry.mockReturnValue({ plugins: [] });
   providerMocks.resolveActivatableProviderOwnerPluginIds.mockImplementation(
     ({ pluginIds }: { pluginIds: string[] }) => pluginIds,
@@ -157,6 +164,78 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
     for (const provider of ["moonshotai", "moonshot-ai"]) {
       expect(canonicalizeManifestModelCatalogProviderAlias({ provider })).toBe("moonshot");
     }
+  });
+
+  it("reuses the current plugin metadata snapshot for repeated alias lookups", () => {
+    const plugins = [
+      {
+        providers: ["moonshot"],
+        modelCatalog: {
+          aliases: {
+            "moonshot-ai": { provider: "moonshot" },
+          },
+        },
+      },
+    ];
+    manifestMocks.getCurrentPluginMetadataSnapshot.mockReturnValue({ plugins });
+
+    expect(canonicalizeManifestModelCatalogProviderAlias({ provider: "moonshot-ai" })).toBe(
+      "moonshot",
+    );
+    expect(canonicalizeManifestModelCatalogProviderAlias({ provider: "moonshot-ai" })).toBe(
+      "moonshot",
+    );
+    expect(manifestMocks.loadPluginManifestRegistry).not.toHaveBeenCalled();
+    expect(manifestMocks.getCurrentPluginMetadataSnapshot).toHaveBeenLastCalledWith({
+      config: undefined,
+      env: process.env,
+      requireDefaultDiscoveryContext: true,
+      workspaceDir: undefined,
+    });
+  });
+
+  it("requests an exact configured workspace snapshot", () => {
+    const cfg = { plugins: { allow: ["openai"] } };
+    manifestMocks.getCurrentPluginMetadataSnapshot.mockReturnValue({ plugins: [] });
+
+    canonicalizeManifestModelCatalogProviderAlias({
+      provider: "openai",
+      cfg,
+      workspaceDir: "/workspace",
+    });
+
+    expect(manifestMocks.getCurrentPluginMetadataSnapshot).toHaveBeenCalledWith({
+      config: cfg,
+      env: process.env,
+      workspaceDir: "/workspace",
+    });
+  });
+
+  it("keeps custom environments on their own manifest registry context", () => {
+    const env = { HOME: "/custom-home" };
+    manifestMocks.getCurrentPluginMetadataSnapshot.mockReturnValue({ plugins: [] });
+    manifestMocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          providers: ["moonshot"],
+          modelCatalog: {
+            aliases: {
+              "moonshot-ai": { provider: "moonshot" },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(canonicalizeManifestModelCatalogProviderAlias({ provider: "moonshot-ai", env })).toBe(
+      "moonshot",
+    );
+    expect(manifestMocks.getCurrentPluginMetadataSnapshot).not.toHaveBeenCalled();
+    expect(manifestMocks.loadPluginManifestRegistry).toHaveBeenCalledWith({
+      config: undefined,
+      env,
+      workspaceDir: undefined,
+    });
   });
 });
 

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -7,6 +7,7 @@ import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { planManifestModelCatalogRows } from "../../model-catalog/manifest-planner.js";
 import { normalizePluginsConfig } from "../../plugins/config-state.js";
+import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
 import { listOpenClawPluginManifestMetadata } from "../../plugins/manifest-metadata-scan.js";
 import { passesManifestOwnerBasePolicy } from "../../plugins/manifest-owner-policy.js";
 import { loadPluginManifestRegistry } from "../../plugins/manifest-registry.js";
@@ -207,14 +208,29 @@ export function canonicalizeManifestModelCatalogProviderAlias(params: {
   if (!provider) {
     return params.provider;
   }
+  const env = params.env ?? process.env;
+  // Gateway plugin metadata is process-stable. Reuse its lifecycle-owned snapshot
+  // so every model turn does not rediscover the same manifest alias table.
+  const currentPlugins =
+    env === process.env
+      ? getCurrentPluginMetadataSnapshot({
+          config: params.cfg,
+          workspaceDir: params.workspaceDir,
+          env,
+          ...(params.cfg === undefined ? { requireDefaultDiscoveryContext: true } : {}),
+        })?.plugins
+      : undefined;
+  const plugins =
+    currentPlugins ??
+    loadPluginManifestRegistry({
+      config: params.cfg,
+      workspaceDir: params.workspaceDir,
+      env,
+    }).plugins;
   return (
     resolveManifestModelCatalogProviderAlias({
       provider,
-      plugins: loadPluginManifestRegistry({
-        config: params.cfg,
-        workspaceDir: params.workspaceDir,
-        env: params.env ?? process.env,
-      }).plugins,
+      plugins,
     }) ?? params.provider
   );
 }


### PR DESCRIPTION
Closes #105543

## What Problem This Solves

Resolves a problem where every warm Gateway agent turn spent about 75-80 ms rediscovering plugin manifest metadata before model execution, even though the Gateway already owns a compatible process-stable metadata snapshot.

## Why This Change Was Made

Manifest model-catalog alias resolution now reuses the Gateway-owned snapshot only when the process environment, config, workspace, and discovery context match. Calls with custom environments or incompatible/default contexts retain the existing manifest-registry fallback.

This PR is AI-assisted. I reviewed the implementation and understand the snapshot compatibility and fallback boundaries.

## User Impact

Repeated turns through a running Gateway begin model execution sooner, without changing provider aliases or plugin discovery behavior outside the active Gateway context.

## Evidence

- Live OpenAI/Crabbox before, `run_3de969063a9a` on AWS c7a.48xlarge:
  - warm model resolution: 78 ms, 82 ms
  - warm startup: 89 ms, 92 ms
- Live OpenAI/Crabbox after, `run_1250de37aa7d` on the same lease:
  - warm model resolution: 4 ms, 3 ms (about 95% lower)
  - warm startup: 18 ms, 11 ms
  - combined warm startup plus prep median: 197 ms -> 117 ms (about 41% lower)
- Isolated alias benchmark, `run_812ebc00b525`: repeated registry-backed alias lookups cost about 35-43 ms each.
- Blacksmith Testbox: `corepack pnpm test src/agents/embedded-agent-runner/model.static-catalog.test.ts` — 21/21 passed.
- Blacksmith Testbox: targeted `pnpm format:check` — passed.
- Autoreview: clean after adding exact default/config/workspace matching and custom-environment fallback coverage.
- `check:changed` passed conflict, attribution, boundary, dependency, duplicate, and format checks; the unrelated Plugin SDK API baseline hash mismatch is present outside this two-file diff.
