### PR TITLE
fix(ci): allow snapshot repository SQLite maintenance

### DIFF
--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -47,7 +47,11 @@ const rawSqliteAllowPathGroups = {
     "src/state/openclaw-state-db.ts",
     "src/state/sqlite-schema-shape.test-support.ts",
   ],
-  "backup snapshot maintenance": ["src/commands/backup-verify.ts", "src/infra/backup-create.ts"],
+  "backup snapshot maintenance": [
+    "src/commands/backup-verify.ts",
+    "src/infra/backup-create.ts",
+    "src/snapshot/local-repository.ts",
+  ],
   "agent auth profile read-only bootstrap": ["src/agents/auth-profiles/sqlite.ts"],
   "read-only SQLite status probes": [
     "src/commands/doctor-db-bloat.ts",


### PR DESCRIPTION
## What Problem This Solves

`src/snapshot/local-repository.ts` performs low-level SQLite snapshot verification and sanitization, but it was not added to the raw SQLite guardrail allowlist when the verified snapshot repository landed in #105718.

That makes `pnpm check:architecture` fail on current `main` and on unrelated pull requests:

- https://github.com/openclaw/openclaw/actions/runs/29211552829/job/86700074606
- https://github.com/openclaw/openclaw/actions/runs/29211566995/job/86700101098

## Why This Change Was Made

Add the repository module to the existing `backup snapshot maintenance` reason group. This records the narrow low-level SQLite boundary without weakening the guard or creating a new exception category.

Kysely is not appropriate for this code path: it opens an isolated snapshot copy for integrity/schema validation and removes transient delivery rows before publication.

## User Impact

No runtime behavior changes. This restores the architecture gate on `main` and unblocks unrelated pull requests.

## Evidence

- Blacksmith Testbox: `tbx_01kxc7p3fbvq4py1yd4056aafj`
- Testbox workflow: https://github.com/openclaw/openclaw/actions/runs/29211906242
- `pnpm check:architecture`: passed on rebased head `8cd03a3ab0`
- `pnpm check:changed -- scripts/check-kysely-guardrails.mjs`: passed
- Fresh `gpt-5.6-sol` medium committed-branch autoreview: clean, confidence 0.91
- `git diff --check`: passed

No changelog entry: this is CI guardrail metadata only.
