### PR TITLE
fix(imessage): avoid surrogate pair truncation in replyToId sanitizer

### DIFF
--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -17,7 +17,7 @@ import {
   hasPersistedIMessageEcho,
   resetPersistedIMessageEchoCacheForTest,
 } from "./monitor/persisted-echo-cache.js";
-import { sendMessageIMessage } from "./send.js";
+import { sanitizeReplyToId, sendMessageIMessage } from "./send.js";
 import { installIMessageStateRuntimeForTest } from "./test-support/runtime.js";
 
 const IMESSAGE_TEST_CFG = {
@@ -1337,5 +1337,18 @@ describe("sendMessageIMessage CLI stream errors", () => {
       }),
     ).rejects.toThrow("iMessage CLI stderr stream error: stderr pipe broken");
     expect(kill).toHaveBeenCalledWith("SIGKILL");
+  });
+});
+
+describe("sanitizeReplyToId surrogate pair boundary", () => {
+  it("does not split surrogate pairs at the 256-unit truncation boundary", () => {
+    // 255 ASCII chars + emoji lands surrogate pair at position 256
+    const id = "a".repeat(255) + "\u{1F600}";
+    const result = sanitizeReplyToId(id);
+    expect(result).toBeDefined();
+    expect(result!.length).toBeLessThanOrEqual(256);
+    // No dangling surrogate at the truncation boundary
+    const lastCu = result!.charCodeAt(result!.length - 1);
+    expect(lastCu < 0xd800 || lastCu > 0xdfff).toBe(true);
   });
 });

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -193,7 +193,7 @@ function stripUnsafeReplyTagChars(value: string): string {
   return next;
 }
 
-function sanitizeReplyToId(rawReplyToId?: string): string | undefined {
+export function sanitizeReplyToId(rawReplyToId?: string): string | undefined {
   const trimmed = rawReplyToId?.trim();
   if (!trimmed) {
     return undefined;

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -18,6 +18,7 @@ import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime"
 import { sleep as delay } from "openclaw/plugin-sdk/runtime-env";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-chunking";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveIMessageAccount, type ResolvedIMessageAccount } from "./accounts.js";
 import {
   appendIMessageApprovalReactionHintForOutboundMessage,
@@ -202,7 +203,7 @@ function sanitizeReplyToId(rawReplyToId?: string): string | undefined {
     return undefined;
   }
   if (sanitized.length > MAX_REPLY_TO_ID_LENGTH) {
-    return sanitized.slice(0, MAX_REPLY_TO_ID_LENGTH);
+    return truncateUtf16Safe(sanitized, MAX_REPLY_TO_ID_LENGTH);
   }
   return sanitized;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the iMessage `sanitizeReplyToId` function could produce an invalid Unicode string when a `replyToId` value exceeds 256 characters and a non-BMP character (emoji, rare CJK, mathematical symbols, etc.) straddles the truncation boundary. `String.prototype.slice(0, 256)` operates on UTF-16 code units, so a surrogate pair split at position 256 produces a dangling surrogate — an invalid string that downstream iMessage CLI tools may reject or garble.

## Why This Change Was Made

`sanitizeReplyToId` now uses `truncateUtf16Safe` from `@openclaw/normalization-core/utf16-slice`, which adjusts the cutoff boundary backward by one code unit when it would otherwise land inside a surrogate pair. The SDK utility is already used throughout the iMessage extension (cli-output.ts, coalesce.ts, monitor/connect.ts) for the same purpose, so this change is consistent with existing practice. Valid ASCII-only replyToId values and short replyToId values are unaffected.

## User Impact

Non-BMP characters in replyToId values that happen to sit at the 256-char truncation boundary no longer produce dangling surrogates — they are either fully included (if within limit after normalization) or fully excluded (if the boundary would split the pair). The truncation remains at most 256 code units, never exceeding the downstream field limit.

## Evidence

- Claim proved at current head `a8de4e0434b5`: the real script-level proof below reproduces the bug and confirms the fix.

- Real proof via isolated Node runtime using the same boundary guard as the actual `truncateUtf16Safe` SDK function:

```text
$ node --input-type=module -e '
const text = "a".repeat(255) + "\u{1F600}";  // 257 code units
// Before: .slice(0, 256) splits surrogate pair
const before = text.slice(0, 256);
const bcu = before.charCodeAt(before.length - 1);
console.log("BEFORE: clean=" + !(bcu >= 0xD800 && bcu <= 0xDFFF) + " last=0x" + bcu.toString(16));

// After: truncateUtf16Safe avoids split
let end = Math.min(text.length, 256);
if (end < text.length && end > 0) {
  const cu = text.charCodeAt(end - 1);
  if (cu >= 0xD800 && cu <= 0xDBFF) end -= 1;
}
const after = text.slice(0, end);
const acu = after.charCodeAt(after.length - 1);
console.log("AFTER:  clean=" + !(acu >= 0xD800 && acu <= 0xDFFF) + " last=0x" + acu.toString(16));
'
BEFORE: clean=false last=0xd83d
AFTER:  clean=true last=0x61
```

- Focused regression test asserting `sanitizeReplyToId` never leaves a dangling surrogate at the 256-unit boundary.

```text
 Test Files  1 passed (1)
      Tests  48 passed (48)
```

```ts
it("does not split surrogate pairs at the 256-unit truncation boundary", () => {
  const id = "a".repeat(255) + "\u{1F600}";
  const result = sanitizeReplyToId(id);
  expect(result).toBeDefined();
  expect(result!.length).toBeLessThanOrEqual(256);
  const lastCu = result!.charCodeAt(result!.length - 1);
  expect(lastCu < 0xD800 || lastCu > 0xDFFF).toBe(true);
});
```

- Diff hygiene: `git diff --check upstream/main...HEAD` passed clean.

AI-assisted: yes. I trunk-based the fix via `truncateUtf16Safe`, which is the same SDK utility qingminglong deployed in PR #105103 for the `--ttl` boundary and is already used elsewhere in this extension.

## What was not tested

- Actual iMessage CLI invocation with a non-BMP replyToId (requires physical macOS + Messages.app). Truncation behavior is verified at the unit level with a focused regression test.
