### PR TITLE
fix(media): parse local file extensions across path styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Cross-platform media paths:** parse local media extensions from the final filename segment for both POSIX and Windows path styles, preventing dotted Windows directories from being mistaken for file extensions. (#105439, #105614) Thanks @xiaobao-k8s.
 - **Provider network retries:** align provider read/poll/download and agent-wait recovery for transient connection errors, retry bounded provider `ENOTFOUND` failures while leaving gateway `ENOTFOUND` and non-idempotent create operations fail-fast. (#101496) Thanks @xialonglee.
 - **Session retry classification:** stop permanent provider errors whose identifiers or payload details merely contain 429/5xx digit sequences from re-sending full context, and share bounded rate-limit-window parsing across retry paths. (#105258) Thanks @destire-mio.
 - **LINE directive templates:** suppress confirms and buttons with blank required fields or unlabeled actions while preserving valid titleless buttons and surrounding reply text. (#105520) Thanks @edenfunf.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Cross-platform media paths:** parse local media extensions from the final filename segment for both POSIX and Windows path styles, preventing dotted Windows directories from being mistaken for file extensions. (#105439, #105614) Thanks @xiaobao-k8s.
 - **Provider network retries:** align provider read/poll/download and agent-wait recovery for transient connection errors, retry bounded provider `ENOTFOUND` failures while leaving gateway `ENOTFOUND` and non-idempotent create operations fail-fast. (#101496) Thanks @xialonglee.
 - **Session retry classification:** stop permanent provider errors whose identifiers or payload details merely contain 429/5xx digit sequences from re-sending full context, and share bounded rate-limit-window parsing across retry paths. (#105258) Thanks @destire-mio.
 - **LINE directive templates:** suppress confirms and buttons with blank required fields or unlabeled actions while preserving valid titleless buttons and surrounding reply text. (#105520) Thanks @edenfunf.

--- a/packages/media-core/src/mime.test.ts
+++ b/packages/media-core/src/mime.test.ts
@@ -209,6 +209,8 @@ describe("getFileExtension", () => {
     { filePath: "https://cdn.example.com/bad%ZZ%2Emp4", expected: undefined },
     { filePath: "https://cdn.example.com/render%2Emp4/", expected: undefined },
     { filePath: String.raw`C:\media\clip.MP4`, expected: ".mp4" },
+    { filePath: String.raw`C:\media.folder\clip`, expected: undefined },
+    { filePath: String.raw`C:\media.folder\clip.MP4`, expected: ".mp4" },
   ] as const)("extracts $expected from $filePath", ({ filePath, expected }) => {
     expect(getFileExtension(filePath)).toBe(expected);
   });

--- a/packages/media-core/src/mime.ts
+++ b/packages/media-core/src/mime.ts
@@ -1,6 +1,7 @@
 // Media Core module implements mime behavior.
 import path from "node:path";
 import { type MediaKind, mediaKindFromMime } from "./constants.js";
+import { extnameFromAnyPath } from "./file-name.js";
 import { createLazyImportLoader } from "./lazy-import.js";
 
 /** Maximum byte prefix passed to dependency MIME sniffers for bounded memory/CPU work. */
@@ -157,7 +158,7 @@ export function getFileExtension(filePath?: string | null): string | undefined {
   } catch {
     // fall back to plain path parsing
   }
-  const ext = path.extname(filePath).toLowerCase();
+  const ext = extnameFromAnyPath(filePath).toLowerCase();
   return ext || undefined;
 }
 


### PR DESCRIPTION
Closes #105439

## What Problem This Solves

On Linux and macOS, host-native `path.extname()` can misread a dotted directory in a Windows-style local path as the file extension. An extensionless path such as `C:\\media.folder\\clip` could therefore produce a corrupted extension.

## Why This Change Was Made

The final patch reuses media-core's existing `extnameFromAnyPath()` helper for local paths. That helper owns cross-platform filename segmentation; the dedicated HTTP URL pathname/decoding branch is unchanged.

## User Impact

Shared media MIME detection and Plugin SDK consumers now parse the final filename segment correctly across POSIX and Windows path styles.

Release-note context: **Cross-platform media paths:** parse local media extensions from the final filename segment for both path styles, preventing dotted Windows directories from being mistaken for file extensions. Thanks @xiaobao-k8s.

## Evidence

- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29214240134
- `pnpm test packages/media-core/src/mime.test.ts` — 121 tests passed.
- `pnpm check:changed` — passed, including Plugin SDK baseline, tsgo, lint, import-cycle, and boundary guards.
- Fresh autoreview — clean, no actionable findings.
- Tests cover both the dotted-directory false positive and a valid `.MP4` filename under the same directory.

## Risk

Low. Only plain local-path parsing changes, through an existing canonical helper; URL behavior is unchanged.
