### PR TITLE
fix(ui): center composer footer controls between divider and card edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Docs: https://docs.openclaw.ai
 - **Control UI session workspace shortcut:** expand or collapse the active Chat pane's session workspace rail with ⇧⌘B without changing the main app sidebar or the separate detail and Canvas preview panel. Thanks @shakkernerd.
 - **Control UI Settings shortcut:** open Settings with ⇧⌘, while leaving the browser-owned ⌘, shortcut unchanged. Thanks @shakkernerd.
 - **Control UI chat layout:** center the transcript on the composer axis, keep assistant and tool output left and user bubbles right within the same readable frame, and preserve custom message-width overrides. (#104474) Thanks @shakkernerd.
-- **Control UI composer footer:** center the chat settings chip and model controls between the divider and the card edge instead of pinning them to the divider.
+- **Control UI composer footer:** center the chat settings chip and model controls between the divider and the card edge instead of pinning them to the divider. (#105866)
 - **Control UI assistant actions:** keep assistant name and time first while placing hover actions beside them on the left instead of at the far edge. Thanks @shakkernerd.
 - **Cron model selection:** choose an agent-turn model in Control UI Quick Create and show configured or default models in cron job rows and details. (#95341) Thanks @ly85206559.
 - **Control UI GitHub previews:** show issue and pull request state, title, author, activity, comments, and change statistics in hover and keyboard-focus cards. (#100434)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - **Control UI session workspace shortcut:** expand or collapse the active Chat pane's session workspace rail with ⇧⌘B without changing the main app sidebar or the separate detail and Canvas preview panel. Thanks @shakkernerd.
 - **Control UI Settings shortcut:** open Settings with ⇧⌘, while leaving the browser-owned ⌘, shortcut unchanged. Thanks @shakkernerd.
 - **Control UI chat layout:** center the transcript on the composer axis, keep assistant and tool output left and user bubbles right within the same readable frame, and preserve custom message-width overrides. (#104474) Thanks @shakkernerd.
+- **Control UI composer footer:** center the chat settings chip and model controls between the divider and the card edge instead of pinning them to the divider.
 - **Control UI assistant actions:** keep assistant name and time first while placing hover actions beside them on the left instead of at the far edge. Thanks @shakkernerd.
 - **Cron model selection:** choose an agent-turn model in Control UI Quick Create and show configured or default models in cron job rows and details. (#95341) Thanks @ly85206559.
 - **Control UI GitHub previews:** show issue and pull request state, title, author, activity, comments, and change statistics in hover and keyboard-focus cards. (#100434)

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -147,6 +147,22 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
       await expect
         .poll(() => model.evaluate((node) => node.closest(".agent-chat__composer-footer") != null))
         .toBe(true);
+      // The settings chip must sit centered between the footer divider and
+      // the card edge (the old asymmetric footer padding pinned it to the top).
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const footer = document
+              .querySelector(".agent-chat__composer-footer")
+              ?.getBoundingClientRect();
+            const chip = document.querySelector(".chat-settings-chip")?.getBoundingClientRect();
+            if (!footer || !chip) {
+              return null;
+            }
+            return Math.abs(chip.top - footer.top - (footer.bottom - chip.bottom));
+          }),
+        )
+        .toBeLessThanOrEqual(1.5);
       await expect.poll(() => composer.locator(".agent-chat__composer-header").count()).toBe(0);
       await expect
         .poll(() => model.locator(".chat-controls__inline-select-label").textContent())

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1858,7 +1858,9 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   gap: 8px;
   min-height: 44px;
   border-top: 1px solid color-mix(in srgb, var(--border) 64%, transparent);
-  padding: 0 var(--chat-box-inset) var(--chat-box-inset);
+  /* Split the inset evenly so the settings chip sits centered between the
+     divider and the card edge instead of hugging the divider. */
+  padding: calc(var(--chat-box-inset) / 2) var(--chat-box-inset);
 }
 
 .agent-chat__composer-meta,


### PR DESCRIPTION
The chat composer footer used asymmetric padding (top 0, bottom `--chat-box-inset`), so the Chat settings chip and model controls hugged the top divider with all the breathing room below:

- before: 1px above the chip, 8px below
- after: 4px / 4px (footer height unchanged at 45px desktop, 49px mobile)

Fix: split the inset evenly — `padding: calc(var(--chat-box-inset) / 2) var(--chat-box-inset)`.

Verified with the mock-gateway e2e harness (Chromium + measurement of chip vs footer rects) and added a regression assertion to `chat-composer-redesign.e2e.test.ts` that fails on the old CSS and passes with the fix. `ui-e2e` suite for the file: 6/6 green.
