### PR TITLE
fix(sessions): sessions_search slows as transcript history grows

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-c4341e07a8d52e45747e4c2ca54ea6417f197c9303456f942f3d0cbf820b4652  plugin-sdk-api-baseline.json
-d2ceb379239ee66eceb494b50fb9ab9a1d989d00c97aeb4f97c74a7fd13a49a1  plugin-sdk-api-baseline.jsonl
+4d48d01820bdf49966c3a6bdc69da909779d81db7214ed5b54651a8cd544a24c  plugin-sdk-api-baseline.json
+72bad044a66391e838dcbdab5ef6897a40a7026d53c86d7130a55d53d37b15f2  plugin-sdk-api-baseline.jsonl

--- a/src/config/sessions/session-transcript-index.ts
+++ b/src/config/sessions/session-transcript-index.ts
@@ -26,7 +26,7 @@ import {
 
 type TranscriptIndexDatabase = Pick<
   OpenClawAgentKyselyDatabase,
-  "session_transcript_fts" | "session_transcript_index_state" | "transcript_events"
+  "sessions" | "session_transcript_fts" | "session_transcript_index_state" | "transcript_events"
 >;
 
 type TranscriptIndexEntry = {
@@ -340,20 +340,38 @@ export function rebuildSessionTranscriptIndexInTransaction(
  * behind the newest row. Ordered for deterministic reconcile passes.
  */
 export function listSessionsNeedingTranscriptIndexReconcile(db: DatabaseSync): string[] {
+  const kysely = getIndexKysely(db);
   const rows = executeSqliteQuerySync(
     db,
-    getIndexKysely(db)
-      .selectFrom("transcript_events as te")
-      .leftJoin("session_transcript_index_state as st", "st.session_id", "te.session_id")
-      .select("te.session_id")
-      .groupBy("te.session_id")
-      .having((eb) =>
+    kysely
+      .selectFrom("sessions")
+      .innerJoin("transcript_events as latest", (join) =>
+        join
+          .onRef("latest.session_id", "=", "sessions.session_id")
+          .on((eb) =>
+            eb(
+              "latest.seq",
+              "=",
+              eb
+                .selectFrom("transcript_events as candidate")
+                .select("candidate.seq")
+                .whereRef("candidate.session_id", "=", "sessions.session_id")
+                .orderBy("candidate.seq", "desc")
+                .limit(1),
+            ),
+          ),
+      )
+      .leftJoin("session_transcript_index_state as st", "st.session_id", "sessions.session_id")
+      .select("sessions.session_id")
+      .where((eb) =>
         eb.or([
-          eb(eb.fn.coalesce(eb.fn.max("st.needs_rebuild"), eb.val(1)), "!=", 0),
-          eb(eb.fn.max("te.seq"), ">", eb.fn.coalesce(eb.fn.max("st.indexed_seq"), eb.val(-1))),
+          eb(eb.fn.coalesce("st.needs_rebuild", eb.val(1)), "!=", 0),
+          eb("latest.seq", ">", eb.fn.coalesce("st.indexed_seq", eb.val(-1))),
         ]),
       )
-      .orderBy("te.session_id"),
+      // The transcript PK makes the correlated latest-row lookup one index seek per session.
+      // Grouping transcript_events here made every healthy search rescan the entire history.
+      .orderBy("sessions.session_id"),
   ).rows;
   return rows.flatMap((row) => (typeof row.session_id === "string" ? [row.session_id] : []));
 }

--- a/src/config/sessions/session-transcript-search.test.ts
+++ b/src/config/sessions/session-transcript-search.test.ts
@@ -17,7 +17,10 @@ import {
   deleteSqliteTranscript,
   replaceSqliteTranscriptEvents,
 } from "./session-accessor.sqlite.js";
-import { extractTranscriptIndexEntry } from "./session-transcript-index.js";
+import {
+  extractTranscriptIndexEntry,
+  listSessionsNeedingTranscriptIndexReconcile,
+} from "./session-transcript-index.js";
 import {
   resetSessionTranscriptSearchForTest,
   searchSessionTranscripts,
@@ -233,6 +236,38 @@ describe("searchSessionTranscripts", () => {
     const result = search("historic");
     expect(result.indexing).toBe(false);
     expect(result.hits).toHaveLength(1);
+  });
+
+  it("detects missing, dirty, and lagging transcript index watermarks", async () => {
+    await appendUserMessage("session-1", "agent:main:main", "indexed message");
+    const { db, kysely } = agentKysely();
+    const pending = () => listSessionsNeedingTranscriptIndexReconcile(db);
+
+    expect(pending()).toEqual([]);
+
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .updateTable("session_transcript_index_state")
+        .set({ needs_rebuild: 1 })
+        .where("session_id", "=", "session-1"),
+    );
+    expect(pending()).toEqual(["session-1"]);
+
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .updateTable("session_transcript_index_state")
+        .set({ indexed_seq: -1, needs_rebuild: 0 })
+        .where("session_id", "=", "session-1"),
+    );
+    expect(pending()).toEqual(["session-1"]);
+
+    executeSqliteQuerySync(
+      db,
+      kysely.deleteFrom("session_transcript_index_state").where("session_id", "=", "session-1"),
+    );
+    expect(pending()).toEqual(["session-1"]);
   });
 
   it("sweeps orphaned index rows during reconcile", async () => {


### PR DESCRIPTION
Closes #105581

## What Problem This Solves

Fixes an issue where users searching retained sessions would experience latency that grew with total transcript history, even when every transcript search index was already healthy. In a 400-session / 400,000-event steady-state benchmark, the complete search spent about 50 ms rescanning historical rows before doing the FTS query.

## Why This Change Was Made

The reconciliation check now starts from canonical sessions and uses the transcript `(session_id, seq)` primary key to seek directly to each session's latest event. This preserves the existing missing, dirty, and lagging-watermark behavior without grouping the complete event table; the regression test exercises all three states.

This PR also refreshes the already-stale generated Plugin SDK API hash on current `main`, required for the changed-file gate to pass. It does not change Plugin SDK source or behavior.

AI-assisted: yes. The implementation and generated metadata were inspected, tested on Node 24 Testbox, and independently reviewed before commit.

## User Impact

`sessions_search` stays responsive as transcript history grows. In the history-heavy benchmark, complete search latency fell from 49.64 ms average to 0.74 ms average (about 67x faster) with unchanged results and indexing semantics.

## Evidence

Deterministic isolated benchmark, 400 sessions x 1,000 events, 50 measured runs after warmup:

| Surface | Before avg | After avg | Before p95 | After p95 |
| --- | ---: | ---: | ---: | ---: |
| Healthy-index reconciliation | 48.97 ms | 0.32 ms | 50.32 ms | 0.41 ms |
| Complete transcript search | 49.64 ms | 0.74 ms | 51.11 ms | 0.82 ms |

Real isolated Gateway RPC over the same 400,000-event shape, 30 measured calls after warmup:

- `sessions.search`: 1.00 ms average, 0.98 ms p50, 1.14 ms p95
- Returned 10/10 expected results on every call

Validation:

- `corepack pnpm test src/config/sessions/session-transcript-search.test.ts src/config/sessions/store.session-lifecycle-mutation.test.ts src/agents/tools/sessions-search-tool.test.ts src/gateway/server-methods/sessions-search.test.ts` — 49 tests passed across three Vitest shards
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` — passed generated baselines, core + core-test typechecks, targeted lint, database-first guards, and import-cycle checks
- `corepack pnpm plugin-sdk:api:check` — generated API hash matches current source
- `autoreview --mode local` — clean, no actionable findings; correctness confidence 0.93

Testbox proof: `tbx_01kxbp2j59dqh0mgas8c8qer2t`, `tbx_01kxbpv4492j2y4zxp48xhwkgs`, `tbx_01kxbq6gz1xxvaqqazeqk82kx3`, and `tbx_01kxbqw7nttqhqf5xezwkkh4rp`.
