### PR TITLE
fix(ui): explain why automation runs do not start

### DIFF
--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -702,6 +702,21 @@ export type CronStatus = {
   nextWakeAtMs?: number | null;
 };
 
+export type CronRunResult =
+  | { ok: true; ran: true }
+  | { ok: true; enqueued: true; runId: string }
+  | {
+      ok: true;
+      ran: false;
+      reason:
+        | "not-due"
+        | "already-running"
+        | "restart-recovery-pending"
+        | "invalid-spec"
+        | "stopped";
+    }
+  | { ok: false };
+
 export type CronRunLogEntry = {
   ts: number;
   jobId: string;

--- a/ui/src/e2e/cron-filters.e2e.test.ts
+++ b/ui/src/e2e/cron-filters.e2e.test.ts
@@ -292,4 +292,50 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
       await context.close();
     }
   });
+
+  it("shows why a requested run was not started", async () => {
+    const existingJob = cronJob(
+      "already-running-job",
+      "Long-running automation",
+      { kind: "every", everyMs: 60_000 },
+      { runningAtMs: Date.parse("2026-05-29T08:10:00.000Z") },
+    );
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1_280 },
+    });
+    const page = await context.newPage();
+    const pageErrors: string[] = [];
+    page.on("pageerror", (error) => pageErrors.push(String(error)));
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "cron.list": cronListResponse([existingJob]),
+        "cron.run": { ok: true, ran: false, reason: "already-running" },
+        "cron.runs": { entries: [], total: 0, offset: 0, limit: 50, hasMore: false },
+        "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}cron`);
+      await jobTitle(page, existingJob.name).waitFor({ timeout: 10_000 });
+      await jobTitle(page, existingJob.name).click();
+      await expect
+        .poll(async () => (await gateway.getRequests("cron.runs")).length)
+        .toBeGreaterThan(0);
+      const historyRequestsBeforeRun = (await gateway.getRequests("cron.runs")).length;
+
+      await page.locator('[data-test-id="cron-run-now"]').click();
+      await gateway.waitForRequest("cron.run");
+
+      await expect
+        .poll(() => page.locator(".cron-error-banner").textContent())
+        .toContain("This automation is already running.");
+      expect(await gateway.getRequests("cron.runs")).toHaveLength(historyRequestsBeforeRun);
+      expect(pageErrors).toEqual([]);
+    } finally {
+      await context.close();
+    }
+  });
 });

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3558,6 +3558,14 @@ export const en: TranslationMap = {
       more: "More actions",
       history: "History",
     },
