### PR TITLE
improve: start Gateway and first agent turn faster

### DIFF
--- a/src/cli/command-bootstrap.ts
+++ b/src/cli/command-bootstrap.ts
@@ -22,6 +22,7 @@ export async function ensureCliCommandBootstrap(params: {
   beforeStateMigrations?: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
   loadPlugins?: boolean;
   pluginRegistry?: CliPluginRegistryPolicy;
+  skipPristineStartupStateMigrations?: boolean;
 }) {
   if (!params.skipConfigGuard) {
     const { ensureConfigReady } = await loadConfigGuardModule();
@@ -33,6 +34,9 @@ export async function ensureCliCommandBootstrap(params: {
         ? { beforeStateMigrations: params.beforeStateMigrations }
         : {}),
       ...(params.suppressDoctorStdout ? { suppressDoctorStdout: true } : {}),
+      ...(params.skipPristineStartupStateMigrations
+        ? { skipPristineStartupStateMigrations: true }
+        : {}),
     });
   }
   if (!params.loadPlugins) {

--- a/src/cli/command-execution-startup.ts
+++ b/src/cli/command-execution-startup.ts
@@ -71,6 +71,7 @@ export async function ensureCliExecutionBootstrap(params: {
   beforeStateMigrations?: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
   loadPlugins?: boolean;
   skipConfigGuard?: boolean;
+  skipPristineStartupStateMigrations?: boolean;
 }) {
   await ensureCliCommandBootstrap({
     runtime: params.runtime,
@@ -83,5 +84,8 @@ export async function ensureCliExecutionBootstrap(params: {
     loadPlugins: params.loadPlugins ?? params.startupPolicy.loadPlugins,
     pluginRegistry: params.startupPolicy.pluginRegistry,
     skipConfigGuard: params.skipConfigGuard ?? params.startupPolicy.skipConfigGuard,
+    ...(params.skipPristineStartupStateMigrations
+      ? { skipPristineStartupStateMigrations: true }
+      : {}),
   });
 }

--- a/src/cli/gateway-cli/pre-bootstrap.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.ts
@@ -26,6 +26,7 @@ let selectedGatewayRunEnvironment: GatewayRunEnvironmentSelection | undefined;
 let appliedGatewayRunConfigEnvironment: GatewayRunEnvironmentSelection | undefined;
 let lastGuardedGatewayRunSnapshot: ConfigFileSnapshot | undefined;
 let preparedGatewayRunBootstrapSnapshot: ConfigFileSnapshot | undefined;
+let preparedGatewayRunStateWasPristine = false;
 let preparedGatewayRunReset: PreparedGatewayRunReset | undefined;
 let gatewayRunTargetSelectedByConfig = false;
 
@@ -621,6 +622,11 @@ export async function selectGatewayRunEnvironment(params: GatewayRunGuardParams)
 
 export async function prepareGatewayRunBootstrap(params: GatewayRunGuardParams): Promise<boolean> {
   preparedGatewayRunReset = undefined;
+  preparedGatewayRunStateWasPristine = false;
+  const pristineSelectionSignature = resolveGatewayConfigSelectionSignature(process.env);
+  const { canSkipPristineStartupStateMigrations } =
+    await import("../../commands/doctor/shared/pristine-startup-state.js");
+  const selectedStateWasPristine = canSkipPristineStartupStateMigrations(process.env);
   // Stop the early proxy before recovery can select another config/state target. Its lifecycle
   // restores the underlying env snapshot so the selected target's trusted dotenv can replace it.
   await getGatewayRunRuntimeHooks().releaseManagedProxy?.();
@@ -637,6 +643,11 @@ export async function prepareGatewayRunBootstrap(params: GatewayRunGuardParams):
         recoverSuspicious: true,
         restoreSuspicious: true,
       });
+  preparedGatewayRunStateWasPristine =
+    guarded &&
+    !params.opts.reset &&
+    selectedStateWasPristine &&
+    resolveGatewayConfigSelectionSignature(process.env) === pristineSelectionSignature;
   await pinGatewayRunRuntimePaths();
   // Dev reset deletes the state directory before recreating config. Migrating first would
   // archive legacy state and then delete its imported SQLite rows.
@@ -650,6 +661,11 @@ export async function prepareGatewayRunBootstrap(params: GatewayRunGuardParams):
     };
   }
   return shouldBootstrap;
