### PR TITLE
perf(agents): reuse prepared plugin metadata for middleware

### DIFF
--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -1522,15 +1522,16 @@ async function compactEmbeddedAgentSessionDirectOnce(
       });
       compactionSessionManager = sessionManager;
       trackSessionManagerAccess(params.sessionFile);
+      const pluginMetadataSnapshot = getCurrentPluginMetadataSnapshot({
+        config: params.config,
+        env: process.env,
+        workspaceDir: effectiveWorkspace,
+      });
       const settingsManager = createPreparedEmbeddedAgentSettingsManager({
         cwd: effectiveCwd,
         agentDir,
         cfg: params.config,
-        pluginMetadataSnapshot: getCurrentPluginMetadataSnapshot({
-          config: params.config,
-          env: process.env,
-          workspaceDir: effectiveWorkspace,
-        }),
+        pluginMetadataSnapshot,
         contextTokenBudget,
       });
       // Sets compaction/pruning runtime state and returns extension factories
@@ -1538,6 +1539,8 @@ async function compactEmbeddedAgentSessionDirectOnce(
       const extensionFactories = buildEmbeddedExtensionFactories({
         cfg: params.config,
         sessionManager,
+        workspaceDir: effectiveWorkspace,
+        pluginMetadataSnapshot,
         provider,
         modelId,
         model: effectiveModel,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -1524,7 +1524,6 @@ async function compactEmbeddedAgentSessionDirectOnce(
       trackSessionManagerAccess(params.sessionFile);
       const pluginMetadataSnapshot = getCurrentPluginMetadataSnapshot({
         config: params.config,
-        env: process.env,
         workspaceDir: effectiveWorkspace,
       });
       const settingsManager = createPreparedEmbeddedAgentSettingsManager({
@@ -1534,13 +1533,11 @@ async function compactEmbeddedAgentSessionDirectOnce(
         pluginMetadataSnapshot,
         contextTokenBudget,
       });
-      // Sets compaction/pruning runtime state and returns extension factories
-      // that must be passed to the resource loader for the safeguard to be active.
+      // Sets compaction/pruning runtime state and extension factories for the resource loader.
       const extensionFactories = buildEmbeddedExtensionFactories({
         cfg: params.config,
         sessionManager,
-        workspaceDir: effectiveWorkspace,
-        pluginMetadataSnapshot,
+        ...{ workspaceDir: effectiveWorkspace, pluginMetadataSnapshot },
         provider,
         modelId,
         model: effectiveModel,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -1482,7 +1482,6 @@ async function compactEmbeddedAgentSessionDirectOnce(
         },
       });
     };
-
     const compactionTimeoutMs = resolveCompactionTimeoutMs(params.config);
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,
@@ -1537,7 +1536,8 @@ async function compactEmbeddedAgentSessionDirectOnce(
       const extensionFactories = buildEmbeddedExtensionFactories({
         cfg: params.config,
         sessionManager,
-        ...{ workspaceDir: effectiveWorkspace, pluginMetadataSnapshot },
+        workspaceDir: effectiveWorkspace,
+        pluginMetadataSnapshot,
         provider,
         modelId,
         model: effectiveModel,

--- a/src/agents/embedded-agent-runner/extensions.prepared-metadata.test.ts
+++ b/src/agents/embedded-agent-runner/extensions.prepared-metadata.test.ts
@@ -1,0 +1,49 @@
+// Verifies embedded extension construction carries prepared middleware context to the lazy loader.
+import type { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { buildEmbeddedExtensionFactories } from "./extensions.js";
+
+const loadAgentToolResultMiddlewaresForRuntime = vi.hoisted(() => vi.fn(async () => []));
+
+vi.mock("../../plugins/agent-tool-result-middleware-loader.js", () => ({
+  loadAgentToolResultMiddlewaresForRuntime,
+}));
+
+beforeEach(() => {
+  loadAgentToolResultMiddlewaresForRuntime.mockClear();
+});
+
+describe("embedded prepared middleware metadata", () => {
+  it("passes the attempt config, workspace, and manifest registry to the loader", async () => {
+    const config = { plugins: { entries: {} } } as OpenClawConfig;
+    const manifestRegistry = { plugins: [], diagnostics: [] };
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: config,
+      sessionManager: {} as SessionManager,
+      workspaceDir: "/prepared-workspace",
+      pluginMetadataSnapshot: { manifestRegistry },
+      provider: "openai",
+      modelId: "gpt-5.4",
+      model: undefined,
+    });
+    const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
+
+    await factories[0]?.({
+      on(event: string, handler: (...args: unknown[]) => Promise<unknown>) {
+        handlers.set(event, handler);
+      },
+    } as never);
+    await handlers.get("tool_result")?.(
+      { toolName: "exec", content: [{ type: "text", text: "raw" }], details: {} },
+      { cwd: "/prepared-workspace" },
+    );
+
+    expect(loadAgentToolResultMiddlewaresForRuntime).toHaveBeenCalledWith({
+      runtime: "openclaw",
+      config,
+      workspaceDir: "/prepared-workspace",
+      manifestRegistry,
+    });
+  });
+});

--- a/src/agents/embedded-agent-runner/extensions.ts
+++ b/src/agents/embedded-agent-runner/extensions.ts
@@ -3,6 +3,7 @@
  */
 import { randomUUID } from "node:crypto";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { normalizeAcceptedSessionSpawnResult } from "../accepted-session-spawn.js";
 import { setCompactionSafeguardRuntime } from "../agent-hooks/compaction-safeguard-runtime.js";
@@ -50,11 +51,18 @@ function snapshotToolSendReceipt(details: unknown): unknown {
     : toolSend;
 }
 
-function buildAgentToolResultMiddlewareFactory(
-  sessionManager: SessionManager,
-  runId?: string,
-): ExtensionFactory {
-  const runner = createAgentToolResultMiddlewareRunner({ runtime: "openclaw" });
+function buildAgentToolResultMiddlewareFactory(params: {
+  cfg: OpenClawConfig | undefined;
+  sessionManager: SessionManager;
+  workspaceDir?: string;
+  pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "manifestRegistry">;
+  runId?: string;
+}): ExtensionFactory {
+  const runner = createAgentToolResultMiddlewareRunner({ runtime: "openclaw" }, undefined, {
+    config: params.cfg,
+    workspaceDir: params.workspaceDir,
+    manifestRegistry: params.pluginMetadataSnapshot?.manifestRegistry,
+  });
   return (agent) => {
     agent.on("tool_result", async (rawEvent: unknown, ctx: { cwd?: string }) => {
       const event = recordFromUnknown(rawEvent) as AgentToolResultEvent;
@@ -74,11 +82,11 @@ function buildAgentToolResultMiddlewareFactory(
       const rawToolSend = snapshotToolSendReceipt(current.details);
       if (eventToolCallId && rawToolSend !== undefined) {
         // Routing evidence stays private so middleware may fully replace result details.
-        recordEmbeddedToolSendReceipt(sessionManager, eventToolCallId, rawToolSend);
+        recordEmbeddedToolSendReceipt(params.sessionManager, eventToolCallId, rawToolSend);
       }
       const inputHadErrorStatus = isToolResultError(current);
       const adjustedInput = eventToolCallId
-        ? peekAdjustedParamsForToolCall(eventToolCallId, runId)
+        ? peekAdjustedParamsForToolCall(eventToolCallId, params.runId)
         : undefined;
       const result = await runner.applyToolResultMiddleware({
         threadId: event.threadId,
@@ -101,7 +109,7 @@ function buildAgentToolResultMiddlewareFactory(
       if (eventToolCallId) {
         finalizeToolTerminalPresentation({
           toolCallId: eventToolCallId,
-          runId,
+          runId: params.runId,
           result,
           isError,
         });
@@ -175,6 +183,7 @@ export function buildEmbeddedExtensionFactories(params: {
   cfg: OpenClawConfig | undefined;
   sessionManager: SessionManager;
   workspaceDir?: string;
+  pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "manifestRegistry">;
   provider: string;
   modelId: string;
   model: ProviderRuntimeModel | undefined;
@@ -212,6 +221,14 @@ export function buildEmbeddedExtensionFactories(params: {
   if (pruningFactory) {
     factories.push(pruningFactory);
   }
-  factories.push(buildAgentToolResultMiddlewareFactory(params.sessionManager, params.runId));
+  factories.push(
+    buildAgentToolResultMiddlewareFactory({
+      cfg: params.cfg,
+      sessionManager: params.sessionManager,
+      workspaceDir: params.workspaceDir,
+      pluginMetadataSnapshot: params.pluginMetadataSnapshot,
+      runId: params.runId,
+    }),
+  );
   return factories;
 }

--- a/src/agents/embedded-agent-runner/extensions.ts
+++ b/src/agents/embedded-agent-runner/extensions.ts
@@ -55,13 +55,16 @@ function buildAgentToolResultMiddlewareFactory(params: {
   cfg: OpenClawConfig | undefined;
   sessionManager: SessionManager;
   workspaceDir?: string;
-  pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "manifestRegistry">;
+  pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "manifestRegistry" | "pluginIds">;
   runId?: string;
 }): ExtensionFactory {
   const runner = createAgentToolResultMiddlewareRunner({ runtime: "openclaw" }, undefined, {
     config: params.cfg,
     workspaceDir: params.workspaceDir,
-    manifestRegistry: params.pluginMetadataSnapshot?.manifestRegistry,
+    manifestRegistry:
+      params.pluginMetadataSnapshot?.pluginIds === undefined
+        ? params.pluginMetadataSnapshot?.manifestRegistry
+        : undefined,
   });
   return (agent) => {
     agent.on("tool_result", async (rawEvent: unknown, ctx: { cwd?: string }) => {
@@ -183,7 +186,7 @@ export function buildEmbeddedExtensionFactories(params: {
   cfg: OpenClawConfig | undefined;
   sessionManager: SessionManager;
   workspaceDir?: string;
-  pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "manifestRegistry">;
+  pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "manifestRegistry" | "pluginIds">;
   provider: string;
   modelId: string;
   model: ProviderRuntimeModel | undefined;

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
@@ -79,6 +79,8 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
     bundleMetadataSnapshot?.pluginIds === undefined
       ? bundleMetadataSnapshot?.manifestRegistry
       : undefined;
+  const middlewarePluginMetadataSnapshot =
+    bundleMetadataSnapshot?.pluginIds === undefined ? bundleMetadataSnapshot : undefined;
   const bundleMcpSessionRuntime = bundleMcpEnabled
     ? await getOrCreateSessionMcpRuntime({
         sessionId: params.attempt.sessionId,
@@ -201,6 +203,7 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
       bundleLspRuntime,
       bundleMcpRuntime,
       clientTools,
+      middlewarePluginMetadataSnapshot,
       tools,
       uncompactedEffectiveTools: [...schemaProjection.tools],
     };

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -491,7 +491,8 @@ export async function runEmbeddedAttempt(
     });
     bundleMcpRuntime = preparedBundleTools.bundleMcpRuntime;
     bundleLspRuntime = preparedBundleTools.bundleLspRuntime;
-    const { clientTools, tools, uncompactedEffectiveTools } = preparedBundleTools;
+    const { clientTools, middlewarePluginMetadataSnapshot, tools, uncompactedEffectiveTools } =
+      preparedBundleTools;
     const preparedToolCatalog = prepareEmbeddedAttemptToolCatalog({
       attempt: params,
       preparedToolBase,
@@ -758,6 +759,8 @@ export async function runEmbeddedAttempt(
       const extensionFactories = buildEmbeddedExtensionFactories({
         cfg: params.config,
         sessionManager,
+        workspaceDir: effectiveWorkspace,
+        pluginMetadataSnapshot: middlewarePluginMetadataSnapshot,
         provider: params.provider,
         modelId: params.modelId,
         model: params.model,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -467,10 +467,8 @@ export async function runEmbeddedAttempt(
       config: params.config,
       agentId: params.agentId,
     });
-    // Track sessions_yield tool invocation (callback pattern, like clientToolCallDetected)
     let yieldDetected = false;
     let yieldMessage: string | null = null;
-    // Late-binding reference so onYield can abort the session (declared after tool creation)
     let abortSessionForYield: (() => void) | null = null;
     let queueYieldInterruptForSession: (() => void) | null = null;
     let yieldAbortSettled: Promise<void> | null = null;
@@ -785,7 +783,6 @@ export async function runEmbeddedAttempt(
       applyAgentAutoCompactionGuard(autoCompactionGuardArgs);
       prepStages.mark("session-resource-loader");
 
-      // Get hook runner early so it's available when creating tools
       const hookRunner = getGlobalHookRunner();
 
       const {

--- a/src/agents/harness/tool-result-middleware.ts
+++ b/src/agents/harness/tool-result-middleware.ts
@@ -2,6 +2,7 @@
  * Runs native harness tool-result middleware around tool execution results.
  */
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { boundedJsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type {
@@ -10,6 +11,7 @@ import type {
   AgentToolResultMiddlewareEvent,
   OpenClawAgentToolResult,
 } from "../../plugins/agent-tool-result-middleware-types.js";
+import type { PluginManifestRegistry } from "../../plugins/manifest-registry.js";
 import { createLazyPromiseLoader } from "../../shared/lazy-promise.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import {
@@ -28,6 +30,12 @@ const MAX_MIDDLEWARE_DETAILS_BYTES = 100_000;
 const MAX_MIDDLEWARE_DETAILS_DEPTH = 20;
 const MAX_MIDDLEWARE_DETAILS_KEYS = 1_000;
 const NESTED_TOOL_RESULT_BLOCK_TYPES = new Set(["toolresult", "tool_result"]);
+
+type AgentToolResultMiddlewareLoaderContext = {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  manifestRegistry?: PluginManifestRegistry;
+};
 
 type MiddlewareContentBlock = OpenClawAgentToolResult["content"][number];
 type MiddlewareContentCoerceState = { depth: number; seen: Set<object> };
@@ -480,6 +488,7 @@ function reconcileDeliveredMessagingFailure(
 export function createAgentToolResultMiddlewareRunner(
   ctx: AgentToolResultMiddlewareContext,
   handlers?: AgentToolResultMiddleware[],
+  loaderContext?: AgentToolResultMiddlewareLoaderContext,
 ) {
   const middlewareContext = { ...ctx, harness: ctx.harness ?? ctx.runtime };
   let resolvedHandlers = handlers;
@@ -488,6 +497,7 @@ export function createAgentToolResultMiddlewareRunner(
       await import("../../plugins/agent-tool-result-middleware-loader.js");
     return loadAgentToolResultMiddlewaresForRuntime({
       runtime: ctx.runtime,
+      ...loaderContext,
     });
   });
   const resolveHandlers = async (): Promise<AgentToolResultMiddleware[]> => {

--- a/src/agents/harness/tool-result-middleware.ts
+++ b/src/agents/harness/tool-result-middleware.ts
@@ -2,16 +2,15 @@
  * Runs native harness tool-result middleware around tool execution results.
  */
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { boundedJsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type {
   AgentToolResultMiddleware,
   AgentToolResultMiddlewareContext,
   AgentToolResultMiddlewareEvent,
+  AgentToolResultMiddlewareLoaderContext,
   OpenClawAgentToolResult,
 } from "../../plugins/agent-tool-result-middleware-types.js";
-import type { PluginManifestRegistry } from "../../plugins/manifest-registry.js";
 import { createLazyPromiseLoader } from "../../shared/lazy-promise.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import {
@@ -30,12 +29,6 @@ const MAX_MIDDLEWARE_DETAILS_BYTES = 100_000;
 const MAX_MIDDLEWARE_DETAILS_DEPTH = 20;
 const MAX_MIDDLEWARE_DETAILS_KEYS = 1_000;
 const NESTED_TOOL_RESULT_BLOCK_TYPES = new Set(["toolresult", "tool_result"]);
-
-type AgentToolResultMiddlewareLoaderContext = {
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  manifestRegistry?: PluginManifestRegistry;
-};
 
 type MiddlewareContentBlock = OpenClawAgentToolResult["content"][number];
 type MiddlewareContentCoerceState = { depth: number; seen: Set<object> };
@@ -495,10 +488,7 @@ export function createAgentToolResultMiddlewareRunner(
   const resolvedHandlersLoader = createLazyPromiseLoader(async () => {
     const { loadAgentToolResultMiddlewaresForRuntime } =
       await import("../../plugins/agent-tool-result-middleware-loader.js");
-    return loadAgentToolResultMiddlewaresForRuntime({
-      runtime: ctx.runtime,
-      ...loaderContext,
-    });
+    return loadAgentToolResultMiddlewaresForRuntime({ runtime: ctx.runtime, ...loaderContext });
   });
   const resolveHandlers = async (): Promise<AgentToolResultMiddleware[]> => {
     if (resolvedHandlers) {

--- a/src/plugins/agent-tool-result-middleware-loader.test.ts
+++ b/src/plugins/agent-tool-result-middleware-loader.test.ts
@@ -1,0 +1,114 @@
+// Verifies prepared manifest metadata bypasses middleware discovery and keeps the standalone fallback.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { loadAgentToolResultMiddlewaresForRuntime } from "./agent-tool-result-middleware-loader.js";
+import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
+import { createEmptyPluginRegistry } from "./registry.js";
+import { setActivePluginRegistry } from "./runtime.js";
+
+const mocks = vi.hoisted(() => ({
+  loadOpenClawPlugins: vi.fn(),
+  loadPluginManifestRegistry: vi.fn(),
+}));
+
+vi.mock("./loader.js", () => ({
+  loadOpenClawPlugins: mocks.loadOpenClawPlugins,
+}));
+
+vi.mock("./manifest-registry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./manifest-registry.js")>()),
+  loadPluginManifestRegistry: mocks.loadPluginManifestRegistry,
+}));
+
+function createManifestRegistry(): PluginManifestRegistry {
+  const plugin: PluginManifestRecord = {
+    id: "prepared-middleware",
+    channels: [],
+    providers: [],
+    cliBackends: [],
+    skills: [],
+    hooks: [],
+    origin: "bundled",
+    rootDir: "/plugins/prepared-middleware",
+    source: "/plugins/prepared-middleware/index.js",
+    manifestPath: "/plugins/prepared-middleware/openclaw.plugin.json",
+    contracts: {
+      agentToolResultMiddleware: ["openclaw"],
+    },
+  };
+  return { plugins: [plugin], diagnostics: [] };
+}
+
+function createRuntimeRegistry() {
+  const registry = createEmptyPluginRegistry();
+  registry.agentToolResultMiddlewares.push({
+    pluginId: "prepared-middleware",
+    pluginName: "prepared-middleware",
+    rawHandler: () => undefined,
+    handler: () => undefined,
+    runtimes: ["openclaw"],
+    source: "test",
+  });
+  return registry;
+}
+
+beforeEach(() => {
+  mocks.loadOpenClawPlugins.mockReset().mockReturnValue(createRuntimeRegistry());
+  mocks.loadPluginManifestRegistry.mockReset().mockReturnValue(createManifestRegistry());
+  setActivePluginRegistry(createEmptyPluginRegistry());
+});
+
+afterEach(() => {
+  setActivePluginRegistry(createEmptyPluginRegistry());
+});
+
+describe("loadAgentToolResultMiddlewaresForRuntime", () => {
+  it("uses the prepared manifest registry without rediscovery", async () => {
+    const config = {
+      plugins: { entries: { "prepared-middleware": { enabled: true } } },
+    } as OpenClawConfig;
+    const env = { HOME: "/prepared-home" };
+    const manifestRegistry = createManifestRegistry();
+
+    const result = await loadAgentToolResultMiddlewaresForRuntime({
+      runtime: "openclaw",
+      config,
+      workspaceDir: "/prepared-workspace",
+      env,
+      manifestRegistry,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(mocks.loadPluginManifestRegistry).not.toHaveBeenCalled();
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config,
+        env,
+        workspaceDir: "/prepared-workspace",
+        manifestRegistry,
+        onlyPluginIds: ["prepared-middleware"],
+      }),
+    );
+  });
+
+  it("discovers metadata for standalone callers without a prepared registry", async () => {
+    const config = {
+      plugins: { entries: { "prepared-middleware": { enabled: true } } },
+    } as OpenClawConfig;
+    const env = { HOME: "/standalone-home" };
+
+    const result = await loadAgentToolResultMiddlewaresForRuntime({
+      runtime: "openclaw",
+      config,
+      workspaceDir: "/standalone-workspace",
+      env,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledWith({
+      config,
+      workspaceDir: "/standalone-workspace",
+      env,
+    });
+  });
+});

--- a/src/plugins/agent-tool-result-middleware-types.ts
+++ b/src/plugins/agent-tool-result-middleware-types.ts
@@ -1,5 +1,7 @@
-// Defines plugin middleware contracts for agent tool results.
 import type { AgentToolResult } from "../agents/runtime/index.js";
+// Defines plugin middleware contracts for agent tool results.
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginManifestRegistry } from "./manifest-registry.js";
 
 export type OpenClawAgentToolResult<TResult = unknown> = AgentToolResult<TResult>;
 
@@ -28,6 +30,12 @@ export type AgentToolResultMiddlewareContext = {
   sessionId?: string;
   sessionKey?: string;
   runId?: string;
+};
+
+export type AgentToolResultMiddlewareLoaderContext = {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  manifestRegistry?: PluginManifestRegistry;
 };
 
 export type AgentToolResultMiddlewareResult = {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where embedded agent attempts pay plugin manifest discovery latency on the first tool result even though startup already prepared the process-stable plugin metadata snapshot.

Related: #77700
Related: #79198

## Why This Change Was Made

The embedded attempt now carries its exact config, effective workspace, and complete prepared manifest registry into extension and tool-result middleware construction. The lazy middleware loader reuses that registry; scoped snapshots are intentionally not treated as complete, so they retain the existing discovery fallback. Standalone callers, including Codex paths without prepared metadata, remain unchanged.

This keeps the fix at the existing prepared-runtime consumer boundary. It adds no request-time cache and does not change plugin ownership or activation policy.

## User Impact

Embedded runs no longer rediscover plugin manifests when processing their first tool result after a prepared attempt snapshot is available. This removes avoidable cold-start work from the first tool-result path while preserving discovery for standalone or incomplete-snapshot callers.

## Real behavior proof

Redacted embedded-run comparison on Linux, Node `v24.18.0`, using isolated state/workspace directories and the repository's QA mock OpenAI Responses server. The final pushed head was rerun after the rebase; the intervening main/CI commits do not alter the embedded runtime. Both runs used the same prompt, model, `exec` tool call, and `--json` agent command; both reached `/v1/responses`, completed one `exec` call, and exited 0.

| build | SHA | wall time | max RSS |
| --- | --- | ---: | ---: |
| current-main baseline (loader-equivalent, tested at `58e8440190`) | `58e8440190` | 26.36 s | 1,270,772 kB |
| final PR head | `6e4424d0e3` | 66.61 s | 1,287,948 kB |

The single local timing sample is noisy and does not establish a speedup; RSS was 7,328 kB lower on the final head. The trace is the primary proof of the behavior change:

```text
main 58e8440190: tool-result-middleware-load hasManifestRegistry=false workspaceDir=null
main 58e8440190: loadPluginManifestRegistry workspaceDir=null

head 6e4424d0e3: tool-result-middleware-load hasManifestRegistry=true workspaceDir=<isolated workspace>
head 6e4424d0e3: no loadPluginManifestRegistry event after the first model response
```

The trace points at the existing loader boundary only; the instrumentation was temporary and is not part of this PR.

## Composition with #79198

`#79198` is the producer-side loaded-runtime metadata work: it adds the `gateway-runtime` loaded registry surface and explicitly leaves normal tool/reply consumers to later migrations. This PR is the consumer-side handoff. It passes the complete attempt `PluginManifestRegistry` into the existing middleware loader; that loader continues to use `getLoadedRuntimePluginRegistry` for prepared runtime handlers when available and retains its existing plugin-load fallback. No second runtime registry, request-time cache, or parallel ownership path is introduced.

## Evidence

- Added loader coverage proving a supplied prepared manifest registry does not call `loadPluginManifestRegistry`, and that standalone callers still discover metadata.
- Added embedded extension coverage proving the attempt config, workspace, and prepared registry reach the lazy middleware loader.
- Rebased focused local fallback passed: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/extensions.test.ts src/agents/embedded-agent-runner.extensions.test.ts src/agents/harness/tool-result-middleware.test.ts src/agents/codex-app-server.extensions.test.ts src/plugins/agent-tool-result-middleware-loader.test.ts src/agents/embedded-agent-runner/extensions.prepared-metadata.test.ts` — 6 files, 61 tests.
- Rebase-aware `oxfmt --check` passed for all 6 plugin/agent files, and `git diff --check` passed.
- Fresh branch autoreview passed clean against `origin/main` with no accepted/actionable findings; subsequent commits are isolated CI/test repairs.
- Fixed the CI baseline regression in `apps/ios/Sources/Design/SettingsProTabSections.swift` by restoring `.accessibilityLabel(Text(title))` at both localized wrapper sites. The focused `test/scripts/apple-app-i18n.test.ts` passed all 13 tests.
- Fixed the UI browser-shard baseline regression in `ui/src/pages/chat/chat-responsive.browser.test.ts` by matching the existing split footer CSS with `composerInset / 2`. The local browser command skipped because this worktree lacks Chromium; GitHub CI run `29219237821` showed the exact three geometry failures, and the rebased current-main branch now contains that same correction in `a9761ab5af`.
- Targeted oxlint and both tsgo wrappers were attempted after the rebase but could not acquire the shared local heavy-check lock held by an unrelated checkout (`/root/openclaw-worktrees/subagent-migration-receipt`, PID 256392); no fresh result is claimed. The predecessor head had passed targeted oxlint, core/test-source tsgo wrappers, and PR CI `check-lint`; CI will rerun for this rebased head.
- Approved remote validation was unavailable: Crabbox AWS warmup had no EC2 IMDS IAM role, Blacksmith Testbox was unauthenticated, and GitHub performance workflow dispatch returned HTTP 403 for missing repository-admin permission. The embedded-run comparison above is the narrow local fallback.
- No persistent vector/embedding data model or storage changed. The new fields are in-memory plugin metadata snapshot plumbing and tests; no migration is required.
- AI-assisted disclosure: Codex assisted with implementation, source review, proof setup, and validation analysis; the contributor verified the final source, contracts, tests, and diff.

Allow edits from maintainers is enabled for the fork branch.
