### PR TITLE
fix(config): prune cron-run descendant sessions

### DIFF
--- a/src/config/sessions/session-registry-maintenance.test.ts
+++ b/src/config/sessions/session-registry-maintenance.test.ts
@@ -143,6 +143,47 @@ describe("runSessionRegistryMaintenanceForStore", () => {
     ).toEqual(sessionEntry("recent-run", now));
   });
 
+  it("applies pruning to stale cron-run descendant rows", async () => {
+    const now = Date.now();
+    const staleParentKey = "agent:main:cron:done-job:run:old-run";
+    const staleChildKey = "agent:main:cron:done-job:run:old-run:subagent:worker";
+    const runningParentKey = "agent:main:cron:running-job:run:old-run";
+    const runningChildKey = "agent:main:cron:running-job:run:old-run:thread:reply";
+    const ordinaryKey = "agent:main:subagent:ordinary-worker";
+    const storePath = await createStore({
+      [staleParentKey]: sessionEntry("done-run", now - 8 * DAY_MS),
+      [staleChildKey]: sessionEntry("done-run-child", now - 8 * DAY_MS),
+      [runningParentKey]: sessionEntry("running-run", now - 8 * DAY_MS),
+      [runningChildKey]: sessionEntry("running-run-child", now - 8 * DAY_MS),
+      [ordinaryKey]: sessionEntry("ordinary-worker", now - 8 * DAY_MS),
+    });
+
+    const result = await runSessionRegistryMaintenanceForStore({
+      apply: true,
+      retentionMs: 7 * DAY_MS,
+      runningCronJobIds: new Set(["running-job"]),
+      storePath,
+    });
+
+    expect(result).toEqual({
+      beforeCount: 5,
+      afterCount: 3,
+      preservedRunning: 2,
+      pruned: 2,
+    });
+    expect(loadSessionEntry({ sessionKey: staleParentKey, storePath })).toBeUndefined();
+    expect(loadSessionEntry({ sessionKey: staleChildKey, storePath })).toBeUndefined();
+    expect(loadSessionEntry({ sessionKey: runningParentKey, storePath })).toEqual(
+      sessionEntry("running-run", now - 8 * DAY_MS),
+    );
+    expect(loadSessionEntry({ sessionKey: runningChildKey, storePath })).toEqual(
+      sessionEntry("running-run-child", now - 8 * DAY_MS),
+    );
+    expect(loadSessionEntry({ sessionKey: ordinaryKey, storePath })).toEqual(
+      sessionEntry("ordinary-worker", now - 8 * DAY_MS),
+    );
+  });
+
   it("skips generic session maintenance while applying task registry pruning", async () => {
     const now = Date.now();
     const oldOrdinaryKey = "agent:main:subagent:old-worker";

--- a/src/config/sessions/session-registry-maintenance.ts
+++ b/src/config/sessions/session-registry-maintenance.ts
@@ -34,7 +34,7 @@ function parseCronRunSessionJobId(sessionKey: string): string | undefined {
   if (!parsed) {
     return undefined;
   }
-  return /^cron:([^:]+):run:[^:]+$/u.exec(parsed.rest)?.[1];
+  return /^cron:([^:]+):run:[^:]+(?:$|:)/u.exec(parsed.rest)?.[1];
 }
 
 function buildSessionRegistryPreserveKeys(params: {


### PR DESCRIPTION
## What Problem This Solves

Completed cron run cleanup can leave stale descendant session registry rows behind, such as subagent or thread rows under `agent:<id>:cron:<job>:run:<runId>:...`.

## Why This Change Was Made

`isCronRunSessionKey()` already treats cron-run descendants as cron-run session keys, but session registry maintenance only matched exact `cron:<job>:run:<runId>` rows. This caused stale descendants to be preserved as ordinary sessions.

This change aligns session registry maintenance with the existing cron-run session key classification.

## User Impact

Cron run session registry maintenance now prunes stale completed cron-run descendants while still preserving descendants for currently running cron jobs and preserving ordinary non-cron sessions.

## Evidence

- `git diff --check`
- Added focused regression coverage in
  `src/config/sessions/session-registry-maintenance.test.ts`.
- `codex review --base origin/main`: no actionable regressions found.

### Local SQLite Runtime Proof

In addition to the committed regression test, I ran a temporary local runtime
harness against an isolated SQLite-backed session registry. This was not a
mocked store and did not use any personal OpenClaw state.

The temporary harness used production APIs only:

- `replaceSessionEntry()` to persist the SQLite-backed registry rows;
- `beginSessionWorkAdmission()` to register an active runtime admission;
- `runSessionRegistryMaintenanceForStore({ apply: true, ... })` to execute the
  production maintenance path; and
- `listSessionEntries()` to read the persisted rows before and after apply.

The committed regression test provides the reviewable and CI-reproducible
version of this scenario. The terminal transcript below is supplementary local
runtime evidence from the same production persistence and maintenance APIs.

Raw terminal output:

```text
PR #105633 real SQLite maintenance proof
before (6): ["agent:main:cron:active-job:run:active-run:subagent:worker","agent:main:cron:done-job:run:old-run","agent:main:cron:done-job:run:old-run:subagent:worker","agent:main:cron:running-job:run:old-run","agent:main:cron:running-job:run:old-run:thread:reply","agent:main:subagent:ordinary-worker"]
result: {"afterCount":4,"beforeCount":6,"preservedRunning":2,"pruned":2}
after (4): ["agent:main:cron:active-job:run:active-run:subagent:worker","agent:main:cron:running-job:run:old-run","agent:main:cron:running-job:run:old-run:thread:reply","agent:main:subagent:ordinary-worker"]

✓ 1 test passed
```

## AI Assistance

This PR was developed with assistance from OpenAI Codex for codebase navigation, implementation, and review. I reviewed the final implementation and tests and understand the behavior change.