### PR TITLE
fix(auto-reply): retry reply-session init CAS conflicts with backoff

### DIFF
--- a/src/auto-reply/reply/session-init-conflict-retry.ts
+++ b/src/auto-reply/reply/session-init-conflict-retry.ts
@@ -1,0 +1,59 @@
+import { computeBackoff, sleepWithAbort, type BackoffPolicy } from "../../infra/backoff.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+
+const log = createSubsystemLogger("session-init");
+
+/**
+ * Raised when reply-session initialization loses its revision compare-and-swap.
+ * The message shape is load-bearing for channel retry classification.
+ */
+export class ReplySessionInitConflictError extends Error {
+  constructor(sessionKey: string) {
+    super(`reply session initialization conflicted for ${sessionKey}`);
+    this.name = "ReplySessionInitConflictError";
+  }
+}
+
+const SESSION_INIT_CONFLICT_MAX_ATTEMPTS = 5;
+const SESSION_INIT_CONFLICT_BACKOFF_POLICY = {
+  initialMs: 250,
+  maxMs: 4_000,
+  factor: 2,
+  jitter: 0.05,
+} satisfies BackoffPolicy;
+
+/**
+ * Retry only the unlocked outer attempt. Sleeping while holding the session-store
+ * writer lane would prevent the competing commit from settling.
+ */
+export async function runWithSessionInitConflictRetry<T>(
+  attempt: () => Promise<T>,
+  options?: {
+    maxAttempts?: number;
+    signal?: AbortSignal;
+    sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  },
+): Promise<T> {
+  const maxAttempts = options?.maxAttempts ?? SESSION_INIT_CONFLICT_MAX_ATTEMPTS;
+  const sleep = options?.sleep ?? sleepWithAbort;
+  for (let attemptIndex = 0; ; attemptIndex += 1) {
+    try {
+      return await attempt();
+    } catch (error) {
+      if (
+        !(error instanceof ReplySessionInitConflictError) ||
+        attemptIndex >= maxAttempts - 1 ||
+        options?.signal?.aborted === true
+      ) {
+        throw error;
+      }
+      const backoffMs = computeBackoff(SESSION_INIT_CONFLICT_BACKOFF_POLICY, attemptIndex + 1);
+      log.debug(
+        `reply session initialization conflicted; retrying in ${backoffMs}ms (attempt ${attemptIndex + 2}/${maxAttempts})`,
+      );
+      // Cancellation must interrupt the wait itself; otherwise shutdown can
+      // sleep through the backoff and start one more session-init attempt.
+      await sleep(backoffMs, options?.signal);
+    }
+  }
+}

--- a/src/auto-reply/reply/session.init-conflict-retry.test.ts
+++ b/src/auto-reply/reply/session.init-conflict-retry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ReplySessionInitConflictError, runWithSessionInitConflictRetry } from "./session.js";
 
 const SESSION_KEY = "agent:main:dashboard:test";
@@ -79,21 +79,48 @@ describe("runWithSessionInitConflictRetry", () => {
     expect(calls).toBe(1);
   });
 
