### PR TITLE
fix: inherit provider-level contextWindow/maxTokens when applying model defaults

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -221,12 +221,19 @@ export function applyModelDefaults(
 
         const contextWindow = isPositiveNumber(raw.contextWindow)
           ? raw.contextWindow
-          : DEFAULT_CONTEXT_TOKENS;
+          : isPositiveNumber(nextProvider.contextWindow)
+            ? nextProvider.contextWindow
+            : DEFAULT_CONTEXT_TOKENS;
         if (raw.contextWindow !== contextWindow) {
           modelMutated = true;
         }
 
-        const defaultMaxTokens = Math.min(DEFAULT_MODEL_MAX_TOKENS, contextWindow);
+        const defaultMaxTokens = Math.min(
+          isPositiveNumber(nextProvider.maxTokens)
+            ? nextProvider.maxTokens
+            : DEFAULT_MODEL_MAX_TOKENS,
+          contextWindow,
+        );
         const rawMaxTokens = isPositiveNumber(raw.maxTokens) ? raw.maxTokens : defaultMaxTokens;
         const maxTokens = resolveNormalizedProviderModelMaxTokens({
           providerId,

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -481,4 +481,99 @@ describe("applyModelDefaults", () => {
     const model = next.models?.providers?.myproxy?.models?.[0];
     expect(model?.api).toBe("openai-completions");
   });
+
+  it("inherits provider-level contextWindow when model omits it", () => {
+    const cfg = {
+      models: {
+        providers: {
+          myproxy: {
+            baseUrl: "https://proxy.example/v1",
+            apiKey: "sk-test",
+            api: "openai-completions",
+            contextWindow: 50_000,
+            maxTokens: 4_096,
+            models: [
+              {
+                id: "custom-model",
+                name: "Custom",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const next = applyModelDefaults(cfg);
+    const model = next.models?.providers?.myproxy?.models?.[0];
+
+    expect(model?.contextWindow).toBe(50_000);
+    expect(model?.maxTokens).toBe(4_096);
+  });
+
+  it("lets per-model contextWindow override provider-level default", () => {
+    const cfg = {
+      models: {
+        providers: {
+          myproxy: {
+            baseUrl: "https://proxy.example/v1",
+            apiKey: "sk-test",
+            api: "openai-completions",
+            contextWindow: 50_000,
+            maxTokens: 4_096,
+            models: [
+              {
+                id: "custom-model",
+                name: "Custom",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 120_000,
+                maxTokens: 8_192,
+              },
+            ],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const next = applyModelDefaults(cfg);
+    const model = next.models?.providers?.myproxy?.models?.[0];
+
+    expect(model?.contextWindow).toBe(120_000);
+    expect(model?.maxTokens).toBe(8_192);
+  });
+
+  it("clamps provider-level maxTokens to the resolved contextWindow", () => {
+    const cfg = {
+      models: {
+        providers: {
+          myproxy: {
+            baseUrl: "https://proxy.example/v1",
+            apiKey: "sk-test",
+            api: "openai-completions",
+            contextWindow: 32_768,
+            maxTokens: 40_960,
+            models: [
+              {
+                id: "custom-model",
+                name: "Custom",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const next = applyModelDefaults(cfg);
+    const model = next.models?.providers?.myproxy?.models?.[0];
+
+    expect(model?.contextWindow).toBe(32_768);
+    expect(model?.maxTokens).toBe(32_768);
+  });
 });

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -504,7 +504,7 @@ describe("applyModelDefaults", () => {
           },
         },
       },
-    } satisfies OpenClawConfig;
+    } as OpenClawConfig;
 
     const next = applyModelDefaults(cfg);
     const model = next.models?.providers?.myproxy?.models?.[0];
@@ -537,7 +537,7 @@ describe("applyModelDefaults", () => {
           },
         },
       },
-    } satisfies OpenClawConfig;
+    } as OpenClawConfig;
 
     const next = applyModelDefaults(cfg);
     const model = next.models?.providers?.myproxy?.models?.[0];
@@ -568,7 +568,7 @@ describe("applyModelDefaults", () => {
           },
         },
       },
-    } satisfies OpenClawConfig;
+    } as OpenClawConfig;
 
     const next = applyModelDefaults(cfg);
     const model = next.models?.providers?.myproxy?.models?.[0];


### PR DESCRIPTION
## What Problem This Solves

Closes #105803

When a provider config sets `contextWindow` and `maxTokens` at the provider
level (documented as defaults for models under that provider), `applyModelDefaults`
in `src/config/defaults.ts` ignored them. Models that omitted these fields
silently received `DEFAULT_CONTEXT_TOKENS` / `DEFAULT_MODEL_MAX_TOKENS` instead.

Provider-level `contextTokens` inheritance is addressed separately in #105841.

## Evidence

**Before** — model without contextWindow/maxTokens gets global defaults:
```
model.contextWindow === 200000 (DEFAULT_CONTEXT_TOKENS)
model.maxTokens === 8192 (DEFAULT_MODEL_MAX_TOKENS)
```

**After** — model inherits provider-level defaults:
```
model.contextWindow === 50000 (from provider config)
model.maxTokens === 4096 (from provider config)
```

**Tests** (3 new + 18 existing = 21 pass):
```
 ✓ inherits provider-level contextWindow when model omits it
 ✓ lets per-model contextWindow override provider-level default
 ✓ clamps provider-level maxTokens to the resolved contextWindow
```

## Why This Change Was Made

`ModelProviderConfig` exposes `contextWindow` and `maxTokens` as provider-level
defaults, documented in `docs/concepts/model-providers.md`. The runtime path
(#44786) already respects provider-level defaults for discovered models, but
the static config-loading path (`applyModelDefaults`) only looked at per-model
values.

## Merge Risk

Low — 7-line change in a well-tested function. Per-model overrides still
take precedence; the fallback chain is now model → provider → global default,
matching the documented behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)