### PR TITLE
feat: add native Skills management parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Native Skills parity:** add Installed and Browse skill management to iOS and ClawHub Browse to macOS, matching Android readiness filters, enable/disable controls, exact-version review, and Gateway-enforced risk acknowledgement. (#105741)
 - **SQLite snapshots:** add `openclaw backup sqlite create|list|verify|restore` for compact, verified global and per-agent database artifacts with fresh-target-only restore. (#94805) Thanks @giodl73-repo.
 - **GPT-5.6 Ultra and runtime switching:** support Sol, Terra, and Luna across OpenClaw and Codex engines; keep model, runtime, and thinking selection atomic through `/model` and fallback; and add live matrix coverage for both harnesses. (#98021) Thanks @anyech.
 - **OpenAI GPT-5.6 defaults:** use `openai/gpt-5.6` (Sol alias) for fresh API-key setup and exact `openai/gpt-5.6-sol` for fresh Codex/OAuth setup, while preserving existing primaries, fallbacks, aliases, and explicit GPT-5.5 selections. (#103234)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Native Skills parity:** add Installed and Browse skill management to iOS and ClawHub Browse to macOS, matching Android readiness filters, enable/disable controls, exact-version review, and Gateway-enforced risk acknowledgement. (#105741)
 - **SQLite snapshots:** add `openclaw backup sqlite create|list|verify|restore` for compact, verified global and per-agent database artifacts with fresh-target-only restore. (#94805) Thanks @giodl73-repo.
 - **GPT-5.6 Ultra and runtime switching:** support Sol, Terra, and Luna across OpenClaw and Codex engines; keep model, runtime, and thinking selection atomic through `/model` and fallback; and add live matrix coverage for both harnesses. (#98021) Thanks @anyech.
 - **OpenAI GPT-5.6 defaults:** use `openai/gpt-5.6` (Sol alias) for fresh API-key setup and exact `openai/gpt-5.6-sol` for fresh Codex/OAuth setup, while preserving existing primaries, fallbacks, aliases, and explicit GPT-5.5 selections. (#103234)

--- a/apps/.i18n/apple-translation-contradictions.json
+++ b/apps/.i18n/apple-translation-contradictions.json
@@ -326,11 +326,59 @@
       ]
     },
     {
+      "locale": "es",
+      "source": "All",
+      "translations": [
+        "Todas",
+        "Todo"
+      ]
+    },
+    {
+      "locale": "fr",
+      "source": "All",
+      "translations": [
+        "Tous",
+        "Tout"
+      ]
+    },
+    {
+      "locale": "it",
+      "source": "All",
+      "translations": [
+        "Tutte",
+        "Tutti"
+      ]
+    },
+    {
+      "locale": "ko",
+      "source": "All",
+      "translations": [
+        "모두",
+        "전체"
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "All",
+      "translations": [
+        "Alle",
+        "Alles"
+      ]
+    },
+    {
       "locale": "pl",
       "source": "All",
       "translations": [
         "Wszystkie",
         "Wszystko"
+      ]
+    },
+    {
+      "locale": "pt-BR",
+      "source": "All",
+      "translations": [
+        "Todos",
+        "Tudo"
       ]
     },
     {
@@ -1876,6 +1924,46 @@
       ]
     },
     {
+      "locale": "fa",
+      "source": "Disable",
+      "translations": [
+        "غیرفعال کردن",
+        "غیرفعال‌کردن"
+      ]
+    },
+    {
+      "locale": "hi",
+      "source": "Disable",
+      "translations": [
+        "अक्षम करें",
+        "बंद करें"
+      ]
+    },
+    {
+      "locale": "ru",
+      "source": "Disable",
+      "translations": [
+        "Выключить",
+        "Отключить"
+      ]
+    },
+    {
+      "locale": "th",
+      "source": "Disable",
+      "translations": [
+        "ปิดใช้",
+        "ปิดใช้งาน"
+      ]
+    },
+    {
+      "locale": "zh-CN",
+      "source": "Disable",
+      "translations": [
+        "停用",
+        "禁用"
+      ]
+    },
+    {
       "locale": "de",
       "source": "Discovered",
       "translations": [
@@ -2495,6 +2583,30 @@
       ]
     },
     {
+      "locale": "es",
+      "source": "Enable",
+      "translations": [
+        "Activar",
+        "Habilitar"
+      ]
+    },
+    {
+      "locale": "fa",
+      "source": "Enable",
+      "translations": [
+        "فعال‌سازی",
+        "فعال‌کردن"
+      ]
+    },
+    {
+      "locale": "ja-JP",
+      "source": "Enable",
+      "translations": [
+        "有効にする",
+        "有効化"
+      ]
+    },
+    {
       "locale": "ar",
       "source": "Enable Talk",
       "translations": [
@@ -2947,7 +3059,16 @@
       "source": "Gateway offline",
       "translations": [
         "Gateway がオフラインです",
-        "Gateway オフライン"
+        "Gateway オフライン",
+        "Gatewayはオフラインです"
+      ]
+    },
+    {
+      "locale": "pl",
+      "source": "Gateway offline",
+      "translations": [
+        "Gateway jest offline",
+        "Gateway offline"
       ]
     },
     {
@@ -2956,6 +3077,14 @@
       "translations": [
         "Gateway не в сети",
         "Gateway офлайн"
+      ]
+    },
+    {
+      "locale": "sv",
+      "source": "Gateway offline",
+      "translations": [
+        "Gateway offline",
+        "Gateway är offline"
       ]
     },
     {
@@ -3119,6 +3248,102 @@
       "translations": [
         "檢查",
         "檢視"
+      ]
+    },
+    {
+      "locale": "ar",
+      "source": "Installed",
+      "translations": [
+        "المثبتة",
+        "مثبّت"
+      ]
+    },
+    {
+      "locale": "es",
+      "source": "Installed",
+      "translations": [
+        "Instaladas",
+        "Instalado"
+      ]
+    },
+    {
+      "locale": "fr",
+      "source": "Installed",
+      "translations": [
+        "Installé",
+        "Installés"
+      ]
+    },
+    {
+      "locale": "hi",
+      "source": "Installed",
+      "translations": [
+        "इंस्टॉल किए गए",
+        "इंस्टॉल किया गया"
+      ]
+    },
+    {
+      "locale": "id",
+      "source": "Installed",
+      "translations": [
+        "Terinstal",
+        "Terpasang"
+      ]
+    },
+    {
+      "locale": "it",
+      "source": "Installed",
+      "translations": [
+        "Installate",
+        "Installato"
+      ]
+    },
+    {
+      "locale": "pl",
+      "source": "Installed",
+      "translations": [
+        "Zainstalowane",
+        "Zainstalowano"
+      ]
+    },
+    {
+      "locale": "pt-BR",
+      "source": "Installed",
+      "translations": [
+        "Instaladas",
+        "Instalado"
+      ]
+    },
+    {
+      "locale": "ru",
+      "source": "Installed",
+      "translations": [
+        "Установленные",
+        "Установлено"
+      ]
+    },
+    {
+      "locale": "sv",
+      "source": "Installed",
+      "translations": [
+        "Installerad",
+        "Installerade"
+      ]
+    },
+    {
+      "locale": "tr",
+      "source": "Installed",
+      "translations": [
+        "Yüklendi",
+        "Yüklü"
+      ]
+    },
+    {
+      "locale": "uk",
+      "source": "Installed",
+      "translations": [
+        "Встановлено",
+        "Установлені"
       ]
     },
     {
@@ -3677,6 +3902,38 @@
       ]
     },
     {
+      "locale": "fa",
+      "source": "Missing: %@",
+      "translations": [
+        "مفقود: %@",
+        "مورد مفقود: %@"
+      ]
+    },
+    {
+      "locale": "it",
+      "source": "Missing: %@",
+      "translations": [
+        "Manca: %@",
+        "Mancante: %@"
+      ]
+    },
+    {
+      "locale": "pl",
+      "source": "Missing: %@",
+      "translations": [
+        "Brak: %@",
+        "Brakuje: %@"
+      ]
+    },
+    {
+      "locale": "th",
+      "source": "Missing: %@",
+      "translations": [
+        "ขาด: %@",
+        "ขาดหาย: %@"
+      ]
+    },
+    {
       "locale": "ar",
       "source": "Needs attention",
       "translations": [
@@ -4125,6 +4382,94 @@
       "translations": [
         "沒有最近工作階段",
         "沒有最近的工作階段"
+      ]
+    },
+    {
+      "locale": "ar",
+      "source": "No skills found",
+      "translations": [
+        "لم يتم العثور على Skills",
+        "لم يتم العثور على مهارات"
+      ]
+    },
+    {
+      "locale": "fa",
+      "source": "No skills found",
+      "translations": [
+        "هیچ Skillsی پیدا نشد",
+        "هیچ Skillی یافت نشد"
+      ]
+    },
+    {
+      "locale": "hi",
+      "source": "No skills found",
+      "translations": [
+        "कोई Skill नहीं मिला",
+        "कोई skills नहीं मिलीं"
+      ]
+    },
+    {
+      "locale": "id",
+      "source": "No skills found",
+      "translations": [
+        "Tidak ada skill yang ditemukan",
+        "Tidak ada skills ditemukan"
+      ]
+    },
+    {
+      "locale": "ko",
+      "source": "No skills found",
+      "translations": [
+        "Skills를 찾을 수 없음",
+        "스킬을 찾을 수 없음"
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "No skills found",
+      "translations": [
+        "Geen Skills gevonden",
+        "Geen skills gevonden"
+      ]
+    },
+    {
+      "locale": "pl",
+      "source": "No skills found",
+      "translations": [
+        "Nie znaleziono Skills",
+        "Nie znaleziono umiejętności"
+      ]
+    },
+    {
+      "locale": "pt-BR",
+      "source": "No skills found",
+      "translations": [
+        "Nenhuma Skill encontrada",
+        "Nenhuma skill encontrada"
+      ]
+    },
+    {
+      "locale": "ru",
+      "source": "No skills found",
+      "translations": [
+        "Skills не найдены",
+        "Навыки не найдены"
+      ]
+    },
+    {
+      "locale": "sv",
+      "source": "No skills found",
+      "translations": [
+        "Inga Skills hittades",
+        "Inga färdigheter hittades"
+      ]
+    },
+    {
+      "locale": "zh-CN",
+      "source": "No skills found",
+      "translations": [
+        "未找到 Skills",
+        "未找到技能"
       ]
     },
     {
@@ -5042,6 +5387,14 @@
       ]
     },
     {
+      "locale": "it",
+      "source": "Ready",
+      "translations": [
+        "Pronta",
+        "Pronto"
+      ]
+    },
+    {
       "locale": "nl",
       "source": "Ready",
       "translations": [
@@ -5815,6 +6168,70 @@
       "translations": [
         "Область",
         "Обсяг"
+      ]
+    },
+    {
+      "locale": "fa",
+      "source": "Search ClawHub",
+      "translations": [
+        "جستجو در ClawHub",
+        "جستجوی ClawHub"
+      ]
+    },
+    {
+      "locale": "hi",
+      "source": "Search ClawHub",
+      "translations": [
+        "ClawHub खोजें",
+        "ClawHub में खोजें"
+      ]
+    },
+    {
+      "locale": "id",
+      "source": "Search ClawHub",
+      "translations": [
+        "Cari ClawHub",
+        "Cari di ClawHub"
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "Search ClawHub",
+      "translations": [
+        "ClawHub zoeken",
+        "Zoeken in ClawHub"
+      ]
+    },
+    {
+      "locale": "pl",
+      "source": "Search ClawHub",
+      "translations": [
+        "Przeszukaj ClawHub",
+        "Wyszukaj w ClawHub"
+      ]
+    },
+    {
+      "locale": "pt-BR",
+      "source": "Search ClawHub",
+      "translations": [
+        "Buscar no ClawHub",
+        "Pesquisar no ClawHub"
+      ]
+    },
+    {
+      "locale": "th",
+      "source": "Search ClawHub",
+      "translations": [
+        "ค้นหา ClawHub",
+        "ค้นหาใน ClawHub"
+      ]
+    },
+    {
+      "locale": "vi",
+      "source": "Search ClawHub",
+      "translations": [
+        "Tìm kiếm ClawHub",
+        "Tìm kiếm trên ClawHub"
       ]
     },
     {

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -20387,7 +20387,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 1285,
+      "line": 1281,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Can't reach gateway at %1$@:%2$@. Verify Tailscale Serve is enabled and publishes this Gateway.",
       "surface": "apple",
@@ -20395,7 +20395,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1294,
+      "line": 1290,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Can't reach gateway at %1$@:%2$@. Check Tailscale or LAN.",
       "surface": "apple",
@@ -20403,7 +20403,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 1300,
+      "line": 1296,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "TLS fingerprint verification timed out for %1$@:%2$@. Secure endpoint was reached, but TLS did not finish in time.",
       "surface": "apple",
@@ -20411,7 +20411,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 1308,
+      "line": 1304,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "No secure gateway endpoint was detected at %1$@:%2$@. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "apple",
@@ -20419,7 +20419,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1318,
+      "line": 1314,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Could not read the TLS certificate from %1$@:%2$@.",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -19395,7 +19395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 153,
+      "line": 151,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Skills",
       "surface": "apple",
@@ -19403,7 +19403,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 167,
+      "line": 165,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Connect to manage Gateway skills.",
       "surface": "apple",
@@ -19411,7 +19411,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 169,
+      "line": 167,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Loading installed skills and readiness.",
       "surface": "apple",
@@ -19419,7 +19419,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 172,
+      "line": 170,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "%@ ready · %@ need setup",
       "surface": "apple",
@@ -19427,7 +19427,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 179,
+      "line": 176,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "offline",
       "surface": "apple",
@@ -19435,7 +19435,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 181,
+      "line": 178,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "loading",
       "surface": "apple",
@@ -19443,7 +19443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 197,
+      "line": 194,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Skills section",
       "surface": "apple",
@@ -19451,7 +19451,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 212,
+      "line": 209,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Installed",
       "surface": "apple",
@@ -19459,7 +19459,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 215,
+      "line": 212,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Refresh Skills",
       "surface": "apple",
@@ -19467,7 +19467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 233,
+      "line": 229,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Search installed skills",
       "surface": "apple",
@@ -19475,7 +19475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 242,
+      "line": 238,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Installed skill filter",
       "surface": "apple",
@@ -19483,7 +19483,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 256,
+      "line": 252,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Connect to load and manage installed skills.",
       "surface": "apple",
@@ -19491,7 +19491,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 263,
+      "line": 258,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Loading skills",
       "surface": "apple",
@@ -19499,7 +19499,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 264,
+      "line": 259,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Reading the Gateway skill catalog.",
       "surface": "apple",
@@ -19507,7 +19507,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 271,
+      "line": 265,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "No matching skills",
       "surface": "apple",
@@ -19515,7 +19515,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 271,
+      "line": 265,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "No skills installed",
       "surface": "apple",
@@ -19523,7 +19523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 273,
+      "line": 267,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Browse ClawHub to discover and install skills.",
       "surface": "apple",
@@ -19531,7 +19531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 274,
+      "line": 268,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Change the search or readiness filter.",
       "surface": "apple",
@@ -19539,7 +19539,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 319,
+      "line": 311,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "ClawHub",
       "surface": "apple",
@@ -19547,7 +19547,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 322,
+      "line": 314,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Search ClawHub",
       "surface": "apple",
@@ -19555,7 +19555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 349,
+      "line": 340,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Search",
       "surface": "apple",
@@ -19563,7 +19563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 353,
+      "line": 344,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "The Gateway verifies the exact reviewed release before download.",
       "surface": "apple",
@@ -19571,7 +19571,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 366,
+      "line": 357,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Gateway offline",
       "surface": "apple",
@@ -19579,7 +19579,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 367,
+      "line": 358,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Connect to search and install ClawHub skills.",
       "surface": "apple",
@@ -19587,7 +19587,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 374,
+      "line": 364,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Gateway update required",
       "surface": "apple",
@@ -19595,7 +19595,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 375,
+      "line": 365,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Update the Gateway to search and install ClawHub skills from iOS.",
       "surface": "apple",
@@ -19603,7 +19603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 382,
+      "line": 371,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Searching ClawHub",
       "surface": "apple",
@@ -19611,7 +19611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 383,
+      "line": 372,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Loading verified skill releases.",
       "surface": "apple",
@@ -19619,7 +19619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 390,
+      "line": 378,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "No skills found",
       "surface": "apple",
@@ -19627,7 +19627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 391,
+      "line": 379,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Try another search or refresh the catalog.",
       "surface": "apple",
@@ -19635,7 +19635,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 478,
+      "line": 463,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Could not load skills",
       "surface": "apple",
@@ -19643,7 +19643,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 519,
+      "line": 501,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "ClawHub unavailable",
       "surface": "apple",
@@ -19651,7 +19651,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 560,
+      "line": 540,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Could not review skill",
       "surface": "apple",
@@ -19659,7 +19659,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 617,
+      "line": 593,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
       "surface": "apple",
@@ -19667,7 +19667,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 644,
+      "line": 616,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Gateway blocked install",
       "surface": "apple",
@@ -19675,7 +19675,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 660,
+      "line": 631,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "The Gateway installed the reviewed version.",
       "surface": "apple",
@@ -19683,7 +19683,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 669,
+      "line": 639,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Install result unknown",
       "surface": "apple",
@@ -19691,7 +19691,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 704,
+      "line": 672,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Skill disabled",
       "surface": "apple",
@@ -19699,7 +19699,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 704,
+      "line": 672,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Skill enabled",
       "surface": "apple",
@@ -19707,7 +19707,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 712,
+      "line": 679,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Could not enable skill",
       "surface": "apple",
@@ -19715,7 +19715,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 713,
+      "line": 680,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Could not disable skill",
       "surface": "apple",
@@ -19723,7 +19723,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 823,
+      "line": 787,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Disable",
       "surface": "apple",
@@ -19731,7 +19731,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 823,
+      "line": 787,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Enable",
       "surface": "apple",
@@ -19739,7 +19739,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 835,
+      "line": 799,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Off",
       "surface": "apple",
@@ -19747,7 +19747,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 838,
+      "line": 802,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Ready",
       "surface": "apple",
@@ -19755,7 +19755,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 839,
+      "line": 803,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Needs Setup",
       "surface": "apple",
@@ -19763,7 +19763,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 851,
+      "line": 815,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Missing: %@",
       "surface": "apple",
@@ -19771,7 +19771,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 879,
+      "line": 843,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Install",
       "surface": "apple",
@@ -19779,7 +19779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 936,
+      "line": 899,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "The Gateway will verify this exact release with ClawHub before download.",
       "surface": "apple",
@@ -19787,7 +19787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 940,
+      "line": 903,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "This gateway connection needs operator.admin to install skills.",
       "surface": "apple",
@@ -19795,7 +19795,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 947,
+      "line": 910,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Review ClawHub skill",
       "surface": "apple",
@@ -19803,7 +19803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 955,
+      "line": 918,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Verify and install",
       "surface": "apple",
@@ -19811,7 +19811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 979,
+      "line": 942,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Gateway warning",
       "surface": "apple",
@@ -19819,7 +19819,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 989,
+      "line": 952,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "The Gateway requires explicit acknowledgement for this release.",
       "surface": "apple",
@@ -19827,7 +19827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 994,
+      "line": 957,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Review warning details",
       "surface": "apple",
@@ -19835,7 +19835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 996,
+      "line": 959,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Expand and review the Gateway warning before acknowledging this exact version.",
       "surface": "apple",
@@ -19843,7 +19843,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1002,
+      "line": 965,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Review Gateway warning",
       "surface": "apple",
@@ -19851,7 +19851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1006,
+      "line": 969,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -19859,7 +19859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1010,
+      "line": 973,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Acknowledge and install",
       "surface": "apple",
@@ -19867,7 +19867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1030,
+      "line": 993,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Version",
       "surface": "apple",
@@ -19875,7 +19875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1031,
+      "line": 994,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Publisher",
       "surface": "apple",
@@ -19883,7 +19883,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1078,
+      "line": 1041,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "The connected Gateway changed. Refresh Skills and try again.",
       "surface": "apple",
@@ -19891,7 +19891,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1079,
+      "line": 1042,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Could not encode the Gateway request.",
       "surface": "apple",
@@ -19899,7 +19899,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1080,
+      "line": 1043,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "ClawHub did not report an installable version for this skill.",
       "surface": "apple",
@@ -25787,7 +25787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 134,
+      "line": 131,
       "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
       "source": "Installed",
       "surface": "apple",
@@ -25795,7 +25795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 134,
+      "line": 131,
       "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
       "source": "Review",
       "surface": "apple",
@@ -25803,7 +25803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 149,
+      "line": 146,
       "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
       "source": "Review ClawHub skill",
       "surface": "apple",
@@ -25811,7 +25811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 151,
+      "line": 148,
       "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
       "source": "The Gateway will verify this exact release with ClawHub before download.",
       "surface": "apple",
@@ -25819,7 +25819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 157,
+      "line": 154,
       "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
       "source": "Verify and install",
       "surface": "apple",
@@ -25827,7 +25827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 178,
+      "line": 175,
       "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
       "source": "Gateway warning",
       "surface": "apple",
@@ -25835,7 +25835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 183,
+      "line": 180,
       "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
       "source": "Review warning details",
       "surface": "apple",
@@ -25843,7 +25843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 189,
+      "line": 186,
       "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
       "source": "Expand and review the Gateway warning before acknowledging this exact version.",
       "surface": "apple",
@@ -25851,7 +25851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 194,
+      "line": 191,
       "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -25859,7 +25859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 195,
+      "line": 192,
       "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
       "source": "Acknowledge and install",
       "surface": "apple",
@@ -25867,7 +25867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 214,
+      "line": 211,
       "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
       "source": "Version",
       "surface": "apple",
@@ -25875,7 +25875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 215,
+      "line": 212,
       "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
       "source": "Publisher",
       "surface": "apple",
@@ -34339,7 +34339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 332,
+      "line": 331,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/SkillManagement.swift",
       "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -1299,7 +1299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6450,
+      "line": 6456,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "One time",
       "surface": "android",
@@ -1307,7 +1307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6459,
+      "line": 6465,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron",
       "surface": "android",
@@ -1315,7 +1315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6460,
+      "line": 6466,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Scheduled",
       "surface": "android",
@@ -1323,7 +1323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6468,
+      "line": 6474,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${days}d",
       "surface": "android",
@@ -1331,7 +1331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6469,
+      "line": 6475,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${hours}h",
       "surface": "android",
@@ -1339,7 +1339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6470,
+      "line": 6476,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${minutes}m",
       "surface": "android",
@@ -1347,7 +1347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6471,
+      "line": 6477,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Repeating",
       "surface": "android",
@@ -1355,7 +1355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6487,
+      "line": 6493,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No prompt",
       "surface": "android",
@@ -1363,7 +1363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6504,
+      "line": 6510,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway",
       "surface": "android",
@@ -1371,7 +1371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6512,
+      "line": 6518,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected to $gatewayLabel",
       "surface": "android",
@@ -1379,7 +1379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6513,
+      "line": 6519,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your agents are ready",
       "surface": "android",
@@ -1387,7 +1387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6515,
+      "line": 6521,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This phone stays dormant until the gateway needs it, then wakes, syncs, and goes back to sleep.",
       "surface": "android",
@@ -1395,7 +1395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6519,
+      "line": 6525,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Selected on this phone",
       "surface": "android",
@@ -1403,7 +1403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6522,
+      "line": 6528,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The overview refreshes on reconnect and when this screen opens.",
       "surface": "android",
@@ -1411,7 +1411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6527,
+      "line": 6533,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting",
       "surface": "android",
@@ -1419,7 +1419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6528,
+      "line": 6534,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "OpenClaw is syncing back up",
       "surface": "android",
@@ -1427,7 +1427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6530,
+      "line": 6536,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The gateway session is coming back online. Agent shortcuts should settle automatically in a moment.",
       "surface": "android",
@@ -1435,7 +1435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6534,
+      "line": 6540,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway session in progress",
       "surface": "android",
@@ -1443,7 +1443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6537,
+      "line": 6543,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "If the gateway is reachable, reconnect should complete without intervention.",
       "surface": "android",
@@ -1451,7 +1451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6542,
+      "line": 6548,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1459,7 +1459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6543,
+      "line": 6549,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your phone stays quiet until it is needed",
       "surface": "android",
@@ -1467,7 +1467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6545,
+      "line": 6551,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pair this device to your gateway to wake it only for real work, keep a live agent overview handy, and avoid battery-draining background loops.",
       "surface": "android",
@@ -1475,7 +1475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6549,
+      "line": 6555,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to load your agents",
       "surface": "android",
@@ -1483,7 +1483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6552,
+      "line": 6558,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "When connected, the gateway can wake the phone with a silent push instead of holding an always-on session.",
       "surface": "android",
@@ -1491,7 +1491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6584,
+      "line": 6590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Main",
       "surface": "android",
@@ -1499,7 +1499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6599,
+      "line": 6605,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Active on this phone",
       "surface": "android",
@@ -1507,7 +1507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6600,
+      "line": 6606,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Default agent",
       "surface": "android",
@@ -1515,7 +1515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6601,
+      "line": 6607,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Ready",
       "surface": "android",
@@ -1523,7 +1523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7159,
+      "line": 7166,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Dream",
       "surface": "android",
@@ -1683,7 +1683,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 115,
+      "line": 120,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/SkillManagement.kt",
       "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
       "surface": "android",
@@ -1691,7 +1691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 171,
+      "line": 216,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/SkillManagement.kt",
       "source": "The result for $slug is unknown. Reconnect, refresh Skills, then retry; the Gateway safely joins a matching install that is still running.",
       "surface": "android",
@@ -9747,7 +9747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 130,
+      "line": 131,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skills",
       "surface": "android",
@@ -9755,7 +9755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 131,
+      "line": 132,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Manage installed skills and add trusted releases from ClawHub.",
       "surface": "android",
@@ -9763,7 +9763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 145,
+      "line": 146,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Browse",
       "surface": "android",
@@ -9771,7 +9771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 163,
+      "line": 164,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skill changes require operator.admin. Reconnect with an admin-capable gateway token.",
       "surface": "android",
@@ -9779,7 +9779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 228,
+      "line": 230,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Inspect and manage installed skill state.",
       "surface": "android",
@@ -9787,7 +9787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 236,
+      "line": 238,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Status",
       "surface": "android",
@@ -9795,7 +9795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 238,
+      "line": 240,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Missing",
       "surface": "android",
@@ -9803,7 +9803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 276,
+      "line": 278,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Refresh",
       "surface": "android",
@@ -9811,7 +9811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 276,
+      "line": 278,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -9819,7 +9819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 371,
+      "line": 373,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Search installed skills",
       "surface": "android",
@@ -9827,7 +9827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 389,
+      "line": 391,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Connect the gateway to load skills.",
       "surface": "android",
@@ -9835,7 +9835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 394,
+      "line": 396,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "No skills installed.",
       "surface": "android",
@@ -9843,7 +9843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 395,
+      "line": 397,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skills installed on the gateway will appear here.",
       "surface": "android",
@@ -9851,7 +9851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 400,
+      "line": 402,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "No installed skills match this search.",
       "surface": "android",
@@ -9859,7 +9859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 427,
+      "line": 429,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Gateway switch",
       "surface": "android",
@@ -9867,7 +9867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 429,
+      "line": 431,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Disabled for all agents.",
       "surface": "android",
@@ -9875,7 +9875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 429,
+      "line": 431,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Enabled for eligible agents.",
       "surface": "android",
@@ -9883,7 +9883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 460,
+      "line": 462,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Connect the gateway to load skill details.",
       "surface": "android",
@@ -9891,7 +9891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 466,
+      "line": 468,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skill detail is not available in the current skills status.",
       "surface": "android",
@@ -9899,7 +9899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 473,
+      "line": 475,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skill Key",
       "surface": "android",
@@ -9907,7 +9907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 474,
+      "line": 476,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Display",
       "surface": "android",
@@ -9915,7 +9915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 475,
+      "line": 477,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Source",
       "surface": "android",
@@ -9923,7 +9923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 476,
+      "line": 478,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Install Options",
       "surface": "android",
@@ -9931,7 +9931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 482,
+      "line": 484,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Description",
       "surface": "android",
@@ -9939,7 +9939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 519,
+      "line": 521,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Open skill detail",
       "surface": "android",
@@ -9947,7 +9947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 549,
+      "line": 552,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Find on ClawHub",
       "surface": "android",
@@ -9955,7 +9955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 551,
+      "line": 554,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Search registry metadata. The Gateway verifies trust again before any download.",
       "surface": "android",
@@ -9963,7 +9963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 570,
+      "line": 573,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Search ClawHub",
       "surface": "android",
@@ -9971,7 +9971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 575,
+      "line": 578,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Search",
       "surface": "android",
@@ -9979,7 +9979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 575,
+      "line": 578,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Searching",
       "surface": "android",
@@ -9987,7 +9987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 598,
+      "line": 602,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Version $it",
       "surface": "android",
@@ -9995,7 +9995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 606,
+      "line": 611,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Installing",
       "surface": "android",
@@ -10003,7 +10003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 607,
+      "line": 612,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Loading",
       "surface": "android",
@@ -10011,7 +10011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 667,
+      "line": 672,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -10019,7 +10019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 705,
+      "line": 710,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Review",
       "surface": "android",
@@ -10027,7 +10027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 711,
+      "line": 716,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Dismiss",
       "surface": "android",
@@ -10035,7 +10035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 718,
+      "line": 723,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Acknowledge Gateway warning and install",
       "surface": "android",
@@ -10043,7 +10043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 737,
+      "line": 742,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Review ClawHub skill",
       "surface": "android",
@@ -10051,7 +10051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 744,
+      "line": 749,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Version",
       "surface": "android",
@@ -10059,7 +10059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 745,
+      "line": 750,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Publisher",
       "surface": "android",
@@ -10067,7 +10067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 747,
+      "line": 752,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "The Gateway will verify this exact release with ClawHub before download. If the release needs explicit risk acknowledgement, Android will show the Gateway warning before retrying.",
       "surface": "android",
@@ -10075,7 +10075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 755,
+      "line": 760,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Verify and install",
       "surface": "android",
@@ -10083,7 +10083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 760,
+      "line": 765,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Cancel",
       "surface": "android",
@@ -10091,7 +10091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 802,
+      "line": 807,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "All",
       "surface": "android",
@@ -10099,7 +10099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 804,
+      "line": 809,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Needs Setup",
       "surface": "android",
@@ -10107,7 +10107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 821,
+      "line": 826,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -10115,7 +10115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 822,
+      "line": 827,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Setup",
       "surface": "android",
@@ -10123,7 +10123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 823,
+      "line": 828,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -10131,7 +10131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 836,
+      "line": 841,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Disabled",
       "surface": "android",
@@ -10139,7 +10139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 837,
+      "line": 842,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Blocked",
       "surface": "android",
@@ -10147,7 +10147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 838,
+      "line": 843,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Not available to this agent",
       "surface": "android",
@@ -10155,7 +10155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 840,
+      "line": 845,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Needs setup",
       "surface": "android",
@@ -10163,7 +10163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 848,
+      "line": 853,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "This skill is disabled on the gateway. Enable it here when the current connection has operator.admin.",
       "surface": "android",
@@ -10171,7 +10171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 849,
+      "line": 854,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "This skill is blocked by the gateway allowlist. Allowlist changes stay on desktop or CLI.",
       "surface": "android",
@@ -10179,7 +10179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 850,
+      "line": 855,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI.",
       "surface": "android",
@@ -10187,7 +10187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 852,
+      "line": 857,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "This skill is installed but not currently eligible to run. Use desktop or CLI for configuration changes.",
       "surface": "android",
@@ -10195,7 +10195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 853,
+      "line": 858,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Ready on this gateway. Android can enable or disable it globally; setup and configuration stay on desktop or CLI.",
       "surface": "android",
@@ -10203,7 +10203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 858,
+      "line": 863,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "No missing items",
       "surface": "android",
@@ -10211,7 +10211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 859,
+      "line": 864,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "1 missing item",
       "surface": "android",
@@ -10219,7 +10219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 860,
+      "line": 865,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "$count missing items",
       "surface": "android",
@@ -10227,7 +10227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 865,
+      "line": 870,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "This skill needs 1 setup item. Android shows what is installed; setup/config changes stay on desktop or CLI.",
       "surface": "android",
@@ -10235,7 +10235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 866,
+      "line": 871,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "This skill needs $count setup items. Android shows what is installed; setup/config changes stay on desktop or CLI.",
       "surface": "android",
@@ -10243,7 +10243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 871,
+      "line": 876,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Built-in",
       "surface": "android",
@@ -10251,7 +10251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 871,
+      "line": 876,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Bundled",
       "surface": "android",
@@ -10259,7 +10259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 872,
+      "line": 877,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Installed",
       "surface": "android",
@@ -10267,7 +10267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 873,
+      "line": 878,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Workspace",
       "surface": "android",
@@ -10275,7 +10275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 874,
+      "line": 879,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Extra",
       "surface": "android",
@@ -10283,7 +10283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 875,
+      "line": 880,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skill",
       "surface": "android",
@@ -17557,13 +17557,21 @@
       "kind": "ui-localized-call",
       "line": 927,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
+      "source": "Skills",
+      "surface": "apple",
+      "id": "native.apple.e2eaba9832a2fad7"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 928,
+      "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Voice & Talk",
       "surface": "apple",
       "id": "native.apple.fd44d6742909f55c"
     },
     {
       "kind": "ui-localized-call",
-      "line": 928,
+      "line": 929,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Diagnostics",
       "surface": "apple",
@@ -17571,7 +17579,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 929,
+      "line": 930,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Privacy",
       "surface": "apple",
@@ -17579,7 +17587,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 931,
+      "line": 932,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Licenses",
       "surface": "apple",
@@ -17587,7 +17595,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 932,
+      "line": 933,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "About",
       "surface": "apple",
@@ -17595,7 +17603,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 939,
+      "line": 940,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Preparing one-time setup…",
       "surface": "apple",
@@ -17603,7 +17611,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 944,
+      "line": 945,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "surface": "apple",
@@ -17611,7 +17619,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 946,
+      "line": 947,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
       "surface": "apple",
@@ -17619,7 +17627,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1036,
+      "line": 1037,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "This gateway is on your tailnet. Turn on Tailscale on this device, then tap Connect.",
       "surface": "apple",
@@ -17627,7 +17635,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1043,
+      "line": 1044,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Pairing required. Run /pair approve in your OpenClaw chat, then connect again.",
       "surface": "apple",
@@ -17635,7 +17643,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1046,
+      "line": 1047,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Secure handshake failed. Check Tailscale, then connect again.",
       "surface": "apple",
@@ -17643,7 +17651,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1055,
+      "line": 1056,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connection timed out. Make sure Tailscale is connected, then try again.",
       "surface": "apple",
@@ -17651,7 +17659,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1059,
+      "line": 1060,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connected, but some controls are restricted for nodes. This is expected.",
       "surface": "apple",
@@ -17659,7 +17667,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1066,
+      "line": 1067,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup code applied. Connecting...",
       "surface": "apple",
@@ -17667,7 +17675,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1067,
+      "line": 1068,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Checking gateway reachability...",
       "surface": "apple",
@@ -17675,7 +17683,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1068,
+      "line": 1069,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "QR loaded. Connecting to %@:%@...",
       "surface": "apple",
@@ -17683,7 +17691,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1131,
+      "line": 1132,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not loaded",
       "surface": "apple",
@@ -17691,7 +17699,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1134,
+      "line": 1135,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Configured",
       "surface": "apple",
@@ -17699,7 +17707,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1135,
+      "line": 1136,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not configured",
       "surface": "apple",
@@ -17707,7 +17715,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1142,
+      "line": 1143,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not active",
       "surface": "apple",
@@ -17715,7 +17723,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1172,
+      "line": 1173,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Apple Review demo mode",
       "surface": "apple",
@@ -17723,7 +17731,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1175,
+      "line": 1176,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connected",
       "surface": "apple",
@@ -17731,7 +17739,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1181,
+      "line": 1182,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "offline",
       "surface": "apple",
@@ -17739,7 +17747,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1181,
+      "line": 1182,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "online",
       "surface": "apple",
@@ -17747,7 +17755,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1199,
+      "line": 1200,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Live gateway requests are disabled in demo mode.",
       "surface": "apple",
@@ -17755,7 +17763,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1203,
+      "line": 1204,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Foreground approvals still appear while OpenClaw is connected.",
       "surface": "apple",
@@ -17763,7 +17771,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1206,
+      "line": 1207,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway requests will appear here.",
       "surface": "apple",
@@ -17771,7 +17779,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1207,
+      "line": 1208,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connect to the gateway.",
       "surface": "apple",
@@ -17779,7 +17787,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1211,
+      "line": 1212,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Demo mode only",
       "surface": "apple",
@@ -17787,7 +17795,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1218,
+      "line": 1219,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "loaded",
       "surface": "apple",
@@ -17795,7 +17803,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1219,
+      "line": 1220,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "missing",
       "surface": "apple",
@@ -17803,7 +17811,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1228,
+      "line": 1229,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Waiting for gateway",
       "surface": "apple",
@@ -17811,7 +17819,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1245,
+      "line": 1246,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "1 waiting",
       "surface": "apple",
@@ -17819,7 +17827,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1248,
+      "line": 1249,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "%@ waiting",
       "surface": "apple",
@@ -17827,7 +17835,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1259,
+      "line": 1260,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Review gateway action",
       "surface": "apple",
@@ -17835,7 +17843,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1261,
+      "line": 1262,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Agent: %@",
       "surface": "apple",
@@ -17843,7 +17851,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1270,
+      "line": 1271,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Resolving",
       "surface": "apple",
@@ -17851,7 +17859,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1271,
+      "line": 1272,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "High",
       "surface": "apple",
@@ -17859,7 +17867,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1277,
+      "line": 1278,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Permission can be saved",
       "surface": "apple",
@@ -17867,7 +17875,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1278,
+      "line": 1279,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "One-time approval",
       "surface": "apple",
@@ -17875,7 +17883,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1281,
+      "line": 1282,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Medium",
       "surface": "apple",
@@ -17883,7 +17891,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1282,
+      "line": 1283,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Review",
       "surface": "apple",
@@ -17891,7 +17899,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1288,
+      "line": 1289,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Talk + Wake",
       "surface": "apple",
@@ -17899,7 +17907,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1289,
+      "line": 1290,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Talk on",
       "surface": "apple",
@@ -17907,7 +17915,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1290,
+      "line": 1291,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Wake on",
       "surface": "apple",
@@ -17915,7 +17923,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1291,
+      "line": 1292,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Off",
       "surface": "apple",
@@ -17923,7 +17931,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1295,
+      "line": 1296,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "demo",
       "surface": "apple",
@@ -17931,7 +17939,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1296,
+      "line": 1297,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "ready",
       "surface": "apple",
@@ -17939,7 +17947,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1297,
+      "line": 1298,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "check",
       "surface": "apple",
@@ -17947,7 +17955,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1298,
+      "line": 1299,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "partial",
       "surface": "apple",
@@ -17955,7 +17963,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1302,
+      "line": 1303,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "pending",
       "surface": "apple",
@@ -17963,7 +17971,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1304,
+      "line": 1305,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "pass",
       "surface": "apple",
@@ -17971,7 +17979,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1315,
+      "line": 1316,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Requesting iOS location permission…",
       "surface": "apple",
@@ -17979,7 +17987,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1381,
+      "line": 1382,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "This build uses OpenClaw's hosted push relay at %@ for notification delivery data.",
       "surface": "apple",
@@ -17987,7 +17995,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1385,
+      "line": 1386,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "This build is not configured to use OpenClaw's hosted push relay.",
       "surface": "apple",
@@ -17995,7 +18003,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1390,
+      "line": 1391,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Enabling this sends delivery data through OpenClaw's hosted push relay.",
       "surface": "apple",
@@ -18059,7 +18067,15 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 171,
+      "line": 162,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "Skills",
+      "surface": "apple",
+      "id": "native.apple.1f52746515df3fa5"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 176,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Diagnostics",
       "surface": "apple",
@@ -18067,7 +18083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 176,
+      "line": 181,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Privacy",
       "surface": "apple",
@@ -18075,7 +18091,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 186,
+      "line": 191,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "About",
       "surface": "apple",
@@ -18083,7 +18099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 198,
+      "line": 203,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Licenses",
       "surface": "apple",
@@ -18091,7 +18107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 282,
+      "line": 293,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway",
       "surface": "apple",
@@ -18099,7 +18115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 288,
+      "line": 299,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Address",
       "surface": "apple",
@@ -18107,7 +18123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 289,
+      "line": 300,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Server",
       "surface": "apple",
@@ -18115,7 +18131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 290,
+      "line": 301,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovered",
       "surface": "apple",
@@ -18123,7 +18139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 296,
+      "line": 307,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Agents",
       "surface": "apple",
@@ -18131,7 +18147,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 355,
+      "line": 366,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Switch Gateway",
       "surface": "apple",
@@ -18139,7 +18155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 362,
+      "line": 373,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Approvals",
       "surface": "apple",
@@ -18147,7 +18163,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 364,
+      "line": 375,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Out-of-app approval alerts need notification permission.",
       "surface": "apple",
@@ -18155,7 +18171,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 366,
+      "line": 377,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No gateway actions are waiting for review.",
       "surface": "apple",
@@ -18163,7 +18179,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 367,
+      "line": 378,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Review pending gateway actions.",
       "surface": "apple",
@@ -18171,7 +18187,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 369,
+      "line": 380,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Alerts Off",
       "surface": "apple",
@@ -18179,7 +18195,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 371,
+      "line": 382,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "clear",
       "surface": "apple",
@@ -18187,7 +18203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 389,
+      "line": 400,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Apple Watch",
       "surface": "apple",
@@ -18195,7 +18211,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 392,
+      "line": 403,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Relay remains available; direct mode adds an independent Gateway node.",
       "surface": "apple",
@@ -18203,7 +18219,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 394,
+      "line": 405,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Install the OpenClaw watch app before enabling direct mode.",
       "surface": "apple",
@@ -18211,7 +18227,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 397,
+      "line": 408,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Reachable",
       "surface": "apple",
@@ -18219,7 +18235,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 399,
+      "line": 410,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Installed",
       "surface": "apple",
@@ -18227,7 +18243,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 400,
+      "line": 411,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Unavailable",
       "surface": "apple",
@@ -18235,7 +18251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 407,
+      "line": 418,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Enable Direct Gateway Connection",
       "surface": "apple",
@@ -18243,7 +18259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 423,
+      "line": 434,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "The watch receives a one-time pairing code and stores its own device token. A reachable secure Gateway URL is required away from the iPhone.",
       "surface": "apple",
@@ -18251,7 +18267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 431,
+      "line": 442,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Direct node features",
       "surface": "apple",
@@ -18259,7 +18275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 441,
+      "line": 452,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Notifications are off",
       "surface": "apple",
@@ -18267,7 +18283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 443,
+      "line": 454,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Enable Notifications to receive approval alerts while OpenClaw is not open.",
       "surface": "apple",
@@ -18275,7 +18291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 452,
+      "line": 463,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Open Notifications",
       "surface": "apple",
@@ -18283,7 +18299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 462,
+      "line": 473,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Pending approvals",
       "surface": "apple",
@@ -18291,7 +18307,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 479,
+      "line": 490,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Review exec approval",
       "surface": "apple",
@@ -18299,7 +18315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 486,
+      "line": 497,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Reviewing",
       "surface": "apple",
@@ -18307,7 +18323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 520,
+      "line": 531,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Allow Once",
       "surface": "apple",
@@ -18315,7 +18331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 529,
+      "line": 540,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Allow Always",
       "surface": "apple",
@@ -18323,7 +18339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 538,
+      "line": 549,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Deny",
       "surface": "apple",
@@ -18331,7 +18347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 549,
+      "line": 560,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Dismiss",
       "surface": "apple",
@@ -18339,7 +18355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 559,
+      "line": 570,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No approvals waiting",
       "surface": "apple",
@@ -18347,7 +18363,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 589,
+      "line": 600,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Camera",
       "surface": "apple",
@@ -18355,7 +18371,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 595,
+      "line": 606,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Keep Awake",
       "surface": "apple",
@@ -18363,7 +18379,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 606,
+      "line": 617,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice & Talk",
       "surface": "apple",
@@ -18371,7 +18387,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 621,
+      "line": 632,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Health Check",
       "surface": "apple",
@@ -18379,7 +18395,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 622,
+      "line": 633,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run app, permission, and gateway-adjacent checks without editing setup.",
       "surface": "apple",
@@ -18387,7 +18403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 630,
+      "line": 641,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run Diagnostics",
       "surface": "apple",
@@ -18395,7 +18411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 640,
+      "line": 651,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Platform",
       "surface": "apple",
@@ -18403,7 +18419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 643,
+      "line": 654,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "App",
       "surface": "apple",
@@ -18411,7 +18427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 646,
+      "line": 657,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Model",
       "surface": "apple",
@@ -18419,7 +18435,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 658,
+      "line": 669,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Camera Access",
       "surface": "apple",
@@ -18427,7 +18443,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 664,
+      "line": 675,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Background Listening",
       "surface": "apple",
@@ -18435,7 +18451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 689,
+      "line": 700,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Notifications",
       "surface": "apple",
@@ -18443,7 +18459,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 698,
+      "line": 709,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Turns OpenClaw notification delivery on or off",
       "surface": "apple",
@@ -18451,7 +18467,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 718,
+      "line": 729,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Reconnect",
       "surface": "apple",
@@ -18459,7 +18475,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 728,
+      "line": 739,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Diagnose",
       "surface": "apple",
@@ -18467,7 +18483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 744,
+      "line": 755,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "License files are not available in this build.",
       "surface": "apple",
@@ -18475,7 +18491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 761,
+      "line": 772,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "apple",
@@ -18483,7 +18499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 801,
+      "line": 812,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -18491,7 +18507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 803,
+      "line": 814,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Personal AI on your devices",
       "surface": "apple",
@@ -18499,7 +18515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 820,
+      "line": 831,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "iOS",
       "surface": "apple",
@@ -18507,7 +18523,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 827,
+      "line": 838,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Website",
       "surface": "apple",
@@ -18515,7 +18531,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 832,
+      "line": 843,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Docs",
       "surface": "apple",
@@ -18523,7 +18539,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 837,
+      "line": 848,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "GitHub",
       "surface": "apple",
@@ -18531,7 +18547,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 842,
+      "line": 853,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discord",
       "surface": "apple",
@@ -18539,7 +18555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 847,
+      "line": 858,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "© 2026 OpenClaw Foundation — MIT License.",
       "surface": "apple",
@@ -18547,7 +18563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 853,
+      "line": 864,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Title",
       "surface": "apple",
@@ -18555,7 +18571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 893,
+      "line": 904,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Location",
       "surface": "apple",
@@ -18563,7 +18579,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 911,
+      "line": 922,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Location Sharing",
       "surface": "apple",
@@ -18571,7 +18587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 924,
+      "line": 935,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Access Level",
       "surface": "apple",
@@ -18579,7 +18595,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 946,
+      "line": 957,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Chooses While Using the App or Always",
       "surface": "apple",
@@ -18587,7 +18603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 966,
+      "line": 977,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default Agent",
       "surface": "apple",
@@ -18595,7 +18611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 967,
+      "line": 978,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default",
       "surface": "apple",
@@ -18603,7 +18619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 977,
+      "line": 988,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Used for new Chat and Talk sessions.",
       "surface": "apple",
@@ -18611,7 +18627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 984,
+      "line": 995,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Paste setup code",
       "surface": "apple",
@@ -18619,7 +18635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 990,
+      "line": 1001,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Scan QR",
       "surface": "apple",
@@ -18627,7 +18643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1000,
+      "line": 1011,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connect",
       "surface": "apple",
@@ -18635,7 +18651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1009,
+      "line": 1020,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Setup Code",
       "surface": "apple",
@@ -18643,7 +18659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1022,
+      "line": 1033,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovered Gateways",
       "surface": "apple",
@@ -18651,7 +18667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1024,
+      "line": 1035,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "surface": "apple",
@@ -18659,7 +18675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1038,
+      "line": 1049,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Pair a gateway to make it available here.",
       "surface": "apple",
@@ -18667,7 +18683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1047,
+      "line": 1058,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Paired Gateways",
       "surface": "apple",
@@ -18675,7 +18691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1050,
+      "line": 1061,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Switch gateways without pairing again.",
       "surface": "apple",
@@ -18683,7 +18699,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1080,
+      "line": 1091,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Active Gateway",
       "surface": "apple",
@@ -18691,7 +18707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1092,
+      "line": 1103,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Forget",
       "surface": "apple",
@@ -18699,7 +18715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1104,
+      "line": 1115,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Forget Gateway",
       "surface": "apple",
@@ -18707,7 +18723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1157,
+      "line": 1168,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Manual Gateway",
       "surface": "apple",
@@ -18715,7 +18731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1158,
+      "line": 1169,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Use Manual Gateway",
       "surface": "apple",
@@ -18723,7 +18739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1159,
+      "line": 1170,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Host",
       "surface": "apple",
@@ -18731,7 +18747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1163,
+      "line": 1174,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Port",
       "surface": "apple",
@@ -18739,7 +18755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1167,
+      "line": 1178,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Unencrypted",
       "surface": "apple",
@@ -18747,7 +18763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1170,
+      "line": 1181,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Secure (TLS)",
       "surface": "apple",
@@ -18755,7 +18771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1174,
+      "line": 1185,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connection security",
       "surface": "apple",
@@ -18763,7 +18779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1185,
+      "line": 1196,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connect Manual",
       "surface": "apple",
@@ -18771,7 +18787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1215,
+      "line": 1226,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Auto-connect on launch",
       "surface": "apple",
@@ -18779,7 +18795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1216,
+      "line": 1227,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Auth Token",
       "surface": "apple",
@@ -18787,7 +18803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1217,
+      "line": 1228,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Password",
       "surface": "apple",
@@ -18795,7 +18811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1222,
+      "line": 1233,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Custom Headers",
       "surface": "apple",
@@ -18803,7 +18819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1229,
+      "line": 1240,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Reset Onboarding",
       "surface": "apple",
@@ -18811,7 +18827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1259,
+      "line": 1270,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice Wake",
       "surface": "apple",
@@ -18819,7 +18835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1262,
+      "line": 1273,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Talk Mode",
       "surface": "apple",
@@ -18827,7 +18843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1270,
+      "line": 1281,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Speech Language",
       "surface": "apple",
@@ -18835,7 +18851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1277,
+      "line": 1288,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Speakerphone",
       "surface": "apple",
@@ -18843,7 +18859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1281,
+      "line": 1292,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Wake Words",
       "surface": "apple",
@@ -18851,7 +18867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1303,
+      "line": 1314,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice",
       "surface": "apple",
@@ -18859,7 +18875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1304,
+      "line": 1315,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Provider",
       "surface": "apple",
@@ -18867,7 +18883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1311,
+      "line": 1322,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Realtime Voice",
       "surface": "apple",
@@ -18875,7 +18891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1312,
+      "line": 1323,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Default",
       "surface": "apple",
@@ -18883,7 +18899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1319,
+      "line": 1330,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice Mode",
       "surface": "apple",
@@ -18891,7 +18907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1322,
+      "line": 1333,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Active Voice",
       "surface": "apple",
@@ -18899,7 +18915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1326,
+      "line": 1337,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Last Voice Issue",
       "surface": "apple",
@@ -18907,7 +18923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1328,
+      "line": 1339,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Transport",
       "surface": "apple",
@@ -18915,7 +18931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1331,
+      "line": 1342,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "API Key",
       "surface": "apple",
@@ -18923,7 +18939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1338,
+      "line": 1349,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Show Talk Control",
       "surface": "apple",
@@ -18931,7 +18947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1339,
+      "line": 1350,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default Share Instruction",
       "surface": "apple",
@@ -18939,7 +18955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1346,
+      "line": 1357,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run Share Self-Test",
       "surface": "apple",
@@ -18947,7 +18963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1363,
+      "line": 1374,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovery Debug Logs",
       "surface": "apple",
@@ -18955,7 +18971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1366,
+      "line": 1377,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Debug Screen Status",
       "surface": "apple",
@@ -18963,7 +18979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1370,
+      "line": 1381,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovery Logs",
       "surface": "apple",
@@ -18971,7 +18987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1378,
+      "line": 1389,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Device",
       "surface": "apple",
@@ -18979,7 +18995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1379,
+      "line": 1390,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Device Name",
       "surface": "apple",
@@ -18987,7 +19003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1381,
+      "line": 1392,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Instance ID",
       "surface": "apple",
@@ -18995,7 +19011,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1405,
+      "line": 1416,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "On",
       "surface": "apple",
@@ -19003,7 +19019,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1406,
+      "line": 1417,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Off",
       "surface": "apple",
@@ -19011,7 +19027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 98,
+      "line": 99,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Copy full commit hash",
       "surface": "apple",
@@ -19019,7 +19035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 105,
+      "line": 106,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Copy build info",
       "surface": "apple",
@@ -19027,7 +19043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 115,
+      "line": 116,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Copy Commit",
       "surface": "apple",
@@ -19035,7 +19051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 126,
+      "line": 127,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Copy Build Info",
       "surface": "apple",
@@ -19043,7 +19059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 167,
+      "line": 168,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Unavailable",
       "surface": "apple",
@@ -19051,7 +19067,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 187,
+      "line": 188,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Version %1$@, commit %2$@, built %3$@, timestamp %4$@",
       "surface": "apple",
@@ -19059,7 +19075,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 196,
+      "line": 197,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Version %1$@, commit %2$@, build date unavailable",
       "surface": "apple",
@@ -19067,7 +19083,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 203,
+      "line": 204,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Version %1$@, commit unavailable, built %2$@, timestamp %3$@",
       "surface": "apple",
@@ -19075,7 +19091,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 210,
+      "line": 211,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Version %@, commit unavailable, build date unavailable",
       "surface": "apple",
@@ -19083,7 +19099,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 306,
+      "line": 307,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Checking",
       "surface": "apple",
@@ -19091,7 +19107,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 307,
+      "line": 308,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Enabled",
       "surface": "apple",
@@ -19099,7 +19115,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 308,
+      "line": 309,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Off",
       "surface": "apple",
@@ -19107,7 +19123,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 309,
+      "line": 310,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Setup",
       "surface": "apple",
@@ -19115,7 +19131,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 310,
+      "line": 311,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Denied",
       "surface": "apple",
@@ -19123,7 +19139,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 311,
+      "line": 312,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Not Enabled",
       "surface": "apple",
@@ -19131,7 +19147,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 312,
+      "line": 313,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Unknown",
       "surface": "apple",
@@ -19139,7 +19155,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 319,
+      "line": 320,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Checking iOS notification permission.",
       "surface": "apple",
@@ -19147,7 +19163,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 322,
+      "line": 323,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "OpenClaw can show approval prompts and event alerts when the app is not active.",
       "surface": "apple",
@@ -19155,7 +19171,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 324,
+      "line": 325,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "OpenClaw notifications are off.",
       "surface": "apple",
@@ -19163,7 +19179,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 327,
+      "line": 328,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Finish notification setup to receive alerts when the app is not active.",
       "surface": "apple",
@@ -19171,7 +19187,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 329,
+      "line": 330,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Notifications have been denied. Enable them in iOS Settings.",
       "surface": "apple",
@@ -19179,7 +19195,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 332,
+      "line": 333,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Enable notifications to receive approval prompts and event alerts outside the app.",
       "surface": "apple",
@@ -19187,7 +19203,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 334,
+      "line": 335,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "OpenClaw cannot determine the current notification permission state.",
       "surface": "apple",
@@ -19195,7 +19211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 457,
+      "line": 458,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Connected",
       "surface": "apple",
@@ -19203,7 +19219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 459,
+      "line": 460,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Gateway online",
       "surface": "apple",
@@ -19211,7 +19227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 460,
+      "line": 461,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Connected to openclaw-gateway.tailnet.ts.net.",
       "surface": "apple",
@@ -19219,7 +19235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 470,
+      "line": 471,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Loading",
       "surface": "apple",
@@ -19227,7 +19243,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 472,
+      "line": 473,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Checking gateway",
       "surface": "apple",
@@ -19235,7 +19251,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 473,
+      "line": 474,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Refreshing connection, discovery, and device trust state.",
       "surface": "apple",
@@ -19243,7 +19259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 479,
+      "line": 480,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Empty",
       "surface": "apple",
@@ -19251,7 +19267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 481,
+      "line": 482,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "No gateway configured",
       "surface": "apple",
@@ -19259,7 +19275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 482,
+      "line": 483,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Scan a setup QR code, paste a setup code, or choose a discovered gateway.",
       "surface": "apple",
@@ -19267,7 +19283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 488,
+      "line": 489,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Error",
       "surface": "apple",
@@ -19275,7 +19291,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 490,
+      "line": 491,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Tailscale warning",
       "surface": "apple",
@@ -19283,7 +19299,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 491,
+      "line": 492,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Tailscale is off on this device. Turn it on, then try again.",
       "surface": "apple",
@@ -19291,7 +19307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 540,
+      "line": 541,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Address",
       "surface": "apple",
@@ -19299,7 +19315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 542,
+      "line": 543,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Server",
       "surface": "apple",
@@ -19307,7 +19323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 544,
+      "line": 545,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Discovered",
       "surface": "apple",
@@ -19315,7 +19331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 546,
+      "line": 547,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Default Agent",
       "surface": "apple",
@@ -19323,7 +19339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 568,
+      "line": 569,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Reconnect",
       "surface": "apple",
@@ -19331,7 +19347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 569,
+      "line": 570,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Diagnose",
       "surface": "apple",
@@ -19339,7 +19355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 578,
+      "line": 579,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Scan QR",
       "surface": "apple",
@@ -19347,7 +19363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 579,
+      "line": 580,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Connect",
       "surface": "apple",
@@ -19355,11 +19371,539 @@
     },
     {
       "kind": "ui-call",
-      "line": 581,
+      "line": 582,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "surface": "apple",
       "id": "native.apple.f439c34a9ce3a332"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 13,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Browse",
+      "surface": "apple",
+      "id": "native.apple.acf33c8c3efde926"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 29,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "All",
+      "surface": "apple",
+      "id": "native.apple.57f55061e45f732b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 153,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Skills",
+      "surface": "apple",
+      "id": "native.apple.02a59c6d5de241c6"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 167,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Connect to manage Gateway skills.",
+      "surface": "apple",
+      "id": "native.apple.de33b4b220a48b7b"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 169,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Loading installed skills and readiness.",
+      "surface": "apple",
+      "id": "native.apple.395f4d55dfb4b1bf"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 172,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "%@ ready · %@ need setup",
+      "surface": "apple",
+      "id": "native.apple.b5a47111394ae9d2"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 179,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "offline",
+      "surface": "apple",
+      "id": "native.apple.06c8a70b3321dd77"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 181,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "loading",
+      "surface": "apple",
+      "id": "native.apple.bbf921f4a20e6d64"
+    },
+    {
+      "kind": "ui-call",
+      "line": 197,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Skills section",
+      "surface": "apple",
+      "id": "native.apple.50af4928abeb5493"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 212,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Installed",
+      "surface": "apple",
+      "id": "native.apple.5be2a1662a9d8454"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 215,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Refresh Skills",
+      "surface": "apple",
+      "id": "native.apple.493e64eee96d3b2c"
+    },
+    {
+      "kind": "ui-call",
+      "line": 233,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Search installed skills",
+      "surface": "apple",
+      "id": "native.apple.2fc9bfee92bad603"
+    },
+    {
+      "kind": "ui-call",
+      "line": 242,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Installed skill filter",
+      "surface": "apple",
+      "id": "native.apple.b7a9e8ede061b45c"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 256,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Connect to load and manage installed skills.",
+      "surface": "apple",
+      "id": "native.apple.d5075a70296450e1"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 263,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Loading skills",
+      "surface": "apple",
+      "id": "native.apple.d23235f31ddc7d87"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 264,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Reading the Gateway skill catalog.",
+      "surface": "apple",
+      "id": "native.apple.ad8ceb4f98255843"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 271,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "No matching skills",
+      "surface": "apple",
+      "id": "native.apple.0550dad32f8ef785"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 271,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "No skills installed",
+      "surface": "apple",
+      "id": "native.apple.adcee8faa45b0365"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 273,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Browse ClawHub to discover and install skills.",
+      "surface": "apple",
+      "id": "native.apple.e7e5b1011a14fc4b"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 274,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Change the search or readiness filter.",
+      "surface": "apple",
+      "id": "native.apple.f54b778b8ea52ece"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 319,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "ClawHub",
+      "surface": "apple",
+      "id": "native.apple.44d2b179910face4"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 322,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Search ClawHub",
+      "surface": "apple",
+      "id": "native.apple.8e161683e7efa2a4"
+    },
+    {
+      "kind": "ui-call",
+      "line": 349,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Search",
+      "surface": "apple",
+      "id": "native.apple.c7050536b0ee103f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 353,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "surface": "apple",
+      "id": "native.apple.a390ab96444bced8"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 366,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Gateway offline",
+      "surface": "apple",
+      "id": "native.apple.85d609abe4548150"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 367,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Connect to search and install ClawHub skills.",
+      "surface": "apple",
+      "id": "native.apple.37ce41bbd2c854dd"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 374,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Gateway update required",
+      "surface": "apple",
+      "id": "native.apple.a21337a8fba8d90c"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 375,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "surface": "apple",
+      "id": "native.apple.503fadc03e3b4090"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 382,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Searching ClawHub",
+      "surface": "apple",
+      "id": "native.apple.b542672608467c0a"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 383,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Loading verified skill releases.",
+      "surface": "apple",
+      "id": "native.apple.5acf38408914a884"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 390,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "No skills found",
+      "surface": "apple",
+      "id": "native.apple.c0261398045e7911"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 391,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Try another search or refresh the catalog.",
+      "surface": "apple",
+      "id": "native.apple.eb605facc8feeed7"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 478,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Could not load skills",
+      "surface": "apple",
+      "id": "native.apple.29c8087ab70bedcd"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 519,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "ClawHub unavailable",
+      "surface": "apple",
+      "id": "native.apple.cf8f37f9d39bf57b"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 560,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Could not review skill",
+      "surface": "apple",
+      "id": "native.apple.43406555e5144718"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 617,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "surface": "apple",
+      "id": "native.apple.1633604644edf7b3"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 644,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Gateway blocked install",
+      "surface": "apple",
+      "id": "native.apple.3cc22b37bdb9fcd1"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 660,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "The Gateway installed the reviewed version.",
+      "surface": "apple",
+      "id": "native.apple.95223294a767ccd7"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 669,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Install result unknown",
+      "surface": "apple",
+      "id": "native.apple.71d7b3860ab9f02c"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 704,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Skill disabled",
+      "surface": "apple",
+      "id": "native.apple.e69ba6c4d73eb72f"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 704,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Skill enabled",
+      "surface": "apple",
+      "id": "native.apple.8677a968b0a7729d"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 712,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Could not enable skill",
+      "surface": "apple",
+      "id": "native.apple.b4577e30f257ad79"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 713,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Could not disable skill",
+      "surface": "apple",
+      "id": "native.apple.b9d22e7d493eb2bb"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 823,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Disable",
+      "surface": "apple",
+      "id": "native.apple.1f06ad201d9b6bed"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 823,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Enable",
+      "surface": "apple",
+      "id": "native.apple.b284f85f4efc0fa7"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 835,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Off",
+      "surface": "apple",
+      "id": "native.apple.0d4cc831b423aa98"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 838,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Ready",
+      "surface": "apple",
+      "id": "native.apple.c63a20f1143b62ca"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 839,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Needs Setup",
+      "surface": "apple",
+      "id": "native.apple.892d7433a4468f5a"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 851,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Missing: %@",
+      "surface": "apple",
+      "id": "native.apple.113dacafa42bb62e"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 879,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Install",
+      "surface": "apple",
+      "id": "native.apple.1824681020aa336b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 936,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "surface": "apple",
+      "id": "native.apple.7d9b36be7a7df9a8"
+    },
+    {
+      "kind": "ui-call",
+      "line": 940,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "surface": "apple",
+      "id": "native.apple.4fb1f26e4de787dd"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 947,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Review ClawHub skill",
+      "surface": "apple",
+      "id": "native.apple.0f902fcad255ae3f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 955,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Verify and install",
+      "surface": "apple",
+      "id": "native.apple.8f61d18ceca765da"
+    },
+    {
+      "kind": "ui-call",
+      "line": 979,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Gateway warning",
+      "surface": "apple",
+      "id": "native.apple.64ac6815468e764b"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 989,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "surface": "apple",
+      "id": "native.apple.cfb4fe56e0a7f93b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 994,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Review warning details",
+      "surface": "apple",
+      "id": "native.apple.91447e88c95f0f72"
+    },
+    {
+      "kind": "ui-call",
+      "line": 996,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "surface": "apple",
+      "id": "native.apple.9ad3235988108fce"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 1002,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Review Gateway warning",
+      "surface": "apple",
+      "id": "native.apple.b79b3886a801b83e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1006,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Cancel",
+      "surface": "apple",
+      "id": "native.apple.8a3adec4b6d6eb15"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1010,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Acknowledge and install",
+      "surface": "apple",
+      "id": "native.apple.30304ca2865ea3b4"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1030,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Version",
+      "surface": "apple",
+      "id": "native.apple.c1499a39573b3633"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1031,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Publisher",
+      "surface": "apple",
+      "id": "native.apple.4789ad34a901e14e"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 1078,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "surface": "apple",
+      "id": "native.apple.ba780a0a9b2fd426"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 1079,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "Could not encode the Gateway request.",
+      "surface": "apple",
+      "id": "native.apple.af9d5bb3dd35cfff"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 1080,
+      "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "surface": "apple",
+      "id": "native.apple.7a5a1b9342f01954"
     },
     {
       "kind": "ui-modifier",
@@ -25171,6 +25715,174 @@
     },
     {
       "kind": "ui-call",
+      "line": 24,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "Browse ClawHub",
+      "surface": "apple",
+      "id": "native.apple.48155cd3182d0fc1"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 26,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "Discover skills",
+      "surface": "apple",
+      "id": "native.apple.2a63044f55e90b32"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 27,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "surface": "apple",
+      "id": "native.apple.5fef1d6003e5df6f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 30,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "Search ClawHub",
+      "surface": "apple",
+      "id": "native.apple.f5aa33a76f62e6e9"
+    },
+    {
+      "kind": "ui-call",
+      "line": 37,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "Search",
+      "surface": "apple",
+      "id": "native.apple.1b08dbd63dadda23"
+    },
+    {
+      "kind": "ui-call",
+      "line": 48,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "Results",
+      "surface": "apple",
+      "id": "native.apple.84bdcdb604ccadd6"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 50,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "Searching ClawHub…",
+      "surface": "apple",
+      "id": "native.apple.2539b847d0cc4326"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 55,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "No skills found",
+      "surface": "apple",
+      "id": "native.apple.ce42e5d6c37b59e8"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 56,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "Try another search or refresh the catalog.",
+      "surface": "apple",
+      "id": "native.apple.c27ee52f9350a02f"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 134,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "Installed",
+      "surface": "apple",
+      "id": "native.apple.fc107db526febdee"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 134,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "Review",
+      "surface": "apple",
+      "id": "native.apple.101103e2d97e04cd"
+    },
+    {
+      "kind": "ui-call",
+      "line": 149,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "Review ClawHub skill",
+      "surface": "apple",
+      "id": "native.apple.8976aca17f4dfbdc"
+    },
+    {
+      "kind": "ui-call",
+      "line": 151,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "surface": "apple",
+      "id": "native.apple.b5a521cd4f77fff0"
+    },
+    {
+      "kind": "ui-call",
+      "line": 157,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "Verify and install",
+      "surface": "apple",
+      "id": "native.apple.86078f1c84e735d7"
+    },
+    {
+      "kind": "ui-call",
+      "line": 178,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "Gateway warning",
+      "surface": "apple",
+      "id": "native.apple.fbbba0a83466864c"
+    },
+    {
+      "kind": "ui-call",
+      "line": 183,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "Review warning details",
+      "surface": "apple",
+      "id": "native.apple.8957dc102983dbb0"
+    },
+    {
+      "kind": "ui-call",
+      "line": 189,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "surface": "apple",
+      "id": "native.apple.1b9020d8308c0563"
+    },
+    {
+      "kind": "ui-call",
+      "line": 194,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "Cancel",
+      "surface": "apple",
+      "id": "native.apple.ee2577b784c64ac6"
+    },
+    {
+      "kind": "ui-call",
+      "line": 195,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "Acknowledge and install",
+      "surface": "apple",
+      "id": "native.apple.9fa34dc1057cbcee"
+    },
+    {
+      "kind": "ui-call",
+      "line": 214,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "Version",
+      "surface": "apple",
+      "id": "native.apple.5e36364c63057778"
+    },
+    {
+      "kind": "ui-call",
+      "line": 215,
+      "path": "apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift",
+      "source": "Publisher",
+      "surface": "apple",
+      "id": "native.apple.cac171668ece3a4d"
+    },
+    {
+      "kind": "ui-call",
       "line": 82,
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "No config sections available.",
@@ -30923,7 +31635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 21,
+      "line": 24,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Skills",
       "surface": "apple",
@@ -30931,15 +31643,23 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 22,
+      "line": 25,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
-      "source": "Optional capabilities that become available when their requirements are met.",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
       "surface": "apple",
-      "id": "native.apple.0f62bd687b786431"
+      "id": "native.apple.50be0aae3f54705e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 62,
+      "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
+      "source": "Skills section",
+      "surface": "apple",
+      "id": "native.apple.5a3f840bde899fbe"
     },
     {
       "kind": "conditional-branch",
-      "line": 67,
+      "line": 87,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Loading skills",
       "surface": "apple",
@@ -30947,7 +31667,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 67,
+      "line": 87,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "\\(ready) ready · \\(needsSetup) need setup",
       "surface": "apple",
@@ -30955,7 +31675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 69,
+      "line": 89,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Enable ready skills, or install missing tools on the Gateway or this Mac.",
       "surface": "apple",
@@ -30963,7 +31683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 78,
+      "line": 98,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "\\(total)",
       "surface": "apple",
@@ -30971,7 +31691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 93,
+      "line": 113,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Controls",
       "surface": "apple",
@@ -30979,7 +31699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 95,
+      "line": 115,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Skill catalog",
       "surface": "apple",
@@ -30987,7 +31707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 96,
+      "line": 116,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Refresh after changing binaries, environment variables, or skill config.",
       "surface": "apple",
@@ -30995,15 +31715,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 106,
+      "line": 126,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Refresh",
       "surface": "apple",
       "id": "native.apple.be08a918dffd2913"
     },
     {
+      "kind": "ui-call",
+      "line": 131,
+      "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
+      "source": "Search installed skills",
+      "surface": "apple",
+      "id": "native.apple.90f5eb0762593f89"
+    },
+    {
       "kind": "conditional-branch",
-      "line": 134,
+      "line": 158,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Loading…",
       "surface": "apple",
@@ -31011,7 +31739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 134,
+      "line": 158,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "No skills reported yet",
       "surface": "apple",
@@ -31019,7 +31747,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 135,
+      "line": 159,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Reading the Gateway skill catalog.",
       "surface": "apple",
@@ -31027,7 +31755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 170,
+      "line": 194,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "No skills match this filter.",
       "surface": "apple",
@@ -31035,7 +31763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 182,
+      "line": 206,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Filter",
       "surface": "apple",
@@ -31043,7 +31771,23 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 222,
+      "line": 249,
+      "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
+      "source": "Installed",
+      "surface": "apple",
+      "id": "native.apple.ebbf5e9abc1fd8b9"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 250,
+      "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
+      "source": "Browse",
+      "surface": "apple",
+      "id": "native.apple.a4b3ea71236c5789"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 268,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "All",
       "surface": "apple",
@@ -31051,7 +31795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 224,
+      "line": 270,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Ready",
       "surface": "apple",
@@ -31059,7 +31803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 226,
+      "line": 272,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Needs Setup",
       "surface": "apple",
@@ -31067,7 +31811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 228,
+      "line": 274,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Disabled",
       "surface": "apple",
@@ -31075,7 +31819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 276,
+      "line": 322,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Website",
       "surface": "apple",
@@ -31083,7 +31827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 310,
+      "line": 356,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Details",
       "surface": "apple",
@@ -31091,7 +31835,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 336,
+      "line": 382,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Needs setup",
       "surface": "apple",
@@ -31099,7 +31843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 351,
+      "line": 397,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Managed",
       "surface": "apple",
@@ -31107,7 +31851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 353,
+      "line": 399,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Workspace",
       "surface": "apple",
@@ -31115,7 +31859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 355,
+      "line": 401,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Extra",
       "surface": "apple",
@@ -31123,7 +31867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 357,
+      "line": 403,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Plugin",
       "surface": "apple",
@@ -31131,7 +31875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 418,
+      "line": 464,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Missing binaries: \\(self.missingBins.joined(separator: \", \"))",
       "surface": "apple",
@@ -31139,7 +31883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 423,
+      "line": 469,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Missing env: \\(self.missingEnv.joined(separator: \", \"))",
       "surface": "apple",
@@ -31147,7 +31891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 428,
+      "line": 474,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Requires config: \\(self.missingConfig.joined(separator: \", \"))",
       "surface": "apple",
@@ -31155,7 +31899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 455,
+      "line": 501,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Set \\(envKey)",
       "surface": "apple",
@@ -31163,7 +31907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 471,
+      "line": 517,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Install on Gateway",
       "surface": "apple",
@@ -31171,7 +31915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 484,
+      "line": 530,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Install on This Mac",
       "surface": "apple",
@@ -31179,7 +31923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 489,
+      "line": 535,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Switches to Local mode to install on this Mac.",
       "surface": "apple",
@@ -31187,7 +31931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 597,
+      "line": 643,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Get your key →",
       "surface": "apple",
@@ -31195,7 +31939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 602,
+      "line": 648,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Saved to openclaw.json under skills.entries.\\(self.editor.skillKey)",
       "surface": "apple",
@@ -31203,7 +31947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 606,
+      "line": 652,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -31211,7 +31955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 608,
+      "line": 654,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Save",
       "surface": "apple",
@@ -31219,7 +31963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 636,
+      "line": 682,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Set API Key",
       "surface": "apple",
@@ -31227,7 +31971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 636,
+      "line": 682,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Set Environment Variable",
       "surface": "apple",
@@ -31235,7 +31979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 705,
+      "line": 757,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Skill disabled",
       "surface": "apple",
@@ -31243,7 +31987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 705,
+      "line": 757,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Skill enabled",
       "surface": "apple",
@@ -31251,7 +31995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 783,
+      "line": 835,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Bundled",
       "surface": "apple",
@@ -33592,6 +34336,14 @@
       "source": "Apple Watch",
       "surface": "apple",
       "id": "native.apple.2f45f005d2a7c3c2"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 332,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/SkillManagement.swift",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "surface": "apple",
+      "id": "native.apple.3fe61126fd4ca8aa"
     },
     {
       "kind": "conditional-branch",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -34339,7 +34339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 331,
+      "line": 292,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/SkillManagement.swift",
       "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -19658,7 +19658,7 @@
       "id": "native.apple.43406555e5144718"
     },
     {
-      "kind": "ui-localized-call",
+      "kind": "ui-localized-call-multiline",
       "line": 593,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
@@ -19667,7 +19667,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 616,
+      "line": 619,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Gateway blocked install",
       "surface": "apple",
@@ -19675,7 +19675,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 631,
+      "line": 634,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "The Gateway installed the reviewed version.",
       "surface": "apple",
@@ -19683,7 +19683,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 639,
+      "line": 642,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Install result unknown",
       "surface": "apple",
@@ -19691,7 +19691,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 672,
+      "line": 675,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Skill disabled",
       "surface": "apple",
@@ -19699,7 +19699,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 672,
+      "line": 675,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Skill enabled",
       "surface": "apple",
@@ -19707,7 +19707,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 679,
+      "line": 682,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Could not enable skill",
       "surface": "apple",
@@ -19715,7 +19715,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 680,
+      "line": 683,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Could not disable skill",
       "surface": "apple",
@@ -19723,7 +19723,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 787,
+      "line": 790,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Disable",
       "surface": "apple",
@@ -19731,7 +19731,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 787,
+      "line": 790,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Enable",
       "surface": "apple",
@@ -19739,7 +19739,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 799,
+      "line": 802,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Off",
       "surface": "apple",
@@ -19747,7 +19747,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 802,
+      "line": 805,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Ready",
       "surface": "apple",
@@ -19755,7 +19755,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 803,
+      "line": 806,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Needs Setup",
       "surface": "apple",
@@ -19763,7 +19763,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 815,
+      "line": 818,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Missing: %@",
       "surface": "apple",
@@ -19771,7 +19771,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 843,
+      "line": 846,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Install",
       "surface": "apple",
@@ -19779,7 +19779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 899,
+      "line": 902,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "The Gateway will verify this exact release with ClawHub before download.",
       "surface": "apple",
@@ -19787,7 +19787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 903,
+      "line": 906,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "This gateway connection needs operator.admin to install skills.",
       "surface": "apple",
@@ -19795,7 +19795,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 910,
+      "line": 913,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Review ClawHub skill",
       "surface": "apple",
@@ -19803,7 +19803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 918,
+      "line": 921,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Verify and install",
       "surface": "apple",
@@ -19811,7 +19811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 942,
+      "line": 945,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Gateway warning",
       "surface": "apple",
@@ -19819,7 +19819,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 952,
+      "line": 955,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "The Gateway requires explicit acknowledgement for this release.",
       "surface": "apple",
@@ -19827,7 +19827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 957,
+      "line": 960,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Review warning details",
       "surface": "apple",
@@ -19835,7 +19835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 959,
+      "line": 962,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Expand and review the Gateway warning before acknowledging this exact version.",
       "surface": "apple",
@@ -19843,7 +19843,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 965,
+      "line": 968,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Review Gateway warning",
       "surface": "apple",
@@ -19851,7 +19851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 969,
+      "line": 972,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -19859,7 +19859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 973,
+      "line": 976,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Acknowledge and install",
       "surface": "apple",
@@ -19867,7 +19867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 993,
+      "line": 996,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Version",
       "surface": "apple",
@@ -19875,7 +19875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 994,
+      "line": 997,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Publisher",
       "surface": "apple",
@@ -19883,7 +19883,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1041,
+      "line": 1044,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "The connected Gateway changed. Refresh Skills and try again.",
       "surface": "apple",
@@ -19891,7 +19891,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1042,
+      "line": 1045,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "Could not encode the Gateway request.",
       "surface": "apple",
@@ -19899,7 +19899,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1043,
+      "line": 1046,
       "path": "apps/ios/Sources/Design/SettingsSkillsDestination.swift",
       "source": "ClawHub did not report an installable version for this skill.",
       "surface": "apple",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -10974,6 +10974,11 @@
       "translated": "القنوات"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "الصوت والتحدث"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "القنوات"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "تظهر هنا أجهزة Gateway المكتشفة والإعداد اليدوي عندما لا يكون Gateway متصلًا بعد."
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "تصفح"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "الكل"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "اتصل لإدارة Skills في Gateway."
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "جارٍ تحميل Skills المثبتة والتحقق من جاهزيتها."
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ جاهزة · %@ تحتاج إلى إعداد"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "غير متصل"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "جارٍ التحميل"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "قسم Skills"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "المثبتة"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "تحديث Skills"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "البحث في Skills المثبتة"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "عامل تصفية Skills المثبتة"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "اتصل لتحميل Skills المثبتة وإدارتها."
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "جارٍ تحميل Skills"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "جارٍ قراءة كتالوج Skills في Gateway."
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "لا توجد Skills مطابقة"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "لا توجد Skills مثبتة"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "تصفّح ClawHub لاكتشاف المهارات وتثبيتها."
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "غيّر البحث أو عامل تصفية الجاهزية."
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "البحث في ClawHub"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "بحث"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "يتحقق Gateway من الإصدار الدقيق الذي تمت مراجعته قبل التنزيل."
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway غير متصل"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "اتصل للبحث عن مهارات ClawHub وتثبيتها."
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "يلزم تحديث Gateway"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "حدّث Gateway للبحث عن مهارات ClawHub وتثبيتها من iOS."
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "جارٍ البحث في ClawHub"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "جارٍ تحميل إصدارات المهارات المتحقق منها."
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "لم يتم العثور على مهارات"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "جرّب بحثًا آخر أو حدّث الكتالوج."
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "تعذر تحميل المهارات"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub غير متاح"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "تعذرت مراجعة المهارة"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "أعد الاتصال وحدّث Skills، ثم أعد المحاولة. سينضم Gateway بأمان إلى عملية تثبيت مطابقة لا تزال قيد التشغيل."
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "حظر Gateway التثبيت"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "ثبّت Gateway الإصدار الذي تمت مراجعته."
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "نتيجة التثبيت غير معروفة"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "تم تعطيل المهارة"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "تم تمكين المهارة"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "تعذر تمكين المهارة"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "تعذر تعطيل المهارة"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "تعطيل"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "تمكين"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "متوقف"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "جاهز"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "يتطلب الإعداد"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "مفقود: %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "تثبيت"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "سيتحقق Gateway من هذا الإصدار تحديدًا عبر ClawHub قبل التنزيل."
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "يتطلب اتصال Gateway هذا صلاحية operator.admin لتثبيت المهارات."
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "مراجعة مهارة ClawHub"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "التحقق والتثبيت"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "تحذير Gateway"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "يتطلب Gateway إقرارًا صريحًا لهذا الإصدار."
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "مراجعة تفاصيل التحذير"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "وسّع تحذير Gateway وراجعه قبل الإقرار بهذا الإصدار تحديدًا."
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "مراجعة تحذير Gateway"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "إلغاء"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "الإقرار والتثبيت"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "الإصدار"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "الناشر"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "تغيّر Gateway المتصل. حدّث Skills وحاول مرة أخرى."
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "تعذّر ترميز طلب Gateway."
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "لم يُبلغ ClawHub عن إصدار قابل للتثبيت لهذه المهارة."
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "لم يتم تكوين رمز Telegram."
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "تصفّح ClawHub"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "اكتشاف المهارات"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "يتحقق Gateway من الإصدار الدقيق الذي تمت مراجعته قبل التنزيل."
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "البحث في ClawHub"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "بحث"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "النتائج"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "جارٍ البحث في ClawHub…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "لم يتم العثور على مهارات"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "جرّب بحثًا آخر أو حدّث الكتالوج."
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "مثبّتة"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "مراجعة"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "مراجعة مهارة ClawHub"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "سيتحقق Gateway من هذا الإصدار تحديدًا عبر ClawHub قبل التنزيل."
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "تحقق وثبّت"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "تحذير Gateway"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "مراجعة تفاصيل التحذير"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "وسّع تحذير Gateway وراجعه قبل الإقرار بهذا الإصدار تحديدًا."
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "إلغاء"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "إقرار وتثبيت"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "الإصدار"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "الناشر"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "لا توجد أقسام تكوين متاحة."
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "إمكانات اختيارية تصبح متاحة عند استيفاء متطلباتها."
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "أدِر الإمكانات المثبتة أو اكتشف الإصدارات الموثّقة على ClawHub."
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "قسم Skills"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "تحديث"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "البحث في Skills المثبتة"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "جارٍ التحميل…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "فلتر"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "المثبتة"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "تصفح"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "قيّم Gateway إصدارًا مختلفًا من ClawHub. راجع Skill مرة أخرى قبل التثبيت."
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -10974,6 +10974,11 @@
       "translated": "Kanäle"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "Sprache & Sprechen"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "Kanäle"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "Entdeckte Gateways und die manuelle Einrichtung werden hier angezeigt, wenn das Gateway noch nicht verbunden ist."
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "Durchsuchen"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "Alle"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "Verbinden, um Gateway-Skills zu verwalten."
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "Installierte Skills und Bereitschaft werden geladen."
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ bereit · %@ müssen eingerichtet werden"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "offline"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "wird geladen"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "Skills-Bereich"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "Installiert"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "Skills aktualisieren"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "Installierte Skills durchsuchen"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "Filter für installierte Skills"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "Verbinden, um installierte Skills zu laden und zu verwalten."
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "Skills werden geladen"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Der Skill-Katalog des Gateways wird gelesen."
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "Keine passenden Skills"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "Keine Skills installiert"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "Durchsuche ClawHub, um Skills zu entdecken und zu installieren."
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "Ändere die Suche oder den Bereitschaftsfilter."
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "ClawHub durchsuchen"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "Suchen"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Das Gateway überprüft vor dem Download exakt die geprüfte Version."
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway offline"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "Stelle eine Verbindung her, um ClawHub-Skills zu suchen und zu installieren."
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "Gateway-Update erforderlich"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "Aktualisiere das Gateway, um ClawHub-Skills über iOS zu suchen und zu installieren."
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "ClawHub wird durchsucht"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "Verifizierte Skill-Versionen werden geladen."
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "Keine Skills gefunden"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Versuche es mit einer anderen Suche oder aktualisiere den Katalog."
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "Skills konnten nicht geladen werden"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub nicht verfügbar"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "Skill konnte nicht geprüft werden"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "Stelle die Verbindung wieder her, aktualisiere Skills und versuche es erneut. Das Gateway setzt eine passende, noch laufende Installation sicher fort."
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "Gateway hat die Installation blockiert"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "Das Gateway hat die geprüfte Version installiert."
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "Installationsergebnis unbekannt"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "Skill deaktiviert"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "Skill aktiviert"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "Skill konnte nicht aktiviert werden"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "Skill konnte nicht deaktiviert werden"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "Deaktivieren"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "Aktivieren"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "Aus"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "Bereit"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "Einrichtung erforderlich"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "Fehlt: %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "Installieren"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Das Gateway überprüft vor dem Download dieses exakte Release mit ClawHub."
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "Diese Gateway-Verbindung benötigt operator.admin, um Skills zu installieren."
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "ClawHub-Skill prüfen"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "Überprüfen und installieren"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "Gateway-Warnung"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "Das Gateway erfordert eine ausdrückliche Bestätigung für dieses Release."
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "Warnungsdetails prüfen"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Erweitern und prüfen Sie die Gateway-Warnung, bevor Sie diese exakte Version bestätigen."
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "Gateway-Warnung prüfen"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "Abbrechen"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "Bestätigen und installieren"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "Version"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "Herausgeber"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "Das verbundene Gateway wurde geändert. Aktualisieren Sie Skills und versuchen Sie es erneut."
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "Die Gateway-Anfrage konnte nicht codiert werden."
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHub hat keine installierbare Version für diesen Skill gemeldet."
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "Kein Telegram-Token konfiguriert."
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "ClawHub durchsuchen"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "Skills entdecken"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Das Gateway überprüft vor dem Download exakt die geprüfte Version."
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "ClawHub durchsuchen"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "Suchen"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "Ergebnisse"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "ClawHub wird durchsucht…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "Keine Skills gefunden"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Versuchen Sie eine andere Suche oder aktualisieren Sie den Katalog."
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "Installiert"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "Prüfen"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "ClawHub-Skill prüfen"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Das Gateway überprüft vor dem Download genau diese Version mit ClawHub."
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "Überprüfen und installieren"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "Gateway-Warnung"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "Warnungsdetails prüfen"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Erweitern und prüfen Sie die Gateway-Warnung, bevor Sie genau diese Version bestätigen."
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "Abbrechen"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "Bestätigen und installieren"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "Version"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "Herausgeber"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "Keine Konfigurationsabschnitte verfügbar."
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "Optionale Funktionen, die verfügbar werden, wenn ihre Anforderungen erfüllt sind."
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "Verwalten Sie installierte Funktionen oder entdecken Sie verifizierte Versionen auf ClawHub."
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "Bereich „Skills“"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "Aktualisieren"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "Installierte Skills durchsuchen"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "Wird geladen…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "Filter"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "Installiert"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "Durchsuchen"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "Das Gateway hat eine andere ClawHub-Version geprüft. Prüfen Sie den Skill vor der Installation erneut."
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -10974,6 +10974,11 @@
       "translated": "Canales"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "Voz y conversación"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "Canales"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "Los gateways descubiertos y la configuración manual aparecen aquí cuando el gateway aún no se ha conectado."
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "Explorar"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "Todas"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "Conéctate para gestionar las Skills del Gateway."
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "Cargando las Skills instaladas y su disponibilidad."
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ listas · %@ requieren configuración"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "sin conexión"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "cargando"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "Sección Skills"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "Instaladas"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "Actualizar Skills"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "Buscar Skills instaladas"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "Filtro de Skills instaladas"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "Conéctate para cargar y gestionar las Skills instaladas."
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "Cargando Skills"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Leyendo el catálogo de Skills del Gateway."
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "No hay Skills coincidentes"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "No hay Skills instaladas"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "Explora ClawHub para descubrir e instalar Skills."
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "Cambia la búsqueda o el filtro de disponibilidad."
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "Buscar en ClawHub"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "Buscar"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "El Gateway verifica la versión exacta revisada antes de descargarla."
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway sin conexión"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "Conéctate para buscar e instalar Skills de ClawHub."
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "Se requiere actualizar el Gateway"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "Actualiza el Gateway para buscar e instalar Skills de ClawHub desde iOS."
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "Buscando en ClawHub"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "Cargando versiones verificadas de Skills."
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "No se encontraron Skills"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Prueba con otra búsqueda o actualiza el catálogo."
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "No se pudieron cargar las Skills"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub no está disponible"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "No se pudo revisar la Skill"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "Vuelve a conectarte, actualiza Skills e inténtalo de nuevo. El Gateway se une de forma segura a una instalación coincidente que aún esté en curso."
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "El Gateway bloqueó la instalación"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "El Gateway instaló la versión revisada."
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "Resultado de la instalación desconocido"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "Skill desactivada"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "Skill activada"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "No se pudo activar la Skill"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "No se pudo desactivar la Skill"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "Desactivar"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "Activar"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "Desactivado"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "Listo"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "Requiere configuración"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "Falta: %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "Instalar"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "El Gateway verificará esta versión exacta con ClawHub antes de descargarla."
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "Esta conexión con el Gateway necesita operator.admin para instalar Skills."
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "Revisar la Skill de ClawHub"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "Verificar e instalar"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "Advertencia del Gateway"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "El Gateway requiere una confirmación explícita para esta versión."
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "Revisar los detalles de la advertencia"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Expanda y revise la advertencia del Gateway antes de confirmar esta versión exacta."
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "Revisar advertencia del Gateway"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "Cancelar"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "Aceptar e instalar"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "Versión"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "Editor"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "El Gateway conectado ha cambiado. Actualiza Skills e inténtalo de nuevo."
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "No se pudo codificar la solicitud del Gateway."
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHub no indicó una versión instalable para esta skill."
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "No hay ningún token de Telegram configurado."
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "Explorar ClawHub"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "Descubrir skills"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "El Gateway verifica la versión exacta revisada antes de descargarla."
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "Buscar en ClawHub"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "Buscar"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "Resultados"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "Buscando en ClawHub…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "No se encontraron skills"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Prueba con otra búsqueda o actualiza el catálogo."
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "Instalada"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "Revisar"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "Revisar skill de ClawHub"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "El Gateway verificará esta versión exacta con ClawHub antes de descargarla."
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "Verificar e instalar"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "Advertencia del Gateway"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "Revisar los detalles de la advertencia"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Expande y revisa la advertencia del Gateway antes de aceptar esta versión exacta."
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "Cancelar"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "Aceptar e instalar"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "Versión"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "Editor"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "No hay secciones de configuración disponibles."
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "Capacidades opcionales que están disponibles cuando se cumplen sus requisitos."
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "Gestiona las funcionalidades instaladas o descubre versiones verificadas en ClawHub."
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "Sección Skills"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "Actualizar"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "Buscar Skills instaladas"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "Cargando…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "Filtro"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "Instaladas"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "Explorar"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "El Gateway evaluó una versión diferente de ClawHub. Revisa de nuevo la Skill antes de instalarla."
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -10974,6 +10974,11 @@
       "translated": "کانال‌ها"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "صدا و صحبت"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "کانال‌ها"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "Gatewayهای کشف‌شده و راه‌اندازی دستی زمانی اینجا نمایش داده می‌شوند که Gateway هنوز متصل نشده باشد."
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "مرور"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "همه"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "برای مدیریت Skills در Gateway متصل شوید."
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "در حال بارگیری Skills نصب‌شده و وضعیت آمادگی."
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ آماده · %@ نیازمند راه‌اندازی"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "آفلاین"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "در حال بارگیری"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "بخش Skills"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "نصب‌شده"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "به‌روزرسانی Skills"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "جست‌وجوی Skills نصب‌شده"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "فیلتر Skills نصب‌شده"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "برای بارگیری و مدیریت Skills نصب‌شده متصل شوید."
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "در حال بارگیری Skills"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "در حال خواندن فهرست Skills در Gateway."
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "هیچ Skill منطبقی یافت نشد"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "هیچ Skillی نصب نشده است"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "برای یافتن و نصب Skills، در ClawHub مرور کنید."
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "جستجو یا فیلتر آمادگی را تغییر دهید."
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "جستجو در ClawHub"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "جستجو"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway پیش از دانلود، نسخه دقیق بررسی‌شده را تأیید می‌کند."
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway آفلاین است"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "برای جستجو و نصب Skills از ClawHub متصل شوید."
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "به‌روزرسانی Gateway لازم است"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "برای جستجو و نصب Skills از ClawHub در iOS، Gateway را به‌روزرسانی کنید."
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "در حال جستجو در ClawHub"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "در حال بارگیری نسخه‌های تأییدشده Skills."
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "هیچ Skillی یافت نشد"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "جستجوی دیگری را امتحان کنید یا کاتالوگ را تازه‌سازی کنید."
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "بارگیری Skills ممکن نبود"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub در دسترس نیست"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "بررسی Skill ممکن نبود"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "دوباره متصل شوید، Skills را تازه‌سازی کنید و سپس دوباره تلاش کنید. Gateway با خیال راحت به نصب منطبقِ در حال اجرا می‌پیوندد."
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "Gateway نصب را مسدود کرد"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "Gateway نسخه بررسی‌شده را نصب کرد."
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "نتیجه نصب نامشخص است"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "Skill غیرفعال شد"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "Skill فعال شد"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "Skill فعال نشد"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "Skill غیرفعال نشد"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "غیرفعال‌کردن"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "فعال‌کردن"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "خاموش"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "آماده"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "نیازمند راه‌اندازی"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "مورد مفقود: %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "نصب"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway پیش از دانلود، دقیقاً همین نسخه را با ClawHub تأیید می‌کند."
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "این اتصال Gateway برای نصب Skills به operator.admin نیاز دارد."
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "بررسی Skill در ClawHub"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "تأیید و نصب"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "هشدار Gateway"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "Gateway برای این نسخه به تأیید صریح نیاز دارد."
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "بررسی جزئیات هشدار"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "پیش از تأیید دقیقاً همین نسخه، هشدار Gateway را باز و بررسی کنید."
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "بررسی هشدار Gateway"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "لغو"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "تأیید و نصب"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "نسخه"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "ناشر"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "Gateway متصل تغییر کرده است. Skills را تازه‌سازی کنید و دوباره امتحان کنید."
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "رمزگذاری درخواست Gateway ممکن نشد."
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHub نسخه‌ای قابل نصب برای این مهارت اعلام نکرد."
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "هیچ توکن Telegram پیکربندی نشده است."
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "مرور ClawHub"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "کشف مهارت‌ها"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway پیش از دانلود، انتشار دقیق بررسی‌شده را تأیید می‌کند."
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "جست‌وجو در ClawHub"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "جست‌وجو"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "نتایج"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "در حال جست‌وجو در ClawHub…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "مهارتی یافت نشد"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "جست‌وجوی دیگری را امتحان کنید یا کاتالوگ را تازه‌سازی کنید."
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "نصب‌شده"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "بررسی"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "بررسی مهارت ClawHub"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway پیش از دانلود، دقیقاً همین نسخه را با ClawHub تأیید خواهد کرد."
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "تأیید و نصب"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "هشدار Gateway"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "بررسی جزئیات هشدار"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "پیش از تأیید دقیقاً همین نسخه، هشدار Gateway را باز کرده و بررسی کنید."
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "لغو"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "تأیید و نصب"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "نسخه"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "ناشر"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "هیچ بخش پیکربندی موجود نیست."
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "قابلیت‌های اختیاری که وقتی پیش‌نیازهایشان برآورده شود در دسترس قرار می‌گیرند."
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "قابلیت‌های نصب‌شده را مدیریت کنید یا نسخه‌های تأییدشده را در ClawHub بیابید."
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "بخش Skills"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "بازخوانی"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "جست‌وجوی Skills نصب‌شده"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "در حال بارگذاری…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "فیلتر"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "نصب‌شده"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "مرور"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "Gateway نسخه دیگری از ClawHub را ارزیابی کرده است. پیش از نصب، Skill را دوباره بررسی کنید."
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -10974,6 +10974,11 @@
       "translated": "Canaux"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "Voix et conversation"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "Canaux"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "Les gateways détectées et la configuration manuelle apparaissent ici lorsque la gateway n’est pas encore connectée."
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "Parcourir"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "Tout"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "Connectez-vous pour gérer les Skills du Gateway."
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "Chargement des Skills installés et de leur état de préparation."
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ prêts · %@ à configurer"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "hors ligne"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "chargement"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "Section Skills"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "Installés"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "Actualiser les Skills"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "Rechercher parmi les Skills installés"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "Filtre des Skills installés"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "Connectez-vous pour charger et gérer les Skills installés."
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "Chargement des Skills"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Lecture du catalogue de Skills du Gateway."
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "Aucun Skill correspondant"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "Aucun Skill installé"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "Parcourez ClawHub pour découvrir et installer des Skills."
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "Modifiez la recherche ou le filtre de disponibilité."
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "Rechercher dans ClawHub"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "Rechercher"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Le Gateway vérifie la version exacte examinée avant le téléchargement."
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway hors ligne"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "Connectez-vous pour rechercher et installer des Skills ClawHub."
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "Mise à jour du Gateway requise"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "Mettez à jour le Gateway pour rechercher et installer des Skills ClawHub depuis iOS."
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "Recherche dans ClawHub"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "Chargement des versions vérifiées des Skills."
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "Aucun Skill trouvé"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Essayez une autre recherche ou actualisez le catalogue."
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "Impossible de charger les Skills"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub indisponible"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "Impossible d’examiner le Skill"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "Reconnectez-vous, actualisez Skills, puis réessayez. Le Gateway rejoint en toute sécurité une installation correspondante toujours en cours."
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "Le Gateway a bloqué l’installation"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "Le Gateway a installé la version examinée."
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "Résultat de l’installation inconnu"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "Skill désactivé"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "Skill activé"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "Impossible d’activer le skill"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "Impossible de désactiver le skill"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "Désactiver"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "Activer"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "Désactivé"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "Prêt"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "Configuration requise"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "Manquant : %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "Installer"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Le Gateway vérifiera cette version exacte auprès de ClawHub avant le téléchargement."
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "Cette connexion au Gateway nécessite operator.admin pour installer des skills."
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "Examiner le skill ClawHub"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "Vérifier et installer"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "Avertissement du Gateway"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "Le Gateway exige une confirmation explicite pour cette version."
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "Examiner les détails de l’avertissement"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Développez et examinez l’avertissement du Gateway avant de confirmer cette version exacte."
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "Examiner l’avertissement du Gateway"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "Annuler"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "Accepter et installer"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "Version"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "Éditeur"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "Le Gateway connecté a changé. Actualisez les Skills et réessayez."
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "Impossible d’encoder la requête du Gateway."
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHub n’a indiqué aucune version installable pour ce Skill."
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "Aucun jeton Telegram configuré."
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "Parcourir ClawHub"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "Découvrir des Skills"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Le Gateway vérifie la version exacte examinée avant le téléchargement."
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "Rechercher dans ClawHub"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "Rechercher"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "Résultats"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "Recherche dans ClawHub…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "Aucun Skill trouvé"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Essayez une autre recherche ou actualisez le catalogue."
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "Installé"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "Examiner"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "Examiner le Skill ClawHub"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Le Gateway vérifiera cette version exacte auprès de ClawHub avant le téléchargement."
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "Vérifier et installer"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "Avertissement du Gateway"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "Examiner les détails de l’avertissement"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Développez et examinez l’avertissement du Gateway avant de confirmer cette version exacte."
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "Annuler"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "Confirmer et installer"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "Version"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "Éditeur"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "Aucune section de configuration disponible."
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "Fonctionnalités facultatives qui deviennent disponibles lorsque leurs exigences sont satisfaites."
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "Gérez les fonctionnalités installées ou découvrez les versions vérifiées sur ClawHub."
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "Section Skills"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "Actualiser"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "Rechercher dans les Skills installés"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "Chargement…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "Filtre"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "Installés"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "Parcourir"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "Le Gateway a évalué une autre version de ClawHub. Examinez à nouveau le Skill avant de l’installer."
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -10974,6 +10974,11 @@
       "translated": "चैनल"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "वॉइस और टॉक"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "चैनल"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "जब Gateway अभी तक कनेक्ट नहीं हुआ हो, तो खोजे गए gateways और मैन्युअल सेटअप यहाँ दिखाई देते हैं।"
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "ब्राउज़ करें"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "सभी"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "Gateway Skills प्रबंधित करने के लिए कनेक्ट करें।"
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "इंस्टॉल किए गए Skills और उनकी तैयारी लोड की जा रही है।"
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ तैयार · %@ को सेटअप की आवश्यकता है"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "ऑफ़लाइन"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "लोड हो रहा है"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "Skills अनुभाग"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "इंस्टॉल किए गए"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "Skills रीफ़्रेश करें"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "इंस्टॉल किए गए Skills खोजें"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "इंस्टॉल किए गए Skills का फ़िल्टर"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "इंस्टॉल किए गए Skills लोड और प्रबंधित करने के लिए कनेक्ट करें।"
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "Skills लोड किए जा रहे हैं"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Gateway की Skills कैटलॉग पढ़ी जा रही है।"
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "कोई मेल खाता Skill नहीं मिला"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "कोई Skill इंस्टॉल नहीं है"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "Skills खोजने और इंस्टॉल करने के लिए ClawHub ब्राउज़ करें।"
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "खोज या तैयारी फ़िल्टर बदलें।"
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "ClawHub में खोजें"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "खोजें"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway डाउनलोड से पहले समीक्षा किए गए सटीक रिलीज़ की पुष्टि करता है।"
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway ऑफ़लाइन है"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "ClawHub Skills खोजने और इंस्टॉल करने के लिए कनेक्ट करें।"
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "Gateway अपडेट आवश्यक है"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "iOS से ClawHub Skills खोजने और इंस्टॉल करने के लिए Gateway अपडेट करें।"
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "ClawHub में खोज की जा रही है"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "सत्यापित Skill रिलीज़ लोड किए जा रहे हैं।"
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "कोई Skill नहीं मिला"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "कोई अन्य खोज आज़माएँ या कैटलॉग रीफ़्रेश करें।"
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "Skills लोड नहीं किए जा सके"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub उपलब्ध नहीं है"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "Skill की समीक्षा नहीं की जा सकी"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "फिर से कनेक्ट करें, Skills रीफ़्रेश करें, फिर दोबारा कोशिश करें। Gateway अभी भी चल रहे मेल खाते इंस्टॉलेशन से सुरक्षित रूप से जुड़ जाता है।"
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "Gateway ने इंस्टॉलेशन रोक दिया"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "Gateway ने समीक्षा किया गया संस्करण इंस्टॉल कर दिया।"
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "इंस्टॉल का परिणाम अज्ञात है"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "Skill अक्षम किया गया"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "Skill सक्षम किया गया"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "Skill सक्षम नहीं किया जा सका"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "Skill अक्षम नहीं किया जा सका"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "अक्षम करें"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "सक्षम करें"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "बंद"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "तैयार"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "सेटअप आवश्यक है"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "अनुपलब्ध: %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "इंस्टॉल करें"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "डाउनलोड से पहले Gateway, ClawHub के साथ इसी रिलीज़ को सत्यापित करेगा।"
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "Skills इंस्टॉल करने के लिए इस Gateway कनेक्शन को operator.admin की आवश्यकता है।"
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "ClawHub Skill की समीक्षा करें"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "सत्यापित करके इंस्टॉल करें"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "Gateway चेतावनी"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "Gateway को इस रिलीज़ के लिए स्पष्ट स्वीकृति की आवश्यकता है।"
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "चेतावनी के विवरण की समीक्षा करें"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "इसी संस्करण को स्वीकार करने से पहले Gateway चेतावनी को विस्तृत करके उसकी समीक्षा करें।"
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "Gateway चेतावनी की समीक्षा करें"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "रद्द करें"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "स्वीकार करें और इंस्टॉल करें"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "संस्करण"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "प्रकाशक"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "कनेक्ट किया गया Gateway बदल गया है। Skills को रीफ़्रेश करें और फिर से प्रयास करें।"
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "Gateway अनुरोध को एन्कोड नहीं किया जा सका।"
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHub ने इस स्किल के लिए इंस्टॉल करने योग्य संस्करण की जानकारी नहीं दी।"
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "कोई Telegram टोकन कॉन्फ़िगर नहीं किया गया है।"
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "ClawHub ब्राउज़ करें"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "स्किल खोजें"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway डाउनलोड से पहले समीक्षा की गई सटीक रिलीज़ को सत्यापित करता है।"
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "ClawHub में खोजें"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "खोजें"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "परिणाम"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "ClawHub में खोजा जा रहा है…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "कोई स्किल नहीं मिली"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "कोई अन्य खोज आज़माएँ या कैटलॉग को रीफ़्रेश करें।"
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "इंस्टॉल किया गया"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "समीक्षा करें"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "ClawHub स्किल की समीक्षा करें"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "डाउनलोड से पहले Gateway इस सटीक रिलीज़ को ClawHub से सत्यापित करेगा।"
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "सत्यापित करें और इंस्टॉल करें"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "Gateway चेतावनी"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "चेतावनी का विवरण देखें"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "इस सटीक संस्करण को स्वीकार करने से पहले Gateway चेतावनी को विस्तृत करके उसकी समीक्षा करें।"
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "रद्द करें"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "स्वीकार करें और इंस्टॉल करें"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "संस्करण"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "प्रकाशक"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "कोई कॉन्फ़िग सेक्शन उपलब्ध नहीं है।"
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "वैकल्पिक क्षमताएँ जो उनकी आवश्यकताएँ पूरी होने पर उपलब्ध हो जाती हैं।"
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "इंस्टॉल की गई क्षमताओं को प्रबंधित करें या ClawHub पर सत्यापित रिलीज़ खोजें।"
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "Skills अनुभाग"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "रिफ्रेश"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "इंस्टॉल किए गए Skills खोजें"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "लोड हो रहा है…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "फ़िल्टर"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "इंस्टॉल किए गए"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "ब्राउज़ करें"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "Gateway ने किसी अन्य ClawHub रिलीज़ का मूल्यांकन किया था। इंस्टॉल करने से पहले Skill की दोबारा समीक्षा करें।"
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -10974,6 +10974,11 @@
       "translated": "Saluran"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "Suara & Bicara"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "Saluran"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "Gateway yang ditemukan dan pengaturan manual akan muncul di sini saat Gateway belum terhubung."
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "Jelajahi"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "Semua"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "Hubungkan untuk mengelola Skills Gateway."
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "Memuat Skills yang terinstal dan status kesiapannya."
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ siap · %@ perlu disiapkan"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "offline"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "memuat"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "Bagian Skills"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "Terinstal"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "Muat Ulang Skills"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "Cari Skills yang terinstal"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "Filter Skills yang terinstal"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "Hubungkan untuk memuat dan mengelola Skills yang terinstal."
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "Memuat Skills"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Membaca katalog Skills Gateway."
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "Tidak ada Skills yang cocok"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "Tidak ada Skills yang terinstal"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "Jelajahi ClawHub untuk menemukan dan menginstal skill."
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "Ubah filter pencarian atau kesiapan."
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "Cari di ClawHub"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "Cari"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway memverifikasi rilis persis yang telah ditinjau sebelum diunduh."
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway offline"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "Hubungkan untuk mencari dan menginstal skill ClawHub."
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "Pembaruan Gateway diperlukan"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "Perbarui Gateway untuk mencari dan menginstal skill ClawHub dari iOS."
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "Mencari di ClawHub"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "Memuat rilis skill terverifikasi."
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "Tidak ada skill yang ditemukan"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Coba pencarian lain atau segarkan katalog."
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "Tidak dapat memuat skill"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub tidak tersedia"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "Tidak dapat meninjau skill"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "Hubungkan kembali, segarkan Skills, lalu coba lagi. Gateway akan bergabung dengan aman ke proses instalasi yang cocok dan masih berjalan."
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "Gateway memblokir instalasi"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "Gateway telah menginstal versi yang ditinjau."
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "Hasil instalasi tidak diketahui"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "Skill dinonaktifkan"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "Skill diaktifkan"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "Tidak dapat mengaktifkan skill"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "Tidak dapat menonaktifkan skill"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "Nonaktifkan"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "Aktifkan"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "Nonaktif"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "Siap"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "Perlu Disiapkan"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "Tidak ada: %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "Instal"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway akan memverifikasi rilis ini secara persis dengan ClawHub sebelum mengunduh."
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "Koneksi Gateway ini memerlukan operator.admin untuk menginstal skill."
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "Tinjau skill ClawHub"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "Verifikasi dan instal"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "Peringatan Gateway"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "Gateway memerlukan konfirmasi eksplisit untuk rilis ini."
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "Tinjau detail peringatan"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Perluas dan tinjau peringatan Gateway sebelum mengonfirmasi versi ini secara persis."
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "Tinjau peringatan Gateway"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "Batal"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "Pahami dan instal"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "Versi"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "Penerbit"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "Gateway yang terhubung telah berubah. Segarkan Skills dan coba lagi."
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "Tidak dapat mengodekan permintaan Gateway."
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHub tidak melaporkan versi yang dapat diinstal untuk skill ini."
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "Tidak ada token Telegram yang dikonfigurasi."
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "Jelajahi ClawHub"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "Temukan skill"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway memverifikasi rilis yang telah ditinjau secara persis sebelum mengunduh."
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "Cari di ClawHub"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "Cari"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "Hasil"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "Mencari di ClawHub…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "Tidak ada skill yang ditemukan"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Coba pencarian lain atau segarkan katalog."
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "Terinstal"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "Tinjau"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "Tinjau skill ClawHub"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway akan memverifikasi rilis ini secara persis dengan ClawHub sebelum mengunduh."
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "Verifikasi dan instal"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "Peringatan Gateway"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "Tinjau detail peringatan"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Perluas dan tinjau peringatan Gateway sebelum mengonfirmasi versi ini secara persis."
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "Batal"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "Konfirmasi dan instal"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "Versi"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "Penerbit"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "Tidak ada bagian config yang tersedia."
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "Kemampuan opsional yang tersedia saat persyaratannya terpenuhi."
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "Kelola kapabilitas yang terinstal atau temukan rilis terverifikasi di ClawHub."
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "Bagian Skills"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "Segarkan"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "Cari skill yang terinstal"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "Memuat…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "Filter"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "Terinstal"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "Jelajahi"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "Gateway mengevaluasi rilis ClawHub yang berbeda. Tinjau kembali skill tersebut sebelum menginstal."
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -10974,6 +10974,11 @@
       "translated": "Canali"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "Voce e conversazione"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "Canali"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "I gateway rilevati e la configurazione manuale compaiono qui quando il gateway non è ancora connesso."
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "Sfoglia"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "Tutte"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "Connettiti per gestire le Skills del Gateway."
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "Caricamento delle Skills installate e del relativo stato."
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ pronte · %@ da configurare"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "offline"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "caricamento"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "Sezione Skills"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "Installate"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "Aggiorna Skills"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "Cerca tra le Skills installate"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "Filtro delle Skills installate"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "Connettiti per caricare e gestire le Skills installate."
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "Caricamento delle Skills"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Lettura del catalogo delle Skills del Gateway."
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "Nessuna Skill corrispondente"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "Nessuna Skill installata"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "Esplora ClawHub per scoprire e installare skill."
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "Modifica la ricerca o il filtro di disponibilità."
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "Cerca in ClawHub"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "Cerca"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Il Gateway verifica la versione esatta approvata prima del download."
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway offline"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "Connettiti per cercare e installare skill di ClawHub."
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "Aggiornamento del Gateway richiesto"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "Aggiorna il Gateway per cercare e installare skill di ClawHub da iOS."
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "Ricerca in ClawHub"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "Caricamento delle versioni verificate delle skill."
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "Nessuna skill trovata"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Prova un'altra ricerca o aggiorna il catalogo."
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "Impossibile caricare le skill"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub non disponibile"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "Impossibile esaminare la skill"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "Riconnettiti, aggiorna Skills, quindi riprova. Il Gateway si ricollega in modo sicuro a un'installazione corrispondente ancora in corso."
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "Il Gateway ha bloccato l'installazione"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "Il Gateway ha installato la versione approvata."
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "Esito dell'installazione sconosciuto"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "Skill disabilitata"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "Skill abilitata"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "Impossibile abilitare la skill"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "Impossibile disabilitare la skill"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "Disabilita"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "Abilita"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "Disattivata"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "Pronta"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "Configurazione necessaria"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "Manca: %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "Installa"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Il Gateway verificherà questa versione specifica con ClawHub prima del download."
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "Questa connessione al Gateway richiede operator.admin per installare le skill."
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "Esamina la skill di ClawHub"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "Verifica e installa"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "Avviso del Gateway"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "Il Gateway richiede una conferma esplicita per questa versione."
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "Esamina i dettagli dell'avviso"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Espandi ed esamina l'avviso del Gateway prima di confermare questa versione specifica."
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "Esamina l'avviso del Gateway"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "Annulla"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "Conferma e installa"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "Versione"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "Autore"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "Il Gateway connesso è cambiato. Aggiorna Skills e riprova."
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "Impossibile codificare la richiesta del Gateway."
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHub non ha indicato una versione installabile per questa skill."
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "Nessun token Telegram configurato."
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "Esplora ClawHub"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "Scopri le skill"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Il Gateway verifica la versione esatta esaminata prima del download."
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "Cerca in ClawHub"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "Cerca"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "Risultati"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "Ricerca in ClawHub…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "Nessuna skill trovata"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Prova un'altra ricerca o aggiorna il catalogo."
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "Installata"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "Esamina"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "Esamina la skill di ClawHub"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Il Gateway verificherà questa versione esatta con ClawHub prima del download."
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "Verifica e installa"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "Avviso del Gateway"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "Esamina i dettagli dell'avviso"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Espandi ed esamina l'avviso del Gateway prima di confermare questa versione esatta."
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "Annulla"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "Conferma e installa"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "Versione"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "Editore"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "Nessuna sezione di configurazione disponibile."
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "Funzionalità opzionali che diventano disponibili quando i relativi requisiti sono soddisfatti."
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "Gestisci le funzionalità installate o scopri le versioni verificate su ClawHub."
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "Sezione Skills"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "Aggiorna"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "Cerca nelle skill installate"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "Caricamento…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "Filtro"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "Installate"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "Esplora"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "Il Gateway ha valutato una versione diversa di ClawHub. Esamina nuovamente la skill prima di installarla."
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -10974,6 +10974,11 @@
       "translated": "チャンネル"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "音声とトーク"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "チャンネル"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "Gatewayがまだ接続されていない場合、検出されたGatewayと手動セットアップがここに表示されます。"
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "閲覧"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "すべて"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "接続してGatewayのSkillsを管理します。"
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "インストール済みのSkillsと準備状況を読み込んでいます。"
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ 件が準備完了 · %@ 件はセットアップが必要"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "オフライン"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "読み込み中"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "Skillsセクション"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "インストール済み"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "Skillsを更新"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "インストール済みのSkillsを検索"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "インストール済みSkillsのフィルター"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "接続してインストール済みのSkillsを読み込み、管理します。"
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "Skillsを読み込み中"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "GatewayのSkillsカタログを読み込んでいます。"
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "一致するSkillsはありません"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "Skillsがインストールされていません"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "ClawHubを閲覧して、Skillsを見つけてインストールできます。"
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "検索条件または準備状況フィルターを変更してください。"
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "ClawHubを検索"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "検索"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gatewayは、ダウンロード前にレビュー済みリリースが完全に一致することを確認します。"
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gatewayはオフラインです"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "接続してClawHubのSkillsを検索し、インストールしてください。"
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "Gatewayのアップデートが必要です"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "iOSからClawHubのSkillsを検索してインストールするには、Gatewayをアップデートしてください。"
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "ClawHubを検索中"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "検証済みのSkillリリースを読み込んでいます。"
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "Skillsが見つかりません"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "別のキーワードで検索するか、カタログを更新してください。"
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "Skillsを読み込めませんでした"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHubを利用できません"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "Skillをレビューできませんでした"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "再接続してSkillsを更新してから、もう一度お試しください。Gatewayは、まだ実行中の同一インストールに安全に合流します。"
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "Gatewayがインストールをブロックしました"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "Gatewayがレビュー済みバージョンをインストールしました。"
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "インストール結果は不明です"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "Skillを無効にしました"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "Skillを有効にしました"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "Skillを有効にできませんでした"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "Skillを無効にできませんでした"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "無効にする"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "有効にする"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "オフ"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "準備完了"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "セットアップが必要"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "不足: %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "インストール"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gatewayはダウンロード前に、ClawHubでこのリリースと完全に一致することを確認します。"
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "このGateway接続でSkillsをインストールするには、operator.adminが必要です。"
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "ClawHubのSkillを確認"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "確認してインストール"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "Gatewayの警告"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "Gatewayでは、このリリースに対する明示的な確認が必要です。"
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "警告の詳細を確認"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "このバージョンを確認する前に、Gatewayの警告を展開して内容を確認してください。"
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "Gatewayの警告を確認"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "キャンセル"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "確認してインストール"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "バージョン"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "公開元"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "接続先のGatewayが変更されました。Skillsを更新して、もう一度お試しください。"
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "Gatewayリクエストをエンコードできませんでした。"
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHubから、このスキルのインストール可能なバージョンが報告されませんでした。"
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "Telegram トークンが設定されていません。"
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "ClawHubを閲覧"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "スキルを探す"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gatewayはダウンロード前に、確認済みのリリースと完全に一致することを検証します。"
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "ClawHubを検索"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "検索"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "検索結果"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "ClawHubを検索中…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "スキルが見つかりません"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "別のキーワードで検索するか、カタログを更新してください。"
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "インストール済み"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "確認"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "ClawHubスキルを確認"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gatewayはダウンロード前に、ClawHubでこの正確なリリースを検証します。"
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "検証してインストール"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "Gatewayの警告"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "警告の詳細を確認"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "この正確なバージョンを承認する前に、Gatewayの警告を展開して確認してください。"
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "キャンセル"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "承認してインストール"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "バージョン"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "発行元"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "利用可能な設定セクションがありません。"
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "要件が満たされると利用可能になる任意の機能です。"
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "インストール済みの機能を管理するか、ClawHubで検証済みのリリースを探します。"
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "Skillsセクション"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "更新"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "インストール済みのSkillsを検索"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "読み込み中…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "フィルター"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "インストール済み"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "参照"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "Gatewayが別のClawHubリリースを評価しました。インストールする前に、Skillをもう一度確認してください。"
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -10974,6 +10974,11 @@
       "translated": "채널"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "음성 및 대화"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "채널"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "Gateway가 아직 연결되지 않은 경우, 발견된 Gateway와 수동 설정이 여기에 표시됩니다."
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "둘러보기"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "전체"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "Gateway Skills를 관리하려면 연결하세요."
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "설치된 Skills 및 준비 상태를 불러오는 중입니다."
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@개 준비됨 · %@개 설정 필요"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "오프라인"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "불러오는 중"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "Skills 섹션"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "설치됨"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "Skills 새로 고침"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "설치된 Skills 검색"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "설치된 Skills 필터"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "설치된 Skills를 불러오고 관리하려면 연결하세요."
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "Skills 불러오는 중"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Gateway Skills 카탈로그를 읽는 중입니다."
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "일치하는 Skills 없음"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "설치된 Skills 없음"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "ClawHub를 둘러보고 스킬을 찾아 설치하세요."
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "검색어나 준비 상태 필터를 변경하세요."
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "ClawHub 검색"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "검색"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway는 다운로드 전에 검토된 정확한 릴리스를 확인합니다."
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway 오프라인"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "연결하여 ClawHub 스킬을 검색하고 설치하세요."
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "Gateway 업데이트 필요"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "iOS에서 ClawHub 스킬을 검색하고 설치하려면 Gateway를 업데이트하세요."
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "ClawHub 검색 중"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "확인된 스킬 릴리스를 불러오는 중입니다."
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "스킬을 찾을 수 없음"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "다른 검색어를 사용하거나 카탈로그를 새로 고침해 보세요."
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "스킬을 불러올 수 없음"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub를 사용할 수 없음"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "스킬을 검토할 수 없음"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "다시 연결하고 Skills를 새로 고친 후 다시 시도하세요. Gateway는 아직 실행 중인 일치하는 설치 작업에 안전하게 다시 연결됩니다."
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "Gateway가 설치를 차단함"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "Gateway가 검토된 버전을 설치했습니다."
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "설치 결과 알 수 없음"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "Skill 비활성화됨"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "Skill 활성화됨"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "Skill을 활성화할 수 없음"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "Skill을 비활성화할 수 없음"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "비활성화"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "활성화"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "꺼짐"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "준비됨"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "설정 필요"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "누락됨: %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "설치"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway가 다운로드 전에 ClawHub에서 이 정확한 릴리스를 확인합니다."
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "이 Gateway 연결에서 Skill을 설치하려면 operator.admin이 필요합니다."
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "ClawHub Skill 검토"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "확인 및 설치"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "Gateway 경고"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "Gateway에서 이 릴리스에 대한 명시적 확인이 필요합니다."
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "경고 세부 정보 검토"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "이 정확한 버전을 확인하기 전에 Gateway 경고를 펼쳐 검토하세요."
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "Gateway 경고 검토"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "취소"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "확인 및 설치"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "버전"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "게시자"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "연결된 Gateway가 변경되었습니다. Skills를 새로 고친 후 다시 시도하세요."
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "Gateway 요청을 인코딩할 수 없습니다."
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHub에서 이 Skill에 설치 가능한 버전을 제공하지 않았습니다."
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "구성된 Telegram 토큰이 없습니다."
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "ClawHub 둘러보기"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "Skill 찾아보기"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway는 다운로드 전에 검토된 정확한 릴리스를 확인합니다."
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "ClawHub 검색"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "검색"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "결과"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "ClawHub 검색 중…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "Skill을 찾을 수 없음"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "다른 검색어를 사용하거나 카탈로그를 새로 고치세요."
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "설치됨"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "검토"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "ClawHub Skill 검토"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway가 다운로드 전에 ClawHub를 통해 이 정확한 릴리스를 확인합니다."
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "확인 및 설치"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "Gateway 경고"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "경고 세부 정보 검토"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "이 정확한 버전을 승인하기 전에 Gateway 경고를 펼쳐 검토하세요."
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "취소"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "승인 및 설치"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "버전"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "게시자"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "사용 가능한 구성 섹션이 없습니다."
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "요구 사항이 충족되면 사용할 수 있게 되는 선택적 기능입니다."
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "설치된 기능을 관리하거나 ClawHub에서 검증된 릴리스를 찾아보세요."
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "Skills 섹션"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "새로 고침"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "설치된 Skills 검색"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "로드 중…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "필터"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "설치됨"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "찾아보기"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "Gateway가 다른 ClawHub 릴리스를 평가했습니다. 설치하기 전에 해당 Skill을 다시 검토하세요."
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -10974,6 +10974,11 @@
       "translated": "Kanalen"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "Spraak en praten"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "Kanalen"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "Ontdekte gateways en handmatige configuratie staan hier wanneer de gateway nog niet is verbonden."
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "Bladeren"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "Alles"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "Maak verbinding om Gateway-skills te beheren."
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "Geïnstalleerde skills en gereedheid laden."
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ gereed · %@ moeten worden ingesteld"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "offline"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "laden"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "Skills-sectie"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "Geïnstalleerd"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "Skills vernieuwen"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "Geïnstalleerde skills zoeken"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "Filter voor geïnstalleerde skills"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "Maak verbinding om geïnstalleerde skills te laden en beheren."
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "Skills laden"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "De Gateway-skillcatalogus lezen."
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "Geen overeenkomende skills"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "Geen skills geïnstalleerd"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "Blader door ClawHub om skills te ontdekken en te installeren."
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "Wijzig de zoekopdracht of het gereedheidsfilter."
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "Zoeken in ClawHub"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "Zoeken"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "De Gateway verifieert vóór het downloaden de exacte beoordeelde release."
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway offline"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "Maak verbinding om ClawHub-skills te zoeken en te installeren."
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "Gateway-update vereist"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "Werk de Gateway bij om vanuit iOS ClawHub-skills te zoeken en te installeren."
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "ClawHub doorzoeken"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "Geverifieerde skillreleases laden."
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "Geen skills gevonden"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Probeer een andere zoekopdracht of vernieuw de catalogus."
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "Skills konden niet worden geladen"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub niet beschikbaar"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "Skill kon niet worden beoordeeld"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "Maak opnieuw verbinding, vernieuw Skills en probeer het opnieuw. De Gateway sluit veilig aan bij een overeenkomende installatie die nog wordt uitgevoerd."
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "Gateway heeft de installatie geblokkeerd"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "De Gateway heeft de beoordeelde versie geïnstalleerd."
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "Installatieresultaat onbekend"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "Skill uitgeschakeld"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "Skill ingeschakeld"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "Kan skill niet inschakelen"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "Kan skill niet uitschakelen"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "Uitschakelen"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "Inschakelen"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "Uit"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "Gereed"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "Configuratie vereist"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "Ontbreekt: %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "Installeren"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "De Gateway verifieert vóór het downloaden exact deze release bij ClawHub."
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "Deze Gateway-verbinding heeft operator.admin nodig om skills te installeren."
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "ClawHub-skill controleren"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "Verifiëren en installeren"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "Gateway-waarschuwing"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "De Gateway vereist een expliciete bevestiging voor deze release."
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "Waarschuwingsdetails bekijken"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Vouw de Gateway-waarschuwing uit en bekijk deze voordat u exact deze versie bevestigt."
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "Gateway-waarschuwing bekijken"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "Annuleren"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "Bevestigen en installeren"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "Versie"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "Uitgever"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "De verbonden Gateway is gewijzigd. Vernieuw Skills en probeer het opnieuw."
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "Het Gateway-verzoek kon niet worden gecodeerd."
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHub heeft geen installeerbare versie voor deze skill gemeld."
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "Geen Telegram-token geconfigureerd."
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "Door ClawHub bladeren"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "Skills ontdekken"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "De Gateway verifieert vóór het downloaden de exacte beoordeelde release."
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "Zoeken in ClawHub"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "Zoeken"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "Resultaten"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "ClawHub doorzoeken…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "Geen skills gevonden"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Probeer een andere zoekopdracht of vernieuw de catalogus."
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "Geïnstalleerd"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "Beoordelen"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "ClawHub-skill beoordelen"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "De Gateway verifieert vóór het downloaden deze exacte release bij ClawHub."
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "Verifiëren en installeren"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "Gateway-waarschuwing"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "Waarschuwingsdetails bekijken"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Vouw de Gateway-waarschuwing uit en bekijk deze voordat u deze exacte versie bevestigt."
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "Annuleren"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "Bevestigen en installeren"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "Versie"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "Uitgever"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "Geen configuratiesecties beschikbaar."
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "Optionele mogelijkheden die beschikbaar worden wanneer aan de vereisten is voldaan."
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "Beheer geïnstalleerde mogelijkheden of ontdek geverifieerde releases op ClawHub."
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "Skills-sectie"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "Vernieuwen"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "Geïnstalleerde skills zoeken"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "Laden…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "Filter"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "Geïnstalleerd"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "Bladeren"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "De Gateway heeft een andere ClawHub-release beoordeeld. Bekijk de skill opnieuw voordat u deze installeert."
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -10974,6 +10974,11 @@
       "translated": "Kanały"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "Głos i rozmowa"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "Kanały"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "Wykryte Gateway i konfiguracja ręczna pojawią się tutaj, gdy Gateway nie jest jeszcze połączony."
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "Przeglądaj"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "Wszystkie"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "Połącz się, aby zarządzać Skills w Gateway."
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "Wczytywanie zainstalowanych Skills i ich gotowości."
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ gotowych · %@ wymaga konfiguracji"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "offline"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "wczytywanie"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "Sekcja Skills"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "Zainstalowane"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "Odśwież Skills"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "Szukaj w zainstalowanych Skills"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "Filtr zainstalowanych Skills"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "Połącz się, aby wczytać zainstalowane Skills i nimi zarządzać."
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "Wczytywanie Skills"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Odczytywanie katalogu Skills w Gateway."
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "Brak pasujących Skills"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "Brak zainstalowanych Skills"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "Przeglądaj ClawHub, aby odkrywać i instalować umiejętności."
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "Zmień wyszukiwanie lub filtr gotowości."
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "Przeszukaj ClawHub"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "Szukaj"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway weryfikuje dokładnie sprawdzone wydanie przed pobraniem."
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway jest offline"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "Połącz się, aby wyszukiwać i instalować umiejętności z ClawHub."
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "Wymagana aktualizacja Gateway"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "Zaktualizuj Gateway, aby wyszukiwać i instalować umiejętności z ClawHub w systemie iOS."
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "Przeszukiwanie ClawHub"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "Wczytywanie zweryfikowanych wydań umiejętności."
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "Nie znaleziono umiejętności"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Spróbuj wyszukać inaczej lub odśwież katalog."
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "Nie udało się wczytać umiejętności"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub jest niedostępny"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "Nie udało się sprawdzić umiejętności"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "Połącz się ponownie, odśwież Skills, a następnie spróbuj jeszcze raz. Gateway bezpiecznie dołączy do nadal trwającej, zgodnej instalacji."
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "Gateway zablokował instalację"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "Gateway zainstalował sprawdzoną wersję."
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "Wynik instalacji jest nieznany"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "Skill wyłączony"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "Skill włączony"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "Nie udało się włączyć skilla"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "Nie udało się wyłączyć skilla"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "Wyłącz"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "Włącz"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "Wył."
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "Gotowe"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "Wymaga konfiguracji"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "Brak: %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "Zainstaluj"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway zweryfikuje dokładnie to wydanie w ClawHub przed pobraniem."
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "To połączenie z Gateway wymaga uprawnienia operator.admin do instalowania skilli."
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "Sprawdź skill w ClawHub"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "Zweryfikuj i zainstaluj"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "Ostrzeżenie Gateway"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "Gateway wymaga wyraźnego potwierdzenia tego wydania."
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "Sprawdź szczegóły ostrzeżenia"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Rozwiń i sprawdź ostrzeżenie Gateway przed potwierdzeniem dokładnie tej wersji."
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "Sprawdź ostrzeżenie Gateway"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "Anuluj"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "Potwierdź i zainstaluj"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "Wersja"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "Wydawca"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "Połączony Gateway uległ zmianie. Odśwież Skills i spróbuj ponownie."
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "Nie udało się zakodować żądania Gateway."
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHub nie zgłosił wersji tego skillu dostępnej do instalacji."
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "Nie skonfigurowano tokena Telegram."
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "Przeglądaj ClawHub"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "Odkrywaj skille"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway weryfikuje dokładnie sprawdzone wydanie przed pobraniem."
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "Przeszukaj ClawHub"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "Szukaj"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "Wyniki"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "Przeszukiwanie ClawHub…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "Nie znaleziono żadnych skilli"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Spróbuj wyszukać coś innego lub odśwież katalog."
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "Zainstalowano"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "Sprawdź"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "Sprawdź skill z ClawHub"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway zweryfikuje dokładnie to wydanie w ClawHub przed pobraniem."
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "Zweryfikuj i zainstaluj"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "Ostrzeżenie Gateway"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "Sprawdź szczegóły ostrzeżenia"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Rozwiń i sprawdź ostrzeżenie Gateway przed zaakceptowaniem dokładnie tej wersji."
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "Anuluj"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "Zaakceptuj i zainstaluj"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "Wersja"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "Wydawca"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "Brak dostępnych sekcji konfiguracji."
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "Opcjonalne funkcje, które stają się dostępne po spełnieniu ich wymagań."
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "Zarządzaj zainstalowanymi funkcjami lub odkrywaj zweryfikowane wydania w ClawHub."
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "Sekcja Skills"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "Odśwież"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "Wyszukaj zainstalowane umiejętności"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "Ładowanie…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "Filtr"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "Zainstalowane"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "Przeglądaj"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "Gateway ocenił inne wydanie ClawHub. Sprawdź umiejętność ponownie przed instalacją."
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -10974,6 +10974,11 @@
       "translated": "Canais"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "Voz e fala"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "Canais"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "Gateways descobertos e configuração manual ficam aqui quando o gateway ainda não se conectou."
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "Explorar"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "Tudo"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "Conecte-se para gerenciar as Skills do Gateway."
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "Carregando Skills instaladas e status de prontidão."
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ prontas · %@ precisam de configuração"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "offline"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "carregando"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "Seção de Skills"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "Instaladas"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "Atualizar Skills"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "Buscar Skills instaladas"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "Filtro de Skills instaladas"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "Conecte-se para carregar e gerenciar as Skills instaladas."
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "Carregando Skills"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Lendo o catálogo de Skills do Gateway."
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "Nenhuma Skill correspondente"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "Nenhuma Skill instalada"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "Explore o ClawHub para descobrir e instalar Skills."
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "Altere a busca ou o filtro de disponibilidade."
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "Buscar no ClawHub"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "Buscar"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "O Gateway verifica a versão exata revisada antes do download."
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway offline"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "Conecte-se para buscar e instalar Skills do ClawHub."
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "É necessário atualizar o Gateway"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "Atualize o Gateway para buscar e instalar Skills do ClawHub pelo iOS."
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "Buscando no ClawHub"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "Carregando versões verificadas de Skills."
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "Nenhuma Skill encontrada"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Tente outra busca ou atualize o catálogo."
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "Não foi possível carregar as Skills"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub indisponível"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "Não foi possível revisar a Skill"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "Reconecte-se, atualize Skills e tente novamente. O Gateway retoma com segurança uma instalação correspondente que ainda esteja em andamento."
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "O Gateway bloqueou a instalação"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "O Gateway instalou a versão revisada."
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "Resultado da instalação desconhecido"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "Skill desativada"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "Skill ativada"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "Não foi possível ativar a skill"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "Não foi possível desativar a skill"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "Desativar"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "Ativar"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "Desativado"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "Pronto"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "Requer configuração"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "Ausente: %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "Instalar"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "O Gateway verificará esta versão exata com o ClawHub antes do download."
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "Esta conexão com o Gateway requer operator.admin para instalar skills."
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "Revisar skill do ClawHub"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "Verificar e instalar"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "Aviso do Gateway"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "O Gateway exige uma confirmação explícita para esta versão."
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "Revisar detalhes do aviso"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Expanda e revise o aviso do Gateway antes de confirmar esta versão exata."
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "Revisar aviso do Gateway"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "Cancelar"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "Confirmar e instalar"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "Versão"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "Publicador"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "O Gateway conectado mudou. Atualize as Skills e tente novamente."
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "Não foi possível codificar a solicitação do Gateway."
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "O ClawHub não informou uma versão instalável para esta skill."
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "Nenhum token do Telegram configurado."
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "Explorar o ClawHub"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "Descobrir skills"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "O Gateway verifica a versão exata revisada antes do download."
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "Pesquisar no ClawHub"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "Pesquisar"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "Resultados"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "Pesquisando no ClawHub…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "Nenhuma skill encontrada"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Tente outra pesquisa ou atualize o catálogo."
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "Instalada"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "Revisar"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "Revisar skill do ClawHub"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "O Gateway verificará esta versão exata com o ClawHub antes do download."
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "Verificar e instalar"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "Aviso do Gateway"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "Revisar detalhes do aviso"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Expanda e revise o aviso do Gateway antes de confirmar esta versão exata."
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "Cancelar"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "Confirmar e instalar"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "Versão"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "Publicador"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "Nenhuma seção de configuração disponível."
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "Recursos opcionais que ficam disponíveis quando seus requisitos são atendidos."
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "Gerencie os recursos instalados ou descubra versões verificadas no ClawHub."
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "Seção Skills"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "Atualizar"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "Pesquisar skills instaladas"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "Carregando…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "Filtro"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "Instaladas"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "Explorar"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "O Gateway avaliou uma versão diferente do ClawHub. Revise a skill novamente antes de instalá-la."
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -10974,6 +10974,11 @@
       "translated": "Каналы"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "Голос и разговор"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "Каналы"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "Здесь отображаются обнаруженные Gateway и ручная настройка, пока Gateway еще не подключен."
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "Обзор"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "Все"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "Подключитесь для управления навыками Gateway."
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "Загрузка установленных навыков и проверка их готовности."
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ готовы · %@ требуют настройки"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "не в сети"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "загрузка"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "Раздел Skills"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "Установленные"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "Обновить Skills"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "Поиск установленных навыков"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "Фильтр установленных навыков"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "Подключитесь, чтобы загрузить установленные навыки и управлять ими."
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "Загрузка навыков"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Чтение каталога навыков Gateway."
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "Подходящие навыки не найдены"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "Нет установленных навыков"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "Просматривайте ClawHub, чтобы находить и устанавливать навыки."
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "Измените поисковый запрос или фильтр готовности."
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "Поиск в ClawHub"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "Поиск"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Перед загрузкой Gateway проверяет точную версию, прошедшую проверку."
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway не в сети"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "Подключитесь, чтобы искать и устанавливать навыки ClawHub."
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "Требуется обновление Gateway"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "Обновите Gateway, чтобы искать и устанавливать навыки ClawHub с устройства iOS."
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "Поиск в ClawHub"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "Загрузка проверенных выпусков навыков."
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "Навыки не найдены"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Попробуйте другой поисковый запрос или обновите каталог."
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "Не удалось загрузить навыки"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub недоступен"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "Не удалось проверить навык"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "Подключитесь повторно, обновите Skills и повторите попытку. Gateway безопасно присоединится к соответствующей установке, если она ещё выполняется."
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "Gateway заблокировал установку"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "Gateway установил проверенную версию."
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "Результат установки неизвестен"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "Навык отключён"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "Навык включён"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "Не удалось включить навык"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "Не удалось отключить навык"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "Отключить"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "Включить"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "Выкл."
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "Готово"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "Требуется настройка"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "Отсутствует: %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "Установить"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Перед загрузкой Gateway проверит этот конкретный выпуск через ClawHub."
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "Для установки навыков этому подключению к Gateway требуется operator.admin."
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "Проверить навык ClawHub"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "Проверить и установить"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "Предупреждение Gateway"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "Gateway требует явного подтверждения для этого выпуска."
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "Просмотреть сведения о предупреждении"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Разверните и просмотрите предупреждение Gateway, прежде чем подтвердить эту конкретную версию."
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "Просмотреть предупреждение Gateway"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "Отмена"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "Подтвердить и установить"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "Версия"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "Издатель"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "Подключённый Gateway изменился. Обновите Skills и повторите попытку."
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "Не удалось закодировать запрос Gateway."
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHub не сообщил об устанавливаемой версии этого навыка."
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "Токен Telegram не настроен."
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "Открыть ClawHub"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "Найти навыки"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Перед скачиванием Gateway проверяет точную версию выпуска, которую вы просмотрели."
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "Поиск в ClawHub"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "Поиск"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "Результаты"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "Поиск в ClawHub…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "Навыки не найдены"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Попробуйте изменить запрос или обновить каталог."
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "Установлено"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "Просмотреть"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "Просмотреть навык ClawHub"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway проверит именно этот релиз в ClawHub перед загрузкой."
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "Проверить и установить"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "Предупреждение Gateway"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "Просмотреть сведения о предупреждении"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Разверните и просмотрите предупреждение Gateway, прежде чем подтвердить установку именно этой версии."
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "Отмена"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "Подтвердить и установить"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "Версия"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "Издатель"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "Разделы конфигурации недоступны."
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "Дополнительные возможности, которые становятся доступны при выполнении требований."
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "Управляйте установленными возможностями или находите проверенные релизы в ClawHub."
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "Раздел Skills"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "Обновить"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "Поиск установленных навыков"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "Загрузка…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "Фильтр"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "Установлено"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "Обзор"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "Gateway проверил другой релиз ClawHub. Перед установкой проверьте навык ещё раз."
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -10974,6 +10974,11 @@
       "translated": "Kanaler"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "Röst och tal"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "Kanaler"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "Upptäckta Gateways och manuell konfiguration visas här när gatewayen inte har anslutit än."
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "Bläddra"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "Alla"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "Anslut för att hantera Gateway-Skills."
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "Läser in installerade Skills och kontrollerar om de är redo."
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ redo · %@ behöver konfigureras"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "offline"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "läser in"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "Sektionen Skills"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "Installerade"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "Uppdatera Skills"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "Sök bland installerade Skills"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "Filter för installerade Skills"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "Anslut för att läsa in och hantera installerade Skills."
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "Läser in Skills"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Läser katalogen med Gateway-Skills."
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "Inga matchande Skills"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "Inga Skills installerade"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "Bläddra i ClawHub för att upptäcka och installera färdigheter."
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "Ändra sök- eller beredskapsfiltret."
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "Sök i ClawHub"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "Sök"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway verifierar den exakta granskade versionen före hämtning."
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway är offline"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "Anslut för att söka efter och installera färdigheter från ClawHub."
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "Gateway måste uppdateras"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "Uppdatera Gateway för att söka efter och installera färdigheter från ClawHub via iOS."
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "Söker i ClawHub"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "Läser in verifierade färdighetsversioner."
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "Inga färdigheter hittades"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Prova en annan sökning eller uppdatera katalogen."
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "Det gick inte att läsa in färdigheter"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub är inte tillgängligt"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "Det gick inte att granska färdigheten"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "Anslut igen, uppdatera Skills och försök sedan igen. Gateway ansluter säkert till en matchande installation som fortfarande pågår."
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "Gateway blockerade installationen"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "Gateway installerade den granskade versionen."
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "Installationsresultat okänt"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "Skill inaktiverad"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "Skill aktiverad"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "Det gick inte att aktivera skill"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "Det gick inte att inaktivera skill"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "Inaktivera"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "Aktivera"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "Av"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "Klar"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "Kräver konfiguration"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "Saknas: %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "Installera"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway verifierar exakt den här versionen med ClawHub före nedladdning."
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "Den här Gateway-anslutningen behöver operator.admin för att installera skills."
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "Granska skill på ClawHub"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "Verifiera och installera"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "Gateway-varning"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "Gateway kräver ett uttryckligt godkännande för den här versionen."
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "Granska varningsinformationen"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Expandera och granska Gateway-varningen innan du godkänner exakt den här versionen."
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "Granska Gateway-varning"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "Avbryt"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "Bekräfta och installera"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "Version"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "Utgivare"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "Ansluten Gateway har ändrats. Uppdatera Skills och försök igen."
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "Det gick inte att koda Gateway-begäran."
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHub rapporterade ingen installerbar version för denna skill."
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "Ingen Telegram-token har konfigurerats."
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "Bläddra i ClawHub"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "Upptäck skills"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway verifierar den exakta granskade versionen före nedladdning."
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "Sök i ClawHub"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "Sök"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "Resultat"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "Söker i ClawHub…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "Inga skills hittades"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Prova en annan sökning eller uppdatera katalogen."
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "Installerad"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "Granska"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "Granska skill från ClawHub"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway kommer att verifiera exakt den här versionen med ClawHub före nedladdning."
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "Verifiera och installera"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "Gateway-varning"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "Granska varningsinformationen"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Expandera och granska Gateway-varningen innan du godkänner exakt den här versionen."
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "Avbryt"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "Godkänn och installera"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "Version"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "Utgivare"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "Inga konfigurationsavsnitt tillgängliga."
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "Valfria funktioner som blir tillgängliga när deras krav är uppfyllda."
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "Hantera installerade funktioner eller hitta verifierade versioner på ClawHub."
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "Skills-avsnitt"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "Uppdatera"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "Sök bland installerade skills"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "Läser in…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "Filter"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "Installerat"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "Bläddra"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "Gateway utvärderade en annan ClawHub-version. Granska denna skill igen innan du installerar."
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -10974,6 +10974,11 @@
       "translated": "ช่องทาง"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "เสียงและการพูดคุย"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "ช่องทาง"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "Gateway ที่ค้นพบและการตั้งค่าด้วยตนเองจะแสดงที่นี่เมื่อ Gateway ยังไม่ได้เชื่อมต่อ"
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "เรียกดู"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "ทั้งหมด"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "เชื่อมต่อเพื่อจัดการ Skills ของ Gateway"
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "กำลังโหลด Skills ที่ติดตั้งและตรวจสอบความพร้อม"
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "พร้อมใช้งาน %@ · ต้องตั้งค่า %@"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "ออฟไลน์"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "กำลังโหลด"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "ส่วน Skills"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "ติดตั้งแล้ว"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "รีเฟรช Skills"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "ค้นหา Skills ที่ติดตั้ง"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "ตัวกรอง Skills ที่ติดตั้ง"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "เชื่อมต่อเพื่อโหลดและจัดการ Skills ที่ติดตั้ง"
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "กำลังโหลด Skills"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "กำลังอ่านแค็ตตาล็อก Skills ของ Gateway"
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "ไม่พบ Skills ที่ตรงกัน"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "ยังไม่ได้ติดตั้ง Skills"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "เรียกดู ClawHub เพื่อค้นหาและติดตั้ง Skills"
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "เปลี่ยนตัวกรองการค้นหาหรือความพร้อมใช้งาน"
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "ค้นหาใน ClawHub"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "ค้นหา"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway จะตรวจสอบรุ่นที่ผ่านการตรวจทานอย่างถูกต้องก่อนดาวน์โหลด"
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway ออฟไลน์"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "เชื่อมต่อเพื่อค้นหาและติดตั้ง Skills จาก ClawHub"
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "ต้องอัปเดต Gateway"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "อัปเดต Gateway เพื่อค้นหาและติดตั้ง Skills จาก ClawHub ผ่าน iOS"
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "กำลังค้นหาใน ClawHub"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "กำลังโหลดรุ่นของ Skills ที่ผ่านการตรวจสอบแล้ว"
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "ไม่พบ Skills"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "ลองค้นหาแบบอื่นหรือรีเฟรชแค็ตตาล็อก"
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "ไม่สามารถโหลด Skills ได้"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub ไม่พร้อมใช้งาน"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "ไม่สามารถตรวจทาน Skill ได้"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "เชื่อมต่อใหม่ รีเฟรช Skills แล้วลองอีกครั้ง Gateway จะเข้าร่วมการติดตั้งที่ตรงกันซึ่งยังดำเนินอยู่ได้อย่างปลอดภัย"
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "Gateway บล็อกการติดตั้ง"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "Gateway ติดตั้งเวอร์ชันที่ผ่านการตรวจทานแล้ว"
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "ไม่ทราบผลการติดตั้ง"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "ปิดใช้งาน Skill แล้ว"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "เปิดใช้งาน Skill แล้ว"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "ไม่สามารถเปิดใช้งาน Skill ได้"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "ไม่สามารถปิดใช้งาน Skill ได้"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "ปิดใช้งาน"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "เปิดใช้งาน"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "ปิด"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "พร้อม"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "ต้องตั้งค่า"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "ขาด: %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "ติดตั้ง"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway จะตรวจสอบรีลีสนี้กับ ClawHub ก่อนดาวน์โหลด"
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "การเชื่อมต่อ Gateway นี้ต้องมี operator.admin เพื่อติดตั้ง Skills"
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "ตรวจสอบ Skill ใน ClawHub"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "ตรวจสอบและติดตั้ง"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "คำเตือนจาก Gateway"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "Gateway กำหนดให้ยืนยันการรับทราบอย่างชัดเจนสำหรับรีลีสนี้"
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "ตรวจสอบรายละเอียดคำเตือน"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "ขยายและตรวจสอบคำเตือนจาก Gateway ก่อนยืนยันการรับทราบเวอร์ชันนี้"
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "ตรวจสอบคำเตือนของ Gateway"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "ยกเลิก"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "รับทราบและติดตั้ง"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "เวอร์ชัน"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "ผู้เผยแพร่"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "Gateway ที่เชื่อมต่อมีการเปลี่ยนแปลง รีเฟรช Skills แล้วลองอีกครั้ง"
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "ไม่สามารถเข้ารหัสคำขอของ Gateway ได้"
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHub ไม่ได้รายงานเวอร์ชันที่ติดตั้งได้สำหรับ Skill นี้"
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "ไม่ได้กำหนดค่าโทเค็น Telegram"
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "เรียกดู ClawHub"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "ค้นพบ Skills"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway จะตรวจสอบรุ่นที่ผ่านการตรวจสอบโดยตรงก่อนดาวน์โหลด"
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "ค้นหาใน ClawHub"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "ค้นหา"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "ผลลัพธ์"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "กำลังค้นหาใน ClawHub…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "ไม่พบ Skills"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "ลองค้นหาอย่างอื่นหรือรีเฟรชแค็ตตาล็อก"
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "ติดตั้งแล้ว"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "ตรวจสอบ"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "ตรวจสอบ Skill จาก ClawHub"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway จะตรวจสอบรีลีสนี้กับ ClawHub ก่อนดาวน์โหลด"
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "ตรวจสอบและติดตั้ง"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "คำเตือนจาก Gateway"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "ตรวจสอบรายละเอียดคำเตือน"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "ขยายและตรวจสอบคำเตือนจาก Gateway ก่อนยอมรับเวอร์ชันนี้"
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "ยกเลิก"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "ยอมรับและติดตั้ง"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "เวอร์ชัน"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "ผู้เผยแพร่"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "ไม่มีส่วนการกำหนดค่าที่พร้อมใช้งาน"
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "ความสามารถเสริมที่จะพร้อมใช้งานเมื่อเป็นไปตามข้อกำหนด"
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "จัดการความสามารถที่ติดตั้งไว้หรือค้นหารีลีสที่ผ่านการตรวจสอบแล้วบน ClawHub"
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "ส่วน Skills"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "รีเฟรช"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "ค้นหา Skills ที่ติดตั้งไว้"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "กำลังโหลด…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "ตัวกรอง"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "ติดตั้งแล้ว"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "เรียกดู"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "Gateway ประเมินรีลีสอื่นของ ClawHub โปรดตรวจสอบ Skill อีกครั้งก่อนติดตั้ง"
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -10974,6 +10974,11 @@
       "translated": "Kanallar"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "Ses ve Konuşma"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "Kanallar"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "Gateway henüz bağlanmadığında keşfedilen Gateway'ler ve manuel kurulum burada yer alır."
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "Göz At"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "Tümü"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "Gateway Skills'ı yönetmek için bağlanın."
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "Yüklü Skills ve hazır olma durumları yükleniyor."
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ hazır · %@ kurulum gerektiriyor"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "çevrimdışı"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "yükleniyor"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "Skills bölümü"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "Yüklü"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "Skills'ı Yenile"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "Yüklü Skills içinde ara"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "Yüklü skill filtresi"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "Yüklü Skills'ı yüklemek ve yönetmek için bağlanın."
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "Skills yükleniyor"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Gateway skill kataloğu okunuyor."
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "Eşleşen skill yok"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "Yüklü skill yok"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "Skill'leri keşfetmek ve yüklemek için ClawHub'a göz atın."
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "Arama veya hazır olma filtresini değiştirin."
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "ClawHub'da ara"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "Ara"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway, indirmeden önce incelenen sürümün tam olarak eşleştiğini doğrular."
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway çevrimdışı"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "ClawHub Skill'lerini aramak ve yüklemek için bağlanın."
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "Gateway güncellemesi gerekli"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "iOS'tan ClawHub Skill'lerini aramak ve yüklemek için Gateway'i güncelleyin."
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "ClawHub aranıyor"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "Doğrulanmış Skill sürümleri yükleniyor."
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "Skill bulunamadı"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Başka bir arama yapmayı veya kataloğu yenilemeyi deneyin."
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "Skill'ler yüklenemedi"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub kullanılamıyor"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "Skill incelenemedi"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "Yeniden bağlanın, Skills'i yenileyin ve tekrar deneyin. Gateway, hâlâ devam eden eşleşen bir yüklemeye güvenli bir şekilde katılır."
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "Gateway yüklemeyi engelledi"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "Gateway, incelenen sürümü yükledi."
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "Yükleme sonucu bilinmiyor"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "Skill devre dışı bırakıldı"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "Skill etkinleştirildi"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "Skill etkinleştirilemedi"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "Skill devre dışı bırakılamadı"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "Devre dışı bırak"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "Etkinleştir"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "Kapalı"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "Hazır"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "Kurulum gerekiyor"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "Eksik: %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "Yükle"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway, indirmeden önce tam olarak bu sürümü ClawHub ile doğrulayacak."
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "Bu Gateway bağlantısının Skills yükleyebilmesi için operator.admin yetkisi gerekiyor."
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "ClawHub Skill'ini incele"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "Doğrula ve yükle"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "Gateway uyarısı"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "Gateway, bu sürüm için açık onay gerektiriyor."
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "Uyarı ayrıntılarını incele"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Tam olarak bu sürümü onaylamadan önce Gateway uyarısını genişletip inceleyin."
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "Gateway uyarısını incele"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "İptal"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "Onayla ve yükle"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "Sürüm"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "Yayıncı"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "Bağlı Gateway değişti. Skills'i yenileyip tekrar deneyin."
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "Gateway isteği kodlanamadı."
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHub bu skill için yüklenebilir bir sürüm bildirmedi."
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "Telegram token'ı yapılandırılmamış."
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "ClawHub'a göz at"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "Skill'leri keşfet"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway, indirmeden önce incelenen sürümün tam olarak eşleştiğini doğrular."
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "ClawHub'da ara"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "Ara"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "Sonuçlar"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "ClawHub aranıyor…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "Skill bulunamadı"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Başka bir arama yapmayı veya kataloğu yenilemeyi deneyin."
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "Yüklendi"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "İncele"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "ClawHub skill'ini incele"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway, indirmeden önce tam olarak bu sürümü ClawHub ile doğrulayacak."
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "Doğrula ve yükle"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "Gateway uyarısı"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "Uyarı ayrıntılarını incele"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Tam olarak bu sürümü onaylamadan önce Gateway uyarısını genişletip inceleyin."
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "İptal"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "Onayla ve yükle"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "Sürüm"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "Yayıncı"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "Kullanılabilir config bölümü yok."
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "Gereksinimleri karşılandığında kullanılabilir hale gelen isteğe bağlı yetenekler."
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "Yüklü özellikleri yönetin veya ClawHub'da doğrulanmış sürümleri keşfedin."
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "Skills bölümü"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "Yenile"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "Yüklü Skills öğelerinde ara"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "Yükleniyor…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "Filtre"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "Yüklü"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "Göz at"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "Gateway farklı bir ClawHub sürümünü değerlendirdi. Yüklemeden önce Skill'i tekrar inceleyin."
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -10974,6 +10974,11 @@
       "translated": "Канали"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "Голос і розмова"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "Канали"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "Виявлені gateway та ручне налаштування відображаються тут, коли gateway ще не підключено."
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "Огляд"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "Усі"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "Підключіться, щоб керувати навичками Gateway."
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "Завантаження встановлених навичок і перевірка їхньої готовності."
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ готові · %@ потребують налаштування"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "не в мережі"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "завантаження"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "Розділ Skills"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "Установлені"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "Оновити Skills"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "Пошук установлених навичок"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "Фільтр установлених навичок"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "Підключіться, щоб завантажити встановлені навички та керувати ними."
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "Завантаження навичок"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Зчитування каталогу навичок Gateway."
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "Відповідних навичок немає"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "Немає встановлених навичок"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "Переглядайте ClawHub, щоб знаходити й установлювати навички."
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "Змініть пошуковий запит або фільтр готовності."
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "Пошук у ClawHub"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "Пошук"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway перевіряє точний схвалений випуск перед завантаженням."
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway не в мережі"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "Підключіться, щоб шукати й установлювати навички ClawHub."
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "Потрібне оновлення Gateway"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "Оновіть Gateway, щоб шукати й установлювати навички ClawHub з iOS."
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "Пошук у ClawHub"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "Завантаження перевірених випусків навичок."
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "Навичок не знайдено"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Спробуйте інший пошуковий запит або оновіть каталог."
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "Не вдалося завантажити навички"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub недоступний"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "Не вдалося перевірити навичку"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "Підключіться знову, оновіть Skills і повторіть спробу. Gateway безпечно приєднається до відповідного встановлення, якщо воно ще триває."
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "Gateway заблокував установлення"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "Gateway установив перевірену версію."
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "Результат встановлення невідомий"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "Skill вимкнено"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "Skill увімкнено"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "Не вдалося увімкнути Skill"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "Не вдалося вимкнути Skill"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "Вимкнути"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "Увімкнути"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "Вимкнено"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "Готово"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "Потребує налаштування"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "Відсутнє: %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "Встановити"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway перевірить цей конкретний випуск через ClawHub перед завантаженням."
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "Для встановлення Skills це підключення до Gateway потребує operator.admin."
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "Переглянути Skill у ClawHub"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "Перевірити та встановити"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "Попередження Gateway"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "Gateway вимагає явного підтвердження для цього випуску."
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "Переглянути подробиці попередження"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Розгорніть і перегляньте попередження Gateway, перш ніж підтвердити цю конкретну версію."
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "Переглянути попередження Gateway"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "Скасувати"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "Підтвердити та встановити"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "Версія"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "Видавець"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "Підключений Gateway змінився. Оновіть Skills і спробуйте ще раз."
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "Не вдалося закодувати запит Gateway."
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHub не повідомив про доступну для встановлення версію цієї навички."
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "Токен Telegram не налаштовано."
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "Переглянути ClawHub"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "Знайти навички"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway перевіряє точний переглянутий випуск перед завантаженням."
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "Пошук у ClawHub"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "Пошук"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "Результати"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "Пошук у ClawHub…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "Навичок не знайдено"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Спробуйте інший пошуковий запит або оновіть каталог."
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "Встановлено"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "Переглянути"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "Переглянути навичку ClawHub"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway перевірить саме цей випуск у ClawHub перед завантаженням."
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "Перевірити та встановити"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "Попередження Gateway"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "Переглянути деталі попередження"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Розгорніть і перегляньте попередження Gateway, перш ніж підтвердити ознайомлення саме з цією версією."
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "Скасувати"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "Підтвердити ознайомлення та встановити"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "Версія"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "Видавець"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "Немає доступних розділів конфігурації."
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "Необов’язкові можливості, які стають доступними, коли виконано їхні вимоги."
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "Керуйте встановленими можливостями або знаходьте перевірені випуски в ClawHub."
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "Розділ Skills"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "Оновити"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "Пошук установлених навичок"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "Завантаження…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "Фільтр"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "Установлено"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "Огляд"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "Gateway перевірив інший випуск ClawHub. Перегляньте навичку ще раз перед установленням."
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -10974,6 +10974,11 @@
       "translated": "Kênh"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "Giọng nói & Trò chuyện"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "Kênh"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "Các Gateway đã phát hiện và thiết lập thủ công sẽ hiển thị ở đây khi Gateway chưa kết nối."
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "Duyệt"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "Tất cả"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "Kết nối để quản lý Skills của Gateway."
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "Đang tải các Skills đã cài đặt và trạng thái sẵn sàng."
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ sẵn sàng · %@ cần thiết lập"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "ngoại tuyến"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "đang tải"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "Mục Skills"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "Đã cài đặt"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "Làm mới Skills"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "Tìm kiếm Skills đã cài đặt"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "Bộ lọc Skills đã cài đặt"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "Kết nối để tải và quản lý các Skills đã cài đặt."
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "Đang tải Skills"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Đang đọc danh mục Skills của Gateway."
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "Không có Skills phù hợp"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "Chưa cài đặt Skills nào"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "Duyệt ClawHub để khám phá và cài đặt các Skills."
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "Thay đổi bộ lọc tìm kiếm hoặc trạng thái sẵn sàng."
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "Tìm kiếm trên ClawHub"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "Tìm kiếm"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway xác minh chính xác bản phát hành đã được xem xét trước khi tải xuống."
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway ngoại tuyến"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "Kết nối để tìm kiếm và cài đặt các Skills từ ClawHub."
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "Cần cập nhật Gateway"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "Cập nhật Gateway để tìm kiếm và cài đặt các Skills từ ClawHub trên iOS."
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "Đang tìm kiếm trên ClawHub"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "Đang tải các bản phát hành Skills đã được xác minh."
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "Không tìm thấy Skills nào"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Hãy thử tìm kiếm nội dung khác hoặc làm mới danh mục."
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "Không thể tải Skills"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub không khả dụng"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "Không thể xem xét Skill"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "Hãy kết nối lại, làm mới Skills rồi thử lại. Gateway sẽ tham gia an toàn vào tiến trình cài đặt tương ứng vẫn đang chạy."
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "Gateway đã chặn cài đặt"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "Gateway đã cài đặt phiên bản được xem xét."
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "Không rõ kết quả cài đặt"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "Đã tắt Skill"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "Đã bật Skill"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "Không thể bật Skill"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "Không thể tắt Skill"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "Tắt"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "Bật"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "Tắt"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "Sẵn sàng"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "Cần thiết lập"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "Thiếu: %@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "Cài đặt"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway sẽ xác minh chính xác bản phát hành này với ClawHub trước khi tải xuống."
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "Kết nối Gateway này cần operator.admin để cài đặt Skills."
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "Xem lại Skill trên ClawHub"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "Xác minh và cài đặt"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "Cảnh báo Gateway"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "Gateway yêu cầu xác nhận rõ ràng đối với bản phát hành này."
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "Xem lại chi tiết cảnh báo"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Mở rộng và xem lại cảnh báo của Gateway trước khi xác nhận chính xác phiên bản này."
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "Xem lại cảnh báo của Gateway"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "Hủy"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "Xác nhận và cài đặt"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "Phiên bản"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "Nhà phát hành"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "Gateway được kết nối đã thay đổi. Hãy làm mới Skills và thử lại."
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "Không thể mã hóa yêu cầu Gateway."
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHub không cung cấp phiên bản có thể cài đặt cho skill này."
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "Chưa cấu hình token Telegram."
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "Duyệt ClawHub"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "Khám phá các skill"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway xác minh chính xác bản phát hành đã được xem xét trước khi tải xuống."
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "Tìm kiếm trên ClawHub"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "Tìm kiếm"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "Kết quả"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "Đang tìm kiếm trên ClawHub…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "Không tìm thấy skill nào"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "Hãy thử tìm kiếm khác hoặc làm mới danh mục."
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "Đã cài đặt"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "Xem lại"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "Xem lại skill trên ClawHub"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway sẽ xác minh chính xác bản phát hành này với ClawHub trước khi tải xuống."
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "Xác minh và cài đặt"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "Cảnh báo Gateway"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "Xem lại chi tiết cảnh báo"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "Mở rộng và xem lại cảnh báo Gateway trước khi xác nhận chính xác phiên bản này."
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "Hủy"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "Xác nhận và cài đặt"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "Phiên bản"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "Nhà phát hành"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "Không có phần cấu hình nào."
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "Các khả năng tùy chọn sẽ khả dụng khi đáp ứng yêu cầu."
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "Quản lý các tính năng đã cài đặt hoặc khám phá các bản phát hành đã được xác minh trên ClawHub."
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "Phần Skills"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "Làm mới"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "Tìm kiếm Skills đã cài đặt"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "Đang tải…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "Bộ lọc"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "Đã cài đặt"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "Duyệt tìm"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "Gateway đã đánh giá một bản phát hành ClawHub khác. Hãy xem lại skill trước khi cài đặt."
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -10974,6 +10974,11 @@
       "translated": "频道"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "语音与通话"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "频道"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "当 Gateway 尚未连接时，已发现的 Gateway 和手动设置会显示在这里。"
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "浏览"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "全部"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "连接以管理 Gateway Skills。"
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "正在加载已安装的 Skills 及其就绪状态。"
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ 已就绪 · %@ 需要设置"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "离线"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "正在加载"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "Skills 部分"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "已安装"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "刷新 Skills"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "搜索已安装的 Skills"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "已安装 Skills 筛选条件"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "连接以加载和管理已安装的 Skills。"
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "正在加载 Skills"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "正在读取 Gateway Skills 目录。"
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "没有匹配的 Skills"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "未安装任何 Skills"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "浏览 ClawHub 以发现并安装技能。"
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "更改搜索或就绪状态筛选条件。"
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "搜索 ClawHub"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "搜索"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway 会在下载前验证经过审核的确切版本。"
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway 离线"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "连接以搜索和安装 ClawHub 技能。"
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "需要更新 Gateway"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "更新 Gateway，以便从 iOS 搜索和安装 ClawHub 技能。"
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "正在搜索 ClawHub"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "正在加载已验证的技能版本。"
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "未找到技能"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "请尝试其他搜索或刷新目录。"
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "无法加载技能"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub 不可用"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "无法审核技能"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "请重新连接，刷新 Skills，然后重试。Gateway 会安全地接入仍在运行的匹配安装任务。"
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "Gateway 已阻止安装"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "Gateway 已安装经过审核的版本。"
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "安装结果未知"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "技能已禁用"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "技能已启用"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "无法启用技能"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "无法禁用技能"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "禁用"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "启用"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "关闭"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "就绪"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "需要设置"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "缺少：%@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "安装"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "下载前，Gateway 将通过 ClawHub 验证此确切版本。"
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "此 Gateway 连接需要 operator.admin 权限才能安装技能。"
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "查看 ClawHub 技能"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "验证并安装"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "Gateway 警告"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "Gateway 要求明确确认此版本。"
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "查看警告详情"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "确认此确切版本前，请展开并查看 Gateway 警告。"
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "查看 Gateway 警告"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "取消"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "确认并安装"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "版本"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "发布者"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "连接的 Gateway 已更改。请刷新 Skills 后重试。"
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "无法对 Gateway 请求进行编码。"
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHub 未提供此技能的可安装版本。"
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "未配置 Telegram 令牌。"
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "浏览 ClawHub"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "发现技能"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway 会在下载前验证经过审核的确切版本。"
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "搜索 ClawHub"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "搜索"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "结果"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "正在搜索 ClawHub…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "未找到技能"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "请尝试其他搜索词或刷新目录。"
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "已安装"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "查看"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "查看 ClawHub 技能"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway 将在下载前通过 ClawHub 验证此确切版本。"
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "验证并安装"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "Gateway 警告"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "查看警告详情"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "确认此确切版本前，请展开并查看 Gateway 警告。"
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "取消"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "确认并安装"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "版本"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "发布者"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "没有可用的配置部分。"
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "满足要求后可用的可选功能。"
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "管理已安装的功能，或在 ClawHub 上发现经过验证的版本。"
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "Skills 部分"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "刷新"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "搜索已安装的 Skills"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "正在加载…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "筛选"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "已安装"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "浏览"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "Gateway 评估了另一个 ClawHub 版本。请在安装前重新查看该 Skill。"
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -10974,6 +10974,11 @@
       "translated": "頻道"
     },
     {
+      "id": "native.apple.e2eaba9832a2fad7",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
       "id": "native.apple.fd44d6742909f55c",
       "source": "Voice & Talk",
       "translated": "語音與對話"
@@ -11287,6 +11292,11 @@
       "id": "native.apple.8a159fab30307884",
       "source": "Channels",
       "translated": "頻道"
+    },
+    {
+      "id": "native.apple.1f52746515df3fa5",
+      "source": "Skills",
+      "translated": "Skills"
     },
     {
       "id": "native.apple.1573249126ddd84f",
@@ -12102,6 +12112,336 @@
       "id": "native.apple.f439c34a9ce3a332",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "translated": "在 gateway 尚未連線時，探索到的閘道器和手動設定會顯示在這裡。"
+    },
+    {
+      "id": "native.apple.acf33c8c3efde926",
+      "source": "Browse",
+      "translated": "瀏覽"
+    },
+    {
+      "id": "native.apple.57f55061e45f732b",
+      "source": "All",
+      "translated": "全部"
+    },
+    {
+      "id": "native.apple.02a59c6d5de241c6",
+      "source": "Skills",
+      "translated": "Skills"
+    },
+    {
+      "id": "native.apple.de33b4b220a48b7b",
+      "source": "Connect to manage Gateway skills.",
+      "translated": "連線以管理 Gateway Skills。"
+    },
+    {
+      "id": "native.apple.395f4d55dfb4b1bf",
+      "source": "Loading installed skills and readiness.",
+      "translated": "正在載入已安裝的 Skills 與就緒狀態。"
+    },
+    {
+      "id": "native.apple.b5a47111394ae9d2",
+      "source": "%@ ready · %@ need setup",
+      "translated": "%@ 已就緒 · %@ 需要設定"
+    },
+    {
+      "id": "native.apple.06c8a70b3321dd77",
+      "source": "offline",
+      "translated": "離線"
+    },
+    {
+      "id": "native.apple.bbf921f4a20e6d64",
+      "source": "loading",
+      "translated": "載入中"
+    },
+    {
+      "id": "native.apple.50af4928abeb5493",
+      "source": "Skills section",
+      "translated": "Skills 區段"
+    },
+    {
+      "id": "native.apple.5be2a1662a9d8454",
+      "source": "Installed",
+      "translated": "已安裝"
+    },
+    {
+      "id": "native.apple.493e64eee96d3b2c",
+      "source": "Refresh Skills",
+      "translated": "重新整理 Skills"
+    },
+    {
+      "id": "native.apple.2fc9bfee92bad603",
+      "source": "Search installed skills",
+      "translated": "搜尋已安裝的 Skills"
+    },
+    {
+      "id": "native.apple.b7a9e8ede061b45c",
+      "source": "Installed skill filter",
+      "translated": "已安裝的 Skills 篩選器"
+    },
+    {
+      "id": "native.apple.d5075a70296450e1",
+      "source": "Connect to load and manage installed skills.",
+      "translated": "連線以載入及管理已安裝的 Skills。"
+    },
+    {
+      "id": "native.apple.d23235f31ddc7d87",
+      "source": "Loading skills",
+      "translated": "正在載入 Skills"
+    },
+    {
+      "id": "native.apple.ad8ceb4f98255843",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "正在讀取 Gateway Skills 目錄。"
+    },
+    {
+      "id": "native.apple.0550dad32f8ef785",
+      "source": "No matching skills",
+      "translated": "沒有符合的 Skills"
+    },
+    {
+      "id": "native.apple.adcee8faa45b0365",
+      "source": "No skills installed",
+      "translated": "尚未安裝 Skills"
+    },
+    {
+      "id": "native.apple.e7e5b1011a14fc4b",
+      "source": "Browse ClawHub to discover and install skills.",
+      "translated": "瀏覽 ClawHub 以探索並安裝 Skills。"
+    },
+    {
+      "id": "native.apple.f54b778b8ea52ece",
+      "source": "Change the search or readiness filter.",
+      "translated": "變更搜尋或就緒狀態篩選條件。"
+    },
+    {
+      "id": "native.apple.44d2b179910face4",
+      "source": "ClawHub",
+      "translated": "ClawHub"
+    },
+    {
+      "id": "native.apple.8e161683e7efa2a4",
+      "source": "Search ClawHub",
+      "translated": "搜尋 ClawHub"
+    },
+    {
+      "id": "native.apple.c7050536b0ee103f",
+      "source": "Search",
+      "translated": "搜尋"
+    },
+    {
+      "id": "native.apple.a390ab96444bced8",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway 會在下載前驗證確切的已審核版本。"
+    },
+    {
+      "id": "native.apple.85d609abe4548150",
+      "source": "Gateway offline",
+      "translated": "Gateway 離線"
+    },
+    {
+      "id": "native.apple.37ce41bbd2c854dd",
+      "source": "Connect to search and install ClawHub skills.",
+      "translated": "連線以搜尋並安裝 ClawHub Skills。"
+    },
+    {
+      "id": "native.apple.a21337a8fba8d90c",
+      "source": "Gateway update required",
+      "translated": "需要更新 Gateway"
+    },
+    {
+      "id": "native.apple.503fadc03e3b4090",
+      "source": "Update the Gateway to search and install ClawHub skills from iOS.",
+      "translated": "更新 Gateway，以便從 iOS 搜尋並安裝 ClawHub Skills。"
+    },
+    {
+      "id": "native.apple.b542672608467c0a",
+      "source": "Searching ClawHub",
+      "translated": "正在搜尋 ClawHub"
+    },
+    {
+      "id": "native.apple.5acf38408914a884",
+      "source": "Loading verified skill releases.",
+      "translated": "正在載入已驗證的 Skill 版本。"
+    },
+    {
+      "id": "native.apple.c0261398045e7911",
+      "source": "No skills found",
+      "translated": "找不到 Skills"
+    },
+    {
+      "id": "native.apple.eb605facc8feeed7",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "請嘗試其他搜尋條件或重新整理目錄。"
+    },
+    {
+      "id": "native.apple.29c8087ab70bedcd",
+      "source": "Could not load skills",
+      "translated": "無法載入 Skills"
+    },
+    {
+      "id": "native.apple.cf8f37f9d39bf57b",
+      "source": "ClawHub unavailable",
+      "translated": "ClawHub 無法使用"
+    },
+    {
+      "id": "native.apple.43406555e5144718",
+      "source": "Could not review skill",
+      "translated": "無法審核 Skill"
+    },
+    {
+      "id": "native.apple.1633604644edf7b3",
+      "source": "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+      "translated": "請重新連線、重新整理 Skills，然後重試。Gateway 會安全地接續仍在執行中的相符安裝作業。"
+    },
+    {
+      "id": "native.apple.3cc22b37bdb9fcd1",
+      "source": "Gateway blocked install",
+      "translated": "Gateway 已封鎖安裝"
+    },
+    {
+      "id": "native.apple.95223294a767ccd7",
+      "source": "The Gateway installed the reviewed version.",
+      "translated": "Gateway 已安裝經審核的版本。"
+    },
+    {
+      "id": "native.apple.71d7b3860ab9f02c",
+      "source": "Install result unknown",
+      "translated": "安裝結果未知"
+    },
+    {
+      "id": "native.apple.e69ba6c4d73eb72f",
+      "source": "Skill disabled",
+      "translated": "Skill 已停用"
+    },
+    {
+      "id": "native.apple.8677a968b0a7729d",
+      "source": "Skill enabled",
+      "translated": "Skill 已啟用"
+    },
+    {
+      "id": "native.apple.b4577e30f257ad79",
+      "source": "Could not enable skill",
+      "translated": "無法啟用 Skill"
+    },
+    {
+      "id": "native.apple.b9d22e7d493eb2bb",
+      "source": "Could not disable skill",
+      "translated": "無法停用 Skill"
+    },
+    {
+      "id": "native.apple.1f06ad201d9b6bed",
+      "source": "Disable",
+      "translated": "停用"
+    },
+    {
+      "id": "native.apple.b284f85f4efc0fa7",
+      "source": "Enable",
+      "translated": "啟用"
+    },
+    {
+      "id": "native.apple.0d4cc831b423aa98",
+      "source": "Off",
+      "translated": "關閉"
+    },
+    {
+      "id": "native.apple.c63a20f1143b62ca",
+      "source": "Ready",
+      "translated": "就緒"
+    },
+    {
+      "id": "native.apple.892d7433a4468f5a",
+      "source": "Needs Setup",
+      "translated": "需要設定"
+    },
+    {
+      "id": "native.apple.113dacafa42bb62e",
+      "source": "Missing: %@",
+      "translated": "缺少：%@"
+    },
+    {
+      "id": "native.apple.1824681020aa336b",
+      "source": "Install",
+      "translated": "安裝"
+    },
+    {
+      "id": "native.apple.7d9b36be7a7df9a8",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway 會在下載前透過 ClawHub 驗證此確切版本。"
+    },
+    {
+      "id": "native.apple.4fb1f26e4de787dd",
+      "source": "This gateway connection needs operator.admin to install skills.",
+      "translated": "此 Gateway 連線需要 operator.admin 權限才能安裝 Skills。"
+    },
+    {
+      "id": "native.apple.0f902fcad255ae3f",
+      "source": "Review ClawHub skill",
+      "translated": "檢閱 ClawHub Skill"
+    },
+    {
+      "id": "native.apple.8f61d18ceca765da",
+      "source": "Verify and install",
+      "translated": "驗證並安裝"
+    },
+    {
+      "id": "native.apple.64ac6815468e764b",
+      "source": "Gateway warning",
+      "translated": "Gateway 警告"
+    },
+    {
+      "id": "native.apple.cfb4fe56e0a7f93b",
+      "source": "The Gateway requires explicit acknowledgement for this release.",
+      "translated": "Gateway 要求明確確認此版本。"
+    },
+    {
+      "id": "native.apple.91447e88c95f0f72",
+      "source": "Review warning details",
+      "translated": "檢閱警告詳細資訊"
+    },
+    {
+      "id": "native.apple.9ad3235988108fce",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "展開並檢閱 Gateway 警告，然後再確認此確切版本。"
+    },
+    {
+      "id": "native.apple.b79b3886a801b83e",
+      "source": "Review Gateway warning",
+      "translated": "檢閱 Gateway 警告"
+    },
+    {
+      "id": "native.apple.8a3adec4b6d6eb15",
+      "source": "Cancel",
+      "translated": "取消"
+    },
+    {
+      "id": "native.apple.30304ca2865ea3b4",
+      "source": "Acknowledge and install",
+      "translated": "確認並安裝"
+    },
+    {
+      "id": "native.apple.c1499a39573b3633",
+      "source": "Version",
+      "translated": "版本"
+    },
+    {
+      "id": "native.apple.4789ad34a901e14e",
+      "source": "Publisher",
+      "translated": "發行者"
+    },
+    {
+      "id": "native.apple.ba780a0a9b2fd426",
+      "source": "The connected Gateway changed. Refresh Skills and try again.",
+      "translated": "已連線的 Gateway 已變更。請重新整理 Skills 後再試一次。"
+    },
+    {
+      "id": "native.apple.af9d5bb3dd35cfff",
+      "source": "Could not encode the Gateway request.",
+      "translated": "無法編碼 Gateway 請求。"
+    },
+    {
+      "id": "native.apple.7a5a1b9342f01954",
+      "source": "ClawHub did not report an installable version for this skill.",
+      "translated": "ClawHub 未提供此 skill 的可安裝版本。"
     },
     {
       "id": "native.apple.798c3584ad95f8da",
@@ -15734,6 +16074,111 @@
       "translated": "未設定 Telegram 權杖。"
     },
     {
+      "id": "native.apple.48155cd3182d0fc1",
+      "source": "Browse ClawHub",
+      "translated": "瀏覽 ClawHub"
+    },
+    {
+      "id": "native.apple.2a63044f55e90b32",
+      "source": "Discover skills",
+      "translated": "探索 Skills"
+    },
+    {
+      "id": "native.apple.5fef1d6003e5df6f",
+      "source": "The Gateway verifies the exact reviewed release before download.",
+      "translated": "Gateway 會在下載前驗證已檢閱的確切版本。"
+    },
+    {
+      "id": "native.apple.f5aa33a76f62e6e9",
+      "source": "Search ClawHub",
+      "translated": "搜尋 ClawHub"
+    },
+    {
+      "id": "native.apple.1b08dbd63dadda23",
+      "source": "Search",
+      "translated": "搜尋"
+    },
+    {
+      "id": "native.apple.84bdcdb604ccadd6",
+      "source": "Results",
+      "translated": "結果"
+    },
+    {
+      "id": "native.apple.2539b847d0cc4326",
+      "source": "Searching ClawHub…",
+      "translated": "正在搜尋 ClawHub…"
+    },
+    {
+      "id": "native.apple.ce42e5d6c37b59e8",
+      "source": "No skills found",
+      "translated": "找不到 Skills"
+    },
+    {
+      "id": "native.apple.c27ee52f9350a02f",
+      "source": "Try another search or refresh the catalog.",
+      "translated": "請嘗試其他搜尋條件或重新整理目錄。"
+    },
+    {
+      "id": "native.apple.fc107db526febdee",
+      "source": "Installed",
+      "translated": "已安裝"
+    },
+    {
+      "id": "native.apple.101103e2d97e04cd",
+      "source": "Review",
+      "translated": "檢閱"
+    },
+    {
+      "id": "native.apple.8976aca17f4dfbdc",
+      "source": "Review ClawHub skill",
+      "translated": "檢閱 ClawHub skill"
+    },
+    {
+      "id": "native.apple.b5a521cd4f77fff0",
+      "source": "The Gateway will verify this exact release with ClawHub before download.",
+      "translated": "Gateway 會在下載前透過 ClawHub 驗證此確切版本。"
+    },
+    {
+      "id": "native.apple.86078f1c84e735d7",
+      "source": "Verify and install",
+      "translated": "驗證並安裝"
+    },
+    {
+      "id": "native.apple.fbbba0a83466864c",
+      "source": "Gateway warning",
+      "translated": "Gateway 警告"
+    },
+    {
+      "id": "native.apple.8957dc102983dbb0",
+      "source": "Review warning details",
+      "translated": "檢視警告詳細資訊"
+    },
+    {
+      "id": "native.apple.1b9020d8308c0563",
+      "source": "Expand and review the Gateway warning before acknowledging this exact version.",
+      "translated": "在確認此確切版本前，請展開並檢視 Gateway 警告。"
+    },
+    {
+      "id": "native.apple.ee2577b784c64ac6",
+      "source": "Cancel",
+      "translated": "取消"
+    },
+    {
+      "id": "native.apple.9fa34dc1057cbcee",
+      "source": "Acknowledge and install",
+      "translated": "確認並安裝"
+    },
+    {
+      "id": "native.apple.5e36364c63057778",
+      "source": "Version",
+      "translated": "版本"
+    },
+    {
+      "id": "native.apple.cac171668ece3a4d",
+      "source": "Publisher",
+      "translated": "發布者"
+    },
+    {
       "id": "native.apple.0a65101d40a6704c",
       "source": "No config sections available.",
       "translated": "沒有可用的 config 區段。"
@@ -19334,9 +19779,14 @@
       "translated": "Skills"
     },
     {
-      "id": "native.apple.0f62bd687b786431",
-      "source": "Optional capabilities that become available when their requirements are met.",
-      "translated": "在符合需求時即可使用的選用功能。"
+      "id": "native.apple.50be0aae3f54705e",
+      "source": "Manage installed capabilities or discover verified releases on ClawHub.",
+      "translated": "管理已安裝的功能，或在 ClawHub 上探索經驗證的版本。"
+    },
+    {
+      "id": "native.apple.5a3f840bde899fbe",
+      "source": "Skills section",
+      "translated": "Skills 區段"
     },
     {
       "id": "native.apple.d40a7bb04c5534ec",
@@ -19379,6 +19829,11 @@
       "translated": "重新整理"
     },
     {
+      "id": "native.apple.90f5eb0762593f89",
+      "source": "Search installed skills",
+      "translated": "搜尋已安裝的 Skills"
+    },
+    {
       "id": "native.apple.85a9941ff7a30fbe",
       "source": "Loading…",
       "translated": "載入中…"
@@ -19402,6 +19857,16 @@
       "id": "native.apple.2beddcc70ea0d96a",
       "source": "Filter",
       "translated": "篩選"
+    },
+    {
+      "id": "native.apple.ebbf5e9abc1fd8b9",
+      "source": "Installed",
+      "translated": "已安裝"
+    },
+    {
+      "id": "native.apple.a4b3ea71236c5789",
+      "source": "Browse",
+      "translated": "瀏覽"
     },
     {
       "id": "native.apple.eb868667821fbf7c",
@@ -20997,6 +21462,11 @@
       "id": "native.apple.2f45f005d2a7c3c2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.3fe61126fd4ca8aa",
+      "source": "The Gateway evaluated a different ClawHub release. Review the skill again before installing.",
+      "translated": "Gateway 評估了另一個 ClawHub 版本。請在安裝前再次檢視該 Skill。"
     },
     {
       "id": "native.apple.e97067187c9a359d",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Creates or adopts Android's existing per-device chat session before loading connected history, preserving prior conversations while isolating each device. Thanks @snowzlmbot.
 Adds polished Installed/Browse skill management on Android with readiness filters, enable/disable controls, and readable Gateway-enforced ClawHub risk review. Thanks @snowzlmbot.
+Marks already installed ClawHub slugs in Browse and prevents fresh-install retries from overwriting or failing against existing skill directories. (#105741)
 Routes exec approval review through the Gateway's durable approval records, including first-answer-wins results from other authorized surfaces, fail-closed reconciliation after ambiguous writes, and compatibility with older Gateway v4 peers.
 Keeps Android session search in the Sessions screen with direct focus, clear controls, and accurate loading and no-match states. Thanks @IWhatsskill.
 Shows the localized app version, Git commit, and build date together on the About screen, with real provenance in repository-backed debug builds.

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -6152,6 +6152,12 @@ class NodeRuntime private constructor(
               ?.trim()
               ?.takeIf(String::isNotEmpty),
           clawHubValid = clawHub?.boolean("valid") == true,
+          clawHubOwnerHandle =
+            clawHub
+              ?.get("ownerHandle")
+              .asStringOrNull()
+              ?.trim()
+              ?.takeIf(String::isNotEmpty),
           clawHubInstalledVersion =
             clawHub
               ?.get("installedVersion")
@@ -6894,6 +6900,7 @@ data class GatewaySkillSummary(
   val installCount: Int,
   val clawHubSlug: String? = null,
   val clawHubValid: Boolean = false,
+  val clawHubOwnerHandle: String? = null,
   val clawHubInstalledVersion: String? = null,
 )
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/SkillManagement.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SkillManagement.kt
@@ -81,6 +81,11 @@ internal fun parseClawHubInstallReview(
   val version = latestVersion?.string("version") ?: fallback.version ?: return null
   val ownerDisplayName = owner?.string("displayName")
   val ownerHandle = owner?.string("handle")
+  val reviewedSlug =
+    canonicalClawHubSkillReference(
+      slug = skill?.string("slug") ?: fallback.slug,
+      ownerHandle = ownerHandle,
+    ) ?: return null
   val author =
     when {
       ownerDisplayName != null && ownerHandle != null && !ownerDisplayName.equals(ownerHandle, ignoreCase = true) ->
@@ -90,7 +95,7 @@ internal fun parseClawHubInstallReview(
       else -> "Unknown publisher"
     }
   return GatewayClawHubInstallReview(
-    slug = fallback.slug,
+    slug = reviewedSlug,
     displayName = skill?.string("displayName") ?: fallback.displayName,
     summary = skill?.string("summary") ?: fallback.summary,
     version = version,
@@ -162,11 +167,51 @@ internal fun formatClawHubInstallMessage(
 internal fun isClawHubSkillInstalled(
   skills: List<GatewaySkillSummary>,
   slug: String,
+): Boolean {
+  val reference = parseClawHubSkillReference(slug) ?: return false
+  return skills.any { it.matchesClawHubReference(reference) }
+}
+
+internal fun isClawHubSkillInstalled(
+  skills: List<GatewaySkillSummary>,
+  slug: String,
   version: String,
 ): Boolean =
-  skills.any {
-    it.clawHubValid && it.clawHubSlug == slug && it.clawHubInstalledVersion == version
-  }
+  parseClawHubSkillReference(slug)?.let { reference ->
+    skills.any { it.matchesClawHubReference(reference) && it.clawHubInstalledVersion == version }
+  } ?: false
+
+private data class ClawHubSkillReference(
+  val slug: String,
+  val ownerHandle: String?,
+)
+
+private fun parseClawHubSkillReference(rawValue: String): ClawHubSkillReference? {
+  val value = rawValue.trim()
+  if (value.isEmpty()) return null
+  if (!value.startsWith("@")) return ClawHubSkillReference(value, null)
+  val parts = value.drop(1).split("/")
+  if (parts.size != 2 || parts.any(String::isEmpty)) return null
+  return ClawHubSkillReference(slug = parts[1], ownerHandle = parts[0].lowercase())
+}
+
+private fun canonicalClawHubSkillReference(
+  slug: String,
+  ownerHandle: String?,
+): String? {
+  val reference = parseClawHubSkillReference(slug) ?: return null
+  val owner = ownerHandle?.trim()?.takeIf(String::isNotEmpty)?.lowercase() ?: reference.ownerHandle
+  return owner?.let { "@$it/${reference.slug}" } ?: reference.slug
+}
+
+private fun GatewaySkillSummary.matchesClawHubReference(reference: ClawHubSkillReference): Boolean {
+  if (!clawHubValid) return false
+  val installedReference = clawHubSlug?.let(::parseClawHubSkillReference) ?: return false
+  if (!installedReference.slug.equals(reference.slug, ignoreCase = true)) return false
+  val requestedOwner = reference.ownerHandle ?: return true
+  val installedOwner = installedReference.ownerHandle ?: clawHubOwnerHandle
+  return installedOwner?.equals(requestedOwner, ignoreCase = true) == true
+}
 
 internal fun clawHubInstallOutcomeUnknownMessage(slug: String): String = "The result for $slug is unknown. Reconnect, refresh Skills, then retry; the Gateway safely joins a matching install that is still running."
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt
@@ -7,6 +7,7 @@ import ai.openclaw.app.GatewayClawHubSkillSummary
 import ai.openclaw.app.GatewaySkillSummary
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.i18n.nativeString
+import ai.openclaw.app.isClawHubSkillInstalled
 import ai.openclaw.app.ui.design.ClawDetailRow
 import ai.openclaw.app.ui.design.ClawIconButton
 import ai.openclaw.app.ui.design.ClawListPanel
@@ -184,6 +185,7 @@ internal fun SkillsSettingsScreen(
       SkillsTab.Browse ->
         ClawHubSkillSearchPanel(
           state = clawHubState,
+          installedSkills = skills,
           query = clawHubQuery,
           isConnected = isConnected,
           methodsAvailable = clawHubMethodsAvailable,
@@ -534,6 +536,7 @@ private fun SkillListRow(
 @Composable
 private fun ClawHubSkillSearchPanel(
   state: GatewayClawHubSkillSearchState,
+  installedSkills: List<GatewaySkillSummary>,
   query: String,
   isConnected: Boolean,
   methodsAvailable: Boolean,
@@ -593,6 +596,7 @@ private fun ClawHubSkillSearchPanel(
   }
   if (state.results.isNotEmpty()) {
     ClawListPanel(items = state.results) { skill ->
+      val installed = isClawHubSkillInstalled(installedSkills, skill.slug)
       ClawDetailRow(
         title = skill.displayName,
         subtitle = listOfNotNull(skill.summary, skill.version?.let { nativeString("Version \$it", it) }).joinToString(" · "),
@@ -603,12 +607,13 @@ private fun ClawHubSkillSearchPanel(
           ClawSecondaryButton(
             text =
               when {
+                installed -> nativeString("Installed")
                 installing -> nativeString("Installing")
                 reviewing -> nativeString("Loading")
                 else -> nativeString("Review")
               },
             onClick = { onReviewInstall(skill) },
-            enabled = isConnected && methodsAvailable && !reviewing && !installing,
+            enabled = isConnected && methodsAvailable && !installed && !reviewing && !installing,
           )
         },
       )

--- a/apps/android/app/src/main/res/values-ar/strings.xml
+++ b/apps/android/app/src/main/res/values-ar/strings.xml
@@ -130,7 +130,7 @@
     <string name="native_15b61974b2707a7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الموقع"</string>
     <string name="native_16196f98cecd6839" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مثال America/New_York"</string>
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الجلسة المستهدفة"</string>
-    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مراجعة Skill في ClawHub"</string>
+    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مراجعة مهارة ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مضيف العقدة"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المستوى"</string>
@@ -672,7 +672,7 @@
     <string name="native_7728331d12fcfc1a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إشعار أمان"</string>
     <string name="native_7765ad1890a192a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تجاهل تحذير الصورة المشتركة"</string>
     <string name="native_77706d90347b2e64" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"السماح للمجدول بتشغيل هذه المهمة."</string>
-    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"قيّم Gateway إصدارًا مختلفًا من ClawHub. راجع المهارة مرة أخرى قبل التثبيت."</string>
+    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"قيّم Gateway إصدارًا مختلفًا من ClawHub. راجع Skill مرة أخرى قبل التثبيت."</string>
     <string name="native_77ab6bb71f77154d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فتح وصول النظام"</string>
     <string name="native_7817cd06563196ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الصورة غير متاحة"</string>
     <string name="native_788011833a5a0f22" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الإشعارات"</string>
@@ -1225,7 +1225,7 @@
     <string name="native_e02b4aac2b335f6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المساعد يعمل"</string>
     <string name="native_e02b54dc002b9644" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يمكن لـ OpenClaw عرض قائمة التطبيقات الظاهرة في المشغّل."</string>
     <string name="native_e064109f58271ec5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فشل التحدث: %1$s"</string>
-    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"البحث في المهارات المثبّتة"</string>
+    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"البحث في Skills المثبتة"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فحص"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الطرفية"</string>
@@ -1365,7 +1365,7 @@
     <string name="native_f85ae4b0b7ed13c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dismiss Task"</string>
     <string name="native_f87908f1a1e901c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فشلت المحادثة"</string>
     <string name="native_f89aeeeee0922951" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw · مباشر"</string>
-    <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مثبّت"</string>
+    <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المثبتة"</string>
     <string name="native_f8c2745155505d39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"انتهت مهلة انتظار الرد؛ حاول مجددًا أو حدّث الصفحة."</string>
     <string name="native_f8cd133f0ea1031b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"العثور على المحادثات السابقة"</string>
     <string name="native_f92e2ad582c0e13f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جارٍ التحديث"</string>

--- a/apps/android/app/src/main/res/values-de/strings.xml
+++ b/apps/android/app/src/main/res/values-de/strings.xml
@@ -130,7 +130,7 @@
     <string name="native_15b61974b2707a7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Standort"</string>
     <string name="native_16196f98cecd6839" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"z. B. America/New_York"</string>
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sitzungsziel"</string>
-    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub-Skill überprüfen"</string>
+    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub-Skill prüfen"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Node-Host"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Stufe"</string>

--- a/apps/android/app/src/main/res/values-es/strings.xml
+++ b/apps/android/app/src/main/res/values-es/strings.xml
@@ -130,7 +130,7 @@
     <string name="native_15b61974b2707a7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ubicación"</string>
     <string name="native_16196f98cecd6839" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"p. ej. America/New_York"</string>
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Destino de la sesión"</string>
-    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Revisar la skill de ClawHub"</string>
+    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Revisar la Skill de ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Host del nodo"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nivel"</string>
@@ -453,7 +453,7 @@
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Abriendo la conexión con el Gateway"</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No hay apps coincidentes."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Enviar al chat"</string>
-    <string name="native_5342e09f2729fbc6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Habilitar"</string>
+    <string name="native_5342e09f2729fbc6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Activar"</string>
     <string name="native_53972e864229c7cc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ejecuciones recientes"</string>
     <string name="native_53981ad2bcd1778c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Alinea el código QR dentro del cuadrado."</string>
     <string name="native_53a8b711770580bd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No se pudieron cargar las aprobaciones."</string>
@@ -672,7 +672,7 @@
     <string name="native_7728331d12fcfc1a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aviso de seguridad"</string>
     <string name="native_7765ad1890a192a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Descartar advertencia de imagen compartida"</string>
     <string name="native_77706d90347b2e64" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Permitir que el programador ejecute este trabajo."</string>
-    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"El Gateway evaluó una versión diferente de ClawHub. Revisa la skill de nuevo antes de instalarla."</string>
+    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"El Gateway evaluó una versión diferente de ClawHub. Revisa de nuevo la Skill antes de instalarla."</string>
     <string name="native_77ab6bb71f77154d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Abrir acceso del sistema"</string>
     <string name="native_7817cd06563196ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Imagen no disponible"</string>
     <string name="native_788011833a5a0f22" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Notificaciones"</string>
@@ -1225,7 +1225,7 @@
     <string name="native_e02b4aac2b335f6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Asistente trabajando"</string>
     <string name="native_e02b54dc002b9644" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw puede listar las apps visibles en el lanzador."</string>
     <string name="native_e064109f58271ec5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Error al hablar: %1$s"</string>
-    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Buscar skills instaladas"</string>
+    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Buscar Skills instaladas"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inspeccionar"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Terminal"</string>
@@ -1365,7 +1365,7 @@
     <string name="native_f85ae4b0b7ed13c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dismiss Task"</string>
     <string name="native_f87908f1a1e901c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"El chat falló"</string>
     <string name="native_f89aeeeee0922951" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw · En vivo"</string>
-    <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Instalado"</string>
+    <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Instaladas"</string>
     <string name="native_f8c2745155505d39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Se agotó el tiempo de espera de una respuesta; inténtalo de nuevo o actualiza."</string>
     <string name="native_f8cd133f0ea1031b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Buscar conversaciones anteriores"</string>
     <string name="native_f92e2ad582c0e13f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Actualizando"</string>

--- a/apps/android/app/src/main/res/values-fa/strings.xml
+++ b/apps/android/app/src/main/res/values-fa/strings.xml
@@ -672,7 +672,7 @@
     <string name="native_7728331d12fcfc1a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اعلان امنیتی"</string>
     <string name="native_7765ad1890a192a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رد کردن هشدار تصویر اشتراکی"</string>
     <string name="native_77706d90347b2e64" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"به زمان‌بند اجازه بده این کار را اجرا کند."</string>
-    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway نسخه متفاوتی از ClawHub را ارزیابی کرد. پیش از نصب، مهارت را دوباره بررسی کنید."</string>
+    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway نسخه دیگری از ClawHub را ارزیابی کرده است. پیش از نصب، Skill را دوباره بررسی کنید."</string>
     <string name="native_77ab6bb71f77154d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"باز کردن دسترسی سیستم"</string>
     <string name="native_7817cd06563196ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تصویر در دسترس نیست"</string>
     <string name="native_788011833a5a0f22" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اعلان‌ها"</string>
@@ -1225,7 +1225,7 @@
     <string name="native_e02b4aac2b335f6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دستیار در حال کار است"</string>
     <string name="native_e02b54dc002b9644" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw می‌تواند برنامه‌های قابل‌نمایش در لانچر را فهرست کند."</string>
     <string name="native_e064109f58271ec5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مکالمه ناموفق بود: %1$s"</string>
-    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جستجوی مهارت‌های نصب‌شده"</string>
+    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جست‌وجوی Skills نصب‌شده"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بررسی"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ترمینال"</string>

--- a/apps/android/app/src/main/res/values-fr/strings.xml
+++ b/apps/android/app/src/main/res/values-fr/strings.xml
@@ -911,7 +911,7 @@
     <string name="native_a4ae750b610e875e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ancrage"</string>
     <string name="native_a4fe65264ef7dbb3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Langue"</string>
     <string name="native_a52403af63fa3f46" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cette application est plus ancienne que le Gateway. Mettez à jour OpenClaw sur cet appareil, puis réessayez."</string>
-    <string name="native_a52ace420f2175d0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tous"</string>
+    <string name="native_a52ace420f2175d0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tout"</string>
     <string name="native_a53a8b84da7bc600" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Session du Gateway en cours"</string>
     <string name="native_a61935d6be7b9f04" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"En attente de vérification"</string>
     <string name="native_a626442da425ff22" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucun Skill installé."</string>
@@ -1225,7 +1225,7 @@
     <string name="native_e02b4aac2b335f6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Assistant en cours de travail"</string>
     <string name="native_e02b54dc002b9644" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw peut répertorier les applications visibles dans le lanceur."</string>
     <string name="native_e064109f58271ec5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Échec de la conversation : %1$s"</string>
-    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rechercher dans les compétences installées"</string>
+    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rechercher dans les Skills installés"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inspecter"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Terminal"</string>

--- a/apps/android/app/src/main/res/values-hi/strings.xml
+++ b/apps/android/app/src/main/res/values-hi/strings.xml
@@ -130,7 +130,7 @@
     <string name="native_15b61974b2707a7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"स्थान"</string>
     <string name="native_16196f98cecd6839" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"जैसे America/New_York"</string>
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सत्र लक्ष्य"</string>
-    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub skill की समीक्षा करें"</string>
+    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub Skill की समीक्षा करें"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"नोड होस्ट"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"स्तर"</string>
@@ -672,7 +672,7 @@
     <string name="native_7728331d12fcfc1a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सुरक्षा सूचना"</string>
     <string name="native_7765ad1890a192a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"साझा-छवि चेतावनी खारिज करें"</string>
     <string name="native_77706d90347b2e64" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"शेड्यूलर को यह जॉब चलाने की अनुमति दें।"</string>
-    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ने किसी अन्य ClawHub रिलीज़ का मूल्यांकन किया। इंस्टॉल करने से पहले Skill की फिर से समीक्षा करें।"</string>
+    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ने किसी अन्य ClawHub रिलीज़ का मूल्यांकन किया था। इंस्टॉल करने से पहले Skill की दोबारा समीक्षा करें।"</string>
     <string name="native_77ab6bb71f77154d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सिस्टम एक्सेस खोलें"</string>
     <string name="native_7817cd06563196ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"छवि उपलब्ध नहीं है"</string>
     <string name="native_788011833a5a0f22" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सूचनाएँ"</string>

--- a/apps/android/app/src/main/res/values-in/strings.xml
+++ b/apps/android/app/src/main/res/values-in/strings.xml
@@ -1012,7 +1012,7 @@
     <string name="native_b8be1981f8a9ecc2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kelola skill yang terinstal dan tambahkan rilis tepercaya dari ClawHub."</string>
     <string name="native_b8ed5279e897be5d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mengirim…"</string>
     <string name="native_b906e4f5d8dd6128" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Belum ada agen yang dimuat."</string>
-    <string name="native_b93a70717669740b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cari ClawHub"</string>
+    <string name="native_b93a70717669740b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cari di ClawHub"</string>
     <string name="native_b95a17e08fdcdf57" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chat sedang memeriksa kondisi Gateway."</string>
     <string name="native_b96a4e034aae9cd8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Perlu penyandingan"</string>
     <string name="native_b9cf97697898d132" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Proses Aktif"</string>
@@ -1225,7 +1225,7 @@
     <string name="native_e02b4aac2b335f6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Asisten sedang bekerja"</string>
     <string name="native_e02b54dc002b9644" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw dapat menampilkan daftar aplikasi yang terlihat di launcher."</string>
     <string name="native_e064109f58271ec5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gagal berbicara: %1$s"</string>
-    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cari skill terinstal"</string>
+    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cari Skills yang terinstal"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Periksa"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Terminal"</string>

--- a/apps/android/app/src/main/res/values-it/strings.xml
+++ b/apps/android/app/src/main/res/values-it/strings.xml
@@ -1225,7 +1225,7 @@
     <string name="native_e02b4aac2b335f6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Assistente al lavoro"</string>
     <string name="native_e02b54dc002b9644" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw può elencare le app visibili nel launcher."</string>
     <string name="native_e064109f58271ec5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversazione non riuscita: %1$s"</string>
-    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cerca tra le skill installate"</string>
+    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cerca nelle skill installate"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ispeziona"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Terminale"</string>

--- a/apps/android/app/src/main/res/values-ja/strings.xml
+++ b/apps/android/app/src/main/res/values-ja/strings.xml
@@ -453,7 +453,7 @@
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gatewayへの接続を開始中"</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"一致するアプリはありません。"</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"チャットに送信"</string>
-    <string name="native_5342e09f2729fbc6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"有効化"</string>
+    <string name="native_5342e09f2729fbc6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"有効にする"</string>
     <string name="native_53972e864229c7cc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最近の実行"</string>
     <string name="native_53981ad2bcd1778c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"QRコードを四角形の内側に合わせてください。"</string>
     <string name="native_53a8b711770580bd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"承認を読み込めませんでした。"</string>
@@ -672,7 +672,7 @@
     <string name="native_7728331d12fcfc1a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"セキュリティに関する通知"</string>
     <string name="native_7765ad1890a192a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"共有画像の警告を閉じる"</string>
     <string name="native_77706d90347b2e64" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"スケジューラーによるこのジョブの実行を許可します。"</string>
-    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gatewayが別のClawHubリリースを評価しました。インストールする前に、スキルをもう一度確認してください。"</string>
+    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gatewayが別のClawHubリリースを評価しました。インストールする前に、Skillをもう一度確認してください。"</string>
     <string name="native_77ab6bb71f77154d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"システムアクセスを開く"</string>
     <string name="native_7817cd06563196ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"画像を利用できません"</string>
     <string name="native_788011833a5a0f22" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"通知"</string>
@@ -1003,7 +1003,7 @@
     <string name="native_b78426f40a794c5d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"未ペアリング"</string>
     <string name="native_b7b190b4be0b2385" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gatewayがこのスマートフォンを認識しました"</string>
     <string name="native_b7b89bf0fd930a9f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"設定済みのモデルはありません"</string>
-    <string name="native_b7e3e4aa4257b9a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無効化"</string>
+    <string name="native_b7e3e4aa4257b9a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無効にする"</string>
     <string name="native_b8352b44a588721c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"アプリの言語"</string>
     <string name="native_b8380b8a2317b9fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gatewayをペアリング中"</string>
     <string name="native_b860c709e9ba7e6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"保存済みの認証情報が無効です"</string>
@@ -1225,7 +1225,7 @@
     <string name="native_e02b4aac2b335f6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"アシスタントが作業中"</string>
     <string name="native_e02b54dc002b9644" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw はランチャーに表示されるアプリを一覧表示できます。"</string>
     <string name="native_e064109f58271ec5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"会話に失敗しました: %1$s"</string>
-    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"インストール済みスキルを検索"</string>
+    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"インストール済みのSkillsを検索"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"検査"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ターミナル"</string>

--- a/apps/android/app/src/main/res/values-ko/strings.xml
+++ b/apps/android/app/src/main/res/values-ko/strings.xml
@@ -130,7 +130,7 @@
     <string name="native_15b61974b2707a7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"위치"</string>
     <string name="native_16196f98cecd6839" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"예: America/New_York"</string>
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"세션 대상"</string>
-    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub 스킬 검토"</string>
+    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub Skill 검토"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"노드 호스트"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"수준"</string>
@@ -672,7 +672,7 @@
     <string name="native_7728331d12fcfc1a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"보안 알림"</string>
     <string name="native_7765ad1890a192a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"공유 이미지 경고 닫기"</string>
     <string name="native_77706d90347b2e64" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"스케줄러가 이 작업을 실행하도록 허용합니다."</string>
-    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway에서 다른 ClawHub 릴리스를 평가했습니다. 설치하기 전에 Skill을 다시 검토하세요."</string>
+    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway가 다른 ClawHub 릴리스를 평가했습니다. 설치하기 전에 해당 Skill을 다시 검토하세요."</string>
     <string name="native_77ab6bb71f77154d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"시스템 접근 권한 열기"</string>
     <string name="native_7817cd06563196ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"이미지를 사용할 수 없음"</string>
     <string name="native_788011833a5a0f22" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"알림"</string>
@@ -911,7 +911,7 @@
     <string name="native_a4ae750b610e875e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"기준점"</string>
     <string name="native_a4fe65264ef7dbb3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"언어"</string>
     <string name="native_a52403af63fa3f46" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"이 앱이 Gateway보다 오래된 버전입니다. 이 기기의 OpenClaw를 업데이트한 후 다시 시도하세요."</string>
-    <string name="native_a52ace420f2175d0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"모두"</string>
+    <string name="native_a52ace420f2175d0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"전체"</string>
     <string name="native_a53a8b84da7bc600" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 세션 진행 중"</string>
     <string name="native_a61935d6be7b9f04" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"검토 대기 중"</string>
     <string name="native_a626442da425ff22" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"설치된 Skills가 없습니다."</string>
@@ -1225,7 +1225,7 @@
     <string name="native_e02b4aac2b335f6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"어시스턴트 작업 중"</string>
     <string name="native_e02b54dc002b9644" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw는 런처에 표시되는 앱을 나열할 수 있습니다."</string>
     <string name="native_e064109f58271ec5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"대화 실패: %1$s"</string>
-    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"설치된 Skill 검색"</string>
+    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"설치된 Skills 검색"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"검사"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"터미널"</string>

--- a/apps/android/app/src/main/res/values-nl/strings.xml
+++ b/apps/android/app/src/main/res/values-nl/strings.xml
@@ -672,7 +672,7 @@
     <string name="native_7728331d12fcfc1a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Beveiligingsmelding"</string>
     <string name="native_7765ad1890a192a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Waarschuwing gedeelde afbeelding sluiten"</string>
     <string name="native_77706d90347b2e64" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sta toe dat de planner deze taak uitvoert."</string>
-    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"De Gateway heeft een andere ClawHub-release beoordeeld. Controleer de skill opnieuw voordat u deze installeert."</string>
+    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"De Gateway heeft een andere ClawHub-release beoordeeld. Bekijk de skill opnieuw voordat u deze installeert."</string>
     <string name="native_77ab6bb71f77154d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Systeemtoegang openen"</string>
     <string name="native_7817cd06563196ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Afbeelding niet beschikbaar"</string>
     <string name="native_788011833a5a0f22" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Meldingen"</string>
@@ -911,7 +911,7 @@
     <string name="native_a4ae750b610e875e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Anker"</string>
     <string name="native_a4fe65264ef7dbb3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Taal"</string>
     <string name="native_a52403af63fa3f46" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Deze app is ouder dan de Gateway. Werk OpenClaw op dit apparaat bij en probeer het opnieuw."</string>
-    <string name="native_a52ace420f2175d0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Alle"</string>
+    <string name="native_a52ace420f2175d0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Alles"</string>
     <string name="native_a53a8b84da7bc600" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway-sessie wordt uitgevoerd"</string>
     <string name="native_a61935d6be7b9f04" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wacht op beoordeling"</string>
     <string name="native_a626442da425ff22" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen skills geïnstalleerd."</string>
@@ -1012,7 +1012,7 @@
     <string name="native_b8be1981f8a9ecc2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Beheer geïnstalleerde skills en voeg vertrouwde releases van ClawHub toe."</string>
     <string name="native_b8ed5279e897be5d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verzenden…"</string>
     <string name="native_b906e4f5d8dd6128" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nog geen agents geladen."</string>
-    <string name="native_b93a70717669740b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub doorzoeken"</string>
+    <string name="native_b93a70717669740b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zoeken in ClawHub"</string>
     <string name="native_b95a17e08fdcdf57" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chat controleert de status van de Gateway."</string>
     <string name="native_b96a4e034aae9cd8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Koppeling vereist"</string>
     <string name="native_b9cf97697898d132" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Actieve uitvoeringen"</string>

--- a/apps/android/app/src/main/res/values-pl/strings.xml
+++ b/apps/android/app/src/main/res/values-pl/strings.xml
@@ -130,7 +130,7 @@
     <string name="native_15b61974b2707a7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Lokalizacja"</string>
     <string name="native_16196f98cecd6839" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"np. America/New_York"</string>
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cel sesji"</string>
-    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sprawdź umiejętność ClawHub"</string>
+    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sprawdź skill w ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Host węzła"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Poziom"</string>
@@ -672,7 +672,7 @@
     <string name="native_7728331d12fcfc1a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Informacja o bezpieczeństwie"</string>
     <string name="native_7765ad1890a192a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Odrzuć ostrzeżenie o udostępnionym obrazie"</string>
     <string name="native_77706d90347b2e64" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zezwól harmonogramowi na uruchomienie tego zadania."</string>
-    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway zweryfikował inne wydanie ClawHub. Przed instalacją ponownie sprawdź umiejętność."</string>
+    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ocenił inne wydanie ClawHub. Sprawdź umiejętność ponownie przed instalacją."</string>
     <string name="native_77ab6bb71f77154d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otwórz dostęp systemowy"</string>
     <string name="native_7817cd06563196ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Obraz niedostępny"</string>
     <string name="native_788011833a5a0f22" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Powiadomienia"</string>
@@ -1225,7 +1225,7 @@
     <string name="native_e02b4aac2b335f6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Asystent pracuje"</string>
     <string name="native_e02b54dc002b9644" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw może wyświetlać listę aplikacji widocznych w launcherze."</string>
     <string name="native_e064109f58271ec5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rozmowa nie powiodła się: %1$s"</string>
-    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Szukaj zainstalowanych umiejętności"</string>
+    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Szukaj w zainstalowanych Skills"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sprawdź"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Terminal"</string>

--- a/apps/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/apps/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -130,7 +130,7 @@
     <string name="native_15b61974b2707a7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Localização"</string>
     <string name="native_16196f98cecd6839" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ex.: America/New_York"</string>
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Alvo da sessão"</string>
-    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Analisar a skill do ClawHub"</string>
+    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Revisar skill do ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Host do nó"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nível"</string>
@@ -285,7 +285,7 @@
     <string name="native_31e392d1c0378bec" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aplicar"</string>
     <string name="native_31fbef162594de01" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Continuar"</string>
     <string name="native_3217b0565007c0ae" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitorando · %1$s tarefas agendadas"</string>
-    <string name="native_3227aa9666253f7a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Navegar"</string>
+    <string name="native_3227aa9666253f7a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Explorar"</string>
     <string name="native_32d3fedad4cfedcc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"tabs"</string>
     <string name="native_331551b0de4157c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pendente"</string>
     <string name="native_331596ba1eaf8a5c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversa: %1$s"</string>
@@ -1365,7 +1365,7 @@
     <string name="native_f85ae4b0b7ed13c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dismiss Task"</string>
     <string name="native_f87908f1a1e901c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Falha no chat"</string>
     <string name="native_f89aeeeee0922951" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw · Ao vivo"</string>
-    <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Instalado"</string>
+    <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Instaladas"</string>
     <string name="native_f8c2745155505d39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"O tempo de espera por uma resposta esgotou; tente novamente ou atualize."</string>
     <string name="native_f8cd133f0ea1031b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Encontre conversas anteriores"</string>
     <string name="native_f92e2ad582c0e13f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Atualizando"</string>

--- a/apps/android/app/src/main/res/values-sv/strings.xml
+++ b/apps/android/app/src/main/res/values-sv/strings.xml
@@ -672,7 +672,7 @@
     <string name="native_7728331d12fcfc1a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Säkerhetsmeddelande"</string>
     <string name="native_7765ad1890a192a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Avfärda varning om delad bild"</string>
     <string name="native_77706d90347b2e64" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tillåt schemaläggaren att köra det här jobbet."</string>
-    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway utvärderade en annan ClawHub-version. Granska skill igen innan du installerar."</string>
+    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway utvärderade en annan ClawHub-version. Granska denna skill igen innan du installerar."</string>
     <string name="native_77ab6bb71f77154d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Öppna systemåtkomst"</string>
     <string name="native_7817cd06563196ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bilden är inte tillgänglig"</string>
     <string name="native_788011833a5a0f22" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aviseringar"</string>

--- a/apps/android/app/src/main/res/values-th/strings.xml
+++ b/apps/android/app/src/main/res/values-th/strings.xml
@@ -130,7 +130,7 @@
     <string name="native_15b61974b2707a7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตำแหน่งที่ตั้ง"</string>
     <string name="native_16196f98cecd6839" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เช่น America/New_York"</string>
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เป้าหมายเซสชัน"</string>
-    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบ Skills ของ ClawHub"</string>
+    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบ Skill จาก ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โฮสต์โหนด"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ระดับ"</string>
@@ -1225,7 +1225,7 @@
     <string name="native_e02b4aac2b335f6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ผู้ช่วยกำลังทำงาน"</string>
     <string name="native_e02b54dc002b9644" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw สามารถแสดงรายการแอปที่มองเห็นได้ใน Launcher"</string>
     <string name="native_e064109f58271ec5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พูดไม่สำเร็จ: %1$s"</string>
-    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหา Skills ที่ติดตั้งแล้ว"</string>
+    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหา Skills ที่ติดตั้ง"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบ"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เทอร์มินัล"</string>

--- a/apps/android/app/src/main/res/values-tr/strings.xml
+++ b/apps/android/app/src/main/res/values-tr/strings.xml
@@ -130,7 +130,7 @@
     <string name="native_15b61974b2707a7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Konum"</string>
     <string name="native_16196f98cecd6839" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"örn. America/New_York"</string>
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Oturum hedefi"</string>
-    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub becerisini incele"</string>
+    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub Skill\'ini incele"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Düğüm ana makinesi"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Düzey"</string>
@@ -672,7 +672,7 @@
     <string name="native_7728331d12fcfc1a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Güvenlik bildirimi"</string>
     <string name="native_7765ad1890a192a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Paylaşılan görüntü uyarısını kapat"</string>
     <string name="native_77706d90347b2e64" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zamanlayıcının bu işi çalıştırmasına izin ver."</string>
-    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway farklı bir ClawHub sürümünü değerlendirdi. Yüklemeden önce skill\'i tekrar inceleyin."</string>
+    <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway farklı bir ClawHub sürümünü değerlendirdi. Yüklemeden önce Skill\'i tekrar inceleyin."</string>
     <string name="native_77ab6bb71f77154d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sistem Erişimini Aç"</string>
     <string name="native_7817cd06563196ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Görsel kullanılamıyor"</string>
     <string name="native_788011833a5a0f22" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bildirimler"</string>
@@ -1225,7 +1225,7 @@
     <string name="native_e02b4aac2b335f6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Asistan çalışıyor"</string>
     <string name="native_e02b54dc002b9644" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw, başlatıcıda görünen uygulamaları listeleyebilir."</string>
     <string name="native_e064109f58271ec5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Konuşma başarısız oldu: %1$s"</string>
-    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yüklü skill\'lerde ara"</string>
+    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yüklü Skills içinde ara"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İncele"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Terminal"</string>
@@ -1365,7 +1365,7 @@
     <string name="native_f85ae4b0b7ed13c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dismiss Task"</string>
     <string name="native_f87908f1a1e901c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sohbet başarısız oldu"</string>
     <string name="native_f89aeeeee0922951" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw · Canlı"</string>
-    <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yüklendi"</string>
+    <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yüklü"</string>
     <string name="native_f8c2745155505d39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yanıt beklenirken zaman aşımına uğradı; tekrar deneyin veya yenileyin."</string>
     <string name="native_f8cd133f0ea1031b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Önceki konuşmaları bulun"</string>
     <string name="native_f92e2ad582c0e13f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yenileniyor"</string>

--- a/apps/android/app/src/main/res/values-vi/strings.xml
+++ b/apps/android/app/src/main/res/values-vi/strings.xml
@@ -130,7 +130,7 @@
     <string name="native_15b61974b2707a7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Vị trí"</string>
     <string name="native_16196f98cecd6839" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ví dụ: America/New_York"</string>
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mục tiêu phiên"</string>
-    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Xem xét skill ClawHub"</string>
+    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Xem lại Skill trên ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Máy chủ nút"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cấp độ"</string>
@@ -1012,7 +1012,7 @@
     <string name="native_b8be1981f8a9ecc2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Quản lý các skill đã cài đặt và thêm các bản phát hành đáng tin cậy từ ClawHub."</string>
     <string name="native_b8ed5279e897be5d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Đang gửi…"</string>
     <string name="native_b906e4f5d8dd6128" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chưa tải agent nào."</string>
-    <string name="native_b93a70717669740b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tìm kiếm ClawHub"</string>
+    <string name="native_b93a70717669740b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tìm kiếm trên ClawHub"</string>
     <string name="native_b95a17e08fdcdf57" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cuộc trò chuyện đang kiểm tra trạng thái của Gateway."</string>
     <string name="native_b96a4e034aae9cd8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cần ghép đôi"</string>
     <string name="native_b9cf97697898d132" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Lượt chạy đang hoạt động"</string>
@@ -1225,7 +1225,7 @@
     <string name="native_e02b4aac2b335f6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Trợ lý đang làm việc"</string>
     <string name="native_e02b54dc002b9644" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw có thể liệt kê các ứng dụng hiển thị trong launcher."</string>
     <string name="native_e064109f58271ec5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Trò chuyện không thành công: %1$s"</string>
-    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tìm kiếm skill đã cài đặt"</string>
+    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tìm kiếm Skills đã cài đặt"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kiểm tra"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dòng lệnh"</string>

--- a/apps/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -130,7 +130,7 @@
     <string name="native_15b61974b2707a7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"位置"</string>
     <string name="native_16196f98cecd6839" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"例如 America/New_York"</string>
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"工作階段目標"</string>
-    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"檢閱 ClawHub 技能"</string>
+    <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"檢閱 ClawHub Skill"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"節點主機"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"層級"</string>
@@ -1225,7 +1225,7 @@
     <string name="native_e02b4aac2b335f6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"助理正在處理"</string>
     <string name="native_e02b54dc002b9644" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 可以列出啟動器可見的 App。"</string>
     <string name="native_e064109f58271ec5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"對話失敗：%1$s"</string>
-    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"搜尋已安裝的技能"</string>
+    <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"搜尋已安裝的 Skills"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"檢查"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"終端機"</string>

--- a/apps/android/app/src/test/java/ai/openclaw/app/SkillManagementTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SkillManagementTest.kt
@@ -48,7 +48,7 @@ class SkillManagementTest {
 
     assertEquals(
       GatewayClawHubInstallReview(
-        slug = "alpha",
+        slug = "@alice/alpha",
         displayName = "Alpha Skill",
         summary = "Reviewed metadata",
         version = "2.0.0",
@@ -186,10 +186,14 @@ class SkillManagementTest {
         installCount = 0,
         clawHubSlug = "registry-slug",
         clawHubValid = true,
+        clawHubOwnerHandle = "registry-owner",
         clawHubInstalledVersion = "1.2.3",
       )
 
     assertTrue(isClawHubSkillInstalled(listOf(skill), "registry-slug", "1.2.3"))
+    assertTrue(isClawHubSkillInstalled(listOf(skill), "registry-slug"))
+    assertTrue(isClawHubSkillInstalled(listOf(skill), "@registry-owner/registry-slug", "1.2.3"))
+    assertFalse(isClawHubSkillInstalled(listOf(skill), "@other-owner/registry-slug", "1.2.3"))
     assertFalse(isClawHubSkillInstalled(listOf(skill), "registry-slug", "1.2.4"))
     assertFalse(isClawHubSkillInstalled(listOf(skill.copy(clawHubValid = false)), "registry-slug", "1.2.3"))
     assertFalse(isClawHubSkillInstalled(listOf(skill), "custom-frontmatter-key", "1.2.3"))

--- a/apps/ios/CHANGELOG.md
+++ b/apps/ios/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Adds Installed and Browse skill management with readiness filters, enable/disable controls, exact-version ClawHub review, and Gateway-enforced risk acknowledgement. (#105741)
 - Routes iPhone and Apple Watch exec approvals through durable Gateway records, preserves safety warnings, shows the first recorded decision across surfaces, reconciles uncertain replies, and remains compatible with shipped Gateway v4 approval RPCs.
 - Improves Gateway onboarding diagnostics, permission registration refreshes, Talk session switching, agent overview refresh ordering, and Apple Watch acknowledgment, activation, and cold-start event handling.
 

--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -924,6 +924,7 @@ extension SettingsProTab {
         case .approvals: String(localized: "Approvals")
         case .permissions: String(localized: "Permissions")
         case .channels: String(localized: "Channels")
+        case .skills: String(localized: "Skills")
         case .voice: String(localized: "Voice & Talk")
         case .diagnostics: String(localized: "Diagnostics")
         case .privacy: String(localized: "Privacy")

--- a/apps/ios/Sources/Design/SettingsProTabSections.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSections.swift
@@ -157,6 +157,11 @@ extension SettingsProTab {
                 title: "Channels",
                 route: .channels)
             self.settingsListRow(
+                icon: "sparkles",
+                iconColor: OpenClawBrand.accent,
+                title: "Skills",
+                route: .skills)
+            self.settingsListRow(
                 icon: "waveform",
                 iconColor: .pink,
                 title: "Voice & Talk",
@@ -226,6 +231,10 @@ extension SettingsProTab {
             SettingsChannelsDestination()
                 .navigationTitle(title(for: route))
                 .navigationBarTitleDisplayMode(.inline)
+        case .skills:
+            SettingsSkillsDestination()
+                .navigationTitle(title(for: route))
+                .navigationBarTitleDisplayMode(.inline)
         default:
             List {
                 switch route {
@@ -237,6 +246,8 @@ extension SettingsProTab {
                     self.approvalsDestination
                 case .permissions:
                     self.permissionsDestination
+                case .skills:
+                    EmptyView()
                 case .voice:
                     self.voiceDestination
                 case .diagnostics:

--- a/apps/ios/Sources/Design/SettingsProTabSupport.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSupport.swift
@@ -10,6 +10,7 @@ enum SettingsRoute: Hashable {
     case approvals
     case permissions
     case channels
+    case skills
     case voice
     case diagnostics
     case privacy

--- a/apps/ios/Sources/Design/SettingsSkillsDestination.swift
+++ b/apps/ios/Sources/Design/SettingsSkillsDestination.swift
@@ -81,16 +81,16 @@ struct SettingsSkillsDestination: View {
             .padding(.vertical, 12)
         }
         .font(OpenClawType.body)
-        .task(id: refreshID) { await self.loadInitialState() }
+        .task(id: self.refreshID) { await self.loadInitialState() }
         .refreshable { await self.refreshVisibleSection() }
-        .onChange(of: appModel.connectedGatewayID) { _, _ in
+        .onChange(of: self.appModel.connectedGatewayID) { _, _ in
             self.resetGatewayState()
         }
-        .onChange(of: section) { _, section in
+        .onChange(of: self.section) { _, section in
             guard section == .browse, self.searchResults.isEmpty else { return }
             Task { await self.searchClawHub() }
         }
-        .sheet(item: $reviewSheet) { sheet in
+        .sheet(item: self.$reviewSheet) { sheet in
             switch sheet {
             case let .install(review, route):
                 SkillsInstallReviewSheet(
@@ -98,8 +98,7 @@ struct SettingsSkillsDestination: View {
                     canInstall: self.canAdmin,
                     isInstalling: self.installingSlug == review.slug,
                     onCancel: { self.reviewSheet = nil },
-                    onInstall: { Task { await self.install(review, route: route, acknowledgeRisk: false) } }
-                )
+                    onInstall: { Task { await self.install(review, route: route, acknowledgeRisk: false) } })
             case let .risk(review, route, message, warning):
                 SkillsRiskReviewSheet(
                     review: review,
@@ -107,42 +106,41 @@ struct SettingsSkillsDestination: View {
                     warning: warning,
                     isInstalling: self.installingSlug == review.slug,
                     onCancel: { self.reviewSheet = nil },
-                    onInstall: { Task { await self.install(review, route: route, acknowledgeRisk: true) } }
-                )
+                    onInstall: { Task { await self.install(review, route: route, acknowledgeRisk: true) } })
             }
         }
     }
 
     private var refreshID: String {
         [
-            canRead ? "connected" : "offline",
-            scenePhase == .active ? "active" : "inactive",
-            appModel.connectedGatewayID ?? "no-gateway",
+            self.canRead ? "connected" : "offline",
+            self.scenePhase == .active ? "active" : "inactive",
+            self.appModel.connectedGatewayID ?? "no-gateway",
         ].joined(separator: ":")
     }
 
     private var canRead: Bool {
-        appModel.isOperatorGatewayConnected
+        self.appModel.isOperatorGatewayConnected
     }
 
     private var canAdmin: Bool {
-        appModel.hasOperatorAdminScope
+        self.appModel.hasOperatorAdminScope
     }
 
     private var isLoadingInstalled: Bool {
-        installedLoadID != nil
+        self.installedLoadID != nil
     }
 
     private var isSearching: Bool {
-        searchID != nil
+        self.searchID != nil
     }
 
     private var readyCount: Int {
-        installedSkills.count(where: Self.isReady)
+        self.installedSkills.count(where: Self.isReady)
     }
 
     private var setupCount: Int {
-        installedSkills.count(where: Self.needsSetup)
+        self.installedSkills.count(where: Self.needsSetup)
     }
 
     private var summaryCard: some View {
@@ -164,32 +162,31 @@ struct SettingsSkillsDestination: View {
     }
 
     private var summaryText: String {
-        guard canRead else { return String(localized: "Connect to manage Gateway skills.") }
-        if isLoadingInstalled, installedSkills.isEmpty {
+        guard self.canRead else { return String(localized: "Connect to manage Gateway skills.") }
+        if self.isLoadingInstalled, self.installedSkills.isEmpty {
             return String(localized: "Loading installed skills and readiness.")
         }
         return String(
             format: String(localized: "%@ ready · %@ need setup"),
-            readyCount.formatted(),
-            setupCount.formatted()
-        )
+            self.readyCount.formatted(),
+            self.setupCount.formatted())
     }
 
     private var summaryValue: String {
-        guard canRead else { return String(localized: "offline") }
-        if isLoadingInstalled, installedSkills.isEmpty {
+        guard self.canRead else { return String(localized: "offline") }
+        if self.isLoadingInstalled, self.installedSkills.isEmpty {
             return String(localized: "loading")
         }
-        return installedSkills.count.formatted()
+        return self.installedSkills.count.formatted()
     }
 
     private var summaryColor: Color {
-        guard canRead else { return .secondary }
-        return setupCount > 0 ? OpenClawBrand.warn : OpenClawBrand.ok
+        guard self.canRead else { return .secondary }
+        return self.setupCount > 0 ? OpenClawBrand.warn : OpenClawBrand.ok
     }
 
     private var sectionPicker: some View {
-        Picker(selection: $section) {
+        Picker(selection: self.$section) {
             ForEach(SkillsSettingsSection.allCases) { section in
                 Text(verbatim: section.title).font(OpenClawType.captionSemiBold).tag(section)
             }
@@ -214,8 +211,7 @@ struct SettingsSkillsDestination: View {
                         actionIcon: self.isLoadingInstalled ? "hourglass" : "arrow.clockwise",
                         actionAccessibilityLabel: "Refresh Skills",
                         isActionDisabled: self.isLoadingInstalled,
-                        action: { Task { await self.loadInstalled() } }
-                    )
+                        action: { Task { await self.loadInstalled() } })
                     self.installedRows
                 }
             }
@@ -228,8 +224,8 @@ struct SettingsSkillsDestination: View {
             VStack(alignment: .leading, spacing: 10) {
                 TextField(
                     text: self.$installedQuery,
-                    prompt: Text("Search installed skills").font(OpenClawType.body)
-                ) {
+                    prompt: Text("Search installed skills").font(OpenClawType.body))
+                {
                     Text("Search installed skills").font(OpenClawType.body)
                 }
                 .font(OpenClawType.body)
@@ -249,34 +245,31 @@ struct SettingsSkillsDestination: View {
 
     @ViewBuilder
     private var installedRows: some View {
-        if !canRead {
+        if !self.canRead {
             ProStatusRow(
                 icon: "wifi.slash",
                 title: "Gateway offline",
                 detail: "Connect to load and manage installed skills.",
                 value: "offline",
-                color: .secondary
-            )
-        } else if isLoadingInstalled, installedSkills.isEmpty {
+                color: .secondary)
+        } else if self.isLoadingInstalled, self.installedSkills.isEmpty {
             ProStatusRow(
                 icon: "hourglass",
                 title: "Loading skills",
                 detail: "Reading the Gateway skill catalog.",
                 value: "loading",
-                color: OpenClawBrand.accent
-            )
-        } else if filteredInstalledSkills.isEmpty {
+                color: OpenClawBrand.accent)
+        } else if self.filteredInstalledSkills.isEmpty {
             ProStatusRow(
                 icon: "tray",
-                title: installedSkills.isEmpty ? "No skills installed" : "No matching skills",
-                detail: installedSkills.isEmpty
+                title: self.installedSkills.isEmpty ? "No skills installed" : "No matching skills",
+                detail: self.installedSkills.isEmpty
                     ? "Browse ClawHub to discover and install skills."
                     : "Change the search or readiness filter.",
                 value: "empty",
-                color: .secondary
-            )
+                color: .secondary)
         } else {
-            ForEach(Array(filteredInstalledSkills.enumerated()), id: \.element.id) { index, skill in
+            ForEach(Array(self.filteredInstalledSkills.enumerated()), id: \.element.id) { index, skill in
                 if index > 0 {
                     Divider().padding(.leading, 58)
                 }
@@ -284,15 +277,14 @@ struct SettingsSkillsDestination: View {
                     skill: skill,
                     canAdmin: self.canAdmin,
                     isBusy: self.mutationIDs[skill.skillKey] != nil,
-                    onToggle: { enabled in Task { await self.setEnabled(skill, enabled: enabled) } }
-                )
+                    onToggle: { enabled in Task { await self.setEnabled(skill, enabled: enabled) } })
             }
         }
     }
 
     private var filteredInstalledSkills: [SkillStatus] {
-        let query = installedQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        return installedSkills.filter { skill in
+        let query = self.installedQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        return self.installedSkills.filter { skill in
             let matchesQuery = query.isEmpty
                 || skill.name.localizedCaseInsensitiveContains(query)
                 || skill.skillKey.localizedCaseInsensitiveContains(query)
@@ -321,8 +313,7 @@ struct SettingsSkillsDestination: View {
                         actionIcon: self.isSearching ? "hourglass" : "arrow.clockwise",
                         actionAccessibilityLabel: "Search ClawHub",
                         isActionDisabled: self.isSearching || self.clawHubSupported == false,
-                        action: { Task { await self.searchClawHub() } }
-                    )
+                        action: { Task { await self.searchClawHub() } })
                     self.browseRows
                 }
             }
@@ -335,8 +326,8 @@ struct SettingsSkillsDestination: View {
             VStack(alignment: .leading, spacing: 10) {
                 TextField(
                     text: self.$browseQuery,
-                    prompt: Text("Search ClawHub").font(OpenClawType.body)
-                ) {
+                    prompt: Text("Search ClawHub").font(OpenClawType.body))
+                {
                     Text("Search ClawHub").font(OpenClawType.body)
                 }
                 .font(OpenClawType.body)
@@ -360,40 +351,36 @@ struct SettingsSkillsDestination: View {
 
     @ViewBuilder
     private var browseRows: some View {
-        if !canRead {
+        if !self.canRead {
             ProStatusRow(
                 icon: "wifi.slash",
                 title: "Gateway offline",
                 detail: "Connect to search and install ClawHub skills.",
                 value: "offline",
-                color: .secondary
-            )
-        } else if clawHubSupported == false {
+                color: .secondary)
+        } else if self.clawHubSupported == false {
             ProStatusRow(
                 icon: "arrow.up.circle",
                 title: "Gateway update required",
                 detail: "Update the Gateway to search and install ClawHub skills from iOS.",
                 value: "update",
-                color: OpenClawBrand.warn
-            )
-        } else if isSearching, searchResults.isEmpty {
+                color: OpenClawBrand.warn)
+        } else if self.isSearching, self.searchResults.isEmpty {
             ProStatusRow(
                 icon: "hourglass",
                 title: "Searching ClawHub",
                 detail: "Loading verified skill releases.",
                 value: "loading",
-                color: OpenClawBrand.accent
-            )
-        } else if searchResults.isEmpty {
+                color: OpenClawBrand.accent)
+        } else if self.searchResults.isEmpty {
             ProStatusRow(
                 icon: "magnifyingglass",
                 title: "No skills found",
                 detail: "Try another search or refresh the catalog.",
                 value: "empty",
-                color: .secondary
-            )
+                color: .secondary)
         } else {
-            ForEach(Array(searchResults.enumerated()), id: \.element.id) { index, skill in
+            ForEach(Array(self.searchResults.enumerated()), id: \.element.id) { index, skill in
                 if index > 0 {
                     Divider().padding(.leading, 58)
                 }
@@ -401,67 +388,65 @@ struct SettingsSkillsDestination: View {
                     skill: skill,
                     installed: SkillManagementContract.installed(self.installedSkills, slug: skill.slug),
                     isBusy: self.reviewingSlug == skill.slug,
-                    onReview: { Task { await self.review(skill) } }
-                )
+                    onReview: { Task { await self.review(skill) } })
             }
         }
     }
 
     private func loadInitialState() async {
-        guard scenePhase == .active else { return }
-        guard canRead else {
-            resetGatewayState()
+        guard self.scenePhase == .active else { return }
+        guard self.canRead else {
+            self.resetGatewayState()
             return
         }
-        let gatewayID = appModel.connectedGatewayID
-        if loadedGatewayID != gatewayID {
-            resetGatewayState()
-            loadedGatewayID = gatewayID
+        let gatewayID = self.appModel.connectedGatewayID
+        if self.loadedGatewayID != gatewayID {
+            self.resetGatewayState()
+            self.loadedGatewayID = gatewayID
         }
-        await updateClawHubSupport()
-        await loadInstalled()
+        await self.updateClawHubSupport()
+        await self.loadInstalled()
     }
 
     private func refreshVisibleSection() async {
-        await updateClawHubSupport()
-        if section == .installed {
-            await loadInstalled()
+        await self.updateClawHubSupport()
+        if self.section == .installed {
+            await self.loadInstalled()
         } else {
-            await loadInstalled()
-            await searchClawHub()
+            await self.loadInstalled()
+            await self.searchClawHub()
         }
     }
 
     private func updateClawHubSupport() async {
-        let gatewayID = appModel.connectedGatewayID
+        let gatewayID = self.appModel.connectedGatewayID
         guard let route = await appModel.operatorSession.currentRoute(ifGatewayID: gatewayID) else {
-            clawHubSupported = nil
+            self.clawHubSupported = nil
             return
         }
         var values: [Bool?] = []
         for method in clawHubSkillGatewayMethods.sorted() {
             let supported = await appModel.operatorSession.supportsServerMethod(
                 method,
-                ifCurrentRoute: route
-            )
+                ifCurrentRoute: route)
             values.append(supported)
         }
-        guard appModel.connectedGatewayID == gatewayID else { return }
+        guard self.appModel.connectedGatewayID == gatewayID else { return }
         if values.contains(false) {
-            clawHubSupported = false
+            self.clawHubSupported = false
         } else if values.allSatisfy({ $0 == true }) {
-            clawHubSupported = true
+            self.clawHubSupported = true
         } else {
-            clawHubSupported = nil
+            self.clawHubSupported = nil
         }
     }
 
     private func loadInstalled() async {
-        guard canRead, installedLoadID == nil else { return }
-        let gatewayID = appModel.connectedGatewayID
+        guard self.canRead, self.installedLoadID == nil else { return }
+        let gatewayID = self.appModel.connectedGatewayID
         let operationID = UUID()
-        installedLoadID = operationID
-        notice = nil
+        self.installedLoadID = operationID
+        self.notice = nil
         defer {
             if self.installedLoadID == operationID {
                 self.installedLoadID = nil
@@ -470,29 +455,28 @@ struct SettingsSkillsDestination: View {
         do {
             let route = try await gatewayRoute()
             let skills = try await fetchInstalledSkills(route: route)
-            guard appModel.connectedGatewayID == gatewayID else { return }
-            installedSkills = skills
+            guard self.appModel.connectedGatewayID == gatewayID else { return }
+            self.installedSkills = skills
         } catch {
-            guard appModel.connectedGatewayID == gatewayID else { return }
-            notice = SkillsNotice(
+            guard self.appModel.connectedGatewayID == gatewayID else { return }
+            self.notice = SkillsNotice(
                 title: String(localized: "Could not load skills"),
                 message: error.localizedDescription,
                 warning: nil,
-                isError: true
-            )
+                isError: true)
         }
     }
 
     private func searchClawHub() async {
-        guard canRead,
-              loadedGatewayID == appModel.connectedGatewayID,
-              clawHubSupported != false,
-              searchID == nil
+        guard self.canRead,
+              self.loadedGatewayID == self.appModel.connectedGatewayID,
+              self.clawHubSupported != false,
+              self.searchID == nil
         else { return }
-        let gatewayID = appModel.connectedGatewayID
+        let gatewayID = self.appModel.connectedGatewayID
         let operationID = UUID()
-        searchID = operationID
-        notice = nil
+        self.searchID = operationID
+        self.notice = nil
         defer {
             if self.searchID == operationID {
                 self.searchID = nil
@@ -502,38 +486,35 @@ struct SettingsSkillsDestination: View {
             let route = try await gatewayRoute()
             let request = ClawHubSearchRequest(
                 query: browseQuery.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
-                limit: 25
-            )
+                limit: 25)
             let data = try await self.request(
                 method: "skills.search",
                 params: request,
                 timeoutSeconds: 20,
-                route: route
-            )
+                route: route)
             let results = try JSONDecoder().decode(ClawHubSkillSearchResult.self, from: data).results
-            guard appModel.connectedGatewayID == gatewayID else { return }
-            searchResults = results
+            guard self.appModel.connectedGatewayID == gatewayID else { return }
+            self.searchResults = results
         } catch {
-            guard appModel.connectedGatewayID == gatewayID else { return }
-            notice = SkillsNotice(
+            guard self.appModel.connectedGatewayID == gatewayID else { return }
+            self.notice = SkillsNotice(
                 title: String(localized: "ClawHub unavailable"),
                 message: error.localizedDescription,
                 warning: nil,
-                isError: true
-            )
+                isError: true)
         }
     }
 
     private func review(_ skill: ClawHubSkillSummary) async {
-        guard canRead,
-              loadedGatewayID == appModel.connectedGatewayID,
-              reviewID == nil
+        guard self.canRead,
+              self.loadedGatewayID == self.appModel.connectedGatewayID,
+              self.reviewID == nil
         else { return }
-        let gatewayID = appModel.connectedGatewayID
+        let gatewayID = self.appModel.connectedGatewayID
         let operationID = UUID()
-        reviewID = operationID
-        reviewingSlug = skill.slug
-        notice = nil
+        self.reviewID = operationID
+        self.reviewingSlug = skill.slug
+        self.notice = nil
         defer {
             if self.reviewID == operationID {
                 self.reviewID = nil
@@ -546,39 +527,37 @@ struct SettingsSkillsDestination: View {
                 method: "skills.detail",
                 params: ClawHubDetailRequest(slug: skill.slug),
                 timeoutSeconds: 20,
-                route: route
-            )
+                route: route)
             let detail = try JSONDecoder().decode(ClawHubSkillDetail.self, from: data)
-            guard appModel.connectedGatewayID == gatewayID else { return }
+            guard self.appModel.connectedGatewayID == gatewayID else { return }
             guard let review = ClawHubSkillInstallReview(detail: detail, fallback: skill) else {
                 throw SkillsSettingsError.missingInstallVersion
             }
-            reviewSheet = .install(review, route: route)
+            self.reviewSheet = .install(review, route: route)
         } catch {
-            guard appModel.connectedGatewayID == gatewayID else { return }
-            notice = SkillsNotice(
+            guard self.appModel.connectedGatewayID == gatewayID else { return }
+            self.notice = SkillsNotice(
                 title: String(localized: "Could not review skill"),
                 message: error.localizedDescription,
                 warning: nil,
-                isError: true
-            )
+                isError: true)
         }
     }
 
     private func install(
         _ review: ClawHubSkillInstallReview,
         route: GatewayNodeSessionRoute,
-        acknowledgeRisk: Bool
-    ) async {
-        guard canAdmin,
-              loadedGatewayID == appModel.connectedGatewayID,
-              installID == nil
+        acknowledgeRisk: Bool) async
+    {
+        guard self.canAdmin,
+              self.loadedGatewayID == self.appModel.connectedGatewayID,
+              self.installID == nil
         else { return }
-        let gatewayID = appModel.connectedGatewayID
+        let gatewayID = self.appModel.connectedGatewayID
         let operationID = UUID()
-        installID = operationID
-        installingSlug = review.slug
-        notice = nil
+        self.installID = operationID
+        self.installingSlug = review.slug
+        self.notice = nil
         defer {
             if self.installID == operationID {
                 self.installID = nil
@@ -591,43 +570,37 @@ struct SettingsSkillsDestination: View {
                 slug: review.slug,
                 version: review.version,
                 acknowledgeClawHubRisk: acknowledgeRisk ? true : nil,
-                timeoutMs: clawHubInstallTimeoutMilliseconds
-            )
+                timeoutMs: clawHubInstallTimeoutMilliseconds)
             let data = try await self.request(
                 method: "skills.install",
                 params: request,
                 timeoutSeconds: 125,
-                route: route
-            )
+                route: route)
             let result = try JSONDecoder().decode(SkillInstallResult.self, from: data)
-            guard appModel.connectedGatewayID == gatewayID else { return }
-            installedSkills = try await fetchInstalledSkills(route: route)
-            guard appModel.connectedGatewayID == gatewayID else { return }
+            guard self.appModel.connectedGatewayID == gatewayID else { return }
+            self.installedSkills = try await self.fetchInstalledSkills(route: route)
+            guard self.appModel.connectedGatewayID == gatewayID else { return }
             guard SkillManagementContract.installed(
-                installedSkills,
+                self.installedSkills,
                 slug: review.slug,
-                version: review.version
-            )
+                version: review.version)
             else {
-                reviewSheet = nil
-                notice = SkillsNotice(
+                self.reviewSheet = nil
+                self.notice = SkillsNotice(
                     title: String(localized: "Install result unknown"),
                     message: String(
                         localized:
-                        "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running."
-                    ),
+                        "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running."),
                     warning: result.warning,
-                    isError: true
-                )
+                    isError: true)
                 return
             }
-            reviewSheet = nil
-            notice = SkillsNotice(
+            self.reviewSheet = nil
+            self.notice = SkillsNotice(
                 title: String(localized: "Installed"),
                 message: result.message,
                 warning: result.warning,
-                isError: false
-            )
+                isError: false)
         } catch let error as GatewayResponseError {
             guard self.appModel.connectedGatewayID == gatewayID else { return }
             let rejection = SkillManagementContract.rejection(from: error, attemptedVersion: review.version)
@@ -636,53 +609,49 @@ struct SettingsSkillsDestination: View {
                     review,
                     route: route,
                     message: rejection.message,
-                    warning: rejection.warning
-                )
+                    warning: rejection.warning)
             } else {
                 self.reviewSheet = nil
                 self.notice = SkillsNotice(
                     title: String(localized: "Gateway blocked install"),
                     message: rejection.message,
                     warning: rejection.warning,
-                    isError: true
-                )
+                    isError: true)
             }
         } catch {
-            guard appModel.connectedGatewayID == gatewayID else { return }
+            guard self.appModel.connectedGatewayID == gatewayID else { return }
             if let skills = try? await fetchInstalledSkills(route: route),
                appModel.connectedGatewayID == gatewayID
             {
-                installedSkills = skills
+                self.installedSkills = skills
                 if SkillManagementContract.installed(skills, slug: review.slug, version: review.version) {
-                    reviewSheet = nil
-                    notice = SkillsNotice(
+                    self.reviewSheet = nil
+                    self.notice = SkillsNotice(
                         title: String(localized: "Installed"),
                         message: String(localized: "The Gateway installed the reviewed version."),
                         warning: nil,
-                        isError: false
-                    )
+                        isError: false)
                     return
                 }
             }
-            reviewSheet = nil
-            notice = SkillsNotice(
+            self.reviewSheet = nil
+            self.notice = SkillsNotice(
                 title: String(localized: "Install result unknown"),
                 message: error.localizedDescription,
                 warning: nil,
-                isError: true
-            )
+                isError: true)
         }
     }
 
     private func setEnabled(_ skill: SkillStatus, enabled: Bool) async {
-        guard canAdmin,
-              loadedGatewayID == appModel.connectedGatewayID,
-              mutationIDs[skill.skillKey] == nil
+        guard self.canAdmin,
+              self.loadedGatewayID == self.appModel.connectedGatewayID,
+              self.mutationIDs[skill.skillKey] == nil
         else { return }
-        let gatewayID = appModel.connectedGatewayID
+        let gatewayID = self.appModel.connectedGatewayID
         let operationID = UUID()
-        mutationIDs[skill.skillKey] = operationID
-        notice = nil
+        self.mutationIDs[skill.skillKey] = operationID
+        self.notice = nil
         defer {
             if self.mutationIDs[skill.skillKey] == operationID {
                 self.mutationIDs.removeValue(forKey: skill.skillKey)
@@ -690,31 +659,28 @@ struct SettingsSkillsDestination: View {
         }
         do {
             let route = try await gatewayRoute()
-            _ = try await request(
+            _ = try await self.request(
                 method: "skills.update",
                 params: SkillEnabledRequest(skillKey: skill.skillKey, enabled: enabled),
                 timeoutSeconds: 20,
-                route: route
-            )
-            guard appModel.connectedGatewayID == gatewayID else { return }
+                route: route)
+            guard self.appModel.connectedGatewayID == gatewayID else { return }
             let skills = try await fetchInstalledSkills(route: route)
-            guard appModel.connectedGatewayID == gatewayID else { return }
-            installedSkills = skills
-            notice = SkillsNotice(
+            guard self.appModel.connectedGatewayID == gatewayID else { return }
+            self.installedSkills = skills
+            self.notice = SkillsNotice(
                 title: enabled ? String(localized: "Skill enabled") : String(localized: "Skill disabled"),
                 message: skill.name,
                 warning: nil,
-                isError: false
-            )
+                isError: false)
         } catch {
-            guard appModel.connectedGatewayID == gatewayID else { return }
-            notice = SkillsNotice(
+            guard self.appModel.connectedGatewayID == gatewayID else { return }
+            self.notice = SkillsNotice(
                 title: enabled ? String(localized: "Could not enable skill") :
                     String(localized: "Could not disable skill"),
                 message: error.localizedDescription,
                 warning: nil,
-                isError: true
-            )
+                isError: true)
         }
     }
 
@@ -723,8 +689,7 @@ struct SettingsSkillsDestination: View {
             method: "skills.status",
             params: EmptySkillsRequest(),
             timeoutSeconds: 20,
-            route: route
-        )
+            route: route)
         return try JSONDecoder().decode(SkillsStatusReport.self, from: data).skills.sorted {
             $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
         }
@@ -734,21 +699,20 @@ struct SettingsSkillsDestination: View {
         method: String,
         params: some Encodable,
         timeoutSeconds: Int,
-        route: GatewayNodeSessionRoute
-    ) async throws -> Data {
+        route: GatewayNodeSessionRoute) async throws -> Data
+    {
         let data = try JSONEncoder().encode(params)
         guard let json = String(data: data, encoding: .utf8) else { throw SkillsSettingsError.invalidPayload }
-        return try await appModel.operatorSession.request(
+        return try await self.appModel.operatorSession.request(
             method: method,
             paramsJSON: json,
             timeoutSeconds: timeoutSeconds,
             ifCurrentRoute: route,
-            distinguishPreDispatchRouteChange: true
-        )
+            distinguishPreDispatchRouteChange: true)
     }
 
     private func gatewayRoute() async throws -> GatewayNodeSessionRoute {
-        let gatewayID = appModel.connectedGatewayID
+        let gatewayID = self.appModel.connectedGatewayID
         guard let route = await appModel.operatorSession.currentRoute(ifGatewayID: gatewayID),
               appModel.connectedGatewayID == gatewayID
         else {
@@ -758,19 +722,19 @@ struct SettingsSkillsDestination: View {
     }
 
     private func resetGatewayState() {
-        loadedGatewayID = nil
-        installedSkills = []
-        searchResults = []
-        clawHubSupported = nil
-        notice = nil
-        reviewSheet = nil
-        installedLoadID = nil
-        searchID = nil
-        reviewID = nil
-        reviewingSlug = nil
-        installID = nil
-        installingSlug = nil
-        mutationIDs = [:]
+        self.loadedGatewayID = nil
+        self.installedSkills = []
+        self.searchResults = []
+        self.clawHubSupported = nil
+        self.notice = nil
+        self.reviewSheet = nil
+        self.installedLoadID = nil
+        self.searchID = nil
+        self.reviewID = nil
+        self.reviewingSlug = nil
+        self.installID = nil
+        self.installingSlug = nil
+        self.mutationIDs = [:]
     }
 
     static func isReady(_ skill: SkillStatus) -> Bool {
@@ -831,23 +795,23 @@ private struct InstalledSkillRow: View {
     }
 
     private var statusLabel: String {
-        if skill.disabled {
+        if self.skill.disabled {
             return String(localized: "Off")
         }
-        return SettingsSkillsDestination.isReady(skill)
+        return SettingsSkillsDestination.isReady(self.skill)
             ? String(localized: "Ready")
             : String(localized: "Needs Setup")
     }
 
     private var statusColor: Color {
-        if skill.disabled {
+        if self.skill.disabled {
             return .secondary
         }
-        return SettingsSkillsDestination.isReady(skill) ? OpenClawBrand.ok : OpenClawBrand.warn
+        return SettingsSkillsDestination.isReady(self.skill) ? OpenClawBrand.ok : OpenClawBrand.warn
     }
 
     private var missingSummary: String {
-        let values = skill.missing.bins + skill.missing.env + skill.missing.config
+        let values = self.skill.missing.bins + self.skill.missing.env + self.skill.missing.config
         return values.isEmpty ? "" : String(format: String(localized: "Missing: %@"), values.joined(separator: ", "))
     }
 }
@@ -902,8 +866,7 @@ private struct SkillsNoticeCard: View {
             HStack(alignment: .top, spacing: 12) {
                 ProIconBadge(
                     systemName: self.notice.isError ? "exclamationmark.triangle" : "checkmark.circle",
-                    color: self.notice.isError ? OpenClawBrand.warn : OpenClawBrand.ok
-                )
+                    color: self.notice.isError ? OpenClawBrand.warn : OpenClawBrand.ok)
                 VStack(alignment: .leading, spacing: 4) {
                     Text(self.notice.title).font(OpenClawType.subheadSemiBold)
                     Text(self.notice.message).font(OpenClawType.caption).textSelection(.enabled)
@@ -1082,8 +1045,8 @@ private enum SkillsSettingsError: LocalizedError {
     }
 }
 
-private extension String {
-    var nilIfEmpty: String? {
+extension String {
+    fileprivate var nilIfEmpty: String? {
         isEmpty ? nil : self
     }
 }

--- a/apps/ios/Sources/Design/SettingsSkillsDestination.swift
+++ b/apps/ios/Sources/Design/SettingsSkillsDestination.swift
@@ -1,0 +1,1089 @@
+import OpenClawKit
+import SwiftUI
+
+private enum SkillsSettingsSection: String, CaseIterable, Identifiable {
+    case installed
+    case browse
+
+    var id: String {
+        rawValue
+    }
+
+    var title: String {
+        self == .installed ? String(localized: "Installed") : String(localized: "Browse")
+    }
+}
+
+private enum InstalledSkillFilter: String, CaseIterable, Identifiable {
+    case all
+    case ready
+    case setup
+    case off
+
+    var id: String {
+        rawValue
+    }
+
+    var title: String {
+        switch self {
+        case .all: String(localized: "All")
+        case .ready: String(localized: "Ready")
+        case .setup: String(localized: "Needs Setup")
+        case .off: String(localized: "Off")
+        }
+    }
+}
+
+private enum SkillsReviewSheet: Identifiable {
+    case install(ClawHubSkillInstallReview, route: GatewayNodeSessionRoute)
+    case risk(ClawHubSkillInstallReview, route: GatewayNodeSessionRoute, message: String, warning: String?)
+
+    var id: String {
+        switch self {
+        case let .install(review, _): "install:\(review.id)"
+        case let .risk(review, _, _, _): "risk:\(review.id)"
+        }
+    }
+}
+
+struct SettingsSkillsDestination: View {
+    @Environment(NodeAppModel.self) private var appModel
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var section: SkillsSettingsSection = .installed
+    @State private var installedFilter: InstalledSkillFilter = .all
+    @State private var installedQuery = ""
+    @State private var installedSkills: [SkillStatus] = []
+    @State private var installedLoadID: UUID?
+    @State private var mutationIDs: [String: UUID] = [:]
+    @State private var browseQuery = ""
+    @State private var searchResults: [ClawHubSkillSummary] = []
+    @State private var searchID: UUID?
+    @State private var reviewingSlug: String?
+    @State private var reviewID: UUID?
+    @State private var installingSlug: String?
+    @State private var installID: UUID?
+    @State private var reviewSheet: SkillsReviewSheet?
+    @State private var clawHubSupported: Bool?
+    @State private var notice: SkillsNotice?
+    @State private var loadedGatewayID: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                self.summaryCard
+                self.sectionPicker
+                if self.section == .installed {
+                    self.installedContent
+                } else {
+                    self.browseContent
+                }
+            }
+            .padding(.vertical, 12)
+        }
+        .font(OpenClawType.body)
+        .task(id: refreshID) { await self.loadInitialState() }
+        .refreshable { await self.refreshVisibleSection() }
+        .onChange(of: appModel.connectedGatewayID) { _, _ in
+            self.resetGatewayState()
+        }
+        .onChange(of: section) { _, section in
+            guard section == .browse, self.searchResults.isEmpty else { return }
+            Task { await self.searchClawHub() }
+        }
+        .sheet(item: $reviewSheet) { sheet in
+            switch sheet {
+            case let .install(review, route):
+                SkillsInstallReviewSheet(
+                    review: review,
+                    canInstall: self.canAdmin,
+                    isInstalling: self.installingSlug == review.slug,
+                    onCancel: { self.reviewSheet = nil },
+                    onInstall: { Task { await self.install(review, route: route, acknowledgeRisk: false) } }
+                )
+            case let .risk(review, route, message, warning):
+                SkillsRiskReviewSheet(
+                    review: review,
+                    message: message,
+                    warning: warning,
+                    isInstalling: self.installingSlug == review.slug,
+                    onCancel: { self.reviewSheet = nil },
+                    onInstall: { Task { await self.install(review, route: route, acknowledgeRisk: true) } }
+                )
+            }
+        }
+    }
+
+    private var refreshID: String {
+        [
+            canRead ? "connected" : "offline",
+            scenePhase == .active ? "active" : "inactive",
+            appModel.connectedGatewayID ?? "no-gateway",
+        ].joined(separator: ":")
+    }
+
+    private var canRead: Bool {
+        appModel.isOperatorGatewayConnected
+    }
+
+    private var canAdmin: Bool {
+        appModel.hasOperatorAdminScope
+    }
+
+    private var isLoadingInstalled: Bool {
+        installedLoadID != nil
+    }
+
+    private var isSearching: Bool {
+        searchID != nil
+    }
+
+    private var readyCount: Int {
+        installedSkills.count(where: Self.isReady)
+    }
+
+    private var setupCount: Int {
+        installedSkills.count(where: Self.needsSetup)
+    }
+
+    private var summaryCard: some View {
+        ProCard(radius: SettingsLayout.cardRadius) {
+            HStack(spacing: 12) {
+                ProIconBadge(systemName: "sparkles", color: OpenClawBrand.accent)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Skills").font(OpenClawType.headline)
+                    Text(self.summaryText)
+                        .font(OpenClawType.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 8)
+                ProValuePill(value: self.summaryValue, color: self.summaryColor)
+            }
+        }
+        .padding(.horizontal, OpenClawProMetric.pagePadding)
+    }
+
+    private var summaryText: String {
+        guard canRead else { return String(localized: "Connect to manage Gateway skills.") }
+        if isLoadingInstalled, installedSkills.isEmpty {
+            return String(localized: "Loading installed skills and readiness.")
+        }
+        return String(
+            format: String(localized: "%@ ready · %@ need setup"),
+            readyCount.formatted(),
+            setupCount.formatted()
+        )
+    }
+
+    private var summaryValue: String {
+        guard canRead else { return String(localized: "offline") }
+        if isLoadingInstalled, installedSkills.isEmpty {
+            return String(localized: "loading")
+        }
+        return installedSkills.count.formatted()
+    }
+
+    private var summaryColor: Color {
+        guard canRead else { return .secondary }
+        return setupCount > 0 ? OpenClawBrand.warn : OpenClawBrand.ok
+    }
+
+    private var sectionPicker: some View {
+        Picker(selection: $section) {
+            ForEach(SkillsSettingsSection.allCases) { section in
+                Text(verbatim: section.title).font(OpenClawType.captionSemiBold).tag(section)
+            }
+        } label: {
+            Text("Skills section").font(OpenClawType.captionSemiBold)
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal, OpenClawProMetric.pagePadding)
+    }
+
+    private var installedContent: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            self.installedControls
+            if let notice {
+                SkillsNoticeCard(notice: notice)
+            }
+            ProCard(padding: 0, radius: SettingsLayout.cardRadius) {
+                VStack(spacing: 0) {
+                    ProPanelHeader(
+                        title: "Installed",
+                        value: self.filteredInstalledSkills.count.formatted(),
+                        actionIcon: self.isLoadingInstalled ? "hourglass" : "arrow.clockwise",
+                        actionAccessibilityLabel: "Refresh Skills",
+                        isActionDisabled: self.isLoadingInstalled,
+                        action: { Task { await self.loadInstalled() } }
+                    )
+                    self.installedRows
+                }
+            }
+            .padding(.horizontal, OpenClawProMetric.pagePadding)
+        }
+    }
+
+    private var installedControls: some View {
+        ProCard(radius: SettingsLayout.cardRadius) {
+            VStack(alignment: .leading, spacing: 10) {
+                TextField(
+                    text: self.$installedQuery,
+                    prompt: Text("Search installed skills").font(OpenClawType.body)
+                ) {
+                    Text("Search installed skills").font(OpenClawType.body)
+                }
+                .font(OpenClawType.body)
+                .textFieldStyle(.roundedBorder)
+                Picker(selection: self.$installedFilter) {
+                    ForEach(InstalledSkillFilter.allCases) { filter in
+                        Text(verbatim: filter.title).font(OpenClawType.captionSemiBold).tag(filter)
+                    }
+                } label: {
+                    Text("Installed skill filter").font(OpenClawType.captionSemiBold)
+                }
+                .pickerStyle(.segmented)
+            }
+        }
+        .padding(.horizontal, OpenClawProMetric.pagePadding)
+    }
+
+    @ViewBuilder
+    private var installedRows: some View {
+        if !canRead {
+            ProStatusRow(
+                icon: "wifi.slash",
+                title: "Gateway offline",
+                detail: "Connect to load and manage installed skills.",
+                value: "offline",
+                color: .secondary
+            )
+        } else if isLoadingInstalled, installedSkills.isEmpty {
+            ProStatusRow(
+                icon: "hourglass",
+                title: "Loading skills",
+                detail: "Reading the Gateway skill catalog.",
+                value: "loading",
+                color: OpenClawBrand.accent
+            )
+        } else if filteredInstalledSkills.isEmpty {
+            ProStatusRow(
+                icon: "tray",
+                title: installedSkills.isEmpty ? "No skills installed" : "No matching skills",
+                detail: installedSkills.isEmpty
+                    ? "Browse ClawHub to discover and install skills."
+                    : "Change the search or readiness filter.",
+                value: "empty",
+                color: .secondary
+            )
+        } else {
+            ForEach(Array(filteredInstalledSkills.enumerated()), id: \.element.id) { index, skill in
+                if index > 0 {
+                    Divider().padding(.leading, 58)
+                }
+                InstalledSkillRow(
+                    skill: skill,
+                    canAdmin: self.canAdmin,
+                    isBusy: self.mutationIDs[skill.skillKey] != nil,
+                    onToggle: { enabled in Task { await self.setEnabled(skill, enabled: enabled) } }
+                )
+            }
+        }
+    }
+
+    private var filteredInstalledSkills: [SkillStatus] {
+        let query = installedQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        return installedSkills.filter { skill in
+            let matchesQuery = query.isEmpty
+                || skill.name.localizedCaseInsensitiveContains(query)
+                || skill.skillKey.localizedCaseInsensitiveContains(query)
+                || skill.description.localizedCaseInsensitiveContains(query)
+            let matchesFilter = switch self.installedFilter {
+            case .all: true
+            case .ready: Self.isReady(skill)
+            case .setup: Self.needsSetup(skill)
+            case .off: skill.disabled
+            }
+            return matchesQuery && matchesFilter
+        }
+    }
+
+    private var browseContent: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            self.browseControls
+            if let notice {
+                SkillsNoticeCard(notice: notice)
+            }
+            ProCard(padding: 0, radius: SettingsLayout.cardRadius) {
+                VStack(spacing: 0) {
+                    ProPanelHeader(
+                        title: "ClawHub",
+                        value: self.searchResults.count.formatted(),
+                        actionIcon: self.isSearching ? "hourglass" : "arrow.clockwise",
+                        actionAccessibilityLabel: "Search ClawHub",
+                        isActionDisabled: self.isSearching || self.clawHubSupported == false,
+                        action: { Task { await self.searchClawHub() } }
+                    )
+                    self.browseRows
+                }
+            }
+            .padding(.horizontal, OpenClawProMetric.pagePadding)
+        }
+    }
+
+    private var browseControls: some View {
+        ProCard(radius: SettingsLayout.cardRadius) {
+            VStack(alignment: .leading, spacing: 10) {
+                TextField(
+                    text: self.$browseQuery,
+                    prompt: Text("Search ClawHub").font(OpenClawType.body)
+                ) {
+                    Text("Search ClawHub").font(OpenClawType.body)
+                }
+                .font(OpenClawType.body)
+                .textFieldStyle(.roundedBorder)
+                .submitLabel(.search)
+                .onSubmit { Task { await self.searchClawHub() } }
+                Button {
+                    Task { await self.searchClawHub() }
+                } label: {
+                    Label("Search", systemImage: "magnifyingglass").font(OpenClawType.subheadSemiBold)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!self.canRead || self.isSearching || self.clawHubSupported == false)
+                Text("The Gateway verifies the exact reviewed release before download.")
+                    .font(OpenClawType.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.horizontal, OpenClawProMetric.pagePadding)
+    }
+
+    @ViewBuilder
+    private var browseRows: some View {
+        if !canRead {
+            ProStatusRow(
+                icon: "wifi.slash",
+                title: "Gateway offline",
+                detail: "Connect to search and install ClawHub skills.",
+                value: "offline",
+                color: .secondary
+            )
+        } else if clawHubSupported == false {
+            ProStatusRow(
+                icon: "arrow.up.circle",
+                title: "Gateway update required",
+                detail: "Update the Gateway to search and install ClawHub skills from iOS.",
+                value: "update",
+                color: OpenClawBrand.warn
+            )
+        } else if isSearching, searchResults.isEmpty {
+            ProStatusRow(
+                icon: "hourglass",
+                title: "Searching ClawHub",
+                detail: "Loading verified skill releases.",
+                value: "loading",
+                color: OpenClawBrand.accent
+            )
+        } else if searchResults.isEmpty {
+            ProStatusRow(
+                icon: "magnifyingglass",
+                title: "No skills found",
+                detail: "Try another search or refresh the catalog.",
+                value: "empty",
+                color: .secondary
+            )
+        } else {
+            ForEach(Array(searchResults.enumerated()), id: \.element.id) { index, skill in
+                if index > 0 {
+                    Divider().padding(.leading, 58)
+                }
+                ClawHubSkillRow(
+                    skill: skill,
+                    installed: SkillManagementContract.installed(self.installedSkills, slug: skill.slug),
+                    isBusy: self.reviewingSlug == skill.slug,
+                    onReview: { Task { await self.review(skill) } }
+                )
+            }
+        }
+    }
+
+    private func loadInitialState() async {
+        guard scenePhase == .active else { return }
+        guard canRead else {
+            resetGatewayState()
+            return
+        }
+        let gatewayID = appModel.connectedGatewayID
+        if loadedGatewayID != gatewayID {
+            resetGatewayState()
+            loadedGatewayID = gatewayID
+        }
+        await updateClawHubSupport()
+        await loadInstalled()
+    }
+
+    private func refreshVisibleSection() async {
+        await updateClawHubSupport()
+        if section == .installed {
+            await loadInstalled()
+        } else {
+            await loadInstalled()
+            await searchClawHub()
+        }
+    }
+
+    private func updateClawHubSupport() async {
+        let gatewayID = appModel.connectedGatewayID
+        guard let route = await appModel.operatorSession.currentRoute(ifGatewayID: gatewayID) else {
+            clawHubSupported = nil
+            return
+        }
+        var values: [Bool?] = []
+        for method in clawHubSkillGatewayMethods.sorted() {
+            let supported = await appModel.operatorSession.supportsServerMethod(
+                method,
+                ifCurrentRoute: route
+            )
+            values.append(supported)
+        }
+        guard appModel.connectedGatewayID == gatewayID else { return }
+        if values.contains(false) {
+            clawHubSupported = false
+        } else if values.allSatisfy({ $0 == true }) {
+            clawHubSupported = true
+        } else {
+            clawHubSupported = nil
+        }
+    }
+
+    private func loadInstalled() async {
+        guard canRead, installedLoadID == nil else { return }
+        let gatewayID = appModel.connectedGatewayID
+        let operationID = UUID()
+        installedLoadID = operationID
+        notice = nil
+        defer {
+            if self.installedLoadID == operationID {
+                self.installedLoadID = nil
+            }
+        }
+        do {
+            let route = try await gatewayRoute()
+            let skills = try await fetchInstalledSkills(route: route)
+            guard appModel.connectedGatewayID == gatewayID else { return }
+            installedSkills = skills
+        } catch {
+            guard appModel.connectedGatewayID == gatewayID else { return }
+            notice = SkillsNotice(
+                title: String(localized: "Could not load skills"),
+                message: error.localizedDescription,
+                warning: nil,
+                isError: true
+            )
+        }
+    }
+
+    private func searchClawHub() async {
+        guard canRead,
+              loadedGatewayID == appModel.connectedGatewayID,
+              clawHubSupported != false,
+              searchID == nil
+        else { return }
+        let gatewayID = appModel.connectedGatewayID
+        let operationID = UUID()
+        searchID = operationID
+        notice = nil
+        defer {
+            if self.searchID == operationID {
+                self.searchID = nil
+            }
+        }
+        do {
+            let route = try await gatewayRoute()
+            let request = ClawHubSearchRequest(
+                query: browseQuery.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+                limit: 25
+            )
+            let data = try await self.request(
+                method: "skills.search",
+                params: request,
+                timeoutSeconds: 20,
+                route: route
+            )
+            let results = try JSONDecoder().decode(ClawHubSkillSearchResult.self, from: data).results
+            guard appModel.connectedGatewayID == gatewayID else { return }
+            searchResults = results
+        } catch {
+            guard appModel.connectedGatewayID == gatewayID else { return }
+            notice = SkillsNotice(
+                title: String(localized: "ClawHub unavailable"),
+                message: error.localizedDescription,
+                warning: nil,
+                isError: true
+            )
+        }
+    }
+
+    private func review(_ skill: ClawHubSkillSummary) async {
+        guard canRead,
+              loadedGatewayID == appModel.connectedGatewayID,
+              reviewID == nil
+        else { return }
+        let gatewayID = appModel.connectedGatewayID
+        let operationID = UUID()
+        reviewID = operationID
+        reviewingSlug = skill.slug
+        notice = nil
+        defer {
+            if self.reviewID == operationID {
+                self.reviewID = nil
+                self.reviewingSlug = nil
+            }
+        }
+        do {
+            let route = try await gatewayRoute()
+            let data = try await request(
+                method: "skills.detail",
+                params: ClawHubDetailRequest(slug: skill.slug),
+                timeoutSeconds: 20,
+                route: route
+            )
+            let detail = try JSONDecoder().decode(ClawHubSkillDetail.self, from: data)
+            guard appModel.connectedGatewayID == gatewayID else { return }
+            guard let review = ClawHubSkillInstallReview(detail: detail, fallback: skill) else {
+                throw SkillsSettingsError.missingInstallVersion
+            }
+            reviewSheet = .install(review, route: route)
+        } catch {
+            guard appModel.connectedGatewayID == gatewayID else { return }
+            notice = SkillsNotice(
+                title: String(localized: "Could not review skill"),
+                message: error.localizedDescription,
+                warning: nil,
+                isError: true
+            )
+        }
+    }
+
+    private func install(
+        _ review: ClawHubSkillInstallReview,
+        route: GatewayNodeSessionRoute,
+        acknowledgeRisk: Bool
+    ) async {
+        guard canAdmin,
+              loadedGatewayID == appModel.connectedGatewayID,
+              installID == nil
+        else { return }
+        let gatewayID = appModel.connectedGatewayID
+        let operationID = UUID()
+        installID = operationID
+        installingSlug = review.slug
+        notice = nil
+        defer {
+            if self.installID == operationID {
+                self.installID = nil
+                self.installingSlug = nil
+            }
+        }
+        do {
+            let request = ClawHubInstallRequest(
+                source: "clawhub",
+                slug: review.slug,
+                version: review.version,
+                acknowledgeClawHubRisk: acknowledgeRisk ? true : nil,
+                timeoutMs: clawHubInstallTimeoutMilliseconds
+            )
+            let data = try await self.request(
+                method: "skills.install",
+                params: request,
+                timeoutSeconds: 125,
+                route: route
+            )
+            let result = try JSONDecoder().decode(SkillInstallResult.self, from: data)
+            guard appModel.connectedGatewayID == gatewayID else { return }
+            installedSkills = try await fetchInstalledSkills(route: route)
+            guard appModel.connectedGatewayID == gatewayID else { return }
+            guard SkillManagementContract.installed(
+                installedSkills,
+                slug: review.slug,
+                version: review.version
+            )
+            else {
+                reviewSheet = nil
+                notice = SkillsNotice(
+                    title: String(localized: "Install result unknown"),
+                    message: String(
+                        localized:
+                        "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running."
+                    ),
+                    warning: result.warning,
+                    isError: true
+                )
+                return
+            }
+            reviewSheet = nil
+            notice = SkillsNotice(
+                title: String(localized: "Installed"),
+                message: result.message,
+                warning: result.warning,
+                isError: false
+            )
+        } catch let error as GatewayResponseError {
+            guard self.appModel.connectedGatewayID == gatewayID else { return }
+            let rejection = SkillManagementContract.rejection(from: error, attemptedVersion: review.version)
+            if rejection.requiresAcknowledgement, !acknowledgeRisk {
+                self.reviewSheet = .risk(
+                    review,
+                    route: route,
+                    message: rejection.message,
+                    warning: rejection.warning
+                )
+            } else {
+                self.reviewSheet = nil
+                self.notice = SkillsNotice(
+                    title: String(localized: "Gateway blocked install"),
+                    message: rejection.message,
+                    warning: rejection.warning,
+                    isError: true
+                )
+            }
+        } catch {
+            guard appModel.connectedGatewayID == gatewayID else { return }
+            if let skills = try? await fetchInstalledSkills(route: route),
+               appModel.connectedGatewayID == gatewayID
+            {
+                installedSkills = skills
+                if SkillManagementContract.installed(skills, slug: review.slug, version: review.version) {
+                    reviewSheet = nil
+                    notice = SkillsNotice(
+                        title: String(localized: "Installed"),
+                        message: String(localized: "The Gateway installed the reviewed version."),
+                        warning: nil,
+                        isError: false
+                    )
+                    return
+                }
+            }
+            reviewSheet = nil
+            notice = SkillsNotice(
+                title: String(localized: "Install result unknown"),
+                message: error.localizedDescription,
+                warning: nil,
+                isError: true
+            )
+        }
+    }
+
+    private func setEnabled(_ skill: SkillStatus, enabled: Bool) async {
+        guard canAdmin,
+              loadedGatewayID == appModel.connectedGatewayID,
+              mutationIDs[skill.skillKey] == nil
+        else { return }
+        let gatewayID = appModel.connectedGatewayID
+        let operationID = UUID()
+        mutationIDs[skill.skillKey] = operationID
+        notice = nil
+        defer {
+            if self.mutationIDs[skill.skillKey] == operationID {
+                self.mutationIDs.removeValue(forKey: skill.skillKey)
+            }
+        }
+        do {
+            let route = try await gatewayRoute()
+            _ = try await request(
+                method: "skills.update",
+                params: SkillEnabledRequest(skillKey: skill.skillKey, enabled: enabled),
+                timeoutSeconds: 20,
+                route: route
+            )
+            guard appModel.connectedGatewayID == gatewayID else { return }
+            let skills = try await fetchInstalledSkills(route: route)
+            guard appModel.connectedGatewayID == gatewayID else { return }
+            installedSkills = skills
+            notice = SkillsNotice(
+                title: enabled ? String(localized: "Skill enabled") : String(localized: "Skill disabled"),
+                message: skill.name,
+                warning: nil,
+                isError: false
+            )
+        } catch {
+            guard appModel.connectedGatewayID == gatewayID else { return }
+            notice = SkillsNotice(
+                title: enabled ? String(localized: "Could not enable skill") :
+                    String(localized: "Could not disable skill"),
+                message: error.localizedDescription,
+                warning: nil,
+                isError: true
+            )
+        }
+    }
+
+    private func fetchInstalledSkills(route: GatewayNodeSessionRoute) async throws -> [SkillStatus] {
+        let data = try await request(
+            method: "skills.status",
+            params: EmptySkillsRequest(),
+            timeoutSeconds: 20,
+            route: route
+        )
+        return try JSONDecoder().decode(SkillsStatusReport.self, from: data).skills.sorted {
+            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+    }
+
+    private func request(
+        method: String,
+        params: some Encodable,
+        timeoutSeconds: Int,
+        route: GatewayNodeSessionRoute
+    ) async throws -> Data {
+        let data = try JSONEncoder().encode(params)
+        guard let json = String(data: data, encoding: .utf8) else { throw SkillsSettingsError.invalidPayload }
+        return try await appModel.operatorSession.request(
+            method: method,
+            paramsJSON: json,
+            timeoutSeconds: timeoutSeconds,
+            ifCurrentRoute: route,
+            distinguishPreDispatchRouteChange: true
+        )
+    }
+
+    private func gatewayRoute() async throws -> GatewayNodeSessionRoute {
+        let gatewayID = appModel.connectedGatewayID
+        guard let route = await appModel.operatorSession.currentRoute(ifGatewayID: gatewayID),
+              appModel.connectedGatewayID == gatewayID
+        else {
+            throw SkillsSettingsError.gatewayChanged
+        }
+        return route
+    }
+
+    private func resetGatewayState() {
+        loadedGatewayID = nil
+        installedSkills = []
+        searchResults = []
+        clawHubSupported = nil
+        notice = nil
+        reviewSheet = nil
+        installedLoadID = nil
+        searchID = nil
+        reviewID = nil
+        reviewingSlug = nil
+        installID = nil
+        installingSlug = nil
+        mutationIDs = [:]
+    }
+
+    static func isReady(_ skill: SkillStatus) -> Bool {
+        SkillManagementContract.ready(skill)
+    }
+
+    static func needsSetup(_ skill: SkillStatus) -> Bool {
+        SkillManagementContract.needsSetup(skill)
+    }
+}
+
+private struct InstalledSkillRow: View {
+    let skill: SkillStatus
+    let canAdmin: Bool
+    let isBusy: Bool
+    let onToggle: (Bool) -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Text(self.skill.emoji ?? "✨")
+                .font(OpenClawType.title3)
+                .frame(width: 32, height: 32)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 5) {
+                HStack(spacing: 7) {
+                    Text(self.skill.name).font(OpenClawType.subheadSemiBold)
+                    Text(verbatim: self.statusLabel)
+                        .font(OpenClawType.caption2SemiBold)
+                        .foregroundStyle(self.statusColor)
+                }
+                Text(self.skill.description)
+                    .font(OpenClawType.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                if !self.missingSummary.isEmpty {
+                    Text(verbatim: self.missingSummary)
+                        .font(OpenClawType.caption2)
+                        .foregroundStyle(OpenClawBrand.warn)
+                }
+                if let link = self.skill.clawhub, link.valid, let slug = link.slug {
+                    Text(verbatim: [slug, link.installedVersion].compactMap(\.self).joined(separator: " · "))
+                        .font(OpenClawType.monoSmall)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer(minLength: 8)
+            Button {
+                self.onToggle(self.skill.disabled)
+            } label: {
+                Text(self.skill.disabled ? String(localized: "Enable") : String(localized: "Disable"))
+                    .font(OpenClawType.captionSemiBold)
+            }
+            .buttonStyle(.bordered)
+            .disabled(!self.canAdmin || self.isBusy)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+    }
+
+    private var statusLabel: String {
+        if skill.disabled {
+            return String(localized: "Off")
+        }
+        return SettingsSkillsDestination.isReady(skill)
+            ? String(localized: "Ready")
+            : String(localized: "Needs Setup")
+    }
+
+    private var statusColor: Color {
+        if skill.disabled {
+            return .secondary
+        }
+        return SettingsSkillsDestination.isReady(skill) ? OpenClawBrand.ok : OpenClawBrand.warn
+    }
+
+    private var missingSummary: String {
+        let values = skill.missing.bins + skill.missing.env + skill.missing.config
+        return values.isEmpty ? "" : String(format: String(localized: "Missing: %@"), values.joined(separator: ", "))
+    }
+}
+
+private struct ClawHubSkillRow: View {
+    let skill: ClawHubSkillSummary
+    let installed: Bool
+    let isBusy: Bool
+    let onReview: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            ProIconBadge(systemName: "shippingbox", color: self.installed ? OpenClawBrand.ok : OpenClawBrand.accent)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(self.skill.displayName).font(OpenClawType.subheadSemiBold)
+                Text(self.skill.summary ?? self.skill.slug)
+                    .font(OpenClawType.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                HStack(spacing: 6) {
+                    Text(self.skill.slug).font(OpenClawType.monoSmall).foregroundStyle(.secondary)
+                    if let version = self.skill.version {
+                        Text(verbatim: version).font(OpenClawType.monoSmall).foregroundStyle(.secondary)
+                    }
+                }
+            }
+            Spacer(minLength: 8)
+            Button(action: self.onReview) {
+                Text(self.installed ? String(localized: "Installed") : String(localized: "Install"))
+                    .font(OpenClawType.captionSemiBold)
+            }
+            .buttonStyle(.bordered)
+            .disabled(self.isBusy || self.installed)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+    }
+}
+
+private struct SkillsNotice: Equatable {
+    let title: String
+    let message: String
+    let warning: String?
+    let isError: Bool
+}
+
+private struct SkillsNoticeCard: View {
+    let notice: SkillsNotice
+
+    var body: some View {
+        ProCard(radius: SettingsLayout.cardRadius) {
+            HStack(alignment: .top, spacing: 12) {
+                ProIconBadge(
+                    systemName: self.notice.isError ? "exclamationmark.triangle" : "checkmark.circle",
+                    color: self.notice.isError ? OpenClawBrand.warn : OpenClawBrand.ok
+                )
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(self.notice.title).font(OpenClawType.subheadSemiBold)
+                    Text(self.notice.message).font(OpenClawType.caption).textSelection(.enabled)
+                    if let warning = self.notice.warning {
+                        Text(warning)
+                            .font(OpenClawType.caption)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
+                }
+                Spacer()
+            }
+        }
+        .padding(.horizontal, OpenClawProMetric.pagePadding)
+    }
+}
+
+private struct SkillsInstallReviewSheet: View {
+    let review: ClawHubSkillInstallReview
+    let canInstall: Bool
+    let isInstalling: Bool
+    let onCancel: () -> Void
+    let onInstall: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    SkillsReviewDetails(review: self.review)
+                    Text("The Gateway will verify this exact release with ClawHub before download.")
+                        .font(OpenClawType.caption)
+                        .foregroundStyle(.secondary)
+                    if !self.canInstall {
+                        Text("This gateway connection needs operator.admin to install skills.")
+                            .font(OpenClawType.caption)
+                            .foregroundStyle(OpenClawBrand.warn)
+                    }
+                }
+                .padding(20)
+            }
+            .navigationTitle("Review ClawHub skill")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(action: self.onCancel) { Text("Cancel").font(OpenClawType.subheadSemiBold) }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(action: self.onInstall) {
+                        Text("Verify and install").font(OpenClawType.subheadSemiBold)
+                    }
+                    .disabled(!self.canInstall || self.isInstalling)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+}
+
+private struct SkillsRiskReviewSheet: View {
+    let review: ClawHubSkillInstallReview
+    let message: String
+    let warning: String?
+    let isInstalling: Bool
+    let onCancel: () -> Void
+    let onInstall: () -> Void
+    @State private var warningExpanded = false
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Label {
+                        Text("Gateway warning").font(OpenClawType.headline)
+                    } icon: {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                    }
+                    .foregroundStyle(OpenClawBrand.warn)
+                    SkillsReviewDetails(review: self.review)
+                    Text(self.message).font(OpenClawType.body)
+                    DisclosureGroup(isExpanded: self.$warningExpanded) {
+                        Text(self
+                            .warning ??
+                            String(localized: "The Gateway requires explicit acknowledgement for this release."))
+                            .font(OpenClawType.caption)
+                            .textSelection(.enabled)
+                            .padding(.top, 8)
+                    } label: {
+                        Text("Review warning details").font(OpenClawType.subheadSemiBold)
+                    }
+                    Text("Expand and review the Gateway warning before acknowledging this exact version.")
+                        .font(OpenClawType.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(20)
+            }
+            .navigationTitle("Review Gateway warning")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(action: self.onCancel) { Text("Cancel").font(OpenClawType.subheadSemiBold) }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(action: self.onInstall) {
+                        Text("Acknowledge and install").font(OpenClawType.subheadSemiBold)
+                    }
+                    .disabled(!self.warningExpanded || self.isInstalling)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+}
+
+private struct SkillsReviewDetails: View {
+    let review: ClawHubSkillInstallReview
+
+    var body: some View {
+        ProCard(radius: SettingsLayout.cardRadius) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(self.review.displayName).font(OpenClawType.headline)
+                if let summary = self.review.summary {
+                    Text(summary).font(OpenClawType.body).foregroundStyle(.secondary)
+                }
+                SkillsReviewLine(label: "Version", value: self.review.version)
+                SkillsReviewLine(label: "Publisher", value: self.review.author)
+            }
+        }
+    }
+}
+
+private struct SkillsReviewLine: View {
+    let label: LocalizedStringKey
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(self.label).font(OpenClawType.captionSemiBold).foregroundStyle(.secondary)
+            Text(self.value).font(OpenClawType.body)
+        }
+    }
+}
+
+private struct EmptySkillsRequest: Encodable {}
+
+private struct ClawHubSearchRequest: Encodable {
+    let query: String?
+    let limit: Int
+}
+
+private struct ClawHubDetailRequest: Encodable { let slug: String }
+
+private struct ClawHubInstallRequest: Encodable {
+    let source: String
+    let slug: String
+    let version: String
+    let acknowledgeClawHubRisk: Bool?
+    let timeoutMs: Int
+}
+
+private struct SkillEnabledRequest: Encodable {
+    let skillKey: String
+    let enabled: Bool
+}
+
+private enum SkillsSettingsError: LocalizedError {
+    case gatewayChanged
+    case invalidPayload
+    case missingInstallVersion
+
+    var errorDescription: String? {
+        switch self {
+        case .gatewayChanged: String(localized: "The connected Gateway changed. Refresh Skills and try again.")
+        case .invalidPayload: String(localized: "Could not encode the Gateway request.")
+        case .missingInstallVersion: String(localized: "ClawHub did not report an installable version for this skill.")
+        }
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/apps/ios/Sources/Design/SettingsSkillsDestination.swift
+++ b/apps/ios/Sources/Design/SettingsSkillsDestination.swift
@@ -590,7 +590,10 @@ struct SettingsSkillsDestination: View {
                     title: String(localized: "Install result unknown"),
                     message: String(
                         localized:
-                        "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running."),
+                        """
+                        Reconnect, refresh Skills, then retry. \
+                        The Gateway safely joins a matching install still running.
+                        """),
                     warning: result.warning,
                     isError: true)
                 return

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -366,10 +366,6 @@ final class GatewayConnectionController {
         return nil
     }
 
-    func connect(_ gateway: GatewayDiscoveryModel.DiscoveredGateway) async {
-        _ = await self.connectWithDiagnostics(gateway)
-    }
-
     func connectManual(
         host: String,
         port: Int,

--- a/apps/ios/Sources/Services/WatchConnectivityTransport.swift
+++ b/apps/ios/Sources/Services/WatchConnectivityTransport.swift
@@ -57,18 +57,6 @@ final class WatchConnectivityTransport: NSObject, @unchecked Sendable {
         WCSession.isSupported()
     }
 
-    nonisolated static func currentStatusSnapshot() -> WatchMessagingStatus {
-        guard WCSession.isSupported() else {
-            return WatchMessagingStatus(
-                supported: false,
-                paired: false,
-                appInstalled: false,
-                reachable: false,
-                activationState: "unsupported")
-        }
-        return self.status(for: WCSession.default)
-    }
-
     func status() async -> WatchMessagingStatus {
         try? await self.ensureActivated()
         return self.currentStatusSnapshot()

--- a/apps/ios/Sources/Services/WatchMessagingService.swift
+++ b/apps/ios/Sources/Services/WatchMessagingService.swift
@@ -108,10 +108,6 @@ final class WatchMessagingService: @preconcurrency WatchMessagingServicing {
         WatchConnectivityTransport.isSupportedOnDevice()
     }
 
-    nonisolated static func currentStatusSnapshot() -> WatchMessagingStatus {
-        WatchConnectivityTransport.currentStatusSnapshot()
-    }
-
     func status() async -> WatchMessagingStatus {
         await self.transport.status()
     }

--- a/apps/ios/Tests/OpenClawTypographyTests.swift
+++ b/apps/ios/Tests/OpenClawTypographyTests.swift
@@ -182,6 +182,9 @@ struct OpenClawTypographyTests {
         let channels = try String(
             contentsOf: Self.sourceURL("Design/SettingsChannelsDestination.swift"),
             encoding: .utf8)
+        let skills = try String(
+            contentsOf: Self.sourceURL("Design/SettingsSkillsDestination.swift"),
+            encoding: .utf8)
         let docs = try String(contentsOf: Self.sourceURL("Design/OpenClawDocsScreen.swift"), encoding: .utf8)
         let chatTab = try String(contentsOf: Self.sourceURL("Design/ChatProTab.swift"), encoding: .utf8)
         let chatTypography = try String(
@@ -322,7 +325,11 @@ struct OpenClawTypographyTests {
         #expect(skillWorkshop.contains("Text(\"Apply\")"))
         #expect(skillWorkshop.contains("Text(\"Reject\")"))
 
-        for source in [agentDestinations, dreaming, instances, channels, docs] {
+        #expect(skills.contains("Text(\"Gateway warning\").font(OpenClawType.headline)"))
+        #expect(skills.contains("Text(\"Acknowledge and install\").font(OpenClawType.subheadSemiBold)"))
+        #expect(skills.contains("prompt: Text(\"Search ClawHub\").font(OpenClawType.body)"))
+
+        for source in [agentDestinations, dreaming, instances, channels, skills, docs] {
             #expect(source.contains(".font(OpenClawType.body)"))
         }
 

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -332,6 +332,27 @@ struct RootTabsSourceGuardTests {
             "SettingsDetailRow(\"Model\", value: .verbatim(DeviceInfoHelper.modelIdentifier()))"))
     }
 
+    @Test func `settings exposes guarded installed and ClawHub skill management`() throws {
+        let settingsSource = try String(contentsOf: Self.settingsProTabSectionsSourceURL(), encoding: .utf8)
+        let skillsSource = try String(contentsOf: Self.settingsSkillsSourceURL(), encoding: .utf8)
+
+        #expect(settingsSource.contains("title: \"Skills\""))
+        #expect(settingsSource.contains("route: .skills"))
+        #expect(skillsSource.contains("case installed"))
+        #expect(skillsSource.contains("case browse"))
+        #expect(skillsSource.contains("case setup"))
+        #expect(skillsSource.contains("case off"))
+        #expect(skillsSource.contains("method: \"skills.status\""))
+        #expect(skillsSource.contains("method: \"skills.search\""))
+        #expect(skillsSource.contains("method: \"skills.detail\""))
+        #expect(skillsSource.contains("method: \"skills.install\""))
+        #expect(skillsSource.contains("method: \"skills.update\""))
+        #expect(skillsSource.contains(".disabled(!self.warningExpanded || self.isInstalling)"))
+        #expect(skillsSource.contains("SkillManagementContract.installed"))
+        #expect(skillsSource.contains("ifCurrentRoute: route"))
+        #expect(skillsSource.contains("distinguishPreDispatchRouteChange: true"))
+    }
+
     @Test func `routed headers use shared adaptive layout`() throws {
         let componentsSource = try String(contentsOf: Self.proComponentsSourceURL(), encoding: .utf8)
         let featureChromeSource = try String(contentsOf: Self.iPadSidebarScreenChromeSourceURL(), encoding: .utf8)
@@ -1750,6 +1771,13 @@ extension RootTabsSourceGuardTests {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("Sources/Design/SettingsChannelsDestination.swift")
+    }
+
+    private static func settingsSkillsSourceURL() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/Design/SettingsSkillsDestination.swift")
     }
 
     private static func sharedChatPreviewSourceURL() -> URL {

--- a/apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift
+++ b/apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift
@@ -25,8 +25,8 @@ struct ClawHubSkillsBrowser: View {
                 SettingsCardRow(
                     title: "Discover skills",
                     subtitle: "The Gateway verifies the exact reviewed release before download.",
-                    showsDivider: false
-                ) {
+                    showsDivider: false)
+                {
                     TextField("Search ClawHub", text: self.$model.query)
                         .textFieldStyle(.roundedBorder)
                         .frame(width: 260)
@@ -54,8 +54,8 @@ struct ClawHubSkillsBrowser: View {
                     SettingsCardRow(
                         title: "No skills found",
                         subtitle: "Try another search or refresh the catalog.",
-                        showsDivider: false
-                    ) {
+                        showsDivider: false)
+                    {
                         EmptyView()
                     }
                 } else {
@@ -65,11 +65,10 @@ struct ClawHubSkillsBrowser: View {
                                 skill: skill,
                                 installed: SkillManagementContract.installed(
                                     self.installedSkills,
-                                    slug: skill.slug
-                                ),
+                                    slug: skill.slug),
                                 isBusy: self.model.reviewingSlug == skill.slug,
-                                showsDivider: index != self.model.results.count - 1
-                            ) {
+                                showsDivider: index != self.model.results.count - 1)
+                            {
                                 Task { await self.model.review(skill) }
                             }
                         }
@@ -78,7 +77,7 @@ struct ClawHubSkillsBrowser: View {
             }
         }
         .task { await self.model.searchIfNeeded() }
-        .sheet(item: $model.sheet) { sheet in
+        .sheet(item: self.$model.sheet) { sheet in
             switch sheet {
             case let .install(review, route):
                 ClawHubInstallReviewSheet(
@@ -91,8 +90,7 @@ struct ClawHubSkillsBrowser: View {
                                 self.onInstalled(skills)
                             }
                         }
-                    }
-                )
+                    })
             case let .risk(review, route, message, warning):
                 ClawHubRiskReviewSheet(
                     review: review,
@@ -106,8 +104,7 @@ struct ClawHubSkillsBrowser: View {
                                 self.onInstalled(skills)
                             }
                         }
-                    }
-                )
+                    })
             }
         }
     }
@@ -122,10 +119,10 @@ private struct ClawHubSkillResultRow: View {
 
     var body: some View {
         SettingsCardRow(
-            title: skill.displayName,
-            subtitle: skill.summary ?? skill.slug,
-            showsDivider: showsDivider
-        ) {
+            title: self.skill.displayName,
+            subtitle: self.skill.summary ?? self.skill.slug,
+            showsDivider: self.showsDivider)
+        {
             if let version = self.skill.version {
                 Text(version)
                     .font(.caption.monospacedDigit())
@@ -258,35 +255,34 @@ private final class ClawHubSkillsBrowserModel {
     private var hasSearched = false
 
     func searchIfNeeded() async {
-        guard !hasSearched else { return }
-        await search()
+        guard !self.hasSearched else { return }
+        await self.search()
     }
 
     func search() async {
-        guard !isSearching else { return }
-        isSearching = true
-        notice = nil
+        guard !self.isSearching else { return }
+        self.isSearching = true
+        self.notice = nil
         defer { self.isSearching = false }
         do {
             guard let route = await GatewayConnection.shared.captureRoute() else {
                 throw ClawHubSkillsBrowserError.gatewayUnavailable
             }
-            results = try await GatewayConnection.shared.skillsSearch(query: query, on: route)
-            hasSearched = true
+            self.results = try await GatewayConnection.shared.skillsSearch(query: self.query, on: route)
+            self.hasSearched = true
         } catch {
-            notice = Notice(
+            self.notice = Notice(
                 title: "ClawHub unavailable",
                 message: error.localizedDescription,
                 warning: nil,
-                isError: true
-            )
+                isError: true)
         }
     }
 
     func review(_ skill: ClawHubSkillSummary) async {
-        guard reviewingSlug == nil else { return }
-        reviewingSlug = skill.slug
-        notice = nil
+        guard self.reviewingSlug == nil else { return }
+        self.reviewingSlug = skill.slug
+        self.notice = nil
         defer { self.reviewingSlug = nil }
         do {
             guard let route = await GatewayConnection.shared.captureRoute() else {
@@ -296,51 +292,47 @@ private final class ClawHubSkillsBrowserModel {
             guard let review = ClawHubSkillInstallReview(detail: detail, fallback: skill) else {
                 throw ClawHubSkillsBrowserError.missingInstallVersion
             }
-            sheet = .install(review, route: route)
+            self.sheet = .install(review, route: route)
         } catch {
-            notice = Notice(
+            self.notice = Notice(
                 title: "Could not review skill",
                 message: error.localizedDescription,
                 warning: nil,
-                isError: true
-            )
+                isError: true)
         }
     }
 
     func install(
         _ review: ClawHubSkillInstallReview,
         route: GatewayConnection.Route,
-        acknowledgeRisk: Bool
-    ) async -> [SkillStatus]? {
-        guard installingSlug == nil else { return nil }
-        installingSlug = review.slug
-        notice = nil
+        acknowledgeRisk: Bool) async -> [SkillStatus]?
+    {
+        guard self.installingSlug == nil else { return nil }
+        self.installingSlug = review.slug
+        self.notice = nil
         defer { self.installingSlug = nil }
         do {
             let result = try await GatewayConnection.shared.skillsInstallClawHub(
                 slug: review.slug,
                 version: review.version,
                 acknowledgeRisk: acknowledgeRisk,
-                on: route
-            )
+                on: route)
             let report = try await GatewayConnection.shared.skillsStatus(on: route)
             guard SkillManagementContract.installed(report.skills, slug: review.slug, version: review.version) else {
-                sheet = nil
-                notice = Notice(
+                self.sheet = nil
+                self.notice = Notice(
                     title: "Install result unknown",
                     message: "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
                     warning: result.warning,
-                    isError: true
-                )
+                    isError: true)
                 return nil
             }
-            sheet = nil
-            notice = Notice(
+            self.sheet = nil
+            self.notice = Notice(
                 title: "Installed",
                 message: result.message,
                 warning: result.warning,
-                isError: false
-            )
+                isError: false)
             return report.skills
         } catch let error as GatewayResponseError {
             let rejection = SkillManagementContract.rejection(from: error, attemptedVersion: review.version)
@@ -349,38 +341,34 @@ private final class ClawHubSkillsBrowserModel {
                     review,
                     route: route,
                     message: rejection.message,
-                    warning: rejection.warning
-                )
+                    warning: rejection.warning)
             } else {
                 self.sheet = nil
                 self.notice = Notice(
                     title: "Gateway blocked install",
                     message: rejection.message,
                     warning: rejection.warning,
-                    isError: true
-                )
+                    isError: true)
             }
             return nil
         } catch {
             if let report = try? await GatewayConnection.shared.skillsStatus(on: route),
                SkillManagementContract.installed(report.skills, slug: review.slug, version: review.version)
             {
-                sheet = nil
-                notice = Notice(
+                self.sheet = nil
+                self.notice = Notice(
                     title: "Installed",
                     message: "The Gateway installed the reviewed version.",
                     warning: nil,
-                    isError: false
-                )
+                    isError: false)
                 return report.skills
             }
-            sheet = nil
-            notice = Notice(
+            self.sheet = nil
+            self.notice = Notice(
                 title: "Install result unknown",
                 message: error.localizedDescription,
                 warning: nil,
-                isError: true
-            )
+                isError: true)
             return nil
         }
     }

--- a/apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift
+++ b/apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift
@@ -322,7 +322,9 @@ private final class ClawHubSkillsBrowserModel {
                 self.sheet = nil
                 self.notice = Notice(
                     title: "Install result unknown",
+                    // swiftlint:disable line_length
                     message: "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+                    // swiftlint:enable line_length
                     warning: result.warning,
                     isError: true)
                 return nil

--- a/apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift
+++ b/apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift
@@ -1,0 +1,401 @@
+import Observation
+import OpenClawKit
+import SwiftUI
+
+private enum ClawHubReviewSheet: Identifiable {
+    case install(ClawHubSkillInstallReview, route: GatewayConnection.Route)
+    case risk(ClawHubSkillInstallReview, route: GatewayConnection.Route, message: String, warning: String?)
+
+    var id: String {
+        switch self {
+        case let .install(review, _): "install:\(review.id)"
+        case let .risk(review, _, _, _): "risk:\(review.id)"
+        }
+    }
+}
+
+struct ClawHubSkillsBrowser: View {
+    @State private var model = ClawHubSkillsBrowserModel()
+    let installedSkills: [SkillStatus]
+    let onInstalled: ([SkillStatus]) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            SettingsCardGroup("Browse ClawHub") {
+                SettingsCardRow(
+                    title: "Discover skills",
+                    subtitle: "The Gateway verifies the exact reviewed release before download.",
+                    showsDivider: false
+                ) {
+                    TextField("Search ClawHub", text: self.$model.query)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 260)
+                        .onSubmit { Task { await self.model.search() } }
+                    Button {
+                        Task { await self.model.search() }
+                    } label: {
+                        Label("Search", systemImage: "magnifyingglass")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(self.model.isSearching)
+                }
+            }
+
+            if let notice = self.model.notice {
+                ClawHubNoticeCard(notice: notice)
+            }
+
+            SettingsCardGroup("Results") {
+                if self.model.isSearching, self.model.results.isEmpty {
+                    SettingsCardRow(title: "Searching ClawHub…", showsDivider: false) {
+                        ProgressView().controlSize(.small)
+                    }
+                } else if self.model.results.isEmpty {
+                    SettingsCardRow(
+                        title: "No skills found",
+                        subtitle: "Try another search or refresh the catalog.",
+                        showsDivider: false
+                    ) {
+                        EmptyView()
+                    }
+                } else {
+                    LazyVStack(spacing: 0) {
+                        ForEach(Array(self.model.results.enumerated()), id: \.element.id) { index, skill in
+                            ClawHubSkillResultRow(
+                                skill: skill,
+                                installed: SkillManagementContract.installed(
+                                    self.installedSkills,
+                                    slug: skill.slug
+                                ),
+                                isBusy: self.model.reviewingSlug == skill.slug,
+                                showsDivider: index != self.model.results.count - 1
+                            ) {
+                                Task { await self.model.review(skill) }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .task { await self.model.searchIfNeeded() }
+        .sheet(item: $model.sheet) { sheet in
+            switch sheet {
+            case let .install(review, route):
+                ClawHubInstallReviewSheet(
+                    review: review,
+                    isInstalling: self.model.installingSlug == review.slug,
+                    onCancel: { self.model.sheet = nil },
+                    onInstall: {
+                        Task {
+                            if let skills = await self.model.install(review, route: route, acknowledgeRisk: false) {
+                                self.onInstalled(skills)
+                            }
+                        }
+                    }
+                )
+            case let .risk(review, route, message, warning):
+                ClawHubRiskReviewSheet(
+                    review: review,
+                    message: message,
+                    warning: warning,
+                    isInstalling: self.model.installingSlug == review.slug,
+                    onCancel: { self.model.sheet = nil },
+                    onInstall: {
+                        Task {
+                            if let skills = await self.model.install(review, route: route, acknowledgeRisk: true) {
+                                self.onInstalled(skills)
+                            }
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+
+private struct ClawHubSkillResultRow: View {
+    let skill: ClawHubSkillSummary
+    let installed: Bool
+    let isBusy: Bool
+    let showsDivider: Bool
+    let onReview: () -> Void
+
+    var body: some View {
+        SettingsCardRow(
+            title: skill.displayName,
+            subtitle: skill.summary ?? skill.slug,
+            showsDivider: showsDivider
+        ) {
+            if let version = self.skill.version {
+                Text(version)
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            Button(self.installed ? "Installed" : "Review", action: self.onReview)
+                .buttonStyle(.bordered)
+                .disabled(self.isBusy || self.installed)
+        }
+    }
+}
+
+private struct ClawHubInstallReviewSheet: View {
+    let review: ClawHubSkillInstallReview
+    let isInstalling: Bool
+    let onCancel: () -> Void
+    let onInstall: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text("Review ClawHub skill").font(.title2.bold())
+            ClawHubReviewDetails(review: self.review)
+            Text("The Gateway will verify this exact release with ClawHub before download.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            HStack {
+                Spacer()
+                Button("Cancel", action: self.onCancel)
+                Button("Verify and install", action: self.onInstall)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(self.isInstalling)
+            }
+        }
+        .padding(24)
+        .frame(width: 480)
+    }
+}
+
+private struct ClawHubRiskReviewSheet: View {
+    let review: ClawHubSkillInstallReview
+    let message: String
+    let warning: String?
+    let isInstalling: Bool
+    let onCancel: () -> Void
+    let onInstall: () -> Void
+    @State private var warningExpanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Label("Gateway warning", systemImage: "exclamationmark.triangle.fill")
+                .font(.title2.bold())
+                .foregroundStyle(.orange)
+            ClawHubReviewDetails(review: self.review)
+            Text(self.message).font(.body)
+            DisclosureGroup("Review warning details", isExpanded: self.$warningExpanded) {
+                Text(self.warning ?? "The Gateway requires explicit acknowledgement for this release.")
+                    .font(.callout)
+                    .textSelection(.enabled)
+                    .padding(.top, 8)
+            }
+            Text("Expand and review the Gateway warning before acknowledging this exact version.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            HStack {
+                Spacer()
+                Button("Cancel", action: self.onCancel)
+                Button("Acknowledge and install", action: self.onInstall)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!self.warningExpanded || self.isInstalling)
+            }
+        }
+        .padding(24)
+        .frame(width: 520)
+    }
+}
+
+private struct ClawHubReviewDetails: View {
+    let review: ClawHubSkillInstallReview
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(self.review.displayName).font(.headline)
+            if let summary = self.review.summary {
+                Text(summary).foregroundStyle(.secondary)
+            }
+            LabeledContent("Version", value: self.review.version)
+            LabeledContent("Publisher", value: self.review.author)
+        }
+    }
+}
+
+private struct ClawHubNoticeCard: View {
+    let notice: ClawHubSkillsBrowserModel.Notice
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: self.notice.isError ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                .foregroundStyle(self.notice.isError ? .orange : .green)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(self.notice.title).font(.headline)
+                Text(self.notice.message).font(.footnote).textSelection(.enabled)
+                if let warning = self.notice.warning {
+                    Text(warning).font(.footnote).foregroundStyle(.secondary).textSelection(.enabled)
+                }
+            }
+            Spacer()
+        }
+        .padding(14)
+        .background(.quaternary.opacity(0.45), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+}
+
+@MainActor
+@Observable
+private final class ClawHubSkillsBrowserModel {
+    struct Notice {
+        let title: String
+        let message: String
+        let warning: String?
+        let isError: Bool
+    }
+
+    var query = ""
+    var results: [ClawHubSkillSummary] = []
+    var isSearching = false
+    var reviewingSlug: String?
+    var installingSlug: String?
+    var sheet: ClawHubReviewSheet?
+    var notice: Notice?
+    private var hasSearched = false
+
+    func searchIfNeeded() async {
+        guard !hasSearched else { return }
+        await search()
+    }
+
+    func search() async {
+        guard !isSearching else { return }
+        isSearching = true
+        notice = nil
+        defer { self.isSearching = false }
+        do {
+            guard let route = await GatewayConnection.shared.captureRoute() else {
+                throw ClawHubSkillsBrowserError.gatewayUnavailable
+            }
+            results = try await GatewayConnection.shared.skillsSearch(query: query, on: route)
+            hasSearched = true
+        } catch {
+            notice = Notice(
+                title: "ClawHub unavailable",
+                message: error.localizedDescription,
+                warning: nil,
+                isError: true
+            )
+        }
+    }
+
+    func review(_ skill: ClawHubSkillSummary) async {
+        guard reviewingSlug == nil else { return }
+        reviewingSlug = skill.slug
+        notice = nil
+        defer { self.reviewingSlug = nil }
+        do {
+            guard let route = await GatewayConnection.shared.captureRoute() else {
+                throw ClawHubSkillsBrowserError.gatewayUnavailable
+            }
+            let detail = try await GatewayConnection.shared.skillsDetail(slug: skill.slug, on: route)
+            guard let review = ClawHubSkillInstallReview(detail: detail, fallback: skill) else {
+                throw ClawHubSkillsBrowserError.missingInstallVersion
+            }
+            sheet = .install(review, route: route)
+        } catch {
+            notice = Notice(
+                title: "Could not review skill",
+                message: error.localizedDescription,
+                warning: nil,
+                isError: true
+            )
+        }
+    }
+
+    func install(
+        _ review: ClawHubSkillInstallReview,
+        route: GatewayConnection.Route,
+        acknowledgeRisk: Bool
+    ) async -> [SkillStatus]? {
+        guard installingSlug == nil else { return nil }
+        installingSlug = review.slug
+        notice = nil
+        defer { self.installingSlug = nil }
+        do {
+            let result = try await GatewayConnection.shared.skillsInstallClawHub(
+                slug: review.slug,
+                version: review.version,
+                acknowledgeRisk: acknowledgeRisk,
+                on: route
+            )
+            let report = try await GatewayConnection.shared.skillsStatus(on: route)
+            guard SkillManagementContract.installed(report.skills, slug: review.slug, version: review.version) else {
+                sheet = nil
+                notice = Notice(
+                    title: "Install result unknown",
+                    message: "Reconnect, refresh Skills, then retry. The Gateway safely joins a matching install still running.",
+                    warning: result.warning,
+                    isError: true
+                )
+                return nil
+            }
+            sheet = nil
+            notice = Notice(
+                title: "Installed",
+                message: result.message,
+                warning: result.warning,
+                isError: false
+            )
+            return report.skills
+        } catch let error as GatewayResponseError {
+            let rejection = SkillManagementContract.rejection(from: error, attemptedVersion: review.version)
+            if rejection.requiresAcknowledgement, !acknowledgeRisk {
+                self.sheet = .risk(
+                    review,
+                    route: route,
+                    message: rejection.message,
+                    warning: rejection.warning
+                )
+            } else {
+                self.sheet = nil
+                self.notice = Notice(
+                    title: "Gateway blocked install",
+                    message: rejection.message,
+                    warning: rejection.warning,
+                    isError: true
+                )
+            }
+            return nil
+        } catch {
+            if let report = try? await GatewayConnection.shared.skillsStatus(on: route),
+               SkillManagementContract.installed(report.skills, slug: review.slug, version: review.version)
+            {
+                sheet = nil
+                notice = Notice(
+                    title: "Installed",
+                    message: "The Gateway installed the reviewed version.",
+                    warning: nil,
+                    isError: false
+                )
+                return report.skills
+            }
+            sheet = nil
+            notice = Notice(
+                title: "Install result unknown",
+                message: error.localizedDescription,
+                warning: nil,
+                isError: true
+            )
+            return nil
+        }
+    }
+}
+
+private enum ClawHubSkillsBrowserError: LocalizedError {
+    case gatewayUnavailable
+    case missingInstallVersion
+
+    var errorDescription: String? {
+        switch self {
+        case .gatewayUnavailable:
+            "Connect to a Gateway and try again."
+        case .missingInstallVersion:
+            "ClawHub did not report an installable version for this skill."
+        }
+    }
+}

--- a/apps/macos/Sources/OpenClaw/GatewayConnection+ClawHubSkills.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection+ClawHubSkills.swift
@@ -1,0 +1,51 @@
+import Foundation
+import OpenClawKit
+import OpenClawProtocol
+
+extension GatewayConnection {
+    func skillsStatus(on route: Route) async throws -> SkillsStatusReport {
+        try await self.requestDecoded(method: .skillsStatus, ifCurrentRoute: route)
+    }
+
+    func skillsSearch(query: String, limit: Int = 25, on route: Route) async throws -> [ClawHubSkillSummary] {
+        var params: [String: AnyCodable] = ["limit": AnyCodable(limit)]
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            params["query"] = AnyCodable(trimmed)
+        }
+        let result: ClawHubSkillSearchResult = try await self.requestDecoded(
+            method: .skillsSearch,
+            params: params,
+            ifCurrentRoute: route)
+        return result.results
+    }
+
+    func skillsDetail(slug: String, on route: Route) async throws -> ClawHubSkillDetail {
+        try await self.requestDecoded(
+            method: .skillsDetail,
+            params: ["slug": AnyCodable(slug)],
+            ifCurrentRoute: route)
+    }
+
+    func skillsInstallClawHub(
+        slug: String,
+        version: String,
+        acknowledgeRisk: Bool = false,
+        on route: Route) async throws -> SkillInstallResult
+    {
+        var params: [String: AnyCodable] = [
+            "source": AnyCodable("clawhub"),
+            "slug": AnyCodable(slug),
+            "version": AnyCodable(version),
+            "timeoutMs": AnyCodable(clawHubInstallTimeoutMilliseconds),
+        ]
+        if acknowledgeRisk {
+            params["acknowledgeClawHubRisk"] = AnyCodable(true)
+        }
+        return try await self.requestDecoded(
+            method: .skillsInstall,
+            params: params,
+            timeoutMs: Double(clawHubInstallTimeoutMilliseconds + 5000),
+            ifCurrentRoute: route)
+    }
+}

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -1396,52 +1396,6 @@ extension GatewayConnection {
         try await self.requestDecoded(method: .skillsStatus)
     }
 
-    func skillsStatus(on route: Route) async throws -> SkillsStatusReport {
-        try await self.requestDecoded(method: .skillsStatus, ifCurrentRoute: route)
-    }
-
-    func skillsSearch(query: String, limit: Int = 25, on route: Route) async throws -> [ClawHubSkillSummary] {
-        var params: [String: AnyCodable] = ["limit": AnyCodable(limit)]
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmed.isEmpty {
-            params["query"] = AnyCodable(trimmed)
-        }
-        let result: ClawHubSkillSearchResult = try await self.requestDecoded(
-            method: .skillsSearch,
-            params: params,
-            ifCurrentRoute: route)
-        return result.results
-    }
-
-    func skillsDetail(slug: String, on route: Route) async throws -> ClawHubSkillDetail {
-        try await self.requestDecoded(
-            method: .skillsDetail,
-            params: ["slug": AnyCodable(slug)],
-            ifCurrentRoute: route)
-    }
-
-    func skillsInstallClawHub(
-        slug: String,
-        version: String,
-        acknowledgeRisk: Bool = false,
-        on route: Route) async throws -> SkillInstallResult
-    {
-        var params: [String: AnyCodable] = [
-            "source": AnyCodable("clawhub"),
-            "slug": AnyCodable(slug),
-            "version": AnyCodable(version),
-            "timeoutMs": AnyCodable(clawHubInstallTimeoutMilliseconds),
-        ]
-        if acknowledgeRisk {
-            params["acknowledgeClawHubRisk"] = AnyCodable(true)
-        }
-        return try await self.requestDecoded(
-            method: .skillsInstall,
-            params: params,
-            timeoutMs: Double(clawHubInstallTimeoutMilliseconds + 5000),
-            ifCurrentRoute: route)
-    }
-
     func skillsInstall(
         name: String,
         installId: String,

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -155,6 +155,8 @@ actor GatewayConnection {
         case sessionsPreview = "sessions.preview"
         case chatSend = "chat.send"
         case skillsStatus = "skills.status"
+        case skillsSearch = "skills.search"
+        case skillsDetail = "skills.detail"
         case skillsInstall = "skills.install"
         case skillsUpdate = "skills.update"
         case voicewakeGet = "voicewake.get"
@@ -535,6 +537,25 @@ extension GatewayConnection {
         timeoutMs: Double? = nil) async throws -> T
     {
         let data = try await requestRaw(method: method, params: params, timeoutMs: timeoutMs)
+        do {
+            return try self.decoder.decode(T.self, from: data)
+        } catch {
+            throw GatewayDecodingError(method: method.rawValue, message: error.localizedDescription)
+        }
+    }
+
+    func requestDecoded<T: Decodable>(
+        method: Method,
+        params: [String: AnyCodable]? = nil,
+        timeoutMs: Double? = nil,
+        ifCurrentRoute route: Route) async throws -> T
+    {
+        let data = try await self.request(
+            method: method.rawValue,
+            params: params,
+            timeoutMs: timeoutMs,
+            ifCurrentRoute: route,
+            distinguishPreDispatchRouteChange: true)
         do {
             return try self.decoder.decode(T.self, from: data)
         } catch {
@@ -1373,6 +1394,52 @@ extension GatewayConnection {
 
     func skillsStatus() async throws -> SkillsStatusReport {
         try await self.requestDecoded(method: .skillsStatus)
+    }
+
+    func skillsStatus(on route: Route) async throws -> SkillsStatusReport {
+        try await self.requestDecoded(method: .skillsStatus, ifCurrentRoute: route)
+    }
+
+    func skillsSearch(query: String, limit: Int = 25, on route: Route) async throws -> [ClawHubSkillSummary] {
+        var params: [String: AnyCodable] = ["limit": AnyCodable(limit)]
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            params["query"] = AnyCodable(trimmed)
+        }
+        let result: ClawHubSkillSearchResult = try await self.requestDecoded(
+            method: .skillsSearch,
+            params: params,
+            ifCurrentRoute: route)
+        return result.results
+    }
+
+    func skillsDetail(slug: String, on route: Route) async throws -> ClawHubSkillDetail {
+        try await self.requestDecoded(
+            method: .skillsDetail,
+            params: ["slug": AnyCodable(slug)],
+            ifCurrentRoute: route)
+    }
+
+    func skillsInstallClawHub(
+        slug: String,
+        version: String,
+        acknowledgeRisk: Bool = false,
+        on route: Route) async throws -> SkillInstallResult
+    {
+        var params: [String: AnyCodable] = [
+            "source": AnyCodable("clawhub"),
+            "slug": AnyCodable(slug),
+            "version": AnyCodable(version),
+            "timeoutMs": AnyCodable(clawHubInstallTimeoutMilliseconds),
+        ]
+        if acknowledgeRisk {
+            params["acknowledgeClawHubRisk"] = AnyCodable(true)
+        }
+        return try await self.requestDecoded(
+            method: .skillsInstall,
+            params: params,
+            timeoutMs: Double(clawHubInstallTimeoutMilliseconds + 5000),
+            ifCurrentRoute: route)
     }
 
     func skillsInstall(

--- a/apps/macos/Sources/OpenClaw/SkillsModels.swift
+++ b/apps/macos/Sources/OpenClaw/SkillsModels.swift
@@ -1,74 +1,10 @@
-import Foundation
-import OpenClawProtocol
+import OpenClawKit
 
-struct SkillsStatusReport: Codable {
-    let workspaceDir: String
-    let managedSkillsDir: String
-    let skills: [SkillStatus]
-}
-
-struct SkillStatus: Codable, Identifiable {
-    let name: String
-    let description: String
-    let source: String
-    let filePath: String
-    let baseDir: String
-    let skillKey: String
-    let primaryEnv: String?
-    let emoji: String?
-    let homepage: String?
-    let always: Bool
-    let disabled: Bool
-    let eligible: Bool
-    let requirements: SkillRequirements
-    let missing: SkillMissing
-    let configChecks: [SkillStatusConfigCheck]
-    let install: [SkillInstallOption]
-
-    var id: String {
-        self.name
-    }
-}
-
-struct SkillRequirements: Codable {
-    let bins: [String]
-    let env: [String]
-    let config: [String]
-}
-
-struct SkillMissing: Codable {
-    let bins: [String]
-    let env: [String]
-    let config: [String]
-}
-
-struct SkillStatusConfigCheck: Codable, Identifiable {
-    let path: String
-    let value: AnyCodable?
-    let satisfied: Bool
-
-    var id: String {
-        self.path
-    }
-}
-
-struct SkillInstallOption: Codable, Identifiable {
-    let id: String
-    let kind: String
-    let label: String
-    let bins: [String]
-}
-
-struct SkillInstallResult: Codable {
-    let ok: Bool
-    let message: String
-    let stdout: String?
-    let stderr: String?
-    let code: Int?
-}
-
-struct SkillUpdateResult: Codable {
-    let ok: Bool
-    let skillKey: String
-    let config: [String: AnyCodable]?
-}
+typealias SkillsStatusReport = OpenClawKit.SkillsStatusReport
+typealias SkillStatus = OpenClawKit.SkillStatus
+typealias SkillRequirements = OpenClawKit.SkillRequirements
+typealias SkillMissing = OpenClawKit.SkillMissing
+typealias SkillStatusConfigCheck = OpenClawKit.SkillStatusConfigCheck
+typealias SkillInstallOption = OpenClawKit.SkillInstallOption
+typealias SkillInstallResult = OpenClawKit.SkillInstallResult
+typealias SkillUpdateResult = OpenClawKit.SkillUpdateResult

--- a/apps/macos/Sources/OpenClaw/SkillsSettings.swift
+++ b/apps/macos/Sources/OpenClaw/SkillsSettings.swift
@@ -1,4 +1,5 @@
 import Observation
+import OpenClawKit
 import OpenClawProtocol
 import SwiftUI
 
@@ -6,6 +7,8 @@ struct SkillsSettings: View {
     @Bindable var state: AppState
     @State private var model = SkillsSettingsModel()
     @State private var envEditor: EnvEditorState?
+    @State private var section: SkillsSection = .installed
+    @State private var searchText = ""
     @State private var filter: SkillsFilter = .all
     @State private var didScheduleInitialRefresh = false
 
@@ -19,12 +22,19 @@ struct SkillsSettings: View {
             VStack(alignment: .leading, spacing: 20) {
                 SettingsPageHeader(
                     title: "Skills",
-                    subtitle: "Optional capabilities that become available when their requirements are met.")
+                    subtitle: "Manage installed capabilities or discover verified releases on ClawHub.")
 
-                self.skillsSummaryPanel
-                self.controlsCard
-                self.statusBanner
-                self.skillsList
+                self.sectionPicker
+                if self.section == .installed {
+                    self.skillsSummaryPanel
+                    self.controlsCard
+                    self.statusBanner
+                    self.skillsList
+                } else {
+                    ClawHubSkillsBrowser(installedSkills: self.model.skills) { skills in
+                        self.model.acceptInstalledSkills(skills)
+                    }
+                }
                 Spacer(minLength: 8)
             }
             .settingsDetailContent()
@@ -48,10 +58,20 @@ struct SkillsSettings: View {
         }
     }
 
+    private var sectionPicker: some View {
+        Picker("Skills section", selection: self.$section) {
+            ForEach(SkillsSection.allCases) { section in
+                Text(section.title).tag(section)
+            }
+        }
+        .labelsHidden()
+        .pickerStyle(.segmented)
+    }
+
     private var skillsSummaryPanel: some View {
         let total = self.model.skills.count
-        let ready = self.model.skills.count(where: { !$0.disabled && $0.eligible })
-        let needsSetup = self.model.skills.count(where: { !$0.disabled && !$0.eligible })
+        let ready = self.model.skills.count(where: SkillManagementContract.ready)
+        let needsSetup = self.model.skills.count(where: SkillManagementContract.needsSetup)
 
         return HStack(alignment: .center, spacing: 14) {
             ZStack {
@@ -107,6 +127,10 @@ struct SkillsSettings: View {
                 }
                 .buttonStyle(.bordered)
                 .help("Refresh")
+
+                TextField("Search installed skills", text: self.$searchText)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 220)
 
                 self.headerFilter
             }
@@ -191,17 +215,39 @@ struct SkillsSettings: View {
     }
 
     private var filteredSkills: [SkillStatus] {
-        self.model.skills.filter { skill in
-            switch self.filter {
+        let query = self.searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return self.model.skills.filter { skill in
+            let matchesQuery = query.isEmpty
+                || skill.name.localizedCaseInsensitiveContains(query)
+                || skill.skillKey.localizedCaseInsensitiveContains(query)
+                || skill.description.localizedCaseInsensitiveContains(query)
+            let matchesFilter = switch self.filter {
             case .all:
                 true
             case .ready:
-                !skill.disabled && skill.eligible
+                SkillManagementContract.ready(skill)
             case .needsSetup:
-                !skill.disabled && !skill.eligible
+                SkillManagementContract.needsSetup(skill)
             case .disabled:
                 skill.disabled
             }
+            return matchesQuery && matchesFilter
+        }
+    }
+}
+
+private enum SkillsSection: String, CaseIterable, Identifiable {
+    case installed
+    case browse
+
+    var id: String {
+        self.rawValue
+    }
+
+    var title: String {
+        switch self {
+        case .installed: "Installed"
+        case .browse: "Browse"
         }
     }
 }
@@ -333,14 +379,14 @@ private struct SkillRow: View {
         if self.skill.disabled {
             return "Disabled"
         }
-        return self.requirementsMet && self.skill.eligible ? "Ready" : "Needs setup"
+        return self.requirementsMet && SkillManagementContract.ready(self.skill) ? "Ready" : "Needs setup"
     }
 
     private var statusColor: Color {
         if self.skill.disabled {
             return .secondary
         }
-        return self.requirementsMet && self.skill.eligible ? .green : .orange
+        return self.requirementsMet && SkillManagementContract.ready(self.skill) ? .green : .orange
     }
 
     private var sourceLabel: String {
@@ -675,6 +721,12 @@ final class SkillsSettingsModel {
             self.error = error.localizedDescription
         }
         self.isLoading = false
+    }
+
+    func acceptInstalledSkills(_ skills: [SkillStatus]) {
+        self.skills = skills.sorted { $0.name < $1.name }
+        self.hasLoaded = true
+        self.error = nil
     }
 
     fileprivate func install(skill: SkillStatus, option: SkillInstallOption, target: InstallTarget) async {

--- a/apps/macos/Tests/OpenClawIPCTests/ClawHubSkillsBrowserSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ClawHubSkillsBrowserSmokeTests.swift
@@ -1,0 +1,10 @@
+@testable import OpenClaw
+import Testing
+
+@MainActor
+struct ClawHubSkillsBrowserSmokeTests {
+    @Test func `ClawHub browser builds guarded review flow`() {
+        let view = ClawHubSkillsBrowser(installedSkills: [], onInstalled: { _ in })
+        _ = view.body
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/ClawHubSkillsBrowserSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ClawHubSkillsBrowserSmokeTests.swift
@@ -1,5 +1,5 @@
-@testable import OpenClaw
 import Testing
+@testable import OpenClaw
 
 @MainActor
 struct ClawHubSkillsBrowserSmokeTests {

--- a/apps/shared/OpenClawKit/Package.swift
+++ b/apps/shared/OpenClawKit/Package.swift
@@ -59,7 +59,7 @@ let package = Package(
             ]),
         .testTarget(
             name: "OpenClawKitTests",
-            dependencies: ["OpenClawKit", "OpenClawChatUI"],
+            dependencies: ["OpenClawKit", "OpenClawChatUI", "OpenClawProtocol"],
             path: "Tests/OpenClawKitTests",
             swiftSettings: [
                 .enableUpcomingFeature("StrictConcurrency"),

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/SkillManagement.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/SkillManagement.swift
@@ -40,7 +40,7 @@ public struct SkillStatus: Codable, Identifiable, Sendable {
     public let clawhub: ClawHubInstalledSkillLink?
 
     public var id: String {
-        skillKey
+        self.skillKey
     }
 
     public init(
@@ -64,8 +64,8 @@ public struct SkillStatus: Codable, Identifiable, Sendable {
         missing: SkillMissing,
         configChecks: [SkillStatusConfigCheck],
         install: [SkillInstallOption],
-        clawhub: ClawHubInstalledSkillLink? = nil
-    ) {
+        clawhub: ClawHubInstalledSkillLink? = nil)
+    {
         self.name = name
         self.description = description
         self.source = source
@@ -120,7 +120,7 @@ public struct SkillStatusConfigCheck: Codable, Identifiable, Sendable {
     public let satisfied: Bool
 
     public var id: String {
-        path
+        self.path
     }
 
     public init(path: String, value: OpenClawProtocol.AnyCodable?, satisfied: Bool) {
@@ -162,8 +162,8 @@ public struct SkillInstallResult: Codable, Sendable {
         code: Int? = nil,
         slug: String? = nil,
         version: String? = nil,
-        warning: String? = nil
-    ) {
+        warning: String? = nil)
+    {
         self.ok = ok
         self.message = message
         self.stdout = stdout
@@ -197,7 +197,7 @@ public struct ClawHubSkillSummary: Codable, Identifiable, Hashable, Sendable {
     public let version: String?
 
     public var id: String {
-        slug
+        self.slug
     }
 
     public init(slug: String, displayName: String, summary: String?, version: String?) {
@@ -241,7 +241,7 @@ public struct ClawHubSkillInstallReview: Identifiable, Hashable, Sendable {
     public let author: String
 
     public var id: String {
-        "\(slug)@\(version)"
+        "\(self.slug)@\(self.version)"
     }
 
     public init(slug: String, displayName: String, summary: String?, version: String, author: String) {
@@ -258,23 +258,22 @@ public struct ClawHubSkillInstallReview: Identifiable, Hashable, Sendable {
         let handle = detail.owner?.handle?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
         guard let reviewedSlug = SkillManagementContract.canonicalClawHubReference(
             slug: detailSlug ?? fallback.slug,
-            ownerHandle: handle
-        )
+            ownerHandle: handle)
         else { return nil }
-        slug = reviewedSlug
+        self.slug = reviewedSlug
         self.displayName = detail.skill?.displayName ?? fallback.displayName
-        summary = detail.skill?.summary ?? fallback.summary
+        self.summary = detail.skill?.summary ?? fallback.summary
         self.version = version
         let displayName = detail.owner?.displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
         switch (displayName?.nilIfEmpty, handle?.nilIfEmpty) {
         case let (.some(name), .some(handle)) where name.caseInsensitiveCompare(handle) != .orderedSame:
-            author = "\(name) (@\(handle))"
+            self.author = "\(name) (@\(handle))"
         case let (.some(name), _):
-            author = name
+            self.author = name
         case let (_, .some(handle)):
-            author = "@\(handle)"
+            self.author = "@\(handle)"
         default:
-            author = "Unknown publisher"
+            self.author = "Unknown publisher"
         }
     }
 }
@@ -312,17 +311,17 @@ public enum SkillManagementContract {
     }
 
     public static func needsSetup(_ skill: SkillStatus) -> Bool {
-        !skill.disabled && !ready(skill)
+        !skill.disabled && !self.ready(skill)
     }
 
     public static func rejection(
         from error: GatewayResponseError,
-        attemptedVersion: String?
-    ) -> ClawHubSkillInstallRejection {
+        attemptedVersion: String?) -> ClawHubSkillInstallRejection
+    {
         let reviewedVersion = attemptedVersion?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
-        let gatewayVersion = string(error.details["version"]?.value)
-        let warning = string(error.details["warning"]?.value)
-        let acknowledgementRequested = string(error.details["clawhubTrustCode"]?.value)
+        let gatewayVersion = self.string(error.details["version"]?.value)
+        let warning = self.string(error.details["warning"]?.value)
+        let acknowledgementRequested = self.string(error.details["clawhubTrustCode"]?.value)
             == "clawhub_risk_acknowledgement_required"
         // Bind consent to the exact detail response version. A moving ClawHub release
         // must be reviewed again instead of inheriting acknowledgement for older bytes.
@@ -335,8 +334,7 @@ public enum SkillManagementContract {
             message: message,
             warning: warning,
             acknowledgeVersion: requiresAcknowledgement ? reviewedVersion : nil,
-            requiresAcknowledgement: requiresAcknowledgement
-        )
+            requiresAcknowledgement: requiresAcknowledgement)
     }
 
     private static func string(_ value: Any?) -> String? {
@@ -363,8 +361,8 @@ public enum SkillManagementContract {
 
     private static func matches(
         _ installed: ClawHubInstalledSkillLink?,
-        reference: (slug: String, ownerHandle: String?)
-    ) -> Bool {
+        reference: (slug: String, ownerHandle: String?)) -> Bool
+    {
         guard installed?.valid == true,
               let installedSlug = installed?.slug,
               let installedReference = clawHubReference(installedSlug),
@@ -376,8 +374,8 @@ public enum SkillManagementContract {
     }
 }
 
-private extension String {
-    var nilIfEmpty: String? {
+extension String {
+    fileprivate var nilIfEmpty: String? {
         isEmpty ? nil : self
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/SkillManagement.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/SkillManagement.swift
@@ -1,0 +1,383 @@
+import Foundation
+import OpenClawProtocol
+
+public let clawHubSkillGatewayMethods: Set<String> = ["skills.search", "skills.detail", "skills.install"]
+public let clawHubInstallTimeoutMilliseconds = 120_000
+
+public struct SkillsStatusReport: Codable, Sendable {
+    public let workspaceDir: String
+    public let managedSkillsDir: String
+    public let skills: [SkillStatus]
+
+    public init(workspaceDir: String, managedSkillsDir: String, skills: [SkillStatus]) {
+        self.workspaceDir = workspaceDir
+        self.managedSkillsDir = managedSkillsDir
+        self.skills = skills
+    }
+}
+
+public struct SkillStatus: Codable, Identifiable, Sendable {
+    public let name: String
+    public let description: String
+    public let source: String
+    public let bundled: Bool?
+    public let filePath: String
+    public let baseDir: String
+    public let skillKey: String
+    public let primaryEnv: String?
+    public let emoji: String?
+    public let homepage: String?
+    public let always: Bool
+    public let disabled: Bool
+    public let blockedByAllowlist: Bool?
+    public let blockedByAgentFilter: Bool?
+    public let platformIncompatible: Bool?
+    public let eligible: Bool
+    public let requirements: SkillRequirements
+    public let missing: SkillMissing
+    public let configChecks: [SkillStatusConfigCheck]
+    public let install: [SkillInstallOption]
+    public let clawhub: ClawHubInstalledSkillLink?
+
+    public var id: String {
+        skillKey
+    }
+
+    public init(
+        name: String,
+        description: String,
+        source: String,
+        bundled: Bool? = nil,
+        filePath: String,
+        baseDir: String,
+        skillKey: String,
+        primaryEnv: String?,
+        emoji: String?,
+        homepage: String?,
+        always: Bool,
+        disabled: Bool,
+        blockedByAllowlist: Bool? = nil,
+        blockedByAgentFilter: Bool? = nil,
+        platformIncompatible: Bool? = nil,
+        eligible: Bool,
+        requirements: SkillRequirements,
+        missing: SkillMissing,
+        configChecks: [SkillStatusConfigCheck],
+        install: [SkillInstallOption],
+        clawhub: ClawHubInstalledSkillLink? = nil
+    ) {
+        self.name = name
+        self.description = description
+        self.source = source
+        self.bundled = bundled
+        self.filePath = filePath
+        self.baseDir = baseDir
+        self.skillKey = skillKey
+        self.primaryEnv = primaryEnv
+        self.emoji = emoji
+        self.homepage = homepage
+        self.always = always
+        self.disabled = disabled
+        self.blockedByAllowlist = blockedByAllowlist
+        self.blockedByAgentFilter = blockedByAgentFilter
+        self.platformIncompatible = platformIncompatible
+        self.eligible = eligible
+        self.requirements = requirements
+        self.missing = missing
+        self.configChecks = configChecks
+        self.install = install
+        self.clawhub = clawhub
+    }
+}
+
+public struct SkillRequirements: Codable, Sendable {
+    public let bins: [String]
+    public let env: [String]
+    public let config: [String]
+
+    public init(bins: [String], env: [String], config: [String]) {
+        self.bins = bins
+        self.env = env
+        self.config = config
+    }
+}
+
+public struct SkillMissing: Codable, Sendable {
+    public let bins: [String]
+    public let env: [String]
+    public let config: [String]
+
+    public init(bins: [String], env: [String], config: [String]) {
+        self.bins = bins
+        self.env = env
+        self.config = config
+    }
+}
+
+public struct SkillStatusConfigCheck: Codable, Identifiable, Sendable {
+    public let path: String
+    public let value: OpenClawProtocol.AnyCodable?
+    public let satisfied: Bool
+
+    public var id: String {
+        path
+    }
+
+    public init(path: String, value: OpenClawProtocol.AnyCodable?, satisfied: Bool) {
+        self.path = path
+        self.value = value
+        self.satisfied = satisfied
+    }
+}
+
+public struct SkillInstallOption: Codable, Identifiable, Sendable {
+    public let id: String
+    public let kind: String
+    public let label: String
+    public let bins: [String]
+
+    public init(id: String, kind: String, label: String, bins: [String]) {
+        self.id = id
+        self.kind = kind
+        self.label = label
+        self.bins = bins
+    }
+}
+
+public struct SkillInstallResult: Codable, Sendable {
+    public let ok: Bool
+    public let message: String
+    public let stdout: String?
+    public let stderr: String?
+    public let code: Int?
+    public let slug: String?
+    public let version: String?
+    public let warning: String?
+
+    public init(
+        ok: Bool,
+        message: String,
+        stdout: String? = nil,
+        stderr: String? = nil,
+        code: Int? = nil,
+        slug: String? = nil,
+        version: String? = nil,
+        warning: String? = nil
+    ) {
+        self.ok = ok
+        self.message = message
+        self.stdout = stdout
+        self.stderr = stderr
+        self.code = code
+        self.slug = slug
+        self.version = version
+        self.warning = warning
+    }
+}
+
+public struct SkillUpdateResult: Codable, Sendable {
+    public let ok: Bool
+    public let skillKey: String
+    public let config: [String: OpenClawProtocol.AnyCodable]?
+}
+
+public struct ClawHubInstalledSkillLink: Codable, Sendable {
+    public let status: String
+    public let valid: Bool
+    public let slug: String?
+    public let ownerHandle: String?
+    public let installedVersion: String?
+    public let reason: String?
+}
+
+public struct ClawHubSkillSummary: Codable, Identifiable, Hashable, Sendable {
+    public let slug: String
+    public let displayName: String
+    public let summary: String?
+    public let version: String?
+
+    public var id: String {
+        slug
+    }
+
+    public init(slug: String, displayName: String, summary: String?, version: String?) {
+        self.slug = slug
+        self.displayName = displayName
+        self.summary = summary
+        self.version = version
+    }
+}
+
+public struct ClawHubSkillSearchResult: Codable, Sendable {
+    public let results: [ClawHubSkillSummary]
+}
+
+public struct ClawHubSkillDetail: Codable, Sendable {
+    public struct Skill: Codable, Sendable {
+        public let slug: String?
+        public let displayName: String
+        public let summary: String?
+    }
+
+    public struct Version: Codable, Sendable {
+        public let version: String
+    }
+
+    public struct Owner: Codable, Sendable {
+        public let handle: String?
+        public let displayName: String?
+    }
+
+    public let skill: Skill?
+    public let latestVersion: Version?
+    public let owner: Owner?
+}
+
+public struct ClawHubSkillInstallReview: Identifiable, Hashable, Sendable {
+    public let slug: String
+    public let displayName: String
+    public let summary: String?
+    public let version: String
+    public let author: String
+
+    public var id: String {
+        "\(slug)@\(version)"
+    }
+
+    public init(slug: String, displayName: String, summary: String?, version: String, author: String) {
+        self.slug = slug
+        self.displayName = displayName
+        self.summary = summary
+        self.version = version
+        self.author = author
+    }
+
+    public init?(detail: ClawHubSkillDetail, fallback: ClawHubSkillSummary) {
+        guard let version = detail.latestVersion?.version ?? fallback.version else { return nil }
+        let detailSlug = detail.skill?.slug?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        let handle = detail.owner?.handle?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        guard let reviewedSlug = SkillManagementContract.canonicalClawHubReference(
+            slug: detailSlug ?? fallback.slug,
+            ownerHandle: handle
+        )
+        else { return nil }
+        slug = reviewedSlug
+        self.displayName = detail.skill?.displayName ?? fallback.displayName
+        summary = detail.skill?.summary ?? fallback.summary
+        self.version = version
+        let displayName = detail.owner?.displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch (displayName?.nilIfEmpty, handle?.nilIfEmpty) {
+        case let (.some(name), .some(handle)) where name.caseInsensitiveCompare(handle) != .orderedSame:
+            author = "\(name) (@\(handle))"
+        case let (.some(name), _):
+            author = name
+        case let (_, .some(handle)):
+            author = "@\(handle)"
+        default:
+            author = "Unknown publisher"
+        }
+    }
+}
+
+public struct ClawHubSkillInstallRejection: Equatable, Sendable {
+    public let message: String
+    public let warning: String?
+    public let acknowledgeVersion: String?
+    public let requiresAcknowledgement: Bool
+}
+
+public enum SkillManagementContract {
+    public static func supportsClawHub(methods: Set<String>) -> Bool {
+        methods.isSuperset(of: clawHubSkillGatewayMethods)
+    }
+
+    public static func installed(_ skills: [SkillStatus], slug: String, version: String) -> Bool {
+        guard let reference = clawHubReference(slug) else { return false }
+        return skills.contains {
+            self.matches($0.clawhub, reference: reference) && $0.clawhub?.installedVersion == version
+        }
+    }
+
+    public static func installed(_ skills: [SkillStatus], slug: String) -> Bool {
+        guard let reference = clawHubReference(slug) else { return false }
+        return skills.contains { self.matches($0.clawhub, reference: reference) }
+    }
+
+    public static func ready(_ skill: SkillStatus) -> Bool {
+        !skill.disabled
+            && skill.eligible
+            && skill.blockedByAllowlist != true
+            && skill.blockedByAgentFilter != true
+            && skill.platformIncompatible != true
+    }
+
+    public static func needsSetup(_ skill: SkillStatus) -> Bool {
+        !skill.disabled && !ready(skill)
+    }
+
+    public static func rejection(
+        from error: GatewayResponseError,
+        attemptedVersion: String?
+    ) -> ClawHubSkillInstallRejection {
+        let reviewedVersion = attemptedVersion?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        let gatewayVersion = string(error.details["version"]?.value)
+        let warning = string(error.details["warning"]?.value)
+        let acknowledgementRequested = string(error.details["clawhubTrustCode"]?.value)
+            == "clawhub_risk_acknowledgement_required"
+        // Bind consent to the exact detail response version. A moving ClawHub release
+        // must be reviewed again instead of inheriting acknowledgement for older bytes.
+        let requiresAcknowledgement = acknowledgementRequested && reviewedVersion != nil
+            && gatewayVersion == reviewedVersion
+        let message = acknowledgementRequested && !requiresAcknowledgement
+            ? "The Gateway evaluated a different ClawHub release. Review the skill again before installing."
+            : error.message
+        return ClawHubSkillInstallRejection(
+            message: message,
+            warning: warning,
+            acknowledgeVersion: requiresAcknowledgement ? reviewedVersion : nil,
+            requiresAcknowledgement: requiresAcknowledgement
+        )
+    }
+
+    private static func string(_ value: Any?) -> String? {
+        (value as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+
+    fileprivate static func clawHubReference(_ rawValue: String) -> (slug: String, ownerHandle: String?)? {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return nil }
+        guard value.hasPrefix("@") else { return (value, nil) }
+        let parts = value.dropFirst().split(separator: "/", omittingEmptySubsequences: false)
+        guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else { return nil }
+        return (String(parts[1]), String(parts[0]).lowercased())
+    }
+
+    fileprivate static func canonicalClawHubReference(slug: String, ownerHandle: String?) -> String? {
+        guard let reference = clawHubReference(slug) else { return nil }
+        let owner = ownerHandle?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty?
+            .lowercased() ?? reference.ownerHandle
+        return owner.map { "@\($0)/\(reference.slug)" } ?? reference.slug
+    }
+
+    private static func matches(
+        _ installed: ClawHubInstalledSkillLink?,
+        reference: (slug: String, ownerHandle: String?)
+    ) -> Bool {
+        guard installed?.valid == true,
+              let installedSlug = installed?.slug,
+              let installedReference = clawHubReference(installedSlug),
+              installedReference.slug.caseInsensitiveCompare(reference.slug) == .orderedSame
+        else { return false }
+        guard let ownerHandle = reference.ownerHandle else { return true }
+        let installedOwner = installedReference.ownerHandle ?? installed?.ownerHandle
+        return installedOwner?.caseInsensitiveCompare(ownerHandle) == .orderedSame
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/SkillManagement.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/SkillManagement.swift
@@ -153,26 +153,6 @@ public struct SkillInstallResult: Codable, Sendable {
     public let slug: String?
     public let version: String?
     public let warning: String?
-
-    public init(
-        ok: Bool,
-        message: String,
-        stdout: String? = nil,
-        stderr: String? = nil,
-        code: Int? = nil,
-        slug: String? = nil,
-        version: String? = nil,
-        warning: String? = nil)
-    {
-        self.ok = ok
-        self.message = message
-        self.stdout = stdout
-        self.stderr = stderr
-        self.code = code
-        self.slug = slug
-        self.version = version
-        self.warning = warning
-    }
 }
 
 public struct SkillUpdateResult: Codable, Sendable {
@@ -198,13 +178,6 @@ public struct ClawHubSkillSummary: Codable, Identifiable, Hashable, Sendable {
 
     public var id: String {
         self.slug
-    }
-
-    public init(slug: String, displayName: String, summary: String?, version: String?) {
-        self.slug = slug
-        self.displayName = displayName
-        self.summary = summary
-        self.version = version
     }
 }
 
@@ -244,14 +217,6 @@ public struct ClawHubSkillInstallReview: Identifiable, Hashable, Sendable {
         "\(self.slug)@\(self.version)"
     }
 
-    public init(slug: String, displayName: String, summary: String?, version: String, author: String) {
-        self.slug = slug
-        self.displayName = displayName
-        self.summary = summary
-        self.version = version
-        self.author = author
-    }
-
     public init?(detail: ClawHubSkillDetail, fallback: ClawHubSkillSummary) {
         guard let version = detail.latestVersion?.version ?? fallback.version else { return nil }
         let detailSlug = detail.skill?.slug?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
@@ -286,10 +251,6 @@ public struct ClawHubSkillInstallRejection: Equatable, Sendable {
 }
 
 public enum SkillManagementContract {
-    public static func supportsClawHub(methods: Set<String>) -> Bool {
-        methods.isSuperset(of: clawHubSkillGatewayMethods)
-    }
-
     public static func installed(_ skills: [SkillStatus], slug: String, version: String) -> Bool {
         guard let reference = clawHubReference(slug) else { return false }
         return skills.contains {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/SkillManagementTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/SkillManagementTests.swift
@@ -1,14 +1,13 @@
 import Foundation
 import OpenClawProtocol
-@testable import OpenClawKit
 import Testing
+@testable import OpenClawKit
 
 struct SkillManagementTests {
     @Test func `detail review uses exact detail version and publisher`() throws {
         let data = Data(
             #"{"skill":{"displayName":"Weather","summary":"Forecasts"},"latestVersion":{"version":"2.0.0"},"owner":{"handle":"molly","displayName":"Molly"}}"#
-                .utf8
-        )
+                .utf8)
         let detail = try JSONDecoder().decode(ClawHubSkillDetail.self, from: data)
         let review = try #require(ClawHubSkillInstallReview(
             detail: detail,
@@ -16,9 +15,7 @@ struct SkillManagementTests {
                 slug: "weather",
                 displayName: "Old Weather",
                 summary: nil,
-                version: "1.0.0"
-            )
-        ))
+                version: "1.0.0")))
 
         #expect(review.slug == "@molly/weather")
         #expect(review.displayName == "Weather")
@@ -35,8 +32,7 @@ struct SkillManagementTests {
                 "clawhubTrustCode": AnyCodable("clawhub_risk_acknowledgement_required"),
                 "version": AnyCodable("2.0.0"),
                 "warning": AnyCodable("Automated analysis found risky behavior."),
-            ]
-        )
+            ])
         let accepted = SkillManagementContract.rejection(from: matching, attemptedVersion: "2.0.0")
         #expect(accepted.requiresAcknowledgement)
         #expect(accepted.acknowledgeVersion == "2.0.0")
@@ -55,9 +51,7 @@ struct SkillManagementTests {
                 slug: "@molly/weather",
                 ownerHandle: "molly",
                 installedVersion: "2.0.0",
-                reason: nil
-            )
-        )
+                reason: nil))
         #expect(SkillManagementContract.installed([linked], slug: "weather", version: "2.0.0"))
         #expect(!SkillManagementContract.installed([linked], slug: "weather", version: "2.0.1"))
         #expect(SkillManagementContract.installed([linked], slug: "weather"))
@@ -71,9 +65,7 @@ struct SkillManagementTests {
                 slug: "weather",
                 ownerHandle: "molly",
                 installedVersion: "2.0.0",
-                reason: nil
-            )
-        )
+                reason: nil))
         #expect(SkillManagementContract.installed([linked], slug: "@molly/weather", version: "2.0.0"))
         #expect(!SkillManagementContract.installed([linked], slug: "@other/weather", version: "2.0.0"))
     }
@@ -93,8 +85,8 @@ struct SkillManagementTests {
     private static func skill(
         clawhub: ClawHubInstalledSkillLink?,
         blockedByAgentFilter: Bool? = nil,
-        platformIncompatible: Bool? = nil
-    ) -> SkillStatus {
+        platformIncompatible: Bool? = nil) -> SkillStatus
+    {
         SkillStatus(
             name: "Weather",
             description: "Forecasts",
@@ -114,7 +106,6 @@ struct SkillManagementTests {
             missing: SkillMissing(bins: [], env: [], config: []),
             configChecks: [],
             install: [],
-            clawhub: clawhub
-        )
+            clawhub: clawhub)
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/SkillManagementTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/SkillManagementTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import OpenClawProtocol
+@testable import OpenClawKit
+import Testing
+
+struct SkillManagementTests {
+    @Test func `detail review uses exact detail version and publisher`() throws {
+        let data = Data(
+            #"{"skill":{"displayName":"Weather","summary":"Forecasts"},"latestVersion":{"version":"2.0.0"},"owner":{"handle":"molly","displayName":"Molly"}}"#
+                .utf8
+        )
+        let detail = try JSONDecoder().decode(ClawHubSkillDetail.self, from: data)
+        let review = try #require(ClawHubSkillInstallReview(
+            detail: detail,
+            fallback: ClawHubSkillSummary(
+                slug: "weather",
+                displayName: "Old Weather",
+                summary: nil,
+                version: "1.0.0"
+            )
+        ))
+
+        #expect(review.slug == "@molly/weather")
+        #expect(review.displayName == "Weather")
+        #expect(review.version == "2.0.0")
+        #expect(review.author == "Molly (@molly)")
+    }
+
+    @Test func `risk acknowledgement stays bound to reviewed version`() {
+        let matching = GatewayResponseError(
+            method: "skills.install",
+            code: "UNAVAILABLE",
+            message: "Review warning",
+            details: [
+                "clawhubTrustCode": AnyCodable("clawhub_risk_acknowledgement_required"),
+                "version": AnyCodable("2.0.0"),
+                "warning": AnyCodable("Automated analysis found risky behavior."),
+            ]
+        )
+        let accepted = SkillManagementContract.rejection(from: matching, attemptedVersion: "2.0.0")
+        #expect(accepted.requiresAcknowledgement)
+        #expect(accepted.acknowledgeVersion == "2.0.0")
+
+        let stale = SkillManagementContract.rejection(from: matching, attemptedVersion: "1.0.0")
+        #expect(!stale.requiresAcknowledgement)
+        #expect(stale.acknowledgeVersion == nil)
+        #expect(stale.message.contains("different ClawHub release"))
+    }
+
+    @Test func `installed readback requires valid provenance and exact version`() {
+        let linked = Self.skill(
+            clawhub: ClawHubInstalledSkillLink(
+                status: "linked",
+                valid: true,
+                slug: "@molly/weather",
+                ownerHandle: "molly",
+                installedVersion: "2.0.0",
+                reason: nil
+            )
+        )
+        #expect(SkillManagementContract.installed([linked], slug: "weather", version: "2.0.0"))
+        #expect(!SkillManagementContract.installed([linked], slug: "weather", version: "2.0.1"))
+        #expect(SkillManagementContract.installed([linked], slug: "weather"))
+    }
+
+    @Test func `owner qualified readback matches split provenance identity`() {
+        let linked = Self.skill(
+            clawhub: ClawHubInstalledSkillLink(
+                status: "linked",
+                valid: true,
+                slug: "weather",
+                ownerHandle: "molly",
+                installedVersion: "2.0.0",
+                reason: nil
+            )
+        )
+        #expect(SkillManagementContract.installed([linked], slug: "@molly/weather", version: "2.0.0"))
+        #expect(!SkillManagementContract.installed([linked], slug: "@other/weather", version: "2.0.0"))
+    }
+
+    @Test func `agent filtered skills need setup instead of reporting ready`() {
+        let blocked = Self.skill(clawhub: nil, blockedByAgentFilter: true)
+        #expect(!SkillManagementContract.ready(blocked))
+        #expect(SkillManagementContract.needsSetup(blocked))
+    }
+
+    @Test func `platform incompatible skills need setup instead of reporting ready`() {
+        let blocked = Self.skill(clawhub: nil, platformIncompatible: true)
+        #expect(!SkillManagementContract.ready(blocked))
+        #expect(SkillManagementContract.needsSetup(blocked))
+    }
+
+    private static func skill(
+        clawhub: ClawHubInstalledSkillLink?,
+        blockedByAgentFilter: Bool? = nil,
+        platformIncompatible: Bool? = nil
+    ) -> SkillStatus {
+        SkillStatus(
+            name: "Weather",
+            description: "Forecasts",
+            source: "openclaw-managed",
+            filePath: "/tmp/weather/SKILL.md",
+            baseDir: "/tmp/weather",
+            skillKey: "weather",
+            primaryEnv: nil,
+            emoji: "☀️",
+            homepage: nil,
+            always: false,
+            disabled: false,
+            blockedByAgentFilter: blockedByAgentFilter,
+            platformIncompatible: platformIncompatible,
+            eligible: true,
+            requirements: SkillRequirements(bins: [], env: [], config: []),
+            missing: SkillMissing(bins: [], env: [], config: []),
+            configChecks: [],
+            install: [],
+            clawhub: clawhub
+        )
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/SkillManagementTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/SkillManagementTests.swift
@@ -8,14 +8,13 @@ struct SkillManagementTests {
         let data = Data(
             #"{"skill":{"displayName":"Weather","summary":"Forecasts"},"latestVersion":{"version":"2.0.0"},"owner":{"handle":"molly","displayName":"Molly"}}"#
                 .utf8)
+        let fallbackData = Data(
+            #"{"slug":"weather","displayName":"Old Weather","summary":null,"version":"1.0.0"}"#.utf8)
         let detail = try JSONDecoder().decode(ClawHubSkillDetail.self, from: data)
+        let fallback = try JSONDecoder().decode(ClawHubSkillSummary.self, from: fallbackData)
         let review = try #require(ClawHubSkillInstallReview(
             detail: detail,
-            fallback: ClawHubSkillSummary(
-                slug: "weather",
-                displayName: "Old Weather",
-                summary: nil,
-                version: "1.0.0")))
+            fallback: fallback))
 
         #expect(review.slug == "@molly/weather")
         #expect(review.displayName == "Weather")


### PR DESCRIPTION
Closes #105741

## What Problem This Solves

iOS and macOS lacked Android's native Skills management experience. Users could not consistently inspect installed skill readiness, enable or disable skills, discover ClawHub releases, review publisher/version details, or acknowledge a Gateway risk warning from every native app.

## Why This Change Was Made

Adds a shared Apple skill-management contract and complete Installed/Browse surfaces on iOS and macOS, while tightening Android's installed-state detection. Exact reviewed ClawHub versions and publisher-qualified identities remain bound to one Gateway route; the Gateway continues to own trust evaluation, installation, and configuration.

No new Gateway protocol, config, fallback, or runtime state surface is introduced.

## User Impact

iOS, Android, and macOS now present the same core Skills workflow: installed search and readiness filters, enable/disable controls, ClawHub search and review, exact-version installation, installed-state readback, and explicit risk acknowledgement after warning details are expanded.

## Evidence

- Fresh autoreview: clean; no accepted/actionable findings.
- Local static proof: `git diff --check`; Swift parser validation for the new shared, iOS, and macOS sources.
- Android Testbox compile found and drove a missing-import fix; subsequent Blacksmith attempts were shut down during checkout before repository commands and will be replaced by exact-head CI proof.
- Native source inventory regenerated from current `main` (`4294` entries).
- Pending before merge: generated locale artifact refresh, Android unit/lint lanes, macOS Swift build/tests, and iOS simulator build.

Agent-assisted implementation; sanitized transcript omitted because no transcript attachment was requested.
