### PR TITLE
fix(ci): keep unused exports advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1604,18 +1604,9 @@ jobs:
                 ' "$1"
               }
               if has_package_script "deadcode:dependencies" &&
-                has_package_script "deadcode:unused-files" &&
-                has_package_script "deadcode:exports"; then
+                has_package_script "deadcode:unused-files"; then
                 pnpm deadcode:dependencies
                 pnpm deadcode:unused-files
-                pnpm deadcode:exports
-              elif [[ "$HISTORICAL_TARGET" == "true" ]] &&
-                has_package_script "deadcode:dependencies" &&
-                has_package_script "deadcode:unused-files" &&
-                has_package_script "deadcode:report:ci:ts-unused"; then
-                pnpm deadcode:dependencies
-                pnpm deadcode:unused-files
-                pnpm deadcode:report:ci:ts-unused
               elif [[ "$HISTORICAL_TARGET" == "true" ]] && has_package_script "deadcode:ci"; then
                 pnpm deadcode:ci
               else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1597,12 +1597,30 @@ jobs:
               fi
               ;;
             dependencies)
-              if pnpm run --silent 2>/dev/null | grep -q '^  deadcode:dependencies$'; then
+              has_package_script() {
+                node -e '
+                  const scripts = require("./package.json").scripts ?? {};
+                  process.exit(Object.hasOwn(scripts, process.argv[1]) ? 0 : 1);
+                ' "$1"
+              }
+              if has_package_script "deadcode:dependencies" &&
+                has_package_script "deadcode:unused-files" &&
+                has_package_script "deadcode:exports"; then
                 pnpm deadcode:dependencies
                 pnpm deadcode:unused-files
                 pnpm deadcode:exports
-              else
+              elif [[ "$HISTORICAL_TARGET" == "true" ]] &&
+                has_package_script "deadcode:dependencies" &&
+                has_package_script "deadcode:unused-files" &&
+                has_package_script "deadcode:report:ci:ts-unused"; then
+                pnpm deadcode:dependencies
+                pnpm deadcode:unused-files
+                pnpm deadcode:report:ci:ts-unused
+              elif [[ "$HISTORICAL_TARGET" == "true" ]] && has_package_script "deadcode:ci"; then
                 pnpm deadcode:ci
+              else
+                echo "Target does not provide a supported deadcode check." >&2
+                exit 1
               fi
               ;;
             test-types)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -111,7 +111,7 @@ job budget.
 
 Android CI runs both `testPlayDebugUnitTest` and `testThirdPartyDebugUnitTest` and then builds the Play debug APK. The third-party flavor has no separate source set or manifest; its unit-test lane still compiles the flavor with the SMS/call-log BuildConfig flags, while avoiding a duplicate debug APK packaging job on every Android-relevant push.
 
-The `check-dependencies` shard runs a production Knip dependency-only pass, the unused-file allowlist check, and the enforced unused-exports baseline ratchet. The unused-file guard fails when a PR adds a new unreviewed unused file or leaves a stale allowlist entry, while preserving intentional dynamic plugin, generated, build, live-test, and package bridge surfaces that Knip cannot resolve statically. The unused-exports ratchet likewise rejects new findings and stale required baseline entries, so the checked-in debt can only shrink. The former ts-prune and ts-unused-exports advisory reports no longer run.
+The `check-dependencies` shard runs a production Knip dependency-only pass and the unused-file allowlist check. The unused-file guard fails when a PR adds a new unreviewed unused file or leaves a stale allowlist entry, while preserving intentional dynamic plugin, generated, build, live-test, and package bridge surfaces that Knip cannot resolve statically. The unused-exports baseline remains available as an advisory maintenance scan through `pnpm deadcode:exports`; after deleting dead code, regenerate it with `pnpm deadcode:exports:update`.
 
 ## ClawSweeper activity forwarding
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1746,17 +1746,13 @@ describe("ci workflow guards", () => {
     expect(preflightGuards).toContain("pnpm deps:patches:check");
   });
 
