### PR TITLE
refactor(process): trim internal type surface

### DIFF
--- a/src/process/spawn-utils.ts
+++ b/src/process/spawn-utils.ts
@@ -9,7 +9,7 @@ type SpawnFallback = {
   options: SpawnOptions;
 };
 
-export type SpawnWithFallbackResult = {
+type SpawnWithFallbackResult = {
   child: ChildProcess;
   usedFallback: boolean;
   fallbackLabel?: string;

--- a/src/process/supervisor/index.ts
+++ b/src/process/supervisor/index.ts
@@ -21,6 +21,5 @@ export type {
   RunRecord,
   RunState,
   SpawnInput,
-  SpawnMode,
   TerminationReason,
 } from "./types.js";

--- a/src/process/supervisor/registry.ts
+++ b/src/process/supervisor/registry.ts
@@ -15,7 +15,7 @@ function resolveMaxExitedRecords(value?: number): number {
   return Math.max(1, Math.floor(value));
 }
 
-export type RunRegistry = {
+type RunRegistry = {
   add: (record: RunRecord) => void;
   get: (runId: string) => RunRecord | undefined;
   updateState: (

--- a/src/process/supervisor/types.ts
+++ b/src/process/supervisor/types.ts
@@ -46,8 +46,6 @@ export type ManagedRun = {
   cancel: (reason?: TerminationReason) => void;
 };
 
-export type SpawnMode = "child" | "pty";
-
 export type ManagedRunStdin = {
   write: (data: string, cb?: (err?: Error | null) => void) => void;
   end: () => void;


### PR DESCRIPTION
## What Problem This Solves

The process supervisor exposed a dead mode alias and two result/registry types that have no consumers outside their defining modules. This adds accidental type surface without a contract.

## Why This Change Was Made

- Delete the unused `SpawnMode` alias and its barrel re-export; `SpawnInput` already owns the closed `"child" | "pty"` modes.
- Keep `RunRegistry` private to the registry implementation.
- Keep `SpawnWithFallbackResult` private to the spawn utility.

## User Impact

No runtime behavior change. Supervisor spawning, registry retention, and fallback execution use the same implementations and return shapes.

## Evidence

- Exhaustive repository search and codebase-memory indexing found zero `SpawnMode` consumers, only a local `RunRegistry` plus the test's inferred alias, and only a local `SpawnWithFallbackResult`.
- Testbox: 15 focused process tests passed.
- Testbox `check:changed` passed the full core lane.
- Fresh `gpt-5.6-sol` medium autoreview: no findings, 0.98 confidence.
- `git diff --check`: passed.
