### PR TITLE
fix(exec): clear inactive background session ids

### DIFF
--- a/src/agents/bash-process-registry.test.ts
+++ b/src/agents/bash-process-registry.test.ts
@@ -245,6 +245,25 @@ describe("bash process registry", () => {
     expect(createSessionSlug()).toBe("amber-atlas");
   });
 
+  it("drops an inactive background id when deleting a removed session", () => {
+    const session = createRegistrySession({
+      id: "inactive-background",
+      maxOutputChars: 100,
+      pendingMaxOutputChars: 30_000,
+      backgrounded: false,
+    });
+
+    addSession(session);
+    markBackgrounded(session);
+    expect(getActiveBackgroundExecSessionCount()).toBe(1);
+
+    session.backgrounded = false;
+    deleteSession(session.id);
+
+    expect(listRunningSessions()).toHaveLength(0);
+    expect(getActiveBackgroundExecSessionCount()).toBe(0);
+  });
+
   it("clears background activity in the test reset", () => {
     const session = createRegistrySession({
       maxOutputChars: 100,

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -144,8 +144,12 @@ export function getFinishedSession(id: string) {
 
 /** Removes visible session records without changing live-process activity. */
 export function deleteSession(id: string) {
+  const session = runningSessions.get(id);
   runningSessions.delete(id);
   finishedSessions.delete(id);
+  if (!session?.backgrounded) {
+    activeBackgroundExecSessionIds.delete(id);
+  }
 }
 
 /** Appends process output while enforcing aggregate and pending-output caps. */


### PR DESCRIPTION
## Summary
Fixes #105670

## Changes
- Clean stale `activeBackgroundExecSessionIds` entries when `deleteSession` removes a session that is no longer marked backgrounded.
- Preserve live hidden background exec tracking until the process exit path runs, so suspend/id-reservation semantics for still-running processes remain intact.
- Add regression coverage for deleting an inactive removed session.

## Test Plan
- `node scripts/test-projects.mjs src/agents/bash-process-registry.test.ts src/infra/gateway-suspend-coordinator.test.ts`
- `PATH=/tmp/orbit-9852f075/bin:$PATH corepack pnpm protocol:check`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/agents/bash-process-registry.ts src/agents/bash-process-registry.test.ts`
- `git diff --check`