### PR TITLE
fix: usage page fails while session cache refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI usage refresh:** preserve pending session rows while the background usage cache refreshes, preventing cold or stale caches from failing the Usage page.
 - **SQLite maintenance schema validation:** reject current-version global and agent databases with missing or drifted canonical tables, constraints, indexes, triggers, or table options before compaction, while accepting supported additive-migration layouts.
 - **iOS Watch relay commands:** allow paired iPhone nodes to advertise and invoke `watch.status` and `watch.notify` through the default Gateway policy while preserving the direct watchOS node's fixed minimal command surface.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI usage refresh:** preserve pending session rows while the background usage cache refreshes, preventing cold or stale caches from failing the Usage page.
 - **SQLite maintenance schema validation:** reject current-version global and agent databases with missing or drifted canonical tables, constraints, indexes, triggers, or table options before compaction, while accepting supported additive-migration layouts.
 - **iOS Watch relay commands:** allow paired iPhone nodes to advertise and invoke `watch.status` and `watch.notify` through the default Gateway policy while preserving the direct watchOS node's fixed minimal command surface.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -284,7 +284,7 @@ describe("sessions.usage", () => {
     expect(expectDefined(sessions[0], "sessions[0] test invariant").agentId).toBe("opus");
   });
 
-  it("loads selected session summaries in one batched cache read and reports refresh status", async () => {
+  it("returns pending cache rows with null usage while refresh runs", async () => {
     vi.mocked(discoverAllSessions).mockResolvedValueOnce([
       {
         sessionId: "s-a",
@@ -304,7 +304,10 @@ describe("sessions.usage", () => {
     ]);
     vi.mocked(loadSessionCostSummariesFromCache).mockImplementation(async ({ sessions }) => ({
       summaries: sessions.map((session) => {
-        const tokens = session.sessionId === "s-a" ? 10 : session.sessionId === "s-b" ? 20 : 30;
+        if (session.sessionId === "s-c") {
+          return null;
+        }
+        const tokens = session.sessionId === "s-a" ? 10 : 20;
         return {
           input: tokens,
           output: 0,
@@ -339,7 +342,12 @@ describe("sessions.usage", () => {
     };
     expect(result.cacheStatus?.status).toBe("refreshing");
     expect(result.sessions.map((session) => session.sessionId)).toEqual(["s-a", "s-b", "s-c"]);
-    expect(result.totals.totalTokens).toBe(60);
+    expect(result.sessions.map((session) => session.usage?.totalTokens ?? null)).toEqual([
+      10,
+      20,
+      null,
+    ]);
+    expect(result.totals.totalTokens).toBe(30);
   });
 
   it("passes the requested timezone offset to session daily summaries", async () => {

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -1445,7 +1445,8 @@ export const usageHandlers: GatewayRequestHandlers = {
 
     for (const [entryIndex, merged] of mergedEntries.entries()) {
       const agentId = merged.agentId;
-      const usage = usageByEntryIndex[entryIndex];
+      // A cold or stale cache intentionally yields null until its background refresh completes.
+      const usage = usageByEntryIndex[entryIndex] ?? null;
 
       if (usage) {
         addCostUsageTotals(aggregateTotals, usage);
@@ -1594,7 +1595,7 @@ export const usageHandlers: GatewayRequestHandlers = {
           providerOverride: merged.storeEntry?.providerOverride,
           modelProvider: merged.storeEntry?.modelProvider,
           model: merged.storeEntry?.model,
-          usage: expectDefined(usage, "session usage summary"),
+          usage,
           contextWeight: includeContextWeight
             ? (merged.storeEntry?.systemPromptReport ?? null)
             : undefined,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users refreshing the Usage page would see `expected session usage summary to be defined` when a cold or stale session-usage cache was still rebuilding in the background.

## Why This Change Was Made

The Gateway now preserves pending session rows with `usage: null`, matching the public response type and the Control UI's existing pending-data handling. Aggregate totals continue to include only summaries that are available, and the focused cache test now covers the mixed ready/pending case.

## User Impact

The Usage page loads and reports its refresh state instead of failing while session usage data is being rebuilt. Pending rows fill in normally after the background refresh completes.

## Evidence

- Reproduced the red Usage-page error in the existing Chrome profile against current `main` before the fix.
- Before-fix regression proof: the focused Gateway test failed with `expected session usage summary to be defined` for a legitimate pending cache row.
- Black-box Gateway proof on Testbox `tbx_01kxbs0s5mdbdmhz13r731xhhp`: first uncached request succeeded with one pending row and `refreshing`; retry succeeded with zero pending rows and `fresh`; empty-range request also succeeded.
- Mocked Control UI browser proof: pending-cache warning rendered, no danger/error callout appeared, and the expected `sessions.usage` request was observed.
- Latest-base focused proof on Testbox `tbx_01kxbsmmyskxsqyhcyx9ys1fv1` ([run 29204077369](https://github.com/openclaw/openclaw/actions/runs/29204077369)): 46 Gateway tests and 9 Usage UI/cache tests passed.
- `pnpm build` and `pnpm check:changed` passed on Testbox; the latter covered formatting, core/test typechecks, lint, and repository guards.
- Fresh autoreview: clean, no accepted/actionable findings; patch judged correct at 0.94 confidence.

AI-assisted change; implementation and validation were inspected before submission.
