### PR TITLE
ci(release): trace LTS post-prompt cleanup

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -4675,11 +4675,20 @@ export async function runEmbeddedAttempt(
         }
 
         await sessionLockController.waitForSessionEvents(activeSession);
+        log.debug(
+          `run cleanup: stage=post-prompt-session-events runId=${params.runId} sessionId=${params.sessionId}`,
+        );
         await waitForPendingEvents();
+        log.debug(
+          `run cleanup: stage=post-prompt-pending-events runId=${params.runId} sessionId=${params.sessionId}`,
+        );
         if (repairedRejectedThinkingReplay) {
           activeSession.agent.state.messages = activeSessionManager.buildSessionContext().messages;
         }
         await sessionLockController.releaseForPrompt();
+        log.debug(
+          `run cleanup: stage=prompt-lock-released runId=${params.runId} sessionId=${params.sessionId}`,
+        );
 
         if (
           shouldWaitForCompletionRequiredAsyncTasks({
@@ -4737,6 +4746,9 @@ export async function runEmbeddedAttempt(
             await sessionLockController.waitForSessionEvents(activeSession);
           }
         }
+        log.debug(
+          `run cleanup: stage=completion-required-async-tasks runId=${params.runId} sessionId=${params.sessionId}`,
+        );
 
         // Capture snapshot before compaction wait so we have complete messages if timeout occurs
         // Check compaction state before and after to avoid race condition where compaction starts during capture
@@ -4757,6 +4769,9 @@ export async function runEmbeddedAttempt(
           if (onBlockReplyFlush) {
             await onBlockReplyFlush();
           }
+          log.debug(
+            `run cleanup: stage=block-reply-flush runId=${params.runId} sessionId=${params.sessionId}`,
+          );
 
           // Skip compaction wait when yield aborted the run — the signal is
           // already tripped and abortable() would immediately reject.
@@ -4792,8 +4807,14 @@ export async function runEmbeddedAttempt(
             throw err;
           }
         }
+        log.debug(
+          `run cleanup: stage=compaction-wait runId=${params.runId} sessionId=${params.sessionId}`,
+        );
 
         await sessionLockController.waitForSessionEvents(activeSession);
+        log.debug(
+          `run cleanup: stage=post-compaction-session-events runId=${params.runId} sessionId=${params.sessionId}`,
+        );
         await sessionLockController.withSessionWriteLock(async () => {
           // Check if ANY compaction occurred during the entire attempt (prompt + retry).
           // Using a cumulative count (> 0) instead of a delta check avoids missing


### PR DESCRIPTION
## What Problem This Solves

The exact `extended-stable/2026.6.33` Telegram release canary receives inbound messages and completes the deterministic model prompt in under 150 ms, but no reply is observed before the 60-second deadline. Existing retained diagnostics stop at prompt completion and cannot identify which post-prompt drain/flush/compaction boundary is blocking.

## Why This Change Was Made

Add behavior-neutral DEBUG milestones after each post-prompt await boundary. Messages use the trusted release workflow's existing retained `run cleanup:` prefix and contain only stage, run ID, and session ID—no prompts, message content, paths, errors, or credentials.

## User Impact

No normal user-visible behavior change. These milestones are emitted only at DEBUG and allow the exact LTS release check to identify the deterministic delivery blocker without weakening candidate provenance.

## Evidence

- Exact failing LTS run: https://github.com/openclaw/openclaw/actions/runs/29200507474
- Prompt completion: 68–144 ms; no visible reply; retained artifacts preserved
- Fresh LTS-target Testbox `tbx_01kxbp354gqfpt5m1d3jancy7q`: targeted oxfmt and oxlint clean with `CI=true`
- Fresh autoreview: accepted separate reply-flush milestone; final clean, correctness 0.99
- `git diff --check`: clean

