### PR TITLE
refactor(plugins): trim registry exports

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -4841,7 +4841,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/plugins/registry.ts: PluginWebFetchProviderRegistration",
   "src/plugins/registry.ts: PluginWebSearchProviderRegistration",
   "src/plugins/registry.ts: PluginWorkerProviderRegistration",
-  "src/plugins/registry.ts: resolvePluginPath",
   "src/plugins/roots.ts: PluginCacheInputs",
   "src/plugins/runtime-channel-state.ts: ActivePluginChannelRegistrySnapshot",
   "src/plugins/runtime-channel-state.ts: PLUGIN_REGISTRY_STATE",

--- a/src/plugins/plugin-registry.test.ts
+++ b/src/plugins/plugin-registry.test.ts
@@ -37,7 +37,6 @@ import {
   resolvePluginContributionOwners,
   resolveProviderOwners,
 } from "./plugin-registry.js";
-import { resolvePluginPath } from "./registry.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 
 const tempDirs: string[] = [];
@@ -210,27 +209,6 @@ function expectSnapshotPluginIds(snapshot: InstalledPluginIndex, expectedPluginI
 }
 
 describe("plugin registry facade", () => {
-  it("resolves relative plugin API paths against the plugin root", () => {
-    const pluginRoot = path.join(makeTempDir(), "plugins", "demo");
-
-    expect(resolvePluginPath("data/cache.json", pluginRoot)).toBe(
-      path.join(pluginRoot, "data", "cache.json"),
-    );
-    expect(resolvePluginPath("./data/cache.json", pluginRoot)).toBe(
-      path.join(pluginRoot, "data", "cache.json"),
-    );
-  });
-
-  it("keeps absolute and home plugin API paths user-resolved", () => {
-    const pluginRoot = path.join(makeTempDir(), "plugins", "demo");
-    const absolute = path.resolve(pluginRoot, "..", "outside.txt");
-
-    expect(resolvePluginPath(absolute, pluginRoot)).toBe(resolvePluginPath(absolute, undefined));
-    expect(resolvePluginPath("~/openclaw/plugin.txt", pluginRoot)).toBe(
-      resolvePluginPath("~/openclaw/plugin.txt", undefined),
-    );
-  });
-
   it("resolves cold plugin records and contribution owners without loading runtime", () => {
     const rootDir = makeTempDir();
     const candidate = createCandidate(rootDir);

--- a/src/plugins/registry-api.ts
+++ b/src/plugins/registry-api.ts
@@ -37,7 +37,7 @@ function normalizeLogger(logger: PluginLogger): PluginLogger {
   };
 }
 
-export function resolvePluginPath(input: string, rootDir: string | undefined): string {
+function resolvePluginPath(input: string, rootDir: string | undefined): string {
   const trimmed = input.trim();
   if (!trimmed || path.isAbsolute(trimmed) || trimmed.startsWith("~")) {
     return resolveUserPath(input);

--- a/src/plugins/registry-registrars-capabilities.ts
+++ b/src/plugins/registry-registrars-capabilities.ts
@@ -158,5 +158,3 @@ export function createCapabilityRegistrars(state: PluginRegistryState) {
     registerCompactionProvider,
   };
 }
-
-export type CapabilityRegistrars = ReturnType<typeof createCapabilityRegistrars>;

--- a/src/plugins/registry-registrars-host.ts
+++ b/src/plugins/registry-registrars-host.ts
@@ -708,5 +708,3 @@ export function createHostRegistrars(state: PluginRegistryState) {
     registerConversationBindingResolvedHandler,
   };
 }
-
-export type HostRegistrars = ReturnType<typeof createHostRegistrars>;

--- a/src/plugins/registry-registrars-memory.ts
+++ b/src/plugins/registry-registrars-memory.ts
@@ -141,5 +141,3 @@ export function createMemoryRegistrars(state: PluginRegistryState) {
     registerMemoryEmbeddingProvider,
   };
 }
-
-export type MemoryRegistrars = ReturnType<typeof createMemoryRegistrars>;

--- a/src/plugins/registry-registrars-network.ts
+++ b/src/plugins/registry-registrars-network.ts
@@ -338,5 +338,3 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
     registerChannel,
   };
 }
-
-export type NetworkRegistrars = ReturnType<typeof createNetworkRegistrars>;

--- a/src/plugins/registry-registrars-operations.ts
+++ b/src/plugins/registry-registrars-operations.ts
@@ -452,5 +452,3 @@ export function createOperationRegistrars(state: PluginRegistryState) {
     registerCommand,
   };
 }
-
-export type OperationRegistrars = ReturnType<typeof createOperationRegistrars>;

