### PR TITLE
fix(codex): preserve subagent completions after sessions_yield

### DIFF
--- a/extensions/codex/src/app-server/attempt-steering.test.ts
+++ b/extensions/codex/src/app-server/attempt-steering.test.ts
@@ -11,15 +11,19 @@ describe("Codex app-server steering queue", () => {
     vi.useRealTimers();
   });
 
-  it("resolves queued steering only after Codex reports consuming it", async () => {
-    const request = vi.fn(async () => ({ turnId: "turn-1" }));
-    const queue = createCodexSteeringQueue({
+  function createQueue(request: ReturnType<typeof vi.fn>, signal = new AbortController().signal) {
+    return createCodexSteeringQueue({
       client: { request } as never,
       threadId: "thread-1",
       turnId: "turn-1",
       answerPendingUserInput: () => false,
-      signal: new AbortController().signal,
+      signal,
     });
+  }
+
+  it("resolves only after the matching Codex user message completes", async () => {
+    const request = vi.fn(async (_method: string, _params: unknown) => ({ turnId: "turn-1" }));
+    const queue = createQueue(request);
 
     const queued = queue.queue("accepted", { debounceMs: 0 });
     let settled = false;
@@ -27,43 +31,22 @@ describe("Codex app-server steering queue", () => {
       settled = true;
     });
     await vi.advanceTimersByTimeAsync(0);
-    expect(settled).toBe(false);
-    expect(queue.confirmConsumed(["initial prompt"])).toBe(false);
-    expect(settled).toBe(false);
-    expect(queue.confirmConsumed(["accepted"])).toBe(true);
-    await queued;
 
+    const requestParams = request.mock.calls[0]?.[1] as { clientUserMessageId?: string };
+    expect(requestParams.clientUserMessageId).toBe("openclaw:turn-1:steer:1");
+    expect(settled).toBe(false);
+    expect(queue.confirmConsumed("unrelated-user-message")).toBe(false);
+    expect(queue.confirmConsumed(requestParams.clientUserMessageId ?? "")).toBe(true);
+    await queued;
     expect(request).toHaveBeenCalledWith("turn/steer", {
       threadId: "thread-1",
       expectedTurnId: "turn-1",
       input: [{ type: "text", text: "accepted", text_elements: [] }],
+      clientUserMessageId: "openclaw:turn-1:steer:1",
     });
   });
 
-  it("rejects queued steering when turn/steer is rejected", async () => {
-    const request = vi.fn(async () => {
-      throw new Error("cannot steer a compact turn");
-    });
-    const queue = createCodexSteeringQueue({
-      client: { request } as never,
-      threadId: "thread-1",
-      turnId: "turn-1",
-      answerPendingUserInput: () => false,
-      signal: new AbortController().signal,
-    });
-
-    const queued = queue.queue("rejected", { debounceMs: 0 });
-    const rejected = expect(queued).rejects.toThrow("cannot steer a compact turn");
-    await vi.advanceTimersByTimeAsync(0);
-    await rejected;
-    expect(request).toHaveBeenCalledWith("turn/steer", {
-      threadId: "thread-1",
-      expectedTurnId: "turn-1",
-      input: [{ type: "text", text: "rejected", text_elements: [] }],
-    });
-  });
-
-  it("resolves when Codex reports consumption before turn/steer is acknowledged", async () => {
+  it("handles user-message completion before the steer response", async () => {
     let acceptSteer: (() => void) | undefined;
     const steerAccepted = new Promise<void>((resolve) => {
       acceptSteer = resolve;
@@ -72,43 +55,27 @@ describe("Codex app-server steering queue", () => {
       await steerAccepted;
       return { turnId: "turn-1" };
     });
-    const queue = createCodexSteeringQueue({
-      client: { request } as never,
-      threadId: "thread-1",
-      turnId: "turn-1",
-      answerPendingUserInput: () => false,
-      signal: new AbortController().signal,
-    });
+    const queue = createQueue(request);
 
     const queued = queue.queue("consumed first", { debounceMs: 0 });
     await vi.advanceTimersByTimeAsync(0);
-    expect(request).toHaveBeenCalledTimes(1);
-    expect(queue.confirmConsumed(["consumed first"])).toBe(true);
+    expect(queue.confirmConsumed("openclaw:turn-1:steer:1")).toBe(true);
     await queued;
 
     acceptSteer?.();
     await vi.advanceTimersByTimeAsync(0);
   });
 
-  it("batches queued steering after a nonzero debounce while the turn is active", async () => {
-    vi.useFakeTimers();
+  it("batches text under one correlated user-message id", async () => {
     const request = vi.fn(async () => ({ turnId: "turn-1" }));
-    const queue = createCodexSteeringQueue({
-      client: { request } as never,
-      threadId: "thread-1",
-      turnId: "turn-1",
-      answerPendingUserInput: () => false,
-      signal: new AbortController().signal,
-    });
+    const queue = createQueue(request);
 
-    const firstQueued = queue.queue("first", { debounceMs: 5 });
-    const secondQueued = queue.queue("second", { debounceMs: 5 });
-
-    expect(request).not.toHaveBeenCalled();
+    const first = queue.queue("first", { debounceMs: 5 });
+    const second = queue.queue("second", { debounceMs: 5 });
     await vi.advanceTimersByTimeAsync(5);
-    expect(queue.confirmConsumed(["first", "second"])).toBe(true);
-    await Promise.all([firstQueued, secondQueued]);
 
+    expect(queue.confirmConsumed("openclaw:turn-1:steer:1")).toBe(true);
+    await Promise.all([first, second]);
     expect(request).toHaveBeenCalledWith("turn/steer", {
       threadId: "thread-1",
       expectedTurnId: "turn-1",
@@ -116,30 +83,86 @@ describe("Codex app-server steering queue", () => {
         { type: "text", text: "first", text_elements: [] },
         { type: "text", text: "second", text_elements: [] },
       ],
+      clientUserMessageId: "openclaw:turn-1:steer:1",
     });
   });
 
-  it("rejects queued steering when the run aborts before debounce flush", async () => {
+  it("rejects the batch when Codex rejects turn/steer", async () => {
+    const request = vi.fn(async () => {
+      throw new Error("cannot steer this turn");
+    });
+    const queue = createQueue(request);
+
+    const queued = queue.queue("rejected", { debounceMs: 0 });
+    const rejected = expect(queued).rejects.toThrow("cannot steer this turn");
+    await vi.advanceTimersByTimeAsync(0);
+    await rejected;
+  });
+
+  it("rejects accepted but unconsumed steering when cancelled", async () => {
+    const request = vi.fn(async () => ({ turnId: "turn-1" }));
+    const queue = createQueue(request);
+
+    const queued = queue.queue("completion wake", { debounceMs: 0 });
+    const rejected = expect(queued).rejects.toThrow("steering queue cancelled");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(request).toHaveBeenCalledTimes(1);
+
+    queue.cancel();
+    await rejected;
+    expect(queue.confirmConsumed("openclaw:turn-1:steer:1")).toBe(false);
+    await expect(queue.queue("too late", { debounceMs: 0 })).rejects.toThrow(
+      "steering queue cancelled",
+    );
+  });
+
+  it("rejects accepted but unconsumed steering when the run aborts", async () => {
     const controller = new AbortController();
     const request = vi.fn(async () => ({ turnId: "turn-1" }));
-    const queue = createCodexSteeringQueue({
-      client: { request } as never,
-      threadId: "thread-1",
-      turnId: "turn-1",
-      answerPendingUserInput: () => false,
-      signal: controller.signal,
-    });
+    const queue = createQueue(request, controller.signal);
 
-    const queued = queue.queue("aborted", { debounceMs: 1 });
-    const rejected = expect(queued).rejects.toThrow("codex app-server steering queue aborted");
+    const queued = queue.queue("completion wake", { debounceMs: 0 });
+    const rejected = expect(queued).rejects.toThrow("steering queue aborted");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(request).toHaveBeenCalledTimes(1);
+
     controller.abort();
-    await vi.advanceTimersByTimeAsync(1);
-
     await rejected;
-    expect(request).not.toHaveBeenCalled();
+    expect(queue.confirmConsumed("openclaw:turn-1:steer:1")).toBe(false);
+    await expect(queue.queue("too late", { debounceMs: 0 })).rejects.toThrow(
+      "steering queue aborted",
+    );
   });
 
-  it("answers pending user input without sending turn/steer", async () => {
+  it("does not dispatch a chained batch after cancellation", async () => {
+    let acceptFirstSteer: (() => void) | undefined;
+    const firstSteerAccepted = new Promise<void>((resolve) => {
+      acceptFirstSteer = resolve;
+    });
+    const request = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        await firstSteerAccepted;
+        return { turnId: "turn-1" };
+      })
+      .mockResolvedValue({ turnId: "turn-1" });
+    const queue = createQueue(request);
+
+    const first = queue.queue("on the wire", { debounceMs: 0 });
+    const firstRejected = expect(first).rejects.toThrow("steering queue cancelled");
+    await vi.advanceTimersByTimeAsync(0);
+    const second = queue.queue("waiting", { debounceMs: 0 });
+    const secondRejected = expect(second).rejects.toThrow("steering queue cancelled");
+    await vi.advanceTimersByTimeAsync(0);
+
+    queue.cancel();
+    acceptFirstSteer?.();
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.all([firstRejected, secondRejected]);
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("answers pending user input without steering", async () => {
     const request = vi.fn(async () => ({ turnId: "turn-1" }));
     const answerPendingUserInput = vi.fn(() => true);
     const queue = createCodexSteeringQueue({
@@ -151,170 +174,33 @@ describe("Codex app-server steering queue", () => {
     });
 
     await queue.queue("answer locally", { debounceMs: 0 });
-
     expect(answerPendingUserInput).toHaveBeenCalledWith("answer locally");
     expect(request).not.toHaveBeenCalled();
   });
 
-  it("answers pending user input before applying the steering availability fence", async () => {
+  it("rejects before dispatch when the run is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
     const request = vi.fn(async () => ({ turnId: "turn-1" }));
-    const answerPendingUserInput = vi.fn(() => true);
-    const rejectSteering = vi.fn(() => new Error("turn release pending"));
-    const queue = createCodexSteeringQueue({
-      client: { request } as never,
-      threadId: "thread-1",
-      turnId: "turn-1",
-      answerPendingUserInput,
-      rejectSteering,
-      signal: new AbortController().signal,
-    });
+    const queue = createQueue(request, controller.signal);
 
-    await queue.queue("prompt answer", { debounceMs: 0 });
-
-    expect(answerPendingUserInput).toHaveBeenCalledWith("prompt answer");
-    expect(rejectSteering).not.toHaveBeenCalled();
-    expect(request).not.toHaveBeenCalled();
-  });
-
-  it("rejects ordinary steering when the turn is unavailable", async () => {
-    const request = vi.fn(async () => ({ turnId: "turn-1" }));
-    const queue = createCodexSteeringQueue({
-      client: { request } as never,
-      threadId: "thread-1",
-      turnId: "turn-1",
-      answerPendingUserInput: () => false,
-      rejectSteering: () => new Error("turn release pending"),
-      signal: new AbortController().signal,
-    });
-
-    await expect(queue.queue("completion wake", { debounceMs: 0 })).rejects.toThrow(
-      "turn release pending",
+    await expect(queue.queue("aborted", { debounceMs: 0 })).rejects.toThrow(
+      "steering queue aborted",
     );
     expect(request).not.toHaveBeenCalled();
   });
 
-  it("holds steering while paused and resumes both delivered and buffered text", async () => {
-    let acceptFirstSteer: (() => void) | undefined;
-    const firstSteerAccepted = new Promise<void>((resolve) => {
-      acceptFirstSteer = resolve;
-    });
-    const request = vi
-      .fn()
-      .mockImplementationOnce(async () => {
-        await firstSteerAccepted;
-        return { turnId: "turn-1" };
-      })
-      .mockResolvedValue({ turnId: "turn-1" });
-    const queue = createCodexSteeringQueue({
-      client: { request } as never,
-      threadId: "thread-1",
-      turnId: "turn-1",
-      answerPendingUserInput: () => false,
-      signal: new AbortController().signal,
-    });
-
-    const inFlight = queue.queue("already dispatched", { debounceMs: 0 });
-    await vi.advanceTimersByTimeAsync(0);
-    queue.pause();
-    acceptFirstSteer?.();
-    await vi.advanceTimersByTimeAsync(0);
-
-    const buffered = queue.queue("arrived while paused", { debounceMs: 0 });
-    expect(request).toHaveBeenCalledTimes(1);
-
-    queue.resume();
-    await vi.advanceTimersByTimeAsync(0);
-    expect(queue.confirmConsumed(["already dispatched"])).toBe(true);
-    expect(queue.confirmConsumed(["arrived while paused"])).toBe(true);
-    await Promise.all([inFlight, buffered]);
-
-    expect(request).toHaveBeenCalledTimes(2);
-    expect(request).toHaveBeenLastCalledWith("turn/steer", {
-      threadId: "thread-1",
-      expectedTurnId: "turn-1",
-      input: [{ type: "text", text: "arrived while paused", text_elements: [] }],
-    });
-  });
-
-  it("rejects an in-flight logical delivery when the queue is cancelled", async () => {
-    let acceptSteer: (() => void) | undefined;
-    const steerAccepted = new Promise<void>((resolve) => {
-      acceptSteer = resolve;
-    });
-    const request = vi.fn(async () => {
-      await steerAccepted;
-      return { turnId: "turn-1" };
-    });
-    const queue = createCodexSteeringQueue({
-      client: { request } as never,
-      threadId: "thread-1",
-      turnId: "turn-1",
-      answerPendingUserInput: () => false,
-      signal: new AbortController().signal,
-    });
-
-    const queued = queue.queue("accepted too late", { debounceMs: 0 });
-    const rejected = expect(queued).rejects.toThrow("steering queue cancelled");
-    await vi.advanceTimersByTimeAsync(0);
-    expect(request).toHaveBeenCalledTimes(1);
-
-    queue.cancel();
-    acceptSteer?.();
-    await vi.advanceTimersByTimeAsync(0);
-    await rejected;
-  });
-
-  it("rejects an acknowledged but unconsumed steer when the queue is cancelled", async () => {
+  it("rejects a debounced batch when the run aborts before dispatch", async () => {
+    const controller = new AbortController();
     const request = vi.fn(async () => ({ turnId: "turn-1" }));
-    const queue = createCodexSteeringQueue({
-      client: { request } as never,
-      threadId: "thread-1",
-      turnId: "turn-1",
-      answerPendingUserInput: () => false,
-      signal: new AbortController().signal,
-    });
+    const queue = createQueue(request, controller.signal);
 
-    const queued = queue.queue("accepted but not consumed", { debounceMs: 0 });
-    await vi.advanceTimersByTimeAsync(0);
-    expect(request).toHaveBeenCalledTimes(1);
+    const queued = queue.queue("aborted", { debounceMs: 5 });
+    const rejected = expect(queued).rejects.toThrow("steering queue aborted");
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(5);
 
-    queue.cancel();
-    await expect(queued).rejects.toThrow("steering queue cancelled");
-  });
-
-  it("does not dispatch a chained batch after it is paused and cancelled", async () => {
-    let acceptFirstSteer: (() => void) | undefined;
-    const firstSteerAccepted = new Promise<void>((resolve) => {
-      acceptFirstSteer = resolve;
-    });
-    const request = vi
-      .fn()
-      .mockImplementationOnce(async () => {
-        await firstSteerAccepted;
-        return { turnId: "turn-1" };
-      })
-      .mockResolvedValue({ turnId: "turn-1" });
-    const queue = createCodexSteeringQueue({
-      client: { request } as never,
-      threadId: "thread-1",
-      turnId: "turn-1",
-      answerPendingUserInput: () => false,
-      signal: new AbortController().signal,
-    });
-
-    const first = queue.queue("already on the wire", { debounceMs: 0 });
-    const firstRejected = expect(first).rejects.toThrow("steering queue cancelled");
-    await vi.advanceTimersByTimeAsync(0);
-    const second = queue.queue("waiting in the send chain", { debounceMs: 0 });
-    const secondRejected = expect(second).rejects.toThrow("steering queue cancelled");
-    await vi.advanceTimersByTimeAsync(0);
-
-    queue.pause();
-    queue.cancel();
-    acceptFirstSteer?.();
-    await vi.advanceTimersByTimeAsync(0);
-    await Promise.all([firstRejected, secondRejected]);
-
-    expect(request).toHaveBeenCalledTimes(1);
+    await rejected;
+    expect(request).not.toHaveBeenCalled();
   });
 });

--- a/extensions/codex/src/app-server/attempt-steering.test.ts
+++ b/extensions/codex/src/app-server/attempt-steering.test.ts
@@ -11,7 +11,7 @@ describe("Codex app-server steering queue", () => {
     vi.useRealTimers();
   });
 
-  it("resolves queued steering only after turn/steer is accepted", async () => {
+  it("resolves queued steering only after Codex reports consuming it", async () => {
     const request = vi.fn(async () => ({ turnId: "turn-1" }));
     const queue = createCodexSteeringQueue({
       client: { request } as never,
@@ -22,7 +22,15 @@ describe("Codex app-server steering queue", () => {
     });
 
     const queued = queue.queue("accepted", { debounceMs: 0 });
+    let settled = false;
+    void queued.finally(() => {
+      settled = true;
+    });
     await vi.advanceTimersByTimeAsync(0);
+    expect(settled).toBe(false);
+    expect(queue.confirmConsumed(["initial prompt"])).toBe(false);
+    expect(settled).toBe(false);
+    expect(queue.confirmConsumed(["accepted"])).toBe(true);
     await queued;
 
     expect(request).toHaveBeenCalledWith("turn/steer", {
@@ -55,6 +63,33 @@ describe("Codex app-server steering queue", () => {
     });
   });
 
+  it("resolves when Codex reports consumption before turn/steer is acknowledged", async () => {
+    let acceptSteer: (() => void) | undefined;
+    const steerAccepted = new Promise<void>((resolve) => {
+      acceptSteer = resolve;
+    });
+    const request = vi.fn(async () => {
+      await steerAccepted;
+      return { turnId: "turn-1" };
+    });
+    const queue = createCodexSteeringQueue({
+      client: { request } as never,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      answerPendingUserInput: () => false,
+      signal: new AbortController().signal,
+    });
+
+    const queued = queue.queue("consumed first", { debounceMs: 0 });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(queue.confirmConsumed(["consumed first"])).toBe(true);
+    await queued;
+
+    acceptSteer?.();
+    await vi.advanceTimersByTimeAsync(0);
+  });
+
   it("batches queued steering after a nonzero debounce while the turn is active", async () => {
     vi.useFakeTimers();
     const request = vi.fn(async () => ({ turnId: "turn-1" }));
@@ -71,6 +106,7 @@ describe("Codex app-server steering queue", () => {
 
     expect(request).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(5);
+    expect(queue.confirmConsumed(["first", "second"])).toBe(true);
     await Promise.all([firstQueued, secondQueued]);
 
     expect(request).toHaveBeenCalledWith("turn/steer", {
@@ -118,5 +154,167 @@ describe("Codex app-server steering queue", () => {
 
     expect(answerPendingUserInput).toHaveBeenCalledWith("answer locally");
     expect(request).not.toHaveBeenCalled();
+  });
+
+  it("answers pending user input before applying the steering availability fence", async () => {
+    const request = vi.fn(async () => ({ turnId: "turn-1" }));
+    const answerPendingUserInput = vi.fn(() => true);
+    const rejectSteering = vi.fn(() => new Error("turn release pending"));
+    const queue = createCodexSteeringQueue({
+      client: { request } as never,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      answerPendingUserInput,
+      rejectSteering,
+      signal: new AbortController().signal,
+    });
+
+    await queue.queue("prompt answer", { debounceMs: 0 });
+
+    expect(answerPendingUserInput).toHaveBeenCalledWith("prompt answer");
+    expect(rejectSteering).not.toHaveBeenCalled();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("rejects ordinary steering when the turn is unavailable", async () => {
+    const request = vi.fn(async () => ({ turnId: "turn-1" }));
+    const queue = createCodexSteeringQueue({
+      client: { request } as never,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      answerPendingUserInput: () => false,
+      rejectSteering: () => new Error("turn release pending"),
+      signal: new AbortController().signal,
+    });
+
+    await expect(queue.queue("completion wake", { debounceMs: 0 })).rejects.toThrow(
+      "turn release pending",
+    );
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("holds steering while paused and resumes both delivered and buffered text", async () => {
+    let acceptFirstSteer: (() => void) | undefined;
+    const firstSteerAccepted = new Promise<void>((resolve) => {
+      acceptFirstSteer = resolve;
+    });
+    const request = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        await firstSteerAccepted;
+        return { turnId: "turn-1" };
+      })
+      .mockResolvedValue({ turnId: "turn-1" });
+    const queue = createCodexSteeringQueue({
+      client: { request } as never,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      answerPendingUserInput: () => false,
+      signal: new AbortController().signal,
+    });
+
+    const inFlight = queue.queue("already dispatched", { debounceMs: 0 });
+    await vi.advanceTimersByTimeAsync(0);
+    queue.pause();
+    acceptFirstSteer?.();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const buffered = queue.queue("arrived while paused", { debounceMs: 0 });
+    expect(request).toHaveBeenCalledTimes(1);
+
+    queue.resume();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(queue.confirmConsumed(["already dispatched"])).toBe(true);
+    expect(queue.confirmConsumed(["arrived while paused"])).toBe(true);
+    await Promise.all([inFlight, buffered]);
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenLastCalledWith("turn/steer", {
+      threadId: "thread-1",
+      expectedTurnId: "turn-1",
+      input: [{ type: "text", text: "arrived while paused", text_elements: [] }],
+    });
+  });
+
+  it("rejects an in-flight logical delivery when the queue is cancelled", async () => {
+    let acceptSteer: (() => void) | undefined;
+    const steerAccepted = new Promise<void>((resolve) => {
+      acceptSteer = resolve;
+    });
+    const request = vi.fn(async () => {
+      await steerAccepted;
+      return { turnId: "turn-1" };
+    });
+    const queue = createCodexSteeringQueue({
+      client: { request } as never,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      answerPendingUserInput: () => false,
+      signal: new AbortController().signal,
+    });
+
+    const queued = queue.queue("accepted too late", { debounceMs: 0 });
+    const rejected = expect(queued).rejects.toThrow("steering queue cancelled");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(request).toHaveBeenCalledTimes(1);
+
+    queue.cancel();
+    acceptSteer?.();
+    await vi.advanceTimersByTimeAsync(0);
+    await rejected;
+  });
+
+  it("rejects an acknowledged but unconsumed steer when the queue is cancelled", async () => {
+    const request = vi.fn(async () => ({ turnId: "turn-1" }));
+    const queue = createCodexSteeringQueue({
+      client: { request } as never,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      answerPendingUserInput: () => false,
+      signal: new AbortController().signal,
+    });
+
+    const queued = queue.queue("accepted but not consumed", { debounceMs: 0 });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(request).toHaveBeenCalledTimes(1);
+
+    queue.cancel();
+    await expect(queued).rejects.toThrow("steering queue cancelled");
+  });
+
+  it("does not dispatch a chained batch after it is paused and cancelled", async () => {
+    let acceptFirstSteer: (() => void) | undefined;
+    const firstSteerAccepted = new Promise<void>((resolve) => {
+      acceptFirstSteer = resolve;
+    });
+    const request = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        await firstSteerAccepted;
+        return { turnId: "turn-1" };
+      })
+      .mockResolvedValue({ turnId: "turn-1" });
+    const queue = createCodexSteeringQueue({
+      client: { request } as never,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      answerPendingUserInput: () => false,
+      signal: new AbortController().signal,
+    });
+
+    const first = queue.queue("already on the wire", { debounceMs: 0 });
+    const firstRejected = expect(first).rejects.toThrow("steering queue cancelled");
+    await vi.advanceTimersByTimeAsync(0);
+    const second = queue.queue("waiting in the send chain", { debounceMs: 0 });
+    const secondRejected = expect(second).rejects.toThrow("steering queue cancelled");
+    await vi.advanceTimersByTimeAsync(0);
+
+    queue.pause();
+    queue.cancel();
+    acceptFirstSteer?.();
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.all([firstRejected, secondRejected]);
+
+    expect(request).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/codex/src/app-server/attempt-steering.ts
+++ b/extensions/codex/src/app-server/attempt-steering.ts
@@ -22,16 +22,27 @@ export function createCodexSteeringQueue(params: {
   threadId: string;
   turnId: string;
   answerPendingUserInput: (text: string) => boolean;
+  rejectSteering?: () => Error | undefined;
   signal: AbortSignal;
 }) {
   type PendingSteerText = {
     text: string;
     resolve: () => void;
     reject: (error: unknown) => void;
+    settled: boolean;
+  };
+  type PendingSteerBatch = {
+    items: PendingSteerText[];
+    dispatchedItems?: PendingSteerText[];
   };
   let batchedTexts: PendingSteerText[] = [];
+  const deliveredBatches: PendingSteerText[][] = [];
+  const pendingTexts = new Set<PendingSteerText>();
   let batchTimer: NodeJS.Timeout | undefined;
   let sendChain: Promise<void> = Promise.resolve();
+  let dispatchingBatch: PendingSteerBatch | undefined;
+  let paused = false;
+  const dispatchWaiters = new Set<() => void>();
 
   const clearBatchTimer = () => {
     if (batchTimer) {
@@ -54,28 +65,77 @@ export function createCodexSteeringQueue(params: {
     });
   };
 
-  const enqueueSend = (texts: string[]) => {
-    const send = sendChain.then(() => sendTexts(texts));
+  const wakeDispatchWaiters = () => {
+    for (const wake of dispatchWaiters) {
+      wake();
+    }
+    dispatchWaiters.clear();
+  };
+
+  const enqueueSend = (batch: PendingSteerBatch) => {
+    const send = sendChain.then(async () => {
+      while (true) {
+        const liveItems = batch.items.filter((item) => !item.settled);
+        if (liveItems.length === 0) {
+          return;
+        }
+        if (!paused) {
+          batch.dispatchedItems = liveItems;
+          dispatchingBatch = batch;
+          await sendTexts(liveItems.map((item) => item.text));
+          return;
+        }
+        await new Promise<void>((resolve) => {
+          dispatchWaiters.add(resolve);
+        });
+      }
+    });
     sendChain = send.catch((error: unknown) => {
       embeddedAgentLog.debug("codex app-server queued steer failed", { error });
     });
     return send;
   };
 
+  const resolveItem = (item: PendingSteerText) => {
+    if (item.settled) {
+      return;
+    }
+    item.settled = true;
+    pendingTexts.delete(item);
+    item.resolve();
+  };
+
+  const rejectItem = (item: PendingSteerText, error: unknown) => {
+    if (item.settled) {
+      return;
+    }
+    item.settled = true;
+    pendingTexts.delete(item);
+    item.reject(error);
+  };
+
   const flushBatch = () => {
     clearBatchTimer();
     const items = batchedTexts;
     batchedTexts = [];
-    const send = enqueueSend(items.map((item) => item.text));
+    const batch: PendingSteerBatch = { items };
+    const send = enqueueSend(batch);
     void send.then(
       () => {
-        for (const item of items) {
-          item.resolve();
+        const deliveredItems = (batch.dispatchedItems ?? []).filter((item) => !item.settled);
+        if (deliveredItems.length > 0) {
+          deliveredBatches.push(deliveredItems);
+        }
+        if (dispatchingBatch === batch) {
+          dispatchingBatch = undefined;
         }
       },
       (error: unknown) => {
         for (const item of items) {
-          item.reject(error);
+          rejectItem(item, error);
+        }
+        if (dispatchingBatch === batch) {
+          dispatchingBatch = undefined;
         }
       },
     );
@@ -87,9 +147,18 @@ export function createCodexSteeringQueue(params: {
       if (params.answerPendingUserInput(text)) {
         return;
       }
+      const unavailable = params.rejectSteering?.();
+      if (unavailable) {
+        throw unavailable;
+      }
       return await new Promise<void>((resolve, reject) => {
-        batchedTexts.push({ text, resolve, reject });
+        const item = { text, resolve, reject, settled: false };
+        batchedTexts.push(item);
+        pendingTexts.add(item);
         clearBatchTimer();
+        if (paused) {
+          return;
+        }
         const debounceMs = normalizeCodexSteerDebounceMs(options?.debounceMs);
         if (debounceMs === 0) {
           void flushBatch().catch(() => undefined);
@@ -102,15 +171,55 @@ export function createCodexSteeringQueue(params: {
       });
     },
     async flushPending() {
+      if (paused) {
+        return;
+      }
       await flushBatch().catch(() => undefined);
+    },
+    confirmConsumed(texts: readonly string[]) {
+      const items = deliveredBatches[0] ?? dispatchingBatch?.dispatchedItems;
+      if (
+        !items ||
+        items.length !== texts.length ||
+        items.some((item, index) => item.text !== texts[index])
+      ) {
+        return false;
+      }
+      if (deliveredBatches[0] === items) {
+        deliveredBatches.shift();
+      }
+      for (const item of items) {
+        resolveItem(item);
+      }
+      return true;
+    },
+    pause() {
+      paused = true;
+      clearBatchTimer();
+    },
+    resume() {
+      if (!paused) {
+        return;
+      }
+      paused = false;
+      if (batchedTexts.length > 0) {
+        void flushBatch().catch(() => undefined);
+      }
+      wakeDispatchWaiters();
     },
     cancel() {
       clearBatchTimer();
-      const items = batchedTexts;
       batchedTexts = [];
-      for (const item of items) {
-        item.reject(new Error("codex app-server steering queue cancelled"));
+      deliveredBatches.length = 0;
+      dispatchingBatch = undefined;
+      const error = new Error("codex app-server steering queue cancelled");
+      // A turn/steer request can already be accepted when terminal release
+      // starts. Reject its logical delivery until Codex confirms consumption:
+      // interrupting the old turn clears accepted-but-pending input.
+      for (const item of pendingTexts) {
+        rejectItem(item, error);
       }
+      wakeDispatchWaiters();
     },
   };
 }

--- a/extensions/codex/src/app-server/attempt-steering.ts
+++ b/extensions/codex/src/app-server/attempt-steering.ts
@@ -22,7 +22,6 @@ export function createCodexSteeringQueue(params: {
   threadId: string;
   turnId: string;
   answerPendingUserInput: (text: string) => boolean;
-  rejectSteering?: () => Error | undefined;
   signal: AbortSignal;
 }) {
   type PendingSteerText = {
@@ -33,67 +32,20 @@ export function createCodexSteeringQueue(params: {
   };
   type PendingSteerBatch = {
     items: PendingSteerText[];
-    dispatchedItems?: PendingSteerText[];
   };
   let batchedTexts: PendingSteerText[] = [];
-  const deliveredBatches: PendingSteerText[][] = [];
+  const dispatchedBatches = new Map<string, PendingSteerBatch>();
   const pendingTexts = new Set<PendingSteerText>();
   let batchTimer: NodeJS.Timeout | undefined;
+  let batchSequence = 0;
   let sendChain: Promise<void> = Promise.resolve();
-  let dispatchingBatch: PendingSteerBatch | undefined;
-  let paused = false;
-  const dispatchWaiters = new Set<() => void>();
+  let closedError: Error | undefined;
 
   const clearBatchTimer = () => {
     if (batchTimer) {
       clearTimeout(batchTimer);
       batchTimer = undefined;
     }
-  };
-
-  const sendTexts = async (texts: string[]) => {
-    if (texts.length === 0) {
-      return;
-    }
-    if (params.signal.aborted) {
-      throw new Error("codex app-server steering queue aborted");
-    }
-    await params.client.request("turn/steer", {
-      threadId: params.threadId,
-      expectedTurnId: params.turnId,
-      input: texts.map(toCodexTextInput),
-    });
-  };
-
-  const wakeDispatchWaiters = () => {
-    for (const wake of dispatchWaiters) {
-      wake();
-    }
-    dispatchWaiters.clear();
-  };
-
-  const enqueueSend = (batch: PendingSteerBatch) => {
-    const send = sendChain.then(async () => {
-      while (true) {
-        const liveItems = batch.items.filter((item) => !item.settled);
-        if (liveItems.length === 0) {
-          return;
-        }
-        if (!paused) {
-          batch.dispatchedItems = liveItems;
-          dispatchingBatch = batch;
-          await sendTexts(liveItems.map((item) => item.text));
-          return;
-        }
-        await new Promise<void>((resolve) => {
-          dispatchWaiters.add(resolve);
-        });
-      }
-    });
-    sendChain = send.catch((error: unknown) => {
-      embeddedAgentLog.debug("codex app-server queued steer failed", { error });
-    });
-    return send;
   };
 
   const resolveItem = (item: PendingSteerText) => {
@@ -114,113 +66,131 @@ export function createCodexSteeringQueue(params: {
     item.reject(error);
   };
 
+  const closeQueue = (error: Error) => {
+    if (closedError) {
+      return;
+    }
+    closedError = error;
+    params.signal.removeEventListener("abort", abortQueue);
+    clearBatchTimer();
+    batchedTexts = [];
+    dispatchedBatches.clear();
+    for (const item of pendingTexts) {
+      rejectItem(item, error);
+    }
+  };
+  const abortQueue = () => {
+    closeQueue(new Error("codex app-server steering queue aborted"));
+  };
+  const cancelQueue = () => {
+    closeQueue(new Error("codex app-server steering queue cancelled"));
+  };
+
+  const sendBatch = async (items: PendingSteerText[]) => {
+    const liveItems = items.filter((item) => !item.settled);
+    if (liveItems.length === 0) {
+      return;
+    }
+    const unavailableError =
+      closedError ??
+      (params.signal.aborted ? new Error("codex app-server steering queue aborted") : undefined);
+    if (unavailableError) {
+      for (const item of liveItems) {
+        rejectItem(item, unavailableError);
+      }
+      throw unavailableError;
+    }
+    const clientUserMessageId = `openclaw:${params.turnId}:steer:${++batchSequence}`;
+    const batch = { items: liveItems };
+    // RPC acceptance is not delivery: interrupt clears accepted pending input.
+    // Keep the batch unsettled until Codex echoes this id on userMessage completion.
+    dispatchedBatches.set(clientUserMessageId, batch);
+    try {
+      await params.client.request("turn/steer", {
+        threadId: params.threadId,
+        expectedTurnId: params.turnId,
+        input: liveItems.map((item) => toCodexTextInput(item.text)),
+        clientUserMessageId,
+      });
+    } catch (error) {
+      dispatchedBatches.delete(clientUserMessageId);
+      for (const item of liveItems) {
+        rejectItem(item, error);
+      }
+      throw error;
+    }
+  };
+
+  const enqueueSend = (items: PendingSteerText[]) => {
+    const send = sendChain.then(() => sendBatch(items));
+    sendChain = send.catch((error: unknown) => {
+      embeddedAgentLog.debug("codex app-server queued steer failed", { error });
+    });
+    return send;
+  };
+
   const flushBatch = () => {
     clearBatchTimer();
     const items = batchedTexts;
     batchedTexts = [];
-    const batch: PendingSteerBatch = { items };
-    const send = enqueueSend(batch);
-    void send.then(
-      () => {
-        const deliveredItems = (batch.dispatchedItems ?? []).filter((item) => !item.settled);
-        if (deliveredItems.length > 0) {
-          deliveredBatches.push(deliveredItems);
-        }
-        if (dispatchingBatch === batch) {
-          dispatchingBatch = undefined;
-        }
-      },
-      (error: unknown) => {
-        for (const item of items) {
-          rejectItem(item, error);
-        }
-        if (dispatchingBatch === batch) {
-          dispatchingBatch = undefined;
-        }
-      },
-    );
+    if (items.length === 0) {
+      return sendChain;
+    }
+    const send = enqueueSend(items);
+    void send.catch(() => undefined);
     return send;
   };
+
+  params.signal.addEventListener("abort", abortQueue, { once: true });
+  if (params.signal.aborted) {
+    abortQueue();
+  }
 
   return {
     async queue(text: string, options?: CodexSteeringQueueOptions) {
       if (params.answerPendingUserInput(text)) {
         return;
       }
-      const unavailable = params.rejectSteering?.();
-      if (unavailable) {
-        throw unavailable;
+      if (closedError) {
+        throw closedError;
+      }
+      if (params.signal.aborted) {
+        throw new Error("codex app-server steering queue aborted");
       }
       return await new Promise<void>((resolve, reject) => {
         const item = { text, resolve, reject, settled: false };
         batchedTexts.push(item);
         pendingTexts.add(item);
         clearBatchTimer();
-        if (paused) {
-          return;
-        }
         const debounceMs = normalizeCodexSteerDebounceMs(options?.debounceMs);
         if (debounceMs === 0) {
-          void flushBatch().catch(() => undefined);
+          void flushBatch();
           return;
         }
         batchTimer = setTimeout(() => {
           batchTimer = undefined;
-          void flushBatch().catch(() => undefined);
+          void flushBatch();
         }, debounceMs);
       });
     },
     async flushPending() {
-      if (paused) {
+      if (closedError) {
         return;
       }
       await flushBatch().catch(() => undefined);
     },
-    confirmConsumed(texts: readonly string[]) {
-      const items = deliveredBatches[0] ?? dispatchingBatch?.dispatchedItems;
-      if (
-        !items ||
-        items.length !== texts.length ||
-        items.some((item, index) => item.text !== texts[index])
-      ) {
+    confirmConsumed(clientUserMessageId: string) {
+      const batch = dispatchedBatches.get(clientUserMessageId);
+      if (!batch) {
         return false;
       }
-      if (deliveredBatches[0] === items) {
-        deliveredBatches.shift();
-      }
-      for (const item of items) {
+      dispatchedBatches.delete(clientUserMessageId);
+      for (const item of batch.items) {
         resolveItem(item);
       }
       return true;
     },
-    pause() {
-      paused = true;
-      clearBatchTimer();
-    },
-    resume() {
-      if (!paused) {
-        return;
-      }
-      paused = false;
-      if (batchedTexts.length > 0) {
-        void flushBatch().catch(() => undefined);
-      }
-      wakeDispatchWaiters();
-    },
-    cancel() {
-      clearBatchTimer();
-      batchedTexts = [];
-      deliveredBatches.length = 0;
-      dispatchingBatch = undefined;
-      const error = new Error("codex app-server steering queue cancelled");
-      // A turn/steer request can already be accepted when terminal release
-      // starts. Reject its logical delivery until Codex confirms consumption:
-      // interrupting the old turn clears accepted-but-pending input.
-      for (const item of pendingTexts) {
-        rejectItem(item, error);
-      }
-      wakeDispatchWaiters();
-    },
+    cancel: cancelQueue,
   };
 }
 

--- a/extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts
@@ -1,5 +1,67 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { createCodexAttemptLifecycleController } from "./run-attempt-lifecycle-controller.js";
 import { buildCodexLifecycleTerminalMeta } from "./run-attempt-lifecycle-terminal.js";
+
+function createTerminalReleaseHarness() {
+  const order: string[] = [];
+  const cancel = vi.fn(() => order.push("cancel"));
+  const request = vi.fn(async (method: string) => {
+    order.push(method);
+    return {};
+  });
+  const resolveCompletion = vi.fn();
+  const state = {
+    completed: false,
+    activeAppServerTurnRequests: 0,
+    currentTurnHadNonTerminalDynamicToolResult: false,
+    pendingTerminalDynamicToolRelease: undefined,
+    terminalDynamicToolReleaseCheckScheduled: false,
+    resolveCompletion,
+  };
+  const controller = createCodexAttemptLifecycleController(
+    {
+      prompt: {
+        context: {
+          runtime: {
+            connection: {
+              params: {},
+              attemptStartedAt: 0,
+              runAbortController: new AbortController(),
+              fastModeAutoProgressState: {},
+            },
+          },
+        },
+      },
+      state: { client: { request } },
+    } as never,
+    {
+      state,
+      activeTurnItemIds: new Set(),
+      pendingOpenClawDynamicToolCompletionIds: new Set(),
+      steeringQueueRef: { current: { cancel } },
+      turnWatches: {
+        clearCompletionIdleTimer: vi.fn(),
+        clearAssistantCompletionIdleTimer: vi.fn(),
+        clearTerminalIdleTimer: vi.fn(),
+      },
+    } as never,
+  );
+  return { cancel, controller, order, request, resolveCompletion, state };
+}
+
+function terminalYieldResult(success: boolean) {
+  return {
+    call: {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-yield",
+      tool: "sessions_yield",
+      arguments: {},
+    },
+    response: { success, terminate: true, contentItems: [] },
+    durationMs: 1,
+  };
+}
 
 describe("buildCodexLifecycleTerminalMeta", () => {
   it("marks sessions_yield as a paused parent continuation", () => {
@@ -38,5 +100,40 @@ describe("buildCodexLifecycleTerminalMeta", () => {
       status: "cancelled",
       stopReason: "stop",
     });
+  });
+});
+
+describe("Codex terminal dynamic-tool release", () => {
+  it("fences unconsumed steering before interrupting a successful yield", async () => {
+    const harness = createTerminalReleaseHarness();
+
+    harness.controller.scheduleTurnReleaseAfterTerminalDynamicTool(terminalYieldResult(true));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    expect(harness.cancel).toHaveBeenCalled();
+    expect(harness.request).toHaveBeenCalledWith(
+      "turn/interrupt",
+      { threadId: "thread-1", turnId: "turn-1" },
+      { timeoutMs: 5_000 },
+    );
+    expect(harness.order.indexOf("cancel")).toBeLessThan(harness.order.indexOf("turn/interrupt"));
+    expect(harness.state.completed).toBe(true);
+    expect(harness.resolveCompletion).toHaveBeenCalledOnce();
+  });
+
+  it("keeps steering open when the yield result fails", async () => {
+    const harness = createTerminalReleaseHarness();
+
+    harness.controller.scheduleTurnReleaseAfterTerminalDynamicTool(terminalYieldResult(false));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    expect(harness.cancel).not.toHaveBeenCalled();
+    expect(harness.request).not.toHaveBeenCalled();
+    expect(harness.state.completed).toBe(false);
+    expect(harness.resolveCompletion).not.toHaveBeenCalled();
   });
 });

--- a/extensions/codex/src/app-server/run-attempt-lifecycle-controller.ts
+++ b/extensions/codex/src/app-server/run-attempt-lifecycle-controller.ts
@@ -75,6 +75,9 @@ export function createCodexAttemptLifecycleController(
       tool: value.call.tool,
       durationMs: value.durationMs,
     });
+    // Interrupt drops accepted pending input. Reject unconsumed steering first so
+    // completion delivery can use its fallback path instead of reporting success.
+    turnRuntime.steeringQueueRef.current?.cancel();
     interruptCodexTurnBestEffort(resourceState.client, {
       threadId: value.call.threadId,
       turnId: value.call.turnId,
@@ -98,6 +101,16 @@ export function createCodexAttemptLifecycleController(
     state.terminalDynamicToolReleaseCheckScheduled = true;
     const immediate = setImmediate(() => {
       state.terminalDynamicToolReleaseCheckScheduled = false;
+      if (
+        state.pendingTerminalDynamicToolRelease?.response.success === true &&
+        !state.currentTurnHadNonTerminalDynamicToolResult &&
+        state.activeAppServerTurnRequests === 0 &&
+        pendingOpenClawDynamicToolCompletionIds.size === 0
+      ) {
+        // Tool response flush plus sibling classification commits terminal release.
+        // Fence steering now; active Codex items may delay the actual interrupt.
+        turnRuntime.steeringQueueRef.current?.cancel();
+      }
       const action = resolveTerminalDynamicToolBatchAction({
         activeAppServerTurnRequests: state.activeAppServerTurnRequests,
         activeTurnItemIdsCount: activeTurnItemIds.size,

--- a/extensions/codex/src/app-server/run-attempt-notification-controller.ts
+++ b/extensions/codex/src/app-server/run-attempt-notification-controller.ts
@@ -87,6 +87,12 @@ export function createCodexAttemptNotificationController(
       onReportExecutionNotification: reportExecutionNotification,
     });
     state.turnCrossedToolHandoff = notificationState.turnCrossedToolHandoff;
+    if (notificationState.isCurrentTurnNotification && notification.method === "item/completed") {
+      const item = readCodexNotificationItem(notification.params);
+      if (item?.type === "userMessage" && typeof item.clientId === "string") {
+        steeringQueue?.confirmConsumed(item.clientId);
+      }
+    }
     if (notificationState.isTurnAbortMarker) {
       state.sawCodexInterruptMarker = true;
     }

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -289,7 +289,7 @@ export function createCodexAttemptServerRequestController(
           });
         }
         pendingOpenClawDynamicToolCompletionIds.delete(call.callId);
-        if (response.terminate === true) {
+        if (response.terminate === true && response.success) {
           scheduleTurnReleaseAfterTerminalDynamicTool({
             call,
             response,

--- a/extensions/codex/src/app-server/run-attempt.steering.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.steering.test.ts
@@ -73,7 +73,7 @@ async function waitAndQueueActiveRunMessage(
 
 describe("runCodexAppServerAttempt steering", () => {
   it("forwards queued user input to the active app-server turn", async () => {
-    const { requests, waitForMethod, completeTurn } = createStartedThreadHarness();
+    const { requests, waitForMethod, completeTurn, notify } = createStartedThreadHarness();
     const params = createSteeringParams();
 
     const run = runCodexAppServerAttempt(params, {
@@ -81,11 +81,50 @@ describe("runCodexAppServerAttempt steering", () => {
     });
     await waitForMethod("turn/start");
 
-    await waitAndQueueActiveRunMessage(params.sessionId, "more context", { debounceMs: 0 });
+    let handle:
+      | { queueMessage: (text: string, options?: { debounceMs?: number }) => Promise<void> }
+      | undefined;
+    await vi.waitFor(() => {
+      handle = activeRunRegistrationMocks.setActiveEmbeddedRun.mock.calls.findLast(
+        (call) => call[0] === params.sessionId,
+      )?.[1] as typeof handle;
+      expect(handle).toBeDefined();
+    }, fastWait);
+    const delivered = handle!.queueMessage("more context", { debounceMs: 0 });
+    let deliverySettled = false;
+    void delivered.finally(() => {
+      deliverySettled = true;
+    });
     await vi.waitFor(
       () => expect(requests.map((entry) => entry.method)).toContain("turn/steer"),
       fastWait,
     );
+    const steer = requests.find((entry) => entry.method === "turn/steer");
+    const clientUserMessageId = (steer?.params as { clientUserMessageId?: string } | undefined)
+      ?.clientUserMessageId;
+    expect(clientUserMessageId).toBe("openclaw:turn-1:steer:1");
+    if (!clientUserMessageId) {
+      throw new Error("turn/steer clientUserMessageId missing");
+    }
+    expect(deliverySettled).toBe(false);
+    await notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { id: "unrelated-user-message", type: "userMessage", clientId: "other-client-id" },
+      },
+    });
+    expect(deliverySettled).toBe(false);
+    await notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { id: "steered-user-message", type: "userMessage", clientId: clientUserMessageId },
+      },
+    });
+    await delivered;
 
     await completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
@@ -104,11 +143,11 @@ describe("runCodexAppServerAttempt steering", () => {
     expect(threadStartParams?.sandbox).toBe("danger-full-access");
     expect(threadStartParams?.approvalsReviewer).toBe("user");
     expect(threadStartParams?.developerInstructions).not.toContain(CODEX_GPT5_BEHAVIOR_CONTRACT);
-    const steer = requests.find((entry) => entry.method === "turn/steer");
     expect(steer?.params).toEqual({
       threadId: "thread-1",
       expectedTurnId: "turn-1",
       input: [{ type: "text", text: "more context", text_elements: [] }],
+      clientUserMessageId: "openclaw:turn-1:steer:1",
     });
   });
 
@@ -135,6 +174,7 @@ describe("runCodexAppServerAttempt steering", () => {
               threadId: "thread-1",
               expectedTurnId: "turn-1",
               input: [{ type: "text", text: "subagent complete", text_elements: [] }],
+              clientUserMessageId: "openclaw:turn-1:steer:1",
             },
           },
         ]),
@@ -174,6 +214,7 @@ describe("runCodexAppServerAttempt steering", () => {
               threadId: "thread-1",
               expectedTurnId: "turn-1",
               input: [{ type: "text", text: "session-file registered", text_elements: [] }],
+              clientUserMessageId: "openclaw:turn-1:steer:1",
             },
           },
         ]),
@@ -216,6 +257,7 @@ describe("runCodexAppServerAttempt steering", () => {
             { type: "text", text: "first", text_elements: [] },
             { type: "text", text: "second", text_elements: [] },
           ],
+          clientUserMessageId: "openclaw:turn-1:steer:1",
         },
       },
     ]);
@@ -240,6 +282,7 @@ describe("runCodexAppServerAttempt steering", () => {
           threadId: "thread-1",
           expectedTurnId: "turn-1",
           input: [{ type: "text", text: "late steer", text_elements: [] }],
+          clientUserMessageId: "openclaw:turn-1:steer:1",
         },
       },
     ]);
@@ -276,6 +319,7 @@ describe("runCodexAppServerAttempt steering", () => {
             { type: "text", text: "first", text_elements: [] },
             { type: "text", text: "second", text_elements: [] },
           ],
+          clientUserMessageId: "openclaw:turn-1:steer:1",
         },
       },
     ]);


### PR DESCRIPTION
Closes #104806

## What Problem This Solves

Fixes a P0 message-loss race in the Codex runtime. A parent could accept a subagent completion steer, call `sessions_yield`, interrupt the turn, and lose that accepted input before Codex consumed it.

## Why This Change Was Made

Codex distinguishes RPC acceptance from transcript consumption. `turn/steer` accepts input into the active turn queue; `turn/interrupt` clears pending input. The durable consumption signal is the matching completed `userMessage` item.

This revision keeps each steer pending under an exact `clientUserMessageId` until Codex emits `item/completed` for the matching `userMessage.clientId`. A successful terminal yield cancels unconsumed steering before interrupt, allowing the existing completion fallback to retry on a fresh parent turn. A failed or non-terminal yield leaves steering usable. Run abort closes the queue immediately, so no accepted-but-unconsumed wake can hang through cleanup.

The implementation replaces the earlier FIFO inference with one canonical identity-based path. No config, migration, or shared announce-routing change.

Upstream Codex contract checked at `1d941253e9354fe583a033660a6288df66e27488`:

- [`turn/steer` accepts `clientUserMessageId`](https://github.com/openai/codex/blob/1d941253e9354fe583a033660a6288df66e27488/codex-rs/app-server/README.md#L990-L1007)
- [the app server forwards that ID to core steering](https://github.com/openai/codex/blob/1d941253e9354fe583a033660a6288df66e27488/codex-rs/app-server/src/request_processors/turn_processor.rs#L937-L952)
- [interrupt clears queued pending input](https://github.com/openai/codex/blob/1d941253e9354fe583a033660a6288df66e27488/codex-rs/core/src/session/input_queue.rs#L119-L124)
- [task abort invokes that clear](https://github.com/openai/codex/blob/1d941253e9354fe583a033660a6288df66e27488/codex-rs/core/src/tasks/mod.rs#L497-L524)

## User Impact

Codex-backed orchestrators no longer falsely report a yielded subagent completion as delivered into an interrupted turn. The result reaches the parent exactly once through the normal retry path, and the parent session remains usable.

## Evidence

Exact candidate: `5093e8aef1530af1971aa524c85e091f0c3ea8e3`

- focused steering and lifecycle suites: 22/22 passed locally and on Linux Testbox; terminal-yield assertions live at the deterministic lifecycle-controller boundary instead of the cold full-attempt harness
- Codex extension runtime and test type checks: passed
- targeted formatting and lint: passed
- production build: passed at patch-identical pre-rebase head
- fresh structured autoreview: no actionable findings
- fresh [Testbox production build and live proof](https://github.com/openclaw/openclaw/actions/runs/29488811910) at pre-rebase head `278a0aa20496b0af6294153864703f32fef91fba`: real Gateway, forced Codex runtime, real `sessions_spawn`, successful `sessions_yield`, child completion in the parent transcript exactly once, and a successful second turn in the same session; 224 seconds including the production build. The final rebase changed only the main parent; `git patch-id --stable` remained `786317cb39b7e49361ce5a5d222b076037b1b116`.

Release-note context: Fix Codex subagent completion delivery after `sessions_yield`. Thanks @algal.

---

AI-assisted: investigated, rewritten, tested, and drafted with agentic tools. Maintainer reviewed the dependency contract, behavior, proof, and final diff.
