### PR TITLE
fix(ui): queued steers appear only above composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI queued messages:** keep messages waiting behind an active run in the composer queue only, adding them to the transcript once sending actually starts.
 - **SQLite maintenance schema validation:** reject current-version global and agent databases with missing or drifted canonical tables, constraints, indexes, triggers, or table options before compaction, while accepting supported additive-migration layouts.
 - **iOS Watch relay commands:** allow paired iPhone nodes to advertise and invoke `watch.status` and `watch.notify` through the default Gateway policy while preserving the direct watchOS node's fixed minimal command surface.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI queued messages:** keep messages waiting behind an active run in the composer queue only, adding them to the transcript once sending actually starts.
 - **SQLite maintenance schema validation:** reject current-version global and agent databases with missing or drifted canonical tables, constraints, indexes, triggers, or table options before compaction, while accepting supported additive-migration layouts.
 - **iOS Watch relay commands:** allow paired iPhone nodes to advertise and invoke `watch.status` and `watch.notify` through the default Gateway policy while preserving the direct watchOS node's fixed minimal command surface.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -1776,6 +1776,46 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
+  it("keeps a steerable queued message above the composer while a run is active", async () => {
+    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page);
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+
+      const activePrompt = "keep this run active";
+      await page.locator(".agent-chat__composer-combobox textarea").fill(activePrompt);
+      await page.getByRole("button", { name: "Send message" }).click();
+
+      await gateway.waitForRequest("chat.send");
+      await page.getByRole("button", { name: "Stop generating" }).waitFor({ timeout: 10_000 });
+
+      const queuedPrompt = "show this only above the composer";
+      await page.locator(".agent-chat__composer-combobox textarea").fill(queuedPrompt);
+      await page.getByRole("button", { name: "Queue message" }).click();
+
+      const queue = page.locator(".chat-queue");
+      await queue.getByText("Waiting for current run").waitFor({ timeout: 10_000 });
+      await queue.getByText(queuedPrompt).waitFor({ timeout: 10_000 });
+      expect(await page.locator(".chat-thread").getByText(queuedPrompt).count()).toBe(0);
+      expect(await gateway.getRequests("chat.send")).toHaveLength(1);
+      if (artifactDir) {
+        await page.screenshot({
+          path: `${artifactDir}/steer-queue-composer-only.png`,
+          fullPage: true,
+        });
+      }
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
   it("scrolls a delayed pending send into view before the ACK resolves", async () => {
     const context = await newBrowserContext({
       locale: "en-US",

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -1627,6 +1627,23 @@ describe("buildChatItems", () => {
     ]);
   });
 
+  it("keeps steerable queued sends out of the thread until sending starts", () => {
+    const queued = {
+      id: "pending-send-1",
+      text: "wait above the composer",
+      createdAt: 2,
+      sendSubmittedAtMs: 10,
+    };
+
+    expect(messageGroups({ queue: [{ ...queued, sendState: "waiting-idle" }] })).toStrictEqual([]);
+
+    const groups = messageGroups({ queue: [{ ...queued, sendState: "sending" }] });
+    expect(groups).toHaveLength(1);
+    expect(messageRecord(groupAt(groups, 0)).content).toStrictEqual([
+      { type: "text", text: "wait above the composer" },
+    ]);
+  });
+
   it("renders submitted queued attachment sends with attachment blocks before chat.send ACK", () => {
     const groups = messageGroups({
       queue: [

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -866,7 +866,6 @@ function shouldRenderQueuedSendInThread(item: ChatQueueItem): boolean {
   }
   return (
     item.sendState === "waiting-model" ||
-    item.sendState === "waiting-idle" ||
     item.sendState === "sending" ||
     item.sendState === "waiting-reconnect"
   );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who queued a steerable follow-up behind an active Control UI run saw that message twice: once as a user turn in the transcript and again in the waiting row above the composer.

## Why This Change Was Made

Messages in the pre-send `waiting-idle` state now stay in the composer queue only. Optimistic transcript rendering remains unchanged once sending starts, including the existing model-update and reconnect states.

## User Impact

Queued follow-ups appear once above the composer while they wait. They join the transcript only when their send actually begins.

## Evidence

- Focused UI projection test: 89 tests passed.
- Mocked-Gateway Chromium E2E: queued text was visible in `Waiting for current run`, absent from the transcript, and no second `chat.send` occurred.
- `pnpm check:changed`: formatting, core-test and UI typechecks, and changed-file lint passed.
- Blacksmith Testbox: `tbx_01kxbsn6wy32kphjxyvcvq5245`; [exact-head CI run 29204066765](https://github.com/openclaw/openclaw/actions/runs/29204066765).
- Fresh branch autoreview: no actionable findings; correctness 0.94.

AI-assisted: yes. The change and tests were reviewed and validated against the user-visible behavior.
