### PR TITLE
fix: sidebar sort, group, and customize menus render behind the resize divider

### DIFF
--- a/ui/src/app/native-link-routing.ts
+++ b/ui/src/app/native-link-routing.ts
@@ -1,3 +1,4 @@
+import { promoteToPopoverTopLayer } from "../components/menu-surface.ts";
 import { NativeLinkMenu, type NativeLinkMenuAction } from "../components/native-link-menu.ts";
 import { copyToClipboard } from "../lib/clipboard.ts";
 
@@ -160,17 +161,8 @@ export function startNativeLinkRouting(): NativeLinkRouting {
       postNativeLink(postMessage, url, action);
     };
     menu = nextMenu;
-    nextMenu.setAttribute("popover", "manual");
     container.append(nextMenu);
-    if (typeof nextMenu.showPopover === "function") {
-      try {
-        nextMenu.showPopover();
-        return;
-      } catch {
-        // Fall through to an in-dialog element when the top-layer API is unavailable.
-      }
-    }
-    nextMenu.removeAttribute("popover");
+    promoteToPopoverTopLayer(nextMenu);
   };
 
   const handleClick = (event: MouseEvent) => {

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -1271,6 +1271,27 @@ describe("AppSidebar multi-select", () => {
   });
 });
 
+describe("AppSidebar transient menus", () => {
+  // Regression: the nav column is a stacking context (z-index 10) painted
+  // below the sidebar resizer (z-index 20), so transient menus must render
+  // through the top-layer surface host instead of plain fixed divs.
+  it("hosts the session sort menu in the top-layer menu surface", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
+
+    const trigger = sidebar.querySelector<HTMLButtonElement>(".sidebar-session-sort");
+    if (!trigger) {
+      throw new Error("expected sort menu trigger");
+    }
+    trigger.click();
+    await sidebar.updateComplete;
+
+    const menu = sidebar.querySelector(".sidebar-session-sort-menu");
+    expect(menu).not.toBeNull();
+    expect(menu?.closest("openclaw-menu-surface")).not.toBeNull();
+  });
+});
+
 describe("AppSidebar custom group reordering", () => {
   async function mountWithGroups(groups: string[]) {
     const client = {} as GatewayBrowserClient;

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -31,6 +31,7 @@ import {
 } from "../app/context.ts";
 import { controlUiPublicAssetPath } from "../app/public-assets.ts";
 import type { ThemeMode } from "../app/theme.ts";
+import "./menu-surface.ts";
 import "./session-menu.ts";
 import "./sidebar-attention.ts";
 import "./sidebar-build-chip.ts";
@@ -1714,49 +1715,51 @@ class AppSidebar extends OpenClawLightDomContentsElement {
       return nothing;
     }
     return html`
-      <div
-        class="sidebar-customize-menu"
-        role="menu"
-        aria-label=${t("nav.customize")}
-        style="left: ${position.x}px; top: ${position.y}px;"
-      >
-        <div class="sidebar-customize-menu__title">${t("nav.customize")}</div>
-        ${SIDEBAR_NAV_ROUTES.filter((routeId) => this.isRouteEnabled(routeId)).map((routeId) => {
-          const pinned = this.sidebarPinnedRoutes.includes(routeId);
-          return html`
-            <button
-              type="button"
-              class="sidebar-customize-menu__item"
-              role="menuitemcheckbox"
-              tabindex="-1"
-              aria-checked=${String(pinned)}
-              @click=${() => this.togglePinnedRoute(routeId)}
-            >
-              <span class="nav-item__icon" aria-hidden="true"
-                >${icons[navigationIconForRoute(routeId)]}</span
-              >
-              <span class="sidebar-customize-menu__text">${titleForRoute(routeId)}</span>
-              <span class="sidebar-customize-menu__check" aria-hidden="true">
-                ${pinned ? icons.check : nothing}
-              </span>
-            </button>
-          `;
-        })}
-        <div class="sidebar-customize-menu__separator" role="separator"></div>
-        <button
-          type="button"
-          class="sidebar-customize-menu__item"
-          role="menuitem"
-          tabindex="-1"
-          @click=${() => {
-            this.onUpdatePinnedRoutes?.([...DEFAULT_SIDEBAR_PINNED_ROUTES]);
-            this.closeCustomizeMenu({ restoreFocus: true });
-          }}
+      <openclaw-menu-surface>
+        <div
+          class="sidebar-customize-menu"
+          role="menu"
+          aria-label=${t("nav.customize")}
+          style="left: ${position.x}px; top: ${position.y}px;"
         >
-          <span class="nav-item__icon" aria-hidden="true">${icons.refresh}</span>
-          <span class="sidebar-customize-menu__text">${t("nav.customizeReset")}</span>
-        </button>
-      </div>
+          <div class="sidebar-customize-menu__title">${t("nav.customize")}</div>
+          ${SIDEBAR_NAV_ROUTES.filter((routeId) => this.isRouteEnabled(routeId)).map((routeId) => {
+            const pinned = this.sidebarPinnedRoutes.includes(routeId);
+            return html`
+              <button
+                type="button"
+                class="sidebar-customize-menu__item"
+                role="menuitemcheckbox"
+                tabindex="-1"
+                aria-checked=${String(pinned)}
+                @click=${() => this.togglePinnedRoute(routeId)}
+              >
+                <span class="nav-item__icon" aria-hidden="true"
+                  >${icons[navigationIconForRoute(routeId)]}</span
+                >
+                <span class="sidebar-customize-menu__text">${titleForRoute(routeId)}</span>
+                <span class="sidebar-customize-menu__check" aria-hidden="true">
+                  ${pinned ? icons.check : nothing}
+                </span>
+              </button>
+            `;
+          })}
+          <div class="sidebar-customize-menu__separator" role="separator"></div>
+          <button
+            type="button"
+            class="sidebar-customize-menu__item"
+            role="menuitem"
+            tabindex="-1"
+            @click=${() => {
+              this.onUpdatePinnedRoutes?.([...DEFAULT_SIDEBAR_PINNED_ROUTES]);
+              this.closeCustomizeMenu({ restoreFocus: true });
+            }}
+          >
+            <span class="nav-item__icon" aria-hidden="true">${icons.refresh}</span>
+            <span class="sidebar-customize-menu__text">${t("nav.customizeReset")}</span>
+          </button>
+        </div>
+      </openclaw-menu-surface>
     `;
   }
 
@@ -1862,55 +1865,57 @@ class AppSidebar extends OpenClawLightDomContentsElement {
       return nothing;
     }
     return html`
-      <div
-        class="session-menu sidebar-session-group-menu"
-        role="menu"
-        aria-label=${t("sessionsView.groupMenu", { group: menu.group })}
-        style="left: ${menu.x}px; top: ${menu.y}px;"
-      >
-        <button
-          type="button"
-          class="session-menu__item"
-          role="menuitem"
-          tabindex="-1"
-          ?disabled=${!this.connected}
-          @click=${() => {
-            this.closeSessionGroupMenu();
-            this.renameSessionGroupFromMenu(menu.group);
-          }}
+      <openclaw-menu-surface>
+        <div
+          class="session-menu sidebar-session-group-menu"
+          role="menu"
+          aria-label=${t("sessionsView.groupMenu", { group: menu.group })}
+          style="left: ${menu.x}px; top: ${menu.y}px;"
         >
-          <span class="session-menu__icon" aria-hidden="true">${icons.edit}</span>
-          <span class="session-menu__text">${t("sessionsView.renameGroupMenu")}</span>
-        </button>
-        <button
-          type="button"
-          class="session-menu__item"
-          role="menuitem"
-          tabindex="-1"
-          @click=${() => {
-            this.closeSessionGroupMenu();
-            this.createSessionGroup();
-          }}
-        >
-          <span class="session-menu__icon" aria-hidden="true">${icons.folder}</span>
-          <span class="session-menu__text">${t("sessionsView.newGroup")}</span>
-        </button>
-        <div class="session-menu__separator" role="separator"></div>
-        <button
-          type="button"
-          class="session-menu__item session-menu__item--destructive"
-          role="menuitem"
-          tabindex="-1"
-          ?disabled=${!this.connected}
-          @click=${() => {
-            this.closeSessionGroupMenu();
-            this.deleteSessionGroupFromMenu(menu.group);
-          }}
-        >
-          <span class="session-menu__icon" aria-hidden="true">${icons.trash}</span>
-          <span class="session-menu__text">${t("sessionsView.deleteGroupMenu")}</span>
-        </button>
-      </div>
+          <button
+            type="button"
+            class="session-menu__item"
+            role="menuitem"
+            tabindex="-1"
+            ?disabled=${!this.connected}
+            @click=${() => {
+              this.closeSessionGroupMenu();
+              this.renameSessionGroupFromMenu(menu.group);
+            }}
+          >
+            <span class="session-menu__icon" aria-hidden="true">${icons.edit}</span>
+            <span class="session-menu__text">${t("sessionsView.renameGroupMenu")}</span>
+          </button>
+          <button
+            type="button"
+            class="session-menu__item"
+            role="menuitem"
+            tabindex="-1"
+            @click=${() => {
+              this.closeSessionGroupMenu();
+              this.createSessionGroup();
+            }}
+          >
+            <span class="session-menu__icon" aria-hidden="true">${icons.folder}</span>
+            <span class="session-menu__text">${t("sessionsView.newGroup")}</span>
+          </button>
+          <div class="session-menu__separator" role="separator"></div>
+          <button
+            type="button"
+            class="session-menu__item session-menu__item--destructive"
+            role="menuitem"
+            tabindex="-1"
+            ?disabled=${!this.connected}
+            @click=${() => {
+              this.closeSessionGroupMenu();
+              this.deleteSessionGroupFromMenu(menu.group);
+            }}
+          >
+            <span class="session-menu__icon" aria-hidden="true">${icons.trash}</span>
+            <span class="session-menu__text">${t("sessionsView.deleteGroupMenu")}</span>
+          </button>
+        </div>
+      </openclaw-menu-surface>
     `;
   }
 
@@ -1924,56 +1929,58 @@ class AppSidebar extends OpenClawLightDomContentsElement {
       { grouping: "none", label: t("sessionsView.groupByNone") },
     ] as const satisfies ReadonlyArray<{ grouping: SidebarSessionsGrouping; label: string }>;
     return html`
-      <div
-        class="sidebar-session-sort-menu"
-        role="menu"
-        aria-label=${t("chat.sidebar.sortSessions")}
-        style="left: ${position.x}px; top: ${position.y}px;"
-      >
-        <div class="sidebar-session-sort-menu__title">${t("sessionsView.groupBy")}</div>
-        ${groupingOptions.map(
-          (option) => html`
-            <button
-              type="button"
-              class="sidebar-session-sort-menu__item"
-              role="menuitemradio"
-              tabindex="-1"
-              aria-checked=${String(this.sessionsGrouping === option.grouping)}
-              @click=${() => {
-                this.setSessionsGrouping(option.grouping);
-                this.closeSessionSortMenu({ restoreFocus: true });
-              }}
-            >
-              <span class="session-menu__check" aria-hidden="true">
-                ${this.sessionsGrouping === option.grouping ? icons.check : nothing}
-              </span>
-              <span class="session-menu__text">${option.label}</span>
-            </button>
-          `,
-        )}
-        <div class="session-menu__separator" role="separator"></div>
-        <div class="sidebar-session-sort-menu__title">${t("chat.sidebar.sortBy")}</div>
-        ${SIDEBAR_SESSION_SORT_OPTIONS.map(
-          (option) => html`
-            <button
-              type="button"
-              class="sidebar-session-sort-menu__item"
-              role="menuitemradio"
-              tabindex="-1"
-              aria-checked=${String(this.sessionSortMode === option.mode)}
-              @click=${() => {
-                this.sessionSortMode = option.mode;
-                this.closeSessionSortMenu({ restoreFocus: true });
-              }}
-            >
-              <span class="session-menu__check" aria-hidden="true">
-                ${this.sessionSortMode === option.mode ? icons.check : nothing}
-              </span>
-              <span class="session-menu__text">${t(option.labelKey)}</span>
-            </button>
-          `,
-        )}
-      </div>
+      <openclaw-menu-surface>
+        <div
+          class="sidebar-session-sort-menu"
+          role="menu"
+          aria-label=${t("chat.sidebar.sortSessions")}
+          style="left: ${position.x}px; top: ${position.y}px;"
+        >
+          <div class="sidebar-session-sort-menu__title">${t("sessionsView.groupBy")}</div>
+          ${groupingOptions.map(
+            (option) => html`
+              <button
+                type="button"
+                class="sidebar-session-sort-menu__item"
+                role="menuitemradio"
+                tabindex="-1"
+                aria-checked=${String(this.sessionsGrouping === option.grouping)}
+                @click=${() => {
+                  this.setSessionsGrouping(option.grouping);
+                  this.closeSessionSortMenu({ restoreFocus: true });
+                }}
+              >
+                <span class="session-menu__check" aria-hidden="true">
+                  ${this.sessionsGrouping === option.grouping ? icons.check : nothing}
+                </span>
+                <span class="session-menu__text">${option.label}</span>
+              </button>
+            `,
+          )}
+          <div class="session-menu__separator" role="separator"></div>
+          <div class="sidebar-session-sort-menu__title">${t("chat.sidebar.sortBy")}</div>
+          ${SIDEBAR_SESSION_SORT_OPTIONS.map(
+            (option) => html`
+              <button
+                type="button"
+                class="sidebar-session-sort-menu__item"
+                role="menuitemradio"
+                tabindex="-1"
+                aria-checked=${String(this.sessionSortMode === option.mode)}
+                @click=${() => {
+                  this.sessionSortMode = option.mode;
+                  this.closeSessionSortMenu({ restoreFocus: true });
+                }}
+              >
+                <span class="session-menu__check" aria-hidden="true">
+                  ${this.sessionSortMode === option.mode ? icons.check : nothing}
+                </span>
+                <span class="session-menu__text">${t(option.labelKey)}</span>
+              </button>
+            `,
+          )}
+        </div>
+      </openclaw-menu-surface>
     `;
   }
 

