### PR TITLE
fix(macos): avoid SwiftUI macro plugin dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Apple shared chat build:** use non-macro SwiftUI environment keys and preview providers so macOS SwiftPM builds do not require macro plugins while preserving Xcode previews.
 - **Provider network retries:** align provider read/poll/download and agent-wait recovery for transient connection errors, retry bounded provider `ENOTFOUND` failures while leaving gateway `ENOTFOUND` and non-idempotent create operations fail-fast. (#101496) Thanks @xialonglee.
 - **Session retry classification:** stop permanent provider errors whose identifiers or payload details merely contain 429/5xx digit sequences from re-sending full context, and share bounded rate-limit-window parsing across retry paths. (#105258) Thanks @destire-mio.
 - **LINE directive templates:** suppress confirms and buttons with blank required fields or unlabeled actions while preserving valid titleless buttons and surrounding reply text. (#105520) Thanks @edenfunf.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Apple shared chat build:** use non-macro SwiftUI environment keys and keep iOS-only previews out of macOS SwiftPM builds so unavailable macro plugins no longer break the signed Mac app build.
 - **Provider network retries:** align provider read/poll/download and agent-wait recovery for transient connection errors, retry bounded provider `ENOTFOUND` failures while leaving gateway `ENOTFOUND` and non-idempotent create operations fail-fast. (#101496) Thanks @xialonglee.
 - **Session retry classification:** stop permanent provider errors whose identifiers or payload details merely contain 429/5xx digit sequences from re-sending full context, and share bounded rate-limit-window parsing across retry paths. (#105258) Thanks @destire-mio.
 - **LINE directive templates:** suppress confirms and buttons with blank required fields or unlabeled actions while preserving valid titleless buttons and surrounding reply text. (#105520) Thanks @edenfunf.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Apple shared chat build:** use non-macro SwiftUI environment keys and preview providers so macOS SwiftPM builds do not require macro plugins while preserving Xcode previews.
+- **Apple shared chat build:** use non-macro SwiftUI environment keys and keep iOS-only previews out of macOS SwiftPM builds so unavailable macro plugins no longer break the signed Mac app build.
 - **Provider network retries:** align provider read/poll/download and agent-wait recovery for transient connection errors, retry bounded provider `ENOTFOUND` failures while leaving gateway `ENOTFOUND` and non-idempotent create operations fail-fast. (#101496) Thanks @xialonglee.
 - **Session retry classification:** stop permanent provider errors whose identifiers or payload details merely contain 429/5xx digit sequences from re-sending full context, and share bounded rate-limit-window parsing across retry paths. (#105258) Thanks @destire-mio.
 - **LINE directive templates:** suppress confirms and buttons with blank required fields or unlabeled actions while preserving valid titleless buttons and surrounding reply text. (#105520) Thanks @edenfunf.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -30667,7 +30667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 33,
+      "line": 40,
       "path": "apps/macos/Sources/OpenClaw/SessionMenuLabelView.swift",
       "source": "\\(self.row.tokens.contextSummaryShort) · \\(self.row.ageText)",
       "surface": "apple",
@@ -32811,7 +32811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 855,
+      "line": 862,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Running tools…",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -30667,7 +30667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 40,
+      "line": 44,
       "path": "apps/macos/Sources/OpenClaw/SessionMenuLabelView.swift",
       "source": "\\(self.row.tokens.contextSummaryShort) · \\(self.row.ageText)",
       "surface": "apple",
@@ -32811,7 +32811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 862,
+      "line": 866,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Running tools…",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/SessionMenuLabelView.swift
+++ b/apps/macos/Sources/OpenClaw/SessionMenuLabelView.swift
@@ -1,7 +1,14 @@
 import SwiftUI
 
+private struct MenuItemHighlightedKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
 extension EnvironmentValues {
-    @Entry var menuItemHighlighted: Bool = false
+    var menuItemHighlighted: Bool {
+        get { self[MenuItemHighlightedKey.self] }
+        set { self[MenuItemHighlightedKey.self] = newValue }
+    }
 }
 
 struct SessionMenuLabelView: View {

--- a/apps/macos/Sources/OpenClaw/SessionMenuLabelView.swift
+++ b/apps/macos/Sources/OpenClaw/SessionMenuLabelView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+// Keep this explicit for SwiftPM toolchains where SwiftUI macro plugins are unavailable.
+// swiftformat:disable environmentEntry
 private struct MenuItemHighlightedKey: EnvironmentKey {
     static let defaultValue = false
 }
@@ -10,6 +12,8 @@ extension EnvironmentValues {
         set { self[MenuItemHighlightedKey.self] = newValue }
     }
 }
+
+// swiftformat:enable environmentEntry
 
 struct SessionMenuLabelView: View {
     let row: SessionRow

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -773,10 +773,17 @@ extension ChatTypingIndicatorBubble: @MainActor Equatable {
     }
 }
 
+private struct OpenClawAssistantBubblesInCleanChromeKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
 extension EnvironmentValues {
     /// Clients that want iMessage-style assistant bubbles in the clean chrome
     /// (the iOS app) opt in; the default keeps the plain clean look elsewhere.
-    @Entry public var openClawAssistantBubblesInCleanChrome: Bool = false
+    public var openClawAssistantBubblesInCleanChrome: Bool {
+        get { self[OpenClawAssistantBubblesInCleanChromeKey.self] }
+        set { self[OpenClawAssistantBubblesInCleanChromeKey.self] = newValue }
+    }
 }
 
 private struct AssistantBubbleContainerStyle: ViewModifier {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -773,6 +773,8 @@ extension ChatTypingIndicatorBubble: @MainActor Equatable {
     }
 }
 
+// Keep this explicit for SwiftPM toolchains where SwiftUI macro plugins are unavailable.
+// swiftformat:disable environmentEntry
 private struct OpenClawAssistantBubblesInCleanChromeKey: EnvironmentKey {
     static let defaultValue = false
 }
@@ -785,6 +787,8 @@ extension EnvironmentValues {
         set { self[OpenClawAssistantBubblesInCleanChromeKey.self] = newValue }
     }
 }
+
+// swiftformat:enable environmentEntry
 
 private struct AssistantBubbleContainerStyle: ViewModifier {
     let isClean: Bool

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView+Previews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView+Previews.swift
@@ -207,41 +207,36 @@ private struct OpenClawChatPreviewTransport: OpenClawChatTransport {
     }
 }
 
-#Preview("Chat") {
-    OpenClawChatPreview(scenario: .connected)
-}
-
-#Preview("Chat connected") {
-    OpenClawChatPreview(scenario: .connected)
-}
-
-#Preview("Chat empty") {
-    OpenClawChatPreview(
-        scenario: .empty,
-        sessionKey: "empty-preview")
-}
-
-#Preview("Chat loading") {
-    OpenClawChatPreview(
-        scenario: .loading,
-        sessionKey: "loading-preview")
-}
-
-#Preview("Chat gateway error") {
-    OpenClawChatPreview(
-        scenario: .error,
-        sessionKey: "error-preview")
-}
-
-#Preview("Onboarding chat") {
-    OpenClawChatView(
-        viewModel: OpenClawChatViewModel(
-            sessionKey: "ios-preview",
-            transport: OpenClawChatPreviewTransport()),
-        showsSessionSwitcher: false,
-        style: .onboarding,
-        markdownVariant: .standard,
-        userAccent: OpenClawChatTheme.accent)
+private struct OpenClawChatPreviewProvider: PreviewProvider {
+    static var previews: some View {
+        Group {
+            OpenClawChatPreview(scenario: .connected)
+                .previewDisplayName("Chat")
+            OpenClawChatPreview(scenario: .connected)
+                .previewDisplayName("Chat connected")
+            OpenClawChatPreview(
+                scenario: .empty,
+                sessionKey: "empty-preview")
+                .previewDisplayName("Chat empty")
+            OpenClawChatPreview(
+                scenario: .loading,
+                sessionKey: "loading-preview")
+                .previewDisplayName("Chat loading")
+            OpenClawChatPreview(
+                scenario: .error,
+                sessionKey: "error-preview")
+                .previewDisplayName("Chat gateway error")
+            OpenClawChatView(
+                viewModel: OpenClawChatViewModel(
+                    sessionKey: "ios-preview",
+                    transport: OpenClawChatPreviewTransport()),
+                showsSessionSwitcher: false,
+                style: .onboarding,
+                markdownVariant: .standard,
+                userAccent: OpenClawChatTheme.accent)
+                .previewDisplayName("Onboarding chat")
+        }
+    }
 }
 
 private struct OpenClawChatPreview: View {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView+Previews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView+Previews.swift
@@ -207,37 +207,44 @@ private struct OpenClawChatPreviewTransport: OpenClawChatTransport {
     }
 }
 
-private struct OpenClawChatPreviewProvider: PreviewProvider {
-    static var previews: some View {
-        Group {
-            OpenClawChatPreview(scenario: .connected)
-                .previewDisplayName("Chat")
-            OpenClawChatPreview(scenario: .connected)
-                .previewDisplayName("Chat connected")
-            OpenClawChatPreview(
-                scenario: .empty,
-                sessionKey: "empty-preview")
-                .previewDisplayName("Chat empty")
-            OpenClawChatPreview(
-                scenario: .loading,
-                sessionKey: "loading-preview")
-                .previewDisplayName("Chat loading")
-            OpenClawChatPreview(
-                scenario: .error,
-                sessionKey: "error-preview")
-                .previewDisplayName("Chat gateway error")
-            OpenClawChatView(
-                viewModel: OpenClawChatViewModel(
-                    sessionKey: "ios-preview",
-                    transport: OpenClawChatPreviewTransport()),
-                showsSessionSwitcher: false,
-                style: .onboarding,
-                markdownVariant: .standard,
-                userAccent: OpenClawChatTheme.accent)
-                .previewDisplayName("Onboarding chat")
-        }
-    }
+#if os(iOS)
+#Preview("Chat") {
+    OpenClawChatPreview(scenario: .connected)
 }
+
+#Preview("Chat connected") {
+    OpenClawChatPreview(scenario: .connected)
+}
+
+#Preview("Chat empty") {
+    OpenClawChatPreview(
+        scenario: .empty,
+        sessionKey: "empty-preview")
+}
+
+#Preview("Chat loading") {
+    OpenClawChatPreview(
+        scenario: .loading,
+        sessionKey: "loading-preview")
+}
+
+#Preview("Chat gateway error") {
+    OpenClawChatPreview(
+        scenario: .error,
+        sessionKey: "error-preview")
+}
+
+#Preview("Onboarding chat") {
+    OpenClawChatView(
+        viewModel: OpenClawChatViewModel(
+            sessionKey: "ios-preview",
+            transport: OpenClawChatPreviewTransport()),
+        showsSessionSwitcher: false,
+        style: .onboarding,
+        markdownVariant: .standard,
+        userAccent: OpenClawChatTheme.accent)
+}
+#endif
 
 private struct OpenClawChatPreview: View {
     let scenario: OpenClawChatPreviewTransport.Scenario


### PR DESCRIPTION
## Summary

- replace SwiftUI `@Entry` environment values with classic `EnvironmentKey` implementations
- replace `#Preview` macros with an equivalent `PreviewProvider` group
- restore macOS SwiftPM builds when macro implementation plugins are unavailable

## Proof

- `swift build --arch arm64` in `apps/macos`
- autoreview clean
