### PR TITLE
fix(mcp): clamp oversized MCP timeouts

### DIFF
--- a/packages/normalization-core/src/number-coercion.test.ts
+++ b/packages/normalization-core/src/number-coercion.test.ts
@@ -95,6 +95,7 @@ describe("number-coercion", () => {
     expect(finiteSecondsToTimerSafeMilliseconds(1.5)).toBe(1_500);
     expect(finiteSecondsToTimerSafeMilliseconds(1.5, { floorSeconds: true })).toBe(1_000);
     expect(finiteSecondsToTimerSafeMilliseconds(10_000_000)).toBe(MAX_TIMER_TIMEOUT_MS);
+    expect(finiteSecondsToTimerSafeMilliseconds(Number.MAX_VALUE)).toBe(MAX_TIMER_TIMEOUT_MS);
     expect(finiteSecondsToTimerSafeMilliseconds("10")).toBeUndefined();
     expect(finiteSecondsToTimerSafeMilliseconds(Number.POSITIVE_INFINITY)).toBeUndefined();
     expect(clampTimerTimeoutMs(0, 10)).toBe(10);

--- a/packages/normalization-core/src/number-coercion.ts
+++ b/packages/normalization-core/src/number-coercion.ts
@@ -214,6 +214,9 @@ export function finiteSecondsToTimerSafeMilliseconds(
     return undefined;
   }
   const boundedSeconds = opts.floorSeconds ? Math.floor(seconds) : seconds;
+  if (boundedSeconds >= MAX_TIMER_TIMEOUT_SECONDS) {
+    return MAX_TIMER_TIMEOUT_MS;
+  }
   const milliseconds = Math.floor(boundedSeconds * 1000);
   if (!Number.isFinite(milliseconds) || milliseconds <= 0) {
     return undefined;

--- a/src/agents/mcp-transport-config.test.ts
+++ b/src/agents/mcp-transport-config.test.ts
@@ -1,4 +1,5 @@
 // Verifies MCP transport config normalization and startup-safety filtering.
+import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { logWarn } from "../logger.js";
 import { resolveMcpTransportConfig } from "./mcp-transport-config.js";
@@ -44,6 +45,32 @@ describe("resolveMcpTransportConfig", () => {
         connectionTimeoutMs: 2_000,
         requestTimeoutMs: 7_000,
         supportsParallelToolCalls: true,
+      }),
+    );
+  });
+
+  it("clamps oversized MCP request timeout aliases to the Node timer maximum", () => {
+    const seconds = resolveMcpTransportConfig("probe", {
+      command: "node",
+      connectTimeout: 1e306,
+      timeout: 1e306,
+    });
+    const milliseconds = resolveMcpTransportConfig("probe", {
+      command: "node",
+      connectionTimeoutMs: 1e306,
+      requestTimeoutMs: 1e306,
+    });
+
+    expect(seconds).toEqual(
+      expect.objectContaining({
+        connectionTimeoutMs: MAX_TIMER_TIMEOUT_MS,
+        requestTimeoutMs: MAX_TIMER_TIMEOUT_MS,
+      }),
+    );
+    expect(milliseconds).toEqual(
+      expect.objectContaining({
+        connectionTimeoutMs: MAX_TIMER_TIMEOUT_MS,
+        requestTimeoutMs: MAX_TIMER_TIMEOUT_MS,
       }),
     );
   });

--- a/src/agents/mcp-transport-config.ts
+++ b/src/agents/mcp-transport-config.ts
@@ -1,6 +1,11 @@
 /**
  * Resolves MCP transport command, environment, and timeout configuration.
  */
