### PR TITLE
fix(skills): globally installed ClawHub skills falsely show as not tracked [AI-assisted]

### DIFF
--- a/src/skills/discovery/status-workspace.test.ts
+++ b/src/skills/discovery/status-workspace.test.ts
@@ -323,4 +323,149 @@ describe("buildWorkspaceSkillStatus", () => {
       expect(skill.install).toStrictEqual([]);
     }
   });
+
+  async function writeManagedSkillWithOrigin(params: {
+    managedRoot: string;
+    slug: string;
+    installedVersion: string;
+    installedAt: number;
+    registry?: string;
+  }): Promise<string> {
+    const skillDir = path.join(params.managedRoot, "skills", params.slug);
+    const registry = params.registry ?? "https://clawhub.example.com";
+    const origin = {
+      version: 1,
+      registry,
+      slug: params.slug,
+      installedVersion: params.installedVersion,
+      installedAt: params.installedAt,
+    };
+    await fs.mkdir(path.join(skillDir, ".clawhub"), { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      `---\nname: ${params.slug}\ndescription: managed\n---\n`,
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(skillDir, ".clawhub", "origin.json"),
+      `${JSON.stringify(origin, null, 2)}\n`,
+      "utf8",
+    );
+    return skillDir;
+  }
+
+  async function writeScopeLockfile(params: {
+    scopeRoot: string;
+    slug: string;
+    entry: Record<string, unknown>;
+  }): Promise<string> {
+    const lockPath = path.join(params.scopeRoot, ".clawhub", "lock.json");
+    await fs.mkdir(path.join(params.scopeRoot, ".clawhub"), { recursive: true });
+    await fs.writeFile(
+      lockPath,
+      `${JSON.stringify({ version: 1, skills: { [params.slug]: params.entry } }, null, 2)}\n`,
+      "utf8",
+    );
+    return lockPath;
+  }
+
+  it("links a globally installed (managed) skill against the managed ClawHub lockfile", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const managedRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-managed-"));
+    tempDirs.push(managedRoot);
+    const managedSkillsDir = path.join(managedRoot, "skills");
+    const slug = "weather-global";
+    const installedAt = 1700000000000;
+    const registry = "https://clawhub.example.com";
+
+    const skillDir = await writeManagedSkillWithOrigin({
+      managedRoot,
+      slug,
+      installedVersion: "1.0.0",
+      installedAt,
+      registry,
+    });
+    const managedLockPath = await writeScopeLockfile({
+      scopeRoot: managedRoot,
+      slug,
+      entry: { version: "1.0.0", installedAt, registry },
+    });
+
+    const entry: SkillEntry = {
+      skill: createCanonicalFixtureSkill({
+        name: slug,
+        description: "managed",
+        filePath: path.join(skillDir, "SKILL.md"),
+        baseDir: skillDir,
+        source: "openclaw-managed",
+      }),
+      frontmatter: {},
+      metadata: {},
+    };
+
+    const report = buildWorkspaceSkillStatus(workspaceDir, {
+      managedSkillsDir,
+      entries: [entry],
+    });
+    const skill = requireReportedSkill(report, slug);
+
+    expect(skill.clawhub?.status).toBe("linked");
+    expect(skill.clawhub?.valid).toBe(true);
+    expect(skill.clawhub?.lockPath).toBe(managedLockPath);
+  });
+
+  it("does not cross-link a managed skill to the workspace lockfile for the same slug", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const managedRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-managed-"));
+    tempDirs.push(managedRoot);
+    const managedSkillsDir = path.join(managedRoot, "skills");
+    const slug = "dupe-slug";
+    const installedAt = 1700000000000;
+    const registry = "https://clawhub.example.com";
+
+    const skillDir = await writeManagedSkillWithOrigin({
+      managedRoot,
+      slug,
+      installedVersion: "1.0.0",
+      installedAt,
+      registry,
+    });
+    // Managed lockfile exists but tracks a different slug only.
+    const managedLockPath = await writeScopeLockfile({
+      scopeRoot: managedRoot,
+      slug: "other-skill",
+      entry: { version: "1.0.0", installedAt, registry },
+    });
+    // Workspace lockfile tracks the same slug - a blanket fallback would
+    // incorrectly validate the managed skill against it.
+    await writeScopeLockfile({
+      scopeRoot: workspaceDir,
+      slug,
+      entry: { version: "1.0.0", installedAt, registry },
+    });
+
+    const entry: SkillEntry = {
+      skill: createCanonicalFixtureSkill({
+        name: slug,
+        description: "managed",
+        filePath: path.join(skillDir, "SKILL.md"),
+        baseDir: skillDir,
+        source: "openclaw-managed",
+      }),
+      frontmatter: {},
+      metadata: {},
+    };
+
+    const report = buildWorkspaceSkillStatus(workspaceDir, {
+      managedSkillsDir,
+      entries: [entry],
+    });
+    const skill = requireReportedSkill(report, slug);
+
+    // The managed skill must resolve against the managed lockfile (which lacks
+    // its slug), not the workspace lockfile that happens to track the same slug.
+    expect(skill.clawhub?.status).toBe("invalid");
+    expect(skill.clawhub?.valid).toBe(false);
+    expect(skill.clawhub?.lockPath).toBe(managedLockPath);
+  });
 });

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -252,7 +252,20 @@ type BuildSkillStatusContext = {
   agentSkillFilter?: string[];
   workspaceDir: string;
   clawhubLockRead: ClawHubSkillsLockfileStatusRead;
+  managedSkillsDir: string;
+  managedClawhubLockRead: ClawHubSkillsLockfileStatusRead;
 };
