### PR TITLE
test(agents): satisfy LTS session lock lint

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -98,7 +98,9 @@ describe("embedded attempt session lock lifecycle", () => {
       });
 
     await nestedWriteStarted;
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
     const settledBeforeNestedWrite = parentSettled;
     finishNestedWrite();
     await Promise.all([parentWrite, nestedWrite]);
@@ -148,7 +150,9 @@ describe("embedded attempt session lock lifecycle", () => {
       });
 
     await nestedWriteStarted;
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
     const settledBeforeNestedWrite = parentSettled;
     const releasedBeforeNestedWrite = releaseOwned.mock.calls.length;
     finishNestedWrite();
@@ -199,7 +203,9 @@ describe("embedded attempt session lock lifecycle", () => {
       });
 
     await nestedWriteStarted;
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
     const settledBeforeNestedWrite = parentSettled;
     finishNestedWrite();
     await Promise.all([parentWrite, nestedWrite]);
@@ -254,7 +260,9 @@ describe("embedded attempt session lock lifecycle", () => {
 
     await ownedReleaseStarted;
     startLateWrite();
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
     const settledBeforeRelease = lateWriteSettled;
     const acquisitionsBeforeRelease = acquireSessionWriteLockLocal.mock.calls.length;
     finishOwnedRelease();


### PR DESCRIPTION
## What Problem This Solves

The LTS session-lock fix landed with four test-only `no-promise-executor-return` lint failures because concise Promise executors returned `setImmediate()` handles.

Failed check: https://github.com/openclaw/openclaw/actions/runs/29204243048/job/86680819646

## Why This Change Was Made

Use block-bodied Promise executors so the test callbacks return `void` and satisfy the repository lint contract.

## User Impact

No runtime behavior change. Restores a green LTS branch after the session-lock fix.

## Evidence

- Targeted `oxlint` on `attempt.session-lock.test.ts`: clean.
- Targeted oxfmt and `git diff --check`: clean.
- The prior exact-head CI run had green runtime tests, prod/test types, boundaries, and all other relevant shards; only these four lint diagnostics failed.
