### PR TITLE
fix(line): skip confirm/buttons templates with a blank required field (#105511)

### DIFF
--- a/extensions/line/src/reply-payload-transform.test.ts
+++ b/extensions/line/src/reply-payload-transform.test.ts
@@ -163,6 +163,25 @@ describe("parseLineDirectives", () => {
         expect(result.text, testCase.name).toBe(testCase.expectedText);
       }
     });
+
+    it("skips the confirm template when a required field is blank (#105511)", () => {
+      const cases = [
+        { name: "blank question", text: "[[confirm:  | Yes | No]]" },
+        { name: "blank yes label", text: "[[confirm: Proceed? |  | No]]" },
+        { name: "blank no label", text: "[[confirm: Proceed? | Yes | ]]" },
+      ] as const;
+
+      for (const testCase of cases) {
+        const result = parseLineDirectives({ text: testCase.text });
+        expect(getLineData(result).templateMessage, testCase.name).toBeUndefined();
+      }
+    });
+
+    it("preserves surrounding text instead of dropping the message on a blank confirm (#105511)", () => {
+      const result = parseLineDirectives({ text: "Please decide: [[confirm:  | Yes | No]]" });
+      expect(getLineData(result).templateMessage).toBeUndefined();
+      expect(result.text).toBe("Please decide:");
+    });
   });
 
   describe("buttons", () => {
@@ -227,6 +246,18 @@ describe("parseLineDirectives", () => {
             testCase.expectedActionCount,
           );
         }
+      }
+    });
+
+    it("skips the buttons template when title or text is blank (#105511)", () => {
+      const cases = [
+        { name: "blank title", text: "[[buttons:  | Choose an option | Opt1:d1]]" },
+        { name: "blank text", text: "[[buttons: Menu |  | Opt1:d1]]" },
+      ] as const;
+
+      for (const testCase of cases) {
+        const result = parseLineDirectives({ text: testCase.text });
+        expect(getLineData(result).templateMessage, testCase.name).toBeUndefined();
       }
     });
   });

--- a/extensions/line/src/reply-payload-transform.ts
+++ b/extensions/line/src/reply-payload-transform.ts
@@ -92,15 +92,20 @@ export function parseLineDirectives(payload: ReplyPayload): ReplyPayload {
         ? noPart.split(":").map((s) => s.trim())
         : [noPart, normalizeLowercaseStringOrEmpty(noPart)];
 
-      lineData.templateMessage = {
-        type: "confirm",
-        text: question,
-        confirmLabel: yesLabel,
-        confirmData: yesData,
-        cancelLabel: noLabel,
-        cancelData: noData,
-        altText: question,
-      };
+      // LINE rejects a confirm template whose text or either action label is
+      // empty (HTTP 400), which drops the whole message. Skip building it when a
+      // required field is blank so the rest of the reply still sends (#105511).
+      if (question && yesLabel && noLabel) {
+        lineData.templateMessage = {
+          type: "confirm",
+          text: question,
+          confirmLabel: yesLabel,
+          confirmData: yesData,
+          cancelLabel: noLabel,
+          cancelData: noData,
+          altText: question,
+        };
+      }
     }
     text = text.replace(confirmMatch[0], "").trim();
   }
@@ -145,7 +150,10 @@ export function parseLineDirectives(payload: ReplyPayload): ReplyPayload {
         return { type: "message" as const, label, data: data || label };
       });
 
-      if (actions.length > 0) {
+      // LINE rejects a buttons template with an empty title or text (HTTP 400),
+      // which drops the whole message. Require both (alongside at least one
+      // action) so a blank required field degrades to plain text (#105511).
+      if (actions.length > 0 && title && bodyText) {
         lineData.templateMessage = {
           type: "buttons",
           title,


### PR DESCRIPTION
## What Problem This Solves

The LINE `[[confirm:]]` and `[[buttons:]]` directives only checked that the pipe-separated fields were *present* (`parts.length >= 3`), not that the required ones were *non-empty*. A blank question / action label (confirm) or title / text (buttons) — common when an LLM omits one — produces a LINE template that the Messaging API rejects with **HTTP 400**, so the **entire message is dropped** (message loss).

Fixes #105511 (reported by @edenfunf).

## Why This Change Was Made

The sibling directives (`[[location:]]`, `[[media_player:]]`, `[[event:]]`) already guard their content with `field || "fallback"`; confirm/buttons did not. This adds the missing guard: when a required pipe-separated field is blank, skip building the template. The directive is still stripped, so the rest of the reply sends as plain text instead of an invalid payload.

Scoped deliberately to the **pipe-separated required fields** (`question`/`yes`/`no` for confirm; `title`/`text` for buttons). Comma-list trailing-blank handling stays with the sibling PR #105381, so the two changes don't overlap.

## User Impact

- A LINE reply with a blank confirm/buttons required field no longer 400s and drops the whole message; it degrades to plain text.
- Valid directives are unchanged.

## Evidence

**Real behavior** — ran the actual `parseLineDirectives` (not a mock). Exact head:

```
AFTER (this PR):
[confirm blank question] template=NONE (no invalid payload)   outText=undefined
[confirm valid         ] template=confirm (would POST to LINE) outText=undefined
[buttons blank title   ] template=NONE (no invalid payload)   outText=undefined
[buttons valid         ] template=buttons (would POST to LINE) outText=undefined
[msg-loss guard        ] template=NONE (no invalid payload)   outText="Please decide:"

BEFORE (current main) — the bug:
[confirm blank question] template={"type":"confirm","text":"","confirmLabel":"Yes"}  -> LINE 400 @ altText
[buttons blank title   ] template={"type":"buttons","text":"Choose","title":""}      -> LINE 400 @ template/title
[msg-loss guard        ] template={"type":"confirm","text":""}  outText="Please decide:"  -> whole message dropped
```

The `msg-loss guard` case is the key one: before, a blank confirm inside a reply produced an invalid template that LINE rejects, dropping the `"Please decide:"` text too; after, the template is skipped and `"Please decide:"` still sends.

**Regression tests** (`node scripts/run-vitest.mjs run extensions/line/src/reply-payload-transform.test.ts` -> 15/15):

- `skips the confirm template when a required field is blank` — blank question / yes / no.
- `preserves surrounding text instead of dropping the message on a blank confirm` — asserts the text still sends.
- `skips the buttons template when title or text is blank`.

**Discriminator**: reverting `reply-payload-transform.ts` to `main` fails all three new tests.

Reported-by: @edenfunf
