### PR TITLE
ci(release): trace LTS final snapshot lock

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -4818,130 +4818,127 @@ export async function runEmbeddedAttempt(
         log.debug(
           `run cleanup: stage=final-snapshot-lock-wait runId=${params.runId} sessionId=${params.sessionId}`,
         );
-        try {
-          await sessionLockController.withSessionWriteLock(async () => {
-            log.debug(
-              `run cleanup: stage=final-snapshot-lock-acquired runId=${params.runId} sessionId=${params.sessionId}`,
-            );
-            // Check if ANY compaction occurred during the entire attempt (prompt + retry).
-            // Using a cumulative count (> 0) instead of a delta check avoids missing
-            // compactions that complete during activeSession.prompt() before the delta
-            // baseline is sampled.
-            compactionOccurredThisAttempt = getCompactionCount() > 0;
-            // Append cache-TTL timestamp AFTER prompt + compaction retry completes.
-            // Previously this was before the prompt, which caused a custom entry to be
-            // inserted between compaction and the next prompt — breaking the
-            // prepareCompaction() guard that checks the last entry type, leading to
-            // double-compaction. See: https://github.com/openclaw/openclaw/issues/9282
-            // Skip when timed out during compaction — session state may be inconsistent.
-            // Also skip when compaction ran this attempt — appending a custom entry
-            // after compaction would break the guard again. See: #28491
-            appendAttemptCacheTtlIfNeeded({
-              sessionManager: activeSessionManager,
-              timedOutDuringCompaction,
-              compactionOccurredThisAttempt,
-              config: params.config,
-              provider: params.provider,
-              modelId: params.modelId,
-              modelApi: params.model.api,
-              isCacheTtlEligibleProvider,
-            });
-
-            // If timeout occurred during compaction, use pre-compaction snapshot when available
-            // (compaction restructures messages but does not add user/assistant turns).
-            const snapshotSelection = selectCompactionTimeoutSnapshot({
-              timedOutDuringCompaction,
-              preCompactionSnapshot,
-              preCompactionSessionId,
-              currentSnapshot: activeSession.messages.slice(),
-              currentSessionId: activeSession.sessionId,
-            });
-            if (timedOutDuringCompaction) {
-              if (!isProbeSession) {
-                log.warn(
-                  `using ${snapshotSelection.source} snapshot: timed out during compaction runId=${params.runId} sessionId=${params.sessionId}`,
-                );
-              }
-            }
-            messagesSnapshot = projectToolSearchTargetTranscriptMessages(
-              snapshotSelection.messagesSnapshot,
-              toolSearchTargetTranscriptProjections,
-            );
-            sessionIdUsed = snapshotSelection.sessionIdUsed;
-
-            lastAssistant = messagesSnapshot
-              .slice()
-              .toReversed()
-              .find((message): message is AssistantMessage => message.role === "assistant");
-            currentAttemptAssistant = findCurrentAttemptAssistantMessage({
-              messagesSnapshot,
-              prePromptMessageCount,
-            });
-            attemptUsage = getUsageTotals();
-            cacheBreak = cacheObservabilityEnabled
-              ? completePromptCacheObservation({
-                  sessionId: params.sessionId,
-                  promptCacheKey: params.promptCacheKey,
-                  sessionKey: params.sessionKey,
-                  usage: attemptUsage,
-                })
-              : null;
-            lastCallUsage = normalizeUsage(currentAttemptAssistant?.usage);
-            const promptCacheObservation =
-              cacheObservabilityEnabled &&
-              (cacheBreak ||
-                promptCacheChangesForTurn ||
-                typeof attemptUsage?.cacheRead === "number")
-                ? {
-                    broke: Boolean(cacheBreak),
-                    ...(typeof cacheBreak?.previousCacheRead === "number"
-                      ? { previousCacheRead: cacheBreak.previousCacheRead }
-                      : {}),
-                    ...(typeof cacheBreak?.cacheRead === "number"
-                      ? { cacheRead: cacheBreak.cacheRead }
-                      : typeof attemptUsage?.cacheRead === "number"
-                        ? { cacheRead: attemptUsage.cacheRead }
-                        : {}),
-                    changes: cacheBreak?.changes ?? promptCacheChangesForTurn,
-                  }
-                : undefined;
-            const fallbackLastCacheTouchAt = readLastCacheTtlTimestamp(activeSessionManager, {
-              provider: params.provider,
-              modelId: params.modelId,
-            });
-            promptCache = buildContextEnginePromptCacheInfo({
-              retention: effectivePromptCacheRetention,
-              lastCallUsage,
-              observation: promptCacheObservation,
-              lastCacheTouchAt: resolvePromptCacheTouchTimestamp({
-                lastCallUsage,
-                assistantTimestamp: currentAttemptAssistant?.timestamp,
-                fallbackLastCacheTouchAt,
-              }),
-            });
-
-            if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {
-              try {
-                activeSessionManager.appendCustomEntry("openclaw:prompt-error", {
-                  timestamp: Date.now(),
-                  runId: params.runId,
-                  sessionId: params.sessionId,
-                  provider: params.provider,
-                  model: params.modelId,
-                  api: params.model.api,
-                  error: formatErrorMessage(promptError),
-                });
-              } catch (entryErr) {
-                log.warn(`failed to persist prompt error entry: ${String(entryErr)}`);
-              }
-            }
+        const finalSnapshotWrite = sessionLockController.withSessionWriteLock(async () => {
+          log.debug(
+            `run cleanup: stage=final-snapshot-lock-acquired runId=${params.runId} sessionId=${params.sessionId}`,
+          );
+          // Check if ANY compaction occurred during the entire attempt (prompt + retry).
+          // Using a cumulative count (> 0) instead of a delta check avoids missing
+          // compactions that complete during activeSession.prompt() before the delta
+          // baseline is sampled.
+          compactionOccurredThisAttempt = getCompactionCount() > 0;
+          // Append cache-TTL timestamp AFTER prompt + compaction retry completes.
+          // Previously this was before the prompt, which caused a custom entry to be
+          // inserted between compaction and the next prompt — breaking the
+          // prepareCompaction() guard that checks the last entry type, leading to
+          // double-compaction. See: https://github.com/openclaw/openclaw/issues/9282
+          // Skip when timed out during compaction — session state may be inconsistent.
+          // Also skip when compaction ran this attempt — appending a custom entry
+          // after compaction would break the guard again. See: #28491
+          appendAttemptCacheTtlIfNeeded({
+            sessionManager: activeSessionManager,
+            timedOutDuringCompaction,
+            compactionOccurredThisAttempt,
+            config: params.config,
+            provider: params.provider,
+            modelId: params.modelId,
+            modelApi: params.model.api,
+            isCacheTtlEligibleProvider,
           });
-        } catch (err) {
+
+          // If timeout occurred during compaction, use pre-compaction snapshot when available
+          // (compaction restructures messages but does not add user/assistant turns).
+          const snapshotSelection = selectCompactionTimeoutSnapshot({
+            timedOutDuringCompaction,
+            preCompactionSnapshot,
+            preCompactionSessionId,
+            currentSnapshot: activeSession.messages.slice(),
+            currentSessionId: activeSession.sessionId,
+          });
+          if (timedOutDuringCompaction) {
+            if (!isProbeSession) {
+              log.warn(
+                `using ${snapshotSelection.source} snapshot: timed out during compaction runId=${params.runId} sessionId=${params.sessionId}`,
+              );
+            }
+          }
+          messagesSnapshot = projectToolSearchTargetTranscriptMessages(
+            snapshotSelection.messagesSnapshot,
+            toolSearchTargetTranscriptProjections,
+          );
+          sessionIdUsed = snapshotSelection.sessionIdUsed;
+
+          lastAssistant = messagesSnapshot
+            .slice()
+            .toReversed()
+            .find((message): message is AssistantMessage => message.role === "assistant");
+          currentAttemptAssistant = findCurrentAttemptAssistantMessage({
+            messagesSnapshot,
+            prePromptMessageCount,
+          });
+          attemptUsage = getUsageTotals();
+          cacheBreak = cacheObservabilityEnabled
+            ? completePromptCacheObservation({
+                sessionId: params.sessionId,
+                promptCacheKey: params.promptCacheKey,
+                sessionKey: params.sessionKey,
+                usage: attemptUsage,
+              })
+            : null;
+          lastCallUsage = normalizeUsage(currentAttemptAssistant?.usage);
+          const promptCacheObservation =
+            cacheObservabilityEnabled &&
+            (cacheBreak || promptCacheChangesForTurn || typeof attemptUsage?.cacheRead === "number")
+              ? {
+                  broke: Boolean(cacheBreak),
+                  ...(typeof cacheBreak?.previousCacheRead === "number"
+                    ? { previousCacheRead: cacheBreak.previousCacheRead }
+                    : {}),
+                  ...(typeof cacheBreak?.cacheRead === "number"
+                    ? { cacheRead: cacheBreak.cacheRead }
+                    : typeof attemptUsage?.cacheRead === "number"
+                      ? { cacheRead: attemptUsage.cacheRead }
+                      : {}),
+                  changes: cacheBreak?.changes ?? promptCacheChangesForTurn,
+                }
+              : undefined;
+          const fallbackLastCacheTouchAt = readLastCacheTtlTimestamp(activeSessionManager, {
+            provider: params.provider,
+            modelId: params.modelId,
+          });
+          promptCache = buildContextEnginePromptCacheInfo({
+            retention: effectivePromptCacheRetention,
+            lastCallUsage,
+            observation: promptCacheObservation,
+            lastCacheTouchAt: resolvePromptCacheTouchTimestamp({
+              lastCallUsage,
+              assistantTimestamp: currentAttemptAssistant?.timestamp,
+              fallbackLastCacheTouchAt,
+            }),
+          });
+
+          if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {
+            try {
+              activeSessionManager.appendCustomEntry("openclaw:prompt-error", {
+                timestamp: Date.now(),
+                runId: params.runId,
+                sessionId: params.sessionId,
+                provider: params.provider,
+                model: params.modelId,
+                api: params.model.api,
+                error: formatErrorMessage(promptError),
+              });
+            } catch (entryErr) {
+              log.warn(`failed to persist prompt error entry: ${String(entryErr)}`);
+            }
+          }
+        });
+        await finalSnapshotWrite.catch((err) => {
           log.warn(
             `run cleanup: stage=final-snapshot-lock-failed runId=${params.runId} sessionId=${params.sessionId} error=${formatErrorMessage(err)}`,
           );
           throw err;
-        }
+        });
 
         // Let the active context engine run its post-turn lifecycle. These hooks
         // may call runtime LLM capabilities, so only their transcript rewrite

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -4933,7 +4933,7 @@ export async function runEmbeddedAttempt(
             }
           }
         });
