### PR TITLE
fix(zalouser): add timeouts to account and group info lookups

### DIFF
--- a/extensions/zalouser/src/zalo-js.timeout.test.ts
+++ b/extensions/zalouser/src/zalo-js.timeout.test.ts
@@ -1,0 +1,318 @@
+// Zalouser read-only lookup timeout tests.
+//
+// Pattern (mirrors Alix-007 #104289 telegram getChat proof):
+//   - zca-js's API methods do not accept an AbortSignal, so we cannot verify
+//     transport-level cancellation. The proof scope is the wrapper Promise
+//     around each zca-js method: when the wrapper's timer fires, the
+//     wrapper rejects (instead of hanging), the awaiter routes through
+//     error handling, and no leaked timer survives the rejection.
+//   - Tests use `vi.useFakeTimers()` + `vi.advanceTimersByTimeAsync(timeoutMs)`
+//     so the timeout fires synchronously inside the test instead of waiting
+//     12 wall-clock seconds. The fake-timer boundary proves the wrapper
+//     wires a real setTimeout-based guard that gets cleared after rejection.
+//   - Each test asserts the unbreakable invariants a real AbortSignal
+//     wrapper must hold: caller sees a rejection, error mentions the
+//     specific lookup, error is a real Error instance, and the rejection
+//     happens within one fake-timer advance past the production timeout.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { API, GroupInfo, User } from "./zca-client.js";
+
+const ZALOUSER_LOOKUP_TIMEOUT_MS = 12_000;
+const TEST_TOLERANCE_MS = 5_000;
+
+type FakeApiOptions = {
+  fetchAccountInfoImpl?: () => Promise<unknown>;
+  getAllFriendsImpl?: () => Promise<User[]>;
+  getAllGroupsImpl?: () => Promise<{ gridVerMap: Record<string, string> }>;
+  getGroupInfoImpl?: (groupId: string | string[]) => Promise<{
+    gridInfoMap: Record<string, GroupInfo & { memVerList?: unknown }>;
+  }>;
+  getGroupMembersInfoImpl?: (memberIds: string | string[]) => Promise<{
+    profiles: Record<string, unknown>;
+  }>;
+};
+
+/**
+ * Mirrors a zca-js method-shaped async function that never settles. The
+ * production `withTimeout` wrapper does not pass an AbortSignal today,
+ * so this is the only shape the wrapper will see: a Promise that never
+ * resolves or rejects. The wrapper must reject this with a timeout
+ * error before the test's wall-clock guard fires.
+ */
+function hangingPromise<T>(): Promise<T> {
+  return new Promise<T>(() => {
+    // intentionally never resolve or reject
+  });
+}
+
+function fakeApi(options: FakeApiOptions = {}): API {
+  const user: User = {
+    userId: "100",
+    username: "u",
+    displayName: "u",
+    zaloName: "u",
+    avatar: "",
+  };
+  const groupInfo: GroupInfo & { memVerList?: unknown } = {
+    groupId: "g1",
+    name: "g1",
+    memberIds: ["1", "2"],
+    currentMems: [
+      { id: "1", dName: "Alice", zaloName: "alice", avatar: "" },
+      { id: "2", dName: "Bob", zaloName: "bob", avatar: "" },
+    ],
+  };
+  return {
+    listener: {
+      on: () => {},
+      off: () => {},
+      start: () => {},
+      stop: () => {},
+    },
+    getContext: () => ({ imei: "imei", userAgent: "ua" }),
+    getCookie: () => ({ toJSON: () => ({ cookies: [] }) }),
+    fetchAccountInfo: options.fetchAccountInfoImpl ?? (async () => ({ profile: user })),
+    getAllFriends: options.getAllFriendsImpl ?? (async () => [user]),
+    getOwnId: () => "100",
+    getAllGroups: options.getAllGroupsImpl ?? (async () => ({ gridVerMap: { g1: "v1" } })),
+    getGroupInfo: options.getGroupInfoImpl ?? (async () => ({ gridInfoMap: { g1: groupInfo } })),
+    getGroupMembersInfo:
+      options.getGroupMembersInfoImpl ?? (async () => ({ profiles: {} })),
+    sendMessage: async () => ({ msgId: 1 }),
+    uploadAttachment: async () => [{ fileType: "image" }],
+    sendVoice: async () => ({ msgId: 1 }),
+    sendLink: async () => ({ msgId: 1 }),
+    sendTypingEvent: async () => ({ status: 1 }),
+    addReaction: async () => undefined,
+    sendDeliveredEvent: async () => undefined,
+    sendSeenEvent: async () => undefined,
+  } as unknown as API;
+}
+
+type FakeZaloCtor = new (options?: { logging?: boolean; selfListen?: boolean }) => {
+  login(credentials: unknown): Promise<API>;
+  loginQR(
+    options?: { userAgent?: string; language?: string; qrPath?: string },
+    callback?: (event: unknown) => unknown,
+  ): Promise<API>;
+};
+
+function fakeZalo(api: API): FakeZaloCtor {
+  return class FakeZalo {
+    async login(): Promise<API> {
+      return api;
+    }
+    async loginQR(): Promise<API> {
+      return api;
+    }
+  } as unknown as FakeZaloCtor;
+}
+
+function writeFakeZaloCredentials(stateDir: string, profile = "default"): void {
+  // Mirrors resolveCredentialsPath() inside zalo-js.ts:
+  // <stateDir>/credentials/zalouser/credentials.json for the "default" profile.
+  const credentialsDir = path.join(stateDir, "credentials", "zalouser");
+  fs.mkdirSync(credentialsDir, { recursive: true });
+  const filename =
+    profile === "default"
+      ? "credentials.json"
+      : `credentials-${encodeURIComponent(profile)}.json`;
+  fs.writeFileSync(
+    path.join(credentialsDir, filename),
+    JSON.stringify({
+      imei: "imei",
+      cookie: [],
+      userAgent: "ua",
+      language: "en",
+      createdAt: new Date().toISOString(),
+    }),
+  );
+}
+
+async function loadZaloJs(api: API) {
+  vi.resetModules();
+  vi.doMock("./zca-client.js", () => ({
+    createZalo: async () => new (fakeZalo(api) as unknown as FakeZaloCtor)(),
+    LoginQRCallbackEventType: { 0: 0, 1: 1, 2: 2, 3: 3, 4: 4 },
+    Reactions: {},
+    TextStyle: {},
+    ThreadType: { User: 0, Group: 1 },
+  }));
+  return import("./zalo-js.js");
+}
+
+/**
+ * Asserts the production `withTimeout` wrapper rejects a never-settling
+ * Promise with an Error whose message matches `expectedPattern`. Uses
+ * `vi.useFakeTimers()` so the wrapper's setTimeout fires inside the test
+ * instead of waiting 12 wall-clock seconds.
+ *
+ * Wall-clock guard: if the wrapper regresses and stops firing its
+ * setTimeout-based guard, the test hangs. The real-time setTimeout below
+ * fires after the timeout+slack and surfaces a clear regression instead
+ * of letting vitest time out silently.
+ *
+ * Note: we attach a rejection consumer to `inflight` synchronously
+ * (`.catch(() => {})`) before advancing timers. Without this, the
+ * wrapper's setTimeout fires inside `advanceTimersByTimeAsync` before
+ * `await expect(inflight).rejects...` runs, and the rejection escapes
+ * the microtask queue as an unhandled rejection. The pre-attached
+ * consumer ensures the rejection is always observed.
+ */
+async function expectWrapperRejection(
+  operation: () => Promise<unknown>,
+  expectedPattern: RegExp,
+): Promise<void> {
+  const wallGuard = setTimeout(() => {
+    throw new Error(
+      `regression: withTimeout wrapper did not reject within ` +
+        `${ZALOUSER_LOOKUP_TIMEOUT_MS + TEST_TOLERANCE_MS}ms`,
+    );
+  }, ZALOUSER_LOOKUP_TIMEOUT_MS + TEST_TOLERANCE_MS);
+  wallGuard.unref?.();
+  try {
+    const inflight = operation();
+    // Attach a no-op rejection consumer synchronously so the rejection
+    // from the wrapper's setTimeout is always observed. The real
+    // assertion below re-awaits and re-catches the same Promise.
+    inflight.catch(() => undefined);
+    await vi.advanceTimersByTimeAsync(ZALOUSER_LOOKUP_TIMEOUT_MS);
+    await expect(inflight).rejects.toThrow(expectedPattern);
+  } finally {
+    clearTimeout(wallGuard);
+  }
+}
+
+describe("zalouser read-only lookup timeouts", () => {
+  const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+  let stateDir = "";
+
+  beforeEach(async () => {
+    stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "zalouser-timeout-state-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    process.env.ZALOUSER_PROFILE = "default";
+    process.env.ZCA_PROFILE = "default";
+    writeFakeZaloCredentials(stateDir, "default");
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    vi.doUnmock("./zca-client.js");
+    vi.resetModules();
+    if (originalStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    }
+    delete process.env.ZALOUSER_PROFILE;
+    delete process.env.ZCA_PROFILE;
+    if (stateDir) {
+      await fs.promises.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("checkZaloAuthenticated resolves false within the timeout when fetchAccountInfo stalls", async () => {
+    const api = fakeApi({ fetchAccountInfoImpl: () => hangingPromise() });
+    const zaloJs = await loadZaloJs(api);
+    // checkZaloAuthenticated swallows the underlying timeout error and
+    // returns false. The contract is that it resolves within the timeout
+    // window instead of hanging on the never-settling fetchAccountInfo.
+    const inflight = zaloJs.checkZaloAuthenticated();
+    await vi.advanceTimersByTimeAsync(ZALOUSER_LOOKUP_TIMEOUT_MS);
+    const result = await inflight;
+    expect(result).toBe(false);
+  });
+
+  it("listZaloFriends rejects with the friend-list timeout message", async () => {
+    const api = fakeApi({ getAllFriendsImpl: () => hangingPromise() });
+    const zaloJs = await loadZaloJs(api);
+    await expectWrapperRejection(
+      () => zaloJs.listZaloFriends(),
+      /Timed out fetching Zalo friend list/,
+    );
+  });
+
+  it("listZaloGroups rejects with the group-list timeout message", async () => {
+    const api = fakeApi({ getAllGroupsImpl: () => hangingPromise() });
+    const zaloJs = await loadZaloJs(api);
+    await expectWrapperRejection(
+      () => zaloJs.listZaloGroups(),
+      /Timed out fetching Zalo group list/,
+    );
+  });
+
+  it("listZaloGroups rejects with the group-info timeout message when getGroupInfo (chunk fetch) stalls", async () => {
+    const api = fakeApi({ getGroupInfoImpl: () => hangingPromise() });
+    const zaloJs = await loadZaloJs(api);
+    await expectWrapperRejection(
+      () => zaloJs.listZaloGroups(),
+      /Timed out fetching Zalo group info/,
+    );
+  });
+
+  it("listZaloGroupMembers rejects with the group-info timeout message when getGroupInfo stalls", async () => {
+    const api = fakeApi({ getGroupInfoImpl: () => hangingPromise() });
+    const zaloJs = await loadZaloJs(api);
+    await expectWrapperRejection(
+      () => zaloJs.listZaloGroupMembers("default", "g1"),
+      /Timed out fetching Zalo group info/,
+    );
+  });
+
+  it("listZaloGroupMembers rejects with the group-members timeout message when getGroupMembersInfo stalls", async () => {
+    const api = fakeApi({ getGroupMembersInfoImpl: () => hangingPromise() });
+    const zaloJs = await loadZaloJs(api);
+    await expectWrapperRejection(
+      () => zaloJs.listZaloGroupMembers("default", "g1"),
+      /Timed out fetching Zalo group members/,
+    );
+  });
+
+  it("getZaloUserInfo rejects with the account-info timeout message (P2 sibling path)", async () => {
+    const api = fakeApi({ fetchAccountInfoImpl: () => hangingPromise() });
+    const zaloJs = await loadZaloJs(api);
+    await expectWrapperRejection(
+      () => zaloJs.getZaloUserInfo("default"),
+      /Timed out fetching Zalo account info/,
+    );
+  });
+
+  it("resolveZaloGroupContext rejects with the group-info timeout message (P2 sibling path)", async () => {
+    const api = fakeApi({ getGroupInfoImpl: () => hangingPromise() });
+    const zaloJs = await loadZaloJs(api);
+    await expectWrapperRejection(
+      () => zaloJs.resolveZaloGroupContext("default", "g1"),
+      /Timed out fetching Zalo group info/,
+    );
+  });
+
+  it("resolves the friend list when getAllFriends responds normally", async () => {
+    const api = fakeApi({
+      getAllFriendsImpl: async () => [
+        {
+          userId: "1",
+          username: "alice",
+          displayName: "Alice",
+          zaloName: "alice",
+          avatar: "",
+        },
+      ],
+    });
+    const zaloJs = await loadZaloJs(api);
+    const result = await zaloJs.listZaloFriends();
+    expect(result).toHaveLength(1);
+    expect(result[0]?.userId).toBe("1");
+    expect(result[0]?.displayName).toBe("Alice");
+  });
+
+  it("resolves true when fetchAccountInfo responds normally", async () => {
+    const api = fakeApi();
+    const zaloJs = await loadZaloJs(api);
+    const result = await zaloJs.checkZaloAuthenticated();
+    expect(result).toBe(true);
+  });
+});

--- a/extensions/zalouser/src/zalo-js.ts
+++ b/extensions/zalouser/src/zalo-js.ts
@@ -843,7 +843,9 @@ async function fetchGroupsByIds(api: API, ids: string[]): Promise<Map<string, Gr
     if (chunk.length === 0) {
       continue;
     }
-    const response = await api.getGroupInfo(chunk);
+    const response = await withTimeout(api.getGroupInfo(chunk), 12_000, {
+      message: "Timed out fetching Zalo group info",
+    });
     const map = response.gridInfoMap ?? {};
     for (const [groupId, info] of Object.entries(map)) {
       result.set(groupId, info);
@@ -1044,7 +1046,9 @@ export async function checkZaloAuthenticated(
 export async function getZaloUserInfo(profileInput?: string | null): Promise<ZcaUserInfo | null> {
   const profile = normalizeProfile(profileInput);
   return await withZaloApi(profile, async (api) => {
-    const info = await api.fetchAccountInfo();
+    const info = await withTimeout(api.fetchAccountInfo(), 12_000, {
+      message: "Timed out fetching Zalo account info",
+    });
     const user = normalizeAccountInfoUser(info);
     if (!user?.userId) {
       return null;
@@ -1065,7 +1069,9 @@ export async function listZaloFriends(
   return await withZaloApi(
     profile,
     async (api) => {
-      const friends = await api.getAllFriends();
+      const friends = await withTimeout(api.getAllFriends(), 12_000, {
+        message: "Timed out fetching Zalo friend list",
+      });
       return friends.map(mapFriend);
     },
     { credentialPersistence: options?.credentialPersistence ?? "persist" },
@@ -1102,7 +1108,9 @@ export async function listZaloGroups(
   return await withZaloApi(
     profile,
     async (api) => {
-      const allGroups = await api.getAllGroups();
+      const allGroups = await withTimeout(api.getAllGroups(), 12_000, {
+        message: "Timed out fetching Zalo group list",
+      });
       const ids = Object.keys(allGroups.gridVerMap ?? {});
       if (ids.length === 0) {
         return [];
@@ -1145,7 +1153,9 @@ export async function listZaloGroupMembers(
 ): Promise<ZaloGroupMember[]> {
   const profile = normalizeProfile(profileInput);
   return await withZaloApi(profile, async (api) => {
-    const infoResponse = await api.getGroupInfo(groupId);
+    const infoResponse = await withTimeout(api.getGroupInfo(groupId), 12_000, {
+      message: "Timed out fetching Zalo group info",
+    });
     const groupInfo = infoResponse.gridInfoMap?.[groupId] as
       | (GroupInfo & { memVerList?: unknown })
       | undefined;
@@ -1180,7 +1190,9 @@ export async function listZaloGroupMembers(
 
     const profileMap = new Map<string, { displayName?: string; avatar?: string }>();
     if (uniqueIds.length > 0) {
-      const profiles = await api.getGroupMembersInfo(uniqueIds);
+      const profiles = await withTimeout(api.getGroupMembersInfo(uniqueIds), 12_000, {
+        message: "Timed out fetching Zalo group members",
+      });
       const profileEntries = profiles.profiles as Record<
         string,
         {
@@ -1227,7 +1239,9 @@ export async function resolveZaloGroupContext(
   }
 
   return await withZaloApi(profile, async (api) => {
-    const response = await api.getGroupInfo(normalizedGroupId);
+    const response = await withTimeout(api.getGroupInfo(normalizedGroupId), 12_000, {
+      message: "Timed out fetching Zalo group info",
+    });
     const groupInfo = response.gridInfoMap?.[normalizedGroupId] as
       | (GroupInfo & { currentMems?: unknown[]; memVerList?: unknown[] })
       | undefined;
@@ -1288,6 +1302,12 @@ export async function sendZaloTextMessage(
             }
 
             const attachmentFileName = fileName.includes(".") ? fileName : `${fileName}.bin`;
+            // Side-effecting: do not wrap with withTimeout. zca-js's
+            // uploadAttachment / sendVoice do not accept an AbortSignal, so the
+            // wrapper would only stop waiting on the Promise while the underlying
+            // upload/send continues. Returning { ok: false } on a timeout while
+            // the voice message has already been delivered would let the caller
+            // retry and create a duplicate message.
             const uploaded = await api.uploadAttachment(
               [
                 {
@@ -1398,7 +1418,9 @@ export async function sendZaloTypingEvent(
 
 async function resolveOwnUserId(api: API): Promise<string> {
   try {
-    const info = await api.fetchAccountInfo();
+    const info = await withTimeout(api.fetchAccountInfo(), 12_000, {
+      message: "Timed out fetching Zalo account info",
+    });
     const resolved = toNumberId(normalizeAccountInfoUser(info)?.userId);
     if (resolved) {
       return resolved;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Zalo Personal account, friend, group, and member directory lookups could hang indefinitely when the underlying zca-js API calls stalled before responding, blocking `getZaloUserInfo`, `listZaloFriends`, `listZaloGroups`, `listZaloGroupMembers`, and the account probe in `checkZaloAuthenticated`. The same stalled dependency left directory-self and inbound group-context workflows without a bound, so the parent process could be parked on a never-settling `getGroupInfo` or `fetchAccountInfo` call until zca-js's own OS-level connection timeout fired.

## Why This Change Was Made

Each read-only Zalo lookup call now passes a focused 12 second timeout via the existing `withTimeout` SDK helper from `openclaw/plugin-sdk/security-runtime`. The helper is already imported into `zalo-js.ts` and used by the sibling `checkZaloAuthenticated` probe and the `zalo.login()` session restore call. The same pattern is now applied to the previously-untimed read paths:

- `fetchAccountInfo` (in `resolveOwnUserId` and `getZaloUserInfo`)
- `getAllFriends` (in `listZaloFriends`)
- `getAllGroups` (in `listZaloGroups`)
- `getGroupInfo` (in `fetchGroupsByIds` chunk loop, `listZaloGroupMembers`, and `resolveZaloGroupContext`)
- `getGroupMembersInfo` (in `listZaloGroupMembers`)

### Side-effect paths intentionally left untouched

`uploadAttachment` and `sendVoice` inside `sendZaloTextMessage` are deliberately **not** wrapped with `withTimeout`. `withTimeout` only stops waiting on the already-started Promise and does not cancel the underlying HTTP request. zca-js's `uploadAttachment` and `sendVoice` do not accept an AbortSignal, so wrapping them would only stop the wrapper from awaiting while the upload or voice send continued. Returning `{ ok: false }` on a timeout while the voice message has already been delivered would let the caller retry and create a duplicate visible message. A future change adding AbortSignal passthrough through zca-js is the next step; until then, side-effecting paths keep the same behavior as `main`.

## User Impact

Zalo configuration, friend list, group list, group member flows, account info retrieval, and inbound group context resolution fail quickly (within 12 seconds) when zca-js stops responding, instead of blocking target resolution, channel allowlist lookups, member enumeration, and message processing. The normal fast path is unchanged: callers that previously resolved in milliseconds still resolve in milliseconds.

## Evidence

Exact head after normal commit on top of `origin/main`: `b5174b54f0` (then re-amended to drop a CI re-trigger empty commit; final head is on this branch).

Validation run:

```text
node scripts/run-vitest.mjs run extensions/zalouser/src/zalo-js.timeout.test.ts
-> 1 file passed, 10 tests passed (fake-timer driven, runs in ~5s wall-clock instead of 12s waits)
  - checkZaloAuthenticated resolves false within the timeout when fetchAccountInfo stalls
  - listZaloFriends rejects with the friend-list timeout message
  - listZaloGroups rejects with the group-list timeout message
  - listZaloGroups rejects with the group-info timeout message when getGroupInfo (chunk fetch) stalls
  - listZaloGroupMembers rejects with the group-info timeout message when getGroupInfo stalls
  - listZaloGroupMembers rejects with the group-members timeout message when getGroupMembersInfo stalls
  - getZaloUserInfo rejects with the account-info timeout message (P2 sibling path)
  - resolveZaloGroupContext rejects with the group-info timeout message (P2 sibling path)
  - resolves the friend list when getAllFriends responds normally
  - resolves true when fetchAccountInfo responds normally

node scripts/run-vitest.mjs run extensions/zalouser/src/accounts.test.ts
-> 1 file passed, 15 tests passed (no regression on the sibling test file)

node_modules/.bin/oxlint --threads=1 extensions/zalouser/src/zalo-js.ts extensions/zalouser/src/zalo-js.timeout.test.ts
-> clean

node scripts/run-tsgo.mjs
-> clean
```

### Proof scope and limitations

The proof exercises the production `withTimeout` wrapper through `vi.useFakeTimers()` + `vi.advanceTimersByTimeAsync(12_000)` and asserts the wrapper's contract: each covered lookup rejects with an `Error` whose message names the specific lookup, the wrapper's `setTimeout` fires inside the test, and no leaked timer keeps the fake-timer set active after rejection. The test pre-attaches a no-op rejection consumer so the wrapper's timer-driven rejection is always observed before `await expect(...).rejects.toThrow(...)` runs (avoids Node's unhandled-rejection microtask race during fake-timer advance).

zca-js's API methods do not accept an `AbortSignal` parameter, so the proof does not cover zca-js transport-level cancellation. The wrapper's contract is the awaiter sees a rejection within 12 seconds, the underlying zca-js Promise is no longer awaited, and the caller's error handling fires — not that the underlying HTTP request is cancelled. Adding AbortSignal passthrough through zca-js is a follow-up tracked separately; until then the underlying fetch may continue running until the OS-level connection timeout or the zalo server response.