+  it("cancels an in-progress backoff without starting another attempt", async () => {
+    const controller = new AbortController();
+    const { attempt, state } = conflictingAttempt(Number.POSITIVE_INFINITY);
+    const sleepStarted = Promise.withResolvers<void>();
+    const sleep = vi.fn(
+      async (_ms: number, signal?: AbortSignal) =>
+        await new Promise<void>((_resolve, reject) => {
+          expect(signal).toBe(controller.signal);
+          signal?.addEventListener(
+            "abort",
+            () => reject(new Error("aborted", { cause: signal.reason })),
+            { once: true },
+          );
+          sleepStarted.resolve();
+        }),
+    );
+
+    const retrying = runWithSessionInitConflictRetry(attempt, {
+      signal: controller.signal,
+      sleep,
+    });
+    await sleepStarted.promise;
+    controller.abort(new Error("stop retrying"));
+
+    await expect(retrying).rejects.toThrow("aborted");
+    expect(state.calls).toBe(1);
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
   it("applies capped exponential backoff between attempts", async () => {
     const delays: number[] = [];
     const { attempt } = conflictingAttempt(Number.POSITIVE_INFINITY);
-    await runWithSessionInitConflictRetry(attempt, {
-      sleep: async (ms) => {
-        delays.push(ms);
-      },
-    }).catch(() => {});
-    expect(delays).toHaveLength(4);
-    const bases = [250, 500, 1000, 2000] as const;
-    for (const [index, base] of bases.entries()) {
-      const delay = delays[index] ?? Number.NaN;
-      expect(delay).toBeGreaterThanOrEqual(base);
-      expect(delay).toBeLessThan(base + 100);
-      expect(delay).toBeLessThanOrEqual(4000 + 100);
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      await runWithSessionInitConflictRetry(attempt, {
+        sleep: async (ms) => {
+          delays.push(ms);
+        },
+      }).catch(() => {});
+      expect(delays).toEqual([250, 500, 1_000, 2_000]);
+    } finally {
+      randomSpy.mockRestore();
     }
   });
 });

--- a/src/auto-reply/reply/session.init-conflict-retry.test.ts
+++ b/src/auto-reply/reply/session.init-conflict-retry.test.ts
@@ -4,10 +4,10 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
-  initSessionState,
   ReplySessionInitConflictError,
   runWithSessionInitConflictRetry,
