### PR TITLE
fix(ui): unblock stale-chunk recovery when the document probe hangs

### DIFF
--- a/ui/src/app/router-outlet.test.ts
+++ b/ui/src/app/router-outlet.test.ts
@@ -50,6 +50,7 @@ afterEach(() => {
   document.body.replaceChildren();
   resetStaleChunkReloadStateForTest();
   vi.unstubAllGlobals();
+  vi.useRealTimers();
 });
 
 describe("openclaw-router-outlet", () => {
@@ -122,8 +123,20 @@ describe("openclaw-router-outlet", () => {
   });
 
   it("schedules stale-chunk recovery and falls back to revalidation while offline", async () => {
+    vi.useFakeTimers();
     let loadCount = 0;
-    const fetchMock = vi.fn(async () => new Response(null, { status: 503 }));
+    const fetchMock = vi.fn<typeof fetch>(
+      async (_input, init) =>
+        await new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal) {
+            return;
+          }
+          signal.addEventListener("abort", () => reject(new Error("document probe aborted")), {
+            once: true,
+          });
+        }),
+    );
     vi.stubGlobal("fetch", fetchMock);
     const router = createRouter<RouteId, TestContext, TestModule, TestData>({
       routes: [
@@ -149,13 +162,17 @@ describe("openclaw-router-outlet", () => {
     const alert = outlet.querySelector('[role="alert"]');
     expect(alert?.textContent).toContain("Importing a module script failed.");
     expect(alert?.textContent).toContain("Reload the page");
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(loadCount).toBe(1);
-
     outlet.querySelector<HTMLButtonElement>("button")?.click();
-    await vi.waitFor(() => expect(loadCount).toBe(2));
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(3_000);
+    vi.runAllTicks();
+    await settleOutlet(outlet);
+    expect(loadCount).toBe(2);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     outlet.remove();
     router.stop();
   });

--- a/ui/src/app/stale-chunk-reload.test.ts
+++ b/ui/src/app/stale-chunk-reload.test.ts
@@ -8,6 +8,51 @@ import {
 } from "./stale-chunk-reload.ts";
 
 const GUARD_KEY = "openclaw.controlUi.staleChunkReloadBuildId";
+const PROBE_TIMEOUT_MS = 3_000;
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve: (value: T) => void = () => {
+    throw new Error("deferred promise was not initialized");
+  };
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+function stubDocumentFetch(...responses: Response[]) {
+  const fetchMock = vi.fn<typeof fetch>(async () => {
+    const response = responses.shift();
+    if (!response) {
+      throw new Error("unexpected document probe");
+    }
+    return response;
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function stubHangingDocumentFetch() {
+  const fetchMock = vi.fn<typeof fetch>(
+    async (_input, init) =>
+      await new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) {
+          return;
+        }
+        signal.addEventListener("abort", () => reject(new Error("document probe aborted")), {
+          once: true,
+        });
+      }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
 
 function memoryStorage(initial: Record<string, string> = {}) {
   const store = new Map(Object.entries(initial));
@@ -19,6 +64,8 @@ function memoryStorage(initial: Record<string, string> = {}) {
 
 afterEach(() => {
   resetStaleChunkReloadStateForTest();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
 });
 
 describe("isStaleChunkImportError", () => {
@@ -42,12 +89,12 @@ describe("scheduleStaleChunkReload", () => {
   it("reloads once the document probe succeeds and records the build guard", async () => {
     const reload = vi.fn();
     const storage = memoryStorage();
+    stubDocumentFetch(new Response(null, { status: 200 }));
     await expect(
       scheduleStaleChunkReload({
         now: () => 1000,
         buildId: "build-a",
         storage,
-        probeDocument: async () => true,
         reload,
       }),
     ).resolves.toBe(true);
@@ -58,12 +105,12 @@ describe("scheduleStaleChunkReload", () => {
   it("never auto-reloads twice for the same build, but recovers on a newer build", async () => {
     const reload = vi.fn();
     const storage = memoryStorage({ [GUARD_KEY]: "build-a" });
+    stubDocumentFetch(new Response(null, { status: 200 }));
     await expect(
       scheduleStaleChunkReload({
         now: () => 1000,
         buildId: "build-a",
         storage,
-        probeDocument: async () => true,
         reload,
       }),
     ).resolves.toBe(false);
@@ -74,7 +121,6 @@ describe("scheduleStaleChunkReload", () => {
         now: () => 2000,
         buildId: "build-b",
         storage,
-        probeDocument: async () => true,
         reload,
       }),
     ).resolves.toBe(true);
@@ -85,11 +131,11 @@ describe("scheduleStaleChunkReload", () => {
   it("does not reload or set the guard while the gateway is unreachable", async () => {
     const reload = vi.fn();
     const storage = memoryStorage();
+    stubDocumentFetch(new Response(null, { status: 503 }));
     await expect(
       scheduleStaleChunkReload({
         now: () => 1000,
         storage,
-        probeDocument: async () => false,
         reload,
       }),
     ).resolves.toBe(false);
@@ -99,11 +145,11 @@ describe("scheduleStaleChunkReload", () => {
 
   it("does not auto-reload when the guard cannot be persisted", async () => {
     const reload = vi.fn();
+    stubDocumentFetch(new Response(null, { status: 200 }));
     await expect(
       scheduleStaleChunkReload({
         now: () => 1000,
         storage: null,
-        probeDocument: async () => true,
         reload,
       }),
     ).resolves.toBe(false);
@@ -117,7 +163,6 @@ describe("scheduleStaleChunkReload", () => {
             throw new Error("quota exceeded");
           },
         },
-        probeDocument: async () => true,
         reload,
       }),
     ).resolves.toBe(false);
@@ -126,23 +171,63 @@ describe("scheduleStaleChunkReload", () => {
 
   it("applies an in-memory cooldown between attempts", async () => {
     const reload = vi.fn();
-    const probeDocument = vi.fn(async () => true);
     const storage = memoryStorage();
+    const fetchMock = stubDocumentFetch(
+      new Response(null, { status: 503 }),
+      new Response(null, { status: 200 }),
+    );
     await expect(
       scheduleStaleChunkReload({
         now: () => 1000,
         storage,
-        probeDocument: async () => false,
         reload,
       }),
     ).resolves.toBe(false);
-    await expect(
-      scheduleStaleChunkReload({ now: () => 2000, storage, probeDocument, reload }),
-    ).resolves.toBe(false);
-    expect(probeDocument).not.toHaveBeenCalled();
-    await expect(
-      scheduleStaleChunkReload({ now: () => 7000, storage, probeDocument, reload }),
-    ).resolves.toBe(true);
+    await expect(scheduleStaleChunkReload({ now: () => 2000, storage, reload })).resolves.toBe(
+      false,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await expect(scheduleStaleChunkReload({ now: () => 7000, storage, reload })).resolves.toBe(
+      true,
+    );
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("settles and aborts a hanging document probe after its deadline", async () => {
+    vi.useFakeTimers();
+    const reload = vi.fn();
+    const fetchMock = stubHangingDocumentFetch();
+    const retry = retryStaleChunkReload({ reload });
+
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+
+    const result = expect(retry).resolves.toBe(false);
+    await vi.advanceTimersByTimeAsync(PROBE_TIMEOUT_MS);
+    await result;
+
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("coalesces automatic and manual probes and clears the busy state", async () => {
+    const firstProbe = deferred<Response>();
+    const fetchMock = vi.fn<typeof fetch>().mockImplementationOnce(async () => firstProbe.promise);
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const reload = vi.fn();
+    const storage = memoryStorage();
+
+    const automatic = scheduleStaleChunkReload({ now: () => 1000, storage, reload });
+    const manual = retryStaleChunkReload({ reload });
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    firstProbe.resolve(new Response(null, { status: 503 }));
+    await expect(Promise.all([automatic, manual])).resolves.toEqual([false, false]);
+    await expect(retryStaleChunkReload({ reload })).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(reload).toHaveBeenCalledTimes(1);
   });
 });
@@ -150,17 +235,15 @@ describe("scheduleStaleChunkReload", () => {
 describe("retryStaleChunkReload", () => {
   it("reloads without the rate guard when the gateway is reachable", async () => {
     const reload = vi.fn();
-    await expect(retryStaleChunkReload({ probeDocument: async () => true, reload })).resolves.toBe(
-      true,
-    );
+    stubDocumentFetch(new Response(null, { status: 200 }));
+    await expect(retryStaleChunkReload({ reload })).resolves.toBe(true);
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
   it("does not reload while the gateway is unreachable", async () => {
     const reload = vi.fn();
-    await expect(retryStaleChunkReload({ probeDocument: async () => false, reload })).resolves.toBe(
-      false,
-    );
+    stubDocumentFetch(new Response(null, { status: 503 }));
+    await expect(retryStaleChunkReload({ reload })).resolves.toBe(false);
     expect(reload).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/app/stale-chunk-reload.ts
+++ b/ui/src/app/stale-chunk-reload.ts
@@ -13,6 +13,9 @@ import { CONTROL_UI_BUILD_INFO } from "../build-info.ts";
 const RELOAD_GUARD_STORAGE_KEY = "openclaw.controlUi.staleChunkReloadBuildId";
 // Bounds document probes across rapid re-renders of the same error state.
 const ATTEMPT_COOLDOWN_MS = 5_000;
+// Keep timeout below the cooldown so a timed-out retry re-render cannot start
+// another probe immediately while the gateway is still unreachable.
+const DOCUMENT_PROBE_TIMEOUT_MS = 3_000;
 
 const MODULE_IMPORT_ERROR_PATTERNS = [
   /importing a module script failed/i, // WebKit
@@ -25,11 +28,11 @@ type StaleChunkReloadDeps = {
   now?: () => number;
   buildId?: string;
   storage?: Pick<Storage, "getItem" | "setItem"> | null;
-  probeDocument?: () => Promise<boolean>;
   reload?: () => void;
 };
 
 let lastAttemptAt: number | null = null;
+let inFlightDocumentProbe: Promise<boolean> | null = null;
 
 export function isStaleChunkImportError(error: unknown): boolean {
   return (
@@ -51,13 +54,33 @@ function sessionStorageOrNull(): Pick<Storage, "getItem" | "setItem"> | null {
   }
 }
 
-async function probeControlUiDocument(): Promise<boolean> {
-  try {
-    const response = await fetch(window.location.href, { method: "HEAD", cache: "no-store" });
-    return response.ok;
-  } catch {
-    return false;
+function probeControlUiDocument(): Promise<boolean> {
+  if (inFlightDocumentProbe) {
+    return inFlightDocumentProbe;
   }
+  const probe = (async () => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), DOCUMENT_PROBE_TIMEOUT_MS);
+    try {
+      const response = await fetch(window.location.href, {
+        method: "HEAD",
+        cache: "no-store",
+        signal: controller.signal,
+      });
+      return response.ok;
+    } catch {
+      return false;
+    } finally {
+      clearTimeout(timeout);
+    }
+  })();
+  const settledProbe = probe.finally(() => {
+    if (inFlightDocumentProbe === settledProbe) {
+      inFlightDocumentProbe = null;
+    }
+  });
+  inFlightDocumentProbe = settledProbe;
+  return settledProbe;
 }
 
 function readGuardBuildId(storage: Pick<Storage, "getItem" | "setItem"> | null): string | null {
@@ -104,7 +127,7 @@ export async function scheduleStaleChunkReload(deps: StaleChunkReloadDeps = {}):
   if (readGuardBuildId(storage) === buildId) {
     return false;
   }
-  if (!(await (deps.probeDocument ?? probeControlUiDocument)())) {
+  if (!(await probeControlUiDocument())) {
     return false;
   }
   // A reload resets the in-memory state, so without a persisted guard a broken
@@ -123,7 +146,7 @@ export async function scheduleStaleChunkReload(deps: StaleChunkReloadDeps = {}):
  * recoverable panel error with a fatal navigation error in app webviews.
  */
 export async function retryStaleChunkReload(deps: StaleChunkReloadDeps = {}): Promise<boolean> {
-  if (!(await (deps.probeDocument ?? probeControlUiDocument)())) {
+  if (!(await probeControlUiDocument())) {
     return false;
   }
   (deps.reload ?? reloadControlUiDocument)();
@@ -132,6 +155,7 @@ export async function retryStaleChunkReload(deps: StaleChunkReloadDeps = {}): Pr
 
 export function resetStaleChunkReloadStateForTest(): void {
   lastAttemptAt = null;
+  inFlightDocumentProbe = null;
 }
 
 /**


### PR DESCRIPTION
Related: #104304

## What Problem This Solves

Fixes an issue where Control UI users can remain on a stale hashed-chunk error after a gateway update when the document `HEAD` probe never settles. Automatic recovery and the Retry action both wait on that probe, so the fallback route revalidation cannot run.

On current `main`, the probe had no deadline or abort signal, and automatic/manual callers started independent probes. A temporary deterministic regression check on that behavior failed in three ways: no abort signal was passed, concurrent callers made two requests, and the router Retry path made a second probe instead of reaching fallback revalidation.

## Why This Change Was Made

The stale-chunk recovery owner now uses one bounded document probe with an explicit `AbortController`, a 3-second timer, and `finally` cleanup. Concurrent automatic and manual callers share the same in-flight promise; identity-checked cleanup releases the busy state after settlement so later retries can probe again. The deadline is below the existing 5-second attempt cooldown, preventing a timeout-driven re-render from immediately starting another probe.

This PR was AI-assisted. The implementation, callers, tests, dependency contract, and final branch diff were inspected against the repository guidance; fresh autoreview reported no accepted or actionable findings.

The abort behavior follows the platform contract documented by [MDN for `AbortController.abort()`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort) and the [Fetch standard](https://fetch.spec.whatwg.org/#fetch-method), where aborting the controller rejects the fetch. An explicit owned timer is used instead of `AbortSignal.timeout()` because native timeout scheduling was not controlled by this repository's Vitest/jsdom fake timers; the explicit timer makes the deadline and cleanup deterministic.

## User Impact

The stale-chunk panel now settles a hung document probe within 3 seconds. Automatic and manual recovery do not duplicate the request, and Retry can reach route revalidation after the probe aborts. Existing build guards, cooldown behavior, successful reloads, and offline no-reload behavior remain unchanged. There is no config, protocol, or rendered-layout change.

## Evidence

- Regression proof before the fix: the temporary current-`main` checks failed for the missing signal, duplicate concurrent probes, and router fallback revalidation path described above.
- Focused post-fix validation: `node scripts/run-vitest.mjs ui/src/app/stale-chunk-reload.test.ts ui/src/app/router-outlet.test.ts` — 2 files, 18 tests passed.
- Targeted lint passed: `node scripts/run-oxlint.mjs ui/src/app/stale-chunk-reload.ts ui/src/app/stale-chunk-reload.test.ts ui/src/app/router-outlet.test.ts`.
- UI and test UI typechecks passed with the repository `run-tsgo` wrappers.
- UI production build passed: `node scripts/ui.js build`.
- Formatting and whitespace checks passed with `oxfmt --check` and `git diff --check`.
- Fresh autoreview against `origin/main` passed with no accepted/actionable findings.
- Testbox warmup was attempted but unavailable because Blacksmith authentication was missing. Per the repository fallback rule, the focused tests ran through the narrow local `node scripts/run-vitest.mjs` wrapper instead; no credentialed remote execution was performed.
- A dedicated Control UI browser E2E was not feasible for this isolated fix: the existing scenarios do not replace hashed production assets in place or trigger the browser's Vite preload-error path. The router-outlet integration test exercises the actual custom-element recovery/revalidation seam with fake fetch and fake timers. Full browser/package-update proof remains a CI or follow-up gap.
- No screenshot is included because this changes recovery timing and state, not visual layout.