-        await finalSnapshotWrite.catch((err) => {
+        await finalSnapshotWrite.catch((err: unknown) => {
           log.warn(
             `run cleanup: stage=final-snapshot-lock-failed runId=${params.runId} sessionId=${params.sessionId} error=${formatErrorMessage(err)}`,
           );

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -4815,118 +4815,133 @@ export async function runEmbeddedAttempt(
         log.debug(
           `run cleanup: stage=post-compaction-session-events runId=${params.runId} sessionId=${params.sessionId}`,
         );
-        await sessionLockController.withSessionWriteLock(async () => {
-          // Check if ANY compaction occurred during the entire attempt (prompt + retry).
-          // Using a cumulative count (> 0) instead of a delta check avoids missing
-          // compactions that complete during activeSession.prompt() before the delta
-          // baseline is sampled.
-          compactionOccurredThisAttempt = getCompactionCount() > 0;
-          // Append cache-TTL timestamp AFTER prompt + compaction retry completes.
-          // Previously this was before the prompt, which caused a custom entry to be
-          // inserted between compaction and the next prompt — breaking the
-          // prepareCompaction() guard that checks the last entry type, leading to
-          // double-compaction. See: https://github.com/openclaw/openclaw/issues/9282
-          // Skip when timed out during compaction — session state may be inconsistent.
-          // Also skip when compaction ran this attempt — appending a custom entry
-          // after compaction would break the guard again. See: #28491
-          appendAttemptCacheTtlIfNeeded({
-            sessionManager: activeSessionManager,
-            timedOutDuringCompaction,
-            compactionOccurredThisAttempt,
-            config: params.config,
-            provider: params.provider,
-            modelId: params.modelId,
-            modelApi: params.model.api,
-            isCacheTtlEligibleProvider,
-          });
+        log.debug(
+          `run cleanup: stage=final-snapshot-lock-wait runId=${params.runId} sessionId=${params.sessionId}`,
+        );
+        try {
+          await sessionLockController.withSessionWriteLock(async () => {
+            log.debug(
+              `run cleanup: stage=final-snapshot-lock-acquired runId=${params.runId} sessionId=${params.sessionId}`,
+            );
+            // Check if ANY compaction occurred during the entire attempt (prompt + retry).
+            // Using a cumulative count (> 0) instead of a delta check avoids missing
+            // compactions that complete during activeSession.prompt() before the delta
+            // baseline is sampled.
+            compactionOccurredThisAttempt = getCompactionCount() > 0;
+            // Append cache-TTL timestamp AFTER prompt + compaction retry completes.
+            // Previously this was before the prompt, which caused a custom entry to be
+            // inserted between compaction and the next prompt — breaking the
+            // prepareCompaction() guard that checks the last entry type, leading to
+            // double-compaction. See: https://github.com/openclaw/openclaw/issues/9282
+            // Skip when timed out during compaction — session state may be inconsistent.
+            // Also skip when compaction ran this attempt — appending a custom entry
+            // after compaction would break the guard again. See: #28491
+            appendAttemptCacheTtlIfNeeded({
+              sessionManager: activeSessionManager,
+              timedOutDuringCompaction,
+              compactionOccurredThisAttempt,
+              config: params.config,
+              provider: params.provider,
+              modelId: params.modelId,
+              modelApi: params.model.api,
+              isCacheTtlEligibleProvider,
+            });
 
-          // If timeout occurred during compaction, use pre-compaction snapshot when available
-          // (compaction restructures messages but does not add user/assistant turns).
-          const snapshotSelection = selectCompactionTimeoutSnapshot({
-            timedOutDuringCompaction,
-            preCompactionSnapshot,
-            preCompactionSessionId,
-            currentSnapshot: activeSession.messages.slice(),
-            currentSessionId: activeSession.sessionId,
-          });
-          if (timedOutDuringCompaction) {
-            if (!isProbeSession) {
-              log.warn(
-                `using ${snapshotSelection.source} snapshot: timed out during compaction runId=${params.runId} sessionId=${params.sessionId}`,
-              );
+            // If timeout occurred during compaction, use pre-compaction snapshot when available
+            // (compaction restructures messages but does not add user/assistant turns).
+            const snapshotSelection = selectCompactionTimeoutSnapshot({
+              timedOutDuringCompaction,
+              preCompactionSnapshot,
+              preCompactionSessionId,
+              currentSnapshot: activeSession.messages.slice(),
+              currentSessionId: activeSession.sessionId,
+            });
+            if (timedOutDuringCompaction) {
+              if (!isProbeSession) {
+                log.warn(
+                  `using ${snapshotSelection.source} snapshot: timed out during compaction runId=${params.runId} sessionId=${params.sessionId}`,
+                );
+              }
             }
-          }
-          messagesSnapshot = projectToolSearchTargetTranscriptMessages(
-            snapshotSelection.messagesSnapshot,
-            toolSearchTargetTranscriptProjections,
-          );
-          sessionIdUsed = snapshotSelection.sessionIdUsed;
+            messagesSnapshot = projectToolSearchTargetTranscriptMessages(
+              snapshotSelection.messagesSnapshot,
+              toolSearchTargetTranscriptProjections,
+            );
+            sessionIdUsed = snapshotSelection.sessionIdUsed;
 
-          lastAssistant = messagesSnapshot
-            .slice()
-            .toReversed()
-            .find((message): message is AssistantMessage => message.role === "assistant");
-          currentAttemptAssistant = findCurrentAttemptAssistantMessage({
-            messagesSnapshot,
-            prePromptMessageCount,
-          });
-          attemptUsage = getUsageTotals();
-          cacheBreak = cacheObservabilityEnabled
-            ? completePromptCacheObservation({
-                sessionId: params.sessionId,
-                promptCacheKey: params.promptCacheKey,
-                sessionKey: params.sessionKey,
-                usage: attemptUsage,
-              })
-            : null;
-          lastCallUsage = normalizeUsage(currentAttemptAssistant?.usage);
-          const promptCacheObservation =
-            cacheObservabilityEnabled &&
-            (cacheBreak || promptCacheChangesForTurn || typeof attemptUsage?.cacheRead === "number")
-              ? {
-                  broke: Boolean(cacheBreak),
-                  ...(typeof cacheBreak?.previousCacheRead === "number"
-                    ? { previousCacheRead: cacheBreak.previousCacheRead }
-                    : {}),
-                  ...(typeof cacheBreak?.cacheRead === "number"
-                    ? { cacheRead: cacheBreak.cacheRead }
-                    : typeof attemptUsage?.cacheRead === "number"
-                      ? { cacheRead: attemptUsage.cacheRead }
+            lastAssistant = messagesSnapshot
+              .slice()
+              .toReversed()
+              .find((message): message is AssistantMessage => message.role === "assistant");
+            currentAttemptAssistant = findCurrentAttemptAssistantMessage({
+              messagesSnapshot,
+              prePromptMessageCount,
+            });
+            attemptUsage = getUsageTotals();
+            cacheBreak = cacheObservabilityEnabled
+              ? completePromptCacheObservation({
+                  sessionId: params.sessionId,
+                  promptCacheKey: params.promptCacheKey,
+                  sessionKey: params.sessionKey,
+                  usage: attemptUsage,
+                })
+              : null;
+            lastCallUsage = normalizeUsage(currentAttemptAssistant?.usage);
+            const promptCacheObservation =
+              cacheObservabilityEnabled &&
+              (cacheBreak ||
+                promptCacheChangesForTurn ||
+                typeof attemptUsage?.cacheRead === "number")
+                ? {
+                    broke: Boolean(cacheBreak),
+                    ...(typeof cacheBreak?.previousCacheRead === "number"
+                      ? { previousCacheRead: cacheBreak.previousCacheRead }
                       : {}),
-                  changes: cacheBreak?.changes ?? promptCacheChangesForTurn,
-                }
-              : undefined;
-          const fallbackLastCacheTouchAt = readLastCacheTtlTimestamp(activeSessionManager, {
-            provider: params.provider,
-            modelId: params.modelId,
-          });
-          promptCache = buildContextEnginePromptCacheInfo({
-            retention: effectivePromptCacheRetention,
-            lastCallUsage,
-            observation: promptCacheObservation,
-            lastCacheTouchAt: resolvePromptCacheTouchTimestamp({
+                    ...(typeof cacheBreak?.cacheRead === "number"
+                      ? { cacheRead: cacheBreak.cacheRead }
+                      : typeof attemptUsage?.cacheRead === "number"
+                        ? { cacheRead: attemptUsage.cacheRead }
+                        : {}),
+                    changes: cacheBreak?.changes ?? promptCacheChangesForTurn,
+                  }
+                : undefined;
+            const fallbackLastCacheTouchAt = readLastCacheTtlTimestamp(activeSessionManager, {
+              provider: params.provider,
+              modelId: params.modelId,
+            });
+            promptCache = buildContextEnginePromptCacheInfo({
+              retention: effectivePromptCacheRetention,
               lastCallUsage,
-              assistantTimestamp: currentAttemptAssistant?.timestamp,
-              fallbackLastCacheTouchAt,
-            }),
-          });
+              observation: promptCacheObservation,
+              lastCacheTouchAt: resolvePromptCacheTouchTimestamp({
+                lastCallUsage,
+                assistantTimestamp: currentAttemptAssistant?.timestamp,
+                fallbackLastCacheTouchAt,
+              }),
+            });
 
-          if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {
-            try {
-              activeSessionManager.appendCustomEntry("openclaw:prompt-error", {
-                timestamp: Date.now(),
-                runId: params.runId,
-                sessionId: params.sessionId,
-                provider: params.provider,
-                model: params.modelId,
-                api: params.model.api,
-                error: formatErrorMessage(promptError),
-              });
-            } catch (entryErr) {
-              log.warn(`failed to persist prompt error entry: ${String(entryErr)}`);
+            if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {
+              try {
+                activeSessionManager.appendCustomEntry("openclaw:prompt-error", {
+                  timestamp: Date.now(),
+                  runId: params.runId,
+                  sessionId: params.sessionId,
+                  provider: params.provider,
+                  model: params.modelId,
+                  api: params.model.api,
+                  error: formatErrorMessage(promptError),
+                });
+              } catch (entryErr) {
+                log.warn(`failed to persist prompt error entry: ${String(entryErr)}`);
+              }
             }
-          }
-        });
+          });
+        } catch (err) {
+          log.warn(
+            `run cleanup: stage=final-snapshot-lock-failed runId=${params.runId} sessionId=${params.sessionId} error=${formatErrorMessage(err)}`,
+          );
+          throw err;
+        }
 
         // Let the active context engine run its post-turn lifecycle. These hooks
         // may call runtime LLM capabilities, so only their transcript rewrite


### PR DESCRIPTION
## What Problem This Solves

The exact LTS Telegram candidate still times out after both provider prompts complete. Existing diagnostics prove the stall begins at the final session snapshot lock but do not retain the lock acquisition error or owner.

Run: https://github.com/openclaw/openclaw/actions/runs/29204631764

## Why This Change Was Made

Add bounded lifecycle markers immediately before and after the final snapshot lock acquisition, plus a warning that records the existing formatted acquisition error before rethrowing it unchanged.

## User Impact

No behavior change. The next exact LTS run will identify the contending lock owner so the release blocker can be fixed without speculative backports.

## Evidence

- Exact candidate `b4e23556f1a2730b9681dacf6238bdb8c6aa579b`: prompts and prior cleanup milestones complete; canary still times out at 60 seconds.
- Targeted oxfmt and `git diff --check`: clean.
- Fresh autoreview: no findings, patch correct at 0.99 confidence.
- Final branch diff: 13 additions, 1 replacement in the existing cleanup path.
