### PR TITLE
fix(ui): keep sessions visible when deletion is a no-op

### DIFF
--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -550,6 +550,43 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
     }
   });
 
+  it("keeps a session row when the Gateway reports no deletion", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const key = "agent:main:research";
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.delete": { ok: true, deleted: false },
+        "sessions.list": sessionsListResponse([
+          sessionRow("agent:main:main", "Main", Date.parse("2026-07-01T16:00:00.000Z")),
+          sessionRow(key, "Research notes", Date.parse("2026-07-01T15:00:00.000Z")),
+        ]),
+      },
+      sessionKey: "agent:main:main",
+    });
+    page.on("dialog", (dialog) => void dialog.accept());
+
+    try {
+      await page.goto(`${server.baseUrl}sessions`);
+      const row = page.locator(".session-data-row").filter({ hasText: "Research notes" });
+      await row.waitFor({ state: "visible", timeout: 10_000 });
+
+      await row.getByRole("button", { name: "Open session menu" }).click();
+      const menu = page.getByRole("menu", { name: "Actions for Research notes" });
+      await menu.getByRole("menuitem", { name: "Delete…" }).click();
+
+      const request = await gateway.waitForRequest("sessions.delete");
+      expect(requireRecord(request.params)).toMatchObject({ key });
+      await row.waitFor({ state: "visible" });
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps sidebar sessions visible through a same-client Gateway reconnect", async () => {
     const context = await browser.newContext({
       locale: "en-US",

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -82,6 +82,57 @@ function sessionChangedEvent(key: string): GatewayEventFrame {
 }
 
 describe("createSessionCapability", () => {
+  it("keeps a session when sessions.delete reports no deletion", async () => {
+    const key = "agent:main:missing";
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.delete") {
+        return { ok: true, deleted: false };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { gateway } = createGatewayHarness(client);
+    const sessions = createSessionCapability(gateway);
+
+    await expect(sessions.delete(key)).resolves.toEqual({ deleted: false });
+    expect(sessions.state.deletedSessions).toEqual([]);
+    expect(request).toHaveBeenCalledTimes(1);
+    sessions.dispose();
+  });
+
+  it("excludes lifecycle no-ops from batch deletion results", async () => {
+    const keptKey = "agent:main:kept";
+    const deletedKey = "agent:main:deleted";
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "sessions.delete") {
+        const key = (params as { key?: string } | undefined)?.key;
+        return { ok: true, deleted: key === deletedKey };
+      }
+      if (method === "sessions.list") {
+        return sessionsResult([{ key: keptKey, kind: "direct", updatedAt: 1 }], 2);
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { gateway } = createGatewayHarness(client);
+    const sessions = createSessionCapability(gateway);
+    const deletedSnapshots: string[][] = [];
+    const unsubscribe = sessions.subscribe((next) => {
+      deletedSnapshots.push(next.deletedSessions.map((target) => target.key));
+    });
+
+    await expect(sessions.deleteMany([{ key: keptKey }, { key: deletedKey }])).resolves.toEqual({
+      deleted: [deletedKey],
+      errors: [],
+      preservedWorktrees: [],
+    });
+    expect(deletedSnapshots.some((keys) => keys.includes(deletedKey))).toBe(true);
+    expect(deletedSnapshots.some((keys) => keys.includes(keptKey))).toBe(false);
+    expect(request).toHaveBeenCalledTimes(3);
+    unsubscribe();
+    sessions.dispose();
+  });
+
   it("advances the canonical list revision only for sessions.list publications", async () => {
     const request = vi.fn(async (method: string) => {
       if (method !== "sessions.list") {

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -151,6 +151,11 @@ type SessionGateway = {
 
 type SessionRequestClient = Pick<GatewayBrowserClient, "request">;
 
+type SessionDeleteResponse = {
+  deleted: boolean;
+  worktreePreserved?: SessionDeleteOutcome["worktreePreserved"];
+};
+
 type SessionConnectionScope = {
   client: GatewayBrowserClient;
   epoch: number;
@@ -353,11 +358,17 @@ function requestSessionDelete(
   client: SessionRequestClient,
   key: string,
   options: SessionDeleteOptions = {},
-): Promise<{ deleted?: boolean; worktreePreserved?: SessionDeleteOutcome["worktreePreserved"] }> {
-  return client.request("sessions.delete", {
+): Promise<SessionDeleteResponse> {
+  return client.request<SessionDeleteResponse>("sessions.delete", {
     ...buildSessionRequestParams(key, options.agentId),
     deleteTranscript: options.deleteTranscript ?? true,
   });
+}
+
+function confirmsSessionDeletion(response: SessionDeleteResponse): boolean {
+  // A successful RPC can still be a lifecycle no-op. Only the canonical result
+  // may drive optimistic removal, navigation, and model-override cleanup.
+  return response.deleted;
 }
 
 function requestSessionReset(
@@ -1060,6 +1071,9 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       if (!isCurrentConnection(scope)) {
         return { deleted: false };
       }
+      if (!confirmsSessionDeletion(response)) {
+        return { deleted: false };
+      }
       publish({ ...state, deletedSessions: [{ key, agentId: options.agentId }] });
       setModelOverride(key, undefined);
       await refresh({ agentId: options.agentId, force: true });
@@ -1094,6 +1108,9 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         const response = await requestSessionDelete(scope.client, target.key, target);
         if (!isCurrentConnection(scope)) {
           break;
+        }
+        if (!confirmsSessionDeletion(response)) {
+          continue;
         }
         deleted.push(target.key);
         if (response.worktreePreserved) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users deleting a session would see it removed locally when the Gateway accepted the request but reported that no deletion occurred. Batch deletion could likewise report no-op targets as deleted and clear their model overrides.

## Why This Change Was Made

The Control UI now treats the Gateway's `deleted` result as the canonical outcome for both single and batch deletion. Optimistic removal, navigation, and model-override cleanup run only after a confirmed deletion.

## User Impact

Sessions remain visible and usable when a lifecycle race or already-missing target makes deletion a no-op. Batch results contain only sessions the Gateway actually deleted.

## Evidence

- `corepack pnpm test ui/src/lib/sessions/index.test.ts` — 17 passed on Blacksmith Testbox `tbx_01kxccbyhyy8z8xbhve827geen`.
- `corepack pnpm test ui/src/e2e/session-management.e2e.test.ts` — 11 existing Chromium cases passed; the new no-op case initially reproduced the failure and passes after the fix.
- Focused source-blind Chromium contract — the rendered Sessions row remains visible after `{ deleted: false }`, and the request targets the selected key.
- `corepack pnpm check:changed` — passed on the same Testbox.
- Fresh Codex autoreview — clean; no accepted or actionable findings.