--- a/ui/src/components/menu-surface.browser.test.ts
+++ b/ui/src/components/menu-surface.browser.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it } from "vitest";
+import "../test-helpers/load-styles.ts";
+import "./menu-surface.ts";
+import "./resizable-divider.ts";
+
+// Real-browser regression for the sidebar menu z-order bug: the nav column is
+// a stacking context (.shell-nav z-index 10) painted below the sidebar
+// resizer (.sidebar-resizer z-index 20), so a fixed-position menu rendered
+// inside the nav is overdrawn by the divider unless it is promoted to the
+// popover top layer via openclaw-menu-surface.
+//
+// The repo-level test shard also collects *.browser.test.ts under jsdom,
+// which has neither the Popover API nor real layout; the paint-order
+// assertions only mean anything in the Chromium lane, so skip elsewhere.
+const hasPopoverApi = typeof HTMLElement.prototype.showPopover === "function";
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+// The default browser-lane viewport (414px) triggers the mobile drawer
+// layout, which hides the resizer entirely; the bug only exists on the
+// desktop grid. Dynamic import keeps jsdom collection from touching the
+// browser-only context module.
+async function useDesktopViewport() {
+  const { page } = await import("@vitest/browser/context");
+  await page.viewport(1280, 800);
+}
+
+function mountShell() {
+  const shell = document.createElement("div");
+  shell.className = "shell";
+  // The shell entry animation animates the whole grid; skip it so fixed
+  // positioning and hit-testing are stable at assertion time.
+  shell.style.animation = "none";
+  const nav = document.createElement("div");
+  nav.className = "shell-nav";
+  const divider = document.createElement("resizable-divider");
+  divider.className = "sidebar-resizer";
+  const content = document.createElement("main");
+  content.className = "content";
+  shell.append(nav, divider, content);
+  document.body.append(shell);
+  return { nav, divider };
+}
+
+function createSortMenu() {
+  const menu = document.createElement("div");
+  menu.className = "sidebar-session-sort-menu";
+  const item = document.createElement("button");
+  item.type = "button";
+  item.className = "sidebar-session-sort-menu__item";
+  item.textContent = "Created";
+  menu.append(item);
+  return menu;
+}
+
+/** Places the menu so it straddles the divider, then hit-tests on the divider line. */
+function hitTestOnDivider(menu: HTMLElement, divider: HTMLElement): Element | null {
+  const dividerBounds = divider.getBoundingClientRect();
+  menu.style.left = `${Math.round(dividerBounds.left) - 120}px`;
+  menu.style.top = "100px";
+  const menuBounds = menu.getBoundingClientRect();
+  expect(menuBounds.right).toBeGreaterThan(dividerBounds.left);
+  const x = dividerBounds.left + dividerBounds.width / 2;
+  const y = menuBounds.top + menuBounds.height / 2;
+  return document.elementFromPoint(x, y);
+}
+
+describe.skipIf(!hasPopoverApi)("sidebar menu stacking", () => {
+  it("overdraws a plain fixed menu inside the nav with the resizer divider (the bug shape)", async () => {
+    await useDesktopViewport();
+    const { nav, divider } = mountShell();
+    const menu = createSortMenu();
+    nav.append(menu);
+
+    expect(hitTestOnDivider(menu, divider)).toBe(divider);
+  });
+
+  it("paints a menu hosted in openclaw-menu-surface above the resizer divider", async () => {
+    await useDesktopViewport();
+    const { nav, divider } = mountShell();
+    const surface = document.createElement("openclaw-menu-surface");
+    const menu = createSortMenu();
+    surface.append(menu);
+    nav.append(surface);
+
+    expect(surface.matches(":popover-open")).toBe(true);
+    const hit = hitTestOnDivider(menu, divider);
+    expect(hit).not.toBeNull();
+    expect(menu.contains(hit)).toBe(true);
+  });
+});

