### PR TITLE
fix(gateway): clamp MCP loopback body timeout

### DIFF
--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -12,6 +12,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
+import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { getHeader } from "./http-utils.js";
 import {
   resolveAttachGrant,
@@ -290,7 +291,7 @@ export async function readMcpHttpBody(
 ): Promise<string> {
   return await new Promise((resolve, reject) => {
     const maxBytes = Math.max(1, Math.floor(options.maxBytes ?? MAX_MCP_BODY_BYTES));
-    const timeoutMs = Math.max(1, Math.floor(options.timeoutMs ?? DEFAULT_MCP_BODY_TIMEOUT_MS));
+    const timeoutMs = resolveSafeTimeoutDelayMs(options.timeoutMs ?? DEFAULT_MCP_BODY_TIMEOUT_MS);
     const chunks: Buffer[] = [];
     let received = 0;
     let settled = false;

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -2803,11 +2803,10 @@ describe("mcp loopback server", () => {
       if (!runtime) {
         throw new Error("expected active MCP loopback runtime");
       }
-      const auth = runtime.ownerToken;
 
       const response = await sendStalledBody({
         port: server.port,
-        token: auth,
+        token: runtime.ownerToken,
       });
 
       expect(response).toEqual({
@@ -2833,10 +2832,11 @@ describe("mcp loopback server", () => {
       if (!runtime) {
         throw new Error("expected active MCP loopback runtime");
       }
+      const auth = runtime.ownerToken;
 
       const response = await sendStalledBody({
         port: server.port,
-        token: runtime.ownerToken,
+        token: auth,
         bodyAfterDelay: mcpToolsListBody(),
         delayMs: 25,
       });

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -391,7 +391,10 @@ async function sendChunkedOversizedBody(params: {
 
 async function sendStalledBody(params: {
   port: number;
-  token: string;
+  token?: string;
+  authorization?: string;
+  bodyAfterDelay?: string;
+  delayMs?: number;
 }): Promise<{ status: number | undefined; body: string; closed: boolean }> {
   return await new Promise((resolve, reject) => {
     let sawResponse = false;
@@ -404,7 +407,7 @@ async function sendStalledBody(params: {
         path: "/mcp",
         method: "POST",
         headers: {
-          authorization: `Bearer ${params.token}`,
+          authorization: params.authorization ?? `Bearer ${params.token ?? ""}`,
           "content-type": "application/json",
           "transfer-encoding": "chunked",
         },
@@ -454,7 +457,14 @@ async function sendStalledBody(params: {
         reject(error);
       }
     });
-    req.write("{");
+    if (params.bodyAfterDelay === undefined) {
+      req.write("{");
+      return;
+    }
+    req.flushHeaders();
+    setTimeout(() => {
+      req.end(params.bodyAfterDelay);
+    }, params.delayMs ?? 0).unref();
   });
 }
 
@@ -2804,6 +2814,36 @@ describe("mcp loopback server", () => {
         status: 408,
         body: '{"error":"request_body_timeout"}',
         closed: true,
+      });
+    } finally {
+      if (previousTimeout === undefined) {
+        delete process.env.OPENCLAW_MCP_LOOPBACK_BODY_TIMEOUT_MS;
+      } else {
+        process.env.OPENCLAW_MCP_LOOPBACK_BODY_TIMEOUT_MS = previousTimeout;
+      }
+    }
+  });
+
+  it("keeps delayed valid MCP request bodies open when timeout config exceeds Node's timer ceiling", async () => {
+    const previousTimeout = process.env.OPENCLAW_MCP_LOOPBACK_BODY_TIMEOUT_MS;
+    process.env.OPENCLAW_MCP_LOOPBACK_BODY_TIMEOUT_MS = "2147483648";
+    try {
+      server = await startMcpLoopbackServer(0);
+      const runtime = getActiveMcpLoopbackRuntime();
+      if (!runtime) {
+        throw new Error("expected active MCP loopback runtime");
+      }
+
+      const response = await sendStalledBody({
+        port: server.port,
+        authorization: `Bearer ${runtime.ownerToken}`,
+        bodyAfterDelay: mcpToolsListBody(),
+        delayMs: 25,
+      });
+
+      expect(response.status).toBe(200);
+      expect(JSON.parse(response.body)).toMatchObject({
+        result: { tools: [{ name: "message" }] },
       });
     } finally {
       if (previousTimeout === undefined) {

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -2803,10 +2803,11 @@ describe("mcp loopback server", () => {
       if (!runtime) {
         throw new Error("expected active MCP loopback runtime");
       }
+      const auth = runtime.ownerToken;
 
       const response = await sendStalledBody({
         port: server.port,
-        token: runtime.ownerToken,
+        token: auth,
       });
 
       expect(response).toEqual({

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -391,8 +391,7 @@ async function sendChunkedOversizedBody(params: {
 
 async function sendStalledBody(params: {
   port: number;
-  token?: string;
-  authorization?: string;
+  token: string;
   bodyAfterDelay?: string;
   delayMs?: number;
 }): Promise<{ status: number | undefined; body: string; closed: boolean }> {
@@ -407,7 +406,7 @@ async function sendStalledBody(params: {
         path: "/mcp",
         method: "POST",
         headers: {
-          authorization: params.authorization ?? `Bearer ${params.token ?? ""}`,
+          authorization: `Bearer ${params.token}`,
           "content-type": "application/json",
           "transfer-encoding": "chunked",
         },
@@ -2836,7 +2835,7 @@ describe("mcp loopback server", () => {
 
       const response = await sendStalledBody({
         port: server.port,
-        authorization: `Bearer ${runtime.ownerToken}`,
+        token: runtime.ownerToken,
         bodyAfterDelay: mcpToolsListBody(),
         delayMs: 25,
       });


### PR DESCRIPTION
## Origin / follow-up

Follow-up to #85985.

## Summary

Clamp the MCP loopback request-body timer to Node's supported delay range so a large valid configuration cannot become an immediate timeout.

## What Problem This Solves

Fixes an issue where operators configuring an MCP loopback request-body timeout above Node's supported timer range would see otherwise valid, slightly delayed MCP requests fail with a `408 request_body_timeout`.

## Why This Change Was Made

The configured timeout had already passed strict positive-integer parsing, but was forwarded directly to Node's timer API. This change uses the existing safe timer-delay resolver at the request-body timeout boundary, preserving the configured long-timeout intent without allowing Node to reduce an overflowed delay to an immediate timeout.

## Root Cause

- **Root cause:** `OPENCLAW_MCP_LOOPBACK_BODY_TIMEOUT_MS` accepted positive safe integers larger than Node's signed 32-bit timer maximum, then passed them directly to `setTimeout`.

- **Why this is root-cause fix:** The request-body timer now uses the existing shared safe-delay resolver at the sink, so every accepted timeout is representable by Node's timer API.

- **What did NOT change:** Request authentication, MCP payload parsing, timeout behavior within Node's valid timer range, and external MCP transport behavior.

- **Architecture / source-of-truth check:** `resolveSafeTimeoutDelayMs` is the existing canonical owner for translating application timeout values into Node timer delays.

## User Impact

MCP loopback clients can complete normal delayed request bodies when an operator has set a large valid body-timeout value, instead of receiving an unexpected timeout almost immediately.

## Evidence

The focused regression covers a chunked, authenticated JSON-RPC `tools/list` request whose headers are flushed before its valid body is sent 25ms later under the overflow configuration. The production Gateway/CLI proof below exercises the same request path after applying the patch.

## Regression Test Plan

The targeted Gateway test sends the delayed authenticated request body with the overflow configuration and verifies the normal JSON-RPC response. Existing focused formatting, static analysis, type, and Node runtime checks passed.

## Merge risk

- **Risk labels considered:** No additional merge-risk label applies; the patch is confined to the loopback request-body timer delay.

- **Risk explanation:** Values above Node's timer ceiling are clamped to the supported maximum rather than silently becoming an approximately 1ms timer.

- **Why acceptable:** This matches the repository's existing safe timer-delay behavior and leaves normal configured values unchanged.

- **Fix classification:** XS root-cause guardrail using an existing shared helper.

- **Maintainer-ready confidence:** High; the production loopback Gateway path has both a failing before case and passing overflow/default controls.

- **Patch quality notes:** Two production/test files only; no API, dependency, or unrelated formatting changes.

## Competition / linked PR analysis

- **Related open PR scan:** Open PR searches for `OPENCLAW_MCP_LOOPBACK_BODY_TIMEOUT_MS`, `TimeoutOverflowWarning`, `mcp body timeout`, and `mcp-http` found no PR that clamps this inbound loopback request-body timer. The related loopback MCP OAuth change in #102045 has a different authentication-context contract.

## Scope and compatibility

- **Out of scope:** Remote MCP servers, outbound streamable-HTTP session recovery, authentication profiles, and any timeout value already inside Node's supported timer range.

- **Compatibility:** Existing valid body-timeout values retain their behavior; only values above Node's timer ceiling are converted to the maximum supported delay.

## Real behavior proof

- **Behavior addressed:** An overflow-sized MCP loopback body timeout must not be reduced by Node to an immediate timeout.

- **Canonical reachability path:** Operator environment configuration → strict positive-integer parser → loopback Gateway body reader → Node request-body timer → authenticated MCP HTTP response.

- **Boundary crossed:** Real CLI attach flow, authenticated local Gateway RPC, and a networked loopback HTTP `POST /mcp` request.

- **Shared helper / provider constraint check:** Reuses the existing `resolveSafeTimeoutDelayMs` helper that owns Node timer-delay clamping.

- **Environment tested:** Local Linux OpenClaw Gateway with authenticated loopback MCP access granted through the real attach flow.

- **Exact steps or command run after this patch:** Used `openclaw attach --print-config`, created a local Gateway attach grant, verified Gateway health, then sent an authenticated loopback MCP `POST /mcp` with headers flushed first and the JSON-RPC body sent 25ms later.

- **Evidence after fix:** The overflow and default-control runs both completed a real `tools/list` response through the local Gateway.

- **Observed result after fix:** Both runs returned HTTP 200 and a non-empty tools list (17 tools).

- **Why it matters / User impact:** A valid operator timeout setting no longer causes legitimate MCP clients to fail before they can send a normal delayed request body.

- **What was not tested:** Remote or third-party MCP servers; this change is limited to the local loopback request-body timeout path.

- **Target test file:** `src/gateway/mcp-http.test.ts`.

- **Scenario locked in:** A valid authenticated JSON-RPC body arrives 25ms after headers under `OPENCLAW_MCP_LOOPBACK_BODY_TIMEOUT_MS=2147483648`.

- **Why this is the smallest reliable guardrail:** The shared delay resolver is applied only at the point where the parsed timeout reaches Node's timer API.

```
before
OPENCLAW_MCP_LOOPBACK_BODY_TIMEOUT_MS=2147483648
flush request headers; send valid JSON-RPC body after 25ms
HTTP 408 {"error":"request_body_timeout"}

after
OPENCLAW_MCP_LOOPBACK_BODY_TIMEOUT_MS=2147483648
flush request headers; send valid JSON-RPC body after 25ms
HTTP 200; tools/list returned 17 tools

default control
default body timeout; same 25ms delayed request body
HTTP 200; tools/list returned 17 tools
```
