### PR TITLE
refactor(agents): remove stale embedded runner exports

### DIFF
--- a/src/agents/embedded-agent-runner.ts
+++ b/src/agents/embedded-agent-runner.ts
@@ -15,7 +15,6 @@ export {
   queueEmbeddedAgentMessage,
   queueEmbeddedAgentMessageWithOutcome,
   resolveActiveEmbeddedRunSessionId,
-  resolveActiveEmbeddedRunSessionId as resolveActiveEmbeddedAgentRunSessionId,
   resolveActiveEmbeddedRunSessionIdBySessionFile,
   waitForEmbeddedAgentRunEnd,
 } from "./embedded-agent-runner/runs.js";

--- a/src/agents/embedded-agent-runner/run/helpers.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.ts
@@ -96,7 +96,7 @@ const ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL = "ANTHROPIC_MAGIC_STRING_TRIGGER_R
 const ANTHROPIC_MAGIC_STRING_REPLACEMENT = "ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)";
 
 // Avoid Anthropic's refusal test token poisoning session transcripts.
-export function scrubAnthropicRefusalMagic(prompt: string): string {
+function scrubAnthropicRefusalMagic(prompt: string): string {
   if (!prompt.includes(ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL)) {
     return prompt;
   }

--- a/src/agents/embedded-agent.ts
+++ b/src/agents/embedded-agent.ts
@@ -16,7 +16,6 @@ export {
   isEmbeddedAgentRunStreaming,
   queueEmbeddedAgentMessage,
   queueEmbeddedAgentMessageWithOutcome,
-  resolveActiveEmbeddedAgentRunSessionId,
   resolveActiveEmbeddedRunSessionId,
   resolveActiveEmbeddedRunSessionIdBySessionFile,
   resolveEmbeddedSessionLane,


### PR DESCRIPTION
## What Problem This Solves

The embedded-agent barrels still exposed the obsolete `resolveActiveEmbeddedAgentRunSessionId` alias even though the canonical `resolveActiveEmbeddedRunSessionId` name is used throughout the repository and the alias has no consumer. The Anthropic refusal-token scrubber was also exported despite having only one same-file caller.

## Why This Change Was Made

- Remove the stale session-ID alias from both embedded-agent re-export layers.
- Keep the canonical resolver unchanged.
- Make `scrubAnthropicRefusalMagic` module-private while preserving its runtime behavior through `resolveEmbeddedAttemptBasePrompt`.

This deletes unsupported internal surface instead of carrying compatibility names with no contract or caller.

## User Impact

None. Runtime session resolution and Anthropic prompt handling are unchanged.

## Evidence

- Fresh codebase-memory index: no function or consumer for `resolveActiveEmbeddedAgentRunSessionId`; the scrubber has one same-file caller
- `pnpm test:serial src/agents/embedded-agent-runner/aliases.test.ts src/agents/embedded-agent-runner/run/helpers.test.ts` (19 passed)
- `pnpm check:changed -- src/agents/embedded-agent.ts src/agents/embedded-agent-runner.ts src/agents/embedded-agent-runner/run/helpers.ts` passed all touched-file checks; stopped only on the pre-existing Plugin SDK API baseline hash drift
- `git diff --check`
- Fresh `gpt-5.6-sol` autoreview, medium reasoning: clean, confidence 0.96
- Full open-PR overlap audit plus live tail: no active PR changes either removed export