--- a/ui/src/components/menu-surface.test.ts
+++ b/ui/src/components/menu-surface.test.ts
@@ -1,0 +1,62 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { promoteToPopoverTopLayer } from "./menu-surface.ts";
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("promoteToPopoverTopLayer", () => {
+  it("shows the element as a manual popover when the API is available", () => {
+    const element = document.createElement("div");
+    const showPopover = vi.fn();
+    element.showPopover = showPopover;
+    promoteToPopoverTopLayer(element);
+    expect(element.getAttribute("popover")).toBe("manual");
+    expect(showPopover).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to in-flow rendering when the API is unavailable", () => {
+    // jsdom elements have no showPopover.
+    const element = document.createElement("div");
+    promoteToPopoverTopLayer(element);
+    expect(element.hasAttribute("popover")).toBe(false);
+  });
+
+  it("falls back to in-flow rendering when showPopover throws", () => {
+    const element = document.createElement("div");
+    element.showPopover = vi.fn(() => {
+      throw new Error("top layer unavailable");
+    });
+    promoteToPopoverTopLayer(element);
+    expect(element.hasAttribute("popover")).toBe(false);
+  });
+});
+
+describe("openclaw-menu-surface", () => {
+  it("promotes itself to the top layer on every connect", () => {
+    const surface = document.createElement("openclaw-menu-surface");
+    const showPopover = vi.fn();
+    surface.showPopover = showPopover;
+    document.body.append(surface);
+    expect(surface.getAttribute("popover")).toBe("manual");
+    expect(showPopover).toHaveBeenCalledTimes(1);
+
+    // Menus toggle by removing/re-adding the surface; each reopen must
+    // re-enter the top layer.
+    surface.remove();
+    document.body.append(surface);
+    expect(showPopover).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps children rendered in-flow when the popover API is unavailable", () => {
+    const surface = document.createElement("openclaw-menu-surface");
+    const menu = document.createElement("div");
+    menu.className = "menu";
+    surface.append(menu);
+    document.body.append(surface);
+    expect(surface.hasAttribute("popover")).toBe(false);
+    expect(surface.querySelector(".menu")).toBe(menu);
+  });
+});

