### PR TITLE
fix(ci): allowlist sqlite-schema-contract raw node:sqlite access

### DIFF
--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -37,6 +37,7 @@ const rawSqliteAllowPathGroups = {
   "SQLite database lifecycle, schema, transactions, and pragmas": [
     "src/infra/node-sqlite.ts",
     "src/infra/sqlite-index-schema.ts",
+    "src/infra/sqlite-schema-contract.ts",
     "src/infra/sqlite-integrity.ts",
     "src/infra/sqlite-pragma.test-support.ts",
     "src/infra/sqlite-transaction.ts",


### PR DESCRIPTION
Related: unblocks fresh PRs based on #105585 (e.g. #105594).

## What Problem This Solves

Every PR branched from main after #105585 fails the `check-additional-runtime-topology-architecture` lane: the new `src/infra/sqlite-schema-contract.ts` uses raw `node:sqlite` (`DatabaseSync` schema introspection) but was never added to the Kysely guardrail allowlist in `scripts/check-kysely-guardrails.mjs`. The lane only runs on PRs, so main itself stays green while all fresh PRs inherit the failure.

## Why This Change Was Made

`sqlite-schema-contract.ts` is schema-introspection/bootstrap code — exactly the class the "SQLite database lifecycle, schema, transactions, and pragmas" allowlist group exists for (it sits beside `sqlite-index-schema.ts` there). One allowlist line, no behavior change.

## User Impact

None at runtime; unblocks CI for all in-flight PRs.

## Evidence

`node scripts/check-kysely-guardrails.mjs` fails on main's tree with 8 violations in `sqlite-schema-contract.ts` and prints `Kysely guardrails OK` with this change.
