### PR TITLE
fix(delivery): prevent duplicate generated-media handoffs

### DIFF
--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -855,6 +855,76 @@ describe("normalizeAgentCommandReplyPayloads", () => {
     expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
   });
 
+  it("preserves duplicate media needed for a delivery operation", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+    const delivery = { pin: { enabled: true, required: true } };
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ mediaUrls: ["/tmp/generated-image.png"], delivery }] as never,
+      result: {
+        ...createResult(),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            mediaUrls: ["/tmp/generated-image.png"],
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(latestOutboundDeliveryArgs().payloads).toEqual([
+      expect.objectContaining({
+        mediaUrls: ["/tmp/generated-image.png"],
+        delivery,
+      }),
+    ]);
+  });
+
+  it("drops audioAsVoice when its media was already delivered", async () => {
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ mediaUrls: ["/tmp/voice.ogg"], audioAsVoice: true }],
+      result: {
+        ...createResult(),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            mediaUrls: ["/tmp/voice.ogg"],
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.payloads).toEqual([]);
+    expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
+  });
+
   it("dedupes delivered file media before normalization can add a failure warning", async () => {
     createReplyMediaPathNormalizerMock.mockImplementationOnce(
       (..._args: unknown[]) =>

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -1,7 +1,10 @@
 // Covers agent-command reply normalization and outbound delivery status.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
-import type { ChannelOutboundAdapter } from "../../channels/plugins/types.js";
+import type {
+  ChannelOutboundAdapter,
+  ChannelThreadingAdapter,
+} from "../../channels/plugins/types.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
@@ -33,6 +36,9 @@ type NormalizeParams = Parameters<typeof normalizeAgentCommandReplyPayloads>[0];
 type RunResult = NormalizeParams["result"];
 type DeliverParams = Parameters<typeof deliverAgentCommandResult>[0];
 type TextPayloadLike = { text?: unknown };
+type ResolveReplyTransportParams = Parameters<
+  NonNullable<ChannelThreadingAdapter["resolveReplyTransport"]>
+>[0];
 type MediaNormalizerOptions = {
   sessionKey?: unknown;
   agentId?: unknown;
@@ -51,19 +57,28 @@ const slackOutboundForTest: ChannelOutboundAdapter = {
 // Two registries let tests switch between no-channel and Slack-capable delivery
 // without loading the full plugin runtime.
 const emptyRegistry = createTestRegistry([]);
+const slackPluginForTest = createOutboundTestPlugin({
+  id: "slack",
+  outbound: slackOutboundForTest,
+  messaging: {
+    enableInteractiveReplies: ({ cfg }) =>
+      (cfg.channels?.slack as { capabilities?: { interactiveReplies?: boolean } } | undefined)
+        ?.capabilities?.interactiveReplies === true,
+  },
+});
 const slackRegistry = createTestRegistry([
   {
     pluginId: "slack",
     source: "test",
-    plugin: createOutboundTestPlugin({
-      id: "slack",
-      outbound: slackOutboundForTest,
-      messaging: {
-        enableInteractiveReplies: ({ cfg }) =>
-          (cfg.channels?.slack as { capabilities?: { interactiveReplies?: boolean } } | undefined)
-            ?.capabilities?.interactiveReplies === true,
+    plugin: {
+      ...slackPluginForTest,
+      threading: {
+        resolveReplyTransport: ({ threadId }: ResolveReplyTransportParams) => ({
+          replyToId: threadId == null ? undefined : String(threadId),
+          threadId: null,
+        }),
       },
-    }),
+    },
   },
 ]);
 
@@ -110,6 +125,8 @@ function latestOutboundDeliveryArgs(): {
   channel?: string;
   to?: string;
   accountId?: string;
+  replyToId?: string | null;
+  threadId?: string | number | null;
   payloads: ReplyPayload[];
   bestEffort?: boolean;
   queuePolicy?: string;
@@ -122,6 +139,8 @@ function latestOutboundDeliveryArgs(): {
     channel?: string;
     to?: string;
     accountId?: string;
+    replyToId?: string | null;
+    threadId?: string | number | null;
     payloads: ReplyPayload[];
     bestEffort?: boolean;
     queuePolicy?: string;
@@ -788,6 +807,831 @@ describe("normalizeAgentCommandReplyPayloads", () => {
       },
     ]);
     expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
+  });
+
+  it("does not automatically redeliver text and media already sent to the same target", async () => {
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+        threadId: "171.222",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "The image is ready.", mediaUrls: ["/tmp/generated-image.png"] }],
+      result: {
+        ...createResult(),
+        didSendViaMessagingTool: true,
+        messagingToolSentTexts: ["The image is ready."],
+        messagingToolSentMediaUrls: ["/tmp/generated-image.png"],
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            threadId: "171.222",
+            text: "The image is ready.",
+            mediaUrls: ["/tmp/generated-image.png"],
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.payloads).toEqual([]);
+    expect(delivered.deliverySucceeded).toBe(true);
+    expectDeliveryStatusFields(delivered, {
+      requested: true,
+      attempted: false,
+      status: "suppressed",
+      succeeded: true,
+      reason: "no_visible_payload",
+    });
+    expect(delivered.messagingToolSentMediaUrls).toEqual(["/tmp/generated-image.png"]);
+    expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
+  });
+
+  it("dedupes delivered file media before normalization can add a failure warning", async () => {
+    createReplyMediaPathNormalizerMock.mockImplementationOnce(
+      (..._args: unknown[]) =>
+        async (payload: ReplyPayload): Promise<ReplyPayload> => ({
+          ...payload,
+          text: `${payload.text ?? ""}\n⚠️ Media failed.`,
+          mediaUrl: undefined,
+          mediaUrls: undefined,
+        }),
+    );
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "The image is ready.", mediaUrls: ["file:///tmp/generated-image.png"] }],
+      result: {
+        ...createResult(),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            text: "The image is ready.",
+            mediaUrls: ["file:///tmp/generated-image.png"],
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.payloads).toEqual([]);
+    expect(createReplyMediaPathNormalizerMock).not.toHaveBeenCalled();
+    expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
+  });
+
+  it("dedupes media encoded in a final MEDIA directive", async () => {
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "MEDIA:/tmp/generated-image.png" }],
+      result: {
+        ...createResult(),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            mediaUrls: ["/tmp/generated-image.png"],
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.payloads).toEqual([]);
+    expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps unsent media when only the matching text was already delivered", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+        threadId: "171.222",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "The image is ready.", mediaUrls: ["/tmp/generated-image.png"] }],
+      result: {
+        ...createResult(),
+        didSendViaMessagingTool: true,
+        messagingToolSentTexts: ["The image is ready."],
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            threadId: "171.222",
+            text: "The image is ready.",
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(latestOutboundDeliveryArgs().payloads).toEqual([
+      expect.objectContaining({
+        text: "",
+        mediaUrls: ["/tmp/generated-image.png"],
+      }),
+    ]);
+  });
+
+  it("dedupes sent text after applying the delivery response prefix", async () => {
+    const delivered = await deliverAgentCommandResult({
+      cfg: {
+        messages: { responsePrefix: "Bot:" },
+      } as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "Ready" }],
+      result: {
+        ...createResult(),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            text: "Ready",
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.payloads).toEqual([]);
+    expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
+  });
+
+  it("does not add unresolved dynamic prefixes to message-tool evidence", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {
+        messages: { responsePrefix: "[{modelFull}]" },
+      } as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "Ready" }],
+      result: {
+        ...createResult({
+          meta: {
+            durationMs: 1,
+            agentMeta: { provider: "openai", model: "gpt-5.4" },
+          } as RunResult["meta"],
+        }),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            text: "Ready",
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(latestOutboundDeliveryArgs().payloads).toEqual([
+      expect.objectContaining({ text: "[openai/gpt-5.4] Ready" }),
+    ]);
+  });
+
+  it("dedupes exact short text on a confirmed matching route", async () => {
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "Ready" }],
+      result: {
+        ...createResult(),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            text: "Ready",
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.payloads).toEqual([]);
+    expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
+  });
+
+  it("dedupes visible text after parsing a final reply directive", async () => {
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "[[reply_to_current]] Ready" }],
+      result: {
+        ...createResult(),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            text: "Ready",
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.payloads).toEqual([]);
+    expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
+  });
+
+  it("does not apply ambiguous global evidence across message-tool targets", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "Ready", mediaUrls: ["/tmp/generated-image.png"] }],
+      result: {
+        ...createResult(),
+        messagingToolSentTexts: ["Ready"],
+        messagingToolSentMediaUrls: ["/tmp/generated-image.png"],
+        messagingToolSentTargets: [
+          { tool: "message", provider: "slack", to: "channel:C123" },
+          { tool: "message", provider: "slack", to: "channel:C999" },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(latestOutboundDeliveryArgs().payloads).toEqual([
+      expect.objectContaining({
+        text: "Ready",
+        mediaUrls: ["/tmp/generated-image.png"],
+      }),
+    ]);
+  });
+
+  it("preserves final text that extends a message-tool send", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "The image is ready. Dimensions are 1024x1024." }],
+      result: {
+        ...createResult(),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            text: "The image is ready.",
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(latestOutboundDeliveryArgs().payloads).toEqual([
+      expect.objectContaining({
+        text: "The image is ready. Dimensions are 1024x1024.",
+      }),
+    ]);
+  });
+
+  it.each([
+    { name: "emoji", sentText: "❌ Failed", finalText: "✅ Failed" },
+    { name: "letter case", sentText: "US", finalText: "us" },
+    {
+      name: "significant whitespace",
+      sentText: "const x = 1;\n  return x;",
+      finalText: "const x = 1;\n return x;",
+    },
+  ])("preserves $name differences in exact replies", async ({ sentText, finalText }) => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: finalText }],
+      result: {
+        ...createResult(),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            text: sentText,
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(latestOutboundDeliveryArgs().payloads).toEqual([
+      expect.objectContaining({ text: finalText }),
+    ]);
+  });
+
+  it("matches dedupe against the command thread instead of payload reply metadata", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+        threadId: "thread-a",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "The image is ready.", replyToId: "thread-b" }],
+      result: {
+        ...createResult(),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            threadId: "thread-b",
+            text: "The image is ready.",
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
+    expect(latestOutboundDeliveryArgs().replyToId).toBe("thread-a");
+  });
+
+  it("keeps presentation content when only the matching text was already delivered", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+    const presentation = {
+      blocks: [{ type: "buttons" as const, buttons: [{ label: "Open", value: "open" }] }],
+    };
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "The image is ready.", presentation }] as never,
+      result: {
+        ...createResult(),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            text: "The image is ready.",
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(latestOutboundDeliveryArgs().payloads).toEqual([
+      expect.objectContaining({
+        text: "",
+        presentation,
+      }),
+    ]);
+  });
+
+  it("keeps location content when only the matching text was already delivered", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+    const location = { latitude: 48.858844, longitude: 2.294351 };
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "The image is ready.", location }] as never,
+      result: {
+        ...createResult(),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            text: "The image is ready.",
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(latestOutboundDeliveryArgs().payloads).toEqual([
+      expect.objectContaining({
+        text: "",
+        location,
+      }),
+    ]);
+  });
+
+  it("keeps BTW content when the base text was already delivered", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "The image is ready.", btw: { question: "What changed?" } }] as never,
+      result: {
+        ...createResult(),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            text: "The image is ready.",
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(latestOutboundDeliveryArgs().payloads).toEqual([
+      expect.objectContaining({
+        text: "BTW\nQuestion: What changed?\n\nThe image is ready.",
+      }),
+    ]);
+  });
+
+  it("keeps delivery operations when the base text was already delivered", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+    const delivery = { pin: { enabled: true, required: true } };
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "Ready", delivery }] as never,
+      result: {
+        ...createResult(),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            text: "Ready",
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(latestOutboundDeliveryArgs().payloads).toEqual([
+      expect.objectContaining({ text: "Ready", delivery }),
+    ]);
+  });
+
+  it("does not dedupe an explicit send from a different account against the default account", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "Ready" }],
+      result: {
+        ...createResult(),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            accountId: "work",
+            to: "channel:C123",
+            text: "Ready",
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
+    expect(latestOutboundDeliveryArgs().accountId).toBe("default");
+  });
+
+  it("does not dedupe accountless default-account evidence against an explicit account", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+        replyAccountId: "work",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "Ready" }],
+      result: {
+        ...createResult(),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            text: "Ready",
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
+    expect(latestOutboundDeliveryArgs().accountId).toBe("work");
+  });
+
+  it("dedupes accountless evidence against the non-default run account", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+        replyAccountId: "work",
+        runContext: {
+          messageChannel: "slack",
+          currentChannelId: "channel:C123",
+          accountId: "work",
+        },
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "Ready" }],
+      result: {
+        ...createResult(),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            text: "Ready",
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
+  });
+
+  it("does not dedupe accountless source evidence against an explicit cross-account delivery", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+        replyAccountId: "other",
+        runContext: {
+          messageChannel: "slack",
+          currentChannelId: "channel:C123",
+          accountId: "work",
+        },
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "Ready" }],
+      result: {
+        ...createResult(),
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C123",
+            text: "Ready",
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
+    expect(latestOutboundDeliveryArgs().accountId).toBe("other");
+  });
+
+  it("does not dedupe targetless cross-session messaging evidence", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "The image is ready." }],
+      result: {
+        ...createResult(),
+        didSendViaMessagingTool: true,
+        messagingToolSentTexts: ["The image is ready."],
+      } as RunResult,
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
+    expect(latestOutboundDeliveryArgs().payloads).toEqual([
+      expect.objectContaining({ text: "The image is ready." }),
+    ]);
+  });
+
+  it("keeps automatic delivery when message-tool media went to another target", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "completion handoff",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "channel:C123",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "The image is ready.", mediaUrls: ["/tmp/generated-image.png"] }],
+      result: {
+        ...createResult(),
+        messagingToolSentTexts: ["The image is ready."],
+        messagingToolSentMediaUrls: ["/tmp/generated-image.png"],
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:OTHER",
+            text: "The image is ready.",
+            mediaUrls: ["/tmp/generated-image.png"],
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
+    expect(latestOutboundDeliveryArgs().payloads).toEqual([
+      expect.objectContaining({
+        text: "The image is ready.",
+        mediaUrls: ["/tmp/generated-image.png"],
+      }),
+    ]);
   });
 
   it("adds sent deliveryStatus to JSON output after delivery completes", async () => {

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -1483,6 +1483,40 @@ describe("normalizeAgentCommandReplyPayloads", () => {
     ]);
   });
 
