### PR TITLE
fix(reply): strip newline/whitespace-separated leading NO_REPLY sentinel

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -7,6 +7,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import {
   isSilentReplyText,
   SILENT_REPLY_TOKEN,
+  startsWithNewlineSeparatedSilentToken,
   startsWithSilentToken,
   stripLeadingSilentToken,
   stripSilentToken,
@@ -147,6 +148,13 @@ function isWakeContinuationRun(runId: string): boolean {
 function stripAndClassifyReply(text: string): string | null {
   let result = text;
   let didStrip = false;
+  // Strip newline-separated leading NO_REPLY preamble before checking
+  // for glued-attached tokens; the shared leading-token stripper removes
+  // repeated occurrences. (#103735)
+  if (startsWithNewlineSeparatedSilentToken(result, SILENT_REPLY_TOKEN)) {
+    result = stripLeadingSilentToken(result, SILENT_REPLY_TOKEN);
+    didStrip = true;
+  }
   const hasLeadingSilentToken = startsWithSilentToken(result, SILENT_REPLY_TOKEN);
   if (hasLeadingSilentToken) {
     result = stripLeadingSilentToken(result, SILENT_REPLY_TOKEN);

--- a/src/auto-reply/reply/agent-runner-presentation.streaming-sentinel.test.ts
+++ b/src/auto-reply/reply/agent-runner-presentation.streaming-sentinel.test.ts
@@ -1,0 +1,52 @@
+// Covers sentinel stripping on the partial streaming/draft delivery path (#103735).
+import { describe, expect, it } from "vitest";
+import type { ReplyPayload } from "../types.js";
+import type { AgentTurnParams } from "./agent-runner-execution.types.js";
+import { createAgentTurnPresentation } from "./agent-runner-presentation.js";
+import type { ReplyMediaContext } from "./reply-media-paths.js";
+
+function buildPresentation() {
+  return createAgentTurnPresentation({
+    turn: {
+      followupRun: { run: { silentExpected: false } },
+      isHeartbeat: false,
+      typingSignals: { signalTextDelta: async () => {} },
+    } as unknown as AgentTurnParams,
+    replyMediaContext: {} as ReplyMediaContext,
+    directlySentBlockKeys: new Set<string>(),
+    directlySentBlockPayloads: [],
+    heartbeatState: { didLogStrip: false },
+  });
+}
+
+function prepare(text: string): string | undefined {
+  const payload: ReplyPayload = { text };
+  return buildPresentation().preparePartialForTyping(payload);
+}
+
+describe("preparePartialForTyping NO_REPLY sentinel handling", () => {
+  it("strips newline-separated leading NO_REPLY from partial updates (#103735)", () => {
+    expect(prepare("NO_REPLY\n\nWait — the user")).toBe("Wait — the user");
+    expect(prepare("NO_REPLY\nHere is the answer")).toBe("Here is the answer");
+  });
+
+  it("strips repeated newline-separated sentinels from partial updates", () => {
+    expect(prepare("NO_REPLY\nNO_REPLY\n\nWait — the user")).toBe("Wait — the user");
+  });
+
+  it("still strips glued-attached tokens", () => {
+    expect(prepare("NO_REPLYhello")).toBe("hello");
+  });
+
+  it("preserves single-space-separated natural-language text", () => {
+    expect(prepare("NO_REPLY is the documented sentinel")).toBe(
+      "NO_REPLY is the documented sentinel",
+    );
+  });
+
+  it("suppresses exact and prefix-fragment sentinel drafts", () => {
+    expect(prepare("NO_REPLY")).toBeUndefined();
+    expect(prepare("NO_REPLY\n\n")).toBeUndefined();
+    expect(prepare("NO_RE")).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/agent-runner-presentation.ts
+++ b/src/auto-reply/reply/agent-runner-presentation.ts
@@ -7,6 +7,7 @@ import {
   isSilentReplyPrefixText,
   isSilentReplyText,
   SILENT_REPLY_TOKEN,
+  startsWithNewlineSeparatedSilentToken,
   startsWithSilentToken,
   stripLeadingSilentToken,
 } from "../tokens.js";
@@ -60,7 +61,14 @@ export function createAgentTurnPresentation(params: {
     ) {
       return { skip: true };
     }
-    if (text && startsWithSilentToken(text, SILENT_REPLY_TOKEN)) {
+    // Also catch newline-separated preambles ("NO_REPLY\n\nWait…") so partial
+    // streaming and draft updates never expose the sentinel while the final
+    // normalized reply strips it. (#103735)
+    if (
+      text &&
+      (startsWithSilentToken(text, SILENT_REPLY_TOKEN) ||
+        startsWithNewlineSeparatedSilentToken(text, SILENT_REPLY_TOKEN))
+    ) {
       text = stripLeadingSilentToken(text, SILENT_REPLY_TOKEN);
     }
     if (!text) {

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -10,6 +10,7 @@ import {
   isSilentReplyPayloadText,
   isSilentReplyText,
   SILENT_REPLY_TOKEN,
+  startsWithNewlineSeparatedSilentToken,
   startsWithSilentToken,
   stripLeadingSilentToken,
   stripSilentToken,
@@ -63,6 +64,17 @@ export function normalizeReplyPayload(
       return null;
     }
     text = "";
+  }
+  // Strip newline-separated leading NO_REPLY preambles (e.g.
+  // "NO_REPLY\n\nWait — the user"). The model emits the sentinel as a
+  // standalone line before the real reply body; the shared leading-token
+  // stripper removes repeated occurrences. (#103735)
+  if (text && startsWithNewlineSeparatedSilentToken(text, silentToken)) {
+    text = stripLeadingSilentToken(text, silentToken);
+    if (!hasContent(text)) {
+      opts.onSkip?.("silent");
+      return null;
+    }
   }
   // Strip NO_REPLY from mixed-content messages (e.g. "😄 NO_REPLY") so the
   // token never leaks to end users.  If stripping leaves nothing, treat it as

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -5,6 +5,7 @@ import {
   isSilentReplyPrefixText,
   isSilentReplyPayloadText,
   isSilentReplyText,
+  startsWithNewlineSeparatedSilentToken,
   startsWithSilentToken,
   stripLeadingSilentToken,
   stripSilentToken,
@@ -281,6 +282,54 @@ describe("startsWithSilentToken", () => {
     expect(startsWithSilentToken("NO_REPLY—note")).toBe(false);
     expect(startsWithSilentToken("NO_REPLY")).toBe(false);
     expect(startsWithSilentToken("  NO_REPLY  ")).toBe(false);
+  });
+});
+
+describe("startsWithNewlineSeparatedSilentToken", () => {
+  it("matches NO_REPLY separated from word content by newlines (#103735)", () => {
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLY\n\nWait — the user")).toBe(true);
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLY\nWait")).toBe(true);
+    expect(startsWithNewlineSeparatedSilentToken("  NO_REPLY  \n\nThe answer")).toBe(true);
+  });
+
+  it("does not match single-space-separated leading text", () => {
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLY is the documented sentinel")).toBe(
+      false,
+    );
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLY -- nope")).toBe(false);
+  });
+
+  it("matches NO_REPLY separated from emoji by newlines", () => {
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLY\n\n😀 Hello")).toBe(true);
+  });
+
+  it("matches NO_REPLY separated from punctuation by newlines", () => {
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLY\n-- note")).toBe(true);
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLY\n\n— Wait")).toBe(true);
+  });
+
+  it("does not match glued-attached or trailing tokens", () => {
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLYhello")).toBe(false);
+    expect(startsWithNewlineSeparatedSilentToken("Hello NO_REPLY")).toBe(false);
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLY: explanation")).toBe(false);
+  });
+});
+
+describe("newline-separated preamble stripping via stripLeadingSilentToken", () => {
+  it("strips the NO_REPLY preamble and keeps the reply body", () => {
+    expect(stripLeadingSilentToken("NO_REPLY\n\nWait — the user")).toBe("Wait — the user");
+    expect(stripLeadingSilentToken("NO_REPLY\nHere is the answer")).toBe("Here is the answer");
+    expect(stripLeadingSilentToken("  NO_REPLY  \n\nThe answer")).toBe("The answer");
+  });
+
+  it("strips repeated newline-separated sentinels (#103735)", () => {
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLY\nNO_REPLY\n\nWait — the user")).toBe(
+      true,
+    );
+    expect(stripLeadingSilentToken("NO_REPLY\nNO_REPLY\n\nWait — the user")).toBe(
+      "Wait — the user",
+    );
+    expect(stripLeadingSilentToken("NO_REPLY NO_REPLY\nanswer")).toBe("answer");
   });
 });
 

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -287,6 +287,45 @@ export function startsWithSilentToken(
   return getSilentLeadingAttachedRegex(token).test(text);
 }
 
+const silentLeadingNewlineRegexByToken = new Map<string, RegExp>();
+
+function getSilentLeadingNewlineRegex(token: string): RegExp {
+  const cached = silentLeadingNewlineRegexByToken.get(token);
+  if (cached) {
+    return cached;
+  }
+  const escaped = escapeRegExp(token);
+  // Match a leading sentinel that is separated from substantive word content
+  // by at least one newline. This catches the common preamble where the model
+  // emits "NO_REPLY" on its own line before the real reply body, while
+  // preserving single-space-separated natural-language text like
+  // "NO_REPLY is the documented sentinel".
+  const regex = new RegExp(`^\\s*${escaped}\\s*[\\n\\r]+\\s*\\S`, "iu");
+  silentLeadingNewlineRegexByToken.set(token, regex);
+  return regex;
+}
+
+/**
+ * Check whether text starts with a silent reply token that is separated from
+ * word content by a newline — the model emitted the sentinel as a standalone
+ * preamble line before the real reply body. Strip with
+ * `stripLeadingSilentToken`, which already owns whitespace-tolerant repeated
+ * leading-token removal.
+ *
+ * Distinct from `startsWithSilentToken`, which only catches glued-attached
+ * tokens ("NO_REPLYhello"). Single-space-separated natural-language text
+ * ("NO_REPLY is the documented sentinel") is preserved.
+ */
+export function startsWithNewlineSeparatedSilentToken(
+  text: string | undefined,
+  token: string = SILENT_REPLY_TOKEN,
+): boolean {
+  if (!text) {
+    return false;
+  }
+  return getSilentLeadingNewlineRegex(token).test(text);
+}
+
 export function isSilentReplyPrefixText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,


### PR DESCRIPTION
## What Problem This Solves

When a model emits the `NO_REPLY` sentinel as a standalone preamble line before the real reply body (e.g. `"NO_REPLY\n\nWait — the user"`), the existing glued-token gate (`startsWithSilentToken`) misses it — the token is followed by a newline, not a word character — so the sentinel leaks into user-visible reply text. Fixes #103735.

## Fix (review feedback applied)

Per the review finding, this revision **reuses the established `stripLeadingSilentToken` helper** instead of introducing a second stripper regex:

- `tokens.ts` adds only a **detection** helper, `startsWithNewlineSeparatedSilentToken` — it gates on "leading sentinel separated from content by a newline" so single-space natural-language text (`"NO_REPLY is the documented sentinel"`) is preserved. The previous `stripLeadingNewlineSeparatedSilentToken` stripper is **removed**; stripping is done by the existing `stripLeadingSilentToken`, which already owns whitespace-tolerant **repeated** leading-token removal.
- **Partial streaming / draft path covered** (second review finding): `agent-runner-presentation.ts` (`normalizeStreamingText` → `preparePartialForTyping`) now applies the same detection, so intermediate streaming/draft updates never expose the sentinel that the final normalized reply would strip.

**Wired into 3 delivery paths:**
| Path | File | Strip call |
|------|------|------|
| Final reply | `normalize-reply.ts` | `stripLeadingSilentToken` (shared) |
| Partial streaming / draft | `agent-runner-presentation.ts` | `stripLeadingSilentToken` (shared) |
| Subagent announce | `subagent-announce.ts` | `stripLeadingSilentToken` (shared) |

**Changes (6 files, +169/−1):** detection helper + three call-site gates + regression tests; no new stripper implementation.

## Evidence

**Focused regression tests (all passing):**
```
$ node scripts/run-vitest.mjs src/auto-reply/tokens.test.ts
  Tests  77 passed — incl. repeated newline-separated sentinels:
    ✓ strips "NO_REPLY\nNO_REPLY\n\nWait — the user" → "Wait — the user"
    ✓ strips "NO_REPLY NO_REPLY\nanswer" → "answer"

$ node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-presentation.streaming-sentinel.test.ts
  Tests  5 passed — partial streaming/draft path:
    ✓ strips newline-separated leading NO_REPLY from partial updates
    ✓ strips repeated newline-separated sentinels from partial updates
    ✓ still strips glued-attached tokens
    ✓ preserves single-space-separated natural-language text
    ✓ suppresses exact and prefix-fragment sentinel drafts

$ node scripts/run-vitest.mjs src/agents/subagent-announce.test.ts
  Tests  14 passed
$ node scripts/run-vitest.mjs src/auto-reply/reply/reply-utils.test.ts   # normalizeReplyPayload
  passed
```
`tsgo` core + core-test + test-src type configs, oxfmt, and oxlint all pass on the changed files.

**Telegram visible proof:** the prior Mantis recording (run 29219353452, Overall: true) demonstrated the before/after behavior for candidate `0c1f22d2`; the branch has since been rebased and the review feedback applied. Requesting a fresh exact-head capture below.

The unrelated OAuth refresh-threshold change from an earlier revision lives in #107256.
