### PR TITLE
refactor(gateway): privatize module helpers

### DIFF
--- a/src/gateway/message-action-turn-capability.ts
+++ b/src/gateway/message-action-turn-capability.ts
@@ -69,7 +69,7 @@ function evictOldestCapability(): void {
   }
 }
 
-export function sweepExpiredMessageActionTurnCapabilities(nowMs: number = Date.now()): number {
+function sweepExpiredMessageActionTurnCapabilities(nowMs: number = Date.now()): number {
   let removed = 0;
   for (const [token, capability] of capabilitiesByToken) {
     if (nowMs >= capability.expiresAtMs) {

--- a/src/gateway/server-methods/optional-model-catalog.ts
+++ b/src/gateway/server-methods/optional-model-catalog.ts
@@ -50,7 +50,7 @@ function startOptionalServerMethodModelCatalogValueLoad<T>(params: {
   };
 }
 
-export function startOptionalServerMethodModelCatalogLoad(
+function startOptionalServerMethodModelCatalogLoad(
   context: GatewayRequestContext,
 ): OptionalServerMethodModelCatalogLoad<ModelCatalogEntry[]> {
   return startOptionalServerMethodModelCatalogValueLoad({


### PR DESCRIPTION
## What Problem This Solves

Two Gateway implementation helpers were exported even though each has only one same-module caller. The exports suggest reusable contracts where none exist.

## Why This Change Was Made

Keep both named helpers for local ownership and readability, but make them module-private:

- the optional model-catalog starter used by the public timed loader,
- the expired message-action capability sweep used during minting.

The snapshot catalog starter remains exported because chat startup imports it directly.

## User Impact

No behavior change. Catalog loading, timeouts, capability expiry, and minting execute the same code.

## Evidence

- Exhaustive repository search found no outside consumers for either privatized helper.
- Codebase-memory traces show one same-module caller for each helper.
- Testbox: 126 focused Gateway tests passed.
- Testbox `check:changed` passed the full core lane, including API baseline, typechecks, lint, import-cycle, database-first, and Gateway guards.
- Fresh `gpt-5.6-sol` medium autoreview: no findings, 0.94 confidence.
- `git diff --check`: passed.