+  it.each([{ delivery: { pin: false } }, { delivery: { pin: { enabled: false } } }])(
+    "dedupes text for disabled delivery metadata: $delivery",
+    async ({ delivery }) => {
+      const delivered = await deliverAgentCommandResult({
+        cfg: {} as OpenClawConfig,
+        deps: {} as CliDeps,
+        runtime: { log: vi.fn(), error: vi.fn() } as never,
+        opts: {
+          message: "completion handoff",
+          deliver: true,
+          replyChannel: "slack",
+          replyTo: "channel:C123",
+        } as AgentCommandOpts,
+        outboundSession: undefined,
+        sessionEntry: undefined,
+        payloads: [{ text: "Ready", delivery }] as never,
+        result: {
+          ...createResult(),
+          messagingToolSentTargets: [
+            {
+              tool: "message",
+              provider: "slack",
+              to: "channel:C123",
+              text: "Ready",
+            },
+          ],
+        } as RunResult,
+      });
+
+      expect(delivered.payloads).toEqual([]);
+      expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("does not dedupe an explicit send from a different account against the default account", async () => {
     deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
 

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -617,9 +617,10 @@ export async function deliverAgentCommandResult(
       opts.deliveryTargetMode ??
       effectiveDeliveryPlan.deliveryTargetMode ??
       (opts.to ? "explicit" : "implicit");
-    const defaultAccountId = deliveryPlugin
-      ? resolveChannelDefaultAccountId({ plugin: deliveryPlugin, cfg })
-      : undefined;
+    const defaultAccountId =
+      !effectiveDeliveryPlan.resolvedAccountId && deliveryPlugin?.config?.listAccountIds
+        ? resolveChannelDefaultAccountId({ plugin: deliveryPlugin, cfg })
+        : undefined;
     const resolvedAccountId = effectiveDeliveryPlan.resolvedAccountId ?? defaultAccountId;
     const resolvedDeliveryPlan =
       resolvedAccountId === effectiveDeliveryPlan.resolvedAccountId

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -6,14 +6,21 @@ import {
   resolveDefaultAgentId,
 } from "../../agents/agent-scope-config.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
-import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { copyReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { normalizeReplyPayload } from "../../auto-reply/reply/normalize-reply.js";
 import { createReplyMediaPathNormalizer } from "../../auto-reply/reply/reply-media-paths.runtime.js";
+import { formatBtwTextForExternalDelivery } from "../../auto-reply/reply/reply-payloads-base.js";
+import {
+  filterMessagingToolMediaDuplicates,
+  resolveMessagingToolPayloadDedupe,
+} from "../../auto-reply/reply/reply-payloads-dedupe.runtime.js";
+import { resolveResponsePrefixTemplate } from "../../auto-reply/reply/response-prefix-template.js";
 import {
   sendDurableMessageBatch,
   serializeDurableMessagePayloadOutcomes,
   type SerializedDurableMessagePayloadOutcome,
 } from "../../channels/message/runtime.js";
+import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import { createReplyPrefixContext } from "../../channels/reply-prefix.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
@@ -30,10 +37,12 @@ import {
   createOutboundPayloadPlan,
   formatOutboundPayloadLog,
   type NormalizedOutboundPayload,
+  projectOutboundPayloadPlanForDelivery,
   projectOutboundPayloadPlanForJson,
   projectOutboundPayloadPlanForOutbound,
 } from "../../infra/outbound/payloads.js";
 import type { OutboundSessionContext } from "../../infra/outbound/session-context.js";
+import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import type { MessagingToolSend } from "../embedded-agent-messaging.types.js";
@@ -306,16 +315,19 @@ async function normalizeReplyMediaPathsForDelivery(params: {
   outboundSession: OutboundSessionContext | undefined;
   deliveryChannel: string;
   accountId?: string;
-}): Promise<ReplyPayload[]> {
+}): Promise<{
+  payloads: ReplyPayload[];
+  normalizeMediaPaths?: (payload: ReplyPayload) => Promise<ReplyPayload>;
+}> {
   if (params.payloads.length === 0) {
-    return params.payloads;
+    return { payloads: params.payloads };
   }
   const agentId =
     params.outboundSession?.agentId ??
     resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg });
   const workspaceDir = agentId ? resolveAgentWorkspaceDir(params.cfg, agentId) : undefined;
   if (!workspaceDir) {
-    return params.payloads;
+    return { payloads: params.payloads };
   }
   const normalizeMediaPaths = createReplyMediaPathNormalizer({
     cfg: params.cfg,
@@ -329,7 +341,131 @@ async function normalizeReplyMediaPathsForDelivery(params: {
   for (const payload of params.payloads) {
     result.push(await normalizeMediaPaths(payload));
   }
-  return result;
+  return { payloads: result, normalizeMediaPaths };
+}
+
+async function normalizeSentMediaUrlsForDelivery(params: {
+  sentMediaUrls: readonly string[];
+  normalizeMediaPaths?: (payload: ReplyPayload) => Promise<ReplyPayload>;
+}): Promise<string[]> {
+  const normalizedUrls: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of params.sentMediaUrls) {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      continue;
+    }
+    if (!seen.has(trimmed)) {
+      seen.add(trimmed);
+      normalizedUrls.push(trimmed);
+    }
+    if (!params.normalizeMediaPaths) {
+      continue;
+    }
+    try {
+      const normalized = await params.normalizeMediaPaths({
+        mediaUrl: trimmed,
+        mediaUrls: [trimmed],
+      });
+      for (const mediaUrl of [normalized.mediaUrl, ...(normalized.mediaUrls ?? [])]) {
+        const candidate = mediaUrl?.trim();
+        if (!candidate || seen.has(candidate)) {
+          continue;
+        }
+        seen.add(candidate);
+        normalizedUrls.push(candidate);
+      }
+    } catch {
+      // Keep the original evidence. Delivery normalization will report invalid media separately.
+    }
+  }
+  return normalizedUrls;
+}
+
+const UNRESOLVED_RESPONSE_PREFIX_VAR_PATTERN = /\{[a-zA-Z][a-zA-Z0-9.]*\}/;
+
+async function filterAlreadyDeliveredReplyPayloads(params: {
+  cfg: OpenClawConfig;
+  payloads: ReplyPayload[];
+  result: RunResult;
+  deliveryChannel: string;
+  deliveryTarget: string;
+  accountId?: string;
+  sourceAccountId?: string;
+  defaultAccountId?: string;
+  threadId?: string | number;
+  normalizeMediaPaths?: (payload: ReplyPayload) => Promise<ReplyPayload>;
+  normalizeSentTexts?: (sentTexts: readonly string[]) => string[];
+}): Promise<ReplyPayload[]> {
+  const sentTexts = params.result.messagingToolSentTexts ?? [];
+  const sentMediaUrls = params.result.messagingToolSentMediaUrls ?? [];
+  // The message tool injects the run account after telemetry captures its
+  // original args. Preserve that source route before falling back to default.
+  const implicitToolAccountId = params.sourceAccountId ?? params.defaultAccountId;
+  const sentTargets = (params.result.messagingToolSentTargets ?? []).flatMap((target) => {
+    if (target.accountId || !params.accountId) {
+      return [target];
+    }
+    return implicitToolAccountId ? [{ ...target, accountId: implicitToolAccountId }] : [];
+  });
+  if (sentTexts.length === 0 && sentMediaUrls.length === 0 && sentTargets.length === 0) {
+    return params.payloads;
+  }
+
+  const decision = resolveMessagingToolPayloadDedupe({
+    config: params.cfg,
+    messageProvider: params.deliveryChannel,
+    messagingToolSentTargets: sentTargets,
+    originatingTo: params.deliveryTarget,
+    originatingThreadId: params.threadId,
+    accountId: params.accountId,
+  });
+  if (!decision.matchingRoute) {
+    return params.payloads;
+  }
+  const routeSentMediaUrls = decision.useGlobalSentMediaUrlEvidenceFallback
+    ? sentMediaUrls
+    : decision.routeSentMediaUrls;
+  const rawRouteSentTexts = decision.useGlobalSentTextEvidenceFallback
+    ? sentTexts
+    : decision.routeSentTexts;
+  const routeSentTexts = params.normalizeSentTexts?.(rawRouteSentTexts) ?? rawRouteSentTexts;
+  const exactRouteSentTexts = new Set(routeSentTexts.filter((text) => Boolean(text.trim())));
+  const normalizedSentMediaUrls = await normalizeSentMediaUrlsForDelivery({
+    sentMediaUrls: routeSentMediaUrls,
+    normalizeMediaPaths: params.normalizeMediaPaths,
+  });
+  const mediaFiltered = filterMessagingToolMediaDuplicates({
+    payloads: params.payloads,
+    sentMediaUrls: normalizedSentMediaUrls,
+  });
+
+  const filteredPayloads: ReplyPayload[] = [];
+  for (const candidate of mediaFiltered) {
+    if (candidate.delivery) {
+      filteredPayloads.push(candidate);
+      continue;
+    }
+    const effectiveCandidateText =
+      formatBtwTextForExternalDelivery(candidate) ?? candidate.text ?? "";
+    if (!effectiveCandidateText.trim() || !exactRouteSentTexts.has(effectiveCandidateText)) {
+      filteredPayloads.push(candidate);
+      continue;
+    }
+    const withoutDuplicateText = copyReplyPayloadMetadata(candidate, {
+      ...candidate,
+      text: undefined,
+    });
+    if (
+      hasReplyPayloadContent(withoutDuplicateText, {
+        trimText: true,
+        extraContent: withoutDuplicateText.location != null,
+      })
+    ) {
+      filteredPayloads.push(withoutDuplicateText);
+    }
+  }
+  return filteredPayloads;
 }
 
 /** Normalizes reply payloads and media paths before delivery. */
@@ -342,6 +478,7 @@ export function normalizeAgentCommandReplyPayloads(params: {
   deliveryChannel?: string;
   accountId?: string;
   applyChannelTransforms?: boolean;
+  includeRunModelContext?: boolean;
 }): ReplyPayload[] {
   const payloads = params.payloads ?? [];
   if (payloads.length === 0) {
@@ -372,7 +509,7 @@ export function normalizeAgentCommandReplyPayloads(params: {
   });
   const modelUsed = params.result.meta.agentMeta?.model;
   const providerUsed = params.result.meta.agentMeta?.provider;
-  if (providerUsed && modelUsed) {
+  if (params.includeRunModelContext !== false && providerUsed && modelUsed) {
     replyPrefix.onModelSelected({
       provider: providerUsed,
       model: modelUsed,
@@ -380,6 +517,16 @@ export function normalizeAgentCommandReplyPayloads(params: {
     });
   }
   const responsePrefixContext = replyPrefix.responsePrefixContextProvider();
+  const resolvedResponsePrefix = resolveResponsePrefixTemplate(
+    replyPrefix.responsePrefix,
+    responsePrefixContext,
+  );
+  const responsePrefix =
+    params.includeRunModelContext === false &&
+    resolvedResponsePrefix &&
+    UNRESOLVED_RESPONSE_PREFIX_VAR_PATTERN.test(resolvedResponsePrefix)
+      ? undefined
+      : replyPrefix.responsePrefix;
   const transformReplyPayload = deliveryPlugin?.messaging?.transformReplyPayload
     ? (payload: ReplyPayload) =>
         deliveryPlugin.messaging?.transformReplyPayload?.({
@@ -392,7 +539,7 @@ export function normalizeAgentCommandReplyPayloads(params: {
   const normalizedPayloads: ReplyPayload[] = [];
   for (const payload of payloads) {
     const normalized = normalizeReplyPayload(payload as ReplyPayload, {
-      responsePrefix: replyPrefix.responsePrefix,
+      responsePrefix,
       applyChannelTransforms,
       responsePrefixContext,
       transformReplyPayload,
@@ -470,12 +617,19 @@ export async function deliverAgentCommandResult(
       opts.deliveryTargetMode ??
       effectiveDeliveryPlan.deliveryTargetMode ??
       (opts.to ? "explicit" : "implicit");
-    const resolvedAccountId = effectiveDeliveryPlan.resolvedAccountId;
+    const defaultAccountId = deliveryPlugin
+      ? resolveChannelDefaultAccountId({ plugin: deliveryPlugin, cfg })
+      : undefined;
+    const resolvedAccountId = effectiveDeliveryPlan.resolvedAccountId ?? defaultAccountId;
+    const resolvedDeliveryPlan =
+      resolvedAccountId === effectiveDeliveryPlan.resolvedAccountId
+        ? effectiveDeliveryPlan
+        : { ...effectiveDeliveryPlan, resolvedAccountId };
     const resolved =
       deliver && isDeliveryChannelKnown && deliveryChannel
         ? resolveAgentOutboundTarget({
             cfg,
-            plan: effectiveDeliveryPlan,
+            plan: resolvedDeliveryPlan,
             targetMode,
             validateExplicitTarget: true,
           })
@@ -494,10 +648,11 @@ export async function deliverAgentCommandResult(
     return {
       deliveryPlan,
       deliveryChannel,
-      effectiveDeliveryPlan,
+      effectiveDeliveryPlan: resolvedDeliveryPlan,
       deliveryPlugin,
       isDeliveryChannelKnown,
       targetMode,
+      defaultAccountId,
       resolvedAccountId,
       resolved,
       resolvedTarget: resolved.resolvedTarget,
@@ -570,6 +725,7 @@ export async function deliverAgentCommandResult(
   const {
     deliveryChannel,
     isDeliveryChannelKnown,
+    defaultAccountId,
     resolvedAccountId,
     resolvedTarget,
     deliveryTarget,
@@ -624,22 +780,72 @@ export async function deliverAgentCommandResult(
     accountId: resolvedAccountId,
     applyChannelTransforms: deliver,
   });
+  const canonicalReplyPayloads = projectOutboundPayloadPlanForDelivery(
+    createOutboundPayloadPlan(normalizedReplyPayloads),
+  );
+  const shouldFilterDeliveredPayloads =
+    deliver &&
+    !deliveryStatus &&
+    Boolean(deliveryTarget) &&
+    !isInternalMessageChannel(deliveryChannel);
+  const normalizeSentTexts = (sentTexts: readonly string[]) =>
+    normalizeAgentCommandReplyPayloads({
+      cfg,
+      opts,
+      outboundSession,
+      payloads: sentTexts.map((text) => ({ text })),
+      result,
+      deliveryChannel,
+      accountId: resolvedAccountId,
+      applyChannelTransforms: deliver,
+      includeRunModelContext: false,
+    }).flatMap((payload) => (payload.text?.trim() ? [payload.text] : []));
+  const filterDeliveredPayloads = (
+    replyPayloads: ReplyPayload[],
+    normalizeMediaPaths?: (payload: ReplyPayload) => Promise<ReplyPayload>,
+  ) => {
+    if (!shouldFilterDeliveredPayloads || !deliveryTarget) {
+      return Promise.resolve(replyPayloads);
+    }
+    return filterAlreadyDeliveredReplyPayloads({
+      cfg,
+      payloads: replyPayloads,
+      result,
+      deliveryChannel,
+      deliveryTarget,
+      accountId: resolvedAccountId,
+      sourceAccountId: turnSourceAccountId,
+      defaultAccountId,
+      // Command delivery projects payloads onto one batch route below, so
+      // per-payload reply metadata does not change the destination here.
+      threadId: resolvedThreadTarget ?? resolvedReplyToId ?? undefined,
+      normalizeMediaPaths,
+      normalizeSentTexts,
+    });
+  };
+  // Remove exact raw media matches before blocked-path normalization can turn
+  // a successful message-tool send into a false media failure warning.
+  const rawFilteredReplyPayloads = await filterDeliveredPayloads(canonicalReplyPayloads);
   // Auto-reply-style media-path normalization must also run for the CLI
   // `--deliver` path. Without it, relative reply media paths reach the
   // outbound loader unresolved and `assertLocalMediaAllowed` fails with
   // "Local media path is not under an allowed directory". Mirrors the
   // normalizer wiring in `src/auto-reply/reply/agent-runner.ts`.
-  const mediaNormalizedReplyPayloads =
+  const mediaNormalization =
     deliver && !deliveryStatus && !isInternalMessageChannel(deliveryChannel)
       ? await normalizeReplyMediaPathsForDelivery({
           cfg,
-          payloads: normalizedReplyPayloads,
+          payloads: rawFilteredReplyPayloads,
           sessionKey: effectiveSessionKey,
           outboundSession,
           deliveryChannel,
           accountId: resolvedAccountId,
         })
-      : normalizedReplyPayloads;
+      : { payloads: rawFilteredReplyPayloads };
+  const mediaNormalizedReplyPayloads = await filterDeliveredPayloads(
+    mediaNormalization.payloads,
+    mediaNormalization.normalizeMediaPaths,
+  );
   params.assertDeliveryCurrent?.();
   const outboundPayloadPlan = createOutboundPayloadPlan(mediaNormalizedReplyPayloads);
   const normalizedPayloads = projectOutboundPayloadPlanForJson(outboundPayloadPlan);

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -12,6 +12,7 @@ import { createReplyMediaPathNormalizer } from "../../auto-reply/reply/reply-med
 import { formatBtwTextForExternalDelivery } from "../../auto-reply/reply/reply-payloads-base.js";
 import {
   filterMessagingToolMediaDuplicates,
+  hasEnabledDeliveryOperation,
   resolveMessagingToolPayloadDedupe,
 } from "../../auto-reply/reply/reply-payloads-dedupe.runtime.js";
 import { resolveResponsePrefixTemplate } from "../../auto-reply/reply/response-prefix-template.js";
@@ -442,7 +443,7 @@ async function filterAlreadyDeliveredReplyPayloads(params: {
 
   const filteredPayloads: ReplyPayload[] = [];
   for (const candidate of mediaFiltered) {
-    if (candidate.delivery) {
+    if (hasEnabledDeliveryOperation(candidate)) {
       filteredPayloads.push(candidate);
       continue;
     }

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -412,7 +412,7 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads[0]?.text).toBe("discord-only text");
   });
 
-  it("falls back to global text dedupe for legacy multi-target messaging telemetry", async () => {
+  it("does not apply ambiguous global text evidence across multiple routes", async () => {
     const { replyPayloads } = await buildReplyPayloads({
       ...baseParams,
       payloads: [{ text: "hello world!" }],
@@ -425,7 +425,8 @@ describe("buildReplyPayloads media filter integration", () => {
       ],
     });
 
-    expect(replyPayloads).toHaveLength(0);
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]?.text).toBe("hello world!");
   });
 
   it("dedupes final media only against message-tool media sent to the same route", async () => {
@@ -455,7 +456,7 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads[0]?.mediaUrl).toBe("file:///tmp/discord-photo.jpg");
   });
 
-  it("falls back to global media dedupe for legacy multi-target messaging telemetry", async () => {
+  it("does not apply ambiguous global media evidence across multiple routes", async () => {
     const { replyPayloads } = await buildReplyPayloads({
       ...baseParams,
       payloads: [{ text: "photo", mediaUrl: "file:///tmp/photo.jpg" }],
@@ -471,8 +472,7 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads).toHaveLength(1);
     expectFields(replyPayloads[0], {
       text: "photo",
-      mediaUrl: undefined,
-      mediaUrls: undefined,
+      mediaUrl: "file:///tmp/photo.jpg",
     });
   });
 

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -251,7 +251,7 @@ describe("resolveFollowupDeliveryPayloads", () => {
     ).toStrictEqual([]);
   });
 
-  it("falls back to global text dedupe for legacy multi-target messaging telemetry", () => {
+  it("does not apply ambiguous global text evidence across multiple routes", () => {
     expect(
       resolveFollowupDeliveryPayloads({
         cfg: baseConfig,
@@ -264,7 +264,7 @@ describe("resolveFollowupDeliveryPayloads", () => {
           { tool: "discord", provider: "discord", to: "channel:C2" },
         ],
       }),
-    ).toStrictEqual([]);
+    ).toStrictEqual([{ text: "hello world!" }]);
   });
 
   it("dedupes final media only against message-tool media sent to the same route", () => {
@@ -293,7 +293,7 @@ describe("resolveFollowupDeliveryPayloads", () => {
     ).toEqual([{ text: "photo", mediaUrl: "file:///tmp/discord-photo.jpg" }]);
   });
 
-  it("falls back to global media dedupe for legacy multi-target messaging telemetry", () => {
+  it("does not apply ambiguous global media evidence across multiple routes", () => {
     expect(
       resolveFollowupDeliveryPayloads({
         cfg: baseConfig,
@@ -306,7 +306,7 @@ describe("resolveFollowupDeliveryPayloads", () => {
           { tool: "discord", provider: "discord", to: "channel:C2" },
         ],
       }),
-    ).toEqual([{ text: "photo", mediaUrl: undefined, mediaUrls: undefined }]);
+    ).toEqual([{ text: "photo", mediaUrl: "file:///tmp/photo.jpg" }]);
   });
 
   it("delivers distinct replies when a messaging tool already sent to the same provider and target", () => {

--- a/src/auto-reply/reply/reply-payloads-base.ts
+++ b/src/auto-reply/reply/reply-payloads-base.ts
@@ -90,7 +90,9 @@ export function applyReplyTagsToPayload(
 
 /** True when a payload has visible or playable content for delivery. */
 export function isRenderablePayload(payload: ReplyPayload): boolean {
-  return hasReplyPayloadContent(payload, { extraContent: payload.audioAsVoice });
+  return hasReplyPayloadContent(payload, {
+    extraContent: payload.audioAsVoice || payload.location != null,
+  });
 }
 
 /** True when a payload should stay internal as reasoning-only output. */

--- a/src/auto-reply/reply/reply-payloads-dedupe.runtime.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.runtime.ts
@@ -2,6 +2,7 @@
 export {
   filterMessagingToolDuplicates,
   filterMessagingToolMediaDuplicates,
+  hasEnabledDeliveryOperation,
   resolveMessagingToolPayloadDedupe,
   shouldDedupeMessagingToolRepliesForRoute,
   type MessagingToolPayloadDedupeDecision,

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -114,7 +114,7 @@ export function filterMessagingToolMediaDuplicates(params: {
 
 export function hasEnabledDeliveryOperation(payload: ReplyPayload): boolean {
   const pin = payload.delivery?.pin;
-  return pin === true || (typeof pin === "object" && pin.enabled === true);
+  return pin === true || (typeof pin === "object" && pin.enabled);
 }
 
 function normalizeMediaForDedupe(value: string): string {

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -57,6 +57,14 @@ export function filterMessagingToolMediaDuplicates(params: {
 
   let nextPayloads: ReplyPayload[] | undefined;
   for (const [index, payload] of payloads.entries()) {
+    // Delivery operations apply to the message created by this payload. Keep
+    // its content intact so dedupe cannot silently skip the operation.
+    if (hasEnabledDeliveryOperation(payload)) {
+      if (nextPayloads) {
+        nextPayloads.push(payload);
+      }
+      continue;
+    }
     const mediaUrl = payload.mediaUrl;
     const mediaUrls = payload.mediaUrls;
     const stripSingle = mediaUrl && sentSet.has(normalizeMediaForDedupe(mediaUrl));
@@ -85,10 +93,15 @@ export function filterMessagingToolMediaDuplicates(params: {
       continue;
     }
 
+    const nextMediaUrl = stripSingle ? undefined : mediaUrl;
+    const nextMediaUrls = filteredUrls?.length ? filteredUrls : undefined;
     const nextPayload = copyReplyPayloadMetadata(payload, {
       ...payload,
-      mediaUrl: stripSingle ? undefined : mediaUrl,
-      mediaUrls: filteredUrls?.length ? filteredUrls : undefined,
+      mediaUrl: nextMediaUrl,
+      mediaUrls: nextMediaUrls,
+      ...(payload.audioAsVoice === true && !nextMediaUrl && !nextMediaUrls
+        ? { audioAsVoice: undefined }
+        : {}),
     });
     if (!nextPayloads) {
       nextPayloads = payloads.slice(0, index);
@@ -97,6 +110,11 @@ export function filterMessagingToolMediaDuplicates(params: {
   }
 
   return nextPayloads ?? payloads;
+}
+
+function hasEnabledDeliveryOperation(payload: ReplyPayload): boolean {
+  const pin = payload.delivery?.pin;
+  return pin === true || (typeof pin === "object" && pin.enabled === true);
 }
 
 function normalizeMediaForDedupe(value: string): string {

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -112,7 +112,7 @@ export function filterMessagingToolMediaDuplicates(params: {
   return nextPayloads ?? payloads;
 }
 
-function hasEnabledDeliveryOperation(payload: ReplyPayload): boolean {
+export function hasEnabledDeliveryOperation(payload: ReplyPayload): boolean {
   const pin = payload.delivery?.pin;
   return pin === true || (typeof pin === "object" && pin.enabled === true);
 }

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -390,13 +390,14 @@ export function resolveMessagingToolPayloadDedupe(params: {
       Array.isArray(target.mediaUrls) &&
       target.mediaUrls.some((url) => typeof url === "string" && Boolean(url.trim())),
   );
+  const allTargetsMatchRoute = matchingRoute && matchingTargets.length === sentTargets.length;
 
   return {
     shouldDedupePayloads: matchingRoute || sentTargets.length === 0,
     matchingRoute,
     routeSentTexts,
     routeSentMediaUrls,
-    useGlobalSentTextEvidenceFallback: matchingRoute && !hasTargetTextEvidence,
-    useGlobalSentMediaUrlEvidenceFallback: matchingRoute && !hasTargetMediaUrlEvidence,
+    useGlobalSentTextEvidenceFallback: allTargetsMatchRoute && !hasTargetTextEvidence,
+    useGlobalSentMediaUrlEvidenceFallback: allTargetsMatchRoute && !hasTargetMediaUrlEvidence,
   };
 }

--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -78,6 +78,41 @@ describe("filterMessagingToolMediaDuplicates", () => {
     expect(result).toEqual([{ text: "gallery", mediaUrl: undefined, mediaUrls: undefined }]);
   });
 
+  it("preserves media for payloads with delivery operations", () => {
+    const delivery = { pin: { enabled: true, required: true } };
+    const payload = { mediaUrl: "file:///tmp/photo.jpg", delivery };
+    const result = filterMessagingToolMediaDuplicates({
+      payloads: [payload],
+      sentMediaUrls: ["file:///tmp/photo.jpg"],
+    });
+    expect(result).toEqual([payload]);
+  });
+
+  it.each([{ delivery: { pin: false } }, { delivery: { pin: { enabled: false } } }])(
+    "dedupes media for disabled delivery metadata: $delivery",
+    ({ delivery }) => {
+      const result = filterMessagingToolMediaDuplicates({
+        payloads: [{ mediaUrl: "file:///tmp/photo.jpg", delivery }],
+        sentMediaUrls: ["file:///tmp/photo.jpg"],
+      });
+      expect(result).toEqual([{ mediaUrl: undefined, mediaUrls: undefined, delivery }]);
+    },
+  );
+
+  it("clears audioAsVoice when dedupe removes all media", () => {
+    const result = filterMessagingToolMediaDuplicates({
+      payloads: [{ mediaUrl: "file:///tmp/voice.ogg", audioAsVoice: true }],
+      sentMediaUrls: ["file:///tmp/voice.ogg"],
+    });
+    expect(result).toEqual([
+      {
+        mediaUrl: undefined,
+        mediaUrls: undefined,
+        audioAsVoice: undefined,
+      },
+    ]);
+  });
+
   it("returns payloads unchanged when no media present", () => {
     const payloads = [{ text: "plain text" }];
     const result = filterMessagingToolMediaDuplicates({

--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -324,7 +324,7 @@ describe("resolveMessagingToolPayloadDedupe", () => {
     });
   });
 
-  it("preserves global evidence fallback for legacy multi-target records", () => {
+  it("rejects global evidence fallback for legacy mixed-route records", () => {
     expect(
       resolveMessagingToolPayloadDedupe({
         messageProvider: "slack",
@@ -332,6 +332,26 @@ describe("resolveMessagingToolPayloadDedupe", () => {
         messagingToolSentTargets: [
           { tool: "slack", provider: "slack", to: "channel:C1" },
           { tool: "discord", provider: "discord", to: "channel:C2" },
+        ],
+      }),
+    ).toEqual({
+      shouldDedupePayloads: true,
+      matchingRoute: true,
+      routeSentTexts: [],
+      routeSentMediaUrls: [],
+      useGlobalSentTextEvidenceFallback: false,
+      useGlobalSentMediaUrlEvidenceFallback: false,
+    });
+  });
+
+  it("preserves global evidence fallback when every legacy target matches", () => {
+    expect(
+      resolveMessagingToolPayloadDedupe({
+        messageProvider: "slack",
+        originatingTo: "channel:C1",
+        messagingToolSentTargets: [
+          { tool: "slack", provider: "slack", to: "channel:C1" },
+          { tool: "message", provider: "slack", to: "channel:C1" },
         ],
       }),
     ).toEqual({

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -870,7 +870,7 @@ function emitMessageDeliveryError(params: {
 function normalizeEmptyPayloadForDelivery(payload: ReplyPayload): ReplyPayload | null {
   const text = typeof payload.text === "string" ? payload.text : "";
   if (!text.trim()) {
-    if (!hasReplyPayloadContent({ ...payload, text })) {
+    if (!hasReplyPayloadContent({ ...payload, text }, { extraContent: payload.location != null })) {
       return null;
     }
     if (text) {
@@ -2270,12 +2270,17 @@ async function deliverOutboundPayloadsCore(
         deliveryHandler.sendPayload &&
         ((effectivePayload.isError === true &&
           deliveryHandler.sendTextOnlyErrorPayloads === true) ||
-          hasReplyPayloadContent({
-            presentation: effectivePayload.presentation,
-            interactive: effectivePayload.interactive,
-            channelData: effectivePayload.channelData,
-            location: effectivePayload.location,
-          }) ||
+          hasReplyPayloadContent(
+            {
+              presentation: effectivePayload.presentation,
+              interactive: effectivePayload.interactive,
+              channelData: effectivePayload.channelData,
+              location: effectivePayload.location,
+            },
+            {
+              extraContent: effectivePayload.location != null,
+            },
+          ) ||
           effectivePayload.audioAsVoice === true ||
           effectivePayload.videoAsNote === true)
       ) {

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -488,6 +488,23 @@ describe("normalizeOutboundPayloadsForJson", () => {
       { text: "final answer", mediaUrl: null, mediaUrls: undefined, audioAsVoice: undefined },
     ]);
   });
+
+  it("preserves portable locations during JSON normalization", () => {
+    const location = { latitude: 48.858844, longitude: 2.294351 };
+    expect(normalizeOutboundPayloadsForJson([{ location }])).toEqual([
+      {
+        text: "",
+        mediaUrl: null,
+        mediaUrls: undefined,
+        audioAsVoice: undefined,
+        presentation: undefined,
+        delivery: undefined,
+        interactive: undefined,
+        channelData: undefined,
+        location,
+      },
+    ]);
+  });
 });
 
 describe("normalizeOutboundPayloads", () => {
@@ -495,6 +512,13 @@ describe("normalizeOutboundPayloads", () => {
     const channelData = { line: { flexMessage: { altText: "Card", contents: {} } } };
     expect(normalizeOutboundPayloads([{ channelData }])).toEqual([
       { text: "", mediaUrls: [], channelData },
+    ]);
+  });
+
+  it("keeps location-only payloads", () => {
+    const location = { latitude: 48.858844, longitude: 2.294351 };
+    expect(normalizeOutboundPayloads([{ location }])).toEqual([
+      { text: "", mediaUrls: [], location },
     ]);
   });
 

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -37,6 +37,7 @@ export type NormalizedOutboundPayload = {
   delivery?: ReplyPayloadDelivery;
   interactive?: InteractiveReply;
   channelData?: Record<string, unknown>;
+  location?: ReplyPayload["location"];
   /** Hook-only content for audio-only TTS payloads. Never used as channel text/caption. */
   hookContent?: string;
 };
@@ -51,6 +52,7 @@ export type OutboundPayloadJson = {
   delivery?: ReplyPayloadDelivery;
   interactive?: InteractiveReply;
   channelData?: Record<string, unknown>;
+  location?: ReplyPayload["location"];
 };
 
 /** Prepared payload entry that keeps source indexing plus reusable projections. */
@@ -326,7 +328,10 @@ export function projectOutboundPayloadPlanForOutbound(
     if (
       !hasReplyPayloadContent(
         { ...payload, text, mediaUrls: entry.parts.mediaUrls },
-        { hasChannelData: entry.hasChannelData },
+        {
+          hasChannelData: entry.hasChannelData,
+          extraContent: payload.location != null,
+        },
       )
     ) {
       continue;
@@ -339,6 +344,7 @@ export function projectOutboundPayloadPlanForOutbound(
       ...(payload.delivery ? { delivery: payload.delivery } : {}),
       ...(entry.hasInteractive ? { interactive: payload.interactive } : {}),
       ...(entry.hasChannelData ? { channelData: payload.channelData } : {}),
+      ...(payload.location ? { location: payload.location } : {}),
     });
   }
   return normalizedPayloads;
@@ -360,6 +366,7 @@ export function projectOutboundPayloadPlanForJson(
       delivery: payload.delivery,
       interactive: payload.interactive,
       channelData: payload.channelData,
+      ...(payload.location ? { location: payload.location } : {}),
     });
   }
   return normalized;
@@ -397,6 +404,7 @@ export function summarizeOutboundPayloadForTransport(
     delivery: payload.delivery,
     interactive: payload.interactive,
     channelData: payload.channelData,
+    ...(payload.location ? { location: payload.location } : {}),
     ...(text || !spokenText ? {} : { hookContent: spokenText }),
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Generated media can be delivered twice when a model both sends it through the message tool and returns the same media in its completion payload. Legacy global delivery telemetry also cannot safely identify which route carried a payload when a run targets multiple routes.

Fixes #88307.

## Why This Change Was Made

Delivery deduplication now compares completion payloads against route-scoped message-tool evidence. Account fallback is resolved only when routing did not already select an account and the channel plugin exposes account enumeration. Ambiguous global-only evidence is deliberately ignored for multi-route runs so valid payloads are not dropped.

## User Impact

Users no longer receive duplicate generated-media handoffs on a single route. Multi-route deliveries retain payloads unless evidence proves the same payload was already sent on that route.

## Evidence

- 691 focused tests passed across delivery, outbound payload, gateway, command, and auto-reply suites in Blacksmith Testbox `tbx_01kxc3z4kwtx37jb1xjtd7gp1y`.
- Fresh `gpt-5.6-sol` high autoreview reported no accepted or actionable findings after the regression fixes.
- `git diff --check` passes.
- The broad changed gate was attempted remotely, but the Testbox full-sync classified 2,568 unrelated files and hit the current `@smithy/node-http-handler` shrinkwrap override mismatch. The exact focused touched-surface proof above is green; exact-head GitHub CI remains required before merge.
