### PR TITLE
feat(ui): make the sidebar agent chip body the menu trigger

### DIFF
--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -276,7 +276,7 @@ describe("AppSidebar agent chip", () => {
     agents: [{ id: "main", identity: { name: "Molty" } }, { id: "research" }],
   } as AgentsListResult;
 
-  it("resumes the newest session for the active agent from the chip body", async () => {
+  it("resumes the newest session when the menu switches to an agent with cached rows", async () => {
     const gatewayHarness = createGatewayHarness({} as GatewayBrowserClient);
     const setSessionKey = vi.fn();
     (gatewayHarness.gateway as { setSessionKey: (key: string) => void }).setSessionKey =
@@ -284,6 +284,8 @@ describe("AppSidebar agent chip", () => {
     const { sidebar } = await mountSidebar(
       gatewayHarness.gateway,
       createSessions("main", ["agent:main:main", "agent:main:task"]),
+      "panel",
+      TWO_AGENTS,
     );
     const onNavigate = vi.fn();
     sidebar.connected = true;
@@ -291,24 +293,27 @@ describe("AppSidebar agent chip", () => {
     await sidebar.updateComplete;
 
     sidebar.querySelector<HTMLButtonElement>(".sidebar-agent-chip__main")?.click();
+    await sidebar.updateComplete;
+    const rows = [
+      ...(sidebar.querySelectorAll<HTMLButtonElement>(
+        '.sidebar-agent-menu [role="menuitemradio"]',
+      ) ?? []),
+    ];
+    rows.find((row) => row.textContent?.includes("Molty"))?.click();
     // createSessionState stamps ascending updatedAt, so the last key is newest.
     expect(setSessionKey).toHaveBeenCalledWith("agent:main:task");
     expect(onNavigate).toHaveBeenCalledWith("chat", { search: "?session=agent%3Amain%3Atask" });
   });
 
-  it("shows offline and routes the chip body to settings when disconnected", async () => {
+  it("shows offline in the chip subtitle when disconnected", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
-    const onNavigate = vi.fn();
     sidebar.connected = false;
-    sidebar.onNavigate = onNavigate;
     await sidebar.updateComplete;
 
     expect(sidebar.querySelector(".sidebar-agent-chip__subtitle")?.textContent?.trim()).toBe(
       "Offline",
     );
-    sidebar.querySelector<HTMLButtonElement>(".sidebar-agent-chip__main")?.click();
-    expect(onNavigate).toHaveBeenCalledWith("config");
   });
 
   it("shows a working subtitle while the agent has an active run", async () => {
@@ -403,7 +408,7 @@ describe("AppSidebar agent chip", () => {
     await sidebar.updateComplete;
 
     expect(sidebar.querySelector(".sidebar-agent-chip__name")?.textContent?.trim()).toBe("Molty");
-    sidebar.querySelector<HTMLButtonElement>(".sidebar-agent-chip__menu-toggle")?.click();
+    sidebar.querySelector<HTMLButtonElement>(".sidebar-agent-chip__main")?.click();
     await sidebar.updateComplete;
 
     const menu = sidebar.querySelector(".sidebar-agent-menu");

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -1411,7 +1411,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     return { activeId, agent, agents };
   }
 
-  /** Newest visible session for an agent; the footer chip resumes here. */
+  /** Newest visible session for an agent; the chip menu's agent switch resumes here. */
   private latestAgentSessionRow(agentId: string): SessionsListResult["sessions"][number] | null {
     const normalized = normalizeAgentId(agentId);
     const rows =
@@ -2981,7 +2981,6 @@ class AppSidebar extends OpenClawLightDomContentsElement {
               .menuOpen=${this.agentMenuPosition !== null}
               .menuUnread=${chipMenuUnread}
               .newSessionDisabled=${!this.connected}
-              .onOpenConversation=${() => this.openAgentConversation(chipAgentId)}
               .onNewSession=${() => this.onOpenNewSession?.(chipAgentId)}
               .onToggleMenu=${(trigger: HTMLElement) => this.toggleAgentMenu(trigger)}
             ></openclaw-sidebar-agent-chip>

--- a/ui/src/components/sidebar-agent-chip.ts
+++ b/ui/src/components/sidebar-agent-chip.ts
@@ -6,8 +6,8 @@ import { icons } from "./icons.ts";
 import "./tooltip.ts";
 
 /** Sidebar footer identity chip: the beginner-facing entrance to the active
-    agent. The body resumes the agent's latest conversation; the trailing
-    controls create a session or open the utility menu owned by app-sidebar. */
+    agent. The body opens the agent/utility menu owned by app-sidebar; the
+    trailing control creates a session. */
 class SidebarAgentChip extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) agentName = "";
   @property({ attribute: false }) avatarUrl: string | null = null;
@@ -19,7 +19,6 @@ class SidebarAgentChip extends OpenClawLightDomContentsElement {
   /** Unread sessions exist on non-active agents; surfaces on the menu toggle. */
   @property({ attribute: false }) menuUnread = false;
   @property({ attribute: false }) newSessionDisabled = false;
-  @property({ attribute: false }) onOpenConversation?: () => void;
   @property({ attribute: false }) onNewSession?: () => void;
   @property({ attribute: false }) onToggleMenu?: (trigger: HTMLElement) => void;
 
@@ -28,9 +27,11 @@ class SidebarAgentChip extends OpenClawLightDomContentsElement {
       <div class="sidebar-agent-chip">
         <button
           type="button"
-          class="sidebar-agent-chip__main"
-          aria-label=${t("agentChip.openConversation", { name: this.agentName })}
-          @click=${() => this.onOpenConversation?.()}
+          class="sidebar-agent-chip__main ${this.menuOpen ? "sidebar-agent-chip__main--open" : ""}"
+          aria-haspopup="menu"
+          aria-expanded=${String(this.menuOpen)}
+          aria-label=${t("agentChip.menuLabel")}
+          @click=${(event: MouseEvent) => this.onToggleMenu?.(event.currentTarget as HTMLElement)}
         >
           <span class="sidebar-agent-chip__avatar">
             ${this.avatarUrl
@@ -60,6 +61,13 @@ class SidebarAgentChip extends OpenClawLightDomContentsElement {
               ? html`<span class="sidebar-agent-chip__subtitle">${this.subtitle}</span>`
               : nothing}
           </span>
+          ${this.menuUnread && !this.menuOpen
+            ? html`<span
+                class="session-unread-dot sidebar-agent-chip__menu-unread"
+                role="img"
+                aria-label=${t("sessionsView.unread")}
+              ></span>`
+            : nothing}
         </button>
         <openclaw-tooltip .content=${t("chat.runControls.newSession")}>
           <button
@@ -72,25 +80,6 @@ class SidebarAgentChip extends OpenClawLightDomContentsElement {
             ${icons.plus}
           </button>
         </openclaw-tooltip>
-        <button
-          type="button"
-          class="sidebar-agent-chip__action sidebar-agent-chip__menu-toggle ${this.menuOpen
-            ? "sidebar-agent-chip__menu-toggle--open"
-            : ""}"
-          aria-label=${t("agentChip.menuLabel")}
-          aria-haspopup="menu"
-          aria-expanded=${String(this.menuOpen)}
-          @click=${(event: MouseEvent) => this.onToggleMenu?.(event.currentTarget as HTMLElement)}
-        >
-          ${icons.chevronDown}
-          ${this.menuUnread && !this.menuOpen
-            ? html`<span
-                class="session-unread-dot sidebar-agent-chip__menu-unread"
-                role="img"
-                aria-label=${t("sessionsView.unread")}
-              ></span>`
-            : nothing}
-        </button>
       </div>
     `;
   }

--- a/ui/src/components/sidebar-agent-chip.ts
+++ b/ui/src/components/sidebar-agent-chip.ts
@@ -30,7 +30,7 @@ class SidebarAgentChip extends OpenClawLightDomContentsElement {
           class="sidebar-agent-chip__main ${this.menuOpen ? "sidebar-agent-chip__main--open" : ""}"
           aria-haspopup="menu"
           aria-expanded=${String(this.menuOpen)}
-          aria-label=${t("agentChip.menuLabel")}
+          aria-label="${this.agentName} · ${t("agentChip.menuLabel")}"
           @click=${(event: MouseEvent) => this.onToggleMenu?.(event.currentTarget as HTMLElement)}
         >
           <span class="sidebar-agent-chip__avatar">

--- a/ui/src/e2e/mobile-pairing.e2e.test.ts
+++ b/ui/src/e2e/mobile-pairing.e2e.test.ts
@@ -73,7 +73,7 @@ describeControlUiE2e("Control UI mobile pairing mocked Gateway E2E", () => {
       expect(response?.status()).toBe(200);
 
       // Pairing folded into the footer agent-chip menu.
-      await page.locator(".sidebar-agent-chip__menu-toggle").click();
+      await page.locator(".sidebar-agent-chip__main").click();
       const sidebarPairingButton = page.locator(".sidebar-pair-mobile");
       await sidebarPairingButton.waitFor();
       await expect.poll(async () => sidebarPairingButton.isEnabled()).toBe(true);

--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:15.643Z",
+  "generatedAt": "2026-07-13T02:03:00.675Z",
   "locale": "ar",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:03.678Z",
+  "generatedAt": "2026-07-13T02:02:59.850Z",
   "locale": "de",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:04.967Z",
+  "generatedAt": "2026-07-13T02:02:59.980Z",
   "locale": "es",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:30.122Z",
+  "generatedAt": "2026-07-13T02:03:01.858Z",
   "locale": "fa",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:10.401Z",
+  "generatedAt": "2026-07-13T02:03:00.396Z",
   "locale": "fr",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/hi.meta.json
+++ b/ui/src/i18n/.i18n/hi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:12.225Z",
+  "generatedAt": "2026-07-13T02:03:00.531Z",
   "locale": "hi",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:22.028Z",
+  "generatedAt": "2026-07-13T02:03:01.200Z",
   "locale": "id",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:17.215Z",
+  "generatedAt": "2026-07-13T02:03:00.801Z",
   "locale": "it",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:06.522Z",
+  "generatedAt": "2026-07-13T02:03:00.109Z",
   "locale": "ja-JP",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:08.972Z",
+  "generatedAt": "2026-07-13T02:03:00.251Z",
   "locale": "ko",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:28.044Z",
+  "generatedAt": "2026-07-13T02:03:01.726Z",
   "locale": "nl",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:23.596Z",
+  "generatedAt": "2026-07-13T02:03:01.333Z",
   "locale": "pl",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:01.790Z",
+  "generatedAt": "2026-07-13T02:02:59.721Z",
   "locale": "pt-BR",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ru.meta.json
+++ b/ui/src/i18n/.i18n/ru.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:31.633Z",
+  "generatedAt": "2026-07-13T02:03:01.991Z",
   "locale": "ru",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:25.192Z",
+  "generatedAt": "2026-07-13T02:03:01.470Z",
   "locale": "th",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:18.774Z",
+  "generatedAt": "2026-07-13T02:03:00.935Z",
   "locale": "tr",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:20.688Z",
+  "generatedAt": "2026-07-13T02:03:01.073Z",
   "locale": "uk",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:26.704Z",
+  "generatedAt": "2026-07-13T02:03:01.599Z",
   "locale": "vi",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:38:58.239Z",
+  "generatedAt": "2026-07-13T02:02:59.473Z",
   "locale": "zh-CN",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T23:39:00.329Z",
+  "generatedAt": "2026-07-13T02:02:59.602Z",
   "locale": "zh-TW",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "af455e10897ce5768dd3da979cc2da4c4a57869802d92ea2950c435f52e6ccc8",
-  "totalKeys": 3094,
-  "translatedKeys": 3094,
+  "sourceHash": "c8e7af50475c0c30179aac9a8ae8ba9a913035c8911da4197c0318f2c5d192a5",
+  "totalKeys": 3093,
+  "translatedKeys": 3093,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -389,7 +389,6 @@ export const ar: TranslationMap = {
     confirmForceDelete: "فشل أخذ اللقطة: {error}\n\nهل تريد الحذف دون لقطة؟",
   },
   agentChip: {
-    openConversation: "افتح محادثتك مع {name}",
     menuLabel: "قائمة الوكيل",
     agents: "الوكلاء",
     working: "جارٍ العمل…",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -394,7 +394,6 @@ export const de: TranslationMap = {
     confirmForceDelete: "Snapshot fehlgeschlagen: {error}\n\nOhne Snapshot löschen?",
   },
   agentChip: {
-    openConversation: "Öffne deine Unterhaltung mit {name}",
     menuLabel: "Agentenmenü",
     agents: "Agents",
     working: "Arbeitet…",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -389,7 +389,6 @@ export const en: TranslationMap = {
     confirmForceDelete: "Snapshot failed: {error}\n\nDelete without a snapshot?",
   },
   agentChip: {
-    openConversation: "Open your conversation with {name}",
     menuLabel: "Agent menu",
     agents: "Agents",
     working: "Working…",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -392,7 +392,6 @@ export const es: TranslationMap = {
     confirmForceDelete: "Error al crear snapshot: {error}\n\n¿Eliminar sin snapshot?",
   },
   agentChip: {
-    openConversation: "Abre tu conversación con {name}",
     menuLabel: "Menú del agente",
     agents: "Agentes",
     working: "Procesando…",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -392,7 +392,6 @@ export const fa: TranslationMap = {
     confirmForceDelete: "snapshot ناموفق بود: {error}\n\nبدون snapshot حذف شود؟",
   },
   agentChip: {
-    openConversation: "گفت‌وگوی خود با {name} را باز کنید",
     menuLabel: "منوی عامل",
     agents: "عامل‌ها",
     working: "در حال کار…",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -395,7 +395,6 @@ export const fr: TranslationMap = {
       "Échec de la création de l’instantané : {error}\n\nSupprimer sans instantané ?",
   },
   agentChip: {
-    openConversation: "Ouvrir votre conversation avec {name}",
     menuLabel: "Menu de l’agent",
     agents: "Agents",
     working: "Traitement en cours…",

--- a/ui/src/i18n/locales/hi.ts
+++ b/ui/src/i18n/locales/hi.ts
@@ -391,7 +391,6 @@ export const hi: TranslationMap = {
     confirmForceDelete: "Snapshot विफल: {error}\n\nSnapshot के बिना हटाएँ?",
   },
   agentChip: {
-    openConversation: "{name} के साथ अपनी बातचीत खोलें",
     menuLabel: "एजेंट मेनू",
     agents: "एजेंट",
     working: "काम हो रहा है…",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -391,7 +391,6 @@ export const id: TranslationMap = {
     confirmForceDelete: "Snapshot gagal: {error}\n\nHapus tanpa snapshot?",
   },
   agentChip: {
-    openConversation: "Buka percakapan Anda dengan {name}",
     menuLabel: "Menu agen",
     agents: "Agen",
     working: "Sedang bekerja…",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -394,7 +394,6 @@ export const it: TranslationMap = {
     confirmForceDelete: "Snapshot non riuscito: {error}\n\nEliminare senza uno snapshot?",
   },
   agentChip: {
-    openConversation: "Apri la tua conversazione con {name}",
     menuLabel: "Menu dell'agente",
     agents: "Agenti",
     working: "In elaborazione…",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -397,7 +397,6 @@ export const ja_JP: TranslationMap = {
       "スナップショットに失敗しました: {error}\n\nスナップショットなしで削除しますか？",
   },
   agentChip: {
-    openConversation: "{name}との会話を開く",
     menuLabel: "エージェントメニュー",
     agents: "エージェント",
     working: "作業中…",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -390,7 +390,6 @@ export const ko: TranslationMap = {
     confirmForceDelete: "스냅샷 실패: {error}\n\n스냅샷 없이 삭제할까요?",
   },
   agentChip: {
-    openConversation: "{name}님과의 대화 열기",
     menuLabel: "에이전트 메뉴",
     agents: "에이전트",
     working: "작업 중…",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -393,7 +393,6 @@ export const nl: TranslationMap = {
     confirmForceDelete: "Snapshot mislukt: {error}\n\nVerwijderen zonder snapshot?",
   },
   agentChip: {
-    openConversation: "Open je gesprek met {name}",
     menuLabel: "Agentmenu",
     agents: "Agents",
     working: "Bezig…",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -392,7 +392,6 @@ export const pl: TranslationMap = {
     confirmForceDelete: "Tworzenie migawki nie powiodło się: {error}\n\nUsunąć bez migawki?",
   },
   agentChip: {
-    openConversation: "Otwórz swoją rozmowę z {name}",
     menuLabel: "Menu agenta",
     agents: "Agenci",
     working: "Pracuje…",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -391,7 +391,6 @@ export const pt_BR: TranslationMap = {
     confirmForceDelete: "Falha ao criar snapshot: {error}\n\nExcluir sem um snapshot?",
   },
   agentChip: {
-    openConversation: "Abra sua conversa com {name}",
     menuLabel: "Menu do agente",
     agents: "Agentes",
     working: "Trabalhando…",

--- a/ui/src/i18n/locales/ru.ts
+++ b/ui/src/i18n/locales/ru.ts
@@ -393,7 +393,6 @@ export const ru: TranslationMap = {
     confirmForceDelete: "Не удалось создать снимок: {error}\n\nУдалить без снимка?",
   },
   agentChip: {
-    openConversation: "Открыть беседу с {name}",
     menuLabel: "Меню агента",
     agents: "Агенты",
     working: "Выполняется…",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -387,7 +387,6 @@ export const th: TranslationMap = {
     confirmForceDelete: "สร้างสแนปช็อตไม่สำเร็จ: {error}\n\nลบโดยไม่มีสแนปช็อตหรือไม่?",
   },
   agentChip: {
-    openConversation: "เปิดการสนทนาของคุณกับ {name}",
     menuLabel: "เมนูเอเจนต์",
     agents: "เอเจนต์",
     working: "กำลังทำงาน…",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -395,7 +395,6 @@ export const tr: TranslationMap = {
       "Anlık görüntü başarısız oldu: {error}\n\nAnlık görüntü olmadan silinsin mi?",
   },
   agentChip: {
-    openConversation: "{name} ile konuşmanızı açın",
     menuLabel: "Ajan menüsü",
     agents: "Ajanlar",
     working: "Çalışıyor…",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -392,7 +392,6 @@ export const uk: TranslationMap = {
     confirmForceDelete: "Не вдалося створити знімок: {error}\n\nВидалити без знімка?",
   },
   agentChip: {
-    openConversation: "Відкрити вашу розмову з {name}",
     menuLabel: "Меню агента",
     agents: "Агенти",
     working: "Працює…",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -391,7 +391,6 @@ export const vi: TranslationMap = {
     confirmForceDelete: "Tạo snapshot thất bại: {error}\n\nXóa mà không có snapshot?",
   },
   agentChip: {
-    openConversation: "Mở cuộc trò chuyện của bạn với {name}",
     menuLabel: "Menu tác nhân",
     agents: "Tác nhân",
     working: "Đang làm việc…",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -387,7 +387,6 @@ export const zh_CN: TranslationMap = {
     confirmForceDelete: "快照失败：{error}\n\n不创建快照直接删除？",
   },
   agentChip: {
-    openConversation: "打开你与 {name} 的对话",
     menuLabel: "智能体菜单",
     agents: "代理",
     working: "正在工作…",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -387,7 +387,6 @@ export const zh_TW: TranslationMap = {
     confirmForceDelete: "快照失敗：{error}\n\n要在沒有快照的情況下刪除嗎？",
   },
   agentChip: {
-    openConversation: "開啟您與 {name} 的對話",
     menuLabel: "代理程式選單",
     agents: "代理程式",
     working: "處理中…",

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1974,7 +1974,8 @@ openclaw-session-menu[popover] {
 }
 
 .sidebar-agent-chip__main:hover,
-.sidebar-agent-chip__main:focus-visible {
+.sidebar-agent-chip__main:focus-visible,
+.sidebar-agent-chip__main--open {
   background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
 }
 
@@ -2093,24 +2094,11 @@ openclaw-session-menu[popover] {
   stroke-linejoin: round;
 }
 
-.sidebar-agent-chip__menu-toggle {
-  position: relative;
-}
-
-.sidebar-agent-chip__menu-toggle svg {
-  transition: transform var(--duration-fast) ease;
-}
-
 .sidebar-agent-chip__menu-unread {
-  position: absolute;
-  top: 3px;
-  right: 3px;
+  flex: none;
+  margin-left: auto;
   width: 6px;
   height: 6px;
-}
-
-.sidebar-agent-chip__menu-toggle--open svg {
-  transform: rotate(180deg);
 }
 
 /* The docs row is the menu's only real hyperlink; keep it looking like a row. */


### PR DESCRIPTION
## What Problem This Solves

The sidebar footer agent chip had a tiny chevron button as the only way to open the agent menu, while the large name/avatar area resumed the latest conversation. The big obvious click target and the menu entrance were split, and the chevron was a small, easy-to-miss hit area.

## Why This Change Was Made

Make the whole chip body (avatar + agent name + subtitle) the menu trigger and remove the chevron toggle entirely. One large, discoverable button instead of a 28px arrow. The new-session `+` button stays as the only trailing action. Resuming a conversation remains available through the menu's agent rows (which already resume the newest session), and the unread dot for other agents moves onto the chip body.

## User Impact

- Clicking the agent name/avatar in the sidebar footer now opens the agent menu (agent switching, capabilities, settings, mobile pairing).
- The chevron arrow button is gone.
- Offline routing to Settings via the chip body is gone; the menu's Settings row covers it.

## Evidence

- `ui/src/components/sidebar-agent-chip.ts`: chip body is the menu trigger (`aria-haspopup`/`aria-expanded`), chevron button and `onOpenConversation` removed.
- `ui/src/components/app-sidebar.test.ts`: updated chip tests — body click opens the menu; newest-session resume covered via the menu agent row.
- `ui/src/e2e/mobile-pairing.e2e.test.ts`: pairing e2e opens the menu via the chip body.
- Removed the now-unused `agentChip.openConversation` i18n key; locale bundles pruned via `pnpm ui:i18n:sync` (fallbacks=0) and `pnpm ui:i18n:check` is clean on Testbox.
- `pnpm test ui/src/components/app-sidebar.test.ts` on Blacksmith Testbox: 38 passed.
- Codex autoreview (gpt-5.6-sol): one accessibility finding (agent name dropped from the trigger's accessible name) — fixed by composing the visible name into the `aria-label`.
