### PR TITLE
refactor(infra): trim internal helper surface

### DIFF
--- a/src/infra/exec-approval-policy-snapshot.ts
+++ b/src/infra/exec-approval-policy-snapshot.ts
@@ -39,7 +39,7 @@ function compareOptionalUtf8(left: string | undefined, right: string | undefined
 }
 
 /** Cross-runtime order: tuple fields, absent before present, UTF-8 byte lexicographic. */
-export function compareExecApprovalPolicyRules(
+function compareExecApprovalPolicyRules(
   left: ExecApprovalPolicyRule,
   right: ExecApprovalPolicyRule,
 ): number {

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -11,11 +11,6 @@ import { isSqliteLockError } from "./sqlite-transaction.js";
 // checkpoints so state databases do not accumulate unbounded WAL files.
 export const DEFAULT_SQLITE_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const DEFAULT_SQLITE_WAL_CHECKPOINT_INTERVAL_MS = 30 * 60 * 1000;
-/**
- * @deprecated Use DEFAULT_SQLITE_WAL_CHECKPOINT_INTERVAL_MS.
- * Periodic checkpoints default to PASSIVE.
- */
-export const DEFAULT_SQLITE_WAL_TRUNCATE_INTERVAL_MS = DEFAULT_SQLITE_WAL_CHECKPOINT_INTERVAL_MS;
 // 512 pages (~2MB at 4KB pages) per periodic pass keeps page release strictly
 // bounded so maintenance can never behave like a blocking full VACUUM.
 const INCREMENTAL_VACUUM_MAX_PAGES_PER_PASS = 512;


### PR DESCRIPTION
## What Problem This Solves

Two core infrastructure modules expose symbols that have no consumers outside their defining files:

- a deprecated SQLite WAL interval alias that is not part of package or plugin SDK exports
- an exec approval policy comparator used only by the local canonicalization helper

These exports enlarge the apparent internal API and preserve a stale compatibility name without a supported public contract.

## Why This Change Was Made

Remove the unused WAL alias and keep the comparator module-private. The canonical WAL interval constant and all runtime behavior remain unchanged.

## User Impact

None. This is an internal API-surface cleanup with no runtime, config, protocol, or plugin SDK behavior change.

## Evidence

- Codebase-memory index: no graph result for the removed WAL alias; no external caller for the comparator
- Repository search: no consumers, docs, package export, or plugin SDK export for either removed surface
- Testbox: 192 focused infra tests passed
- Testbox: `pnpm check:changed -- src/infra/sqlite-wal.ts src/infra/exec-approval-policy-snapshot.ts`
- Fresh autoreview: `gpt-5.6-sol`, medium reasoning, clean at 0.90 confidence
- `git diff --check`
