### PR TITLE
fix(ui): keep plugin monogram UTF-16-safe

### DIFF
--- a/ui/src/pages/plugins/presentation.test.ts
+++ b/ui/src/pages/plugins/presentation.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Tests for plugin catalog presentation helpers.
+ */
+import { describe, expect, it } from "vitest";
+import { pluginMonogram } from "./presentation.ts";
+
+describe("ui/pages/plugins/presentation", () => {
+  it("builds monograms from one or two words", () => {
+    expect(pluginMonogram("OpenClaw")).toBe("OP");
+    expect(pluginMonogram("Foo Bar")).toBe("FB");
+  });
+
+  it("trims whitespace before building the monogram", () => {
+    expect(pluginMonogram("  Linear  ")).toBe("LI");
+    expect(pluginMonogram("  GitHub   Copilot  ")).toBe("GC");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(pluginMonogram("")).toBe("");
+    expect(pluginMonogram("   ")).toBe("");
+  });
+
+  it("does not split surrogate pairs when truncating a single word", () => {
+    const monogram = pluginMonogram("a😀b");
+    expect(monogram).toBe("A");
+    expect(() => encodeURIComponent(monogram)).not.toThrow();
+  });
+});

--- a/ui/src/pages/plugins/presentation.test.ts
+++ b/ui/src/pages/plugins/presentation.test.ts
@@ -25,4 +25,14 @@ describe("ui/pages/plugins/presentation", () => {
     expect(monogram).toBe("A");
     expect(() => encodeURIComponent(monogram)).not.toThrow();
   });
+
+  it("does not split surrogate pairs when taking initials from two words", () => {
+    const leadingEmoji = pluginMonogram("😀 Plugin");
+    expect(leadingEmoji).toBe("😀P");
+    expect(() => encodeURIComponent(leadingEmoji)).not.toThrow();
+
+    const trailingEmoji = pluginMonogram("Plugin 😀");
+    expect(trailingEmoji).toBe("P😀");
+    expect(() => encodeURIComponent(trailingEmoji)).not.toThrow();
+  });
 });

--- a/ui/src/pages/plugins/presentation.ts
+++ b/ui/src/pages/plugins/presentation.ts
@@ -219,6 +219,10 @@ export function pluginFallbackGradient(id: string): readonly [string, string] {
   );
 }
 
+function firstInitial(word: string): string {
+  return String.fromCodePoint(word.codePointAt(0) ?? 0);
+}
+
 export function pluginMonogram(name: string): string {
   const words = name.trim().split(/\s+/u).filter(Boolean);
   if (words.length === 0) {
@@ -226,7 +230,9 @@ export function pluginMonogram(name: string): string {
   }
   const first = expectDefined(words[0], "plugin monogram first word");
   const second = words[1];
-  const initials = second ? `${first.charAt(0)}${second.charAt(0)}` : sliceUtf16Safe(first, 0, 2);
+  const initials = second
+    ? `${firstInitial(first)}${firstInitial(second)}`
+    : sliceUtf16Safe(first, 0, 2);
   return initials.toLocaleUpperCase();
 }
 

--- a/ui/src/pages/plugins/presentation.ts
+++ b/ui/src/pages/plugins/presentation.ts
@@ -1,6 +1,7 @@
 // Presentation data for the plugins catalog: bundled cover art, deterministic
 // fallback gradients, category shelving, and curated connector suggestions.
 import { expectDefined } from "@openclaw/normalization-core";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { inferControlUiPublicAssetPath } from "../../app/public-assets.ts";
 import { t } from "../../i18n/index.ts";
 
@@ -225,7 +226,7 @@ export function pluginMonogram(name: string): string {
   }
   const first = expectDefined(words[0], "plugin monogram first word");
   const second = words[1];
-  const initials = second ? `${first.charAt(0)}${second.charAt(0)}` : first.slice(0, 2);
+  const initials = second ? `${first.charAt(0)}${second.charAt(0)}` : sliceUtf16Safe(first, 0, 2);
   return initials.toLocaleUpperCase();
 }
 


### PR DESCRIPTION
## What Problem This Solves

`pluginMonogram` builds the two-letter fallback text for plugin catalog tiles. Both branches previously could produce invalid UTF-16:
- The single-word branch fell back to `first.slice(0, 2)`.
- The two-word branch used `first.charAt(0)` and `second.charAt(0)`.
Both count UTF-16 code units, so a name whose word contains an astral character (emoji, many CJK extensions, etc.) can have its surrogate pair split. The resulting string is invalid UTF-16 and will cause `encodeURIComponent` to throw.

## Why This Change Was Made

- Replaced the single-word `slice(0, 2)` with `sliceUtf16Safe(first, 0, 2)` from `@openclaw/normalization-core/utf16-slice`.
- Replaced the two-word `charAt(0)` calls with `String.fromCodePoint(word.codePointAt(0) ?? 0)` so a leading or trailing astral character contributes a complete code point instead of a lone surrogate half.

## User Impact

Plugin catalog tiles no longer risk producing an invalid monogram when a plugin name contains astral characters in either the first or second word.

## Evidence

- `ui/src/pages/plugins/presentation.ts`: `pluginMonogram` now truncates the single-word branch with `sliceUtf16Safe` and takes full code points for the two-word branch.
- Regression tests in `ui/src/pages/plugins/presentation.test.ts` cover `"a😀b"` (single word), `"😀 Plugin"` (leading emoji), and `"Plugin 😀"` (trailing emoji), asserting the monogram is well-formed and `encodeURIComponent(monogram)` succeeds.
- Existing monogram cases (two-word names, normal single words, whitespace trimming) remain unchanged.

## Real behavior proof

- Test command:
  ```bash
  pnpm test ui/src/pages/plugins/presentation.test.ts
  ```
- Before behavior:
  - `pluginMonogram("a😀b")` produced `"A\ud83d"`.
  - `pluginMonogram("Plugin 😀")` produced `"P\ud83d"`.
  - Both make `encodeURIComponent` throw `URIError: URI malformed`.
- After behavior:
  - `pluginMonogram("a😀b")` produces `"A"`.
  - `pluginMonogram("Plugin 😀")` produces `"P😀"`.
  - `encodeURIComponent` succeeds for both.
