### PR TITLE
feat(gateway): include produced messageId on chat final/aborted events

### DIFF
--- a/packages/gateway-protocol/src/schema/logs-chat.ts
+++ b/packages/gateway-protocol/src/schema/logs-chat.ts
@@ -192,6 +192,10 @@ export const ChatFinalEventSchema = closedObject({
   usage: Type.Optional(Type.Unknown()),
   stopReason: Type.Optional(Type.String()),
   yielded: Type.Optional(Type.Literal(true)),
+  // Stable transcript id of the assistant message this run produced, when
+  // available. Lets clients dedup on (sessionKey, messageId) instead of
+  // re-deriving "the last transcript entry".
+  messageId: Type.Optional(NonEmptyString),
 });
 
 /** Terminal event for user-initiated or coordinator-initiated cancellation. */
@@ -201,6 +205,7 @@ export const ChatAbortedEventSchema = closedObject({
   message: Type.Optional(Type.Unknown()),
   errorMessage: Type.Optional(Type.String()),
   stopReason: Type.Optional(Type.String()),
+  messageId: Type.Optional(NonEmptyString),
 });
 
 /** Terminal event for failed chat runs with an optional normalized failure kind. */

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -323,6 +323,17 @@ async function persistApprovedCliUserTurnTranscript(params: RunCliAgentParams): 
   return persisted !== undefined || recorder.hasPersisted() || recorder.isBlocked();
 }
 
