### PR TITLE
refactor(whatsapp): reuse SDK normalization and account selection

### DIFF
--- a/extensions/whatsapp/src/normalize-target.ts
+++ b/extensions/whatsapp/src/normalize-target.ts
@@ -1,6 +1,10 @@
 // Whatsapp helper module supports normalize target behavior.
 import { normalizeE164 } from "openclaw/plugin-sdk/account-resolution";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeStringEntries,
+  uniqueStrings,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 
 const WHATSAPP_USER_JID_RE = /^(\d+)(?::\d+)?@s\.whatsapp\.net$/i;
 const WHATSAPP_LEGACY_USER_JID_RE = /^(\d+)@c\.us$/i;
@@ -111,19 +115,11 @@ export function normalizeWhatsAppMessagingTarget(raw: string): string | undefine
 }
 
 export function normalizeWhatsAppAllowFromEntries(allowFrom: Array<string | number>): string[] {
-  const seen = new Set<string>();
-  const normalized = allowFrom
-    .map((entry) => String(entry).trim())
-    .filter((entry): entry is string => Boolean(entry))
-    .map(normalizeWhatsAppAllowFromEntry)
-    .filter((entry): entry is string => Boolean(entry));
-  return normalized.filter((entry) => {
-    if (seen.has(entry)) {
-      return false;
-    }
-    seen.add(entry);
-    return true;
-  });
+  return uniqueStrings(
+    normalizeStringEntries(allowFrom)
+      .map(normalizeWhatsAppAllowFromEntry)
+      .filter((entry): entry is string => Boolean(entry)),
+  );
 }
 
 export function normalizeWhatsAppAllowFromEntry(entry: string): string | null {

--- a/extensions/whatsapp/src/outbound-base.test.ts
+++ b/extensions/whatsapp/src/outbound-base.test.ts
@@ -162,6 +162,7 @@ describe("createWhatsAppOutboundBase", () => {
       cfg: {
         channels: {
           whatsapp: {
+            authDir: "/tmp/whatsapp-default",
             defaultAccount: "work",
             accounts: {
               work: {},
@@ -182,6 +183,50 @@ describe("createWhatsAppOutboundBase", () => {
       fromMe: false,
       participant: "111@s.whatsapp.net",
       messageText: "quoted body",
+    });
+  });
+
+  it("uses the implicit authDir default account for quote metadata lookup", async () => {
+    cacheInboundMessageMeta("default", "15551234567@s.whatsapp.net", "reply-auth-dir", {
+      participant: "444@s.whatsapp.net",
+      body: "implicit default body",
+    });
+    const sendMessageWhatsApp = vi.fn(async () => ({
+      messageId: "msg-auth-dir",
+      toJid: "15551234567@s.whatsapp.net",
+    }));
+    const outbound = createWhatsAppOutboundBase({
+      chunker: (text) => [text],
+      sendMessageWhatsApp,
+      sendPollWhatsApp: vi.fn(),
+      shouldLogVerbose: () => false,
+      resolveTarget: ({ to }) => ({ ok: true as const, to: to ?? "" }),
+    });
+
+    await outbound.sendText!({
+      cfg: {
+        channels: {
+          whatsapp: {
+            authDir: "/tmp/whatsapp-default",
+            accounts: {
+              work: {},
+            },
+          },
+        },
+      } as never,
+      to: "whatsapp:+15551234567",
+      text: "reply",
+      deps: { sendWhatsApp: sendMessageWhatsApp },
+      replyToId: "reply-auth-dir",
+    });
+
+    const options = sendMessageOptionsAt(sendMessageWhatsApp, 0, "whatsapp:+15551234567", "reply");
+    expect(options.quotedMessageKey).toEqual({
+      id: "reply-auth-dir",
+      remoteJid: "15551234567@s.whatsapp.net",
+      fromMe: false,
+      participant: "444@s.whatsapp.net",
+      messageText: "implicit default body",
     });
   });
 
@@ -345,8 +390,11 @@ describe("createWhatsAppOutboundBase", () => {
       cfg: {
         channels: {
           whatsapp: {
+            authDir: "/tmp/whatsapp-default",
+            defaultAccount: "other",
             accounts: {
               work: {},
+              other: {},
             },
           },
         },

--- a/extensions/whatsapp/src/outbound-base.ts
+++ b/extensions/whatsapp/src/outbound-base.ts
@@ -1,10 +1,5 @@
 // Whatsapp plugin module implements outbound base behavior.
-import {
-  DEFAULT_ACCOUNT_ID,
-  listCombinedAccountIds,
-  normalizeOptionalAccountId,
-  resolveListedDefaultAccountId,
-} from "openclaw/plugin-sdk/account-core";
+import { normalizeOptionalAccountId } from "openclaw/plugin-sdk/account-core";
 import { resolveOutboundSendDep } from "openclaw/plugin-sdk/channel-outbound";
 import {
   attachChannelToResult,
@@ -13,6 +8,7 @@ import {
 } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { sendTextMediaPayload } from "openclaw/plugin-sdk/reply-payload";
+import { resolveDefaultWhatsAppAccountId } from "./account-ids.js";
 import {
   normalizeWhatsAppOutboundPayload,
   normalizeWhatsAppPayloadText,
@@ -73,18 +69,7 @@ function resolveQuoteLookupAccountId(cfg?: OpenClawConfig, accountId?: string | 
   if (explicitAccountId) {
     return explicitAccountId;
   }
-  const channelCfg = cfg?.channels?.whatsapp;
-  const configuredIds = listCombinedAccountIds({
-    configuredAccountIds:
-      channelCfg?.accounts && typeof channelCfg.accounts === "object"
-        ? Object.keys(channelCfg.accounts).filter(Boolean)
-        : [],
-    fallbackAccountIdWhenEmpty: DEFAULT_ACCOUNT_ID,
-  });
-  return resolveListedDefaultAccountId({
-    accountIds: configuredIds,
-    configuredDefaultAccountId: normalizeOptionalAccountId(channelCfg?.defaultAccount),
-  });
+  return resolveDefaultWhatsAppAccountId(cfg ?? {});
 }
 
 type WhatsAppOutboundBaseCore = Pick<

--- a/extensions/whatsapp/src/resolve-target.test.ts
+++ b/extensions/whatsapp/src/resolve-target.test.ts
@@ -5,6 +5,7 @@ import {
   isWhatsAppNewsletterJid,
   looksLikeWhatsAppTargetId,
   isWhatsAppUserTarget,
+  normalizeWhatsAppAllowFromEntries,
   normalizeWhatsAppMessagingTarget,
   normalizeWhatsAppTarget,
 } from "./normalize-target.js";
@@ -117,6 +118,20 @@ describe("isWhatsAppGroupJid", () => {
 describe("normalizeWhatsAppMessagingTarget", () => {
   it("normalizes blank inputs to undefined", () => {
     expect(normalizeWhatsAppMessagingTarget("   ")).toBeUndefined();
+  });
+});
+
+describe("normalizeWhatsAppAllowFromEntries", () => {
+  it("deduplicates entries after WhatsApp target normalization", () => {
+    expect(
+      normalizeWhatsAppAllowFromEntries([
+        " +1 (555) 123-4567 ",
+        "15551234567@s.whatsapp.net",
+        15551234567,
+        " ",
+        "invalid",
+      ]),
+    ).toEqual(["15551234567"]);
   });
 });
 

--- a/extensions/whatsapp/src/socket-timing.test.ts
+++ b/extensions/whatsapp/src/socket-timing.test.ts
@@ -58,6 +58,27 @@ describe("resolveWhatsAppSocketTiming", () => {
     });
   });
 
+  it("rejects invalid numeric timing values", () => {
+    expect(
+      resolveWhatsAppSocketTiming(
+        {
+          web: {
+            whatsapp: {
+              keepAliveIntervalMs: 0,
+              connectTimeoutMs: Number.NaN,
+              defaultQueryTimeoutMs: 1.5,
+            },
+          },
+        },
+        {
+          keepAliveIntervalMs: -1,
+          connectTimeoutMs: Number.POSITIVE_INFINITY,
+          defaultQueryTimeoutMs: Number.MAX_SAFE_INTEGER + 1,
+        },
+      ),
+    ).toEqual(DEFAULT_WHATSAPP_SOCKET_TIMING);
+  });
+
   it("marks operation timeout errors as unknown delivery state", () => {
     const error = new WhatsAppSocketOperationTimeoutError(
       "sendMessage",

--- a/extensions/whatsapp/src/socket-timing.ts
+++ b/extensions/whatsapp/src/socket-timing.ts
@@ -6,7 +6,10 @@ import type {
   WAPresence,
 } from "baileys";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import {
+  parseStrictPositiveInteger,
+  resolveTimerTimeoutMs,
+} from "openclaw/plugin-sdk/number-runtime";
 
 export type WhatsAppSocketTimingOptions = {
   keepAliveIntervalMs?: number;
@@ -47,10 +50,6 @@ export class WhatsAppSocketOperationTimeoutError extends Error {
   }
 }
 
-function positiveInteger(value: number | undefined): number | undefined {
-  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
-}
-
 export function resolveWhatsAppSocketTiming(
   cfg: OpenClawConfig,
   overrides?: WhatsAppSocketTimingOptions,
@@ -58,16 +57,16 @@ export function resolveWhatsAppSocketTiming(
   const configured = cfg.web?.whatsapp;
   return {
     keepAliveIntervalMs:
-      positiveInteger(overrides?.keepAliveIntervalMs) ??
-      positiveInteger(configured?.keepAliveIntervalMs) ??
+      parseStrictPositiveInteger(overrides?.keepAliveIntervalMs) ??
+      parseStrictPositiveInteger(configured?.keepAliveIntervalMs) ??
       DEFAULT_WHATSAPP_SOCKET_TIMING.keepAliveIntervalMs,
     connectTimeoutMs:
-      positiveInteger(overrides?.connectTimeoutMs) ??
-      positiveInteger(configured?.connectTimeoutMs) ??
+      parseStrictPositiveInteger(overrides?.connectTimeoutMs) ??
+      parseStrictPositiveInteger(configured?.connectTimeoutMs) ??
       DEFAULT_WHATSAPP_SOCKET_TIMING.connectTimeoutMs,
     defaultQueryTimeoutMs:
-      positiveInteger(overrides?.defaultQueryTimeoutMs) ??
-      positiveInteger(configured?.defaultQueryTimeoutMs) ??
+      parseStrictPositiveInteger(overrides?.defaultQueryTimeoutMs) ??
+      parseStrictPositiveInteger(configured?.defaultQueryTimeoutMs) ??
       DEFAULT_WHATSAPP_SOCKET_TIMING.defaultQueryTimeoutMs,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

WhatsApp socket timing validation, quote metadata account selection, and allowlist normalization each repeated behavior already available through shared SDK or WhatsApp account helpers.

## Why This Change Was Made

- Replaces the local positive-integer validator with `parseStrictPositiveInteger`.
- Keeps an explicitly supplied account ID first, then uses `resolveDefaultWhatsAppAccountId` for configured defaults, sorted account fallback, and the root `authDir` implicit-default rule.
- Composes `normalizeStringEntries` and `uniqueStrings` around WhatsApp-specific target conversion for allowlist entries.
- Adds tests for invalid timing values, explicit and implicit account selection, and duplicates that become equal after WhatsApp target normalization.

## User Impact

There is no new configuration or API surface. Quote metadata lookup now uses the same default-account rules as other WhatsApp account paths, and invalid non-positive, non-finite, fractional, or unsafe timing values fall back to the existing defaults.

## Evidence

- `pnpm test extensions/whatsapp/src/socket-timing.test.ts extensions/whatsapp/src/outbound-base.test.ts extensions/whatsapp/src/resolve-target.test.ts` — 41 tests passed on Blacksmith Testbox `tbx_01kxbq4d3zbxxm463qmk38jsdx` ([run](https://github.com/openclaw/openclaw/actions/runs/29202699121)).
- `pnpm tsgo:extensions` — passed.
- `pnpm tsgo:extensions:test` — passed.
- `pnpm lint:extensions` — passed with 0 warnings and 0 errors.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — no accepted or actionable findings.
- `pnpm check:changed` passed its conflict-marker, attribution, extension-export, duplicate-coverage, dependency-pin, and formatting checks, then stopped on the repository's unrelated Plugin SDK API-baseline hash mismatch.
