### PR TITLE
fix: delay narrated channel progress and remove default title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **SQLite maintenance schema validation:** reject current-version global and agent databases with missing or drifted canonical tables, constraints, indexes, triggers, or table options before compaction, while accepting supported additive-migration layouts.
+- **Channel progress drafts:** omit the redundant default one-word title from narrated status and keep narration behind the existing activity gate, preventing fast turns from flashing a temporary status message while preserving explicit custom or `auto` labels.
 - **iOS Watch relay commands:** allow paired iPhone nodes to advertise and invoke `watch.status` and `watch.notify` through the default Gateway policy while preserving the direct watchOS node's fixed minimal command surface.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **SQLite maintenance schema validation:** reject current-version global and agent databases with missing or drifted canonical tables, constraints, indexes, triggers, or table options before compaction, while accepting supported additive-migration layouts.
-- **Channel progress drafts:** omit the redundant default one-word title from narrated status and keep narration behind the existing activity gate, preventing fast turns from flashing a temporary status message while preserving explicit custom or `auto` labels.
 - **iOS Watch relay commands:** allow paired iPhone nodes to advertise and invoke `watch.status` and `watch.notify` through the default Gateway policy while preserving the direct watchOS node's fixed minimal command surface.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -689,7 +689,7 @@ See [Slash commands](/tools/slash-commands) for the command catalog and behavior
     - `off` disables Discord preview edits.
     - `partial` edits a single preview message as tokens arrive.
     - `block` emits draft-sized chunks; tune size and breakpoints with `streaming.preview.chunk` (`minChars`, `maxChars`, `breakPreference`), clamped to `textChunkLimit`. When block streaming is explicitly enabled, OpenClaw skips the preview stream to avoid double-streaming.
-    - `progress` keeps one editable status draft and updates it with tool progress until final delivery; the shared starter label is a rolling line, so it scrolls away like the rest once enough work appears.
+    - `progress` keeps one editable status draft and updates it with tool progress until final delivery. Raw tool progress uses the shared starter label as a rolling line; narrated status shows only the narration unless a label is explicitly configured.
     - Media, error, and explicit-reply finals cancel pending preview edits.
     - `streaming.preview.toolProgress` (default `true`) controls whether tool/progress updates reuse the preview message.
     - Tool/progress rows render as compact emoji + title + detail when available, for example `🛠️ Bash: run tests` or `🔎 Web Search: for "query"`.

--- a/docs/concepts/progress-drafts.md
+++ b/docs/concepts/progress-drafts.md
@@ -43,10 +43,11 @@ Shelling...
 }
 ```
 
-Defaults from here: an automatic one-word label, a start delay of 5 seconds
-(or immediately on a second work event), compact progress lines while useful
-work happens, and suppression of the older standalone progress messages for
-that turn.
+Defaults from here: a start delay of 5 seconds (or immediately on a second work
+event), compact progress lines while useful work happens, and suppression of
+the older standalone progress messages for that turn. Raw tool-line drafts use
+an automatic one-word label; narrated status omits that redundant title unless
+you configure one explicitly.
 
 This page covers the progress-draft experience and its config knobs. For the
 full streaming-mode matrix, per-channel runtime notes, and legacy key
@@ -56,15 +57,17 @@ migration, see [Streaming and chunking](/concepts/streaming).
 
 | Part           | Purpose                                                                           |
 | -------------- | --------------------------------------------------------------------------------- |
-| Label          | Short starter/status line such as `Working` or `Shelling`.                        |
+| Label          | Optional starter/status line such as `Working` or `Shelling`.                     |
 | Progress lines | Compact run updates using the same tool icons and detail formatter as `/verbose`. |
 
-The label appears once the agent starts meaningful work and stays busy for the
-initial delay, or a second work event fires immediately. It sits at the top of
-the rolling progress-line list, so it scrolls away once enough concrete work
-lines appear. Plain text-only replies never show a progress draft; a line
-appears only for real work updates, for example `🛠️ Bash: run tests`,
-`🔎 Web Search: for "discord edit message"`, or `✍️ Write: to /tmp/file`.
+For raw tool progress, the label appears once the agent starts meaningful work
+and stays busy for the initial delay, or a second work event fires immediately.
+It sits at the top of the rolling progress-line list, so it scrolls away once
+enough concrete work lines appear. Narrated progress shows only the agent's
+plain-language status unless a label is configured explicitly. Plain text-only
+replies never show a progress draft; a line appears only for real work updates,
+for example `🛠️ Bash: run tests`, `🔎 Web Search: for "discord edit message"`,
+or `✍️ Write: to /tmp/file`.
 
 The final answer replaces the draft in place when the channel can safely do
 that; otherwise OpenClaw sends the final answer through normal delivery and
@@ -89,9 +92,10 @@ block-reply delivery — use `streaming.block.enabled` for that.
 
 ## Configure labels
 
-Progress labels live under `channels.<channel>.streaming.progress`. The
-default `label` is `"auto"`, which picks from OpenClaw's built-in single-word
-label pool:
+Progress labels live under `channels.<channel>.streaming.progress`. The default
+raw tool-line label is `"auto"`, which picks from OpenClaw's built-in
+single-word label pool. Narrated progress hides that implicit label; set
+`label: "auto"` explicitly if you want it above narration too:
 
 ```text
 Working, Shelling, Scuttling, Clawing, Pinching, Molting, Bubbling, Tiding,
