### PR TITLE
fix(ui): restore logs auto-follow when re-enabled

### DIFF
--- a/ui/src/e2e/logs-autofollow.e2e.test.ts
+++ b/ui/src/e2e/logs-autofollow.e2e.test.ts
@@ -1,0 +1,92 @@
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+const logLines = Array.from({ length: 200 }, (_value, index) =>
+  JSON.stringify({
+    "0": JSON.stringify({ subsystem: "autofollow-e2e" }),
+    "1": `log line ${index + 1}`,
+    time: new Date(Date.UTC(2026, 6, 13, 12, 0, index)).toISOString(),
+    _meta: { logLevelName: "info" },
+  }),
+);
+
+describeControlUiE2e("Control UI logs auto-follow mocked Gateway E2E", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is not available at ${chromiumExecutablePath}`);
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("returns to the newest line when auto-follow is re-enabled", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 800, width: 1_200 },
+    });
+    const page = await context.newPage();
+    const pageErrors: string[] = [];
+    page.on("pageerror", (error) => pageErrors.push(String(error)));
+    await installMockGateway(page, {
+      methodResponses: {
+        "logs.tail": {
+          cursor: logLines.length,
+          file: "/tmp/openclaw.log",
+          lines: logLines,
+          reset: true,
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}logs`);
+      await expect.poll(() => page.locator(".log-row").count()).toBe(logLines.length);
+
+      const stream = page.locator(".log-stream");
+      const autoFollow = page.getByRole("checkbox", { name: "Auto-follow" });
+      await expect
+        .poll(() => stream.evaluate((element) => element.scrollHeight - element.clientHeight))
+        .toBeGreaterThan(0);
+      await autoFollow.uncheck();
+      await stream.evaluate((element) => {
+        element.scrollTop = 0;
+        element.dispatchEvent(new Event("scroll"));
+      });
+      await expect.poll(() => stream.evaluate((element) => element.scrollTop)).toBe(0);
+
+      await autoFollow.check();
+
+      await expect
+        .poll(() =>
+          stream.evaluate(
+            (element) => element.scrollHeight - element.scrollTop - element.clientHeight,
+          ),
+        )
+        .toBeLessThan(2);
+      expect(pageErrors).toEqual([]);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/pages/logs/logs-page.test.ts
+++ b/ui/src/pages/logs/logs-page.test.ts
@@ -8,12 +8,14 @@ import "./logs-page.ts";
 type TestLogsPage = HTMLElement & {
   context: ApplicationContext;
   connected: boolean;
+  logsAtBottom: boolean;
+  logsAutoFollow: boolean;
   logsEntries: unknown[];
+  scheduleScroll: (force?: boolean) => void;
   readonly updateComplete: Promise<boolean>;
   applyGatewaySnapshot: (snapshot: ApplicationGatewaySnapshot) => void;
   loadLogs: (opts?: { reset?: boolean; quiet?: boolean }) => Promise<boolean>;
   requestUpdate: () => void;
-  scheduleScroll: (force?: boolean) => void;
 };
 
 function deferred<T>() {
@@ -65,6 +67,31 @@ describe("LogsPage lifecycle", () => {
     await Promise.resolve();
 
     expect(requestFrame).not.toHaveBeenCalled();
+  });
+
+  it("forces a scroll when auto-follow is re-enabled away from the bottom", async () => {
+    const client = {
+      request: vi.fn(
+        () =>
+          new Promise(() => {
+            // Keep any incidental request pending; this test only exercises scroll state.
+          }),
+      ),
+    } as unknown as GatewayBrowserClient;
+    const page = document.createElement("openclaw-logs-page") as TestLogsPage;
+    page.context = contextWithClient(client);
+    document.body.append(page);
+    await page.updateComplete;
+
+    page.logsAutoFollow = false;
+    await page.updateComplete;
+    const scheduleScroll = vi.spyOn(page, "scheduleScroll");
+    page.logsAtBottom = false;
+    page.logsAutoFollow = true;
+    await page.updateComplete;
+
+    expect(scheduleScroll).toHaveBeenCalledOnce();
+    expect(scheduleScroll).toHaveBeenCalledWith(true);
   });
 
   it("discards a log response from a replaced gateway source that reuses its client", async () => {

--- a/ui/src/pages/logs/logs-page.ts
+++ b/ui/src/pages/logs/logs-page.ts
@@ -85,12 +85,12 @@ class LogsPage extends OpenClawLightDomElement {
   }
 
   override updated(changed: PropertyValues) {
+    const autoFollowEnabled = this.logsAutoFollow && changed.has("logsAutoFollow");
     if (
-      this.logsAutoFollow &&
-      this.logsAtBottom &&
-      (changed.has("logsEntries") || changed.has("logsAutoFollow"))
+      autoFollowEnabled ||
+      (this.logsAutoFollow && this.logsAtBottom && changed.has("logsEntries"))
     ) {
-      this.scheduleScroll(changed.has("logsAutoFollow"));
+      this.scheduleScroll(autoFollowEnabled);
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who disabled Logs auto-follow, scrolled away from the bottom, and then re-enabled auto-follow would remain at their old scroll position.

## Why This Change Was Made

Re-enabling auto-follow is an explicit request to return to the newest log entry, so that transition now bypasses the ordinary “already near the bottom” guard. New log entries retain the existing guard and do not steal the scroll position while the user is browsing older entries.

## User Impact

The Logs page immediately returns to the newest line when Auto-follow is turned back on. Manual browsing remains stable while Auto-follow is off.

## Evidence

- AWS Crabbox exact-head run `run_12d6ddb86e7a`: 7 focused component tests passed.
- Same run: Playwright Chromium exercised 200 Gateway-provided log lines, disabled Auto-follow, scrolled to the top, re-enabled it, and verified the stream returned to the bottom with no page errors.
- Same run: `pnpm check:changed` passed, including UI/core test typechecks, formatting, and lint.
- Fresh autoreview: clean; no accepted/actionable findings.
