### PR TITLE
fix(slack): include file metadata in attachment placeholders

### DIFF
--- a/extensions/slack/src/file-reference.test.ts
+++ b/extensions/slack/src/file-reference.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { formatSlackFileReference, formatSlackFileReferenceList } from "./file-reference.js";
+
+describe("formatSlackFileReference", () => {
+  it("includes Slack file id, MIME type, and exact byte size when available", () => {
+    expect(
+      formatSlackFileReference({
+        id: "F123",
+        name: "report.pdf",
+        mimetype: "application/pdf",
+        size: 45056,
+      }),
+    ).toBe("report.pdf (application/pdf, 45056 bytes, fileId: F123)");
+  });
+
+  it("preserves the previous compact shape when Slack omits MIME type and size", () => {
+    expect(formatSlackFileReference({ id: "F123", name: "report.pdf" })).toBe(
+      "report.pdf (fileId: F123)",
+    );
+  });
+
+  it("omits malformed optional metadata", () => {
+    expect(
+      formatSlackFileReference({
+        id: "F123",
+        name: "report.pdf",
+        mimetype: "  ",
+        size: -1,
+      }),
+    ).toBe("report.pdf (fileId: F123)");
+  });
+});
+
+describe("formatSlackFileReferenceList", () => {
+  it("formats each file with its own metadata", () => {
+    expect(
+      formatSlackFileReferenceList([
+        { id: "FA", name: "a.jpg", mimetype: "image/jpeg", size: 12 },
+        { id: "FB", name: "b.png", mimetype: "image/png", size: 34 },
+      ]),
+    ).toBe("a.jpg (image/jpeg, 12 bytes, fileId: FA), b.png (image/png, 34 bytes, fileId: FB)");
+  });
+});

--- a/extensions/slack/src/file-reference.ts
+++ b/extensions/slack/src/file-reference.ts
@@ -4,8 +4,13 @@ import type { SlackFile } from "./types.js";
 
 export function formatSlackFileReference(file: SlackFile | undefined): string {
   const name = normalizeOptionalString(file?.name) ?? "file";
+  const mimetype = normalizeOptionalString(file?.mimetype);
+  const size = formatSlackFileSize(file?.size);
   const fileId = normalizeOptionalString(file?.id);
-  return fileId ? `${name} (fileId: ${fileId})` : name;
+  const metadata = [mimetype, size, fileId ? `fileId: ${fileId}` : undefined].filter(
+    (part): part is string => Boolean(part),
+  );
+  return metadata.length > 0 ? `${name} (${metadata.join(", ")})` : name;
 }
 
 export function formatSlackFileReferenceList(files: readonly SlackFile[] | undefined): string {
@@ -13,4 +18,11 @@ export function formatSlackFileReferenceList(files: readonly SlackFile[] | undef
     return "file";
   }
   return files.map((file) => formatSlackFileReference(file)).join(", ");
+}
+
+function formatSlackFileSize(size: unknown): string | undefined {
+  if (typeof size !== "number" || !Number.isSafeInteger(size) || size < 0) {
+    return undefined;
+  }
+  return `${size} bytes`;
 }

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
@@ -115,7 +115,7 @@ describe("resolveSlackThreadContextData", () => {
     {
       path: "/tmp/root.png",
       contentType: "image/png",
-      placeholder: "[Slack file: root.png (fileId: FROOT)]",
+      placeholder: "[Slack file: root.png (image/png, fileId: FROOT)]",
     },
   ];
 

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -1196,16 +1196,20 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       createSlackMessage({
         text: "",
         files: [
-          { id: "FVOICE", name: "voice.ogg" },
-          { id: "FPHOTO", name: "photo.jpg" },
+          { id: "FVOICE", name: "voice.ogg", mimetype: "audio/ogg", size: 3210 },
+          { id: "FPHOTO", name: "photo.jpg", mimetype: "image/jpeg", size: 6543 },
         ],
       }),
     );
 
     assertPrepared(prepared);
     expect(prepared.ctxPayload.RawBody).toContain("[Slack file:");
