### PR TITLE
chore(ui): drop dead config-form search exports

### DIFF
--- a/ui/src/components/config-form.node.ts
+++ b/ui/src/components/config-form.node.ts
@@ -22,8 +22,6 @@ import {
   type JsonSchema,
 } from "./config-form.shared.ts";
 
-export { matchesNodeSearch, parseConfigSearchQuery } from "./config-form.search.ts";
-
 const META_KEYS = new Set(["title", "description", "default", "nullable", "tags", "x-tags"]);
 
 function isAnySchema(schema: JsonSchema): boolean {

--- a/ui/src/components/config-form.search.node.test.ts
+++ b/ui/src/components/config-form.search.node.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { matchesNodeSearch, parseConfigSearchQuery } from "./config-form.node.ts";
+import { matchesNodeSearch, parseConfigSearchQuery } from "./config-form.search.ts";
 
 const schema = {
   type: "object",

--- a/ui/src/components/config-form.search.ts
+++ b/ui/src/components/config-form.search.ts
@@ -7,13 +7,13 @@ export type ConfigSearchCriteria = {
   tags: string[];
 };
 
-export type ConfigFieldMeta = {
+type ConfigFieldMeta = {
   label: string;
   help?: string;
   tags: string[];
 };
 
-export type ConfigSearchTextMatcher = (value: string, query: string) => boolean;
+type ConfigSearchTextMatcher = (value: string, query: string) => boolean;
 
 export function hasConfigSearchCriteria(criteria: ConfigSearchCriteria | undefined): boolean {
   return Boolean(criteria && (criteria.text.length > 0 || criteria.tags.length > 0));

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { i18n } from "../../i18n/index.ts";
 import type { TerminalGatewayClient } from "./terminal-connection.ts";
 
@@ -13,11 +13,14 @@ type CreateOptions = {
 
 // Vitest resets this test module but can retain terminal-panel.ts. Reuse one
 // mock so retained imports and the current test graph share the same identity.
+type CreateGhosttyTerminalMock = Mock<(options: CreateOptions) => Promise<unknown>>;
 const createGhosttyTerminalMock = vi.hoisted(() => {
   const scope = globalThis as typeof globalThis & {
-    __openclawTestCreateGhosttyTerminalMock?: ReturnType<typeof vi.fn>;
+    openclawTestCreateGhosttyTerminalMock?: CreateGhosttyTerminalMock;
   };
-  return (scope.__openclawTestCreateGhosttyTerminalMock ??= vi.fn());
+  return (scope.openclawTestCreateGhosttyTerminalMock ??= vi.fn<
+    (options: CreateOptions) => Promise<unknown>
+  >());
 });
 
 function createTerminalController(dispose: () => void = vi.fn()) {

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -11,7 +11,14 @@ type CreateOptions = {
   onResize?: (size: { columns: number; rows: number }) => void;
 };
 
-const createGhosttyTerminalMock = vi.hoisted(() => vi.fn());
+// Vitest resets this test module but can retain terminal-panel.ts. Reuse one
+// mock so retained imports and the current test graph share the same identity.
+const createGhosttyTerminalMock = vi.hoisted(() => {
+  const scope = globalThis as typeof globalThis & {
+    __openclawTestCreateGhosttyTerminalMock?: ReturnType<typeof vi.fn>;
+  };
+  return (scope.__openclawTestCreateGhosttyTerminalMock ??= vi.fn());
+});
 
 function createTerminalController(dispose: () => void = vi.fn()) {
   return {

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -18,9 +18,8 @@ const createGhosttyTerminalMock = vi.hoisted(() => {
   const scope = globalThis as typeof globalThis & {
     openclawTestCreateGhosttyTerminalMock?: CreateGhosttyTerminalMock;
   };
-  return (scope.openclawTestCreateGhosttyTerminalMock ??= vi.fn<
-    (options: CreateOptions) => Promise<unknown>
-  >());
+  return (scope.openclawTestCreateGhosttyTerminalMock ??=
+    vi.fn<(options: CreateOptions) => Promise<unknown>>());
 });
 
 function createTerminalController(dispose: () => void = vi.fn()) {


### PR DESCRIPTION
## What Problem This Solves

`main` CI is red on `check-dependencies`: the recent recursive settings-search fixes (89ccb5a90d6, 327ec31d23e) removed the last consumers of four exports, and `check-deadcode-exports` now flags them (`matchesNodeSearch`/`parseConfigSearchQuery` re-exports in `ui/src/components/config-form.node.ts`, `ConfigFieldMeta`/`ConfigSearchTextMatcher` types in `config-form.search.ts`). This blocks unrelated PRs whose merge trees inherit the failure (e.g. #105709).

## Why This Change Was Made

Delete the dead re-export line and unexport the two internally-used types instead of allowlisting them — knip confirms zero external importers; both types remain in use within their module.

## User Impact

None; main CI green again.

## Evidence

- `node scripts/check-deadcode-exports.mjs` → baseline matched, no unexpected unused exports (was: 4 unexpected).
- main-tip CI failure: https://github.com/openclaw/openclaw/actions/runs/29209314141/job/86694822618 (same failure on main's own run).
