### PR TITLE
refactor(agents): remove unused auth plan wrapper

### DIFF
--- a/src/agents/runtime-plan/prepare-auth.test.ts
+++ b/src/agents/runtime-plan/prepare-auth.test.ts
@@ -8,9 +8,12 @@ import {
   agentRuntimeAuthPlanMatchesTarget,
   canRunPreparedAgentRuntimeAuthAttempt,
   prepareAgentRuntimeAuth,
-  prepareAgentRuntimeAuthPlan,
   preparedAgentRuntimeProfileAttemptHasCandidate,
 } from "./prepare-auth.js";
+
+function prepareAgentRuntimeAuthPlan(params: Parameters<typeof prepareAgentRuntimeAuth>[0]) {
+  return prepareAgentRuntimeAuth(params).plan;
+}
 
 function authStore(
   profiles: AuthProfileStore["profiles"],

--- a/src/agents/runtime-plan/prepare-auth.ts
+++ b/src/agents/runtime-plan/prepare-auth.ts
@@ -579,10 +579,3 @@ export function prepareAgentRuntimeAuth(
     attempts: attempts.length > 0 ? attempts : [{ kind: "implicit", plan }],
   };
 }
-
-/** Returns the initial immutable plan for auxiliary consumers. */
-export function prepareAgentRuntimeAuthPlan(
-  params: PrepareAgentRuntimeAuthPlanParams,
-): AgentRuntimeAuthPlan {
-  return prepareAgentRuntimeAuth(params).plan;
-}


### PR DESCRIPTION
## What Problem This Solves

Removes an unused production auth-planning wrapper that had no runtime callers and duplicated the canonical planner's `.plan` projection.

## Why This Change Was Made

Production now exposes only `prepareAgentRuntimeAuth`; the focused tests keep their concise plan assertions through a test-local projection. The codebase-memory graph found no production caller for the removed wrapper.

Direct Codex contract inspection confirmed this does not change Codex auth behavior: auth modes remain explicit in `../codex/codex-rs/app-server/src/auth_mode.rs:10`, app-server auth manager construction remains in `../codex/codex-rs/app-server/src/lib.rs:506` and `../codex/codex-rs/app-server/src/lib.rs:758`, and API-key versus ChatGPT bearer handling remains in `../codex/codex-rs/core/src/client.rs:393`.

## User Impact

No user-visible behavior changes. The agent runtime keeps the same auth plan and attempt preparation while carrying one fewer unused production API.

## Evidence

- `pnpm test:serial src/agents/runtime-plan/prepare-auth.test.ts`: 58 passed on Testbox `tbx_01kxbn3ckehgvj12frmwbya7re`
- `pnpm check:changed -- src/agents/runtime-plan/prepare-auth.ts src/agents/runtime-plan/prepare-auth.test.ts`: all touched-file checks passed; stopped only on the pre-existing unrelated Plugin SDK API baseline hash drift
- Fresh `gpt-5.6-sol` medium autoreview: clean, 0.91 confidence
- Full codebase-memory index: removed wrapper had zero callers; refreshed graph contains only the test-local projection
- Open PR overlap audit: no active PR touches either changed file