+import {
+  clampPositiveTimerTimeoutMs,
+  finiteSecondsToTimerSafeMilliseconds,
+  MAX_TIMER_TIMEOUT_SECONDS,
+} from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { resolveOpenClawMcpTransportAlias } from "../config/mcp-config-normalize.js";
@@ -69,11 +74,11 @@ function getPositiveNumber(rawServer: unknown, keys: readonly string[]): number 
 function getConnectionTimeoutMs(rawServer: unknown): number {
   const milliseconds = getPositiveNumber(rawServer, ["connectionTimeoutMs"]);
   if (milliseconds) {
-    return Math.floor(milliseconds);
+    return clampPositiveTimerTimeoutMs(milliseconds) ?? DEFAULT_CONNECTION_TIMEOUT_MS;
   }
   const seconds = getPositiveNumber(rawServer, ["connectTimeout", "connect_timeout"]);
   if (seconds) {
-    return Math.floor(seconds * 1_000);
+    return finiteSecondsToTimerSafeMilliseconds(Math.min(seconds, MAX_TIMER_TIMEOUT_SECONDS)) ?? 1;
   }
   return DEFAULT_CONNECTION_TIMEOUT_MS;
 }
@@ -81,11 +86,11 @@ function getConnectionTimeoutMs(rawServer: unknown): number {
 function getRequestTimeoutMs(rawServer: unknown): number {
   const milliseconds = getPositiveNumber(rawServer, ["requestTimeoutMs"]);
   if (milliseconds) {
-    return Math.floor(milliseconds);
+    return clampPositiveTimerTimeoutMs(milliseconds) ?? DEFAULT_REQUEST_TIMEOUT_MS;
   }
   const seconds = getPositiveNumber(rawServer, ["timeout"]);
   if (seconds) {
-    return Math.floor(seconds * 1_000);
+    return finiteSecondsToTimerSafeMilliseconds(Math.min(seconds, MAX_TIMER_TIMEOUT_SECONDS)) ?? 1;
   }
   return DEFAULT_REQUEST_TIMEOUT_MS;
 }

--- a/src/agents/mcp-transport-config.ts
+++ b/src/agents/mcp-transport-config.ts
@@ -4,7 +4,7 @@
 import {
   clampPositiveTimerTimeoutMs,
   finiteSecondsToTimerSafeMilliseconds,
-  MAX_TIMER_TIMEOUT_SECONDS,
+  resolvePositiveTimerTimeoutMs,
 } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
@@ -78,21 +78,24 @@ function getConnectionTimeoutMs(rawServer: unknown): number {
   }
   const seconds = getPositiveNumber(rawServer, ["connectTimeout", "connect_timeout"]);
   if (seconds) {
-    return finiteSecondsToTimerSafeMilliseconds(Math.min(seconds, MAX_TIMER_TIMEOUT_SECONDS)) ?? 1;
+    return finiteSecondsToTimerSafeMilliseconds(seconds) ?? 1;
   }
   return DEFAULT_CONNECTION_TIMEOUT_MS;
 }
 
