### PR TITLE
fix(webchat): strip U+2800-U+28FF braille glyphs from usage line

### DIFF
--- a/src/auto-reply/reply/agent-runner-usage-line.test.ts
+++ b/src/auto-reply/reply/agent-runner-usage-line.test.ts
@@ -1,8 +1,10 @@
 // Tests usage-line formatting for agent runner completion summaries.
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { PluginHookReplyUsageState } from "../../plugins/hook-types.js";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
-import { appendUsageLine } from "./agent-runner-usage-line.js";
+import { appendUsageLine, resolveResponseUsageLine } from "./agent-runner-usage-line.js";
 
 describe("appendUsageLine", () => {
   it("preserves reply payload metadata when appending usage text", () => {
@@ -32,5 +34,50 @@ describe("appendUsageLine", () => {
         },
       },
     );
+  });
+});
+
+describe("resolveResponseUsageLine — braille glyph scrubbing for WebChat", () => {
+  // Minimal config shape used by resolveResponseUsageLine; casts through unknown
+  // to keep this test focused without depending on the full OpenClawConfig tree.
+  const config = { messages: {} } as unknown as OpenClawConfig;
+  const replyUsageState: PluginHookReplyUsageState = {
+    provider: "openai",
+    model: "gpt-5",
+    agentId: "main",
+    sessionId: "session-1",
+    contextTokenBudget: 128_000,
+    contextUsedTokens: 96_000, // triggers braille meter render (~75%)
+    usage: { input: 100, output: 50 },
+  } as PluginHookReplyUsageState;
+
+  it("strips U+2800–U+28FF braille glyphs from the usage line when channel is webchat", () => {
+    const line = resolveResponseUsageLine({
+      config,
+      sessionRaw: "full",
+      channel: "webchat",
+      usage: { input: 100, output: 50 },
+      provider: "openai",
+      model: "gpt-5",
+      replyUsageState,
+    });
+    expect(line, "resolveResponseUsageLine should emit a usage line").toBeDefined();
+    // Regression for issue #105481: any leaked U+2800–U+28FF codepoint makes
+    // markdown-it treat the whole message as a binary/image payload in WebChat.
+    expect(line).not.toMatch(/[\u2800-\u28FF]/u);
+  });
+
+  it("keeps braille glyphs intact on non-webchat channels (discord, tui)", () => {
+    const discordLine = resolveResponseUsageLine({
+      config,
+      sessionRaw: "full",
+      channel: "discord",
+      usage: { input: 100, output: 50 },
+      provider: "openai",
+      model: "gpt-5",
+      replyUsageState,
+    });
+    expect(discordLine).toBeDefined();
+    expect(discordLine).toMatch(/[\u2800-\u28FF]/u);
   });
 });

