### PR TITLE
fix(reply): reclaim phantom reply work with no activity evidence (#105712)

### DIFF
--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -402,6 +402,11 @@ describe("stuck session recovery", () => {
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
     mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
     mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    // Simulate recent activity to prove this is real reply work, not phantom
+    mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({
+      lastProgressAgeMs: 30_000,
+      lastProgressReason: "model_call:started",
+    });
 
     await recoverStuckDiagnosticSession({
       sessionId: "queued-reply-session",
@@ -415,6 +420,41 @@ describe("stuck session recovery", () => {
     expect(mocks.resetCommandLane).not.toHaveBeenCalled();
     expect(warnLogMessages()).toEqual([
       "stuck session recovery outcome: status=skipped action=keep_lane sessionId=queued-reply-session sessionKey=agent:main:main activeSessionId=queued-reply-session activeWorkKind=embedded_run reason=active_reply_work",
+    ]);
+  });
+
+  it("reclaims phantom reply work with no activity evidence (#105712)", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("phantom-reply-session");
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    // Simulate phantom reply work: registered in registry but no actual activity
+    // This matches the production bug where transcript file is missing (ENOENT)
+    // and there are no model calls or tool executions
+    mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({
+      hasActiveEmbeddedRun: false,
+      activeToolName: undefined,
+      lastProgressAgeMs: 10 * 60_000, // 10 minutes old - exceeds 5 minute threshold
+      lastProgressReason: undefined,
+    });
+    mocks.abortEmbeddedAgentRun.mockReturnValue(true);
+    mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+    mocks.resetCommandLane.mockReturnValue(1);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "phantom-reply-session",
+      sessionKey: "agent:main:main",
+      ageMs: 180_000,
+      queueDepth: 0, // No queued messages - the phantom blocks all traffic
+    });
+
+    expect(mocks.abortEmbeddedAgentRun).toHaveBeenCalledWith("phantom-reply-session");
+    expect(mocks.waitForEmbeddedAgentRunEnd).toHaveBeenCalledWith("phantom-reply-session", 15_000);
+    expect(outcome.status).toBe("aborted");
+    expect(warnLogMessages()).toEqual([
+      expect.stringContaining("stuck session recovery reclaiming phantom_reply_work"),
+      expect.stringContaining("stuck session recovery:"),
+      expect.stringContaining("stuck session recovery outcome: status=aborted action=abort_embedded_run"),
     ]);
   });
 

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -204,18 +204,34 @@ export async function recoverStuckDiagnosticSession(
     }
 
     if (!activeSessionId && activeWorkSessionId && isEmbeddedAgentRunActive(activeWorkSessionId)) {
+      // Check for phantom reply work: a registered operation with no actual activity.
+      // This handles the case where the system believes reply work is active but
+      // there's no evidence of real ongoing work (no transcript, no model calls, etc.).
+      const activitySnapshot = getDiagnosticSessionActivitySnapshot({
+        sessionId: activeWorkSessionId,
+        sessionKey: params.sessionKey,
+      });
+      const hasNoActivityEvidence =
+        !activitySnapshot.hasActiveEmbeddedRun &&
+        !activitySnapshot.activeToolName &&
+        !activitySnapshot.lastProgressReason &&
+        activitySnapshot.lastProgressAgeMs !== undefined &&
+        activitySnapshot.lastProgressAgeMs >= staleActiveProgressAbortMs;
+
       const reclaimStaleReplyWork =
         params.allowActiveAbort !== true &&
-        isActiveRunProgressStale({
-          sessionId: activeWorkSessionId,
-          sessionKey: params.sessionKey,
-          queueDepth: params.queueDepth,
-          staleAbortMs: staleActiveProgressAbortMs,
-        });
+        (hasNoActivityEvidence ||
+          isActiveRunProgressStale({
+            sessionId: activeWorkSessionId,
+            sessionKey: params.sessionKey,
+            queueDepth: params.queueDepth,
+            staleAbortMs: staleActiveProgressAbortMs,
+          }));
       if (params.allowActiveAbort === true || reclaimStaleReplyWork) {
         if (reclaimStaleReplyWork) {
+          const reason = hasNoActivityEvidence ? "phantom_reply_work" : "stale_reply_work";
           diag.warn(
-            `stuck session recovery reclaiming stale active reply work: ${formatRecoveryContext(
+            `stuck session recovery reclaiming ${reason}: ${formatRecoveryContext(
               params,
               { activeSessionId: activeWorkSessionId },
             )}`,


### PR DESCRIPTION
## What Problem This Solves

Fixes #105712 — A chat session lane becomes permanently stuck due to a **phantom active run**: the system believes an `embedded_run` is actively doing reply work, but no such run exists (no transcript file on disk, no model calls, no tool executions). The stuck-session recovery mechanism detects this condition but chooses not to act because the reason is marked as `active_reply_work`, which unconditionally exempts claims from intervention.

**Production impact:**
- Gateway uptime: 5 days before incident
- Messages sent by users trigger ⚠️ warning emoji but get no response
- Recovery requires restarting the entire gateway service (`systemctl --user restart openclaw-gateway`)
- DMs to the same agent function normally — only one specific lane is blocked

## Why This Change Was Made

The root cause is in [`src/logging/diagnostic-stuck-session-recovery.runtime.ts:206-248`](https://github.com/openclaw/openclaw/blob/main/src/logging/diagnostic-stuck-session-recovery.runtime.ts#L206-L248):

```typescript
if (!activeSessionId && activeWorkSessionId && isEmbeddedAgentRunActive(activeWorkSessionId)) {
  const reclaimStaleReplyWork = /* checks queueDepth and progress age */;
  if (params.allowActiveAbort === true || reclaimStaleReplyWork) {
    // abort the run
  } else {
    // BUG: Unconditionally keeps the lane even when there's NO evidence of real work
    return { status: "skipped", action: "keep_lane", reason: "active_reply_work" };
  }
}
```

The problem:
1. `isEmbeddedAgentRunActive()` only checks if the session ID exists in the registry — it doesn't verify actual activity
2. `isActiveRunProgressStale()` returns `false` when `queueDepth <= 0`, so phantom runs with no queued messages are never reclaimed
3. The `else` branch preserves the claim without validating whether there's real ongoing work

## User Impact

**Before fix:**
- Phantom reply work blocks the lane indefinitely
- All messages to the affected channel receive ⚠️ but no response
- Manual gateway restart required

**After fix:**
- Phantom runs are detected by checking activity snapshot for evidence:
  - `hasActiveEmbeddedRun`
  - `activeToolName` (tool execution in progress)
  - `lastProgressReason` (recent diagnostic event)
  - `lastProgressAgeMs >= 5 minutes` (stale threshold)
- Operations with no activity evidence are reclaimed and aborted
- Lane is released automatically without manual intervention

## Evidence

### Code Proof

Changed files:
- `src/logging/diagnostic-stuck-session-recovery.runtime.ts` — Added phantom detection logic
- `src/logging/diagnostic-stuck-session-recovery.runtime.test.ts` — Added test case for #105712

Key changes in runtime code:
```typescript
// Check for phantom reply work: a registered operation with no actual activity.
const activitySnapshot = getDiagnosticSessionActivitySnapshot({
  sessionId: activeWorkSessionId,
  sessionKey: params.sessionKey,
});
const hasNoActivityEvidence =
  !activitySnapshot.hasActiveEmbeddedRun &&
  !activitySnapshot.activeToolName &&
  !activitySnapshot.lastProgressReason &&
  activitySnapshot.lastProgressAgeMs !== undefined &&
  activitySnapshot.lastProgressAgeMs >= staleActiveProgressAbortMs;

// Treat operations with no activity evidence as stale
const reclaimStaleReplyWork =
  params.allowActiveAbort !== true &&
  (hasNoActivityEvidence || isActiveRunProgressStale({...}));
```

### Test Proof

New test case `"reclaims phantom reply work with no activity evidence (#105712)"`:
- Simulates production bug: `queueDepth=0`, no activity evidence, 10-minute-old progress
- Verifies `abortEmbeddedAgentRun` is called
- Verifies outcome is `status: "aborted"` instead of `status: "skipped"`

Existing test updated to prove real reply work is still preserved:
- Added `getDiagnosticSessionActivitySnapshot` mock with recent activity (`lastProgressAgeMs: 30_000`)
- Verifies lane is kept when there's actual evidence of work

### CI Proof

All 26 tests pass:
```
Test Files  1 passed (1)
     Tests  26 passed (26)
Duration  1.63s
```

## Related Issues

- Fixes #105712
- Related to #94701 / PR #94701 (embedded-run recovery with diagnostic metadata)
- Adjacent to #95248 / PR #95299 (Telegram ingress spool blocking)