### PR TITLE
refactor(agents): localize code mode internals

### DIFF
--- a/src/agents/code-mode-control-tools.ts
+++ b/src/agents/code-mode-control-tools.ts
@@ -11,16 +11,16 @@ export const CODE_MODE_EXEC_TOOL_NAME = "exec";
 /** Model-visible Code Mode wait tool name. */
 export const CODE_MODE_WAIT_TOOL_NAME = "wait";
 /** Direct tools whose structured results cannot cross the JSON-only guest bridge. */
-export const CODE_MODE_DIRECT_TOOL_NAMES: ReadonlySet<string> = new Set(["computer"]);
+const CODE_MODE_DIRECT_TOOL_NAMES: ReadonlySet<string> = new Set(["computer"]);
 /** Hook metadata kind for Code Mode exec tools. */
 const CODE_MODE_EXEC_TOOL_KIND = "code_mode_exec";
 
 /** Hook metadata kind type for Code Mode exec tools. */
 type CodeModeExecToolKind = typeof CODE_MODE_EXEC_TOOL_KIND;
 /** Source language accepted by the Code Mode exec tool. */
-export type CodeModeExecToolInputKind = "javascript" | "typescript";
+type CodeModeExecToolInputKind = "javascript" | "typescript";
 /** Metadata attached to before-tool-call events for Code Mode exec. */
-export type CodeModeExecHookMetadata = {
+type CodeModeExecHookMetadata = {
   toolKind: CodeModeExecToolKind;
   toolInputKind?: CodeModeExecToolInputKind;
 };


### PR DESCRIPTION
## What Problem This Solves

Removes three unnecessary production exports from the internal Code Mode control-tool module.

## Why This Change Was Made

`CODE_MODE_DIRECT_TOOL_NAMES`, `CodeModeExecToolInputKind`, and `CodeModeExecHookMetadata` are referenced only inside `src/agents/code-mode-control-tools.ts`. Keeping them module-private matches their ownership and avoids presenting implementation details as reusable APIs.

## User Impact

No user-visible behavior changes. Code Mode tool visibility and before-tool-call metadata remain identical.

## Evidence

- `pnpm test:serial src/agents/code-mode.test.ts`: 65 passed on Testbox `tbx_01kxbn3ckehgvj12frmwbya7re`
- `pnpm check:changed -- src/agents/code-mode-control-tools.ts`: all touched-file checks passed; stopped only on the pre-existing unrelated Plugin SDK API baseline hash drift
- Fresh `gpt-5.6-sol` medium autoreview: clean, 0.86 confidence
- Fresh full codebase-memory index plus repository search: all three declarations have only same-module references
- Open PR overlap audit: no active PR touches the changed file
