### PR TITLE
refactor(whatsapp): reuse SDK tool result helper

### DIFF
--- a/extensions/whatsapp/src/agent-tools-call.test.ts
+++ b/extensions/whatsapp/src/agent-tools-call.test.ts
@@ -119,6 +119,14 @@ describe("WhatsApp call tool", () => {
         throw new Error("missing audio path");
       }
       audioPath = commandAudioPath;
+      if (process.platform !== "win32") {
+        const [workspaceStat, audioStat] = await Promise.all([
+          fs.stat(path.dirname(commandAudioPath)),
+          fs.stat(commandAudioPath),
+        ]);
+        expect(workspaceStat.mode & 0o777).toBe(0o700);
+        expect(audioStat.mode & 0o777).toBe(0o600);
+      }
       const wav = await fs.readFile(commandAudioPath);
       expect(wav.toString("ascii", 0, 4)).toBe("RIFF");
       expect(wav.toString("ascii", 8, 12)).toBe("WAVE");

--- a/extensions/whatsapp/src/agent-tools-call.test.ts
+++ b/extensions/whatsapp/src/agent-tools-call.test.ts
@@ -119,14 +119,6 @@ describe("WhatsApp call tool", () => {
         throw new Error("missing audio path");
       }
       audioPath = commandAudioPath;
-      if (process.platform !== "win32") {
-        const [workspaceStat, audioStat] = await Promise.all([
-          fs.stat(path.dirname(commandAudioPath)),
-          fs.stat(commandAudioPath),
-        ]);
-        expect(workspaceStat.mode & 0o777).toBe(0o700);
-        expect(audioStat.mode & 0o777).toBe(0o600);
-      }
       const wav = await fs.readFile(commandAudioPath);
       expect(wav.toString("ascii", 0, 4)).toBe("RIFF");
       expect(wav.toString("ascii", 8, 12)).toBe("WAVE");

--- a/extensions/whatsapp/src/agent-tools-call.ts
+++ b/extensions/whatsapp/src/agent-tools-call.ts
@@ -12,7 +12,8 @@ import type {
 import { mulawToPcm } from "openclaw/plugin-sdk/realtime-voice";
 import { detectBinary } from "openclaw/plugin-sdk/setup-tools";
 import { resolveOAuthDir } from "openclaw/plugin-sdk/state-paths";
-import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+import { resolvePreferredOpenClawTmpDir, withTempWorkspace } from "openclaw/plugin-sdk/temp-path";
+import { jsonResult } from "openclaw/plugin-sdk/tool-results";
 import { Type } from "typebox";
 import { resolveWhatsAppAccount } from "./accounts.js";
 import { getWhatsAppConnectionController } from "./connection-controller-runtime-context.js";
@@ -66,13 +67,6 @@ const defaultDependencies: WhatsAppCallToolDependencies = {
   resolveStateDir: (accountId) =>
     path.join(resolveOAuthDir(), "whatsapp-calls", normalizeAccountId(accountId)),
 };
-
-function jsonResult(payload: unknown) {
-  return {
-    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
-    details: payload,
-  };
-}
 
 async function isRegularFile(filePath: string): Promise<boolean> {
   try {
@@ -278,59 +272,61 @@ function createWhatsAppCallToolWithDependencies(
         if (!speech.success || !speech.audioBuffer || !speech.sampleRate) {
           throw new Error(speech.error ?? "TTS synthesis failed");
         }
+        const sampleRate = speech.sampleRate;
         const pcm = normalizeTelephonyPcm(speech.audioBuffer, speech.outputFormat);
-        const callWindowMs = resolveCallWindowMs(pcm.length, speech.sampleRate);
-        const tempDir = await fs.mkdtemp(
-          path.join(resolvePreferredOpenClawTmpDir(), "openclaw-whatsapp-call-"),
-        );
-        const audioPath = path.join(tempDir, "message.wav");
-        try {
-          await fs.writeFile(audioPath, wrapPcm16MonoInWav(pcm, speech.sampleRate), {
-            mode: 0o600,
-          });
-          const result = await api.runtime.system.runCommandWithTimeout(
-            [
-              MEOWCALLER_COMMAND,
-              "notify",
-              "--store",
-              sessionStorePath,
-              "--answer-timeout",
-              MEOWCALLER_ANSWER_TIMEOUT,
-              "--max-duration",
-              MEOWCALLER_MAX_DURATION,
-              target,
-              audioPath,
-            ],
-            {
-              cwd: stateDir,
-              env: { MEOW_LOG_LEVEL: "warn" },
-              timeoutMs: callWindowMs,
-              signal,
-              killProcessTree: true,
-              maxOutputBytes: MAX_COMMAND_OUTPUT_BYTES,
-            },
-          );
-          if (result.termination === "signal") {
-            throw new Error("WhatsApp call cancelled");
-          }
-          if (result.termination === "timeout") {
-            throw new Error("MeowCaller exceeded the bounded WhatsApp call window");
-          }
-          if (result.termination !== "exit" || result.code !== 0) {
-            throw new Error(
-              `MeowCaller did not complete the call (code ${result.code ?? "unknown"})`,
+        const callWindowMs = resolveCallWindowMs(pcm.length, sampleRate);
+        return await withTempWorkspace(
+          {
+            rootDir: resolvePreferredOpenClawTmpDir(),
+            prefix: "openclaw-whatsapp-call-",
+          },
+          async (workspace) => {
+            const audioPath = await workspace.write(
+              "message.wav",
+              wrapPcm16MonoInWav(pcm, sampleRate),
             );
-          }
-          return jsonResult({
-            completed: true,
-            recipient: "current WhatsApp requester",
-            callWindowSeconds: Math.ceil(callWindowMs / 1_000),
-            ttsProvider: speech.provider,
-            note: "MeowCaller completed answer, playback, and hangup for the requester-bound call.",
-          });
-        } finally {
-          await fs.rm(tempDir, { recursive: true, force: true });
-        }
+            const result = await api.runtime.system.runCommandWithTimeout(
+              [
+                MEOWCALLER_COMMAND,
+                "notify",
+                "--store",
+                sessionStorePath,
+                "--answer-timeout",
+                MEOWCALLER_ANSWER_TIMEOUT,
+                "--max-duration",
+                MEOWCALLER_MAX_DURATION,
+                target,
+                audioPath,
+              ],
+              {
+                cwd: stateDir,
+                env: { MEOW_LOG_LEVEL: "warn" },
+                timeoutMs: callWindowMs,
+                signal,
+                killProcessTree: true,
+                maxOutputBytes: MAX_COMMAND_OUTPUT_BYTES,
+              },
+            );
+            if (result.termination === "signal") {
+              throw new Error("WhatsApp call cancelled");
+            }
+            if (result.termination === "timeout") {
+              throw new Error("MeowCaller exceeded the bounded WhatsApp call window");
+            }
+            if (result.termination !== "exit" || result.code !== 0) {
+              throw new Error(
+                `MeowCaller did not complete the call (code ${result.code ?? "unknown"})`,
+              );
+            }
+            return jsonResult({
+              completed: true,
+              recipient: "current WhatsApp requester",
+              callWindowSeconds: Math.ceil(callWindowMs / 1_000),
+              ttsProvider: speech.provider,
+              note: "MeowCaller completed answer, playback, and hangup for the requester-bound call.",
+            });
+          },
+        );
       } finally {
         activeCallAccounts.delete(accountId);
       }

--- a/extensions/whatsapp/src/agent-tools-call.ts
+++ b/extensions/whatsapp/src/agent-tools-call.ts
@@ -12,7 +12,7 @@ import type {
 import { mulawToPcm } from "openclaw/plugin-sdk/realtime-voice";
 import { detectBinary } from "openclaw/plugin-sdk/setup-tools";
 import { resolveOAuthDir } from "openclaw/plugin-sdk/state-paths";
-import { resolvePreferredOpenClawTmpDir, withTempWorkspace } from "openclaw/plugin-sdk/temp-path";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { jsonResult } from "openclaw/plugin-sdk/tool-results";
 import { Type } from "typebox";
 import { resolveWhatsAppAccount } from "./accounts.js";
@@ -272,61 +272,59 @@ function createWhatsAppCallToolWithDependencies(
         if (!speech.success || !speech.audioBuffer || !speech.sampleRate) {
           throw new Error(speech.error ?? "TTS synthesis failed");
         }
-        const sampleRate = speech.sampleRate;
         const pcm = normalizeTelephonyPcm(speech.audioBuffer, speech.outputFormat);
-        const callWindowMs = resolveCallWindowMs(pcm.length, sampleRate);
-        return await withTempWorkspace(
-          {
-            rootDir: resolvePreferredOpenClawTmpDir(),
-            prefix: "openclaw-whatsapp-call-",
-          },
-          async (workspace) => {
-            const audioPath = await workspace.write(
-              "message.wav",
-              wrapPcm16MonoInWav(pcm, sampleRate),
-            );
-            const result = await api.runtime.system.runCommandWithTimeout(
-              [
-                MEOWCALLER_COMMAND,
-                "notify",
-                "--store",
-                sessionStorePath,
-                "--answer-timeout",
-                MEOWCALLER_ANSWER_TIMEOUT,
-                "--max-duration",
-                MEOWCALLER_MAX_DURATION,
-                target,
-                audioPath,
-              ],
-              {
-                cwd: stateDir,
-                env: { MEOW_LOG_LEVEL: "warn" },
-                timeoutMs: callWindowMs,
-                signal,
-                killProcessTree: true,
-                maxOutputBytes: MAX_COMMAND_OUTPUT_BYTES,
-              },
-            );
-            if (result.termination === "signal") {
-              throw new Error("WhatsApp call cancelled");
-            }
-            if (result.termination === "timeout") {
-              throw new Error("MeowCaller exceeded the bounded WhatsApp call window");
-            }
-            if (result.termination !== "exit" || result.code !== 0) {
-              throw new Error(
-                `MeowCaller did not complete the call (code ${result.code ?? "unknown"})`,
-              );
-            }
-            return jsonResult({
-              completed: true,
-              recipient: "current WhatsApp requester",
-              callWindowSeconds: Math.ceil(callWindowMs / 1_000),
-              ttsProvider: speech.provider,
-              note: "MeowCaller completed answer, playback, and hangup for the requester-bound call.",
-            });
-          },
+        const callWindowMs = resolveCallWindowMs(pcm.length, speech.sampleRate);
+        const tempDir = await fs.mkdtemp(
+          path.join(resolvePreferredOpenClawTmpDir(), "openclaw-whatsapp-call-"),
         );
+        const audioPath = path.join(tempDir, "message.wav");
+        try {
+          await fs.writeFile(audioPath, wrapPcm16MonoInWav(pcm, speech.sampleRate), {
+            mode: 0o600,
+          });
+          const result = await api.runtime.system.runCommandWithTimeout(
+            [
+              MEOWCALLER_COMMAND,
+              "notify",
+              "--store",
+              sessionStorePath,
+              "--answer-timeout",
+              MEOWCALLER_ANSWER_TIMEOUT,
+              "--max-duration",
+              MEOWCALLER_MAX_DURATION,
+              target,
+              audioPath,
+            ],
+            {
+              cwd: stateDir,
+              env: { MEOW_LOG_LEVEL: "warn" },
+              timeoutMs: callWindowMs,
+              signal,
+              killProcessTree: true,
+              maxOutputBytes: MAX_COMMAND_OUTPUT_BYTES,
+            },
+          );
+          if (result.termination === "signal") {
+            throw new Error("WhatsApp call cancelled");
+          }
+          if (result.termination === "timeout") {
+            throw new Error("MeowCaller exceeded the bounded WhatsApp call window");
+          }
+          if (result.termination !== "exit" || result.code !== 0) {
+            throw new Error(
+              `MeowCaller did not complete the call (code ${result.code ?? "unknown"})`,
+            );
+          }
+          return jsonResult({
+            completed: true,
+            recipient: "current WhatsApp requester",
+            callWindowSeconds: Math.ceil(callWindowMs / 1_000),
+            ttsProvider: speech.provider,
+            note: "MeowCaller completed answer, playback, and hangup for the requester-bound call.",
+          });
+        } finally {
+          await fs.rm(tempDir, { recursive: true, force: true });
+        }
       } finally {
         activeCallAccounts.delete(accountId);
       }


### PR DESCRIPTION
## What Problem This Solves

The WhatsApp call tool contained a local implementation of the same JSON tool-result construction already provided by the plugin SDK.

## Why This Change Was Made

The call tool now imports `jsonResult` from `openclaw/plugin-sdk/tool-results` and deletes the exact local duplicate. Both status and completed-call results continue to use the same JSON serialization and details payload shape.

The temporary audio lifecycle remains unchanged: the tool still creates its directory with `fs.mkdtemp`, writes `message.wav` with mode `0600`, and directly awaits recursive removal in `finally`. Command arguments, timeout and cancellation handling, per-account concurrency, MeowCaller errors, and cleanup-error propagation are unchanged.

## User Impact

There is no user-visible behavior change. The WhatsApp call implementation now uses the shared SDK tool-result helper without changing call or temporary-audio behavior.

## Evidence

- `pnpm test extensions/whatsapp/src/agent-tools-call.test.ts` — 11 tests passed
- `pnpm tsgo:extensions` — passed
- `pnpm lint:extensions` — passed with 0 warnings and 0 errors
- `git diff --check` — passed
- Structured Codex autoreview — clean, no actionable findings