-} from "./session.js";
+} from "./session-init-conflict-retry.js";
+import { initSessionState } from "./session.js";
 
 const commitConflictControl = vi.hoisted(() => ({
   abortController: undefined as AbortController | undefined,
@@ -122,7 +122,10 @@ describe("runWithSessionInitConflictRetry", () => {
   it("cancels an in-progress backoff without starting another attempt", async () => {
     const controller = new AbortController();
     const { attempt, state } = conflictingAttempt(Number.POSITIVE_INFINITY);
-    const sleepStarted = Promise.withResolvers<void>();
+    let markSleepStarted = () => {};
+    const sleepStarted = new Promise<void>((resolve) => {
+      markSleepStarted = resolve;
+    });
     const sleep = vi.fn(
       async (_ms: number, signal?: AbortSignal) =>
         await new Promise<void>((_resolve, reject) => {
@@ -132,7 +135,7 @@ describe("runWithSessionInitConflictRetry", () => {
             () => reject(new Error("aborted", { cause: signal.reason })),
             { once: true },
           );
-          sleepStarted.resolve();
+          markSleepStarted();
         }),
     );
 
@@ -140,7 +143,7 @@ describe("runWithSessionInitConflictRetry", () => {
       signal: controller.signal,
       sleep,
     });
-    await sleepStarted.promise;
+    await sleepStarted;
     controller.abort(new Error("stop retrying"));
 
     await expect(retrying).rejects.toThrow("aborted");

--- a/src/auto-reply/reply/session.init-conflict-retry.test.ts
+++ b/src/auto-reply/reply/session.init-conflict-retry.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { ReplySessionInitConflictError, runWithSessionInitConflictRetry } from "./session.js";
+
+const SESSION_KEY = "agent:main:dashboard:test";
+
+function conflictingAttempt(failures: number) {
+  const state = { calls: 0 };
+  const attempt = async () => {
+    state.calls += 1;
+    if (state.calls <= failures) {
+      throw new ReplySessionInitConflictError(SESSION_KEY);
+    }
+    return "ok" as const;
+  };
+  return { attempt, state };
+}
+
+const instantSleep = async (_ms: number) => {};
+
+describe("runWithSessionInitConflictRetry", () => {
+  it("returns immediately when the first attempt succeeds", async () => {
+    const { attempt, state } = conflictingAttempt(0);
+    await expect(runWithSessionInitConflictRetry(attempt, { sleep: instantSleep })).resolves.toBe(
+      "ok",
+    );
+    expect(state.calls).toBe(1);
+  });
+
+  it("retries conflicts and succeeds once the competing writer settles", async () => {
+    const { attempt, state } = conflictingAttempt(3);
+    await expect(runWithSessionInitConflictRetry(attempt, { sleep: instantSleep })).resolves.toBe(
+      "ok",
+    );
+    expect(state.calls).toBe(4);
+  });
+
+  it("rethrows the conflict after exhausting all attempts", async () => {
+    const { attempt, state } = conflictingAttempt(Number.POSITIVE_INFINITY);
+    await expect(runWithSessionInitConflictRetry(attempt, { sleep: instantSleep })).rejects.toThrow(
+      `reply session initialization conflicted for ${SESSION_KEY}`,
+    );
+    expect(state.calls).toBe(5);
+  });
+
+  it("respects a caller-provided maxAttempts", async () => {
+    const { attempt, state } = conflictingAttempt(Number.POSITIVE_INFINITY);
+    await expect(
+      runWithSessionInitConflictRetry(attempt, { maxAttempts: 2, sleep: instantSleep }),
+    ).rejects.toBeInstanceOf(ReplySessionInitConflictError);
+    expect(state.calls).toBe(2);
+  });
+
+  it("does not retry non-conflict errors", async () => {
+    let calls = 0;
+    const attempt = async () => {
+      calls += 1;
+      throw new Error("reply session initialization aborted");
+    };
+    await expect(runWithSessionInitConflictRetry(attempt, { sleep: instantSleep })).rejects.toThrow(
+      "reply session initialization aborted",
+    );
+    expect(calls).toBe(1);
+  });
+
+  it("stops retrying when the abort signal fires", async () => {
+    const controller = new AbortController();
+    let calls = 0;
+    const attempt = async () => {
+      calls += 1;
+      controller.abort();
+      throw new ReplySessionInitConflictError(SESSION_KEY);
+    };
+    await expect(
+      runWithSessionInitConflictRetry(attempt, {
+        signal: controller.signal,
+        sleep: instantSleep,
+      }),
+    ).rejects.toBeInstanceOf(ReplySessionInitConflictError);
+    expect(calls).toBe(1);
+  });
+
+  it("applies capped exponential backoff between attempts", async () => {
+    const delays: number[] = [];
+    const { attempt } = conflictingAttempt(Number.POSITIVE_INFINITY);
+    await runWithSessionInitConflictRetry(attempt, {
+      sleep: async (ms) => {
+        delays.push(ms);
+      },
+    }).catch(() => {});
+    expect(delays).toHaveLength(4);
+    const bases = [250, 500, 1000, 2000] as const;
+    for (const [index, base] of bases.entries()) {
+      const delay = delays[index] ?? Number.NaN;
+      expect(delay).toBeGreaterThanOrEqual(base);
+      expect(delay).toBeLessThan(base + 100);
+      expect(delay).toBeLessThanOrEqual(4000 + 100);
+    }
+  });
+});

--- a/src/auto-reply/reply/session.init-conflict-retry.test.ts
+++ b/src/auto-reply/reply/session.init-conflict-retry.test.ts
@@ -1,5 +1,45 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { ReplySessionInitConflictError, runWithSessionInitConflictRetry } from "./session.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  initSessionState,
+  ReplySessionInitConflictError,
+  runWithSessionInitConflictRetry,
+} from "./session.js";
+
+const commitConflictControl = vi.hoisted(() => ({
+  abortController: undefined as AbortController | undefined,
+  commitCalls: 0,
+  remainingFailures: 0,
+}));
+
+vi.mock("../../config/sessions/session-accessor.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/sessions/session-accessor.js")>();
+  return {
+    ...actual,
+    commitReplySessionInitialization: async (
+      ...args: Parameters<typeof actual.commitReplySessionInitialization>
+    ) => {
+      commitConflictControl.commitCalls += 1;
+      if (commitConflictControl.remainingFailures > 0) {
+        commitConflictControl.remainingFailures -= 1;
+        if (commitConflictControl.remainingFailures === 0) {
+          setImmediate(() =>
+            commitConflictControl.abortController?.abort(new Error("cancel session init")),
+          );
+        }
+        return {
+          ok: false as const,
+          reason: "stale-snapshot" as const,
+          revision: `forced-conflict-${commitConflictControl.commitCalls}`,
+        };
+      }
+      return await actual.commitReplySessionInitialization(...args);
+    },
+  };
+});
 
 const SESSION_KEY = "agent:main:dashboard:test";
 
@@ -121,6 +161,35 @@ describe("runWithSessionInitConflictRetry", () => {
       expect(delays).toEqual([250, 500, 1_000, 2_000]);
     } finally {
       randomSpy.mockRestore();
+    }
+  });
+});
+
+describe("initSessionState conflict retry wiring", () => {
+  it("cancels the production backoff through the initializer signal", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-conflict-abort-"));
+    const controller = new AbortController();
+    commitConflictControl.abortController = controller;
+    commitConflictControl.commitCalls = 0;
+    commitConflictControl.remainingFailures = 2;
+
+    try {
+      const initializing = initSessionState({
+        cfg: { session: { store: path.join(root, "sessions.json") } } as OpenClawConfig,
+        commandAuthorized: true,
+        ctx: {
+          Body: "hello",
+          SessionKey: SESSION_KEY,
+        },
+        signal: controller.signal,
+      });
+
+      await expect(initializing).rejects.toThrow("aborted");
+      expect(commitConflictControl.commitCalls).toBe(2);
+    } finally {
+      commitConflictControl.abortController = undefined;
+      commitConflictControl.remainingFailures = 0;
+      await fs.rm(root, { recursive: true, force: true });
     }
   });
 });

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -53,7 +53,6 @@ import {
   forgetActiveSessionForShutdown,
   noteActiveSessionForShutdown,
 } from "../../gateway/active-sessions-shutdown-tracker.js";
-import { computeBackoff, sleepWithAbort, type BackoffPolicy } from "../../infra/backoff.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -99,6 +98,10 @@ import {
   type ReplySessionEntryHandle,
 } from "./session-entry-handle.js";
 import { buildSessionEndHookPayload, buildSessionStartHookPayload } from "./session-hooks.js";
