### PR TITLE
fix(cli): show clean errors for missing input files

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -2394,6 +2394,15 @@ describe("config cli", () => {
       expect(payload.configPath).not.toContain("~");
     });
 
+    it("rejects --file when the file does not exist", async () => {
+      await expect(
+        runConfigCommand(["config", "patch", "--file", "/nonexistent/path/patch.json5"]),
+      ).rejects.toThrow("__exit__:1");
+
+      expectErrorIncludes("--file not found: /nonexistent/path/patch.json5");
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    });
+
     it("dry-runs pluginIntegration provider patches against manifest integration metadata", async () => {
       const pluginId = "secret-provider-proof";
       const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-plugin-provider-"));

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -47,6 +47,7 @@ import { diffConfigPaths } from "../gateway/config-diff.js";
 import { buildGatewayReloadPlan } from "../gateway/config-reload-plan.js";
 import { resolveGatewayReloadSettings } from "../gateway/config-reload-settings.js";
 import { danger, info, success, warn } from "../globals.js";
+import { hasErrnoCode } from "../infra/errors.js";
 import { parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
@@ -1503,7 +1504,19 @@ async function readConfigPatchInput(opts: ConfigPatchOptions): Promise<unknown> 
     throw configPatchModeError("provide exactly one of --file <path> or --stdin.");
   }
   const sourceLabel = stdin ? "--stdin" : "--file";
-  const raw = stdin ? await readStdinText() : fs.readFileSync(file as string, "utf8");
+  let raw: string;
+  if (stdin) {
+    raw = await readStdinText();
+  } else {
+    try {
+      raw = fs.readFileSync(file as string, "utf8");
+    } catch (err) {
+      if (hasErrnoCode(err, "ENOENT")) {
+        throw new Error(`--file not found: ${file}`, { cause: err });
+      }
+      throw err;
+    }
+  }
   try {
     return JSON5.parse(raw);
   } catch (err) {

--- a/src/cli/config-set-input.test.ts
+++ b/src/cli/config-set-input.test.ts
@@ -96,6 +96,14 @@ describe("config set input parsing", () => {
     );
   });
 
+  it("rejects --batch-file when the file does not exist", () => {
+    expect(() =>
+      parseBatchSource({
+        batchFile: "/nonexistent/path/batch.json5",
+      }),
+    ).toThrow("--batch-file not found: /nonexistent/path/batch.json5");
+  });
+
   it("rejects malformed --batch-file payloads", () => {
     withBatchFile("openclaw-config-set-input-invalid-", "{}", (batchPath) => {
       expect(() =>

--- a/src/cli/config-set-input.ts
+++ b/src/cli/config-set-input.ts
@@ -5,6 +5,7 @@ import {
   normalizeStringifiedOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import JSON5 from "json5";
+import { hasErrnoCode } from "../infra/errors.js";
 
 export type ConfigSetOptions = {
   strictJson?: boolean;
@@ -136,6 +137,14 @@ export function parseBatchSource(opts: ConfigSetOptions): ConfigSetBatchEntry[] 
   if (!pathname) {
     throw new Error("--batch-file must not be empty.");
   }
-  const raw = fs.readFileSync(pathname, "utf8");
+  let raw: string;
+  try {
+    raw = fs.readFileSync(pathname, "utf8");
+  } catch (err) {
+    if (hasErrnoCode(err, "ENOENT")) {
+      throw new Error(`--batch-file not found: ${pathname}`, { cause: err });
+    }
+    throw err;
+  }
   return parseBatchEntries(raw, "--batch-file");
 }

--- a/src/cli/secrets-cli.test.ts
+++ b/src/cli/secrets-cli.test.ts
@@ -412,6 +412,24 @@ describe("secrets CLI", () => {
     expect(runSecretsApply).not.toHaveBeenCalled();
   });
 
+  it("preserves causes for unrelated apply errors with a similar message", async () => {
+    await withPlanFile(async (planPath) => {
+      runSecretsApply.mockRejectedValueOnce(
+        new Error("Secrets plan file not found during apply", {
+          cause: new Error("provider diagnostic"),
+        }),
+      );
+
+      await expect(
+        createProgram().parseAsync(["secrets", "apply", "--from", planPath], { from: "user" }),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(runtimeErrors.join("\n")).toContain(
+        "Secrets plan file not found during apply | provider diagnostic",
+      );
+    });
+  });
+
   it("does not print skipped-exec note when apply dry-run skippedExecRefs is zero", async () => {
     await withPlanFile(async (planPath) => {
       runSecretsApply.mockResolvedValue(createSecretsApplyResult({ resolvabilityComplete: false }));

--- a/src/cli/secrets-cli.test.ts
+++ b/src/cli/secrets-cli.test.ts
@@ -399,6 +399,19 @@ describe("secrets CLI", () => {
     }, "{invalid json");
   });
 
+  it("rejects --from when the plan file does not exist", async () => {
+    await expect(
+      createProgram().parseAsync(["secrets", "apply", "--from", "/nonexistent/path/plan.json"], {
+        from: "user",
+      }),
+    ).rejects.toThrow("__exit__:1");
+
+    const errorOutput = runtimeErrors.join("\n");
+    expect(errorOutput).toContain("Secrets plan file not found: /nonexistent/path/plan.json");
+    expect(errorOutput).not.toContain("ENOENT");
+    expect(runSecretsApply).not.toHaveBeenCalled();
+  });
+
   it("does not print skipped-exec note when apply dry-run skippedExecRefs is zero", async () => {
     await withPlanFile(async (planPath) => {
       runSecretsApply.mockResolvedValue(createSecretsApplyResult({ resolvabilityComplete: false }));

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -3,7 +3,7 @@ import type { Command } from "commander";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import { danger } from "../globals.js";
-import { formatErrorMessage } from "../infra/errors.js";
+import { formatErrorMessage, hasErrnoCode } from "../infra/errors.js";
 import { defaultRuntime } from "../runtime.js";
 import type { SecretsApplyPlan } from "../secrets/plan.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
@@ -52,7 +52,15 @@ async function readPlanFile(pathname: string): Promise<SecretsApplyPlan> {
     fsModuleLoader.load(),
     import("../secrets/plan.js"),
   ]);
-  const raw = readFileSync(pathname, "utf8");
+  let raw: string;
+  try {
+    raw = readFileSync(pathname, "utf8");
+  } catch (err) {
+    if (hasErrnoCode(err, "ENOENT")) {
+      throw new Error(`Secrets plan file not found: ${pathname}`, { cause: err });
+    }
+    throw err;
+  }
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -333,9 +341,15 @@ export function registerSecretsCli(program: Command): void {
             : "Secrets apply: no changes.",
         );
       } catch (err) {
+        // The missing-plan wrapper already carries a user-friendly message; keep its
+        // ENOENT cause out of the rendered CLI output while preserving it for diagnostics.
+        const message =
+          err instanceof Error && err.message.startsWith("Secrets plan file not found")
+            ? err.message
+            : formatErrorMessage(err);
         defaultRuntime.error(
           danger(
-            `Secrets apply failed: ${formatErrorMessage(err)}. Re-run ${formatCliCommand("openclaw secrets apply --from <path> --dry-run")} to inspect the plan without writing.`,
+            `Secrets apply failed: ${message}. Re-run ${formatCliCommand("openclaw secrets apply --from <path> --dry-run")} to inspect the plan without writing.`,
           ),
         );
         defaultRuntime.exit(1);

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -46,6 +46,8 @@ const secretsApplyLoader = createLazyImportLoader<SecretsApplyModule>(
   () => import("../secrets/apply.js"),
 );
 
+class SecretsPlanFileNotFoundError extends Error {}
+
 async function readPlanFile(pathname: string): Promise<SecretsApplyPlan> {
   // Apply consumes a generated plan shape, not arbitrary JSON.
   const [{ readFileSync }, { isSecretsApplyPlan }] = await Promise.all([
@@ -57,7 +59,9 @@ async function readPlanFile(pathname: string): Promise<SecretsApplyPlan> {
     raw = readFileSync(pathname, "utf8");
   } catch (err) {
     if (hasErrnoCode(err, "ENOENT")) {
-      throw new Error(`Secrets plan file not found: ${pathname}`, { cause: err });
+      throw new SecretsPlanFileNotFoundError(`Secrets plan file not found: ${pathname}`, {
+        cause: err,
+      });
     }
     throw err;
   }
@@ -341,10 +345,10 @@ export function registerSecretsCli(program: Command): void {
             : "Secrets apply: no changes.",
         );
       } catch (err) {
-        // The missing-plan wrapper already carries a user-friendly message; keep its
-        // ENOENT cause out of the rendered CLI output while preserving it for diagnostics.
+        // The missing-plan wrapper already carries a user-facing message. Keep its
+        // ENOENT cause available to diagnostics without rendering the raw filesystem error.
         const message =
-          err instanceof Error && err.message.startsWith("Secrets plan file not found")
+          err instanceof SecretsPlanFileNotFoundError
             ? err.message
             : formatErrorMessage(err);
         defaultRuntime.error(

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -348,9 +348,7 @@ export function registerSecretsCli(program: Command): void {
         // The missing-plan wrapper already carries a user-facing message. Keep its
         // ENOENT cause available to diagnostics without rendering the raw filesystem error.
         const message =
-          err instanceof SecretsPlanFileNotFoundError
-            ? err.message
-            : formatErrorMessage(err);
+          err instanceof SecretsPlanFileNotFoundError ? err.message : formatErrorMessage(err);
         defaultRuntime.error(
           danger(
             `Secrets apply failed: ${message}. Re-run ${formatCliCommand("openclaw secrets apply --from <path> --dry-run")} to inspect the plan without writing.`,


### PR DESCRIPTION
## What Problem This Solves

Three CLI input paths exposed raw Node.js `ENOENT` text when the user supplied a missing file:

- `openclaw config set --batch-file <path>`
- `openclaw config patch --file <path>`
- `openclaw secrets apply --from <path>`

The raw filesystem error is noisy and less actionable than naming the flag and user-supplied path.

## Solution

- Translate only `ENOENT` at each command-owned file-read boundary using the shared `hasErrnoCode` guard.
- Preserve the original error as `cause`; rethrow every non-`ENOENT` failure unchanged.
- Use a typed local missing-plan error so secrets rendering suppresses only that expected raw cause. Unrelated apply errors, including ones with similar message text, retain their diagnostic causes.

## Behavior

The three commands now exit 1 with these messages:

```text
Error: --batch-file not found: /tmp/missing-batch.json5
Error: --file not found: /tmp/missing-patch.json5
Secrets apply failed: Secrets plan file not found: /tmp/missing-plan.json. Re-run openclaw secrets apply --from <path> --dry-run to inspect the plan without writing.
```

No parse, config write, or secrets apply operation runs after the missing input is detected.

## Evidence

- Blacksmith Testbox `tbx_01kxstbgzscnwa3jeeqyr62j8h`: `pnpm test src/cli/config-set-input.test.ts src/cli/config-cli.test.ts src/cli/secrets-cli.test.ts` — 160 passed.
- Real built CLI on the same Testbox: all three commands exited 1 with the expected text; combined output contained neither `ENOENT` nor `no such file or directory`.
- Fresh maintainer-fixup autoreview: clean (`patch is correct`, 0.98).
- `git diff --check` — clean.

## Risk

Low. Success paths are unchanged. Classification is limited to `ENOENT`; permission, parse, validation, and provider errors keep their existing handling.
