### PR TITLE
feat(bootstrap-extra-files): opt-in allowCustomNames for extra bootstrap files

### DIFF
--- a/src/agents/bootstrap-cache.test.ts
+++ b/src/agents/bootstrap-cache.test.ts
@@ -18,7 +18,7 @@ import { loadWorkspaceBootstrapFiles } from "./workspace.js";
 
 function makeFile(name: string, content: string): WorkspaceBootstrapFile {
   return {
-    name: name as WorkspaceBootstrapFile["name"],
+    name,
     path: `/ws/${name}`,
     content,
     missing: false,

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -186,7 +186,8 @@ export type WorkspaceBootstrapFileName =
   | typeof DEFAULT_MEMORY_FILENAME;
 
 export type WorkspaceBootstrapFile = {
-  name: WorkspaceBootstrapFileName;
+  /** Bootstrap filename. Standard names or custom names (when allowCustomNames is enabled). */
+  name: string;
   path: string;
   content?: string;
   missing: boolean;
@@ -1261,6 +1262,7 @@ async function resolveExtraBootstrapPatternPaths(
 export async function loadExtraBootstrapFilesWithDiagnostics(
   dir: string,
   extraPatterns: string[],
+  options?: { allowCustomNames?: boolean },
 ): Promise<{
   files: WorkspaceBootstrapFile[];
   diagnostics: ExtraBootstrapLoadDiagnostic[];
@@ -1287,9 +1289,9 @@ export async function loadExtraBootstrapFilesWithDiagnostics(
   const diagnostics: ExtraBootstrapLoadDiagnostic[] = [];
   for (const relPath of resolvedPaths) {
     const filePath = path.resolve(resolvedDir, relPath);
-    // Only load files whose basename is a recognized bootstrap filename
+    // Only load files whose basename is a recognized bootstrap filename (unless allowCustomNames)
     const baseName = path.basename(relPath);
-    if (!VALID_BOOTSTRAP_NAMES.has(baseName)) {
+    if (!options?.allowCustomNames && !VALID_BOOTSTRAP_NAMES.has(baseName)) {
       diagnostics.push({
         path: filePath,
         reason: "invalid-bootstrap-filename",
@@ -1303,7 +1305,7 @@ export async function loadExtraBootstrapFilesWithDiagnostics(
     });
     if (loaded.ok) {
       files.push({
-        name: baseName as WorkspaceBootstrapFileName,
+        name: baseName,
         path: filePath,
         content: loaded.content,
         missing: false,

--- a/src/hooks/bundled/bootstrap-extra-files/HOOK.md
+++ b/src/hooks/bundled/bootstrap-extra-files/HOOK.md
@@ -47,7 +47,9 @@ workspace root.
 - `paths` (string[]): preferred list of glob/path patterns.
 - `patterns` (string[]): alias of `paths`.
 - `files` (string[]): alias of `paths`.
+- `allowCustomNames` (boolean): when `true`, any filename is accepted (not just recognized bootstrap names). Default: `false`.
 
 All paths are resolved from the workspace and must stay inside it (including realpath checks).
-Only recognized bootstrap basenames are loaded (`AGENTS.md`, `SOUL.md`, `TOOLS.md`,
+By default, only recognized bootstrap basenames are loaded (`AGENTS.md`, `SOUL.md`, `TOOLS.md`,
 `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`, `MEMORY.md`).
+Set `allowCustomNames: true` to load arbitrary filenames.

--- a/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
@@ -74,6 +74,60 @@ describe("bootstrap-extra-files hook", () => {
     );
   });
 
+  it("loads custom-named files when allowCustomNames is true", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-bootstrap-extra-custom-");
+    await fs.writeFile(path.join(tempDir, "MEMBERS.md"), "team members", "utf-8");
+    await fs.writeFile(path.join(tempDir, "REPORT.md"), "report template", "utf-8");
+
+    const cfg: OpenClawConfig = {
+      hooks: {
+        internal: {
+          entries: {
+            "bootstrap-extra-files": {
+              enabled: true,
+              paths: ["MEMBERS.md", "REPORT.md"],
+              allowCustomNames: true,
+            },
+          },
+        },
+      },
+    };
+    const context = await createBootstrapContext({
+      workspaceDir: tempDir,
+      cfg,
+      sessionKey: "agent:main:main",
+      rootFiles: [{ name: "AGENTS.md", content: "root agents" }],
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    const names = context.bootstrapFiles.map((f) => f.name).toSorted();
+    expect(names).toEqual(["AGENTS.md", "MEMBERS.md", "REPORT.md"]);
+    expect(context.bootstrapFiles.find((f) => f.name === "MEMBERS.md")?.content).toBe(
+      "team members",
+    );
+  });
+
+  it("rejects custom-named files when allowCustomNames is false (default)", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-bootstrap-extra-reject-");
+    await fs.writeFile(path.join(tempDir, "CUSTOM.md"), "custom", "utf-8");
+
+    const cfg = createBootstrapExtraConfig(["CUSTOM.md"]);
+    const context = await createBootstrapContext({
+      workspaceDir: tempDir,
+      cfg,
+      sessionKey: "agent:main:main",
+      rootFiles: [{ name: "AGENTS.md", content: "root agents" }],
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    // CUSTOM.md should NOT be added (no allowCustomNames)
+    expect(context.bootstrapFiles.map((f) => f.name)).toEqual(["AGENTS.md"]);
+  });
+
   it("re-applies subagent bootstrap allowlist after extras are added", async () => {
     const tempDir = await makeTempWorkspace("openclaw-bootstrap-extra-subagent-");
     const extraDir = path.join(tempDir, "packages", "persona");

--- a/src/hooks/bundled/bootstrap-extra-files/handler.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.ts
@@ -41,10 +41,13 @@ const bootstrapExtraFilesHook: HookHandler = async (event) => {
     return;
   }
 
+  const allowCustomNames = (hookConfig as Record<string, unknown>).allowCustomNames === true;
+
   try {
     const { files: extras, diagnostics } = await loadExtraBootstrapFilesWithDiagnostics(
       context.workspaceDir,
       patterns,
+      { allowCustomNames },
     );
     if (diagnostics.length > 0) {
       log.debug("skipped extra bootstrap candidates", {


### PR DESCRIPTION
Related: #105731

## What Problem This Solves

Operators who provision agent workspaces centrally (managed / multi-tenant deployments) cannot ship additional curated bootstrap documents to their agents. The `bootstrap-extra-files` hook accepts only a fixed allowlist of file names, so an operator-authored file such as a usage guide is silently ignored and never reaches the agent's bootstrap context. The workaround today is to merge that content into one of the known files, which mixes unrelated concerns in a single document and makes provisioning harder to reason about.

## Why This Change Was Made

The hook gains an explicit opt-in, `allowCustomNames: true`, which routes custom-named files through the existing `loadExtraBootstrapFilesWithDiagnostics` path. Default behavior is deliberately unchanged: with the flag absent or false, custom names are still rejected, so no existing deployment changes behavior. Non-goal: no new discovery or globbing semantics — the operator still lists the files explicitly; this only lifts the name restriction.

## User Impact

Operators can keep operator-curated bootstrap documents as separate, purpose-named files instead of merging them into an existing one. Users who do not enable the flag see no change.

## Evidence

Focused tests on the affected suites (against this branch):

```
$ pnpm vitest run src/hooks/bundled/bootstrap-extra-files/handler.test.ts src/agents/bootstrap-cache.test.ts

 Test Files  3 passed (3)
      Tests  18 passed (18)
```

The PR adds 54 lines of tests in `handler.test.ts` covering the opt-in enabled/disabled paths, plus HOOK.md documentation for the new option.