--- a/ui/src/components/menu-surface.ts
+++ b/ui/src/components/menu-surface.ts
@@ -1,0 +1,39 @@
+/**
+ * Promotes a connected element into the browser popover top layer so transient
+ * menus paint above every in-page stacking context (e.g. the sidebar resizer
+ * divider that sits above the nav's z-index 10 context). Falls back to
+ * in-flow rendering when the Popover API is unavailable (older engines, jsdom).
+ */
+export function promoteToPopoverTopLayer(element: HTMLElement) {
+  element.setAttribute("popover", "manual");
+  if (typeof element.showPopover === "function") {
+    try {
+      element.showPopover();
+      return;
+    } catch {
+      // Fall through to in-flow rendering when the top-layer API is unavailable.
+    }
+  }
+  element.removeAttribute("popover");
+}
+
+/**
+ * Light-DOM host that lifts template-rendered menus into the popover top
+ * layer on connect. Hosts render fixed-position menu markup as children;
+ * closing removes the element, which auto-hides the popover.
+ */
+export class MenuSurface extends HTMLElement {
+  connectedCallback() {
+    promoteToPopoverTopLayer(this);
+  }
+}
+
+if (!customElements.get("openclaw-menu-surface")) {
+  customElements.define("openclaw-menu-surface", MenuSurface);
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "openclaw-menu-surface": MenuSurface;
+  }
+}

