### PR TITLE
chore: capture redacted Slack file event trace

### DIFF
--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -159,6 +159,7 @@ jobs:
   run_mock_parity:
     name: Run QA Lab mock parity lane
     needs: [validate_selected_ref]
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.slack_scenario != 'file-event-trace' }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 30
     env:
@@ -322,7 +323,7 @@ jobs:
   run_live_matrix:
     name: Run Matrix live QA lane
     needs: [authorize_actor, validate_selected_ref]
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.matrix_profile == 'all') }}
+    if: ${{ inputs.slack_scenario != 'file-event-trace' && !(github.event_name == 'workflow_dispatch' && inputs.matrix_profile == 'all') }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 60
     environment: qa-live-shared
@@ -398,7 +399,7 @@ jobs:
   run_live_matrix_sharded:
     name: Run Matrix live QA lane (${{ matrix.profile }})
     needs: [authorize_actor, validate_selected_ref]
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.matrix_profile == 'all' }}
+    if: ${{ inputs.slack_scenario != 'file-event-trace' && github.event_name == 'workflow_dispatch' && inputs.matrix_profile == 'all' }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 60
     environment: qa-live-shared
@@ -482,6 +483,7 @@ jobs:
   run_live_telegram:
     name: Run Telegram live QA lane with Convex leases
     needs: [authorize_actor, validate_selected_ref]
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.slack_scenario != 'file-event-trace' }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 60
     environment: qa-live-shared
@@ -578,6 +580,7 @@ jobs:
   run_live_discord:
     name: Run Discord live QA lane with Convex leases
     needs: [authorize_actor, validate_selected_ref]
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.slack_scenario != 'file-event-trace' }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 60
     environment: qa-live-shared
@@ -653,6 +656,7 @@ jobs:
   run_live_whatsapp:
     name: Run WhatsApp live QA lane with Convex leases
     needs: [authorize_actor, validate_selected_ref]
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.slack_scenario != 'file-event-trace' }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 60
     concurrency:
@@ -783,6 +787,14 @@ jobs:
           fi
 
           echo "output_dir=${output_dir}" >> "$GITHUB_OUTPUT"
+
+          if [[ "$INPUT_SCENARIO" == "file-event-trace" ]]; then
+            mkdir -p "$output_dir"
+            pnpm exec tsx \
+              extensions/qa-lab/src/live-transports/slack/file-event-trace.probe.ts \
+              > "$output_dir/file-event-trace.json"
+            exit 0
+          fi
 
           pnpm openclaw qa slack \
             --repo-root . \

