### PR TITLE
fix(ui): omit blank cron delivery account IDs

### DIFF
--- a/ui/src/e2e/cron-filters.e2e.test.ts
+++ b/ui/src/e2e/cron-filters.e2e.test.ts
@@ -287,6 +287,7 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
           model: "openai/gpt-5.5",
         },
       });
+      expect(requireRecord(requestParams(addRequest).delivery).accountId).toBeUndefined();
     } finally {
       await context.close();
     }

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -324,6 +324,40 @@ describe("cron controller", () => {
     });
   });
 
+  it("omits a blank delivery accountId from cron.add payloads", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.add") {
+        return { id: "job-blank-account-id" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 0, nextWakeAtMs: null };
+      }
+      return {};
+    });
+    const state = createState({
+      client: { request } as unknown as CronState["client"],
+      cronForm: {
+        ...DEFAULT_CRON_FORM,
+        name: "implicit account",
+        scheduleKind: "cron",
+        cronExpr: "0 * * * *",
+        sessionTarget: "isolated",
+        payloadKind: "agentTurn",
+        payloadText: "run this",
+        deliveryMode: "announce",
+        deliveryAccountId: "   ",
+      },
+    });
+
+    await addCronJob(state);
+
+    const addCall = findRequestCall(request.mock.calls, "cron.add");
+    expect(requireRecord(requestPayload(addCall).delivery, "delivery").accountId).toBeUndefined();
+  });
+
   it('omits delivery.channel when the form still uses the "last" sentinel', async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "cron.add") {
@@ -687,7 +721,7 @@ describe("cron controller", () => {
     expect(state.cronEditingJobId).toBeNull();
   });
 
-  it("sends empty delivery.accountId in cron.update to clear persisted account routing", async () => {
+  it("sends null delivery.accountId in cron.update to clear persisted account routing", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "cron.update") {
         return { id: "job-clear-account-id" };
@@ -741,7 +775,7 @@ describe("cron controller", () => {
     });
     expectRecordFields(requireRecord(requestPatch(updateCall).delivery, "delivery"), {
       mode: "announce",
-      accountId: "",
+      accountId: null,
     });
   });
 

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -1017,6 +1017,13 @@ export async function addCronJob(state: CronState): Promise<CronSaveResult> {
       }
     }
     const selectedDeliveryMode = form.deliveryMode;
+    const normalizedDeliveryAccountId = form.deliveryAccountId.trim();
+    // Update patches need null to clear stored routing; create payloads must
+    // omit blanks because the Gateway accountId schema rejects empty strings.
+    const deliveryAccountId =
+      selectedDeliveryMode === "announce"
+        ? normalizedDeliveryAccountId || (editingJob?.delivery?.accountId ? null : undefined)
+        : undefined;
     const delivery =
       selectedDeliveryMode && selectedDeliveryMode !== "none"
         ? {
@@ -1028,8 +1035,7 @@ export async function addCronJob(state: CronState): Promise<CronSaveResult> {
                   })
                 : undefined,
             to: form.deliveryTo.trim() || undefined,
-            accountId:
-              selectedDeliveryMode === "announce" ? form.deliveryAccountId.trim() : undefined,
+            accountId: deliveryAccountId,
             bestEffort: form.deliveryBestEffort,
           }
         : selectedDeliveryMode === "none"


### PR DESCRIPTION
## What Problem This Solves

The Control UI serialized a blank Account ID as `accountId: ""` for announce delivery. That value is rejected by the Gateway's `NonEmptyString` create schema, while update clears require `null`; default cron creation and clearing an existing account route could therefore fail at the protocol boundary.

## Why This Change Was Made

Normalize the form value once, preserve nonblank account IDs, omit blanks from `cron.add`, and send `null` only when an edit clears an existing explicit account route. This matches the separate create and patch schemas without adding compatibility behavior.

## User Impact

Users can create announce-delivery cron jobs without selecting an Account ID, and can clear a previously selected account route while editing.

## Evidence

- Testbox `tbx_01kxcb3pkkb51zck0bet8c6cxs`: `pnpm test ui/src/lib/cron/index.test.ts` — 52 passed.
- Same Testbox: `pnpm test ui/src/e2e/cron-filters.e2e.test.ts` — 2 Chromium scenarios passed; the default create payload omitted `accountId`.
- Same Testbox: `pnpm check:changed` — passed.
- Fresh autoreview: no accepted or actionable findings.

AI-assisted implementation and review. No agent transcript attached.
