### PR TITLE
fix(reply): preserve unsent streamed finals on LTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ Skills own workflows; root owns hard policy and routing.
 - Tests in a Codex worktree or linked/sparse checkout: avoid direct local `pnpm test*`; use `node scripts/run-vitest.mjs <path-or-filter>` for tiny explicit-file proof, or Crabbox/Testbox for anything broader.
 - Checks in a normal source checkout: `pnpm check:changed` delegates to Crabbox/Testbox; lanes: `pnpm changed:lanes --json`; staged: `pnpm check:changed --staged`; full: `pnpm check`.
 - Checks in a Codex worktree or linked/sparse checkout: avoid direct local `pnpm check*`; use `node scripts/crabbox-wrapper.mjs run ... -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` so pnpm runs inside Testbox, not locally.
+- Direct Testbox runs: pass `--provider blacksmith-testbox`; `OPENCLAW_TESTBOX=1` only selects `scripts/pr` prepare behavior.
 - Extension tests: `pnpm test:extensions`, `pnpm test extensions`, `pnpm test extensions/<id>`.
 - Typecheck: `tsgo` lanes only (`pnpm tsgo*`, `pnpm check:test-types`); never add `tsc --noEmit`, `typecheck`, `check:types`.
 - Formatting: `oxfmt`, not Prettier. Use repo wrappers (`pnpm format:*`, `pnpm lint:*`, `scripts/run-oxlint.mjs`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - Gateway and process reliability: cap agent-run cache and JSONL socket buffers, release gateway lock file descriptors, keep WebSocket close reasons UTF-8 safe, survive transient heartbeat file reads, contain SSH-config and Google Meet node-host stream failures, and validate serialized tool payloads by UTF-8 bytes. (#77973, #99291, #98130, #100047, #100389, #101160, #102105, #102450) Thanks @fede-kamel, @chenyangjun-xy, @Pick-cat, @NarahariRaghava, @ogarciarevett, @wangmiao0668000666, and @qingminglong.
 - Sessions and subagents: route Gateway session consumers through the session-accessor seam, serialize reply-session initialization without dropping concurrent metadata, and deliver stale-run subagent completions directly when steering cannot drain. (#90463, #98835, #102160) Thanks @jalehman, @obviyus, and @moguangyu5-design.
 - Agent session locks: drain nested transcript writes before releasing the physical session lock so replies cannot stall after prompt completion.
+- Reply delivery: preserve unsent text-only finals when block streaming emitted only a partial payload, while de-duplicating streamed finals per assistant message. (#93629, #95432) Thanks @liuhao1024 and @yetval.
 - Release rehearsal safety: accept a full commit SHA only for validation-only extended-stable npm preflight, preflight all local npm package artifacts, and retain blocking performance and stable-soak manifest checks for any future publish reuse. (#99352, #101466, #101757) Thanks @kevinslin.
 
 ## 2026.6.8

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -4815,13 +4815,7 @@ export async function runEmbeddedAttempt(
         log.debug(
           `run cleanup: stage=post-compaction-session-events runId=${params.runId} sessionId=${params.sessionId}`,
         );
-        log.debug(
-          `run cleanup: stage=final-snapshot-lock-wait runId=${params.runId} sessionId=${params.sessionId}`,
-        );
-        const finalSnapshotWrite = sessionLockController.withSessionWriteLock(async () => {
-          log.debug(
-            `run cleanup: stage=final-snapshot-lock-acquired runId=${params.runId} sessionId=${params.sessionId}`,
-          );
+        await sessionLockController.withSessionWriteLock(async () => {
           // Check if ANY compaction occurred during the entire attempt (prompt + retry).
           // Using a cumulative count (> 0) instead of a delta check avoids missing
           // compactions that complete during activeSession.prompt() before the delta
@@ -4932,12 +4926,6 @@ export async function runEmbeddedAttempt(
               log.warn(`failed to persist prompt error entry: ${String(entryErr)}`);
             }
           }
-        });
-        await finalSnapshotWrite.catch((err: unknown) => {
-          log.warn(
-            `run cleanup: stage=final-snapshot-lock-failed runId=${params.runId} sessionId=${params.sessionId} error=${formatErrorMessage(err)}`,
-          );
-          throw err;
         });
 
         // Let the active context engine run its post-turn lifecycle. These hooks

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -492,7 +492,7 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads).toHaveLength(0);
   });
 
-  it("drops all final payloads when block pipeline streamed successfully", async () => {
+  it("preserves unsent text-only final payloads after block pipeline streamed partial content", async () => {
     const pipeline: Parameters<typeof buildReplyPayloads>[0]["blockReplyPipeline"] = {
       didStream: () => true,
       isAborted: () => false,
@@ -503,8 +503,36 @@ describe("buildReplyPayloads media filter integration", () => {
       hasBuffered: () => false,
       getSentMediaUrls: () => [],
     };
-    // shouldDropFinalPayloads short-circuits to [] when the pipeline streamed
-    // without aborting, so hasSentPayload is never reached.
+    // The pipeline streamed some partial content, but the final text payload was
+    // never sent (hasSentPayload returns false). The old bug dropped all text-only
+    // finals unconditionally; the fix preserves unsent finals.
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      blockStreamingEnabled: true,
+      blockReplyPipeline: pipeline,
+      replyToMode: "all",
+      payloads: [{ text: "response", replyToId: "post-123" }],
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]?.text).toBe("response");
+  });
+
+  it("drops already-sent text-only final payloads after block pipeline streamed the exact same text", async () => {
+    const pipeline: Parameters<typeof buildReplyPayloads>[0]["blockReplyPipeline"] = {
+      didStream: () => true,
+      isAborted: () => false,
+      hasSentPayload: () => true,
+      hasSentExactPayload: (payload) =>
+        payload.text === "response" && !payload.mediaUrl && !payload.mediaUrls,
+      enqueue: () => {},
+      flush: async () => {},
+      stop: () => {},
+      hasBuffered: () => false,
+      getSentMediaUrls: () => [],
+    };
+    // The final text-only payload matches what the pipeline already sent,
+    // so it should be dropped.
     const { replyPayloads } = await buildReplyPayloads({
       ...baseParams,
       blockStreamingEnabled: true,
@@ -514,6 +542,60 @@ describe("buildReplyPayloads media filter integration", () => {
     });
 
     expect(replyPayloads).toHaveLength(0);
+  });
+
+  it("drops a text-only final with an empty envelope assembled from multiple streamed blocks", async () => {
+    const pipeline: Parameters<typeof buildReplyPayloads>[0]["blockReplyPipeline"] = {
+      didStream: () => true,
+      isAborted: () => false,
+      hasSentPayload: () => true,
+      hasSentExactPayload: () => false,
+      enqueue: () => {},
+      flush: async () => {},
+      stop: () => {},
+      hasBuffered: () => false,
+      getSentMediaUrls: () => [],
+    };
+
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      blockStreamingEnabled: true,
+      blockReplyPipeline: pipeline,
+      payloads: [{ text: "first block second block", channelData: {} }],
+    });
+
+    expect(replyPayloads).toHaveLength(0);
+  });
+
+  it("preserves final rich content when only its text was streamed", async () => {
+    const pipeline: Parameters<typeof buildReplyPayloads>[0]["blockReplyPipeline"] = {
+      didStream: () => true,
+      isAborted: () => false,
+      hasSentPayload: () => true,
+      hasSentExactPayload: () => false,
+      enqueue: () => {},
+      flush: async () => {},
+      stop: () => {},
+      hasBuffered: () => false,
+      getSentMediaUrls: () => [],
+    };
+    const presentation = {
+      blocks: [{ type: "buttons" as const, buttons: [{ label: "Open", value: "open" }] }],
+    };
+
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      blockStreamingEnabled: true,
+      blockReplyPipeline: pipeline,
+      payloads: [{ text: "response", presentation }],
+    });
+
+    expect(replyPayloads).toEqual([
+      expect.objectContaining({
+        text: "response",
+        presentation,
+      }),
+    ]);
   });
 
   it("keeps unsent final media after block pipeline streamed the text", async () => {

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -1,5 +1,8 @@
 /** Builds final reply payloads after sanitization, media normalization, and dedupe. */
-import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import {
+  hasOutboundReplyContent,
+  resolveSendableOutboundReplyParts,
+} from "openclaw/plugin-sdk/reply-payload";
 import { sanitizeUserFacingText } from "../../agents/embedded-agent-helpers/sanitize-user-facing-text.js";
 import type { MessagingToolSend } from "../../agents/embedded-agent-messaging.types.js";
 import type { ReplyToMode } from "../../config/types.js";
@@ -365,7 +368,20 @@ export async function buildReplyPayloads(params: {
     }
     const reply = resolveSendableOutboundReplyParts(payload);
     if (!reply.hasMedia) {
-      return null;
+      // Aggregate coverage suppresses plain text split across streamed blocks; rich content needs
+      // exact evidence. Partial coverage cannot safely reconstruct a formatted remainder, so
+      // preserve the complete final rather than silently truncate it.
+      const hasRichContent = hasOutboundReplyContent(
+        { ...payload, text: undefined, mediaUrl: undefined, mediaUrls: undefined },
+        { trimText: true },
+      );
+      const wasSent = hasRichContent
+        ? params.blockReplyPipeline?.hasSentExactPayload?.(payload)
+        : params.blockReplyPipeline?.hasSentPayload(payload);
+      if (wasSent) {
+        return null;
+      }
+      return payload;
     }
     if (!reply.trimmedText) {
       return payload;

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -707,7 +707,10 @@ describe("runReplyAgent block streaming", () => {
 
     expect(onBlockReply).toHaveBeenCalledTimes(1);
     expect((firstMockCallArg(onBlockReply, "block reply") as { text?: string }).text).toBe("Hello");
-    expect(result).toBeUndefined();
+    // The block pipeline streamed "Hello" but never sent "Final message",
+    // so the unsent text-only final is preserved (not dropped).
+    expect(result).toBeDefined();
+    expect((result as { text?: string }).text).toBe("Final message");
   });
 
   it("returns the final payload when onBlockReply times out", async () => {

--- a/src/auto-reply/reply/block-reply-pipeline.multi-message.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.multi-message.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { setReplyPayloadMetadata } from "../reply-payload.js";
+import { createBlockReplyPipeline } from "./block-reply-pipeline.js";
+
+function blockFor(text: string, assistantMessageIndex: number) {
+  return setReplyPayloadMetadata({ text }, { assistantMessageIndex });
+}
+
+describe("block reply pipeline multi-assistant-message suppression", () => {
+  it("recognizes each fully-streamed message across a multi-message turn", async () => {
+    const sent: string[] = [];
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async (payload) => {
+        if (payload.text) {
+          sent.push(payload.text);
+        }
+      },
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue(blockFor("Alpha one.", 0));
+    pipeline.enqueue(blockFor("Alpha two.", 0));
+    pipeline.enqueue(blockFor("Beta one.", 1));
+    pipeline.enqueue(blockFor("Beta two.", 1));
+    await pipeline.flush({ force: true });
+
+    expect(sent).toEqual(["Alpha one.", "Alpha two.", "Beta one.", "Beta two."]);
+    expect(pipeline.hasSentPayload({ text: "Alpha one. Alpha two." })).toBe(true);
+    expect(pipeline.hasSentPayload({ text: "Beta one. Beta two." })).toBe(true);
+  });
+
+  it("does not treat one message as covering another message's text", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue(blockFor("Alpha one.", 0));
+    pipeline.enqueue(blockFor("Alpha two.", 0));
+    pipeline.enqueue(blockFor("Beta one.", 1));
+    pipeline.enqueue(blockFor("Beta two.", 1));
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.hasSentPayload({ text: "Alpha one. Alpha two. Beta one. Beta two." })).toBe(
+      false,
+    );
+  });
+
+  it("suppresses a single message split into multiple blocks", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue(blockFor("Gamma one.", 0));
+    pipeline.enqueue(blockFor("Gamma two.", 0));
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.hasSentPayload({ text: "Gamma one. Gamma two." })).toBe(true);
+  });
+});

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -131,6 +131,31 @@ describe("createBlockReplyPipeline dedup with threading", () => {
     // Final payload with no replyToId should be recognized as already sent
     expect(pipeline.hasSentPayload({ text: "response text" })).toBe(true);
     expect(pipeline.hasSentPayload({ text: "response text", replyToId: "other-id" })).toBe(true);
+    expect(pipeline.hasSentExactPayload?.({ text: "response text" })).toBe(true);
+    expect(pipeline.hasSentExactPayload?.({ text: "response text", replyToId: "other-id" })).toBe(
+      true,
+    );
+  });
+
+  it("keeps exact payload evidence separate from streamed text coverage", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue({ text: "constx=1" });
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.hasSentPayload({ text: "const x = 1" })).toBe(true);
+    expect(pipeline.hasSentExactPayload?.({ text: "const x = 1" })).toBe(false);
+    expect(
+      pipeline.hasSentExactPayload?.({
+        text: "constx=1",
+        presentation: {
+          blocks: [{ type: "buttons", buttons: [{ label: "Open", value: "open" }] }],
+        },
+      }),
+    ).toBe(false);
   });
 
   it("tracks media URLs delivered via block replies", async () => {

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -18,6 +18,7 @@ export type BlockReplyPipeline = {
   didStream: () => boolean;
   isAborted: () => boolean;
   hasSentPayload: (payload: ReplyPayload) => boolean;
+  hasSentExactPayload?: (payload: ReplyPayload) => boolean;
   getSentMediaUrls: () => readonly string[];
 };
 
@@ -113,7 +114,7 @@ export function createBlockReplyPipeline(params: {
   const bufferedKeys = new Set<string>();
   const bufferedPayloadKeys = new Set<string>();
   const bufferedPayloads: ReplyPayload[] = [];
-  const streamedTextFragments: string[] = [];
+  const streamedTextFragmentsByMessage = new Map<number | undefined, string[]>();
   let bufferedAssistantMessageIndex: number | undefined;
   let sendChain: Promise<void> = Promise.resolve();
   let aborted = false;
@@ -179,7 +180,10 @@ export function createBlockReplyPipeline(params: {
           sentMediaUrls.add(mediaUrl);
         }
         if (!isStatusNotice && reply.trimmedText) {
-          streamedTextFragments.push(reply.trimmedText);
+          const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
+          const fragments = streamedTextFragmentsByMessage.get(assistantMessageIndex) ?? [];
+          fragments.push(reply.trimmedText);
+          streamedTextFragmentsByMessage.set(assistantMessageIndex, fragments);
         }
         if (!isStatusNotice) {
           didStream = true;
@@ -315,12 +319,13 @@ export function createBlockReplyPipeline(params: {
     hasBuffered: () => coalescer?.hasBuffered() || bufferedPayloads.length > 0,
     didStream: () => didStream,
     isAborted: () => aborted,
+    hasSentExactPayload: (payload) => sentContentKeys.has(createBlockReplyContentKey(payload)),
     hasSentPayload: (payload) => {
       const payloadKey = createBlockReplyContentKey(payload);
       if (sentContentKeys.has(payloadKey)) {
         return true;
       }
-      if (!didStream || streamedTextFragments.length === 0) {
+      if (!didStream) {
         return false;
       }
       const reply = resolveSendableOutboundReplyParts(payload);
@@ -328,7 +333,13 @@ export function createBlockReplyPipeline(params: {
         return false;
       }
       const normalize = (text: string) => text.replace(/\s+/g, "");
-      return normalize(streamedTextFragments.join("")) === normalize(reply.trimmedText);
+      const target = normalize(reply.trimmedText);
+      for (const fragments of streamedTextFragmentsByMessage.values()) {
+        if (fragments.length > 0 && normalize(fragments.join("")) === target) {
+          return true;
+        }
+      }
+      return false;
     },
     getSentMediaUrls: () => Array.from(sentMediaUrls),
   };


### PR DESCRIPTION
## What Problem This Solves

The extended-stable Telegram release canary completed its model turn and final session snapshot, but emitted no reply. LTS still dropped every text-only final after any successful block stream, even when the exact final payload had never been sent.

## Why This Change Was Made

Backport the paired upstream fixes from #93629 and #95432. Preserve unsent text-only finals, retain exact rich-payload de-duplication, and scope aggregate streamed-text evidence per assistant message so multi-message turns do not duplicate replies. The temporary lock-owner trace is removed now that exact run 29205533449 proved the lock is acquired promptly.

## User Impact

Completed Telegram and other channel replies no longer disappear after partial block streaming. Already-streamed finals remain de-duplicated per assistant message.

## Evidence

- Exact failing LTS candidate: `b026dd70f0be63cdf582a2cca809d97ce7a3fb02`
- Release QA run: https://github.com/openclaw/openclaw/actions/runs/29205533449
- Failure proof: both turns completed and acquired the final snapshot lock; the channel canary timed out without a delivered reply.
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29206749609 (focused tests, oxfmt, and oxlint command completed; runner closeout remained pending)
- Fresh autoreview: clean, no accepted/actionable findings, 0.97 confidence.
- `git diff --check`

## Proof Gaps

- Exact Telegram release QA rerun is required after merge.