+
+// Returns true when `child` is `parent` or lives somewhere below it. Both
+// paths are resolved first so symlinked config/workspace dirs classify the
+// same as their real paths.
+function isPathInsideDir(child: string, parent: string): boolean {
+  const relative = path.relative(path.resolve(parent), path.resolve(child));
+  return (
+    relative === "" ||
+    (relative.length > 0 && !relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
 
 function buildSkillStatus(
   indexed: SkillIndexEntry,
@@ -294,13 +307,21 @@ function buildSkillStatus(
   const availableToAgent = eligible && !blockedByAgentFilter;
   const userInvocable = indexed.userInvocable;
 
+  const skillDir = entry.skill.baseDir;
+  // ClawHub linkage is resolved against the skill's owning install scope:
+  // a managed/global skill (under managedSkillsDir) is tracked by the managed
+  // ClawHub lockfile at dirname(managedSkillsDir), while a workspace skill is
+  // tracked by the workspace lockfile. Routing each scope to its own lockfile
+  // avoids cross-linking identical slugs between independent install scopes.
+  const isManagedSkill = isPathInsideDir(skillDir, context.managedSkillsDir);
+  const clawhubScopeDir = isManagedSkill ? path.dirname(context.managedSkillsDir) : workspaceDir;
   const clawhub =
     workspaceDir && !bundled
       ? resolveClawHubSkillStatusLinkSync({
-          workspaceDir,
-          skillDir: entry.skill.baseDir,
+          workspaceDir: clawhubScopeDir,
+          skillDir,
           skillKey,
-          lockRead: context.clawhubLockRead,
+          lockRead: isManagedSkill ? context.managedClawhubLockRead : context.clawhubLockRead,
         })
       : undefined;
   const skillCard = resolveLocalSkillCardStatusSync(entry.skill.baseDir);
@@ -367,6 +388,13 @@ export function buildWorkspaceSkillStatus(
   const prefs = resolveSkillsInstallPreferences(opts?.config);
   const allowBundled = resolveBundledAllowlist(opts?.config);
   const clawhubLockRead = readClawHubSkillsLockfileStatusSync(workspaceDir);
+  // Globally installed (managed) skills are tracked by the ClawHub lockfile at
+  // the managed scope root (dirname(managedSkillsDir), e.g. CONFIG_DIR), not
+  // the workspace lockfile. Read it once here so each managed skill resolves
+  // against its own lockfile.
+  const managedClawhubLockRead = readClawHubSkillsLockfileStatusSync(
+    path.dirname(managedSkillsDir),
+  );
   const skillIndexEntries = buildSkillIndexEntries(skillEntries, {
     bundledNames: bundledContext.names,
     agentSkillFilter,
@@ -385,6 +413,8 @@ export function buildWorkspaceSkillStatus(
         agentSkillFilter,
         workspaceDir,
         clawhubLockRead,
+        managedSkillsDir,
+        managedClawhubLockRead,
       }),
     ),
   };

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -256,17 +256,6 @@ type BuildSkillStatusContext = {
   managedClawhubLockRead: ClawHubSkillsLockfileStatusRead;
 };
 
-// Returns true when `child` is `parent` or lives somewhere below it. Both
-// paths are resolved first so symlinked config/workspace dirs classify the
-// same as their real paths.
-function isPathInsideDir(child: string, parent: string): boolean {
-  const relative = path.relative(path.resolve(parent), path.resolve(child));
-  return (
-    relative === "" ||
-    (relative.length > 0 && !relative.startsWith("..") && !path.isAbsolute(relative))
-  );
-}
-
 function buildSkillStatus(
   indexed: SkillIndexEntry,
   context: BuildSkillStatusContext,
@@ -308,12 +297,14 @@ function buildSkillStatus(
   const userInvocable = indexed.userInvocable;
 
   const skillDir = entry.skill.baseDir;
-  // ClawHub linkage is resolved against the skill's owning install scope:
-  // a managed/global skill (under managedSkillsDir) is tracked by the managed
-  // ClawHub lockfile at dirname(managedSkillsDir), while a workspace skill is
-  // tracked by the workspace lockfile. Routing each scope to its own lockfile
-  // avoids cross-linking identical slugs between independent install scopes.
-  const isManagedSkill = isPathInsideDir(skillDir, context.managedSkillsDir);
+  // ClawHub linkage is resolved against the skill's owning install scope. A
+  // managed/global skill (canonical source "openclaw-managed", i.e. a `--global`
+  // install under CONFIG_DIR/skills) is tracked by the managed ClawHub lockfile
+  // at dirname(managedSkillsDir); a workspace skill is tracked by the workspace
+  // lockfile. Classifying by the loader-assigned source (not the resolved path)
+  // keeps symlinked managed installs on the managed lockfile, and routing each
+  // scope to its own lockfile avoids cross-linking identical slugs between scopes.
+  const isManagedSkill = skillSource === "openclaw-managed";
   const clawhubScopeDir = isManagedSkill ? path.dirname(context.managedSkillsDir) : workspaceDir;
   const clawhub =
     workspaceDir && !bundled


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

Closes #105530

## What Problem This Solves

Fixes an issue where users who install a ClawHub skill globally (`openclaw skills install <slug> --global`) see the skill flagged as `ClawHub link invalid` in the skill list, with the message:

> Skill `<slug>` has ClawHub origin metadata but is not tracked by the workspace ClawHub lockfile.

The skill is in fact correctly installed and tracked - but in the **global** lockfile (`~/.openclaw/.clawhub/lock.json`, i.e. `CONFIG_DIR/.clawhub/lock.json`), not the workspace lockfile. The status check only consulted the workspace lockfile, so every globally installed skill false-positive'd as invalid.

## Why This Change Was Made

`buildWorkspaceSkillStatus` read a single ClawHub lockfile (the workspace's) and passed it to every skill's linkage resolver, including skills installed under the managed/global skills directory (`CONFIG_DIR/skills`). It also passed the workspace dir as the expected-install-dir base, so a managed skill (installed at `CONFIG_DIR/skills/<slug>`) could never match the expected `workspaceDir/skills/<slug>`.

The fix resolves each skill's ClawHub linkage against its **owning install scope**:

- a skill under `managedSkillsDir` (a `--global` install) is checked against the managed lockfile at `dirname(managedSkillsDir)/.clawhub/lock.json` (i.e. `CONFIG_DIR/.clawhub/lock.json`), with the managed dir as the expected install root;
- a skill under the workspace `skills/` dir keeps the existing workspace-lockfile + workspace-install-root behavior.

The resolver (`resolveClawHubSkillStatusLinkSync`) is unchanged - the scope is selected at the single call site in `buildSkillStatus`, and the managed lockfile is read once in `buildWorkspaceSkillStatus`. Routing each scope to its own lockfile means identical slugs installed in both scopes cannot cross-link: a workspace skill only ever checks the workspace lockfile, a managed skill only ever checks the managed lockfile.

## User Impact

Globally installed ClawHub skills that are correctly tracked in the global lockfile now show as valid/linked in the skill list instead of being falsely flagged `ClawHub link invalid`. Workspace-scoped skills are unchanged.

## Evidence

Real behavior captured by driving the real `buildWorkspaceSkillStatus` against an on-disk managed skill (`<managedRoot>/skills/weather-global/` with `.clawhub/origin.json`) plus a matching managed ClawHub lockfile (`<managedRoot>/.clawhub/lock.json`). The workspace has no ClawHub lockfile, mirroring a clean workspace with a `--global` install. Regression tests live in `src/skills/discovery/status-workspace.test.ts`.

**Before fix (current `main`)** - the managed skill is resolved against the (missing) workspace lockfile, so it false-positives as invalid. Actual `skill.clawhub` returned by `buildWorkspaceSkillStatus`:

```
status: "invalid"
valid: false
reason: "Skill \"weather-global\" has ClawHub origin metadata but is not tracked by the workspace ClawHub lockfile."
registry: "https://clawhub.example.com"
slug: "weather-global"
installedVersion: "1.0.0"
installedAt: 1700000000000
originPath: <managedRoot>/skills/weather-global/.clawhub/origin.json
(no lockPath - the workspace lockfile is missing)
```

**After fix** - the managed skill is resolved against its owning managed lockfile and links correctly. Actual `skill.clawhub` returned by `buildWorkspaceSkillStatus`:

```
status: "linked"
valid: true
registry: "https://clawhub.example.com"
slug: "weather-global"
installedVersion: "1.0.0"
installedAt: 1700000000000
originPath: <managedRoot>/skills/weather-global/.clawhub/origin.json
lockPath: <managedRoot>/.clawhub/lock.json
```

**Cross-scope isolation** (no cross-linking): a second regression test installs a managed skill whose slug also exists in the workspace lockfile. On `main`, the managed skill resolves against the workspace lockfile (`lockPath` = the workspace lockfile - wrong scope). After the fix, it resolves against the managed lockfile only (`lockPath` = the managed lockfile), staying `invalid` because the managed lockfile does not track it - it is never validated by the workspace lockfile's same-slug entry.

Local verification:

- `pnpm tsgo` (core prod types) - pass
- `oxlint` + `oxfmt --check` on changed files - pass
- `node scripts/run-vitest.mjs src/skills/discovery/status-workspace.test.ts` - 10/10 pass (both new regression tests fail on `main`, pass after the fix)
- `node scripts/run-vitest.mjs src/skills/discovery/status.test.ts src/skills/lifecycle/clawhub.test.ts` - 11 passed | 1 skipped (no regressions in the resolver's own suite)

Not tested: macOS/iOS skill discovery paths (Windows host); the live `openclaw skills list` UI (the proof drives the real `buildWorkspaceSkillStatus` function directly against a real on-disk managed install).
