### PR TITLE
fix(gateway): add base64 validation before decode in persistInboundImagesForTranscript

### DIFF
--- a/src/gateway/chat-attachments.base64.test.ts
+++ b/src/gateway/chat-attachments.base64.test.ts
@@ -1,61 +1,33 @@
 import { describe, it, expect } from "vitest";
+import { isValidBase64 } from "./chat-attachments.js";
 
-// Regression tests for isValidBase64, exercised through the persistInboundImagesForTranscript
-// code path. The function is defined in chat-attachments.ts.
-// We test it directly since it's the guard added before Buffer.from decode.
-
-describe("isValidBase64", () => {
-  it("accepts valid base64", async () => {
-    const mod = await import("./chat-attachments.js");
-    // isValidBase64 is not exported from the module in production but is tested here
-    // via the module's internal function. We reimplement the logic for testing.
-    expect(true).toBe(true);
-  });
-});
-
-describe("base64 validation rules", () => {
-  it("rejects empty string", async () => {
-    const { Check } = await import("typebox/value");
-    const { Type } = await import("typebox");
-    // The guard throws when isValidBase64 returns false
-    const schema = Type.String();
-    expect(true).toBe(true);
-  });
-
-  it("correctly validates base64 content", () => {
-    function isBase64DataCharCode(code: number): boolean {
-      return (
-        (code >= 0x41 && code <= 0x5a) ||
-        (code >= 0x61 && code <= 0x7a) ||
-        (code >= 0x30 && code <= 0x39) ||
-        code === 0x2b ||
-        code === 0x2f
-      );
-    }
-    function isValidBase64(value: string): boolean {
-      if (value.length === 0 || value.length % 4 !== 0) return false;
-      let padding = 0,
-        sawPadding = false;
-      for (let i = 0; i < value.length; i++) {
-        const code = value.charCodeAt(i);
-        if (code === 0x3d) {
-          padding++;
-          if (padding > 2) return false;
-          sawPadding = true;
-          continue;
-        }
-        if (sawPadding || !isBase64DataCharCode(code)) return false;
-      }
-      return true;
-    }
+describe("isValidBase64 — production function", () => {
+  it("accepts valid padded base64", () => {
     expect(isValidBase64("dGVzdA==")).toBe(true);
     expect(
       isValidBase64(
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
       ),
     ).toBe(true);
+  });
+
+  it("rejects empty string", () => {
     expect(isValidBase64("")).toBe(false);
+  });
+
+  it("rejects string with invalid characters", () => {
     expect(isValidBase64("invalid!")).toBe(false);
+  });
+
+  it("rejects unpadded base64 (length not divisible by 4)", () => {
     expect(isValidBase64("abc")).toBe(false);
+  });
+
+  it("rejects strings with padding in middle", () => {
+    expect(isValidBase64("abc=defg")).toBe(false);
+  });
+
+  it("rejects strings with too much padding", () => {
+    expect(isValidBase64("a===")).toBe(false);
   });
 });

--- a/src/gateway/chat-attachments.base64.test.ts
+++ b/src/gateway/chat-attachments.base64.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+
+// Regression tests for isValidBase64, exercised through the persistInboundImagesForTranscript
+// code path. The function is defined in chat-attachments.ts.
+// We test it directly since it's the guard added before Buffer.from decode.
+
+describe("isValidBase64", () => {
+  it("accepts valid base64", async () => {
+    const mod = await import("./chat-attachments.js");
+    // isValidBase64 is not exported from the module in production but is tested here
+    // via the module's internal function. We reimplement the logic for testing.
+    expect(true).toBe(true);
+  });
+});
+
+describe("base64 validation rules", () => {
+  it("rejects empty string", async () => {
+    const { Check } = await import("typebox/value");
+    const { Type } = await import("typebox");
+    // The guard throws when isValidBase64 returns false
+    const schema = Type.String();
+    expect(true).toBe(true);
+  });
+
+  it("correctly validates base64 content", () => {
+    function isBase64DataCharCode(code: number): boolean {
+      return (
+        (code >= 0x41 && code <= 0x5a) ||
+        (code >= 0x61 && code <= 0x7a) ||
+        (code >= 0x30 && code <= 0x39) ||
+        code === 0x2b ||
+        code === 0x2f
+      );
+    }
+    function isValidBase64(value: string): boolean {
+      if (value.length === 0 || value.length % 4 !== 0) return false;
+      let padding = 0,
+        sawPadding = false;
+      for (let i = 0; i < value.length; i++) {
+        const code = value.charCodeAt(i);
+        if (code === 0x3d) {
+          padding++;
+          if (padding > 2) return false;
+          sawPadding = true;
+          continue;
+        }
+        if (sawPadding || !isBase64DataCharCode(code)) return false;
+      }
+      return true;
+    }
+    expect(isValidBase64("dGVzdA==")).toBe(true);
+    expect(
+      isValidBase64(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+      ),
+    ).toBe(true);
+    expect(isValidBase64("")).toBe(false);
+    expect(isValidBase64("invalid!")).toBe(false);
+    expect(isValidBase64("abc")).toBe(false);
+  });
+});

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -71,6 +71,9 @@ export async function persistInboundImagesForTranscript(params: {
   const inline: SavedMedia[] = [];
   for (const image of params.images) {
     try {
+      if (!isValidBase64(image.data)) {
+        throw new Error(`attachment: invalid base64 content (${image.mimeType})`);
+      }
       inline.push(
         await saveMediaBuffer(Buffer.from(image.data, "base64"), image.mimeType, "inbound"),
       );

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -202,7 +202,7 @@ function resolveAttachmentMime(params: {
   );
 }
 
-function isBase64DataCharCode(code: number): boolean {
+export function isBase64DataCharCode(code: number): boolean {
   return (
     (code >= 0x41 && code <= 0x5a) ||
     (code >= 0x61 && code <= 0x7a) ||
@@ -212,7 +212,7 @@ function isBase64DataCharCode(code: number): boolean {
   );
 }
 
-function isValidBase64(value: string): boolean {
+export function isValidBase64(value: string): boolean {
   if (value.length === 0 || value.length % 4 !== 0) {
     return false;
   }


### PR DESCRIPTION
## Summary

Fixes #105837

**Problem**: `persistInboundImagesForTranscript` decodes base64 image data via `Buffer.from(data, "base64")` without validating the encoding first. Malformed base64 can silently produce garbage bytes or unexpected errors.

**Solution**: Add `isValidBase64` guard before decode, throwing a clear error message when the image data is not valid base64. Export `isValidBase64` from the module so it can be tested directly against the production implementation.

**What changed**: One guard in `src/gateway/chat-attachments.ts:74` — `if (!isValidBase64(image.data))` before `Buffer.from` decode. Exported both `isValidBase64` and `isBase64DataCharCode` (previously module-private) to enable direct production testing. Rewrote `chat-attachments.base64.test.ts` to import and validate against the exported production function instead of using placeholder assertions and a reimplemented copy.

**NOT changed**: No changes to existing test behavior, no changes to image persistence logic, no changes to error handling outside this new guard. All existing tests continue to pass. The existing placeholder tests were replaced entirely with real assertions against the production function.

## Real behavior proof

**Behavior addressed**: `isValidBase64` guard validates base64 before `Buffer.from` decode in `persistInboundImagesForTranscript`.
**Real environment tested**: Linux x64, Node.js 25.9.0, OpenClaw `main@HEAD` with this patch applied.
**Exact steps or command run after this patch**: `node --import tsx/esm -e "..."` (simulates the guard+decode path of `persistInboundImagesForTranscript`)
**After-fix evidence**: 6/6 scenarios passed (see terminal output below).
**Observed result after the fix**: Valid 1x1 PNG image passes guard and decodes to 70 bytes; malformed/empty/unpadded inputs are all rejected by the guard before reaching `Buffer.from`.
**What was not tested**: End-to-end Gateway server with actual multipart uploads (requires full runtime); the guard+decode path is exactly what `persistInboundImagesForTranscript` does at lines 73-75.

## Tests and validation

```
$ pnpm test src/gateway/chat-attachments.base64.test.ts --reporter=verbose

 ✓ |gateway-core| isValidBase64 — production function > accepts valid padded base64
 ✓ |gateway-core| isValidBase64 — production function > rejects empty string
 ✓ |gateway-core| isValidBase64 — production function > rejects string with invalid characters
 ✓ |gateway-core| isValidBase64 — production function > rejects unpadded base64 (length not divisible by 4)
 ✓ |gateway-core| isValidBase64 — production function > rejects strings with padding in middle
 ✓ |gateway-core| isValidBase64 — production function > rejects strings with too much padding
 ...

 Test Files  4 passed (4)
      Tests  24 passed (24)
```

Real runtime behavior proof — the guard+decode path that `persistInboundImagesForTranscript` executes at lines 73-75:

```
$ node --import tsx/esm -e "..."

=== Real behavior proof: persistInboundImagesForTranscript guard ===

✓ Valid 1x1 PNG: guard passes, Buffer.from yields 70 bytes
✓ Malformed string 'invalid!': guard threw — attachment: invalid base64 content
✓ Empty string '': guard threw — attachment: invalid base64 content
✓ Unpadded base64 'abc': guard threw — attachment: invalid base64 content
✓ Padding in middle 'abc=defg': guard threw — attachment: invalid base64 content
✓ Excessive padding 'a===': guard threw — attachment: invalid base64 content

6/6 scenarios passed
```

Validated against the exported production `isValidBase64` function:

| Input | Expected | Result |
|-------|----------|--------|
| `"dGVzdA=="` (valid padded) | ✅ accept | passed |
| `"iVBORw0KGgo..."` (valid PNG base64) | ✅ accept | passed |
| `""` (empty) | ❌ reject | passed |
| `"invalid!"` (invalid chars) | ❌ reject | passed |
| `"abc"` (unpadded, length 3) | ❌ reject | passed |
| `"abc=defg"` (padding in middle) | ❌ reject | passed |
| `"a==="` (excessive padding) | ❌ reject | passed |

## Risk checklist

- [x] This change is backwards compatible — valid base64 inputs continue to decode as before
- [x] This change has been tested with existing configurations
- [ ] I have updated relevant documentation
- [x] Breaking changes (if any) are documented in Summary

---
merge-risk: 🚨 compatibility — new validation may reject previously-silently-accepted malformed base64; this is the intended fix.
