### PR TITLE
fix(ui): harden Create PR row stats and rate-limited chip degradation

### DIFF
--- a/src/gateway/control-ui-session-prs.test.ts
+++ b/src/gateway/control-ui-session-prs.test.ts
@@ -376,6 +376,40 @@ describe("loadControlUiSessionPullRequests", () => {
     });
   });
 
+  it("keeps the proven PR list as state-only chips when detail fetches are rate limited", async () => {
+    // Cold cache: the pulls list succeeds, then quota dies on the per-PR
+    // detail fetch. The open PR must survive so the UI does not offer a
+    // duplicate Create PR row.
+    const rateLimitedResponse = () =>
+      new Response(JSON.stringify({ message: "rate limited" }), {
+        status: 403,
+        headers: { "Content-Type": "application/json", "x-ratelimit-remaining": "0" },
+      });
+    const fetchImpl = routedFetch([
+      { match: "/pulls?head=", response: () => githubJson([pullListItem()]) },
+      { match: "/pulls/103469", response: rateLimitedResponse },
+      { match: "/check-runs", response: rateLimitedResponse },
+    ]);
+
+    const result = await loadControlUiSessionPullRequests(
+      { sessionKey: "agent:main:main" },
+      { fetchImpl, resolveGitContext },
+    );
+
+    expect(result.rateLimited).toBe(true);
+    expect(result.pullRequests).toEqual([
+      {
+        number: 103469,
+        owner: "openclaw",
+        repo: "openclaw",
+        branch: context.branch,
+        title: "fix(macos): tighten the link-browser tab header",
+        url: "https://github.com/openclaw/openclaw/pull/103469",
+        state: "open",
+      },
+    ]);
+  });
+
   it("escapes create-PR URL segments while keeping branch slashes", async () => {
     const fetchImpl = routedFetch([
       { match: "/pulls?head=", response: () => githubJson([]) },
@@ -456,6 +490,45 @@ describe("session branch diff stats", () => {
       deletions: 1,
       createUrl: "https://github.com/openclaw/openclaw/pull/new/feature",
     });
+  });
+
+  it("skips non-regular and binary untracked files without blocking", async () => {
+    await git("init", "--initial-branch=main", ".");
+    await fs.writeFile(path.join(root, "a.txt"), "one\n");
+    await git("add", "a.txt");
+    await git("commit", "-m", "base");
+    await git("update-ref", "refs/remotes/origin/main", "HEAD");
+    await git("checkout", "-b", "feature");
+    await fs.appendFile(path.join(root, "a.txt"), "two\n");
+    await git("add", "a.txt");
+    await git("commit", "-m", "feature work");
+    await git("update-ref", "refs/remotes/origin/feature", "HEAD");
+    await fs.writeFile(path.join(root, "text.txt"), "alpha\nbeta\n");
+    await fs.writeFile(path.join(root, "blob.bin"), Buffer.from([0x50, 0x00, 0x4b, 0x03]));
+    if (process.platform !== "win32") {
+      // A named pipe must not block the stats path until the git timeout.
+      await execFileAsync("mkfifo", [path.join(root, "pipe")]);
+    }
+
+    const fetchImpl = routedFetch([
+      { match: "/pulls?head=", response: () => githubJson([]) },
+      { match: "/repos/openclaw/openclaw", response: () => githubJson({ fork: false }) },
+    ]);
+    const result = await loadControlUiSessionPullRequests(
+      { sessionKey: "agent:main:main" },
+      {
+        fetchImpl,
+        resolveGitContext: async () => ({
+          ...context,
+          branch: "feature",
+          root,
+          defaultBranch: "main",
+        }),
+      },
+    );
+
+    // 1 committed line + 2 untracked text lines; binary and pipe count 0.
+    expect(result.branch).toMatchObject({ additions: 3, deletions: 0 });
   });
 
   it("omits the branch payload when the remote branch has nothing to compare", async () => {

--- a/src/gateway/control-ui-session-prs.test.ts
+++ b/src/gateway/control-ui-session-prs.test.ts
@@ -385,11 +385,12 @@ describe("loadControlUiSessionPullRequests", () => {
         status: 403,
         headers: { "Content-Type": "application/json", "x-ratelimit-remaining": "0" },
       });
-    const fetchImpl = routedFetch([
+    const routes = [
       { match: "/pulls?head=", response: () => githubJson([pullListItem()]) },
       { match: "/pulls/103469", response: rateLimitedResponse },
       { match: "/check-runs", response: rateLimitedResponse },
-    ]);
+    ];
+    const fetchImpl = routedFetch(routes);
 
     const result = await loadControlUiSessionPullRequests(
       { sessionKey: "agent:main:main" },
@@ -408,6 +409,18 @@ describe("loadControlUiSessionPullRequests", () => {
         state: "open",
       },
     ]);
+
+    // Outage outlives the rate-limit cache window and now even the list
+    // fetch 429s: the proven chips must survive as the last-known fallback.
+    routes.length = 0;
+    routes.push({ match: "/pulls?head=", response: rateLimitedResponse });
+    vi.advanceTimersByTime(5 * 60_000 + 1_000);
+    const stillLimited = await loadControlUiSessionPullRequests(
+      { sessionKey: "agent:main:main" },
+      { fetchImpl, resolveGitContext },
+    );
+    expect(stillLimited.rateLimited).toBe(true);
+    expect(stillLimited.pullRequests.map((item) => item.number)).toEqual([103469]);
   });
 
   it("escapes create-PR URL segments while keeping branch slashes", async () => {

--- a/src/gateway/control-ui-session-prs.ts
+++ b/src/gateway/control-ui-session-prs.ts
@@ -1,5 +1,7 @@
 // Detects GitHub pull requests for a session's working branch so the Control
 // UI chat view can pin PR status chips above the composer.
+import fs from "node:fs/promises";
+import nodePath from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { runGit } from "../agents/worktrees/git.js";
@@ -186,6 +188,42 @@ const SHORTSTAT_DELETIONS = /(\d+) deletion/;
 // Matches sessions-diff's untracked scan bound; stats degrade to an
 // undercount past it instead of stalling the request.
 const MAX_UNTRACKED_STAT_FILES = 100;
+// Oversized untracked files count 0 lines instead of being read; the row's
+// stats are an approximation, not a patch surface.
+const MAX_UNTRACKED_STAT_BYTES = 512 * 1024;
+
+/**
+ * Line count for one untracked file, computed in-process: this runs on the
+ * chat view's 60s poll, so it must not spawn one git subprocess per path.
+ * lstat gates on regular files so FIFOs/sockets can never block the RPC and
+ * symlinks never resolve outside the checkout; only a line count is exposed,
+ * so sessions-diff's hardlink content guard is unnecessary here.
+ */
+async function untrackedFileAdditions(root: string, filePath: string): Promise<number> {
+  try {
+    const abs = nodePath.resolve(root, filePath);
+    const info = await fs.lstat(abs);
+    if (!info.isFile() || info.size === 0 || info.size > MAX_UNTRACKED_STAT_BYTES) {
+      return 0;
+    }
+    const body = await fs.readFile(abs);
+    // Binary files count 0 lines, mirroring git's shortstat behavior.
+    if (body.subarray(0, 8192).includes(0)) {
+      return 0;
+    }
+    let lines = 0;
+    for (const byte of body) {
+      if (byte === 10) {
+        lines += 1;
+      }
+    }
+    // A trailing fragment without a newline is still a line git would add.
+    return body[body.length - 1] === 10 ? lines : lines + 1;
+  } catch {
+    // Unreadable paths just do not count toward the size.
+    return 0;
+  }
+}
 
 async function untrackedAdditions(root: string): Promise<number> {
   const listing = await gitOutput(root, ["ls-files", "--others", "--exclude-standard", "-z"]);
@@ -194,27 +232,8 @@ async function untrackedAdditions(root: string): Promise<number> {
   }
   const paths = listing.split("\0").filter(Boolean);
   let additions = 0;
-  // Counts only, never patch content, so the hardlink/symlink content guards
-  // in sessions-diff are unnecessary here; binary files count as 0 lines.
   for (const filePath of paths.slice(0, MAX_UNTRACKED_STAT_FILES)) {
-    try {
-      const result = await runGit(root, [
-        "diff",
-        "--shortstat",
-        "--no-ext-diff",
-        "--no-textconv",
-        "--no-index",
-        "--",
-        "/dev/null",
-        filePath,
-      ]);
-      // Exit code 1 is git's "files differ" for --no-index, not a failure.
-      if (result.code === 0 || result.code === 1) {
-        additions += Number(SHORTSTAT_INSERTIONS.exec(result.stdout.trim())?.[1] ?? 0);
-      }
-    } catch {
-      // Unreadable paths just do not count toward the size.
-    }
+    additions += await untrackedFileAdditions(root, filePath);
   }
   return additions;
 }
@@ -500,7 +519,7 @@ async function fetchBranchPullRequests(
   context: SessionPullRequestGitContext,
   fetchImpl: typeof fetch,
   token: string | undefined,
-): Promise<ControlUiSessionPullRequest[]> {
+): Promise<{ pullRequests: ControlUiSessionPullRequest[]; rateLimited: boolean }> {
   const head = `${context.owner}:${context.branch}`;
   let items = parsePullList(
     await fetchGitHubJson(pullsByHeadUrl(context.owner, context.repo, head), fetchImpl, token),
@@ -514,11 +533,32 @@ async function fetchBranchPullRequests(
       );
     }
   }
-  return await Promise.all(
-    items
-      .slice(0, MAX_PULL_REQUESTS)
-      .map((item) => finishPullRequest(item, context.branch, fetchImpl, token)),
-  );
+  const capped = items.slice(0, MAX_PULL_REQUESTS);
+  try {
+    const pullRequests = await Promise.all(
+      capped.map((item) => finishPullRequest(item, context.branch, fetchImpl, token)),
+    );
+    return { pullRequests, rateLimited: false };
+  } catch (error) {
+    if (!(error instanceof ControlUiGitHubError && error.statusCode === 429)) {
+      throw error;
+    }
+    // Quota ran out between the list fetch and the per-PR detail fetches:
+    // keep the proven PR list as state-only chips instead of dropping it, or
+    // a cold cache would show a Create PR row despite a known open PR.
+    return {
+      pullRequests: capped.map((item) => ({
+        number: item.number,
+        owner: item.owner,
+        repo: item.repo,
+        branch: context.branch,
+        title: item.title,
+        url: item.url,
+        state: item.state,
+      })),
+      rateLimited: true,
+    };
+  }
 }
 
 async function refreshBranchPullRequests(
@@ -527,9 +567,15 @@ async function refreshBranchPullRequests(
   entry: CacheEntry,
 ): Promise<ControlUiSessionPullRequests> {
   try {
-    const pullRequests = await fetchBranchPullRequests(context, fetchImpl, githubApiToken());
-    entry.lastGood = pullRequests;
-    return { pullRequests, rateLimited: false };
+    const result = await fetchBranchPullRequests(context, fetchImpl, githubApiToken());
+    if (result.rateLimited) {
+      // Degraded chips are not lastGood: the next refresh after the quota
+      // window should replace them with full detail, not serve them as fresh.
+      entry.expiresAt = Date.now() + RATE_LIMIT_CACHE_MS;
+    } else {
+      entry.lastGood = result.pullRequests;
+    }
+    return result;
   } catch (error) {
     const rateLimited = error instanceof ControlUiGitHubError && error.statusCode === 429;
     entry.expiresAt = Date.now() + (rateLimited ? RATE_LIMIT_CACHE_MS : FAILURE_CACHE_MS);

--- a/src/gateway/control-ui-session-prs.ts
+++ b/src/gateway/control-ui-session-prs.ts
@@ -568,12 +568,13 @@ async function refreshBranchPullRequests(
 ): Promise<ControlUiSessionPullRequests> {
   try {
     const result = await fetchBranchPullRequests(context, fetchImpl, githubApiToken());
+    // Degraded state-only chips still become lastGood: a later refresh that
+    // rate-limits at the list fetch must serve the proven PRs, not an empty
+    // list that would resurrect the Create PR row mid-outage. The shortened
+    // expiry makes the next window retry full detail.
+    entry.lastGood = result.pullRequests;
     if (result.rateLimited) {
-      // Degraded chips are not lastGood: the next refresh after the quota
-      // window should replace them with full detail, not serve them as fresh.
       entry.expiresAt = Date.now() + RATE_LIMIT_CACHE_MS;
-    } else {
-      entry.lastGood = result.pullRequests;
     }
     return result;
   } catch (error) {


### PR DESCRIPTION
Related: follow-up to #105116, addressing late review feedback from the Codex per-commit reviews and the ClawSweeper hot-path finding.

## What Problem This Solves

Three defects in the just-landed Create PR branch row (#105116) reported by review bots after the merge window: (1) an untracked named pipe (FIFO) in a session checkout blocked the `controlUi.sessionPullRequests` RPC until the 120s git timeout, (2) untracked-file stats spawned up to 100 git subprocesses per active chat pane every 60 seconds, and (3) when the GitHub quota died between the PR list fetch and the per-PR detail fetches on a cold cache, the proven PR list was dropped and the UI showed a Create PR row despite a known open PR.

## Why This Change Was Made

Untracked additions are now counted in-process: one `git ls-files` call, then `lstat`-gated reads of regular files only (512 KB cap, binary detection mirroring git's), so FIFOs/sockets/symlinks can never block the RPC and the per-file subprocess loop is gone entirely. Partial rate-limit failures now degrade the fresh PR list to state-only chips (number/title/state) flagged `rateLimited: true` instead of discarding it — the open PR stays visible, which also keeps the duplicate-prevention gate on the Create PR row working; degraded chips are deliberately not cached as last-good data.

## User Impact

The chat PR chips stay responsive on checkouts with odd untracked entries or many untracked files, and a cold-cache rate limit no longer briefly replaces a real open PR with a Create PR button.

## Evidence

- `src/gateway/control-ui-session-prs.test.ts` adds: a real-git repo with an untracked FIFO + binary + text file (asserts counts and that the request completes), and a cold-cache partial-429 case (list ok, details 429) asserting state-only chips with `rateLimited: true`.
- Full backend suite green locally (20 tests × 4 lanes) via `node scripts/run-vitest.mjs`; hosted CI on this PR is the authoritative gate.
