### PR TITLE
fix(sqlite): reject incomplete maintenance schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **SQLite maintenance schema validation:** reject current-version global and agent databases with missing or drifted canonical tables, constraints, indexes, triggers, or table options before compaction, while accepting supported additive-migration layouts.
 - **iOS Watch relay commands:** allow paired iPhone nodes to advertise and invoke `watch.status` and `watch.notify` through the default Gateway policy while preserving the direct watchOS node's fixed minimal command surface.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.

--- a/src/commands/doctor-state-sqlite-compact.test.ts
+++ b/src/commands/doctor-state-sqlite-compact.test.ts
@@ -10,6 +10,7 @@ import {
   OPENCLAW_STATE_SCHEMA_VERSION,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { OPENCLAW_STATE_SCHEMA_SQL } from "../state/openclaw-state-schema.generated.js";
 import {
   type DoctorStateSqliteCompactReport,
   runDoctorStateSqliteCompact,
@@ -46,11 +47,7 @@ function seedStateDatabase(params: {
     database.exec(`
       PRAGMA auto_vacuum = NONE;
       PRAGMA journal_mode = WAL;
-      CREATE TABLE schema_meta (
-        meta_key TEXT PRIMARY KEY,
-        role TEXT NOT NULL,
-        schema_version INTEGER NOT NULL
-      );
+      ${OPENCLAW_STATE_SCHEMA_SQL}
       CREATE TABLE compact_payload (
         id INTEGER PRIMARY KEY,
         payload TEXT NOT NULL
@@ -58,7 +55,19 @@ function seedStateDatabase(params: {
       PRAGMA user_version = ${schemaVersion};
     `);
     database
-      .prepare("INSERT INTO schema_meta (meta_key, role, schema_version) VALUES (?, ?, ?)")
+      .prepare(
+        `
+          INSERT INTO schema_meta (
+            meta_key,
+            role,
+            schema_version,
+            agent_id,
+            app_version,
+            created_at,
+            updated_at
+          ) VALUES (?, ?, ?, NULL, NULL, 1, 1)
+        `,
+      )
       .run("primary", params.role ?? "global", schemaVersion);
     if (params.withBloat) {
       const insert = database.prepare("INSERT INTO compact_payload (payload) VALUES (?)");

--- a/src/infra/sqlite-schema-contract.test.ts
+++ b/src/infra/sqlite-schema-contract.test.ts
@@ -1,0 +1,209 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { assertSqliteSchemaContains } from "./sqlite-schema-contract.js";
+
+const CANONICAL_SCHEMA = `
+  CREATE TABLE parents (
+    id TEXT PRIMARY KEY,
+    value TEXT NOT NULL CHECK (length(value) > 0)
+  );
+  CREATE TABLE other_parents (
+    id TEXT PRIMARY KEY
+  );
+  CREATE TABLE children (
+    id TEXT PRIMARY KEY,
+    parent_id TEXT NOT NULL,
+    other_parent_id TEXT NOT NULL,
+    value TEXT,
+    FOREIGN KEY (parent_id) REFERENCES parents(id) ON DELETE CASCADE,
+    FOREIGN KEY (other_parent_id) REFERENCES other_parents(id) ON DELETE RESTRICT
+  );
+  CREATE TABLE events (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    payload TEXT NOT NULL DEFAULT 'pending'
+  );
+  CREATE TABLE features (
+    id INTEGER PRIMARY KEY,
+    name TEXT COLLATE NOCASE,
+    code TEXT UNIQUE ON CONFLICT REPLACE,
+    normalized_name TEXT GENERATED ALWAYS AS (lower(name)) STORED,
+    parent_id TEXT,
+    FOREIGN KEY (parent_id) REFERENCES parents(id) DEFERRABLE INITIALLY DEFERRED
+  );
+  CREATE INDEX idx_children_parent ON children(parent_id, id);
+  CREATE TRIGGER children_value_after_update
+  AFTER UPDATE OF value ON children
+  BEGIN
+    UPDATE parents SET value = NEW.value WHERE id = NEW.parent_id;
+  END;
+`;
+
+describe("assertSqliteSchemaContains", () => {
+  it("accepts the canonical schema plus unrelated objects", () => {
+    const database = createDatabase(CANONICAL_SCHEMA);
+    try {
+      database.exec(`
+        CREATE TABLE custom_records (id INTEGER PRIMARY KEY);
+        CREATE INDEX idx_custom_records_id ON custom_records(id);
+      `);
+
+      expect(() =>
+        assertSqliteSchemaContains(database, "test database", CANONICAL_SCHEMA),
+      ).not.toThrow();
+    } finally {
+      database.close();
+    }
+  });
+
+  it("accepts canonical columns created in additive-migration order", () => {
+    const migratedSchema = CANONICAL_SCHEMA.replace(
+      `
+  CREATE TABLE parents (
+    id TEXT PRIMARY KEY,
+    value TEXT NOT NULL CHECK (length(value) > 0)
+  );`,
+      `
+  CREATE TABLE parents (
+    value TEXT NOT NULL CHECK (length(value) > 0),
+    id TEXT PRIMARY KEY
+  );`,
+    );
+    const database = createDatabase(migratedSchema);
+    try {
+      expect(() =>
+        assertSqliteSchemaContains(database, "test database", CANONICAL_SCHEMA),
+      ).not.toThrow();
+    } finally {
+      database.close();
+    }
+  });
+
+  it("accepts only an allowlisted additive-migration default", () => {
+    const migratedSchema = CANONICAL_SCHEMA.replace(
+      "value TEXT NOT NULL CHECK (length(value) > 0)",
+      "value TEXT NOT NULL DEFAULT 'legacy' CHECK (length(value) > 0)",
+    );
+    const database = createDatabase(migratedSchema);
+    try {
+      expect(() => assertSqliteSchemaContains(database, "test database", CANONICAL_SCHEMA)).toThrow(
+        "column definitions differ for parents",
+      );
+      expect(() =>
+        assertSqliteSchemaContains(database, "test database", CANONICAL_SCHEMA, {
+          allowedColumnDefinitions: {
+            "parents.value": ["value TEXT NOT NULL DEFAULT 'legacy' CHECK (length(value) > 0)"],
+          },
+        }),
+      ).not.toThrow();
+    } finally {
+      database.close();
+    }
+  });
+
+  it("accepts equivalent foreign keys declared in migration order", () => {
+    const migratedSchema = CANONICAL_SCHEMA.replace(
+      `    FOREIGN KEY (parent_id) REFERENCES parents(id) ON DELETE CASCADE,
+    FOREIGN KEY (other_parent_id) REFERENCES other_parents(id) ON DELETE RESTRICT`,
+      `    FOREIGN KEY (other_parent_id) REFERENCES other_parents(id) ON DELETE RESTRICT,
+    FOREIGN KEY (parent_id) REFERENCES parents(id) ON DELETE CASCADE`,
+    );
+    const database = createDatabase(migratedSchema);
+    try {
+      expect(() =>
+        assertSqliteSchemaContains(database, "test database", CANONICAL_SCHEMA),
+      ).not.toThrow();
+    } finally {
+      database.close();
+    }
+  });
+
+  it.each([
+    {
+      name: "table",
+      schema: CANONICAL_SCHEMA.replace(/CREATE TABLE parents \([\s\S]*?\);\s*/u, "").replace(
+        /CREATE TRIGGER children_value_after_update[\s\S]*?END;\s*/u,
+        "",
+      ),
+      expected: "missing table parents",
+    },
+    {
+      name: "column",
+      schema: CANONICAL_SCHEMA.replace("value TEXT NOT NULL", "value BLOB NOT NULL"),
+      expected: "column definitions differ for parents",
+    },
+    {
+      name: "foreign key",
+      schema: CANONICAL_SCHEMA.replace(
+        /,\s*FOREIGN KEY \(parent_id\) REFERENCES parents\(id\) ON DELETE CASCADE/u,
+        "",
+      ),
+      expected: "table constraints differ for children",
+    },
+    {
+      name: "check constraint",
+      schema: CANONICAL_SCHEMA.replace(" CHECK (length(value) > 0)", ""),
+      expected: "column definitions differ for parents",
+    },
+    {
+      name: "AUTOINCREMENT",
+      schema: CANONICAL_SCHEMA.replace(" PRIMARY KEY AUTOINCREMENT", " PRIMARY KEY"),
+      expected: "column definitions differ for events",
+    },
+    {
+      name: "required default",
+      schema: CANONICAL_SCHEMA.replace(" DEFAULT 'pending'", ""),
+      expected: "column definitions differ for events",
+    },
+    {
+      name: "collation",
+      schema: CANONICAL_SCHEMA.replace("name TEXT COLLATE NOCASE", "name TEXT"),
+      expected: "column definitions differ for features",
+    },
+    {
+      name: "generated expression",
+      schema: CANONICAL_SCHEMA.replace("lower(name)", "upper(name)"),
+      expected: "column definitions differ for features",
+    },
+    {
+      name: "conflict clause",
+      schema: CANONICAL_SCHEMA.replace(" ON CONFLICT REPLACE", " ON CONFLICT IGNORE"),
+      expected: "column definitions differ for features",
+    },
+    {
+      name: "foreign-key deferral",
+      schema: CANONICAL_SCHEMA.replace(" DEFERRABLE INITIALLY DEFERRED", ""),
+      expected: "table constraints differ for features",
+    },
+    {
+      name: "index",
+      schema: CANONICAL_SCHEMA.replace(
+        "CREATE INDEX idx_children_parent ON children(parent_id, id)",
+        "CREATE INDEX idx_children_parent ON children(id, parent_id)",
+      ),
+      expected: "missing or drifted index idx_children_parent",
+    },
+    {
+      name: "trigger",
+      schema: CANONICAL_SCHEMA.replace(
+        "UPDATE parents SET value = NEW.value WHERE id = NEW.parent_id",
+        "UPDATE parents SET value = NULL WHERE id = NEW.parent_id",
+      ),
+      expected: "missing or drifted trigger children_value_after_update",
+    },
+  ])("rejects a drifted required $name", ({ schema, expected }) => {
+    const database = createDatabase(schema);
+    try {
+      expect(() => assertSqliteSchemaContains(database, "test database", CANONICAL_SCHEMA)).toThrow(
+        expected,
+      );
+    } finally {
+      database.close();
+    }
+  });
+});
+
+function createDatabase(schema: string): DatabaseSync {
+  const database = new DatabaseSync(":memory:");
+  database.exec(schema);
+  return database;
+}

--- a/src/infra/sqlite-schema-contract.ts
+++ b/src/infra/sqlite-schema-contract.ts
@@ -1,0 +1,526 @@
+import type { DatabaseSync } from "node:sqlite";
+import { requireNodeSqlite } from "./node-sqlite.js";
+
+type SqliteIndexListRow = {
+  name: string;
+  origin: string;
+  partial: number;
+  unique: number;
+};
+
+type SqliteIndexTermRow = {
+  cid: number;
+  coll: string;
+  desc: number;
+  key: number;
+  name: string | null;
+  seqno: number;
+};
+
+type SqliteIndexTermContract = Omit<SqliteIndexTermRow, "cid"> & {
+  kind: "column" | "expression" | "rowid";
+};
+
+type SqliteSchemaRow = {
+  name: string;
+  sql: string | null;
+};
+
+type SqliteTableListRow = {
+  name: string;
+  strict: number;
+  wr: number;
+};
+
+type SqliteIndexContract = {
+  name: string | null;
+  origin: string;
+  partial: number;
+  sql: string | null;
+  terms: SqliteIndexTermContract[];
+  unique: number;
+};
+
+type SqliteTableDefinition = {
+  columns: Map<string, string>;
+  constraints: string[];
+};
+
+type SqliteTableContract = {
+  definition: SqliteTableDefinition | null;
+  indexes: SqliteIndexContract[];
+  strict: number;
+  triggers: Array<{ name: string; sql: string | null }>;
+  virtualTableSql: string | null;
+  withoutRowid: number;
+};
+
+type SqliteSchemaContract = Map<string, SqliteTableContract>;
+
+export type SqliteSchemaCompatibility = {
+  /**
+   * Exact definitions produced by supported additive migrations when SQLite
+   * requires a temporary default that the clean schema does not retain.
+   */
+  allowedColumnDefinitions?: Readonly<Record<string, readonly string[]>>;
+};
+
+const schemaContractCache = new Map<string, SqliteSchemaContract>();
+const TABLE_CONSTRAINT_KEYWORDS = new Set(["CHECK", "FOREIGN", "PRIMARY", "UNIQUE"]);
+
+/**
+ * Require every object from one committed schema while allowing unrelated
+ * tables and indexes that do not replace a canonical object.
+ */
+export function assertSqliteSchemaContains(
+  database: DatabaseSync,
+  databaseLabel: string,
+  schemaSql: string,
+  compatibility: SqliteSchemaCompatibility = {},
+): void {
+  let expected = schemaContractCache.get(schemaSql);
+  if (!expected) {
+    expected = buildSqliteSchemaContract(schemaSql);
+    schemaContractCache.set(schemaSql, expected);
+  }
+
+  const mismatches: string[] = [];
+  for (const [tableName, expectedTable] of expected) {
+    const actualTable = collectSqliteTableContract(database, tableName);
+    if (!actualTable) {
+      mismatches.push(`missing table ${tableName}`);
+      continue;
+    }
+
+    const definitionMismatch = compareTableDefinitions(
+      tableName,
+      actualTable.definition,
+      expectedTable.definition,
+      compatibility,
+    );
+    if (definitionMismatch) {
+      mismatches.push(`${definitionMismatch} differ for ${tableName}`);
+    }
+    for (const expectedIndex of expectedTable.indexes) {
+      if (!actualTable.indexes.some((actualIndex) => isEqual(actualIndex, expectedIndex))) {
+        mismatches.push(`missing or drifted index ${expectedIndex.name ?? `on ${tableName}`}`);
+      }
+    }
+    for (const expectedTrigger of expectedTable.triggers) {
+      if (!actualTable.triggers.some((actualTrigger) => isEqual(actualTrigger, expectedTrigger))) {
+        mismatches.push(`missing or drifted trigger ${expectedTrigger.name}`);
+      }
+    }
+    if (actualTable.virtualTableSql !== expectedTable.virtualTableSql) {
+      mismatches.push(`virtual table definition differs for ${tableName}`);
+    }
+    if (
+      actualTable.strict !== expectedTable.strict ||
+      actualTable.withoutRowid !== expectedTable.withoutRowid
+    ) {
+      mismatches.push(`table options differ for ${tableName}`);
+    }
+  }
+
+  if (mismatches.length > 0) {
+    const shown = mismatches.slice(0, 8);
+    if (mismatches.length > shown.length) {
+      shown.push(`${mismatches.length - shown.length} additional mismatch(es)`);
+    }
+    throw new Error(
+      `SQLite schema is incomplete or noncanonical for ${databaseLabel}: ${shown.join("; ")}`,
+    );
+  }
+}
+
+function buildSqliteSchemaContract(schemaSql: string): SqliteSchemaContract {
+  const sqlite = requireNodeSqlite();
+  const database = new sqlite.DatabaseSync(":memory:");
+  try {
+    database.exec(schemaSql);
+    const rows = database
+      .prepare(
+        `
+          SELECT name
+          FROM sqlite_schema
+          WHERE type = 'table'
+            AND name NOT LIKE 'sqlite_%'
+          ORDER BY name
+        `,
+      )
+      .all() as Array<{ name: string }>;
+    return new Map(
+      rows.map((row) => {
+        const contract = collectSqliteTableContract(database, row.name);
+        if (!contract) {
+          throw new Error(`Could not collect generated SQLite schema table ${row.name}.`);
+        }
+        return [row.name, contract];
+      }),
+    );
+  } finally {
+    database.close();
+  }
+}
+
+function collectSqliteTableContract(
+  database: DatabaseSync,
+  tableName: string,
+): SqliteTableContract | undefined {
+  const table = database
+    .prepare("SELECT name, sql FROM sqlite_schema WHERE type = 'table' AND name = ?")
+    .get(tableName) as SqliteSchemaRow | undefined;
+  if (!table) {
+    return undefined;
+  }
+
+  const quotedTable = quoteSqliteIdentifier(tableName);
+  const tableList = (database.prepare("PRAGMA table_list").all() as SqliteTableListRow[]).find(
+    (entry) => entry.name === tableName,
+  );
+  if (!tableList) {
+    throw new Error(`Could not inspect SQLite table options for ${tableName}.`);
+  }
+  const indexes = (
+    database.prepare(`PRAGMA index_list(${quotedTable})`).all() as SqliteIndexListRow[]
+  )
+    .map((index) => collectSqliteIndexContract(database, index))
+    .toSorted(compareJson);
+  const triggers = (
+    database
+      .prepare(
+        `
+          SELECT name, sql
+          FROM sqlite_schema
+          WHERE type = 'trigger' AND tbl_name = ?
+          ORDER BY name
+        `,
+      )
+      .all(tableName) as SqliteSchemaRow[]
+  ).map((trigger) => ({
+    name: trigger.name,
+    sql: normalizeSchemaSql(trigger.sql),
+  }));
+  const normalizedTableSql = normalizeSchemaSql(table.sql);
+  const isVirtualTable =
+    normalizedTableSql !== null && /^CREATE VIRTUAL TABLE /iu.test(normalizedTableSql);
+
+  return {
+    definition: isVirtualTable ? null : parseTableDefinition(table.sql, tableName),
+    indexes,
+    strict: tableList.strict,
+    triggers,
+    virtualTableSql: isVirtualTable ? normalizedTableSql : null,
+    withoutRowid: tableList.wr,
+  };
+}
+
+function compareTableDefinitions(
+  tableName: string,
+  actual: SqliteTableDefinition | null,
+  expected: SqliteTableDefinition | null,
+  compatibility: SqliteSchemaCompatibility,
+): "column definitions" | "table constraints" | "table definition" | null {
+  if (!actual || !expected) {
+    return actual === expected ? null : "table definition";
+  }
+  if (actual.columns.size !== expected.columns.size) {
+    return "column definitions";
+  }
+  for (const [columnName, expectedDefinition] of expected.columns) {
+    const actualDefinition = actual.columns.get(columnName);
+    if (actualDefinition === expectedDefinition) {
+      continue;
+    }
+    const allowed = compatibility.allowedColumnDefinitions?.[`${tableName}.${columnName}`] ?? [];
+    if (!allowed.some((definition) => normalizeSqlWhitespace(definition) === actualDefinition)) {
+      return "column definitions";
+    }
+  }
+  return isEqual(actual.constraints, expected.constraints) ? null : "table constraints";
+}
+
+function parseTableDefinition(sql: string | null, tableName: string): SqliteTableDefinition {
+  if (sql === null) {
+    throw new Error(`Could not inspect SQLite table definition for ${tableName}.`);
+  }
+  const open = findSqlCharacter(sql, "(");
+  if (open === -1) {
+    throw new Error(`SQLite table ${tableName} has no column definition.`);
+  }
+  const close = findSqlClosingParenthesis(sql, open);
+  const columns = new Map<string, string>();
+  const constraints: string[] = [];
+  for (const rawDefinition of splitSqlList(sql.slice(open + 1, close))) {
+    const definition = normalizeSqlWhitespace(rawDefinition);
+    if (!definition) {
+      continue;
+    }
+    const token = readSqlToken(definition, 0);
+    if (!token) {
+      throw new Error(`SQLite table ${tableName} contains an unreadable definition.`);
+    }
+    if (readTableConstraintKeyword(definition, token)) {
+      constraints.push(definition);
+      continue;
+    }
+    const columnName = normalizeSqlIdentifier(token.raw);
+    if (columns.has(columnName)) {
+      throw new Error(`SQLite table ${tableName} contains duplicate column ${columnName}.`);
+    }
+    columns.set(columnName, definition);
+  }
+  return {
+    columns: new Map([...columns].toSorted(([left], [right]) => left.localeCompare(right))),
+    constraints: constraints.toSorted(),
+  };
+}
+
+type SqlToken = {
+  end: number;
+  keyword: string | null;
+  raw: string;
+};
+
+function readTableConstraintKeyword(sql: string, first: SqlToken): string | null {
+  let token: SqlToken | null = first;
+  if (token.keyword === "CONSTRAINT") {
+    const name = readSqlToken(sql, token.end);
+    token = name ? readSqlToken(sql, name.end) : null;
+  }
+  return token?.keyword && TABLE_CONSTRAINT_KEYWORDS.has(token.keyword) ? token.keyword : null;
+}
+
+function readSqlToken(sql: string, start: number): SqlToken | null {
+  let index = start;
+  while (index < sql.length && /\s/u.test(sql[index] ?? "")) {
+    index += 1;
+  }
+  const char = sql[index];
+  if (!char) {
+    return null;
+  }
+  if (char === '"' || char === "`") {
+    const end = skipSqlQuoted(sql, index, char);
+    return { end, keyword: null, raw: sql.slice(index, end) };
+  }
+  if (char === "[") {
+    const end = skipSqlQuoted(sql, index, char);
+    return { end, keyword: null, raw: sql.slice(index, end) };
+  }
+  let end = index;
+  while (end < sql.length && !/[\s(,]/u.test(sql[end] ?? "")) {
+    end += 1;
+  }
+  const raw = sql.slice(index, end);
+  return { end, keyword: raw.toUpperCase(), raw };
+}
+
+function normalizeSqlIdentifier(identifier: string): string {
+  if (identifier.startsWith('"') && identifier.endsWith('"')) {
+    return identifier.slice(1, -1).replaceAll('""', '"').toLowerCase();
+  }
+  if (identifier.startsWith("`") && identifier.endsWith("`")) {
+    return identifier.slice(1, -1).replaceAll("``", "`").toLowerCase();
+  }
+  if (identifier.startsWith("[") && identifier.endsWith("]")) {
+    return identifier.slice(1, -1).toLowerCase();
+  }
+  return identifier.toLowerCase();
+}
+
+function collectSqliteIndexContract(
+  database: DatabaseSync,
+  index: SqliteIndexListRow,
+): SqliteIndexContract {
+  const row = database
+    .prepare("SELECT sql FROM sqlite_schema WHERE type = 'index' AND name = ?")
+    .get(index.name) as { sql?: unknown } | undefined;
+  const terms = (
+    database
+      .prepare(`PRAGMA index_xinfo(${quoteSqliteIdentifier(index.name)})`)
+      .all() as SqliteIndexTermRow[]
+  ).map(({ cid, coll, desc, key, name, seqno }) => ({
+    coll,
+    desc,
+    key,
+    kind: sqliteIndexTermKind(cid),
+    name,
+    seqno,
+  }));
+  return {
+    name: index.name.startsWith("sqlite_autoindex_") ? null : index.name,
+    origin: index.origin,
+    partial: index.partial,
+    sql: normalizeSchemaSql(typeof row?.sql === "string" ? row.sql : null),
+    terms,
+    unique: index.unique,
+  };
+}
+
+function sqliteIndexTermKind(cid: number): SqliteIndexTermContract["kind"] {
+  return cid === -2 ? "expression" : cid === -1 ? "rowid" : "column";
+}
+
+function normalizeSchemaSql(sql: string | null): string | null {
+  if (sql === null) {
+    return null;
+  }
+  const normalized = normalizeSqlWhitespace(sql).replace(/;\s*$/u, "").trim();
+  return normalized
+    .replace(/^(CREATE TABLE) IF NOT EXISTS /iu, "$1 ")
+    .replace(/^(CREATE VIRTUAL TABLE) IF NOT EXISTS /iu, "$1 ")
+    .replace(/^(CREATE UNIQUE INDEX) IF NOT EXISTS /iu, "$1 ")
+    .replace(/^(CREATE INDEX) IF NOT EXISTS /iu, "$1 ")
+    .replace(/^(CREATE TRIGGER) IF NOT EXISTS /iu, "$1 ");
+}
+
+function splitSqlList(sql: string): string[] {
+  const items: string[] = [];
+  let depth = 0;
+  let start = 0;
+  let index = 0;
+  while (index < sql.length) {
+    const next = skipSqlQuotedOrComment(sql, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+    const char = sql[index];
+    if (char === "(") {
+      depth += 1;
+    } else if (char === ")") {
+      depth -= 1;
+    } else if (char === "," && depth === 0) {
+      items.push(sql.slice(start, index));
+      start = index + 1;
+    }
+    index += 1;
+  }
+  items.push(sql.slice(start));
+  return items;
+}
+
+function findSqlCharacter(sql: string, character: string): number {
+  let index = 0;
+  while (index < sql.length) {
+    const next = skipSqlQuotedOrComment(sql, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+    if (sql[index] === character) {
+      return index;
+    }
+    index += 1;
+  }
+  return -1;
+}
+
+function findSqlClosingParenthesis(sql: string, open: number): number {
+  let depth = 0;
+  let index = open;
+  while (index < sql.length) {
+    const next = skipSqlQuotedOrComment(sql, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+    const char = sql[index];
+    if (char === "(") {
+      depth += 1;
+    } else if (char === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+    index += 1;
+  }
+  throw new Error("SQLite schema contains an unterminated table definition.");
+}
+
+function normalizeSqlWhitespace(sql: string): string {
+  let normalized = "";
+  let pendingSpace = false;
+  let index = 0;
+  while (index < sql.length) {
+    const quoted = skipSqlQuoted(sql, index, sql[index] ?? "");
+    if (quoted !== index) {
+      if (pendingSpace && normalized.length > 0) {
+        normalized += " ";
+      }
+      normalized += sql.slice(index, quoted);
+      pendingSpace = false;
+      index = quoted;
+      continue;
+    }
+    const comment = skipSqlComment(sql, index);
+    if (comment !== index) {
+      pendingSpace = true;
+      index = comment;
+      continue;
+    }
+    const char = sql[index] ?? "";
+    if (/\s/u.test(char)) {
+      pendingSpace = true;
+    } else {
+      if (pendingSpace && normalized.length > 0) {
+        normalized += " ";
+      }
+      normalized += char;
+      pendingSpace = false;
+    }
+    index += 1;
+  }
+  return normalized.trim();
+}
+
+function skipSqlQuotedOrComment(sql: string, index: number): number {
+  const quoted = skipSqlQuoted(sql, index, sql[index] ?? "");
+  return quoted !== index ? quoted : skipSqlComment(sql, index);
+}
+
+function skipSqlQuoted(sql: string, index: number, quote: string): number {
+  if (quote !== "'" && quote !== '"' && quote !== "`" && quote !== "[") {
+    return index;
+  }
+  const closingQuote = quote === "[" ? "]" : quote;
+  let cursor = index + 1;
+  while (cursor < sql.length) {
+    if (sql[cursor] !== closingQuote) {
+      cursor += 1;
+      continue;
+    }
+    if (quote !== "[" && sql[cursor + 1] === closingQuote) {
+      cursor += 2;
+      continue;
+    }
+    return cursor + 1;
+  }
+  return sql.length;
+}
+
+function skipSqlComment(sql: string, index: number): number {
+  if (sql.startsWith("--", index)) {
+    const newline = sql.indexOf("\n", index + 2);
+    return newline === -1 ? sql.length : newline + 1;
+  }
+  if (sql.startsWith("/*", index)) {
+    const close = sql.indexOf("*/", index + 2);
+    return close === -1 ? sql.length : close + 2;
+  }
+  return index;
+}
+
+function quoteSqliteIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+function isEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function compareJson(left: unknown, right: unknown): number {
+  return JSON.stringify(left).localeCompare(JSON.stringify(right));
+}

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -15,6 +15,7 @@ import {
   type CanonicalSqliteUniqueIndex,
 } from "../infra/sqlite-index-schema.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
+import { assertSqliteSchemaContains } from "../infra/sqlite-schema-contract.js";
 import {
   runSqliteImmediateTransactionSync,
   type SqliteTransactionOptions,
@@ -610,6 +611,7 @@ export function assertOpenClawAgentDatabaseForMaintenance(
       `OpenClaw agent database ${options.pathname} metadata schema version ${metadata.schemaVersion ?? "invalid"} does not match ${OPENCLAW_AGENT_SCHEMA_VERSION}; run openclaw doctor --fix before compacting it.`,
     );
   }
+  assertSqliteSchemaContains(database, options.pathname, OPENCLAW_AGENT_SCHEMA_SQL);
 }
 
 function ensureAgentSchema(db: DatabaseSync, agentId: string, pathname: string): void {

--- a/src/state/openclaw-database-maintenance.test.ts
+++ b/src/state/openclaw-database-maintenance.test.ts
@@ -1,0 +1,241 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import {
+  assertOpenClawAgentDatabaseForMaintenance,
+  OPENCLAW_AGENT_SCHEMA_VERSION,
+} from "./openclaw-agent-db.js";
+import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.generated.js";
+import {
+  assertOpenClawStateDatabaseForMaintenance,
+  OPENCLAW_STATE_SCHEMA_VERSION,
+} from "./openclaw-state-db.js";
+import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.generated.js";
+
+describe("OpenClaw database maintenance schema validation", () => {
+  it("accepts the current global and agent schemas", () => {
+    const globalDatabase = createGlobalDatabase();
+    const agentDatabase = createAgentDatabase();
+    try {
+      expect(() =>
+        assertOpenClawStateDatabaseForMaintenance(globalDatabase, {
+          pathname: "global.sqlite",
+        }),
+      ).not.toThrow();
+      expect(() =>
+        assertOpenClawAgentDatabaseForMaintenance(agentDatabase, {
+          agentId: "worker-1",
+          pathname: "agent.sqlite",
+        }),
+      ).not.toThrow();
+    } finally {
+      agentDatabase.close();
+      globalDatabase.close();
+    }
+  });
+
+  it("accepts a global schema produced by an additive column migration", () => {
+    const schemaWithoutMigratedColumn = OPENCLAW_STATE_SCHEMA_SQL.replace(
+      "  delivery_thread_id_type TEXT,\n",
+      "",
+    );
+    const database = createGlobalDatabase(schemaWithoutMigratedColumn);
+    try {
+      database.exec("ALTER TABLE cron_jobs ADD COLUMN delivery_thread_id_type TEXT;");
+
+      expect(() =>
+        assertOpenClawStateDatabaseForMaintenance(database, {
+          pathname: "global.sqlite",
+        }),
+      ).not.toThrow();
+    } finally {
+      database.close();
+    }
+  });
+
+  it("accepts a migrated required column with its temporary default", () => {
+    const schemaWithoutMigratedColumn = OPENCLAW_STATE_SCHEMA_SQL.replace(
+      "  owner_session_key TEXT,\n  name TEXT NOT NULL,\n  description TEXT,\n",
+      "  owner_session_key TEXT,\n  description TEXT,\n",
+    );
+    const database = createGlobalDatabase(schemaWithoutMigratedColumn);
+    try {
+      database.exec("ALTER TABLE cron_jobs ADD COLUMN name TEXT NOT NULL DEFAULT '';");
+
+      expect(() =>
+        assertOpenClawStateDatabaseForMaintenance(database, {
+          pathname: "global.sqlite",
+        }),
+      ).not.toThrow();
+    } finally {
+      database.close();
+    }
+  });
+
+  it("accepts the migrated conversation kind with its temporary default", () => {
+    const schemaWithoutMigratedColumn = OPENCLAW_STATE_SCHEMA_SQL.replace(
+      "  conversation_kind TEXT NOT NULL,\n",
+      "",
+    ).replace(
+      `CREATE INDEX IF NOT EXISTS idx_current_conversation_bindings_conversation
+  ON current_conversation_bindings(channel, account_id, conversation_kind, conversation_id);
+`,
+      "",
+    );
+    const database = createGlobalDatabase(schemaWithoutMigratedColumn);
+    try {
+      database.exec(`
+        ALTER TABLE current_conversation_bindings
+          ADD COLUMN conversation_kind TEXT NOT NULL DEFAULT 'channel';
+        CREATE INDEX idx_current_conversation_bindings_conversation
+          ON current_conversation_bindings(channel, account_id, conversation_kind, conversation_id);
+      `);
+
+      expect(() =>
+        assertOpenClawStateDatabaseForMaintenance(database, {
+          pathname: "global.sqlite",
+        }),
+      ).not.toThrow();
+    } finally {
+      database.close();
+    }
+  });
+
+  it("rejects a current global database with a missing canonical table", () => {
+    const database = createGlobalDatabase();
+    try {
+      database.exec("DROP TABLE delivery_queue_entries;");
+
+      expect(() =>
+        assertOpenClawStateDatabaseForMaintenance(database, {
+          pathname: "global.sqlite",
+        }),
+      ).toThrow("missing table delivery_queue_entries");
+    } finally {
+      database.close();
+    }
+  });
+
+  it("rejects a current global database with a drifted canonical index", () => {
+    const database = createGlobalDatabase();
+    try {
+      database.exec(`
+        DROP INDEX idx_task_runs_status;
+        CREATE INDEX idx_task_runs_status ON task_runs(task_id);
+      `);
+
+      expect(() =>
+        assertOpenClawStateDatabaseForMaintenance(database, {
+          pathname: "global.sqlite",
+        }),
+      ).toThrow("missing or drifted index idx_task_runs_status");
+    } finally {
+      database.close();
+    }
+  });
+
+  it("rejects a current agent database with a missing canonical table", () => {
+    const database = createAgentDatabase();
+    try {
+      database.exec("DROP TABLE auth_profile_store;");
+
+      expect(() =>
+        assertOpenClawAgentDatabaseForMaintenance(database, {
+          agentId: "worker-1",
+          pathname: "agent.sqlite",
+        }),
+      ).toThrow("missing table auth_profile_store");
+    } finally {
+      database.close();
+    }
+  });
+
+  it("rejects a current agent database with a drifted canonical trigger", () => {
+    const database = createAgentDatabase();
+    try {
+      database.exec(`
+        DROP TRIGGER memory_index_sources_revision_after_insert;
+        CREATE TRIGGER memory_index_sources_revision_after_insert
+        AFTER INSERT ON memory_index_sources
+        BEGIN
+          UPDATE memory_index_state SET revision = 0 WHERE id = 1;
+        END;
+      `);
+
+      expect(() =>
+        assertOpenClawAgentDatabaseForMaintenance(database, {
+          agentId: "worker-1",
+          pathname: "agent.sqlite",
+        }),
+      ).toThrow("missing or drifted trigger memory_index_sources_revision_after_insert");
+    } finally {
+      database.close();
+    }
+  });
+
+  it("rejects a current agent database with a missing canonical check constraint", () => {
+    const database = createAgentDatabase();
+    try {
+      database.exec(`
+        DROP TABLE memory_index_state;
+        CREATE TABLE memory_index_state (
+          id INTEGER PRIMARY KEY,
+          revision INTEGER NOT NULL
+        );
+        INSERT INTO memory_index_state (id, revision) VALUES (1, 0);
+      `);
+
+      expect(() =>
+        assertOpenClawAgentDatabaseForMaintenance(database, {
+          agentId: "worker-1",
+          pathname: "agent.sqlite",
+        }),
+      ).toThrow("column definitions differ for memory_index_state");
+    } finally {
+      database.close();
+    }
+  });
+});
+
+function createGlobalDatabase(schemaSql = OPENCLAW_STATE_SCHEMA_SQL): DatabaseSync {
+  const database = new DatabaseSync(":memory:");
+  database.exec(schemaSql);
+  database.exec(`PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION};`);
+  database
+    .prepare(
+      `
+        INSERT INTO schema_meta (
+          meta_key,
+          role,
+          schema_version,
+          agent_id,
+          app_version,
+          created_at,
+          updated_at
+        ) VALUES ('primary', 'global', ?, NULL, NULL, 1, 1)
+      `,
+    )
+    .run(OPENCLAW_STATE_SCHEMA_VERSION);
+  return database;
+}
+
+function createAgentDatabase(): DatabaseSync {
+  const database = new DatabaseSync(":memory:");
+  database.exec(OPENCLAW_AGENT_SCHEMA_SQL);
+  database.exec(`PRAGMA user_version = ${OPENCLAW_AGENT_SCHEMA_VERSION};`);
+  database
+    .prepare(
+      `
+        INSERT INTO schema_meta (
+          meta_key,
+          role,
+          schema_version,
+          agent_id,
+          app_version,
+          created_at,
+          updated_at
+        ) VALUES ('primary', 'agent', ?, 'worker-1', NULL, 1, 1)
+      `,
+    )
+    .run(OPENCLAW_AGENT_SCHEMA_VERSION);
+  return database;
+}

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -16,6 +16,10 @@ import {
   type CanonicalSqliteUniqueIndex,
 } from "../infra/sqlite-index-schema.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
+import {
+  assertSqliteSchemaContains,
+  type SqliteSchemaCompatibility,
+} from "../infra/sqlite-schema-contract.js";
 import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
 import {
   createNewerSqliteSchemaVersionError,
@@ -59,6 +63,35 @@ const OPENCLAW_STATE_CANONICAL_UNIQUE_INDEXES = [
     `,
   },
 ] as const satisfies readonly CanonicalSqliteUniqueIndex[];
+const OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY = {
+  allowedColumnDefinitions: {
+    "commitments.attempts": ["attempts INTEGER NOT NULL DEFAULT 0"],
+    "commitments.confidence": ["confidence REAL NOT NULL DEFAULT 0"],
+    "commitments.created_at_ms": ["created_at_ms INTEGER NOT NULL DEFAULT 0"],
+    "commitments.dedupe_key": ["dedupe_key TEXT NOT NULL DEFAULT ''"],
+    "commitments.due_timezone": ["due_timezone TEXT NOT NULL DEFAULT 'UTC'"],
+    "commitments.kind": ["kind TEXT NOT NULL DEFAULT 'followup'"],
+    "commitments.reason": ["reason TEXT NOT NULL DEFAULT ''"],
+    "commitments.sensitivity": ["sensitivity TEXT NOT NULL DEFAULT 'normal'"],
+    "commitments.source": ["source TEXT NOT NULL DEFAULT 'unknown'"],
+    "commitments.suggested_text": ["suggested_text TEXT NOT NULL DEFAULT ''"],
+    "cron_jobs.created_at_ms": ["created_at_ms INTEGER NOT NULL DEFAULT 0"],
+    "cron_jobs.enabled": ["enabled INTEGER NOT NULL DEFAULT 1"],
+    "cron_jobs.name": ["name TEXT NOT NULL DEFAULT ''"],
+    "cron_jobs.payload_kind": ["payload_kind TEXT NOT NULL DEFAULT 'message'"],
+    "cron_jobs.schedule_kind": ["schedule_kind TEXT NOT NULL DEFAULT 'manual'"],
+    "cron_jobs.session_target": ["session_target TEXT NOT NULL DEFAULT 'main'"],
+    "cron_jobs.wake_mode": ["wake_mode TEXT NOT NULL DEFAULT 'auto'"],
+    "cron_run_logs.created_at": ["created_at INTEGER NOT NULL DEFAULT 0"],
+    "cron_run_logs.entry_json": ["entry_json TEXT NOT NULL DEFAULT '{}'"],
+    "current_conversation_bindings.conversation_kind": [
+      "conversation_kind TEXT NOT NULL DEFAULT 'channel'",
+    ],
+    "current_conversation_bindings.target_agent_id": [
+      "target_agent_id TEXT NOT NULL DEFAULT 'main'",
+    ],
+  },
+} satisfies SqliteSchemaCompatibility;
 
 /** Open shared SQLite database handle plus WAL maintenance lifecycle. */
 export type OpenClawStateDatabase = {
@@ -135,6 +168,12 @@ export function assertOpenClawStateDatabaseForMaintenance(
       `OpenClaw state database ${options.pathname} metadata schema version ${schemaVersion} does not match ${OPENCLAW_STATE_SCHEMA_VERSION}; run openclaw doctor --fix before compacting it.`,
     );
   }
+  assertSqliteSchemaContains(
+    database,
+    options.pathname,
+    OPENCLAW_STATE_SCHEMA_SQL,
+    OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY,
+  );
 }
 
 const stateDbLog = createSubsystemLogger("state/db");


### PR DESCRIPTION
Related: #94805
Related: #94967

## What Problem This Solves

Fixes an issue where SQLite maintenance operations could trust a current-version global or agent database even when required tables, column clauses, constraints, indexes, triggers, virtual-table definitions, or table options had drifted. That made compaction and future snapshot/restore work capable of preserving a structurally incomplete database.

## Why This Change Was Made

Maintenance now validates the full canonical schema contract before touching a database. Column declaration order and table-constraint order remain migration-safe, while temporary defaults are accepted only for the exact additive migrations OpenClaw has shipped.

## User Impact

Operators get a hard failure with a concrete schema mismatch instead of compacting, snapshotting, or restoring a database whose current-version metadata hides structural drift. Existing databases produced by supported additive migrations remain accepted.

## Evidence

- Blacksmith Testbox through Crabbox: `tbx_01kxbqm8vw76mgsmeymqsbrkn9` (`violet-hermit`), Actions run https://github.com/openclaw/openclaw/actions/runs/29202964021
- Focused SQLite bundle: 174 passed, 2 platform-specific skips
- Path-scoped `pnpm check:changed`: passed on the seven touched files; the known current-main Plugin SDK hash drift was regenerated only inside the disposable Testbox command and restored on exit
- Structured branch autoreview: clean, no accepted/actionable findings
- Regression coverage includes missing tables, drifted columns/checks/defaults/collations/generated expressions/conflict clauses/AUTOINCREMENT/foreign-key deferral, unsafe canonical index replacement, trigger drift, migration column order, and supported temporary migration defaults
