### PR TITLE
perf(model): reuse plugin-metadata snapshot for manifest alias canonicalization (#105543)

### DIFF
--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -7,6 +7,7 @@ import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { planManifestModelCatalogRows } from "../../model-catalog/manifest-planner.js";
 import { normalizePluginsConfig } from "../../plugins/config-state.js";
+import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
 import { listOpenClawPluginManifestMetadata } from "../../plugins/manifest-metadata-scan.js";
 import { passesManifestOwnerBasePolicy } from "../../plugins/manifest-owner-policy.js";
 import { loadPluginManifestRegistry } from "../../plugins/manifest-registry.js";
@@ -207,16 +208,28 @@ export function canonicalizeManifestModelCatalogProviderAlias(params: {
   if (!provider) {
     return params.provider;
   }
-  return (
-    resolveManifestModelCatalogProviderAlias({
-      provider,
-      plugins: loadPluginManifestRegistry({
-        config: params.cfg,
-        workspaceDir: params.workspaceDir,
-        env: params.env ?? process.env,
-      }).plugins,
-    }) ?? params.provider
-  );
+  const env = params.env ?? process.env;
+  // Warm model-resolution passes call this per turn (and twice per pass via
+  // normalizeProviderModelRef). loadPluginManifestRegistry re-runs full
+  // filesystem discovery + manifest parsing every call, so reuse the
+  // process-stable Gateway plugin-metadata snapshot when one exists. Fall back to
+  // a direct registry load when there is no current snapshot (cold start /
+  // non-Gateway callers) rather than building a fresh full snapshot (#105543).
+  const currentSnapshot = getCurrentPluginMetadataSnapshot({
+    config: params.cfg,
+    env,
+    ...(params.workspaceDir !== undefined
+      ? { workspaceDir: params.workspaceDir }
+      : { allowWorkspaceScopedSnapshot: true }),
+  });
+  const plugins =
+    currentSnapshot?.plugins ??
+    loadPluginManifestRegistry({
+      config: params.cfg,
+      workspaceDir: params.workspaceDir,
+      env,
+    }).plugins;
+  return resolveManifestModelCatalogProviderAlias({ provider, plugins }) ?? params.provider;
 }
 
 /** Returns whether a bundled static catalog asks runtime discovery to augment its rows. */


### PR DESCRIPTION
## What Problem This Solves

Warm Gateway agent turns repeatedly rescan plugin manifests while canonicalizing an already-known model provider alias. `canonicalizeManifestModelCatalogProviderAlias` calls `loadPluginManifestRegistry`, which re-runs full plugin **filesystem discovery + manifest parsing on every call** — nothing is memoized on that path. It runs per turn (and twice per pass via the three `normalizeProviderModelRef` call sites), adding tens of ms of pre-model latency to every turn.

Fixes #105543 (reported by @steipete).

## Why This Change Was Made

The Gateway already owns a **process-stable plugin-metadata snapshot** (`getCurrentPluginMetadataSnapshot`). Plugin metadata is process-stable while the Gateway runs (per `src/plugins/CLAUDE.md`: "Reuse current snapshots… avoid per-call stat/read/hash freshness"), so the alias path should read from it.

The change reuses the **current** snapshot when one exists and falls back to the direct `loadPluginManifestRegistry` load only when there is no current snapshot (cold start / non-Gateway callers):

```ts
const currentSnapshot = getCurrentPluginMetadataSnapshot({ config: params.cfg, env, /* workspace scope */ });
const plugins = currentSnapshot?.plugins ?? loadPluginManifestRegistry({ config: params.cfg, workspaceDir: params.workspaceDir, env }).plugins;
```

No new cache is introduced. The cold path keeps the previous behavior exactly (no fresh full-snapshot build), so no caller is newly routed through snapshot construction.

## User Impact

- Warm-turn model resolution no longer rescans plugin manifests to canonicalize a known provider alias; the per-turn pre-model delay drops accordingly.
- Alias resolution behavior is identical; cold/non-Gateway callers are unchanged.

## Evidence

**Real behavior benchmark** — simulated a warm Gateway (built a snapshot, registered it via `setCurrentPluginMetadataSnapshot`), then timed both paths in one process (12 warm samples each):

```
current snapshot present: true (plugins=139)

[OLD loadPluginManifestRegistry(...).plugins       ] warm-avg=15.29ms
[NEW canonicalize (warm: reuses current snapshot)  ] warm-avg=0.01ms

correctness: canonicalize("openai") = "openai" (unchanged resolution)
```

Warm alias lookup drops from a full rescan (~15 ms here; ~35–43 ms in the report) to a cached read.

**Resolution correctness / no regression** — `model.static-catalog.test.ts` (17, incl. `canonicalizes unambiguous manifest-owned aliases`) + `model.test.ts` (124, incl. the real unmocked `moonshotai` / `moonshot-ai` manifest-owned alias tests) all green. The cold path still uses `loadPluginManifestRegistry`, so the mocked-registry tests resolve exactly as before.

Pre-existing unrelated `TS4058` in `src/secrets/config-io.ts` is present on `main` without this change (verified by reverting the file and re-running tsgo).