--- a/ui/src/components/session-menu.ts
+++ b/ui/src/components/session-menu.ts
@@ -5,6 +5,7 @@ import { EDITOR_IDS, EDITOR_LABELS, type EditorId } from "../lib/editor-links.ts
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { icons } from "./icons.ts";
 import { activateMenuShortcut, menuShortcutHint } from "./menu-shortcuts.ts";
+import { promoteToPopoverTopLayer } from "./menu-surface.ts";
 
 export type SessionMenuData = {
   key: string;
@@ -80,16 +81,7 @@ class SessionMenu extends OpenClawLightDomElement {
     // which paints below the sidebar resizer divider (z-index 20); promoting
     // the menu to the popover top layer keeps app chrome from bleeding
     // through it (same pattern as openclaw-native-link-menu).
-    this.setAttribute("popover", "manual");
-    if (typeof this.showPopover === "function") {
-      try {
-        this.showPopover();
-        return;
-      } catch {
-        // Fall through to in-flow rendering when the top-layer API is unavailable.
-      }
-    }
-    this.removeAttribute("popover");
+    promoteToPopoverTopLayer(this);
   }
 
   override disconnectedCallback() {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1700,6 +1700,10 @@ html.openclaw-native-nav .topbar .topbar-nav-toggle {
   box-shadow: var(--shadow-lg);
 }
 
+/* Popover hosts live in the top layer so menus escape in-page stacking
+   contexts (e.g. the sidebar resizer above the nav); the host itself must
+   stay a zero-size shell around its fixed-position menu. */
+openclaw-menu-surface[popover],
 openclaw-native-link-menu[popover],
 openclaw-session-menu[popover] {
   width: 0;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the sidebar's transient menus — the sessions sort/group-by menu (filter icon), the session-group context menu, and the "Customize sidebar" menu — rendered behind the sidebar resize divider. Opening one of these menus near the sidebar edge painted the divider line straight across the open menu.

## Why This Change Was Made

The nav column (`.shell-nav`) is a stacking context at `z-index: 10` and the resizer divider sibling sits at `z-index: 20`, so no `z-index` on a menu rendered inside the nav can escape it. `openclaw-session-menu` and `openclaw-native-link-menu` already solved this by promoting themselves into the browser popover top layer; the three menus rendered inline by `app-sidebar` were left behind. This change extracts that promotion into one shared `promoteToPopoverTopLayer` helper plus a tiny `openclaw-menu-surface` host element, wraps the three inline menus in it, and rewires the two existing implementations onto the shared helper — one canonical top-layer path for all transient menus, with the same graceful in-flow fallback when the Popover API is unavailable.

## User Impact

Sidebar menus (sort/group-by, session-group context menu, customize sidebar) now always paint above the resize divider and other app chrome. No behavior change otherwise: positioning, focus, keyboard handling, and outside-click dismissal are untouched.

## Evidence

- New real-browser (Chromium) regression test proves paint order via hit-testing on the divider line: a plain fixed menu inside the nav loses hit-testing to the divider (the bug shape), while a menu hosted in `openclaw-menu-surface` wins (`ui/src/components/menu-surface.browser.test.ts`). The suite skips in jsdom shards where paint order is meaningless.
- Unit tests cover the promotion helper and its fallbacks (`ui/src/components/menu-surface.test.ts`), plus an `app-sidebar` regression asserting the sort menu is hosted in the top-layer surface.
- Live-verified in a real browser against the repo stylesheets: hit-test on the divider line returned the divider for the plain menu and the menu item for the surface-hosted menu (`:popover-open` true).
- Focused suites green on Blacksmith Testbox through Crabbox (`tbx_01kxbpxpnsxsg9qap01e0qjn48`): `app-sidebar.test.ts` (34), `session-menu.test.ts` (19), `native-link-routing.test.ts` (8), `menu-surface.test.ts` (5), `menu-surface.browser.test.ts` (2, Chromium lane); `pnpm check:changed` green on the same lease.
