### PR TITLE
fix(recovery): reclaim terminal-phase reply operations in stuck-session recovery

### DIFF
--- a/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
@@ -15,20 +15,20 @@ import { testing as replyRunTesting } from "../auto-reply/reply/reply-run-regist
 import { enqueueCommandInLane, getQueueSize, resetCommandLane } from "../process/command-queue.js";
 import { resetCommandQueueStateForTest } from "../process/command-queue.test-support.js";
 import { resetDiagnosticRunActivityForTest } from "./diagnostic-run-activity.js";
-import {
-  testing as recoveryTesting,
-  recoverStuckDiagnosticSession,
-} from "./diagnostic-stuck-session-recovery.runtime.js";
+import type { SessionAttentionClassification } from "./diagnostic-session-attention.js";
 import {
   requestStuckSessionRecoveryOutcome,
   resetDiagnosticSessionRecoveryCoordinatorForTest,
 } from "./diagnostic-session-recovery-coordinator.js";
-import type { SessionAttentionClassification } from "./diagnostic-session-attention.js";
-import { logSessionStateChange, logMessageQueued } from "./diagnostic.js";
 import {
   getDiagnosticSessionState,
   resetDiagnosticSessionStateForTest,
 } from "./diagnostic-session-state.js";
+import {
+  testing as recoveryTesting,
+  recoverStuckDiagnosticSession,
+} from "./diagnostic-stuck-session-recovery.runtime.js";
+import { logSessionStateChange, logMessageQueued } from "./diagnostic.js";
 
 async function expectPendingAfterEventLoopTurn(promise: Promise<unknown>): Promise<void> {
   let settled = false;

--- a/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
@@ -448,7 +448,7 @@ describe("stuck session recovery integration", () => {
       eventType: "session.stuck",
       reason: "stale_session_state",
       classification: "stale_session_state",
-      activeWorkKind: "embedded_run",
+      activeWorkKind: undefined,
       recoveryEligible: true,
     };
 

--- a/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
@@ -6,14 +6,29 @@ import {
   setActiveEmbeddedRun,
 } from "../agents/embedded-agent-runner/runs.js";
 import { testing as embeddedRunTesting } from "../agents/embedded-agent-runner/runs.test-support.js";
-import { createReplyOperation } from "../auto-reply/reply/reply-run-registry.js";
+import {
+  REPLY_RUN_TERMINAL_SETTLE_TIMEOUT_MS,
+  type ReplyOperation,
+  createReplyOperation,
+} from "../auto-reply/reply/reply-run-registry.js";
 import { testing as replyRunTesting } from "../auto-reply/reply/reply-run-registry.test-support.js";
 import { enqueueCommandInLane, getQueueSize, resetCommandLane } from "../process/command-queue.js";
 import { resetCommandQueueStateForTest } from "../process/command-queue.test-support.js";
+import { resetDiagnosticRunActivityForTest } from "./diagnostic-run-activity.js";
 import {
   testing as recoveryTesting,
   recoverStuckDiagnosticSession,
 } from "./diagnostic-stuck-session-recovery.runtime.js";
+import {
+  requestStuckSessionRecoveryOutcome,
+  resetDiagnosticSessionRecoveryCoordinatorForTest,
+} from "./diagnostic-session-recovery-coordinator.js";
+import type { SessionAttentionClassification } from "./diagnostic-session-attention.js";
+import { logSessionStateChange, logMessageQueued } from "./diagnostic.js";
+import {
+  getDiagnosticSessionState,
+  resetDiagnosticSessionStateForTest,
+} from "./diagnostic-session-state.js";
 
 async function expectPendingAfterEventLoopTurn(promise: Promise<unknown>): Promise<void> {
   let settled = false;
@@ -31,12 +46,21 @@ async function expectPendingAfterEventLoopTurn(promise: Promise<unknown>): Promi
   expect(settled).toBe(false);
 }
 
+function delay(ms: number): Promise<"blocked"> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve("blocked"), ms);
+  });
+}
+
 describe("stuck session recovery integration", () => {
   afterEach(() => {
     recoveryTesting.resetRecoveriesInFlight();
     embeddedRunTesting.resetActiveEmbeddedRuns();
     replyRunTesting.resetReplyRunRegistry();
     resetCommandQueueStateForTest();
+    resetDiagnosticSessionRecoveryCoordinatorForTest();
+    resetDiagnosticSessionStateForTest();
+    resetDiagnosticRunActivityForTest();
   });
 
   it("does not reset a blocked lane while a reply operation is still active", async () => {
@@ -302,5 +326,174 @@ describe("stuck session recovery integration", () => {
 
     expect(resetCommandLane(lane)).toBe(1);
     await expect(queued).resolves.toBe("drained");
+  });
+
+  describe("terminal-phase reclaim (#105712)", () => {
+    // Phantom terminal-phase reply operations stay in the registry when:
+    // - fail() + retainFailureUntilComplete (failed phase, retained until complete())
+    // - abortByUser() on a running operation (aborted phase, 60s settle window)
+    // complete() calls clearState() immediately, so "completed" phantoms
+    // are never in the registry at recovery time. Only "failed" (with
+    // retainFailureUntilComplete) and "aborted" (post-backend abortByUser)
+    // remain registered.
+    // The recovery sees isEmbeddedAgentRunActive=true via the reply-run registry.
+    //
+    // E2E reclaim proof: clears diagnostic activity to simulate a stale phantom
+    // (no recent progress events). The terminal settle window guard then falls
+    // back to params.ageMs (> 60s), allowing the reclaim path to fire.
+
+    async function runReclaimProof(
+      label: string,
+      setup: (op: ReplyOperation) => void,
+    ): Promise<void> {
+      const sessionKey = `agent:main:e2e-${label}`;
+      const sessionId = `e2e-${label}-session`;
+      const lane = resolveEmbeddedSessionLane(sessionKey);
+      const operation = createReplyOperation({
+        sessionKey,
+        sessionId,
+        resetTriggered: false,
+      });
+
+      setup(operation);
+
+      // Simulate stale diagnostic state: clear activity so the settle window
+      // guard falls back to params.ageMs (> 60s → reclaim).
+      resetDiagnosticRunActivityForTest();
+
+      // Queue a message that should be delivered after reclaim
+      const queued = enqueueCommandInLane(lane, async () => "drained", {
+        warnAfterMs: Number.MAX_SAFE_INTEGER,
+      });
+
+      const outcome = await recoverStuckDiagnosticSession({
+        sessionId,
+        sessionKey,
+        ageMs: REPLY_RUN_TERMINAL_SETTLE_TIMEOUT_MS + 1000,
+        queueDepth: 1,
+      });
+
+      // Type-narrow the discriminated union before accessing variant-only fields
+      expect(outcome.status).toBe("aborted");
+      expect(outcome.action).toBe("abort_embedded_run");
+      if (outcome.status === "aborted") {
+        expect(outcome.aborted).toBe(true);
+        expect(outcome.drained).toBe(true);
+      }
+
+      const result = await Promise.race([
+        queued,
+        new Promise<string>((r) => {
+          setTimeout(() => r("TIMEOUT"), 5000);
+        }),
+      ]);
+      expect(result).toBe("drained");
+    }
+
+    it("reclaims a terminal failed phantom (retainFailureUntilComplete) and delivers queued messages", async () => {
+      await runReclaimProof("failed", (op) => {
+        op.retainFailureUntilComplete();
+        op.fail("run_failed", new Error("e2e phantom"));
+      });
+    });
+
+    it("reclaims a terminal aborted phantom (running → abortByUser) and delivers queued messages", async () => {
+      await runReclaimProof("aborted", (op) => {
+        op.setPhase("running");
+        op.abortByUser();
+      });
+    });
+
+    it("keeps the lane when a terminal reply operation is still within the settle window", async () => {
+      const sessionKey = "agent:main:terminal-settle";
+      const sessionId = "terminal-settle-session";
+      const lane = resolveEmbeddedSessionLane(sessionKey);
+      const operation = createReplyOperation({
+        sessionKey,
+        sessionId,
+        resetTriggered: false,
+      });
+      // fail with retainFailureUntilComplete keeps the operation in the registry
+      operation.retainFailureUntilComplete();
+      operation.fail("run_failed", new Error("simulated failure"));
+
+      // Block the lane with an unresponsive task
+      void enqueueCommandInLane(lane, () => new Promise<never>(() => {}), {
+        warnAfterMs: Number.MAX_SAFE_INTEGER,
+      });
+      const queued = enqueueCommandInLane(lane, async () => "drained", {
+        warnAfterMs: Number.MAX_SAFE_INTEGER,
+      });
+      expect(getQueueSize(lane)).toBe(2);
+
+      // Session age is well within the 60s settle window → recovery should NOT reclaim
+      await recoverStuckDiagnosticSession({
+        sessionId,
+        sessionKey,
+        ageMs: 30_000,
+        queueDepth: 1,
+      });
+
+      // Lane should still be blocked (settle window not expired)
+      await expect(Promise.race([queued, delay(100)])).resolves.toBe("blocked");
+      expect(getQueueSize(lane)).toBe(2);
+    });
+  });
+
+  describe("stuck session recovery coordinator integration", () => {
+    const sessionKey = "agent:main:coordinator-test";
+    const sessionId = "coordinator-test-session";
+
+    const staleClassification: SessionAttentionClassification = {
+      eventType: "session.stuck",
+      reason: "stale_session_state",
+      classification: "stale_session_state",
+      activeWorkKind: "embedded_run",
+      recoveryEligible: true,
+    };
+
+    it("reclaims a terminal-phase reply operation through the full coordinator pipeline and updates diagnostic state", async () => {
+      // 1. Create diagnostic session state: "processing"
+      logSessionStateChange({ sessionId, sessionKey, state: "processing" });
+      logMessageQueued({ sessionId, sessionKey, source: "test" });
+
+      // 2. Create phantom reply operation (terminal phase)
+      const operation = createReplyOperation({
+        sessionKey,
+        sessionId,
+        resetTriggered: false,
+      });
+      operation.retainFailureUntilComplete();
+      operation.fail("run_failed", new Error("coordinator phantom"));
+
+      // Clear diagnostic activity so the terminal settle guard falls back to ageMs
+      resetDiagnosticRunActivityForTest();
+
+      // 3. Call through the coordinator with the real runtime function
+      const outcome = await requestStuckSessionRecoveryOutcome({
+        recover: (params) =>
+          recoverStuckDiagnosticSession({
+            ...params,
+            sessionId,
+          }),
+        request: {
+          sessionId,
+          sessionKey,
+          ageMs: REPLY_RUN_TERMINAL_SETTLE_TIMEOUT_MS + 1000,
+          queueDepth: 1,
+          expectedState: "processing",
+        },
+        classification: staleClassification,
+      });
+
+      // 4. Verify outcome was returned from the runtime+coordinator pipeline
+      expect(outcome).toBeDefined();
+      expect(outcome?.status).toBe("aborted");
+      expect(outcome?.action).toBe("abort_embedded_run");
+
+      // 5. Verify: diagnostic session state was updated to "idle" by the coordinator
+      const state = getDiagnosticSessionState({ sessionId, sessionKey });
+      expect(state.state).toBe("idle");
+    });
   });
 });

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -405,6 +405,7 @@ describe("stuck session recovery", () => {
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
     mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
     mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    mocks.resolveEmbeddedAgentReplyRunPhase.mockReturnValue("running");
 
     await recoverStuckDiagnosticSession({
       sessionId: "queued-reply-session",
@@ -419,6 +420,103 @@ describe("stuck session recovery", () => {
     expect(warnLogMessages()).toEqual([
       "stuck session recovery outcome: status=skipped action=keep_lane sessionId=queued-reply-session sessionKey=agent:main:main activeSessionId=queued-reply-session activeWorkKind=embedded_run reason=active_reply_work",
     ]);
+  });
+
+  it.each(["failed", "aborted"])(
+    "reclaims terminal-phase reply operations (phase=%s, phantom embedded_run) instead of keeping the lane",
+    async (phase) => {
+      mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("phantom-reply-session");
+      mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+      mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
+      mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+      mocks.resolveEmbeddedAgentReplyRunPhase.mockReturnValue(phase);
+      mocks.abortEmbeddedAgentRun.mockReturnValue(true);
+      mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+      mocks.getCommandLaneActiveTaskIds.mockReturnValue([]);
+      mocks.getCommandLaneSnapshot.mockReturnValue({
+        lane: "session:agent:main:main",
+        queuedCount: 0,
+        activeCount: 0,
+        maxConcurrent: 1,
+        draining: false,
+        generation: 0,
+      });
+      mocks.resetCommandLane.mockReturnValue(1);
+
+      await recoverStuckDiagnosticSession({
+        sessionId: "phantom-reply-session",
+        sessionKey: "agent:main:main",
+        ageMs: 180_000,
+        queueDepth: 1,
+      });
+
+      expect(mocks.abortEmbeddedAgentRun).toHaveBeenCalledWith("phantom-reply-session");
+      expect(mocks.resetCommandLane).toHaveBeenCalledWith("session:agent:main:main");
+      expect(warnLogMessages()).toEqual([
+        `stuck session recovery reclaiming terminal reply operation: sessionId=phantom-reply-session sessionKey=agent:main:main age=180s queueDepth=1 activeSessionId=phantom-reply-session phase=${phase}`,
+        "stuck session recovery: sessionId=phantom-reply-session sessionKey=agent:main:main age=180s action=abort_embedded_run aborted=true drained=true released=1",
+        "stuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=phantom-reply-session sessionKey=agent:main:main activeSessionId=phantom-reply-session activeWorkKind=embedded_run lane=session:agent:main:main aborted=true drained=true forceCleared=false released=1",
+      ]);
+    },
+  );
+
+  it("keeps the lane when terminal-phase reply operation is still within the settle window", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("fresh-terminal-session");
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    mocks.resolveEmbeddedAgentReplyRunPhase.mockReturnValue("failed");
+    // lastProgressAgeMs = 30s — well within the 60s terminal settle window
+    mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({
+      lastProgressAgeMs: 30_000,
+    });
+
+    await recoverStuckDiagnosticSession({
+      sessionId: "fresh-terminal-session",
+      sessionKey: "agent:main:main",
+      ageMs: 180_000,
+      queueDepth: 1,
+    });
+
+    expect(mocks.abortEmbeddedAgentRun).not.toHaveBeenCalled();
+    expect(mocks.forceClearEmbeddedAgentRun).not.toHaveBeenCalled();
+    expect(mocks.resetCommandLane).not.toHaveBeenCalled();
+    expect(warnLogMessages().some((m) => m.includes("still within settle window"))).toBe(true);
+  });
+
+  it("reclaims no-progress reply operations (phase=running, phantom without diagnostic activity)", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("phantom-running-session");
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    mocks.resolveEmbeddedAgentReplyRunPhase.mockReturnValue("running");
+    mocks.abortEmbeddedAgentRun.mockReturnValue(true);
+    mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+    mocks.getCommandLaneActiveTaskIds.mockReturnValue([]);
+    mocks.getCommandLaneSnapshot.mockReturnValue({
+      lane: "session:agent:main:main",
+      queuedCount: 0,
+      activeCount: 0,
+      maxConcurrent: 1,
+      draining: false,
+      generation: 0,
+    });
+    mocks.resetCommandLane.mockReturnValue(1);
+    // getDiagnosticSessionActivitySnapshot returns {} (default reset) → lastProgressAgeMs undefined
+    // fallbackAgeMs falls back to params.ageMs = 720s → >= staleActiveProgressAbortMs (5 min)
+
+    await recoverStuckDiagnosticSession({
+      sessionId: "phantom-running-session",
+      sessionKey: "agent:main:main",
+      ageMs: 720_000,
+      queueDepth: 1,
+    });
+
+    expect(mocks.abortEmbeddedAgentRun).toHaveBeenCalledWith("phantom-running-session");
+    expect(mocks.resetCommandLane).toHaveBeenCalledWith("session:agent:main:main");
+    expect(warnLogMessages().some((m) => m.includes("reclaiming stale active reply work"))).toBe(
+      true,
+    );
   });
 
   it("aborts stale reply work without an embedded handle when active abort recovery is enabled", async () => {

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -10,6 +10,7 @@ import {
   resolveActiveEmbeddedRunHandleSessionId,
   resolveActiveEmbeddedRunHandleSessionIdBySessionFile,
 } from "../agents/embedded-agent-runner/runs.js";
+import { REPLY_RUN_TERMINAL_SETTLE_TIMEOUT_MS } from "../auto-reply/reply/reply-run-registry.js";
 import {
   getCommandLaneActiveTaskIds,
   getCommandLaneSnapshot,
@@ -61,6 +62,13 @@ function isActiveRunProgressStale(params: {
   sessionKey?: string;
   queueDepth?: number;
   staleAbortMs: number;
+  /**
+   * Fallback session age used when no diagnostic progress exists (e.g. a
+   * phantom reply operation that died before any progress event). Without
+   * this fallback, sessions with undefined lastProgressAgeMs are never
+   * reclaimed (#105712).
+   */
+  fallbackAgeMs?: number;
 }): boolean {
   if ((params.queueDepth ?? 0) <= 0) {
     return false;
@@ -70,7 +78,12 @@ function isActiveRunProgressStale(params: {
     sessionKey: params.sessionKey,
   });
   const lastProgressAgeMs = activity.lastProgressAgeMs;
-  return typeof lastProgressAgeMs === "number" && lastProgressAgeMs >= params.staleAbortMs;
+  if (typeof lastProgressAgeMs === "number") {
+    return lastProgressAgeMs >= params.staleAbortMs;
+  }
+  // No diagnostic events recorded — fall back to the overall session age
+  // so a phantom with zero diagnostic activity can still be reclaimed.
+  return typeof params.fallbackAgeMs === "number" && params.fallbackAgeMs >= params.staleAbortMs;
 }
 
 function formatRecoveryContext(
@@ -169,6 +182,7 @@ export async function recoverStuckDiagnosticSession(
           sessionKey: params.sessionKey,
           queueDepth: params.queueDepth,
           staleAbortMs: staleActiveProgressAbortMs,
+          fallbackAgeMs: params.ageMs,
         });
       if (params.allowActiveAbort !== true && !reclaimStaleActiveRun) {
         const outcome: StuckSessionRecoveryOutcome = {
@@ -219,23 +233,55 @@ export async function recoverStuckDiagnosticSession(
         diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
         return outcome;
       }
-      const reclaimStaleReplyWork =
-        params.allowActiveAbort !== true &&
-        isActiveRunProgressStale({
+
+      // Terminal-phase reply operations (failed/aborted) hold their sessionKey
+      // in the reply-run registry but represent already-settled work, not
+      // evidence of active reply work. Without this guard the recovery loop
+      // unconditionally keeps the lane (active_reply_work → keep_lane), even
+      // though a terminal-phase operation will never produce further progress,
+      // permanently wedging the lane (#105712).
+      //
+      // On current main, complete() clears registry state immediately so
+      // "completed" operations are never reachable here. "failed" operations
+      // remain in the registry only when retainFailureUntilComplete is set
+      // (fail() → scheduleTerminalSettle). "aborted" operations from
+      // post-backend abortByUser also remain registered.
+      if (activeReplyPhase === "failed" || activeReplyPhase === "aborted") {
+        // Wait for the terminal settlement window before reclaiming so
+        // pending delivery/cleanup (retainFailureUntilComplete) can settle
+        // naturally. The diagnostic progress age approximates how long the
+        // operation has been terminal; when no progress exists fall back to
+        // the overall session age.
+        const terminalActivity = getDiagnosticSessionActivitySnapshot({
           sessionId: activeWorkSessionId,
           sessionKey: params.sessionKey,
-          queueDepth: params.queueDepth,
-          staleAbortMs: staleActiveProgressAbortMs,
         });
-      if (params.allowActiveAbort === true || reclaimStaleReplyWork) {
-        if (reclaimStaleReplyWork) {
+        const terminalPhaseAgeMs =
+          typeof terminalActivity.lastProgressAgeMs === "number"
+            ? terminalActivity.lastProgressAgeMs
+            : params.ageMs;
+        if (terminalPhaseAgeMs < REPLY_RUN_TERMINAL_SETTLE_TIMEOUT_MS) {
           diag.warn(
-            `stuck session recovery reclaiming stale active reply work: ${formatRecoveryContext(
-              params,
-              { activeSessionId: activeWorkSessionId },
-            )}`,
+            `stuck session recovery: terminal reply operation still within settle window sessionId=${activeWorkSessionId} phase=${activeReplyPhase} ageMs=${terminalPhaseAgeMs}`,
           );
+          const outcome: StuckSessionRecoveryOutcome = {
+            status: "skipped",
+            action: "keep_lane",
+            reason: "active_reply_work",
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            activeSessionId: activeWorkSessionId,
+            activeWorkKind: "embedded_run",
+          };
+          diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
+          return outcome;
         }
+        diag.warn(
+          `stuck session recovery reclaiming terminal reply operation: ${formatRecoveryContext(
+            params,
+            { activeSessionId: activeWorkSessionId },
+          )} phase=${activeReplyPhase}`,
+        );
         const result = await abortAndDrainEmbeddedAgentRun({
           sessionId: activeWorkSessionId,
           sessionKey: params.sessionKey,
@@ -248,17 +294,48 @@ export async function recoverStuckDiagnosticSession(
         forceCleared = result.forceCleared;
         activeSessionId = activeWorkSessionId;
       } else {
-        const outcome: StuckSessionRecoveryOutcome = {
-          status: "skipped",
-          action: "keep_lane",
-          reason: "active_reply_work",
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          activeSessionId: activeWorkSessionId,
-          activeWorkKind: "embedded_run",
-        };
-        diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
-        return outcome;
+        const reclaimStaleReplyWork =
+          params.allowActiveAbort !== true &&
+          isActiveRunProgressStale({
+            sessionId: activeWorkSessionId,
+            sessionKey: params.sessionKey,
+            queueDepth: params.queueDepth,
+            staleAbortMs: staleActiveProgressAbortMs,
+            fallbackAgeMs: params.ageMs,
+          });
+        if (params.allowActiveAbort === true || reclaimStaleReplyWork) {
+          if (reclaimStaleReplyWork) {
+            diag.warn(
+              `stuck session recovery reclaiming stale active reply work: ${formatRecoveryContext(
+                params,
+                { activeSessionId: activeWorkSessionId },
+              )}`,
+            );
+          }
+          const result = await abortAndDrainEmbeddedAgentRun({
+            sessionId: activeWorkSessionId,
+            sessionKey: params.sessionKey,
+            settleMs: STUCK_SESSION_ABORT_SETTLE_MS,
+            forceClear: true,
+            reason: "stuck_recovery",
+          });
+          aborted = result.aborted;
+          drained = result.drained;
+          forceCleared = result.forceCleared;
+          activeSessionId = activeWorkSessionId;
+        } else {
+          const outcome: StuckSessionRecoveryOutcome = {
+            status: "skipped",
+            action: "keep_lane",
+            reason: "active_reply_work",
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            activeSessionId: activeWorkSessionId,
+            activeWorkKind: "embedded_run",
+          };
+          diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
+          return outcome;
+        }
       }
     }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stuck-session recovery permanently wedges a channel lane when the reply-run registry holds a terminal-phase reply operation that will never produce progress. The lane stays stuck until the Gateway restarts.

Two phantom scenarios exist:
1. A ReplyOperation with terminal phase (failed/aborted) remains in the registry via `retainFailureUntilComplete`. Recovery sees `isEmbeddedAgentRunActive = true` and unconditionally returns `keep_lane` with `reason=active_reply_work` — the lane is permanently wedged.
2. A ReplyOperation with `phase=running` but zero diagnostic progress events (`lastProgressAgeMs = undefined`). `isActiveRunProgressStale` returns `false` for undefined ages, so the stale-progress path never fires.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #105712
- [x] This PR fixes a bug or regression

## Evidence

- **Behavior addressed**: Stuck-session recovery permanently wedges a channel lane when a terminal-phase reply operation (failed/aborted) remains in the reply-run registry. Recovery unconditionally returns keep_lane with reason=active_reply_work.
- **Real environment tested**: Linux (Ubuntu), Node 22.22.3, branch fix/reclaim-terminal-embedded-run-105712-v2 (based on latest origin/main)
- **Exact steps or command run after this patch**:

  ```
  node scripts/run-vitest.mjs src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/logging/diagnostic-stuck-session-recovery.integration.test.ts
  node --import tsx scripts/proof-e2e-recovery.mjs
  ```

- **Evidence after fix**:

  40/40 tests pass (30 unit + 10 integration)

  **Real diagnostic heartbeat-driven proof** — diagnostic process started with real recovery function, phantom created, heartbeat triggered recovery via coordinator pipeline (95s run):

  ```
  [diagnostic] stuck session recovery: terminal reply operation still within settle window phase=failed ageMs=29978
  [diagnostic] stuck session recovery outcome: status=skipped action=keep_lane reason=active_reply_work
  ← First heartbeat (30s): ageMs=30s < 60s settle window → PROTECTED ✅ quiet-but-live

  [diagnostic] stuck session recovery: terminal reply operation still within settle window phase=failed ageMs=59980
  [diagnostic] stuck session recovery outcome: status=skipped action=keep_lane reason=active_reply_work
  ← Second heartbeat (60s): ageMs=60s still just under threshold → PROTECTED ✅

  [diagnostic] stuck session recovery reclaiming terminal reply operation: phase=failed age=90s
  [diagnostic] reply run stale takeover: forced release reason=stuck_recovery
  [diagnostic] stuck session recovery: action=abort_embedded_run aborted=true drained=true
  [diagnostic] stuck session recovery outcome: status=aborted activeWorkKind=embedded_run
  ← Third heartbeat (90s): ageMs=90s > 60s → RECLAIMED! State: processing → idle ✅
  ```

  **Result**: Terminal-phase reclaim line present: YES, Session state transitioned to "idle": YES, Settle window guard triggered: YES — **ALL PASSED**

  New coordinator pipeline test (test #40) verifies the full chain:
  - `requestStuckSessionRecoveryOutcome` (coordinator) → `recoverStuckDiagnosticSession` (runtime) → `applyRecoveryOutcomeToDiagnosticState` (state update: "processing" → "idle")

- **Observed result after fix**:
  1. Terminal-phase phantom beyond 60s settle window -> reclaimed, lane released, queued message delivered
  2. Terminal-phase phantom within settle window -> lane kept (60s grace period honored)
  3. Running-phase phantom with zero diagnostic progress -> reclaimed via fallbackAgeMs after 5min stale threshold
  4. Healthy running operation with recent progress -> NOT reclaimed (no false positive)
  5. Coordinator applies outcome to diagnostic session state: "processing" -> "idle"

- **What was not tested**: Gateway restart flow, channel-specific delivery, compaction safety with terminal-phase operations.

- **Fix completeness pre-check (4 questions)**:
  - ✅ Auth guard: Not needed
  - ✅ Enum completeness: Covers all terminal phases (failed, aborted)
  - ✅ Path coverage: fallbackAgeMs covers both runtime branches
  - ✅ Cleanup symmetry: abortAndDrainEmbeddedAgentRun(forceClear:true) on both paths

### Real-World Reproduction Reports

Issue #105712 has independent user reports on release build 2026.6.11 (includes prior recovery fixes):
- mcaldas (Jul 13): "three variants in ~36 hours on the same 2026.6.11 install"
- ryanschmidt (Jul 17): "Another repro on 2026.6.11 (Docker, arm64, Slack Socket Mode)"

## Root Cause

recoverStuckDiagnosticSession unconditionally trusts the reply-run registry when determining if a session has active work. When a reply operation reaches terminal phase (failed with retainFailureUntilComplete, or aborted via abortByUser), the operation stays in the registry for the 60s terminal settle window. Recovery sees isEmbeddedAgentRunActive = true via isReplyRunActiveForSessionId and returns keep_lane. Separately, isActiveRunProgressStale returns false for undefined lastProgressAgeMs, so sessions with zero diagnostic events are never reclaimed.

## User-visible / Behavior Changes

None. Internal recovery logic fix.

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes

## Risks and Mitigations

Highest risk area: fallbackAgeMs could theoretically reclaim a session with active handle but zero diagnostic progress. Mitigation: queueDepth guard prevents reclaim when no queued work, 5min stale floor prevents reclaiming young sessions, zero-diagnostic-events-for-5min is practically indistinguishable from a phantom.

Fixes #105712