--- a/src/plugins/registry-registrars-providers.ts
+++ b/src/plugins/registry-registrars-providers.ts
@@ -499,5 +499,3 @@ export function createProviderRegistrars(state: PluginRegistryState) {
     registerMigrationProvider,
   };
 }
-
-export type ProviderRegistrars = ReturnType<typeof createProviderRegistrars>;

--- a/src/plugins/registry-registrars-tools-hooks.ts
+++ b/src/plugins/registry-registrars-tools-hooks.ts
@@ -513,5 +513,3 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
     rollbackHooks,
   };
 }
-
-export type ToolHookRegistrars = ReturnType<typeof createToolHookRegistrars>;

--- a/src/plugins/registry-state.ts
+++ b/src/plugins/registry-state.ts
@@ -16,7 +16,7 @@ export type PluginSideEffectGuard = {
   active: boolean;
 };
 
-export type PluginRegistrationCapabilities = {
+type PluginRegistrationCapabilities = {
   /** Broad registry writes that discovery and live activation both need. */
   capabilityHandlers: boolean;
   /** Setup-runtime may publish pre-listen gateway surfaces without full activation. */
@@ -37,7 +37,7 @@ export function resolvePluginRegistrationCapabilities(
   };
 }
 
-export function normalizeHookTimeoutMs(value: unknown): number | undefined {
+function normalizeHookTimeoutMs(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
     return undefined;
   }

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -1,6 +1,9 @@
 // Verifies plugin registry behavior with runtime config inputs.
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveUserPath } from "../utils.js";
 import { createPluginRecord } from "./loader-records.js";
 import { createPluginRegistry } from "./registry.js";
 import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
@@ -21,6 +24,27 @@ function createTestRegistry(runtime: PluginRuntime) {
 }
 
 describe("plugin registry runtime config scope", () => {
+  it("resolves plugin API paths against the plugin root", () => {
+    const pluginRoot = path.join(os.tmpdir(), "openclaw-plugins", "demo");
+    const pluginRegistry = createTestRegistry(createPluginRuntime());
+    const record = createPluginRecord({
+      id: "path-plugin",
+      name: "Path Plugin",
+      source: path.join(pluginRoot, "index.js"),
+      rootDir: pluginRoot,
+      origin: "global",
+      enabled: true,
+      configSchema: false,
+    });
+    const api = pluginRegistry.createApi(record, { config: {} as OpenClawConfig });
+    const absolute = path.resolve(pluginRoot, "..", "outside.txt");
+
+    expect(api.resolvePath("data/cache.json")).toBe(path.join(pluginRoot, "data", "cache.json"));
+    expect(api.resolvePath("./data/cache.json")).toBe(path.join(pluginRoot, "data", "cache.json"));
+    expect(api.resolvePath(absolute)).toBe(absolute);
+    expect(api.resolvePath("~/openclaw/plugin.txt")).toBe(resolveUserPath("~/openclaw/plugin.txt"));
+  });
+
   it("adds plugin context to lazy runtime resolution failures", () => {
     const runtime = new Proxy({} as PluginRuntime, {
       get() {

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -55,7 +55,6 @@ export type {
   PluginSessionExtensionRegistryRegistration,
 } from "./registry-types.js";
 export { createEmptyPluginRegistry } from "./registry-empty.js";
-export { resolvePluginPath } from "./registry-api.js";
 
 /**
  * Compose the registry state, domain registrars, scoped runtime, and plugin API.


### PR DESCRIPTION
## What Problem This Solves

The plugin-registry decomposition in #105783 exposed ten owner-private symbols that Knip immediately reported as unused exports. One path helper also remained baseline-allowlisted solely for direct internal tests.

## Why This Change Was Made

- Delete seven unused registrar return-type aliases.
- Privatize the registration-capability type and hook-timeout normalizer.
- Remove the stale `resolvePluginPath` barrel export and dead-export baseline entry.
- Move path-resolution assertions onto the supported `OpenClawPluginApi.resolvePath` surface.

## User Impact

No runtime behavior or public Plugin SDK contract changes. Plugin path resolution retains the same relative, absolute, and home-path behavior.

## Evidence

- Fresh Testbox `pnpm deadcode:exports`: baseline matched 5,708 entries.
- Fresh Testbox focused suite: 2 files, 32 tests passed.
- Fresh Testbox targeted `check:changed`: passed in 10m45s.
- Fresh committed-branch `gpt-5.6-sol` medium autoreview: no findings, patch correct at 0.93 confidence.
- `git diff --check` passes.
- Net reduction: 27 additions, 41 deletions across 13 files.

No changelog entry: this is an internal export cleanup with unchanged runtime behavior.
