### PR TITLE
feat: add exact-turn capability projection reports

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -93,6 +93,7 @@ import {
 } from "../../../trajectory/metadata.js";
 import {
   createTrajectoryRuntimeRecorder,
+  recordTrajectoryToolResult,
   toTrajectoryToolDefinitions,
 } from "../../../trajectory/runtime.js";
 import { resolveUserPath } from "../../../utils.js";
@@ -3960,7 +3961,10 @@ export async function runEmbeddedAttempt(
           shouldEmitToolOutput: params.shouldEmitToolOutput,
           sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
           hasDeliveredMessageToolOnlySourceReply: () => didDeliverSourceReplyViaMessageTool,
-          onAgentToolResult: params.onAgentToolResult,
+          onAgentToolResult: (event) => {
+            recordTrajectoryToolResult(trajectoryRecorder, event);
+            params.onAgentToolResult?.(event);
+          },
           onToolResult: params.onToolResult,
           onReasoningStream: params.onReasoningStream,
           streamReasoningInNonStreamModes: params.streamReasoningInNonStreamModes,

--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   sessionsTailCommand: vi.fn(),
   sessionsCompactCommand: vi.fn(),
   exportTrajectoryCommand: vi.fn(),
+  capabilityProjectionCommand: vi.fn(),
   commitmentsListCommand: vi.fn(),
   commitmentsDismissCommand: vi.fn(),
   tasksListCommand: vi.fn(),
@@ -37,6 +38,7 @@ const sessionsCleanupCommand = mocks.sessionsCleanupCommand;
 const sessionsTailCommand = mocks.sessionsTailCommand;
 const sessionsCompactCommand = mocks.sessionsCompactCommand;
 const exportTrajectoryCommand = mocks.exportTrajectoryCommand;
+const capabilityProjectionCommand = mocks.capabilityProjectionCommand;
 const commitmentsListCommand = mocks.commitmentsListCommand;
 const commitmentsDismissCommand = mocks.commitmentsDismissCommand;
 const tasksListCommand = mocks.tasksListCommand;
@@ -105,6 +107,10 @@ vi.mock("../../commands/export-trajectory.js", () => ({
   exportTrajectoryCommand: mocks.exportTrajectoryCommand,
 }));
 
+vi.mock("../../commands/capability-projection.js", () => ({
+  capabilityProjectionCommand: mocks.capabilityProjectionCommand,
+}));
+
 vi.mock("../../commands/commitments.js", () => ({
   commitmentsListCommand: mocks.commitmentsListCommand,
   commitmentsDismissCommand: mocks.commitmentsDismissCommand,
@@ -150,6 +156,7 @@ describe("registerStatusHealthSessionsCommands", () => {
     sessionsTailCommand.mockResolvedValue(undefined);
     sessionsCompactCommand.mockResolvedValue(undefined);
     exportTrajectoryCommand.mockResolvedValue(undefined);
+    capabilityProjectionCommand.mockResolvedValue(undefined);
     commitmentsListCommand.mockResolvedValue(undefined);
     commitmentsDismissCommand.mockResolvedValue(undefined);
     tasksListCommand.mockResolvedValue(undefined);
@@ -473,6 +480,37 @@ describe("registerStatusHealthSessionsCommands", () => {
     expectCommandOptions(exportTrajectoryCommand, {
       requestJsonBase64: "eyJzZXNzaW9uS2V5IjoiYWdlbnQ6bWFpbjp0ZWxlZ3JhbTpkaXJlY3Q6b3duZXIifQ",
       json: true,
+    });
+  });
+
+  it("runs sessions capability-projection with explicit read-only inputs", async () => {
+    await runCli([
+      "sessions",
+      "--agent",
+      "main",
+      "capability-projection",
+      "--session-key",
+      "agent:main:discord:channel:synthetic",
+      "--run-id",
+      "run-synthetic",
+      "--window-start",
+      "2026-07-12T15:59:00Z",
+      "--window-end",
+      "2026-07-12T16:01:00Z",
+      "--evidence-file",
+      "/tmp/evidence.json",
+      "--output-root",
+      "/tmp/output",
+    ]);
+
+    expectCommandOptions(capabilityProjectionCommand, {
+      sessionKey: "agent:main:discord:channel:synthetic",
+      agent: "main",
+      runId: "run-synthetic",
+      windowStart: "2026-07-12T15:59:00Z",
+      windowEnd: "2026-07-12T16:01:00Z",
+      evidenceFile: "/tmp/evidence.json",
+      outputRoot: "/tmp/output",
     });
   });
 

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -357,6 +357,47 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     });
 
   sessionsCmd
+    .command("capability-projection")
+    .description("Generate a deterministic capability projection report from sanitized evidence")
+    .requiredOption("--session-key <key>", "Session key to inspect")
+    .option("--agent <id>", "Agent id for resolving the session store")
+    .option("--store <path>", "Path to session store (default: resolved from the agent)")
+    .option("--run-id <id>", "Select the exact context.compiled run id")
+    .option("--event-sequence <number>", "Select the exact context.compiled event sequence")
+    .requiredOption("--window-start <rfc3339>", "Start of the evidence/selection window")
+    .requiredOption("--window-end <rfc3339>", "End of the evidence/selection window")
+    .requiredOption("--evidence-file <path>", "Closed sanitized-evidence JSON array")
+    .requiredOption("--output-root <path>", "Approved root containing generated reports")
+    .option(
+      "--output-dir <path>",
+      "Output directory (default: <output-root>/reports/capability-projection)",
+    )
+    .option("--workspace <path>", "Workspace identity recorded in the report")
+    .action(async (opts, command) => {
+      const parentOpts = command.parent?.opts() as { store?: string; agent?: string } | undefined;
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const { capabilityProjectionCommand } =
+          await import("../../commands/capability-projection.js");
+        await capabilityProjectionCommand(
+          {
+            sessionKey: opts.sessionKey as string,
+            agent: (opts.agent as string | undefined) ?? parentOpts?.agent,
+            store: (opts.store as string | undefined) ?? parentOpts?.store,
+            runId: opts.runId as string | undefined,
+            eventSequence: opts.eventSequence as string | undefined,
+            windowStart: opts.windowStart as string | undefined,
+            windowEnd: opts.windowEnd as string | undefined,
+            evidenceFile: opts.evidenceFile as string,
+            outputRoot: opts.outputRoot as string,
+            outputDir: opts.outputDir as string | undefined,
+            workspace: opts.workspace as string | undefined,
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  sessionsCmd
     .command("compact <key>")
     .description("Compact a stored session transcript via the running gateway")
     .option("--agent <id>", "Agent id that owns the session (required for global keys)")

--- a/src/commands/capability-projection-collectors.ts
+++ b/src/commands/capability-projection-collectors.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { readSafeTranscriptToolResultEvents } from "../trajectory/export.js";
 import type { TrajectoryEvent } from "../trajectory/types.js";
 import type {
   CapabilityName,
@@ -351,8 +350,11 @@ function successfulResult(
   runId: string,
   expected: ExpectedTrajectoryContext,
 ): SafeExistingToolResult | null {
+  // Transcript timestamps do not prove run ownership. Only runtime events with
+  // the selected run identity may upgrade callability to verified.
   if (
-    (event.source === "runtime" ? event.runId !== runId : event.source !== "transcript") ||
+    event.source !== "runtime" ||
+    event.runId !== runId ||
     event.sessionId !== expected.sessionId ||
     event.sessionKey !== expected.sessionKey ||
     event.type !== "tool.result" ||
@@ -375,9 +377,7 @@ function successfulResult(
         ? event.data.toolName
         : null;
   const success =
-    event.data.success === true ||
-    (event.source === "transcript" && event.data.isError !== true) ||
-    (event.data.isError !== true && event.data.status === "ok");
+    event.data.success === true || (event.data.isError !== true && event.data.status === "ok");
   return toolName && success ? { ts: event.ts, runId, toolName, success: true } : null;
 }
 
@@ -389,7 +389,6 @@ export async function collectExactTurnFromTrajectory(
   trajectoryPath: string,
   selection: ExactTurnSelection,
   expected: ExpectedTrajectoryContext,
-  transcriptPath?: string,
 ): Promise<TrajectoryCollection> {
   try {
     const evidenceWindowStart = Date.parse(expected.evidenceWindow.start);
@@ -425,31 +424,9 @@ export async function collectExactTurnFromTrajectory(
       return { compiled: null, successfulToolResults: [], errorCode: "EVIDENCE_COLLECTION_FAILED" };
     }
     const lines = (await fs.readFile(trajectoryPath, "utf8")).split("\n");
-    const runtimeEvents = lines.flatMap((line) => {
+    const events = lines.flatMap((line) => {
       const event = parseEvent(line);
       return event ? [event] : [];
-    });
-    const transcriptEvents = transcriptPath
-      ? await readSafeTranscriptToolResultEvents({
-          sessionFile: transcriptPath,
-          sessionId: expected.sessionId,
-          sessionKey: expected.sessionKey,
-        })
-      : [];
-    const sourceOrder: Record<TrajectoryEvent["source"], number> = {
-      runtime: 0,
-      transcript: 1,
-      export: 2,
-    };
-    const events = [...runtimeEvents, ...transcriptEvents].toSorted((left, right) => {
-      const byTimestamp = Date.parse(left.ts) - Date.parse(right.ts);
-      if (byTimestamp !== 0) {
-        return byTimestamp;
-      }
-      const bySource = sourceOrder[left.source] - sourceOrder[right.source];
-      return bySource !== 0
-        ? bySource
-        : (left.sourceSeq ?? left.seq) - (right.sourceSeq ?? right.seq);
     });
     const candidates = events.flatMap((event, index) => {
       const compiled = toCompiled(event);

--- a/src/commands/capability-projection-collectors.ts
+++ b/src/commands/capability-projection-collectors.ts
@@ -1,0 +1,431 @@
+import fs from "node:fs/promises";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { TrajectoryEvent } from "../trajectory/types.js";
+import type {
+  CapabilityName,
+  EvidenceRecord,
+  EvidenceState,
+  MutationRisk,
+  ToolFact,
+} from "./capability-projection-model.js";
+
+export type SafeCompiledContext = {
+  ts: string;
+  seq: number;
+  sessionId: string;
+  sessionKey: string;
+  runId: string | null;
+  toolNames: string[];
+};
+
+export type SafeExistingToolResult = {
+  ts: string;
+  runId: string;
+  toolName: string;
+  success: true;
+};
+
+export type ExactTurnSelection =
+  | { mode: "exact_run_id"; runId: string }
+  | { mode: "exact_event_sequence"; sequence: number }
+  | { mode: "latest_in_window"; start: string; end: string };
+
+export type TrajectoryCollection = {
+  compiled: SafeCompiledContext | null;
+  successfulToolResults: SafeExistingToolResult[];
+  errorCode?:
+    | "MISSING_SESSION_PROJECTION"
+    | "AMBIGUOUS_SESSION_PROJECTION"
+    | "EVIDENCE_COLLECTION_FAILED";
+};
+
+const MAX_TRAJECTORY_BYTES = 50 * 1024 * 1024;
+
+const BASE_TOOL_CATALOG: Array<{
+  capability: CapabilityName;
+  name: string;
+  mutationRisk: MutationRisk;
+}> = [
+  { capability: "goal_tools", name: "create_goal", mutationRisk: "mutating" },
+  { capability: "goal_tools", name: "get_goal", mutationRisk: "read_only" },
+  { capability: "goal_tools", name: "update_goal", mutationRisk: "mutating" },
+  { capability: "llm_task", name: "llm_task", mutationRisk: "mutating" },
+  { capability: "task_flow", name: "task_flow_list", mutationRisk: "read_only" },
+  { capability: "task_flow", name: "task_flow_show", mutationRisk: "read_only" },
+  { capability: "task_flow", name: "task_flow_cancel", mutationRisk: "mutating" },
+  { capability: "commitments", name: "commitments_list", mutationRisk: "read_only" },
+  { capability: "commitments", name: "commitments_dismiss", mutationRisk: "mutating" },
+  { capability: "browser", name: "browser", mutationRisk: "mutating" },
+  { capability: "memory", name: "memory_get", mutationRisk: "privacy_sensitive_read" },
+  { capability: "memory", name: "memory_search", mutationRisk: "privacy_sensitive_read" },
+  { capability: "messaging", name: "message", mutationRisk: "mutating" },
+  { capability: "shell_execution", name: "exec", mutationRisk: "mutating" },
+  { capability: "shell_execution", name: "process", mutationRisk: "mutating" },
+  { capability: "readiness_health", name: "readiness_health", mutationRisk: "read_only" },
+];
+
+export function classifyCapabilityToolName(
+  name: string,
+): { capability: CapabilityName; mutationRisk: MutationRisk } | null {
+  if (name.startsWith("workboard_")) {
+    return {
+      capability: "workboard",
+      mutationRisk: /(?:list|get|read|search|status)/u.test(name) ? "read_only" : "mutating",
+    };
+  }
+  if (name.startsWith("llm_task")) {
+    return { capability: "llm_task", mutationRisk: "mutating" };
+  }
+  if (name.startsWith("hook")) {
+    return { capability: "hooks", mutationRisk: "unknown" };
+  }
+  if (name === "Bash" || name === "shell" || name.startsWith("exec")) {
+    return { capability: "shell_execution", mutationRisk: "mutating" };
+  }
+  if (name === "gateway_health" || name === "readiness_canary") {
+    return { capability: "readiness_health", mutationRisk: "read_only" };
+  }
+  return BASE_TOOL_CATALOG.find((entry) => entry.name === name) ?? null;
+}
+
+function state(
+  value: EvidenceState["value"],
+  basis: EvidenceState["basis"],
+  evidenceRefs: string[],
+): EvidenceState {
+  return { value, basis, evidenceRefs: [...new Set(evidenceRefs)].sort() };
+}
+
+function booleanField(fields: EvidenceRecord["fields"], name: string): boolean | null {
+  const value = fields[name];
+  return typeof value === "boolean" ? value : null;
+}
+
+function stringArrayField(fields: EvidenceRecord["fields"], name: string): string[] {
+  const value = fields[name];
+  return Array.isArray(value) && value.every((item) => typeof item === "string") ? value : [];
+}
+
+/** Builds tool facts only from already-sanitized, closed evidence records. */
+export function collectToolFactsFromSanitizedEvidence(params: {
+  evidence: EvidenceRecord[];
+  compiled: SafeCompiledContext | null;
+  evidenceWindow: { start: string; end: string };
+}): ToolFact[] {
+  const windowStart = Date.parse(params.evidenceWindow.start);
+  const windowEnd = Date.parse(params.evidenceWindow.end);
+  const isTemporallyAligned = (record: EvidenceRecord): boolean => {
+    if (record.status !== "collected" || !record.observedAt) {
+      return false;
+    }
+    const observedAt = Date.parse(record.observedAt);
+    return (
+      Number.isFinite(observedAt) &&
+      observedAt >= windowStart &&
+      observedAt <= windowEnd &&
+      (record.periodRelation === "exact_turn" || record.periodRelation === "same_period")
+    );
+  };
+  const targetEvidence = params.evidence.filter(isTemporallyAligned);
+  const names = new Set(BASE_TOOL_CATALOG.map((entry) => entry.name));
+  for (const record of targetEvidence) {
+    for (const field of ["toolNames", "allowedToolNames", "deniedToolNames"]) {
+      for (const name of stringArrayField(record.fields, field)) {
+        if (classifyCapabilityToolName(name)) {
+          names.add(name);
+        }
+      }
+    }
+  }
+  for (const name of params.compiled?.toolNames ?? []) {
+    if (classifyCapabilityToolName(name)) {
+      names.add(name);
+    }
+  }
+  return [...names]
+    .sort((a, b) => a.localeCompare(b))
+    .flatMap<ToolFact>((name) => {
+      const classification = classifyCapabilityToolName(name);
+      if (!classification) {
+        return [];
+      }
+      const config = targetEvidence.filter(
+        (record) =>
+          record.kind === "raw_config" && record.fields.capability === classification.capability,
+      );
+      const runtime = targetEvidence.filter(
+        (record) =>
+          record.kind === "plugin_runtime" &&
+          stringArrayField(record.fields, "toolNames").includes(name),
+      );
+      const policy = targetEvidence.filter((record) => record.kind === "effective_policy");
+      const allowed = policy.some((record) =>
+        stringArrayField(record.fields, "allowedToolNames").includes(name),
+      );
+      const denied = policy.some((record) =>
+        stringArrayField(record.fields, "deniedToolNames").includes(name),
+      );
+      const registry = targetEvidence.some(
+        (record) =>
+          record.kind === "derived_registry" &&
+          stringArrayField(record.fields, "toolNames").includes(name),
+      );
+      const selfReport = targetEvidence.some(
+        (record) =>
+          record.kind === "agent_self_report" &&
+          stringArrayField(record.fields, "toolNames").includes(name),
+      );
+      const configuredValues = config
+        .map(
+          (record) =>
+            booleanField(record.fields, "configured") ?? booleanField(record.fields, "enabled"),
+        )
+        .filter((value): value is boolean => value !== null);
+      const runtimeValues = runtime
+        .map((record) => booleanField(record.fields, "loaded"))
+        .filter((value): value is boolean => value !== null);
+      const configEnabledValues = config
+        .map((record) => booleanField(record.fields, "enabled"))
+        .filter((value): value is boolean => value !== null);
+      const runtimeEnabledValues = runtime
+        .map((record) => booleanField(record.fields, "enabled"))
+        .filter((value): value is boolean => value !== null);
+      const configured = resolveBooleanEvidenceState(
+        configuredValues,
+        config.map((record) => record.id),
+      );
+      const runtimeLoaded = resolveBooleanEvidenceState(
+        runtimeValues,
+        runtime.map((record) => record.id),
+      );
+      const policyAllowed =
+        allowed && denied
+          ? {
+              ...state(
+                "unknown",
+                "none",
+                policy.map((record) => record.id),
+              ),
+              reasonCode: "CONFLICTING_EVIDENCE",
+            }
+          : denied
+            ? state(
+                "false",
+                "direct",
+                policy.map((record) => record.id),
+              )
+            : allowed
+              ? state(
+                  "true",
+                  "direct",
+                  policy.map((record) => record.id),
+                )
+              : state("unknown", "none", []);
+      const evidencePeriodMismatch = params.evidence.some((record) => {
+        if (isTemporallyAligned(record)) {
+          return false;
+        }
+        if (record.kind === "raw_config") {
+          return record.fields.capability === classification.capability;
+        }
+        return ["toolNames", "allowedToolNames", "deniedToolNames"].some((field) =>
+          stringArrayField(record.fields, field).includes(name),
+        );
+      });
+      return [
+        {
+          capability: classification.capability,
+          name,
+          mutationRisk: classification.mutationRisk,
+          configured,
+          runtimeLoaded,
+          policyAllowed,
+          turnProjected: state("unknown", "none", []),
+          disabled:
+            configEnabledValues.includes(false) &&
+            !configEnabledValues.includes(true) &&
+            runtimeEnabledValues.includes(false) &&
+            !runtimeEnabledValues.includes(true),
+          derivedRegistryLoaded: registry,
+          selfReportedCallable: selfReport,
+          evidencePeriodMismatch,
+        },
+      ];
+    });
+}
+
+function resolveBooleanEvidenceState(values: boolean[], evidenceRefs: string[]): EvidenceState {
+  const unique = new Set(values);
+  if (unique.size === 0) {
+    return state("unknown", "none", []);
+  }
+  if (unique.size > 1) {
+    return {
+      ...state("unknown", "none", evidenceRefs),
+      reasonCode: "CONFLICTING_EVIDENCE",
+    };
+  }
+  return state(values[0] ? "true" : "false", "direct", evidenceRefs);
+}
+
+function parseEvent(line: string): TrajectoryEvent | null {
+  try {
+    const value = JSON.parse(line) as unknown;
+    if (
+      !isRecord(value) ||
+      value.traceSchema !== "openclaw-trajectory" ||
+      value.schemaVersion !== 1 ||
+      typeof value.type !== "string" ||
+      typeof value.ts !== "string" ||
+      typeof value.seq !== "number" ||
+      typeof value.sessionId !== "string"
+    ) {
+      return null;
+    }
+    return value as TrajectoryEvent;
+  } catch {
+    return null;
+  }
+}
+
+function safeToolNames(data: Record<string, unknown> | undefined): string[] {
+  if (!Array.isArray(data?.tools)) {
+    return [];
+  }
+  return [
+    ...new Set(
+      data.tools.flatMap((item) =>
+        isRecord(item) && typeof item.name === "string" ? [item.name] : [],
+      ),
+    ),
+  ].sort();
+}
+
+function toCompiled(event: TrajectoryEvent): SafeCompiledContext | null {
+  if (event.type !== "context.compiled" || typeof event.sessionKey !== "string") {
+    return null;
+  }
+  return {
+    ts: event.ts,
+    seq: event.sourceSeq ?? event.seq,
+    sessionId: event.sessionId,
+    sessionKey: event.sessionKey,
+    runId: event.runId ?? null,
+    toolNames: safeToolNames(event.data),
+  };
+}
+
+function matchesSelection(event: SafeCompiledContext, selection: ExactTurnSelection): boolean {
+  if (selection.mode === "exact_run_id") {
+    return event.runId === selection.runId;
+  }
+  if (selection.mode === "exact_event_sequence") {
+    return event.seq === selection.sequence;
+  }
+  const timestamp = Date.parse(event.ts);
+  return timestamp >= Date.parse(selection.start) && timestamp <= Date.parse(selection.end);
+}
+
+function successfulResult(
+  event: TrajectoryEvent,
+  runId: string,
+  expected: { sessionId: string; sessionKey: string },
+): SafeExistingToolResult | null {
+  if (
+    event.runId !== runId ||
+    event.sessionId !== expected.sessionId ||
+    event.sessionKey !== expected.sessionKey ||
+    event.type !== "tool.result" ||
+    !isRecord(event.data)
+  ) {
+    return null;
+  }
+  const toolName =
+    typeof event.data.name === "string"
+      ? event.data.name
+      : typeof event.data.toolName === "string"
+        ? event.data.toolName
+        : null;
+  const success =
+    event.data.success === true || (event.data.isError !== true && event.data.status === "ok");
+  return toolName && success ? { ts: event.ts, runId, toolName, success: true } : null;
+}
+
+/**
+ * Reads one bounded trajectory artifact and immediately reduces events to safe
+ * identifiers. No generic tool invocation or runtime mutation interface exists here.
+ */
+export async function collectExactTurnFromTrajectory(
+  trajectoryPath: string,
+  selection: ExactTurnSelection,
+  expected: { sessionId: string; sessionKey: string },
+): Promise<TrajectoryCollection> {
+  try {
+    if (selection.mode === "latest_in_window") {
+      const start = Date.parse(selection.start);
+      const end = Date.parse(selection.end);
+      if (!Number.isFinite(start) || !Number.isFinite(end) || start > end) {
+        return {
+          compiled: null,
+          successfulToolResults: [],
+          errorCode: "EVIDENCE_COLLECTION_FAILED",
+        };
+      }
+    }
+    const stat = await fs.stat(trajectoryPath);
+    if (!stat.isFile() || stat.size > MAX_TRAJECTORY_BYTES) {
+      return { compiled: null, successfulToolResults: [], errorCode: "EVIDENCE_COLLECTION_FAILED" };
+    }
+    const lines = (await fs.readFile(trajectoryPath, "utf8")).split("\n");
+    const events = lines.flatMap((line) => {
+      const event = parseEvent(line);
+      return event ? [event] : [];
+    });
+    const candidates = events.flatMap((event, index) => {
+      const compiled = toCompiled(event);
+      return compiled &&
+        compiled.sessionId === expected.sessionId &&
+        compiled.sessionKey === expected.sessionKey &&
+        matchesSelection(compiled, selection)
+        ? [{ compiled, index }]
+        : [];
+    });
+    const selected =
+      selection.mode === "latest_in_window"
+        ? candidates
+            .sort((a, b) => Date.parse(b.compiled.ts) - Date.parse(a.compiled.ts))
+            .slice(0, 1)
+        : candidates;
+    if (selected.length === 0) {
+      return { compiled: null, successfulToolResults: [], errorCode: "MISSING_SESSION_PROJECTION" };
+    }
+    if (selected.length > 1) {
+      return {
+        compiled: null,
+        successfulToolResults: [],
+        errorCode: "AMBIGUOUS_SESSION_PROJECTION",
+      };
+    }
+    const { compiled, index: compiledIndex } = selected[0];
+    const nextCompilationOffset = events
+      .slice(compiledIndex + 1)
+      .findIndex(
+        (event) =>
+          event.type === "context.compiled" &&
+          event.sessionId === expected.sessionId &&
+          event.sessionKey === expected.sessionKey,
+      );
+    const turnEnd =
+      nextCompilationOffset === -1 ? events.length : compiledIndex + 1 + nextCompilationOffset;
+    const turnEvents = events.slice(compiledIndex + 1, turnEnd);
+    const successfulToolResults = compiled.runId
+      ? turnEvents.flatMap((event) => {
+          const result = successfulResult(event, compiled.runId as string, expected);
+          return result ? [result] : [];
+        })
+      : [];
+    return { compiled, successfulToolResults };
+  } catch {
+    return { compiled: null, successfulToolResults: [], errorCode: "EVIDENCE_COLLECTION_FAILED" };
+  }
+}

--- a/src/commands/capability-projection-collectors.ts
+++ b/src/commands/capability-projection-collectors.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { readSafeTranscriptToolResultEvents } from "../trajectory/export.js";
 import type { TrajectoryEvent } from "../trajectory/types.js";
 import type {
   CapabilityName,
@@ -46,6 +47,19 @@ type ExpectedTrajectoryContext = {
 };
 
 const MAX_TRAJECTORY_BYTES = 50 * 1024 * 1024;
+const READ_ONLY_WORKBOARD_TOOLS = new Set([
+  "workboard_board",
+  "workboard_boards",
+  "workboard_card",
+  "workboard_cards",
+  "workboard_get",
+  "workboard_list",
+  "workboard_run",
+  "workboard_runs",
+  "workboard_search",
+  "workboard_stats",
+  "workboard_status",
+]);
 
 const BASE_TOOL_CATALOG: Array<{
   capability: CapabilityName;
@@ -76,7 +90,7 @@ export function classifyCapabilityToolName(
   if (name.startsWith("workboard_")) {
     return {
       capability: "workboard",
-      mutationRisk: /(?:list|get|read|search|status)/u.test(name) ? "read_only" : "mutating",
+      mutationRisk: READ_ONLY_WORKBOARD_TOOLS.has(name) ? "read_only" : "mutating",
     };
   }
   if (name.startsWith("llm_task")) {
@@ -338,7 +352,7 @@ function successfulResult(
   expected: ExpectedTrajectoryContext,
 ): SafeExistingToolResult | null {
   if (
-    event.runId !== runId ||
+    (event.source === "runtime" ? event.runId !== runId : event.source !== "transcript") ||
     event.sessionId !== expected.sessionId ||
     event.sessionKey !== expected.sessionKey ||
     event.type !== "tool.result" ||
@@ -361,7 +375,9 @@ function successfulResult(
         ? event.data.toolName
         : null;
   const success =
-    event.data.success === true || (event.data.isError !== true && event.data.status === "ok");
+    event.data.success === true ||
+    (event.source === "transcript" && event.data.isError !== true) ||
+    (event.data.isError !== true && event.data.status === "ok");
   return toolName && success ? { ts: event.ts, runId, toolName, success: true } : null;
 }
 
@@ -373,6 +389,7 @@ export async function collectExactTurnFromTrajectory(
   trajectoryPath: string,
   selection: ExactTurnSelection,
   expected: ExpectedTrajectoryContext,
+  transcriptPath?: string,
 ): Promise<TrajectoryCollection> {
   try {
     const evidenceWindowStart = Date.parse(expected.evidenceWindow.start);
@@ -408,9 +425,31 @@ export async function collectExactTurnFromTrajectory(
       return { compiled: null, successfulToolResults: [], errorCode: "EVIDENCE_COLLECTION_FAILED" };
     }
     const lines = (await fs.readFile(trajectoryPath, "utf8")).split("\n");
-    const events = lines.flatMap((line) => {
+    const runtimeEvents = lines.flatMap((line) => {
       const event = parseEvent(line);
       return event ? [event] : [];
+    });
+    const transcriptEvents = transcriptPath
+      ? await readSafeTranscriptToolResultEvents({
+          sessionFile: transcriptPath,
+          sessionId: expected.sessionId,
+          sessionKey: expected.sessionKey,
+        })
+      : [];
+    const sourceOrder: Record<TrajectoryEvent["source"], number> = {
+      runtime: 0,
+      transcript: 1,
+      export: 2,
+    };
+    const events = [...runtimeEvents, ...transcriptEvents].toSorted((left, right) => {
+      const byTimestamp = Date.parse(left.ts) - Date.parse(right.ts);
+      if (byTimestamp !== 0) {
+        return byTimestamp;
+      }
+      const bySource = sourceOrder[left.source] - sourceOrder[right.source];
+      return bySource !== 0
+        ? bySource
+        : (left.sourceSeq ?? left.seq) - (right.sourceSeq ?? right.seq);
     });
     const candidates = events.flatMap((event, index) => {
       const compiled = toCompiled(event);
@@ -426,7 +465,10 @@ export async function collectExactTurnFromTrajectory(
     const selected =
       selection.mode === "latest_in_window"
         ? candidates
-            .sort((a, b) => Date.parse(b.compiled.ts) - Date.parse(a.compiled.ts))
+            .sort((a, b) => {
+              const byTimestamp = Date.parse(b.compiled.ts) - Date.parse(a.compiled.ts);
+              return byTimestamp !== 0 ? byTimestamp : b.compiled.seq - a.compiled.seq;
+            })
             .slice(0, 1)
         : candidates;
     if (selected.length === 0) {

--- a/src/commands/capability-projection-collectors.ts
+++ b/src/commands/capability-projection-collectors.ts
@@ -39,6 +39,12 @@ export type TrajectoryCollection = {
     | "EVIDENCE_COLLECTION_FAILED";
 };
 
+type ExpectedTrajectoryContext = {
+  sessionId: string;
+  sessionKey: string;
+  evidenceWindow: { start: string; end: string };
+};
+
 const MAX_TRAJECTORY_BYTES = 50 * 1024 * 1024;
 
 const BASE_TOOL_CATALOG: Array<{
@@ -329,7 +335,7 @@ function matchesSelection(event: SafeCompiledContext, selection: ExactTurnSelect
 function successfulResult(
   event: TrajectoryEvent,
   runId: string,
-  expected: { sessionId: string; sessionKey: string },
+  expected: ExpectedTrajectoryContext,
 ): SafeExistingToolResult | null {
   if (
     event.runId !== runId ||
@@ -337,6 +343,14 @@ function successfulResult(
     event.sessionKey !== expected.sessionKey ||
     event.type !== "tool.result" ||
     !isRecord(event.data)
+  ) {
+    return null;
+  }
+  const eventTimestamp = Date.parse(event.ts);
+  if (
+    !Number.isFinite(eventTimestamp) ||
+    eventTimestamp < Date.parse(expected.evidenceWindow.start) ||
+    eventTimestamp > Date.parse(expected.evidenceWindow.end)
   ) {
     return null;
   }
@@ -358,13 +372,30 @@ function successfulResult(
 export async function collectExactTurnFromTrajectory(
   trajectoryPath: string,
   selection: ExactTurnSelection,
-  expected: { sessionId: string; sessionKey: string },
+  expected: ExpectedTrajectoryContext,
 ): Promise<TrajectoryCollection> {
   try {
+    const evidenceWindowStart = Date.parse(expected.evidenceWindow.start);
+    const evidenceWindowEnd = Date.parse(expected.evidenceWindow.end);
+    if (
+      !Number.isFinite(evidenceWindowStart) ||
+      !Number.isFinite(evidenceWindowEnd) ||
+      evidenceWindowStart > evidenceWindowEnd
+    ) {
+      return {
+        compiled: null,
+        successfulToolResults: [],
+        errorCode: "EVIDENCE_COLLECTION_FAILED",
+      };
+    }
     if (selection.mode === "latest_in_window") {
-      const start = Date.parse(selection.start);
-      const end = Date.parse(selection.end);
-      if (!Number.isFinite(start) || !Number.isFinite(end) || start > end) {
+      const selectionStart = Date.parse(selection.start);
+      const selectionEnd = Date.parse(selection.end);
+      if (
+        !Number.isFinite(selectionStart) ||
+        !Number.isFinite(selectionEnd) ||
+        selectionStart > selectionEnd
+      ) {
         return {
           compiled: null,
           successfulToolResults: [],
@@ -386,6 +417,8 @@ export async function collectExactTurnFromTrajectory(
       return compiled &&
         compiled.sessionId === expected.sessionId &&
         compiled.sessionKey === expected.sessionKey &&
+        Date.parse(compiled.ts) >= evidenceWindowStart &&
+        Date.parse(compiled.ts) <= evidenceWindowEnd &&
         matchesSelection(compiled, selection)
         ? [{ compiled, index }]
         : [];

--- a/src/commands/capability-projection-model.ts
+++ b/src/commands/capability-projection-model.ts
@@ -1,0 +1,365 @@
+import { createHash } from "node:crypto";
+
+export const CAPABILITY_NAMES = [
+  "goal_tools",
+  "workboard",
+  "llm_task",
+  "task_flow",
+  "commitments",
+  "hooks",
+  "browser",
+  "memory",
+  "messaging",
+  "shell_execution",
+  "readiness_health",
+] as const;
+
+export type CapabilityName = (typeof CAPABILITY_NAMES)[number];
+export type EvidenceValue = "true" | "false" | "unknown" | "not_applicable";
+export type EvidenceBasis = "direct" | "derived" | "historical" | "none";
+export type CallabilityStatus =
+  | "verified_callable_read_only"
+  | "verified_callable_from_existing_turn_evidence"
+  | "projected_not_call_tested"
+  | "projected_but_not_safely_probed"
+  | "not_projected"
+  | "disabled"
+  | "unknown_due_to_evidence_gap";
+export type MutationRisk = "read_only" | "mutating" | "privacy_sensitive_read" | "unknown";
+
+export const MISMATCH_CODES = [
+  "CAPABILITY_MEMBER_STATE_MIXED",
+  "CONFIGURED_NOT_LOADED",
+  "DERIVED_REGISTRY_STALE",
+  "EVIDENCE_COLLECTION_FAILED",
+  "EVIDENCE_PERIOD_MISMATCH",
+  "HISTORICAL_CURRENT_STATE_DIFFERENCE",
+  "LOADED_NOT_CONFIGURED",
+  "LOADED_NOT_POLICY_ALLOWED",
+  "MISSING_SESSION_PROJECTION",
+  "PARTIAL_PLUGIN_INSPECTION",
+  "POLICY_ALLOWED_NOT_PROJECTED",
+  "PROJECTED_NOT_POLICY_ALLOWED",
+  "PROJECTED_NOT_RUNTIME_LOADED",
+  "PROJECTED_NOT_SAFELY_CALL_TESTED",
+  "SELF_REPORT_UNCORROBORATED",
+] as const;
+
+export type MismatchCode = (typeof MISMATCH_CODES)[number];
+
+export type EvidenceState = {
+  value: EvidenceValue;
+  basis: EvidenceBasis;
+  evidenceRefs: string[];
+  reasonCode?: string;
+};
+
+export type ToolRecord = {
+  name: string;
+  membership: "required" | "optional";
+  mutationRisk: MutationRisk;
+  configured: EvidenceState;
+  runtimeLoaded: EvidenceState;
+  policyAllowed: EvidenceState;
+  turnProjected: EvidenceState;
+  callabilityStatus: CallabilityStatus;
+  mismatchCodes: MismatchCode[];
+  mismatchReason: string | null;
+  evidenceRefs: string[];
+};
+
+export type CapabilityRecord = {
+  name: CapabilityName;
+  summary: {
+    configured: EvidenceState;
+    runtimeLoaded: EvidenceState;
+    policyAllowed: EvidenceState;
+    turnProjected: EvidenceState;
+  };
+  callabilityCounts: Partial<Record<CallabilityStatus, number>>;
+  tools: ToolRecord[];
+  mismatchCodes: MismatchCode[];
+  mismatchReason: string | null;
+  evidenceRefs: string[];
+};
+
+export type EvidenceRecord = {
+  id: string;
+  rank: number;
+  kind:
+    | "context_compiled"
+    | "gateway_policy_log"
+    | "plugin_runtime"
+    | "effective_policy"
+    | "health_probe"
+    | "raw_config"
+    | "derived_registry"
+    | "agent_self_report"
+    | "existing_tool_result";
+  source: string;
+  observedAt: string | null;
+  periodRelation: "exact_turn" | "same_period" | "current" | "historical" | "unknown";
+  status: "collected" | "partial" | "failed" | "missing";
+  fields: Record<string, string | number | boolean | null | string[]>;
+  redactionApplied: boolean;
+};
+
+export type CollectionError = {
+  collector: string;
+  code: string;
+  message: string;
+  occurredAt: string;
+  affectedClaims: string[];
+};
+
+export type CapabilityProjectionReport = {
+  schema: "openclaw.capability-projection-report";
+  schemaVersion: 1;
+  reportId: string;
+  generatedAt: string;
+  host: {
+    hostname: string;
+    user: string;
+    uid: number;
+    instanceDir: string;
+    workspaceDir: string;
+  };
+  openclawVersion: { value: string | null; evidenceRefs: string[] };
+  target: {
+    agentId: string;
+    sessionKey: string;
+    sessionId: string | null;
+    runId: string | null;
+    turnSequence: number | null;
+    contextCompiledAt: string | null;
+    selectionMode: "exact_run_id" | "exact_event_sequence" | "latest_in_window" | "unresolved";
+  };
+  evidenceWindow: { start: string; end: string };
+  capabilities: CapabilityRecord[];
+  evidence: EvidenceRecord[];
+  observations: Array<{
+    code: string;
+    period: "current" | "historical";
+    severity: "info" | "watch" | "block";
+    summary: string;
+    evidenceRefs: string[];
+  }>;
+  collectionErrors: CollectionError[];
+  redaction: {
+    policy: "allowlist-before-serialization-v1";
+    excludedFieldClasses: string[];
+    notes: string[];
+  };
+  overallConfidence: { level: "high" | "medium" | "low"; reasonCodes: string[] };
+};
+
+export type ToolFact = {
+  capability: CapabilityName;
+  name: string;
+  membership?: "required" | "optional";
+  mutationRisk: MutationRisk;
+  configured: EvidenceState;
+  runtimeLoaded: EvidenceState;
+  policyAllowed: EvidenceState;
+  turnProjected: EvidenceState;
+  existingSuccessfulCall?: boolean;
+  disabled?: boolean;
+  derivedRegistryLoaded?: boolean;
+  selfReportedCallable?: boolean;
+  evidencePeriodMismatch?: boolean;
+};
+
+const MISMATCH_REASON: Record<MismatchCode, string> = {
+  CAPABILITY_MEMBER_STATE_MIXED: "Capability members have different evidence states.",
+  CONFIGURED_NOT_LOADED:
+    "Configuration enables the tool, but runtime evidence says it is not loaded.",
+  DERIVED_REGISTRY_STALE:
+    "Derived registry evidence conflicts with higher-authority runtime evidence.",
+  EVIDENCE_COLLECTION_FAILED: "A required evidence collector failed.",
+  EVIDENCE_PERIOD_MISMATCH: "Evidence does not describe the selected turn's time period.",
+  HISTORICAL_CURRENT_STATE_DIFFERENCE:
+    "Historical evidence differs from the current health snapshot.",
+  LOADED_NOT_CONFIGURED:
+    "Runtime evidence reports the tool loaded without affirmative configuration evidence.",
+  LOADED_NOT_POLICY_ALLOWED: "The tool is loaded but effective policy does not allow it.",
+  MISSING_SESSION_PROJECTION: "No unambiguous context.compiled event was selected.",
+  PARTIAL_PLUGIN_INSPECTION: "Plugin runtime inspection was incomplete.",
+  POLICY_ALLOWED_NOT_PROJECTED:
+    "Effective policy allows the tool, but the exact turn did not project it.",
+  PROJECTED_NOT_POLICY_ALLOWED:
+    "The exact turn projected the tool despite policy evidence denying it.",
+  PROJECTED_NOT_RUNTIME_LOADED:
+    "The exact turn projected the tool without affirmative runtime-loaded evidence.",
+  PROJECTED_NOT_SAFELY_CALL_TESTED:
+    "The tool is projected but was intentionally not invoked for verification.",
+  SELF_REPORT_UNCORROBORATED: "Agent self-report is not corroborated by higher-authority evidence.",
+};
+
+function sortedUnique(values: Iterable<string>): string[] {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+function stateSummary(states: EvidenceState[]): EvidenceState {
+  if (states.length === 0) {
+    return { value: "unknown", basis: "none", evidenceRefs: [] };
+  }
+  const values = new Set(states.map((state) => state.value));
+  const evidenceRefs = sortedUnique(states.flatMap((state) => state.evidenceRefs));
+  if (values.size === 1) {
+    const state = states[0];
+    return { value: state.value, basis: state.basis, evidenceRefs };
+  }
+  return {
+    value: "unknown",
+    basis: "derived",
+    evidenceRefs,
+    reasonCode: "CAPABILITY_MEMBER_STATE_MIXED",
+  };
+}
+
+function resolveCallability(fact: ToolFact): CallabilityStatus {
+  if (fact.disabled) {
+    return "disabled";
+  }
+  if (fact.turnProjected.value === "false") {
+    return "not_projected";
+  }
+  if (fact.turnProjected.value !== "true") {
+    return "unknown_due_to_evidence_gap";
+  }
+  if (fact.existingSuccessfulCall) {
+    return fact.mutationRisk === "read_only" || fact.mutationRisk === "privacy_sensitive_read"
+      ? "verified_callable_read_only"
+      : "verified_callable_from_existing_turn_evidence";
+  }
+  return fact.mutationRisk === "mutating" || fact.mutationRisk === "privacy_sensitive_read"
+    ? "projected_but_not_safely_probed"
+    : "projected_not_call_tested";
+}
+
+function mismatchCodesForFact(fact: ToolFact, callability: CallabilityStatus): MismatchCode[] {
+  const codes: MismatchCode[] = [];
+  if (fact.configured.value === "true" && fact.runtimeLoaded.value === "false") {
+    codes.push("CONFIGURED_NOT_LOADED");
+  }
+  if (fact.runtimeLoaded.value === "true" && fact.configured.value === "false") {
+    codes.push("LOADED_NOT_CONFIGURED");
+  }
+  if (fact.runtimeLoaded.value === "true" && fact.policyAllowed.value === "false") {
+    codes.push("LOADED_NOT_POLICY_ALLOWED");
+  }
+  if (fact.policyAllowed.value === "true" && fact.turnProjected.value === "false") {
+    codes.push("POLICY_ALLOWED_NOT_PROJECTED");
+  }
+  if (fact.turnProjected.value === "true" && fact.policyAllowed.value === "false") {
+    codes.push("PROJECTED_NOT_POLICY_ALLOWED");
+  }
+  if (fact.turnProjected.value === "true" && fact.runtimeLoaded.value === "false") {
+    codes.push("PROJECTED_NOT_RUNTIME_LOADED");
+  }
+  if (
+    callability === "projected_not_call_tested" ||
+    callability === "projected_but_not_safely_probed"
+  ) {
+    codes.push("PROJECTED_NOT_SAFELY_CALL_TESTED");
+  }
+  if (fact.derivedRegistryLoaded === true && fact.runtimeLoaded.value === "false") {
+    codes.push("DERIVED_REGISTRY_STALE");
+  }
+  if (
+    fact.selfReportedCallable &&
+    callability !== "verified_callable_read_only" &&
+    callability !== "verified_callable_from_existing_turn_evidence"
+  ) {
+    codes.push("SELF_REPORT_UNCORROBORATED");
+  }
+  if (fact.evidencePeriodMismatch) {
+    codes.push("EVIDENCE_PERIOD_MISMATCH");
+  }
+  return [...new Set(codes)].sort();
+}
+
+export function buildCapabilityRecords(facts: ToolFact[]): CapabilityRecord[] {
+  return CAPABILITY_NAMES.map((name) => {
+    const tools = facts
+      .filter((fact) => fact.capability === name)
+      .map<ToolRecord>((fact) => {
+        const callabilityStatus = resolveCallability(fact);
+        const mismatchCodes = mismatchCodesForFact(fact, callabilityStatus);
+        return {
+          name: fact.name,
+          membership: fact.membership ?? "required",
+          mutationRisk: fact.mutationRisk,
+          configured: fact.configured,
+          runtimeLoaded: fact.runtimeLoaded,
+          policyAllowed: fact.policyAllowed,
+          turnProjected: fact.turnProjected,
+          callabilityStatus,
+          mismatchCodes,
+          mismatchReason: mismatchCodes.map((code) => MISMATCH_REASON[code]).join(" ") || null,
+          evidenceRefs: sortedUnique([
+            ...fact.configured.evidenceRefs,
+            ...fact.runtimeLoaded.evidenceRefs,
+            ...fact.policyAllowed.evidenceRefs,
+            ...fact.turnProjected.evidenceRefs,
+          ]),
+        };
+      })
+      .sort(
+        (a, b) =>
+          a.name.toLowerCase().localeCompare(b.name.toLowerCase()) || a.name.localeCompare(b.name),
+      );
+    const required = tools.filter((tool) => tool.membership === "required");
+    const summaryTools = required.length > 0 ? required : tools;
+    const summary = {
+      configured: stateSummary(summaryTools.map((tool) => tool.configured)),
+      runtimeLoaded: stateSummary(summaryTools.map((tool) => tool.runtimeLoaded)),
+      policyAllowed: stateSummary(summaryTools.map((tool) => tool.policyAllowed)),
+      turnProjected: stateSummary(summaryTools.map((tool) => tool.turnProjected)),
+    };
+    const mismatchCodes = sortedUnique([
+      ...tools.flatMap((tool) => tool.mismatchCodes),
+      ...Object.values(summary)
+        .filter((state) => state.reasonCode === "CAPABILITY_MEMBER_STATE_MIXED")
+        .map(() => "CAPABILITY_MEMBER_STATE_MIXED"),
+    ]) as MismatchCode[];
+    const callabilityCounts: Partial<Record<CallabilityStatus, number>> = {};
+    for (const tool of tools) {
+      callabilityCounts[tool.callabilityStatus] =
+        (callabilityCounts[tool.callabilityStatus] ?? 0) + 1;
+    }
+    return {
+      name,
+      summary,
+      callabilityCounts,
+      tools,
+      mismatchCodes,
+      mismatchReason: mismatchCodes.map((code) => MISMATCH_REASON[code]).join(" ") || null,
+      evidenceRefs: sortedUnique(tools.flatMap((tool) => tool.evidenceRefs)),
+    };
+  });
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([key]) => key !== "generatedAt" && key !== "reportId")
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, canonicalize(item)]),
+    );
+  }
+  return value;
+}
+
+export function computeCapabilityReportId(
+  report: Omit<CapabilityProjectionReport, "reportId">,
+): string {
+  const digest = createHash("sha256")
+    .update(JSON.stringify(canonicalize(report)))
+    .digest("hex");
+  return `cpr-v1-${digest.slice(0, 16)}`;
+}

--- a/src/commands/capability-projection-model.ts
+++ b/src/commands/capability-projection-model.ts
@@ -163,6 +163,7 @@ export type ToolFact = {
   policyAllowed: EvidenceState;
   turnProjected: EvidenceState;
   existingSuccessfulCall?: boolean;
+  existingSuccessfulCallEvidenceRefs?: string[];
   disabled?: boolean;
   derivedRegistryLoaded?: boolean;
   selfReportedCallable?: boolean;
@@ -302,6 +303,7 @@ export function buildCapabilityRecords(facts: ToolFact[]): CapabilityRecord[] {
             ...fact.runtimeLoaded.evidenceRefs,
             ...fact.policyAllowed.evidenceRefs,
             ...fact.turnProjected.evidenceRefs,
+            ...(fact.existingSuccessfulCallEvidenceRefs ?? []),
           ]),
         };
       })

--- a/src/commands/capability-projection-render.ts
+++ b/src/commands/capability-projection-render.ts
@@ -159,7 +159,13 @@ export async function publishCapabilityProjectionPair(params: {
   outputDir: string;
   fsImpl?: PublicationFs;
   platform?: NodeJS.Platform;
-}): Promise<{ jsonPath: string; markdownPath: string }> {
+}): Promise<{
+  jsonPath: string;
+  markdownPath: string;
+  pointerPath: string;
+  latestJsonPath: string;
+  latestMarkdownPath: string;
+}> {
   if ((params.platform ?? process.platform) !== "linux") {
     throw new Error("Atomic capability projection publication is supported on Linux only");
   }
@@ -259,10 +265,16 @@ export async function publishCapabilityProjectionPair(params: {
       }
     }
     await fsImpl.symlink(path.join(".versions", versionName), stagedPointer);
-    // Readers resolve this pointer once before opening either format. Renaming
-    // it is the sole visibility commit, so it never names a partial pair.
+    // Renaming the pointer is the sole visibility commit. Pair readers use the
+    // version-pinned paths returned below, never two independent latest-link opens.
     await fsImpl.rename(stagedPointer, currentPointer);
-    return { jsonPath, markdownPath };
+    return {
+      jsonPath: path.join(versionDir, "current-turn.json"),
+      markdownPath: path.join(versionDir, "current-turn.md"),
+      pointerPath: currentPointer,
+      latestJsonPath: jsonPath,
+      latestMarkdownPath: markdownPath,
+    };
   } catch (error) {
     await fsImpl.rm(stagedPointer, { force: true }).catch(() => undefined);
     await fsImpl.rm(stagedVersionDir, { recursive: true, force: true }).catch(() => undefined);

--- a/src/commands/capability-projection-render.ts
+++ b/src/commands/capability-projection-render.ts
@@ -1,0 +1,274 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isPathInside } from "../infra/path-guards.js";
+import type { CapabilityProjectionReport } from "./capability-projection-model.js";
+import { CapabilityProjectionReportSchema } from "./capability-projection-schema.js";
+
+function escapeMarkdown(value: string): string {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("|", "\\|")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\n", " ");
+}
+
+function state(value: { value: string }): string {
+  return value.value;
+}
+
+export function renderCapabilityProjectionJson(report: CapabilityProjectionReport): string {
+  const validated = CapabilityProjectionReportSchema.parse(report);
+  return `${JSON.stringify(validated, null, 2)}\n`;
+}
+
+export function renderCapabilityProjectionMarkdown(report: CapabilityProjectionReport): string {
+  const validated = CapabilityProjectionReportSchema.parse(report);
+  const lines = [
+    "# Capability Projection Report",
+    "",
+    `- Schema: \`${validated.schema}@${validated.schemaVersion}\``,
+    `- Report ID: \`${validated.reportId}\``,
+    `- Generated: \`${validated.generatedAt}\``,
+    `- Agent: \`${escapeMarkdown(validated.target.agentId)}\``,
+    `- Session: \`${escapeMarkdown(validated.target.sessionKey)}\``,
+    `- Run: \`${escapeMarkdown(validated.target.runId ?? "unknown")}\``,
+    `- Confidence: \`${validated.overallConfidence.level}\``,
+    "",
+    "## Capability summary",
+    "",
+    "| Capability | Configured | Runtime loaded | Policy allowed | Turn projected | Callability |",
+    "|---|---|---|---|---|---|",
+  ];
+  for (const capability of validated.capabilities) {
+    const callability = Object.entries(capability.callabilityCounts)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([name, count]) => `${name}:${count}`)
+      .join(", ");
+    lines.push(
+      `| ${capability.name} | ${state(capability.summary.configured)} | ${state(capability.summary.runtimeLoaded)} | ${state(capability.summary.policyAllowed)} | ${state(capability.summary.turnProjected)} | ${escapeMarkdown(callability)} |`,
+    );
+  }
+  for (const capability of validated.capabilities) {
+    lines.push(
+      "",
+      `## ${capability.name}`,
+      "",
+      `<!-- capability:${capability.name} -->`,
+      "",
+      "| Tool | Configured | Loaded | Allowed | Projected | Callability | Mismatches |",
+      "|---|---|---|---|---|---|---|",
+    );
+    for (const tool of capability.tools) {
+      lines.push(
+        `| ${escapeMarkdown(tool.name)} <!-- tool:${escapeMarkdown(tool.name)} --> | ${state(tool.configured)} | ${state(tool.runtimeLoaded)} | ${state(tool.policyAllowed)} | ${state(tool.turnProjected)} | ${tool.callabilityStatus} | ${tool.mismatchCodes.join(", ")} |`,
+      );
+    }
+  }
+  lines.push("", "## Collection errors", "");
+  if (validated.collectionErrors.length === 0) {
+    lines.push("None.");
+  } else {
+    for (const error of validated.collectionErrors) {
+      lines.push(`- \`${escapeMarkdown(error.code)}\`: ${escapeMarkdown(error.message)}`);
+    }
+  }
+  lines.push("", "## Evidence index", "");
+  for (const evidence of validated.evidence) {
+    lines.push(
+      `- \`${escapeMarkdown(evidence.id)}\` rank ${evidence.rank}: ${evidence.kind} (${evidence.status}, ${evidence.periodRelation})`,
+    );
+  }
+  lines.push(
+    "",
+    "## Redaction",
+    "",
+    `Policy: \`${validated.redaction.policy}\`.`,
+    "",
+    ...validated.redaction.notes.map((note) => `- ${escapeMarkdown(note)}`),
+    "",
+  );
+  return `${lines.join("\n")}\n`;
+}
+
+export function assertCapabilityProjectionParity(
+  report: CapabilityProjectionReport,
+  markdown: string,
+): void {
+  for (const capability of report.capabilities) {
+    if (!markdown.includes(`<!-- capability:${capability.name} -->`)) {
+      throw new Error("Capability projection Markdown parity check failed");
+    }
+    for (const tool of capability.tools) {
+      if (!markdown.includes(`<!-- tool:${escapeMarkdown(tool.name)} -->`)) {
+        throw new Error("Capability projection Markdown parity check failed");
+      }
+    }
+  }
+}
+
+type PublicationFs = Pick<
+  typeof fs,
+  | "chmod"
+  | "lstat"
+  | "mkdir"
+  | "readFile"
+  | "readlink"
+  | "realpath"
+  | "rename"
+  | "rm"
+  | "symlink"
+  | "writeFile"
+>;
+
+async function ensureOutputDirectory(
+  fsImpl: PublicationFs,
+  root: string,
+  outputDir: string,
+): Promise<void> {
+  const rootStat = await fsImpl.lstat(root);
+  if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
+    throw new Error("Capability projection output root is not a real directory");
+  }
+  const realRoot = await fsImpl.realpath(root);
+  const relative = path.relative(root, outputDir);
+  let cursor = realRoot;
+  for (const segment of relative.split(path.sep).filter(Boolean)) {
+    cursor = path.join(cursor, segment);
+    try {
+      const stat = await fsImpl.lstat(cursor);
+      if (stat.isSymbolicLink() || !stat.isDirectory()) {
+        throw new Error("Capability projection output path contains a non-directory component");
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+      await fsImpl.mkdir(cursor, { mode: 0o700 });
+    }
+  }
+  if (outputDir !== root) {
+    await fsImpl.chmod(outputDir, 0o700);
+  }
+}
+
+export async function publishCapabilityProjectionPair(params: {
+  report: CapabilityProjectionReport;
+  outputRoot: string;
+  outputDir: string;
+  fsImpl?: PublicationFs;
+  platform?: NodeJS.Platform;
+}): Promise<{ jsonPath: string; markdownPath: string }> {
+  if ((params.platform ?? process.platform) !== "linux") {
+    throw new Error("Atomic capability projection publication is supported on Linux only");
+  }
+  const fsImpl = params.fsImpl ?? fs;
+  const root = path.resolve(params.outputRoot);
+  const outputDir = path.resolve(params.outputDir);
+  if (outputDir !== root && !isPathInside(root, outputDir)) {
+    throw new Error("Capability projection output path escaped the approved root");
+  }
+  await ensureOutputDirectory(fsImpl, root, outputDir);
+  const json = renderCapabilityProjectionJson(params.report);
+  const markdown = renderCapabilityProjectionMarkdown(params.report);
+  assertCapabilityProjectionParity(params.report, markdown);
+  const jsonPath = path.join(outputDir, "current-turn.json");
+  const markdownPath = path.join(outputDir, "current-turn.md");
+  const versionsDir = path.join(outputDir, ".versions");
+  const nonce = `${process.pid}-${Date.now()}`;
+  const contentHash = createHash("sha256").update(json).update("\0").update(markdown).digest("hex");
+  const versionName = `${params.report.reportId}-${contentHash.slice(0, 16)}`;
+  const versionDir = path.join(versionsDir, versionName);
+  const stagedVersionDir = path.join(versionsDir, `.${versionName}.${nonce}.tmp`);
+  const currentPointer = path.join(outputDir, ".current");
+  const stagedPointer = `${currentPointer}.${nonce}.tmp`;
+  const stableLinks = [
+    { path: jsonPath, target: path.join(".current", "current-turn.json") },
+    { path: markdownPath, target: path.join(".current", "current-turn.md") },
+  ];
+  const createdLinks: string[] = [];
+  try {
+    try {
+      await fsImpl.mkdir(versionsDir, { mode: 0o700 });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error;
+      }
+      const versionsStat = await fsImpl.lstat(versionsDir);
+      if (versionsStat.isSymbolicLink() || !versionsStat.isDirectory()) {
+        throw new Error("Capability projection versions path is not a real directory");
+      }
+    }
+    await fsImpl.chmod(versionsDir, 0o700);
+    await fsImpl.mkdir(stagedVersionDir, { mode: 0o700 });
+    await fsImpl.writeFile(path.join(stagedVersionDir, "current-turn.json"), json, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    await fsImpl.writeFile(path.join(stagedVersionDir, "current-turn.md"), markdown, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    await fsImpl.chmod(path.join(stagedVersionDir, "current-turn.json"), 0o600);
+    await fsImpl.chmod(path.join(stagedVersionDir, "current-turn.md"), 0o600);
+    await fsImpl.rename(stagedVersionDir, versionDir).catch(async (error) => {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error;
+      }
+      await fsImpl.rm(stagedVersionDir, { recursive: true, force: true });
+    });
+    try {
+      const currentStat = await fsImpl.lstat(currentPointer);
+      if (!currentStat.isSymbolicLink()) {
+        throw new Error("Capability projection current pointer is not a symlink");
+      }
+      const currentTarget = await fsImpl.readlink(currentPointer);
+      if (!/^\.versions\/cpr-v1-[a-f0-9]{16}-[a-f0-9]{16}$/u.test(currentTarget)) {
+        throw new Error("Capability projection current pointer has an unexpected target");
+      }
+      const currentVersionDir = path.resolve(outputDir, currentTarget);
+      if (!isPathInside(versionsDir, currentVersionDir)) {
+        throw new Error("Capability projection current pointer escaped the versions directory");
+      }
+      const currentVersionStat = await fsImpl.lstat(currentVersionDir);
+      if (currentVersionStat.isSymbolicLink() || !currentVersionStat.isDirectory()) {
+        throw new Error("Capability projection current pointer target is not a real directory");
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+    for (const link of stableLinks) {
+      try {
+        const existingTarget = await fsImpl.readlink(link.path);
+        if (existingTarget !== link.target) {
+          throw new Error("Capability projection output link has an unexpected target");
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw error;
+        }
+        const stagedLink = `${link.path}.${nonce}.tmp`;
+        await fsImpl.symlink(link.target, stagedLink);
+        await fsImpl.rename(stagedLink, link.path);
+        createdLinks.push(link.path);
+      }
+    }
+    await fsImpl.symlink(path.join(".versions", versionName), stagedPointer);
+    // Readers resolve this pointer once before opening either format. Renaming
+    // it is the sole visibility commit, so it never names a partial pair.
+    await fsImpl.rename(stagedPointer, currentPointer);
+    return { jsonPath, markdownPath };
+  } catch (error) {
+    await fsImpl.rm(stagedPointer, { force: true }).catch(() => undefined);
+    await fsImpl.rm(stagedVersionDir, { recursive: true, force: true }).catch(() => undefined);
+    for (const link of createdLinks) {
+      await fsImpl.rm(link, { force: true }).catch(() => undefined);
+    }
+    throw error;
+  }
+}

--- a/src/commands/capability-projection-schema.ts
+++ b/src/commands/capability-projection-schema.ts
@@ -1,0 +1,267 @@
+import { z } from "zod";
+import { CAPABILITY_NAMES, MISMATCH_CODES } from "./capability-projection-model.js";
+
+const stringArray = z.array(z.string());
+const evidenceIdSchema = z.string().regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/u);
+const evidenceRefArray = z.array(evidenceIdSchema);
+const toolNameSchema = z
+  .string()
+  .regex(
+    /^(?:Bash|browser|create_goal|exec|gateway_health|get_goal|llm_task(?:_[a-z0-9_]+)?|memory_(?:get|search)|message|process|readiness_(?:canary|health)|shell|task_flow_(?:cancel|list|show)|commitments_(?:dismiss|list)|update_goal|workboard_[a-z0-9_]+|hook[a-z0-9_.:-]*)$/u,
+  );
+const toolNameArray = z.array(toolNameSchema);
+const hookNameArray = z.array(z.string().regex(/^hook[a-z0-9_.:-]{0,127}$/u));
+const capabilityIdSchema = z.enum(CAPABILITY_NAMES);
+const pluginIdSchema = z.enum([
+  "workboard",
+  "llm-task",
+  "task-flow",
+  "commitments",
+  "hooks",
+  "browser",
+  "memory",
+  "messaging",
+  "shell-execution",
+  "readiness-health",
+]);
+const sourceSchema = z.enum([
+  "selected trajectory event",
+  "gateway policy audit",
+  "plugin runtime inspection",
+  "effective policy resolver",
+  "current health probe",
+  "canonical config",
+  "derived registry",
+  "agent self-report",
+  "existing tool result",
+  "sanitized fixture",
+]);
+const stateSchema = z.strictObject({
+  value: z.enum(["true", "false", "unknown", "not_applicable"]),
+  basis: z.enum(["direct", "derived", "historical", "none"]),
+  evidenceRefs: evidenceRefArray,
+  reasonCode: z
+    .string()
+    .regex(/^[A-Z][A-Z0-9_]{0,127}$/u)
+    .optional(),
+});
+
+const evidenceBase = {
+  id: evidenceIdSchema,
+  rank: z.number().int().min(1).max(8),
+  source: sourceSchema,
+  observedAt: z.iso.datetime().nullable(),
+  periodRelation: z.enum(["exact_turn", "same_period", "current", "historical", "unknown"]),
+  status: z.enum(["collected", "partial", "failed", "missing"]),
+  redactionApplied: z.boolean(),
+};
+
+// Each evidence kind has a closed field allowlist. Raw commands, config, logs,
+// prompts, messages, arguments, results, and environment values have no slot.
+export const CapabilityProjectionEvidenceSchema = z.discriminatedUnion("kind", [
+  z.strictObject({
+    ...evidenceBase,
+    kind: z.literal("context_compiled"),
+    fields: z.strictObject({
+      sessionId: z.string(),
+      sessionKey: z.string(),
+      runId: z.string().nullable(),
+      sequence: z.number().int(),
+      toolNames: toolNameArray,
+    }),
+  }),
+  z.strictObject({
+    ...evidenceBase,
+    kind: z.literal("gateway_policy_log"),
+    fields: z.strictObject({
+      ruleCode: z.string().regex(/^[A-Z][A-Z0-9_]{0,127}$/u),
+      toolNames: toolNameArray,
+      correlation: z.enum(["run", "time_window"]),
+    }),
+  }),
+  z.strictObject({
+    ...evidenceBase,
+    kind: z.literal("plugin_runtime"),
+    fields: z.strictObject({
+      pluginId: pluginIdSchema,
+      enabled: z.boolean().nullable(),
+      loaded: z.boolean().nullable(),
+      toolNames: toolNameArray,
+      hookNames: hookNameArray,
+    }),
+  }),
+  z.strictObject({
+    ...evidenceBase,
+    kind: z.literal("effective_policy"),
+    fields: z.strictObject({
+      profile: z
+        .enum(["minimal", "messaging", "coding", "full", "custom", "fixture", "unknown"])
+        .nullable(),
+      allowedToolNames: toolNameArray,
+      deniedToolNames: toolNameArray,
+      sandboxMode: z.enum(["off", "non-main", "all", "fixture", "unknown"]).nullable(),
+    }),
+  }),
+  z.strictObject({
+    ...evidenceBase,
+    kind: z.literal("health_probe"),
+    fields: z.strictObject({
+      component: z.enum(["gateway", "node", "discord", "readiness_monitor", "control_plane"]),
+      healthy: z.boolean().nullable(),
+      statusCode: z.enum([
+        "healthy",
+        "unhealthy",
+        "connected",
+        "disconnected",
+        "ready",
+        "not_ready",
+        "ok",
+        "error",
+        "timeout",
+        "unknown",
+      ]),
+    }),
+  }),
+  z.strictObject({
+    ...evidenceBase,
+    kind: z.literal("raw_config"),
+    fields: z.strictObject({
+      capability: capabilityIdSchema,
+      configured: z.boolean().nullable(),
+      enabled: z.boolean().nullable(),
+    }),
+  }),
+  z.strictObject({
+    ...evidenceBase,
+    kind: z.literal("derived_registry"),
+    fields: z.strictObject({
+      registryId: capabilityIdSchema,
+      toolNames: toolNameArray,
+      hookNames: hookNameArray,
+    }),
+  }),
+  z.strictObject({
+    ...evidenceBase,
+    kind: z.literal("agent_self_report"),
+    fields: z.strictObject({
+      claimCode: z.string().regex(/^[A-Z][A-Z0-9_]{0,127}$/u),
+      toolNames: toolNameArray,
+    }),
+  }),
+  z.strictObject({
+    ...evidenceBase,
+    kind: z.literal("existing_tool_result"),
+    fields: z.strictObject({
+      toolName: toolNameSchema,
+      runId: evidenceIdSchema,
+      success: z.literal(true),
+      operationClass: z.enum(["read_only", "mutating", "privacy_sensitive_read", "unknown"]),
+    }),
+  }),
+]);
+
+const toolSchema = z.strictObject({
+  name: toolNameSchema,
+  membership: z.enum(["required", "optional"]),
+  mutationRisk: z.enum(["read_only", "mutating", "privacy_sensitive_read", "unknown"]),
+  configured: stateSchema,
+  runtimeLoaded: stateSchema,
+  policyAllowed: stateSchema,
+  turnProjected: stateSchema,
+  callabilityStatus: z.enum([
+    "verified_callable_read_only",
+    "verified_callable_from_existing_turn_evidence",
+    "projected_not_call_tested",
+    "projected_but_not_safely_probed",
+    "not_projected",
+    "disabled",
+    "unknown_due_to_evidence_gap",
+  ]),
+  mismatchCodes: z.array(z.enum(MISMATCH_CODES)),
+  mismatchReason: z.string().nullable(),
+  evidenceRefs: evidenceRefArray,
+});
+
+export const CapabilityProjectionReportSchema = z.strictObject({
+  schema: z.literal("openclaw.capability-projection-report"),
+  schemaVersion: z.literal(1),
+  reportId: z.string().regex(/^cpr-v1-[a-f0-9]{16}$/u),
+  generatedAt: z.iso.datetime(),
+  host: z.strictObject({
+    hostname: z.string(),
+    user: z.string(),
+    uid: z.number().int().nonnegative(),
+    instanceDir: z.string(),
+    workspaceDir: z.string(),
+  }),
+  openclawVersion: z.strictObject({
+    value: z
+      .string()
+      .regex(/^[A-Za-z0-9.+_-]{1,64}$/u)
+      .nullable(),
+    evidenceRefs: evidenceRefArray,
+  }),
+  target: z.strictObject({
+    agentId: z.string(),
+    sessionKey: z.string(),
+    sessionId: z.string().nullable(),
+    runId: z.string().nullable(),
+    turnSequence: z.number().int().nullable(),
+    contextCompiledAt: z.iso.datetime().nullable(),
+    selectionMode: z.enum([
+      "exact_run_id",
+      "exact_event_sequence",
+      "latest_in_window",
+      "unresolved",
+    ]),
+  }),
+  evidenceWindow: z.strictObject({ start: z.iso.datetime(), end: z.iso.datetime() }),
+  capabilities: z.array(
+    z.strictObject({
+      name: z.enum(CAPABILITY_NAMES),
+      summary: z.strictObject({
+        configured: stateSchema,
+        runtimeLoaded: stateSchema,
+        policyAllowed: stateSchema,
+        turnProjected: stateSchema,
+      }),
+      callabilityCounts: z.record(z.string(), z.number().int().nonnegative()),
+      tools: z.array(toolSchema),
+      mismatchCodes: z.array(z.enum(MISMATCH_CODES)),
+      mismatchReason: z.string().nullable(),
+      evidenceRefs: evidenceRefArray,
+    }),
+  ),
+  evidence: z.array(CapabilityProjectionEvidenceSchema),
+  observations: z.array(
+    z.strictObject({
+      code: z.string(),
+      period: z.enum(["current", "historical"]),
+      severity: z.enum(["info", "watch", "block"]),
+      summary: z.string(),
+      evidenceRefs: evidenceRefArray,
+    }),
+  ),
+  collectionErrors: z.array(
+    z.strictObject({
+      collector: z.string().regex(/^[a-z][a-z0-9_-]{0,63}$/u),
+      code: z.string().regex(/^[A-Z][A-Z0-9_]{0,127}$/u),
+      message: z.literal("Evidence collection did not complete; affected claims remain unknown."),
+      occurredAt: z.iso.datetime(),
+      affectedClaims: evidenceRefArray,
+    }),
+  ),
+  redaction: z.strictObject({
+    policy: z.literal("allowlist-before-serialization-v1"),
+    excludedFieldClasses: stringArray,
+    notes: stringArray,
+  }),
+  overallConfidence: z.strictObject({
+    level: z.enum(["high", "medium", "low"]),
+    reasonCodes: stringArray,
+  }),
+});
+
+export const capabilityProjectionReportJsonSchema = CapabilityProjectionReportSchema.toJSONSchema({
+  target: "draft-2020-12",
+});

--- a/src/commands/capability-projection.test.ts
+++ b/src/commands/capability-projection.test.ts
@@ -786,13 +786,11 @@ describe("capability projection acceptance fixtures", () => {
     expect(wrongSession.errorCode).toBe("MISSING_SESSION_PROJECTION");
   });
 
-  it("verifies a successful tool result from the canonical transcript branch", async () => {
+  it("verifies only a runtime tool result carrying the selected run identity", async () => {
     const dir = await makeTempDir();
     const trajectory = path.join(dir, "fixture.trajectory.jsonl");
-    const transcript = path.join(dir, "fixture.jsonl");
-    await fs.writeFile(
-      trajectory,
-      `${JSON.stringify({
+    const events = [
+      {
         traceSchema: "openclaw-trajectory",
         schemaVersion: 1,
         traceId: "t",
@@ -804,36 +802,22 @@ describe("capability projection acceptance fixtures", () => {
         sessionKey,
         runId,
         data: { tools: [{ name: "memory_get" }] },
-      })}\n`,
-    );
-    await fs.writeFile(
-      transcript,
-      `${[
-        {
-          type: "session",
-          version: 3,
-          id: "s",
-          timestamp: "2026-07-12T15:59:00.000Z",
-          cwd: dir,
-        },
-        {
-          type: "message",
-          id: "result-1",
-          parentId: null,
-          timestamp: "2026-07-12T16:00:00.500Z",
-          message: {
-            role: "toolResult",
-            toolCallId: "call-1",
-            toolName: "memory_get",
-            content: [{ type: "text", text: "private result must be discarded" }],
-            isError: false,
-            timestamp: Date.parse("2026-07-12T16:00:00.500Z"),
-          },
-        },
-      ]
-        .map((entry) => JSON.stringify(entry))
-        .join("\n")}\n`,
-    );
+      },
+      {
+        traceSchema: "openclaw-trajectory",
+        schemaVersion: 1,
+        traceId: "t",
+        source: "runtime",
+        type: "tool.result",
+        ts: "2026-07-12T16:00:00.500Z",
+        seq: 2,
+        sessionId: "s",
+        sessionKey,
+        runId,
+        data: { name: "memory_get", success: true, result: "private result must be discarded" },
+      },
+    ];
+    await fs.writeFile(trajectory, `${events.map((event) => JSON.stringify(event)).join("\n")}\n`);
     const collected = await collectExactTurnFromTrajectory(
       trajectory,
       { mode: "exact_run_id", runId },
@@ -842,7 +826,6 @@ describe("capability projection acceptance fixtures", () => {
         sessionKey,
         evidenceWindow: { start: "2026-07-12T15:59:00Z", end: "2026-07-12T16:01:00Z" },
       },
-      transcript,
     );
     expect(collected.successfulToolResults).toEqual([
       {

--- a/src/commands/capability-projection.test.ts
+++ b/src/commands/capability-projection.test.ts
@@ -425,8 +425,15 @@ describe("capability projection acceptance fixtures", () => {
         successful: ["memory_get"],
       }),
     );
-    expect(tool(report, "memory", "memory_get").callabilityStatus).toBe(
-      "verified_callable_read_only",
+    const memoryGet = tool(report, "memory", "memory_get");
+    expect(memoryGet.callabilityStatus).toBe("verified_callable_read_only");
+    expect(memoryGet.evidenceRefs).toContain("existing-tool-result-1");
+    expect(report.evidence).toContainEqual(
+      expect.objectContaining({
+        id: "existing-tool-result-1",
+        kind: "existing_tool_result",
+        fields: expect.objectContaining({ toolName: "memory_get", success: true }),
+      }),
     );
   });
 

--- a/src/commands/capability-projection.test.ts
+++ b/src/commands/capability-projection.test.ts
@@ -985,6 +985,43 @@ describe("collector and publication safety", () => {
     expect(runtime.error).toHaveBeenCalledWith(
       "Capability projection --agent conflicts with the canonical session owner.",
     );
+    vi.clearAllMocks();
+    await fs.writeFile(
+      evidenceFile,
+      JSON.stringify([
+        {
+          id: "reserved",
+          rank: 1,
+          kind: "context_compiled",
+          source: "sanitized fixture",
+          observedAt: now,
+          periodRelation: "exact_turn",
+          status: "collected",
+          fields: {
+            sessionId: "s",
+            sessionKey,
+            runId,
+            sequence: 1,
+            toolNames: ["memory_get"],
+          },
+          redactionApplied: true,
+        },
+      ]),
+    );
+    await capabilityProjectionCommand(
+      {
+        sessionKey,
+        runId,
+        windowStart: "2026-07-12T15:59:00Z",
+        windowEnd: "2026-07-12T16:01:00Z",
+        evidenceFile,
+        outputRoot: dir,
+      },
+      runtime,
+    );
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Capability projection evidence failed semantic validation.",
+    );
   });
 
   it("has a closed evidence schema with no arbitrary evidence fields", () => {

--- a/src/commands/capability-projection.test.ts
+++ b/src/commands/capability-projection.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
 import { collectExactTurnFromTrajectory } from "./capability-projection-collectors.js";
 import type { CapabilityName, EvidenceState, ToolFact } from "./capability-projection-model.js";
 import {
@@ -13,6 +14,7 @@ import {
 import { capabilityProjectionReportJsonSchema } from "./capability-projection-schema.js";
 import {
   buildCapabilityProjectionReport,
+  capabilityProjectionCommand,
   type CapabilityProjectionInput,
 } from "./capability-projection.js";
 
@@ -649,6 +651,19 @@ describe("capability projection acceptance fixtures", () => {
         traceId: "t",
         source: "runtime",
         type: "tool.result",
+        ts: "2026-07-12T16:00:00.500Z",
+        seq: 2,
+        sessionId: "s",
+        sessionKey,
+        runId,
+        data: { name: "exec", success: true },
+      },
+      {
+        traceSchema: "openclaw-trajectory",
+        schemaVersion: 1,
+        traceId: "t",
+        source: "runtime",
+        type: "tool.result",
         ts: now,
         seq: 2,
         sessionId: "s",
@@ -703,7 +718,11 @@ describe("capability projection acceptance fixtures", () => {
         mode: "exact_event_sequence",
         sequence: 1,
       },
-      { sessionId: "s", sessionKey },
+      {
+        sessionId: "s",
+        sessionKey,
+        evidenceWindow: { start: "2026-07-12T15:59:00Z", end: now },
+      },
     );
     expect(collected.compiled?.toolNames).toEqual(["exec"]);
     expect(collected.successfulToolResults).toEqual([]);
@@ -711,7 +730,11 @@ describe("capability projection acceptance fixtures", () => {
     const wrongSession = await collectExactTurnFromTrajectory(
       trajectory,
       { mode: "exact_event_sequence", sequence: 1 },
-      { sessionId: "other-session", sessionKey },
+      {
+        sessionId: "other-session",
+        sessionKey,
+        evidenceWindow: { start: "2026-07-12T15:59:00Z", end: "2026-07-12T16:01:00Z" },
+      },
     );
     expect(wrongSession.errorCode).toBe("MISSING_SESSION_PROJECTION");
   });
@@ -757,6 +780,63 @@ describe("capability projection acceptance fixtures", () => {
 });
 
 describe("collector and publication safety", () => {
+  it("rejects unredacted CLI evidence and conflicting session ownership", async () => {
+    const dir = await makeTempDir();
+    const evidenceFile = path.join(dir, "evidence.json");
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    } as unknown as RuntimeEnv;
+    await fs.writeFile(
+      evidenceFile,
+      JSON.stringify([
+        {
+          id: "unsafe",
+          rank: 8,
+          kind: "agent_self_report",
+          source: "sanitized fixture",
+          observedAt: now,
+          periodRelation: "same_period",
+          status: "collected",
+          fields: { claimCode: "CALLABLE", toolNames: ["memory_get"] },
+          redactionApplied: false,
+        },
+      ]),
+    );
+    await capabilityProjectionCommand(
+      {
+        sessionKey,
+        runId,
+        windowStart: "2026-07-12T15:59:00Z",
+        windowEnd: "2026-07-12T16:01:00Z",
+        evidenceFile,
+        outputRoot: dir,
+      },
+      runtime,
+    );
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Capability projection evidence file is invalid or unreadable.",
+    );
+    vi.clearAllMocks();
+    await fs.writeFile(evidenceFile, "[]");
+    await capabilityProjectionCommand(
+      {
+        sessionKey,
+        agent: "other",
+        runId,
+        windowStart: "2026-07-12T15:59:00Z",
+        windowEnd: "2026-07-12T16:01:00Z",
+        evidenceFile,
+        outputRoot: dir,
+      },
+      runtime,
+    );
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Capability projection --agent conflicts with the canonical session owner.",
+    );
+  });
+
   it("has a closed evidence schema with no arbitrary evidence fields", () => {
     const schemaText = JSON.stringify(capabilityProjectionReportJsonSchema);
     expect(schemaText).toContain("context_compiled");
@@ -775,7 +855,11 @@ describe("collector and publication safety", () => {
         start: "2026-07-12T00:00:00Z",
         end: "2026-07-12T01:00:00Z",
       },
-      { sessionId: "fixture", sessionKey },
+      {
+        sessionId: "fixture",
+        sessionKey,
+        evidenceWindow: { start: "2026-07-12T00:00:00Z", end: "2026-07-12T01:00:00Z" },
+      },
     );
     expect(result.errorCode).toBe("MISSING_SESSION_PROJECTION");
     const invalid = await collectExactTurnFromTrajectory(
@@ -785,7 +869,11 @@ describe("collector and publication safety", () => {
         start: "not-a-date",
         end: "2026-07-12T01:00:00Z",
       },
-      { sessionId: "fixture", sessionKey },
+      {
+        sessionId: "fixture",
+        sessionKey,
+        evidenceWindow: { start: "2026-07-12T00:00:00Z", end: "2026-07-12T01:00:00Z" },
+      },
     );
     expect(invalid.errorCode).toBe("EVIDENCE_COLLECTION_FAILED");
     const reversed = await collectExactTurnFromTrajectory(
@@ -795,7 +883,11 @@ describe("collector and publication safety", () => {
         start: "2026-07-12T02:00:00Z",
         end: "2026-07-12T01:00:00Z",
       },
-      { sessionId: "fixture", sessionKey },
+      {
+        sessionId: "fixture",
+        sessionKey,
+        evidenceWindow: { start: "2026-07-12T00:00:00Z", end: "2026-07-12T03:00:00Z" },
+      },
     );
     expect(reversed.errorCode).toBe("EVIDENCE_COLLECTION_FAILED");
   });

--- a/src/commands/capability-projection.test.ts
+++ b/src/commands/capability-projection.test.ts
@@ -1,0 +1,929 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { collectExactTurnFromTrajectory } from "./capability-projection-collectors.js";
+import type { CapabilityName, EvidenceState, ToolFact } from "./capability-projection-model.js";
+import {
+  assertCapabilityProjectionParity,
+  publishCapabilityProjectionPair,
+  renderCapabilityProjectionJson,
+  renderCapabilityProjectionMarkdown,
+} from "./capability-projection-render.js";
+import { capabilityProjectionReportJsonSchema } from "./capability-projection-schema.js";
+import {
+  buildCapabilityProjectionReport,
+  type CapabilityProjectionInput,
+} from "./capability-projection.js";
+
+const tempDirs: string[] = [];
+const now = "2026-07-12T16:00:00.000Z";
+const sessionKey = "agent:main:discord:channel:synthetic";
+const runId = "run-synthetic";
+
+function direct(value: EvidenceState["value"], ref: string): EvidenceState {
+  return { value, basis: "direct", evidenceRefs: [ref] };
+}
+
+function fact(
+  capability: CapabilityName,
+  name: string,
+  options: Partial<Omit<ToolFact, "capability" | "name">> = {},
+): ToolFact {
+  return {
+    capability,
+    name,
+    mutationRisk: "read_only",
+    configured: direct("true", "config"),
+    runtimeLoaded: direct("true", "runtime"),
+    policyAllowed: direct("true", "policy"),
+    turnProjected: direct("unknown", "placeholder"),
+    ...options,
+  };
+}
+
+const PLUGIN_ID_BY_CAPABILITY = {
+  goal_tools: "hooks",
+  workboard: "workboard",
+  llm_task: "llm-task",
+  task_flow: "task-flow",
+  commitments: "commitments",
+  hooks: "hooks",
+  browser: "browser",
+  memory: "memory",
+  messaging: "messaging",
+  shell_execution: "shell-execution",
+  readiness_health: "readiness-health",
+} as const;
+
+function evidenceFromFacts(facts: ToolFact[]): CapabilityProjectionInput["evidence"] {
+  return facts.flatMap((item) => {
+    const suffix = `${item.capability}-${item.name}`;
+    const configured =
+      item.configured.value === "true" ? true : item.configured.value === "false" ? false : null;
+    const loaded =
+      item.runtimeLoaded.value === "true"
+        ? true
+        : item.runtimeLoaded.value === "false"
+          ? false
+          : null;
+    const allowed = item.policyAllowed.value === "true" ? [item.name] : [];
+    const denied = item.policyAllowed.value === "false" ? [item.name] : [];
+    const records: CapabilityProjectionInput["evidence"] = [
+      {
+        id: `config-${suffix}`,
+        rank: 6,
+        kind: "raw_config",
+        source: "sanitized fixture",
+        observedAt: now,
+        periodRelation: "same_period",
+        status: "collected",
+        fields: {
+          capability: item.capability,
+          configured,
+          enabled: item.capability === "goal_tools" ? null : configured,
+        },
+        redactionApplied: true,
+      },
+      {
+        id: `runtime-${suffix}`,
+        rank: 3,
+        kind: "plugin_runtime",
+        source: "sanitized fixture",
+        observedAt: now,
+        periodRelation: "same_period",
+        status: "collected",
+        fields: {
+          pluginId: PLUGIN_ID_BY_CAPABILITY[item.capability],
+          enabled: loaded,
+          loaded,
+          toolNames: [item.name],
+          hookNames: [],
+        },
+        redactionApplied: true,
+      },
+      {
+        id: `policy-${suffix}`,
+        rank: 4,
+        kind: "effective_policy",
+        source: "sanitized fixture",
+        observedAt: now,
+        periodRelation: "same_period",
+        status: "collected",
+        fields: {
+          profile: "fixture",
+          allowedToolNames: allowed,
+          deniedToolNames: denied,
+          sandboxMode: "fixture",
+        },
+        redactionApplied: true,
+      },
+    ];
+    if (item.derivedRegistryLoaded) {
+      records.push({
+        id: `registry-${suffix}`,
+        rank: 7,
+        kind: "derived_registry",
+        source: "sanitized fixture",
+        observedAt: now,
+        periodRelation: "same_period",
+        status: "collected",
+        fields: { registryId: item.capability, toolNames: [item.name], hookNames: [] },
+        redactionApplied: true,
+      });
+    }
+    if (item.selfReportedCallable) {
+      records.push({
+        id: `self-report-${suffix}`,
+        rank: 8,
+        kind: "agent_self_report",
+        source: "sanitized fixture",
+        observedAt: now,
+        periodRelation: "same_period",
+        status: "collected",
+        fields: { claimCode: "CALLABLE", toolNames: [item.name] },
+        redactionApplied: true,
+      });
+    }
+    return records;
+  });
+}
+
+function input(params: {
+  facts: ToolFact[];
+  tools?: string[];
+  successful?: string[];
+  missing?: boolean;
+  evidence?: CapabilityProjectionInput["evidence"];
+  observations?: CapabilityProjectionInput["observations"];
+  errors?: CapabilityProjectionInput["collectionErrors"];
+}): CapabilityProjectionInput {
+  return {
+    generatedAt: now,
+    host: {
+      hostname: "fixture-host",
+      user: "fixture-user",
+      uid: 1000,
+      instanceDir: "/fixture/instance",
+      workspaceDir: "/fixture/workspace",
+    },
+    openclawVersion: "fixture-version",
+    agentId: "main",
+    sessionKey,
+    evidenceWindow: { start: "2026-07-12T15:59:00.000Z", end: "2026-07-12T16:01:00.000Z" },
+    selection: { mode: "exact_run_id", runId },
+    trajectory: params.missing
+      ? { compiled: null, successfulToolResults: [], errorCode: "MISSING_SESSION_PROJECTION" }
+      : {
+          compiled: {
+            ts: now,
+            seq: 7,
+            sessionId: "session-synthetic",
+            sessionKey,
+            runId,
+            toolNames: [...(params.tools ?? [])],
+          },
+          successfulToolResults: (params.successful ?? []).map((toolName) => ({
+            ts: now,
+            runId,
+            toolName,
+            success: true as const,
+          })),
+        },
+    evidence: [...evidenceFromFacts(params.facts), ...(params.evidence ?? [])],
+    observations: params.observations,
+    collectionErrors: params.errors,
+  };
+}
+
+function tool(
+  report: ReturnType<typeof buildCapabilityProjectionReport>,
+  capability: CapabilityName,
+  name: string,
+) {
+  const record = report.capabilities
+    .find((item) => item.name === capability)
+    ?.tools.find((item) => item.name === name);
+  if (!record) {
+    throw new Error(`missing fixture tool ${capability}/${name}`);
+  }
+  return record;
+}
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-capability-projection-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("capability projection acceptance fixtures", () => {
+  it("reproduces Workboard loaded but not allowed or projected", () => {
+    const report = buildCapabilityProjectionReport(
+      input({
+        facts: [
+          fact("workboard", "workboard_create", {
+            policyAllowed: direct("false", "policy"),
+            mutationRisk: "mutating",
+          }),
+        ],
+      }),
+    );
+    const record = tool(report, "workboard", "workboard_create");
+    expect(record.runtimeLoaded.value).toBe("true");
+    expect(record.policyAllowed.value).toBe("false");
+    expect(record.turnProjected.value).toBe("false");
+    expect(record.mismatchCodes).toContain("LOADED_NOT_POLICY_ALLOWED");
+  });
+
+  it("derives historical acceptance facts from sanitized evidence only", () => {
+    const report = buildCapabilityProjectionReport({
+      ...input({ facts: [] }),
+      evidence: [
+        {
+          id: "workboard-runtime",
+          rank: 3,
+          kind: "plugin_runtime",
+          source: "sanitized fixture",
+          observedAt: now,
+          periodRelation: "same_period",
+          status: "collected",
+          fields: {
+            pluginId: "workboard",
+            enabled: true,
+            loaded: true,
+            toolNames: ["workboard_list"],
+            hookNames: [],
+          },
+          redactionApplied: true,
+        },
+        {
+          id: "policy",
+          rank: 4,
+          kind: "effective_policy",
+          source: "sanitized fixture",
+          observedAt: now,
+          periodRelation: "same_period",
+          status: "collected",
+          fields: {
+            profile: "fixture",
+            allowedToolNames: ["memory_get"],
+            deniedToolNames: ["workboard_list", "create_goal", "get_goal", "update_goal"],
+            sandboxMode: "fixture",
+          },
+          redactionApplied: true,
+        },
+        {
+          id: "llm-task-runtime",
+          rank: 3,
+          kind: "plugin_runtime",
+          source: "sanitized fixture",
+          observedAt: now,
+          periodRelation: "same_period",
+          status: "collected",
+          fields: {
+            pluginId: "llm-task",
+            enabled: false,
+            loaded: false,
+            toolNames: ["llm_task"],
+            hookNames: [],
+          },
+          redactionApplied: true,
+        },
+        {
+          id: "llm-task-config",
+          rank: 6,
+          kind: "raw_config",
+          source: "sanitized fixture",
+          observedAt: now,
+          periodRelation: "same_period",
+          status: "collected",
+          fields: { capability: "llm_task", configured: false, enabled: false },
+          redactionApplied: true,
+        },
+      ],
+    });
+    expect(tool(report, "workboard", "workboard_list").runtimeLoaded.value).toBe("true");
+    expect(tool(report, "workboard", "workboard_list").policyAllowed.value).toBe("false");
+    expect(tool(report, "goal_tools", "get_goal").policyAllowed.value).toBe("false");
+    expect(tool(report, "llm_task", "llm_task").configured.value).toBe("false");
+    expect(tool(report, "llm_task", "llm_task").callabilityStatus).toBe("disabled");
+  });
+
+  it("does not combine current, historical, or failed evidence with the selected period", () => {
+    const report = buildCapabilityProjectionReport({
+      ...input({ facts: [] }),
+      evidence: [
+        {
+          id: "stale-policy",
+          rank: 4,
+          kind: "effective_policy",
+          source: "sanitized fixture",
+          periodRelation: "same_period",
+          status: "collected",
+          observedAt: "2026-07-11T16:00:00.000Z",
+          fields: {
+            profile: "fixture",
+            allowedToolNames: ["memory_get"],
+            deniedToolNames: [],
+            sandboxMode: "fixture",
+          },
+          redactionApplied: true,
+        },
+        {
+          id: "failed-runtime",
+          rank: 3,
+          kind: "plugin_runtime",
+          source: "sanitized fixture",
+          observedAt: now,
+          periodRelation: "same_period",
+          status: "failed",
+          fields: {
+            pluginId: "memory",
+            enabled: true,
+            loaded: true,
+            toolNames: ["memory_get"],
+            hookNames: [],
+          },
+          redactionApplied: true,
+        },
+      ],
+    });
+    const record = tool(report, "memory", "memory_get");
+    expect(record.policyAllowed.value).toBe("unknown");
+    expect(record.runtimeLoaded.value).toBe("unknown");
+    expect(record.mismatchCodes).toContain("EVIDENCE_PERIOD_MISMATCH");
+    expect(report.overallConfidence.level).toBe("medium");
+    expect(report.overallConfidence.reasonCodes).toContain("EVIDENCE_COLLECTION_FAILED");
+  });
+
+  it("reports absent goal tools without probing them", () => {
+    const report = buildCapabilityProjectionReport(
+      input({
+        facts: [
+          fact("goal_tools", "get_goal", {
+            configured: direct("false", "config"),
+            runtimeLoaded: direct("false", "runtime"),
+            policyAllowed: direct("false", "policy"),
+          }),
+        ],
+      }),
+    );
+    expect(tool(report, "goal_tools", "get_goal").callabilityStatus).toBe("not_projected");
+  });
+
+  it("reports LLM Task disabled", () => {
+    const report = buildCapabilityProjectionReport(
+      input({
+        facts: [
+          fact("llm_task", "llm_task", {
+            configured: direct("false", "config"),
+            runtimeLoaded: direct("false", "runtime"),
+            policyAllowed: direct("false", "policy"),
+            disabled: true,
+          }),
+        ],
+      }),
+    );
+    expect(tool(report, "llm_task", "llm_task").callabilityStatus).toBe("disabled");
+  });
+
+  it("verifies an existing successful read-only call", () => {
+    const report = buildCapabilityProjectionReport(
+      input({
+        facts: [fact("memory", "memory_get")],
+        tools: ["memory_get"],
+        successful: ["memory_get"],
+      }),
+    );
+    expect(tool(report, "memory", "memory_get").callabilityStatus).toBe(
+      "verified_callable_read_only",
+    );
+  });
+
+  it("does not probe a projected mutating tool", () => {
+    const report = buildCapabilityProjectionReport(
+      input({
+        facts: [fact("messaging", "message", { mutationRisk: "mutating" })],
+        tools: ["message"],
+      }),
+    );
+    expect(tool(report, "messaging", "message").callabilityStatus).toBe(
+      "projected_but_not_safely_probed",
+    );
+  });
+
+  it("detects stale derived registry evidence", () => {
+    const report = buildCapabilityProjectionReport(
+      input({
+        facts: [
+          fact("hooks", "hook_tool", {
+            runtimeLoaded: direct("false", "runtime"),
+            derivedRegistryLoaded: true,
+          }),
+        ],
+      }),
+    );
+    expect(tool(report, "hooks", "hook_tool").mismatchCodes).toContain("DERIVED_REGISTRY_STALE");
+  });
+
+  it("keeps current healthy and historical failure evidence separate", () => {
+    const report = buildCapabilityProjectionReport(
+      input({
+        facts: [fact("readiness_health", "gateway_health")],
+        observations: [
+          {
+            code: "CURRENT_HEALTHY",
+            period: "current",
+            severity: "info",
+            summary: "Current sanitized probe passed.",
+            evidenceRefs: ["health-current"],
+          },
+          {
+            code: "HISTORICAL_CURRENT_STATE_DIFFERENCE",
+            period: "historical",
+            severity: "watch",
+            summary: "A historical sanitized probe failed.",
+            evidenceRefs: ["health-history"],
+          },
+        ],
+      }),
+    );
+    expect(report.observations.map((item) => item.period)).toEqual(["current", "historical"]);
+  });
+
+  it("turns collection failure into unknown rather than false", () => {
+    const report = buildCapabilityProjectionReport(
+      input({ facts: [fact("browser", "browser")], missing: true }),
+    );
+    expect(tool(report, "browser", "browser").turnProjected.value).toBe("unknown");
+    expect(report.overallConfidence.level).toBe("low");
+  });
+
+  it("excludes secret-bearing source data by construction", () => {
+    const report = buildCapabilityProjectionReport(
+      input({ facts: [fact("memory", "memory_search")], tools: ["memory_search"] }),
+    );
+    const outputs = `${renderCapabilityProjectionJson(report)}${renderCapabilityProjectionMarkdown(report)}`;
+    for (const forbidden of [
+      "Bearer secret",
+      "cookie=session-secret",
+      "BEGIN PRIVATE KEY",
+      "systemPrompt",
+      "private message",
+      "tool result secret",
+      "sk-test-secret",
+    ]) {
+      expect(outputs.toLowerCase()).not.toContain(forbidden.toLowerCase());
+    }
+    expect(() =>
+      buildCapabilityProjectionReport({
+        ...input({ facts: [] }),
+        evidence: [
+          {
+            id: "unsafe",
+            rank: 8,
+            kind: "agent_self_report",
+            source: "sanitized fixture",
+            observedAt: now,
+            periodRelation: "same_period",
+            status: "collected",
+            fields: { claimCode: "token=fixture-secret", toolNames: ["memory_get"] },
+            redactionApplied: false,
+          },
+        ],
+      }),
+    ).toThrow();
+    expect(() =>
+      buildCapabilityProjectionReport({
+        ...input({ facts: [] }),
+        evidence: [
+          {
+            id: "unsafe-bare-credential",
+            rank: 8,
+            kind: "agent_self_report",
+            source: "sanitized fixture",
+            observedAt: now,
+            periodRelation: "same_period",
+            status: "collected",
+            fields: { claimCode: "sk-proj-abcdefghijklmnop", toolNames: ["memory_get"] },
+            redactionApplied: false,
+          },
+        ],
+      }),
+    ).toThrow();
+    expect(() =>
+      buildCapabilityProjectionReport({
+        ...input({ facts: [] }),
+        observations: [
+          {
+            code: "UNSAFE_OBSERVATION",
+            period: "current",
+            severity: "watch",
+            summary: "authorization: Bearer fixture-secret",
+            evidenceRefs: ["fixture"],
+          },
+        ],
+      }),
+    ).toThrow("prohibited secret-bearing value");
+  });
+
+  it("renders JSON and Markdown from the same normalized record", () => {
+    const report = buildCapabilityProjectionReport(
+      input({ facts: [fact("browser", "browser")], tools: ["browser"] }),
+    );
+    const markdown = renderCapabilityProjectionMarkdown(report);
+    expect(() => assertCapabilityProjectionParity(report, markdown)).not.toThrow();
+    expect(JSON.parse(renderCapabilityProjectionJson(report)).reportId).toBe(report.reportId);
+  });
+
+  it("blocks exact-turn conclusions when session projection is missing", () => {
+    const report = buildCapabilityProjectionReport(
+      input({ facts: [fact("shell_execution", "exec")], missing: true }),
+    );
+    expect(report.target.selectionMode).toBe("unresolved");
+    expect(report.collectionErrors.map((error) => error.code)).toContain(
+      "MISSING_SESSION_PROJECTION",
+    );
+  });
+
+  it("retains partial plugin inspection as a safe evidence gap", () => {
+    const report = buildCapabilityProjectionReport(
+      input({
+        facts: [
+          fact("workboard", "workboard_list", {
+            runtimeLoaded: {
+              value: "unknown",
+              basis: "none",
+              evidenceRefs: [],
+              reasonCode: "PARTIAL_PLUGIN_INSPECTION",
+            },
+          }),
+        ],
+        errors: [
+          {
+            collector: "plugin-runtime",
+            code: "PARTIAL_PLUGIN_INSPECTION",
+            message: "raw unsafe stderr",
+            occurredAt: now,
+            affectedClaims: ["workboard.runtimeLoaded"],
+          },
+        ],
+      }),
+    );
+    expect(tool(report, "workboard", "workboard_list").runtimeLoaded.value).toBe("unknown");
+    expect(renderCapabilityProjectionJson(report)).not.toContain("raw unsafe stderr");
+  });
+
+  it("reports policy allowed but not projected", () => {
+    const report = buildCapabilityProjectionReport(
+      input({ facts: [fact("memory", "memory_get")] }),
+    );
+    expect(tool(report, "memory", "memory_get").mismatchCodes).toContain(
+      "POLICY_ALLOWED_NOT_PROJECTED",
+    );
+  });
+
+  it("reports projection and policy conflict", () => {
+    const report = buildCapabilityProjectionReport(
+      input({
+        facts: [fact("browser", "browser", { policyAllowed: direct("false", "policy") })],
+        tools: ["browser"],
+      }),
+    );
+    expect(tool(report, "browser", "browser").mismatchCodes).toContain(
+      "PROJECTED_NOT_POLICY_ALLOWED",
+    );
+  });
+
+  it("produces the same report ID under reordered evidence", () => {
+    const facts = [fact("memory", "memory_search"), fact("memory", "memory_get")];
+    const first = buildCapabilityProjectionReport(
+      input({ facts, tools: ["memory_search", "memory_get"] }),
+    );
+    const second = buildCapabilityProjectionReport(
+      input({ facts: [...facts].reverse(), tools: ["memory_get", "memory_search"] }),
+    );
+    expect(second.reportId).toBe(first.reportId);
+  });
+
+  it("does not use successful shell evidence from another run", async () => {
+    const dir = await makeTempDir();
+    const trajectory = path.join(dir, "fixture.trajectory.jsonl");
+    const events = [
+      {
+        traceSchema: "openclaw-trajectory",
+        schemaVersion: 1,
+        traceId: "t",
+        source: "runtime",
+        type: "tool.result",
+        ts: now,
+        seq: 0,
+        sessionId: "s",
+        sessionKey,
+        runId,
+        data: { name: "exec", success: true },
+      },
+      {
+        traceSchema: "openclaw-trajectory",
+        schemaVersion: 1,
+        traceId: "t",
+        source: "runtime",
+        type: "context.compiled",
+        ts: now,
+        seq: 1,
+        sessionId: "s",
+        sessionKey,
+        runId,
+        data: {
+          tools: [{ name: "exec", description: "discard me", parameters: { secret: true } }],
+          prompt: "discard me",
+        },
+      },
+      {
+        traceSchema: "openclaw-trajectory",
+        schemaVersion: 1,
+        traceId: "t",
+        source: "runtime",
+        type: "tool.result",
+        ts: now,
+        seq: 2,
+        sessionId: "s",
+        sessionKey,
+        runId: "other-run",
+        data: { name: "exec", success: true, result: "discard me" },
+      },
+      {
+        traceSchema: "openclaw-trajectory",
+        schemaVersion: 1,
+        traceId: "t",
+        source: "runtime",
+        type: "tool.result",
+        ts: now,
+        seq: 2,
+        sessionId: "other-session",
+        sessionKey: "agent:main:discord:channel:other",
+        runId,
+        data: { name: "exec", success: true },
+      },
+      {
+        traceSchema: "openclaw-trajectory",
+        schemaVersion: 1,
+        traceId: "t",
+        source: "runtime",
+        type: "context.compiled",
+        ts: "2026-07-12T16:00:01.000Z",
+        seq: 3,
+        sessionId: "s",
+        sessionKey,
+        runId,
+        data: { tools: [{ name: "exec" }] },
+      },
+      {
+        traceSchema: "openclaw-trajectory",
+        schemaVersion: 1,
+        traceId: "t",
+        source: "runtime",
+        type: "tool.result",
+        ts: "2026-07-12T16:00:02.000Z",
+        seq: 4,
+        sessionId: "s",
+        sessionKey,
+        runId,
+        data: { name: "exec", success: true },
+      },
+    ];
+    await fs.writeFile(trajectory, `${events.map((event) => JSON.stringify(event)).join("\n")}\n`);
+    const collected = await collectExactTurnFromTrajectory(
+      trajectory,
+      {
+        mode: "exact_event_sequence",
+        sequence: 1,
+      },
+      { sessionId: "s", sessionKey },
+    );
+    expect(collected.compiled?.toolNames).toEqual(["exec"]);
+    expect(collected.successfulToolResults).toEqual([]);
+    expect(JSON.stringify(collected)).not.toContain("discard me");
+    const wrongSession = await collectExactTurnFromTrajectory(
+      trajectory,
+      { mode: "exact_event_sequence", sequence: 1 },
+      { sessionId: "other-session", sessionKey },
+    );
+    expect(wrongSession.errorCode).toBe("MISSING_SESSION_PROJECTION");
+  });
+
+  it("does not treat readiness observability as autonomy", () => {
+    const report = buildCapabilityProjectionReport(
+      input({
+        facts: [fact("readiness_health", "readiness_canary")],
+        tools: ["readiness_canary"],
+        observations: [
+          {
+            code: "READINESS_OBSERVABILITY_ONLY",
+            period: "current",
+            severity: "info",
+            summary: "Observability only; no recovery or autonomy action.",
+            evidenceRefs: ["canary"],
+          },
+        ],
+      }),
+    );
+    expect(report.capabilities.map((item) => item.name)).not.toContain("autonomy");
+    expect(report.observations[0]?.code).toBe("READINESS_OBSERVABILITY_ONLY");
+  });
+
+  it("does not promote uncorroborated agent self-report", () => {
+    const report = buildCapabilityProjectionReport(
+      input({
+        facts: [
+          fact("goal_tools", "create_goal", {
+            configured: direct("false", "config"),
+            runtimeLoaded: direct("false", "runtime"),
+            policyAllowed: direct("false", "policy"),
+            mutationRisk: "mutating",
+            selfReportedCallable: true,
+          }),
+        ],
+      }),
+    );
+    expect(tool(report, "goal_tools", "create_goal").mismatchCodes).toContain(
+      "SELF_REPORT_UNCORROBORATED",
+    );
+  });
+});
+
+describe("collector and publication safety", () => {
+  it("has a closed evidence schema with no arbitrary evidence fields", () => {
+    const schemaText = JSON.stringify(capabilityProjectionReportJsonSchema);
+    expect(schemaText).toContain("context_compiled");
+    expect(schemaText).toContain("additionalProperties");
+    expect(schemaText).not.toContain('"fields":{}');
+  });
+
+  it("requires explicit bounds for latest-in-window through its closed selection type", async () => {
+    const dir = await makeTempDir();
+    const trajectory = path.join(dir, "fixture.jsonl");
+    await fs.writeFile(trajectory, "");
+    const result = await collectExactTurnFromTrajectory(
+      trajectory,
+      {
+        mode: "latest_in_window",
+        start: "2026-07-12T00:00:00Z",
+        end: "2026-07-12T01:00:00Z",
+      },
+      { sessionId: "fixture", sessionKey },
+    );
+    expect(result.errorCode).toBe("MISSING_SESSION_PROJECTION");
+    const invalid = await collectExactTurnFromTrajectory(
+      trajectory,
+      {
+        mode: "latest_in_window",
+        start: "not-a-date",
+        end: "2026-07-12T01:00:00Z",
+      },
+      { sessionId: "fixture", sessionKey },
+    );
+    expect(invalid.errorCode).toBe("EVIDENCE_COLLECTION_FAILED");
+    const reversed = await collectExactTurnFromTrajectory(
+      trajectory,
+      {
+        mode: "latest_in_window",
+        start: "2026-07-12T02:00:00Z",
+        end: "2026-07-12T01:00:00Z",
+      },
+      { sessionId: "fixture", sessionKey },
+    );
+    expect(reversed.errorCode).toBe("EVIDENCE_COLLECTION_FAILED");
+  });
+
+  it("publishes mode-0600 files only under the approved root", async () => {
+    const root = await makeTempDir();
+    const report = buildCapabilityProjectionReport(
+      input({ facts: [fact("browser", "browser")], tools: ["browser"] }),
+    );
+    const result = await publishCapabilityProjectionPair({
+      report,
+      outputRoot: root,
+      outputDir: path.join(root, "reports"),
+    });
+    expect((await fs.stat(result.jsonPath)).mode & 0o777).toBe(0o600);
+    expect((await fs.stat(result.markdownPath)).mode & 0o777).toBe(0o600);
+    await expect(
+      publishCapabilityProjectionPair({
+        report,
+        outputRoot: root,
+        outputDir: path.join(root, "..", "escape"),
+      }),
+    ).rejects.toThrow("escaped");
+    const outside = await makeTempDir();
+    await fs.symlink(outside, path.join(root, "linked"));
+    await expect(
+      publishCapabilityProjectionPair({
+        report,
+        outputRoot: root,
+        outputDir: path.join(root, "linked", "reports"),
+      }),
+    ).rejects.toThrow("non-directory");
+    await expect(
+      publishCapabilityProjectionPair({
+        report,
+        outputRoot: root,
+        outputDir: path.join(root, "windows"),
+        platform: "win32",
+      }),
+    ).rejects.toThrow("supported on Linux only");
+    await expect(
+      publishCapabilityProjectionPair({
+        report,
+        outputRoot: root,
+        outputDir: path.join(root, "darwin"),
+        platform: "darwin",
+      }),
+    ).rejects.toThrow("supported on Linux only");
+    const versionsOutside = await makeTempDir();
+    const versionsOutput = path.join(root, "versions-link");
+    await fs.mkdir(versionsOutput);
+    await fs.symlink(versionsOutside, path.join(versionsOutput, ".versions"));
+    await expect(
+      publishCapabilityProjectionPair({
+        report,
+        outputRoot: root,
+        outputDir: versionsOutput,
+        platform: "linux",
+      }),
+    ).rejects.toThrow("not a real directory");
+    const symlinkRootTarget = await makeTempDir();
+    const symlinkRootParent = await makeTempDir();
+    const symlinkRoot = path.join(symlinkRootParent, "root-link");
+    await fs.symlink(symlinkRootTarget, symlinkRoot);
+    await expect(
+      publishCapabilityProjectionPair({
+        report,
+        outputRoot: symlinkRoot,
+        outputDir: path.join(symlinkRoot, "reports"),
+        platform: "linux",
+      }),
+    ).rejects.toThrow("root is not a real directory");
+    const hostileCurrentOutput = path.join(root, "hostile-current");
+    await fs.mkdir(hostileCurrentOutput);
+    await fs.symlink(versionsOutside, path.join(hostileCurrentOutput, ".current"));
+    await expect(
+      publishCapabilityProjectionPair({
+        report,
+        outputRoot: root,
+        outputDir: hostileCurrentOutput,
+        platform: "linux",
+      }),
+    ).rejects.toThrow("unexpected target");
+  });
+
+  it("preserves the previous complete pair when publication fails", async () => {
+    const root = await makeTempDir();
+    const outputDir = path.join(root, "reports");
+    const report = buildCapabilityProjectionReport(
+      input({ facts: [fact("browser", "browser")], tools: ["browser"] }),
+    );
+    await publishCapabilityProjectionPair({ report, outputRoot: root, outputDir });
+    const oldJson = await fs.readFile(path.join(outputDir, "current-turn.json"), "utf8");
+    const oldMarkdown = await fs.readFile(path.join(outputDir, "current-turn.md"), "utf8");
+    const nextReport = buildCapabilityProjectionReport({
+      ...input({ facts: [fact("browser", "browser")], tools: ["browser"] }),
+      generatedAt: "2026-07-12T16:01:00.000Z",
+    });
+    const fsImpl = {
+      chmod: fs.chmod,
+      lstat: fs.lstat,
+      mkdir: fs.mkdir,
+      readFile: fs.readFile,
+      readlink: fs.readlink,
+      realpath: fs.realpath,
+      rm: fs.rm,
+      symlink: fs.symlink,
+      writeFile: fs.writeFile,
+      rename: vi.fn(async (from: string, to: string) => {
+        if (to.endsWith(".current")) {
+          throw new Error("fixture publication failure");
+        }
+        await fs.rename(from, to);
+      }),
+    };
+    await expect(
+      publishCapabilityProjectionPair({ report: nextReport, outputRoot: root, outputDir, fsImpl }),
+    ).rejects.toThrow("fixture publication failure");
+    expect(await fs.readFile(path.join(outputDir, "current-turn.json"), "utf8")).toBe(oldJson);
+    expect(await fs.readFile(path.join(outputDir, "current-turn.md"), "utf8")).toBe(oldMarkdown);
+  });
+
+  it("exposes no generic tool invocation or mutation callback", async () => {
+    const source = await fs.readFile(
+      new URL("./capability-projection-collectors.ts", import.meta.url),
+      "utf8",
+    );
+    expect(source).not.toMatch(/invokeTool|executeTool|sendMessage|mutate|restart|spawn/u);
+    expect(source).not.toContain("/home/admin/.openclaw");
+  });
+});

--- a/src/commands/capability-projection.test.ts
+++ b/src/commands/capability-projection.test.ts
@@ -241,6 +241,24 @@ describe("capability projection acceptance fixtures", () => {
     expect(record.mismatchCodes).toContain("LOADED_NOT_POLICY_ALLOWED");
   });
 
+  it("uses an explicit Workboard read-only catalog with a mutating fallback", () => {
+    const report = buildCapabilityProjectionReport(
+      input({
+        facts: [
+          fact("workboard", "workboard_boards"),
+          fact("workboard", "workboard_get_or_create"),
+        ],
+        tools: ["workboard_boards", "workboard_get_or_create"],
+      }),
+    );
+    expect(tool(report, "workboard", "workboard_boards").callabilityStatus).toBe(
+      "projected_not_call_tested",
+    );
+    expect(tool(report, "workboard", "workboard_get_or_create").callabilityStatus).toBe(
+      "projected_but_not_safely_probed",
+    );
+  });
+
   it("derives historical acceptance facts from sanitized evidence only", () => {
     const report = buildCapabilityProjectionReport({
       ...input({ facts: [] }),
@@ -360,6 +378,12 @@ describe("capability projection acceptance fixtures", () => {
     expect(record.mismatchCodes).toContain("EVIDENCE_PERIOD_MISMATCH");
     expect(report.overallConfidence.level).toBe("medium");
     expect(report.overallConfidence.reasonCodes).toContain("EVIDENCE_COLLECTION_FAILED");
+  });
+
+  it("does not report high confidence when capability evidence is absent", () => {
+    const report = buildCapabilityProjectionReport(input({ facts: [] }));
+    expect(report.overallConfidence.level).toBe("medium");
+    expect(report.overallConfidence.reasonCodes).toContain("MISSING_CAPABILITY_EVIDENCE");
   });
 
   it("reports absent goal tools without probing them", () => {
@@ -499,6 +523,22 @@ describe("capability projection acceptance fixtures", () => {
         ],
       }),
     ).toThrow();
+    expect(() =>
+      buildCapabilityProjectionReport({
+        ...input({ facts: [] }),
+        trajectory: {
+          compiled: {
+            ts: now,
+            seq: 7,
+            sessionId: "session-synthetic",
+            sessionKey,
+            runId: "sk-proj-abcdefghijklmnop",
+            toolNames: ["memory_get"],
+          },
+          successfulToolResults: [],
+        },
+      }),
+    ).toThrow("prohibited secret-bearing value");
     expect(() =>
       buildCapabilityProjectionReport({
         ...input({ facts: [] }),
@@ -739,6 +779,116 @@ describe("capability projection acceptance fixtures", () => {
     expect(wrongSession.errorCode).toBe("MISSING_SESSION_PROJECTION");
   });
 
+  it("verifies a successful tool result from the canonical transcript branch", async () => {
+    const dir = await makeTempDir();
+    const trajectory = path.join(dir, "fixture.trajectory.jsonl");
+    const transcript = path.join(dir, "fixture.jsonl");
+    await fs.writeFile(
+      trajectory,
+      `${JSON.stringify({
+        traceSchema: "openclaw-trajectory",
+        schemaVersion: 1,
+        traceId: "t",
+        source: "runtime",
+        type: "context.compiled",
+        ts: now,
+        seq: 1,
+        sessionId: "s",
+        sessionKey,
+        runId,
+        data: { tools: [{ name: "memory_get" }] },
+      })}\n`,
+    );
+    await fs.writeFile(
+      transcript,
+      `${[
+        {
+          type: "session",
+          version: 3,
+          id: "s",
+          timestamp: "2026-07-12T15:59:00.000Z",
+          cwd: dir,
+        },
+        {
+          type: "message",
+          id: "result-1",
+          parentId: null,
+          timestamp: "2026-07-12T16:00:00.500Z",
+          message: {
+            role: "toolResult",
+            toolCallId: "call-1",
+            toolName: "memory_get",
+            content: [{ type: "text", text: "private result must be discarded" }],
+            isError: false,
+            timestamp: Date.parse("2026-07-12T16:00:00.500Z"),
+          },
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n")}\n`,
+    );
+    const collected = await collectExactTurnFromTrajectory(
+      trajectory,
+      { mode: "exact_run_id", runId },
+      {
+        sessionId: "s",
+        sessionKey,
+        evidenceWindow: { start: "2026-07-12T15:59:00Z", end: "2026-07-12T16:01:00Z" },
+      },
+      transcript,
+    );
+    expect(collected.successfulToolResults).toEqual([
+      {
+        ts: "2026-07-12T16:00:00.500Z",
+        runId,
+        toolName: "memory_get",
+        success: true,
+      },
+    ]);
+    expect(JSON.stringify(collected)).not.toContain("private result");
+  });
+
+  it("selects the highest sequence when latest events share a timestamp", async () => {
+    const dir = await makeTempDir();
+    const trajectory = path.join(dir, "fixture.trajectory.jsonl");
+    const events = [
+      {
+        traceSchema: "openclaw-trajectory",
+        schemaVersion: 1,
+        traceId: "t",
+        source: "runtime",
+        type: "context.compiled",
+        ts: now,
+        seq: 1,
+        sessionId: "s",
+        sessionKey,
+        runId: "run-1",
+        data: { tools: [{ name: "memory_get" }] },
+      },
+      {
+        traceSchema: "openclaw-trajectory",
+        schemaVersion: 1,
+        traceId: "t",
+        source: "runtime",
+        type: "context.compiled",
+        ts: now,
+        seq: 2,
+        sessionId: "s",
+        sessionKey,
+        runId: "run-2",
+        data: { tools: [{ name: "memory_search" }] },
+      },
+    ];
+    await fs.writeFile(trajectory, `${events.map((event) => JSON.stringify(event)).join("\n")}\n`);
+    const collected = await collectExactTurnFromTrajectory(
+      trajectory,
+      { mode: "latest_in_window", start: now, end: now },
+      { sessionId: "s", sessionKey, evidenceWindow: { start: now, end: now } },
+    );
+    expect(collected.compiled?.seq).toBe(2);
+    expect(collected.compiled?.toolNames).toEqual(["memory_search"]);
+  });
+
   it("does not treat readiness observability as autonomy", () => {
     const report = buildCapabilityProjectionReport(
       input({
@@ -904,6 +1054,9 @@ describe("collector and publication safety", () => {
     });
     expect((await fs.stat(result.jsonPath)).mode & 0o777).toBe(0o600);
     expect((await fs.stat(result.markdownPath)).mode & 0o777).toBe(0o600);
+    expect(path.dirname(result.jsonPath)).toBe(path.dirname(result.markdownPath));
+    expect(result.jsonPath).not.toBe(result.latestJsonPath);
+    expect(result.markdownPath).not.toBe(result.latestMarkdownPath);
     await expect(
       publishCapabilityProjectionPair({
         report,

--- a/src/commands/capability-projection.test.ts
+++ b/src/commands/capability-projection.test.ts
@@ -1038,6 +1038,22 @@ describe("collector and publication safety", () => {
     expect(schemaText).not.toContain('"fields":{}');
   });
 
+  it("rejects reserved and duplicate external evidence IDs", () => {
+    const base = evidenceFromFacts([fact("memory", "memory_get")])[0];
+    expect(() =>
+      buildCapabilityProjectionReport({
+        ...input({ facts: [] }),
+        evidence: [{ ...base, id: "context-compiled" }],
+      }),
+    ).toThrow("Reserved evidence ID");
+    expect(() =>
+      buildCapabilityProjectionReport({
+        ...input({ facts: [] }),
+        evidence: [base, { ...base }],
+      }),
+    ).toThrow("Evidence IDs must be unique");
+  });
+
   it("requires explicit bounds for latest-in-window through its closed selection type", async () => {
     const dir = await makeTempDir();
     const trajectory = path.join(dir, "fixture.jsonl");

--- a/src/commands/capability-projection.ts
+++ b/src/commands/capability-projection.ts
@@ -61,7 +61,7 @@ export function resolveCapabilityProjectionTrajectoryPath(params: {
   agentId?: string;
   storePath?: string;
   env?: NodeJS.ProcessEnv;
-}): { sessionId: string; trajectoryPath: string } | null {
+}): { sessionId: string; sessionFile: string; trajectoryPath: string } | null {
   const agentId = params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey);
   const entry = loadSessionEntry({
     agentId,
@@ -82,6 +82,7 @@ export function resolveCapabilityProjectionTrajectoryPath(params: {
   );
   return {
     sessionId: entry.sessionId,
+    sessionFile,
     trajectoryPath: resolveTrajectoryFilePath({
       env: params.env,
       sessionFile,
@@ -102,11 +103,16 @@ export async function collectCapabilityProjectionTrajectory(params: {
   if (!target) {
     return { compiled: null, successfulToolResults: [], errorCode: "MISSING_SESSION_PROJECTION" };
   }
-  return await collectExactTurnFromTrajectory(target.trajectoryPath, params.selection, {
-    sessionId: target.sessionId,
-    sessionKey: params.sessionKey,
-    evidenceWindow: params.evidenceWindow,
-  });
+  return await collectExactTurnFromTrajectory(
+    target.trajectoryPath,
+    params.selection,
+    {
+      sessionId: target.sessionId,
+      sessionKey: params.sessionKey,
+      evidenceWindow: params.evidenceWindow,
+    },
+    target.sessionFile,
+  );
 }
 
 function selectionMode(
@@ -153,7 +159,7 @@ function safeCollectionError(input: CollectionError): CollectionError {
 
 const SAFE_EVIDENCE_SOURCE_RE = /^[A-Za-z0-9_. -]{1,160}$/u;
 const SECRET_BEARING_VALUE_RE =
-  /(?:authorization|bearer\s+|cookie\s*[:=]|begin [A-Z ]*private key|(?:api[_-]?key|password|secret|token)\s*[:=]|https?:\/\/\S*\?)/iu;
+  /(?:authorization|bearer\s+|cookie\s*[:=]|begin [A-Z ]*private key|(?:api[_-]?key|password|secret|token)\s*[:=]|https?:\/\/\S*\?|\bsk-(?:proj-)?[A-Za-z0-9_-]{8,}\b|\bgh[pousr]_[A-Za-z0-9_]{20,}\b|\bgithub_pat_[A-Za-z0-9_]{20,}\b|\bxox[baprs]-[A-Za-z0-9-]{10,}\b|\b[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\b)/iu;
 
 function validateEvidenceStrings(value: unknown, key = "evidence"): void {
   if (typeof value === "string") {
@@ -181,6 +187,9 @@ function validateEvidenceStrings(value: unknown, key = "evidence"): void {
 function sanitizeEvidenceRecord(input: EvidenceRecord): EvidenceRecord {
   if (input.redactionApplied !== true) {
     throw new Error("Evidence record is not marked as redacted");
+  }
+  if (input.kind === "context_compiled" || input.kind === "existing_tool_result") {
+    throw new Error("Reserved evidence kind cannot be supplied externally");
   }
   const parsed = CapabilityProjectionEvidenceSchema.parse({ ...input, redactionApplied: true });
   validateEvidenceStrings(parsed);
@@ -270,6 +279,7 @@ export function buildCapabilityProjectionReport(
         },
         redactionApplied: true,
       };
+  validateEvidenceStrings(contextEvidence);
   const sanitizedInputEvidence = input.evidence.map(sanitizeEvidenceRecord);
   const evidence = [contextEvidence, ...sanitizedInputEvidence].sort(
     (a, b) =>
@@ -284,6 +294,17 @@ export function buildCapabilityProjectionReport(
   });
   const capabilities = buildCapabilityRecords(withProjection(facts, input.trajectory));
   const lowConfidence = !compiled;
+  const hasUnknownRequiredEvidence = capabilities.some((capability) =>
+    capability.tools
+      .filter((tool) => tool.membership === "required")
+      .some(
+        (tool) =>
+          tool.configured.value === "unknown" ||
+          tool.runtimeLoaded.value === "unknown" ||
+          tool.policyAllowed.value === "unknown" ||
+          tool.turnProjected.value === "unknown",
+      ),
+  );
   const evidenceGapReasonCodes = [
     ...new Set(
       sanitizedInputEvidence
@@ -345,13 +366,19 @@ export function buildCapabilityProjectionReport(
     overallConfidence: {
       level: lowConfidence
         ? ("low" as const)
-        : collectionErrors.length > 0 || evidenceGapReasonCodes.length > 0
+        : collectionErrors.length > 0 ||
+            evidenceGapReasonCodes.length > 0 ||
+            hasUnknownRequiredEvidence
           ? ("medium" as const)
           : ("high" as const),
       reasonCodes: lowConfidence
         ? [input.trajectory.errorCode ?? "MISSING_SESSION_PROJECTION"]
         : [
-            ...new Set([...collectionErrors.map((error) => error.code), ...evidenceGapReasonCodes]),
+            ...new Set([
+              ...collectionErrors.map((error) => error.code),
+              ...evidenceGapReasonCodes,
+              ...(hasUnknownRequiredEvidence ? ["MISSING_CAPABILITY_EVIDENCE"] : []),
+            ]),
           ].sort(),
     },
   };

--- a/src/commands/capability-projection.ts
+++ b/src/commands/capability-projection.ts
@@ -62,7 +62,7 @@ export function resolveCapabilityProjectionTrajectoryPath(params: {
   agentId?: string;
   storePath?: string;
   env?: NodeJS.ProcessEnv;
-}): { sessionId: string; sessionFile: string; trajectoryPath: string } | null {
+}): { sessionId: string; trajectoryPath: string } | null {
   const agentId = params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey);
   const entry = loadSessionEntry({
     agentId,
@@ -83,7 +83,6 @@ export function resolveCapabilityProjectionTrajectoryPath(params: {
   );
   return {
     sessionId: entry.sessionId,
-    sessionFile,
     trajectoryPath: resolveTrajectoryFilePath({
       env: params.env,
       sessionFile,
@@ -104,16 +103,11 @@ export async function collectCapabilityProjectionTrajectory(params: {
   if (!target) {
     return { compiled: null, successfulToolResults: [], errorCode: "MISSING_SESSION_PROJECTION" };
   }
-  return await collectExactTurnFromTrajectory(
-    target.trajectoryPath,
-    params.selection,
-    {
-      sessionId: target.sessionId,
-      sessionKey: params.sessionKey,
-      evidenceWindow: params.evidenceWindow,
-    },
-    target.sessionFile,
-  );
+  return await collectExactTurnFromTrajectory(target.trajectoryPath, params.selection, {
+    sessionId: target.sessionId,
+    sessionKey: params.sessionKey,
+    evidenceWindow: params.evidenceWindow,
+  });
 }
 
 function selectionMode(

--- a/src/commands/capability-projection.ts
+++ b/src/commands/capability-projection.ts
@@ -236,6 +236,9 @@ function sanitizeEvidenceRecord(input: EvidenceRecord): EvidenceRecord {
   if (input.kind === "context_compiled" || input.kind === "existing_tool_result") {
     throw new Error("Reserved evidence kind cannot be supplied externally");
   }
+  if (input.id === "context-compiled" || input.id.startsWith("existing-tool-result-")) {
+    throw new Error("Reserved evidence ID cannot be supplied externally");
+  }
   const parsed = CapabilityProjectionEvidenceSchema.parse({ ...input, redactionApplied: true });
   validateEvidenceStrings(parsed);
   return parsed as EvidenceRecord;
@@ -326,6 +329,10 @@ export function buildCapabilityProjectionReport(
       };
   validateEvidenceStrings(contextEvidence);
   const sanitizedInputEvidence = input.evidence.map(sanitizeEvidenceRecord);
+  const inputEvidenceIds = new Set(sanitizedInputEvidence.map((record) => record.id));
+  if (inputEvidenceIds.size !== sanitizedInputEvidence.length) {
+    throw new Error("Evidence IDs must be unique");
+  }
   const facts = collectToolFactsFromSanitizedEvidence({
     evidence: sanitizedInputEvidence,
     compiled,

--- a/src/commands/capability-projection.ts
+++ b/src/commands/capability-projection.ts
@@ -1,0 +1,348 @@
+import os from "node:os";
+import { resolveSessionFilePath, resolveSessionFilePathOptions } from "../config/sessions/paths.js";
+import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import { resolveTrajectoryFilePath } from "../trajectory/paths.js";
+import {
+  collectExactTurnFromTrajectory,
+  collectToolFactsFromSanitizedEvidence,
+  classifyCapabilityToolName,
+  type ExactTurnSelection,
+  type TrajectoryCollection,
+} from "./capability-projection-collectors.js";
+import {
+  buildCapabilityRecords,
+  computeCapabilityReportId,
+  type CapabilityProjectionReport,
+  type CollectionError,
+  type EvidenceRecord,
+} from "./capability-projection-model.js";
+import {
+  CapabilityProjectionEvidenceSchema,
+  CapabilityProjectionReportSchema,
+} from "./capability-projection-schema.js";
+
+export type CapabilityProjectionInput = {
+  generatedAt: string;
+  host: CapabilityProjectionReport["host"];
+  openclawVersion: string | null;
+  agentId: string;
+  sessionKey: string;
+  evidenceWindow: { start: string; end: string };
+  selection: ExactTurnSelection;
+  trajectory: TrajectoryCollection;
+  evidence: EvidenceRecord[];
+  observations?: CapabilityProjectionReport["observations"];
+  collectionErrors?: CollectionError[];
+};
+
+export function resolveCapabilityProjectionTrajectoryPath(params: {
+  sessionKey: string;
+  agentId?: string;
+  storePath?: string;
+  env?: NodeJS.ProcessEnv;
+}): { sessionId: string; trajectoryPath: string } | null {
+  const agentId = params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey);
+  const entry = loadSessionEntry({
+    agentId,
+    sessionKey: params.sessionKey,
+    storePath: params.storePath,
+    env: params.env,
+    clone: false,
+    hydrateSkillPromptRefs: false,
+    readConsistency: "latest",
+  });
+  if (!entry?.sessionId) {
+    return null;
+  }
+  const sessionFile = resolveSessionFilePath(
+    entry.sessionId,
+    entry,
+    resolveSessionFilePathOptions({ agentId, storePath: params.storePath }),
+  );
+  return {
+    sessionId: entry.sessionId,
+    trajectoryPath: resolveTrajectoryFilePath({
+      env: params.env,
+      sessionFile,
+      sessionId: entry.sessionId,
+    }),
+  };
+}
+
+export async function collectCapabilityProjectionTrajectory(params: {
+  sessionKey: string;
+  selection: ExactTurnSelection;
+  agentId?: string;
+  storePath?: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<TrajectoryCollection> {
+  const target = resolveCapabilityProjectionTrajectoryPath(params);
+  if (!target) {
+    return { compiled: null, successfulToolResults: [], errorCode: "MISSING_SESSION_PROJECTION" };
+  }
+  return await collectExactTurnFromTrajectory(target.trajectoryPath, params.selection, {
+    sessionId: target.sessionId,
+    sessionKey: params.sessionKey,
+  });
+}
+
+function selectionMode(
+  selection: ExactTurnSelection,
+): CapabilityProjectionReport["target"]["selectionMode"] {
+  return selection.mode;
+}
+
+function withProjection(facts: ToolFact[], trajectory: TrajectoryCollection): ToolFact[] {
+  if (!trajectory.compiled) {
+    return facts.map((fact) => ({
+      ...fact,
+      turnProjected: {
+        value: "unknown",
+        basis: "none",
+        evidenceRefs: [],
+        reasonCode: trajectory.errorCode ?? "MISSING_SESSION_PROJECTION",
+      },
+      existingSuccessfulCall: false,
+    }));
+  }
+  const projected = new Set(trajectory.compiled.toolNames);
+  const successful = new Set(trajectory.successfulToolResults.map((result) => result.toolName));
+  return facts.map((fact) => ({
+    ...fact,
+    turnProjected: {
+      value: projected.has(fact.name) ? "true" : "false",
+      basis: "direct",
+      evidenceRefs: ["context-compiled"],
+    },
+    existingSuccessfulCall: successful.has(fact.name),
+  }));
+}
+
+function safeCollectionError(input: CollectionError): CollectionError {
+  return {
+    collector: input.collector,
+    code: input.code,
+    message: "Evidence collection did not complete; affected claims remain unknown.",
+    occurredAt: input.occurredAt,
+    affectedClaims: [...new Set(input.affectedClaims)].sort(),
+  };
+}
+
+const SAFE_EVIDENCE_SOURCE_RE = /^[A-Za-z0-9_. -]{1,160}$/u;
+const SECRET_BEARING_VALUE_RE =
+  /(?:authorization|bearer\s+|cookie\s*[:=]|begin [A-Z ]*private key|(?:api[_-]?key|password|secret|token)\s*[:=]|https?:\/\/\S*\?)/iu;
+
+function validateEvidenceStrings(value: unknown, key = "evidence"): void {
+  if (typeof value === "string") {
+    if (SECRET_BEARING_VALUE_RE.test(value)) {
+      throw new Error("Evidence contains a prohibited secret-bearing value");
+    }
+    if (key === "source" && !SAFE_EVIDENCE_SOURCE_RE.test(value)) {
+      throw new Error("Evidence source must be a safe label");
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      validateEvidenceStrings(item, key);
+    }
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const [childKey, childValue] of Object.entries(value)) {
+      validateEvidenceStrings(childValue, childKey);
+    }
+  }
+}
+
+function sanitizeEvidenceRecord(input: EvidenceRecord): EvidenceRecord {
+  const parsed = CapabilityProjectionEvidenceSchema.parse({ ...input, redactionApplied: true });
+  validateEvidenceStrings(parsed);
+  return parsed as EvidenceRecord;
+}
+
+const OBSERVATION_SUMMARIES: Record<string, string> = {
+  CURRENT_HEALTHY: "Current sanitized health evidence passed.",
+  HISTORICAL_CURRENT_STATE_DIFFERENCE:
+    "Historical evidence differs from the current sanitized health snapshot.",
+  READINESS_OBSERVABILITY_ONLY:
+    "Readiness evidence is observability only and does not establish autonomy or recovery.",
+};
+
+function sanitizeObservations(
+  observations: CapabilityProjectionReport["observations"],
+): CapabilityProjectionReport["observations"] {
+  validateEvidenceStrings(observations);
+  return observations.map((observation) => {
+    if (!/^[A-Z][A-Z0-9_]{0,127}$/u.test(observation.code)) {
+      throw new Error("Observation contains an unsafe code");
+    }
+    return {
+      code: observation.code,
+      period: observation.period,
+      severity: observation.severity,
+      summary:
+        OBSERVATION_SUMMARIES[observation.code] ?? "Observation recorded from sanitized evidence.",
+      evidenceRefs: observation.evidenceRefs.map((reference) => {
+        if (!/^[A-Za-z0-9_.:-]{1,160}$/u.test(reference)) {
+          throw new Error("Observation contains an unsafe evidence reference");
+        }
+        return reference;
+      }),
+    };
+  });
+}
+
+export function buildCapabilityProjectionReport(
+  input: CapabilityProjectionInput,
+): CapabilityProjectionReport {
+  const collectionErrors = (input.collectionErrors ?? []).map(safeCollectionError);
+  if (input.trajectory.errorCode) {
+    collectionErrors.push({
+      collector: "trajectory",
+      code: input.trajectory.errorCode,
+      message: "Evidence collection did not complete; affected claims remain unknown.",
+      occurredAt: input.generatedAt,
+      affectedClaims: ["turnProjected", "callabilityStatus"],
+    });
+  }
+  const compiled = input.trajectory.compiled;
+  const contextEvidence: EvidenceRecord = compiled
+    ? {
+        id: "context-compiled",
+        rank: 1,
+        kind: "context_compiled",
+        source: "selected trajectory event",
+        observedAt: compiled.ts,
+        periodRelation: "exact_turn",
+        status: "collected",
+        fields: {
+          sessionId: compiled.sessionId,
+          sessionKey: compiled.sessionKey,
+          runId: compiled.runId,
+          sequence: compiled.seq,
+          toolNames: [...new Set(compiled.toolNames)]
+            .filter((name) => classifyCapabilityToolName(name) !== null)
+            .sort(),
+        },
+        redactionApplied: true,
+      }
+    : {
+        id: "context-compiled",
+        rank: 1,
+        kind: "context_compiled",
+        source: "selected trajectory event",
+        observedAt: null,
+        periodRelation: "unknown",
+        status: "missing",
+        fields: {
+          sessionId: "",
+          sessionKey: input.sessionKey,
+          runId: null,
+          sequence: 0,
+          toolNames: [],
+        },
+        redactionApplied: true,
+      };
+  const sanitizedInputEvidence = input.evidence.map(sanitizeEvidenceRecord);
+  const evidence = [contextEvidence, ...sanitizedInputEvidence].sort(
+    (a, b) =>
+      a.rank - b.rank ||
+      (a.observedAt ?? "~").localeCompare(b.observedAt ?? "~") ||
+      a.id.localeCompare(b.id),
+  );
+  const facts = collectToolFactsFromSanitizedEvidence({
+    evidence: sanitizedInputEvidence,
+    compiled,
+    evidenceWindow: input.evidenceWindow,
+  });
+  const capabilities = buildCapabilityRecords(withProjection(facts, input.trajectory));
+  const lowConfidence = !compiled;
+  const evidenceGapReasonCodes = [
+    ...new Set(
+      sanitizedInputEvidence
+        .filter((record) => record.status !== "collected")
+        .map((record) =>
+          record.kind === "plugin_runtime" && record.status === "partial"
+            ? "PARTIAL_PLUGIN_INSPECTION"
+            : "EVIDENCE_COLLECTION_FAILED",
+        ),
+    ),
+  ].sort();
+  const base = {
+    schema: "openclaw.capability-projection-report" as const,
+    schemaVersion: 1 as const,
+    generatedAt: new Date(input.generatedAt).toISOString(),
+    host: input.host,
+    openclawVersion: {
+      value: input.openclawVersion,
+      evidenceRefs: input.openclawVersion ? ["openclaw-version"] : [],
+    },
+    target: {
+      agentId: input.agentId,
+      sessionKey: input.sessionKey,
+      sessionId: compiled?.sessionId ?? null,
+      runId: compiled?.runId ?? null,
+      turnSequence: compiled?.seq ?? null,
+      contextCompiledAt: compiled?.ts ?? null,
+      selectionMode: compiled ? selectionMode(input.selection) : ("unresolved" as const),
+    },
+    evidenceWindow: {
+      start: new Date(input.evidenceWindow.start).toISOString(),
+      end: new Date(input.evidenceWindow.end).toISOString(),
+    },
+    capabilities,
+    evidence,
+    observations: sanitizeObservations(input.observations ?? []).sort(
+      (a, b) => a.period.localeCompare(b.period) || a.code.localeCompare(b.code),
+    ),
+    collectionErrors: collectionErrors.sort(
+      (a, b) => a.collector.localeCompare(b.collector) || a.code.localeCompare(b.code),
+    ),
+    redaction: {
+      policy: "allowlist-before-serialization-v1" as const,
+      excludedFieldClasses: [
+        "authorization_headers",
+        "cookies",
+        "credentials",
+        "environment",
+        "messages",
+        "private_certificate_material",
+        "prompts",
+        "raw_config",
+        "raw_logs",
+        "tool_arguments",
+        "tool_results",
+      ],
+      notes: ["Collectors reduce source data to fixed allowlisted fields before serialization."],
+    },
+    overallConfidence: {
+      level: lowConfidence
+        ? ("low" as const)
+        : collectionErrors.length > 0 || evidenceGapReasonCodes.length > 0
+          ? ("medium" as const)
+          : ("high" as const),
+      reasonCodes: lowConfidence
+        ? [input.trajectory.errorCode ?? "MISSING_SESSION_PROJECTION"]
+        : [
+            ...new Set([...collectionErrors.map((error) => error.code), ...evidenceGapReasonCodes]),
+          ].sort(),
+    },
+  };
+  const report: CapabilityProjectionReport = { ...base, reportId: computeCapabilityReportId(base) };
+  return CapabilityProjectionReportSchema.parse(report) as CapabilityProjectionReport;
+}
+
+export function defaultCapabilityProjectionHost(params: {
+  instanceDir: string;
+  workspaceDir: string;
+}): CapabilityProjectionReport["host"] {
+  return {
+    hostname: os.hostname(),
+    user: os.userInfo().username,
+    uid: process.getuid?.() ?? os.userInfo().uid,
+    instanceDir: params.instanceDir,
+    workspaceDir: params.workspaceDir,
+  };
+}

--- a/src/commands/capability-projection.ts
+++ b/src/commands/capability-projection.ts
@@ -21,6 +21,7 @@ import {
   type CapabilityProjectionReport,
   type CollectionError,
   type EvidenceRecord,
+  type ToolFact,
 } from "./capability-projection-model.js";
 import { publishCapabilityProjectionPair } from "./capability-projection-render.js";
 import {

--- a/src/commands/capability-projection.ts
+++ b/src/commands/capability-projection.ts
@@ -122,7 +122,11 @@ function selectionMode(
   return selection.mode;
 }
 
-function withProjection(facts: ToolFact[], trajectory: TrajectoryCollection): ToolFact[] {
+function withProjection(
+  facts: ToolFact[],
+  trajectory: TrajectoryCollection,
+  resultEvidenceRefs: ReadonlyMap<string, string[]>,
+): ToolFact[] {
   if (!trajectory.compiled) {
     return facts.map((fact) => ({
       ...fact,
@@ -133,6 +137,7 @@ function withProjection(facts: ToolFact[], trajectory: TrajectoryCollection): To
         reasonCode: trajectory.errorCode ?? "MISSING_SESSION_PROJECTION",
       },
       existingSuccessfulCall: false,
+      existingSuccessfulCallEvidenceRefs: [],
     }));
   }
   const projected = new Set(trajectory.compiled.toolNames);
@@ -145,7 +150,46 @@ function withProjection(facts: ToolFact[], trajectory: TrajectoryCollection): To
       evidenceRefs: ["context-compiled"],
     },
     existingSuccessfulCall: successful.has(fact.name),
+    existingSuccessfulCallEvidenceRefs: resultEvidenceRefs.get(fact.name) ?? [],
   }));
+}
+
+function buildExistingResultEvidence(
+  facts: ToolFact[],
+  trajectory: TrajectoryCollection,
+): { records: EvidenceRecord[]; refsByTool: Map<string, string[]> } {
+  const factsByName = new Map(facts.map((fact) => [fact.name, fact]));
+  const refsByTool = new Map<string, string[]>();
+  const results = trajectory.successfulToolResults
+    .filter((result) => factsByName.has(result.toolName))
+    .toSorted(
+      (left, right) =>
+        left.ts.localeCompare(right.ts) ||
+        left.toolName.localeCompare(right.toolName) ||
+        left.runId.localeCompare(right.runId),
+    );
+  const records = results.map<EvidenceRecord>((result, index) => {
+    const id = `existing-tool-result-${index + 1}`;
+    refsByTool.set(result.toolName, [...(refsByTool.get(result.toolName) ?? []), id]);
+    return {
+      id,
+      rank: 1,
+      kind: "existing_tool_result",
+      source: "existing tool result",
+      observedAt: result.ts,
+      periodRelation: "exact_turn",
+      status: "collected",
+      fields: {
+        toolName: result.toolName,
+        runId: result.runId,
+        success: true,
+        operationClass: factsByName.get(result.toolName)?.mutationRisk ?? "unknown",
+      },
+      redactionApplied: true,
+    };
+  });
+  records.forEach(validateEvidenceStrings);
+  return { records, refsByTool };
 }
 
 function safeCollectionError(input: CollectionError): CollectionError {
@@ -282,18 +326,21 @@ export function buildCapabilityProjectionReport(
       };
   validateEvidenceStrings(contextEvidence);
   const sanitizedInputEvidence = input.evidence.map(sanitizeEvidenceRecord);
-  const evidence = [contextEvidence, ...sanitizedInputEvidence].sort(
-    (a, b) =>
-      a.rank - b.rank ||
-      (a.observedAt ?? "~").localeCompare(b.observedAt ?? "~") ||
-      a.id.localeCompare(b.id),
-  );
   const facts = collectToolFactsFromSanitizedEvidence({
     evidence: sanitizedInputEvidence,
     compiled,
     evidenceWindow: input.evidenceWindow,
   });
-  const capabilities = buildCapabilityRecords(withProjection(facts, input.trajectory));
+  const resultEvidence = buildExistingResultEvidence(facts, input.trajectory);
+  const evidence = [contextEvidence, ...resultEvidence.records, ...sanitizedInputEvidence].sort(
+    (a, b) =>
+      a.rank - b.rank ||
+      (a.observedAt ?? "~").localeCompare(b.observedAt ?? "~") ||
+      a.id.localeCompare(b.id),
+  );
+  const capabilities = buildCapabilityRecords(
+    withProjection(facts, input.trajectory, resultEvidence.refsByTool),
+  );
   const lowConfidence = !compiled;
   const hasUnknownRequiredEvidence = capabilities.some((capability) =>
     capability.tools

--- a/src/commands/capability-projection.ts
+++ b/src/commands/capability-projection.ts
@@ -1,8 +1,13 @@
+import fs from "node:fs/promises";
 import os from "node:os";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
 import { resolveSessionFilePath, resolveSessionFilePathOptions } from "../config/sessions/paths.js";
 import { loadSessionEntry } from "../config/sessions/session-accessor.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { resolveTrajectoryFilePath } from "../trajectory/paths.js";
+import { VERSION } from "../version.js";
 import {
   collectExactTurnFromTrajectory,
   collectToolFactsFromSanitizedEvidence,
@@ -17,6 +22,7 @@ import {
   type CollectionError,
   type EvidenceRecord,
 } from "./capability-projection-model.js";
+import { publishCapabilityProjectionPair } from "./capability-projection-render.js";
 import {
   CapabilityProjectionEvidenceSchema,
   CapabilityProjectionReportSchema,
@@ -34,6 +40,20 @@ export type CapabilityProjectionInput = {
   evidence: EvidenceRecord[];
   observations?: CapabilityProjectionReport["observations"];
   collectionErrors?: CollectionError[];
+};
+
+export type CapabilityProjectionCommandOptions = {
+  sessionKey?: string;
+  agent?: string;
+  store?: string;
+  runId?: string;
+  eventSequence?: string;
+  windowStart?: string;
+  windowEnd?: string;
+  evidenceFile?: string;
+  outputRoot?: string;
+  outputDir?: string;
+  workspace?: string;
 };
 
 export function resolveCapabilityProjectionTrajectoryPath(params: {
@@ -73,6 +93,7 @@ export function resolveCapabilityProjectionTrajectoryPath(params: {
 export async function collectCapabilityProjectionTrajectory(params: {
   sessionKey: string;
   selection: ExactTurnSelection;
+  evidenceWindow: { start: string; end: string };
   agentId?: string;
   storePath?: string;
   env?: NodeJS.ProcessEnv;
@@ -84,6 +105,7 @@ export async function collectCapabilityProjectionTrajectory(params: {
   return await collectExactTurnFromTrajectory(target.trajectoryPath, params.selection, {
     sessionId: target.sessionId,
     sessionKey: params.sessionKey,
+    evidenceWindow: params.evidenceWindow,
   });
 }
 
@@ -157,6 +179,9 @@ function validateEvidenceStrings(value: unknown, key = "evidence"): void {
 }
 
 function sanitizeEvidenceRecord(input: EvidenceRecord): EvidenceRecord {
+  if (input.redactionApplied !== true) {
+    throw new Error("Evidence record is not marked as redacted");
+  }
   const parsed = CapabilityProjectionEvidenceSchema.parse({ ...input, redactionApplied: true });
   validateEvidenceStrings(parsed);
   return parsed as EvidenceRecord;
@@ -345,4 +370,120 @@ export function defaultCapabilityProjectionHost(params: {
     instanceDir: params.instanceDir,
     workspaceDir: params.workspaceDir,
   };
+}
+
+function resolveCommandSelection(
+  opts: CapabilityProjectionCommandOptions,
+): ExactTurnSelection | null {
+  const windowStart = opts.windowStart?.trim();
+  const windowEnd = opts.windowEnd?.trim();
+  const startMs = windowStart ? Date.parse(windowStart) : Number.NaN;
+  const endMs = windowEnd ? Date.parse(windowEnd) : Number.NaN;
+  if (
+    !windowStart ||
+    !windowEnd ||
+    !Number.isFinite(startMs) ||
+    !Number.isFinite(endMs) ||
+    startMs > endMs
+  ) {
+    return null;
+  }
+  const selectors = [Boolean(opts.runId?.trim()), Boolean(opts.eventSequence?.trim())].filter(
+    Boolean,
+  ).length;
+  if (selectors > 1) {
+    return null;
+  }
+  if (opts.runId?.trim()) {
+    return { mode: "exact_run_id", runId: opts.runId.trim() };
+  }
+  if (opts.eventSequence?.trim()) {
+    const sequence = Number(opts.eventSequence);
+    return Number.isSafeInteger(sequence) && sequence >= 0
+      ? { mode: "exact_event_sequence", sequence }
+      : null;
+  }
+  return { mode: "latest_in_window", start: windowStart, end: windowEnd };
+}
+
+/** Generates a report from local trajectory metadata plus a closed sanitized-evidence file. */
+export async function capabilityProjectionCommand(
+  opts: CapabilityProjectionCommandOptions,
+  runtime: RuntimeEnv,
+): Promise<void> {
+  const sessionKey = opts.sessionKey?.trim();
+  const selection = resolveCommandSelection(opts);
+  const evidenceFile = opts.evidenceFile?.trim();
+  const outputRoot = opts.outputRoot?.trim();
+  if (!sessionKey || !selection || !evidenceFile || !outputRoot) {
+    runtime.error(
+      "Capability projection requires --session-key, --evidence-file, --output-root, both --window-start/--window-end, and at most one exact selector: --run-id or --event-sequence.",
+    );
+    runtime.exit(1);
+    return;
+  }
+  let evidence: EvidenceRecord[];
+  try {
+    const parsed = JSON.parse(await fs.readFile(path.resolve(evidenceFile), "utf8")) as unknown;
+    evidence = CapabilityProjectionEvidenceSchema.array().parse(parsed) as EvidenceRecord[];
+    if (evidence.some((record) => record.redactionApplied !== true)) {
+      throw new Error("unredacted evidence");
+    }
+  } catch {
+    runtime.error("Capability projection evidence file is invalid or unreadable.");
+    runtime.exit(1);
+    return;
+  }
+  const targetAgentId = resolveAgentIdFromSessionKey(sessionKey);
+  if (opts.agent?.trim() && opts.agent.trim() !== targetAgentId) {
+    runtime.error("Capability projection --agent conflicts with the canonical session owner.");
+    runtime.exit(1);
+    return;
+  }
+  const evidenceWindow = { start: opts.windowStart as string, end: opts.windowEnd as string };
+  const trajectory = await collectCapabilityProjectionTrajectory({
+    sessionKey,
+    selection,
+    evidenceWindow,
+    agentId: targetAgentId,
+    storePath: opts.store,
+  });
+  const workspaceDir = path.resolve(opts.workspace ?? process.cwd());
+  const resolvedOutputRoot = path.resolve(outputRoot);
+  const resolvedOutputDir = path.resolve(
+    opts.outputDir ?? path.join(resolvedOutputRoot, "reports", "capability-projection"),
+  );
+  const generatedAt = new Date().toISOString();
+  const report = buildCapabilityProjectionReport({
+    generatedAt,
+    host: defaultCapabilityProjectionHost({
+      instanceDir: resolveStateDir(process.env),
+      workspaceDir,
+    }),
+    openclawVersion: VERSION,
+    agentId: targetAgentId,
+    sessionKey,
+    evidenceWindow,
+    selection,
+    trajectory,
+    evidence,
+  });
+  try {
+    const published = await publishCapabilityProjectionPair({
+      report,
+      outputRoot: resolvedOutputRoot,
+      outputDir: resolvedOutputDir,
+    });
+    runtime.log(
+      JSON.stringify({
+        reportId: report.reportId,
+        confidence: report.overallConfidence.level,
+        jsonPath: published.jsonPath,
+        markdownPath: published.markdownPath,
+      }),
+    );
+  } catch {
+    runtime.error("Capability projection publication failed.");
+    runtime.exit(1);
+  }
 }

--- a/src/commands/capability-projection.ts
+++ b/src/commands/capability-projection.ts
@@ -481,20 +481,27 @@ export async function capabilityProjectionCommand(
     opts.outputDir ?? path.join(resolvedOutputRoot, "reports", "capability-projection"),
   );
   const generatedAt = new Date().toISOString();
-  const report = buildCapabilityProjectionReport({
-    generatedAt,
-    host: defaultCapabilityProjectionHost({
-      instanceDir: resolveStateDir(process.env),
-      workspaceDir,
-    }),
-    openclawVersion: VERSION,
-    agentId: targetAgentId,
-    sessionKey,
-    evidenceWindow,
-    selection,
-    trajectory,
-    evidence,
-  });
+  let report: CapabilityProjectionReport;
+  try {
+    report = buildCapabilityProjectionReport({
+      generatedAt,
+      host: defaultCapabilityProjectionHost({
+        instanceDir: resolveStateDir(process.env),
+        workspaceDir,
+      }),
+      openclawVersion: VERSION,
+      agentId: targetAgentId,
+      sessionKey,
+      evidenceWindow,
+      selection,
+      trajectory,
+      evidence,
+    });
+  } catch {
+    runtime.error("Capability projection evidence failed semantic validation.");
+    runtime.exit(1);
+    return;
+  }
   try {
     const published = await publishCapabilityProjectionPair({
       report,

--- a/src/trajectory/export.ts
+++ b/src/trajectory/export.ts
@@ -482,43 +482,6 @@ function buildTranscriptEvents(params: {
   return events;
 }
 
-/**
- * Reads the canonical active transcript branch and returns only safe tool-result
- * identifiers. Result content never crosses this boundary.
- */
-export async function readSafeTranscriptToolResultEvents(params: {
-  sessionFile: string;
-  sessionId: string;
-  sessionKey: string;
-}): Promise<TrajectoryEvent[]> {
-  const { branchEntries } = await readSessionBranch(params.sessionFile);
-  return buildTranscriptEvents({
-    entries: branchEntries,
-    sessionId: params.sessionId,
-    sessionKey: params.sessionKey,
-    workspaceDir: path.dirname(params.sessionFile),
-    traceId: params.sessionId,
-  }).flatMap((event) => {
-    if (event.type !== "tool.result" || !isRecord(event.data?.message)) {
-      return [];
-    }
-    const message = event.data.message;
-    if (message.role !== "toolResult" || typeof message.toolName !== "string") {
-      return [];
-    }
-    return [
-      {
-        ...event,
-        workspaceDir: undefined,
-        data: {
-          name: message.toolName,
-          isError: message.isError === true,
-        },
-      },
-    ];
-  });
-}
-
 function sortTrajectoryEvents(events: TrajectoryEvent[]): TrajectoryEvent[] {
   const sourceOrder: Record<TrajectoryEvent["source"], number> = {
     runtime: 0,

--- a/src/trajectory/export.ts
+++ b/src/trajectory/export.ts
@@ -482,6 +482,43 @@ function buildTranscriptEvents(params: {
   return events;
 }
 
+/**
+ * Reads the canonical active transcript branch and returns only safe tool-result
+ * identifiers. Result content never crosses this boundary.
+ */
+export async function readSafeTranscriptToolResultEvents(params: {
+  sessionFile: string;
+  sessionId: string;
+  sessionKey: string;
+}): Promise<TrajectoryEvent[]> {
+  const { branchEntries } = await readSessionBranch(params.sessionFile);
+  return buildTranscriptEvents({
+    entries: branchEntries,
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    workspaceDir: path.dirname(params.sessionFile),
+    traceId: params.sessionId,
+  }).flatMap((event) => {
+    if (event.type !== "tool.result" || !isRecord(event.data?.message)) {
+      return [];
+    }
+    const message = event.data.message;
+    if (message.role !== "toolResult" || typeof message.toolName !== "string") {
+      return [];
+    }
+    return [
+      {
+        ...event,
+        workspaceDir: undefined,
+        data: {
+          name: message.toolName,
+          isError: message.isError === true,
+        },
+      },
+    ];
+  });
+}
+
 function sortTrajectoryEvents(events: TrajectoryEvent[]): TrajectoryEvent[] {
   const sourceOrder: Record<TrajectoryEvent["source"], number> = {
     runtime: 0,

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -9,7 +9,11 @@ import {
   resolveTrajectoryPointerFilePath,
   resolveTrajectoryPointerOpenFlags,
 } from "./paths.js";
-import { createTrajectoryRuntimeRecorder, toTrajectoryToolDefinitions } from "./runtime.js";
+import {
+  createTrajectoryRuntimeRecorder,
+  recordTrajectoryToolResult,
+  toTrajectoryToolDefinitions,
+} from "./runtime.js";
 
 type TrajectoryRuntimeRecorder = NonNullable<ReturnType<typeof createTrajectoryRuntimeRecorder>>;
 
@@ -103,6 +107,38 @@ describe("trajectory runtime", () => {
     expect(JSON.stringify(parsed.data)).not.toContain("sk-other-secret-token");
     expect(JSON.stringify(parsed.data)).not.toContain("ya29.fake-access-token");
     expect(JSON.stringify(parsed.data)).not.toContain("abcd-efgh-ijkl-mnop");
+  });
+
+  it("records tool completion without arguments or result content", () => {
+    const writes: string[] = [];
+    const recorder = expectTrajectoryRuntimeRecorder(
+      createTrajectoryRuntimeRecorder({
+        runId: "run-1",
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        writer: {
+          filePath: "/tmp/session.trajectory.jsonl",
+          write: (line) => {
+            writes.push(line);
+          },
+          flush: async () => undefined,
+        },
+      }),
+    );
+
+    recordTrajectoryToolResult(recorder, { toolName: "memory_get", isError: false });
+
+    const parsed = JSON.parse(writes[0]);
+    expect(parsed).toMatchObject({
+      type: "tool.result",
+      source: "runtime",
+      runId: "run-1",
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      data: { name: "memory_get", success: true, isError: false },
+    });
+    expect(parsed.data).not.toHaveProperty("result");
+    expect(parsed.data).not.toHaveProperty("arguments");
   });
 
   it("bounds large runtime event fields before serialization", () => {

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -46,6 +46,23 @@ type TrajectoryRuntimeRecorder = {
   describeFlushState: () => string | undefined;
 };
 
+type SafeTrajectoryToolResult = {
+  toolName: string;
+  isError: boolean;
+};
+
+/** Records only the fields needed to prove callability for the recorder-owned run. */
+export function recordTrajectoryToolResult(
+  recorder: Pick<TrajectoryRuntimeRecorder, "recordEvent"> | null,
+  event: SafeTrajectoryToolResult,
+): void {
+  recorder?.recordEvent("tool.result", {
+    name: event.toolName,
+    success: !event.isError,
+    isError: event.isError,
+  });
+}
+
 const writers = new Map<string, TrajectoryRuntimeWriter>();
 const windowFlushes = new KeyedAsyncQueue();
 const MAX_TRAJECTORY_WRITERS = 100;


### PR DESCRIPTION
Closes #105588

## What Problem This Solves

Operators currently cannot distinguish whether an OpenClaw capability is configured, runtime-loaded, policy-allowed, projected into an exact turn, or actually callable. This adds a deterministic read-only report contract that preserves those states separately instead of collapsing them into an ambiguous "available" flag.

## Why This Change Was Made

Adds `openclaw sessions capability-projection`, a closed-schema collector/model/renderer pipeline that selects authoritative `context.compiled` evidence by exact run, exact event sequence, or a bounded latest-in-window query. It accepts only pre-sanitized allowlisted auxiliary evidence, records successful callability only from runtime tool-result events carrying the selected run/session identity, and publishes JSON and Markdown from one validated normalized object using an atomic version pointer.

The command does not invoke tools, probe mutating capabilities, change policy/configuration, or contact external services. Tool completion trajectory events retain only tool name and success/error state; arguments and results are excluded.

## User Impact

Reviewers can generate machine-readable and human-readable capability projections with explicit evidence gaps and deterministic mismatch codes. This PR implements the command and synthetic proof only; it does not generate NathanAI's first live report or change any live capability surface.

## Evidence

- Issue: #105588
- Branch: `feat/capability-projection-report-v1`
- Commit: `95a9631714e5c323e2df9f6b3a78b49bd0653581`
- Focused tests:
  - `node scripts/run-vitest.mjs src/commands/capability-projection.test.ts src/cli/program/register.status-health-sessions.test.ts src/trajectory/runtime.test.ts`
  - PASS: 3 shards, 80 tests total (`31 + 32 + 17`)
- Formatting: `node_modules/.bin/oxfmt --write` on all touched final-delta files; PASS
- Diff hygiene: `git diff --check origin/main...HEAD`; PASS
- Mandatory autoreview: `gpt-5.6-sol`; final corrective review clean, no accepted/actionable findings (confidence 0.94)
- Schema/secret/determinism/parity proof is covered by `src/commands/capability-projection.test.ts`, including all requested fixture scenarios, closed evidence unions, credential/header/cookie/PEM/prompt/result exclusions, reordered-input determinism, and JSON/Markdown parity.
- Collector side-effect review:
  - canonical session accessors and bounded local trajectory reads only;
  - no subprocess collector or generic tool invocation interface;
  - no mutating callability probes;
  - runtime tool-result evidence stores only name/success/error under recorder-owned run/session identity.
- Sanitized copied-evidence dry run (outside all live report destinations):
  - root: `/tmp/capability-projection-dry-run-95a9631`
  - JSON mode/hash: `0600`, `8b0a926b8660bc5a4310bccc8d67375a0144cf2effedeb20bc25ad88b5729d0b`
  - Markdown mode/hash: `0600`, `b144dc5504696ef3f04bba84906d66e69fbf1917fa8db2d465c30c3076472acd`
  - secret-pattern scan: no matches

No live NathanAI report was generated. No OpenClaw configuration, runtime policy, plugin, service, permission, readiness monitor, Discord message, goal, Workboard card, Task Flow, commitment, certificate, or host setting was changed.

Known conservative behavior: missing or ambiguous exact-turn evidence blocks authoritative projection; missing auxiliary evidence remains unknown; verified callability requires a matching runtime tool-result event and otherwise remains explicitly unverified. Publication is Linux-only in v1 because the atomic pair contract depends on rename/symlink semantics.
