### PR TITLE
fix: stabilize TUI PTY lifecycle CI

### DIFF
--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -11,18 +11,20 @@ import {
 } from "../../test/helpers/openclaw-test-instance.js";
 import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createDeferred } from "../test-utils/deferred.js";
 import { GatewayChatClient } from "./gateway-chat.js";
 import { sleep, startPty, waitFor, type PtyRun } from "./tui-pty-test-support.js";
 
 type MockModelServer = {
   baseUrl: string;
   requests: (modelId?: string) => MockModelRequest[];
+  releaseFirstResponse: (modelId: string) => void;
   stop: () => Promise<void>;
 };
 
 type MockModelBehavior = {
   replyText: string;
-  firstResponseDelayMs?: number;
+  holdFirstResponse?: boolean;
   followupReplyText?: string;
   invalidEditLoop?: boolean;
 };
@@ -45,7 +47,7 @@ const GATEWAY_SCENARIOS = {
     modelId: "tui-pty-validation",
     toolsProfile: "coding",
     replyText: "FIRST_RUN_ACTIVE",
-    firstResponseDelayMs: 0,
+    holdFirstResponse: false,
     followupReplyText: "FOLLOWUP_RUN_COMPLETE",
     invalidEditLoop: true,
   },
@@ -54,7 +56,7 @@ const GATEWAY_SCENARIOS = {
     modelId: "tui-pty-new-session",
     toolsProfile: "minimal",
     replyText: "FIRST_RUN_ACTIVE",
-    firstResponseDelayMs: 0,
+    holdFirstResponse: false,
     followupReplyText: "FOLLOWUP_RUN_COMPLETE",
   },
   followup: {
@@ -62,7 +64,7 @@ const GATEWAY_SCENARIOS = {
     modelId: "tui-pty-followup",
     toolsProfile: "minimal",
     replyText: "FIRST_RUN_ACTIVE",
-    firstResponseDelayMs: 1_500,
+    holdFirstResponse: true,
     followupReplyText: "FOLLOWUP_RUN_COMPLETE",
   },
   emptyReply: {
@@ -70,7 +72,7 @@ const GATEWAY_SCENARIOS = {
     modelId: "tui-pty-empty-reply",
     toolsProfile: "minimal",
     replyText: "[[reply_to_current]]",
-    firstResponseDelayMs: 0,
+    holdFirstResponse: false,
     followupReplyText: "FOLLOWUP_RUN_COMPLETE",
   },
   cancel: {
@@ -78,7 +80,7 @@ const GATEWAY_SCENARIOS = {
     modelId: "tui-pty-cancel",
     toolsProfile: "minimal",
     replyText: "FIRST_RUN_ACTIVE",
-    firstResponseDelayMs: 1_500,
+    holdFirstResponse: true,
     followupReplyText: "FOLLOWUP_RUN_COMPLETE",
   },
   collect: {
@@ -86,7 +88,7 @@ const GATEWAY_SCENARIOS = {
     modelId: "tui-pty-collect",
     toolsProfile: "minimal",
     replyText: "FIRST_RUN_ACTIVE",
-    firstResponseDelayMs: 1_500,
+    holdFirstResponse: true,
     followupReplyText: "FOLLOWUP_RUN_COMPLETE",
   },
 } as const satisfies Record<string, GatewayScenario>;
@@ -97,6 +99,9 @@ const LOCAL_STARTUP_TIMEOUT_MS = 60_000;
 const LOCAL_OUTPUT_TIMEOUT_MS = 120_000;
 const LOCAL_EXIT_TIMEOUT_MS = 4_000;
 const LOCAL_TEST_TIMEOUT_MS = 150_000;
+const SUBMISSION_SETTLE_MS = 150;
+const SESSION_ROLLOVER_RETRY_TIMEOUT_MS = 5_000;
+const SESSION_ROLLOVER_BUSY_MESSAGE = "abort the current run before /new";
 
 function createIdempotentCleanup(cleanup: () => Promise<void>) {
   let cleanupPromise: Promise<void> | undefined;
@@ -114,6 +119,37 @@ async function waitForOutputAfter(run: PtyRun, needle: string, offset: number) {
         `timed out waiting for ${JSON.stringify(needle)} after offset ${offset}\n${run.output()}`,
       ),
   });
+}
+
+async function createFreshSession(run: PtyRun, newSessionPrefix: string) {
+  const retryDeadline = Date.now() + SESSION_ROLLOVER_RETRY_TIMEOUT_MS;
+  while (true) {
+    const outputOffset = run.output().length;
+    await run.write("/new\r", { delay: false });
+    const outcome = await waitFor({
+      timeoutMs: LOCAL_STARTUP_TIMEOUT_MS,
+      read: () => {
+        const hasOutput = (needle: string) => run.output().slice(outputOffset).includes(needle);
+        if (hasOutput(newSessionPrefix)) {
+          return "created" as const;
+        }
+        if (hasOutput(SESSION_ROLLOVER_BUSY_MESSAGE)) {
+          return "busy" as const;
+        }
+        return null;
+      },
+      onTimeout: () => new Error(`timed out creating a fresh session\n${run.output()}`),
+    });
+    if (outcome === "created") {
+      return;
+    }
+    if (Date.now() >= retryDeadline) {
+      throw new Error(`session rollover stayed busy\n${run.output()}`);
+    }
+    // The response text can render before terminal lifecycle cleanup. Retry only
+    // after the command's explicit guard rejects the rollover, never while creation is pending.
+    await sleep(50);
+  }
 }
 
 async function readRequestBody(req: IncomingMessage): Promise<string> {
@@ -134,7 +170,11 @@ function writeJson(res: ServerResponse, status: number, body: unknown) {
   res.end(text);
 }
 
-async function writeResponsesSse(res: ServerResponse, text: string, completionDelayMs = 0) {
+async function writeResponsesSse(
+  res: ServerResponse,
+  text: string,
+  completionGate?: Promise<void>,
+) {
   const id = "msg_tui_pty_local";
   const events = [
     {
@@ -189,8 +229,8 @@ async function writeResponsesSse(res: ServerResponse, text: string, completionDe
     connection: "keep-alive",
   });
   res.write(`data: ${JSON.stringify(events[0])}\n\n`);
-  if (completionDelayMs > 0) {
-    await sleep(completionDelayMs);
+  if (completionGate) {
+    await completionGate;
   }
   if (res.destroyed) {
     return;
@@ -248,6 +288,11 @@ async function startRoutedMockModelServer(
 ): Promise<MockModelServer> {
   const requests: MockModelRequest[] = [];
   const requestsByModel = new Map<string, MockModelRequest[]>();
+  const firstResponseGates = new Map(
+    Object.entries(behaviors)
+      .filter(([, behavior]) => behavior.holdFirstResponse)
+      .map(([modelId]) => [modelId, createDeferred()] as const),
+  );
   const server = createServer((req, res) => {
     void (async () => {
       const url = new URL(req.url ?? "/", "http://127.0.0.1");
@@ -287,7 +332,7 @@ async function startRoutedMockModelServer(
             requestIndex === 0
               ? behavior.replyText
               : (behavior.followupReplyText ?? behavior.replyText),
-            requestIndex === 0 ? (behavior.firstResponseDelayMs ?? 0) : 0,
+            requestIndex === 0 ? firstResponseGates.get(modelId)?.promise : undefined,
           );
           return;
         }
@@ -309,7 +354,14 @@ async function startRoutedMockModelServer(
   return {
     baseUrl: `http://127.0.0.1:${address.port}`,
     requests: (modelId) => (modelId ? (requestsByModel.get(modelId) ?? []) : requests),
+    releaseFirstResponse: (modelId) => {
+      firstResponseGates.get(modelId)?.resolve();
+    },
     stop: async () => {
+      // Never leave a held request owning the shared server during failure cleanup.
+      for (const gate of firstResponseGates.values()) {
+        gate.resolve();
+      }
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));
         // Aborted local runs can leave a provider keep-alive open. Force-close
@@ -597,7 +649,7 @@ async function startSharedGatewayFixture(): Promise<SharedGatewayFixture> {
           scenario.modelId,
           {
             replyText: scenario.replyText,
-            firstResponseDelayMs: scenario.firstResponseDelayMs,
+            holdFirstResponse: scenario.holdFirstResponse,
             followupReplyText: scenario.followupReplyText,
             invalidEditLoop: scenario.invalidEditLoop,
           },
@@ -709,6 +761,7 @@ async function startGatewayModeTui(
     outputTimeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
   });
   const cleanup = createIdempotentCleanup(async () => {
+    shared.mockModel.releaseFirstResponse(scenario.modelId);
     run.dispose();
     for (const key of sessionKeys) {
       await shared.controlClient.abortChat({ sessionKey: key });
@@ -721,6 +774,7 @@ async function startGatewayModeTui(
     gateway: shared.gateway,
     mockModel: {
       requests: () => shared.mockModel.requests(scenario.modelId).slice(requestOffset),
+      releaseFirstResponse: () => shared.mockModel.releaseFirstResponse(scenario.modelId),
     },
     agentId: scenario.agentId,
     sessionKey,
@@ -797,13 +851,7 @@ describe("TUI PTY real backends", () => {
         expect(request?.body.model).toBe("gpt-5.5");
         await fixture.run.waitForOutput("LOCAL_PTY_RESPONSE");
 
-        // Text deltas arrive before the terminal lifecycle event. Wait for the
-        // finished run to become idle so /new exercises session creation.
-        const responseOffset = fixture.run.output().lastIndexOf("LOCAL_PTY_RESPONSE");
-        await waitForOutputAfter(fixture.run, "| idle", responseOffset);
-
-        await fixture.run.write("/new\r", { delay: false });
-        await fixture.run.waitForOutput("new session: agent:main:tui-");
+        await createFreshSession(fixture.run, "new session: agent:main:tui-");
         await fixture.run.write("send after local new\r");
         await waitFor({
           timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
@@ -937,12 +985,8 @@ describe("TUI PTY real backends", () => {
         await fixture.run.write("seed gateway session\r");
         await fixture.run.waitForOutput("FIRST_RUN_ACTIVE");
 
-        const responseOffset = fixture.run.output().lastIndexOf("FIRST_RUN_ACTIVE");
-        await waitForOutputAfter(fixture.run, "| idle", responseOffset);
-
-        await fixture.run.write("/new\r", { delay: false });
         const newSessionPrefix = `new session: agent:${fixture.agentId}:tui-`;
-        await fixture.run.waitForOutput(newSessionPrefix);
+        await createFreshSession(fixture.run, newSessionPrefix);
         const newSessionKey = fixture.run
           .output()
           .match(new RegExp(`new session: (agent:${fixture.agentId}:tui-[a-z0-9-]+)`))?.[1];
@@ -986,7 +1030,12 @@ describe("TUI PTY real backends", () => {
             new Error(`first prompt did not reach the model\n${fixture.run.output()}`),
         });
 
+        const followupOffset = fixture.run.output().length;
         await fixture.run.write("queued followup turn\r");
+        await waitForOutputAfter(fixture.run, "queued followup turn", followupOffset);
+        // Keep the provider held while the echoed input crosses TUI submission.
+        await sleep(SUBMISSION_SETTLE_MS);
+        fixture.mockModel.releaseFirstResponse();
         await waitFor({
           timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
           read: () => (fixture.mockModel.requests().length === 2 ? true : null),
@@ -1094,11 +1143,15 @@ describe("TUI PTY real backends", () => {
           onTimeout: () =>
             new Error(`first prompt did not reach the model\n${fixture.run.output()}`),
         });
+        const followupOffset = fixture.run.output().length;
         await fixture.run.write("must never reach model\r");
-        await sleep(150);
+        await waitForOutputAfter(fixture.run, "must never reach model", followupOffset);
+        await sleep(SUBMISSION_SETTLE_MS);
         await fixture.run.write("\u001b", { delay: false });
         await fixture.run.waitForOutput("aborted");
-        await sleep(1_750);
+        fixture.mockModel.releaseFirstResponse();
+        // Abort has cleared the queue; keep only a short window for a stray provider request.
+        await sleep(250);
 
         expect(fixture.mockModel.requests()).toHaveLength(1);
         expect(fixture.run.output()).not.toContain("FOLLOWUP_RUN_COMPLETE");
@@ -1153,6 +1206,7 @@ describe("TUI PTY real backends", () => {
         });
         const sendResults = await Promise.all([alphaSend, betaSend]);
         expect(sendResults.map((result) => result.status)).toEqual(["started", "started"]);
+        fixture.mockModel.releaseFirstResponse();
         await waitFor({
           timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
           read: () => (fixture.mockModel.requests().length === 2 ? true : null),
@@ -1161,7 +1215,9 @@ describe("TUI PTY real backends", () => {
               `collected prompt did not reach the model\n${fixture.gateway.logs()}\n${fixture.run.output()}`,
             ),
         });
-        await sleep(500);
+        await fixture.run.waitForOutput("FOLLOWUP_RUN_COMPLETE");
+        const completedOffset = fixture.run.output().lastIndexOf("FOLLOWUP_RUN_COMPLETE");
+        await waitForOutputAfter(fixture.run, "| idle", completedOffset);
 
         const requests = fixture.mockModel.requests();
         expect(


### PR DESCRIPTION
## What Problem This Solves

Resolves a main CI failure where the TUI PTY lifecycle test could render the first response before terminal run cleanup completed. The test then sent `/new`, hit the intentional active-run guard, and waited until timeout. Related failure: [Actions run 29193264775](https://github.com/openclaw/openclaw/actions/runs/29193264775), [failed TUI PTY job](https://github.com/openclaw/openclaw/actions/runs/29193264775/job/86651774683).

The followup, cancellation, and collect cases also depended on fixed 1.5–1.75 second provider delays, making them slower and leaving synchronization implicit.

## Why This Change Was Made

The PTY fixture now retries session rollover only after the TUI explicitly reports that the previous run is still active. Queue tests hold the first provider response behind explicit deferred gates, confirm the intended input or gateway acknowledgment, and release the response at the exact lifecycle boundary being tested. Runtime behavior is unchanged.

## User Impact

No user-visible runtime change. Maintainers get deterministic TUI lifecycle coverage and a faster focused suite; a same-box before/after comparison reduced test time from 29.34 seconds to 20.00 seconds (31.8%).

## Evidence

- Fresh exact-head Blacksmith Testbox `amber-crab-6c1b`, [run 29201996313](https://github.com/openclaw/openclaw/actions/runs/29201996313): `8/8` tests passed in `src/tui/tui-pty-local.e2e.test.ts` (`24.95s` test time on the cold proof box).
- Fresh exact-head Testbox: `pnpm check:changed` passed, including format, core-test typecheck, and lint.
- Same-box benchmark before/after: `29.343s` → `19.997s` test time; Vitest duration `32.00s` → `21.10s`.
- Fresh branch-level autoreview: clean; no accepted or actionable findings.

AI-assisted. I reviewed the implementation and validation results.
