### PR TITLE
improve: remove avoidable waits from slow tests

### DIFF
--- a/src/commands/doctor-sqlite-compact.ts
+++ b/src/commands/doctor-sqlite-compact.ts
@@ -23,6 +23,7 @@ export type DoctorSqliteCompactResult = {
 
 type DoctorSqliteCompactOptions = {
   afterMutation?: () => void;
+  busyTimeoutMs?: number;
   sqlitePath: string;
   validateBeforeMutation?: (database: DatabaseSync) => void;
 };
@@ -43,7 +44,9 @@ export function compactDoctorSqliteFile(
   let operationError: unknown;
   let result: DoctorSqliteCompactResult | undefined;
   try {
-    database.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
+    database.exec(
+      `PRAGMA busy_timeout = ${options.busyTimeoutMs ?? OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`,
+    );
     database.exec("PRAGMA trusted_schema = OFF;");
     options.validateBeforeMutation?.(database);
     const before = readCompactSnapshot(database, options.sqlitePath);

--- a/src/commands/doctor-state-sqlite-compact.test.ts
+++ b/src/commands/doctor-state-sqlite-compact.test.ts
@@ -246,7 +246,10 @@ describe("runDoctorStateSqliteCompact", () => {
       reader.exec("BEGIN; SELECT COUNT(*) FROM compact_payload;");
       writer.exec("INSERT INTO compact_payload (payload) VALUES ('newer wal frame');");
 
-      expect(() => runDoctorStateSqliteCompact({ env })).toThrow(/checkpoint remained busy/);
+      // Exercise the real busy checkpoint result without waiting the production lock timeout.
+      expect(() => runDoctorStateSqliteCompact({ env }, { busyTimeoutMs: 0 })).toThrow(
+        /checkpoint remained busy/,
+      );
       expect(readPragma(writer, "auto_vacuum")).toBe(0);
     } finally {
       reader.exec("ROLLBACK;");

--- a/src/commands/doctor-state-sqlite-compact.ts
+++ b/src/commands/doctor-state-sqlite-compact.ts
@@ -33,9 +33,14 @@ type DoctorStateSqliteCompactOptions = {
   env?: NodeJS.ProcessEnv;
 };
 
+type DoctorStateSqliteCompactDeps = {
+  busyTimeoutMs?: number;
+};
+
 /** Compact only the canonical shared state database resolved for this invocation. */
 export function runDoctorStateSqliteCompact(
   options: DoctorStateSqliteCompactOptions = {},
+  deps: DoctorStateSqliteCompactDeps = {},
 ): DoctorStateSqliteCompactReport {
   const env = options.env ?? process.env;
   const sqlitePath = resolveOpenClawStateSqlitePath(env);
@@ -59,6 +64,7 @@ export function runDoctorStateSqliteCompact(
 
   const compact = compactDoctorSqliteFile({
     afterMutation: () => ensureOpenClawStatePermissions(sqlitePath, env),
+    ...(deps.busyTimeoutMs !== undefined ? { busyTimeoutMs: deps.busyTimeoutMs } : {}),
     sqlitePath,
     validateBeforeMutation: (database) =>
       assertOpenClawStateDatabaseForMaintenance(database, { pathname: sqlitePath }),

--- a/src/infra/json-files.test.ts
+++ b/src/infra/json-files.test.ts
@@ -213,6 +213,13 @@ describe("json file helpers", () => {
   });
 
   describe("retry behaviors on 'File changed during read'", () => {
+    function skipRetryDelays(): void {
+      vi.spyOn(globalThis, "setTimeout").mockImplementation((callback) => {
+        queueMicrotask(() => callback());
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      });
+    }
+
     /**
      * Helper: spy on fsPromises.lstat for our target file path.
      * Returns a real Stats object with a modified ino to trigger
@@ -248,6 +255,7 @@ describe("json file helpers", () => {
       await withTempDir({ prefix: "openclaw-json-files-retry-" }, async (base) => {
         const filePath = path.join(base, "config.json");
         await fsPromises.writeFile(filePath, '{"ok":true}', "utf8");
+        skipRetryDelays();
 
         // Only fail lstat once (first call) — retry should succeed on 2nd attempt
         const getCalls = setupLstatSpy(filePath, 1);
@@ -263,8 +271,9 @@ describe("json file helpers", () => {
       await withTempDir({ prefix: "openclaw-json-files-exhaust-" }, async (base) => {
         const filePath = path.join(base, "config.json");
         await fsPromises.writeFile(filePath, '{"ok":true}', "utf8");
+        skipRetryDelays();
 
-        // Always fail lstat — all 3 retries should exhaust
+        // Always fail lstat — every retry attempt should exhaust.
         setupLstatSpy(filePath, Infinity);
 
         await expect(readJson(filePath)).rejects.toThrow(JsonFileReadError);
@@ -275,6 +284,7 @@ describe("json file helpers", () => {
       await withTempDir({ prefix: "openclaw-json-files-try-" }, async (base) => {
         const filePath = path.join(base, "config.json");
         await fsPromises.writeFile(filePath, '{"ok":true}', "utf8");
+        skipRetryDelays();
 
         // Always fail lstat — tryReadJson catches and returns null
         setupLstatSpy(filePath, Infinity);

--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -1813,6 +1813,7 @@ describe("openclaw live updater", () => {
           statePath,
         },
         {
+          sleep() {},
           runCommand(command: string, args: string[]) {
             commands.runCommand(command, args);
             if (command === "pnpm" && args.includes("status")) {


### PR DESCRIPTION
## What Problem This Solves

Several focused tests exercised real production retry and lock timeouts even though their assertions covered retry exhaustion, busy handling, or updater sequencing rather than elapsed wall time. Together, those waits added roughly 17 seconds to affected test lanes.

## Why This Change Was Made

This keeps production timing defaults unchanged while adding narrow test seams: the updater test uses its existing sleep dependency, SQLite compaction accepts an internal busy-timeout override, and JSON retry tests replace only the backoff delay with a microtask while preserving real filesystem race checks and retry counts.

## User Impact

No user-visible runtime behavior changes. Maintainers get faster CI and focused test feedback.

AI-assisted: yes.

## Evidence

- Live-updater failure-path test: 10.224s to about 0.21s.
- SQLite busy-checkpoint test: 5.008s to about 2ms.
- JSON retry cases: 51/753/752ms to 1/1/1ms; whole file 1.97s to 231ms.
- Exact-head Blacksmith Testbox through Crabbox (`tbx_01kxc9bfbn17x8y8f57kts3qr6`): 79/79 focused tests passed; `pnpm check:changed` passed all selected formatting, API baseline, typecheck, lint, and guard lanes.
- Testbox Actions run: https://github.com/openclaw/openclaw/actions/runs/29212819742
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings.
