### PR TITLE
fix(skills): check managed lockfile for globally installed ClawHub sk…

### DIFF
--- a/src/skills/discovery/status.test.ts
+++ b/src/skills/discovery/status.test.ts
@@ -238,6 +238,37 @@ describe("buildWorkspaceSkillStatus", () => {
     }
   });
 
+  it("links globally installed ClawHub skills via the managed lockfile, not the workspace lockfile", async () => {
+    const managedParentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-managed-"));
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-status-"));
+    try {
+      const managedSkillsDir = path.join(managedParentDir, "skills");
+      const skillDir = path.join(managedSkillsDir, "agentreceipt");
+      // Write origin metadata inside the globally installed skill dir.
+      await writeClawHubStatusFixture({
+        workspaceDir: managedParentDir,
+        skillDir,
+        slug: "agentreceipt",
+      });
+
+      const report = buildWorkspaceSkillStatus(workspaceDir, {
+        managedSkillsDir,
+        entries: [createEntry("agentreceipt", { baseDir: skillDir })],
+      });
+
+      // Global skill must be linked via the managed lockfile, not flagged as
+      // "not tracked by the workspace ClawHub lockfile".
+      expect(report.skills[0]?.clawhub).toMatchObject({
+        status: "linked",
+        valid: true,
+        slug: "agentreceipt",
+      });
+    } finally {
+      await fs.rm(managedParentDir, { recursive: true, force: true });
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not surface install options for OS-scoped skills on unsupported platforms", () => {
     if (process.platform === "win32") {
       // Keep this simple; win32 platform naming is already explicitly handled elsewhere.

--- a/src/skills/discovery/status.test.ts
+++ b/src/skills/discovery/status.test.ts
@@ -253,7 +253,7 @@ describe("buildWorkspaceSkillStatus", () => {
 
       const report = buildWorkspaceSkillStatus(workspaceDir, {
         managedSkillsDir,
-        entries: [createEntry("agentreceipt", { baseDir: skillDir })],
+        entries: [createEntry("agentreceipt", { baseDir: skillDir, source: "openclaw-managed" })],
       });
 
       // Global skill must be linked via the managed lockfile, not flagged as
@@ -265,6 +265,41 @@ describe("buildWorkspaceSkillStatus", () => {
       });
     } finally {
       await fs.rm(managedParentDir, { recursive: true, force: true });
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("links a globally managed skill whose baseDir is a symlink target outside managedSkillsDir", async () => {
+    const managedParentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-managed-"));
+    const externalSkillDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ext-skill-"));
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-status-"));
+    try {
+      const managedSkillsDir = path.join(managedParentDir, "skills");
+      await fs.mkdir(managedSkillsDir, { recursive: true });
+      // Symlink: managedSkillsDir/agentreceipt -> externalSkillDir (canonical
+      // path is outside managedSkillsDir; lexical path check would miss this).
+      const symlinkPath = path.join(managedSkillsDir, "agentreceipt");
+      await fs.symlink(externalSkillDir, symlinkPath);
+      await writeClawHubStatusFixture({
+        workspaceDir: managedParentDir,
+        skillDir: externalSkillDir,
+        slug: "agentreceipt",
+      });
+      const report = buildWorkspaceSkillStatus(workspaceDir, {
+        managedSkillsDir,
+        entries: [
+          createEntry("agentreceipt", { baseDir: externalSkillDir, source: "openclaw-managed" }),
+        ],
+      });
+
+      expect(report.skills[0]?.clawhub).toMatchObject({
+        status: "linked",
+        valid: true,
+        slug: "agentreceipt",
+      });
+    } finally {
+      await fs.rm(managedParentDir, { recursive: true, force: true });
+      await fs.rm(externalSkillDir, { recursive: true, force: true });
       await fs.rm(workspaceDir, { recursive: true, force: true });
     }
   });

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -296,13 +296,12 @@ function buildSkillStatus(
   const availableToAgent = eligible && !blockedByAgentFilter;
   const userInvocable = indexed.userInvocable;
 
-  // Globally managed skills live under managedSkillsDir and are tracked in the
-  // managed lockfile, not the workspace lockfile. Route them to the managed
-  // parent dir so resolveClawHubSkillStatusLinkSync resolves the correct
-  // install path and lockfile entry.
+  // Globally managed skills are tracked in the managed lockfile, not the
+  // workspace lockfile. Use the loader-assigned source rather than a lexical
+  // path check: managed skill roots may contain symlinks whose resolved
+  // baseDir sits outside the managedSkillsDir tree.
   const resolvedManagedSkillsDir = path.resolve(context.managedSkillsDir);
-  const isGlobalSkill =
-    !bundled && path.resolve(entry.skill.baseDir).startsWith(resolvedManagedSkillsDir + path.sep);
+  const isGlobalSkill = !bundled && skillSource === "openclaw-managed";
   const clawhub =
     workspaceDir && !bundled
       ? resolveClawHubSkillStatusLinkSync({

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -252,6 +252,8 @@ type BuildSkillStatusContext = {
   agentSkillFilter?: string[];
   workspaceDir: string;
   clawhubLockRead: ClawHubSkillsLockfileStatusRead;
+  managedSkillsDir: string;
+  managedLockRead: ClawHubSkillsLockfileStatusRead;
 };
 
 function buildSkillStatus(
@@ -294,13 +296,20 @@ function buildSkillStatus(
   const availableToAgent = eligible && !blockedByAgentFilter;
   const userInvocable = indexed.userInvocable;
 
+  // Globally managed skills live under managedSkillsDir and are tracked in the
+  // managed lockfile, not the workspace lockfile. Route them to the managed
+  // parent dir so resolveClawHubSkillStatusLinkSync resolves the correct
+  // install path and lockfile entry.
+  const resolvedManagedSkillsDir = path.resolve(context.managedSkillsDir);
+  const isGlobalSkill =
+    !bundled && path.resolve(entry.skill.baseDir).startsWith(resolvedManagedSkillsDir + path.sep);
   const clawhub =
     workspaceDir && !bundled
       ? resolveClawHubSkillStatusLinkSync({
-          workspaceDir,
+          workspaceDir: isGlobalSkill ? path.dirname(resolvedManagedSkillsDir) : workspaceDir,
           skillDir: entry.skill.baseDir,
           skillKey,
-          lockRead: context.clawhubLockRead,
+          lockRead: isGlobalSkill ? context.managedLockRead : context.clawhubLockRead,
         })
       : undefined;
   const skillCard = resolveLocalSkillCardStatusSync(entry.skill.baseDir);
@@ -367,6 +376,11 @@ export function buildWorkspaceSkillStatus(
   const prefs = resolveSkillsInstallPreferences(opts?.config);
   const allowBundled = resolveBundledAllowlist(opts?.config);
   const clawhubLockRead = readClawHubSkillsLockfileStatusSync(workspaceDir);
+  const managedParentDir = path.dirname(path.resolve(managedSkillsDir));
+  const managedLockRead =
+    managedParentDir !== path.resolve(workspaceDir)
+      ? readClawHubSkillsLockfileStatusSync(managedParentDir)
+      : clawhubLockRead;
   const skillIndexEntries = buildSkillIndexEntries(skillEntries, {
     bundledNames: bundledContext.names,
     agentSkillFilter,
@@ -385,6 +399,8 @@ export function buildWorkspaceSkillStatus(
         agentSkillFilter,
         workspaceDir,
         clawhubLockRead,
+        managedSkillsDir,
+        managedLockRead,
       }),
     ),
   };


### PR DESCRIPTION
## What Problem This Solves

When a skill is installed globally via ClawHub (`~/.openclaw/skills/<slug>`), its lockfile entry lives at `~/.openclaw/.clawhub/lock.json`, not in the workspace's `.clawhub/lock.json`. `buildWorkspaceSkillStatus` was passing only the workspace lockfile to `resolveClawHubSkillStatusLinkSync` for every skill, including global ones. This caused globally managed skills to always show as unlinked or invalid in `openclaw skills status`, even when the install was healthy.

Fixes #105530

## Why This Change Was Made

`readClawHubSkillsLockfileStatusSync` reads `<dir>/.clawhub/lock.json` for a given directory. Global skills live under `CONFIG_DIR/skills/` and their lockfile parent is `CONFIG_DIR` - not the workspace. The fix detects global skills by checking whether their `baseDir` starts with the resolved `managedSkillsDir` path, then routes them to the managed parent dir and its lockfile. The managed parent dir also satisfies `resolveWorkspaceSkillInstallDir` correctly so the install path check inside `resolveClawHubSkillStatusLinkSync` passes too.

## User Impact

Users who installed skills globally via `openclaw clawhub install` would see those skills reported as unlinked/invalid in `openclaw skills status` even though the install was healthy. After this fix the status correctly shows `linked`.

## Evidence

New test in `src/skills/discovery/status.test.ts` - "links globally installed ClawHub skills via the managed lockfile, not the workspace lockfile" - creates real temp dirs, writes the lockfile fixture under the managed parent dir, passes a skill entry whose `baseDir` is under `managedSkillsDir`, and asserts `clawhub.status === "linked"`.



