### PR TITLE
fix(cli): restore terminal state before exit in logs and hooks commands

### DIFF
--- a/packages/terminal-core/src/restore.test.ts
+++ b/packages/terminal-core/src/restore.test.ts
@@ -111,4 +111,16 @@ describe("restoreTerminalState", () => {
     expect(output).toContain("\x1b[<u");
     expect(output).toContain("\x1b[>4;0m");
   });
+
+  it("writes reset sequences only to a custom TTY stream", () => {
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const resetWrite = vi.fn(() => true);
+    const resetStream = { isTTY: true, write: resetWrite } as unknown as NodeJS.WriteStream;
+
+    configureTerminalIO({ stdinIsTTY: false, stdoutIsTTY: true });
+    restoreTerminalState("test", { resetStream });
+
+    expect(resetWrite).toHaveBeenCalledWith(expect.stringContaining("\x1b[?25h"));
+    expect(stdoutWrite).not.toHaveBeenCalled();
+  });
 });

--- a/packages/terminal-core/src/restore.ts
+++ b/packages/terminal-core/src/restore.ts
@@ -19,6 +19,15 @@ type RestoreTerminalStateOptions = {
    * Default: false.
    */
   resumeStdinIfPaused?: boolean;
+
+  /**
+   * Stream to write the ANSI reset sequence to.
+   * Callers that emit structured data to stdout should route the reset to
+   * stderr so parseable output stays clean.
+   *
+   * Default: process.stdout.
+   */
+  resetStream?: NodeJS.WriteStream;
 };
 
 function reportRestoreFailure(scope: string, err: unknown, reason?: string): void {
@@ -38,6 +47,7 @@ export function restoreTerminalState(
   // Docker TTY note: resuming stdin can keep a container process alive even
   // after the wizard is "done" (stdin_open: true), making installers appear hung.
   const resumeStdin = options.resumeStdinIfPaused ?? options.resumeStdin ?? false;
+  const resetStream = options.resetStream ?? process.stdout;
   try {
     clearActiveProgressLine();
   } catch (err) {
@@ -60,9 +70,9 @@ export function restoreTerminalState(
     }
   }
 
-  if (process.stdout.isTTY) {
+  if (resetStream.isTTY) {
     try {
-      process.stdout.write(RESET_SEQUENCE);
+      resetStream.write(RESET_SEQUENCE);
     } catch (err) {
       reportRestoreFailure("stdout reset", err, reason);
     }

--- a/packages/terminal-core/src/restore.ts
+++ b/packages/terminal-core/src/restore.ts
@@ -74,7 +74,7 @@ export function restoreTerminalState(
     try {
       resetStream.write(RESET_SEQUENCE);
     } catch (err) {
-      reportRestoreFailure("stdout reset", err, reason);
+      reportRestoreFailure("terminal reset", err, reason);
     }
   }
 }

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -149,7 +149,7 @@ function formatHookMissingSummary(hook: HookStatusEntry): string {
 
 function exitHooksCliWithError(err: unknown): never {
   defaultRuntime.error(`${theme.error("Error:")} ${formatErrorMessage(err)}`);
-  process.exit(1);
+  defaultRuntime.exit(1);
 }
 
 function writeHooksOutput(value: string, json: boolean | undefined): void {

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -150,7 +150,7 @@ function formatHookMissingSummary(hook: HookStatusEntry): string {
 function exitHooksCliWithError(err: unknown): never {
   defaultRuntime.error(`${theme.error("Error:")} ${formatErrorMessage(err)}`);
   defaultRuntime.exit(1);
-  throw new Error("unreachable"); // satisfies never return type, tests when mocked
+  throw new Error("unreachable");
 }
 
 function writeHooksOutput(value: string, json: boolean | undefined): void {

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -150,6 +150,7 @@ function formatHookMissingSummary(hook: HookStatusEntry): string {
 function exitHooksCliWithError(err: unknown): never {
   defaultRuntime.error(`${theme.error("Error:")} ${formatErrorMessage(err)}`);
   defaultRuntime.exit(1);
+  throw new Error("unreachable"); // satisfies never return type, tests when mocked
 }
 
 function writeHooksOutput(value: string, json: boolean | undefined): void {

--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -1076,6 +1076,50 @@ describe("logs cli", () => {
       expect(stderrWrites.join("")).toContain("Gateway not reachable");
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
+
+    it("routes terminal reset to stderr in --follow --json so stdout stays parseable JSON in a PTY", async () => {
+      callGatewayFromCli.mockRejectedValueOnce(
+        new GatewayTransportError({
+          kind: "closed",
+          code: 4001,
+          reason: "unauthorized",
+          connectionDetails: { url: "ws://127.0.0.1:18789", urlSource: "cli", message: "" },
+          message: "gateway closed (4001 unauthorized): unauthorized",
+        }),
+      );
+
+      const stdoutWrites = captureStdoutWrites();
+      const stderrWrites = captureStderrWrites();
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+      // Simulate PTY: stderr is a TTY so the terminal reset fires and gets
+      // routed to stderr instead of stdout. Object.defineProperty is needed
+      // because isTTY is an inherited getter not reachable via vi.spyOn.
+      const prevDescriptor = Object.getOwnPropertyDescriptor(process.stderr, "isTTY");
+      Object.defineProperty(process.stderr, "isTTY", {
+        get: () => true,
+        configurable: true,
+      });
+      try {
+        await runLogsCli(["logs", "--follow", "--json", "--url", "ws://127.0.0.1:18789"]);
+      } finally {
+        if (prevDescriptor) {
+          Object.defineProperty(process.stderr, "isTTY", prevDescriptor);
+        } else {
+          delete (process.stderr as unknown as Record<string, unknown>).isTTY;
+        }
+      }
+
+      // stdout must contain only parseable JSON — no ANSI escape bytes
+      const stdout = stdoutWrites.join("");
+      expect(stdout).not.toContain("\x1b[");
+
+      // stderr receives the terminal reset instead of stdout
+      const stderr = stderrWrites.join("");
+      expect(stderr).toContain("\x1b[");
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
   });
 
   it("does not use local fallback for explicit Gateway URLs", async () => {

--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -96,6 +96,21 @@ vi.mock("./gateway-rpc.js", async () => {
   };
 });
 
+vi.mock("../runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("../runtime.js")>("../runtime.js");
+  return {
+    ...actual,
+    defaultRuntime: {
+      ...actual.defaultRuntime,
+      // Override exit to not throw after process.exit — tests mock process.exit
+      // so the unreachable throw in the real exit would escape unhandled.
+      exit: vi.fn((code: number) => {
+        process.exit(code);
+      }),
+    },
+  };
+});
+
 async function runLogsCli(argv: string[]) {
   await runRegisteredCli({
     register: registerLogsCli as (program: import("commander").Command) => void,

--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -98,13 +98,20 @@ vi.mock("./gateway-rpc.js", async () => {
 
 vi.mock("../runtime.js", async () => {
   const actual = await vi.importActual<typeof import("../runtime.js")>("../runtime.js");
+  const terminalRestore = await vi.importActual<
+    typeof import("../../packages/terminal-core/src/restore.js")
+  >("../../packages/terminal-core/src/restore.js");
   return {
     ...actual,
     defaultRuntime: {
       ...actual.defaultRuntime,
       // Override exit to not throw after process.exit — tests mock process.exit
       // so the unreachable throw in the real exit would escape unhandled.
-      exit: vi.fn((code: number) => {
+      exit: vi.fn((code: number, opts?: { resetStream?: NodeJS.WriteStream }) => {
+        terminalRestore.restoreTerminalState("runtime exit", {
+          resumeStdinIfPaused: false,
+          resetStream: opts?.resetStream,
+        });
         process.exit(code);
       }),
     },

--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -1,6 +1,7 @@
 // Logs CLI tests cover log command routing and runtime log output behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayTransportError } from "../gateway/call.js";
+import type { RuntimeExitOptions } from "../runtime.js";
 import { runRegisteredCli } from "../test-utils/command-runner.js";
 import { formatLogTimestamp, registerLogsCli } from "./logs-cli.js";
 
@@ -105,9 +106,7 @@ vi.mock("../runtime.js", async () => {
     ...actual,
     defaultRuntime: {
       ...actual.defaultRuntime,
-      // Override exit to not throw after process.exit — tests mock process.exit
-      // so the unreachable throw in the real exit would escape unhandled.
-      exit: vi.fn((code: number, opts?: { resetStream?: NodeJS.WriteStream }) => {
+      exit: vi.fn((code: number, opts?: RuntimeExitOptions) => {
         terminalRestore.restoreTerminalState("runtime exit", {
           resumeStdinIfPaused: false,
           resetStream: opts?.resetStream,

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -10,7 +10,6 @@ import {
 import { readConnectPairingRequiredMessage } from "../../packages/gateway-protocol/src/connect-error-details.js";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { clearActiveProgressLine } from "../../packages/terminal-core/src/progress-line.js";
-import { restoreTerminalState } from "../../packages/terminal-core/src/restore.js";
 import { createSafeStreamWriter } from "../../packages/terminal-core/src/stream-writer.js";
 import { colorize, isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import {
@@ -26,6 +25,7 @@ import { readConfiguredLogTail } from "../logging/log-tail.js";
 import { parseLogLine } from "../logging/parse-log-line.js";
 import { redactSensitiveLines, resolveRedactOptions } from "../logging/redact.js";
 import { formatTimestamp } from "../logging/timestamps.js";
+import { defaultRuntime } from "../runtime.js";
 import { formatCliCommand } from "./command-format.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "./gateway-rpc.js";
 
@@ -683,8 +683,7 @@ export function registerLogsCli(program: Command) {
           emitJsonLine,
           errorLine,
         );
-        restoreTerminalState("logs follow error", { resumeStdinIfPaused: false });
-        process.exit(1);
+        defaultRuntime.exit(1);
         return;
       }
       if (followRetryAttempt > 0) {

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -10,7 +10,6 @@ import {
 import { readConnectPairingRequiredMessage } from "../../packages/gateway-protocol/src/connect-error-details.js";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { clearActiveProgressLine } from "../../packages/terminal-core/src/progress-line.js";
-import { restoreTerminalState } from "../../packages/terminal-core/src/restore.js";
 import { createSafeStreamWriter } from "../../packages/terminal-core/src/stream-writer.js";
 import { colorize, isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import {
@@ -685,17 +684,10 @@ export function registerLogsCli(program: Command) {
           errorLine,
         );
         // Route terminal reset to stderr in JSON mode so structured
-        // stdout stays parseable. Text mode uses the canonical
-        // defaultRuntime.exit which writes the reset to stdout.
-        if (jsonMode) {
-          restoreTerminalState("logs exit", {
-            resumeStdinIfPaused: false,
-            resetStream: process.stderr,
-          });
-          process.exit(1);
-        } else {
-          defaultRuntime.exit(1);
-        }
+        // stdout stays parseable. Text mode resets to stdout by default.
+        defaultRuntime.exit(1, {
+          resetStream: jsonMode ? process.stderr : undefined,
+        });
         return;
       }
       if (followRetryAttempt > 0) {

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -10,6 +10,7 @@ import {
 import { readConnectPairingRequiredMessage } from "../../packages/gateway-protocol/src/connect-error-details.js";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { clearActiveProgressLine } from "../../packages/terminal-core/src/progress-line.js";
+import { restoreTerminalState } from "../../packages/terminal-core/src/restore.js";
 import { createSafeStreamWriter } from "../../packages/terminal-core/src/stream-writer.js";
 import { colorize, isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import {
@@ -683,7 +684,18 @@ export function registerLogsCli(program: Command) {
           emitJsonLine,
           errorLine,
         );
-        defaultRuntime.exit(1);
+        // Route terminal reset to stderr in JSON mode so structured
+        // stdout stays parseable. Text mode uses the canonical
+        // defaultRuntime.exit which writes the reset to stdout.
+        if (jsonMode) {
+          restoreTerminalState("logs exit", {
+            resumeStdinIfPaused: false,
+            resetStream: process.stderr,
+          });
+          process.exit(1);
+        } else {
+          defaultRuntime.exit(1);
+        }
         return;
       }
       if (followRetryAttempt > 0) {

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -10,6 +10,7 @@ import {
 import { readConnectPairingRequiredMessage } from "../../packages/gateway-protocol/src/connect-error-details.js";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { clearActiveProgressLine } from "../../packages/terminal-core/src/progress-line.js";
+import { restoreTerminalState } from "../../packages/terminal-core/src/restore.js";
 import { createSafeStreamWriter } from "../../packages/terminal-core/src/stream-writer.js";
 import { colorize, isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import {
@@ -682,6 +683,7 @@ export function registerLogsCli(program: Command) {
           emitJsonLine,
           errorLine,
         );
+        restoreTerminalState("logs follow error", { resumeStdinIfPaused: false });
         process.exit(1);
         return;
       }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2,6 +2,11 @@
 import { clearActiveProgressLine } from "../packages/terminal-core/src/progress-line.js";
 import { restoreTerminalState } from "../packages/terminal-core/src/restore.js";
 
+export type RuntimeExitOptions = {
+  /** Route ANSI terminal-reset bytes away from structured stdout when needed. */
+  resetStream?: NodeJS.WriteStream;
+};
+
 export type RuntimeEnv = {
   log: (...args: unknown[]) => void;
   error: (...args: unknown[]) => void;
@@ -10,7 +15,7 @@ export type RuntimeEnv = {
    * Pass `resetStream` to route the ANSI reset sequence to a specific
    * stream (e.g. stderr) when structured output on stdout must stay clean.
    */
-  exit: (code: number, opts?: { resetStream?: NodeJS.WriteStream }) => void;
+  exit: (code: number, opts?: RuntimeExitOptions) => void;
 };
 
 export type OutputRuntimeEnv = RuntimeEnv & {
@@ -117,7 +122,7 @@ export class ExitError extends Error {
 export function createNonExitingRuntime(): OutputRuntimeEnv {
   return {
     ...createRuntimeIo(),
-    exit: (code: number, _opts?: { resetStream?: NodeJS.WriteStream }) => {
+    exit: (code: number, _opts?: RuntimeExitOptions) => {
       throw new ExitError(code);
     },
   };

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -5,7 +5,12 @@ import { restoreTerminalState } from "../packages/terminal-core/src/restore.js";
 export type RuntimeEnv = {
   log: (...args: unknown[]) => void;
   error: (...args: unknown[]) => void;
-  exit: (code: number) => void;
+  /**
+   * Exit the process after restoring terminal state.
+   * Pass `resetStream` to route the ANSI reset sequence to a specific
+   * stream (e.g. stderr) when structured output on stdout must stay clean.
+   */
+  exit: (code: number, opts?: { resetStream?: NodeJS.WriteStream }) => void;
 };
 
 export type OutputRuntimeEnv = RuntimeEnv & {
@@ -88,8 +93,11 @@ function createRuntimeIo(): Pick<OutputRuntimeEnv, "log" | "error" | "writeStdou
 
 export const defaultRuntime: OutputRuntimeEnv = {
   ...createRuntimeIo(),
-  exit: (code) => {
-    restoreTerminalState("runtime exit", { resumeStdinIfPaused: false });
+  exit: (code, opts) => {
+    restoreTerminalState("runtime exit", {
+      resumeStdinIfPaused: false,
+      resetStream: opts?.resetStream,
+    });
     process.exit(code);
     throw new Error("unreachable"); // satisfies tests when mocked
   },
@@ -109,7 +117,7 @@ export class ExitError extends Error {
 export function createNonExitingRuntime(): OutputRuntimeEnv {
   return {
     ...createRuntimeIo(),
-    exit: (code: number) => {
+    exit: (code: number, _opts?: { resetStream?: NodeJS.WriteStream }) => {
       throw new ExitError(code);
     },
   };


### PR DESCRIPTION
## What Problem This Solves

`process.exit(1)` in `logs-cli.ts` and `hooks-cli.ts` bypasses the CLI's standard exit path (`defaultRuntime.exit()`), which calls `restoreTerminalState()` before terminating. This means the terminal state (raw mode, cursor visibility, ANSI reset sequences, active progress line) is not cleaned up when these commands exit on error.

Additionally, the initial JSON-mode fix manually paired `restoreTerminalState()` with `process.exit()` — recreating the divergent exit ownership this PR is intended to remove. Future cleanup added to `defaultRuntime.exit()` would be skipped only for JSON logs.

## Why This Change Was Made

Every other CLI command uses `runtime.exit()` → `restoreTerminalState()` → `process.exit()`. These two call sites were the only exceptions.

This revision centralizes stream-aware exit by extending `RuntimeEnv.exit` with an optional `resetStream` parameter:

- **`src/runtime.ts`**: `RunTimeEnv.exit` gains `opts?: { resetStream?: NodeJS.WriteStream }`. `defaultRuntime.exit` passes `resetStream` to `restoreTerminalState`, preserving stdout as the default.
- **`src/cli/logs-cli.ts`**: Both JSON and text fatal exits route through the single `defaultRuntime.exit(1, { resetStream: jsonMode ? process.stderr : undefined })` — no more split ownership.
- **`src/cli/hooks-cli.ts`**: Already routed through `defaultRuntime.exit(1)` from the prior revision.

## User Impact

Low in practice — `logs follow` does not set raw mode itself, and `restoreTerminalState()` operations all have TTY guards. But it is a defensive fix ensuring terminal state is always restored on exit, and JSON-mode `--follow --json` callers get parseable line-delimited JSON on stdout with terminal reset bytes routed to stderr.

## Evidence

### Tests

- `node scripts/run-vitest.mjs src/cli/logs-cli.test.ts` — 38/38 passed
- `node scripts/run-vitest.mjs src/cli/hooks-cli.test.ts` — 6/6 passed
- `node scripts/run-vitest.mjs packages/terminal-core/src/restore.test.ts` — 4/4 passed
- `pnpm format:check` — clean (3 files)
- `git diff --check` — clean

### Real Behavior Proof

**Setup**: Built CLI from current head (`3fb1c23`), ran inside a PTY (`node-pty`) so both `process.stdout.isTTY=true` and `process.stderr.isTTY=true`, ensuring all `restoreTerminalState()` code paths execute.

**PTY proof — `logs --follow --json --url ws://127.0.0.1:19999`** (dead port triggers fatal exit path):

```
=== VERIFICATION ===
[PASS] JSON lines: 1, ANSI-free: true
[PASS] terminal reset: true (reset=true cursor=true)
```

Full PTY CLI output showing clean JSON and terminal reset:

```
{"type":"error","message":"Gateway not reachable. Is it running and accessible?",...}
ESC[0mESC[?25hESC[?1000lESC[?1002lESC[?1003lESC[?1006lESC[?2004lESC[<uESC[>4;0m
```

- **JSON stdout**: Single line-delimited JSON record with `type`, `message`, `error`, `details`, `hint` fields — fully parseable, zero ANSI escape bytes.
- **Terminal reset**: The full `RESET_SEQUENCE` (reset SGR, show cursor, disable mouse tracking ×4, disable bracketed paste, reset modifyCursorKeys, reset modifyOtherKeys) is present in the PTY output, matching the exact constant in `packages/terminal-core/src/restore.ts`.
- **Exit code**: Process exits with code `1` from `defaultRuntime.exit(1)`.

**Exit code verification**: Both commands exit with code `1`, not timeout (124).

### What Was Not Tested

- `hooks relay` command error path (requires a running agent session)
- Live Gateway connection scenario (requires running Gateway)

## Changes

| File | Change |
|------|--------|
| `src/runtime.ts` | Extend `RuntimeEnv.exit` with optional `resetStream` parameter; pass it through `defaultRuntime.exit` to `restoreTerminalState` |
| `src/cli/logs-cli.ts` | Route JSON+text fatal exits through unified `defaultRuntime.exit(1, { resetStream })`; remove now-unused `restoreTerminalState` direct import and call |
| `src/cli/logs-cli.test.ts` | Update runtime mock to exercise real `restoreTerminalState` during exit, passing `resetStream` through |