+    runNotStarted: {
+      notDue: "This automation is not due yet.",
+      alreadyRunning: "This automation is already running.",
+      recoveryPending: "Scheduler recovery is still in progress.",
+      invalidSpec: "This automation has an invalid schedule or payload.",
+      stopped: "The scheduler is stopped.",
+      unknown: "This automation could not be started.",
+    },
     jobs: {
       schedule: "Schedule",
       lastRun: "Last run",

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -1905,7 +1905,7 @@ describe("cron controller", () => {
           id: "job-due",
           mode: "due",
         });
-        return { ok: true };
+        return { ok: true, enqueued: true, runId: "run-due" };
       }
       if (method === "cron.runs") {
         return { entries: [], total: 0, hasMore: false, nextOffset: null };
@@ -1920,6 +1920,60 @@ describe("cron controller", () => {
     await runCronJob(state, "job-due", "due");
 
     expect(request).toHaveBeenCalledWith("cron.run", { id: "job-due", mode: "due" });
+    expect(request).toHaveBeenCalledWith("cron.runs", expect.any(Object));
+  });
+
+  it.each([
+    ["not-due", "This automation is not due yet."],
+    ["already-running", "This automation is already running."],
+    ["restart-recovery-pending", "Scheduler recovery is still in progress."],
+    ["stopped", "The scheduler is stopped."],
+  ] as const)(
+    "surfaces cron.run %s outcomes without reloading run history",
+    async (reason, message) => {
+      const request = vi.fn(async (method: string) => {
+        if (method === "cron.run") {
+          return { ok: true, ran: false, reason };
+        }
+        return {};
+      });
+      const state = createState({
+        client: { request } as unknown as CronState["client"],
+        cronRunsScope: "job",
+        cronRunsJobId: "job-blocked",
+      });
+
+      await runCronJob(state, "job-blocked", "force");
+
+      expect(state.cronError).toBe(message);
+      expect(request).toHaveBeenCalledWith("cron.run", { id: "job-blocked", mode: "force" });
+      expect(request).not.toHaveBeenCalledWith("cron.runs", expect.anything());
+    },
+  );
+
+  it("reloads the skipped run recorded for an invalid persisted specification", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "cron.run") {
+        return { ok: true, ran: false, reason: "invalid-spec" };
+      }
+      if (method === "cron.runs") {
+        return { entries: [], total: 0, hasMore: false, nextOffset: null };
+      }
+      return {};
+    });
+    const state = createState({
+      client: { request } as unknown as CronState["client"],
+      cronRunsScope: "job",
+      cronRunsJobId: "job-invalid",
+    });
+
+    await runCronJob(state, "job-invalid", "force");
+
+    expect(state.cronError).toBe("This automation has an invalid schedule or payload.");
+    expect(request).toHaveBeenCalledWith(
+      "cron.runs",
+      expect.objectContaining({ id: "job-invalid" }),
+    );
   });
 });
 

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -5,6 +5,7 @@ import type {
   CronJobsEnabledFilter,
   CronJobsListResult,
   CronJobsSortBy,
+  CronRunResult,
   CronRunStatus,
   CronRunScope,
   CronRunLogEntry,
@@ -1113,9 +1114,37 @@ export async function toggleCronJob(
   return updated;
 }
 
+function cronRunNotStartedMessage(result: CronRunResult): string {
+  if (!("reason" in result)) {
+    return t("cron.runNotStarted.unknown");
+  }
+  switch (result.reason) {
+    case "not-due":
+      return t("cron.runNotStarted.notDue");
+    case "already-running":
+      return t("cron.runNotStarted.alreadyRunning");
+    case "restart-recovery-pending":
+      return t("cron.runNotStarted.recoveryPending");
+    case "invalid-spec":
+      return t("cron.runNotStarted.invalidSpec");
+    case "stopped":
+      return t("cron.runNotStarted.stopped");
+  }
+  return t("cron.runNotStarted.unknown");
+}
+
 export async function runCronJob(state: CronState, jobId: string, mode: "force" | "due" = "force") {
   await withCronBusy(state, async (client) => {
-    await client.request("cron.run", { id: jobId, mode });
+    const result = await client.request<CronRunResult>("cron.run", { id: jobId, mode });
+    if (!result.ok || ("ran" in result && !result.ran)) {
+      state.cronError = cronRunNotStartedMessage(result);
+      // Invalid persisted specs create a skipped history entry with diagnostics;
+      // true no-op outcomes have no new history to fetch.
+      if ("reason" in result && result.reason === "invalid-spec") {
+        await loadCronRuns(state, state.cronRunsScope === "all" ? null : jobId);
+      }
+      return;
+    }
     await loadCronRuns(state, state.cronRunsScope === "all" ? null : jobId);
   });
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users clicking **Run now** on an automation received no feedback when the Gateway accepted the request but did not start a run, such as when the job was already running, not due, invalid, stopped, or waiting for restart recovery.

## Why This Change Was Made

The Control UI now consumes the full `cron.run` result contract and shows a reason-specific banner for no-start outcomes. It reloads history only when a run was enqueued or when an invalid persisted specification created a skipped diagnostic entry; true no-op outcomes avoid a pointless history request.

## User Impact

Users now immediately understand why an automation did not start instead of seeing a silent history refresh with no new entry.

## Evidence

- 57 focused cron controller tests passed, including every no-start reason and the invalid-spec history exception.
- 3 Chromium Control UI scenarios passed, including the visible already-running banner and proof that no redundant `cron.runs` request was sent.
- Full changed-surface typecheck, format, lint, and repository guards passed.
- AWS Crabbox: `run_f8acbeb3128a` on exact head `08bc1f1b233`.
- Fresh autoreview: no accepted or actionable findings.
