### PR TITLE
fix(ui): keep usage insights aligned with active filters

### DIFF
--- a/ui/src/e2e/usage-cost-analysis.e2e.test.ts
+++ b/ui/src/e2e/usage-cost-analysis.e2e.test.ts
@@ -338,6 +338,12 @@ describeControlUiE2e("Control UI usage cost analysis mocked Gateway E2E", () => 
         .poll(() => providerCards.filter({ hasText: "Anthropic" }).textContent())
         .toContain("claude-opus-4-8");
 
+      await page.locator(".usage-query-input").fill("missing-session");
+      await page.locator(".usage-query-input").press("Enter");
+      const topProviders = page.locator(".usage-insight-card", { hasText: "Top Providers" });
+      await expect.poll(() => topProviders.textContent()).toContain("No provider data");
+      await expect.poll(() => topProviders.textContent()).not.toContain("openai");
+
       if (process.env.OPENCLAW_CAPTURE_UI_PROOF === "1") {
         const artifactDir = path.join(
           process.cwd(),

--- a/ui/src/pages/usage/view.test.ts
+++ b/ui/src/pages/usage/view.test.ts
@@ -2,10 +2,53 @@
 
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
-import type { UsageProps } from "./types.ts";
+import { buildAggregatesFromSessions } from "./metrics.ts";
+import type { UsageProps, UsageSessionEntry, UsageTotals } from "./types.ts";
 import { renderUsage } from "./view.ts";
 
 const noop = vi.fn();
+
+function usageSession(key: string, agentId: string, provider: string): UsageSessionEntry {
+  const totals: UsageTotals = {
+    input: 100,
+    output: 20,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 120,
+    totalCost: 1,
+    inputCost: 0.8,
+    outputCost: 0.2,
+    cacheReadCost: 0,
+    cacheWriteCost: 0,
+    missingCostEntries: 0,
+  };
+  return {
+    key,
+    label: `${agentId} session`,
+    agentId,
+    modelProvider: provider,
+    model: `${provider}-model`,
+    updatedAt: Date.now(),
+    usage: {
+      ...totals,
+      messageCounts: {
+        total: 2,
+        user: 1,
+        assistant: 1,
+        toolCalls: 0,
+        toolResults: 0,
+        errors: 0,
+      },
+      modelUsage: [{ provider, model: `${provider}-model`, count: 1, totals }],
+    },
+  };
+}
+
+function insightCard(container: ParentNode, title: string): Element | undefined {
+  return Array.from(container.querySelectorAll(".usage-insight-card")).find(
+    (card) => card.querySelector(".usage-insight-title")?.textContent === title,
+  );
+}
 
 function createUsageProps(overrides: Partial<UsageProps> = {}): UsageProps {
   return {
@@ -107,6 +150,61 @@ function createUsageProps(overrides: Partial<UsageProps> = {}): UsageProps {
 }
 
 describe("renderUsage", () => {
+  it("keeps insight aggregates scoped to the selected agent", () => {
+    const container = document.createElement("div");
+    const sessions = [
+      usageSession("agent:main:main", "main", "openai"),
+      usageSession("agent:research:main", "research", "anthropic"),
+    ];
+
+    render(
+      renderUsage(
+        createUsageProps({
+          data: {
+            ...createUsageProps().data,
+            sessions,
+            totals: sessions[0]?.usage ?? null,
+            aggregates: buildAggregatesFromSessions(sessions),
+          },
+          filters: { ...createUsageProps().filters, agentId: "research" },
+        }),
+      ),
+      container,
+    );
+
+    const providers = insightCard(container, "Top Providers");
+    expect(providers?.textContent).toContain("anthropic");
+    expect(providers?.textContent).not.toContain("openai");
+  });
+
+  it("does not fall back to global insights when a query matches no sessions", () => {
+    const container = document.createElement("div");
+    const sessions = [usageSession("agent:main:main", "main", "openai")];
+
+    render(
+      renderUsage(
+        createUsageProps({
+          data: {
+            ...createUsageProps().data,
+            sessions,
+            totals: sessions[0]?.usage ?? null,
+            aggregates: buildAggregatesFromSessions(sessions),
+          },
+          filters: {
+            ...createUsageProps().filters,
+            query: "missing-session",
+            queryDraft: "missing-session",
+          },
+        }),
+      ),
+      container,
+    );
+
+    const providers = insightCard(container, "Top Providers");
+    expect(providers?.textContent).toContain("No provider data");
+    expect(providers?.textContent).not.toContain("openai");
+  });
+
   it("keeps selected session labels on UTF-16 boundaries", () => {
     const container = document.createElement("div");
     const label = `${"a".repeat(19)}🚀${"b".repeat(28)}🚀tail`;

--- a/ui/src/pages/usage/view.ts
+++ b/ui/src/pages/usage/view.ts
@@ -345,7 +345,7 @@ export function renderUsage(props: UsageProps) {
         ? filteredSessions
         : filters.selectedDays.length > 0
           ? dayFilteredSessions
-          : sortedSessions;
+          : agentScopedSessions;
   const hasAggregateFilters =
     filters.selectedSessions.length > 0 ||
     hasQuery ||
@@ -353,7 +353,7 @@ export function renderUsage(props: UsageProps) {
     filters.selectedDays.length > 0 ||
     Boolean(filters.agentId);
   const activeAggregates = hasAggregateFilters
-    ? buildAggregatesFromSessions(aggregateSessions, data.aggregates)
+    ? buildAggregatesFromSessions(aggregateSessions)
     : buildAggregatesFromSessions([], data.aggregates);
   const insightsUseVisiblePage = data.sessionsLimitReached && !hasAggregateFilters;
   const insightTotals = insightsUseVisiblePage


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Usage insight cards ignored the selected agent and showed data from every agent. Queries or other filters that matched zero sessions also fell back to global aggregates, so the page could claim providers, models, tools, or agents were present despite showing zero matching sessions.

## Why This Change Was Made

Filtered insights now derive only from the filtered session set. The Gateway-provided aggregate fallback remains limited to the unfiltered view, where it supplies complete range-wide data.

## User Impact

Usage insight cards now agree with active agent, query, day, hour, and session filters. A zero-result filter shows empty insight categories instead of unrelated global data.

## Evidence

- AWS Crabbox `run_98460cf01e79`: `corepack pnpm test ui/src/pages/usage/view.test.ts` — 10/10 passed, including selected-agent and zero-match regressions.
- AWS Crabbox `run_bd2b4a5ce893`: Chromium Usage-page test passed; a zero-match query showed “No provider data” and no OpenAI aggregate.
- Same AWS run: `corepack pnpm check:changed` passed, including UI/core test types and lint.
- Source-blind behavior contract covered selected-agent isolation, zero-match emptiness, and preservation of unfiltered global aggregates.
- Fresh Codex autoreview — clean; no accepted or actionable findings.
