### PR TITLE
fix(ui): serialize Skills operations

### DIFF
--- a/ui/src/lib/skills/index.test.ts
+++ b/ui/src/lib/skills/index.test.ts
@@ -7,11 +7,13 @@ import {
   loadSkills,
   loadSkillCard,
   loadClawHubDetail,
+  refreshSkills,
   reconcileSkillsAgentId,
   saveSkillApiKey,
   searchClawHub,
   setClawHubSearchQuery,
   setSkillsAgentId,
+  updateSkillEdit,
   updateSkillEnabled,
   type SkillsState,
 } from "./index.ts";
@@ -30,7 +32,7 @@ function createState(): { state: SkillsState; request: ReturnType<typeof vi.fn<T
     skillsLoading: false,
     skillsReport: null,
     skillsError: null,
-    skillsBusyKey: null,
+    skillOperation: null,
     skillEdits: {},
     skillMessages: {},
     clawhubSearchQuery: "github",
@@ -49,7 +51,6 @@ function createState(): { state: SkillsState; request: ReturnType<typeof vi.fn<T
     clawhubDetailSlug: null,
     clawhubDetailLoading: false,
     clawhubDetailError: null,
-    clawhubInstallSlug: null,
     clawhubInstallMessage: null,
     clawhubVerdicts: {},
     clawhubVerdictsLoading: false,
@@ -294,6 +295,28 @@ describe("loadSkills", () => {
     expect(state.skillsReport?.workspaceDir).toBe("/tmp/current-alpha");
     expect(state.skillsReport?.skills.map((skill) => skill.name)).toEqual(["Current Alpha"]);
     expect(state.skillsLoading).toBe(false);
+  });
+
+  it("releases loading ownership when the current client disconnects", async () => {
+    const { state, request } = createState();
+    let rejectStatus: ((reason: unknown) => void) | undefined;
+    request.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectStatus = reject;
+        }),
+    );
+
+    const load = loadSkills(state);
+    await vi.waitFor(() => expect(state.skillsLoading).toBe(true));
+    state.connected = false;
+    expect(rejectStatus).toBeDefined();
+    rejectStatus?.(new Error("gateway disconnected"));
+    await load;
+
+    expect(state.skillsLoading).toBe(false);
+    expect(state.skillsReport).toBeNull();
+    expect(state.skillsError).toBeNull();
   });
 
   it("does not keep skills loading while the optional verdict refresh is pending", async () => {
@@ -662,6 +685,79 @@ describe("loadClawHubDetail", () => {
 });
 
 describe("skill mutations", () => {
+  it("reserves the shared operation while agent refresh is pending", async () => {
+    const { state, request } = createState();
+    request.mockResolvedValue({
+      workspaceDir: "/tmp/workspace",
+      managedSkillsDir: "/tmp/skills",
+      skills: [],
+    });
+    let releaseAgents: (() => void) | undefined;
+    const loadAgents = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseAgents = resolve;
+        }),
+    );
+    const overlappingLoadAgents = vi.fn(async () => undefined);
+
+    const refresh = refreshSkills(state, loadAgents);
+    await vi.waitFor(() => expect(state.skillOperation).toEqual({ kind: "refresh" }));
+    await refreshSkills(state, overlappingLoadAgents);
+    await updateSkillEnabled(state, "github", true);
+
+    expect(overlappingLoadAgents).not.toHaveBeenCalled();
+    expect(request).not.toHaveBeenCalled();
+    expect(releaseAgents).toBeDefined();
+    releaseAgents?.();
+    await refresh;
+
+    expect(request).toHaveBeenCalledOnce();
+    expect(request).toHaveBeenCalledWith("skills.status", {});
+    expect(state.skillOperation).toBeNull();
+  });
+
+  it("retries a refresh when agent reconciliation changes scope", async () => {
+    const { state, request } = createState();
+    const pending: Array<(value: unknown) => void> = [];
+    request.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          pending.push(resolve);
+        }),
+    );
+    state.skillsAgentId = "alpha";
+
+    const refresh = refreshSkills(state, async () => undefined);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    setSkillsAgentId(state, "beta");
+    expectDefined(
+      pending[0],
+      "alpha status request",
+    )({
+      workspaceDir: "/tmp/alpha",
+      managedSkillsDir: "/tmp/skills",
+      skills: [],
+    });
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    expectDefined(
+      pending[1],
+      "beta status request",
+    )({
+      workspaceDir: "/tmp/beta",
+      managedSkillsDir: "/tmp/skills",
+      skills: [],
+    });
+    await refresh;
+
+    expect(request.mock.calls).toEqual([
+      ["skills.status", { agentId: "alpha" }],
+      ["skills.status", { agentId: "beta" }],
+    ]);
+    expect(state.skillsReport?.workspaceDir).toBe("/tmp/beta");
+    expect(state.skillOperation).toBeNull();
+  });
+
   it.each([
     {
       name: "updates skill enablement and records a success message",
@@ -702,8 +798,130 @@ describe("skill mutations", () => {
     const [method, params] = expectedRequest;
     expect(request).toHaveBeenCalledWith(method, params);
     expect(state.skillMessages.github).toEqual({ kind: "success", message: expectedMessage });
-    expect(state.skillsBusyKey).toBeNull();
+    expect(state.skillOperation).toBeNull();
     expect(state.skillsError).toBeNull();
+  });
+
+  it.each([
+    {
+      name: "skill update blocks ClawHub install",
+      firstMethod: "skills.update",
+      start: (state: SkillsState) => updateSkillEnabled(state, "github", true),
+      blocked: (state: SkillsState) => installFromClawHub(state, "calendar"),
+      expectedMutation: { kind: "skill", skillKey: "github" } as const,
+    },
+    {
+      name: "ClawHub install blocks skill update",
+      firstMethod: "skills.install",
+      start: (state: SkillsState) => installFromClawHub(state, "github"),
+      blocked: (state: SkillsState) => updateSkillEnabled(state, "calendar", true),
+      expectedMutation: { kind: "clawhub", slug: "github" } as const,
+    },
+  ])("serializes $name and locks API key edits", async (fixture) => {
+    const { state, request } = createState();
+    let releaseFirst: ((value: unknown) => void) | undefined;
+    request.mockImplementation((method) => {
+      if (method === fixture.firstMethod && !releaseFirst) {
+        return new Promise((resolve) => {
+          releaseFirst = resolve;
+        });
+      }
+      if (method === "skills.status") {
+        return Promise.resolve({
+          workspaceDir: "/tmp/workspace",
+          managedSkillsDir: "/tmp/skills",
+          skills: [],
+        });
+      }
+      return Promise.resolve({});
+    });
+    state.skillEdits.github = "submitted-value";
+
+    const first = fixture.start(state);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+    expect(state.skillOperation).toEqual(fixture.expectedMutation);
+
+    await fixture.blocked(state);
+    updateSkillEdit(state, "github", "late-value");
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(state.skillEdits.github).toBe("submitted-value");
+
+    expect(releaseFirst).toBeDefined();
+    releaseFirst?.({});
+    await first;
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      fixture.firstMethod,
+      "skills.status",
+    ]);
+    expect(state.skillOperation).toBeNull();
+  });
+
+  it("rejects mutations while a status refresh is active", async () => {
+    const { state, request } = createState();
+    state.skillsLoading = true;
+    state.skillEdits.github = "submitted-value";
+
+    await updateSkillEnabled(state, "github", true);
+    await installFromClawHub(state, "github");
+    updateSkillEdit(state, "github", "late-value");
+
+    expect(request).not.toHaveBeenCalled();
+    expect(state.skillEdits.github).toBe("submitted-value");
+    expect(state.skillOperation).toBeNull();
+  });
+
+  it("drops a mutation continuation after a source reset without releasing the new owner", async () => {
+    const { state, request: oldRequest } = createState();
+    let releaseOld: ((value: unknown) => void) | undefined;
+    oldRequest.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseOld = resolve;
+        }),
+    );
+
+    const oldMutation = updateSkillEnabled(state, "github", true);
+    await vi.waitFor(() => expect(oldRequest).toHaveBeenCalledOnce());
+
+    let releaseCurrent: ((value: unknown) => void) | undefined;
+    const currentRequest = vi.fn<TestRequest>((method) => {
+      if (method === "skills.update") {
+        return new Promise((resolve) => {
+          releaseCurrent = resolve;
+        });
+      }
+      return Promise.resolve({
+        workspaceDir: "/tmp/current",
+        managedSkillsDir: "/tmp/skills",
+        skills: [],
+      });
+    });
+    state.client = { request: currentRequest } as unknown as SkillsState["client"];
+    state.skillsAgentRevision += 1;
+    state.skillOperation = null;
+
+    const currentMutation = updateSkillEnabled(state, "calendar", true);
+    await vi.waitFor(() => expect(currentRequest).toHaveBeenCalledOnce());
+    const currentOperation = state.skillOperation;
+    expect(currentOperation).toEqual({ kind: "skill", skillKey: "calendar" });
+
+    expect(releaseOld).toBeDefined();
+    releaseOld?.({});
+    await oldMutation;
+
+    expect(oldRequest.mock.calls.map(([method]) => method)).toEqual(["skills.update"]);
+    expect(state.skillOperation).toBe(currentOperation);
+
+    expect(releaseCurrent).toBeDefined();
+    releaseCurrent?.({});
+    await currentMutation;
+    expect(currentRequest.mock.calls.map(([method]) => method)).toEqual([
+      "skills.update",
+      "skills.status",
+    ]);
+    expect(state.skillsReport?.workspaceDir).toBe("/tmp/current");
+    expect(state.skillOperation).toBeNull();
   });
 
   it("records errors from failed mutations", async () => {
@@ -717,10 +935,10 @@ describe("skill mutations", () => {
       kind: "error",
       message: "skills update failed",
     });
-    expect(state.skillsBusyKey).toBeNull();
+    expect(state.skillOperation).toBeNull();
   });
 
