### PR TITLE
fix(whatsapp): honor mediaUrls precedence in channel payloads

### DIFF
--- a/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
@@ -708,6 +708,41 @@ describe("deliverWebReply", () => {
     expect(replyText(msg)).not.toContain("boom");
   });
 
+  it.each([
+    {
+      name: "prefers trimmed, deduplicated mediaUrls over legacy mediaUrl",
+      mediaUrl: " http://example.com/legacy.jpg ",
+      mediaUrls: [" http://example.com/preferred.jpg ", "http://example.com/preferred.jpg", "   "],
+      expectedMediaUrl: "http://example.com/preferred.jpg",
+    },
+    {
+      name: "falls back to trimmed legacy mediaUrl when mediaUrls are whitespace-only",
+      mediaUrl: " http://example.com/legacy.jpg ",
+      mediaUrls: ["   ", "\t"],
+      expectedMediaUrl: "http://example.com/legacy.jpg",
+    },
+  ])("$name during auto-reply delivery", async ({ mediaUrl, mediaUrls, expectedMediaUrl }) => {
+    vi.clearAllMocks();
+    const msg = makeMsg();
+    mockLoadedImageMedia();
+
+    await deliverWebReply({
+      replyResult: { text: "caption", mediaUrl, mediaUrls },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(loadWebMedia).toHaveBeenCalledTimes(1);
+    expect(loadWebMedia).toHaveBeenCalledWith(expectedMediaUrl, {
+      maxBytes: 1024 * 1024,
+      localRoots: undefined,
+    });
+    expect(msg.platform.sendMedia).toHaveBeenCalledTimes(1);
+  });
+
   it("notifies user when a non-first media send fails instead of dropping silently", async () => {
     vi.clearAllMocks();
     const msg = makeMsg();

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -687,6 +687,36 @@ describe("whatsapp inbound dispatch", () => {
     expect(rememberSentText).toHaveBeenCalledTimes(3);
   });
 
+  it.each([
+    {
+      name: "prefers trimmed, deduplicated mediaUrls over legacy mediaUrl",
+      mediaUrl: " /tmp/legacy.jpg ",
+      mediaUrls: [" /tmp/preferred.jpg ", "/tmp/preferred.jpg", "   "],
+      expectedMediaUrl: "/tmp/preferred.jpg",
+    },
+    {
+      name: "falls back to trimmed legacy mediaUrl when mediaUrls are whitespace-only",
+      mediaUrl: " /tmp/legacy.jpg ",
+      mediaUrls: ["   ", "\t"],
+      expectedMediaUrl: "/tmp/legacy.jpg",
+    },
+  ])("$name during inbound dispatch", async ({ mediaUrl, mediaUrls, expectedMediaUrl }) => {
+    const deliverReply = vi.fn(async () => acceptedDeliveryResult());
+
+    await dispatchBufferedReply({ deliverReply });
+
+    const deliver = getCapturedDeliver();
+    expect(deliver).toBeTypeOf("function");
+    await deliver?.({ text: "caption", mediaUrl, mediaUrls }, { kind: "block" });
+
+    expect(deliverReply).toHaveBeenCalledTimes(1);
+    expectReplyResultFields(deliverReply, {
+      mediaUrl: expectedMediaUrl,
+      mediaUrls: [expectedMediaUrl],
+      text: "caption",
+    });
+  });
+
   it("queues final WhatsApp payloads through durable outbound delivery", async () => {
     deliverInboundReplyWithMessageSendContextMock.mockResolvedValueOnce({
       status: "handled_visible",

--- a/extensions/whatsapp/src/outbound-base.test.ts
+++ b/extensions/whatsapp/src/outbound-base.test.ts
@@ -452,7 +452,7 @@ describe("createWhatsAppOutboundBase", () => {
     expect(options.mediaUrl).toBe("/tmp/voice.ogg");
   });
 
-  it("keeps explicit mediaUrl first when payload also includes mediaUrls", async () => {
+  it("prefers normalized mediaUrls over legacy mediaUrl", async () => {
     const sendMessageWhatsApp = vi.fn(async () => ({
       messageId: "msg-1",
       toJid: "15551234567@s.whatsapp.net",
@@ -472,7 +472,7 @@ describe("createWhatsAppOutboundBase", () => {
       payload: {
         text: "\n\ncaption",
         mediaUrl: "/tmp/primary.ogg",
-        mediaUrls: [" /tmp/secondary.ogg "],
+        mediaUrls: [" /tmp/secondary.ogg ", "/tmp/secondary.ogg", " /tmp/third.ogg "],
       },
       deps: { sendWhatsApp: sendMessageWhatsApp },
     });
@@ -483,9 +483,49 @@ describe("createWhatsAppOutboundBase", () => {
       "whatsapp:+15551234567",
       "caption",
     );
-    expect(firstOptions.mediaUrl).toBe("/tmp/primary.ogg");
+    expect(firstOptions.mediaUrl).toBe("/tmp/secondary.ogg");
     const secondOptions = sendMessageOptionsAt(sendMessageWhatsApp, 1, "whatsapp:+15551234567", "");
-    expect(secondOptions.mediaUrl).toBe("/tmp/secondary.ogg");
+    expect(secondOptions.mediaUrl).toBe("/tmp/third.ogg");
+    expect(sendMessageWhatsApp).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    { name: "mediaUrls is omitted", mediaUrls: undefined },
+    { name: "mediaUrls is empty", mediaUrls: [] },
+    { name: "mediaUrls contains only whitespace", mediaUrls: ["   "] },
+  ])("falls back to legacy mediaUrl when $name", async ({ mediaUrls }) => {
+    const sendMessageWhatsApp = vi.fn(async () => ({
+      messageId: "msg-1",
+      toJid: "15551234567@s.whatsapp.net",
+    }));
+    const outbound = createWhatsAppOutboundBase({
+      chunker: (text) => [text],
+      sendMessageWhatsApp,
+      sendPollWhatsApp: vi.fn(),
+      shouldLogVerbose: () => false,
+      resolveTarget: ({ to }) => ({ ok: true as const, to: to ?? "" }),
+    });
+
+    await outbound.sendPayload!({
+      cfg: {} as never,
+      to: "whatsapp:+15551234567",
+      text: "",
+      payload: {
+        text: "caption",
+        mediaUrl: " /tmp/legacy.ogg ",
+        ...(mediaUrls === undefined ? {} : { mediaUrls }),
+      },
+      deps: { sendWhatsApp: sendMessageWhatsApp },
+    });
+
+    const options = sendMessageOptionsAt(
+      sendMessageWhatsApp,
+      0,
+      "whatsapp:+15551234567",
+      "caption",
+    );
+    expect(options.mediaUrl).toBe("/tmp/legacy.ogg");
+    expect(sendMessageWhatsApp).toHaveBeenCalledTimes(1);
   });
 
   it("uses the caller-provided text normalization for payload delivery", async () => {

--- a/extensions/whatsapp/src/outbound-base.ts
+++ b/extensions/whatsapp/src/outbound-base.ts
@@ -12,8 +12,9 @@ import {
   type ChannelOutboundAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { sendTextMediaPayload } from "openclaw/plugin-sdk/reply-payload";
+import { resolvePayloadMediaUrls, sendTextMediaPayload } from "openclaw/plugin-sdk/reply-payload";
 import {
+  normalizeWhatsAppMediaUrls,
   normalizeWhatsAppOutboundPayload,
   normalizeWhatsAppPayloadText,
 } from "./outbound-media-contract.js";
@@ -264,7 +265,11 @@ export function createWhatsAppOutboundBase({
       if (ctx.payload.isError === true) {
         return { channel: "whatsapp", messageId: "" };
       }
-      const payload = normalizeWhatsAppOutboundPayload(ctx.payload, { normalizeText });
+      const preferredMediaUrls = normalizeWhatsAppMediaUrls(ctx.payload.mediaUrls ?? []);
+      const payload = normalizeWhatsAppOutboundPayload(ctx.payload, {
+        normalizeText,
+        mediaUrls: resolvePayloadMediaUrls({ ...ctx.payload, mediaUrls: preferredMediaUrls }),
+      });
       if (!payload.text && !(payload.mediaUrl || payload.mediaUrls?.length)) {
         if (ctx.payload.interactive || ctx.payload.presentation || ctx.payload.channelData) {
           throw new Error(

--- a/extensions/whatsapp/src/outbound-base.ts
+++ b/extensions/whatsapp/src/outbound-base.ts
@@ -12,9 +12,8 @@ import {
   type ChannelOutboundAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { resolvePayloadMediaUrls, sendTextMediaPayload } from "openclaw/plugin-sdk/reply-payload";
+import { sendTextMediaPayload } from "openclaw/plugin-sdk/reply-payload";
 import {
-  normalizeWhatsAppMediaUrls,
   normalizeWhatsAppOutboundPayload,
   normalizeWhatsAppPayloadText,
 } from "./outbound-media-contract.js";
@@ -265,11 +264,7 @@ export function createWhatsAppOutboundBase({
       if (ctx.payload.isError === true) {
         return { channel: "whatsapp", messageId: "" };
       }
-      const preferredMediaUrls = normalizeWhatsAppMediaUrls(ctx.payload.mediaUrls ?? []);
-      const payload = normalizeWhatsAppOutboundPayload(ctx.payload, {
-        normalizeText,
-        mediaUrls: resolvePayloadMediaUrls({ ...ctx.payload, mediaUrls: preferredMediaUrls }),
-      });
+      const payload = normalizeWhatsAppOutboundPayload(ctx.payload, { normalizeText });
       if (!payload.text && !(payload.mediaUrl || payload.mediaUrls?.length)) {
         if (ctx.payload.interactive || ctx.payload.presentation || ctx.payload.channelData) {
           throw new Error(

--- a/extensions/whatsapp/src/outbound-media-contract.ts
+++ b/extensions/whatsapp/src/outbound-media-contract.ts
@@ -83,17 +83,19 @@ export function normalizeWhatsAppPayloadTextPreservingIndentation(
   return normalized.trim() ? normalized : "";
 }
 
-export function resolveWhatsAppOutboundMediaUrls(
+export function normalizeWhatsAppMediaUrls(mediaUrls: readonly string[]): string[] {
+  return uniqueStrings(mediaUrls.map((entry) => entry.trim()).filter(Boolean));
+}
+
+// The direct API accepts both fields as additive candidates, with mediaUrl first.
+// Keep that contract separate from channel ReplyPayload mediaUrls precedence.
+export function resolveAdditiveWhatsAppMediaUrls(
   payload: Pick<WhatsAppOutboundPayloadLike, "mediaUrl" | "mediaUrls">,
 ): string[] {
-  const primaryMediaUrl = payload.mediaUrl?.trim();
-  const mediaUrls = (payload.mediaUrls ? [...payload.mediaUrls] : [])
-    .map((entry) => entry.trim())
-    .filter((entry): entry is string => Boolean(entry));
-  const orderedMediaUrls = [primaryMediaUrl, ...mediaUrls].filter((entry): entry is string =>
-    Boolean(entry),
-  );
-  return uniqueStrings(orderedMediaUrls);
+  return normalizeWhatsAppMediaUrls([
+    ...(payload.mediaUrl ? [payload.mediaUrl] : []),
+    ...(payload.mediaUrls ?? []),
+  ]);
 }
 
 // Keep new WhatsApp outbound-media behavior in this helper so payload, gateway, and auto-reply paths stay aligned.
@@ -101,9 +103,12 @@ export function normalizeWhatsAppOutboundPayload<T extends WhatsAppOutboundPaylo
   payload: T,
   options?: {
     normalizeText?: (text: string | undefined) => string;
+    mediaUrls?: readonly string[];
   },
 ): NormalizedWhatsAppOutboundPayload<T> {
-  const mediaUrls = resolveWhatsAppOutboundMediaUrls(payload);
+  const mediaUrls = options?.mediaUrls
+    ? normalizeWhatsAppMediaUrls(options.mediaUrls)
+    : resolveAdditiveWhatsAppMediaUrls(payload);
   const normalizeText = options?.normalizeText ?? normalizeWhatsAppPayloadText;
   return {
     ...payload,

--- a/extensions/whatsapp/src/outbound-media-contract.ts
+++ b/extensions/whatsapp/src/outbound-media-contract.ts
@@ -4,7 +4,7 @@ import { sanitizeForPlainText } from "openclaw/plugin-sdk/channel-outbound";
 import { MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS, runFfmpeg } from "openclaw/plugin-sdk/media-runtime";
 import { resolveOutboundMediaUrls } from "openclaw/plugin-sdk/reply-payload";
 import { writeExternalFileWithinRoot } from "openclaw/plugin-sdk/security-runtime";
-import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { normalizeUniqueStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolvePreferredOpenClawTmpDir, withTempWorkspace } from "openclaw/plugin-sdk/temp-path";
 import { resolveWhatsAppDocumentFileName } from "./document-filename.js";
 import { formatError } from "./session-errors.js";
@@ -84,16 +84,12 @@ export function normalizeWhatsAppPayloadTextPreservingIndentation(
   return normalized.trim() ? normalized : "";
 }
 
-function normalizeWhatsAppMediaUrls(mediaUrls: readonly string[]): string[] {
-  return uniqueStrings(mediaUrls.map((entry) => entry.trim()).filter(Boolean));
-}
-
 // The direct API accepts both fields as additive candidates, with mediaUrl first.
 // Keep that contract separate from channel ReplyPayload mediaUrls precedence.
 export function resolveAdditiveWhatsAppMediaUrls(
   payload: Pick<WhatsAppOutboundPayloadLike, "mediaUrl" | "mediaUrls">,
 ): string[] {
-  return normalizeWhatsAppMediaUrls([
+  return normalizeUniqueStringEntries([
     ...(payload.mediaUrl ? [payload.mediaUrl] : []),
     ...(payload.mediaUrls ?? []),
   ]);
@@ -106,8 +102,8 @@ export function normalizeWhatsAppOutboundPayload<T extends WhatsAppOutboundPaylo
     normalizeText?: (text: string | undefined) => string;
   },
 ): NormalizedWhatsAppOutboundPayload<T> {
-  const preferredMediaUrls = normalizeWhatsAppMediaUrls(payload.mediaUrls ?? []);
-  const mediaUrls = normalizeWhatsAppMediaUrls(
+  const preferredMediaUrls = normalizeUniqueStringEntries(payload.mediaUrls);
+  const mediaUrls = normalizeUniqueStringEntries(
     resolveOutboundMediaUrls({ mediaUrl: payload.mediaUrl, mediaUrls: preferredMediaUrls }),
   );
   const normalizeText = options?.normalizeText ?? normalizeWhatsAppPayloadText;

--- a/extensions/whatsapp/src/outbound-media-contract.ts
+++ b/extensions/whatsapp/src/outbound-media-contract.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { sanitizeForPlainText } from "openclaw/plugin-sdk/channel-outbound";
 import { MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS, runFfmpeg } from "openclaw/plugin-sdk/media-runtime";
+import { resolveOutboundMediaUrls } from "openclaw/plugin-sdk/reply-payload";
 import { writeExternalFileWithinRoot } from "openclaw/plugin-sdk/security-runtime";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolvePreferredOpenClawTmpDir, withTempWorkspace } from "openclaw/plugin-sdk/temp-path";
@@ -83,7 +84,7 @@ export function normalizeWhatsAppPayloadTextPreservingIndentation(
   return normalized.trim() ? normalized : "";
 }
 
-export function normalizeWhatsAppMediaUrls(mediaUrls: readonly string[]): string[] {
+function normalizeWhatsAppMediaUrls(mediaUrls: readonly string[]): string[] {
   return uniqueStrings(mediaUrls.map((entry) => entry.trim()).filter(Boolean));
 }
 
@@ -103,12 +104,12 @@ export function normalizeWhatsAppOutboundPayload<T extends WhatsAppOutboundPaylo
   payload: T,
   options?: {
     normalizeText?: (text: string | undefined) => string;
-    mediaUrls?: readonly string[];
   },
 ): NormalizedWhatsAppOutboundPayload<T> {
-  const mediaUrls = options?.mediaUrls
-    ? normalizeWhatsAppMediaUrls(options.mediaUrls)
-    : resolveAdditiveWhatsAppMediaUrls(payload);
+  const preferredMediaUrls = normalizeWhatsAppMediaUrls(payload.mediaUrls ?? []);
+  const mediaUrls = normalizeWhatsAppMediaUrls(
+    resolveOutboundMediaUrls({ mediaUrl: payload.mediaUrl, mediaUrls: preferredMediaUrls }),
+  );
   const normalizeText = options?.normalizeText ?? normalizeWhatsAppPayloadText;
   return {
     ...payload,

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -539,7 +539,7 @@ describe("web outbound", () => {
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 
-  it("prefers explicit mediaUrl over mediaUrls when both are present", async () => {
+  it("keeps direct API mediaUrl ahead of additive mediaUrls", async () => {
     const buf = Buffer.from("img");
     loadWebMediaMock.mockResolvedValueOnce({
       buffer: buf,

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -23,7 +23,7 @@ import { isWhatsAppNewsletterJid } from "./normalize.js";
 import {
   normalizeWhatsAppPayloadText,
   prepareWhatsAppOutboundMedia,
-  resolveWhatsAppOutboundMediaUrls,
+  resolveAdditiveWhatsAppMediaUrls,
 } from "./outbound-media-contract.js";
 import { loadOutboundMediaFromUrl } from "./outbound-media.runtime.js";
 import { markdownToWhatsApp, toWhatsappJid } from "./text-runtime.js";
@@ -156,7 +156,7 @@ export async function sendMessageWhatsApp(
 ): Promise<{ messageId: string; toJid: string }> {
   let text = options.preserveLeadingWhitespace ? body : normalizeWhatsAppPayloadText(body);
   const jid = toWhatsappJid(to);
-  const mediaUrls = resolveWhatsAppOutboundMediaUrls(options);
+  const mediaUrls = resolveAdditiveWhatsAppMediaUrls(options);
   const mediaPayload = options.mediaPayload;
   const primaryMediaUrl = mediaUrls[0] ?? mediaPayload?.fileName;
   const hasMedia = Boolean(mediaPayload || primaryMediaUrl);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where WhatsApp channel payloads containing both `mediaUrls` and the legacy `mediaUrl` field sent the legacy attachment first. Channel payloads are expected to prefer a usable plural list and use the single URL only as a fallback.

## Why This Change Was Made

The shared `normalizeWhatsAppOutboundPayload` path now trims and deduplicates plural media entries before applying `resolveOutboundMediaUrls` from `openclaw/plugin-sdk/reply-payload`. This makes a non-empty, usable `mediaUrls` list authoritative while preserving `mediaUrl` fallback for omitted, empty, or whitespace-only plural lists. Channel `sendPayload`, direct web auto-reply delivery, and inbound buffered dispatch all pass through this same normalizer, so identical ReplyPayloads select the same attachments regardless of entry path.

`createWhatsAppOutboundBase.sendPayload` no longer supplies its own media resolution override; it delegates the complete ReplyPayload media contract to the shared normalizer.

The lower-level `sendMessageWhatsApp` API is intentionally unchanged. Its existing mediaUrl-first, additive candidate ordering now lives behind the explicitly named `resolveAdditiveWhatsAppMediaUrls` helper, separating that direct API contract from channel payload precedence instead of silently changing both call surfaces together.

Tests update the channel expectation and cover plural precedence, legacy fallback, empty arrays, whitespace-only arrays, trimming, deduplication, and the preserved direct-API behavior. Additional delivery and dispatch tests prove the same normalized selection reaches both auto-reply entry paths.

## User Impact

WhatsApp channel and auto-reply paths now send the attachments selected by one canonical ReplyPayload contract. Existing direct callers of `sendMessageWhatsApp` retain their previous media selection behavior.

## Evidence

- Hosted focused tests: `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-whatsapp.config.ts whatsapp/src/outbound-base.test.ts whatsapp/src/send.test.ts whatsapp/src/outbound-adapter.sendpayload.test.ts whatsapp/src/outbound-payload.contract.test.ts whatsapp/src/auto-reply/deliver-reply.test.ts whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts` — 6 files, 157 tests passed.
- Hosted extension typecheck: `pnpm tsgo:extensions` — passed.
- `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, with no accepted/actionable findings after addressing the whitespace-only fallback case.
