### PR TITLE
fix(ui): prevent Worktree create edits from disappearing during save

### DIFF
--- a/ui/src/pages/worktrees/worktrees-page.test.ts
+++ b/ui/src/pages/worktrees/worktrees-page.test.ts
@@ -11,7 +11,9 @@ type WorktreesPageTestElement = HTMLElement & {
   error: string | null;
   busyId: string | null;
   creating: boolean;
+  createOpen: boolean;
   createRepoRoot: string;
+  createName: string;
   createBaseRef: string;
   createBranches: string[];
   updateComplete: Promise<boolean>;
@@ -339,6 +341,68 @@ describe("WorktreesPage lifecycle", () => {
     await creating;
     expect(page.creating).toBe(false);
     expect(page.error).toBeNull();
+  });
+
+  it("locks the create draft and its toggle until create settles", async () => {
+    const pendingCreate = deferred<unknown>();
+    const request = vi.fn((method: string) => {
+      if (method === "worktrees.create") {
+        return pendingCreate.promise;
+      }
+      return Promise.resolve({ worktrees: [] });
+    });
+    const page = document.createElement("openclaw-worktrees-page") as WorktreesPageTestElement;
+    page.context = contextWithGateway(
+      gatewayWithClient({ request } as unknown as GatewayBrowserClient),
+    );
+    page.createOpen = true;
+    page.createRepoRoot = "/tmp/repo";
+    page.createName = "submitted-name";
+    page.createBaseRef = "main";
+    document.body.append(page);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
+    await vi.waitFor(() => expect(page.loading).toBe(false));
+
+    const toggleButton = Array.from(page.querySelectorAll<HTMLButtonElement>("button")).find(
+      (button) => button.textContent?.trim() === "New worktree",
+    );
+    const creating = page.createWorktree();
+    toggleButton?.click();
+    expect(page.createOpen).toBe(true);
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith("worktrees.create", {
+        baseRef: "main",
+        name: "submitted-name",
+        repoRoot: "/tmp/repo",
+      }),
+    );
+    await page.updateComplete;
+
+    const draftInputs = Array.from(
+      page.querySelectorAll<HTMLInputElement>(".worktrees-create input"),
+    );
+    const createButton = page.querySelector<HTMLButtonElement>(".worktrees-create button");
+    expect(draftInputs).toHaveLength(3);
+    expect(draftInputs.every((input) => input.disabled)).toBe(true);
+    expect(createButton?.disabled).toBe(true);
+    expect(toggleButton?.disabled).toBe(true);
+
+    toggleButton?.click();
+    expect(page.createOpen).toBe(true);
+
+    pendingCreate.resolve({});
+    await creating;
+    await page.updateComplete;
+    expect(page.createOpen).toBe(false);
+    expect(toggleButton?.disabled).toBe(false);
+
+    toggleButton?.click();
+    await page.updateComplete;
+    const freshInputs = Array.from(
+      page.querySelectorAll<HTMLInputElement>(".worktrees-create input"),
+    );
+    expect(freshInputs).toHaveLength(3);
+    expect(freshInputs.every((input) => !input.disabled)).toBe(true);
   });
 
   it("uses the current branch when a repository has no remote default", async () => {

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -260,6 +260,11 @@ class WorktreesPage extends OpenClawLightDomElement {
   }
 
   private toggleCreate() {
+    // A successful create closes and resets this shared draft, so the submitted
+    // snapshot must stay atomic until its request settles.
+    if (this.creating) {
+      return;
+    }
     this.createOpen = !this.createOpen;
     if (this.createOpen && !this.createRepoRoot) {
       const agents = this.context.agents.state.agentsList;
@@ -346,6 +351,7 @@ class WorktreesPage extends OpenClawLightDomElement {
           ${t("worktrees.repo")}
           <input
             type="text"
+            ?disabled=${this.creating}
             .value=${this.createRepoRoot}
             @change=${(event: Event) => {
               this.createRepoRoot = (event.target as HTMLInputElement).value;
@@ -358,6 +364,7 @@ class WorktreesPage extends OpenClawLightDomElement {
           ${t("worktrees.name")}
           <input
             type="text"
+            ?disabled=${this.creating}
             placeholder=${t("newSession.worktreeNamePlaceholder")}
             .value=${this.createName}
             @input=${(event: Event) => {
@@ -369,6 +376,7 @@ class WorktreesPage extends OpenClawLightDomElement {
           ${t("newSession.baseBranch")}
           <input
             type="text"
+            ?disabled=${this.creating}
             list="worktrees-create-branches"
             .value=${this.createBaseRef}
             @input=${(event: Event) => {
@@ -399,7 +407,7 @@ class WorktreesPage extends OpenClawLightDomElement {
             <div class="card-sub">${t("worktrees.subtitle")}</div>
           </div>
           <div class="row" style="gap: 8px;">
-            <button class="btn" @click=${() => this.toggleCreate()}>
+            <button class="btn" ?disabled=${this.creating} @click=${() => this.toggleCreate()}>
               ${t("worktrees.newWorktree")}
             </button>
             <button class="btn" ?disabled=${this.operationPending} @click=${() => void this.gc()}>


### PR DESCRIPTION
Closes #105608

## What Problem This Solves

Fixes an issue where users creating a managed Worktree could edit or dismiss the create form while the request was pending, then have those accepted interactions silently discarded when the earlier request completed.

## Why This Change Was Made

The submitted Worktree draft is now treated as one atomic operation: its repository, name, base branch, and form toggle remain locked until creation settles. A regression test covers both the synchronous dismissal guard and the rendered disabled state, including recovery after completion.

## User Impact

Worktree creation no longer acknowledges edits or dismissal that the in-flight request cannot honor. Controls become available again after the request settles.

## Evidence

Playwright against an isolated real Gateway and disposable Git repository:

- Before: all three draft inputs and the **New worktree** toggle remained enabled; a late name edit and dismissal were accepted, while only the earlier submitted worktree persisted.
- After: all three draft inputs, **Create**, and **New worktree** remain disabled; the late edit and dismissal are rejected; the submitted worktree persists and controls recover after settlement.
- The created QA worktree was removed through the Gateway after each run. No page or console errors occurred.

Validation:

- `corepack pnpm test ui/src/pages/worktrees/worktrees-page.test.ts` — 10/10 passed on trusted Testbox.
- `corepack pnpm check:changed` — passed on trusted Testbox.
- `OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/ui.js build` — passed.
- Source-blind behavior validation — 5 pass, 0 fail, 0 blocked; anti-cheat 3/3.
- Fresh autoreview — no actionable findings.
