### PR TITLE
chore(release): trace LTS Telegram delivery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ Skills own workflows; root owns hard policy and routing.
 - Checks in a normal source checkout: `pnpm check:changed` delegates to Crabbox/Testbox; lanes: `pnpm changed:lanes --json`; staged: `pnpm check:changed --staged`; full: `pnpm check`.
 - Checks in a Codex worktree or linked/sparse checkout: avoid direct local `pnpm check*`; use `node scripts/crabbox-wrapper.mjs run ... -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` so pnpm runs inside Testbox, not locally.
 - Direct Testbox runs: pass `--provider blacksmith-testbox`; `OPENCLAW_TESTBOX=1` only selects `scripts/pr` prepare behavior.
-- Crabbox wrapper stop: pass the lease as `--id <lease>`; positional ids are rejected.
+- Crabbox wrapper stop: `node scripts/crabbox-wrapper.mjs stop --provider <provider> --id <lease>`; no positional id or `--timing-json`.
 - Extension tests: `pnpm test:extensions`, `pnpm test extensions`, `pnpm test extensions/<id>`.
 - Typecheck: `tsgo` lanes only (`pnpm tsgo*`, `pnpm check:test-types`); never add `tsc --noEmit`, `typecheck`, `check:types`.
 - Formatting: `oxfmt`, not Prettier. Use repo wrappers (`pnpm format:*`, `pnpm lint:*`, `scripts/run-oxlint.mjs`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ Skills own workflows; root owns hard policy and routing.
 - Checks in a normal source checkout: `pnpm check:changed` delegates to Crabbox/Testbox; lanes: `pnpm changed:lanes --json`; staged: `pnpm check:changed --staged`; full: `pnpm check`.
 - Checks in a Codex worktree or linked/sparse checkout: avoid direct local `pnpm check*`; use `node scripts/crabbox-wrapper.mjs run ... -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` so pnpm runs inside Testbox, not locally.
 - Direct Testbox runs: pass `--provider blacksmith-testbox`; `OPENCLAW_TESTBOX=1` only selects `scripts/pr` prepare behavior.
+- Release-branch Testbox warmup: pass `--blacksmith-ref <candidate-branch-or-sha>`; default `main` can create mixed-base dependency state.
 - Crabbox wrapper stop: `node scripts/crabbox-wrapper.mjs stop --provider <provider> --id <lease>`; no positional id or `--timing-json`.
 - Extension tests: `pnpm test:extensions`, `pnpm test extensions`, `pnpm test extensions/<id>`.
 - Typecheck: `tsgo` lanes only (`pnpm tsgo*`, `pnpm check:test-types`); never add `tsc --noEmit`, `typecheck`, `check:types`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ Skills own workflows; root owns hard policy and routing.
 - Checks in a normal source checkout: `pnpm check:changed` delegates to Crabbox/Testbox; lanes: `pnpm changed:lanes --json`; staged: `pnpm check:changed --staged`; full: `pnpm check`.
 - Checks in a Codex worktree or linked/sparse checkout: avoid direct local `pnpm check*`; use `node scripts/crabbox-wrapper.mjs run ... -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` so pnpm runs inside Testbox, not locally.
 - Direct Testbox runs: pass `--provider blacksmith-testbox`; `OPENCLAW_TESTBOX=1` only selects `scripts/pr` prepare behavior.
+- Crabbox wrapper stop: pass the lease as `--id <lease>`; positional ids are rejected.
 - Extension tests: `pnpm test:extensions`, `pnpm test extensions`, `pnpm test extensions/<id>`.
 - Typecheck: `tsgo` lanes only (`pnpm tsgo*`, `pnpm check:test-types`); never add `tsc --noEmit`, `typecheck`, `check:types`.
 - Formatting: `oxfmt`, not Prettier. Use repo wrappers (`pnpm format:*`, `pnpm lint:*`, `scripts/run-oxlint.mjs`).

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1851,6 +1851,11 @@ export const dispatchTelegramMessage = async ({
                     return undefined;
                   },
                   deliver: async (payload, info) => {
+                    logVerbose(
+                      `[release-debug] telegram deliver kind=${info.kind} ` +
+                        `text=${resolveSendableOutboundReplyParts(payload).trimmedText ? "yes" : "no"} ` +
+                        `media=${resolveSendableOutboundReplyParts(payload).hasMedia ? "yes" : "no"}`,
+                    );
                     if (isDispatchSuperseded()) {
                       return;
                     }
@@ -2401,6 +2406,11 @@ export const dispatchTelegramMessage = async ({
         return { kind: "completed" };
       }
       ({ queuedFinal } = turnResult.dispatchResult);
+      logVerbose(
+        `[release-debug] telegram dispatch result dispatched=yes queuedFinal=${queuedFinal ? "yes" : "no"} ` +
+          `delivered=${deliveryState.snapshot().delivered ? "yes" : "no"} ` +
+          `roomEvent=${isRoomEvent ? "yes" : "no"}`,
+      );
       suppressSilentReplyFallback =
         turnResult.dispatchResult.sourceReplyDeliveryMode === "message_tool_only";
     } catch (err) {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3159,6 +3159,12 @@ async function runEmbeddedAgentInternal(
             didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
             heartbeatToolResponse: attempt.heartbeatToolResponse,
           });
+          log.debug(
+            `[release-debug] embedded payloads runId=${params.runId} ` +
+              `assistantTexts=${attempt.assistantTexts.length} ` +
+              `currentAssistant=${currentAttemptAssistant ? "yes" : "no"} ` +
+              `lastAssistant=${attempt.lastAssistant ? "yes" : "no"} payloads=${payloads.length}`,
+          );
           const payloadsWithToolMedia = mergeAttemptToolMediaPayloads({
             payloads,
             toolMediaUrls: attempt.toolMediaUrls,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1727,6 +1727,12 @@ export async function runReplyAgent(params: {
     }
 
     const payloadArray = runResult.payloads ?? [];
+    logVerbose(
+      `[release-debug] reply runner input runId=${runId} payloads=${payloadArray.length} ` +
+        `blockStreamed=${blockReplyPipeline?.didStream() === true ? "yes" : "no"} ` +
+        `blockAborted=${blockReplyPipeline?.isAborted() === true ? "yes" : "no"} ` +
+        `sourceMode=${opts?.sourceReplyDeliveryMode ?? "default"}`,
+    );
 
     if (blockReplyPipeline) {
       await blockReplyPipeline.flush({ force: true });
@@ -2065,6 +2071,11 @@ export async function runReplyAgent(params: {
       normalizeMediaPaths: replyMediaContext.normalizePayload,
     });
     const { replyPayloads } = payloadResult;
+    logVerbose(
+      `[release-debug] reply runner output runId=${runId} payloads=${replyPayloads.length} ` +
+        `blockStreamed=${blockReplyPipeline?.didStream() === true ? "yes" : "no"} ` +
+        `blockAborted=${blockReplyPipeline?.isAborted() === true ? "yes" : "no"}`,
+    );
     didLogHeartbeatStrip = payloadResult.didLogHeartbeatStrip;
 
     const hasReplyPayloadBeyondFallbackNotice = replyPayloads.some(


### PR DESCRIPTION
## What Problem This Solves

The extended-stable Telegram release canary completes the model turn but emits no observable outbound reply. Existing logs stop before the payload and transport decision boundaries.

## Why This Change Was Made

Add bounded count/boolean diagnostics at embedded payload construction, reply filtering, and Telegram delivery. The logs contain no message text, recipient data, or credentials and do not change runtime decisions.

## User Impact

No behavior change. This temporary release diagnostic identifies the exact boundary dropping the extended-stable canary reply.

## Evidence

- Blacksmith Testbox `tbx_01kxc016656qttam20zczxtktj`: 291 focused tests passed across embedded-runner, reply-payload, and Telegram dispatch suites.
- Blacksmith Testbox formatting check passed for all three touched files.
- Fresh autoreview: clean, 0.95 confidence.
- Failing exact candidate before this trace: `3c3fb62b3b61438926cb9308861bdca626fd875e` in run https://github.com/openclaw/openclaw/actions/runs/29207137732.
