### PR TITLE
fix(cron): explicit cron wakes bypass heartbeat quiet-hours gate (#105413)

### DIFF
--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -41,6 +41,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
     storePath: string;
     target?: "telegram" | "none";
     isolatedSession?: boolean;
+    activeHours?: boolean;
   }): Promise<{ cfg: OpenClawConfig; sessionKey: string }> => {
     const cfg: OpenClawConfig = {
       agents: {
@@ -50,6 +51,9 @@ describe("Ghost reminder bug (issue #13317)", () => {
             every: "5m",
             target: params.target ?? "telegram",
             ...(params.isolatedSession === true ? { isolatedSession: true } : {}),
+            ...(params.activeHours === true
+              ? { activeHours: { start: "08:00", end: "24:00", timezone: "user" as const } }
+              : {}),
           },
         },
       },
@@ -196,6 +200,8 @@ describe("Ghost reminder bug (issue #13317)", () => {
     owningCronLaneTaskMarker?: CommandLaneTaskMarker;
     cronLaneDepth?: number;
     cronNestedLaneDepth?: number;
+    activeHours?: boolean;
+    nowMs?: number;
   }): Promise<{
     result: Awaited<ReturnType<typeof runHeartbeatOnce>>;
     sendTelegram: ReturnType<typeof vi.fn>;
@@ -215,6 +221,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
           storePath,
           target: params.target,
           isolatedSession: params.isolatedSession,
+          activeHours: params.activeHours,
         });
         params.enqueue(sessionKey);
         const owningCronJobMarker = params.owningCronJobId
@@ -244,6 +251,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
             deps: {
               getReplyFromConfig: getReplySpy,
               telegram: sendTelegram,
+              nowMs: () => params.nowMs ?? Date.now(),
               ...(params.cronLaneDepth === undefined && params.cronNestedLaneDepth === undefined
                 ? {}
                 : {
@@ -307,6 +315,30 @@ describe("Ghost reminder bug (issue #13317)", () => {
     );
     expect(result.status).toBe("ran");
     expectCronEventPrompt(calledCtx, "Reminder: Check Base Scout results");
+    expect(sendTelegram).toHaveBeenCalled();
+  });
+
+  it("runs the tagged cron payload outside heartbeat active hours", async () => {
+    const reminderText = "Reminder: Send the overnight report";
+    const { result, sendTelegram, calledCtx, replyCallCount } = await runHeartbeatCase({
+      tmpPrefix: "openclaw-cron-quiet-hours-",
+      replyText: "Overnight report sent",
+      reason: "cron:overnight-report",
+      source: "cron",
+      intent: "immediate",
+      activeHours: true,
+      nowMs: Date.UTC(2025, 0, 1, 7, 0, 0),
+      enqueue: (sessionKey) => {
+        enqueueSystemEvent(reminderText, {
+          sessionKey,
+          contextKey: "cron:overnight-report",
+        });
+      },
+    });
+
+    expect(result.status).toBe("ran");
+    expect(replyCallCount).toBe(1);
+    expectCronEventPrompt(calledCtx, reminderText);
     expect(sendTelegram).toHaveBeenCalled();
   });
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1324,12 +1324,13 @@ export async function runHeartbeatOnce(opts: {
   const agentId = normalizeAgentId(
     explicitAgentId || forcedSessionAgentId || resolveDefaultAgentId(cfg),
   );
+  const wakeSource = opts.source ?? inferHeartbeatWakeSourceFromReason(opts.reason);
   const heartbeat = resolveHeartbeatForWake({
     cfg,
     agentId,
     requestedHeartbeat: opts.heartbeat,
-    source: opts.source,
-    mergeRequestedHeartbeat: opts.source === "cron",
+    source: wakeSource,
+    mergeRequestedHeartbeat: wakeSource === "cron",
   });
   const runScope = opts.runScope ?? "global";
   const allowsUnscheduledTarget =
@@ -1345,7 +1346,12 @@ export async function runHeartbeatOnce(opts: {
   }
 
   const startedAt = opts.deps?.nowMs?.() ?? Date.now();
-  if (!allowsUnscheduledTarget && !isWithinActiveHours(cfg, heartbeat, startedAt)) {
+  // Cron uses the heartbeat runner as execution transport; heartbeat scheduling windows do not own it.
+  if (
+    !allowsUnscheduledTarget &&
+    wakeSource !== "cron" &&
+    !isWithinActiveHours(cfg, heartbeat, startedAt)
+  ) {
     return { status: "skipped", reason: "quiet-hours" };
   }
 
@@ -1445,7 +1451,7 @@ export async function runHeartbeatOnce(opts: {
     heartbeat,
     runScope,
     forcedSessionKey: opts.sessionKey,
-    source: opts.source,
+    source: wakeSource,
     reason: opts.reason,
     nowMs: startedAt,
   });
@@ -1965,7 +1971,7 @@ export async function runHeartbeatOnce(opts: {
         runSessionKey,
         response: heartbeatToolResponse,
         taskNames: dueHeartbeatTasks.map((task) => task.name),
-        wakeSource: opts.source,
+        wakeSource,
         wakeReason: opts.reason,
         occurredAt: startedAt,
       });


### PR DESCRIPTION
Fixes #105413

## What Problem This Solves

Main-session cron jobs execute through the heartbeat runner. Before this change, that transport also inherited `heartbeat.activeHours`, so an explicit cron wake outside the heartbeat window returned `quiet-hours` before reading the queued cron payload. The job was silently skipped even though heartbeat scheduling policy does not own cron execution.

## Why This Change Was Made

The rewrite normalizes the wake source once, before heartbeat override resolution and policy gates. Explicit and reason-inferred cron wakes then use the same source for heartbeat configuration, active-hours admission, preflight prompt selection, and persisted outcome metadata.

Ordinary scheduled heartbeats still obey active hours. Cron still uses the existing tagged-event prompt, delivery, busy-lane, and event-consumption paths; only the heartbeat scheduling-window gate is bypassed.

This replaces the original patch on current main. It preserves @SymbolStar's diagnosis and contributor credit while integrating the newer targeted-notification gate and replacing a weak `not quiet-hours` assertion with a full queued-event execution test.

## User Impact

Recurring or one-shot `sessionTarget: main` / `payload.kind: systemEvent` jobs now run their actual payload outside heartbeat active hours. Inside and outside the window, the model receives the cron-event prompt instead of a generic heartbeat poll.

## Evidence

- Integrated regression queues a tagged cron event at 07:00 UTC with heartbeat active hours 08:00–24:00, then proves:
  - result is `ran`;
  - exactly one model reply is requested;
  - provider is `cron-event`;
  - prompt contains the scheduled payload;
  - prompt excludes heartbeat-poll text;
  - delivery runs.
- Focused local suite: 25/25.
- Blacksmith stress: 30 consecutive focused runs, 750/750 tests, zero failures.
- Heartbeat/cron interaction matrix: 5 files, 98/98 tests, covering ordinary quiet hours, wake coalescing, tagged cron prompts, and main-job heartbeat delegation.
- Blacksmith `check:changed`: production/test types, lint, format, boundaries, import cycles, database-first guard, and related checks passed.
- Autoreview: clean; no accepted/actionable findings, correctness confidence 0.91.
- Live isolated gateway reached readiness on custom port 29741 with the 00:00–00:01 UTC quiet window and OpenAI credentials available. Fresh-state admin RPC correctly required device identity; the Testbox had no approved identity to reuse, so no model-call claim relies on that blocked lane.

Co-authored-by credit is preserved for jindongfu. AI-assisted maintainer rewrite; I reviewed the active-hours gate, wake-source inference, preflight prompt selection, main-session cron caller, event consumption, and sibling wake paths.