-    expect(prepared.ctxPayload.RawBody).toContain("voice.ogg (fileId: FVOICE)");
-    expect(prepared.ctxPayload.RawBody).toContain("photo.jpg (fileId: FPHOTO)");
+    expect(prepared.ctxPayload.RawBody).toContain(
+      "voice.ogg (audio/ogg, 3210 bytes, fileId: FVOICE)",
+    );
+    expect(prepared.ctxPayload.RawBody).toContain(
+      "photo.jpg (image/jpeg, 6543 bytes, fileId: FPHOTO)",
+    );
   });
 
   it("falls back to generic file label when a Slack file name is empty", async () => {
@@ -1392,7 +1396,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       expect(prepared).toBeNull();
       const entries = Array.from(slackCtx.channelHistories.values()).flat();
       expect(entries).toHaveLength(1);
-      expect(entries[0]?.body).toBe("[Slack file: diagram.png (fileId: F1)]");
+      expect(entries[0]?.body).toBe("[Slack file: diagram.png (image/png, fileId: F1)]");
       expect(entries[0]?.media).toHaveLength(1);
       expect(entries[0]?.media?.[0]).toMatchObject({
         contentType: "image/png",
@@ -1516,7 +1520,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       });
       const entries = Array.from(slackCtx.channelHistories.values()).flat();
       expect(entries).toHaveLength(1);
-      expect(entries[0]?.body).toBe("[Slack file: parent.png (fileId: F-parent)]");
+      expect(entries[0]?.body).toBe("[Slack file: parent.png (image/png, fileId: F-parent)]");
       expect(entries[0]?.media).toBeUndefined();
       expect(mockFetch).not.toHaveBeenCalled();
     } finally {
@@ -3790,7 +3794,9 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       expect(root.ctxPayload.CommandBody).toBe("");
       expect(root.ctxPayload.Transcript).toBe("Bill /new please review this");
       expect(root.ctxPayload.MediaTranscribedIndexes).toEqual([1]);
-      expect(root.ctxPayload.RawBody).toContain("[Slack file: voice.mp4 (fileId: FVOICE)]");
+      expect(root.ctxPayload.RawBody).toContain(
+        "[Slack file: voice.mp4 (video/mp4, fileId: FVOICE)]",
+      );
       expect(root.ctxPayload.BodyForAgent).toContain(
         '[Audio transcript (machine-generated, untrusted)]: "Bill /new please review this"',
       );
@@ -3899,7 +3905,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       await expect(fs.stat(downloadedPath as string)).rejects.toMatchObject({ code: "ENOENT" });
       const entries = Array.from(slackCtx.channelHistories.values()).flat();
       expect(entries).toHaveLength(1);
-      expect(entries[0]?.body).toBe("[Slack file: report.pdf (fileId: FPDF)]");
+      expect(entries[0]?.body).toBe("[Slack file: report.pdf (application/pdf, fileId: FPDF)]");
       expect(entries[0]?.media).toBeUndefined();
     } finally {
       globalThis.fetch = originalFetch;


### PR DESCRIPTION
## What Problem This Solves

Fixes the remaining Slack attachment metadata gap from #41657. Slack file-only and fallback delivery already preserve attachment presence through text placeholders, but those placeholders only exposed the file name and Slack file ID.

## Why This Change Was Made

Slack's File object includes metadata such as `mimetype` and `size`; those fields are already present on OpenClaw's Slack file type. This change enriches the existing Slack file-reference formatter so RawBody, BodyForAgent, and thread-context placeholders include MIME type and exact byte size when Slack provides them, while preserving the previous compact shape when metadata is absent.

This intentionally does not add a new shared structured inbound attachment schema. That is a larger cross-channel contract decision; this PR keeps the fix inside the existing Slack placeholder delivery path.

## User Impact

Agents receiving Slack messages with file attachments can now see useful file metadata directly in the delivered message text, including download-failure and no-download fallback paths. Existing messages without MIME type or size continue to render as before.

## Evidence

- Blacksmith Testbox `tbx_01kxcjxh4vqm83efv9dm30rsks`: `corepack pnpm test extensions/slack/src/file-reference.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts` — 141 tests passed.
- Blacksmith Testbox `tbx_01kxcjxh4vqm83efv9dm30rsks`: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` — passed.
- Autoreview: clean, no accepted/actionable findings.
- `git diff --check` — passed.

Fixes #41657.
