### PR TITLE
fix(text): strip plain-text reasoning blocks from user-visible output

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -20,6 +20,7 @@ import {
   resolveAssistantMessagePhase,
   type AssistantPhase,
 } from "../shared/chat-message-content.js";
+import { stripPlainTextReasoningBlock } from "../shared/text/reasoning-tags.js";
 import {
   isMessagingToolDuplicateNormalized,
   normalizeTextForComparison,
@@ -1013,6 +1014,9 @@ export function handleMessageUpdate(
       final: evtType === "text_end",
     });
   }
+  // Strip plain-text reasoning blocks that bypass XML tag filtering.
+  // Models sometimes output reasoning as "Reasoning:\n..." instead of <think> tags.
+  next = stripPlainTextReasoningBlock(next);
   if (next) {
     if (
       !suppressMessageToolOnlySourceReplyOutput &&

--- a/src/agents/embedded-agent-utils.ts
+++ b/src/agents/embedded-agent-utils.ts
@@ -14,7 +14,10 @@ import {
   sanitizeAssistantFinalAnswerText,
   sanitizeAssistantVisibleText,
 } from "../shared/text/assistant-visible-text.js";
-import { stripReasoningTagsFromText } from "../shared/text/reasoning-tags.js";
+import {
+  stripPlainTextReasoningBlock,
+  stripReasoningTagsFromText,
+} from "../shared/text/reasoning-tags.js";
 import { sanitizeUserFacingText } from "./embedded-agent-helpers/sanitize-user-facing-text.js";
 import type { AgentMessage } from "./runtime/index.js";
 import { formatToolDetail, resolveToolDisplay } from "./tool-display.js";
@@ -55,7 +58,8 @@ export function sanitizeAssistantVisibleStreamText(text: string): string {
 
 function finalizeAssistantExtraction(msg: AssistantMessage, extracted: string): string {
   const errorContext = msg.stopReason === "error";
-  return sanitizeUserFacingText(extracted, { errorContext });
+  const sanitized = sanitizeUserFacingText(extracted, { errorContext });
+  return stripPlainTextReasoningBlock(sanitized);
 }
 
 type AssistantTextExtractionResult = {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -68,6 +68,7 @@ import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
 import { POLL_CREATION_PARAM_DEFS, SHARED_POLL_CREATION_PARAM_NAMES } from "../../poll-params.js";
 import { normalizeAccountId, parseSessionDeliveryRoute } from "../../routing/session-key.js";
 import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reasoning-message.js";
+import { stripPlainTextReasoningBlock } from "../../shared/text/reasoning-tags.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { listAllChannelSupportedActions, listChannelSupportedActions } from "../channel-tools.js";
@@ -240,7 +241,10 @@ function sanitizeUserVisibleToolTextResult(
 } {
   const normalized = normalizeEscapedLineBreaksForVisibleText(text);
   const strippedReasoning = stripFormattedReasoningMessage(normalized);
-  const strippedInternal = stripInternalRuntimeContext(strippedReasoning);
+  // rin overlay: also strip plain-text <think>…</think> reasoning blocks that
+  // models emit outside the formatted-reasoning wrapper (Aegis defense-in-depth).
+  const strippedPlainReasoning = stripPlainTextReasoningBlock(strippedReasoning);
+  const strippedInternal = stripInternalRuntimeContext(strippedPlainReasoning);
   const strippedBoot = stripBootEchoFromOutboundText(strippedInternal, bootPrompt);
   const strippedInbound = hasInboundMetadataSentinel(strippedBoot)
     ? stripInboundMetadata(strippedBoot)

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -1,6 +1,6 @@
 // Reasoning tag tests cover parsing and stripping reasoning tag blocks.
 import { describe, expect, it } from "vitest";
-import { stripReasoningTagsFromText } from "./reasoning-tags.js";
+import { stripPlainTextReasoningBlock, stripReasoningTagsFromText } from "./reasoning-tags.js";
 
 describe("stripReasoningTagsFromText", () => {
   function expectStrippedCase(params: {
@@ -343,5 +343,87 @@ describe("stripReasoningTagsFromText", () => {
     { input: "E <think>x</think> F", expected: "E  F" },
   ] as const)("does not leak regex state across repeated calls: %j", (testCase) => {
     expectStrippedCase(testCase);
+  });
+});
+
+describe("stripPlainTextReasoningBlock", () => {
+  describe("strips reasoning blocks", () => {
+    it("strips entire text when it is all reasoning", () => {
+      const input = "Reasoning:\nマスターが「補足おねがい」と言っている。\nスクショを見ると...";
+      expect(stripPlainTextReasoningBlock(input)).toBe("");
+    });
+
+    it("strips reasoning block and preserves text after paragraph break", () => {
+      const input = "Reasoning:\n思考内容...\n分析中...\n\nこれが実際の回答です。";
+      expect(stripPlainTextReasoningBlock(input)).toBe("これが実際の回答です。");
+    });
+
+    it("strips reasoning block with italic lines (formatReasoningMessage style)", () => {
+      const input = "Reasoning:\n_思考内容_\n_分析中_\n\n回答テキスト";
+      expect(stripPlainTextReasoningBlock(input)).toBe("回答テキスト");
+    });
+
+    it("strips entire text when no paragraph break follows", () => {
+      const input = "Reasoning:\n全てが思考内容\n最後まで";
+      expect(stripPlainTextReasoningBlock(input)).toBe("");
+    });
+  });
+
+  describe("false positive protection", () => {
+    it("preserves inline 'Reasoning:' with space (no newline)", () => {
+      const input = "Reasoning: このアプローチが最適です。";
+      expect(stripPlainTextReasoningBlock(input)).toBe(input);
+    });
+
+    it("preserves 'Reasoning:' inside a fenced code block", () => {
+      const input = "Example:\n```\nReasoning:\nsome code\n```\nDone!";
+      expect(stripPlainTextReasoningBlock(input)).toBe(input);
+    });
+
+    it("preserves bare 'Reasoning:' without newline", () => {
+      const input = "Reasoning:";
+      expect(stripPlainTextReasoningBlock(input)).toBe(input);
+    });
+  });
+
+  describe("mid-text and multi-block", () => {
+    it("strips reasoning block in the middle of text", () => {
+      const input = "Hello\nReasoning:\n思考内容\n\nWorld";
+      expect(stripPlainTextReasoningBlock(input)).toBe("Hello\nWorld");
+    });
+
+    it("strips multiple reasoning blocks", () => {
+      const input = "Reasoning:\nfirst\n\nvisible\nReasoning:\nsecond\n\nfinal";
+      expect(stripPlainTextReasoningBlock(input)).toBe("visible\nfinal");
+    });
+
+    it("continues block through italic paragraphs", () => {
+      const input = "Reasoning:\n_line1_\n\n_line2_\n\nActual reply";
+      expect(stripPlainTextReasoningBlock(input)).toBe("Actual reply");
+    });
+  });
+
+  describe("negative matching", () => {
+    it("does not strip mid-line Reasoning:", () => {
+      const input = "Some text Reasoning:\nshould not strip";
+      expect(stripPlainTextReasoningBlock(input)).toBe(input);
+    });
+
+    it("handles empty reasoning body before paragraph break", () => {
+      const input = "Reasoning:\n\n\ntext";
+      expect(stripPlainTextReasoningBlock(input)).toBe("text");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty and null-ish inputs", () => {
+      expect(stripPlainTextReasoningBlock("")).toBe("");
+      expect(stripPlainTextReasoningBlock(null as unknown as string)).toBe(null);
+    });
+
+    it("handles text with no Reasoning: at all", () => {
+      const input = "Just a normal message without any reasoning.";
+      expect(stripPlainTextReasoningBlock(input)).toBe(input);
+    });
   });
 });

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -200,9 +200,12 @@ export function stripPlainTextReasoningBlock(text: string): string {
   const blocks: Array<{ start: number; end: number }> = [];
 
   for (const match of text.matchAll(pattern)) {
-    const fullMatchStart = match.index;
+    const header = match[1];
+    if (header === undefined) {
+      continue;
+    }
     // The "Reasoning:\n" portion starts after the optional \n prefix
-    const reasoningStart = fullMatchStart + match[0].length - match[1].length;
+    const reasoningStart = match.index + match[0].length - header.length;
 
     if (isInsideCode(reasoningStart, codeRegions)) {
       continue;
@@ -213,7 +216,7 @@ export function stripPlainTextReasoningBlock(text: string): string {
     // or at end of text.
     // NOTE: The italic continuation heuristic (?!_) is coupled with
     // formatReasoningMessage() which wraps reasoning lines in _..._.
-    const afterHeader = reasoningStart + match[1].length; // position after "Reasoning:\n"
+    const afterHeader = reasoningStart + header.length; // position after "Reasoning:\n"
     const rest = text.slice(afterHeader);
     const endPattern = /\n\n(?!_)/g;
     let blockEnd = text.length; // default: rest of text
@@ -232,13 +235,13 @@ export function stripPlainTextReasoningBlock(text: string): string {
   }
 
   // Merge overlapping blocks (shouldn't normally happen, but be safe)
-  const merged: Array<{ start: number; end: number }> = [blocks[0]];
-  for (let i = 1; i < blocks.length; i++) {
+  const merged: Array<{ start: number; end: number }> = [];
+  for (const block of blocks) {
     const prev = merged[merged.length - 1];
-    if (blocks[i].start <= prev.end) {
-      prev.end = Math.max(prev.end, blocks[i].end);
+    if (prev && block.start <= prev.end) {
+      prev.end = Math.max(prev.end, block.end);
     } else {
-      merged.push(blocks[i]);
+      merged.push({ ...block });
     }
   }
 

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -168,3 +168,88 @@ export function stripReasoningTagsFromText(
 
   return trimmedResult;
 }
+
+/**
+ * Strip plain-text reasoning blocks that bypass XML tag filtering.
+ *
+ * Detects `Reasoning:\n` (colon + newline) at the start of text or after blank lines,
+ * and removes everything until the next paragraph break followed by a non-italic line,
+ * or end-of-text.
+ *
+ * `Reasoning: inline text` (colon + space + same-line content) is NOT stripped
+ * to avoid false positives on legitimate use of the word.
+ *
+ * Content inside fenced/inline code blocks is protected.
+ */
+export function stripPlainTextReasoningBlock(text: string): string {
+  if (!text) {
+    return text;
+  }
+
+  // Quick check: must contain "Reasoning:" followed by a newline somewhere
+  if (!text.includes("Reasoning:\n")) {
+    return text;
+  }
+
+  const codeRegions = findCodeRegions(text);
+
+  // Match "Reasoning:\n" that is either at the start of text or preceded by a newline
+  const pattern = /(?:^|\n)(Reasoning:\n)/g;
+
+  // Collect all valid (non-code) reasoning block ranges
+  const blocks: Array<{ start: number; end: number }> = [];
+
+  for (const match of text.matchAll(pattern)) {
+    const fullMatchStart = match.index;
+    // The "Reasoning:\n" portion starts after the optional \n prefix
+    const reasoningStart = fullMatchStart + match[0].length - match[1].length;
+
+    if (isInsideCode(reasoningStart, codeRegions)) {
+      continue;
+    }
+
+    // Find the end of this reasoning block.
+    // Block ends at: \n\n followed by a non-italic line (not starting with _)
+    // or at end of text.
+    // NOTE: The italic continuation heuristic (?!_) is coupled with
+    // formatReasoningMessage() which wraps reasoning lines in _..._.
+    const afterHeader = reasoningStart + match[1].length; // position after "Reasoning:\n"
+    const rest = text.slice(afterHeader);
+    const endPattern = /\n\n(?!_)/g;
+    let blockEnd = text.length; // default: rest of text
+
+    for (const endMatch of rest.matchAll(endPattern)) {
+      // blockEnd is the absolute position past the \n\n delimiter
+      blockEnd = afterHeader + endMatch.index + 2;
+      break;
+    }
+
+    blocks.push({ start: reasoningStart, end: blockEnd });
+  }
+
+  if (blocks.length === 0) {
+    return text;
+  }
+
+  // Merge overlapping blocks (shouldn't normally happen, but be safe)
+  const merged: Array<{ start: number; end: number }> = [blocks[0]];
+  for (let i = 1; i < blocks.length; i++) {
+    const prev = merged[merged.length - 1];
+    if (blocks[i].start <= prev.end) {
+      prev.end = Math.max(prev.end, blocks[i].end);
+    } else {
+      merged.push(blocks[i]);
+    }
+  }
+
+  // Build result by skipping the merged block ranges
+  let result = "";
+  let cursor = 0;
+  for (const block of merged) {
+    result += text.slice(cursor, block.start);
+    cursor = block.end;
+  }
+  result += text.slice(cursor);
+
+  return applyTrim(result, "both");
+}


### PR DESCRIPTION
Fixes #105752

## What Problem This Solves

Fixes an issue where users talking to an assistant would see the model's internal deliberation in the reply when the model emits its chain of thought as plain text in the answer body (a leading `Reasoning:` block with continuation lines) instead of using the structured reasoning channel. Tag-based stripping does not match this shape, so the thinking is rendered on every user-visible surface: final answers, streaming updates, and the message tool. In deployments where the assistant talks to end customers, this is content exposure, not just noise.

## Why This Change Was Made

Adds `stripPlainTextReasoningBlock()` and applies it on the three user-visible assistant-text paths. It removes a leading plain-text reasoning block including the italic continuation lines these models emit, and deliberately protects code fences: a fenced block that merely begins with the word "Reasoning" is left untouched. It is a no-op when no such block is present.

Boundary / non-goal: this is output sanitization, not provider-side normalization. If maintainers consider the correct fix to live in provider normalization instead, that is a reasonable call and we are happy to move or close this — we can carry the patch downstream. Opening it because the leak is real and the fix is small and covered by tests.

## User Impact

End users see the answer instead of the model's reasoning preamble, matching the guarantee that already holds for tag-delimited reasoning. No behavior change for models that use the structured channel.

## Evidence

Focused tests on the reasoning-tags suite (against this branch):

```
$ pnpm vitest run src/shared/text/reasoning-tags.test.ts

 Test Files  1 passed (1)
      Tests  74 passed (74)
```

The PR adds 84 lines of tests covering fenced-code protection, continuation-line handling, and no-op cases.