### PR TITLE
fix(ci): restore snapshot architecture and docs gates

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -1264,6 +1264,8 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H1: openclaw backup
   - H2: Notes
+  - H2: SQLite snapshots
+  - H3: Verify and restore
   - H2: What gets backed up
   - H2: Invalid config behavior
   - H2: Size and performance

--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -47,7 +47,11 @@ const rawSqliteAllowPathGroups = {
     "src/state/openclaw-state-db.ts",
     "src/state/sqlite-schema-shape.test-support.ts",
   ],
-  "backup snapshot maintenance": ["src/commands/backup-verify.ts", "src/infra/backup-create.ts"],
+  "backup snapshot maintenance": [
+    "src/commands/backup-verify.ts",
+    "src/infra/backup-create.ts",
+    "src/snapshot/local-repository.ts",
+  ],
   "agent auth profile read-only bootstrap": ["src/agents/auth-profiles/sqlite.ts"],
   "read-only SQLite status probes": [
     "src/commands/doctor-db-bloat.ts",


### PR DESCRIPTION
## What Problem This Solves

`main` CI started failing after the verified SQLite snapshot feature landed. The architecture guard rejected its two intentionally low-level SQLite maintenance calls, and the generated docs map did not include the new backup headings.

## Why This Change Was Made

The snapshot repository is added to the existing narrowly scoped `backup snapshot maintenance` raw-SQLite allowlist, alongside the established backup paths. The generated docs map is refreshed from its source generator.

## User Impact

Restores the architecture and docs gates on `main` without changing runtime behavior.

## Evidence

- `node scripts/check-kysely-guardrails.mjs`
- `node scripts/generate-docs-map.mjs --check`
- `git diff --check`
- fresh `gpt-5.6-sol` high autoreview: no accepted/actionable findings, confidence 0.98
