### PR TITLE
refactor(agents): remove redundant zero usage helper

### DIFF
--- a/src/agents/embedded-agent-runner.cache.live.test.ts
+++ b/src/agents/embedded-agent-runner.cache.live.test.ts
@@ -20,7 +20,7 @@ import {
   resolveLiveDirectModel,
   withLiveCacheHeartbeat,
 } from "./live-cache-test-support.js";
-import { buildZeroUsage } from "./stream-message-shared.js";
+import { buildUsageWithNoCost } from "./stream-message-shared.js";
 
 const describeCacheLive = LIVE_CACHE_TEST_ENABLED ? describe : describe.skip;
 
@@ -213,7 +213,7 @@ function normalizeLiveUsage(
     | undefined,
 ): AssistantMessage["usage"] {
   if (!usage) {
-    return buildZeroUsage();
+    return buildUsageWithNoCost({});
   }
   const input = usage.input ?? 0;
   const output = usage.output ?? 0;

--- a/src/agents/stream-message-shared.ts
+++ b/src/agents/stream-message-shared.ts
@@ -11,17 +11,6 @@ type StreamModelDescriptor = {
   id: string;
 };
 
-export function buildZeroUsage(): Usage {
-  return {
-    input: 0,
-    output: 0,
-    cacheRead: 0,
-    cacheWrite: 0,
-    totalTokens: 0,
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-  };
-}
-
 export function buildUsageWithNoCost(params: {
   input?: number;
   output?: number;
@@ -72,7 +61,7 @@ export function buildAssistantMessageWithZeroUsage(params: {
     model: params.model,
     content: params.content,
     stopReason: params.stopReason,
-    usage: buildZeroUsage(),
+    usage: buildUsageWithNoCost({}),
     timestamp: params.timestamp,
   });
 }


### PR DESCRIPTION
## What Problem This Solves

`buildZeroUsage` duplicated `buildUsageWithNoCost({})` and existed only as a wrapper for one production call and one live-test call.

## Why This Change Was Made

Delete the redundant helper and route both callers through the existing canonical no-cost usage constructor.

This keeps one implementation for zero-cost usage records and removes an unsupported internal export.

## User Impact

None. The emitted `Usage` objects are unchanged.

## Evidence

- Fresh codebase-memory index confirmed the wrapper and its bounded caller surface; post-edit search returns no `buildZeroUsage` node
- `pnpm test:serial src/agents/stream-message-shared.test.ts src/agents/custom-api-registry.test.ts` (8 passed), before and after the change
- `pnpm check:changed -- src/agents/stream-message-shared.ts src/agents/embedded-agent-runner.cache.live.test.ts` passed all touched-file checks; stopped only on the pre-existing Plugin SDK API baseline hash drift
- `git diff --check`
- Fresh `gpt-5.6-sol` autoreview, medium reasoning: clean, confidence 0.99
- Full open-PR overlap audit plus live tail: no active PR overlaps either file