-function getRequestTimeoutMs(rawServer: unknown): number {
+export function resolveMcpRequestTimeoutMs(
+  rawServer: unknown,
+  fallbackMs = DEFAULT_REQUEST_TIMEOUT_MS,
+): number {
   const milliseconds = getPositiveNumber(rawServer, ["requestTimeoutMs"]);
   if (milliseconds) {
     return clampPositiveTimerTimeoutMs(milliseconds) ?? DEFAULT_REQUEST_TIMEOUT_MS;
   }
   const seconds = getPositiveNumber(rawServer, ["timeout"]);
   if (seconds) {
-    return finiteSecondsToTimerSafeMilliseconds(Math.min(seconds, MAX_TIMER_TIMEOUT_SECONDS)) ?? 1;
+    return finiteSecondsToTimerSafeMilliseconds(seconds) ?? 1;
   }
-  return DEFAULT_REQUEST_TIMEOUT_MS;
+  return resolvePositiveTimerTimeoutMs(fallbackMs, DEFAULT_REQUEST_TIMEOUT_MS);
 }
 
 function getBooleanField(rawServer: unknown, keys: readonly string[]): boolean | undefined {
@@ -187,7 +190,7 @@ function resolveHttpTransportConfig(
       : {}),
     description: describeHttpMcpServerLaunchConfig(launch.config),
     connectionTimeoutMs: getConnectionTimeoutMs(rawServer),
-    requestTimeoutMs: getRequestTimeoutMs(rawServer),
+    requestTimeoutMs: resolveMcpRequestTimeoutMs(rawServer),
     supportsParallelToolCalls:
       getBooleanField(rawServer, ["supportsParallelToolCalls", "supports_parallel_tool_calls"]) ??
       false,
@@ -222,7 +225,7 @@ export function resolveMcpTransportConfig(
       cwd: stdioLaunch.config.cwd,
       description: describeStdioMcpServerLaunchConfig(stdioLaunch.config),
       connectionTimeoutMs: getConnectionTimeoutMs(rawServer),
-      requestTimeoutMs: getRequestTimeoutMs(rawServer),
+      requestTimeoutMs: resolveMcpRequestTimeoutMs(rawServer),
       supportsParallelToolCalls:
         getBooleanField(rawServer, ["supportsParallelToolCalls", "supports_parallel_tool_calls"]) ??
         false,

--- a/src/node-host/mcp.test.ts
+++ b/src/node-host/mcp.test.ts
@@ -2,6 +2,7 @@
 
 import { ErrorCode, type CallToolResult, type Tool } from "@modelcontextprotocol/sdk/types.js";
 import { expectDefined } from "@openclaw/normalization-core";
+import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
 import { OpenClawSchema } from "../config/zod-schema.js";
 import {
@@ -216,6 +217,20 @@ describe("node host MCP manager", () => {
     client.onclose?.();
     await expect(manager.callMcpTool({ server: "docs", tool: "slow" })).rejects.toMatchObject({
       code: "MCP_SERVER_UNAVAILABLE" satisfies NodeHostMcpErrorCode,
+    });
+    await manager.close();
+  });
+
+  it("clamps oversized configured and requested MCP tool timeouts", async () => {
+    const client = createClient({ tools: [tool("search")] });
+    const manager = await startNodeHostMcpManager(
+      { docs: { command: "docs", timeout: 1e306 } },
+      { createClient: () => client, resolveTransport: () => transport, warn: vi.fn() },
+    );
+
+    await manager.callMcpTool({ server: "docs", tool: "search", timeoutMs: 1e306 });
+    expect(client.callTool).toHaveBeenCalledWith({ name: "search", arguments: {} }, undefined, {
+      timeout: MAX_TIMER_TIMEOUT_MS,
     });
     await manager.close();
   });

--- a/src/node-host/mcp.ts
+++ b/src/node-host/mcp.ts
@@ -3,6 +3,11 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { ErrorCode, type CallToolResult, type Tool } from "@modelcontextprotocol/sdk/types.js";
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
+import {
+  clampPositiveTimerTimeoutMs,
+  finiteSecondsToTimerSafeMilliseconds,
+  MAX_TIMER_TIMEOUT_SECONDS,
+} from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { NodePluginToolDescriptor } from "../../packages/gateway-protocol/src/schema/nodes.js";
@@ -273,21 +278,18 @@ async function listAllTools(
 }
 
 function resolveCallTimeoutMs(value: number | undefined): number {
-  return typeof value === "number" && Number.isFinite(value) && value > 0
-    ? Math.floor(value)
-    : NODE_MCP_TOOL_CALL_TIMEOUT_MS;
+  return clampPositiveTimerTimeoutMs(value) ?? NODE_MCP_TOOL_CALL_TIMEOUT_MS;
 }
 
 function resolveServerToolCallTimeoutMs(config: McpServerConfig): number {
-  if (
-    typeof config.requestTimeoutMs === "number" &&
-    Number.isFinite(config.requestTimeoutMs) &&
-    config.requestTimeoutMs > 0
-  ) {
-    return Math.floor(config.requestTimeoutMs);
+  const requestTimeoutMs = clampPositiveTimerTimeoutMs(config.requestTimeoutMs);
+  if (requestTimeoutMs) {
+    return requestTimeoutMs;
   }
   if (typeof config.timeout === "number" && Number.isFinite(config.timeout) && config.timeout > 0) {
-    return Math.floor(config.timeout * 1_000);
+    return (
+      finiteSecondsToTimerSafeMilliseconds(Math.min(config.timeout, MAX_TIMER_TIMEOUT_SECONDS)) ?? 1
+    );
   }
   return NODE_MCP_TOOL_CALL_TIMEOUT_MS;
 }

--- a/src/node-host/mcp.ts
+++ b/src/node-host/mcp.ts
@@ -3,17 +3,14 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { ErrorCode, type CallToolResult, type Tool } from "@modelcontextprotocol/sdk/types.js";
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
-import {
-  clampPositiveTimerTimeoutMs,
-  finiteSecondsToTimerSafeMilliseconds,
-  MAX_TIMER_TIMEOUT_SECONDS,
-} from "@openclaw/normalization-core/number-coercion";
+import { clampPositiveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { NodePluginToolDescriptor } from "../../packages/gateway-protocol/src/schema/nodes.js";
 import { matchesMcpToolFilterPattern } from "../agents/agent-bundle-mcp-filter.js";
 import { createMcpJsonSchemaValidator } from "../agents/mcp-json-schema-validator.js";
 import { sanitizeMcpMetadataText } from "../agents/mcp-metadata.js";
+import { resolveMcpRequestTimeoutMs } from "../agents/mcp-transport-config.js";
 import { resolveMcpTransport } from "../agents/mcp-transport.js";
 import { normalizeConfiguredMcpServers } from "../config/mcp-config-normalize.js";
 import type { McpServerConfig } from "../config/types.mcp.js";
@@ -281,19 +278,6 @@ function resolveCallTimeoutMs(value: number | undefined): number {
   return clampPositiveTimerTimeoutMs(value) ?? NODE_MCP_TOOL_CALL_TIMEOUT_MS;
 }
 
-function resolveServerToolCallTimeoutMs(config: McpServerConfig): number {
-  const requestTimeoutMs = clampPositiveTimerTimeoutMs(config.requestTimeoutMs);
-  if (requestTimeoutMs) {
-    return requestTimeoutMs;
-  }
-  if (typeof config.timeout === "number" && Number.isFinite(config.timeout) && config.timeout > 0) {
-    return (
-      finiteSecondsToTimerSafeMilliseconds(Math.min(config.timeout, MAX_TIMER_TIMEOUT_SECONDS)) ?? 1
-    );
-  }
-  return NODE_MCP_TOOL_CALL_TIMEOUT_MS;
-}
-
 function isMcpTimeoutError(error: unknown): boolean {
   return Boolean(
     error &&
@@ -341,7 +325,7 @@ export async function startNodeHostMcpManager(
           client,
           connected: false,
           tools: new Set<string>(),
-          toolCallTimeoutMs: resolveServerToolCallTimeoutMs(config),
+          toolCallTimeoutMs: resolveMcpRequestTimeoutMs(config, NODE_MCP_TOOL_CALL_TIMEOUT_MS),
           detachStderr: resolved.detachStderr,
         };
         // MCP Client exposes callback properties rather than an EventTarget surface.


### PR DESCRIPTION
## Summary

Clamp MCP timeout aliases at the Node-safe timer maximum before they reach MCP SDK request timers.

## What Problem This Solves

`mcp.servers.<name>.timeout` accepts finite positive JSON numbers. A value such as `1e306` was converted from seconds to milliseconds with `Math.floor(timeout * 1000)`, producing `Infinity`. Node then coerced that timer overflow to 1ms, causing a reachable MCP server to be reported as timed out.

## User Impact

Operators can use a very large but finite MCP timeout without silently shrinking a reachable server's request deadline to 1ms.

## Origin / follow-up

Follows #103704, a related MCP timeout follow-up.

- **Gap this fills:** #103704 bounds short-lived OAuth requests but does not normalize finite MCP server timeout aliases after seconds-to-milliseconds conversion.
- **Consistency:** this reuses the existing shared Node timer normalization helpers at the two MCP timeout owners.

## Competition / linked PR analysis

Fresh searches for `MCP timeout`, `requestTimeoutMs`, `connectTimeout`, `TimeoutOverflowWarning`, and `MCP Infinity timeout` found no open PR that fixes this unit-conversion overflow.

Related open PR scan: no same-contract or canonical PR covers the outbound MCP SDK timeout-normalization surface.

- #72515 only rejects mixed `command` and `url` transport configuration; it does not cover timeout normalization.
- #81787 only adds bundle MCP diagnostics, and #93559 only reaps stale MCP processes on session reset.
- #105769 clamps the inbound Gateway loopback request-body timer; it does not normalize configured outbound MCP SDK request or tool-call timeouts.

## Merge risk

- **Why it matters / User impact:** prevents an operator-provided finite timeout from becoming an accidental 1ms request deadline.
- **Risk labels considered:** compatibility, availability.
- **Risk explanation:** oversized configured values now cap at the repository's Node-safe timer maximum instead of reaching Node as `Infinity`.
- **Why acceptable:** normal values retain their existing integer-millisecond behavior; the cap uses the shared timer-safe helpers already used by other timeout owners.
- **Maintainer-ready confidence:** High — both MCP timeout owners and their millisecond/seconds aliases are covered.
- **Patch quality notes:** The timeout-change warnings are intentional root-invariant guards: values are normalized before they enter Node timer consumers, not caught after an SDK request has already timed out. This is not a downstream fallback or symptom mask.
- **Target test file:** `src/agents/mcp-transport-config.test.ts`, `src/node-host/mcp.test.ts`.
- **Root cause:** The source normalization defect multiplied finite seconds by 1,000 without enforcing Node's timer-safe invariant; raw millisecond aliases also reached the runtime without the shared clamp.
- **Why this is root-cause fix:** This restores the source invariant at both timeout normalization owners before values reach MCP SDK request timers, rather than masking a downstream timeout error after the request has already been created.
- **What did NOT change:** Only timer-safe normalization changes; schema acceptance, public API shape, and default timeout values remain unchanged.
- **Architecture / source-of-truth check:** `@openclaw/normalization-core/number-coercion` remains the shared source of truth for timer-safe conversion.
- **Scenario locked in:** `timeout: 1e306` remains finite at schema ingestion and reaches runtime as `2147000000`ms, never `Infinity` or 1ms.
- **Why this is the smallest reliable guardrail:** it updates only the two existing MCP timeout normalization points and their focused regression tests.

## Real behavior proof

- **Behavior or issue addressed:** finite scientific-notation MCP timeouts no longer overflow to a 1ms Node timer.
- **Canonical reachability path:** `openclaw.json` `mcp.servers.<name>.timeout` → schema accepts finite positive number → MCP transport/node-host timeout normalization → MCP SDK HTTP request timer → CLI probe result.
- **Boundary crossed:** local-runtime; Linux OpenClaw CLI → real Streamable HTTP MCP SDK server over loopback HTTP.
- **Shared helper / provider constraint check:** reused `finiteSecondsToTimerSafeMilliseconds`, `clampPositiveTimerTimeoutMs`, and `MAX_TIMER_TIMEOUT_SECONDS`; no provider-owned constraint applies.
- **Real environment tested:** Node 22.22.0 on Linux, current source CLI, and a local MCP SDK Streamable HTTP server delaying every request by 50ms.
- **Exact steps or command run after this patch:** ran `node --import tsx src/entry.ts mcp probe normal --json` with `timeout: 1`, then the identical isolated CLI path with `overflow` configured as `timeout: 1e306`.
- **Evidence after fix:**

```text
normal__delayed_probe
requestTimeoutMs: 1000
overflow__delayed_probe
requestTimeoutMs: 2147000000
```

- **Observed result after fix:** both probes listed the delayed tool; the overflow probe used a finite Node-safe timeout and emitted no `TimeoutOverflowWarning`, 1ms timer coercion, or `Request timed out` failure.
- **What was not tested:** third-party MCP servers and non-Linux platforms.
- **Fix classification:** Root cause fix.

## Review findings addressed

None.

## Regression Test Plan

- Covers oversized seconds and milliseconds aliases in `mcp-transport-config`.
- Covers configured server and caller-supplied tool-call timeouts in `node-host/mcp`.
- Runs the real CLI control and overflow probes against a delayed local MCP SDK HTTP server.

## Risk / Compatibility

This changes only values above the Node timer-safe ceiling. Existing finite, positive in-range timeout configuration remains compatible.

## What was not changed

- No schema/API redesign or migration.
- No default timeout changes.
- No third-party MCP service behavior claim.

## Root Cause

The two MCP timeout owners converted raw values with unbounded `Math.floor(...)`. A seconds value large enough to remain finite in JSON overflowed during conversion to milliseconds, and the resulting `Infinity` was handed to Node's timer machinery.
