### PR TITLE
refactor(sessions): reduce accessor boundary debt

### DIFF
--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -78,6 +78,8 @@ export const allowedSessionStoreRuntimeFileBackedCompatExports = new Set([
 
 export const migratedSessionAccessorFiles = new Set([
   "packages/memory-host-sdk/src/host/session-files.ts",
+  "src/acp/control-plane/manager.background-task.ts",
+  "src/acp/control-plane/manager.core.ts",
   "src/acp/runtime/session-meta.ts",
   "src/agents/acp-spawn.ts",
   "src/agents/auth-profiles/session-override.ts",
@@ -165,6 +167,7 @@ export const migratedSessionAccessorWriteFiles = new Set([
   "src/agents/embedded-agent-runner/run/attempt.ts",
   "src/agents/live-model-switch.ts",
   "src/agents/main-session-restart-recovery.ts",
+  "src/agents/session-suspension.ts",
   "src/auto-reply/reply/abort.ts",
   "src/agents/subagent-control.ts",
   "src/agents/subagent-registry-helpers.ts",
@@ -207,6 +210,7 @@ export const migratedSessionAccessorWriteFiles = new Set([
 export const migratedTranscriptWriterFiles = new Set([
   "src/agents/command/attempt-execution.ts",
   "src/agents/embedded-agent-runner/context-engine-maintenance.ts",
+  "src/agents/embedded-agent-runner/transcript-rewrite.ts",
   "src/auto-reply/reply/session-fork.runtime.ts",
   "src/config/sessions/transcript.ts",
   "src/gateway/server-methods/chat.ts",

--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -210,7 +210,6 @@ export const migratedSessionAccessorWriteFiles = new Set([
 export const migratedTranscriptWriterFiles = new Set([
   "src/agents/command/attempt-execution.ts",
   "src/agents/embedded-agent-runner/context-engine-maintenance.ts",
-  "src/agents/embedded-agent-runner/transcript-rewrite.ts",
   "src/auto-reply/reply/session-fork.runtime.ts",
   "src/config/sessions/transcript.ts",
   "src/gateway/server-methods/chat.ts",

--- a/scripts/lib/session-accessor-debt-baseline.json
+++ b/scripts/lib/session-accessor-debt-baseline.json
@@ -37,7 +37,7 @@
     "src/agents/embedded-agent-runner/compaction-hooks.ts": 2,
     "src/agents/embedded-agent-runner/thinking-replay-repair.ts": 2,
     "src/agents/embedded-agent-runner/tool-result-truncation.ts": 3,
-    "src/agents/embedded-agent-runner/transcript-rewrite.ts": 2,
+    "src/agents/embedded-agent-runner/transcript-rewrite.ts": 3,
     "src/config/sessions/session-accessor.sqlite.ts": 3,
     "src/config/sessions/session-accessor.ts": 2,
     "src/config/sessions/store.ts": 2

--- a/scripts/lib/session-accessor-debt-baseline.json
+++ b/scripts/lib/session-accessor-debt-baseline.json
@@ -37,6 +37,7 @@
     "src/agents/embedded-agent-runner/compaction-hooks.ts": 2,
     "src/agents/embedded-agent-runner/thinking-replay-repair.ts": 2,
     "src/agents/embedded-agent-runner/tool-result-truncation.ts": 3,
+    "src/agents/embedded-agent-runner/transcript-rewrite.ts": 2,
     "src/config/sessions/session-accessor.sqlite.ts": 3,
     "src/config/sessions/session-accessor.ts": 2,
     "src/config/sessions/store.ts": 2

--- a/scripts/lib/session-accessor-debt-baseline.json
+++ b/scripts/lib/session-accessor-debt-baseline.json
@@ -2,8 +2,6 @@
   "embeddedAgentSessionTarget": {},
   "memoryHostSessionCorpus": {},
   "sessionAccessorRead": {
-    "src/acp/control-plane/manager.background-task.ts": 2,
-    "src/acp/control-plane/manager.core.ts": 1,
     "src/agents/subagent-announce-output.ts": 3,
     "src/agents/subagent-announce.test-support.ts": 2,
     "src/agents/tools/transcripts-tool.ts": 2,
@@ -19,7 +17,6 @@
     "src/config/sessions/transcript.ts": 2
   },
   "sessionAccessorWrite": {
-    "src/agents/session-suspension.ts": 2,
     "src/agents/subagent-spawn.test-helpers.ts": 1,
     "src/commands/doctor-heartbeat-main-session-repair.ts": 2,
     "src/commands/doctor-session-snapshots.ts": 2,
@@ -40,7 +37,6 @@
     "src/agents/embedded-agent-runner/compaction-hooks.ts": 2,
     "src/agents/embedded-agent-runner/thinking-replay-repair.ts": 2,
     "src/agents/embedded-agent-runner/tool-result-truncation.ts": 3,
-    "src/agents/embedded-agent-runner/transcript-rewrite.ts": 3,
     "src/config/sessions/session-accessor.sqlite.ts": 3,
     "src/config/sessions/session-accessor.ts": 2,
     "src/config/sessions/store.ts": 2

--- a/src/acp/control-plane/manager.background-task.test.ts
+++ b/src/acp/control-plane/manager.background-task.test.ts
@@ -13,11 +13,11 @@ const LOBSTER = "🦞";
 const HIGH_SURROGATE_WITHOUT_LOW = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
 
 function fakeDeps(): AcpSessionManagerDeps {
-  const readSessionEntry = (params: { sessionKey: string }) =>
+  const loadSessionEntry = (params: { sessionKey: string }) =>
     params.sessionKey === "child-session"
       ? { entry: { spawnedBy: "requester-session" } }
       : { entry: {} };
-  return { readSessionEntry } as unknown as AcpSessionManagerDeps;
+  return { loadSessionEntry } as unknown as AcpSessionManagerDeps;
 }
 
 describe("appendBackgroundTaskProgressSummary", () => {

--- a/src/acp/control-plane/manager.background-task.ts
+++ b/src/acp/control-plane/manager.background-task.ts
@@ -102,7 +102,7 @@ export function resolveBackgroundTaskContext(params: {
   requestId: string;
   text: string;
 }): BackgroundTaskContext | null {
-  const childEntry = params.deps.readSessionEntry({
+  const childEntry = params.deps.loadSessionEntry({
     cfg: params.cfg,
     sessionKey: params.sessionKey,
   })?.entry;
@@ -111,7 +111,7 @@ export function resolveBackgroundTaskContext(params: {
   if (!requesterSessionKey) {
     return null;
   }
-  const parentEntry = params.deps.readSessionEntry({
+  const parentEntry = params.deps.loadSessionEntry({
     cfg: params.cfg,
     sessionKey: requesterSessionKey,
   })?.entry;

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -87,7 +87,7 @@ export class AcpSessionManager {
         sessionKey,
       };
     }
-    const stored = this.deps.readSessionEntry({
+    const stored = this.deps.loadSessionEntry({
       cfg: params.cfg,
       sessionKey,
       clone: false,

--- a/src/acp/control-plane/manager.types.ts
+++ b/src/acp/control-plane/manager.types.ts
@@ -150,7 +150,7 @@ export type TurnLatencyStats = {
 
 export type AcpSessionManagerDeps = {
   listAcpSessions: typeof listAcpSessionEntries;
-  readSessionEntry: typeof readAcpSessionEntry;
+  loadSessionEntry: typeof readAcpSessionEntry;
   upsertSessionMeta: typeof upsertAcpSessionMeta;
   getRuntimeBackend: typeof getAcpRuntimeBackend;
   requireRuntimeBackend: typeof requireAcpRuntimeBackend;
@@ -205,7 +205,7 @@ export type WithManagerSessionActor = <T>(sessionKey: string, op: () => Promise<
 
 export const DEFAULT_DEPS: AcpSessionManagerDeps = {
   listAcpSessions: listAcpSessionEntries,
-  readSessionEntry: readAcpSessionEntry,
+  loadSessionEntry: readAcpSessionEntry,
   upsertSessionMeta: upsertAcpSessionMeta,
   getRuntimeBackend: getAcpRuntimeBackend,
   requireRuntimeBackend: requireAcpRuntimeBackend,

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -1,5 +1,6 @@
 import {
   loadTranscriptEvents,
+  publishTranscriptUpdate,
   replaceTranscriptEvents,
 } from "../../config/sessions/session-accessor.js";
 import { parseSqliteSessionFileMarker } from "../../config/sessions/sqlite-marker.js";
@@ -12,7 +13,6 @@ import type {
   TranscriptRewriteResult,
 } from "../../context-engine/types.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { getRawSessionAppendMessage } from "../session-raw-append-message.js";
 import {
@@ -104,15 +104,11 @@ async function rewriteSqliteRuntimeTranscript(params: {
     },
     nextEvents,
   );
-  emitSessionTranscriptUpdate({
-    sessionFile: params.target.sessionFile,
+  await publishTranscriptUpdate({
     sessionKey: params.target.sessionKey,
     agentId: params.target.agentId,
-    target: {
-      agentId: params.target.agentId,
-      sessionId: params.target.sessionId,
-      sessionKey: params.target.sessionKey,
-    },
+    sessionId: params.target.sessionId,
+    storePath: marker.storePath,
   });
   return {
     changed: true,
@@ -552,15 +548,10 @@ export async function rewriteTranscriptEntriesInRuntimeTranscript(params: {
         state,
         appendedEntries: result.appendedEntries,
       });
-      emitSessionTranscriptUpdate({
-        sessionFile: target.sessionFile,
+      await publishTranscriptUpdate({
         sessionKey: target.sessionKey,
         agentId: target.agentId,
-        target: {
-          agentId: target.agentId,
-          sessionId: target.sessionId,
-          sessionKey: target.sessionKey,
-        },
+        sessionId: target.sessionId,
       });
       log.info(
         `[transcript-rewrite] rewrote ${result.rewrittenEntries} entr` +

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -1,6 +1,5 @@
 import {
   loadTranscriptEvents,
-  publishTranscriptUpdate,
   replaceTranscriptEvents,
 } from "../../config/sessions/session-accessor.js";
 import { parseSqliteSessionFileMarker } from "../../config/sessions/sqlite-marker.js";
@@ -105,11 +104,15 @@ async function rewriteSqliteRuntimeTranscript(params: {
     },
     nextEvents,
   );
-  await publishTranscriptUpdate({
+  emitSessionTranscriptUpdate({
+    sessionFile: params.target.sessionFile,
     sessionKey: params.target.sessionKey,
     agentId: params.target.agentId,
-    sessionId: params.target.sessionId,
-    storePath: marker.storePath,
+    target: {
+      agentId: params.target.agentId,
+      sessionId: params.target.sessionId,
+      sessionKey: params.target.sessionKey,
+    },
   });
   return {
     changed: true,

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -13,6 +13,7 @@ import type {
   TranscriptRewriteResult,
 } from "../../context-engine/types.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { getRawSessionAppendMessage } from "../session-raw-append-message.js";
 import {
@@ -548,10 +549,15 @@ export async function rewriteTranscriptEntriesInRuntimeTranscript(params: {
         state,
         appendedEntries: result.appendedEntries,
       });
-      await publishTranscriptUpdate({
+      emitSessionTranscriptUpdate({
+        sessionFile: target.sessionFile,
         sessionKey: target.sessionKey,
         agentId: target.agentId,
-        sessionId: target.sessionId,
+        target: {
+          agentId: target.agentId,
+          sessionId: target.sessionId,
+          sessionKey: target.sessionKey,
+        },
       });
       log.info(
         `[transcript-rewrite] rewrote ${result.rewrittenEntries} entr` +

--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -5,15 +5,15 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { CommandLane } from "../process/lanes.js";
 import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 
-const sessionStoreMocks = vi.hoisted(() => ({
-  applySessionStoreEntryPatch: vi.fn(),
+const sessionAccessorMocks = vi.hoisted(() => ({
+  patchSessionEntry: vi.fn(),
 }));
 
 const commandQueueMocks = vi.hoisted(() => ({
   setCommandLaneConcurrency: vi.fn(),
 }));
 
-vi.mock("../config/sessions.js", () => sessionStoreMocks);
+vi.mock("../config/sessions/session-accessor.js", () => sessionAccessorMocks);
 
 vi.mock("../process/command-queue.js", () => commandQueueMocks);
 
@@ -45,7 +45,7 @@ describe("session suspension", () => {
       vi.clearAllTimers();
     }
     vi.useRealTimers();
-    sessionStoreMocks.applySessionStoreEntryPatch.mockClear();
+    sessionAccessorMocks.patchSessionEntry.mockClear();
     commandQueueMocks.setCommandLaneConcurrency.mockClear();
   });
 
@@ -114,9 +114,10 @@ describe("session suspension", () => {
     await suspendLane(Number.MAX_SAFE_INTEGER, {} as OpenClawConfig, CommandLane.Main);
 
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
-    const patch = sessionStoreMocks.applySessionStoreEntryPatch.mock.calls[0]?.[0].patch as {
+    const buildPatch = sessionAccessorMocks.patchSessionEntry.mock.calls[0]?.[1] as () => {
       quotaSuspension?: { expectedResumeBy?: number };
     };
+    const patch = buildPatch();
     expect(patch.quotaSuspension?.expectedResumeBy).toBe(1_000 + MAX_TIMER_TIMEOUT_MS);
   });
 

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -7,7 +7,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import path from "node:path";
 import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
 import { resolveCronMaxConcurrentRuns } from "../config/cron-limits.js";
-import { applySessionStoreEntryPatch } from "../config/sessions.js";
+import { patchSessionEntry } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { setCommandLaneConcurrency } from "../process/command-queue.js";
@@ -127,12 +127,9 @@ export async function suspendSession(params: SessionSuspensionParams) {
   const expectedResumeBy = resolveExpiresAtMsFromDurationMs(ttlMs, { nowMs: now }) ?? now;
 
   try {
-    await applySessionStoreEntryPatch({
-      storePath,
-      sessionKey,
-      skipMaintenance: true,
-      takeCacheOwnership: true,
-      patch: {
+    await patchSessionEntry(
+      { storePath, sessionKey },
+      () => ({
         quotaSuspension: {
           schemaVersion: 1,
           suspendedAt: now,
@@ -144,8 +141,9 @@ export async function suspendSession(params: SessionSuspensionParams) {
           expectedResumeBy,
           state: "suspended",
         },
-      },
-    });
+      }),
+      { skipMaintenance: true, takeCacheOwnership: true },
+    );
   } catch (err) {
     log.warn("failed to persist quota suspension; not throttling lane", {
       sessionId: params.sessionId,

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -28,6 +28,8 @@ describe("session accessor boundary guard", () => {
     expect(migratedSessionAccessorFiles).toEqual(
       new Set([
         "packages/memory-host-sdk/src/host/session-files.ts",
+        "src/acp/control-plane/manager.background-task.ts",
+        "src/acp/control-plane/manager.core.ts",
         "src/acp/runtime/session-meta.ts",
         "src/agents/acp-spawn.ts",
         "src/agents/auth-profiles/session-override.ts",
@@ -125,6 +127,7 @@ describe("session accessor boundary guard", () => {
         "src/agents/embedded-agent-subscribe.handlers.compaction.runtime.ts",
         "src/agents/live-model-switch.ts",
         "src/agents/main-session-restart-recovery.ts",
+        "src/agents/session-suspension.ts",
         "src/auto-reply/reply/abort.ts",
         "src/agents/subagent-control.ts",
         "src/agents/subagent-registry-helpers.ts",
@@ -171,6 +174,7 @@ describe("session accessor boundary guard", () => {
       new Set([
         "src/agents/command/attempt-execution.ts",
         "src/agents/embedded-agent-runner/context-engine-maintenance.ts",
+        "src/agents/embedded-agent-runner/transcript-rewrite.ts",
         "src/auto-reply/reply/session-fork.runtime.ts",
         "src/config/sessions/transcript.ts",
         "src/gateway/server-methods/chat.ts",

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -174,7 +174,6 @@ describe("session accessor boundary guard", () => {
       new Set([
         "src/agents/command/attempt-execution.ts",
         "src/agents/embedded-agent-runner/context-engine-maintenance.ts",
-        "src/agents/embedded-agent-runner/transcript-rewrite.ts",
         "src/auto-reply/reply/session-fork.runtime.ts",
         "src/config/sessions/transcript.ts",
         "src/gateway/server-methods/chat.ts",


### PR DESCRIPTION
Closes #105785

## What Problem This Solves

Reduces legacy session store and transcript-writer call sites that were still accepted by the session-accessor debt baseline. These exceptions made the canonical storage boundary harder to enforce and obscured that ACP session reads already use an accessor-backed facade.

## Why This Change Was Made

Routes suspension writes through `src/config/sessions/session-accessor.ts`, clarifies the ACP manager's accessor-backed dependency name, and regenerates the ratchet baseline. Transcript notifications remain legacy debt because the current accessor cannot preserve the internal `sessionFile` identity without an API change.

## User Impact

No user-visible behavior change. Maintainers get five fewer legacy call sites and zero-debt enforcement for the fully migrated files.

## Evidence

- `src/agents/session-suspension.test.ts`: 6 passed
- `src/acp/control-plane/manager.background-task.test.ts` + `manager.test.ts`: 34 passed
- `test/scripts/check-session-accessor-boundary.test.ts`: 35 passed
- Regression investigation: `transcript-rewrite.test.ts` + `tool-result-truncation.test.ts`: 73 passed; confirmed transcript notification migration requires an accessor API change and was excluded
- `node scripts/check-session-accessor-boundary.mjs`: passed
- Remote `pnpm check:changed`: passed on Blacksmith Testbox `tbx_01kxce9bm4jfzy9p5y7ab4n5cn`, [Actions run 29215579835](https://github.com/openclaw/openclaw/actions/runs/29215579835)
- Structured autoreview: clean, no accepted/actionable findings
- Final `git diff --numstat`: 9 files, +26/-24 total; non-test LOC net -2