-  it("uses the target-owned deadcode contract for current and frozen checkouts", () => {
+  it("uses stable deadcode checks for current and frozen checkouts", () => {
     const modern = runDependencyCheckFixture({
       historicalTarget: false,
       scripts: ["deadcode:dependencies", "deadcode:unused-files", "deadcode:exports"],
     });
     expect(modern.status, modern.output).toBe(0);
-    expect(modern.calls).toEqual([
-      "deadcode:dependencies",
-      "deadcode:unused-files",
-      "deadcode:exports",
-    ]);
+    expect(modern.calls).toEqual(["deadcode:dependencies", "deadcode:unused-files"]);
 
     const frozen = runDependencyCheckFixture({
       historicalTarget: true,
@@ -1768,15 +1764,18 @@ describe("ci workflow guards", () => {
       ],
     });
     expect(frozen.status, frozen.output).toBe(0);
-    expect(frozen.calls).toEqual([
-      "deadcode:dependencies",
-      "deadcode:unused-files",
-      "deadcode:report:ci:ts-unused",
-    ]);
+    expect(frozen.calls).toEqual(["deadcode:dependencies", "deadcode:unused-files"]);
+
+    const legacy = runDependencyCheckFixture({
+      historicalTarget: true,
+      scripts: ["deadcode:ci"],
+    });
+    expect(legacy.status, legacy.output).toBe(0);
+    expect(legacy.calls).toEqual(["deadcode:ci"]);
 
     const incompleteCurrent = runDependencyCheckFixture({
       historicalTarget: false,
-      scripts: ["deadcode:dependencies", "deadcode:unused-files"],
+      scripts: ["deadcode:dependencies"],
     });
     expect(incompleteCurrent.status).toBe(1);
     expect(incompleteCurrent.calls).toEqual([]);
@@ -2066,8 +2065,9 @@ describe("ci workflow guards", () => {
     );
     expect(checkShard.run).toContain("pnpm tsgo:scripts");
     expect(checkShard.run).toContain('elif [[ "$HISTORICAL_TARGET" != "true" ]]');
-    expect(checkShard.run).toContain('has_package_script "deadcode:exports"');
-    expect(checkShard.run).toContain('has_package_script "deadcode:report:ci:ts-unused"');
+    expect(checkShard.run).toContain('has_package_script "deadcode:dependencies"');
+    expect(checkShard.run).toContain('has_package_script "deadcode:unused-files"');
+    expect(checkShard.run).not.toContain('has_package_script "deadcode:exports"');
     expect(checkShard.run).toContain(
       'elif [[ "$HISTORICAL_TARGET" == "true" ]] && has_package_script "deadcode:ci"',
     );

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -385,6 +385,55 @@ function writeExecutable(filePath: string, lines: string[]): void {
   chmodSync(filePath, 0o755);
 }
 
+function runDependencyCheckFixture(options: { historicalTarget: boolean; scripts: string[] }): {
+  calls: string[];
+  output: string;
+  status: number | null;
+} {
+  const root = mkdtempSync(path.join(tmpdir(), "openclaw-ci-deadcode-"));
+  try {
+    const fakeBin = path.join(root, "bin");
+    const callsPath = path.join(root, "pnpm-calls.txt");
+    mkdirSync(fakeBin);
+    writeFileSync(
+      path.join(root, "package.json"),
+      `${JSON.stringify({
+        scripts: Object.fromEntries(options.scripts.map((name) => [name, "true"])),
+      })}\n`,
+    );
+    writeExecutable(path.join(fakeBin, "pnpm"), [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      'printf "%s\\n" "$*" >> "$PNPM_CALLS"',
+    ]);
+    const checkShardRun = readCiWorkflow().jobs["check-shard"].steps.find(
+      (step: WorkflowStep) => step.name === "Run check shard",
+    ).run;
+    const run = spawnSync("bash", ["-c", checkShardRun], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FORMAT_CHECK: "false",
+        HISTORICAL_TARGET: options.historicalTarget ? "true" : "false",
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        PNPM_CALLS: callsPath,
+        PR_BASE_SHA: "",
+        TASK: "dependencies",
+      },
+    });
+    return {
+      calls: existsSync(callsPath)
+        ? readFileSync(callsPath, "utf8").trim().split("\n").filter(Boolean)
+        : [],
+      output: `${run.stdout}${run.stderr}`,
+      status: run.status,
+    };
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+}
+
 function runGeneratedPublisherScenario(
   baseChangePath: "a" | "b" | null,
   options: {
@@ -1697,6 +1746,45 @@ describe("ci workflow guards", () => {
     expect(preflightGuards).toContain("pnpm deps:patches:check");
   });
 
+  it("uses the target-owned deadcode contract for current and frozen checkouts", () => {
+    const modern = runDependencyCheckFixture({
+      historicalTarget: false,
+      scripts: ["deadcode:dependencies", "deadcode:unused-files", "deadcode:exports"],
+    });
+    expect(modern.status, modern.output).toBe(0);
+    expect(modern.calls).toEqual([
+      "deadcode:dependencies",
+      "deadcode:unused-files",
+      "deadcode:exports",
+    ]);
+
+    const frozen = runDependencyCheckFixture({
+      historicalTarget: true,
+      scripts: [
+        "deadcode:ci",
+        "deadcode:dependencies",
+        "deadcode:report:ci:ts-unused",
+        "deadcode:unused-files",
+      ],
+    });
+    expect(frozen.status, frozen.output).toBe(0);
+    expect(frozen.calls).toEqual([
+      "deadcode:dependencies",
+      "deadcode:unused-files",
+      "deadcode:report:ci:ts-unused",
+    ]);
+
+    const incompleteCurrent = runDependencyCheckFixture({
+      historicalTarget: false,
+      scripts: ["deadcode:dependencies", "deadcode:unused-files"],
+    });
+    expect(incompleteCurrent.status).toBe(1);
+    expect(incompleteCurrent.calls).toEqual([]);
+    expect(incompleteCurrent.output).toContain(
+      "Target does not provide a supported deadcode check.",
+    );
+  });
+
   it("runs mobile protocol coverage for Node and native-only changes", () => {
     const workflow = readCiWorkflow();
     const coverageStep = workflow.jobs.preflight.steps.find(
@@ -1978,6 +2066,12 @@ describe("ci workflow guards", () => {
     );
     expect(checkShard.run).toContain("pnpm tsgo:scripts");
     expect(checkShard.run).toContain('elif [[ "$HISTORICAL_TARGET" != "true" ]]');
+    expect(checkShard.run).toContain('has_package_script "deadcode:exports"');
+    expect(checkShard.run).toContain('has_package_script "deadcode:report:ci:ts-unused"');
+    expect(checkShard.run).toContain(
+      'elif [[ "$HISTORICAL_TARGET" == "true" ]] && has_package_script "deadcode:ci"',
+    );
+    expect(checkShard.run).toContain("Target does not provide a supported deadcode check.");
 
     const uiInstall = workflow.jobs["checks-ui"].steps.find(
       (step: { name?: string }) => step.name === "Install Playwright Chromium",


### PR DESCRIPTION
## What Problem This Solves

Current CI release tooling could not validate the frozen `release/2026.7.1`
candidate because a new unused-export ratchet was treated as a required target
contract even though that release predates it.

## Why This Change Was Made

Keep the established dependency and unused-file checks as the required CI
contract for current and frozen targets. The unused-export baseline remains
available through `pnpm deadcode:exports` as an advisory maintenance scan, and
older frozen targets retain their aggregate `deadcode:ci` fallback.

## User Impact

No runtime impact. Maintainers can validate frozen release candidates without
backporting newly introduced CI tooling, while dependency and unused-file
regressions remain blocked.

## Evidence

- Blacksmith Testbox `tbx_01kxc491nn56aj109j70afrs5t`, run
  `29210013950`: 53 workflow guard tests passed.
- `actionlint .github/workflows/ci.yml`
- `oxfmt --check` on all changed files
- `git diff --check`
- Autoreview clean, correctness 0.93