-  it("refreshes the current agent after a stale global config mutation succeeds", async () => {
+  it("defers a new agent refresh until a stale global config mutation succeeds", async () => {
     const { state, request } = createState();
     const pendingRequests: Array<{
       method: string;
@@ -740,18 +958,14 @@ describe("skill mutations", () => {
     setSkillsAgentId(state, "beta");
     const betaLoad = loadSkills(state);
     await Promise.resolve();
-    expectDefined(pendingRequests[1], "beta skills request before update").resolve({
-      workspaceDir: "/tmp/beta-before-update",
-      managedSkillsDir: "/tmp/skills",
-      skills: [],
-    });
     await betaLoad;
+    expect(pendingRequests).toHaveLength(1);
 
     expectDefined(pendingRequests[0], "skills update request").resolve({});
     await vi.waitFor(() => {
-      expect(pendingRequests).toHaveLength(3);
+      expect(pendingRequests).toHaveLength(2);
     });
-    expectDefined(pendingRequests[2], "beta skills request after update").resolve({
+    expectDefined(pendingRequests[1], "beta skills request after update").resolve({
       workspaceDir: "/tmp/beta-after-update",
       managedSkillsDir: "/tmp/skills",
       skills: [],
@@ -761,9 +975,41 @@ describe("skill mutations", () => {
     expect(pendingRequests.map(({ method, payload }) => [method, payload])).toEqual([
       ["skills.update", { skillKey: "github", enabled: true }],
       ["skills.status", { agentId: "beta" }],
-      ["skills.status", { agentId: "beta" }],
     ]);
     expect(state.skillsReport?.workspaceDir).toBe("/tmp/beta-after-update");
+    expect(state.skillMessages).toEqual({});
+  });
+
+  it("loads the current agent after a stale mutation fails", async () => {
+    const { state, request } = createState();
+    let rejectUpdate: ((reason: unknown) => void) | undefined;
+    request.mockImplementation((method) => {
+      if (method === "skills.update") {
+        return new Promise((_resolve, reject) => {
+          rejectUpdate = reject;
+        });
+      }
+      return Promise.resolve({
+        workspaceDir: "/tmp/beta-after-error",
+        managedSkillsDir: "/tmp/skills",
+        skills: [],
+      });
+    });
+    state.skillsAgentId = "alpha";
+
+    const mutation = updateSkillEnabled(state, "github", true);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    setSkillsAgentId(state, "beta");
+    expect(rejectUpdate).toBeDefined();
+    rejectUpdate?.(new Error("stale update failed"));
+    await mutation;
+
+    expect(request.mock.calls).toEqual([
+      ["skills.update", { skillKey: "github", enabled: true }],
+      ["skills.status", { agentId: "beta" }],
+    ]);
+    expect(state.skillsReport?.workspaceDir).toBe("/tmp/beta-after-error");
+    expect(state.skillsError).toBeNull();
     expect(state.skillMessages).toEqual({});
   });
 
@@ -919,30 +1165,39 @@ describe("skill mutations", () => {
         slug: "github",
       },
     },
-  ])("ignores $name completion after switching agents", async ({ run, expectedRequest }) => {
-    const { state, request } = createState();
-    const queue = createDeferredRequestQueue(request);
-    state.skillsAgentId = "alpha";
+  ])(
+    "refreshes the current scope after switching during $name",
+    async ({ run, expectedRequest }) => {
+      const { state, request } = createState();
+      const queue = createDeferredRequestQueue(request);
+      state.skillsAgentId = "alpha";
 
-    const pending = run(state);
-    await Promise.resolve();
-    setSkillsAgentId(state, "beta");
-    queue.resolveNext({ message: "Installed" });
-    await pending;
+      const pending = run(state);
+      await Promise.resolve();
+      setSkillsAgentId(state, "beta");
+      queue.resolveNext({ message: "Installed" });
+      await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+      queue.resolveNext({
+        workspaceDir: "/tmp/beta-after-install",
+        managedSkillsDir: "/tmp/skills",
+        skills: [],
+      });
+      await pending;
 
-    expect(request).toHaveBeenCalledTimes(1);
-    expect(request).toHaveBeenCalledWith("skills.install", expectedRequest);
-    expect(state.skillsAgentId).toBe("beta");
-    expect(state.skillsReport).toBeNull();
-    expect(state.skillMessages).toEqual({});
-    expect(state.clawhubInstallMessage).toBeNull();
-    expect(state.skillsBusyKey).toBeNull();
-    expect(state.clawhubInstallSlug).toBeNull();
-  });
+      expect(request).toHaveBeenCalledTimes(2);
+      expect(request).toHaveBeenNthCalledWith(1, "skills.install", expectedRequest);
+      expect(request).toHaveBeenNthCalledWith(2, "skills.status", { agentId: "beta" });
+      expect(state.skillsAgentId).toBe("beta");
+      expect(state.skillsReport?.workspaceDir).toBe("/tmp/beta-after-install");
+      expect(state.skillMessages).toEqual({});
+      expect(state.clawhubInstallMessage).toBeNull();
+      expect(state.skillOperation).toBeNull();
+    },
+  );
 });
 
 describe("reconcileSkillsAgentId", () => {
-  it("resets a deleted selected agent to the current default scope", () => {
+  it("resets a deleted selected agent without releasing its active operation", () => {
     const { state } = createState();
     state.skillsAgentId = "deleted";
     state.skillsReport = {
@@ -950,7 +1205,7 @@ describe("reconcileSkillsAgentId", () => {
       managedSkillsDir: "/tmp/skills",
       skills: [],
     };
-    state.clawhubInstallSlug = "calendar";
+    state.skillOperation = { kind: "clawhub", slug: "calendar" };
 
     reconcileSkillsAgentId(state, {
       defaultId: "main",
@@ -962,6 +1217,6 @@ describe("reconcileSkillsAgentId", () => {
     expect(state.skillsAgentId).toBeNull();
     expect(state.skillsAgentRevision).toBe(1);
     expect(state.skillsReport).toBeNull();
-    expect(state.clawhubInstallSlug).toBeNull();
+    expect(state.skillOperation).toEqual({ kind: "clawhub", slug: "calendar" });
   });
 });

--- a/ui/src/lib/skills/index.ts
+++ b/ui/src/lib/skills/index.ts
@@ -82,7 +82,7 @@ export type SkillsState = {
   skillsLoading: boolean;
   skillsReport: SkillStatusReport | null;
   skillsError: string | null;
-  skillsBusyKey: string | null;
+  skillOperation: SkillOperation;
   skillEdits: Record<string, string>;
   skillMessages: SkillMessageMap;
   clawhubSearchQuery: string;
@@ -93,7 +93,6 @@ export type SkillsState = {
   clawhubDetailSlug: string | null;
   clawhubDetailLoading: boolean;
   clawhubDetailError: string | null;
-  clawhubInstallSlug: string | null;
   clawhubInstallMessage: {
     kind: "success" | "error";
     text: string;
@@ -109,6 +108,30 @@ export type SkillsState = {
   skillCardLoadingKey: string | null;
   skillCardErrors: Record<string, string>;
 };
+
+export type SkillOperation =
+  | { kind: "refresh" }
+  | { kind: "skill"; skillKey: string }
+  | { kind: "clawhub"; slug: string }
+  | null;
+
+type ActiveSkillOperation = Exclude<SkillOperation, null>;
+
+function ownsSkillOperation(
+  state: SkillsState,
+  client: GatewayBrowserClient,
+  operation: ActiveSkillOperation,
+): boolean {
+  return state.connected && state.client === client && state.skillOperation === operation;
+}
+
+function releaseSkillOperation(state: SkillsState, operation: ActiveSkillOperation) {
+  // Agent/source changes can outlive an owner request; identity keeps stale
+  // cleanup from releasing a newer connection's operation.
+  if (state.skillOperation === operation) {
+    state.skillOperation = null;
+  }
+}
 
 type SkillMessage = {
   kind: "success" | "error";
@@ -254,10 +277,8 @@ export function setSkillsAgentId(state: SkillsState, agentId: string | null) {
   state.skillsLoading = false;
   state.skillsReport = null;
   state.skillsError = null;
-  state.skillsBusyKey = null;
   state.skillEdits = {};
   state.skillMessages = {};
-  state.clawhubInstallSlug = null;
   state.clawhubInstallMessage = null;
   state.clawhubVerdicts = {};
   state.clawhubVerdictsLoading = false;
@@ -281,19 +302,36 @@ export function reconcileSkillsAgentId(
   }
 }
 
-export async function loadSkills(state: SkillsState, options?: { clearMessages?: boolean }) {
+export async function loadSkills(
+  state: SkillsState,
+  options?: {
+    clearMessages?: boolean;
+    operation?: Exclude<SkillOperation, null>;
+  },
+) {
+  const client = state.client;
+  if (
+    !client ||
+    !state.connected ||
+    state.skillsLoading ||
+    (state.skillOperation && state.skillOperation !== options?.operation)
+  ) {
+    return;
+  }
   if (options?.clearMessages && Object.keys(state.skillMessages).length > 0) {
     state.skillMessages = {};
   }
-  if (!state.client || !state.connected || state.skillsLoading) {
-    return;
-  }
   const agentScope = captureSkillsAgentScope(state);
+  const ownsLoad = () =>
+    state.client === client &&
+    isSkillsAgentScopeCurrent(state, agentScope) &&
+    (!options?.operation || state.skillOperation === options.operation);
+  const isCurrent = () => state.connected && ownsLoad();
   state.skillsLoading = true;
   state.skillsError = null;
   try {
-    const res = await loadSkillStatusReport(state.client, state.skillsAgentId);
-    if (!isSkillsAgentScopeCurrent(state, agentScope)) {
+    const res = await loadSkillStatusReport(client, state.skillsAgentId);
+    if (!isCurrent()) {
       return;
     }
     if (res && Array.isArray(res.skills)) {
@@ -302,14 +340,55 @@ export async function loadSkills(state: SkillsState, options?: { clearMessages?:
       void loadClawHubSecurityVerdicts(state, res);
     }
   } catch (err) {
-    if (!isSkillsAgentScopeCurrent(state, agentScope)) {
+    if (!isCurrent()) {
       return;
     }
     state.skillsError = getErrorMessage(err);
   } finally {
-    if (isSkillsAgentScopeCurrent(state, agentScope)) {
+    // A transient disconnect invalidates the result, not this invocation's
+    // loading ownership. Source/scope identity still protects newer loads.
+    if (ownsLoad()) {
       state.skillsLoading = false;
     }
+  }
+}
+
+async function loadCurrentSkillsForOperation(
+  state: SkillsState,
+  client: GatewayBrowserClient,
+  operation: ActiveSkillOperation,
+  clearMessages = false,
+) {
+  let shouldClearMessages = clearMessages;
+  // Reconciliation can change scope while a status request is pending. Keep
+  // the operation owner until one response belongs to the current scope.
+  while (ownsSkillOperation(state, client, operation)) {
+    const scope = captureSkillsAgentScope(state);
+    await loadSkills(state, { clearMessages: shouldClearMessages, operation });
+    shouldClearMessages = false;
+    if (!ownsSkillOperation(state, client, operation) || isSkillsAgentScopeCurrent(state, scope)) {
+      return;
+    }
+  }
+}
+
+export async function refreshSkills(state: SkillsState, loadAgents: () => Promise<void>) {
+  const client = state.client;
+  if (!client || !state.connected || state.skillsLoading || state.skillOperation) {
+    return;
+  }
+  const operation = { kind: "refresh" } as const;
+  // Reserve one operation across both awaits so a second refresh or write
+  // cannot enter while agent discovery is still pending.
+  state.skillOperation = operation;
+  try {
+    await loadAgents();
+    if (!ownsSkillOperation(state, client, operation)) {
+      return;
+    }
+    await loadCurrentSkillsForOperation(state, client, operation, true);
+  } finally {
+    releaseSkillOperation(state, operation);
   }
 }
 
@@ -427,6 +506,9 @@ async function loadClawHubSecurityVerdicts(state: SkillsState, report: SkillStat
 }
 
 export function updateSkillEdit(state: SkillsState, skillKey: string, value: string) {
+  if (state.skillOperation || state.skillsLoading) {
+    return;
+  }
   state.skillEdits = { ...state.skillEdits, [skillKey]: value };
 }
 
@@ -434,30 +516,38 @@ async function runSkillMutation(
   state: SkillsState,
   skillKey: string,
   run: (client: GatewayBrowserClient) => Promise<SkillMessage>,
-  options?: { refreshCurrentScopeOnStaleSuccess?: boolean },
 ) {
   const client = state.client;
-  if (!client || !state.connected) {
+  if (!client || !state.connected || state.skillsLoading || state.skillOperation) {
     return;
   }
   const agentScope = captureSkillsAgentScope(state);
-  state.skillsBusyKey = skillKey;
+  const operation = { kind: "skill", skillKey } as const;
+  // All writes share one owner: overlapping refreshes can otherwise publish
+  // a stale snapshot after both Gateway mutations have already succeeded.
+  state.skillOperation = operation;
   state.skillsError = null;
   try {
     const message = await run(client);
-    if (!isSkillsAgentScopeCurrent(state, agentScope)) {
-      if (options?.refreshCurrentScopeOnStaleSuccess) {
-        await loadSkills(state);
-      }
+    if (!ownsSkillOperation(state, client, operation)) {
       return;
     }
-    await loadSkills(state);
     if (!isSkillsAgentScopeCurrent(state, agentScope)) {
+      return;
+    }
+    await loadSkills(state, { operation });
+    if (
+      !ownsSkillOperation(state, client, operation) ||
+      !isSkillsAgentScopeCurrent(state, agentScope)
+    ) {
       return;
     }
     setSkillMessage(state, skillKey, message);
   } catch (err) {
-    if (!isSkillsAgentScopeCurrent(state, agentScope)) {
+    if (
+      !ownsSkillOperation(state, client, operation) ||
+      !isSkillsAgentScopeCurrent(state, agentScope)
+    ) {
       return;
     }
     const message = getErrorMessage(err);
@@ -467,41 +557,35 @@ async function runSkillMutation(
       message,
     });
   } finally {
-    if (isSkillsAgentScopeCurrent(state, agentScope) && state.skillsBusyKey === skillKey) {
-      state.skillsBusyKey = null;
+    if (
+      ownsSkillOperation(state, client, operation) &&
+      !isSkillsAgentScopeCurrent(state, agentScope)
+    ) {
+      await loadCurrentSkillsForOperation(state, client, operation);
     }
+    releaseSkillOperation(state, operation);
   }
 }
 
 export async function updateSkillEnabled(state: SkillsState, skillKey: string, enabled: boolean) {
-  await runSkillMutation(
-    state,
-    skillKey,
-    async (client) => {
-      await client.request("skills.update", { skillKey, enabled });
-      return {
-        kind: "success",
-        message: enabled ? "Skill enabled" : "Skill disabled",
-      };
-    },
-    { refreshCurrentScopeOnStaleSuccess: true },
-  );
+  await runSkillMutation(state, skillKey, async (client) => {
+    await client.request("skills.update", { skillKey, enabled });
+    return {
+      kind: "success",
+      message: enabled ? "Skill enabled" : "Skill disabled",
+    };
+  });
 }
 
 export async function saveSkillApiKey(state: SkillsState, skillKey: string) {
-  await runSkillMutation(
-    state,
-    skillKey,
-    async (client) => {
-      const editValue = state.skillEdits[skillKey] ?? "";
-      await client.request("skills.update", { skillKey, apiKey: editValue });
-      return {
-        kind: "success",
-        message: `API key saved — stored in openclaw.json (skills.entries.${skillKey})`,
-      };
-    },
-    { refreshCurrentScopeOnStaleSuccess: true },
-  );
+  await runSkillMutation(state, skillKey, async (client) => {
+    const editValue = state.skillEdits[skillKey] ?? "";
+    await client.request("skills.update", { skillKey, apiKey: editValue });
+    return {
+      kind: "success",
+      message: `API key saved — stored in openclaw.json (skills.entries.${skillKey})`,
+    };
+  });
 }
 
 export async function installSkill(
@@ -608,28 +692,33 @@ export async function installFromClawHub(
   acknowledgeClawHubRisk = false,
   version?: string,
 ) {
-  if (!state.client || !state.connected) {
+  const client = state.client;
+  if (!client || !state.connected || state.skillsLoading || state.skillOperation) {
     return;
   }
   const agentScope = captureSkillsAgentScope(state);
-  state.clawhubInstallSlug = slug;
+  const operation = { kind: "clawhub", slug } as const;
+  state.skillOperation = operation;
   state.clawhubInstallMessage = null;
   try {
-    const result = await state.client.request<{ message?: string; warning?: string }>(
-      "skills.install",
-      {
-        ...stateSkillsAgentParams(state),
-        source: "clawhub",
-        slug,
-        ...(version ? { version } : {}),
-        ...(acknowledgeClawHubRisk ? { acknowledgeClawHubRisk: true } : {}),
-      },
-    );
+    const result = await client.request<{ message?: string; warning?: string }>("skills.install", {
+      ...stateSkillsAgentParams(state),
+      source: "clawhub",
+      slug,
+      ...(version ? { version } : {}),
+      ...(acknowledgeClawHubRisk ? { acknowledgeClawHubRisk: true } : {}),
+    });
+    if (!ownsSkillOperation(state, client, operation)) {
+      return;
+    }
     if (!isSkillsAgentScopeCurrent(state, agentScope)) {
       return;
     }
-    await loadSkills(state);
-    if (!isSkillsAgentScopeCurrent(state, agentScope)) {
+    await loadSkills(state, { operation });
+    if (
+      !ownsSkillOperation(state, client, operation) ||
+      !isSkillsAgentScopeCurrent(state, agentScope)
+    ) {
       return;
     }
     state.clawhubInstallMessage = {
@@ -637,7 +726,10 @@ export async function installFromClawHub(
       text: formatClawHubInstallMessage(result?.message ?? `Installed ${slug}`, result?.warning),
     };
   } catch (err) {
-    if (isSkillsAgentScopeCurrent(state, agentScope)) {
+    if (
+      ownsSkillOperation(state, client, operation) &&
+      isSkillsAgentScopeCurrent(state, agentScope)
+    ) {
       const trustDetails = getClawHubTrustDetailsFromError(err);
       const needsAcknowledgement =
         trustDetails?.clawhubTrustCode === ClawHubTrustErrorCodes.RISK_ACKNOWLEDGEMENT_REQUIRED;
@@ -654,8 +746,12 @@ export async function installFromClawHub(
       };
     }
   } finally {
-    if (isSkillsAgentScopeCurrent(state, agentScope) && state.clawhubInstallSlug === slug) {
-      state.clawhubInstallSlug = null;
+    if (
+      ownsSkillOperation(state, client, operation) &&
+      !isSkillsAgentScopeCurrent(state, agentScope)
+    ) {
+      await loadCurrentSkillsForOperation(state, client, operation);
     }
+    releaseSkillOperation(state, operation);
   }
 }

--- a/ui/src/lib/skills/index.ts
+++ b/ui/src/lib/skills/index.ts
@@ -493,8 +493,8 @@ export async function saveSkillApiKey(state: SkillsState, skillKey: string) {
     state,
     skillKey,
     async (client) => {
-      const apiKey = state.skillEdits[skillKey] ?? "";
-      await client.request("skills.update", { skillKey, apiKey });
+      const editValue = state.skillEdits[skillKey] ?? "";
+      await client.request("skills.update", { skillKey, apiKey: editValue });
       return {
         kind: "success",
         message: `API key saved — stored in openclaw.json (skills.entries.${skillKey})`,

--- a/ui/src/pages/skills/skills-page.ts
+++ b/ui/src/pages/skills/skills-page.ts
@@ -18,6 +18,7 @@ import {
   loadClawHubDetail,
   loadSkillCard,
   loadSkills,
+  refreshSkills,
   reconcileSkillsAgentId,
   saveSkillApiKey,
   searchClawHub,
@@ -28,6 +29,7 @@ import {
   type ClawHubSearchResult,
   type ClawHubSkillDetail,
   type ClawHubSkillSecurityVerdict,
+  type SkillOperation,
   type SkillMessageMap,
 } from "../../lib/skills/index.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
@@ -60,7 +62,7 @@ class SkillsPage extends OpenClawLightDomElement {
   @state() skillsLoading = false;
   @state() skillsReport: SkillStatusReport | null = null;
   @state() skillsError: string | null = null;
-  @state() skillsBusyKey: string | null = null;
+  @state() skillOperation: SkillOperation = null;
   @state() skillsFilter = "";
   @state() skillsStatusFilter: SkillsStatusFilter = "all";
   @state() skillEdits: Record<string, string> = {};
@@ -75,7 +77,6 @@ class SkillsPage extends OpenClawLightDomElement {
   @state() clawhubDetailSlug: string | null = null;
   @state() clawhubDetailLoading = false;
   @state() clawhubDetailError: string | null = null;
-  @state() clawhubInstallSlug: string | null = null;
   @state() clawhubInstallMessage: {
     kind: "success" | "error";
     text: string;
@@ -180,7 +181,7 @@ class SkillsPage extends OpenClawLightDomElement {
     this.skillsLoading = false;
     this.skillsReport = null;
     this.skillsError = null;
-    this.skillsBusyKey = null;
+    this.skillOperation = null;
     this.skillEdits = {};
     this.skillMessages = {};
     this.skillsDetailKey = null;
@@ -192,7 +193,6 @@ class SkillsPage extends OpenClawLightDomElement {
     this.clawhubDetailSlug = null;
     this.clawhubDetailLoading = false;
     this.clawhubDetailError = null;
-    this.clawhubInstallSlug = null;
     this.clawhubInstallMessage = null;
     this.clawhubVerdicts = {};
     this.clawhubVerdictsLoading = false;
@@ -305,11 +305,13 @@ class SkillsPage extends OpenClawLightDomElement {
   }
 
   private async refreshPage() {
-    await this.loadAgents();
-    await loadSkills(this, { clearMessages: true });
+    await refreshSkills(this, () => this.loadAgents());
   }
 
   private changeAgent(agentId: string) {
+    if (this.skillOperation || this.skillsLoading) {
+      return;
+    }
     const previousAgentId = this.skillsAgentId;
     setSkillsAgentId(this, agentId);
     if (previousAgentId !== this.skillsAgentId) {
@@ -368,7 +370,7 @@ class SkillsPage extends OpenClawLightDomElement {
             statusFilter: this.skillsStatusFilter,
             edits: this.skillEdits,
             messages: this.skillMessages,
-            busyKey: this.skillsBusyKey,
+            operation: this.skillOperation,
             detailKey: this.skillsDetailKey,
             detailTab: this.skillsDetailTab,
             clawhubVerdicts: this.clawhubVerdicts,
@@ -385,7 +387,6 @@ class SkillsPage extends OpenClawLightDomElement {
             clawhubDetailSlug: this.clawhubDetailSlug,
             clawhubDetailLoading: this.clawhubDetailLoading,
             clawhubDetailError: this.clawhubDetailError,
-            clawhubInstallSlug: this.clawhubInstallSlug,
             clawhubInstallMessage: this.clawhubInstallMessage,
             onAgentChange: (agentId) => this.changeAgent(agentId),
             onFilterChange: (next) => (this.skillsFilter = next),

--- a/ui/src/pages/skills/view.test.ts
+++ b/ui/src/pages/skills/view.test.ts
@@ -75,7 +75,7 @@ function createProps(overrides: Partial<SkillsProps> = {}): SkillsProps {
     filter: "",
     statusFilter: "all",
     edits: {},
-    busyKey: null,
+    operation: null,
     messages: {},
     detailKey: null,
     detailTab: "overview",
@@ -93,7 +93,6 @@ function createProps(overrides: Partial<SkillsProps> = {}): SkillsProps {
     clawhubDetailSlug: null,
     clawhubDetailLoading: false,
     clawhubDetailError: null,
-    clawhubInstallSlug: null,
     clawhubInstallMessage: null,
     onAgentChange: () => undefined,
     onFilterChange: () => undefined,
@@ -155,6 +154,85 @@ describe("renderSkills", () => {
     selector!.dispatchEvent(new Event("change", { bubbles: true }));
 
     expect(onAgentChange).toHaveBeenCalledWith("main");
+  });
+
+  it("locks every skill mutation control behind the active mutation", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    dialogRestores.push(() => container.remove());
+    installDialogMethod("showModal", function (this: HTMLDialogElement) {
+      this.setAttribute("open", "");
+    });
+    const calendar = createSkill({
+      skillKey: "calendar",
+      name: "Calendar",
+      missing: { bins: ["calendar-cli"], env: [], config: [], os: [] },
+      install: [
+        { id: "calendar-cli", kind: "brew", label: "Install calendar-cli", bins: ["calendar-cli"] },
+      ],
+    });
+    const report: SkillStatusReport = {
+      workspaceDir: "/tmp/workspace",
+      managedSkillsDir: "/tmp/skills",
+      skills: [createSkill(), calendar],
+    };
+    const onRefresh = vi.fn();
+    const onToggle = vi.fn();
+    const onSaveKey = vi.fn();
+    const onInstall = vi.fn();
+    const onClawHubInstall = vi.fn();
+
+    render(
+      renderSkills(
+        createProps({
+          report,
+          detailKey: "calendar",
+          operation: { kind: "skill", skillKey: "repo-skill" },
+          clawhubResults: [{ score: 1, slug: "github", displayName: "GitHub", version: "1.0.0" }],
+          onRefresh,
+          onToggle,
+          onSaveKey,
+          onInstall,
+          onClawHubInstall,
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    expect(
+      container.querySelector<HTMLSelectElement>('select[name="skills-agent"]')?.disabled,
+    ).toBe(true);
+    const refresh = Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
+      (button) => button.textContent?.trim() === "Refresh",
+    );
+    expect(refresh?.disabled).toBe(true);
+    expect(
+      Array.from(container.querySelectorAll<HTMLInputElement>(".skill-toggle")).every(
+        (toggle) => toggle.disabled,
+      ),
+    ).toBe(true);
+    expect(container.querySelector<HTMLInputElement>('input[type="password"]')?.disabled).toBe(
+      true,
+    );
+    const mutationButtons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("button"),
+    ).filter((button) => /^(Install|Save key)/.test(normalizeText(button)));
+    expect(mutationButtons.length).toBeGreaterThanOrEqual(3);
+    expect(mutationButtons.every((button) => button.disabled)).toBe(true);
+
+    refresh?.click();
+    for (const toggle of container.querySelectorAll<HTMLInputElement>(".skill-toggle")) {
+      toggle.click();
+    }
+    for (const button of mutationButtons) {
+      button.click();
+    }
+    expect(onRefresh).not.toHaveBeenCalled();
+    expect(onToggle).not.toHaveBeenCalled();
+    expect(onSaveKey).not.toHaveBeenCalled();
+    expect(onInstall).not.toHaveBeenCalled();
+    expect(onClawHubInstall).not.toHaveBeenCalled();
   });
 
   it("does not transfer toggle state when a skill leaves the disabled tab", async () => {

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -20,6 +20,7 @@ import {
   type ClawHubSkillSecurityVerdict,
   type ClawHubSearchResult,
   type ClawHubSkillDetail,
+  type SkillOperation,
   type SkillMessageMap,
 } from "../../lib/skills/index.ts";
 import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
@@ -59,7 +60,7 @@ type SkillsProps = {
   filter: string;
   statusFilter: SkillsStatusFilter;
   edits: Record<string, string>;
-  busyKey: string | null;
+  operation: SkillOperation;
   messages: SkillMessageMap;
   detailKey: string | null;
   detailTab: SkillDetailTab;
@@ -77,7 +78,6 @@ type SkillsProps = {
   clawhubDetailSlug: string | null;
   clawhubDetailLoading: boolean;
   clawhubDetailError: string | null;
-  clawhubInstallSlug: string | null;
   clawhubInstallMessage: {
     kind: "success" | "error";
     text: string;
@@ -186,6 +186,18 @@ function agentOptionLabel(agent: SkillsAgentOption, defaultId: string | undefine
   return agent.id === defaultId ? t("skillsPage.defaultAgent", { name: baseName }) : baseName;
 }
 
+function skillControlsLocked(props: SkillsProps): boolean {
+  return props.loading || props.operation !== null;
+}
+
+function activeSkillMutation(props: SkillsProps, skillKey: string): boolean {
+  return props.operation?.kind === "skill" && props.operation.skillKey === skillKey;
+}
+
+function activeClawHubMutation(props: SkillsProps, slug: string): boolean {
+  return props.operation?.kind === "clawhub" && props.operation.slug === slug;
+}
+
 export function renderSkills(props: SkillsProps) {
   const skills = props.report?.skills ?? [];
   const agents = props.agentsList?.agents ?? [];
@@ -236,7 +248,7 @@ export function renderSkills(props: SkillsProps) {
         </div>
         <button
           class="btn"
-          ?disabled=${props.loading || !props.connected}
+          ?disabled=${skillControlsLocked(props) || !props.connected}
           @click=${props.onRefresh}
         >
           ${props.loading ? t("common.loading") : t("common.refresh")}
@@ -267,7 +279,7 @@ export function renderSkills(props: SkillsProps) {
                 <select
                   name="skills-agent"
                   .value=${selectedAgentId}
-                  ?disabled=${props.loading || !props.connected || agents.length < 2}
+                  ?disabled=${skillControlsLocked(props) || !props.connected || agents.length < 2}
                   @change=${(e: Event) =>
                     props.onAgentChange((e.target as HTMLSelectElement).value)}
                 >
@@ -335,8 +347,7 @@ export function renderSkills(props: SkillsProps) {
                     type="button"
                     class="btn btn--sm"
                     style="margin-top: 10px; white-space: normal;"
-                    ?disabled=${props.clawhubInstallSlug ===
-                    props.clawhubInstallMessage.acknowledgeSlug}
+                    ?disabled=${skillControlsLocked(props)}
                     @click=${() =>
                       props.onClawHubInstall(
                         props.clawhubInstallMessage?.acknowledgeSlug ?? "",
@@ -420,13 +431,13 @@ function renderClawHubResults(props: SkillsProps) {
                 : nothing}
               <button
                 class="btn btn--sm"
-                ?disabled=${props.clawhubInstallSlug !== null}
+                ?disabled=${skillControlsLocked(props)}
                 @click=${(e: Event) => {
                   e.stopPropagation();
                   props.onClawHubInstall(r.slug);
                 }}
               >
-                ${props.clawhubInstallSlug === r.slug
+                ${activeClawHubMutation(props, r.slug)
                   ? t("skillsPage.installing")
                   : t("skillsPage.install")}
               </button>
@@ -504,14 +515,14 @@ function renderClawHubDetailDialog(props: SkillsProps) {
                       : nothing}
                     <button
                       class="btn primary"
-                      ?disabled=${props.clawhubInstallSlug !== null}
+                      ?disabled=${skillControlsLocked(props)}
                       @click=${() => {
                         if (props.clawhubDetailSlug) {
                           props.onClawHubInstall(props.clawhubDetailSlug);
                         }
                       }}
                     >
-                      ${props.clawhubInstallSlug === props.clawhubDetailSlug
+                      ${activeClawHubMutation(props, props.clawhubDetailSlug ?? "")
                         ? t("skillsPage.installing")
                         : t("skillsPage.installNamed", { name: detail.skill.displayName })}
                     </button>
@@ -524,7 +535,7 @@ function renderClawHubDetailDialog(props: SkillsProps) {
 }
 
 function renderSkill(skill: SkillStatusEntry, props: SkillsProps) {
-  const busy = props.busyKey === skill.skillKey;
+  const locked = skillControlsLocked(props);
   const dotClass = skillStatusClass(skill);
   const verdict = verdictForSkill(skill, props.clawhubVerdicts);
 
@@ -552,7 +563,7 @@ function renderSkill(skill: SkillStatusEntry, props: SkillsProps) {
             type="checkbox"
             class="skill-toggle"
             .checked=${!skill.disabled}
-            ?disabled=${busy}
+            ?disabled=${locked}
             @change=${(e: Event) => {
               e.stopPropagation();
               props.onToggle(skill.skillKey, skill.disabled);
@@ -565,7 +576,8 @@ function renderSkill(skill: SkillStatusEntry, props: SkillsProps) {
 }
 
 function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
-  const busy = props.busyKey === skill.skillKey;
+  const locked = skillControlsLocked(props);
+  const active = activeSkillMutation(props, skill.skillKey);
   const editValue = props.edits[skill.skillKey] ?? "";
   const message = props.messages[skill.skillKey] ?? null;
   const installOption = skill.install[0];
@@ -666,7 +678,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
                 type="checkbox"
                 class="skill-toggle"
                 .checked=${!skill.disabled}
-                ?disabled=${busy}
+                ?disabled=${locked}
                 @change=${() => props.onToggle(skill.skillKey, skill.disabled)}
               />
             </label>
@@ -676,11 +688,11 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
             ${canInstall
               ? html`<button
                   class="btn"
-                  ?disabled=${busy}
+                  ?disabled=${locked}
                   @click=${() =>
                     installOption && props.onInstall(skill.skillKey, skill.name, installOption.id)}
                 >
-                  ${busy ? t("skillsPage.installing") : installOption?.label}
+                  ${active ? t("skillsPage.installing") : installOption?.label}
                 </button>`
               : nothing}
           </div>
@@ -702,6 +714,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
                     >
                     <input
                       type="password"
+                      ?disabled=${locked}
                       .value=${editValue}
                       @input=${(e: Event) =>
                         props.onEdit(skill.skillKey, (e.target as HTMLInputElement).value)}
@@ -720,7 +733,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
                   })()}
                   <button
                     class="btn primary"
-                    ?disabled=${busy}
+                    ?disabled=${locked}
                     @click=${() => props.onSaveKey(skill.skillKey)}
                   >
                     ${t("skillsPage.saveKey")}

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -566,7 +566,7 @@ function renderSkill(skill: SkillStatusEntry, props: SkillsProps) {
 
 function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
   const busy = props.busyKey === skill.skillKey;
-  const apiKey = props.edits[skill.skillKey] ?? "";
+  const editValue = props.edits[skill.skillKey] ?? "";
   const message = props.messages[skill.skillKey] ?? null;
   const installOption = skill.install[0];
   const canInstall = installOption !== undefined && skill.missing.bins.length > 0;
@@ -702,7 +702,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
                     >
                     <input
                       type="password"
-                      .value=${apiKey}
+                      .value=${editValue}
                       @input=${(e: Event) =>
                         props.onEdit(skill.skillKey, (e.target as HTMLInputElement).value)}
                     />


### PR DESCRIPTION
## What Problem This Solves

The Control UI Skills page allowed overlapping refresh, toggle, install, API-key, and ClawHub operations. Their independently scheduled status refreshes could complete out of order, leaving the UI stale even though all Gateway mutations succeeded. Closes #105618.

## Why This Change Was Made

Use one identity-bearing operation owner for every Skills refresh and mutation. Results now publish only while the originating client, operation, and agent scope still own them; scope changes retry status loading for the current agent, while stale cleanup cannot release a newer owner. The page locks all sibling write, refresh, and agent-scope controls until reconciliation finishes.

## User Impact

Skills operations can no longer overlap and overwrite one another's refreshed state. Users see the final Gateway truth after a mutation, including when they switch agent scope or reconnect while a request is pending.

## Evidence

- Real Gateway + Playwright before fix: a second skill toggle remained enabled, accepted a click, sent a second `skills.update`, and the first skill rendered stale after both writes succeeded.
- Real Gateway + Playwright after fix on rebased head: the second control was disabled, the real click was rejected, only one mutation was sent, server/UI state converged, controls recovered, and test config/skill state was restored.
- Source-blind behavior validation: 12 pass, 0 fail, 0 blocked; anti-cheat 4/4; exact real Gateway mutation and cleanup verified.
- Blacksmith Testbox `tbx_01kxbynm4waepxn2hg5gab1f7h`: focused Skills tests 46/46 passed; changed-file format, typecheck, and lint gates passed; full build passed.
- Fresh autoreview: no accepted or actionable findings; patch rated correct at 0.89 confidence.