+}
+
+/** Prepared fact captured before Gateway bootstrap can create runtime state. */
+export function wasPreparedGatewayRunStatePristine(): boolean {
+  return preparedGatewayRunStateWasPristine;
 }
 
 export async function recheckGatewayRunBootstrap(

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -142,6 +142,7 @@ vi.mock("../../config/paths.js", () => ({
   CONFIG_PATH: "/tmp/openclaw-test-missing-config.json",
   normalizeStateDirEnv: (env?: NodeJS.ProcessEnv) => normalizeStateDirEnv(env),
   pinRuntimePaths: (env?: NodeJS.ProcessEnv) => pinRuntimePaths(env),
+  resolveConfigPath: () => "/tmp/openclaw-test-missing-config.json",
   resolveStateDir: () => "/tmp",
   resolveGatewayPort: (cfg?: { gateway?: { port?: number } }) => cfg?.gateway?.port ?? 18789,
 }));

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -215,6 +215,7 @@ export async function ensureConfigReady(params: {
   suppressDoctorStdout?: boolean;
   allowInvalid?: boolean;
   beforeStateMigrations?: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
+  skipPristineStartupStateMigrations?: boolean;
 }): Promise<void> {
   const commandPath = params.commandPath ?? [];
   const commandName = commandPath[0];
@@ -236,6 +237,9 @@ export async function ensureConfigReady(params: {
           : {}),
         ...(params.beforeStateMigrations
           ? { beforeStateMigrations: params.beforeStateMigrations }
+          : {}),
+        ...(params.skipPristineStartupStateMigrations
+          ? { skipPristineStartupStateMigrations: true }
           : {}),
       });
     try {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -182,11 +182,16 @@ async function tryRunGatewayRunFastPath(
   });
   const beforeRun = async (opts: { force?: boolean; reset?: boolean }) => {
     let beforeStateMigrations: ((snapshot?: ConfigFileSnapshot) => Promise<boolean>) | undefined;
+    let skipPristineStartupStateMigrations = false;
     const shouldBootstrap = await startupTrace.measure("gateway-run-pre-bootstrap", async () => {
-      const { prepareGatewayRunBootstrap, recheckGatewayRunBootstrap } =
-        await import("./gateway-cli/pre-bootstrap.js");
+      const {
+        prepareGatewayRunBootstrap,
+        recheckGatewayRunBootstrap,
+        wasPreparedGatewayRunStatePristine,
+      } = await import("./gateway-cli/pre-bootstrap.js");
       const prepared = await prepareGatewayRunBootstrap({ opts, runtime: defaultRuntime });
       if (prepared) {
+        skipPristineStartupStateMigrations = wasPreparedGatewayRunStatePristine();
         beforeStateMigrations = (snapshot) =>
           recheckGatewayRunBootstrap({
             opts,
@@ -206,6 +211,7 @@ async function tryRunGatewayRunFastPath(
         startupPolicy,
         loadPlugins: false,
         ...(beforeStateMigrations ? { beforeStateMigrations } : {}),
+        ...(skipPristineStartupStateMigrations ? { skipPristineStartupStateMigrations: true } : {}),
       });
       const { reloadTrustedGatewayRunEnvironment } = await import("./gateway-cli/pre-bootstrap.js");
       await reloadTrustedGatewayRunEnvironment({ runtime: defaultRuntime });

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -91,6 +91,9 @@ const runPostCorePluginConvergence = vi.hoisted(() =>
     }),
   ),
 );
+const planStartupPluginConvergence = vi.hoisted(() =>
+  vi.fn(async () => ({ required: true, installRecords: {} })),
+);
 const makeStartupConvergenceResult = vi.hoisted(
   () =>
     (overrides: Partial<StartupConvergenceResult> = {}): StartupConvergenceResult => ({
@@ -138,6 +141,10 @@ vi.mock("../cli/update-cli/post-core-plugin-convergence.js", () => ({
   runPostCorePluginConvergence,
 }));
 
+vi.mock("./doctor/shared/startup-plugin-convergence-plan.js", () => ({
+  planStartupPluginConvergence,
+}));
+
 vi.mock("../config/io.js", () => ({
   readConfigFileSnapshot,
   recoverConfigFromJsonRootSuffix: vi.fn(),
@@ -153,6 +160,7 @@ describe("runDoctorConfigPreflight state migration", () => {
     vi.clearAllMocks();
     needsStartupMigrationCheckpoint.mockReturnValue(false);
     runPostCorePluginConvergence.mockResolvedValue(makeStartupConvergenceResult());
+    planStartupPluginConvergence.mockResolvedValue({ required: true, installRecords: {} });
     autoMigrateLegacyStateDir.mockResolvedValue({
       migrated: false,
       skipped: false,
@@ -360,6 +368,7 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(runPostCorePluginConvergence).toHaveBeenCalledWith({
       cfg: { gateway: { mode: "local", port: 19091 } },
       env: process.env,
+      baselineInstallRecords: {},
     });
     expect(recordSuccessfulStartupMigrations).toHaveBeenCalledWith({
       env: pinnedEnv,
@@ -408,6 +417,49 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(autoMigrateLegacyTaskStateSidecars).not.toHaveBeenCalled();
     expect(runPostCorePluginConvergence).not.toHaveBeenCalled();
     expect(readConfigFileSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it("checkpoints startup migrations without loading plugin convergence when the plan is empty", async () => {
+    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    planStartupPluginConvergence.mockResolvedValueOnce({ required: false, installRecords: {} });
+
+    await runDoctorConfigPreflight({
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+      requireStartupMigrationCheckpoint: true,
+    });
+
+    expect(planStartupPluginConvergence).toHaveBeenCalledWith({
+      config: { gateway: { mode: "local", port: 19091 } },
+      env: process.env,
+    });
+    expect(runPostCorePluginConvergence).not.toHaveBeenCalled();
+    expect(recordSuccessfulStartupMigrations).toHaveBeenCalledOnce();
+  });
+
+  it("skips legacy migration loading for a prepared pristine state root", async () => {
+    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    planStartupPluginConvergence.mockResolvedValueOnce({ required: false, installRecords: {} });
+    const beforeStateMigrations = vi.fn(async () => true);
+
+    await runDoctorConfigPreflight({
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+      requireStartupMigrationCheckpoint: true,
+      skipPristineStartupStateMigrations: true,
+      beforeStateMigrations,
+    });
+
+    expect(autoMigrateLegacyStateDir).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyState).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyPluginDoctorState).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyTaskStateSidecars).not.toHaveBeenCalled();
+    expect(beforeStateMigrations).toHaveBeenNthCalledWith(1);
+    expect(beforeStateMigrations).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ valid: true }),
+    );
+    expect(recordSuccessfulStartupMigrations).toHaveBeenCalledOnce();
   });
 
   it("blocks gateway readiness when startup migrations leave warnings", async () => {

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -24,6 +24,23 @@ const loadDoctorStateMigrations = createLazyRuntimeModule(
 );
 
 const loadDoctorCron = createLazyRuntimeModule(() => import("./doctor/cron/index.js"));
+const startupPreflightTraceStartedAt = performance.now();
+
+async function measureStartupPreflightStep<T>(name: string, run: () => T | Promise<T>): Promise<T> {
+  if (!isTruthyEnvValue(process.env.OPENCLAW_GATEWAY_STARTUP_TRACE)) {
+    return await run();
+  }
+  const startedAt = performance.now();
+  try {
+    return await run();
+  } finally {
+    const durationMs = performance.now() - startedAt;
+    const totalMs = performance.now() - startupPreflightTraceStartedAt;
+    process.stderr.write(
+      `[gateway] startup trace: cli.bootstrap.${name} ${durationMs.toFixed(1)}ms total=${totalMs.toFixed(1)}ms\n`,
+    );
+  }
+}
 
 async function maybeMigrateLegacyConfig(): Promise<string[]> {
   const changes: string[] = [];
@@ -122,12 +139,30 @@ async function runStartupUpgradeConvergence(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
 }): Promise<string[]> {
-  const { runPostCorePluginConvergence } =
-    await import("../cli/update-cli/post-core-plugin-convergence.js");
-  const convergence = await runPostCorePluginConvergence({
-    cfg: params.cfg,
-    env: params.env,
-  });
+  const { planStartupPluginConvergence } = await measureStartupPreflightStep(
+    "plugin-plan-import",
+    () => import("./doctor/shared/startup-plugin-convergence-plan.js"),
+  );
+  const plan = await measureStartupPreflightStep("plugin-plan", () =>
+    planStartupPluginConvergence({
+      config: params.cfg,
+      env: params.env,
+    }),
+  );
+  if (!plan.required) {
+    return [];
+  }
+  const { runPostCorePluginConvergence } = await measureStartupPreflightStep(
+    "plugin-convergence-import",
+    () => import("../cli/update-cli/post-core-plugin-convergence.js"),
+  );
+  const convergence = await measureStartupPreflightStep("plugin-convergence", () =>
+    runPostCorePluginConvergence({
+      cfg: params.cfg,
+      env: params.env,
+      baselineInstallRecords: plan.installRecords,
+    }),
+  );
   if (convergence.changes.length > 0) {
     note(convergence.changes.map((entry) => `- ${entry}`).join("\n"), "Doctor changes");
   }
@@ -182,6 +217,8 @@ export async function runDoctorConfigPreflight(
     /** Return false or reject on config drift; the preflight always unwinds owned resources. */
     beforeStateMigrations?: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
     requireStartupMigrationCheckpoint?: boolean;
+    /** Prepared before Gateway bootstrap can create files under an otherwise pristine state root. */
+    skipPristineStartupStateMigrations?: boolean;
     /**
      * Allows legacy imports whose source lives in the DEFAULT home state dir
      * while OPENCLAW_STATE_DIR points elsewhere. Only explicit doctor repair
@@ -199,6 +236,7 @@ export async function runDoctorConfigPreflight(
   let stateMigrations: Awaited<ReturnType<typeof loadDoctorStateMigrations>> | undefined;
   let startupMigrationEnv = process.env;
   let shouldRecordStartupCheckpoint = false;
+  let skipPristineStartupStateMigrations = options.skipPristineStartupStateMigrations === true;
   let startupMigrationLease: StartupMigrationLease | undefined;
   let startupMigrationHeartbeat: ReturnType<typeof setInterval> | undefined;
   let startupMigrationHeartbeatError: unknown;
@@ -212,6 +250,17 @@ export async function runDoctorConfigPreflight(
     noteStateMigrationResult(result);
   };
   try {
+    if (startupCheckpoint && !skipPristineStartupStateMigrations) {
+      // Capture pristine state before the Gateway's fresh-config guard can prepare runtime state.
+      const { canSkipPristineStartupStateMigrations } = await measureStartupPreflightStep(
+        "pristine-state-plan-import",
+        () => import("./doctor/shared/pristine-startup-state.js"),
+      );
+      skipPristineStartupStateMigrations = await measureStartupPreflightStep(
+        "pristine-state-plan",
+        () => canSkipPristineStartupStateMigrations(process.env),
+      );
+    }
     // The gateway uses this last-moment guard to ensure its prepared config did not change before
     // any automatic migration mutates state. A rejected guard skips every state migration stage.
     const stateMigrationsAllowed =
@@ -244,12 +293,16 @@ export async function runDoctorConfigPreflight(
     // A current version checkpoint proves this state root already completed every automatic
     // migration. Keep repeated Gateway boots out of the legacy/plugin migration import graph.
     stateMigrations =
-      stateMigrationsRequested && (!startupCheckpoint || shouldRecordStartupCheckpoint)
-        ? await loadDoctorStateMigrations()
+      stateMigrationsRequested &&
+      (!startupCheckpoint || shouldRecordStartupCheckpoint) &&
+      !skipPristineStartupStateMigrations
+        ? await measureStartupPreflightStep("state-migrations-import", loadDoctorStateMigrations)
         : undefined;
     if (stateMigrations && stateMigrationsAllowed) {
       const { autoMigrateLegacyStateDir } = stateMigrations;
-      const stateDirResult = await autoMigrateLegacyStateDir({ env: process.env });
+      const stateDirResult = await measureStartupPreflightStep("state-dir-migrations", () =>
+        autoMigrateLegacyStateDir({ env: process.env }),
+      );
       noteStartupStateMigrationResult(stateDirResult);
     }
 
@@ -264,7 +317,11 @@ export async function runDoctorConfigPreflight(
       ...(options.observe === false ? { observe: false } : {}),
       skipPluginValidation: shouldSkipPluginValidationForDoctorConfigPreflight(),
     };
-    let snapshot = addDoctorLegacyIssues(await readConfigFileSnapshot(readOptions));
+    let snapshot = addDoctorLegacyIssues(
+      await measureStartupPreflightStep("config-snapshot", () =>
+        readConfigFileSnapshot(readOptions),
+      ),
+    );
     if (options.repairPrefixedConfig === true && snapshot.exists && !snapshot.valid) {
       if (await recoverConfigFromJsonRootSuffix(snapshot)) {
         note(
@@ -301,8 +358,9 @@ export async function runDoctorConfigPreflight(
 
     const baseConfig = snapshot.sourceConfig ?? snapshot.config ?? {};
     const stateMigrationInput = resolveStateMigrationConfigInput({ snapshot, baseConfig });
+    const freshConfigGuardRequired = stateMigrations !== undefined || shouldRecordStartupCheckpoint;
     const freshConfigGuardAllowed =
-      stateMigrations === undefined ||
+      !freshConfigGuardRequired ||
       !stateMigrationsAllowed ||
       options.beforeStateMigrations === undefined ||
       (await options.beforeStateMigrations(snapshot));

--- a/src/commands/doctor/shared/configured-provider-plugin-ids.ts
+++ b/src/commands/doctor/shared/configured-provider-plugin-ids.ts
@@ -1,0 +1,41 @@
+// Resolves official external provider plugins implied by config and environment state.
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import {
+  resolveOfficialExternalProviderContractPluginIds,
+  resolveOfficialExternalProviderPluginIds,
+  resolveOfficialExternalProviderPluginIdsForEnv,
+} from "../../../plugins/official-external-plugin-catalog.js";
+import {
+  collectConfiguredMediaProviderSelectionIds,
+  collectConfiguredModelProviderSelectionIds,
+} from "./configured-provider-selection-ids.js";
+
+/** Lists official external provider plugins without loading installed plugin registries. */
+export function collectConfiguredOfficialProviderPluginIds(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): string[] {
+  const configuredProviderIds = collectConfiguredModelProviderSelectionIds(params.cfg);
+  const configuredMediaProviderIds = collectConfiguredMediaProviderSelectionIds(params.cfg);
+  const pluginIds = new Set(
+    resolveOfficialExternalProviderPluginIds({ providerIds: configuredProviderIds }),
+  );
+  for (const pluginId of resolveOfficialExternalProviderPluginIdsForEnv(
+    params.env ?? process.env,
+  )) {
+    pluginIds.add(pluginId);
+  }
+  for (const pluginId of resolveOfficialExternalProviderContractPluginIds({
+    contract: "mediaUnderstandingProviders",
+    providerIds: configuredMediaProviderIds,
+  })) {
+    pluginIds.add(pluginId);
+  }
+  for (const pluginId of resolveOfficialExternalProviderContractPluginIds({
+    contract: "speechProviders",
+    providerIds: configuredProviderIds,
+  })) {
+    pluginIds.add(pluginId);
+  }
+  return [...pluginIds].toSorted((left, right) => left.localeCompare(right));
+}

--- a/src/commands/doctor/shared/configured-provider-plugin-installs.ts
+++ b/src/commands/doctor/shared/configured-provider-plugin-installs.ts
@@ -1,107 +1,16 @@
 // Resolves official provider plugins implied by configured auth and model selections.
-import { collectConfiguredModelRefs } from "@openclaw/model-catalog-core/configured-model-refs";
-import { normalizeNullableString as normalizeId } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import {
-  resolveOfficialExternalProviderContractPluginIds,
-  resolveOfficialExternalProviderPluginIds,
-  resolveOfficialExternalProviderPluginIdsForEnv,
-} from "../../../plugins/official-external-plugin-catalog.js";
 import { resolveProviderInstallCatalogEntries } from "../../../plugins/provider-install-catalog.js";
-import { asObjectRecord } from "./object.js";
-
-function collectConfiguredProviderIds(cfg: OpenClawConfig): Set<string> {
-  const ids = new Set<string>();
-  const add = (value: unknown) => {
-    const id = normalizeId(value);
-    if (id) {
-      ids.add(id.toLowerCase());
-    }
-  };
-  for (const profile of Object.values(asObjectRecord(cfg.auth?.profiles) ?? {})) {
-    add(asObjectRecord(profile)?.provider);
-  }
-  for (const providerId of Object.keys(asObjectRecord(cfg.models?.providers) ?? {})) {
-    add(providerId);
-  }
-  const modelByChannel = asObjectRecord(cfg.channels?.modelByChannel);
-  for (const [providerId, channelMap] of Object.entries(modelByChannel ?? {})) {
-    add(providerId);
-    for (const modelRef of Object.values(asObjectRecord(channelMap) ?? {})) {
-      if (typeof modelRef !== "string") {
-        continue;
-      }
-      const slash = modelRef.indexOf("/");
-      if (slash > 0) {
-        add(modelRef.slice(0, slash));
-      }
-    }
-  }
-  for (const { value } of collectConfiguredModelRefs(cfg, {
-    includeChannelModelOverrides: false,
-  })) {
-    const slash = value.indexOf("/");
-    if (slash > 0) {
-      add(value.slice(0, slash));
-    }
-  }
-  return ids;
-}
-
-function collectConfiguredMediaProviderIds(cfg: OpenClawConfig): Set<string> {
-  const ids = new Set<string>();
-  const add = (value: unknown) => {
-    const id = normalizeId(value);
-    if (id) {
-      ids.add(id.toLowerCase());
-    }
-  };
-  const addModels = (value: unknown) => {
-    if (!Array.isArray(value)) {
-      return;
-    }
-    for (const model of value) {
-      add(asObjectRecord(model)?.provider);
-    }
-  };
-  const media = cfg.tools?.media;
-  addModels(media?.models);
-  addModels(media?.image?.models);
-  addModels(media?.audio?.models);
-  addModels(media?.video?.models);
-  return ids;
-}
+import { collectConfiguredOfficialProviderPluginIds } from "./configured-provider-plugin-ids.js";
+import { collectConfiguredProviderSelectionIds } from "./configured-provider-selection-ids.js";
 
 /** Lists external provider plugins implied by configured auth profiles and model refs. */
 export function collectConfiguredProviderPluginIds(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }): string[] {
-  const configuredProviderIds = collectConfiguredProviderIds(params.cfg);
-  const configuredMediaProviderIds = collectConfiguredMediaProviderIds(params.cfg);
-  const selectedProviderIds = new Set([...configuredProviderIds, ...configuredMediaProviderIds]);
-  const pluginIds = new Set(
-    resolveOfficialExternalProviderPluginIds({
-      providerIds: selectedProviderIds,
-    }),
-  );
-  for (const pluginId of resolveOfficialExternalProviderPluginIdsForEnv(
-    params.env ?? process.env,
-  )) {
-    pluginIds.add(pluginId);
-  }
-  for (const pluginId of resolveOfficialExternalProviderContractPluginIds({
-    contract: "mediaUnderstandingProviders",
-    providerIds: configuredMediaProviderIds,
-  })) {
-    pluginIds.add(pluginId);
-  }
-  for (const pluginId of resolveOfficialExternalProviderContractPluginIds({
-    contract: "speechProviders",
-    providerIds: configuredProviderIds,
-  })) {
-    pluginIds.add(pluginId);
-  }
+  const selectedProviderIds = collectConfiguredProviderSelectionIds(params.cfg);
+  const pluginIds = new Set(collectConfiguredOfficialProviderPluginIds(params));
   for (const entry of resolveProviderInstallCatalogEntries({
     config: params.cfg,
     env: params.env,

--- a/src/commands/doctor/shared/configured-provider-selection-ids.ts
+++ b/src/commands/doctor/shared/configured-provider-selection-ids.ts
@@ -1,0 +1,84 @@
+// Reads provider ids selected by auth, model, channel, and media configuration.
+import { collectConfiguredModelRefs } from "@openclaw/model-catalog-core/configured-model-refs";
+import { normalizeNullableString as normalizeId } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { asObjectRecord } from "./object.js";
+
+function collectConfiguredProviderIds(cfg: OpenClawConfig): Set<string> {
+  const ids = new Set<string>();
+  const add = (value: unknown) => {
+    const id = normalizeId(value);
+    if (id) {
+      ids.add(id.toLowerCase());
+    }
+  };
+  for (const profile of Object.values(asObjectRecord(cfg.auth?.profiles) ?? {})) {
+    add(asObjectRecord(profile)?.provider);
+  }
+  for (const providerId of Object.keys(asObjectRecord(cfg.models?.providers) ?? {})) {
+    add(providerId);
+  }
+  const modelByChannel = asObjectRecord(cfg.channels?.modelByChannel);
+  for (const [providerId, channelMap] of Object.entries(modelByChannel ?? {})) {
+    add(providerId);
+    for (const modelRef of Object.values(asObjectRecord(channelMap) ?? {})) {
+      if (typeof modelRef !== "string") {
+        continue;
+      }
+      const slash = modelRef.indexOf("/");
+      if (slash > 0) {
+        add(modelRef.slice(0, slash));
+      }
+    }
+  }
+  for (const { value } of collectConfiguredModelRefs(cfg, {
+    includeChannelModelOverrides: false,
+  })) {
+    const slash = value.indexOf("/");
+    if (slash > 0) {
+      add(value.slice(0, slash));
+    }
+  }
+  return ids;
+}
+
+function collectConfiguredMediaProviderIds(cfg: OpenClawConfig): Set<string> {
+  const ids = new Set<string>();
+  const add = (value: unknown) => {
+    const id = normalizeId(value);
+    if (id) {
+      ids.add(id.toLowerCase());
+    }
+  };
+  const addModels = (value: unknown) => {
+    if (!Array.isArray(value)) {
+      return;
+    }
+    for (const model of value) {
+      add(asObjectRecord(model)?.provider);
+    }
+  };
+  const media = cfg.tools?.media;
+  addModels(media?.models);
+  addModels(media?.image?.models);
+  addModels(media?.audio?.models);
+  addModels(media?.video?.models);
+  return ids;
+}
+
+/** Provider ids used by static and installed-registry plugin matching. */
+export function collectConfiguredProviderSelectionIds(cfg: OpenClawConfig): ReadonlySet<string> {
+  return new Set([...collectConfiguredProviderIds(cfg), ...collectConfiguredMediaProviderIds(cfg)]);
+}
+
+export function collectConfiguredMediaProviderSelectionIds(
+  cfg: OpenClawConfig,
+): ReadonlySet<string> {
+  return collectConfiguredMediaProviderIds(cfg);
+}
+
+export function collectConfiguredModelProviderSelectionIds(
+  cfg: OpenClawConfig,
+): ReadonlySet<string> {
+  return collectConfiguredProviderIds(cfg);
+}

--- a/src/commands/doctor/shared/pristine-startup-state.test.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.test.ts
@@ -1,0 +1,116 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { canSkipPristineStartupStateMigrations } from "./pristine-startup-state.js";
+
+const roots: string[] = [];
+
+function createFixture(config: Record<string, unknown>, stateEntries: string[] = []) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pristine-startup-"));
+  roots.push(root);
+  const stateDir = path.join(root, "state");
+  const configPath = path.join(root, "openclaw.json");
+  fs.writeFileSync(configPath, `${JSON.stringify(config)}\n`);
+  fs.mkdirSync(stateDir, { recursive: true });
+  for (const entry of stateEntries) {
+    fs.mkdirSync(path.join(stateDir, entry), { recursive: true });
+  }
+  return {
+    HOME: root,
+    OPENCLAW_CONFIG: configPath,
+    OPENCLAW_CONFIG_PATH: configPath,
+    OPENCLAW_STATE_DIR: stateDir,
+  };
+}
+
+function addBundledPlugin(
+  env: ReturnType<typeof createFixture>,
+  pluginId: string,
+  options: { doctorContract?: boolean } = {},
+) {
+  const bundledPluginsDir = path.join(env.HOME, "bundled-plugins");
+  const pluginDir = path.join(bundledPluginsDir, pluginId);
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginDir, "openclaw.plugin.json"),
+    `${JSON.stringify({ id: pluginId })}\n`,
+  );
+  if (options.doctorContract) {
+    fs.writeFileSync(path.join(pluginDir, "doctor-contract-api.js"), "export {};\n");
+  }
+  return {
+    ...env,
+    VITEST: "true",
+    OPENCLAW_BUNDLED_PLUGINS_DIR: bundledPluginsDir,
+    OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+  };
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("pristine startup state", () => {
+  it("accepts the core-only Gateway benchmark config", () => {
+    const env = createFixture({
+      browser: { enabled: false },
+      gateway: { mode: "local" },
+      plugins: { enabled: true, entries: { browser: { enabled: false } } },
+    });
+
+    expect(canSkipPristineStartupStateMigrations(env)).toBe(true);
+  });
+
+  it("rejects existing state and migration-bearing agent config", () => {
+    expect(canSkipPristineStartupStateMigrations(createFixture({}, ["agents"]))).toBe(false);
+    expect(
+      canSkipPristineStartupStateMigrations(
+        createFixture({ agents: { defaults: { memorySearch: { provider: "local" } } } }),
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts normal agent/model config backed by a stateless bundled plugin", () => {
+    const env = addBundledPlugin(
+      createFixture({
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-5.6" },
+            models: { "openai/gpt-5.6": { agentRuntime: { id: "openclaw" } } },
+            workspace: "/tmp/workspace",
+          },
+          list: [{ id: "main", workspace: "/tmp/workspace" }],
+        },
+        plugins: { enabled: true, allow: ["openai"], entries: { openai: { enabled: true } } },
+        skills: { allowBundled: [] },
+      }),
+      "openai",
+    );
+
+    expect(canSkipPristineStartupStateMigrations(env)).toBe(true);
+  });
+
+  it("retains migrations for bundled plugins with doctor state surfaces", () => {
+    const env = addBundledPlugin(
+      createFixture({ plugins: { entries: { example: { enabled: true } } } }),
+      "example",
+      { doctorContract: true },
+    );
+
+    expect(canSkipPristineStartupStateMigrations(env)).toBe(false);
+  });
+
+  it("rejects enabled plugin entries and includes", () => {
+    expect(
+      canSkipPristineStartupStateMigrations(
+        createFixture({ plugins: { entries: { example: { enabled: true } } } }),
+      ),
+    ).toBe(false);
+    expect(canSkipPristineStartupStateMigrations(createFixture({ $include: "base.json" }))).toBe(
+      false,
+    );
+  });
+});

--- a/src/commands/doctor/shared/pristine-startup-state.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.ts
@@ -1,0 +1,141 @@
+// Proves when a new state root cannot contain legacy state migration work.
+import fs from "node:fs";
+import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  resolveConfigPath,
+  resolveLegacyStateDirs,
+  resolveStateDir,
+} from "../../../config/paths.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { resolveEffectiveHomeDir } from "../../../infra/home-dir.js";
+import { tryReadJsonSync } from "../../../infra/json-files.js";
+import { inspectBundledPluginStartupMetadata } from "../../../plugins/bundled-plugin-startup-metadata.js";
+import { configMayRequireStartupPluginConvergence } from "./startup-plugin-convergence-plan.js";
+
+const STATEFUL_CONFIG_KEYS = new Set([
+  "accessGroups",
+  "acp",
+  "approvals",
+  "audio",
+  "bindings",
+  "broadcast",
+  "channels",
+  "cloudWorkers",
+  "commitments",
+  "cron",
+  "discovery",
+  "env",
+  "hooks",
+  "marketplaces",
+  "mcp",
+  "media",
+  "memory",
+  "messages",
+  "nodeHost",
+  "proxy",
+  "secrets",
+  "session",
+  "surfaces",
+  "talk",
+  "tools",
+  "transcripts",
+  "web",
+]);
+
+function containsObjectKey(value: unknown, targetKey: string): boolean {
+  if (Array.isArray(value)) {
+    return value.some((entry) => containsObjectKey(entry, targetKey));
+  }
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    Object.hasOwn(value, targetKey) ||
+    Object.values(value).some((entry) => containsObjectKey(entry, targetKey))
+  );
+}
+
+function hasOnlyMigrationSafePluginEntries(
+  config: Record<string, unknown>,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  const plugins = config.plugins;
+  if (!isRecord(plugins)) {
+    return plugins === undefined;
+  }
+  if (Object.keys(plugins).some((key) => !["enabled", "entries", "allow", "deny"].includes(key))) {
+    return false;
+  }
+  if (!isRecord(plugins.entries)) {
+    return plugins.entries === undefined;
+  }
+  return Object.entries(plugins.entries).every(([pluginId, entry]) => {
+    if (!isRecord(entry)) {
+      return false;
+    }
+    if (entry.enabled === false) {
+      return true;
+    }
+    if (entry.config !== undefined) {
+      return false;
+    }
+    const metadata = inspectBundledPluginStartupMetadata({ pluginId, env });
+    return Boolean(metadata && !metadata.hasDoctorContract);
+  });
+}
+
+function configIsPristineStateSafe(configPath: string, env: NodeJS.ProcessEnv): boolean {
+  const config = tryReadJsonSync(configPath);
+  if (!isRecord(config) || Object.hasOwn(config, "$include")) {
+    return false;
+  }
+  if ([...STATEFUL_CONFIG_KEYS].some((key) => Object.hasOwn(config, key))) {
+    return false;
+  }
+  if (containsObjectKey(config.agents, "memorySearch")) {
+    return false;
+  }
+  if (!hasOnlyMigrationSafePluginEntries(config, env)) {
+    return false;
+  }
+  return !configMayRequireStartupPluginConvergence({
+    config: config as OpenClawConfig,
+    env,
+  });
+}
+
+function stateDirHasOnlyConfig(stateDir: string, configPath: string): boolean {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(stateDir, { withFileTypes: true });
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ENOENT";
+  }
+  const resolvedConfigPath = path.resolve(configPath);
+  return entries.every((entry) => path.resolve(stateDir, entry.name) === resolvedConfigPath);
+}
+
+/**
+ * A missing/empty state root plus migration-free bundled config has no legacy data to migrate.
+ * Keep ambiguity on the full migration path; this shortcut only accepts a proven new install.
+ */
+export function canSkipPristineStartupStateMigrations(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const stateDir = resolveStateDir(env);
+  const configPath = resolveConfigPath(env, stateDir);
+  if (!configIsPristineStateSafe(configPath, env) || !stateDirHasOnlyConfig(stateDir, configPath)) {
+    return false;
+  }
+  const homeDir = resolveEffectiveHomeDir(env);
+  if (!homeDir) {
+    return false;
+  }
+  return resolveLegacyStateDirs(() => homeDir).every((legacyDir) => {
+    if (path.resolve(legacyDir) === path.resolve(stateDir)) {
+      return false;
+    }
+    return !fs.existsSync(legacyDir);
+  });
+}

--- a/src/commands/doctor/shared/startup-plugin-convergence-plan.test.ts
+++ b/src/commands/doctor/shared/startup-plugin-convergence-plan.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadInstalledPluginIndexInstallRecords = vi.hoisted(() => vi.fn(async () => ({})));
+const inspectBundledPluginStartupMetadata = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../plugins/installed-plugin-index-record-reader.js", () => ({
+  loadInstalledPluginIndexInstallRecords,
+}));
+vi.mock("../../../plugins/bundled-plugin-startup-metadata.js", () => ({
+  inspectBundledPluginStartupMetadata,
+}));
+
+const { configMayRequireStartupPluginConvergence, planStartupPluginConvergence } =
+  await import("./startup-plugin-convergence-plan.js");
+
+describe("startup plugin convergence planning", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadInstalledPluginIndexInstallRecords.mockResolvedValue({});
+    inspectBundledPluginStartupMetadata.mockReturnValue(undefined);
+  });
+
+  it("keeps a fresh core-only Gateway config out of the plugin repair runtime", async () => {
+    const env = {};
+    const plan = await planStartupPluginConvergence({
+      config: { gateway: { mode: "local", port: 19091 } },
+      env,
+    });
+
+    expect(plan).toEqual({ required: false, installRecords: {} });
+    expect(loadInstalledPluginIndexInstallRecords).toHaveBeenCalledWith({ env });
+  });
+
+  it("carries managed install records into convergence", async () => {
+    const installRecords = {
+      discord: { source: "npm" as const, installPath: "/plugins/discord" },
+    };
+    loadInstalledPluginIndexInstallRecords.mockResolvedValueOnce(installRecords);
+
+    await expect(planStartupPluginConvergence({ config: {}, env: {} })).resolves.toEqual({
+      required: true,
+      installRecords,
+    });
+  });
+
+  it("retains convergence for explicit plugin and runtime configuration", () => {
+    expect(
+      configMayRequireStartupPluginConvergence({
+        config: { plugins: { entries: { example: { enabled: true } } } },
+        env: {},
+      }),
+    ).toBe(true);
+    expect(
+      configMayRequireStartupPluginConvergence({
+        config: { acp: { enabled: true } },
+        env: {},
+      }),
+    ).toBe(true);
+  });
+
+  it("does not repair configured plugins already bundled with the host", () => {
+    inspectBundledPluginStartupMetadata.mockReturnValue({ hasDoctorContract: false });
+
+    expect(
+      configMayRequireStartupPluginConvergence({
+        config: { plugins: { entries: { openai: { enabled: true } } } },
+        env: {},
+      }),
+    ).toBe(false);
+  });
+
+  it("does not infer plugin work from core OpenAI model configuration", () => {
+    expect(
+      configMayRequireStartupPluginConvergence({
+        config: {
+          models: { providers: { openai: { api: "openai-responses", models: [] } } },
+        },
+        env: { OPENAI_API_KEY: "redacted" },
+      }),
+    ).toBe(false);
+  });
+
+  it("retains convergence for official external provider configuration", () => {
+    expect(
+      configMayRequireStartupPluginConvergence({
+        config: { agents: { defaults: { model: { primary: "groq/llama-3.3-70b" } } } },
+        env: {},
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/commands/doctor/shared/startup-plugin-convergence-plan.test.ts
+++ b/src/commands/doctor/shared/startup-plugin-convergence-plan.test.ts
@@ -73,7 +73,15 @@ describe("startup plugin convergence planning", () => {
     expect(
       configMayRequireStartupPluginConvergence({
         config: {
-          models: { providers: { openai: { api: "openai-responses", models: [] } } },
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                api: "openai-responses",
+                models: [],
+              },
+            },
+          },
         },
         env: { OPENAI_API_KEY: "redacted" },
       }),

--- a/src/commands/doctor/shared/startup-plugin-convergence-plan.ts
+++ b/src/commands/doctor/shared/startup-plugin-convergence-plan.ts
@@ -1,0 +1,155 @@
+// Plans first-start plugin convergence without loading the repair/catalog runtime.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { PluginInstallRecord } from "../../../config/types.plugins.js";
+import { inspectBundledPluginStartupMetadata } from "../../../plugins/bundled-plugin-startup-metadata.js";
+import { resolveConfiguredGenericEmbeddingProviderId } from "../../../plugins/embedding-provider-config.js";
+import { collectConfiguredSpeechProviderIds } from "../../../plugins/gateway-startup-speech-providers.js";
+import { loadInstalledPluginIndexInstallRecords } from "../../../plugins/installed-plugin-index-record-reader.js";
+import {
+  hasOfficialExternalChannelTarget,
+  hasOfficialExternalContractTarget,
+  hasOfficialExternalProviderTarget,
+  hasOfficialExternalWebContractEnvTarget,
+  hasOfficialExternalWebSearchTarget,
+} from "../../../plugins/official-external-plugin-targets.js";
+import { collectConfiguredProviderSelectionIds } from "./configured-provider-selection-ids.js";
+import { collectConfiguredRuntimePluginIds } from "./configured-runtime-plugin-installs.js";
+
+export type StartupPluginConvergencePlan = {
+  required: boolean;
+  installRecords: Record<string, PluginInstallRecord>;
+};
+
+function hasPotentialPluginConfig(config: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
+  if (config.plugins?.enabled === false) {
+    return false;
+  }
+  const entries = config.plugins?.entries;
+  if (!isRecord(entries)) {
+    return false;
+  }
+  return Object.entries(entries).some(([pluginId, entry]) => {
+    if (isRecord(entry) && entry.enabled === false) {
+      return false;
+    }
+    return !inspectBundledPluginStartupMetadata({ pluginId, env });
+  });
+}
+
+function collectConfiguredMemoryEmbeddingProviderIds(config: OpenClawConfig): ReadonlySet<string> {
+  const providerIds = new Set<string>();
+  const add = (value: unknown) => {
+    const providerId = normalizeOptionalLowercaseString(value);
+    if (!providerId || providerId === "none" || providerId === "auto") {
+      return;
+    }
+    providerIds.add(providerId);
+    const ownerId = resolveConfiguredGenericEmbeddingProviderId(providerId, config);
+    if (ownerId) {
+      providerIds.add(ownerId);
+    }
+  };
+  const defaults = config.agents?.defaults?.memorySearch;
+  if (defaults?.enabled !== false) {
+    add(defaults?.provider);
+    add(defaults?.fallback);
+  }
+  for (const agent of config.agents?.list ?? []) {
+    if (agent.memorySearch?.enabled === false) {
+      continue;
+    }
+    add(agent.memorySearch?.provider ?? defaults?.provider);
+    add(agent.memorySearch?.fallback ?? defaults?.fallback);
+  }
+  return providerIds;
+}
+
+function hasConfiguredCapabilityPlugin(config: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
+  const memoryEmbeddingProviderIds = collectConfiguredMemoryEmbeddingProviderIds(config);
+  if (memoryEmbeddingProviderIds.size > 0) {
+    if (
+      hasOfficialExternalContractTarget({
+        contract: "memoryEmbeddingProviders",
+        providerIds: memoryEmbeddingProviderIds,
+      })
+    ) {
+      return true;
+    }
+  }
+  const speechProviderIds = collectConfiguredSpeechProviderIds(config);
+  if (
+    hasOfficialExternalContractTarget({
+      contract: "speechProviders",
+      providerIds: speechProviderIds,
+    })
+  ) {
+    return true;
+  }
+  const webFetchProviderId = normalizeOptionalLowercaseString(config.tools?.web?.fetch?.provider);
+  if (
+    webFetchProviderId &&
+    hasOfficialExternalContractTarget({
+      contract: "webFetchProviders",
+      providerIds: new Set([webFetchProviderId]),
+    })
+  ) {
+    return true;
+  }
+  return hasOfficialExternalWebContractEnvTarget({
+    contract: "webFetchProviders",
+    env,
+  });
+}
+
+/** True when config or environment state can require a missing managed plugin repair. */
+export function configMayRequireStartupPluginConvergence(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): boolean {
+  if (params.config.plugins?.enabled === false) {
+    return false;
+  }
+  if (hasPotentialPluginConfig(params.config, params.env)) {
+    return true;
+  }
+  if (collectConfiguredRuntimePluginIds(params.config).length > 0) {
+    return true;
+  }
+  if (
+    hasOfficialExternalProviderTarget({
+      providerIds: collectConfiguredProviderSelectionIds(params.config),
+      env: params.env,
+    })
+  ) {
+    return true;
+  }
+  if (hasOfficialExternalChannelTarget(params)) {
+    return true;
+  }
+  const webSearchProvider = params.config.tools?.web?.search?.provider;
+  if (
+    params.config.tools?.web?.search?.enabled !== false &&
+    hasOfficialExternalWebSearchTarget({
+      providerId: typeof webSearchProvider === "string" ? webSearchProvider : undefined,
+      env: params.env,
+    })
+  ) {
+    return true;
+  }
+  return hasConfiguredCapabilityPlugin(params.config, params.env);
+}
+
+/** Carries the canonical install-record snapshot into the expensive convergence pass. */
+export async function planStartupPluginConvergence(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): Promise<StartupPluginConvergencePlan> {
+  const installRecords = await loadInstalledPluginIndexInstallRecords({ env: params.env });
+  return {
+    required:
+      Object.keys(installRecords).length > 0 || configMayRequireStartupPluginConvergence(params),
+    installRecords,
+  };
+}

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -1216,6 +1216,10 @@ describe("startGatewayPostAttachRuntime", () => {
     );
   });
 
+  it("starts agent runtime plugin prewarm in the first post-ready turn", () => {
+    expect(testing.agentRuntimePluginPrewarmStartDelayMs).toBe(0);
+  });
+
   it("keeps provider auth prewarm alive when Gmail post-ready sidecars stop", async () => {
     vi.useFakeTimers();
     const onPostReadySidecars = vi.fn();
@@ -1682,12 +1686,16 @@ describe("startGatewayPostAttachRuntime", () => {
   it("emits a startup trace span when channel startup is skipped", async () => {
     const trace = createStartupTraceRecorder();
     const logChannels = { info: vi.fn(), error: vi.fn() };
+    const prewarmPrimaryModel = vi.fn(async () => {});
 
     await withEnvAsync(
       { OPENCLAW_SKIP_CHANNELS: "1", OPENCLAW_SKIP_PROVIDERS: undefined },
       async () => {
         await startGatewaySidecars({
-          cfg: { hooks: { internal: { enabled: false } } } as never,
+          cfg: {
+            hooks: { internal: { enabled: false } },
+            agents: { defaults: { model: "openai/gpt-5.6" } },
+          } as never,
           pluginRegistry: createPostAttachParams().pluginRegistry,
           defaultWorkspaceDir: "/tmp/openclaw-workspace",
           deps: {} as never,
@@ -1700,10 +1708,14 @@ describe("startGatewayPostAttachRuntime", () => {
           },
           logChannels,
           startupTrace: trace.startupTrace,
+          prewarmPrimaryModel,
         });
       },
     );
 
+    await vi.waitFor(() => {
+      expect(prewarmPrimaryModel).toHaveBeenCalledOnce();
+    });
     expect(trace.measures).toContain("sidecars.channels");
     expect(trace.measures).toContain("sidecars.channel-skip");
     expect(logChannels.info).toHaveBeenCalledWith(

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -40,7 +40,7 @@ const PRIMARY_MODEL_PREWARM_TIMEOUT_MS = 5_000;
 const STARTUP_PROVIDER_DISCOVERY_TIMEOUT_MS = 5_000;
 const PROVIDER_AUTH_PREWARM_START_DELAY_MS = 5_000;
 const PROVIDER_AUTH_REWARM_DELAY_MS = 1_000;
-const AGENT_RUNTIME_PLUGIN_PREWARM_START_DELAY_MS = 10_000;
+const AGENT_RUNTIME_PLUGIN_PREWARM_START_DELAY_MS = 0;
 const DEFERRED_SIDECAR_START_DELAY_MS = 100;
 const SESSION_LOCK_CLEANUP_CONCURRENCY = 4;
 const SKIP_STARTUP_MODEL_PREWARM_ENV = "OPENCLAW_SKIP_STARTUP_MODEL_PREWARM";
@@ -746,6 +746,17 @@ export async function startGatewaySidecars(params: {
   const skipChannels =
     isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
     isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS);
+  // Agent RPC remains available when transport startup is disabled, so its model metadata must
+  // warm independently instead of leaving the first headless request on the cold path.
+  schedulePrimaryModelPrewarm(
+    {
+      cfg: params.cfg,
+      workspaceDir: params.defaultWorkspaceDir,
+      log: params.log,
+      startupTrace: params.startupTrace,
+    },
+    params.prewarmPrimaryModel,
+  );
   await measureStartup(params.startupTrace, "sidecars.main-session-recovery", async () => {
     try {
       const { markStartupOrphanedMainSessionsForRecovery } =
@@ -760,15 +771,6 @@ export async function startGatewaySidecars(params: {
   await measureStartup(params.startupTrace, "sidecars.channels", async () => {
     if (!skipChannels) {
       try {
-        schedulePrimaryModelPrewarm(
-          {
-            cfg: params.cfg,
-            workspaceDir: params.defaultWorkspaceDir,
-            log: params.log,
-            startupTrace: params.startupTrace,
-          },
-          params.prewarmPrimaryModel,
-        );
         await measureStartup(params.startupTrace, "sidecars.channel-start", () =>
           params.startChannels(),
         );
@@ -1452,6 +1454,7 @@ export async function startGatewayPostAttachRuntime(
 }
 
 export const testing = {
+  agentRuntimePluginPrewarmStartDelayMs: AGENT_RUNTIME_PLUGIN_PREWARM_START_DELAY_MS,
   providerAuthPrewarmStartDelayMs: PROVIDER_AUTH_PREWARM_START_DELAY_MS,
   hasRestartSentinelFast,
   prewarmConfiguredPrimaryModel,

--- a/src/plugins/bundled-plugin-startup-metadata.ts
+++ b/src/plugins/bundled-plugin-startup-metadata.ts
@@ -1,0 +1,40 @@
+// Narrow bundled-plugin facts used before the full metadata/runtime registry is available.
+import fs from "node:fs";
+import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { tryReadJsonSync } from "../infra/json-files.js";
+import { resolveBundledPluginsDir } from "./bundled-dir.js";
+
+const DOCTOR_CONTRACT_BASENAMES = ["doctor-contract-api", "contract-api"] as const;
+const MODULE_EXTENSIONS = ["js", "cjs", "mjs", "ts", "cts", "mts"] as const;
+
+export type BundledPluginStartupMetadata = {
+  hasDoctorContract: boolean;
+};
+
+function hasDoctorContractArtifact(pluginRoot: string): boolean {
+  return [pluginRoot, path.join(pluginRoot, "dist")].some((root) =>
+    DOCTOR_CONTRACT_BASENAMES.some((basename) =>
+      MODULE_EXTENSIONS.some((extension) =>
+        fs.existsSync(path.join(root, `${basename}.${extension}`)),
+      ),
+    ),
+  );
+}
+
+/** Resolves one exact bundled id without scanning or materializing the full plugin catalog. */
+export function inspectBundledPluginStartupMetadata(params: {
+  pluginId: string;
+  env: NodeJS.ProcessEnv;
+}): BundledPluginStartupMetadata | undefined {
+  const bundledPluginsDir = resolveBundledPluginsDir(params.env);
+  if (!bundledPluginsDir) {
+    return undefined;
+  }
+  const pluginRoot = path.join(bundledPluginsDir, params.pluginId);
+  const manifest = tryReadJsonSync(path.join(pluginRoot, "openclaw.plugin.json"));
+  if (!isRecord(manifest) || manifest.id !== params.pluginId) {
+    return undefined;
+  }
+  return { hasDoctorContract: hasDoctorContractArtifact(pluginRoot) };
+}

--- a/src/plugins/official-external-plugin-bundled-catalogs.ts
+++ b/src/plugins/official-external-plugin-bundled-catalogs.ts
@@ -1,0 +1,16 @@
+// Generated bundled catalogs shared by full catalog loading and startup projections.
+import channelCatalog from "../../scripts/lib/official-external-channel-catalog.json" with { type: "json" };
+import pluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
+import providerCatalog from "../../scripts/lib/official-external-provider-catalog.json" with { type: "json" };
+
+export const BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOGS = [
+  channelCatalog,
+  providerCatalog,
+  pluginCatalog,
+] as const;
+
+export const BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_ENTRIES: readonly unknown[] = [
+  ...channelCatalog.entries,
+  ...providerCatalog.entries,
+  ...pluginCatalog.entries,
+];

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -2,9 +2,6 @@
 import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import officialExternalChannelCatalog from "../../scripts/lib/official-external-channel-catalog.json" with { type: "json" };
-import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
-import officialExternalProviderCatalog from "../../scripts/lib/official-external-provider-catalog.json" with { type: "json" };
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import { normalizeClawHubSha256Integrity } from "../infra/clawhub.js";
 import { readResponseWithLimit } from "../infra/http-body.js";
@@ -16,6 +13,7 @@ import type {
   PluginManifestProviderEndpoint,
   PluginPackageInstall,
 } from "./manifest.js";
+import { BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOGS } from "./official-external-plugin-bundled-catalogs.js";
 
 type ManifestKey = typeof MANIFEST_KEY;
 
@@ -244,12 +242,6 @@ type OfficialExternalProviderContract =
   | "memoryEmbeddingProviders"
   | "speechProviders"
   | "webFetchProviders";
-
-const OFFICIAL_CATALOG_SOURCES = [
-  officialExternalChannelCatalog,
-  officialExternalProviderCatalog,
-  officialExternalPluginCatalog,
-] as const;
 
 const SUPPORTED_OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSIONS = new Set([1, 2]);
 export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL =
@@ -580,7 +572,7 @@ async function readHostedCatalogResponseText(params: {
 }
 
 function bundledOfficialExternalPluginCatalogEntries(): OfficialExternalPluginCatalogEntry[] {
-  return OFFICIAL_CATALOG_SOURCES.flatMap((source) =>
+  return BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOGS.flatMap((source) =>
     filterOfficialExternalPluginCatalogEntriesBySourceRefs(
       parseOfficialExternalPluginCatalogEntries(source),
     ),

--- a/src/plugins/official-external-plugin-targets.ts
+++ b/src/plugins/official-external-plugin-targets.ts
@@ -1,0 +1,122 @@
+// Lightweight static projections for deciding whether plugin repair can be skipped.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_ENTRIES } from "./official-external-plugin-bundled-catalogs.js";
+
+type StaticProvider = {
+  id?: string;
+  aliases?: readonly string[];
+  envVars?: readonly string[];
+};
+
+type StaticWebProvider = {
+  id?: string;
+  envVars?: readonly string[];
+};
+
+type StaticManifest = {
+  channel?: { id?: string; envVars?: readonly string[] };
+  contracts?: Record<string, readonly string[]>;
+  providers?: readonly StaticProvider[];
+  webSearchProviders?: readonly StaticWebProvider[];
+};
+
+type StaticEntry = { openclaw?: StaticManifest };
+
+const STATIC_ENTRIES = BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_ENTRIES as readonly StaticEntry[];
+
+function normalizeIds(values: Iterable<string>): Set<string> {
+  return new Set(
+    [...values]
+      .map((value) => normalizeOptionalLowercaseString(value))
+      .filter((value): value is string => Boolean(value)),
+  );
+}
+
+function envHasAny(env: NodeJS.ProcessEnv, names: readonly string[] | undefined): boolean {
+  return names?.some((name) => Boolean(env[name]?.trim())) ?? false;
+}
+
+export function hasOfficialExternalProviderTarget(params: {
+  providerIds: Iterable<string>;
+  env: NodeJS.ProcessEnv;
+}): boolean {
+  const providerIds = normalizeIds(params.providerIds);
+  return STATIC_ENTRIES.some((entry) =>
+    entry.openclaw?.providers?.some(
+      (provider) =>
+        envHasAny(params.env, provider.envVars) ||
+        [provider.id, ...(provider.aliases ?? [])].some((providerId) => {
+          const normalized = normalizeOptionalLowercaseString(providerId);
+          return normalized ? providerIds.has(normalized) : false;
+        }),
+    ),
+  );
+}
+
+export function hasOfficialExternalContractTarget(params: {
+  contract: string;
+  providerIds: Iterable<string>;
+}): boolean {
+  const providerIds = normalizeIds(params.providerIds);
+  if (providerIds.size === 0) {
+    return false;
+  }
+  return STATIC_ENTRIES.some((entry) =>
+    entry.openclaw?.contracts?.[params.contract]?.some((providerId) => {
+      const normalized = normalizeOptionalLowercaseString(providerId);
+      return normalized ? providerIds.has(normalized) : false;
+    }),
+  );
+}
+
+export function hasOfficialExternalWebContractEnvTarget(params: {
+  contract: string;
+  env: NodeJS.ProcessEnv;
+}): boolean {
+  return STATIC_ENTRIES.some((entry) => {
+    const manifest = entry.openclaw;
+    const contractIds = normalizeIds(manifest?.contracts?.[params.contract] ?? []);
+    return manifest?.webSearchProviders?.some((provider) => {
+      const providerId = normalizeOptionalLowercaseString(provider.id);
+      return Boolean(
+        providerId && contractIds.has(providerId) && envHasAny(params.env, provider.envVars),
+      );
+    });
+  });
+}
+
+export function hasOfficialExternalChannelTarget(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): boolean {
+  const channels = isRecord(params.config.channels) ? params.config.channels : undefined;
+  return STATIC_ENTRIES.some((entry) => {
+    const channel = entry.openclaw?.channel;
+    const channelId = normalizeOptionalLowercaseString(channel?.id);
+    if (!channelId) {
+      return false;
+    }
+    const channelConfig = channels?.[channelId];
+    return (
+      (isRecord(channelConfig) && channelConfig.enabled !== false) ||
+      envHasAny(params.env, channel?.envVars)
+    );
+  });
+}
+
+export function hasOfficialExternalWebSearchTarget(params: {
+  providerId?: string;
+  env: NodeJS.ProcessEnv;
+}): boolean {
+  const configuredId = normalizeOptionalLowercaseString(params.providerId);
+  return STATIC_ENTRIES.some((entry) =>
+    entry.openclaw?.webSearchProviders?.some((provider) => {
+      const providerId = normalizeOptionalLowercaseString(provider.id);
+      return Boolean(
+        (configuredId && providerId === configuredId) || envHasAny(params.env, provider.envVars),
+      );
+    }),
+  );
+}

--- a/src/plugins/official-external-plugin-targets.ts
+++ b/src/plugins/official-external-plugin-targets.ts
@@ -114,8 +114,9 @@ export function hasOfficialExternalWebSearchTarget(params: {
   return STATIC_ENTRIES.some((entry) =>
     entry.openclaw?.webSearchProviders?.some((provider) => {
       const providerId = normalizeOptionalLowercaseString(provider.id);
-      return Boolean(
-        (configuredId && providerId === configuredId) || envHasAny(params.env, provider.envVars),
+      return (
+        (configuredId !== undefined && providerId === configuredId) ||
+        envHasAny(params.env, provider.envVars)
       );
     }),
   );


### PR DESCRIPTION
Closes #105745
Closes #105779

## What Problem This Solves

Fixes an issue where users starting a fresh Gateway would wait several extra seconds before readiness, then pay another cold plugin-registry load when sending an agent request immediately after startup.

The startup migration checkpoint imported the full legacy/plugin repair runtime even when a new state root had no migration work. Separately, runtime-plugin prewarming waited ten seconds after readiness, and primary-model metadata prewarming was skipped entirely when channel startup was disabled.

## Why This Change Was Made

Gateway bootstrap now carries an immutable pre-bootstrap fact for proven-new state roots, uses lightweight static plugin/config projections before importing repair runtime, and preserves the full migration/convergence path whenever configured state is ambiguous, externally managed, or migration-capable. Post-ready runtime-plugin warming begins in the first event-loop turn, and primary-model metadata warming no longer depends on channel transports.

The refactor also separates provider-selection collection from installed-registry discovery and shares generated bundled/external catalog inputs through narrow metadata leaves. No migration, plugin repair, payload smoke, config guard, or checkpoint safety condition was removed.

## User Impact

Fresh and short-lived Gateways become ready much faster. Immediate first agent turns no longer absorb the runtime-plugin registry load, while repeated turns retain the existing low fixed overhead.

Release-note context: faster Gateway cold starts and first agent turns; no config or operator action required.

## Evidence

Live AWS Crabbox, Node 24, real `openai/gpt-5.6`, same c7a.48xlarge lease:

- Gateway readiness: 8,286.7 ms -> 5,357.2 ms (35.4% faster).
- First-turn embedded startup: 611 ms -> 344 ms (43.7% faster).
- First-turn runtime-plugin preparation: 214 ms -> 0-1 ms (>99% lower).
- Warm-turn startup: 34-38 ms -> 15 ms.
- Three substantial build/test/refactor turns completed successfully in `run_432375c2aa12`; three short tool-using turns completed in each before/after run.
- Baseline short run: https://crabbox.openclaw.ai/portal/runs/run_7e499db969c0
- Final short run: https://crabbox.openclaw.ai/portal/runs/run_3c23863b9d99

Synthetic five-sample Gateway matrix:

- Default `/readyz` p50: 4,043.6 ms -> 3,578.6 ms (11.5% faster).
- `OPENCLAW_SKIP_CHANNELS=1` p50: 3,973.1 ms -> 3,502.4 ms (11.8% faster).
- `cli.main.gateway-run-bootstrap` p50: 2,329.8 ms -> 108.4 ms (95.3% lower).
- Fifty-plugin config remained on the full safety path: 3,921.6 ms -> 3,896.4 ms.

Implementation commit `97ae4b0bb173`:

- `pnpm build` including CLI bootstrap import guard: passed.
- 189 focused Gateway/doctor/plugin tests: passed.
- `pnpm tsgo:core`: passed.
- Crabbox run: https://crabbox.openclaw.ai/portal/runs/run_70ed648c14f9

Final head `6225899ade39` additionally passed:

- Full remote lint and complete `check:test-types` (`run_09fe1d25d7f0`).
- 62 affected CLI/doctor tests (`run_037c2a95b667`).
- Touched-file `oxfmt --check` (`run_955ae955bc5d`).
- Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/29216784040
- Fresh structured Codex autoreview: no findings (`patch is correct`, confidence 0.95).

Broader focused regression pass: 433 tests passed across Gateway, CLI, doctor, and official plugin catalog surfaces (`run_b557aef3196b`).

Blacksmith Testbox became unavailable during two fresh post-rebase hydrations; final remote proof therefore ran on the already-hydrated trusted AWS Crabbox and exact-head hosted CI. Live OpenAI evidence predates the final test-only repair; the affected lint, type, tests, formatting, autoreview, and hosted CI were rerun afterward.

AI-assisted implementation and review.
