### PR TITLE
fix(ui): isolate retained test modules

### DIFF
--- a/ui/src/components/config-form.node.ts
+++ b/ui/src/components/config-form.node.ts
@@ -22,8 +22,6 @@ import {
   type JsonSchema,
 } from "./config-form.shared.ts";
 
-export { matchesNodeSearch, parseConfigSearchQuery } from "./config-form.search.ts";
-
 const META_KEYS = new Set(["title", "description", "default", "nullable", "tags", "x-tags"]);
 
 function isAnySchema(schema: JsonSchema): boolean {

--- a/ui/src/components/config-form.search.node.test.ts
+++ b/ui/src/components/config-form.search.node.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { matchesNodeSearch, parseConfigSearchQuery } from "./config-form.node.ts";
+import { matchesNodeSearch, parseConfigSearchQuery } from "./config-form.search.ts";
 
 const schema = {
   type: "object",

--- a/ui/src/components/config-form.search.ts
+++ b/ui/src/components/config-form.search.ts
@@ -7,13 +7,13 @@ export type ConfigSearchCriteria = {
   tags: string[];
 };
 
-export type ConfigFieldMeta = {
+type ConfigFieldMeta = {
   label: string;
   help?: string;
   tags: string[];
 };
 
-export type ConfigSearchTextMatcher = (value: string, query: string) => boolean;
+type ConfigSearchTextMatcher = (value: string, query: string) => boolean;
 
 export function hasConfigSearchCriteria(criteria: ConfigSearchCriteria | undefined): boolean {
   return Boolean(criteria && (criteria.text.length > 0 || criteria.tags.length > 0));

--- a/ui/src/components/native-link-menu.test.ts
+++ b/ui/src/components/native-link-menu.test.ts
@@ -1,20 +1,17 @@
 /* @vitest-environment jsdom */
 
-import { html, render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "../i18n/index.ts";
 import { NativeLinkMenu, type NativeLinkMenuAction } from "./native-link-menu.ts";
 
-const NATIVE_LINK_MENU_ELEMENT_NAME = "test-openclaw-native-link-menu";
+const NATIVE_LINK_MENU_ELEMENT_NAME = `test-openclaw-native-link-menu-${crypto.randomUUID()}`;
 const containers: HTMLElement[] = [];
 
 // The non-isolated UI runner resets modules but not customElements. Register
 // the current class graph so instanceof and locale updates share one module.
 class TestNativeLinkMenu extends NativeLinkMenu {}
 
-if (!customElements.get(NATIVE_LINK_MENU_ELEMENT_NAME)) {
-  customElements.define(NATIVE_LINK_MENU_ELEMENT_NAME, TestNativeLinkMenu);
-}
+customElements.define(NATIVE_LINK_MENU_ELEMENT_NAME, TestNativeLinkMenu);
 
 beforeEach(async () => {
   await i18n.setLocale("en");
@@ -35,17 +32,13 @@ async function mountMenu(options: {
   const container = document.createElement("div");
   containers.push(container);
   document.body.append(container);
-  render(
-    html`<test-openclaw-native-link-menu
-      .x=${100}
-      .y=${100}
-      .trigger=${options.trigger ?? null}
-      .onAction=${options.onAction ?? (() => {})}
-      .onClose=${options.onClose ?? (() => {})}
-    ></test-openclaw-native-link-menu>`,
-    container,
-  );
-  const menu = container.querySelector(NATIVE_LINK_MENU_ELEMENT_NAME);
+  const menu = document.createElement(NATIVE_LINK_MENU_ELEMENT_NAME) as NativeLinkMenu;
+  menu.x = 100;
+  menu.y = 100;
+  menu.trigger = options.trigger ?? null;
+  menu.onAction = options.onAction ?? (() => {});
+  menu.onClose = options.onClose ?? (() => {});
+  container.append(menu);
   if (!(menu instanceof NativeLinkMenu)) {
     throw new Error("Expected native link menu");
   }

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -3,7 +3,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { i18n } from "../../i18n/index.ts";
 import type { TerminalGatewayClient } from "./terminal-connection.ts";
-import type { createIsolatedGhosttyTerminal } from "./terminal-runtime.ts";
 
 type CreateOptions = {
   parent: HTMLElement;
@@ -12,14 +11,18 @@ type CreateOptions = {
   onResize?: (size: { columns: number; rows: number }) => void;
 };
 
+type CreateGhosttyTerminalMock = Mock<
+  (options: CreateOptions) => Promise<ReturnType<typeof createTerminalController>>
+>;
+
 // Vitest resets this test module but can retain terminal-panel.ts. Reuse one
 // mock so retained imports and the current test graph share the same identity.
 const createGhosttyTerminalMock = vi.hoisted(() => {
   const scope = globalThis as typeof globalThis & {
-    openclawTestCreateGhosttyTerminalMock?: Mock<typeof createIsolatedGhosttyTerminal>;
+    openclawTestCreateGhosttyTerminalMock?: CreateGhosttyTerminalMock;
   };
   return (scope.openclawTestCreateGhosttyTerminalMock ??=
-    vi.fn<typeof createIsolatedGhosttyTerminal>());
+    vi.fn<(options: CreateOptions) => Promise<ReturnType<typeof createTerminalController>>>());
 });
 
 function createTerminalController(dispose: () => void = vi.fn()) {

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -1,8 +1,9 @@
 /* @vitest-environment jsdom */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { i18n } from "../../i18n/index.ts";
 import type { TerminalGatewayClient } from "./terminal-connection.ts";
+import type { createIsolatedGhosttyTerminal } from "./terminal-runtime.ts";
 
 type CreateOptions = {
   parent: HTMLElement;
@@ -15,9 +16,10 @@ type CreateOptions = {
 // mock so retained imports and the current test graph share the same identity.
 const createGhosttyTerminalMock = vi.hoisted(() => {
   const scope = globalThis as typeof globalThis & {
-    __openclawTestCreateGhosttyTerminalMock?: ReturnType<typeof vi.fn>;
+    openclawTestCreateGhosttyTerminalMock?: Mock<typeof createIsolatedGhosttyTerminal>;
   };
-  return (scope.__openclawTestCreateGhosttyTerminalMock ??= vi.fn());
+  return (scope.openclawTestCreateGhosttyTerminalMock ??=
+    vi.fn<typeof createIsolatedGhosttyTerminal>());
 });
 
 function createTerminalController(dispose: () => void = vi.fn()) {

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -11,7 +11,14 @@ type CreateOptions = {
   onResize?: (size: { columns: number; rows: number }) => void;
 };
 
-const createGhosttyTerminalMock = vi.hoisted(() => vi.fn());
+// Vitest resets this test module but can retain terminal-panel.ts. Reuse one
+// mock so retained imports and the current test graph share the same identity.
+const createGhosttyTerminalMock = vi.hoisted(() => {
+  const scope = globalThis as typeof globalThis & {
+    __openclawTestCreateGhosttyTerminalMock?: ReturnType<typeof vi.fn>;
+  };
+  return (scope.__openclawTestCreateGhosttyTerminalMock ??= vi.fn());
+});
 
 function createTerminalController(dispose: () => void = vi.fn()) {
   return {

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -52,15 +52,13 @@ vi.mock("./terminal-runtime.ts", () => {
 
 import { OpenClawTerminalPanel } from "./terminal-panel.ts";
 
-const TERMINAL_PANEL_ELEMENT_NAME = "test-openclaw-terminal-panel";
+const TERMINAL_PANEL_ELEMENT_NAME = `test-openclaw-terminal-panel-${crypto.randomUUID()}`;
 
 // Keep the mounted panel and i18n manager in the current module graph when
 // the non-isolated runner has retained an earlier production registration.
 class TestTerminalPanel extends OpenClawTerminalPanel {}
 
-if (!customElements.get(TERMINAL_PANEL_ELEMENT_NAME)) {
-  customElements.define(TERMINAL_PANEL_ELEMENT_NAME, TestTerminalPanel);
-}
+customElements.define(TERMINAL_PANEL_ELEMENT_NAME, TestTerminalPanel);
 
 describe("OpenClawTerminalPanel", () => {
   beforeEach(async () => {

--- a/ui/src/pages/approval/approval-page.test.ts
+++ b/ui/src/pages/approval/approval-page.test.ts
@@ -14,9 +14,11 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { applicationContext } from "../../app/context.ts";
 import { i18n } from "../../i18n/index.ts";
-import "./approval-page.ts";
+import { ApprovalPage } from "./approval-page.ts";
 
-const PROVIDER_ELEMENT_NAME = "test-approval-page-context-provider";
+const TEST_ELEMENT_SUFFIX = crypto.randomUUID();
+const PROVIDER_ELEMENT_NAME = `test-approval-page-context-provider-${TEST_ELEMENT_SUFFIX}`;
+const APPROVAL_PAGE_ELEMENT_NAME = `test-openclaw-approval-page-${TEST_ELEMENT_SUFFIX}`;
 
 class ApprovalPageContextProvider extends LitElement {
   private readonly contextProvider = new ContextProvider(this, {
@@ -28,9 +30,10 @@ class ApprovalPageContextProvider extends LitElement {
   }
 }
 
-if (!customElements.get(PROVIDER_ELEMENT_NAME)) {
-  customElements.define(PROVIDER_ELEMENT_NAME, ApprovalPageContextProvider);
-}
+// The non-isolated UI runner resets modules but not customElements. Register
+// the current provider and page graphs so context and locale state stay paired.
+customElements.define(PROVIDER_ELEMENT_NAME, ApprovalPageContextProvider);
+customElements.define(APPROVAL_PAGE_ELEMENT_NAME, class extends ApprovalPage {});
 
 type TestApprovalPage = HTMLElement & {
   approvalId: string;
@@ -122,7 +125,7 @@ function createPage(params: {
 }) {
   const source = createGateway(params.client, params.connected);
   const provider = document.createElement(PROVIDER_ELEMENT_NAME) as ApprovalPageContextProvider;
-  const page = document.createElement("openclaw-approval-page") as TestApprovalPage;
+  const page = document.createElement(APPROVAL_PAGE_ELEMENT_NAME) as TestApprovalPage;
   provider.setContext({
     basePath: "",
     gateway: source.gateway,


### PR DESCRIPTION
## What Problem This Solves

The non-isolated Control UI test runner resets modules while jsdom retains its custom-element registry and Vitest can retain imported production modules. The terminal, native-link, and approval-page tests used fixed test tags, so later evaluations could mount constructors from an earlier graph. The terminal component could also keep the earlier graph's runtime mock, making six terminal tests fail while the current mock saw no calls. The approval page could similarly format with an earlier graph's English locale after the current test selected German.

The config-search tests also reached private helpers through `config-form.node.ts`, leaving test-only re-exports and types in that production module. #105705 removed those exports, but its `checks-ui` failure and this PR's dependency failure created a circular landing block.

## Why This Change Was Made

- Give each terminal/native-link test-module evaluation a fresh UUID-suffixed custom-element tag.
- Give the approval page and its context provider matching fresh tags so locale, context, and the mounted element share one module graph.
- Keep one typed terminal-runtime mock identity on the worker global so retained production imports and the current test graph call the same mock.
- Import config-search helpers from their owning module and remove the private forwarding exports/types. The exact contributor commit from #105705 is retained with Vincent Koc as author.

This completes the isolation intent of #103345 and keeps each test bound to its current module graph without changing product code paths.

## User Impact

No product behavior changes. Control UI CI no longer fails unrelated PRs because terminal and locale-sensitive tests bind to stale constructors or mocks, and the config-search production module no longer exposes test-only helpers.

## Evidence

- Exact head: `4664d040f57286a124221443fb96791969b14202`.
- Hosted reproduction: `checks-node-compact-large-1` failed the approval German-locale assertion on the prior head in workflow https://github.com/openclaw/openclaw/actions/runs/29210221258/job/86697165125.
- Blacksmith Testbox `tbx_01kxc5db66zrmm1pym29qcbgcn`, synced to the exact head: focused approval-page test passed 12/12.
- Same Testbox: full default-worker Control UI suite passed 233 files and 3,695 tests.
- Same Testbox: exact six-file `pnpm check:changed` passed guards, formatting, core-test/UI typechecks, and lint with zero warnings or errors.
- Same Testbox: `pnpm deadcode:exports` matched the 5,962-entry baseline.
- Testbox workflow: https://github.com/openclaw/openclaw/actions/runs/29210621651.
- Fresh `gpt-5.6-sol` medium autoreview on the exact head: clean, no accepted/actionable findings, correctness confidence 0.87.
- Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/29210781581.
