### PR TITLE
fix(sqlite): reject unsafe maintenance schema additions

### DIFF
--- a/src/infra/sqlite-schema-contract.test.ts
+++ b/src/infra/sqlite-schema-contract.test.ts
@@ -55,6 +55,51 @@ describe("assertSqliteSchemaContains", () => {
     }
   });
 
+  it("accepts an extra non-unique index on a canonical table", () => {
+    const database = createDatabase(CANONICAL_SCHEMA);
+    try {
+      database.exec("CREATE INDEX idx_children_value ON children(value);");
+
+      expect(() =>
+        assertSqliteSchemaContains(database, "test database", CANONICAL_SCHEMA),
+      ).not.toThrow();
+    } finally {
+      database.close();
+    }
+  });
+
+  it("rejects an extra unique index on a canonical table", () => {
+    const database = createDatabase(CANONICAL_SCHEMA);
+    try {
+      database.exec("CREATE UNIQUE INDEX idx_children_value_unique ON children(value);");
+
+      expect(() => assertSqliteSchemaContains(database, "test database", CANONICAL_SCHEMA)).toThrow(
+        "unexpected unique index idx_children_value_unique",
+      );
+    } finally {
+      database.close();
+    }
+  });
+
+  it("rejects an extra trigger on a canonical table", () => {
+    const database = createDatabase(CANONICAL_SCHEMA);
+    try {
+      database.exec(`
+        CREATE TRIGGER children_delete_parent_after_insert
+        AFTER INSERT ON children
+        BEGIN
+          DELETE FROM parents WHERE id = NEW.parent_id;
+        END;
+      `);
+
+      expect(() => assertSqliteSchemaContains(database, "test database", CANONICAL_SCHEMA)).toThrow(
+        "unexpected trigger children_delete_parent_after_insert",
+      );
+    } finally {
+      database.close();
+    }
+  });
+
   it("accepts canonical columns created in additive-migration order", () => {
     const migratedSchema = CANONICAL_SCHEMA.replace(
       `

--- a/src/infra/sqlite-schema-contract.ts
+++ b/src/infra/sqlite-schema-contract.ts
@@ -106,9 +106,24 @@ export function assertSqliteSchemaContains(
         mismatches.push(`missing or drifted index ${expectedIndex.name ?? `on ${tableName}`}`);
       }
     }
+    for (const actualIndex of actualTable.indexes) {
+      if (
+        actualIndex.unique === 1 &&
+        !expectedTable.indexes.some((expectedIndex) => isEqual(actualIndex, expectedIndex))
+      ) {
+        mismatches.push(`unexpected unique index ${actualIndex.name ?? `on ${tableName}`}`);
+      }
+    }
     for (const expectedTrigger of expectedTable.triggers) {
       if (!actualTable.triggers.some((actualTrigger) => isEqual(actualTrigger, expectedTrigger))) {
         mismatches.push(`missing or drifted trigger ${expectedTrigger.name}`);
+      }
+    }
+    for (const actualTrigger of actualTable.triggers) {
+      if (
+        !expectedTable.triggers.some((expectedTrigger) => isEqual(actualTrigger, expectedTrigger))
+      ) {
+        mismatches.push(`unexpected trigger ${actualTrigger.name}`);
       }
     }
     if (actualTable.virtualTableSql !== expectedTable.virtualTableSql) {

--- a/src/state/openclaw-database-maintenance.test.ts
+++ b/src/state/openclaw-database-maintenance.test.ts
@@ -133,6 +133,21 @@ describe("OpenClaw database maintenance schema validation", () => {
     }
   });
 
+  it("rejects a current global database with an unexpected unique index", () => {
+    const database = createGlobalDatabase();
+    try {
+      database.exec("CREATE UNIQUE INDEX idx_task_runs_unexpected_owner ON task_runs(owner_key);");
+
+      expect(() =>
+        assertOpenClawStateDatabaseForMaintenance(database, {
+          pathname: "global.sqlite",
+        }),
+      ).toThrow("unexpected unique index idx_task_runs_unexpected_owner");
+    } finally {
+      database.close();
+    }
+  });
+
   it("rejects a current agent database with a missing canonical table", () => {
     const database = createAgentDatabase();
     try {
@@ -144,6 +159,28 @@ describe("OpenClaw database maintenance schema validation", () => {
           pathname: "agent.sqlite",
         }),
       ).toThrow("missing table auth_profile_store");
+    } finally {
+      database.close();
+    }
+  });
+
+  it("rejects a current agent database with an unexpected trigger", () => {
+    const database = createAgentDatabase();
+    try {
+      database.exec(`
+        CREATE TRIGGER sessions_unexpected_delete_after_insert
+        AFTER INSERT ON sessions
+        BEGIN
+          DELETE FROM sessions WHERE session_key = NEW.session_key;
+        END;
+      `);
+
+      expect(() =>
+        assertOpenClawAgentDatabaseForMaintenance(database, {
+          agentId: "worker-1",
+          pathname: "agent.sqlite",
+        }),
+      ).toThrow("unexpected trigger sessions_unexpected_delete_after_insert");
     } finally {
       database.close();
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where snapshot, restore, or compaction could accept an extra UNIQUE index or trigger on a canonical OpenClaw table even though it silently changed future write behavior.

## Why This Change Was Made

Maintenance schema validation now rejects unexpected unique indexes and triggers on canonical tables. It still allows harmless non-unique tuning indexes and unrelated plugin-owned tables.

## User Impact

Unsafe semantic schema additions fail closed before OpenClaw trusts a snapshot, restores a database, or compacts the live store.

## Evidence

- Head: `5ce43d378db1246854e4f8d8740924a4bbce4a4e`
- Crabbox provider: `blacksmith-testbox`
- Testbox: `tbx_01kxcbhzg2g1pdnmn7jt89g4d0`
- Focused SQLite maintenance/snapshot suite: 165 passed with expected platform skips
- Explicit `check:changed` for all three touched paths: passed
- Fresh commit autoreview: clean, no accepted/actionable findings
- `git diff --check`: passed