### PR TITLE
feat(ui): scope the sidebar sessions list to the chip-selected agent

### DIFF
--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -331,6 +331,40 @@ describe("AppSidebar agent chip", () => {
     );
   });
 
+  it("keeps the sessions list flat for the selected agent and flags other-agent unread", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const harness = createSessionsHarness("main", ["agent:main:main"]);
+    const { sidebar } = await mountSidebar(gateway, harness.sessions, "panel", TWO_AGENTS);
+    sidebar.connected = true;
+    const defaults = { modelProvider: null, model: null, contextTokens: null };
+    harness.publishList({
+      result: {
+        ts: 2,
+        path: "",
+        count: 1,
+        defaults,
+        sessions: [{ key: "agent:research:one", kind: "direct", updatedAt: 3, unread: true }],
+      },
+      agentId: "research",
+    });
+    harness.publishList({
+      result: {
+        ts: 3,
+        path: "",
+        count: 1,
+        defaults,
+        sessions: [{ key: "agent:main:main", kind: "direct", updatedAt: 5 }],
+      },
+      agentId: "main",
+    });
+    await sidebar.updateComplete;
+
+    // No per-agent sections: the chip menu owns agent switching now.
+    expect(sidebar.querySelector(".sidebar-agent-section")).toBeNull();
+    expect(sidebar.querySelectorAll(".sidebar-recent-session")).toHaveLength(1);
+    expect(sidebar.querySelector(".sidebar-agent-chip__menu-unread")).not.toBeNull();
+  });
+
   it("opens the footer menu with agent switching and folded-in utilities", async () => {
     const gatewayHarness = createGatewayHarness({} as GatewayBrowserClient);
     const setSessionKey = vi.fn();

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -49,6 +49,7 @@ if (!customElements.get(PROVIDER_ELEMENT_NAME)) {
 type SidebarLifecycleState = HTMLElement & {
   connected: boolean;
   canPairDevice: boolean;
+  sessionKey: string;
   onNavigate: (routeId: string, options?: { search?: string }) => void;
   sessionCatalogs: SessionCatalog[];
   sessionRowsByAgent: Record<string, SessionsListResult["sessions"]>;
@@ -343,7 +344,15 @@ describe("AppSidebar agent chip", () => {
         path: "",
         count: 1,
         defaults,
-        sessions: [{ key: "agent:research:one", kind: "direct", updatedAt: 3, unread: true }],
+        sessions: [
+          {
+            key: "agent:research:one",
+            kind: "direct",
+            label: "Research task",
+            updatedAt: 3,
+            unread: true,
+          },
+        ],
       },
       agentId: "research",
     });
@@ -363,6 +372,14 @@ describe("AppSidebar agent chip", () => {
     expect(sidebar.querySelector(".sidebar-agent-section")).toBeNull();
     expect(sidebar.querySelectorAll(".sidebar-recent-session")).toHaveLength(1);
     expect(sidebar.querySelector(".sidebar-agent-chip__menu-unread")).not.toBeNull();
+
+    // Mid-switch (route agent != loaded result agent) the list renders the
+    // target agent's cached rows instead of flashing empty until refresh.
+    sidebar.sessionKey = "agent:research:one";
+    await sidebar.updateComplete;
+    const rows = [...sidebar.querySelectorAll(".sidebar-recent-session")];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.textContent).toContain("Research task");
   });
 
   it("opens the footer menu with agent switching and folded-in utilities", async () => {

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -228,11 +228,12 @@ async function mountSidebar(
     "openclaw-app-sidebar",
   ) as unknown as SidebarLifecycleState;
   sidebar.variant = variant;
-  provider.setContext(createContext(gateway, sessions, agentsList));
+  const context = createContext(gateway, sessions, agentsList);
+  provider.setContext(context);
   provider.append(sidebar);
   document.body.append(provider);
   await sidebar.updateComplete;
-  return { provider, sidebar };
+  return { provider, sidebar, context };
 }
 
 afterEach(() => {
@@ -335,7 +336,7 @@ describe("AppSidebar agent chip", () => {
   it("keeps the sessions list flat for the selected agent and flags other-agent unread", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const harness = createSessionsHarness("main", ["agent:main:main"]);
-    const { sidebar } = await mountSidebar(gateway, harness.sessions, "panel", TWO_AGENTS);
+    const { sidebar, context } = await mountSidebar(gateway, harness.sessions, "panel", TWO_AGENTS);
     sidebar.connected = true;
     const defaults = { modelProvider: null, model: null, contextTokens: null };
     harness.publishList({
@@ -373,8 +374,10 @@ describe("AppSidebar agent chip", () => {
     expect(sidebar.querySelectorAll(".sidebar-recent-session")).toHaveLength(1);
     expect(sidebar.querySelector(".sidebar-agent-chip__menu-unread")).not.toBeNull();
 
-    // Mid-switch (route agent != loaded result agent) the list renders the
+    // Mid-switch (selected agent != loaded result agent) the list renders the
     // target agent's cached rows instead of flashing empty until refresh.
+    // Chip switch and chat-pane both sync agentSelection with the route.
+    context.agentSelection.state.selectedId = "research";
     sidebar.sessionKey = "agent:research:one";
     await sidebar.updateComplete;
     const rows = [...sidebar.querySelectorAll(".sidebar-recent-session")];

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -939,7 +939,10 @@ class AppSidebar extends OpenClawLightDomContentsElement {
   private visibleSessionRowsInOrder(): SidebarRecentSession[] {
     const navigationState = this.getSessionNavigationState();
     const sections = groupSidebarSessionRows(
-      limitSidebarSessionRows(navigationState.visibleSessions, this.visibleSessionLimit),
+      limitSidebarSessionRows(
+        this.selectedAgentSessionRows(navigationState),
+        this.visibleSessionLimit,
+      ),
       {
         grouping: this.sessionsGrouping,
         knownGroups: this.sessionsGrouping === "category" ? this.knownSessionGroups() : undefined,
@@ -2600,6 +2603,29 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     `;
   }
 
+  /** While a chip switch's refresh is in flight, the loaded result still holds
+      the previous agent; render the target agent's cached rows instead of
+      flashing an empty list. Converges once the refreshed list publishes. */
+  private selectedAgentSessionRows(
+    navigationState: ReturnType<AppSidebar["getSessionNavigationState"]>,
+  ): SidebarRecentSession[] {
+    const selected = normalizeAgentId(navigationState.selectedAgentId);
+    if (normalizeAgentId(this.sessionsAgentId ?? "") === selected) {
+      return navigationState.visibleSessions;
+    }
+    const cached = this.sessionRowsByAgent[selected] ?? [];
+    return filterVisibleSessionRows(cached, {
+      agentId: selected,
+      defaultAgentId: resolveUiDefaultAgentId({
+        agentsList: this.context?.agents.state.agentsList,
+        hello: this.context?.gateway.snapshot.hello,
+      }),
+      filterByAgent: true,
+    })
+      .toSorted(this.compareSidebarSessionRows)
+      .map(navigationState.toSidebarSession);
+  }
+
   private agentUnreadCount(agentId: string): number {
     const rows = this.sessionRowsByAgent[normalizeAgentId(agentId)] ?? [];
     return rows.filter((row) => row.unread === true && row.archived !== true).length;
@@ -2680,7 +2706,8 @@ class AppSidebar extends OpenClawLightDomContentsElement {
 
   private renderSessions() {
     const navigationState = this.getSessionNavigationState();
-    const { visibleSessions, newSessionDisabled, newSessionTitle } = navigationState;
+    const { newSessionDisabled, newSessionTitle } = navigationState;
+    const visibleSessions = this.selectedAgentSessionRows(navigationState);
     const expandedAgentId = this.expandedAgentId();
     return html`
       <section class="sidebar-sessions">

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -2603,18 +2603,24 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     `;
   }
 
-  /** While a chip switch's refresh is in flight, the loaded result still holds
-      the previous agent; render the target agent's cached rows instead of
-      flashing an empty list. Converges once the refreshed list publishes. */
+  /** The list follows the chip-selected agent. While route and loaded result
+      agree with it (every settled online state), keep the navigation rows and
+      their pinned-active semantics; mid-switch or offline, fall back to that
+      agent's loaded/cached raw rows instead of flashing empty or stale. */
   private selectedAgentSessionRows(
     navigationState: ReturnType<AppSidebar["getSessionNavigationState"]>,
   ): SidebarRecentSession[] {
-    const selected = normalizeAgentId(navigationState.selectedAgentId);
-    if (normalizeAgentId(this.sessionsAgentId ?? "") === selected) {
+    const selected = this.expandedAgentId();
+    const loadedAgentId = normalizeAgentId(this.sessionsAgentId ?? "");
+    const routeAgentId = normalizeAgentId(navigationState.selectedAgentId);
+    if (selected === routeAgentId && selected === loadedAgentId) {
       return navigationState.visibleSessions;
     }
-    const cached = this.sessionRowsByAgent[selected] ?? [];
-    return filterVisibleSessionRows(cached, {
+    const rows =
+      selected === loadedAgentId
+        ? (this.sessionsResult?.sessions ?? [])
+        : (this.sessionRowsByAgent[selected] ?? []);
+    return filterVisibleSessionRows(rows, {
       agentId: selected,
       defaultAgentId: resolveUiDefaultAgentId({
         agentsList: this.context?.agents.state.agentsList,

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -938,13 +938,8 @@ class AppSidebar extends OpenClawLightDomContentsElement {
       ranges and batch actions both key off this order. */
   private visibleSessionRowsInOrder(): SidebarRecentSession[] {
     const navigationState = this.getSessionNavigationState();
-    const agents = this.context?.agents.state.agentsList?.agents ?? [];
-    const rows =
-      agents.length > 1
-        ? this.sidebarRowsForAgent(this.expandedAgentId(), navigationState)
-        : navigationState.visibleSessions;
     const sections = groupSidebarSessionRows(
-      limitSidebarSessionRows(rows, this.visibleSessionLimit),
+      limitSidebarSessionRows(navigationState.visibleSessions, this.visibleSessionLimit),
       {
         grouping: this.sessionsGrouping,
         knownGroups: this.sessionsGrouping === "category" ? this.knownSessionGroups() : undefined,
@@ -1034,7 +1029,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     }
   };
 
-  /** Browsing another agent's sessions never navigates; only row clicks do. */
+  /** Chip switching selects the agent and refreshes its session list. */
   private readonly expandAgent = (agentId: string) => {
     const context = this.context;
     if (!context) {
@@ -2605,25 +2600,6 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     `;
   }
 
-  /** Rows for a non-active agent come from the per-agent cache filled on expand. */
-  private sidebarRowsForAgent(
-    agentId: string,
-    navigationState: ReturnType<AppSidebar["getSessionNavigationState"]>,
-  ): SidebarRecentSession[] {
-    const normalized = normalizeAgentId(agentId);
-    if (normalized === normalizeAgentId(navigationState.selectedAgentId)) {
-      return navigationState.visibleSessions;
-    }
-    const cached = this.sessionRowsByAgent[normalized] ?? [];
-    return filterVisibleSessionRows(cached, {
-      agentId: normalized,
-      defaultAgentId: navigationState.selectedAgentId,
-      filterByAgent: true,
-    })
-      .toSorted(this.compareSidebarSessionRows)
-      .map(navigationState.toSidebarSession);
-  }
-
   private agentUnreadCount(agentId: string): number {
     const rows = this.sessionRowsByAgent[normalizeAgentId(agentId)] ?? [];
     return rows.filter((row) => row.unread === true && row.archived !== true).length;
@@ -2702,54 +2678,9 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     `;
   }
 
-  private renderAgentSection(
-    agent: { id: string; name?: string; identity?: { name?: string } },
-    navigationState: ReturnType<AppSidebar["getSessionNavigationState"]>,
-  ) {
-    const agentId = normalizeAgentId(agent.id);
-    const expanded = agentId === this.expandedAgentId();
-    const label = agent.identity?.name ?? agent.name ?? agent.id;
-    const unread = expanded ? 0 : this.agentUnreadCount(agentId);
-    const initial = (label || agent.id).slice(0, 1).toUpperCase();
-    return html`
-      <div class="sidebar-agent-section ${expanded ? "sidebar-agent-section--expanded" : ""}">
-        <button
-          type="button"
-          class="sidebar-agent-section__header"
-          aria-expanded=${String(expanded)}
-          @click=${() => this.expandAgent(agentId)}
-        >
-          <span class="sidebar-session-group-toggle__icon" aria-hidden="true"
-            >${expanded ? icons.chevronDown : icons.chevronRight}</span
-          >
-          <span class="sidebar-agent-section__avatar" aria-hidden="true">${initial}</span>
-          <span class="sidebar-agent-section__name">${label}</span>
-          ${unread > 0
-            ? html`<span
-                class="session-unread-dot sidebar-agent-section__unread"
-                role="img"
-                aria-label=${t("sessionsView.unread")}
-              ></span>`
-            : nothing}
-        </button>
-        ${expanded
-          ? this.renderSessionListBody(this.sidebarRowsForAgent(agentId, navigationState), {
-              showDraft:
-                Boolean(this.draftSessionAgentId) &&
-                normalizeAgentId(this.draftSessionAgentId) === agentId,
-              showFallback: true,
-            })
-          : nothing}
-      </div>
-    `;
-  }
-
   private renderSessions() {
-    const context = this.context;
     const navigationState = this.getSessionNavigationState();
     const { visibleSessions, newSessionDisabled, newSessionTitle } = navigationState;
-    const agents = context?.agents.state.agentsList?.agents ?? [];
-    const multiAgent = agents.length > 1;
     const expandedAgentId = this.expandedAgentId();
     return html`
       <section class="sidebar-sessions">
@@ -2787,12 +2718,12 @@ class AppSidebar extends OpenClawLightDomContentsElement {
               ${icons.plus}
             </button>
           </div>
-          ${multiAgent
-            ? agents.map((agent) => this.renderAgentSection(agent, navigationState))
-            : this.renderSessionListBody(visibleSessions, {
-                showDraft: Boolean(this.draftSessionAgentId),
-                showFallback: true,
-              })}
+          ${this.renderSessionListBody(visibleSessions, {
+            showDraft:
+              Boolean(this.draftSessionAgentId) &&
+              normalizeAgentId(this.draftSessionAgentId) === expandedAgentId,
+            showFallback: true,
+          })}
           ${this.renderSessionCatalogs()}
         </div>
       </section>
@@ -2960,7 +2891,11 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     const gatewayStatus = t("chat.gatewayStatus", {
       status: this.connected ? t("common.online") : t("common.offline"),
     });
-    const { activeId: chipAgentId, agent: chipAgent } = this.activeChipAgent();
+    const { activeId: chipAgentId, agent: chipAgent, agents: chipAgents } = this.activeChipAgent();
+    const chipMenuUnread = chipAgents.some((entry) => {
+      const agentId = normalizeAgentId(entry.id);
+      return agentId !== chipAgentId && this.agentUnreadCount(agentId) > 0;
+    });
     const chipName = chipAgent ? normalizeAgentLabel(chipAgent) : chipAgentId;
     const chipAvatarText =
       (chipAgent ? resolveAgentTextAvatar(chipAgent) : null) ??
@@ -3011,6 +2946,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
               .statusLabel=${gatewayStatus}
               .subtitle=${this.agentChipSubtitle(chipAgentId)}
               .menuOpen=${this.agentMenuPosition !== null}
+              .menuUnread=${chipMenuUnread}
               .newSessionDisabled=${!this.connected}
               .onOpenConversation=${() => this.openAgentConversation(chipAgentId)}
               .onNewSession=${() => this.onOpenNewSession?.(chipAgentId)}

--- a/ui/src/components/sidebar-agent-chip.ts
+++ b/ui/src/components/sidebar-agent-chip.ts
@@ -16,6 +16,8 @@ class SidebarAgentChip extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) statusLabel = "";
   @property({ attribute: false }) subtitle = "";
   @property({ attribute: false }) menuOpen = false;
+  /** Unread sessions exist on non-active agents; surfaces on the menu toggle. */
+  @property({ attribute: false }) menuUnread = false;
   @property({ attribute: false }) newSessionDisabled = false;
   @property({ attribute: false }) onOpenConversation?: () => void;
   @property({ attribute: false }) onNewSession?: () => void;
@@ -81,6 +83,13 @@ class SidebarAgentChip extends OpenClawLightDomContentsElement {
           @click=${(event: MouseEvent) => this.onToggleMenu?.(event.currentTarget as HTMLElement)}
         >
           ${icons.chevronDown}
+          ${this.menuUnread && !this.menuOpen
+            ? html`<span
+                class="session-unread-dot sidebar-agent-chip__menu-unread"
+                role="img"
+                aria-label=${t("sessionsView.unread")}
+              ></span>`
+            : nothing}
         </button>
       </div>
     `;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2093,8 +2093,20 @@ openclaw-session-menu[popover] {
   stroke-linejoin: round;
 }
 
+.sidebar-agent-chip__menu-toggle {
+  position: relative;
+}
+
 .sidebar-agent-chip__menu-toggle svg {
   transition: transform var(--duration-fast) ease;
+}
+
+.sidebar-agent-chip__menu-unread {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  width: 6px;
+  height: 6px;
 }
 
 .sidebar-agent-chip__menu-toggle--open svg {
@@ -2662,29 +2674,7 @@ openclaw-session-menu[popover] {
   color: var(--muted);
 }
 
-.sidebar-agent-section {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.sidebar-agent-section__header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 6px 8px;
-  border: 0;
-  border-radius: 8px;
-  background: transparent;
-  cursor: pointer;
-  text-align: left;
-}
-
-.sidebar-agent-section__header:hover {
-  background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
-}
-
+/* Kept for the agent-chip menu switcher rows (sessions list is single-agent now). */
 .sidebar-agent-section__avatar {
   display: inline-flex;
   align-items: center;
@@ -2696,25 +2686,6 @@ openclaw-session-menu[popover] {
   color: var(--text-strong);
   font-size: 11px;
   font-weight: 600;
-  flex: none;
-}
-
-.sidebar-agent-section__name {
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text);
-}
-
-.sidebar-agent-section--expanded > .sidebar-agent-section__header .sidebar-agent-section__name {
-  color: var(--text-strong);
-}
-
-.sidebar-agent-section__unread {
   flex: none;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #105777: with the footer agent chip owning agent switching, the sessions area still rendered one collapsible section per agent. Users with several agents saw all of them stacked in the sidebar when they only care about the one they selected — the agent-section headers duplicated what the chip now does.

## Why This Change Was Made

The sessions list is now a single flat list scoped to the chip-selected agent; `renderAgentSection` and its per-agent cached-rows helper are deleted, along with the dead section CSS. The list keys off the selected agent and keeps the navigation rows (with pinned-active semantics) whenever the route and loaded result agree with it; mid-switch or offline it falls back to that agent's loaded/cached raw rows so switching never flashes an empty or stale list. Unread activity on non-selected agents doesn't go dark: the chip's menu toggle gains a small unread dot (per-agent dots inside the menu already landed with #105777), and the draft row only shows for the agent it belongs to.

## User Impact

Multi-agent sidebars show only the selected agent's sessions — switch agents via the chip. Unread elsewhere surfaces as a dot on the chip's chevron and per-agent dots in its menu. Single-agent installs are visually unchanged.

## Evidence

- `ui/src/components/app-sidebar.test.ts`: new test proves no `.sidebar-agent-section` renders with two agents, the flat list stays scoped to the selected agent, the menu-toggle unread dot appears for other-agent unread, and the mid-switch cache fallback renders the target agent's cached rows; 38/38 green on Blacksmith Testbox (Linux) plus `pnpm tsgo:ui` and oxlint.
- Codex autoreview (gpt-5.5): two rounds of findings addressed (flash-of-empty on switch, list keyed to route instead of selected agent), final run clean.
- Net deletion: agent-section renderer, per-agent rows helper, and section CSS removed; non-test LOC shrinks outside the added fallback helper.
