### PR TITLE
fix(whatsapp): keep scoped auto-reply test runs deterministic

### DIFF
--- a/extensions/whatsapp/src/auto-reply.test-harness.ts
+++ b/extensions/whatsapp/src/auto-reply.test-harness.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { resetInboundDedupe } from "openclaw/plugin-sdk/reply-runtime";
 import { resetLogger, setLoggerOverride } from "openclaw/plugin-sdk/runtime-env";
 import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/test-env";
@@ -13,6 +14,7 @@ import type { WebInboundMessageInput, WebListenerCloseReason } from "./inbound.j
 import type { WhatsAppSendResult } from "./inbound/send-result.js";
 import { createAcceptedWhatsAppSendResult as createAcceptedWhatsAppSendResultForHarness } from "./inbound/send-result.test-helper.js";
 import { createTestWebInboundMessage } from "./inbound/test-message.test-helper.js";
+import { setWhatsAppRuntime } from "./runtime.js";
 import {
   resetBaileysMocks as _resetBaileysMocks,
   resetLoadConfigMock as _resetLoadConfigMock,
@@ -224,6 +226,8 @@ export function installWebAutoReplyUnitTestHooks(opts?: { pinDns?: boolean }) {
     resetWebAutoReplySessionSockets();
     _resetBaileysMocks();
     _resetLoadConfigMock();
+    // Scoped test files must seed the plugin slot instead of inheriting another file's runtime.
+    setWhatsAppRuntime(createPluginRuntimeMock());
     if (opts?.pinDns) {
       resolvePinnedHostnameSpy = mockPinnedHostnameResolution([TEST_NET_IP]);
     }


### PR DESCRIPTION
Related: #104949

AI-assisted: Codex.

## What Problem This Solves

Fixes an issue where maintainers running the WhatsApp auto-reply tests through a scoped file or plugin filter would see every affected test fail with `WhatsApp runtime not initialized`, even though the full CI grouping passed because another test file happened to seed the shared runtime slot first.

## Why This Change Was Made

The shared WhatsApp auto-reply unit-test hook now installs a fresh standard Plugin SDK runtime mock before each test. This keeps every scoped consumer self-contained while preserving the production fail-fast behavior for genuinely uninitialized plugin runtimes.

## User Impact

No end-user runtime behavior changes. Maintainers can run individual WhatsApp auto-reply files or `pnpm test extensions/whatsapp` deterministically without relying on test-file order.

## Evidence

- Before fix on `origin/main`: the two reported files failed 12/12 tests with the runtime-store error on Blacksmith Testbox.
- After fix: the same two-file command passed 12/12 tests.
- After fix: `pnpm test extensions/whatsapp` passed 89 files and 1,061 tests.
- `pnpm check:changed` passed formatting, extension production/test types, lint, guards, and runtime import-cycle validation.
- Blacksmith Testbox through Crabbox: `tbx_01kxcav3pqeakysrdgh0aftey9`; Actions run https://github.com/openclaw/openclaw/actions/runs/29213610753.
- `git diff --check` passed.
- Structured Codex autoreview: clean, no accepted/actionable findings.
