### PR TITLE
fix(ui): send idle stop aliases as normal messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI chat stop aliases:** send idle conversational words such as `wait`, `stop`, and `exit` as normal messages while retaining them as stop aliases during active runs.
 - **Session retry classification:** stop permanent provider errors whose identifiers or payload details merely contain 429/5xx digit sequences from re-sending full context, and share bounded rate-limit-window parsing across retry paths. (#105258) Thanks @destire-mio.
 - **LINE directive templates:** suppress confirms and buttons with blank required fields or unlabeled actions while preserving valid titleless buttons and surrounding reply text. (#105520) Thanks @edenfunf.
 - **SQLite maintenance schema validation:** reject current-version global and agent databases with missing or drifted canonical tables, constraints, indexes, triggers, or table options before compaction, while accepting supported additive-migration layouts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI chat stop aliases:** send idle conversational words such as `wait`, `stop`, and `exit` as normal messages while retaining them as stop aliases during active runs.
 - **Session retry classification:** stop permanent provider errors whose identifiers or payload details merely contain 429/5xx digit sequences from re-sending full context, and share bounded rate-limit-window parsing across retry paths. (#105258) Thanks @destire-mio.
 - **LINE directive templates:** suppress confirms and buttons with blank required fields or unlabeled actions while preserving valid titleless buttons and surrounding reply text. (#105520) Thanks @edenfunf.
 - **SQLite maintenance schema validation:** reject current-version global and agent databases with missing or drifted canonical tables, constraints, indexes, triggers, or table options before compaction, while accepting supported additive-migration layouts.

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -427,6 +427,30 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
+  it("sends idle stop aliases as ordinary chat messages", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page);
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.waitFor({ state: "visible", timeout: 10_000 });
+      await composer.fill("wait");
+      await page.getByRole("button", { name: "Send message" }).click();
+
+      const sendRequest = await gateway.waitForRequest("chat.send");
+      expect(requireRecord(sendRequest.params).message).toBe("wait");
+      expect(await gateway.getRequests("chat.abort")).toHaveLength(0);
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
   it("persists the chat send shortcut and keeps multiline and IME input safe", async () => {
     const context = await newBrowserContext({
       locale: "en-US",

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -1265,6 +1265,32 @@ describe("handleSendChat", () => {
     );
   });
 
+  it.each(["stop", "esc", "abort", "wait", "exit"])(
+    "sends the idle conversational word %s as a normal message",
+    async (message) => {
+      const request = vi.fn(async (method: string) => {
+        if (method === "chat.send") {
+          return { runId: `idle-${message}`, status: "started" };
+        }
+        throw new Error(`Unexpected request: ${method}`);
+      });
+      const host = makeHost({
+        client: { request } as unknown as ChatHost["client"],
+        chatMessage: message,
+        sessionKey: "agent:main",
+      });
+
+      await handleSendChat(host);
+
+      expect(request).toHaveBeenCalledWith(
+        "chat.send",
+        expect.objectContaining({ message, sessionKey: "agent:main" }),
+      );
+      expect(request).not.toHaveBeenCalledWith("chat.abort", expect.anything());
+      expect(host.chatMessage).toBe("");
+    },
+  );
+
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
@@ -7543,23 +7569,26 @@ describe("handleAbortChat", () => {
     expect(host.chatRunId).toBe("run-main");
   });
 
-  it("clears typed stop commands after aborting the active run", async () => {
-    const request = vi.fn(async () => ({ aborted: true }));
-    const host = makeHost({
-      client: { request } as unknown as ChatHost["client"],
-      chatRunId: "run-main",
-      chatMessage: "/stop",
-      sessionKey: "agent:main",
-    });
+  it.each(["/stop", "stop", "esc", "abort", "wait", "exit"])(
+    "clears the typed stop command %s after aborting the active run",
+    async (message) => {
+      const request = vi.fn(async () => ({ aborted: true }));
+      const host = makeHost({
+        client: { request } as unknown as ChatHost["client"],
+        chatRunId: "run-main",
+        chatMessage: message,
+        sessionKey: "agent:main",
+      });
 
-    await handleSendChat(host);
+      await handleSendChat(host);
 
-    expect(request).toHaveBeenCalledWith("chat.abort", {
-      runId: "run-main",
-      sessionKey: "agent:main",
-    });
-    expect(host.chatMessage).toBe("");
-  });
+      expect(request).toHaveBeenCalledWith("chat.abort", {
+        runId: "run-main",
+        sessionKey: "agent:main",
+      });
+      expect(host.chatMessage).toBe("");
+    },
+  );
 
   it("queues the active run abort while disconnected", async () => {
     const host = makeHost({

--- a/ui/src/pages/chat/chat-send.ts
+++ b/ui/src/pages/chat/chat-send.ts
@@ -96,6 +96,7 @@ import { controlUiNowMs, roundedControlUiDurationMs } from "./performance.ts";
 import type { RenderLifecycle } from "./render-lifecycle.ts";
 import {
   handleAbortChat,
+  hasAbortableSessionRun,
   isChatBusy,
   isChatStopCommand,
   reconcileChatRunLifecycle,
@@ -2167,7 +2168,12 @@ export async function handleSendChat(
   }
 
   if (shouldInterpretChatCommands) {
-    if (isChatStopCommand(message)) {
+    // Natural words such as "wait" and "exit" are stop aliases only while a
+    // run exists. Keep the explicit /stop command available at any time.
+    const shouldAbort =
+      isChatStopCommand(message) &&
+      (message.trim().startsWith("/") || hasAbortableSessionRun(host));
+    if (shouldAbort) {
       if (messageOverride == null) {
         recordNonTranscriptInputHistory(host, message);
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending ordinary idle messages such as `wait`, `stop`, or `exit` in Control UI Chat would silently trigger an abort request instead of sending their text.

## Why This Change Was Made

Natural-language stop aliases now apply only when the selected session has an active run. The explicit `/stop` command remains available while idle, and active-run alias behavior is unchanged.

## User Impact

Users can send these common conversational words normally when Chat is idle without losing the message or issuing an unintended abort.

## Evidence

- Blacksmith Testbox `tbx_01kxc9k9pvg1e7ntqkwch2zkbt`: 211 focused unit assertions passed.
- Chromium Control UI E2E: idle `wait` produced `chat.send` and no `chat.abort`; 1 focused scenario passed.
- Source-blind behavior validation: all four contract clauses passed, including explicit `/stop` and active-run aliases.
- `pnpm check:changed`: passed remotely, including formatting, UI/core typechecks, and changed-file lint.
- Fresh autoreview: clean, no accepted/actionable findings.

AI-assisted change; implementation and proof were reviewed before submission.
