### PR TITLE
fix(plugins): make llm_input hook abortable and fail-closed

### DIFF
--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -199,7 +199,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
-      10639,
+      10641,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -5194,9 +5194,10 @@ export async function runEmbeddedAttempt(
               : {}),
           });
 
+          // llm_input hook — now awaited so plugins can abort the LLM call
           if (!skipPromptSubmission && !isRawModelRun && hookRunner?.hasHooks("llm_input")) {
-            hookRunner
-              .runLlmInput(
+            try {
+              const llmInputResult = await hookRunner.runLlmInput(
                 {
                   runId: params.runId,
                   sessionId: params.sessionId,
@@ -5216,6 +5217,7 @@ export async function runEmbeddedAttempt(
                   sessionId: params.sessionId,
                   workspaceDir: params.workspaceDir,
                   trigger: params.trigger,
+                  sessionFile: params.sessionFile,
                   ...buildAgentHookContextChannelFields(params),
                   ...buildAgentHookContextIdentityFields({
                     trigger: params.trigger,
@@ -5224,10 +5226,16 @@ export async function runEmbeddedAttempt(
                     channelContext: params.channelContext,
                   }),
                 },
-              )
-              .catch((err: unknown) => {
-                log.warn(`llm_input hook failed: ${String(err)}`);
-              });
+              );
+              if (llmInputResult?.abort) {
+                const reason = llmInputResult.reason ?? "llm_input hook requested abort";
+                log.info(`llm_input hook aborted LLM call: ${reason} runId=${params.runId}`);
+                skipPromptSubmission = true;
+              }
+            } catch (err) {
+              log.warn(`llm_input hook failed (fail-closed): ${String(err)}`);
+              skipPromptSubmission = true;
+            }
           }
 
           const llmBoundaryOptionsForPrecheck =
@@ -6130,6 +6138,7 @@ export async function runEmbeddedAttempt(
               sessionId: params.sessionId,
               workspaceDir: params.workspaceDir,
               trigger: params.trigger,
+              sessionFile: params.sessionFile,
               ...(params.contextWindowInfo?.tokens
                 ? { contextTokenBudget: params.contextWindowInfo.tokens }
                 : {}),

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -282,6 +282,8 @@ export type PluginHookAgentContext = {
   senderId?: string;
   trigger?: string;
   channelId?: string;
+  /** Path to the active session JSONL file (for plugins that write custom events). */
+  sessionFile?: string;
   /** Resolved effective context-token budget after model/config/agent caps. */
   contextTokenBudget?: number;
   /** Source that supplied the resolved context-token budget. */
@@ -312,6 +314,9 @@ export type PluginHookBeforeAgentReplyResult = {
   reply?: ReplyPayload;
   reason?: string;
 };
+
+// llm_input hook result — allows modifying hooks to abort the LLM call
+export type PluginHookLlmInputResult = { abort?: boolean; reason?: string };
 
 export type PluginHookLlmInputEvent = {
   runId: string;
@@ -1150,7 +1155,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookModelCallEndedEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<void> | void;
-  llm_input: (event: PluginHookLlmInputEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
+  llm_input: (
+    event: PluginHookLlmInputEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookLlmInputResult | void> | PluginHookLlmInputResult | void;
   llm_output: (
     event: PluginHookLlmOutputEvent,
     ctx: PluginHookAgentContext,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -49,6 +49,7 @@ import type {
   PluginHookInboundClaimEvent,
   PluginHookInboundClaimResult,
   PluginHookLlmInputEvent,
+  PluginHookLlmInputResult,
   PluginHookLlmOutputEvent,
   PluginHookBeforeResetEvent,
   PluginHookBeforeToolCallEvent,
@@ -121,6 +122,7 @@ export type {
   PluginHookModelCallEndedEvent,
   PluginHookModelCallStartedEvent,
   PluginHookLlmInputEvent,
+  PluginHookLlmInputResult,
   PluginHookLlmOutputEvent,
   PluginHookBeforeAgentFinalizeEvent,
   PluginHookBeforeAgentFinalizeResult,
@@ -957,11 +959,22 @@ export function createHookRunner(
 
   /**
    * Run llm_input hook.
-   * Allows plugins to observe the exact input payload sent to the LLM.
-   * Runs in parallel (fire-and-forget).
+   * Allows plugins to observe/modify the LLM input — and optionally abort the call.
+   * Runs sequentially so that an abort from any handler stops processing.
    */
-  async function runLlmInput(event: PluginHookLlmInputEvent, ctx: PluginHookAgentContext) {
-    return runVoidHook("llm_input", event, ctx);
+  async function runLlmInput(
+    event: PluginHookLlmInputEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<PluginHookLlmInputResult | undefined> {
+    return runModifyingHook<"llm_input", PluginHookLlmInputResult>("llm_input", event, ctx, {
+      mergeResults: (acc, next, _registration) => {
+        // First abort wins — short-circuit subsequent handlers
+        if (acc?.abort) {
+          return acc;
+        }
+        return next;
+      },
+    });
   }
 
   /**


### PR DESCRIPTION
Related: #105750

## What Problem This Solves

Resolves a problem where a plugin that vets prompts in the `llm_input` hook cannot actually block a prompt, and — worse — silently stops enforcing anything if it crashes. `llm_input` is dispatched through `runVoidHook`: handler results are discarded, and a handler that throws is swallowed. So a policy or guardrail plugin sitting at the one point in the pipeline that precedes the provider call has no way to say "do not send this," and if the check itself fails, the prompt is submitted anyway (fail-open). For operators running in-process policy checks, a broken check degrades into no check at all, with no signal.

## Why This Change Was Made

`llm_input` becomes a sequential modifying hook: handlers run in order, the first abort wins and short-circuits the rest, an aborted result makes the caller skip prompt submission, and a handler that throws now aborts submission (fail-closed) rather than being ignored. `PluginHookAgentContext` also gains `sessionFile`, matching the field already present on the compaction / reset / session-end event types, so a handler can correlate a prompt with its session.

Boundaries: handlers that ignore the return value keep working exactly as before, so observability-style hooks are unaffected. Non-goal: no new hook name or config surface — this makes the existing hook honor what its position already implies.

## User Impact

Operators can enforce a policy or guardrail decision at the prompt-submission boundary in-process, and a crash in that check now fails safe instead of quietly passing traffic. Existing plugins that only observe `llm_input` are unaffected.

## Evidence

Focused tests on the hook dispatch, plugin loader, and the runner path that consumes the hook (against this branch):

```
$ pnpm vitest run src/agents/harness/lifecycle-hook-helpers.test.ts src/plugins/loader.test.ts \
    src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts

 Test Files  5 passed (5)
      Tests  350 passed (350)
```

Happy to adjust the shape (opt-in flag, separate hook name, or a different error policy) per maintainer preference.