--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -159,7 +159,7 @@ jobs:
   run_mock_parity:
     name: Run QA Lab mock parity lane
     needs: [validate_selected_ref]
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.slack_scenario != 'file-event-trace' }}
+    if: ${{ github.event_name != 'workflow_dispatch' || !startsWith(inputs.slack_scenario, 'file-event-trace') }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 30
     env:
@@ -323,7 +323,7 @@ jobs:
   run_live_matrix:
     name: Run Matrix live QA lane
     needs: [authorize_actor, validate_selected_ref]
-    if: ${{ inputs.slack_scenario != 'file-event-trace' && !(github.event_name == 'workflow_dispatch' && inputs.matrix_profile == 'all') }}
+    if: ${{ !startsWith(inputs.slack_scenario, 'file-event-trace') && !(github.event_name == 'workflow_dispatch' && inputs.matrix_profile == 'all') }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 60
     environment: qa-live-shared
@@ -399,7 +399,7 @@ jobs:
   run_live_matrix_sharded:
     name: Run Matrix live QA lane (${{ matrix.profile }})
     needs: [authorize_actor, validate_selected_ref]
-    if: ${{ inputs.slack_scenario != 'file-event-trace' && github.event_name == 'workflow_dispatch' && inputs.matrix_profile == 'all' }}
+    if: ${{ !startsWith(inputs.slack_scenario, 'file-event-trace') && github.event_name == 'workflow_dispatch' && inputs.matrix_profile == 'all' }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 60
     environment: qa-live-shared
@@ -483,7 +483,7 @@ jobs:
   run_live_telegram:
     name: Run Telegram live QA lane with Convex leases
     needs: [authorize_actor, validate_selected_ref]
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.slack_scenario != 'file-event-trace' }}
+    if: ${{ github.event_name != 'workflow_dispatch' || !startsWith(inputs.slack_scenario, 'file-event-trace') }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 60
     environment: qa-live-shared
@@ -580,7 +580,7 @@ jobs:
   run_live_discord:
     name: Run Discord live QA lane with Convex leases
     needs: [authorize_actor, validate_selected_ref]
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.slack_scenario != 'file-event-trace' }}
+    if: ${{ github.event_name != 'workflow_dispatch' || !startsWith(inputs.slack_scenario, 'file-event-trace') }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 60
     environment: qa-live-shared
@@ -656,7 +656,7 @@ jobs:
   run_live_whatsapp:
     name: Run WhatsApp live QA lane with Convex leases
     needs: [authorize_actor, validate_selected_ref]
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.slack_scenario != 'file-event-trace' }}
+    if: ${{ github.event_name != 'workflow_dispatch' || !startsWith(inputs.slack_scenario, 'file-event-trace') }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 60
     concurrency:
@@ -788,9 +788,13 @@ jobs:
 
           echo "output_dir=${output_dir}" >> "$GITHUB_OUTPUT"
 
-          if [[ "$INPUT_SCENARIO" == "file-event-trace" ]]; then
+          if [[ "$INPUT_SCENARIO" == file-event-trace* ]]; then
             mkdir -p "$output_dir"
-            pnpm exec tsx \
+            trace_mode="api"
+            if [[ "$INPUT_SCENARIO" == "file-event-trace-browser" ]]; then
+              trace_mode="browser"
+            fi
+            OPENCLAW_QA_FILE_TRACE_MODE="$trace_mode" pnpm exec tsx \
               extensions/qa-lab/src/live-transports/slack/file-event-trace.probe.ts \
               > "$output_dir/file-event-trace.json"
             exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Slack delayed file uploads:** deliver newly finalized file sets from `message_changed` events exactly once across persistent and in-memory dedupe, including Enterprise Grid and Slack Connect placeholders, while leaving ordinary edits passive. (#104703) Thanks @dreuvenrsg.
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Memory filename search:** index paths separately from chunk bodies so exact full-path, basename, and stem queries rank the intended memory file first without changing body BM25 scores, snippets, or embeddings. (#96052, #94102) Thanks @Pick-cat.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.

--- a/extensions/qa-lab/src/live-transports/slack/file-event-trace.probe.ts
+++ b/extensions/qa-lab/src/live-transports/slack/file-event-trace.probe.ts
@@ -87,6 +87,15 @@ function summarizeMessage(value: unknown) {
   };
 }
 
+function isFileEvent(event?: Record<string, unknown>, nested?: Record<string, unknown>) {
+  return (
+    event?.subtype === "file_share" ||
+    nested?.subtype === "file_share" ||
+    Array.isArray(event?.files) ||
+    Array.isArray(nested?.files)
+  );
+}
+
 function safeError(error: unknown) {
   const record = asRecord(error);
   const data = asRecord(record?.data);
@@ -94,7 +103,11 @@ function safeError(error: unknown) {
   return typeof code === "string" ? code : error instanceof Error ? error.name : "unknown";
 }
 
-const marker = `OPENCLAW_QA_FILE_FINALIZATION_${Date.now()}`;
+const traceMode = process.env.OPENCLAW_QA_FILE_TRACE_MODE === "browser" ? "browser" : "api";
+const marker =
+  traceMode === "browser"
+    ? `OPENCLAW_QA_BROWSER_FILE_FINALIZATION_${process.env.GITHUB_RUN_ID ?? Date.now()}`
+    : `OPENCLAW_QA_FILE_FINALIZATION_${Date.now()}`;
 const locatorPublicKey = `-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnvIMGBJwjC3rt9eT9m9b
 VPUMkjKB8ww/EydbxUmPr6e4+y0/PM6AC5ZMyGXg4V41pJTNAJO/oBkf8zb7l1FJ
@@ -110,6 +123,8 @@ let lease: Awaited<ReturnType<typeof acquireQaCredentialLease<SlackQaCredential>
 let heartbeat: ReturnType<typeof startQaCredentialLeaseHeartbeat> | undefined;
 let app: App | undefined;
 let uploadedFileIds: string[] = [];
+let locatorMessageTs: string | undefined;
+let targetChannelId: string | undefined;
 
 try {
   lease = await acquireQaCredentialLease({
@@ -121,6 +136,7 @@ try {
   });
   heartbeat = startQaCredentialLeaseHeartbeat(lease);
   const credential = lease.payload;
+  targetChannelId = credential.channelId;
   app = new App({
     token: credential.sutBotToken,
     appToken: credential.sutAppToken,
@@ -133,7 +149,12 @@ try {
     const nested = asRecord(event?.message);
     const eventText = typeof event?.text === "string" ? event.text : "";
     const nestedText = typeof nested?.text === "string" ? nested.text : "";
-    if (event?.type === "message" && (eventText.includes(marker) || nestedText.includes(marker))) {
+    const matchesApiUpload = eventText.includes(marker) || nestedText.includes(marker);
+    const matchesBrowserUpload = event?.channel === targetChannelId && isFileEvent(event, nested);
+    if (
+      event?.type === "message" &&
+      (traceMode === "browser" ? matchesBrowserUpload : matchesApiUpload)
+    ) {
       trace.push({
         sequence: trace.length + 1,
         outer: summarizeMessage(event),
@@ -152,24 +173,38 @@ try {
 
   const web = new WebClient(credential.sutBotToken);
   const auth = await web.auth.test();
-  const teamIdHash = createHash("sha256").update(auth.team_id ?? "").digest("hex");
+  const teamIdHash = createHash("sha256")
+    .update(auth.team_id ?? "")
+    .digest("hex");
   const encryptedWorkspaceLocator = publicEncrypt(
     { key: locatorPublicKey, oaepHash: "sha256" },
     Buffer.from(JSON.stringify({ team: auth.team ?? null, url: auth.url ?? null })),
   ).toString("base64");
-  const upload = (await web.filesUploadV2({
-    channel_id: credential.channelId,
-    initial_comment: marker,
-    file_uploads: [
-      { content: "alpha\n", filename: "qa-finalization-a.txt" },
-      { content: "beta\n", filename: "qa-finalization-b.txt" },
-    ],
-  })) as { files?: Array<{ id?: string }> };
-  uploadedFileIds = (upload.files ?? []).flatMap((file) => (file.id ? [file.id] : []));
+  if (traceMode === "browser") {
+    const locator = await web.apiCall("chat.postMessage", {
+      channel: credential.channelId,
+      text: marker,
+    });
+    const locatorRecord = asRecord(locator);
+    locatorMessageTs = typeof locatorRecord?.ts === "string" ? locatorRecord.ts : undefined;
+    process.stderr.write(`Slack browser trace ready: ${marker}\n`);
+  } else {
+    const upload = (await web.filesUploadV2({
+      channel_id: credential.channelId,
+      initial_comment: marker,
+      file_uploads: [
+        { content: "alpha\n", filename: "qa-finalization-a.txt" },
+        { content: "beta\n", filename: "qa-finalization-b.txt" },
+      ],
+    })) as { files?: Array<{ id?: string }> };
+    uploadedFileIds = (upload.files ?? []).flatMap((file) => (file.id ? [file.id] : []));
+  }
 
   const waitStartedAt = Date.now();
-  while (Date.now() - waitStartedAt < 20_000) {
-    if (trace.length > 0 && Date.now() - lastEventAt >= 4_000) {
+  const waitTimeoutMs = traceMode === "browser" ? 8 * 60_000 : 20_000;
+  const quietPeriodMs = traceMode === "browser" ? 8_000 : 4_000;
+  while (Date.now() - waitStartedAt < waitTimeoutMs) {
+    if (trace.length > 0 && Date.now() - lastEventAt >= quietPeriodMs) {
       break;
     }
     await new Promise<void>((resolve) => {
@@ -183,8 +218,8 @@ try {
         source: "real Slack Socket Mode event stream",
         teamIdHash,
         encryptedWorkspaceLocator,
-        uploadMethod: "WebClient.filesUploadV2",
-        fileUploadCount: 2,
+        uploadMethod: traceMode === "browser" ? "Slack web client" : "WebClient.filesUploadV2",
+        fileUploadCount: traceMode === "browser" ? null : 2,
         eventCount: trace.length,
         trace,
       },
@@ -198,7 +233,12 @@ try {
 } finally {
   if (lease) {
     const web = new WebClient(lease.payload.sutBotToken);
-    await Promise.allSettled(uploadedFileIds.map(async (file) => await web.files.delete({ file })));
+    await Promise.allSettled([
+      ...uploadedFileIds.map(async (file) => await web.files.delete({ file })),
+      ...(locatorMessageTs
+        ? [web.chat.delete({ channel: lease.payload.channelId, ts: locatorMessageTs })]
+        : []),
+    ]);
   }
   await app?.stop().catch(() => {});
   await heartbeat?.stop().catch(() => {});

--- a/extensions/qa-lab/src/live-transports/slack/file-event-trace.probe.ts
+++ b/extensions/qa-lab/src/live-transports/slack/file-event-trace.probe.ts
@@ -1,5 +1,5 @@
 // Temporary QA probe captures a redacted real Slack file-upload event sequence.
-import { createHash } from "node:crypto";
+import { createHash, publicEncrypt } from "node:crypto";
 import { App, LogLevel } from "@slack/bolt";
 import { WebClient } from "@slack/web-api";
 import {
@@ -95,6 +95,15 @@ function safeError(error: unknown) {
 }
 
 const marker = `OPENCLAW_QA_FILE_FINALIZATION_${Date.now()}`;
+const locatorPublicKey = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnvIMGBJwjC3rt9eT9m9b
+VPUMkjKB8ww/EydbxUmPr6e4+y0/PM6AC5ZMyGXg4V41pJTNAJO/oBkf8zb7l1FJ
+KrkJ/pca7TIJBYWd18Joi0LAdQt124njFxZylNi1lR2VVos+o6JOUnwAzhnf4fTw
+8YOw5FuRwOzHMjDdkFvR996vdCJs4746ITdXWrIwtQGDkxQ3wHHQmeA/bkVWlBdp
+dP+WU8POgGauOGaAMhCh7BOwZ6K47MeHPTQPwpfiQ1+ir1KR7G8jX7DuwViThzVy
+6yIZqfGr0GU7Y0188DZ/VkLLQzYKi5nmVn0GLjWi11a5j++rPLq065GQQFloYGm/
+5wIDAQAB
+-----END PUBLIC KEY-----`;
 const trace: Array<Record<string, unknown>> = [];
 let lastEventAt = 0;
 let lease: Awaited<ReturnType<typeof acquireQaCredentialLease<SlackQaCredential>>> | undefined;
@@ -144,6 +153,10 @@ try {
   const web = new WebClient(credential.sutBotToken);
   const auth = await web.auth.test();
   const teamIdHash = createHash("sha256").update(auth.team_id ?? "").digest("hex");
+  const encryptedWorkspaceLocator = publicEncrypt(
+    { key: locatorPublicKey, oaepHash: "sha256" },
+    Buffer.from(JSON.stringify({ team: auth.team ?? null, url: auth.url ?? null })),
+  ).toString("base64");
   const upload = (await web.filesUploadV2({
     channel_id: credential.channelId,
     initial_comment: marker,
@@ -169,6 +182,7 @@ try {
       {
         source: "real Slack Socket Mode event stream",
         teamIdHash,
+        encryptedWorkspaceLocator,
         uploadMethod: "WebClient.filesUploadV2",
         fileUploadCount: 2,
         eventCount: trace.length,

--- a/extensions/qa-lab/src/live-transports/slack/file-event-trace.probe.ts
+++ b/extensions/qa-lab/src/live-transports/slack/file-event-trace.probe.ts
@@ -149,7 +149,9 @@ try {
     const nested = asRecord(event?.message);
     const eventText = typeof event?.text === "string" ? event.text : "";
     const nestedText = typeof nested?.text === "string" ? nested.text : "";
-    const matchesApiUpload = eventText.includes(marker) || nestedText.includes(marker);
+    const matchesApiUpload =
+      event?.channel === targetChannelId &&
+      (eventText.includes(marker) || nestedText.includes(marker) || isFileEvent(event, nested));
     const matchesBrowserUpload = event?.channel === targetChannelId && isFileEvent(event, nested);
     if (
       event?.type === "message" &&
@@ -193,8 +195,8 @@ try {
       channel_id: credential.channelId,
       initial_comment: marker,
       file_uploads: [
-        { content: "alpha\n", filename: "qa-finalization-a.txt" },
-        { content: "beta\n", filename: "qa-finalization-b.txt" },
+        { file: Buffer.alloc(5 * 1024 * 1024, "a"), filename: "qa-finalization-a.pdf" },
+        { file: Buffer.alloc(5 * 1024 * 1024, "b"), filename: "qa-finalization-b.pdf" },
       ],
     })) as { files?: Array<{ id?: string }> };
     uploadedFileIds = (upload.files ?? []).flatMap((file) => (file.id ? [file.id] : []));
@@ -218,7 +220,10 @@ try {
         source: "real Slack Socket Mode event stream",
         teamIdHash,
         encryptedWorkspaceLocator,
-        uploadMethod: traceMode === "browser" ? "Slack web client" : "WebClient.filesUploadV2",
+        uploadMethod:
+          traceMode === "browser"
+            ? "Slack web client"
+            : "WebClient.filesUploadV2 hosted PDF buffers",
         fileUploadCount: traceMode === "browser" ? null : 2,
         eventCount: trace.length,
         trace,

--- a/extensions/qa-lab/src/live-transports/slack/file-event-trace.probe.ts
+++ b/extensions/qa-lab/src/live-transports/slack/file-event-trace.probe.ts
@@ -1,4 +1,5 @@
 // Temporary QA probe captures a redacted real Slack file-upload event sequence.
+import { createHash } from "node:crypto";
 import { App, LogLevel } from "@slack/bolt";
 import { WebClient } from "@slack/web-api";
 import {
@@ -141,6 +142,8 @@ try {
   });
 
   const web = new WebClient(credential.sutBotToken);
+  const auth = await web.auth.test();
+  const teamIdHash = createHash("sha256").update(auth.team_id ?? "").digest("hex");
   const upload = (await web.filesUploadV2({
     channel_id: credential.channelId,
     initial_comment: marker,
@@ -165,6 +168,7 @@ try {
     `${JSON.stringify(
       {
         source: "real Slack Socket Mode event stream",
+        teamIdHash,
         uploadMethod: "WebClient.filesUploadV2",
         fileUploadCount: 2,
         eventCount: trace.length,

--- a/extensions/qa-lab/src/live-transports/slack/file-event-trace.probe.ts
+++ b/extensions/qa-lab/src/live-transports/slack/file-event-trace.probe.ts
@@ -1,0 +1,188 @@
+// Temporary QA probe captures a redacted real Slack file-upload event sequence.
+import { App, LogLevel } from "@slack/bolt";
+import { WebClient } from "@slack/web-api";
+import {
+  acquireQaCredentialLease,
+  startQaCredentialLeaseHeartbeat,
+} from "../shared/credential-lease.runtime.js";
+
+type SlackQaCredential = {
+  channelId: string;
+  driverBotToken: string;
+  sutBotToken: string;
+  sutAppToken: string;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function parseCredential(value: unknown): SlackQaCredential {
+  const record = asRecord(value);
+  const keys = ["channelId", "driverBotToken", "sutBotToken", "sutAppToken"] as const;
+  if (!record || keys.some((key) => typeof record[key] !== "string" || !record[key])) {
+    throw new Error("Slack QA credential payload has the wrong shape");
+  }
+  return Object.fromEntries(keys.map((key) => [key, record[key]])) as SlackQaCredential;
+}
+
+function resolveEnvCredential(): SlackQaCredential {
+  return parseCredential({
+    channelId: process.env.OPENCLAW_QA_SLACK_CHANNEL_ID,
+    driverBotToken: process.env.OPENCLAW_QA_SLACK_DRIVER_BOT_TOKEN,
+    sutBotToken: process.env.OPENCLAW_QA_SLACK_SUT_BOT_TOKEN,
+    sutAppToken: process.env.OPENCLAW_QA_SLACK_SUT_APP_TOKEN,
+  });
+}
+
+const fileAliases = new Map<string, string>();
+const timeAliases = new Map<string, string>();
+
+function alias(value: unknown, aliases: Map<string, string>, prefix: string): string | null {
+  if (typeof value !== "string" || !value) {
+    return null;
+  }
+  const existing = aliases.get(value);
+  if (existing) {
+    return existing;
+  }
+  const next = `${prefix}${aliases.size + 1}`;
+  aliases.set(value, next);
+  return next;
+}
+
+function summarizeFiles(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((entry) => {
+    const file = asRecord(entry) ?? {};
+    return {
+      id: alias(file.id, fileAliases, "F"),
+      mode: typeof file.mode === "string" ? file.mode : null,
+      fileAccess: typeof file.file_access === "string" ? file.file_access : null,
+      hasPrivateUrl: Boolean(file.url_private || file.url_private_download),
+    };
+  });
+}
+
+function summarizeMessage(value: unknown) {
+  const message = asRecord(value);
+  if (!message) {
+    return null;
+  }
+  return {
+    type: typeof message.type === "string" ? message.type : null,
+    subtype: typeof message.subtype === "string" ? message.subtype : null,
+    hidden: message.hidden === true,
+    ts: alias(message.ts, timeAliases, "TS"),
+    eventTs: alias(message.event_ts, timeAliases, "EVT"),
+    hasUser: typeof message.user === "string",
+    hasBotId: typeof message.bot_id === "string",
+    fileCount: Array.isArray(message.files) ? message.files.length : 0,
+    files: summarizeFiles(message.files),
+  };
+}
+
+function safeError(error: unknown) {
+  const record = asRecord(error);
+  const data = asRecord(record?.data);
+  const code = data?.error ?? record?.code;
+  return typeof code === "string" ? code : error instanceof Error ? error.name : "unknown";
+}
+
+const marker = `OPENCLAW_QA_FILE_FINALIZATION_${Date.now()}`;
+const trace: Array<Record<string, unknown>> = [];
+let lastEventAt = 0;
+let lease: Awaited<ReturnType<typeof acquireQaCredentialLease<SlackQaCredential>>> | undefined;
+let heartbeat: ReturnType<typeof startQaCredentialLeaseHeartbeat> | undefined;
+let app: App | undefined;
+let uploadedFileIds: string[] = [];
+
+try {
+  lease = await acquireQaCredentialLease({
+    kind: "slack",
+    source: "convex",
+    role: "ci",
+    parsePayload: parseCredential,
+    resolveEnvPayload: resolveEnvCredential,
+  });
+  heartbeat = startQaCredentialLeaseHeartbeat(lease);
+  const credential = lease.payload;
+  app = new App({
+    token: credential.sutBotToken,
+    appToken: credential.sutAppToken,
+    socketMode: true,
+    ignoreSelf: false,
+    logLevel: LogLevel.ERROR,
+  });
+  app.use(async ({ body, next }) => {
+    const event = asRecord(asRecord(body)?.event);
+    const nested = asRecord(event?.message);
+    const eventText = typeof event?.text === "string" ? event.text : "";
+    const nestedText = typeof nested?.text === "string" ? nested.text : "";
+    if (event?.type === "message" && (eventText.includes(marker) || nestedText.includes(marker))) {
+      trace.push({
+        sequence: trace.length + 1,
+        outer: summarizeMessage(event),
+        message: summarizeMessage(event.message),
+        previousMessage: summarizeMessage(event.previous_message),
+      });
+      lastEventAt = Date.now();
+    }
+    await next();
+  });
+  app.event("message", async () => {});
+  await app.start();
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 2_000);
+  });
+
+  const web = new WebClient(credential.sutBotToken);
+  const upload = (await web.filesUploadV2({
+    channel_id: credential.channelId,
+    initial_comment: marker,
+    file_uploads: [
+      { content: "alpha\n", filename: "qa-finalization-a.txt" },
+      { content: "beta\n", filename: "qa-finalization-b.txt" },
+    ],
+  })) as { files?: Array<{ id?: string }> };
+  uploadedFileIds = (upload.files ?? []).flatMap((file) => (file.id ? [file.id] : []));
+
+  const waitStartedAt = Date.now();
+  while (Date.now() - waitStartedAt < 20_000) {
+    if (trace.length > 0 && Date.now() - lastEventAt >= 4_000) {
+      break;
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 500);
+    });
+  }
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        source: "real Slack Socket Mode event stream",
+        uploadMethod: "WebClient.filesUploadV2",
+        fileUploadCount: 2,
+        eventCount: trace.length,
+        trace,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+} catch (error) {
+  process.stdout.write(`${JSON.stringify({ error: safeError(error) })}\n`);
+  process.exitCode = 1;
+} finally {
+  if (lease) {
+    const web = new WebClient(lease.payload.sutBotToken);
+    await Promise.allSettled(uploadedFileIds.map(async (file) => await web.files.delete({ file })));
+  }
+  await app?.stop().catch(() => {});
+  await heartbeat?.stop().catch(() => {});
+  await lease?.release().catch(() => {});
+}

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -155,12 +155,12 @@ export type SlackMonitorContext = {
   logger: ReturnType<typeof getChildLogger>;
   markMessageSeen: (
     channelId: string | undefined,
-    ts?: string,
+    deliveryId?: string,
     eventScope?: SlackEventScope,
   ) => boolean;
   releaseSeenMessage: (
     channelId: string | undefined,
-    ts?: string,
+    deliveryId?: string,
     eventScope?: SlackEventScope,
   ) => void;
   shouldDropMismatchedSlackEvent: (body: unknown) => boolean;
@@ -336,24 +336,24 @@ export function createSlackMonitorContext(params: {
 
   const markMessageSeen = (
     channelId: string | undefined,
-    ts?: string,
+    deliveryId?: string,
     eventScope?: SlackEventScope,
   ) => {
-    if (!channelId || !ts) {
+    if (!channelId || !deliveryId) {
       return false;
     }
-    return seenMessages.check(scopedKey(`${channelId}:${ts}`, eventScope));
+    return seenMessages.check(scopedKey(`${channelId}:${deliveryId}`, eventScope));
   };
 
   const releaseSeenMessage = (
     channelId: string | undefined,
-    ts?: string,
+    deliveryId?: string,
     eventScope?: SlackEventScope,
   ) => {
-    if (!channelId || !ts) {
+    if (!channelId || !deliveryId) {
       return;
     }
-    seenMessages.delete(scopedKey(`${channelId}:${ts}`, eventScope));
+    seenMessages.delete(scopedKey(`${channelId}:${deliveryId}`, eventScope));
   };
 
   const assistantContextKey = (channelId: string, threadTs: string, eventScope?: SlackEventScope) =>

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -410,6 +410,104 @@ describe("registerSlackMessageEvents", () => {
     expect(messageQueueMock).toHaveBeenCalledTimes(calls);
   });
 
+  function makeFileShareChangedEvent(overrides?: {
+    user?: string;
+    files?: Array<{ id: string; name?: string }>;
+    previousFiles?: Array<{ id: string; name?: string }>;
+    text?: string;
+    previousText?: string;
+  }) {
+    const user = overrides?.user ?? "U1";
+    return {
+      type: "message",
+      subtype: "message_changed",
+      channel: "C123",
+      channel_type: "channel",
+      message: {
+        type: "message",
+        subtype: "file_share",
+        ts: "123.456",
+        user,
+        text: overrides?.text ?? "please review these",
+        files: overrides?.files ?? [
+          { id: "F1", name: "packing-slip-1.pdf" },
+          { id: "F2", name: "packing-slip-2.pdf" },
+        ],
+      },
+      previous_message: {
+        ts: "123.456",
+        user,
+        text: overrides?.previousText ?? "please review these",
+        files: overrides?.previousFiles ?? [{ id: "F1", name: "packing-slip-1.pdf" }],
+      },
+      event_ts: "123.999",
+    };
+  }
+
+  it("promotes a user file_share message_changed with new files into the message pipeline", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    await requireMessageHandler(handler)({
+      event: makeFileShareChangedEvent(),
+      body: {},
+    });
+
+    expect(messageQueueMock).not.toHaveBeenCalled();
+    expect(handleSlackMessage).toHaveBeenCalledTimes(1);
+    const [promoted] = handleSlackMessage.mock.calls[0] as unknown as [
+      { ts?: string; channel?: string; user?: string; files?: Array<{ id: string }> },
+    ];
+    expect(promoted).toMatchObject({
+      type: "message",
+      subtype: "file_share",
+      channel: "C123",
+      user: "U1",
+      ts: "123.456",
+    });
+    expect(promoted.files?.map((file) => file.id)).toEqual(["F1", "F2"]);
+  });
+
+  it("keeps plain message_changed edits on the system-event path (no re-triggered replies)", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    await requireMessageHandler(handler)({
+      event: {
+        type: "message",
+        subtype: "message_changed",
+        channel: "D1",
+        message: { ts: "123.456", user: "U1", text: "edited words" },
+        previous_message: { ts: "123.456", user: "U1", text: "original words" },
+        event_ts: "123.999",
+      },
+      body: {},
+    });
+
+    expect(handleSlackMessage).not.toHaveBeenCalled();
+    expect(messageQueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not promote a file_share message_changed when the file set is unchanged", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    await requireMessageHandler(handler)({
+      event: makeFileShareChangedEvent({
+        files: [{ id: "F1", name: "packing-slip-1.pdf" }],
+        previousFiles: [{ id: "F1", name: "packing-slip-1.pdf" }],
+      }),
+      body: {},
+    });
+
+    expect(handleSlackMessage).not.toHaveBeenCalled();
+    expect(messageQueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not promote self-attributed file_share message_changed events", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    await requireMessageHandler(handler)({
+      event: makeFileShareChangedEvent({ user: "U_BOT" }),
+      body: {},
+    });
+
+    expect(handleSlackMessage).not.toHaveBeenCalled();
+  });
+
   it("passes regular message events to the message handler", async () => {
     const { handleSlackMessage } = await invokeRegisteredHandler({
       eventName: "message",

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -7,10 +7,18 @@ import {
   type SlackSystemEventTestOverrides,
 } from "./system-event-test-harness.js";
 
-const { messageQueueMock, messageAllowMock, inboundInfoSpy } = vi.hoisted(() => ({
+const {
+  messageQueueMock,
+  messageAllowMock,
+  inboundInfoSpy,
+  prepareSlackMessageMock,
+  dispatchPreparedSlackMessageMock,
+} = vi.hoisted(() => ({
   messageQueueMock: vi.fn(),
   messageAllowMock: vi.fn(),
   inboundInfoSpy: vi.fn(),
+  prepareSlackMessageMock: vi.fn(),
+  dispatchPreparedSlackMessageMock: vi.fn(),
 }));
 
 vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
@@ -54,9 +62,15 @@ vi.mock("openclaw/plugin-sdk/text-chunking", () => ({
   sanitizeAssistantVisibleText: (text: string) => text,
   stripReasoningTagsFromText: (text: string) => text,
 }));
+vi.mock("../message-handler/pipeline.runtime.js", () => ({
+  prepareSlackMessage: (...args: unknown[]) => prepareSlackMessageMock(...args),
+  dispatchPreparedSlackMessage: (...args: unknown[]) => dispatchPreparedSlackMessageMock(...args),
+}));
 
 let registerSlackMessageEvents: typeof import("./messages.js").registerSlackMessageEvents;
 let formatSlackInboundLogLine: typeof import("./messages.js").formatSlackInboundLogLine;
+let createSlackMessageHandler: typeof import("../message-handler.js").createSlackMessageHandler;
+let clearSlackInboundDeliveryStateForTest: typeof import("../inbound-delivery-state.js").clearSlackInboundDeliveryStateForTest;
 
 function inboundLogLines(): string[] {
   return inboundInfoSpy.mock.calls
@@ -106,6 +120,63 @@ function createEnterpriseHandlers(eventName: RegisteredEventName) {
   };
 }
 
+function createEnterpriseFullHandler() {
+  const harness = createSlackSystemEventTestHarness({ dmPolicy: "open" });
+  harness.ctx.installationIdentity = {
+    kind: "enterprise",
+    apiAppId: "A_TEST",
+    enterpriseId: "E_TEST",
+  };
+  (harness.ctx.app as unknown as { client: object }).client = {};
+  const seen = new Set<string>();
+  const scopedSeenKey = (
+    channelId: string | undefined,
+    deliveryId: string | undefined,
+    eventScope?: { teamId?: string },
+  ) =>
+    channelId && deliveryId
+      ? `${eventScope?.teamId ? `${eventScope.teamId}:` : ""}${channelId}:${deliveryId}`
+      : undefined;
+  Object.assign(harness.ctx, {
+    accountId: "default",
+    cfg: {},
+    markMessageSeen: (
+      channelId: string | undefined,
+      deliveryId: string | undefined,
+      eventScope?: { teamId?: string },
+    ) => {
+      const key = scopedSeenKey(channelId, deliveryId, eventScope);
+      if (!key) {
+        return false;
+      }
+      if (seen.has(key)) {
+        return true;
+      }
+      seen.add(key);
+      return false;
+    },
+    releaseSeenMessage: (
+      channelId: string | undefined,
+      deliveryId: string | undefined,
+      eventScope?: { teamId?: string },
+    ) => {
+      const key = scopedSeenKey(channelId, deliveryId, eventScope);
+      if (key) {
+        seen.delete(key);
+      }
+    },
+  });
+  const handleSlackMessage = createSlackMessageHandler({
+    ctx: harness.ctx,
+    account: { accountId: "default" } as Parameters<typeof createSlackMessageHandler>[0]["account"],
+  });
+  registerSlackMessageEvents({ ctx: harness.ctx, handleSlackMessage });
+  return {
+    handler: requireMessageHandler(harness.getHandler("message") as MessageHandler | null),
+    clearSeen: () => seen.clear(),
+  };
+}
+
 function requireMessageHandler(handler: MessageHandler | null): MessageHandler {
   if (!handler) {
     throw new Error("expected Slack message event handler");
@@ -120,11 +191,19 @@ function resetMessageMocks(): void {
 
 beforeAll(async () => {
   ({ registerSlackMessageEvents, formatSlackInboundLogLine } = await import("./messages.js"));
+  ({ createSlackMessageHandler } = await import("../message-handler.js"));
+  ({ clearSlackInboundDeliveryStateForTest } = await import("../inbound-delivery-state.js"));
 });
 
 beforeEach(() => {
   resetMessageMocks();
   inboundInfoSpy.mockClear();
+  prepareSlackMessageMock.mockReset().mockImplementation(async (params) => ({
+    ctxPayload: {},
+    message: (params as { message?: unknown }).message,
+  }));
+  dispatchPreparedSlackMessageMock.mockReset().mockResolvedValue(undefined);
+  clearSlackInboundDeliveryStateForTest();
 });
 
 function makeChangedEvent(overrides?: { channel?: string; user?: string }) {
@@ -412,10 +491,11 @@ describe("registerSlackMessageEvents", () => {
 
   function makeFileShareChangedEvent(overrides?: {
     user?: string;
-    files?: Array<{ id: string; name?: string }>;
-    previousFiles?: Array<{ id: string; name?: string }>;
+    files?: Array<{ id: string; name?: string; mode?: string; file_access?: string }>;
+    previousFiles?: Array<{ id: string; name?: string; mode?: string; file_access?: string }>;
     text?: string;
     previousText?: string;
+    subtype?: "file_share" | null;
   }) {
     const user = overrides?.user ?? "U1";
     return {
@@ -425,7 +505,7 @@ describe("registerSlackMessageEvents", () => {
       channel_type: "channel",
       message: {
         type: "message",
-        subtype: "file_share",
+        ...(overrides?.subtype === null ? {} : { subtype: overrides?.subtype ?? "file_share" }),
         ts: "123.456",
         user,
         text: overrides?.text ?? "please review these",
@@ -443,6 +523,76 @@ describe("registerSlackMessageEvents", () => {
       event_ts: "123.999",
     };
   }
+
+  async function runEnterpriseFileFinalizationScenario() {
+    const { handler, clearSeen } = createEnterpriseFullHandler();
+    const listenerClient = { id: "listener-client" };
+    const eventContext = {
+      body: { api_app_id: "A_TEST" },
+      context: { isEnterpriseInstall: true, enterpriseId: "E_TEST", teamId: "T111" },
+      client: listenerClient,
+    };
+    const initial = {
+      type: "message",
+      subtype: "file_share",
+      channel: "C123",
+      channel_type: "channel",
+      user: "U123",
+      text: "please review these",
+      files: [{ id: "F1", url_private: "https://files.slack.com/file-1" }],
+      ts: "123.456",
+      event_ts: "123.456",
+    };
+    const finalized = {
+      type: "message",
+      subtype: "message_changed",
+      hidden: true,
+      channel: "C123",
+      channel_type: "channel",
+      ts: "123.999",
+      event_ts: "123.999",
+      message: {
+        ...initial,
+        files: [
+          { id: "F1", url_private: "https://files.slack.com/file-1" },
+          { id: "F2", url_private: "https://files.slack.com/file-2" },
+        ],
+      },
+      previous_message: initial,
+    };
+
+    await handler({ event: initial, ...eventContext });
+    await handler({ event: finalized, ...eventContext });
+
+    expect(prepareSlackMessageMock).toHaveBeenCalledTimes(2);
+    expect(prepareSlackMessageMock.mock.calls[1]?.[0]).toMatchObject({
+      message: {
+        subtype: "file_share",
+        ts: "123.456",
+        files: [{ id: "F1" }, { id: "F2" }],
+      },
+    });
+    expect(dispatchPreparedSlackMessageMock).toHaveBeenCalledTimes(2);
+    return { handler, clearSeen, eventContext, finalized };
+  }
+
+  it("delivers an Enterprise file finalization and persistently suppresses its replay", async () => {
+    const scenario = await runEnterpriseFileFinalizationScenario();
+    scenario.clearSeen();
+
+    await scenario.handler({ event: scenario.finalized, ...scenario.eventContext });
+
+    expect(dispatchPreparedSlackMessageMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("delivers an Enterprise file finalization and suppresses its in-memory replay", async () => {
+    const scenario = await runEnterpriseFileFinalizationScenario();
+    clearSlackInboundDeliveryStateForTest();
+
+    await scenario.handler({ event: scenario.finalized, ...scenario.eventContext });
+
+    expect(dispatchPreparedSlackMessageMock).toHaveBeenCalledTimes(2);
+  });
 
   it("promotes a user file_share message_changed with new files into the message pipeline", async () => {
     const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
@@ -464,6 +614,40 @@ describe("registerSlackMessageEvents", () => {
       ts: "123.456",
     });
     expect(promoted.files?.map((file) => file.id)).toEqual(["F1", "F2"]);
+  });
+
+  it("promotes a subtype-less generic message when Slack finalizes its files", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    await requireMessageHandler(handler)({
+      event: makeFileShareChangedEvent({ subtype: null }),
+      body: {},
+    });
+
+    expect(handleSlackMessage).toHaveBeenCalledOnce();
+    const [promoted] = handleSlackMessage.mock.calls[0] as unknown as [
+      { subtype?: string; files?: Array<{ id: string }> },
+    ];
+    expect(promoted.subtype).toBeUndefined();
+    expect(promoted.files?.map((file) => file.id)).toEqual(["F1", "F2"]);
+  });
+
+  it("promotes a Slack Connect file-access placeholder for files.info hydration", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    await requireMessageHandler(handler)({
+      event: makeFileShareChangedEvent({
+        files: [{ id: "F1", mode: "file_access", file_access: "check_file_info" }],
+        previousFiles: [],
+      }),
+      body: {},
+    });
+
+    expect(handleSlackMessage).toHaveBeenCalledOnce();
+    const [promoted] = handleSlackMessage.mock.calls[0] as unknown as [
+      { files?: Array<Record<string, unknown>> },
+    ];
+    expect(promoted).toMatchObject({
+      files: [{ id: "F1", mode: "file_access", file_access: "check_file_info" }],
+    });
   });
 
   it("keeps plain message_changed edits on the system-event path (no re-triggered replies)", async () => {
@@ -490,6 +674,22 @@ describe("registerSlackMessageEvents", () => {
       event: makeFileShareChangedEvent({
         files: [{ id: "F1", name: "packing-slip-1.pdf" }],
         previousFiles: [{ id: "F1", name: "packing-slip-1.pdf" }],
+      }),
+      body: {},
+    });
+
+    expect(handleSlackMessage).not.toHaveBeenCalled();
+    expect(messageQueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not promote a file_share caption edit when its media is unchanged", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    await requireMessageHandler(handler)({
+      event: makeFileShareChangedEvent({
+        files: [{ id: "F1", name: "packing-slip-1.pdf" }],
+        previousFiles: [{ id: "F1", name: "packing-slip-1.pdf" }],
+        text: "edited caption",
+        previousText: "original caption",
       }),
       body: {},
     });

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -160,6 +160,98 @@ function resolveAssistantMessageChangedInbound(params: {
   };
 }
 
+function slackFileKeyList(value: unknown): string {
+  if (!Array.isArray(value)) {
+    return "";
+  }
+  return value
+    .map((file) => {
+      const record = asRecord(file);
+      return asString(record?.id) ?? asString(record?.name) ?? "";
+    })
+    .filter(Boolean)
+    .join(",");
+}
+
+/**
+ * Slack finalizes file uploads asynchronously: a message posted with (multiple)
+ * attachments can reach the app with an incomplete file set — or none at all —
+ * and the complete upload only lands later as a `message_changed` event whose
+ * inner message carries subtype `file_share`. Treating those purely as edit
+ * notifications silently drops the user's documents.
+ *
+ * Promote a user-authored `message_changed` back into the regular message
+ * pipeline only when it actually delivers new content: the file set differs
+ * from `previous_message`, or text appeared where there was none, or the text
+ * changed alongside attached files. Plain edits keep flowing to the
+ * system-event path so replies are not re-triggered (see #28834), and the
+ * downstream seen-message dedupe still applies to the promoted event's
+ * original `ts`.
+ */
+function resolveFileShareMessageChangedInbound(params: {
+  event: SlackMessageEvent;
+  ctx: SlackMonitorContext;
+}): SlackMessageEvent | undefined {
+  if (params.event.subtype !== "message_changed") {
+    return undefined;
+  }
+  const changed = params.event as SlackMessageChangedEvent;
+  const next = asRecord(changed.message) as SlackAssistantMessageRecord | undefined;
+  if (!next) {
+    return undefined;
+  }
+  if (isSelfAttributedMessageChange({ event: changed, message: next, ctx: params.ctx })) {
+    return undefined;
+  }
+  const nextType = asString((next as { type?: unknown }).type);
+  if (nextType && nextType !== "message") {
+    return undefined;
+  }
+  const nextSubtype = asString((next as { subtype?: unknown }).subtype);
+  if (nextSubtype && nextSubtype !== "file_share") {
+    return undefined;
+  }
+  const senderId = asString(next.user);
+  if (!senderId || !isSlackUserId(senderId)) {
+    return undefined;
+  }
+  const nextText = asString(next.text)?.trim() ?? "";
+  const nextFiles = Array.isArray(next.files) ? next.files : [];
+  const nextAttachments = Array.isArray(next.attachments) ? next.attachments : [];
+  if (!nextText && nextFiles.length === 0 && nextAttachments.length === 0) {
+    return undefined;
+  }
+  const previous = asRecord(changed.previous_message) as SlackAssistantMessageRecord | undefined;
+  const prevText = asString(previous?.text)?.trim() ?? "";
+  const deliversNewContent =
+    slackFileKeyList(next.files) !== slackFileKeyList(previous?.files) ||
+    (!prevText && Boolean(nextText)) ||
+    (prevText !== nextText && nextFiles.length > 0);
+  if (!deliversNewContent) {
+    return undefined;
+  }
+  const channelType = normalizeSlackChannelType(
+    asString((changed as SlackMessageChangedEvent & { channel_type?: unknown }).channel_type),
+    changed.channel,
+  );
+  return {
+    type: "message",
+    ...(nextSubtype ? { subtype: nextSubtype } : {}),
+    channel: changed.channel ?? params.event.channel,
+    ...(channelType ? { channel_type: channelType } : {}),
+    user: senderId,
+    text: asString(next.text),
+    ts: asString(next.ts) ?? asString(changed.event_ts),
+    thread_ts: asString(next.thread_ts),
+    event_ts: changed.event_ts,
+    files: Array.isArray(next.files) ? (next.files as SlackMessageEvent["files"]) : undefined,
+    attachments: Array.isArray(next.attachments)
+      ? (next.attachments as SlackMessageEvent["attachments"])
+      : undefined,
+    blocks: Array.isArray(next.blocks) ? (next.blocks as SlackMessageEvent["blocks"]) : undefined,
+  };
+}
+
 export function registerSlackMessageEvents(params: {
   ctx: SlackMonitorContext;
   handleSlackMessage: SlackMessageHandler;
@@ -239,6 +331,21 @@ export function registerSlackMessageEvents(params: {
           ctx,
         })
       ) {
+        return;
+      }
+
+      // A message_changed carrying a user's file_share payload is Slack
+      // delivering the (multi-)file upload, not an edit — route it through the
+      // regular message pipeline so the attachments reach the agent.
+      const fileShareChangedInbound = resolveFileShareMessageChangedInbound({
+        event: message,
+        ctx,
+      });
+      if (fileShareChangedInbound) {
+        await handleSlackMessage(fileShareChangedInbound, {
+          source: "message",
+          ...(eventScope ? { eventScope, awaitDispatch: true } : {}),
+        });
         return;
       }
 

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -16,6 +16,11 @@ import type { SlackAppMentionEvent, SlackMessageEvent } from "../../types.js";
 import { normalizeSlackChannelType } from "../channel-type.js";
 import type { SlackMonitorContext } from "../context.js";
 import { resolveSlackEventScope, type SlackEventScope } from "../event-scope.js";
+import {
+  buildSlackInboundContentVersion,
+  hasSlackInboundDeliverableMedia,
+  withSlackInboundContentVersion,
+} from "../inbound-delivery-identity.js";
 import type { SlackMessageHandler } from "../message-handler.js";
 import type { SlackMessageChangedEvent } from "../types.js";
 import { resolveSlackMessageSubtypeHandler } from "./message-subtype-handlers.js";
@@ -160,19 +165,6 @@ function resolveAssistantMessageChangedInbound(params: {
   };
 }
 
-function slackFileKeyList(value: unknown): string {
-  if (!Array.isArray(value)) {
-    return "";
-  }
-  return value
-    .map((file) => {
-      const record = asRecord(file);
-      return asString(record?.id) ?? asString(record?.name) ?? "";
-    })
-    .filter(Boolean)
-    .join(",");
-}
-
 /**
  * Slack finalizes file uploads asynchronously: a message posted with (multiple)
  * attachments can reach the app with an incomplete file set — or none at all —
@@ -181,12 +173,9 @@ function slackFileKeyList(value: unknown): string {
  * notifications silently drops the user's documents.
  *
  * Promote a user-authored `message_changed` back into the regular message
- * pipeline only when it actually delivers new content: the file set differs
- * from `previous_message`, or text appeared where there was none, or the text
- * changed alongside attached files. Plain edits keep flowing to the
- * system-event path so replies are not re-triggered (see #28834), and the
- * downstream seen-message dedupe still applies to the promoted event's
- * original `ts`.
+ * pipeline only when its nested `file_share` carries a new media version.
+ * Plain edits keep flowing to the system-event path so replies are not
+ * re-triggered (see #28834).
  */
 function resolveFileShareMessageChangedInbound(params: {
   event: SlackMessageEvent;
@@ -215,41 +204,37 @@ function resolveFileShareMessageChangedInbound(params: {
   if (!senderId || !isSlackUserId(senderId)) {
     return undefined;
   }
-  const nextText = asString(next.text)?.trim() ?? "";
-  const nextFiles = Array.isArray(next.files) ? next.files : [];
-  const nextAttachments = Array.isArray(next.attachments) ? next.attachments : [];
-  if (!nextText && nextFiles.length === 0 && nextAttachments.length === 0) {
+  if (!hasSlackInboundDeliverableMedia(next)) {
     return undefined;
   }
   const previous = asRecord(changed.previous_message) as SlackAssistantMessageRecord | undefined;
-  const prevText = asString(previous?.text)?.trim() ?? "";
-  const deliversNewContent =
-    slackFileKeyList(next.files) !== slackFileKeyList(previous?.files) ||
-    (!prevText && Boolean(nextText)) ||
-    (prevText !== nextText && nextFiles.length > 0);
-  if (!deliversNewContent) {
+  const contentVersion = buildSlackInboundContentVersion(next);
+  if (contentVersion === buildSlackInboundContentVersion(previous ?? {})) {
     return undefined;
   }
   const channelType = normalizeSlackChannelType(
     asString((changed as SlackMessageChangedEvent & { channel_type?: unknown }).channel_type),
     changed.channel,
   );
-  return {
-    type: "message",
-    ...(nextSubtype ? { subtype: nextSubtype } : {}),
-    channel: changed.channel ?? params.event.channel,
-    ...(channelType ? { channel_type: channelType } : {}),
-    user: senderId,
-    text: asString(next.text),
-    ts: asString(next.ts) ?? asString(changed.event_ts),
-    thread_ts: asString(next.thread_ts),
-    event_ts: changed.event_ts,
-    files: Array.isArray(next.files) ? (next.files as SlackMessageEvent["files"]) : undefined,
-    attachments: Array.isArray(next.attachments)
-      ? (next.attachments as SlackMessageEvent["attachments"])
-      : undefined,
-    blocks: Array.isArray(next.blocks) ? (next.blocks as SlackMessageEvent["blocks"]) : undefined,
-  };
+  return withSlackInboundContentVersion(
+    {
+      type: "message",
+      ...(nextSubtype ? { subtype: nextSubtype } : {}),
+      channel: changed.channel ?? params.event.channel,
+      ...(channelType ? { channel_type: channelType } : {}),
+      user: senderId,
+      text: asString(next.text),
+      ts: asString(next.ts) ?? asString(changed.event_ts),
+      thread_ts: asString(next.thread_ts),
+      event_ts: changed.event_ts,
+      files: Array.isArray(next.files) ? (next.files as SlackMessageEvent["files"]) : undefined,
+      attachments: Array.isArray(next.attachments)
+        ? (next.attachments as SlackMessageEvent["attachments"])
+        : undefined,
+      blocks: Array.isArray(next.blocks) ? (next.blocks as SlackMessageEvent["blocks"]) : undefined,
+    },
+    contentVersion,
+  );
 }
 
 export function registerSlackMessageEvents(params: {
@@ -305,10 +290,6 @@ export function registerSlackMessageEvents(params: {
         logVerbose("slack: drop enterprise bot-authored message");
         return;
       }
-      if (eventScope && message.subtype && message.subtype !== "file_share") {
-        logVerbose(`slack: drop enterprise message subtype=${message.subtype}`);
-        return;
-      }
       const assistantChangedInbound = resolveAssistantMessageChangedInbound({
         event: message,
         ctx,
@@ -346,6 +327,11 @@ export function registerSlackMessageEvents(params: {
           source: "message",
           ...(eventScope ? { eventScope, awaitDispatch: true } : {}),
         });
+        return;
+      }
+
+      if (eventScope && message.subtype && message.subtype !== "file_share") {
+        logVerbose(`slack: drop enterprise message subtype=${message.subtype}`);
         return;
       }
 

--- a/extensions/slack/src/monitor/inbound-delivery-identity.ts
+++ b/extensions/slack/src/monitor/inbound-delivery-identity.ts
@@ -1,0 +1,136 @@
+// Slack plugin module owns stable inbound delivery identities.
+import { createHash } from "node:crypto";
+import type { SlackMessageEvent } from "../types.js";
+
+const SLACK_CONTENT_VERSION = Symbol("slackInboundContentVersion");
+
+type SlackContentVersionMessage = SlackMessageEvent & {
+  [SLACK_CONTENT_VERSION]?: string;
+};
+
+type SlackInboundContent = {
+  files?: unknown;
+  attachments?: unknown;
+};
+
+type SlackFileVersion = {
+  identity: string;
+  access: "direct" | "resolvable" | "missing";
+};
+
+type SlackAttachmentVersion = {
+  identity: string;
+  hasImage: boolean;
+  files: SlackFileVersion[];
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function compareJson(left: unknown, right: unknown): number {
+  const leftJson = JSON.stringify(left) ?? "";
+  const rightJson = JSON.stringify(right) ?? "";
+  return leftJson < rightJson ? -1 : leftJson > rightJson ? 1 : 0;
+}
+
+function projectSlackFiles(value: unknown): SlackFileVersion[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((item, index) => {
+      const file = asRecord(item);
+      if (!file) {
+        return null;
+      }
+      const id = stringField(file, "id");
+      const hasDirectUrl = Boolean(
+        stringField(file, "url_private_download") ?? stringField(file, "url_private"),
+      );
+      return {
+        identity: id ? `id:${id}` : `index:${index}`,
+        access: id ? "resolvable" : hasDirectUrl ? "direct" : "missing",
+      } satisfies SlackFileVersion;
+    })
+    .filter((file): file is SlackFileVersion => file !== null)
+    .toSorted(compareJson);
+}
+
+function projectSlackAttachments(value: unknown): SlackAttachmentVersion[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((item, index) => {
+      const attachment = asRecord(item);
+      if (!attachment || attachment.is_share !== true) {
+        return null;
+      }
+      const ts = stringField(attachment, "ts");
+      const fallbackIdentity = [
+        stringField(attachment, "channel_id"),
+        stringField(attachment, "author_id"),
+      ]
+        .filter(Boolean)
+        .join(":");
+      return {
+        identity: ts ? `ts:${ts}` : fallbackIdentity || `index:${index}`,
+        hasImage: Boolean(stringField(attachment, "image_url")),
+        files: projectSlackFiles(attachment.files),
+      } satisfies SlackAttachmentVersion;
+    })
+    .filter((attachment): attachment is SlackAttachmentVersion => attachment !== null)
+    .filter(
+      (attachment) =>
+        attachment.hasImage || attachment.files.some((file) => file.access !== "missing"),
+    )
+    .toSorted(compareJson);
+}
+
+function projectSlackInboundContent(content: SlackInboundContent) {
+  return {
+    attachments: projectSlackAttachments(content.attachments),
+    files: projectSlackFiles(content.files),
+  };
+}
+
+export function hasSlackInboundDeliverableMedia(content: SlackInboundContent): boolean {
+  const projection = projectSlackInboundContent(content);
+  return (
+    projection.files.some((file) => file.access !== "missing") ||
+    projection.attachments.some(
+      (attachment) =>
+        attachment.hasImage || attachment.files.some((file) => file.access !== "missing"),
+    )
+  );
+}
+
+export function buildSlackInboundContentVersion(content: SlackInboundContent): string {
+  // Mutable previews and URL values are intentionally excluded. An ID remains
+  // one version while files.info hydrates Slack Connect access placeholders.
+  const material = JSON.stringify(projectSlackInboundContent(content));
+  return createHash("sha256").update(material).digest("base64url");
+}
+
+export function withSlackInboundContentVersion(
+  message: SlackMessageEvent,
+  version = buildSlackInboundContentVersion(message),
+): SlackMessageEvent {
+  return { ...message, [SLACK_CONTENT_VERSION]: version } as SlackContentVersionMessage;
+}
+
+export function resolveSlackInboundDeliveryId(message: SlackMessageEvent): string | undefined {
+  if (!message.ts) {
+    return undefined;
+  }
+  const version = (message as SlackContentVersionMessage)[SLACK_CONTENT_VERSION];
+  return version ? `${message.ts}:content-v1:${version}` : message.ts;
+}

--- a/extensions/slack/src/monitor/inbound-delivery-state.test.ts
+++ b/extensions/slack/src/monitor/inbound-delivery-state.test.ts
@@ -3,6 +3,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearSlackRuntime, setSlackRuntime } from "../runtime.js";
 import type { SlackMessageEvent } from "../types.js";
 import {
+  buildSlackInboundContentVersion,
+  withSlackInboundContentVersion,
+} from "./inbound-delivery-identity.js";
+import {
   clearSlackInboundDeliveryStateForTest,
   hasSlackInboundMessageDelivery,
   recordSlackInboundMessageDeliveries,
@@ -58,16 +62,79 @@ describe("slack inbound delivery state", () => {
     await expect(
       hasSlackInboundMessageDelivery({
         accountId: "A1",
-        channelId: "C1",
-        ts: "100.001",
+        message: message("C1", "100.001"),
       }),
     ).resolves.toBe(true);
     await expect(
       hasSlackInboundMessageDelivery({
         accountId: "A2",
-        channelId: "C1",
-        ts: "100.001",
+        message: message("C1", "100.001"),
       }),
     ).resolves.toBe(false);
+  });
+
+  it("keys a same-timestamp finalization by its stable content version", async () => {
+    const initial = { ...message("C1", "100.001"), files: [{ id: "F1" }] };
+    const finalized = withSlackInboundContentVersion({
+      ...initial,
+      files: [
+        { id: "F1", name: "one.pdf" },
+        { id: "F2", name: "two.pdf" },
+      ],
+    });
+    await recordSlackInboundMessageDeliveries({ accountId: "A1", messages: [initial] });
+
+    await expect(
+      hasSlackInboundMessageDelivery({ accountId: "A1", message: finalized }),
+    ).resolves.toBe(false);
+
+    await recordSlackInboundMessageDeliveries({ accountId: "A1", messages: [finalized] });
+    await expect(
+      hasSlackInboundMessageDelivery({
+        accountId: "A1",
+        message: withSlackInboundContentVersion({
+          ...initial,
+          files: [
+            { name: "renamed-one.pdf", id: "F1" },
+            { name: "renamed-two.pdf", id: "F2" },
+          ],
+        }),
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      hasSlackInboundMessageDelivery({
+        accountId: "A1",
+        message: withSlackInboundContentVersion({
+          ...initial,
+          files: [{ id: "F1" }, { id: "F2" }, { id: "F3" }],
+        }),
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("keeps Slack Connect placeholders stable across metadata hydration", () => {
+    const pending = {
+      files: [{ id: "F1", mode: "file_access", file_access: "check_file_info" }],
+    };
+    const available = {
+      files: [{ id: "F1", url_private: "https://files.slack.com/first" }],
+    };
+    const refreshed = {
+      files: [
+        {
+          id: "F1",
+          name: "renamed.pdf",
+          thumb_64: "https://files.slack.com/new-preview",
+          url_private_download: "https://files.slack.com/refreshed",
+        },
+      ],
+    };
+
+    expect(buildSlackInboundContentVersion(pending)).toBe(
+      buildSlackInboundContentVersion(available),
+    );
+    expect(buildSlackInboundContentVersion(available)).toBe(
+      buildSlackInboundContentVersion(refreshed),
+    );
   });
 });

--- a/extensions/slack/src/monitor/inbound-delivery-state.ts
+++ b/extensions/slack/src/monitor/inbound-delivery-state.ts
@@ -2,6 +2,7 @@
 import { createPersistentDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
 import { getOptionalSlackRuntime } from "../runtime.js";
 import type { SlackMessageEvent } from "../types.js";
+import { resolveSlackInboundDeliveryId } from "./inbound-delivery-identity.js";
 
 const TTL_MS = 24 * 60 * 60 * 1000;
 const MAX_ENTRIES = 20_000;
@@ -33,21 +34,26 @@ const deliveredMessages = createPersistentDedupeCache<SlackInboundDeliveryRecord
   },
 });
 
-function makeKey(accountId: string, channelId: string, ts: string, teamId?: string): string {
-  return `${accountId}:${teamId ? `${teamId}:` : ""}${channelId}:${ts}`;
+function makeKey(
+  accountId: string,
+  channelId: string,
+  deliveryId: string,
+  teamId?: string,
+): string {
+  return `${accountId}:${teamId ? `${teamId}:` : ""}${channelId}:${deliveryId}`;
 }
 
 export async function hasSlackInboundMessageDelivery(params: {
   accountId: string;
-  channelId: string | undefined;
-  ts: string | undefined;
+  message: SlackMessageEvent;
   teamId?: string;
 }): Promise<boolean> {
-  if (!params.accountId || !params.channelId || !params.ts) {
+  const deliveryId = resolveSlackInboundDeliveryId(params.message);
+  if (!params.accountId || !params.message.channel || !deliveryId) {
     return false;
   }
   return await deliveredMessages.lookup(
-    makeKey(params.accountId, params.channelId, params.ts, params.teamId),
+    makeKey(params.accountId, params.message.channel, deliveryId, params.teamId),
   );
 }
 
@@ -62,10 +68,11 @@ export async function recordSlackInboundMessageDeliveries(params: {
   const deliveredAt = Date.now();
   const keys = new Set<string>();
   for (const message of params.messages) {
-    if (!message.channel || !message.ts) {
+    const deliveryId = resolveSlackInboundDeliveryId(message);
+    if (!message.channel || !deliveryId) {
       continue;
     }
-    keys.add(makeKey(params.accountId, message.channel, message.ts, params.teamId));
+    keys.add(makeKey(params.accountId, message.channel, deliveryId, params.teamId));
   }
   await Promise.all(
     Array.from(keys, (key) =>

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -15,6 +15,7 @@ import type { SlackMessageEvent } from "../types.js";
 import { stripSlackMentionsForCommandDetection } from "./commands.js";
 import type { SlackMonitorContext } from "./context.js";
 import type { SlackEventScope } from "./event-scope.js";
+import { resolveSlackInboundDeliveryId } from "./inbound-delivery-identity.js";
 import {
   hasSlackInboundMessageDelivery,
   recordSlackInboundMessageDeliveries,
@@ -99,13 +100,13 @@ function shouldDebounceSlackMessage(message: SlackMessageEvent, cfg: SlackMonito
 
 function buildSeenMessageKey(
   channelId: string | undefined,
-  ts: string | undefined,
+  deliveryId: string | undefined,
   teamId?: string,
 ): string | null {
-  if (!channelId || !ts) {
+  if (!channelId || !deliveryId) {
     return null;
   }
-  return `${teamId ? `${teamId}:` : ""}${channelId}:${ts}`;
+  return `${teamId ? `${teamId}:` : ""}${channelId}:${deliveryId}`;
 }
 
 export function createSlackMessageHandler(params: {
@@ -208,7 +209,7 @@ export function createSlackMessageHandler(params: {
           };
           const seenMessageKey = buildSeenMessageKey(
             last.message.channel,
-            last.message.ts,
+            resolveSlackInboundDeliveryId(last.message),
             last.opts.eventScope?.teamId,
           );
           try {
@@ -303,7 +304,7 @@ export function createSlackMessageHandler(params: {
               for (const entry of entries) {
                 const entrySeenKey = buildSeenMessageKey(
                   entry.message.channel,
-                  entry.message.ts,
+                  resolveSlackInboundDeliveryId(entry.message),
                   entry.opts.eventScope?.teamId,
                 );
                 if (entrySeenKey) {
@@ -311,7 +312,7 @@ export function createSlackMessageHandler(params: {
                 }
                 ctx.releaseSeenMessage(
                   entry.message.channel,
-                  entry.message.ts,
+                  resolveSlackInboundDeliveryId(entry.message),
                   entry.opts.eventScope,
                 );
               }
@@ -408,22 +409,25 @@ export function createSlackMessageHandler(params: {
     ctx.rememberSlackChannelType(message.channel, message.channel_type, opts.eventScope);
     const seenMessageKey = buildSeenMessageKey(
       message.channel,
-      message.ts,
+      resolveSlackInboundDeliveryId(message),
       opts.eventScope?.teamId,
     );
     if (
       seenMessageKey &&
       (await hasSlackInboundMessageDelivery({
         accountId: ctx.accountId,
-        channelId: message.channel,
-        ts: message.ts,
+        message,
         ...(opts.eventScope ? { teamId: opts.eventScope.teamId } : {}),
       }))
     ) {
       return undefined;
     }
     const wasSeen = seenMessageKey
-      ? ctx.markMessageSeen(message.channel, message.ts, opts.eventScope)
+      ? ctx.markMessageSeen(
+          message.channel,
+          resolveSlackInboundDeliveryId(message),
+          opts.eventScope,
+        )
       : false;
     if (seenMessageKey && opts.source === "message" && !wasSeen) {
       // Prime exactly one fallback app_mention allowance immediately so a near-simultaneous


### PR DESCRIPTION
Related: #104703

## What Problem This Solves

Fixes an evidence gap where the Slack attachment-finalization repair cannot use the secret-bearing QA workflow because the contributor PR head belongs to a fork.

## Why This Change Was Made

This temporary, AI-assisted staging branch adds one redacted Socket Mode trace probe and narrows a manual QA dispatch to that Slack-only probe. The workflow retains its existing maintainer authorization, trusted-ref validation, protected environment, and Convex credential lease boundaries. This PR will be closed and its branch deleted after the evidence artifact is captured; none of these temporary files belong in #104703.

## User Impact

No shipped user impact. The probe uploads two synthetic text files, records only event shape and aliased identifiers, deletes the files, and releases the QA credential lease.

## Evidence

- `check:changed` passed on Blacksmith Testbox lease `tbx_01kxbysknkpgzw021apzt03mwd`.
- The probe output excludes message text, filenames, workspace/channel/user identifiers, URLs, file contents, and credentials.
- Intended live artifact: `file-event-trace.json` from `QA-Lab - All Lanes` with `slack_scenario=file-event-trace`.