@@ -266,10 +270,8 @@ tool lines with a short plain-language narration of what the agent is doing,
 written by that cheaper model and refreshed as the work moves along:
 
 ```text
-Clawing
-
-Updating the default model in your config, then restarting the gateway to
-pick it up. One agent listing call failed and is being retried.
+Updating the default model in your config, then restarting the gateway to pick
+it up. One agent listing call failed and is being retried.
 ```
 
 Narration is on by default (`streaming.progress.narration`, default `true`)
@@ -277,8 +279,9 @@ and never falls back to the primary model: it runs only with an explicit
 `utilityModel` or a provider-declared default for the agent's primary
 provider. Set `utilityModel: ""` to disable utility routing entirely. Tool lines
 keep accumulating underneath and return if narration stops, and the draft is
-edited only when the narration text actually changes, which also reduces edit
-churn in busy channels. Disable it to keep the raw tool lines:
+edited only after the normal activity gate and when the narration text actually
+changes, which avoids flashes on fast turns and reduces edit churn in busy
+channels. Disable it to keep the raw tool lines:
 
 ```json5
 {

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -2223,6 +2223,7 @@ describe("processDiscordMessage draft streaming", () => {
   });
 
   it("renders narration updates into the Discord progress draft", async () => {
+    vi.useFakeTimers();
     const draftStream = createMockDraftStreamForTest();
 
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
@@ -2230,6 +2231,8 @@ describe("processDiscordMessage draft streaming", () => {
       await params?.replyOptions?.onNarrationUpdate?.({
         text: "Reading the gateway config and restarting agents.",
       });
+      expect(draftStream.update).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(5_000);
       await params?.dispatcher.sendFinalReply({ text: "done" });
       return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
     });
@@ -2241,7 +2244,7 @@ describe("processDiscordMessage draft streaming", () => {
     await runProcessDiscordMessage(ctx);
 
     const updates = draftStream.update.mock.calls.map((call) => call[0]);
-    expect(updates).toContain("Pinching\n\nReading the gateway config and restarting agents.");
+    expect(updates).toContain("Reading the gateway config and restarting agents.");
     expectFinalWithProgressReceipt("done", "🛠️ 1 tool call");
   });
 

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -317,6 +317,35 @@ describe("createChannelProgressDraftCompositor", () => {
     expect(update).toHaveBeenLastCalledWith("Shelling\n\n🛠️ Exec\n🛠️ Wc", expect.anything());
   });
 
+  it("holds narration behind the initial progress delay", async () => {
+    vi.useFakeTimers();
+    try {
+      const update = vi.fn();
+      const progress = createChannelProgressDraftCompositor({
+        entry: { streaming: { mode: "progress" } },
+        mode: "progress",
+        active: true,
+        seed: "test",
+        update,
+      });
+
+      await progress.pushToolProgress("🛠️ Exec");
+      await progress.pushNarrationProgress("Reading the gateway config.");
+
+      expect(update).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(DEFAULT_PROGRESS_DRAFT_INITIAL_DELAY_MS - 1);
+      expect(update).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(update).toHaveBeenCalledWith("Reading the gateway config.", {
+        flush: true,
+        lines: ["🛠️ Exec"],
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("ignores narration once the final reply started and resets it per turn", async () => {
     const update = vi.fn();
     const progress = createChannelProgressDraftCompositor({

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -299,8 +299,10 @@ export function createChannelProgressDraftCompositor(params: {
         return await render();
       }
       narrationText = normalized;
-      await gate.startNow();
-      return await render();
+      // Tool activity owns the delayed start gate. Narration may arrive while
+      // that timer is pending; retain the newest text without flashing a draft
+      // for a turn that finishes inside the grace period.
+      return gate.hasStarted ? await render() : false;
     },
     async pushReasoningProgress(text?: string, options?: { snapshot?: boolean }) {
       if (

--- a/src/channels/streaming.test.ts
+++ b/src/channels/streaming.test.ts
@@ -144,6 +144,31 @@ describe("streaming config resolution", () => {
 });
 
 describe("progress narration", () => {
+  it("omits the implicit progress label when narration is available", () => {
+    const text = formatChannelProgressDraftText({
+      entry: { streaming: { mode: "progress" } },
+      lines: ["🛠️ Exec"],
+      narration: "Counting lines in the workspace files.",
+    });
+
+    expect(text).toBe("Counting lines in the workspace files.");
+  });
+
+  it("keeps an explicitly configured automatic label above narration", () => {
+    const text = formatChannelProgressDraftText({
+      entry: {
+        streaming: {
+          mode: "progress",
+          progress: { label: "auto", labels: ["Clawing"] },
+        },
+      },
+      lines: ["🛠️ Exec"],
+      narration: "Counting lines in the workspace files.",
+    });
+
+    expect(text).toBe("Clawing\n\nCounting lines in the workspace files.");
+  });
+
   it("renders narration instead of tool lines", () => {
     const text = formatChannelProgressDraftText({
       entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -1240,13 +1240,17 @@ export function formatChannelProgressDraftText(params: {
   /** Short narration paragraph; when present it replaces the tool lines. */
   narration?: string;
 }): string {
-  const rawLabel = resolveChannelProgressDraftLabel({
-    entry: params.entry,
-    seed: params.seed,
-    random: params.random,
-  });
-  const resolvedLabel = rawLabel;
   const narration = params.narration ? compactChannelProgressDraftNarration(params.narration) : "";
+  const progress = resolveChannelProgressDraftConfig(params.entry);
+  const hasConfiguredLabel = progress.label !== undefined || progress.labels !== undefined;
+  const resolvedLabel =
+    narration && !hasConfiguredLabel
+      ? undefined
+      : resolveChannelProgressDraftLabel({
+          entry: params.entry,
+          seed: params.seed,
+          random: params.random,
+        });
   if (narration) {
     const formatted = (params.formatLine ?? ((line: string) => line))(narration);
     return resolvedLabel ? `${resolvedLabel}\n\n${formatted}` : formatted;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users receiving narrated channel progress would immediately see a temporary status message with a redundant automatic title such as `Clawing`, even when the operation completed quickly.

## Why This Change Was Made

Narration now waits behind the existing five-second activity gate and replaces the raw tool rows without the implicit automatic title. Explicit custom and `auto` label configuration remains unchanged.

## User Impact

Fast turns no longer flash a progress draft. Longer turns show only the agent's plain-language progress line by default, while operators who explicitly configured a title still get it.

## Evidence

- Blacksmith Testbox focused suite: 150 tests passed across channel streaming, progress compositor, and Discord delivery.
- Behavior timing probes: no draft at 4,999 ms; narration-only draft at 5,000 ms.
- `pnpm check:changed`: formatting, SDK API baseline, core and extension typechecks, lint, and repository guards passed.
- Focused exact-head Testbox run: https://github.com/openclaw/openclaw/actions/runs/29204118198
