### PR TITLE
fix(nextcloud-talk): strip mixed-case Nextcloud Talk target prefixes

### DIFF
--- a/extensions/nextcloud-talk/src/core.test.ts
+++ b/extensions/nextcloud-talk/src/core.test.ts
@@ -81,10 +81,14 @@ describe("nextcloud talk core", () => {
     expect(stripNextcloudTalkTargetPrefix("nextcloud-talk:room:AbC123")).toBe("AbC123");
     expect(stripNextcloudTalkTargetPrefix("nc-talk:room:ops")).toBe("ops");
     expect(stripNextcloudTalkTargetPrefix("nc:room:ops")).toBe("ops");
+    expect(stripNextcloudTalkTargetPrefix("NC-TALK:ROOM:Ops")).toBe("Ops");
     expect(stripNextcloudTalkTargetPrefix("room:   ")).toBeUndefined();
 
     expect(normalizeNextcloudTalkMessagingTarget("room:AbC123")).toBe("nextcloud-talk:abc123");
     expect(normalizeNextcloudTalkMessagingTarget("nc-talk:room:Ops")).toBe("nextcloud-talk:ops");
+    expect(normalizeNextcloudTalkMessagingTarget("NEXTCLOUD-TALK:ROOM:Ops")).toBe(
+      "nextcloud-talk:ops",
+    );
 
     expect(looksLikeNextcloudTalkTargetId("nextcloud-talk:room:abc12345")).toBe(true);
     expect(looksLikeNextcloudTalkTargetId("nc:opsroom1")).toBe(true);

--- a/extensions/nextcloud-talk/src/normalize.ts
+++ b/extensions/nextcloud-talk/src/normalize.ts
@@ -7,15 +7,15 @@ export function stripNextcloudTalkTargetPrefix(raw: string): string | undefined 
 
   let normalized = trimmed;
 
-  if (normalized.startsWith("nextcloud-talk:")) {
+  if (/^nextcloud-talk:/i.test(normalized)) {
     normalized = normalized.slice("nextcloud-talk:".length).trim();
-  } else if (normalized.startsWith("nc-talk:")) {
+  } else if (/^nc-talk:/i.test(normalized)) {
     normalized = normalized.slice("nc-talk:".length).trim();
-  } else if (normalized.startsWith("nc:")) {
+  } else if (/^nc:/i.test(normalized)) {
     normalized = normalized.slice("nc:".length).trim();
   }
 
-  if (normalized.startsWith("room:")) {
+  if (/^room:/i.test(normalized)) {
     normalized = normalized.slice("room:".length).trim();
   }
 

--- a/extensions/nextcloud-talk/src/send.cfg-threading.test.ts
+++ b/extensions/nextcloud-talk/src/send.cfg-threading.test.ts
@@ -149,6 +149,28 @@ describe("nextcloud-talk send cfg threading", () => {
     });
   });
 
+  it("strips mixed-case provider and room prefixes before sending", async () => {
+    const cfg = { source: "provided" } as const;
+    mockNextcloudMessageResponse(12344, 1_706_000_000);
+
+    const result = await sendMessageNextcloudTalk("NC-TALK:ROOM:Ops", "hello", {
+      cfg,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://nextcloud.example.com/ocs/v2.php/apps/spreed/api/v1/bot/Ops/message",
+      expect.any(Object),
+    );
+    expect(result.roomToken).toBe("Ops");
+    expect(result.receipt.raw).toEqual([
+      {
+        channel: "nextcloud-talk",
+        conversationId: "Ops",
+        messageId: "12344",
+      },
+    ]);
+  });
+
   it("preserves caller-authored text on the low-level send path", async () => {
     const cfg = { source: "provided" } as const;
     const text = "Example:\n⚠️ 🛠️ `search repos (agent)` failed";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending to a Nextcloud Talk room could provide a target that OpenClaw recognized as a Nextcloud Talk target, but the send path still used the mixed-case provider prefix as part of the room token.

The broken case is a mismatch between target detection and target stripping:

- Detection already accepts Nextcloud Talk prefixes case-insensitively.
- Stripping only handled lowercase prefixes before this change.

That means a target like `NC-TALK:ROOM:Ops` looked valid to the channel resolver, but the low-level send path treated the whole string as the room token.

Before this fix:

```text
Input target:    NC-TALK:ROOM:Ops
Room token used: NC-TALK:ROOM:Ops
Request URL:     /ocs/v2.php/apps/spreed/api/v1/bot/NC-TALK:ROOM:Ops/message
```

After this fix:

```text
Input target:    NC-TALK:ROOM:Ops
Room token used: Ops
Request URL:     /ocs/v2.php/apps/spreed/api/v1/bot/Ops/message
```

This matters for users who type a target manually, copy a value from another tool, or generate targets through scripts/integrations that preserve display-style casing such as `NC-TALK:` or `ROOM:`.

## Why This Change Was Made

The existing Nextcloud Talk target contract already treats the provider prefix as case-insensitive. This change makes the shared prefix stripping helper follow that same contract for:

```text
nextcloud-talk:
nc-talk:
nc:
room:
```

The fix is intentionally narrow:

- It stays inside the Nextcloud Talk plugin boundary.
- It changes only prefix matching, not the accepted target syntax.
- It does not add config, dependencies, migrations, or fallback behavior.
- It preserves the room token text after stripping the prefixes.

The shared helper is the right place for the fix because it feeds both normalization and outbound delivery. Fixing only the send call site would leave session routing and normalized target behavior inconsistent.

## User Impact

Users can now send Nextcloud Talk messages to rooms with mixed-case target prefixes. These examples now resolve to the intended room token:

| User-provided target | Room token used after stripping |
| --- | --- |
| `NC-TALK:ROOM:Ops` | `Ops` |
| `NEXTCLOUD-TALK:ROOM:Ops` | `Ops` |
| `Nextcloud-Talk:room:Ops` | `Ops` |
| `ROOM:Ops` | `Ops` |

Lowercase inputs continue to behave the same:

| Existing target | Room token |
| --- | --- |
| `room:abc123` | `abc123` |
| `nc-talk:room:ops` | `ops` |
| `nextcloud-talk:room:AbC123` | `AbC123` |

This avoids a user-visible send failure where OpenClaw appears to accept the target but Nextcloud receives a bot API request for a non-existent room token containing the provider prefix.

## Evidence

### Code-path proof

- `extensions/nextcloud-talk/src/normalize.ts` already uses case-insensitive detection in `looksLikeNextcloudTalkTargetId()`, so mixed-case prefixes are treated as Nextcloud Talk targets.
- `extensions/nextcloud-talk/src/channel.ts` wires that detector into the channel account target resolver through `looksLikeId`.
- `extensions/nextcloud-talk/src/normalize.ts` also owns `normalizeNextcloudTalkMessagingTarget()`, which depends on `stripNextcloudTalkTargetPrefix()`.
- `extensions/nextcloud-talk/src/send.ts` calls `stripNextcloudTalkTargetPrefix()` before building the Nextcloud Talk bot message and reaction URLs.
- `extensions/nextcloud-talk/src/session-route.ts` calls the same helper before resolving outbound session routes.

Because these call sites share the helper, making prefix stripping case-insensitive aligns detection, normalization, session routing, message sending, and reaction sending without adding a second path.

### Before/after behavior covered by tests

The regression test in `extensions/nextcloud-talk/src/core.test.ts` proves the normalization helper now strips mixed-case provider and room prefixes:

```text
stripNextcloudTalkTargetPrefix("NC-TALK:ROOM:Ops") -> "Ops"
normalizeNextcloudTalkMessagingTarget("NEXTCLOUD-TALK:ROOM:Ops") -> "nextcloud-talk:ops"
```

The send-path regression test in `extensions/nextcloud-talk/src/send.cfg-threading.test.ts` proves the actual outbound message path uses the stripped room token:

```text
sendMessageNextcloudTalk("NC-TALK:ROOM:Ops", "hello", ...)
```

The mocked fetch call is asserted against:

```text
https://nextcloud.example.com/ocs/v2.php/apps/spreed/api/v1/bot/Ops/message
```

The same test also verifies the returned delivery metadata uses the normalized room token:

```text
result.roomToken = "Ops"
receipt.raw[0].conversationId = "Ops"
```

### Validation run

Focused Nextcloud Talk tests:

```bash
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/nextcloud-talk/src/core.test.ts extensions/nextcloud-talk/src/send.cfg-threading.test.ts
```

Result:

```text
[test] passed 1 Vitest shard in 39.16s
```

Diff whitespace check:

```bash
git diff --check
```

Result: passed.

### Validation notes

Remote Testbox validation could not be started from this checkout because the Crabbox wrapper failed its basic binary sanity check before running tests. The focused local fallback above was used for the touched Nextcloud Talk surface.
