### PR TITLE
chore(release): expose LTS delivery trace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ Skills own workflows; root owns hard policy and routing.
 - Checks in a normal source checkout: `pnpm check:changed` delegates to Crabbox/Testbox; lanes: `pnpm changed:lanes --json`; staged: `pnpm check:changed --staged`; full: `pnpm check`.
 - Checks in a Codex worktree or linked/sparse checkout: avoid direct local `pnpm check*`; use `node scripts/crabbox-wrapper.mjs run ... -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` so pnpm runs inside Testbox, not locally.
 - Direct Testbox runs: pass `--provider blacksmith-testbox`; `OPENCLAW_TESTBOX=1` only selects `scripts/pr` prepare behavior.
-- Release-branch Testbox warmup: pass `--blacksmith-ref <candidate-branch-or-sha>`; default `main` can create mixed-base dependency state.
+- Release-branch Testbox warmup: pass a remote branch/tag to `--blacksmith-ref`; raw SHAs are rejected, and default `main` can create mixed-base dependency state.
 - Crabbox wrapper stop: `node scripts/crabbox-wrapper.mjs stop --provider <provider> --id <lease>`; no positional id or `--timing-json`.
 - Extension tests: `pnpm test:extensions`, `pnpm test extensions`, `pnpm test extensions/<id>`.
 - Typecheck: `tsgo` lanes only (`pnpm tsgo*`, `pnpm check:test-types`); never add `tsc --noEmit`, `typecheck`, `check:types`.

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -148,6 +148,7 @@ export { getTelegramReplyFenceSizeForTests, resetTelegramReplyFenceForTests };
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 const silentReplyDispatchLogger = createSubsystemLogger("telegram/silent-reply-dispatch");
+const releaseDebugLogger = createSubsystemLogger("release-debug/telegram-dispatch");
 
 /** Minimum chars before sending first streaming message (improves push notification UX) */
 const DRAFT_MIN_INITIAL_CHARS = 30;
@@ -1851,7 +1852,7 @@ export const dispatchTelegramMessage = async ({
                     return undefined;
                   },
                   deliver: async (payload, info) => {
-                    logVerbose(
+                    releaseDebugLogger.debug(
                       `[release-debug] telegram deliver kind=${info.kind} ` +
                         `text=${resolveSendableOutboundReplyParts(payload).trimmedText ? "yes" : "no"} ` +
                         `media=${resolveSendableOutboundReplyParts(payload).hasMedia ? "yes" : "no"}`,
@@ -2406,7 +2407,7 @@ export const dispatchTelegramMessage = async ({
         return { kind: "completed" };
       }
       ({ queuedFinal } = turnResult.dispatchResult);
-      logVerbose(
+      releaseDebugLogger.debug(
         `[release-debug] telegram dispatch result dispatched=yes queuedFinal=${queuedFinal ? "yes" : "no"} ` +
           `delivered=${deliveryState.snapshot().delivered ? "yes" : "no"} ` +
           `roomEvent=${isRoomEvent ? "yes" : "no"}`,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -42,6 +42,7 @@ import {
 } from "../../infra/diagnostic-trace-context.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { PluginHookReplyUsageState } from "../../plugins/hook-types.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../sessions/input-provenance.js";
@@ -131,6 +132,7 @@ import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
 
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
+const releaseDebugLogger = createSubsystemLogger("release-debug/reply-runner");
 
 function markBeforeAgentRunBlockedPayloads(payloads: ReplyPayload[]): ReplyPayload[] {
   return payloads.map((payload) =>
@@ -1727,7 +1729,7 @@ export async function runReplyAgent(params: {
     }
 
     const payloadArray = runResult.payloads ?? [];
-    logVerbose(
+    releaseDebugLogger.debug(
       `[release-debug] reply runner input runId=${runId} payloads=${payloadArray.length} ` +
         `blockStreamed=${blockReplyPipeline?.didStream() === true ? "yes" : "no"} ` +
         `blockAborted=${blockReplyPipeline?.isAborted() === true ? "yes" : "no"} ` +
@@ -2071,7 +2073,7 @@ export async function runReplyAgent(params: {
       normalizeMediaPaths: replyMediaContext.normalizePayload,
     });
     const { replyPayloads } = payloadResult;
-    logVerbose(
+    releaseDebugLogger.debug(
       `[release-debug] reply runner output runId=${runId} payloads=${replyPayloads.length} ` +
         `blockStreamed=${blockReplyPipeline?.didStream() === true ? "yes" : "no"} ` +
         `blockAborted=${blockReplyPipeline?.isAborted() === true ? "yes" : "no"}`,


### PR DESCRIPTION
## What Problem This Solves

The extended-stable Telegram canary still loses a valid embedded payload, and the two downstream trace points added in #105689 were routed through verbose-only logging, so the release artifact could not distinguish reply filtering from Telegram dispatch.

## Why This Change Was Made

Route the existing count/boolean trace messages through dedicated debug subsystem loggers. Also correct the Testbox maintainer note: Blacksmith accepts remote branches/tags for candidate warmup, not raw SHAs.

## User Impact

No behavior change. Release diagnostics become visible in the existing debug-enabled gateway artifact without exposing message text, recipient data, or credentials.

## Evidence

- Failing exact LTS trace: https://github.com/openclaw/openclaw/actions/runs/29208407773 at `584f90b5cf3ec1aaad2e07b009b7807634187525`; embedded payload count is 1 on both attempts.
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29208819824 — reply payload and Telegram dispatch suites, 169 tests passed.
- Blacksmith Testbox formatting check passed for both code files.
- Fresh autoreview: clean, 0.96 confidence.
