### PR TITLE
refactor(auth): privatize disabled CLI discovery helper

### DIFF
--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -15,7 +15,6 @@ export {
   externalCliDiscoveryForConfigStatus,
   externalCliDiscoveryForProviderAuth,
   externalCliDiscoveryForProviders,
-  externalCliDiscoveryNone,
   externalCliDiscoveryScoped,
   type ExternalCliAuthDiscovery,
 } from "./auth-profiles/external-cli-discovery.js";

--- a/src/agents/auth-profiles/external-cli-discovery.ts
+++ b/src/agents/auth-profiles/external-cli-discovery.ts
@@ -54,9 +54,7 @@ function normalizeStringList(values: Iterable<string | undefined>): string[] {
 }
 
 /** Disables external CLI auth discovery. */
-export function externalCliDiscoveryNone(params?: {
-  config?: OpenClawConfig;
-}): ExternalCliAuthDiscovery {
+function externalCliDiscoveryNone(params?: { config?: OpenClawConfig }): ExternalCliAuthDiscovery {
   return {
     mode: "none",
     allowKeychainPrompt: false,


### PR DESCRIPTION
## What Problem This Solves

The auth-profile barrel exposed `externalCliDiscoveryNone`, even though every real caller is internal to the discovery module. That creates a public-looking helper with no supported consumer.

## Why This Change Was Made

Keep the named helper for the two local disabled-discovery paths, but make it module-private and remove the stale barrel re-export.

## User Impact

No behavior change. External CLI auth discovery keeps the same disabled-mode result.

## Evidence

- Codebase-memory trace: only `externalCliDiscoveryForProviders` and `externalCliDiscoveryFromScope` call the helper directly.
- `pnpm test:serial src/agents/agent-auth-discovery.external-cli.test.ts src/agents/model-provider-auth.test.ts src/agents/auth-profiles.readonly-sync.test.ts` via Testbox: 28 tests passed.
- `pnpm check:changed -- src/agents/auth-profiles.ts src/agents/auth-profiles/external-cli-discovery.ts` via Testbox: all touched-file checks passed; the run stopped only on the pre-existing Plugin SDK baseline hash drift.
- Fresh `gpt-5.6-sol` medium autoreview: no findings, 0.93 confidence.
- `git diff --check`: passed.
