### PR TITLE
refactor(whatsapp): use retryAsync for outbound delivery retries

### DIFF
--- a/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
@@ -5,7 +5,6 @@ import {
   listMessageReceiptPlatformIds,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { sleep } from "openclaw/plugin-sdk/text-utility-runtime";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { createAcceptedWhatsAppSendResult } from "../inbound/send-result.test-helper.js";
 import { createTestWebInboundMessage } from "../inbound/test-message.test-helper.js";
@@ -36,16 +35,6 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
     ...actual,
     shouldLogVerbose: vi.fn(() => true),
     logVerbose: vi.fn(),
-  };
-});
-
-vi.mock("openclaw/plugin-sdk/text-utility-runtime", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/text-utility-runtime")>(
-    "openclaw/plugin-sdk/text-utility-runtime",
-  );
-  return {
-    ...actual,
-    sleep: vi.fn(async () => {}),
   };
 });
 
@@ -189,6 +178,18 @@ function mockSecondReplySuccess(msg: AdmittedWebInboundMessage) {
   (
     msg.platform.reply as unknown as { mockResolvedValueOnce: (v: unknown) => void }
   ).mockResolvedValueOnce(createAcceptedWhatsAppSendResult("text", "reply-retry-2"));
+}
+
+async function runWithFakeTimers<T>(run: () => Promise<T>): Promise<T> {
+  vi.useFakeTimers();
+  try {
+    const promise = run();
+    await vi.runAllTimersAsync();
+    return await promise;
+  } finally {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  }
 }
 
 const replyLogger = {
@@ -406,17 +407,18 @@ describe("deliverWebReply", () => {
       mockFirstReplyFailure(msg, errorMessage);
       mockSecondReplySuccess(msg);
 
-      await deliverWebReply({
-        replyResult: { text: "hi" },
-        msg,
-        maxMediaBytes: 1024 * 1024,
-        textLimit: 200,
-        replyLogger,
-        skipLog: true,
-      });
+      await runWithFakeTimers(() =>
+        deliverWebReply({
+          replyResult: { text: "hi" },
+          msg,
+          maxMediaBytes: 1024 * 1024,
+          textLimit: 200,
+          replyLogger,
+          skipLog: true,
+        }),
+      );
 
       expect(msg.platform.reply).toHaveBeenCalledTimes(2);
-      expect(sleep).toHaveBeenCalledWith(500);
     },
   );
 
@@ -425,23 +427,23 @@ describe("deliverWebReply", () => {
     mockFirstReplyFailureWithWrappedError(msg, "connection closed");
     mockSecondReplySuccess(msg);
 
-    await deliverWebReply({
-      replyResult: { text: "hi" },
-      msg,
-      maxMediaBytes: 1024 * 1024,
-      textLimit: 200,
-      replyLogger,
-      skipLog: true,
-    });
+    await runWithFakeTimers(() =>
+      deliverWebReply({
+        replyResult: { text: "hi" },
+        msg,
+        maxMediaBytes: 1024 * 1024,
+        textLimit: 200,
+        replyLogger,
+        skipLog: true,
+      }),
+    );
 
     expect(msg.platform.reply).toHaveBeenCalledTimes(2);
-    expect(sleep).toHaveBeenCalledWith(500);
   });
 
   it("does not retry terminal socket operation timeouts", async () => {
     const msg = makeMsg();
     const timeout = new WhatsAppSocketOperationTimeoutError("sendMessage", 60_000);
-    (sleep as unknown as { mockClear: () => void }).mockClear();
     (
       msg.platform.reply as unknown as { mockRejectedValueOnce: (v: unknown) => void }
     ).mockRejectedValueOnce(timeout);
@@ -458,7 +460,6 @@ describe("deliverWebReply", () => {
     ).rejects.toBe(timeout);
 
     expect(msg.platform.reply).toHaveBeenCalledTimes(1);
-    expect(sleep).not.toHaveBeenCalled();
   });
 
   it("sends image media with caption and then remaining text", async () => {
@@ -586,17 +587,18 @@ describe("deliverWebReply", () => {
       msg.platform.sendMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }
     ).mockResolvedValueOnce(createAcceptedWhatsAppSendResult("media", "media-retry-2"));
 
-    await deliverWebReply({
-      replyResult: { text: "caption", mediaUrl: "http://example.com/img.jpg" },
-      msg,
-      maxMediaBytes: 1024 * 1024,
-      textLimit: 200,
-      replyLogger,
-      skipLog: true,
-    });
+    await runWithFakeTimers(() =>
+      deliverWebReply({
+        replyResult: { text: "caption", mediaUrl: "http://example.com/img.jpg" },
+        msg,
+        maxMediaBytes: 1024 * 1024,
+        textLimit: 200,
+        replyLogger,
+        skipLog: true,
+      }),
+    );
 
     expect(msg.platform.sendMedia).toHaveBeenCalledTimes(2);
-    expect(sleep).toHaveBeenCalledWith(500);
   });
 
   it("falls back to text-only when the first media send fails", async () => {

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.ts
@@ -22,8 +22,8 @@ import {
   normalizeWhatsAppOutboundPayload,
   normalizeWhatsAppPayloadTextPreservingIndentation,
   prepareWhatsAppOutboundMedia,
-  sendWhatsAppOutboundWithRetry,
 } from "../outbound-media-contract.js";
+import { sendWhatsAppOutboundWithRetry } from "../outbound-retry.js";
 import { buildQuotedMessageOptions, lookupInboundMessageMeta } from "../quoted-message.js";
 import { newConnectionId } from "../reconnect.js";
 import { formatError } from "../session.js";
@@ -159,11 +159,10 @@ export async function deliverWebReply(params: {
     });
   };
 
-  const sendWithRetry = async <T>(fn: () => Promise<T>, label: string, maxAttempts = 3) => {
+  const sendWithRetry = async <T>(fn: () => Promise<T>, label: string) => {
     try {
       return await sendWhatsAppOutboundWithRetry({
         send: fn,
-        maxAttempts,
         onRetry: ({ attempt, maxAttempts: retryMaxAttempts, backoffMs, errorText }) => {
           logVerbose(
             `Retrying ${label} to ${conversationId} after failure (${attempt}/${retryMaxAttempts - 1}) in ${backoffMs}ms: ${errorText}`,

--- a/extensions/whatsapp/src/outbound-media-contract.ts
+++ b/extensions/whatsapp/src/outbound-media-contract.ts
@@ -6,13 +6,10 @@ import { writeExternalFileWithinRoot } from "openclaw/plugin-sdk/security-runtim
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolvePreferredOpenClawTmpDir, withTempWorkspace } from "openclaw/plugin-sdk/temp-path";
 import { resolveWhatsAppDocumentFileName } from "./document-filename.js";
-import { formatError } from "./session-errors.js";
-import { isWhatsAppSocketOperationTimeoutError } from "./socket-timing.js";
 import {
   sanitizeAssistantVisibleText,
   sanitizeAssistantVisibleTextWithProfile,
   stripToolCallXmlTags,
-  sleep,
 } from "./text-runtime.js";
 
 type WhatsAppOutboundPayloadLike = {
@@ -266,48 +263,4 @@ function deriveWhatsAppDocumentFileName(mediaUrl: string | undefined): string | 
     const fileName = withoutQueryOrFragment.split(/[\\/]/).pop();
     return fileName || undefined;
   }
-}
-
-function isRetryableWhatsAppOutboundError(error: unknown): boolean {
-  if (isWhatsAppSocketOperationTimeoutError(error)) {
-    return false;
-  }
-  return /closed|reset|timed\s*out|disconnect/i.test(formatError(error));
-}
-
-export async function sendWhatsAppOutboundWithRetry<T>(params: {
-  send: () => Promise<T>;
-  onRetry?: (params: {
-    attempt: number;
-    maxAttempts: number;
-    backoffMs: number;
-    error: unknown;
-    errorText: string;
-  }) => Promise<void> | void;
-  maxAttempts?: number;
-}): Promise<T> {
-  const maxAttempts = params.maxAttempts ?? 3;
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    try {
-      return await params.send();
-    } catch (error) {
-      lastError = error;
-      const errorText = formatError(error);
-      const isLastAttempt = attempt === maxAttempts;
-      if (!isRetryableWhatsAppOutboundError(error) || isLastAttempt) {
-        throw error;
-      }
-      const backoffMs = 500 * attempt;
-      await params.onRetry?.({
-        attempt,
-        maxAttempts,
-        backoffMs,
-        error,
-        errorText,
-      });
-      await sleep(backoffMs);
-    }
-  }
-  throw lastError;
 }

--- a/extensions/whatsapp/src/outbound-retry.test.ts
+++ b/extensions/whatsapp/src/outbound-retry.test.ts
@@ -16,25 +16,29 @@ async function runWithFakeTimers<T>(run: () => Promise<T>): Promise<T> {
 }
 
 describe("sendWhatsAppOutboundWithRetry", () => {
+  it.each([new Error("connection closed"), { code: "ECONNRESET" }])(
+    "retries a directly retryable error",
+    async (error) => {
+      const send = vi
+        .fn<() => Promise<string>>()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue("ok");
+
+      await expect(runWithFakeTimers(() => sendWhatsAppOutboundWithRetry({ send }))).resolves.toBe(
+        "ok",
+      );
+
+      expect(send).toHaveBeenCalledTimes(2);
+    },
+  );
+
   it.each([
-    new Error("connection closed"),
-    { error: { code: "ECONNRESET" } },
-    new Error("request failed", { cause: new Error("socket disconnected") }),
-  ])("retries a retryable error graph", async (error) => {
-    const send = vi
-      .fn<() => Promise<string>>()
-      .mockRejectedValueOnce(error)
-      .mockResolvedValue("ok");
-
-    await expect(runWithFakeTimers(() => sendWhatsAppOutboundWithRetry({ send }))).resolves.toBe(
-      "ok",
-    );
-
-    expect(send).toHaveBeenCalledTimes(2);
-  });
-
-  it("does not retry a non-retryable error", async () => {
-    const error = new Error("invalid recipient");
+    { name: "a non-retryable direct error", error: new Error("invalid recipient") },
+    {
+      name: "a retryable signal only in the cause",
+      error: new Error("request failed", { cause: new Error("socket disconnected") }),
+    },
+  ])("does not retry $name", async ({ error }) => {
     const send = vi.fn<() => Promise<string>>().mockRejectedValue(error);
     const onRetry = vi.fn();
 
@@ -47,37 +51,28 @@ describe("sendWhatsAppOutboundWithRetry", () => {
     expect(onRetry).not.toHaveBeenCalled();
   });
 
-  it.each([
-    (timeout: WhatsAppSocketOperationTimeoutError) => timeout,
-    (timeout: WhatsAppSocketOperationTimeoutError) => ({ error: timeout }),
-    (timeout: WhatsAppSocketOperationTimeoutError) => ({
-      lastDisconnect: { error: timeout },
-    }),
-  ])("does not retry an unknown-delivery socket timeout", async (wrap) => {
+  it("does not retry a direct unknown-delivery socket timeout", async () => {
     const timeout = new WhatsAppSocketOperationTimeoutError("sendMessage", 60_000);
-    const error = wrap(timeout);
-    const send = vi.fn<() => Promise<string>>().mockRejectedValue(error);
+    const send = vi.fn<() => Promise<string>>().mockRejectedValue(timeout);
     const onRetry = vi.fn();
 
     const failure = await sendWhatsAppOutboundWithRetry({ send, onRetry }).catch(
       (caught: unknown) => caught,
     );
 
-    expect(failure).toBe(error);
+    expect(failure).toBe(timeout);
     expect(send).toHaveBeenCalledOnce();
     expect(onRetry).not.toHaveBeenCalled();
   });
 
   it("preserves attempts, delays, callback fields, and terminal error identity", async () => {
     const firstError = {
-      error: {
-        output: {
+      output: {
+        statusCode: 503,
+        payload: {
           statusCode: 503,
-          payload: {
-            statusCode: 503,
-            error: "Service Unavailable",
-            message: "connection closed",
-          },
+          error: "Service Unavailable",
+          message: "connection closed",
         },
       },
     };

--- a/extensions/whatsapp/src/outbound-retry.test.ts
+++ b/extensions/whatsapp/src/outbound-retry.test.ts
@@ -1,0 +1,115 @@
+// WhatsApp tests cover outbound retry behavior.
+import { describe, expect, it, vi } from "vitest";
+import { sendWhatsAppOutboundWithRetry } from "./outbound-retry.js";
+import { WhatsAppSocketOperationTimeoutError } from "./socket-timing.js";
+
+async function runWithFakeTimers<T>(run: () => Promise<T>): Promise<T> {
+  vi.useFakeTimers();
+  try {
+    const promise = run();
+    await vi.runAllTimersAsync();
+    return await promise;
+  } finally {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  }
+}
+
+describe("sendWhatsAppOutboundWithRetry", () => {
+  it.each([
+    new Error("connection closed"),
+    { error: { code: "ECONNRESET" } },
+    new Error("request failed", { cause: new Error("socket disconnected") }),
+  ])("retries a retryable error graph", async (error) => {
+    const send = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValue("ok");
+
+    await expect(runWithFakeTimers(() => sendWhatsAppOutboundWithRetry({ send }))).resolves.toBe(
+      "ok",
+    );
+
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a non-retryable error", async () => {
+    const error = new Error("invalid recipient");
+    const send = vi.fn<() => Promise<string>>().mockRejectedValue(error);
+    const onRetry = vi.fn();
+
+    const failure = await sendWhatsAppOutboundWithRetry({ send, onRetry }).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(failure).toBe(error);
+    expect(send).toHaveBeenCalledOnce();
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    (timeout: WhatsAppSocketOperationTimeoutError) => timeout,
+    (timeout: WhatsAppSocketOperationTimeoutError) => ({ error: timeout }),
+    (timeout: WhatsAppSocketOperationTimeoutError) => ({
+      lastDisconnect: { error: timeout },
+    }),
+  ])("does not retry an unknown-delivery socket timeout", async (wrap) => {
+    const timeout = new WhatsAppSocketOperationTimeoutError("sendMessage", 60_000);
+    const error = wrap(timeout);
+    const send = vi.fn<() => Promise<string>>().mockRejectedValue(error);
+    const onRetry = vi.fn();
+
+    const failure = await sendWhatsAppOutboundWithRetry({ send, onRetry }).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(failure).toBe(error);
+    expect(send).toHaveBeenCalledOnce();
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("preserves attempts, delays, callback fields, and terminal error identity", async () => {
+    const firstError = {
+      error: {
+        output: {
+          statusCode: 503,
+          payload: {
+            statusCode: 503,
+            error: "Service Unavailable",
+            message: "connection closed",
+          },
+        },
+      },
+    };
+    const secondError = new Error("socket reset");
+    const terminalError = { code: "ECONNRESET", marker: "terminal" };
+    const send = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(firstError)
+      .mockRejectedValueOnce(secondError)
+      .mockRejectedValueOnce(terminalError);
+    const onRetry = vi.fn();
+
+    const failure = await runWithFakeTimers(() =>
+      sendWhatsAppOutboundWithRetry({ send, onRetry }).catch((caught: unknown) => caught),
+    );
+
+    expect(failure).toBe(terminalError);
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenNthCalledWith(1, {
+      attempt: 1,
+      maxAttempts: 3,
+      backoffMs: 500,
+      error: firstError,
+      errorText: "status=503 Service Unavailable connection closed",
+    });
+    expect(onRetry).toHaveBeenNthCalledWith(2, {
+      attempt: 2,
+      maxAttempts: 3,
+      backoffMs: 1_000,
+      error: secondError,
+      errorText: "socket reset",
+    });
+  });
+});

--- a/extensions/whatsapp/src/outbound-retry.ts
+++ b/extensions/whatsapp/src/outbound-retry.ts
@@ -1,9 +1,4 @@
 // WhatsApp plugin module implements outbound retry behavior.
-import {
-  collectErrorGraphCandidates,
-  extractErrorCode,
-  formatErrorMessage,
-} from "openclaw/plugin-sdk/error-runtime";
 import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
 import { formatError } from "./session-errors.js";
 import { isWhatsAppSocketOperationTimeoutError } from "./socket-timing.js";
@@ -15,30 +10,17 @@ const WHATSAPP_RETRYABLE_OUTBOUND_ERROR_PATTERN = /closed|reset|timed\s*out|disc
 
 class WhatsAppOutboundRetryError extends Error {
   constructor(readonly original: unknown) {
-    super(formatErrorMessage(original), { cause: original });
+    super(formatError(original), { cause: original });
   }
-}
-
-function collectWhatsAppOutboundErrorCandidates(error: unknown): unknown[] {
-  return collectErrorGraphCandidates(error, (current) => [
-    current.cause,
-    current.error,
-    (current.lastDisconnect as { error?: unknown } | undefined)?.error,
-  ]);
 }
 
 function isRetryableWhatsAppOutboundError(error: unknown): boolean {
-  const candidates = collectWhatsAppOutboundErrorCandidates(error);
-  // A local socket timeout may have delivered the message. Retrying any
-  // wrapper around it could duplicate an already accepted outbound message.
-  if (candidates.some(isWhatsAppSocketOperationTimeoutError)) {
+  // Outbound sends surface direct failures; inspecting wrappers or causes can
+  // replay a non-idempotent send. A direct local timeout may have delivered it.
+  if (isWhatsAppSocketOperationTimeoutError(error)) {
     return false;
   }
-  return candidates.some((candidate) => {
-    const code = extractErrorCode(candidate);
-    const message = formatErrorMessage(candidate);
-    return WHATSAPP_RETRYABLE_OUTBOUND_ERROR_PATTERN.test(`${code ?? ""} ${message}`);
-  });
+  return WHATSAPP_RETRYABLE_OUTBOUND_ERROR_PATTERN.test(formatError(error));
 }
 
 type WhatsAppOutboundRetryInfo = {

--- a/extensions/whatsapp/src/outbound-retry.ts
+++ b/extensions/whatsapp/src/outbound-retry.ts
@@ -1,0 +1,95 @@
+// WhatsApp plugin module implements outbound retry behavior.
+import {
+  collectErrorGraphCandidates,
+  extractErrorCode,
+  formatErrorMessage,
+} from "openclaw/plugin-sdk/error-runtime";
+import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
+import { formatError } from "./session-errors.js";
+import { isWhatsAppSocketOperationTimeoutError } from "./socket-timing.js";
+
+const WHATSAPP_OUTBOUND_MAX_ATTEMPTS = 3;
+const WHATSAPP_OUTBOUND_MIN_DELAY_MS = 500;
+const WHATSAPP_OUTBOUND_MAX_DELAY_MS = 1_000;
+const WHATSAPP_RETRYABLE_OUTBOUND_ERROR_PATTERN = /closed|reset|timed\s*out|disconnect/i;
+
+class WhatsAppOutboundRetryError extends Error {
+  constructor(readonly original: unknown) {
+    super(formatErrorMessage(original), { cause: original });
+  }
+}
+
+function collectWhatsAppOutboundErrorCandidates(error: unknown): unknown[] {
+  return collectErrorGraphCandidates(error, (current) => [
+    current.cause,
+    current.error,
+    (current.lastDisconnect as { error?: unknown } | undefined)?.error,
+  ]);
+}
+
+function isRetryableWhatsAppOutboundError(error: unknown): boolean {
+  const candidates = collectWhatsAppOutboundErrorCandidates(error);
+  // A local socket timeout may have delivered the message. Retrying any
+  // wrapper around it could duplicate an already accepted outbound message.
+  if (candidates.some(isWhatsAppSocketOperationTimeoutError)) {
+    return false;
+  }
+  return candidates.some((candidate) => {
+    const code = extractErrorCode(candidate);
+    const message = formatErrorMessage(candidate);
+    return WHATSAPP_RETRYABLE_OUTBOUND_ERROR_PATTERN.test(`${code ?? ""} ${message}`);
+  });
+}
+
+type WhatsAppOutboundRetryInfo = {
+  attempt: number;
+  maxAttempts: number;
+  backoffMs: number;
+  error: unknown;
+  errorText: string;
+};
+
+export async function sendWhatsAppOutboundWithRetry<T>(params: {
+  send: () => Promise<T>;
+  onRetry?: (info: WhatsAppOutboundRetryInfo) => void;
+}): Promise<T> {
+  try {
+    return await retryAsync(
+      async () => {
+        try {
+          return await params.send();
+        } catch (error) {
+          // retryAsync normalizes non-Error throws. Keep the original value in
+          // an Error wrapper so the WhatsApp adapter can restore exact identity.
+          throw new WhatsAppOutboundRetryError(error);
+        }
+      },
+      {
+        attempts: WHATSAPP_OUTBOUND_MAX_ATTEMPTS,
+        minDelayMs: WHATSAPP_OUTBOUND_MIN_DELAY_MS,
+        maxDelayMs: WHATSAPP_OUTBOUND_MAX_DELAY_MS,
+        jitter: 0,
+        shouldRetry: (error) =>
+          error instanceof WhatsAppOutboundRetryError &&
+          isRetryableWhatsAppOutboundError(error.original),
+        onRetry: ({ attempt, maxAttempts, delayMs, err }) => {
+          if (!(err instanceof WhatsAppOutboundRetryError)) {
+            return;
+          }
+          params.onRetry?.({
+            attempt,
+            maxAttempts,
+            backoffMs: delayMs,
+            error: err.original,
+            errorText: formatError(err.original),
+          });
+        },
+      },
+    );
+  } catch (error) {
+    if (error instanceof WhatsAppOutboundRetryError) {
+      throw error.original;
+    }
+    throw error;
+  }
+}

--- a/extensions/whatsapp/src/text-runtime.ts
+++ b/extensions/whatsapp/src/text-runtime.ts
@@ -5,7 +5,7 @@ export {
   sanitizeAssistantVisibleTextWithProfile,
   stripToolCallXmlTags,
 } from "openclaw/plugin-sdk/text-chunking";
-export { normalizeE164, resolveUserPath, sleep } from "openclaw/plugin-sdk/text-utility-runtime";
+export { normalizeE164, resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
 export {
   assertWebChannel,
   isSelfChatMode,


### PR DESCRIPTION
## What Problem This Solves

WhatsApp outbound auto-reply delivery maintained its own retry loop for attempt counting, backoff timing, retry callbacks, and terminal error propagation even though the Plugin SDK already exposes the shared `retryAsync` runtime. Keeping that orchestration separate made WhatsApp retry behavior easier to drift from the canonical retry implementation.

## Why This Change Was Made

This change moves WhatsApp outbound retry orchestration to `retryAsync` while keeping transport-specific classification inside the WhatsApp plugin. The local predicate preserves the established direct `formatError(error)` classification and direct `WhatsAppSocketOperationTimeoutError` veto instead of admitting new wrapper or `cause` shapes. The adapter also preserves the exact terminal value thrown by the send operation. Retry callbacks retain the existing attempt, maximum-attempt, delay, error, and formatted error fields; Boom-specific formatting remains WhatsApp-owned.

## User Impact

No user-visible behavior change is intended. Retryable WhatsApp disconnect failures still receive three attempts with 500 ms and 1000 ms delays, while socket-operation timeouts with unknown delivery state remain non-retryable. The implementation now uses one canonical retry orchestrator with focused coverage for the WhatsApp-specific boundary.

## Evidence

- `corepack pnpm test extensions/whatsapp/src/outbound-retry.test.ts extensions/whatsapp/src/auto-reply/deliver-reply.test.ts` — 36 tests passed after rebasing on Blacksmith Testbox `tbx_01kxc8vvyan5pfv7weqazxfnsk`.
- `corepack pnpm tsgo:extensions` — passed on the same Testbox.
- `corepack pnpm lint:extensions` — passed on the same Testbox.
- `corepack pnpm deadcode:exports` — the PR-owned `extensions/whatsapp/src/text-runtime.ts: sleep` failure is resolved; the command still reports unrelated current-`main` baseline drift outside this PR.
- `git diff --check origin/main...HEAD` — passed after rebase.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean, no accepted or actionable findings (0.93 confidence).