+import {
+  ReplySessionInitConflictError,
+  runWithSessionInitConflictRetry,
+} from "./session-init-conflict-retry.js";
 import { prepareReplySessionParentFork } from "./session-parent-fork-prepare.js";
 import { clearSessionResetRuntimeState } from "./session-reset-cleanup.js";
 import {
@@ -333,68 +336,6 @@ export function resolveReplySessionPreprocessingState(
     sessionKey,
     storePath: attemptContext.storePath,
   };
-}
-
-/**
- * Raised when the optimistic-concurrency commit of reply session
- * initialization loses the revision compare-and-swap. The message shape is
- * load-bearing: channel monitors (e.g. the Telegram poller) match it to
- * classify the failure as retryable.
- */
-export class ReplySessionInitConflictError extends Error {
-  constructor(sessionKey: string) {
-    super(`reply session initialization conflicted for ${sessionKey}`);
-    this.name = "ReplySessionInitConflictError";
-  }
-}
-
-const SESSION_INIT_CONFLICT_MAX_ATTEMPTS = 5;
-const SESSION_INIT_CONFLICT_BACKOFF_POLICY = {
-  initialMs: 250,
-  maxMs: 4_000,
-  factor: 2,
-  jitter: 0.05,
-} satisfies BackoffPolicy;
-
-/**
- * Retries `attempt` on session-init CAS conflicts with jittered exponential
- * backoff. Conflicts are expected when another writer (restart recovery,
- * a concurrent dashboard tab, an active reply run) is mid-commit on the same
- * session key; those commits settle in well under a second, so a delayed
- * fresh attempt almost always wins. Must only wrap the *unlocked* outer
- * attempt: sleeping while holding the session-store writer lane would stall
- * every other writer on the store.
- */
-export async function runWithSessionInitConflictRetry<T>(
-  attempt: () => Promise<T>,
-  options?: {
-    maxAttempts?: number;
-    signal?: AbortSignal;
-    sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
-  },
-): Promise<T> {
-  const maxAttempts = options?.maxAttempts ?? SESSION_INIT_CONFLICT_MAX_ATTEMPTS;
-  const sleep = options?.sleep ?? sleepWithAbort;
-  for (let attemptIndex = 0; ; attemptIndex += 1) {
-    try {
-      return await attempt();
-    } catch (error) {
-      if (
-        !(error instanceof ReplySessionInitConflictError) ||
-        attemptIndex >= maxAttempts - 1 ||
-        options?.signal?.aborted === true
-      ) {
-        throw error;
-      }
-      const backoffMs = computeBackoff(SESSION_INIT_CONFLICT_BACKOFF_POLICY, attemptIndex + 1);
-      log.debug(
-        `reply session initialization conflicted; retrying in ${backoffMs}ms (attempt ${attemptIndex + 2}/${maxAttempts})`,
-      );
-      // Cancellation must interrupt the wait itself; otherwise shutdown can
-      // sleep through the backoff and start one more session-init attempt.
-      await sleep(backoffMs, options?.signal);
-    }
-  }
 }
 
 /** Initializes or reuses the reply session state for one inbound turn. */

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -53,6 +53,7 @@ import {
   forgetActiveSessionForShutdown,
   noteActiveSessionForShutdown,
 } from "../../gateway/active-sessions-shutdown-tracker.js";
