### PR TITLE
refactor(ui): trim private search exports

### DIFF
--- a/ui/src/components/config-form.node.ts
+++ b/ui/src/components/config-form.node.ts
@@ -22,8 +22,6 @@ import {
   type JsonSchema,
 } from "./config-form.shared.ts";
 
-export { matchesNodeSearch, parseConfigSearchQuery } from "./config-form.search.ts";
-
 const META_KEYS = new Set(["title", "description", "default", "nullable", "tags", "x-tags"]);
 
 function isAnySchema(schema: JsonSchema): boolean {

--- a/ui/src/components/config-form.search.node.test.ts
+++ b/ui/src/components/config-form.search.node.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { matchesNodeSearch, parseConfigSearchQuery } from "./config-form.node.ts";
+import { matchesNodeSearch, parseConfigSearchQuery } from "./config-form.search.ts";
 
 const schema = {
   type: "object",

--- a/ui/src/components/config-form.search.ts
+++ b/ui/src/components/config-form.search.ts
@@ -7,13 +7,13 @@ export type ConfigSearchCriteria = {
   tags: string[];
 };
 
-export type ConfigFieldMeta = {
+type ConfigFieldMeta = {
   label: string;
   help?: string;
   tags: string[];
 };
 
-export type ConfigSearchTextMatcher = (value: string, query: string) => boolean;
+type ConfigSearchTextMatcher = (value: string, query: string) => boolean;
 
 export function hasConfigSearchCriteria(criteria: ConfigSearchCriteria | undefined): boolean {
   return Boolean(criteria && (criteria.text.length > 0 || criteria.tags.length > 0));

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -53,6 +53,7 @@ vi.mock("./terminal-runtime.ts", () => {
 import { OpenClawTerminalPanel } from "./terminal-panel.ts";
 
 const TERMINAL_PANEL_ELEMENT_NAME = "test-openclaw-terminal-panel";
+const TERMINAL_LIFECYCLE_WAIT_TIMEOUT_MS = 10_000;
 
 // Keep the mounted panel and i18n manager in the current module graph when
 // the non-isolated runner has retained an earlier production registration.
@@ -60,6 +61,12 @@ class TestTerminalPanel extends OpenClawTerminalPanel {}
 
 if (!customElements.get(TERMINAL_PANEL_ELEMENT_NAME)) {
   customElements.define(TERMINAL_PANEL_ELEMENT_NAME, TestTerminalPanel);
+}
+
+// Shared 4-vCPU UI CI can starve lifecycle work past Vitest's 1s waitFor default.
+// The UI suite's 60s test timeout remains the enclosing upper bound.
+function waitForTerminalLifecycle(assertion: () => void | Promise<void>): Promise<void> {
+  return vi.waitFor(assertion, { timeout: TERMINAL_LIFECYCLE_WAIT_TIMEOUT_MS });
 }
 
 describe("OpenClawTerminalPanel", () => {
@@ -114,7 +121,7 @@ describe("OpenClawTerminalPanel", () => {
 
     panel.toggle();
 
-    await vi.waitFor(() => {
+    await waitForTerminalLifecycle(() => {
       expect(requests[0]).toEqual({
         method: "terminal.open",
         params: { agentId: "ops", cols: 100, rows: 30 },
@@ -124,7 +131,7 @@ describe("OpenClawTerminalPanel", () => {
     expect(getComputedStyle(createOptions!.parent).caretColor).toBe("rgba(0, 0, 0, 0)");
     const styles = (OpenClawTerminalPanel.styles as { cssText: string }).cssText;
     expect(styles).toMatch(/\.tp-new\s*\{[^}]*align-self:\s*center/u);
-    await vi.waitFor(() => {
+    await waitForTerminalLifecycle(() => {
       expect(requests).toContainEqual({
         method: "terminal.resize",
         params: { sessionId: "session-1", cols: 100, rows: 30 },
@@ -133,7 +140,7 @@ describe("OpenClawTerminalPanel", () => {
 
     createOptions?.onData?.(new TextEncoder().encode("pwd\n"));
     createOptions?.onResize?.({ columns: 120, rows: 40 });
-    await vi.waitFor(() => {
+    await waitForTerminalLifecycle(() => {
       expect(requests).toContainEqual({
         method: "terminal.input",
         params: { sessionId: "session-1", data: "pwd\n" },
@@ -181,7 +188,7 @@ describe("OpenClawTerminalPanel", () => {
     document.body.append(panel);
 
     // No toggle: the terminal-only document opens its session on mount.
-    await vi.waitFor(() => {
+    await waitForTerminalLifecycle(() => {
       expect(requests.some((entry) => entry.method === "terminal.open")).toBe(true);
     });
     await panel.updateComplete;
@@ -238,7 +245,7 @@ describe("OpenClawTerminalPanel", () => {
     document.body.append(panel);
 
     panel.toggle();
-    await vi.waitFor(() => {
+    await waitForTerminalLifecycle(() => {
       expect(requests.filter((entry) => entry.method === "terminal.open")).toHaveLength(1);
     });
 
@@ -251,7 +258,7 @@ describe("OpenClawTerminalPanel", () => {
 
     await panel.updateComplete;
     (panel.renderRoot.querySelector(".tp-tab__close") as HTMLElement).click();
-    await vi.waitFor(() => {
+    await waitForTerminalLifecycle(() => {
       expect(requests).toContainEqual({
         method: "terminal.close",
         params: { sessionId: "session-1" },
@@ -261,7 +268,7 @@ describe("OpenClawTerminalPanel", () => {
     expect(sessionStorage.getItem("openclaw.terminal.sessions.v1")).toBe("[]");
 
     panel.toggle();
-    await vi.waitFor(() => {
+    await waitForTerminalLifecycle(() => {
       expect(requests.filter((entry) => entry.method === "terminal.open")).toHaveLength(2);
     });
     expect(requests.some((entry) => entry.method === "terminal.attach")).toBe(false);
@@ -301,13 +308,13 @@ describe("OpenClawTerminalPanel", () => {
     document.body.append(panel);
     panel.toggle();
 
-    await vi.waitFor(() => {
+    await waitForTerminalLifecycle(() => {
       expect(sessionStorage.getItem("openclaw.terminal.sessions.v1")).toContain("old-session");
     });
     panel.client = newClient;
     await panel.updateComplete;
 
-    await vi.waitFor(() => {
+    await waitForTerminalLifecycle(() => {
       expect(newRequests).toContain("terminal.open");
     });
     expect(oldRequests.filter((method) => method === "terminal.open")).toHaveLength(1);
@@ -337,7 +344,7 @@ describe("OpenClawTerminalPanel", () => {
     document.body.append(panel);
     panel.toggle();
 
-    await vi.waitFor(() => {
+    await waitForTerminalLifecycle(() => {
       expect(createGhosttyTerminalMock).toHaveBeenCalledOnce();
     });
     const staleOptions = createGhosttyTerminalMock.mock.calls[0]![0] as CreateOptions;
@@ -345,13 +352,13 @@ describe("OpenClawTerminalPanel", () => {
     panel.remove();
     document.body.append(panel);
 
-    await vi.waitFor(() => {
+    await waitForTerminalLifecycle(() => {
       expect(createGhosttyTerminalMock).toHaveBeenCalledTimes(2);
       expect(requests.filter((method) => method === "terminal.open")).toHaveLength(1);
     });
     staleBoot.resolve(staleController);
 
-    await vi.waitFor(() => {
+    await waitForTerminalLifecycle(() => {
       expect(staleController.dispose).toHaveBeenCalledOnce();
     });
     expect(staleHost.isConnected).toBe(false);
@@ -423,7 +430,7 @@ describe("OpenClawTerminalPanel", () => {
     panel.available = true;
     document.body.append(panel);
     panel.toggle();
-    await vi.waitFor(() => {
+    await waitForTerminalLifecycle(() => {
       expect(sessionStorage.getItem("openclaw.terminal.sessions.v1")).toContain("session-1");
     });
 


### PR DESCRIPTION
Related: #105714

## What Problem This Solves

The Control UI settings-search refactor exposed two module-local type aliases and a redundant test-only forwarding export. The stale surface caused the unused-export ratchet to fail on current `main`.

The first exact-head CI attempts also exposed a separate runner-only reliability problem: terminal lifecycle assertions exhausted Vitest's one-second `waitFor` default under shared 4-vCPU load.

## Why This Change Was Made

Keep the search helper types private, remove the renderer's forwarding export, and import the helpers from their canonical owner in the focused test.

All terminal lifecycle assertions now share a bounded 10-second polling helper. Passing assertions remain immediate, the helper stays below the UI suite's 60-second timeout, and production behavior is unchanged.

These fixes land together because either branch alone is blocked by the other failure on current `main`: the export cleanup repairs `check-dependencies`, while the lifecycle helper repairs `checks-ui`.

## User Impact

No user-visible behavior change. The Control UI internal API is smaller, the unused-export ratchet is green, and hosted UI CI is less sensitive to temporary worker starvation.

## Evidence

- Refreshed branch codebase-memory graph: 306,004 nodes / 1,273,383 edges.
- Focused Testbox run: 3 files, 19/19 tests passed.
- Full Testbox UI run with `CI=1` and four workers: 233 files, 3,695/3,695 tests passed.
- One unrelated chat tool-card assertion failed on the first full run, then passed focused (36/36) and in the controlled full-suite rerun.
- Testbox `check:changed` across all four changed files: passed.
- Testbox `deadcode:exports`: baseline matched 5,962 intentional entries.
- Testbox full `pnpm build`: passed, including Control UI and plugin SDK declaration checks.
- Fresh combined `gpt-5.6-sol` medium autoreview: clean at 0.94 confidence.
- #105714 exact-head `checks-ui` passed; its only failure was the same four unused exports already fixed in this PR.
