### PR TITLE
fix(sessions): keep dirty transcript search from blocking the gateway

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -15,6 +15,7 @@ const rootEntries = [
   "src/agents/code-mode.worker.ts!",
   "src/audit/audit-event-writer.worker.ts!",
   "src/agents/model-provider-auth.worker.ts!",
+  "src/config/sessions/session-transcript-reconcile.worker.ts!",
   "src/infra/kysely-node-sqlite.ts!",
   "src/infra/warning-filter.ts!",
   "src/infra/command-explainer/index.ts!",

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -15,7 +15,7 @@ const rootEntries = [
   "src/agents/code-mode.worker.ts!",
   "src/audit/audit-event-writer.worker.ts!",
   "src/agents/model-provider-auth.worker.ts!",
-  "src/config/sessions/session-transcript-reconcile.worker.ts!",
+  "src/config/sessions/session-transcript-reconcile.worker.ts",
   "src/infra/kysely-node-sqlite.ts!",
   "src/infra/warning-filter.ts!",
   "src/infra/command-explainer/index.ts!",

--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -48,6 +48,9 @@ const rawSqliteAllowPathGroups = {
     "src/infra/backup-create.ts",
     "src/snapshot/local-repository.ts",
   ],
+  "bounded transcript search index reconciliation": [
+    "src/config/sessions/session-transcript-reconcile.ts",
+  ],
   "agent auth profile read-only bootstrap": ["src/agents/auth-profiles/sqlite.ts"],
   "read-only shared state database access": ["src/state/openclaw-state-db-readonly.ts"],
   "read-only SQLite status probes": [

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -111,6 +111,7 @@ const requiredPathGroups = [
   "dist/agents/compaction-planning.worker.js",
   "dist/agents/model-provider-auth.worker.js",
   "dist/audit/audit-event-writer.worker.js",
+  "dist/config/sessions/session-transcript-reconcile.worker.js",
   "dist/task-registry-control.runtime.js",
   "dist/telegram-ingress-worker.runtime.js",
   "dist/build-info.json",

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -1,6 +1,4 @@
 #!/usr/bin/env -S node --import tsx
-// Release Check script supports OpenClaw repository automation.
-
 import { execFileSync, type ExecFileSyncOptions } from "node:child_process";
 import {
   copyFileSync,

--- a/src/config/sessions/session-transcript-index.ts
+++ b/src/config/sessions/session-transcript-index.ts
@@ -40,6 +40,7 @@ type TranscriptIndexWatermark = {
   indexedSeq: number;
   leafEventId: string | null;
   needsRebuild: boolean;
+  updatedAt?: number;
 };
 
 function getIndexKysely(db: DatabaseSync) {
@@ -120,7 +121,7 @@ function readWatermark(db: DatabaseSync, sessionId: string): TranscriptIndexWate
     db,
     getIndexKysely(db)
       .selectFrom("session_transcript_index_state")
-      .select(["indexed_seq", "leaf_event_id", "needs_rebuild"])
+      .select(["indexed_seq", "leaf_event_id", "needs_rebuild", "updated_at"])
       .where("session_id", "=", sessionId),
   );
   if (!row) {
@@ -130,6 +131,7 @@ function readWatermark(db: DatabaseSync, sessionId: string): TranscriptIndexWate
     indexedSeq: row.indexed_seq,
     leafEventId: row.leaf_event_id,
     needsRebuild: row.needs_rebuild !== 0,
+    updatedAt: row.updated_at,
   };
 }
 
@@ -272,8 +274,10 @@ function applyForwardIndex(
 
 /** Marks one session for lazy rebuild without touching its FTS rows. */
 function markSessionTranscriptIndexDirtyInTransaction(db: DatabaseSync, sessionId: string): void {
-  const now = Date.now();
   const watermark = readWatermark(db, sessionId);
+  // Claim generations also live in needs_rebuild. Advancing updated_at
+  // monotonically ensures a mutation can never recreate an older claim token.
+  const now = Math.max(Date.now(), (watermark?.updatedAt ?? 0) + 1);
   writeWatermark(
     db,
     sessionId,

--- a/src/config/sessions/session-transcript-index.ts
+++ b/src/config/sessions/session-transcript-index.ts
@@ -82,7 +82,7 @@ function readMessageText(message: unknown): string | undefined {
  * assistant message text is indexed; tool results, reasoning blocks, and
  * images stay out of the index by construction.
  */
-function extractTranscriptIndexEntry(
+export function extractTranscriptIndexEntry(
   event: unknown,
   fallbackTimestamp: number,
 ): TranscriptIndexEntry | undefined {
@@ -216,6 +216,9 @@ export function indexAppendedTranscriptEventInTransaction(
     return;
   }
   if (watermark.needsRebuild) {
+    // A rebuild may own a generation token in needs_rebuild. Reset it to the
+    // canonical dirty marker so this append invalidates that worker's claim.
+    markSessionTranscriptIndexDirtyInTransaction(db, params.sessionId);
     return;
   }
   if (params.seq !== watermark.indexedSeq + 1) {
@@ -273,7 +276,10 @@ function applyForwardIndex(
 }
 
 /** Marks one session for lazy rebuild without touching its FTS rows. */
-function markSessionTranscriptIndexDirtyInTransaction(db: DatabaseSync, sessionId: string): void {
+export function markSessionTranscriptIndexDirtyInTransaction(
+  db: DatabaseSync,
+  sessionId: string,
+): void {
   const watermark = readWatermark(db, sessionId);
   // Claim generations also live in needs_rebuild. Advancing updated_at
   // monotonically ensures a mutation can never recreate an older claim token.

--- a/src/config/sessions/session-transcript-reconcile.ts
+++ b/src/config/sessions/session-transcript-reconcile.ts
@@ -9,7 +9,10 @@ import {
   openOpenClawAgentDatabase,
   runOpenClawAgentWriteTransaction,
 } from "../../state/openclaw-agent-db.js";
-import { extractTranscriptIndexEntry } from "./session-transcript-index.js";
+import {
+  extractTranscriptIndexEntry,
+  markSessionTranscriptIndexDirtyInTransaction,
+} from "./session-transcript-index.js";
 import {
   resolveVisibleTranscriptAppendParentId,
   selectVisibleTranscriptEventEntries,
@@ -31,6 +34,8 @@ function kysely(db: DatabaseSync) {
 }
 
 function readRevision(db: DatabaseSync, sessionId: string): number | null | undefined {
+  // Transcript mutations advance this value strictly, even within one wall-clock
+  // millisecond, so it is the generation fence for out-of-transaction planning.
   return executeSqliteQueryTakeFirstSync(
     db,
     kysely(db)
@@ -220,15 +225,20 @@ function insertFtsRows(
   }
 }
 
-function selectOrphanFtsRowIds(db: DatabaseSync): Array<number | bigint> {
+type OrphanFtsRow = { rowId: number | bigint; sessionId: string };
+
+function selectOrphanFtsRows(db: DatabaseSync, afterRowId: number | bigint): OrphanFtsRow[] {
   return (
     db
       .prepare(
         /* sqlite-allow-raw: unindexed FTS scan deliberately stays outside BEGIN */
-        "SELECT f.rowid FROM session_transcript_fts AS f WHERE NOT EXISTS (SELECT 1 FROM transcript_events AS e WHERE e.session_id = f.session_id) LIMIT ?",
+        "SELECT f.rowid, f.session_id FROM session_transcript_fts AS f WHERE f.rowid > ? AND NOT EXISTS (SELECT 1 FROM transcript_events AS e WHERE e.session_id = f.session_id) ORDER BY f.rowid LIMIT ?",
       )
-      .all(RECONCILE_BATCH_SIZE) as Array<{ rowid: number | bigint }>
-  ).map((row) => row.rowid);
+      .all(afterRowId, RECONCILE_BATCH_SIZE) as Array<{
+      rowid: number | bigint;
+      session_id: string;
+    }>
+  ).map((row) => ({ rowId: row.rowid, sessionId: row.session_id }));
 }
 
 function selectOrphanWatermarks(db: DatabaseSync): string[] {
@@ -259,11 +269,12 @@ async function reconcileOrphans(params: {
   onProgress?: () => void;
 }): Promise<void> {
   const database = openOpenClawAgentDatabase(params);
+  let orphanFtsCursor: number | bigint = 0;
   while (true) {
     params.onPlanning?.();
-    const rowIds = selectOrphanFtsRowIds(database.db);
+    const rows = selectOrphanFtsRows(database.db, orphanFtsCursor);
     const sessionIds = selectOrphanWatermarks(database.db);
-    if (rowIds.length === 0 && sessionIds.length === 0) {
+    if (rows.length === 0 && sessionIds.length === 0) {
       return;
     }
     params.onRebuildActive?.();
@@ -273,8 +284,13 @@ async function reconcileOrphans(params: {
           /* sqlite-allow-raw: revalidates transcript absence inside the short write */
           "DELETE FROM session_transcript_fts WHERE rowid = ? AND NOT EXISTS (SELECT 1 FROM transcript_events AS e WHERE e.session_id = session_transcript_fts.session_id)",
         );
-        for (const rowId of rowIds) {
-          removeFts.run(rowId);
+        for (const row of rows) {
+          const removed = removeFts.run(row.rowId);
+          if (removed.changes === 0) {
+            // The session was recreated after planning. Hide any retained old
+            // FTS rows until the normal dirty-session rebuild replaces them.
+            markSessionTranscriptIndexDirtyInTransaction(agentDatabase.db, row.sessionId);
+          }
         }
         for (const sessionId of sessionIds) {
           executeSqliteQuerySync(
@@ -298,6 +314,7 @@ async function reconcileOrphans(params: {
       params,
       { operationLabel: "sessions.search.reconcile.orphan-batch" },
     );
+    orphanFtsCursor = rows.at(-1)?.rowId ?? orphanFtsCursor;
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });

--- a/src/config/sessions/session-transcript-reconcile.ts
+++ b/src/config/sessions/session-transcript-reconcile.ts
@@ -1,0 +1,445 @@
+import type { DatabaseSync } from "node:sqlite";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
+import {
+  openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
+} from "../../state/openclaw-agent-db.js";
+import { extractTranscriptIndexEntry } from "./session-transcript-index.js";
+import {
+  resolveVisibleTranscriptAppendParentId,
+  selectVisibleTranscriptEventEntries,
+} from "./transcript-visible-events.js";
+
+const RECONCILE_BATCH_SIZE = 64;
+// Bounds abandoned ownership while leaving headroom for one synchronous
+// planning phase between worker progress and claim-refresh boundaries.
+const RECONCILE_CLAIM_LEASE_MS = 5 * 60_000;
+
+type ReconcileDatabase = Pick<
+  OpenClawAgentKyselyDatabase,
+  "sessions" | "session_transcript_index_state" | "transcript_events"
+>;
+type PlannedEntry = NonNullable<ReturnType<typeof extractTranscriptIndexEntry>>;
+
+function kysely(db: DatabaseSync) {
+  return getNodeSqliteKysely<ReconcileDatabase>(db);
+}
+
+function readRevision(db: DatabaseSync, sessionId: string): number | null | undefined {
+  return executeSqliteQueryTakeFirstSync(
+    db,
+    kysely(db)
+      .selectFrom("sessions")
+      .select("transcript_updated_at")
+      .where("session_id", "=", sessionId),
+  )?.transcript_updated_at;
+}
+
+function ownsClaim(db: DatabaseSync, sessionId: string, token: number): boolean {
+  return (
+    executeSqliteQueryTakeFirstSync(
+      db,
+      kysely(db)
+        .selectFrom("session_transcript_index_state")
+        .select("needs_rebuild")
+        .where("session_id", "=", sessionId),
+    )?.needs_rebuild === token
+  );
+}
+
+function refreshClaim(db: DatabaseSync, sessionId: string, token: number): void {
+  const currentUpdatedAt = executeSqliteQueryTakeFirstSync(
+    db,
+    kysely(db)
+      .selectFrom("session_transcript_index_state")
+      .select("updated_at")
+      .where("session_id", "=", sessionId)
+      .where("needs_rebuild", "=", token),
+  )?.updated_at;
+  if (currentUpdatedAt === undefined) {
+    return;
+  }
+  executeSqliteQuerySync(
+    db,
+    kysely(db)
+      .updateTable("session_transcript_index_state")
+      .set({ updated_at: Math.max(Date.now(), token, currentUpdatedAt) })
+      .where("session_id", "=", sessionId)
+      .where("needs_rebuild", "=", token),
+  );
+}
+
+function tryClaimSession(
+  db: DatabaseSync,
+  sessionId: string,
+  expectedRevision: number | null | undefined,
+): number | undefined {
+  if (readRevision(db, sessionId) !== expectedRevision) {
+    return undefined;
+  }
+  const latestSeq = executeSqliteQueryTakeFirstSync(
+    db,
+    kysely(db)
+      .selectFrom("transcript_events")
+      .select("seq")
+      .where("session_id", "=", sessionId)
+      .orderBy("seq", "desc")
+      .limit(1),
+  )?.seq;
+  if (latestSeq === undefined) {
+    return undefined;
+  }
+  const state = executeSqliteQueryTakeFirstSync(
+    db,
+    kysely(db)
+      .selectFrom("session_transcript_index_state")
+      .select(["indexed_seq", "needs_rebuild", "updated_at"])
+      .where("session_id", "=", sessionId),
+  );
+  const now = Date.now();
+  const reclaimable =
+    state !== undefined &&
+    state.needs_rebuild > 1 &&
+    state.updated_at <= now - RECONCILE_CLAIM_LEASE_MS;
+  if (state && !reclaimable && state.needs_rebuild !== 1 && state.indexed_seq >= latestSeq) {
+    return undefined;
+  }
+  if (!state) {
+    const token = Math.max(2, now);
+    const inserted = executeSqliteQuerySync(
+      db,
+      kysely(db)
+        .insertInto("session_transcript_index_state")
+        .values({
+          session_id: sessionId,
+          indexed_seq: -1,
+          leaf_event_id: null,
+          needs_rebuild: token,
+          updated_at: now,
+        })
+        .onConflict((conflict) => conflict.column("session_id").doNothing()),
+    );
+    return (inserted.numAffectedRows ?? 0n) === 1n ? token : undefined;
+  }
+  // Claim identity is a DB-owned monotonic generation, not randomness. Every
+  // transcript mutation advances updated_at before resetting needs_rebuild=1,
+  // so an invalidated worker can never match a later claimant's token.
+  const token = Math.max(2, now, state.updated_at + 1);
+  const claimed = executeSqliteQuerySync(
+    db,
+    kysely(db)
+      .updateTable("session_transcript_index_state")
+      .set({ needs_rebuild: token, updated_at: token })
+      .where("session_id", "=", sessionId)
+      .where("needs_rebuild", "in", reclaimable ? [0, 1, state.needs_rebuild] : [0, 1])
+      .where("updated_at", "=", state.updated_at),
+  );
+  return (claimed.numAffectedRows ?? 0n) === 1n ? token : undefined;
+}
+
+function selectSessionIds(db: DatabaseSync): string[] {
+  const abandonedBefore = Date.now() - RECONCILE_CLAIM_LEASE_MS;
+  const rows = executeSqliteQuerySync(
+    db,
+    kysely(db)
+      .selectFrom("sessions")
+      .innerJoin("transcript_events as latest", (join) =>
+        join
+          .onRef("latest.session_id", "=", "sessions.session_id")
+          .on((eb) =>
+            eb(
+              "latest.seq",
+              "=",
+              eb
+                .selectFrom("transcript_events as candidate")
+                .select("candidate.seq")
+                .whereRef("candidate.session_id", "=", "sessions.session_id")
+                .orderBy("candidate.seq", "desc")
+                .limit(1),
+            ),
+          ),
+      )
+      .leftJoin(
+        "session_transcript_index_state as state",
+        "state.session_id",
+        "sessions.session_id",
+      )
+      .select("sessions.session_id")
+      .where((eb) =>
+        eb.or([
+          eb(eb.fn.coalesce("state.needs_rebuild", eb.val(1)), "=", 1),
+          eb("latest.seq", ">", eb.fn.coalesce("state.indexed_seq", eb.val(-1))),
+          eb.and([
+            eb("state.needs_rebuild", ">", 1),
+            eb("state.updated_at", "<=", abandonedBefore),
+          ]),
+        ]),
+      )
+      .orderBy("sessions.session_id"),
+  ).rows;
+  return rows.map((row) => row.session_id);
+}
+
+function selectFtsRowIds(db: DatabaseSync, sessionId: string): Array<number | bigint> {
+  return (
+    db
+      .prepare(
+        /* sqlite-allow-raw: FTS5 has no Kysely rowid model; scan happens outside BEGIN */
+        "SELECT rowid FROM session_transcript_fts WHERE session_id = ?",
+      )
+      .all(sessionId) as Array<{ rowid: number | bigint }>
+  ).map((row) => row.rowid);
+}
+
+function deleteFtsRows(db: DatabaseSync, rowIds: readonly (number | bigint)[]): void {
+  const remove = db.prepare(
+    /* sqlite-allow-raw: bounded primary rowid deletes */
+    "DELETE FROM session_transcript_fts WHERE rowid = ?",
+  );
+  for (const rowId of rowIds) {
+    remove.run(rowId);
+  }
+}
+
+function insertFtsRows(
+  db: DatabaseSync,
+  sessionId: string,
+  entries: readonly PlannedEntry[],
+): void {
+  const insert = db.prepare(
+    /* sqlite-allow-raw: FTS5 virtual-table maintenance */
+    "INSERT INTO session_transcript_fts(text, session_id, message_id, role, timestamp) VALUES (?, ?, ?, ?, ?)",
+  );
+  for (const entry of entries) {
+    insert.run(entry.text, sessionId, entry.messageId, entry.role, entry.timestamp);
+  }
+}
+
+function selectOrphanFtsRowIds(db: DatabaseSync): Array<number | bigint> {
+  return (
+    db
+      .prepare(
+        /* sqlite-allow-raw: unindexed FTS scan deliberately stays outside BEGIN */
+        "SELECT f.rowid FROM session_transcript_fts AS f WHERE NOT EXISTS (SELECT 1 FROM transcript_events AS e WHERE e.session_id = f.session_id) LIMIT ?",
+      )
+      .all(RECONCILE_BATCH_SIZE) as Array<{ rowid: number | bigint }>
+  ).map((row) => row.rowid);
+}
+
+function selectOrphanWatermarks(db: DatabaseSync): string[] {
+  return executeSqliteQuerySync(
+    db,
+    kysely(db)
+      .selectFrom("session_transcript_index_state as state")
+      .select("state.session_id")
+      .where((eb) =>
+        eb.not(
+          eb.exists(
+            eb
+              .selectFrom("transcript_events as event")
+              .select("event.session_id")
+              .whereRef("event.session_id", "=", "state.session_id"),
+          ),
+        ),
+      )
+      .limit(RECONCILE_BATCH_SIZE),
+  ).rows.map((row) => row.session_id);
+}
+
+async function reconcileOrphans(params: {
+  agentId: string;
+  env: NodeJS.ProcessEnv;
+  onPlanning?: () => void;
+  onRebuildActive?: () => void;
+  onProgress?: () => void;
+}): Promise<void> {
+  const database = openOpenClawAgentDatabase(params);
+  while (true) {
+    params.onPlanning?.();
+    const rowIds = selectOrphanFtsRowIds(database.db);
+    const sessionIds = selectOrphanWatermarks(database.db);
+    if (rowIds.length === 0 && sessionIds.length === 0) {
+      return;
+    }
+    params.onRebuildActive?.();
+    runOpenClawAgentWriteTransaction(
+      (agentDatabase) => {
+        const removeFts = agentDatabase.db.prepare(
+          /* sqlite-allow-raw: revalidates transcript absence inside the short write */
+          "DELETE FROM session_transcript_fts WHERE rowid = ? AND NOT EXISTS (SELECT 1 FROM transcript_events AS e WHERE e.session_id = session_transcript_fts.session_id)",
+        );
+        for (const rowId of rowIds) {
+          removeFts.run(rowId);
+        }
+        for (const sessionId of sessionIds) {
+          executeSqliteQuerySync(
+            agentDatabase.db,
+            kysely(agentDatabase.db)
+              .deleteFrom("session_transcript_index_state")
+              .where("session_id", "=", sessionId)
+              .where((eb) =>
+                eb.not(
+                  eb.exists(
+                    eb
+                      .selectFrom("transcript_events")
+                      .select("session_id")
+                      .where("session_id", "=", sessionId),
+                  ),
+                ),
+              ),
+          );
+        }
+      },
+      params,
+      { operationLabel: "sessions.search.reconcile.orphan-batch" },
+    );
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    params.onProgress?.();
+  }
+}
+
+/** Reconcile dirty transcript indexes without holding a write lock during planning or FTS scans. */
+export async function reconcileSessionTranscriptIndexes(params: {
+  agentId: string;
+  stateDir: string;
+  onRebuildActive?: () => void;
+  onPlanning?: () => void;
+  onProgress?: () => void;
+}): Promise<void> {
+  const env = { OPENCLAW_STATE_DIR: params.stateDir };
+  const database = openOpenClawAgentDatabase({ agentId: params.agentId, env });
+  for (const sessionId of selectSessionIds(database.db)) {
+    params.onPlanning?.();
+    const revision = readRevision(database.db, sessionId);
+    const rows = executeSqliteQuerySync(
+      database.db,
+      kysely(database.db)
+        .selectFrom("transcript_events")
+        .select(["seq", "event_json"])
+        .where("session_id", "=", sessionId)
+        .orderBy("seq"),
+    ).rows;
+    if (rows.length === 0) {
+      continue;
+    }
+    const events = rows.map((row) => JSON.parse(row.event_json) as unknown);
+    const now = Date.now();
+    const entries = selectVisibleTranscriptEventEntries(events).flatMap(({ event }) => {
+      const entry = extractTranscriptIndexEntry(event, now);
+      return entry ? [entry] : [];
+    });
+    const maxSeq = rows.at(-1)?.seq ?? -1;
+    const leafEventId = resolveVisibleTranscriptAppendParentId(events);
+    const rowIds = selectFtsRowIds(database.db, sessionId);
+    let token: number | undefined;
+    runOpenClawAgentWriteTransaction(
+      (agentDatabase) => {
+        token = tryClaimSession(agentDatabase.db, sessionId, revision);
+      },
+      { agentId: params.agentId, env },
+      { operationLabel: "sessions.search.reconcile.claim" },
+    );
+    if (token === undefined) {
+      continue;
+    }
+    const claimToken = token;
+    // Planning and the potentially full UNINDEXED scan are complete. From this
+    // point onward, progress consists only of claim-guarded bounded writes.
+    params.onRebuildActive?.();
+
+    let owns = true;
+    for (let offset = 0; offset < rowIds.length; offset += RECONCILE_BATCH_SIZE) {
+      if (!owns) {
+        break;
+      }
+      const batch = rowIds.slice(offset, offset + RECONCILE_BATCH_SIZE);
+      runOpenClawAgentWriteTransaction(
+        (agentDatabase) => {
+          owns = ownsClaim(agentDatabase.db, sessionId, claimToken);
+          if (owns) {
+            deleteFtsRows(agentDatabase.db, batch);
+            refreshClaim(agentDatabase.db, sessionId, claimToken);
+          }
+        },
+        { agentId: params.agentId, env },
+        { operationLabel: "sessions.search.reconcile.delete-batch" },
+      );
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      params.onProgress?.();
+    }
+    for (let offset = 0; offset < entries.length; offset += RECONCILE_BATCH_SIZE) {
+      if (!owns) {
+        break;
+      }
+      const batch = entries.slice(offset, offset + RECONCILE_BATCH_SIZE);
+      runOpenClawAgentWriteTransaction(
+        (agentDatabase) => {
+          owns = ownsClaim(agentDatabase.db, sessionId, claimToken);
+          if (owns) {
+            insertFtsRows(agentDatabase.db, sessionId, batch);
+            refreshClaim(agentDatabase.db, sessionId, claimToken);
+          }
+        },
+        { agentId: params.agentId, env },
+        { operationLabel: "sessions.search.reconcile.insert-batch" },
+      );
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      params.onProgress?.();
+    }
+    if (!owns) {
+      continue;
+    }
+
+    runOpenClawAgentWriteTransaction(
+      (agentDatabase) => {
+        if (readRevision(agentDatabase.db, sessionId) !== revision) {
+          return;
+        }
+        const claimUpdatedAt = executeSqliteQueryTakeFirstSync(
+          agentDatabase.db,
+          kysely(agentDatabase.db)
+            .selectFrom("session_transcript_index_state")
+            .select("updated_at")
+            .where("session_id", "=", sessionId)
+            .where("needs_rebuild", "=", claimToken),
+        )?.updated_at;
+        if (claimUpdatedAt === undefined) {
+          return;
+        }
+        executeSqliteQuerySync(
+          agentDatabase.db,
+          kysely(agentDatabase.db)
+            .updateTable("session_transcript_index_state")
+            .set({
+              indexed_seq: maxSeq,
+              leaf_event_id: leafEventId,
+              needs_rebuild: 0,
+              updated_at: Math.max(Date.now(), claimToken, claimUpdatedAt),
+            })
+            .where("session_id", "=", sessionId)
+            .where("needs_rebuild", "=", claimToken),
+        );
+      },
+      { agentId: params.agentId, env },
+      { operationLabel: "sessions.search.reconcile.publish" },
+    );
+  }
+  await reconcileOrphans({
+    agentId: params.agentId,
+    env,
+    onPlanning: params.onPlanning,
+    onRebuildActive: params.onRebuildActive,
+    onProgress: params.onProgress,
+  });
+}

--- a/src/config/sessions/session-transcript-reconcile.worker.ts
+++ b/src/config/sessions/session-transcript-reconcile.worker.ts
@@ -1,0 +1,34 @@
+import { parentPort, workerData } from "node:worker_threads";
+import { reconcileSessionTranscriptIndexes } from "./session-transcript-reconcile.js";
+
+type WorkerInput = { agentId: string; stateDir: string };
+const input = workerData as Partial<WorkerInput> | undefined;
+if (!parentPort || typeof input?.agentId !== "string" || typeof input.stateDir !== "string") {
+  throw new Error("session transcript reconcile worker requires agentId and stateDir");
+}
+const sendToParent: (message: { status: string; error?: string }) => void =
+  parentPort.postMessage.bind(parentPort);
+
+try {
+  sendToParent({ status: "ready" });
+  await reconcileSessionTranscriptIndexes({
+    agentId: input.agentId,
+    stateDir: input.stateDir,
+    onPlanning: () => {
+      sendToParent({ status: "ready" });
+    },
+    onProgress: () => {
+      sendToParent({ status: "progress" });
+    },
+    onRebuildActive: () => {
+      sendToParent({ status: "started" });
+    },
+  });
+  sendToParent({ status: "ok" });
+} catch (error) {
+  sendToParent({
+    status: "failed",
+    error: error instanceof Error ? error.message : String(error),
+  });
+  process.exitCode = 1;
+}

--- a/src/config/sessions/session-transcript-search.test.ts
+++ b/src/config/sessions/session-transcript-search.test.ts
@@ -16,8 +16,17 @@ import {
   appendSqliteTranscriptMessage,
   replaceSqliteTranscriptEvents,
 } from "./session-accessor.sqlite.js";
-import { listSessionsNeedingTranscriptIndexReconcile } from "./session-transcript-index.js";
-import { searchSessionTranscripts } from "./session-transcript-search.js";
+import {
+  extractTranscriptIndexEntry,
+  listSessionsNeedingTranscriptIndexReconcile,
+} from "./session-transcript-index.js";
+import {
+  resetSessionTranscriptSearchForTest,
+  searchSessionTranscripts,
+  sessionTranscriptSearchTesting,
+  waitForSessionTranscriptReconcileActiveForTest,
+  waitForSessionTranscriptReconcileForTest,
+} from "./session-transcript-search.js";
 
 vi.mock("../config.js", async () => ({
   ...(await vi.importActual<typeof import("../config.js")>("../config.js")),
@@ -96,6 +105,17 @@ function agentKysely() {
       >
     >(database.db),
   };
+}
+
+async function finishReconcile(query: string) {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    await waitForSessionTranscriptReconcileForTest();
+    const result = search(query);
+    if (!result.indexing) {
+      return result;
+    }
+  }
+  throw new Error("transcript index did not converge");
 }
 
 describe("searchSessionTranscripts", () => {
@@ -218,6 +238,231 @@ describe("searchSessionTranscripts", () => {
     const result = search("historic");
     expect(result.indexing).toBe(false);
     expect(result.hits).toHaveLength(1);
+  });
+
+  it("returns before a dirty rebuild and keeps the event loop responsive", async () => {
+    const events = Array.from({ length: 512 }, (_, index) => ({
+      type: "message",
+      id: `m-${index}`,
+      parentId: index === 0 ? null : `m-${index - 1}`,
+      message: { role: "user", content: [{ type: "text", text: `responsive needle ${index}` }] },
+    })) as unknown as TranscriptEvent[];
+    await replaceSqliteTranscriptEvents(transcriptScope("session-1", "agent:main:main"), events);
+    const { db, kysely } = agentKysely();
+    executeSqliteQuerySync(db, kysely.deleteFrom("session_transcript_fts"));
+    executeSqliteQuerySync(db, kysely.deleteFrom("session_transcript_index_state"));
+
+    const dirty = search("needle");
+    expect(dirty).toMatchObject({ hits: [], indexing: true });
+    await waitForSessionTranscriptReconcileActiveForTest();
+    let heartbeats = 0;
+    const heartbeat = setInterval(() => {
+      heartbeats += 1;
+    }, 0);
+    const result = await finishReconcile("needle");
+    clearInterval(heartbeat);
+    expect(heartbeats).toBeGreaterThan(1);
+    expect(result.hits).toHaveLength(10);
+  });
+
+  it("serializes concurrent worker claims without duplicate FTS rows", async () => {
+    const events = Array.from({ length: 192 }, (_, index) => ({
+      type: "message",
+      id: `claim-${index}`,
+      parentId: index === 0 ? null : `claim-${index - 1}`,
+      message: { role: "user", content: [{ type: "text", text: `claim payload ${index}` }] },
+    })) as unknown as TranscriptEvent[];
+    await replaceSqliteTranscriptEvents(transcriptScope("session-1", "agent:main:main"), events);
+    const { db, kysely } = agentKysely();
+    executeSqliteQuerySync(db, kysely.deleteFrom("session_transcript_fts"));
+    executeSqliteQuerySync(db, kysely.deleteFrom("session_transcript_index_state"));
+
+    await Promise.all([
+      sessionTranscriptSearchTesting.runReconcileWorker({
+        agentId: "main",
+        stateDir: paths.stateDir,
+      }),
+      sessionTranscriptSearchTesting.runReconcileWorker({
+        agentId: "main",
+        stateDir: paths.stateDir,
+      }),
+    ]);
+
+    const rows = executeSqliteQuerySync(
+      db,
+      kysely.selectFrom("session_transcript_fts").select("message_id"),
+    ).rows;
+    expect(new Set(rows.map((row) => row.message_id)).size).toBe(192);
+    expect(rows).toHaveLength(192);
+    expect(search("claim").indexing).toBe(false);
+  });
+
+  it("reclaims an abandoned worker generation after its lease expires", async () => {
+    await appendUserMessage("session-1", "agent:main:main", "abandoned claim payload");
+    const { db, kysely } = agentKysely();
+    executeSqliteQuerySync(db, kysely.deleteFrom("session_transcript_fts"));
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .updateTable("session_transcript_index_state")
+        .set({ needs_rebuild: 42, updated_at: 1 })
+        .where("session_id", "=", "session-1"),
+    );
+
+    await sessionTranscriptSearchTesting.runReconcileWorker({
+      agentId: "main",
+      stateDir: paths.stateDir,
+    });
+
+    expect(search("abandoned")).toMatchObject({ indexing: false });
+    expect(search("abandoned").hits).toHaveLength(1);
+  });
+
+  it("does not hold a write lock while scanning a large unrelated FTS corpus", async () => {
+    await appendUserMessage("session-1", "agent:main:main", "target dirty");
+    const { db, kysely } = agentKysely();
+    executeSqliteQuerySync(db, kysely.deleteFrom("session_transcript_index_state"));
+    const insert = db.prepare(
+      /* sqlite-allow-raw: focused FTS lock-latency fixture */
+      "INSERT INTO session_transcript_fts(text, session_id, message_id, role, timestamp) VALUES (?, ?, ?, 'user', 1)",
+    );
+    for (let index = 0; index < 10_000; index += 1) {
+      insert.run("unrelated", "unrelated-session", `unrelated-${index}`);
+    }
+
+    expect(search("target").indexing).toBe(true);
+    await waitForSessionTranscriptReconcileActiveForTest();
+    const append = appendUserMessage(
+      "session-1",
+      "agent:main:main",
+      "append stays responsive",
+    ).then(() => "append" as const);
+    const reconcile = waitForSessionTranscriptReconcileForTest().then(() => "reconcile" as const);
+    expect(await Promise.race([append, reconcile])).toBe("append");
+    await reconcile;
+  });
+
+  it("resolves source and dist worker URLs and times out a silent worker", async () => {
+    expect(
+      sessionTranscriptSearchTesting.resolveReconcileWorkerUrl(
+        "file:///repo/src/config/sessions/session-transcript-search.ts",
+      ).pathname,
+    ).toBe("/repo/src/config/sessions/session-transcript-reconcile.worker.ts");
+    expect(
+      sessionTranscriptSearchTesting.resolveReconcileWorkerUrl(
+        "file:///repo/dist/chunks/session-transcript-search-ABC123.js",
+      ).pathname,
+    ).toBe("/repo/dist/config/sessions/session-transcript-reconcile.worker.js");
+    await expect(
+      sessionTranscriptSearchTesting.runReconcileWorker({
+        agentId: "main",
+        stateDir: paths.stateDir,
+        timeoutMs: 25,
+        workerUrl: new URL("data:text/javascript,setInterval(() => {}, 1000)"),
+      }),
+    ).rejects.toThrow(/timed out/);
+    await expect(
+      sessionTranscriptSearchTesting.runReconcileWorker({
+        agentId: "main",
+        stateDir: paths.stateDir,
+        planningTimeoutMs: 25,
+        workerUrl: new URL(
+          "data:text/javascript,import { parentPort } from 'node:worker_threads'; parentPort.postMessage({ status: 'ready' }); setInterval(() => {}, 1000)",
+        ),
+      }),
+    ).rejects.toThrow(/timed out/);
+    const progressingWorker = encodeURIComponent(`
+      import { parentPort } from "node:worker_threads";
+      const timer = setInterval(() => parentPort.postMessage({ status: "progress" }), 100);
+      setTimeout(() => {
+        clearInterval(timer);
+        parentPort.postMessage({ status: "ok" });
+      }, 2500);
+    `);
+    await expect(
+      sessionTranscriptSearchTesting.runReconcileWorker({
+        agentId: "main",
+        stateDir: paths.stateDir,
+        timeoutMs: 1000,
+        workerUrl: new URL(`data:text/javascript,${progressingWorker}`),
+      }),
+    ).resolves.toBeUndefined();
+    const multiSessionWorker = encodeURIComponent(`
+      import { parentPort } from "node:worker_threads";
+      parentPort.postMessage({ status: "ready" });
+      setTimeout(() => parentPort.postMessage({ status: "started" }), 50);
+      setTimeout(() => parentPort.postMessage({ status: "progress" }), 100);
+      setTimeout(() => parentPort.postMessage({ status: "ready" }), 150);
+      setTimeout(() => parentPort.postMessage({ status: "ok" }), 1500);
+    `);
+    await expect(
+      sessionTranscriptSearchTesting.runReconcileWorker({
+        agentId: "main",
+        stateDir: paths.stateDir,
+        timeoutMs: 1000,
+        planningTimeoutMs: 3000,
+        workerUrl: new URL(`data:text/javascript,${multiSessionWorker}`),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("keeps dirty state authoritative across append and rewind races", async () => {
+    const scope = transcriptScope("session-1", "agent:main:main");
+    await replaceSqliteTranscriptEvents(scope, [
+      {
+        type: "message",
+        id: "m1",
+        parentId: null,
+        message: { role: "user", content: [{ type: "text", text: "race origin" }] },
+      },
+      {
+        type: "message",
+        id: "m2",
+        parentId: "m1",
+        message: { role: "assistant", content: [{ type: "text", text: "race appended" }] },
+      },
+    ] as unknown as TranscriptEvent[]);
+    const { db, kysely } = agentKysely();
+    executeSqliteQuerySync(db, kysely.deleteFrom("session_transcript_fts"));
+    executeSqliteQuerySync(db, kysely.deleteFrom("session_transcript_index_state"));
+
+    expect(search("race").indexing).toBe(true);
+    await appendUserMessage("session-1", "agent:main:main", "race later");
+    expect((await finishReconcile("appended")).hits).toHaveLength(1);
+
+    await appendSqliteTranscriptEvent(scope, {
+      type: "leaf",
+      id: "rewind",
+      parentId: "m2",
+      targetId: "m1",
+    } as unknown as TranscriptEvent);
+    expect(search("appended").hits).toHaveLength(0);
+    expect((await finishReconcile("appended")).hits).toHaveLength(0);
+  });
+
+  it("does not publish stale same-count replacements or deleted transcripts", async () => {
+    const scope = transcriptScope("session-1", "agent:main:main");
+    await appendUserMessage("session-1", "agent:main:main", "before replacement");
+    const { db, kysely } = agentKysely();
+    executeSqliteQuerySync(db, kysely.deleteFrom("session_transcript_fts"));
+    executeSqliteQuerySync(db, kysely.deleteFrom("session_transcript_index_state"));
+    expect(search("before").indexing).toBe(true);
+    await replaceSqliteTranscriptEvents(scope, [
+      {
+        type: "message",
+        id: "replacement",
+        parentId: null,
+        message: { role: "user", content: [{ type: "text", text: "after replacement" }] },
+      },
+    ] as unknown as TranscriptEvent[]);
+    expect((await finishReconcile("after")).hits).toHaveLength(1);
+    expect(search("before").hits).toHaveLength(0);
+
+    executeSqliteQuerySync(db, kysely.deleteFrom("session_transcript_index_state"));
+    expect(search("after").indexing).toBe(true);
+    await deleteSqliteTranscript({ agentId: "main", env: env(), sessionId: "session-1" });
+    await waitForSessionTranscriptReconcileForTest();
+    expect(search("after").hits).toHaveLength(0);
   });
 
   it("detects missing, dirty, and lagging transcript index watermarks", async () => {

--- a/src/config/sessions/session-transcript-search.test.ts
+++ b/src/config/sessions/session-transcript-search.test.ts
@@ -16,12 +16,8 @@ import {
   appendSqliteTranscriptMessage,
   replaceSqliteTranscriptEvents,
 } from "./session-accessor.sqlite.js";
+import { listSessionsNeedingTranscriptIndexReconcile } from "./session-transcript-index.js";
 import {
-  extractTranscriptIndexEntry,
-  listSessionsNeedingTranscriptIndexReconcile,
-} from "./session-transcript-index.js";
-import {
-  resetSessionTranscriptSearchForTest,
   searchSessionTranscripts,
   sessionTranscriptSearchTesting,
   waitForSessionTranscriptReconcileActiveForTest,

--- a/src/config/sessions/session-transcript-search.test.ts
+++ b/src/config/sessions/session-transcript-search.test.ts
@@ -497,6 +497,21 @@ describe("searchSessionTranscripts", () => {
     expect(pending()).toEqual(["session-1"]);
   });
 
+  it("hides stale index rows while a missing watermark is being rebuilt", async () => {
+    await appendUserMessage("session-1", "agent:main:main", "stale watermark text");
+    const { db, kysely } = agentKysely();
+    executeSqliteQuerySync(
+      db,
+      kysely.deleteFrom("session_transcript_index_state").where("session_id", "=", "session-1"),
+    );
+
+    const result = search("stale watermark");
+    expect(result.indexing).toBe(true);
+    expect(result.hits).toHaveLength(0);
+    await waitForSessionTranscriptReconcileForTest();
+    expect(search("stale watermark").hits).toHaveLength(1);
+  });
+
   it("sweeps orphaned index rows during reconcile", async () => {
     await appendUserMessage("session-1", "agent:main:main", "anchor row");
     const { db, kysely } = agentKysely();

--- a/src/config/sessions/session-transcript-search.test.ts
+++ b/src/config/sessions/session-transcript-search.test.ts
@@ -340,6 +340,10 @@ describe("searchSessionTranscripts", () => {
     const reconcile = waitForSessionTranscriptReconcileForTest().then(() => "reconcile" as const);
     expect(await Promise.race([append, reconcile])).toBe("append");
     await reconcile;
+    await sessionTranscriptSearchTesting.runReconcileWorker({
+      agentId: "main",
+      stateDir: paths.stateDir,
+    });
   });
 
   it("resolves source and dist worker URLs and times out a silent worker", async () => {
@@ -460,7 +464,7 @@ describe("searchSessionTranscripts", () => {
 
     executeSqliteQuerySync(db, kysely.deleteFrom("session_transcript_index_state"));
     expect(search("after").indexing).toBe(true);
-    await deleteSqliteTranscript({ agentId: "main", env: env(), sessionId: "session-1" });
+    await replaceSqliteTranscriptEvents(transcriptScope("session-1", "agent:main:main"), []);
     await waitForSessionTranscriptReconcileForTest();
     expect(search("after").hits).toHaveLength(0);
   });

--- a/src/config/sessions/session-transcript-search.ts
+++ b/src/config/sessions/session-transcript-search.ts
@@ -93,6 +93,7 @@ function runReconcileWorker(params: {
       timeout = setTimeout(() => {
         finish(() => reject(new Error("session transcript reconcile worker timed out")), true);
       }, timeoutMs);
+      timeout.unref?.();
     };
     const finish = (done: () => void, terminate: boolean) => {
       if (settled) {

--- a/src/config/sessions/session-transcript-search.ts
+++ b/src/config/sessions/session-transcript-search.ts
@@ -246,7 +246,9 @@ export function searchSessionTranscripts(params: {
   // never leave stale keys inside the index. Sessions flagged needs_rebuild
   // are excluded: their rows may still hold rewound-away branch text that
   // sessions_history no longer exposes, so they stay hidden until reconcile
-  // rebuilds them (indexing=true tells the caller to retry).
+  // rebuilds them (indexing=true tells the caller to retry). Requiring a
+  // current clean watermark also hides stale FTS rows before a worker has
+  // claimed a missing or lagging index-state row.
   const statement = database.db.prepare(/* sqlite-allow-raw: FTS5 MATCH/snippet/bm25 */ `
     SELECT sessions.session_key AS session_key, session_transcript_fts.session_id AS session_id,
       message_id, role, timestamp,
@@ -254,10 +256,15 @@ export function searchSessionTranscripts(params: {
       bm25(session_transcript_fts) AS rank
     FROM session_transcript_fts
     JOIN sessions ON sessions.session_id = session_transcript_fts.session_id
+    JOIN session_transcript_index_state AS index_state
+      ON index_state.session_id = session_transcript_fts.session_id
+      AND index_state.needs_rebuild = 0
+      AND index_state.indexed_seq >= COALESCE((
+        SELECT MAX(transcript_events.seq)
+        FROM transcript_events
+        WHERE transcript_events.session_id = session_transcript_fts.session_id
+      ), -1)
     WHERE session_transcript_fts MATCH ?${whereSession}
-      AND session_transcript_fts.session_id NOT IN (
-        SELECT session_id FROM session_transcript_index_state WHERE needs_rebuild != 0
-      )
     ORDER BY rank ASC, timestamp DESC, message_id ASC
     LIMIT ?
   `);

--- a/src/config/sessions/session-transcript-search.ts
+++ b/src/config/sessions/session-transcript-search.ts
@@ -311,13 +311,6 @@ export async function waitForSessionTranscriptReconcileActiveForTest(): Promise<
   await Promise.all(activeReconciles.values());
 }
 
-/** Reset process-local reconcile state between focused tests. */
-export function resetSessionTranscriptSearchForTest(): void {
-  runningReconciles.clear();
-  activeReconciles.clear();
-  reconcileQueue = Promise.resolve();
-}
-
 /** Test-only worker lifecycle and packaging seams. */
 export const sessionTranscriptSearchTesting = {
   reconcileWorkerTimeoutMs: RECONCILE_WORKER_TIMEOUT_MS,

--- a/src/config/sessions/session-transcript-search.ts
+++ b/src/config/sessions/session-transcript-search.ts
@@ -2,24 +2,22 @@
 // inside the accessor's write transactions (session-transcript-index.ts);
 // this module owns the query path and the lazy reconcile that backfills
 // doctor-migrated transcripts and rebuilds branch-rewound sessions.
-import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { Worker } from "node:worker_threads";
+import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
-import {
-  openOpenClawAgentDatabase,
-  runOpenClawAgentWriteTransaction,
-} from "../../state/openclaw-agent-db.js";
+import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { truncateUtf16Safe } from "../../utils.js";
-import {
-  deleteOrphanedTranscriptIndexRowsInTransaction,
-  listSessionsNeedingTranscriptIndexReconcile,
-  rebuildSessionTranscriptIndexInTransaction,
-} from "./session-transcript-index.js";
+import { resolveStateDir } from "../paths.js";
+import { listSessionsNeedingTranscriptIndexReconcile } from "./session-transcript-index.js";
 
 const log = createSubsystemLogger("sessions/search-index");
 const SEARCH_SNIPPET_MAX_CHARS = 500;
 const SEARCH_LIMIT_MAX = 25;
 const SEARCH_QUERY_MAX_CHARS = 4096;
+const RECONCILE_WORKER_TIMEOUT_MS = 60_000;
+const RECONCILE_PLANNING_TIMEOUT_MS = 30 * 60_000;
 
 type SessionTranscriptSearchHit = {
   sessionKey: string;
@@ -38,75 +36,170 @@ type SessionTranscriptSearchResult = {
 };
 
 const runningReconciles = new Map<string, Promise<void>>();
+const activeReconciles = new Map<string, Promise<void>>();
+let reconcileQueue = Promise.resolve();
 
 /**
- * Rebuilds every session whose index state lags its transcript rows, then
- * sweeps orphaned index rows. One write transaction per session keeps the
- * agent DB responsive to live appends between rebuilds.
+ * Starts one worker-owned reconcile per agent. The worker plans outside
+ * transactions and commits bounded batches so Gateway-thread SQLite writers
+ * never wait behind a whole transcript rebuild.
  */
-async function reconcileSessionTranscriptIndex(params: {
-  agentId: string;
-  env?: NodeJS.ProcessEnv;
-}): Promise<void> {
-  const database = openOpenClawAgentDatabase({
-    agentId: params.agentId,
-    ...(params.env ? { env: params.env } : {}),
-  });
-  const sessionIds = listSessionsNeedingTranscriptIndexReconcile(database.db);
-  for (const sessionId of sessionIds) {
-    runOpenClawAgentWriteTransaction(
-      (agentDatabase) => {
-        // Rows are reread inside the transaction: a live append that landed
-        // after the dirty scan is either included here or re-flagged by its
-        // own in-transaction hook, so the rebuild can never go stale.
-        const rows = executeSqliteQuerySync(
-          agentDatabase.db,
-          getNodeSqliteKysely<Pick<OpenClawAgentKyselyDatabase, "transcript_events">>(
-            agentDatabase.db,
-          )
-            .selectFrom("transcript_events")
-            .select(["seq", "event_json"])
-            .where("session_id", "=", sessionId)
-            .orderBy("seq", "asc"),
-        ).rows;
-        if (rows.length === 0) {
-          return;
-        }
-        const events = rows.map((row) => JSON.parse(row.event_json) as unknown);
-        const maxSeq = rows[rows.length - 1]?.seq ?? -1;
-        rebuildSessionTranscriptIndexInTransaction(agentDatabase.db, sessionId, events, maxSeq);
-      },
-      { agentId: params.agentId, ...(params.env ? { env: params.env } : {}) },
-      { operationLabel: "sessions.search.reconcile" },
+function resolveReconcileWorkerUrl(currentModuleUrl = import.meta.url): URL {
+  const currentPath = fileURLToPath(currentModuleUrl);
+  const normalized = currentPath.replaceAll(path.sep, "/");
+  const distIndex = normalized.lastIndexOf("/dist/");
+  if (distIndex >= 0) {
+    return pathToFileURL(
+      path.join(
+        currentPath.slice(0, distIndex + 6),
+        "config",
+        "sessions",
+        "session-transcript-reconcile.worker.js",
+      ),
     );
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
   }
-  runOpenClawAgentWriteTransaction(
-    (agentDatabase) => {
-      deleteOrphanedTranscriptIndexRowsInTransaction(agentDatabase.db);
-    },
-    { agentId: params.agentId, ...(params.env ? { env: params.env } : {}) },
-    { operationLabel: "sessions.search.orphan-sweep" },
-  );
+  const extension = path.extname(currentPath) || ".js";
+  return new URL(`./session-transcript-reconcile.worker${extension}`, currentModuleUrl);
+}
+
+function reconcileKey(params: { agentId: string; env?: NodeJS.ProcessEnv }): string {
+  return `${resolveStateDir(params.env)}\0${params.agentId}`;
+}
+
+function runReconcileWorker(params: {
+  agentId: string;
+  stateDir: string;
+  workerUrl?: URL;
+  timeoutMs?: number;
+  planningTimeoutMs?: number;
+  onStarted?: () => void;
+}): Promise<void> {
+  const workerUrl = params.workerUrl ?? resolveReconcileWorkerUrl();
+  let worker: Worker;
+  try {
+    worker = new Worker(workerUrl, {
+      workerData: { agentId: params.agentId, stateDir: params.stateDir },
+      execArgv: workerUrl.pathname.endsWith(".ts") ? ["--import", "tsx"] : undefined,
+    });
+  } catch (error) {
+    return Promise.reject(error instanceof Error ? error : new Error(String(error)));
+  }
+  worker.unref?.();
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout>;
+    const scheduleTimeout = (timeoutMs: number) => {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => {
+        finish(() => reject(new Error("session transcript reconcile worker timed out")), true);
+      }, timeoutMs);
+    };
+    const finish = (done: () => void, terminate: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      worker.removeAllListeners();
+      if (terminate) {
+        void worker.terminate();
+      }
+      done();
+    };
+    worker.on("message", (message: { status?: unknown; error?: unknown }) => {
+      if (message.status === "ready") {
+        // Planning is read-only and can be large, so it gets a generous
+        // watchdog distinct from bounded-write inactivity.
+        scheduleTimeout(
+          resolveTimerTimeoutMs(params.planningTimeoutMs, RECONCILE_PLANNING_TIMEOUT_MS),
+        );
+        return;
+      }
+      if (message.status === "started") {
+        scheduleTimeout(resolveTimerTimeoutMs(params.timeoutMs, RECONCILE_WORKER_TIMEOUT_MS));
+        params.onStarted?.();
+        return;
+      }
+      if (message.status === "progress") {
+        scheduleTimeout(resolveTimerTimeoutMs(params.timeoutMs, RECONCILE_WORKER_TIMEOUT_MS));
+        return;
+      }
+      finish(
+        () =>
+          message.status === "ok"
+            ? resolve()
+            : reject(
+                new Error(
+                  typeof message.error === "string"
+                    ? message.error
+                    : "session transcript reconcile worker failed",
+                ),
+              ),
+        false,
+      );
+    });
+    worker.once("error", (error) =>
+      finish(
+        () =>
+          reject(
+            error instanceof Error
+              ? new Error(error.message, { cause: error })
+              : new Error(String(error)),
+          ),
+        true,
+      ),
+    );
+    worker.once("exit", (code) =>
+      finish(
+        () =>
+          reject(
+            new Error(
+              `session transcript reconcile worker exited before completing (code ${code})`,
+            ),
+          ),
+        false,
+      ),
+    );
+    scheduleTimeout(resolveTimerTimeoutMs(params.timeoutMs, RECONCILE_WORKER_TIMEOUT_MS));
+  });
 }
 
 function startReconcile(params: { agentId: string; env?: NodeJS.ProcessEnv }): void {
-  if (runningReconciles.has(params.agentId)) {
+  const key = reconcileKey(params);
+  if (runningReconciles.has(key)) {
     return;
   }
-  const pending = reconcileSessionTranscriptIndex(params)
+  let markStarted!: () => void;
+  activeReconciles.set(
+    key,
+    new Promise<void>((resolve) => {
+      markStarted = resolve;
+    }),
+  );
+  // Reconcile is cache maintenance, not request work. One process-wide slot
+  // bounds worker/SQLite pressure while the DB claim protects other processes.
+  const pending = reconcileQueue
+    .then(() =>
+      runReconcileWorker({
+        agentId: params.agentId,
+        stateDir: resolveStateDir(params.env),
+        onStarted: markStarted,
+      }),
+    )
     .catch((error: unknown) => {
-      // The next search re-detects dirty sessions and retries.
+      // Leave the dirty marker intact. A later search retries without ever
+      // falling back to a Gateway-thread rebuild.
       log.warn(
         `session transcript reconcile failed agent=${params.agentId} error=${error instanceof Error ? error.message : String(error)}`,
       );
     })
     .finally(() => {
-      runningReconciles.delete(params.agentId);
+      markStarted();
+      runningReconciles.delete(key);
+      activeReconciles.delete(key);
     });
-  runningReconciles.set(params.agentId, pending);
+  runningReconciles.set(key, pending);
+  reconcileQueue = pending;
 }
 
 function toFtsQuery(query: string): string {
@@ -140,7 +233,7 @@ export function searchSessionTranscripts(params: {
   if (dirtySessions.length > 0) {
     startReconcile(params);
   }
-  const indexing = dirtySessions.length > 0 || runningReconciles.has(params.agentId);
+  const indexing = dirtySessions.length > 0 || runningReconciles.has(reconcileKey(params));
   const limit = Math.min(Math.max(1, params.limit ?? 10), SEARCH_LIMIT_MAX);
   const sessionKeys = params.sessionKeys ?? [];
   const whereSession =
@@ -206,3 +299,28 @@ export function searchSessionTranscripts(params: {
   });
   return { hits: hits.slice(0, limit), indexing, truncated: hits.length > limit };
 }
+
+/** Await active reconcile passes in focused tests. */
+export async function waitForSessionTranscriptReconcileForTest(): Promise<void> {
+  await Promise.all(runningReconciles.values());
+}
+
+/** Await worker startup in focused responsiveness tests. */
+export async function waitForSessionTranscriptReconcileActiveForTest(): Promise<void> {
+  await Promise.all(activeReconciles.values());
+}
+
+/** Reset process-local reconcile state between focused tests. */
+export function resetSessionTranscriptSearchForTest(): void {
+  runningReconciles.clear();
+  activeReconciles.clear();
+  reconcileQueue = Promise.resolve();
+}
+
+/** Test-only worker lifecycle and packaging seams. */
+export const sessionTranscriptSearchTesting = {
+  reconcileWorkerTimeoutMs: RECONCILE_WORKER_TIMEOUT_MS,
+  reconcilePlanningTimeoutMs: RECONCILE_PLANNING_TIMEOUT_MS,
+  resolveReconcileWorkerUrl,
+  runReconcileWorker,
+};

--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -102,6 +102,7 @@ describe("tsdown config", () => {
       "cli/gateway-lifecycle.runtime",
       "agents/compaction-planning.worker",
       "agents/model-provider-auth.worker",
+      "config/sessions/session-transcript-reconcile.worker",
       "plugins/memory-state",
       "subagent-registry.runtime",
       "task-registry-control.runtime",

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -744,6 +744,7 @@ describe("collectMissingPackPaths", () => {
         "dist/agents/compaction-planning.worker.js",
         "dist/agents/model-provider-auth.worker.js",
         "dist/audit/audit-event-writer.worker.js",
+        "dist/config/sessions/session-transcript-reconcile.worker.js",
         "dist/task-registry-control.runtime.js",
         "dist/telegram-ingress-worker.runtime.js",
         "dist/build-info.json",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -259,10 +259,8 @@ function buildCoreDistEntries(): Record<string, string> {
   return {
     index: "src/index.ts",
     entry: "src/entry.ts",
-    // Ensure this module is bundled as an entry so legacy CLI shims can resolve its exports.
+    // Stable entries keep CLI shims resolvable and running gateways off stale hashed chunks.
     "cli/daemon-cli": "src/cli/daemon-cli.ts",
-    // Keep long-lived lazy runtime boundaries on stable filenames so rebuilt
-    // dist/ trees do not strand already-running gateways on stale hashed chunks.
     "agents/auth-profiles.runtime": "src/agents/auth-profiles.runtime.ts",
     "agents/model-catalog.runtime": "src/agents/model-catalog.runtime.ts",
     "agents/models-config.runtime": "src/agents/models-config.runtime.ts",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -270,6 +270,8 @@ function buildCoreDistEntries(): Record<string, string> {
     "agents/compaction-planning.worker": "src/agents/compaction-planning.worker.ts",
     "agents/model-provider-auth.worker": "src/agents/model-provider-auth.worker.ts",
     "audit/audit-event-writer.worker": "src/audit/audit-event-writer.worker.ts",
+    "config/sessions/session-transcript-reconcile.worker":
+      "src/config/sessions/session-transcript-reconcile.worker.ts",
     "acp/control-plane/manager": "src/acp/control-plane/manager.ts",
     "cli/gateway-lifecycle.runtime": "src/cli/gateway-cli/lifecycle.runtime.ts",
     "provider-dispatcher.runtime": "src/auto-reply/reply/provider-dispatcher.runtime.ts",


### PR DESCRIPTION
Closes #105735

## What Problem This Solves

Fixes an issue where searching a session with a dirty transcript index could block the Gateway event loop while the index was rebuilt.

The rebuild began synchronously inside `searchSessionTranscripts`. Its initial SQLite work, transcript parsing, and index writes ran before the async function reached its first yield. Deferring that same work with `setImmediate` would only move the stall to the next event-loop turn.

## Why This Change Was Made

Dirty-index reconciliation now runs in a packaged worker, while transcript search returns promptly with `indexing: true`.

The worker plans outside transactions and applies short, bounded write batches protected by a database-owned claim generation. Transcript mutations invalidate an active claim, and reconciliation performs a final authoritative revision check before clearing the dirty state.

A process-wide single-slot queue bounds worker concurrency. Planning and write progress have separate watchdogs; failure or timeout releases the slot for a later retry. There is no large synchronous fallback when worker startup fails.

Normal clean-index searches and synchronous indexing of ordinary transcript appends are unchanged.

## User Impact

Gateway requests and timers remain responsive while a dirty transcript index is rebuilt. Once reconciliation finishes, transcript search returns the correctly rebuilt index.

Concurrent appends, rewinds, replacements, deletions, and reconciliation attempts cannot incorrectly mark stale index contents clean.

## Evidence

Focused regression and packaging tests:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/config/sessions/session-transcript-search.test.ts \
  src/infra/tsdown-config.test.ts \
  --reporter=verbose \
  --maxWorkers=1
```

Result: 38 tests passed.

The regression coverage proves:

- Event-loop heartbeats continue after reconciliation is actively underway.
- Search eventually returns the rebuilt transcript index.
- Two database connections cannot concurrently own the same rebuild.
- Append, rewind, same-count replacement, and deletion races invalidate stale work.
- Large unrelated FTS contents do not cause long write-lock scans.
- Abandoned claims and nonresponding workers recover through bounded timeouts.
- Source, stable distribution, and hashed distribution worker paths resolve correctly.

Additional validation:

- `pnpm build` passed and emitted the transcript reconciliation worker.
- `pnpm check` passed.
- Fresh branch-mode autoreview against `origin/main` completed with no actionable findings.

## Suggested Review Order

1. `src/config/sessions/session-transcript-reconcile.ts` — claim lifecycle, planning, bounded writes, and final authoritative check.
2. `src/config/sessions/session-transcript-search.ts` — worker queue, deduplication, watchdogs, and search behavior.
3. `src/config/sessions/session-transcript-index.ts` — transcript mutations invalidating active claims.
4. `src/config/sessions/session-transcript-search.test.ts` — responsiveness, concurrency, race, and recovery proof.
5. `src/config/sessions/session-transcript-reconcile.worker.ts` — worker entry and message settlement.
6. `tsdown.config.ts`, `scripts/release-check.ts`, and `src/infra/tsdown-config.test.ts` — packaging and release inventory.

## AI Assistance

This change was developed with Codex assistance. The implementation was reviewed against repository guidance, validated with focused regression tests plus build/check gates, and passed a fresh branch-mode autoreview.

## Real behavior proof

Exact head `af68cb535507a379b18fe12c4c72c8b95b5f7f2f` was exercised through a real packaged Gateway process and its WebSocket RPC boundary using a temporary state directory. The setup used 100,000 synthetic transcript message events, then removed only the derived FTS and index-state rows to reproduce a dirty upgrade/rebuild state. No model or provider call was involved.

Redacted client transcript:

```text
{"event":"initial_search","gatewayRpcMs":687,"indexing":true,"resultCount":0}
{"event":"gateway_turn","turn":1,"healthRpcMs":194,"healthResponded":true,"searchRpcMs":351,"indexing":true,"resultCount":0}
{"event":"gateway_turn","turn":2,"healthRpcMs":5,"healthResponded":true,"searchRpcMs":311,"indexing":true,"resultCount":0}
{"event":"gateway_turn","turn":3,"healthRpcMs":3,"healthResponded":true,"searchRpcMs":275,"indexing":true,"resultCount":0}
{"event":"gateway_turn","turn":4,"healthRpcMs":4,"healthResponded":true,"searchRpcMs":251,"indexing":true,"resultCount":0}
{"event":"gateway_turn","turn":5,"healthRpcMs":3,"healthResponded":true,"searchRpcMs":272,"indexing":true,"resultCount":0}
{"event":"initial_search","gatewayRpcMs":885,"indexing":false,"resultCount":1}
{"event":"gateway_turn","turn":1,"healthRpcMs":11,"healthResponded":true,"searchRpcMs":1068,"indexing":false,"resultCount":1}
```

This demonstrates that unrelated Gateway health requests continued completing over multiple turns while reconciliation was actively reporting `indexing: true`, and that the same real RPC later converged to the rebuilt search result. The Gateway then shut down cleanly and the synthetic state was removed.