+/**
+ * Outcome of persisting a CLI run's assistant turn.
+ *
+ * `owned` keeps the existing "this run owns the visible reply" semantics;
+ * `messageId` is the stable transcript id when the append actually happened.
+ */
+type CliAssistantTranscriptPersistence = {
+  owned: boolean;
+  messageId?: string;
+};
+
 async function persistCliAssistantTranscript(params: {
   runParams: RunCliAgentParams;
   text: string;
@@ -334,13 +345,13 @@ async function persistCliAssistantTranscript(params: {
     cacheWrite?: number;
     total?: number;
   };
-}): Promise<boolean> {
+}): Promise<CliAssistantTranscriptPersistence> {
   const { runParams } = params;
   if (!runParams.persistAssistantTranscript || !runParams.sessionKey || !params.text) {
-    return false;
+    return { owned: false };
   }
   if (runParams.currentInboundEventKind === "room_event") {
-    return true;
+    return { owned: true };
   }
   try {
     const result = await appendExactAssistantMessageToSessionTranscript({
@@ -370,12 +381,14 @@ async function persistCliAssistantTranscript(params: {
     });
     if (!result.ok) {
       log.warn(`CLI assistant transcript persistence skipped: ${result.reason}`);
-      return result.code === "blocked" || result.code === "session-rebound";
+      return { owned: result.code === "blocked" || result.code === "session-rebound" };
     }
-    return true;
+    // Keep the persisted transcript id so the terminal lifecycle event can name
+    // the assistant message this run produced, the same way embedded runs do.
+    return { owned: true, messageId: result.messageId };
   } catch (error) {
     log.warn(`CLI assistant transcript persistence failed: ${formatErrorMessage(error)}`);
-    return false;
+    return { owned: false };
   }
 }
 
@@ -1002,6 +1015,8 @@ export async function runPreparedCliAgent(
     effectiveCliSessionId?: string;
     bindingFlushOk?: boolean;
     assistantTranscriptOwned?: boolean;
+    /** Transcript id of the assistant message this run persisted, when it wrote one. */
+    assistantMessageId?: string;
     usedHistoryPrompt: boolean;
   }): EmbeddedAgentRunResult => {
     const text = resultParams.output.text?.trim();
@@ -1092,6 +1107,9 @@ export async function runPreparedCliAgent(
       payloads,
       meta: {
         durationMs: Date.now() - context.started,
+        // Surfaced on the terminal lifecycle event so Gateway clients can dedup
+        // CLI-backend runs on (sessionKey, messageId) like embedded runs.
+        ...(resultParams.assistantMessageId ? { messageId: resultParams.assistantMessageId } : {}),
         ...(resultParams.output.finalPromptText
           ? { finalPromptText: resultParams.output.finalPromptText }
           : {}),
@@ -1224,7 +1242,7 @@ export async function runPreparedCliAgent(
           assistantText,
           output,
         });
-        const assistantTranscriptOwned = await persistCliAssistantTranscript({
+        const assistantTranscript = await persistCliAssistantTranscript({
           runParams: params,
           // Dispatch owns source-reply transcript mirrors and their idempotency keys.
           // Persisting them here would duplicate the same visible assistant reply.
@@ -1255,7 +1273,10 @@ export async function runPreparedCliAgent(
           output,
           effectiveCliSessionId,
           bindingFlushOk,
-          assistantTranscriptOwned,
+          assistantTranscriptOwned: assistantTranscript.owned,
+          ...(assistantTranscript.messageId
+            ? { assistantMessageId: assistantTranscript.messageId }
+            : {}),
           usedHistoryPrompt,
         });
       } catch (error) {

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -201,6 +201,12 @@ export function handleAgentEnd(
     const phase =
       ctx.params.terminalLifecyclePhase === "finishing" ? "finishing" : isError ? "error" : "end";
     const errorData = isError ? { error: lifecycleErrorText ?? GENERIC_ASSISTANT_ERROR_TEXT } : {};
+    // Stable id of the assistant message this run persisted, when it produced
+    // one. Threaded through so the Gateway terminal event can reference the
+    // produced message instead of clients re-deriving the transcript tail.
+    const messageIdData = evt?.lastAssistantMessageId
+      ? { messageId: evt.lastAssistantMessageId }
+      : {};
     emitAgentEvent({
       runId: ctx.params.runId,
       ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
@@ -214,6 +220,7 @@ export function handleAgentEnd(
         phase,
         ...errorData,
         ...terminalMeta,
+        ...messageIdData,
         ...(livenessState ? { livenessState } : {}),
         ...(replayInvalid ? { replayInvalid } : {}),
         endedAt: Date.now(),
@@ -229,6 +236,7 @@ export function handleAgentEnd(
             phase,
             ...errorData,
             ...terminalMeta,
+            ...messageIdData,
             ...(livenessState ? { livenessState } : {}),
             ...(replayInvalid ? { replayInvalid } : {}),
           },

--- a/src/agents/sessions/agent-session-base.ts
+++ b/src/agents/sessions/agent-session-base.ts
@@ -291,6 +291,8 @@ export abstract class AgentSessionBase {
 
   // Track last assistant message for auto-compaction check
   protected lastAssistantMessage: AssistantMessage | undefined = undefined;
+  /** Stable transcript id of the last assistant message persisted this run. */
+  protected lastAssistantMessageId: string | undefined = undefined;
   protected lastRunEndedForTurnHandoff = false;
 
   /** Internal handler for agent events - shared by subscribe and reconnect */
@@ -339,7 +341,13 @@ export abstract class AgentSessionBase {
     // Notify all listeners
     this.emit(
       event.type === "agent_end"
-        ? { ...event, willRetry: this.willRetryAfterAgentEnd(event) }
+        ? {
+            ...event,
+            willRetry: this.willRetryAfterAgentEnd(event),
+            ...(this.lastAssistantMessageId
+              ? { lastAssistantMessageId: this.lastAssistantMessageId }
+              : {}),
+          }
         : event,
     );
 
@@ -363,10 +371,15 @@ export abstract class AgentSessionBase {
         const toolResultChangedByExtension =
           event.message.role === "toolResult" &&
           this.extensionModifiedToolResultIds.delete(event.message.toolCallId);
-        this.sessionManager.appendMessage(event.message, {
+        const appendedMessageId = this.sessionManager.appendMessage(event.message, {
           invalidateSerializedPrefixCache:
             messageChangedByExtension || toolResultChangedByExtension,
         });
+        // Remember the persisted id of the assistant turn so agent_end can carry
+        // a stable reference to the message this run produced.
+        if (event.message.role === "assistant") {
+          this.lastAssistantMessageId = appendedMessageId;
+        }
       }
       // Other message types (bashExecution, compactionSummary, branchSummary) are persisted elsewhere
 

--- a/src/agents/sessions/agent-session-prompting.ts
+++ b/src/agents/sessions/agent-session-prompting.ts
@@ -52,6 +52,7 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
   private async handlePostAgentRun(): Promise<PostAgentRunAction> {
     const msg = this.lastAssistantMessage;
     this.lastAssistantMessage = undefined;
+    this.lastAssistantMessageId = undefined;
     const endedForTurnHandoff = this.lastRunEndedForTurnHandoff;
     this.lastRunEndedForTurnHandoff = false;
     if (endedForTurnHandoff) {

--- a/src/agents/sessions/agent-session-types.ts
+++ b/src/agents/sessions/agent-session-types.ts
@@ -25,7 +25,17 @@ import type { SettingsManager } from "./settings-manager.js";
 
 export type AgentSessionEvent =
   | Exclude<AgentEvent, { type: "agent_end" }>
-  | { type: "agent_end"; messages: AgentMessage[]; willRetry: boolean }
+  | {
+      type: "agent_end";
+      messages: AgentMessage[];
+      willRetry: boolean;
+      /**
+       * Stable transcript id of the final assistant message this run persisted,
+       * when the run produced one. Lets lifecycle consumers reference the exact
+       * produced message instead of re-deriving "the last transcript entry".
+       */
+      lastAssistantMessageId?: string;
+    }
   | { type: "queue_update"; steering: readonly string[]; followUp: readonly string[] }
   | { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
   | { type: "session_info_changed"; name: string | undefined }

--- a/src/agents/sessions/agent-session.message-id.test.ts
+++ b/src/agents/sessions/agent-session.message-id.test.ts
@@ -1,0 +1,234 @@
+// Persistence-backed coverage for the `messageId` carried on terminal chat
+// events. These tests drive the real `AgentSession` persistence path against a
+// real `SessionManager` writing a real transcript file, then assert the id the
+// session emits on `agent_end` is byte-identical to the id of the assistant
+// entry actually written to disk.
+//
+// The gateway-level test in `server.agent.gateway-server-agent-b.test.ts` only
+// proves the id is *forwarded* (it injects a synthetic lifecycle id). This file
+// covers the other half: that the id is the *produced transcript id*, and that
+// it stays correct across the terminal shapes a run can take — plain final,
+// aborted, auto-retry, contentless, tool loops, and post-run injection.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentMessage } from "../runtime/index.js";
+import { AgentSession, type AgentSessionEvent } from "./agent-session.js";
+import { loadEntriesFromFile, SessionManager } from "./session-manager.js";
+
+const tempPaths: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-session-messageid-"));
+  tempPaths.push(dir);
+  return dir;
+}
+
+type Harness = {
+  session: AgentSession;
+  sessionManager: SessionManager;
+  sessionFile: string;
+  emitted: AgentSessionEvent[];
+  handle: (event: unknown) => Promise<void>;
+};
+
+/**
+ * Builds an `AgentSession` bound to a real on-disk transcript.
+ *
+ * Only the outward-facing collaborators are stubbed (listener fan-out, the
+ * extension bus, retry settings). Everything under test — event dispatch,
+ * `sessionManager.appendMessage`, and the id bookkeeping — is the real
+ * implementation running against real persistence.
+ */
+async function makeHarness(options?: { retryable?: boolean }): Promise<Harness> {
+  const dir = await makeTempDir();
+  const sessionFile = path.join(dir, "session.jsonl");
+  const sessionManager = SessionManager.open(sessionFile, dir, dir);
+  const emitted: AgentSessionEvent[] = [];
+
+  const session = Object.create(AgentSession.prototype) as AgentSession;
+  Object.assign(session, {
+    sessionManager,
+    lastAssistantMessage: undefined,
+    lastAssistantMessageId: undefined,
+    extensionModifiedToolResultIds: new Set<string>(),
+    steeringMessages: [],
+    followUpMessages: [],
+    overflowRecoveryAttempted: false,
+    retryCount: 0,
+    settingsManager: {
+      getRetrySettings: () => ({
+        enabled: options?.retryable === true,
+        maxRetries: options?.retryable === true ? 3 : 0,
+      }),
+    },
+    // Auto-retry classification is orthogonal to id bookkeeping; force the
+    // branch so the retry test exercises a genuine `willRetry: true` terminal.
+    isRetryableError: () => options?.retryable === true,
+    emit: (event: AgentSessionEvent) => {
+      emitted.push(event);
+    },
+    emitExtensionEvent: async () => false,
+    emitQueueUpdate: () => {},
+  });
+
+  return {
+    session,
+    sessionManager,
+    sessionFile,
+    emitted,
+    handle: (event: unknown) =>
+      (
+        session as unknown as { handleAgentEventUnlocked: (e: unknown) => Promise<void> }
+      ).handleAgentEventUnlocked(event),
+  };
+}
+
+function assistantMessage(text: string, stopReason = "stop"): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    stopReason,
+  } as unknown as AgentMessage;
+}
+
+/** Ids of the assistant messages actually persisted to the transcript file. */
+function persistedAssistantIds(sessionFile: string): string[] {
+  return loadEntriesFromFile(sessionFile)
+    .filter(
+      (entry): entry is typeof entry & { id: string; message: { role: string } } =>
+        (entry as { type?: string }).type === "message" &&
+        (entry as { message?: { role?: string } }).message?.role === "assistant",
+    )
+    .map((entry) => entry.id);
+}
+
+function terminalEvents(emitted: AgentSessionEvent[]) {
+  return emitted.filter((event) => event.type === "agent_end");
+}
+
+describe("AgentSession agent_end messageId", () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempPaths.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("carries the id of the assistant message persisted to the transcript", async () => {
+    const { handle, emitted, sessionFile } = await makeHarness();
+    const message = assistantMessage("hello from the agent");
+
+    await handle({ type: "message_end", message });
+    await handle({ type: "agent_end", messages: [message] });
+
+    const [terminal] = terminalEvents(emitted);
+    const persisted = persistedAssistantIds(sessionFile);
+
+    expect(persisted).toHaveLength(1);
+    // The emitted id is the transcript id, not a fresh/synthetic one.
+    expect(terminal).toMatchObject({ lastAssistantMessageId: persisted[0] });
+  });
+
+  it("carries the persisted id on an aborted run that still produced a message", async () => {
+    const { handle, emitted, sessionFile } = await makeHarness();
+    const message = assistantMessage("partial answer", "aborted");
+
+    await handle({ type: "message_end", message });
+    await handle({ type: "agent_end", messages: [message] });
+
+    const [terminal] = terminalEvents(emitted);
+    expect(terminal).toMatchObject({
+      willRetry: false,
+      lastAssistantMessageId: persistedAssistantIds(sessionFile)[0],
+    });
+  });
+
+  it("omits messageId entirely for a contentless run", async () => {
+    const { handle, emitted, sessionFile } = await makeHarness();
+
+    // No assistant message_end: the run ended without producing a message.
+    await handle({ type: "agent_end", messages: [] });
+
+    const [terminal] = terminalEvents(emitted);
+    expect(persistedAssistantIds(sessionFile)).toEqual([]);
+    // Absent rather than empty/stale, so clients can't dedup on a bogus id.
+    expect(terminal).not.toHaveProperty("lastAssistantMessageId");
+  });
+
+  it("reports the final assistant message of a tool loop, not the first or the tool result", async () => {
+    const { handle, emitted, sessionFile } = await makeHarness();
+    const toolCall = assistantMessage("calling a tool", "toolUse");
+    const toolResult = {
+      role: "toolResult",
+      toolCallId: "call-1",
+      content: "tool output",
+    } as unknown as AgentMessage;
+    const finalAnswer = assistantMessage("answer after the tool");
+
+    await handle({ type: "message_end", message: toolCall });
+    await handle({ type: "message_end", message: toolResult });
+    await handle({ type: "message_end", message: finalAnswer });
+    await handle({ type: "agent_end", messages: [toolCall, toolResult, finalAnswer] });
+
+    const persisted = persistedAssistantIds(sessionFile);
+    expect(persisted).toHaveLength(2);
+
+    const [terminal] = terminalEvents(emitted);
+    const reported = (terminal as { lastAssistantMessageId?: string }).lastAssistantMessageId;
+    expect(reported).toBe(persisted[1]);
+    expect(reported).not.toBe(persisted[0]);
+  });
+
+  it("tracks the newest assistant message across an auto-retry within one run", async () => {
+    const { handle, emitted, sessionFile } = await makeHarness({ retryable: true });
+    const failed = assistantMessage("transient failure", "error");
+    const retried = assistantMessage("answer on retry");
+
+    await handle({ type: "message_end", message: failed });
+    await handle({ type: "agent_end", messages: [failed] });
+    await handle({ type: "message_end", message: retried });
+    await handle({ type: "agent_end", messages: [failed, retried] });
+
+    const persisted = persistedAssistantIds(sessionFile);
+    expect(persisted).toHaveLength(2);
+
+    const [firstTerminal, secondTerminal] = terminalEvents(emitted);
+    // First terminal is the retryable one and points at the failed attempt.
+    expect(firstTerminal).toMatchObject({
+      willRetry: true,
+      lastAssistantMessageId: persisted[0],
+    });
+    // The second terminal must advance to the retried message, not repeat it.
+    expect(secondTerminal).toMatchObject({ lastAssistantMessageId: persisted[1] });
+  });
+
+  it("stays pinned to the produced message when another entry is appended after it", async () => {
+    const { handle, emitted, sessionManager, sessionFile } = await makeHarness();
+    const message = assistantMessage("the produced answer");
+
+    await handle({ type: "message_end", message });
+
+    // Something injects into the transcript after the assistant turn — the
+    // exact case that makes "read the last transcript entry" unreliable.
+    sessionManager.appendMessage({
+      role: "user",
+      content: "injected follow-up",
+      timestamp: Date.now(),
+    } as never);
+
+    await handle({ type: "agent_end", messages: [message] });
+
+    const entries = loadEntriesFromFile(sessionFile).filter(
+      (entry) => (entry as { type?: string }).type === "message",
+    );
+    const lastEntryId = (entries.at(-1) as { id: string }).id;
+    const assistantId = persistedAssistantIds(sessionFile)[0];
+
+    // Precondition: the tail is no longer the assistant message.
+    expect(lastEntryId).not.toBe(assistantId);
+
+    const [terminal] = terminalEvents(emitted);
+    expect(terminal).toMatchObject({ lastAssistantMessageId: assistantId });
+  });
+});

--- a/src/auto-reply/reply/agent-lifecycle-terminal.test.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.test.ts
@@ -1,0 +1,35 @@
+// CLI-backend runs persist their assistant turn outside `AgentSession`, so the
+// produced transcript id reaches the terminal lifecycle event through run meta
+// rather than through the session's `lastAssistantMessageId`. These tests pin
+// that hand-off.
+import { describe, expect, it } from "vitest";
+import { resolveAgentLifecycleTerminalMetadata } from "./agent-lifecycle-terminal.js";
+
+describe("resolveAgentLifecycleTerminalMetadata", () => {
+  it("forwards the produced messageId from run meta", () => {
+    const metadata = resolveAgentLifecycleTerminalMetadata({
+      durationMs: 1234,
+      messageId: "msg-abc123",
+      stopReason: "completed",
+    });
+
+    expect(metadata).toMatchObject({ messageId: "msg-abc123", stopReason: "completed" });
+    // Unrelated meta keys stay off the wire.
+    expect(metadata).not.toHaveProperty("durationMs");
+  });
+
+  it("omits messageId when the run persisted no assistant message", () => {
+    const metadata = resolveAgentLifecycleTerminalMetadata({
+      durationMs: 1234,
+      stopReason: "completed",
+    });
+
+    // Absent rather than undefined/empty, so clients cannot dedup on a bogus id.
+    expect(metadata).not.toHaveProperty("messageId");
+  });
+
+  it("returns nothing for absent or non-object meta", () => {
+    expect(resolveAgentLifecycleTerminalMetadata(undefined)).toEqual({});
+    expect(resolveAgentLifecycleTerminalMetadata("msg-abc123")).toEqual({});
+  });
+});

--- a/src/auto-reply/reply/agent-lifecycle-terminal.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.ts
@@ -14,6 +14,9 @@ export type AgentLifecycleTerminalBackstop = {
 };
 
 const DEFERRED_TERMINAL_METADATA_KEYS = [
+  // Stable transcript id of the assistant message the run produced. CLI-backend
+  // runs persist outside AgentSession, so they carry the id through run meta.
+  "messageId",
   "stopReason",
   "yielded",
   "timeoutPhase",

--- a/src/gateway/gateway-final-message-id.live.test.ts
+++ b/src/gateway/gateway-final-message-id.live.test.ts
@@ -1,0 +1,270 @@
+// Live proof that the terminal chat event's `messageId` is the id of the
+// assistant message the run actually persisted.
+//
+// The unit coverage in `agent-session.message-id.test.ts` proves the id is the
+// real transcript id at the session layer, and the gateway test in
+// `server.agent.gateway-server-agent-b.test.ts` proves the lifecycle id is
+// forwarded onto the wire. Neither joins the two ends. This test does: it runs a
+// real gateway, a real external websocket client, and a real agent turn, then
+// correlates the `final` event a client actually received against the transcript
+// row the gateway actually wrote.
+//
+// Run:
+//   OPENCLAW_LIVE=1 OPENCLAW_LIVE_FINAL_MESSAGE_ID=1 \
+//     node node_modules/vitest/vitest.mjs run \
+//     src/gateway/gateway-final-message-id.live.test.ts --no-coverage
+import { randomBytes, randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { EventFrame } from "../../packages/gateway-protocol/src/index.js";
+import { isLiveTestEnabled } from "../agents/live-test-helpers.js";
+import { loadTranscriptEvents } from "../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { setTestEnvValue } from "../test-utils/env.js";
+import { GatewayClient } from "./client.js";
+import {
+  connectTestGatewayClient,
+  createBootstrapWorkspace,
+  ensurePairedTestGatewayClientIdentity,
+  getFreeGatewayPort,
+} from "./gateway-cli-backend.live-helpers.js";
+import { loadSessionEntry } from "./session-utils.js";
+
+const LIVE = isLiveTestEnabled();
+const FINAL_MESSAGE_ID_LIVE = process.env.OPENCLAW_LIVE_FINAL_MESSAGE_ID === "1";
+const describeLive = LIVE && FINAL_MESSAGE_ID_LIVE ? describe : describe.skip;
+
+const LIVE_TIMEOUT_MS = 420_000;
+const GATEWAY_CONNECT_TIMEOUT_MS = 60_000;
+const FINAL_EVENT_TIMEOUT_MS = 240_000;
+const DEFAULT_MODEL = process.env.OPENCLAW_LIVE_FINAL_MESSAGE_ID_MODEL ?? "claude-cli/claude-sonnet-4-6";
+
+type ChatEventPayload = {
+  runId?: string;
+  sessionKey?: string;
+  state?: string;
+  messageId?: string;
+  seq?: number;
+};
+
+function chatPayload(frame: EventFrame): ChatEventPayload | undefined {
+  const candidate = frame as unknown as { event?: string; payload?: ChatEventPayload };
+  return candidate.event === "chat" ? candidate.payload : undefined;
+}
+
+function snapshotEnv(): NodeJS.ProcessEnv {
+  return { ...process.env };
+}
+
+function restoreEnv(previous: NodeJS.ProcessEnv): void {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in previous)) {
+      delete process.env[key];
+    }
+  }
+  Object.assign(process.env, previous);
+}
+
+async function writeLiveGatewayConfig(params: {
+  configPath: string;
+  modelKey: string;
+  port: number;
+  token: string;
+  workspace: string;
+}): Promise<void> {
+  const cfg: OpenClawConfig = {
+    gateway: {
+      mode: "local",
+      port: params.port,
+      auth: { mode: "token", token: params.token },
+    },
+    agents: {
+      list: [{ id: "dev", default: true }],
+      defaults: {
+        workspace: params.workspace,
+        skipBootstrap: true,
+        model: { primary: params.modelKey },
+        models: { [params.modelKey]: { agentRuntime: { id: "claude-cli" } } },
+        sandbox: { mode: "off" },
+      },
+    },
+  };
+  await fs.writeFile(params.configPath, `${JSON.stringify(cfg, null, 2)}\n`);
+}
+
+async function waitForTerminalChatEvent(params: {
+  events: EventFrame[];
+  runId: string;
+  timeoutMs: number;
+}): Promise<ChatEventPayload> {
+  const deadline = Date.now() + params.timeoutMs;
+  while (Date.now() < deadline) {
+    for (const frame of params.events) {
+      const payload = chatPayload(frame);
+      if (
+        payload?.runId === params.runId &&
+        (payload.state === "final" || payload.state === "aborted")
+      ) {
+        return payload;
+      }
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 250);
+    });
+  }
+  throw new Error(`timed out waiting for a terminal chat event for run ${params.runId}`);
+}
+
+describeLive("gateway final chat event messageId (live)", () => {
+  const cleanup: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    for (const task of cleanup.splice(0).reverse()) {
+      await task().catch(() => {});
+    }
+  });
+
+  it(
+    "final event messageId resolves to the assistant transcript row the run wrote",
+    async () => {
+      const { clearRuntimeConfigSnapshot } = await import("../config/config.js");
+      const { startGatewayServer } = await import("./server.js");
+
+      const previousEnv = snapshotEnv();
+      const tempDir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-openclaw-final-msgid-live-"));
+      cleanup.push(async () => {
+        restoreEnv(previousEnv);
+        clearRuntimeConfigSnapshot();
+        await fs.rm(tempDir, { recursive: true, force: true });
+      });
+
+      const stateDir = path.join(tempDir, "state");
+      const { workspaceDir } = await createBootstrapWorkspace(tempDir);
+      const configPath = path.join(tempDir, "openclaw.json");
+      const token = `test-${randomUUID()}`;
+      const port = await getFreeGatewayPort();
+
+      clearRuntimeConfigSnapshot();
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+      setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+      process.env.OPENCLAW_GATEWAY_TOKEN = token;
+      process.env.OPENCLAW_SKIP_BROWSER_CONTROL_SERVER = "1";
+      process.env.OPENCLAW_SKIP_CANVAS_HOST = "1";
+      process.env.OPENCLAW_SKIP_CHANNELS = "1";
+      process.env.OPENCLAW_SKIP_CRON = "1";
+      process.env.OPENCLAW_SKIP_GMAIL_WATCHER = "1";
+      await fs.mkdir(stateDir, { recursive: true });
+      await writeLiveGatewayConfig({
+        configPath,
+        modelKey: DEFAULT_MODEL,
+        port,
+        token,
+        workspace: workspaceDir,
+      });
+
+      const server = await startGatewayServer(port, {
+        bind: "loopback",
+        auth: { mode: "token", token },
+        controlUiEnabled: false,
+      });
+      cleanup.push(async () => {
+        await server.close();
+      });
+
+      const gatewayEvents: EventFrame[] = [];
+      const deviceIdentity = await ensurePairedTestGatewayClientIdentity({
+        displayName: "final-msgid-live",
+      });
+      const client: GatewayClient = await connectTestGatewayClient({
+        url: `ws://127.0.0.1:${port}`,
+        token,
+        deviceIdentity,
+        timeoutMs: GATEWAY_CONNECT_TIMEOUT_MS,
+        requestTimeoutMs: 60_000,
+        tickWatchTimeoutMs: FINAL_EVENT_TIMEOUT_MS + 120_000,
+        clientDisplayName: "final-msgid-live",
+        onEvent: (event) => {
+          gatewayEvents.push(event);
+        },
+      });
+      cleanup.push(async () => {
+        await client.stopAndWait({ timeoutMs: 5_000 });
+      });
+
+      const sessionKey = "agent:dev:live-final-message-id";
+      const replyToken = `MSGID-LIVE-${randomBytes(3).toString("hex").toUpperCase()}`;
+      const runId = `chat-${randomUUID()}`;
+
+      const ack = (await client.request(
+        "chat.send",
+        {
+          sessionKey,
+          message: `Reply with exactly ${replyToken} and nothing else.`,
+          idempotencyKey: runId,
+        },
+        { timeoutMs: 60_000 },
+      )) as { status?: string };
+      expect(["accepted", "ok", "started"]).toContain(ack?.status);
+
+      const terminal = await waitForTerminalChatEvent({
+        events: gatewayEvents,
+        runId,
+        timeoutMs: FINAL_EVENT_TIMEOUT_MS,
+      });
+
+      // 1. The wire carries an id at all.
+      expect(terminal.state).toBe("final");
+      expect(typeof terminal.messageId).toBe("string");
+      expect(terminal.messageId).not.toBe("");
+
+      // 2. That id resolves to a real assistant row in the persisted transcript.
+      const { entry, storePath } = loadSessionEntry(sessionKey);
+      if (!entry?.sessionId) {
+        throw new Error(`live session was not persisted: ${sessionKey}`);
+      }
+      const transcript = await loadTranscriptEvents({
+        agentId: "dev",
+        sessionId: entry.sessionId,
+        sessionKey,
+        storePath,
+      });
+      const assistantRows = transcript.filter(
+        (event) => (event as { message?: { role?: string } }).message?.role === "assistant",
+      );
+      const matched = assistantRows.find(
+        (event) => (event as { id?: string }).id === terminal.messageId,
+      );
+
+      // 3. It is the row carrying this run's reply — not merely *a* valid id.
+      const matchedText = JSON.stringify(
+        (matched as { message?: unknown } | undefined)?.message ?? null,
+      );
+      expect(matched, `no assistant transcript row with id ${terminal.messageId}`).toBeDefined();
+      expect(matchedText).toContain(replyToken);
+
+      // Redacted proof block for the PR. Model output is reduced to the token we
+      // asked for, so nothing beyond the correlation itself is disclosed.
+      console.error(
+        `[final-message-id-live] ${JSON.stringify(
+          {
+            finalEvent: {
+              state: terminal.state,
+              runId: "<redacted>",
+              sessionKey,
+              messageId: terminal.messageId,
+            },
+            transcript: {
+              assistantRowCount: assistantRows.length,
+              matchedRowId: (matched as { id?: string }).id,
+              matchedRowContainsReplyToken: matchedText.includes(replyToken),
+            },
+          },
+          null,
+          2,
+        )}`,
+      );
+    },
+    LIVE_TIMEOUT_MS,
+  );
+});

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -775,6 +775,8 @@ export function createAgentEventHandler({
               firstAssistantTimingEntry: finished,
               abortErrorMessage: readToolValidationErrorSummary(evt.data?.toolErrorSummary),
               yielded: yieldedWaiting ? true : undefined,
+              messageId:
+                typeof evt.data?.messageId === "string" ? evt.data.messageId : undefined,
             },
           );
         }
@@ -1065,6 +1067,7 @@ export function createAgentEventHandler({
       firstAssistantTimingEntry?: ChatRunEntry;
       abortErrorMessage?: string;
       yielded?: true;
+      messageId?: string;
     },
   ) => {
     const { text, shouldSuppressSilent } = resolveBufferedChatTextState(clientRunId, sourceRunId, {
@@ -1085,6 +1088,10 @@ export function createAgentEventHandler({
         ...(spawnedBy && { spawnedBy }),
         seq,
         state: jobState === "done" ? ("final" as const) : ("aborted" as const),
+        // Stable transcript id of the assistant message this run produced, when
+        // available. External clients dedup on `(sessionKey, messageId)` instead
+        // of guessing the last transcript entry.
+        ...(opts?.messageId ? { messageId: opts.messageId } : {}),
         ...(jobState === "aborted" && opts?.abortErrorMessage
           ? { errorMessage: opts.abortErrorMessage }
           : {}),

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -231,6 +231,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       seq: 0,
       state: "final" as const,
       message,
+      messageId: appended.messageId,
     };
     context.broadcast("chat", chatPayload, {
       sessionKeys: sessionKey === "global" && agentId ? [`agent:${agentId}:global`] : [sessionKey],

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -596,4 +596,46 @@ describe("gateway server agent", () => {
 
     webchatWs.close();
   });
+
+  test("final chat event carries the produced assistant messageId", async () => {
+    await writeMainSessionEntry({ sessionId: "sess-main" });
+
+    const webchatWs = await connectWebchatClient({ port });
+
+    registerAgentRunContext("run-msgid-1", { sessionKey: "main" });
+
+    const finalChatP = onceMessage(
+      webchatWs,
+      (o) => {
+        if (o.type !== "event" || o.event !== "chat") {
+          return false;
+        }
+        const payload = o.payload as { state?: unknown; runId?: unknown } | undefined;
+        return payload?.state === "final" && payload.runId === "run-msgid-1";
+      },
+      8000,
+    );
+
+    emitAgentEvent({
+      runId: "run-msgid-1",
+      stream: "assistant",
+      data: { text: "hi from agent" },
+    });
+    // The lifecycle terminal carries the stable id of the assistant message the
+    // run persisted; the gateway must surface it on the final chat event so
+    // external clients can dedup on `(sessionKey, messageId)`.
+    emitAgentEvent({
+      runId: "run-msgid-1",
+      stream: "lifecycle",
+      data: { phase: "end", messageId: "msg-abc123" },
+    });
+
+    const evt = await finalChatP;
+    const payload = evt.payload && typeof evt.payload === "object" ? evt.payload : {};
+    expect(payload.state).toBe("final");
+    expect(payload.runId).toBe("run-msgid-1");
+    expect(payload.messageId).toBe("msg-abc123");
+
+    webchatWs.close();
+  });
 });


### PR DESCRIPTION
Closes #105593.

## What Problem This Solves

The terminal `chat` events (`final` / `aborted`) don't identify which message the run produced. A client reacting to a finished run has to re-fetch the transcript and guess "the last assistant message". That guess breaks when another entry lands after the run's message, and it gives no stable key for deduplicating deliveries of the same message.

This PR adds an optional `messageId` — the transcript id of the assistant message the run persisted — to both events, so clients can identify the exact message by id.

## Changes

- `packages/gateway-protocol`: optional `messageId` on `ChatFinalEventSchema` / `ChatAbortedEventSchema`.
- `src/agents/sessions/agent-session-base.ts` (+ event type): remember the persisted assistant message id at append time; `agent_end` carries it.
- `src/gateway/server-chat.ts`, `src/gateway/server-methods/chat.ts`: forward it onto the wire.
- `src/agents/cli-runner.ts` + `src/auto-reply/reply/agent-lifecycle-terminal.ts`: same for CLI backends (`claude-cli`, `codex-cli`, `google-gemini-cli`), which don't go through `AgentSession.appendMessage`. The transcript append already returned the id and it was being discarded; it now rides run meta to the terminal event.

The field is optional, so existing clients are unaffected. The tracking state is in-memory and reset per run — nothing new is persisted.

## Evidence

**Live test** — `src/gateway/gateway-final-message-id.live.test.ts`: real gateway, real websocket client, real `claude-cli` turn. The `messageId` on the final event the client received equals the id of the persisted assistant transcript row, and that row contains the run's unique reply token:

```
"finalEvent":  { "state": "final", "messageId": "f8115f3a-d9c6-4ff2-86c9-96c8101f8d8c" }
"transcript":  { "matchedRowId": "f8115f3a-d9c6-4ff2-86c9-96c8101f8d8c", "matchedRowContainsReplyToken": true }
```

This test caught a real gap: the first revision only covered the embedded runtime — on a real `claude-cli` run the final event carried no `messageId` at all.

**Unit tests** — `src/agents/sessions/agent-session.message-id.test.ts` drives the real persistence path (real `SessionManager` writing a real transcript file) and asserts the emitted id equals the persisted assistant row id for: final, aborted, contentless (id absent, not stale), tool-loop (last assistant message, not the tool result), auto-retry, and post-run injection (id stays correct when the transcript tail moves — the case where "last entry" guessing fails). Negative control: 5 of 6 fail without the patch.

## Open question

This makes transcript ids part of the wire contract. If you'd rather keep them internal and expose a `run → produced message` lookup instead, I'm happy to rework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
