### PR TITLE
fix(abort): cancel active ACP detached tasks on requester stop

### DIFF
--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -110,7 +110,7 @@ const taskRegistryMocks = vi.hoisted(() => ({
   ),
 }));
 
-vi.mock("../../tasks/task-registry.js", () => ({
+vi.mock("../../tasks/task-owner-access.js", () => ({
   listTasksForOwnerKey: taskRegistryMocks.listTasksForOwnerKey,
 }));
 

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -112,6 +112,9 @@ const taskRegistryMocks = vi.hoisted(() => ({
 
 vi.mock("../../tasks/task-registry.js", () => ({
   listTasksForOwnerKey: taskRegistryMocks.listTasksForOwnerKey,
+}));
+
+vi.mock("../../tasks/task-executor-policy.js", () => ({
   isTerminalTaskStatus: taskRegistryMocks.isTerminalTaskStatus,
 }));
 

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -1628,7 +1628,9 @@ describe("abort detection", () => {
 
     expect(result).toEqual({ stopped: 1 });
     // Allow the fire-and-forget cancel to settle.
-    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
     expect(acpManagerMocks.cancelSession).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionKey: "acp:session:orphan-1",
@@ -1692,7 +1694,9 @@ describe("abort detection", () => {
 
     // Only the active ACP task should be counted (terminal and subagent-covered are skipped).
     expect(result.stopped).toBe(1);
-    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
     expect(acpManagerMocks.cancelSession).toHaveBeenCalledTimes(1);
     expect(acpManagerMocks.cancelSession).toHaveBeenCalledWith(
       expect.objectContaining({ sessionKey: activeAcpKey }),

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -88,6 +88,33 @@ vi.mock("../../acp/control-plane/manager.js", () => ({
   }),
 }));
 
+const taskRegistryMocks = vi.hoisted(() => ({
+  listTasksForOwnerKey: vi.fn(
+    () =>
+      [] as Array<{
+        taskId: string;
+        runtime: string;
+        status: string;
+        childSessionKey?: string;
+        ownerKey: string;
+        task: string;
+        requesterSessionKey: string;
+        scopeKind: string;
+        deliveryStatus: string;
+        notifyPolicy: string;
+        createdAt: number;
+      }>,
+  ),
+  isTerminalTaskStatus: vi.fn((status: string) =>
+    ["succeeded", "failed", "timed_out", "lost", "cancelled"].includes(status),
+  ),
+}));
+
+vi.mock("../../tasks/task-registry.js", () => ({
+  listTasksForOwnerKey: taskRegistryMocks.listTasksForOwnerKey,
+  isTerminalTaskStatus: taskRegistryMocks.isTerminalTaskStatus,
+}));
+
 const suiteTempDirs = createSuiteTempRootTracker({ prefix: "openclaw-abort-" });
 
 describe("abort detection", () => {
@@ -1571,5 +1598,101 @@ describe("abort detection", () => {
 
     expect(result).toEqual({ stopped: 0 });
     expect(subagentRegistryMocks.markSubagentRunTerminated).not.toHaveBeenCalled();
+  });
+
+  it("stopSubagentsForRequester cancels active ACP detached tasks not in the subagent registry", async () => {
+    subagentRegistryMocks.listSubagentRunsForRequester.mockReset().mockReturnValue([]);
+    taskRegistryMocks.listTasksForOwnerKey.mockReset().mockReturnValueOnce([
+      {
+        taskId: "task-acp-1",
+        runtime: "acp",
+        status: "running",
+        childSessionKey: "acp:session:orphan-1",
+        ownerKey: "telegram:owner",
+        task: "background acp task",
+        requesterSessionKey: "telegram:owner",
+        scopeKind: "session",
+        deliveryStatus: "pending",
+        notifyPolicy: "default",
+        createdAt: Date.now() - 5_000,
+      },
+    ]);
+
+    const result = stopSubagentsForRequester({
+      cfg: {} as OpenClawConfig,
+      requesterSessionKey: "telegram:owner",
+    });
+
+    expect(result).toEqual({ stopped: 1 });
+    // Allow the fire-and-forget cancel to settle.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(acpManagerMocks.cancelSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "acp:session:orphan-1",
+        reason: "owner-stopped",
+      }),
+    );
+  });
+
+  it("stopSubagentsForRequester skips terminal ACP tasks and tasks already covered by the subagent registry", async () => {
+    const subagentChildKey = "agent:main:subagent:covered-child";
+    const terminalAcpKey = "acp:session:already-done";
+    const activeAcpKey = "acp:session:active-orphan";
+    const now = Date.now();
+
+    subagentRegistryMocks.listSubagentRunsForRequester.mockReset().mockReturnValueOnce([
+      {
+        runId: "run-covered",
+        childSessionKey: subagentChildKey,
+        requesterSessionKey: "telegram:owner",
+        requesterDisplayKey: "telegram:owner",
+        task: "covered by subagent registry",
+        cleanup: "keep",
+        createdAt: now,
+        endedAt: now - 100,
+      },
+    ]);
+    // First call is for the main requester; subsequent cascade calls for child keys return [].
+    taskRegistryMocks.listTasksForOwnerKey.mockReset().mockReturnValueOnce([
+      {
+        taskId: "task-terminal",
+        runtime: "acp",
+        status: "succeeded",
+        childSessionKey: terminalAcpKey,
+        ownerKey: "telegram:owner",
+        task: "already done",
+        requesterSessionKey: "telegram:owner",
+        scopeKind: "session",
+        deliveryStatus: "delivered",
+        notifyPolicy: "default",
+        createdAt: now - 10_000,
+      },
+      {
+        taskId: "task-active",
+        runtime: "acp",
+        status: "running",
+        childSessionKey: activeAcpKey,
+        ownerKey: "telegram:owner",
+        task: "active orphan",
+        requesterSessionKey: "telegram:owner",
+        scopeKind: "session",
+        deliveryStatus: "pending",
+        notifyPolicy: "default",
+        createdAt: now - 2_000,
+      },
+    ]);
+
+    const result = stopSubagentsForRequester({
+      cfg: {} as OpenClawConfig,
+      requesterSessionKey: "telegram:owner",
+    });
+
+    // Only the active ACP task should be counted (terminal and subagent-covered are skipped).
+    expect(result.stopped).toBe(1);
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(acpManagerMocks.cancelSession).toHaveBeenCalledTimes(1);
+    expect(acpManagerMocks.cancelSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionKey: activeAcpKey }),
+    );
   });
 });

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -1702,4 +1702,51 @@ describe("abort detection", () => {
       expect.objectContaining({ sessionKey: activeAcpKey }),
     );
   });
+
+  it("stopSubagentsForRequester does not let an ended subagent record mask an active ACP task with the same child key", async () => {
+    const sharedChildKey = "acp:session:shared-child";
+    const now = Date.now();
+
+    subagentRegistryMocks.listSubagentRunsForRequester.mockReset().mockReturnValueOnce([
+      {
+        runId: "run-ended",
+        childSessionKey: sharedChildKey,
+        requesterSessionKey: "telegram:owner",
+        requesterDisplayKey: "telegram:owner",
+        task: "ended subagent",
+        cleanup: "keep",
+        createdAt: now - 5_000,
+        endedAt: now - 1_000,
+      },
+    ]);
+    taskRegistryMocks.listTasksForOwnerKey.mockReset().mockReturnValueOnce([
+      {
+        taskId: "task-active",
+        runtime: "acp",
+        status: "running",
+        childSessionKey: sharedChildKey,
+        ownerKey: "telegram:owner",
+        task: "active acp task",
+        requesterSessionKey: "telegram:owner",
+        scopeKind: "session",
+        deliveryStatus: "pending",
+        notifyPolicy: "default",
+        createdAt: now - 1_000,
+      },
+    ]);
+
+    const result = stopSubagentsForRequester({
+      cfg: {} as OpenClawConfig,
+      requesterSessionKey: "telegram:owner",
+    });
+
+    expect(result.stopped).toBe(1);
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    expect(acpManagerMocks.cancelSession).toHaveBeenCalledTimes(1);
+    expect(acpManagerMocks.cancelSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionKey: sharedChildKey }),
+    );
+  });
 });

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -32,7 +32,8 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { isAcpSessionKey, parseAgentSessionKey } from "../../routing/session-key.js";
-import { isTerminalTaskStatus, listTasksForOwnerKey } from "../../tasks/task-registry.js";
+import { isTerminalTaskStatus } from "../../tasks/task-executor-policy.js";
+import { listTasksForOwnerKey } from "../../tasks/task-registry.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import {

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -32,6 +32,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { isAcpSessionKey, parseAgentSessionKey } from "../../routing/session-key.js";
+import { isTerminalTaskStatus, listTasksForOwnerKey } from "../../tasks/task-registry.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import {
@@ -72,6 +73,8 @@ const defaultAbortDeps = {
   getLatestSubagentRunByChildSessionKey,
   listSubagentRunsForController,
   markSubagentRunTerminated,
+  listTasksForOwnerKey,
+  isTerminalTaskStatus,
 };
 
 const abortDeps = {
@@ -97,6 +100,10 @@ export const testing = {
       deps?.listSubagentRunsForController ?? defaultAbortDeps.listSubagentRunsForController;
     abortDeps.markSubagentRunTerminated =
       deps?.markSubagentRunTerminated ?? defaultAbortDeps.markSubagentRunTerminated;
+    abortDeps.listTasksForOwnerKey =
+      deps?.listTasksForOwnerKey ?? defaultAbortDeps.listTasksForOwnerKey;
+    abortDeps.isTerminalTaskStatus =
+      deps?.isTerminalTaskStatus ?? defaultAbortDeps.isTerminalTaskStatus;
   },
   resetDepsForTests(): void {
     abortDeps.getAcpSessionManager = defaultAbortDeps.getAcpSessionManager;
@@ -109,6 +116,8 @@ export const testing = {
       defaultAbortDeps.getLatestSubagentRunByChildSessionKey;
     abortDeps.listSubagentRunsForController = defaultAbortDeps.listSubagentRunsForController;
     abortDeps.markSubagentRunTerminated = defaultAbortDeps.markSubagentRunTerminated;
+    abortDeps.listTasksForOwnerKey = defaultAbortDeps.listTasksForOwnerKey;
+    abortDeps.isTerminalTaskStatus = defaultAbortDeps.isTerminalTaskStatus;
   },
 };
 
@@ -263,10 +272,6 @@ export function stopSubagentsForRequester(params: {
     }
   }
   const runs = Array.from(dedupedRunsByChildKey.values());
-  if (runs.length === 0) {
-    return { stopped: 0 };
-  }
-
   const seenChildKeys = new Set<string>();
   let stopped = 0;
 
@@ -317,6 +322,34 @@ export function stopSubagentsForRequester(params: {
       requesterSessionKey: childKey,
     });
     stopped += cascadeResult.stopped;
+  }
+
+  // Cancel active ACP detached tasks owned by this requester that are not
+  // already covered by the subagent run registry paths above. The subagent
+  // registry only tracks inline/embedded children; ACP spawns create task
+  // records under the requester's ownerKey instead. Each cancel is
+  // fire-and-forget: the ACP manager handles session/run mode internally,
+  // so an indiscriminate kill is avoided.
+  for (const task of abortDeps.listTasksForOwnerKey(requesterKey)) {
+    const childKey = normalizeOptionalString(task.childSessionKey);
+    if (
+      task.runtime !== "acp" ||
+      abortDeps.isTerminalTaskStatus(task.status) ||
+      !childKey ||
+      seenChildKeys.has(childKey)
+    ) {
+      continue;
+    }
+    seenChildKeys.add(childKey);
+    stopped += 1;
+    abortDeps
+      .getAcpSessionManager()
+      .cancelSession({ cfg: params.cfg, sessionKey: childKey, reason: "owner-stopped" })
+      .catch((err: unknown) => {
+        logVerbose(
+          `abort: failed to cancel ACP task ${task.taskId} for ${requesterKey}: ${formatErrorMessage(err)}`,
+        );
+      });
   }
 
   if (stopped > 0) {

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -33,7 +33,7 @@ import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { isAcpSessionKey, parseAgentSessionKey } from "../../routing/session-key.js";
 import { isTerminalTaskStatus } from "../../tasks/task-executor-policy.js";
-import { listTasksForOwnerKey } from "../../tasks/task-registry.js";
+import { listTasksForOwnerKey } from "../../tasks/task-owner-access.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import {

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -281,9 +281,14 @@ export function stopSubagentsForRequester(params: {
     if (!childKey || seenChildKeys.has(childKey)) {
       continue;
     }
-    seenChildKeys.add(childKey);
+    // Only mark as seen when this run is active; ended records must not
+    // block the ACP task loop from cancelling a matching non-terminal task.
+    const isActiveRun = !run.endedAt || run.pauseReason === "sessions_yield";
+    if (isActiveRun) {
+      seenChildKeys.add(childKey);
+    }
 
-    if (!run.endedAt || run.pauseReason === "sessions_yield") {
+    if (isActiveRun) {
       const cleared = clearSessionQueues([childKey]);
       const parsed = parseAgentSessionKey(childKey);
       const storePath = resolveStorePath(params.cfg.session?.store, { agentId: parsed?.agentId });

--- a/src/tasks/task-owner-access.ts
+++ b/src/tasks/task-owner-access.ts
@@ -3,11 +3,14 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import {
   findTaskByRunId,
   getTaskById,
+  listTasksForOwnerKey,
   listTasksForRelatedSessionKey,
   markTaskTerminalById as markTaskTerminalRecordById,
   resolveTaskForLookupToken,
   updateTaskNotifyPolicyById,
 } from "./task-registry.js";
+
+export { listTasksForOwnerKey };
 import type { TaskNotifyPolicy, TaskRecord } from "./task-registry.types.js";
 import { buildTaskStatusSnapshot } from "./task-status.js";
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stopping an agent session would leave ACP detached tasks (spawned via `sessions_spawn` with the ACP runtime) running as orphans. Users stopping an active session could have background ACP child processes continue consuming CPU or memory indefinitely.

Fixes #105228

## Why This Change Was Made

`stopSubagentsForRequester` only traversed the subagent run registry (`listSubagentRunsForController`) to find children to cancel. ACP spawns create task records in the task registry under `ownerKey: requesterInternalKey` instead, making them invisible to the subagent run path. The fix enumerates active ACP tasks via `listTasksForOwnerKey` after the existing subagent run loop and fires a best-effort `cancelSession` for each non-terminal task not already handled. `AcpSessionManager.cancelSession` handles session/run mode semantics internally so persistent-session runtimes are not indiscriminately killed. `seenChildKeys` deduplicates across both paths.

## User Impact

Stopping an agent session now also cancels active ACP background tasks it owns. Previously those tasks could remain running after the parent session was stopped.

## Evidence

Two new tests in `src/auto-reply/reply/abort.test.ts`:

- `stopSubagentsForRequester cancels active ACP detached tasks not in the subagent registry` — verifies `cancelSession` is called for an active ACP task when no subagent runs exist
- `stopSubagentsForRequester skips terminal ACP tasks and tasks already covered by the subagent registry` — verifies terminal tasks and tasks whose child key was already handled by the subagent run loop are not double-cancelled

