### PR TITLE
fix(cli): gateway startup no longer waits for claw animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Provider network retries:** align provider read/poll/download and agent-wait recovery for transient connection errors, retry bounded provider `ENOTFOUND` failures while leaving gateway `ENOTFOUND` and non-idempotent create operations fail-fast. (#101496) Thanks @xialonglee.
-- **Gateway startup banner:** load gateway modules in parallel with the foreground claw animation and settle the banner early when loading wins, preventing terminal art from delaying readiness. (#105748)
 - **Session retry classification:** stop permanent provider errors whose identifiers or payload details merely contain 429/5xx digit sequences from re-sending full context, and share bounded rate-limit-window parsing across retry paths. (#105258) Thanks @destire-mio.
 - **LINE directive templates:** suppress confirms and buttons with blank required fields or unlabeled actions while preserving valid titleless buttons and surrounding reply text. (#105520) Thanks @edenfunf.
 - **SQLite maintenance schema validation:** reject current-version global and agent databases with missing or drifted canonical tables, constraints, indexes, triggers, or table options before compaction, while accepting supported additive-migration layouts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Provider network retries:** align provider read/poll/download and agent-wait recovery for transient connection errors, retry bounded provider `ENOTFOUND` failures while leaving gateway `ENOTFOUND` and non-idempotent create operations fail-fast. (#101496) Thanks @xialonglee.
+- **Gateway startup banner:** load gateway modules in parallel with the foreground claw animation and settle the banner early when loading wins, preventing terminal art from delaying readiness. (#105748)
 - **Session retry classification:** stop permanent provider errors whose identifiers or payload details merely contain 429/5xx digit sequences from re-sending full context, and share bounded rate-limit-window parsing across retry paths. (#105258) Thanks @destire-mio.
 - **LINE directive templates:** suppress confirms and buttons with blank required fields or unlabeled actions while preserving valid titleless buttons and surrounding reply text. (#105520) Thanks @edenfunf.
 - **SQLite maintenance schema validation:** reject current-version global and agent databases with missing or drifted canonical tables, constraints, indexes, triggers, or table options before compaction, while accepting supported additive-migration layouts.

--- a/src/cli/claw-banner.test.ts
+++ b/src/cli/claw-banner.test.ts
@@ -87,6 +87,41 @@ describe("printClawBanner", () => {
     expect(process.listenerCount("SIGINT")).toBe(before);
   });
 
+  it("settles on the static frame when parallel work finishes first", async () => {
+    const staticRows = await runStatic();
+    const chunks: string[] = [];
+    const beforeSigint = process.listenerCount("SIGINT");
+    let settle!: () => void;
+    const settleWhen = new Promise<void>((resolve) => {
+      settle = resolve;
+    });
+    const { runtime } = runtimeStub();
+    const banner = printClawBanner(runtime, {
+      columns: 120,
+      isTty: true,
+      rich: true,
+      env: {},
+      rng: () => 0.99,
+      settleWhen,
+      sleep: () => new Promise<void>(() => {}),
+      write: (chunk) => chunks.push(chunk),
+    });
+
+    expect(chunks[0]).toBe("\x1b[?25l");
+    expect(process.listenerCount("SIGINT")).toBe(beforeSigint + 1);
+    settle();
+    await expect(banner).resolves.toBe("settled");
+
+    const frames = chunks.filter((chunk) => chunk.includes("\x1b[K"));
+    const finalRows = stripAnsi(frames.at(-1) ?? "")
+      .split("\n")
+      .filter((row) => row.length > 0);
+    expect(finalRows).toEqual(staticRows);
+    expect(chunks.at(-2)).toBe("\x1b[?25h");
+    expect(chunks.at(-1)).toBe("\n");
+    expect(process.listenerCount("SIGINT")).toBe(beforeSigint);
+  });
+
   it("varies snips and shimmer passes with the rng", async () => {
     // rng below the thresholds adds a second shimmer pass and a second snip.
     const maximal = (await runAnimated(() => 0)).filter((c) => c.includes("\x1b[K"));

--- a/src/cli/claw-banner.ts
+++ b/src/cli/claw-banner.ts
@@ -43,9 +43,13 @@ type ClawBannerOptions = {
   env?: NodeJS.ProcessEnv;
   /** Injectable randomness for the animation garnish (tests pin it). */
   rng?: () => number;
+  /** Ends the animation on its static frame when parallel startup work settles. */
+  settleWhen?: PromiseLike<unknown>;
   sleep?: (ms: number) => Promise<void>;
   write?: (chunk: string) => void;
 };
+
+export type ClawBannerResult = "static" | "completed" | "settled";
 
 type CellTint = (col: number) => (text: string) => string;
 
@@ -101,10 +105,30 @@ const defaultSleep = (ms: number) =>
 // canned; every sequence ends on the exact static banner.
 async function animateBanner(opts: {
   rng: () => number;
+  settleWhen?: PromiseLike<unknown>;
   sleep: (ms: number) => Promise<void>;
   write: (chunk: string) => void;
-}): Promise<void> {
-  const { rng, sleep, write } = opts;
+}): Promise<Exclude<ClawBannerResult, "static">> {
+  const { rng, settleWhen, sleep, write } = opts;
+  let settleRequested = false;
+  const settleSignal = settleWhen
+    ? Promise.resolve(settleWhen).then(
+        () => {
+          settleRequested = true;
+        },
+        () => {
+          settleRequested = true;
+        },
+      )
+    : null;
+  const pause = async (ms: number): Promise<boolean> => {
+    if (!settleSignal) {
+      await sleep(ms);
+      return true;
+    }
+    await Promise.race([sleep(ms), settleSignal]);
+    return !settleRequested;
+  };
   let drewFrame = false;
   const draw = (lines: string[]) => {
     const prefix = drewFrame ? `\x1b[${ROWS}F` : "";
@@ -139,7 +163,9 @@ async function animateBanner(opts: {
           wordmarkTint: tintAt(identityTint),
         }),
       );
-      await sleep(45);
+      if (!(await pause(45))) {
+        return "settled";
+      }
     }
     // Shimmer: a bright band sweeps the wordmark; rarely it runs twice.
     const shimmerPasses = rng() < 0.2 ? 2 : 1;
@@ -148,22 +174,37 @@ async function animateBanner(opts: {
         const band: CellTint = (col) =>
           col >= x && col < x + 6 ? theme.accentBright : identityTint;
         draw(composeFrame({ wordmarkTint: band }));
-        await sleep(40);
+        if (!(await pause(40))) {
+          return "settled";
+        }
       }
     }
     // Snip: claws open and close once, sometimes twice.
     const snips = rng() < 0.4 ? 2 : 1;
     for (let snip = 0; snip < snips; snip++) {
       draw(composeFrame({ mascotRows: [...MASCOT_OPEN_ROWS, ...MASCOT_ART.slice(2)] }));
-      await sleep(95);
+      if (!(await pause(95))) {
+        return "settled";
+      }
       draw(staticBannerLines());
-      await sleep(115);
+      if (!(await pause(115))) {
+        return "settled";
+      }
     }
     draw(staticBannerLines());
+    return "completed";
   } finally {
-    process.off("SIGINT", onSigint);
-    process.off("SIGTERM", onSigterm);
-    write("\x1b[?25h");
+    try {
+      // Parallel work owns startup latency; leave a complete banner instead of
+      // an interrupted frame before its logs or errors take over the terminal.
+      if (settleRequested && drewFrame) {
+        draw(staticBannerLines());
+      }
+    } finally {
+      process.off("SIGINT", onSigint);
+      process.off("SIGTERM", onSigterm);
+      write("\x1b[?25h");
+    }
   }
 }
 
@@ -174,11 +215,11 @@ async function animateBanner(opts: {
 export async function printClawBanner(
   runtime: RuntimeEnv,
   options: ClawBannerOptions = {},
-): Promise<void> {
+): Promise<ClawBannerResult> {
   const columns = options.columns ?? process.stdout.columns ?? 80;
   if (columns < BANNER_WIDTH) {
     runtime.log(`${plainTitleLine()}\n`);
-    return;
+    return "static";
   }
   const env = options.env ?? process.env;
   const animate =
@@ -188,12 +229,14 @@ export async function printClawBanner(
     !env.VITEST;
   if (!animate) {
     runtime.log(`${staticBannerLines().join("\n")}\n`);
-    return;
+    return "static";
   }
-  await animateBanner({
+  const result = await animateBanner({
     rng: options.rng ?? Math.random,
+    settleWhen: options.settleWhen,
     sleep: options.sleep ?? defaultSleep,
     write: options.write ?? ((chunk) => process.stdout.write(chunk)),
   });
   (options.write ?? ((chunk: string) => process.stdout.write(chunk)))("\n");
+  return result;
 }

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -52,7 +52,7 @@ import { setConsoleSubsystemFilter, setConsoleTimestampPrefix } from "../../logg
 import { withDiagnosticPhase } from "../../logging/diagnostic-phase.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { defaultRuntime } from "../../runtime.js";
-import { printClawBanner } from "../claw-banner.js";
+import { printClawBanner, type ClawBannerResult } from "../claw-banner.js";
 import { formatCliCommand } from "../command-format.js";
 import { formatInvalidConfigPort, formatInvalidPortOption } from "../error-format.js";
 import { withProgress } from "../progress.js";
@@ -131,20 +131,46 @@ function createGatewayCliStartupTrace() {
       );
     }
   };
+  const startMeasure = <T>(name: string, run: () => Awaitable<T>) => {
+    const before = performance.now();
+    let completedAt = before;
+    let emitted = false;
+    const result = withDiagnosticPhase(name, run).finally(() => {
+      completedAt = performance.now();
+    });
+    // Attach both outcomes immediately so callers can finish terminal UI before
+    // consuming or rethrowing the measured result without an unhandled rejection.
+    const settled = result.then(
+      () => {},
+      () => {},
+    );
+    return {
+      result,
+      settled,
+      emit() {
+        if (emitted) {
+          return;
+        }
+        emitted = true;
+        emit(name, completedAt - before, completedAt - started);
+        last = completedAt;
+      },
+    };
+  };
   return {
     mark(name: string) {
       const now = performance.now();
       emit(name, now - last, now - started);
       last = now;
     },
+    startMeasure,
     async measure<T>(name: string, run: () => Awaitable<T>): Promise<T> {
-      const before = performance.now();
+      const measurement = startMeasure(name, run);
       try {
-        return await withDiagnosticPhase(name, run);
+        return await measurement.result;
       } finally {
-        const now = performance.now();
-        emit(name, now - before, now - started);
-        last = now;
+        await measurement.settled;
+        measurement.emit();
       }
     },
   };
@@ -602,23 +628,36 @@ export async function runGatewayCommand(opts: GatewayRunOpts, hooks: GatewayRunR
     process.env.OPENCLAW_RAW_STREAM_PATH = rawStreamPath;
   }
 
-  // Foreground TTY runs get the banner before the module-loading spinner;
-  // managed/piped runs (launchd, tests, logs) stay banner-free.
-  if (process.stdout.isTTY) {
-    await printClawBanner(defaultRuntime);
-  }
-
   const startupTrace = createGatewayCliStartupTrace();
 
   // The heaviest part of gateway startup is loading the server module tree
-  // (channels, plugins, HTTP stack, etc.). Show a spinner so the user sees
-  // progress instead of a silent 15-20 s pause (especially on Windows/NTFS).
-  const { startGatewayServer } = await startupTrace.measure("cli.server-import", () =>
-    withProgress(
-      { label: "Loading gateway modules…", indeterminate: true },
-      async () => import("../../gateway/server.js"),
-    ),
+  // (channels, plugins, HTTP stack, etc.). Start it before the foreground TTY
+  // banner so the animation never extends readiness. If loading wins, the
+  // banner settles cleanly; otherwise its existing spinner owns the wait.
+  const serverImportMeasurement = startupTrace.startMeasure(
+    "cli.server-import",
+    () => import("../../gateway/server.js"),
   );
+  const rawServerImport = serverImportMeasurement.result;
+  const bannerDone: Promise<ClawBannerResult> = process.stdout.isTTY
+    ? printClawBanner(defaultRuntime, { settleWhen: rawServerImport })
+    : Promise.resolve("static");
+  const loadServerModule = async () => {
+    try {
+      const bannerResult = await bannerDone;
+      return bannerResult === "settled"
+        ? await rawServerImport
+        : await withProgress(
+            { label: "Loading gateway modules…", indeterminate: true },
+            async () => rawServerImport,
+          );
+    } finally {
+      // Trace output follows banner or spinner cleanup on both success and error.
+      await serverImportMeasurement.settled;
+      serverImportMeasurement.emit();
+    }
+  };
+  const { startGatewayServer } = await loadServerModule();
 
   setConsoleTimestampPrefix(true);
 


### PR DESCRIPTION
Closes #105748

## What Problem This Solves

Fixes an issue where users starting the Gateway in a foreground terminal would wait for the decorative claw animation before gateway module loading began, adding roughly 1.3–2.1 seconds to startup.

## Why This Change Was Made

Gateway module loading now starts in parallel with the existing animation. If loading wins, the banner immediately settles on its exact static frame and restores terminal state before logs continue; if the animation wins, the existing module-loading spinner owns the remaining wait. Wizard animation behavior and non-interactive output remain unchanged.

Startup trace emission is separated from import completion so both the banner and spinner clean up before trace logs write to the terminal.

## User Impact

Foreground Gateway startup no longer waits for decorative terminal art. Users still see the full animation when startup work is slower, while fast startup proceeds as soon as modules are ready.

## Evidence

- Testbox focused regression suite: 110 tests passed across `src/cli/claw-banner.test.ts`, `src/cli/gateway-cli/run.option-collisions.test.ts`, and `src/commands/onboard-helpers.test.ts`.
- Latest-main Testbox changed gate passed: `tbx_01kxccgaex7eewq4hnf1xs7e4n` ([run 29214490590](https://github.com/openclaw/openclaw/actions/runs/29214490590)).
- Production `pnpm build` passed in Testbox `tbx_01kxcc0kyp7657vwc53xahh9r6`.
- Real 120-column PTY launch against built output: readiness 3.854 s, server import 1.3 ms, 2 animation frames (initial + settled static), cursor restored before startup trace output.
- Behavior contract: all fast-work, slow-work, static/non-TTY, terminal cleanup, and error-propagation clauses passed.
- Fresh `autoreview --mode local`: clean; no accepted/actionable findings.

Exact-head GitHub CI remains the final merge gate.
