### PR TITLE
fix(ui): align session PR rows with the composer width

### DIFF
--- a/ui/src/e2e/chat-pull-requests.e2e.test.ts
+++ b/ui/src/e2e/chat-pull-requests.e2e.test.ts
@@ -199,5 +199,15 @@ describeControlUiE2e("session pull request chips", () => {
       .toBe("https://github.com/openclaw/openclaw/pull/new/claude/cloud-workers-live-events");
     // No dismiss control: the row reflects the checkout itself.
     await expect.poll(() => row.locator(".chat-pr__dismiss").count()).toBe(0);
+
+    // The row shares the composer's centered width; it is part of the input
+    // stack, not a full-pane banner.
+    const rowBox = await page.locator(".chat-prs").boundingBox();
+    const composerBox = await page.locator(".agent-chat__composer-shell").boundingBox();
+    expect(rowBox && composerBox).toBeTruthy();
+    if (rowBox && composerBox) {
+      expect(Math.abs(rowBox.width - composerBox.width)).toBeLessThanOrEqual(1);
+      expect(Math.abs(rowBox.x - composerBox.x)).toBeLessThanOrEqual(1);
+    }
   });
 });

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1175,7 +1175,12 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 .chat-prs {
   display: grid;
   gap: 6px;
-  padding: 0 14px 8px;
+  /* Mirror .agent-chat__composer-shell sizing: the rows belong to the input
+     stack and must not read as a full-pane banner above a narrower composer. */
+  width: calc(100% - 36px);
+  max-width: 48rem;
+  margin: 0 auto;
+  padding: 0 0 8px;
 }
 
 .chat-pr {


### PR DESCRIPTION
Related: #105116

## What Problem This Solves

The session PR chips and the pre-PR Create PR row span the full chat pane while the composer below them is centered at a narrower max width, so the rows read as a detached full-width banner instead of part of the input stack.

## Why This Change Was Made

`.chat-prs` now mirrors `.agent-chat__composer-shell` sizing (`width: calc(100% - 36px); max-width: 48rem; margin: 0 auto`), so the branch row and PR chips align exactly with the composer at every pane width.

## User Impact

The PR status rows visually attach to the composer they sit above.

## Evidence

![width-aligned branch row](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-create-pr-row/branch-row-width-aligned.png)

The chat pull-request e2e now asserts width and x-offset parity (±1px) between `.chat-prs` and `.agent-chat__composer-shell`; both e2e scenarios pass locally under real Chromium.
