### PR TITLE
fix: inherit provider-level contextTokens when applying model defaults

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -242,6 +242,15 @@ export function applyModelDefaults(
           modelMutated = true;
         }
 
+        const contextTokens = isPositiveNumber(raw.contextTokens)
+          ? raw.contextTokens
+          : isPositiveNumber(nextProvider.contextTokens)
+            ? nextProvider.contextTokens
+            : undefined;
+        if (raw.contextTokens !== contextTokens) {
+          modelMutated = true;
+        }
+
         if (!modelMutated) {
           return model;
         }
@@ -254,6 +263,7 @@ export function applyModelDefaults(
           contextWindow,
           maxTokens,
           api,
+          contextTokens,
         }) as ModelDefinitionConfig;
       });
 

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -481,4 +481,76 @@ describe("applyModelDefaults", () => {
     const model = next.models?.providers?.myproxy?.models?.[0];
     expect(model?.api).toBe("openai-completions");
   });
+
+  it("inherits provider-level contextTokens when model omits it", () => {
+    const cfg = {
+      models: {
+        providers: {
+          myproxy: {
+            baseUrl: "https://proxy.example/v1",
+            apiKey: "sk-test",
+            api: "openai-completions",
+            contextTokens: 120_000,
+            models: [
+              {
+                id: "gpt-5.4",
+                name: "GPT-5.4",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 200_000,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const next = applyModelDefaults(cfg);
+    const model = next.models?.providers?.myproxy?.models?.[0];
+
+    expect(model?.contextTokens).toBe(120_000);
+  });
+
+  it("lets per-model contextTokens override provider-level default", () => {
+    const cfg = {
+      models: {
+        providers: {
+          myproxy: {
+            baseUrl: "https://proxy.example/v1",
+            apiKey: "sk-test",
+            api: "openai-completions",
+            contextTokens: 120_000,
+            models: [
+              {
+                id: "gpt-5.4",
+                name: "GPT-5.4",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 200_000,
+                maxTokens: 8192,
+                contextTokens: 50_000,
+              },
+            ],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const next = applyModelDefaults(cfg);
+    const model = next.models?.providers?.myproxy?.models?.[0];
+
+    expect(model?.contextTokens).toBe(50_000);
+  });
+
+  it("leaves contextTokens undefined when neither model nor provider set it", () => {
+    const cfg = buildProxyProviderConfig();
+
+    const next = applyModelDefaults(cfg);
+    const model = next.models?.providers?.myproxy?.models?.[0];
+
+    expect(model?.contextTokens).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Closes #105820

When a provider config sets `contextTokens` (the effective runtime context cap),
`applyModelDefaults` did not propagate it to model entries that omit the field.
Models showed no effective cap, and `openclaw models list` omitted the cap for
those models, even though the runtime (`applyConfiguredContextWindows`) already
falls back to the provider value.

## Evidence

**Before** — model without contextTokens gets undefined:
```
model.contextTokens === undefined  // provider set 120000, but model didn't inherit it
```

**After** — model inherits provider-level contextTokens:
```
model.contextTokens === 120000  // inherited from provider config
```

**Tests** (3 new + 18 existing = 21 pass):
```
 ✓ inherits provider-level contextTokens when model omits it
 ✓ lets per-model contextTokens override provider-level default
 ✓ leaves contextTokens undefined when neither model nor provider set it
```

## Why This Change Was Made

The documentation in `docs/gateway/config-tools.md` says provider-level
`contextTokens` sets a default effective runtime context cap for models
under that provider. Runtime (`src/agents/context.ts`) already falls back
to the provider value, but `applyModelDefaults` in `src/config/defaults.ts`
never read it. This caused config snapshots and `openclaw models list` to
show no effective cap.

## Merge Risk

Low — 9-line change in `src/config/defaults.ts` plus 3 targeted tests.
Per-model `contextTokens` still takes precedence over the provider default;
when neither is set, behavior is unchanged (undefined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)