### PR TITLE
refactor(agents): remove unused live model provider helper

### DIFF
--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -91,13 +91,6 @@ for (const key of HIGH_SIGNAL_LIVE_MODEL_PRIORITY) {
   }
 }
 
-/** Return providers represented in the high-signal live model priority list. */
-export function getHighSignalLiveModelProviders(): string[] {
-  return [...HIGH_SIGNAL_LIVE_MODEL_IDS_BY_PROVIDER.keys()].toSorted((left, right) =>
-    left.localeCompare(right),
-  );
-}
-
 function isHighSignalClaudeModelId(id: string): boolean {
   const normalized = id.replace(/[_.]/g, "-");
   if (!/\bclaude\b/i.test(normalized)) {

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -35,7 +35,6 @@ import {
   DEFAULT_HIGH_SIGNAL_LIVE_MODEL_LIMIT,
   DEFAULT_SMALL_LIVE_MODEL_LIMIT,
   getHighSignalLiveModelPriorityIndex,
-  getHighSignalLiveModelProviders,
   isHighSignalLiveModelRef,
   isSmallLiveModelRef,
   listPrioritizedHighSignalLiveModelRefs,
@@ -181,6 +180,12 @@ function providerFilterList(): string[] | undefined {
     : undefined;
 }
 
+function listHighSignalLiveModelProviders(): string[] {
+  return [...new Set(listPrioritizedHighSignalLiveModelRefs().map((ref) => ref.provider))].toSorted(
+    (left, right) => left.localeCompare(right),
+  );
+}
+
 function providerListFromExplicitModelFilter(params: {
   modelFilter: Set<string> | null;
   providerFilter: Set<string> | null;
@@ -218,7 +223,7 @@ function providerScopedModelRegistryProviders(params: {
             listPrioritizedSmallLiveModelRefs().map((ref) => normalizeProviderId(ref.provider)),
           ),
         ].toSorted((left, right) => left.localeCompare(right))
-      : getHighSignalLiveModelProviders();
+      : listHighSignalLiveModelProviders();
     return providers.filter((provider) =>
       params.providerFilter ? params.providerFilter.has(provider) : true,
     );
@@ -1541,7 +1546,7 @@ describe("providerScopedModelRegistryProviders", () => {
         modelFilter: null,
         providerFilter: null,
       }),
-    ).toEqual(getHighSignalLiveModelProviders());
+    ).toEqual(listHighSignalLiveModelProviders());
   });
 
   it("intersects default modern sweeps with provider filters", () => {


### PR DESCRIPTION
## What Problem This Solves

`getHighSignalLiveModelProviders` was production-exported solely for a live test. That left an unsupported internal export and duplicate API surface for data already available through the prioritized live-model references.

## Why This Change Was Made

Remove the unused production helper and derive the provider list locally in the live test from `listPrioritizedHighSignalLiveModelRefs`.

This keeps the runtime surface smaller while preserving the exact sorted provider-set behavior used by the test harness.

## User Impact

None. This is an internal dead-code cleanup with no runtime behavior change.

## Evidence

- Focused live test: `pnpm test:live -- src/gateway/gateway-models.profiles.live.test.ts -t providerScopedModelRegistryProviders` (11 passed, 123 skipped)
- `pnpm check:changed -- src/agents/live-model-filter.ts src/gateway/gateway-models.profiles.live.test.ts` passed all touched-file checks; stopped only on the pre-existing Plugin SDK API baseline hash drift
- `git diff --check`
- Fresh `gpt-5.6-sol` autoreview, medium reasoning: clean, confidence 0.92
- Full open-PR overlap audit plus live delta: no PR touches the removed symbol or replacement helper
