### PR TITLE
refactor(auto-reply): privatize module internals

### DIFF
--- a/src/auto-reply/reply/progress-narrator.ts
+++ b/src/auto-reply/reply/progress-narrator.ts
@@ -45,7 +45,7 @@ export type ProgressNarrationInput = {
   previousText: string;
 };
 
-export type ProgressNarrator = {
+type ProgressNarrator = {
   noteToolStart: (payload: {
     name?: string;
     phase?: string;

--- a/src/auto-reply/reply/stranded-reply-recovery.ts
+++ b/src/auto-reply/reply/stranded-reply-recovery.ts
@@ -4,7 +4,7 @@ import type { ReplyPayload } from "../types.js";
 import type { FollowupRun } from "./queue/types.js";
 
 export const STRANDED_REPLY_RETRY_MARKER = "stranded-reply-retry";
-export const STRANDED_REPLY_DELIVERY_FAILURE_TEXT =
+const STRANDED_REPLY_DELIVERY_FAILURE_TEXT =
   "I generated a reply but could not deliver it to this chat. Please try again.";
 
 export function buildStrandedReplyDeliveryFailurePayload(): ReplyPayload {
@@ -15,7 +15,7 @@ export function buildStrandedReplyDeliveryFailurePayload(): ReplyPayload {
   });
 }
 
-export function buildStrandedReplyRetryPrompt(finalText: string): string {
+function buildStrandedReplyRetryPrompt(finalText: string): string {
   return (
     `[System] Your previous reply was not delivered to the conversation because ` +
     `you did not call message(action=send). Your reply text was:\n\n` +

--- a/src/auto-reply/reply/typing-policy.ts
+++ b/src/auto-reply/reply/typing-policy.ts
@@ -3,7 +3,7 @@ import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import type { TypingPolicy } from "../types.js";
 
 /** Inputs used to resolve typing behavior for one reply run. */
-export type ResolveRunTypingPolicyParams = {
+type ResolveRunTypingPolicyParams = {
   requestedPolicy?: TypingPolicy;
   suppressTyping?: boolean;
   isHeartbeat?: boolean;
@@ -12,7 +12,7 @@ export type ResolveRunTypingPolicyParams = {
 };
 
 /** Effective typing policy plus suppression flag for a reply run. */
-export type ResolvedRunTypingPolicy = {
+type ResolvedRunTypingPolicy = {
   typingPolicy: TypingPolicy;
   suppressTyping: boolean;
 };


### PR DESCRIPTION
## What Problem This Solves

Three auto-reply modules exported types and helpers that have no consumers outside their defining files. Those exports make internal implementation details look reusable and enlarge the module surface without a contract.

## Why This Change Was Made

Keep the existing named types and helpers for local readability, but remove five unnecessary `export` modifiers:

- the progress narrator's internal return type,
- the typing-policy input and result types,
- the stranded-reply delivery text and retry-prompt builder.

## User Impact

No behavior change. Narration, typing policy, and stranded-reply recovery execute the same code paths with the same values.

## Evidence

- Exhaustive repository search found no imports or consumers for the five symbols outside their defining modules.
- Codebase-memory traces confirmed the stranded-reply prompt builder has one same-module caller and the progress narrator type stays behind its local factory.
- Testbox: 21 focused tests passed across the three adjacent test files.
- Testbox `check:changed` passed every touched-file guard before stopping on the pre-existing Plugin SDK baseline hash drift.
- Fresh `gpt-5.6-sol` medium autoreview: no findings, 0.96 confidence.
- `git diff --check`: passed.
