### PR TITLE
test(ui): align composer footer inset contract

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -860,7 +860,8 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       expect(geometry.textarea?.paddingLeft).toBe(composerInset - 4);
       expect(geometry.footer?.paddingLeft).toBe(composerInset);
       expect(geometry.footer?.paddingRight).toBe(composerInset);
-      expect(geometry.footer?.paddingBottom).toBe(composerInset);
+      expect(geometry.footer?.paddingTop).toBe(composerInset / 2);
+      expect(geometry.footer?.paddingBottom).toBe(composerInset / 2);
     } finally {
       await closeBrowserPage(page);
     }


### PR DESCRIPTION
## What Problem This Solves

PR #105866 intentionally split the chat composer footer's vertical inset in half, but the responsive browser test still required the old full bottom inset. `checks-ui` therefore fails at 393x852, 1366x900, and 1920x1080 on current `main`.

## Why This Change Was Made

Update the browser contract to assert the new symmetric half-insets on both the top and bottom while preserving the full horizontal inset checks.

## User Impact

No runtime behavior change. Restores reliable Control UI CI coverage for the centered composer footer layout.

## Evidence

- [Blacksmith Testbox run 29219565240](https://github.com/openclaw/openclaw/actions/runs/29219565240)
- `pnpm test ui/src/pages/chat/chat-responsive.browser.test.ts`
- `pnpm check:changed`