+import { computeBackoff, sleepWithAbort, type BackoffPolicy } from "../../infra/backoff.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -349,9 +350,12 @@ export class ReplySessionInitConflictError extends Error {
 }
 
 const SESSION_INIT_CONFLICT_MAX_ATTEMPTS = 5;
-const SESSION_INIT_CONFLICT_BASE_BACKOFF_MS = 250;
-const SESSION_INIT_CONFLICT_MAX_BACKOFF_MS = 4000;
-const SESSION_INIT_CONFLICT_JITTER_MS = 100;
+const SESSION_INIT_CONFLICT_BACKOFF_POLICY = {
+  initialMs: 250,
+  maxMs: 4_000,
+  factor: 2,
+  jitter: 0.05,
+} satisfies BackoffPolicy;
 
 /**
  * Retries `attempt` on session-init CAS conflicts with jittered exponential
@@ -367,16 +371,11 @@ export async function runWithSessionInitConflictRetry<T>(
   options?: {
     maxAttempts?: number;
     signal?: AbortSignal;
-    sleep?: (ms: number) => Promise<void>;
+    sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
   },
 ): Promise<T> {
   const maxAttempts = options?.maxAttempts ?? SESSION_INIT_CONFLICT_MAX_ATTEMPTS;
-  const sleep =
-    options?.sleep ??
-    ((ms: number) =>
-      new Promise<void>((resolve) => {
-        setTimeout(resolve, ms);
-      }));
+  const sleep = options?.sleep ?? sleepWithAbort;
   for (let attemptIndex = 0; ; attemptIndex += 1) {
     try {
       return await attempt();
@@ -388,15 +387,13 @@ export async function runWithSessionInitConflictRetry<T>(
       ) {
         throw error;
       }
-      const backoffMs =
-        Math.min(
-          SESSION_INIT_CONFLICT_MAX_BACKOFF_MS,
-          SESSION_INIT_CONFLICT_BASE_BACKOFF_MS * 2 ** attemptIndex,
-        ) + Math.floor(Math.random() * SESSION_INIT_CONFLICT_JITTER_MS);
+      const backoffMs = computeBackoff(SESSION_INIT_CONFLICT_BACKOFF_POLICY, attemptIndex + 1);
       log.debug(
         `reply session initialization conflicted; retrying in ${backoffMs}ms (attempt ${attemptIndex + 2}/${maxAttempts})`,
       );
-      await sleep(backoffMs);
+      // Cancellation must interrupt the wait itself; otherwise shutdown can
+      // sleep through the backoff and start one more session-init attempt.
+      await sleep(backoffMs, options?.signal);
     }
   }
 }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -335,9 +335,78 @@ export function resolveReplySessionPreprocessingState(
   };
 }
 
+/**
+ * Raised when the optimistic-concurrency commit of reply session
+ * initialization loses the revision compare-and-swap. The message shape is
+ * load-bearing: channel monitors (e.g. the Telegram poller) match it to
+ * classify the failure as retryable.
+ */
+export class ReplySessionInitConflictError extends Error {
+  constructor(sessionKey: string) {
+    super(`reply session initialization conflicted for ${sessionKey}`);
+    this.name = "ReplySessionInitConflictError";
+  }
+}
+
+const SESSION_INIT_CONFLICT_MAX_ATTEMPTS = 5;
+const SESSION_INIT_CONFLICT_BASE_BACKOFF_MS = 250;
+const SESSION_INIT_CONFLICT_MAX_BACKOFF_MS = 4000;
+const SESSION_INIT_CONFLICT_JITTER_MS = 100;
+
+/**
+ * Retries `attempt` on session-init CAS conflicts with jittered exponential
+ * backoff. Conflicts are expected when another writer (restart recovery,
+ * a concurrent dashboard tab, an active reply run) is mid-commit on the same
+ * session key; those commits settle in well under a second, so a delayed
+ * fresh attempt almost always wins. Must only wrap the *unlocked* outer
+ * attempt: sleeping while holding the session-store writer lane would stall
+ * every other writer on the store.
+ */
+export async function runWithSessionInitConflictRetry<T>(
+  attempt: () => Promise<T>,
+  options?: {
+    maxAttempts?: number;
+    signal?: AbortSignal;
+    sleep?: (ms: number) => Promise<void>;
+  },
+): Promise<T> {
+  const maxAttempts = options?.maxAttempts ?? SESSION_INIT_CONFLICT_MAX_ATTEMPTS;
+  const sleep =
+    options?.sleep ??
+    ((ms: number) =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, ms);
+      }));
+  for (let attemptIndex = 0; ; attemptIndex += 1) {
+    try {
+      return await attempt();
+    } catch (error) {
+      if (
+        !(error instanceof ReplySessionInitConflictError) ||
+        attemptIndex >= maxAttempts - 1 ||
+        options?.signal?.aborted === true
+      ) {
+        throw error;
+      }
+      const backoffMs =
+        Math.min(
+          SESSION_INIT_CONFLICT_MAX_BACKOFF_MS,
+          SESSION_INIT_CONFLICT_BASE_BACKOFF_MS * 2 ** attemptIndex,
+        ) + Math.floor(Math.random() * SESSION_INIT_CONFLICT_JITTER_MS);
+      log.debug(
+        `reply session initialization conflicted; retrying in ${backoffMs}ms (attempt ${attemptIndex + 2}/${maxAttempts})`,
+      );
+      await sleep(backoffMs);
+    }
+  }
+}
+
 /** Initializes or reuses the reply session state for one inbound turn. */
 export async function initSessionState(params: InitSessionStateParams): Promise<SessionInitResult> {
-  return await initSessionStateAttempt(params, false);
+  return await runWithSessionInitConflictRetry(
+    async () => await initSessionStateAttempt(params, false),
+    { signal: params.signal },
+  );
 }
 
 async function initSessionStateAttempt(
@@ -1056,7 +1125,9 @@ async function initSessionStateAttemptLocked(
     if (!staleSnapshotRetried) {
       return await initSessionStateAttemptLocked(params, attemptContext, true, undefined);
     }
-    throw new Error(`reply session initialization conflicted for ${sessionKey}`);
+    // Propagate a typed conflict so initSessionState can retry with backoff
+    // outside the store writer lane instead of surfacing this to the caller.
+    throw new ReplySessionInitConflictError(sessionKey);
   }
   sessionEntry = committed.sessionEntry;
   sessionId = sessionEntry.sessionId;

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -175,7 +175,6 @@ export type SessionInitResult = {
 };
 
 type InitSessionStateParams = {
-  abortSignal?: AbortSignal;
   cfg: OpenClawConfig;
   commandAuthorized: boolean;
   ctx: MsgContext;
@@ -1035,7 +1034,7 @@ async function initSessionStateAttemptLocked(
   }
   const parentSessionKey = normalizeOptionalString(ctx.ParentSessionKey);
   const alreadyForked = sessionEntry.forkedFromParent === true;
-  if (params.abortSignal?.aborted === true) {
+  if (params.signal?.aborted === true) {
     throw new Error("reply session initialization aborted");
   }
   if (isNewSession) {
@@ -1097,7 +1096,7 @@ async function initSessionStateAttemptLocked(
         warning,
       }),
     prepareSessionEntry: async ({ readEntry, sessionEntry: entryToCommit }) => {
-      if (params.abortSignal?.aborted === true) {
+      if (params.signal?.aborted === true) {
         throw new Error("reply session initialization aborted");
       }
       return await prepareReplySessionParentFork({


### PR DESCRIPTION
## What Problem This Solves

Fixes #102400.

Reply-session initialization retried a lost optimistic-concurrency commit once, immediately, inside the session-store writer lane. A second revision race escaped as `reply session initialization conflicted`, dropping inbound work on callers without a channel-level replay path.

## Why This Change Was Made

The retry belongs at `initSessionState`, the shared owner for every inbound path. The change keeps the existing immediate stale-snapshot retry, then retries the unlocked outer attempt up to five times with the shared jittered exponential-backoff implementation. Each attempt rereads current state; no backoff holds the session-store writer lane.

The maintainer refresh also makes the wait abort-aware, uses the initializer's single canonical `signal` throughout commit and retry cancellation, and isolates the typed conflict/retry policy in a production-owned module. Non-conflict failures still escape immediately.

Persistent conflicts caused by stale active-session state remain a separate recovery mode tracked by #101920; this PR handles bounded transient compare-and-swap races before that recovery path should run.

## User Impact

Transient session-init races no longer silently drop webchat, Slack, heartbeat, Discord, or other shared inbound work. Shutdown and turn cancellation interrupt an active retry delay instead of waiting or starting another attempt.

## Evidence

- Exact reviewed head: `fa78b6fe5e3d70a82fe0966f36057559309f530d`
- Blacksmith Testbox `tbx_01kxdtn1tvse42mvwf6whkgq2e`: 4 focused files, 166/166 tests; `tsgo:core`; `check:test-types`; dead-export baseline; targeted oxlint; full build. [Run 29253923193](https://github.com/openclaw/openclaw/actions/runs/29253923193)
- Exact-head hosted CI: 45 successful jobs, 11 skipped, no failures. [Run 29255054803](https://github.com/openclaw/openclaw/actions/runs/29255054803)
- Fresh whole-branch maintainer autoreview: clean, confidence 0.94.
- Contributor field validation: no repeat conflicts across later gateway restarts after applying the equivalent backoff. [Issue proof](https://github.com/openclaw/openclaw/issues/102400#issuecomment-4953134648)