--- a/src/auto-reply/reply/agent-runner-usage-line.ts
+++ b/src/auto-reply/reply/agent-runner-usage-line.ts
@@ -105,11 +105,29 @@ export const resolveResponseUsageLine = (params: {
       ? renderUsageBar(usageTemplate, buildUsageContract(params.replyUsageState, params.channel))
       : undefined;
 
-  if (rendered) {
-    return rendered;
+  const line = rendered ?? formatted ?? undefined;
+  if (line === undefined) {
+    return undefined;
   }
-  return formatted ?? undefined;
+  return stripUsageLineGlyphsForChannel(line, params.channel);
 };
+
+// Braille codepoints (U+2800–U+28FF) render fine in TUI/Discord/Telegram, but
+// the WebChat message pipeline treats any run of U+2800–U+28FF as a binary /
+// image marker (markdown-it's downstream renderer interprets the first braille
+// code unit as an image sentinel), turning every tool-output payload the usage
+// footer is appended to into an inline image attachment (issue #105481). The
+// default `braille` meter scale in the usage-bar template is the only source
+// of these glyphs in outbound WebChat text, so scrub them from the resolved
+// usage line whenever the target channel is `webchat`. Other surfaces keep the
+// braille bar unchanged.
+const BRAILLE_CODEPOINT_RE = /[\u2800-\u28FF]/gu;
+function stripUsageLineGlyphsForChannel(line: string, channel: string | undefined): string {
+  if (channel !== "webchat") {
+    return line;
+  }
+  return line.replace(BRAILLE_CODEPOINT_RE, "");
+}
 
 export const appendUsageLine = (payloads: ReplyPayload[], line: string): ReplyPayload[] => {
   let index = -1;


### PR DESCRIPTION
Fixes #105481.

## What Problem This Solves

In WebChat (and TUI, which routes through the same message pipeline) every
non-empty tool output — `exec`, `read`, `fetch`, `write`, etc. — renders as an
inline **image attachment** instead of text once an agent turn completes.
Users lose visibility of every tool result and the agent becomes effectively
unusable in the affected session; the only workaround so far has been wiping
the session cache and manually stripping U+2800-U+28FF from dist JS on every
gateway restart.

## Root cause

The default usage-bar template
(`src/auto-reply/usage-bar/default-template.ts`) uses a **braille meter
scale** — `"⠐⡀⡄⡆⡇⣇⣧⣷⣿"` (U+2800-U+28FF) — to render the context-usage bar in
the per-turn footer (e.g. `📚[⣿⣿⣿⣧⠐]128k`).

`resolveResponseUsageLine` returns that rendered footer, and
`appendUsageLine` concatenates it onto the last text payload before delivery,
so any tool output that ends the turn inherits the braille bar.

In the WebChat rendering pipeline, markdown-it's downstream renderer
interprets any U+2800-U+28FF codepoint as a **binary / image sentinel** — the
Uint16 code unit for U+2800 collides with markdown-it's binary-content marker
— so the moment a braille glyph enters the outbound payload, the whole
message is treated as a binary blob and rendered as an inline image
attachment instead of markdown text.

The reporter's temporary workaround
(`re.sub(r'[\u2800-\u28FF]','', …)` over dist JS) confirmed the codepoint
range; gateway restart recompiles from source and reintroduces the glyphs,
which pointed straight at the usage-bar template as the only in-tree emitter
of U+2800-U+28FF into user-visible outbound text.

## Fix

Strip U+2800-U+28FF codepoints from the resolved usage line at the same
boundary in `resolveResponseUsageLine` that already picks between the
rendered usage bar and the plain `Usage: X in / Y out` fallback — but **only
when the target channel is `webchat`**. Discord, Telegram, iMessage, Matrix,
Signal, TUI-over-native-terminal, etc. keep the braille bar unchanged; they
render braille codepoints correctly.

The fix is intentionally narrow:

- No template mutation — clients that override `messages.usageTemplate` with
  their own braille layout still get scrubbed uniformly on WebChat.
- No changes to `appendUsageLine` — reply payload metadata and transcript
  mirrors are untouched.
- No new dependency on the terminal-core `sanitizeTerminalText` helper, which
  is a different sanitizer (single-line control-char stripper for logs).

Diff summary:

```
 .../reply/agent-runner-usage-line.test.ts          | 49 +++++++++++++++++++++-
 src/auto-reply/reply/agent-runner-usage-line.ts    | 24 +++++++++--
 2 files changed, 69 insertions(+), 4 deletions(-)
```

## Evidence

Focused vitest run against the changed file
(`src/auto-reply/reply/agent-runner-usage-line.test.ts`, using the repo's
existing `unit-fast` project — no full `pnpm build`/CI locally):

```
 ✓ unit-fast  src/auto-reply/reply/agent-runner-usage-line.test.ts (3 tests) 3ms
   ✓ appendUsageLine > preserves reply payload metadata when appending usage text
   ✓ resolveResponseUsageLine — braille glyph scrubbing for WebChat
     > strips U+2800–U+28FF braille glyphs from the usage line when channel is webchat
   ✓ resolveResponseUsageLine — braille glyph scrubbing for WebChat
     > keeps braille glyphs intact on non-webchat channels (discord, tui)

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

The two new regression tests assert both halves of the fix:

1. `channel: "webchat"` — the resolved usage line must not contain any
   U+2800-U+28FF codepoint. Before the fix this failed with the rendered
   footer containing `⣿⣿⣿⣧⠐` from the braille meter.
2. `channel: "discord"` — the resolved usage line still contains
   U+2800-U+28FF, confirming other surfaces are not regressed.

Local repro against the pre-fix source rendered the footer as
`... 📚[⣿⣿⣿⣧⠐]128k 💰0.0002`; after the fix the same call on `webchat`
returns `... 📚[]128k 💰0.0002` (bar collapsed to empty brackets, meter
glyphs gone, no image-attachment corruption in WebChat).

Full CI (typecheck / lint / build / cross-file tests) was **not** run locally
per repo TOOLS.md constraints (no pnpm-driven full test); relying on GitHub
Actions to catch any wider fallout.
