### PR TITLE
fix(i18n): align Apple accessibility wrapper contract

### DIFF
--- a/scripts/apple-app-i18n.ts
+++ b/scripts/apple-app-i18n.ts
@@ -182,7 +182,7 @@ const LOCALIZED_WRAPPER_CONTRACTS: Record<string, readonly string[]> = {
     "func gatewaySecureField(\n        _ placeholder: LocalizedStringKey",
     "func settingsToggle(\n        _ title: LocalizedStringKey",
     ".accessibilityLabel(Text(placeholder))",
-    ".accessibilityLabel(title)",
+    ".accessibilityLabel(Text(title))",
   ],
   "apps/ios/Sources/Gateway/GatewayConnectionController+Capabilities.swift": [
     'String(localized: "Secure connection is required for this host.")',


### PR DESCRIPTION
## What Problem This Solves

Fixes a packaging failure where the Apple i18n guard expected a direct accessibility label call after the Settings wrappers had moved to explicit localized `Text` values.

## Why This Change Was Made

Align the wrapper contract with the exact localized SwiftUI form now used by all affected Settings helpers. The raw-string regression guard remains active.

## User Impact

Signed Mac app packaging can complete while localized VoiceOver labels remain enforced.

## Evidence

- `corepack pnpm apple:i18n:check`
- `corepack pnpm test test/scripts/apple-app-i18n.test.ts` (13 passing)
- Blacksmith Testbox focused proof
- Autoreview clean, no actionable findings