### PR TITLE
fix(config): propagate provider-level contextTokens default to models (#105821)

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -181,6 +181,9 @@ export function applyModelDefaults(
         continue;
       }
       const providerApi = normalizedProvider.api;
+      const providerContextTokens = isPositiveNumber(normalizedProvider.contextTokens)
+        ? normalizedProvider.contextTokens
+        : undefined;
       const nextProvider = normalizedProvider;
       if (nextProvider !== provider) {
         mutated = true;
@@ -226,6 +229,13 @@ export function applyModelDefaults(
           modelMutated = true;
         }
 
+        const contextTokens = isPositiveNumber(raw.contextTokens)
+          ? raw.contextTokens
+          : providerContextTokens;
+        if (raw.contextTokens !== contextTokens) {
+          modelMutated = true;
+        }
+
         const defaultMaxTokens = Math.min(DEFAULT_MODEL_MAX_TOKENS, contextWindow);
         const rawMaxTokens = isPositiveNumber(raw.maxTokens) ? raw.maxTokens : defaultMaxTokens;
         const maxTokens = resolveNormalizedProviderModelMaxTokens({
@@ -252,6 +262,7 @@ export function applyModelDefaults(
           input,
           cost,
           contextWindow,
+          contextTokens,
           maxTokens,
           api,
         }) as ModelDefinitionConfig;

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -449,6 +449,69 @@ describe("applyModelDefaults", () => {
     expect(model?.maxTokens).toBe(16384);
   });
 
+  it("propagates provider-level contextTokens default to models", () => {
+    const cfg = {
+      models: {
+        providers: {
+          myproxy: {
+            baseUrl: "https://proxy.example/v1",
+            apiKey: "sk-test",
+            api: "openai-completions",
+            contextTokens: 120_000,
+            models: [
+              {
+                id: "gpt-5.4",
+                name: "GPT-5.4",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 200_000,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const next = applyModelDefaults(cfg);
+    const model = next.models?.providers?.myproxy?.models?.[0];
+
+    expect(model?.contextTokens).toBe(120_000);
+  });
+
+  it("lets per-model contextTokens override provider-level default", () => {
+    const cfg = {
+      models: {
+        providers: {
+          myproxy: {
+            baseUrl: "https://proxy.example/v1",
+            apiKey: "sk-test",
+            api: "openai-completions",
+            contextTokens: 120_000,
+            models: [
+              {
+                id: "gpt-5.4",
+                name: "GPT-5.4",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 200_000,
+                maxTokens: 8192,
+                contextTokens: 96_000,
+              },
+            ],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const next = applyModelDefaults(cfg);
+    const model = next.models?.providers?.myproxy?.models?.[0];
+
+    expect(model?.contextTokens).toBe(96_000);
+  });
+
   it("propagates a provider policy api default to models", () => {
     const cfg = {
       models: {


### PR DESCRIPTION
## What Problem This Solves

`models.providers.*.contextTokens` is documented as a provider-level default effective runtime context cap for models under that provider. However, `applyModelDefaults` in `src/config/defaults.ts` only considered per-model `contextTokens`, so models that omitted the field did not inherit the provider default.

## Why This Change Was Made

The runtime already falls back to provider-level `contextTokens` in `applyConfiguredContextWindows`, but config consumers that read the materialized model entries—such as `openclaw models list` and config snapshots—saw `undefined` and omitted the effective cap. This brings `applyModelDefaults` in line with the documented contract and with the existing provider-level `api` default propagation.

## User Impact

Users who set `contextTokens` on a provider will now see the inherited cap reflected for every model under that provider in `openclaw models list` and other config-aware surfaces, unless a model explicitly overrides it.

## Evidence

### Unit tests
Added regression tests in `src/config/model-alias-defaults.test.ts`:

- `propagates provider-level contextTokens default to models` fails before the fix (`contextTokens` is `undefined`) and passes after (`120000`).
- `lets per-model contextTokens override provider-level default` confirms explicit model values still win.

```bash
node scripts/run-vitest.mjs src/config/model-alias-defaults.test.ts --run
# Test Files  1 passed (1)
# Tests  20 passed (20)
```

### Real CLI output
Config (`~/.openclaw/openclaw.json`, redacted):

```json
{
  "models": {
    "providers": {
      "demo-provider": {
        "baseUrl": "https://demo-provider.example.test/v1",
        "apiKey": "sk-demo-redacted",
        "api": "openai-completions",
        "contextTokens": 120000,
        "models": [
          { "id": "inherited-cap", "name": "Inherited cap model", "contextWindow": 200000, "maxTokens": 8192 },
          { "id": "overridden-cap", "name": "Overridden cap model", "contextWindow": 200000, "maxTokens": 8192, "contextTokens": 96000 }
        ]
      }
    }
  }
}
```

After the fix, `openclaw models list --json --no-color` shows the inherited cap on the first model and the explicit override on the second:

```json
{
  "count": 2,
  "models": [
    {
      "key": "demo-provider/inherited-cap",
      "name": "Inherited cap model",
      "input": "text",
      "contextWindow": 200000,
      "contextTokens": 120000,
      "local": false,
      "available": true,
      "tags": ["default"],
      "missing": false
    },
    {
      "key": "demo-provider/overridden-cap",
      "name": "Overridden cap model",
      "input": "text",
      "contextWindow": 200000,
      "contextTokens": 96000,
      "local": false,
      "available": true,
      "tags": [],
      "missing": false
    }
  ]
}
```

Before the fix, the first row omitted `contextTokens` entirely.

Fixes #105821