### PR TITLE
fix(ci): allow SQLite schema contract inspection

### DIFF
--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -39,6 +39,7 @@ const rawSqliteAllowPathGroups = {
     "src/infra/sqlite-index-schema.ts",
     "src/infra/sqlite-integrity.ts",
     "src/infra/sqlite-pragma.test-support.ts",
+    "src/infra/sqlite-schema-contract.ts",
     "src/infra/sqlite-transaction.ts",
     "src/infra/sqlite-user-version.ts",
     "src/infra/sqlite-wal.ts",


### PR DESCRIPTION
## What Problem This Solves

The architecture CI lane on current `main` fails after #105583 because the new SQLite schema-contract inspector performs intentional raw `node:sqlite` metadata queries without being listed as an approved SQLite boundary.

## Why This Change Was Made

Add `src/infra/sqlite-schema-contract.ts` to the existing lifecycle/schema/transaction/pragma allowlist group. This is the narrow owner-boundary fix: the module must execute generated DDL in an in-memory database and inspect SQLite-native schema metadata, while the guard continues rejecting raw SQLite access everywhere else.

## User Impact

No runtime behavior changes. Architecture CI accepts the intentional schema-inspection boundary introduced by #105583 and remains fail-closed for other raw SQLite access.

## Evidence

- Reproduced on current `main`: `node scripts/check-kysely-guardrails.mjs` reported eight violations in `src/infra/sqlite-schema-contract.ts`.
- Blacksmith Testbox through Crabbox `tbx_01kxbrk5sqe3241yn49fkn65fa`: `pnpm check:architecture` passed, including import-cycle, deprecated API/JSDoc, Kysely type generation, Kysely guardrail, and database-first legacy-store checks. Run: https://github.com/openclaw/openclaw/actions/runs/29203497303
- Fresh autoreview: clean, no accepted/actionable findings (`patch is correct`, confidence 0.98).
- `git diff --check`: passed.

AI-assisted change.
