### PR TITLE
fix(deepinfra): apply request policy to video generation requests

### DIFF
--- a/extensions/deepinfra/video-generation-provider.test.ts
+++ b/extensions/deepinfra/video-generation-provider.test.ts
@@ -196,7 +196,10 @@ describe("deepinfra video generation provider", () => {
         request: requestPolicy,
       }),
     );
-    const postRequest = requireFirstPostJsonRequest();
+    const postRequest = requireFirstPostJsonRequest(
+      postJsonRequestMock,
+      "DeepInfra video submit request",
+    );
     expect(Reflect.get(postRequest ?? {}, "allowPrivateNetwork")).toBe(true);
     expect(Reflect.get(postRequest ?? {}, "dispatcherPolicy")).toBe(dispatcherPolicy);
     const postRequestHeaders = Reflect.get(postRequest ?? {}, "headers");

--- a/extensions/deepinfra/video-generation-provider.test.ts
+++ b/extensions/deepinfra/video-generation-provider.test.ts
@@ -13,6 +13,7 @@ const {
   fetchWithTimeoutMock,
   pollProviderOperationJsonMock,
   resolveProviderHttpRequestConfigMock,
+  sanitizeConfiguredModelProviderRequestMock,
 } = getProviderHttpMocks();
 
 let buildDeepInfraVideoGenerationProvider: typeof import("./video-generation-provider.js").buildDeepInfraVideoGenerationProvider;
@@ -81,7 +82,6 @@ describe("deepinfra video generation provider", () => {
         {
           baseUrl: "https://api.deepinfra.com/v1/openai",
           defaultBaseUrl: "https://api.deepinfra.com/v1/openai",
-          allowPrivateNetwork: false,
           defaultHeaders: {
             Authorization: "Bearer provider-key",
             "Content-Type": "application/json",
@@ -89,6 +89,7 @@ describe("deepinfra video generation provider", () => {
           provider: "deepinfra",
           capability: "video",
           transport: "http",
+          request: undefined,
         },
       ],
     ]);
@@ -142,6 +143,65 @@ describe("deepinfra video generation provider", () => {
       status: "succeeded",
     });
     expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("applies configured request policy to OpenAI-compatible video requests", async () => {
+    const requestPolicy = {
+      allowPrivateNetwork: true,
+      headers: { "X-DeepInfra-Route": "video-policy" },
+    };
+    const dispatcherPolicy = { mode: "env-proxy" as const };
+    resolveProviderHttpRequestConfigMock.mockImplementationOnce((params) => {
+      const headers = new Headers(params.defaultHeaders);
+      for (const [key, value] of Object.entries(params.request?.headers ?? {})) {
+        headers.set(key, value);
+      }
+      return {
+        baseUrl: params.baseUrl ?? params.defaultBaseUrl,
+        allowPrivateNetwork: params.request?.allowPrivateNetwork === true,
+        headers,
+        dispatcherPolicy,
+      };
+    });
+    mockSubmit({
+      id: "videos_policy",
+      status: "succeeded",
+      data: [{ url: "/generated/policy.mp4" }],
+    });
+
+    const provider = buildDeepInfraVideoGenerationProvider();
+    await provider.generateVideo({
+      provider: "deepinfra",
+      model: "deepinfra/Pixverse/Pixverse-T2V",
+      prompt: "A request policy video",
+      cfg: {
+        models: {
+          providers: {
+            deepinfra: {
+              baseUrl: "https://api.deepinfra.com/v1/openai",
+              models: [],
+              request: requestPolicy,
+            },
+          },
+        },
+      },
+    });
+
+    expect(sanitizeConfiguredModelProviderRequestMock).toHaveBeenCalledWith(requestPolicy);
+    expect(resolveProviderHttpRequestConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "deepinfra",
+        capability: "video",
+        transport: "http",
+        request: requestPolicy,
+      }),
+    );
+    const postRequest = requireFirstPostJsonRequest();
+    expect(Reflect.get(postRequest ?? {}, "allowPrivateNetwork")).toBe(true);
+    expect(Reflect.get(postRequest ?? {}, "dispatcherPolicy")).toBe(dispatcherPolicy);
+    const postRequestHeaders = Reflect.get(postRequest ?? {}, "headers");
+    expect(postRequestHeaders).toBeInstanceOf(Headers);
+    expect((postRequestHeaders as Headers).get("x-deepinfra-route")).toBe("video-policy");
   });
 
   it("returns immediately without polling when the submit response already succeeded", async () => {

--- a/extensions/deepinfra/video-generation-provider.transport.test.ts
+++ b/extensions/deepinfra/video-generation-provider.transport.test.ts
@@ -1,0 +1,246 @@
+// DeepInfra transport tests cover real provider-http request policy forwarding.
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { connect, type AddressInfo } from "node:net";
+import { withEnvAsync, withServer } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it, vi } from "vitest";
+
+const resolveApiKeyForProviderMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    apiKey: "test",
+    source: "profile",
+    mode: "api-key",
+  })),
+);
+
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
+  resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+}));
+
+type CapturedRequest = {
+  body: string;
+  headers: IncomingMessage["headers"];
+  method?: string;
+  url?: string;
+};
+
+type DestroyableConnection = {
+  destroy: () => void;
+};
+
+async function buildTransportProofProvider() {
+  vi.resetModules();
+  vi.doUnmock("openclaw/plugin-sdk/provider-http");
+  vi.doMock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
+    resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+  }));
+  const { buildDeepInfraVideoGenerationProvider } = await import("./video-generation-provider.js");
+  return buildDeepInfraVideoGenerationProvider();
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function createDeepInfraHandler(requests: CapturedRequest[]) {
+  return (request: IncomingMessage, response: ServerResponse) => {
+    void (async () => {
+      requests.push({
+        method: request.method,
+        url: request.url,
+        headers: request.headers,
+        body: await readRequestBody(request),
+      });
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          id: "local-request",
+          status: "succeeded",
+          data: [
+            {
+              url: `data:video/webm;base64,${Buffer.from("local-video").toString("base64")}`,
+            },
+          ],
+        }),
+      );
+    })().catch((error: unknown) => {
+      response.writeHead(500, { "content-type": "text/plain" });
+      response.end(error instanceof Error ? error.message : String(error));
+    });
+  };
+}
+
+async function startConnectProxy(upstreamBaseUrl: string): Promise<{
+  connectTargets: string[];
+  proxyUrl: string;
+  stop: () => Promise<void>;
+}> {
+  const upstreamUrl = new URL(upstreamBaseUrl);
+  const upstreamPort = Number(upstreamUrl.port);
+  const connectTargets: string[] = [];
+  const sockets = new Set<DestroyableConnection>();
+  const server = createServer((_request, response) => {
+    response.writeHead(502);
+    response.end("CONNECT required");
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+  server.on("connect", (request, clientSocket, head) => {
+    connectTargets.push(request.url ?? "");
+    const upstreamSocket = connect(upstreamPort, upstreamUrl.hostname, () => {
+      clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      if (head.length > 0) {
+        upstreamSocket.write(head);
+      }
+      clientSocket.pipe(upstreamSocket);
+      upstreamSocket.pipe(clientSocket);
+    });
+    sockets.add(upstreamSocket);
+    upstreamSocket.on("close", () => sockets.delete(upstreamSocket));
+    clientSocket.on("error", () => upstreamSocket.destroy());
+    upstreamSocket.on("error", () => clientSocket.destroy());
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo | null;
+  if (!address) {
+    throw new Error("CONNECT proxy did not bind to a TCP port");
+  }
+  return {
+    connectTargets,
+    proxyUrl: `http://127.0.0.1:${address.port}`,
+    stop: async () => {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+async function generateLocalVideo(params: {
+  baseUrl: string;
+  request?: {
+    allowPrivateNetwork?: boolean;
+    headers?: Record<string, string>;
+    proxy?: { mode: "env-proxy" };
+  };
+}) {
+  const provider = await buildTransportProofProvider();
+  return await provider.generateVideo({
+    provider: "deepinfra",
+    model: "deepinfra/Pixverse/Pixverse-T2V",
+    prompt: "transport proof",
+    cfg: {
+      models: {
+        providers: {
+          deepinfra: {
+            baseUrl: params.baseUrl,
+            models: [],
+            ...(params.request ? { request: params.request } : {}),
+          },
+        },
+      },
+    } as never,
+    timeoutMs: 5_000,
+  });
+}
+
+describe("deepinfra video generation provider transport", () => {
+  it("forwards configured request policy through the real local video transport path", async () => {
+    const requests: CapturedRequest[] = [];
+    await withServer(createDeepInfraHandler(requests), async (baseUrl) => {
+      const result = await generateLocalVideo({
+        baseUrl: `${baseUrl}/v1/openai`,
+        request: {
+          allowPrivateNetwork: true,
+          headers: { "X-DeepInfra-Trace": "transport-proof" },
+        },
+      });
+
+      expect(result.videos).toEqual([
+        {
+          buffer: Buffer.from("local-video"),
+          mimeType: "video/webm",
+          fileName: "video-1.webm",
+        },
+      ]);
+      expect(requests).toHaveLength(1);
+      expect(requests[0]).toMatchObject({
+        method: "POST",
+        url: "/v1/openai/videos",
+      });
+      expect(requests[0]?.headers["x-deepinfra-trace"]).toBe("transport-proof");
+      expect(JSON.parse(requests[0]?.body ?? "{}")).toMatchObject({
+        prompt: "transport proof",
+      });
+    });
+  });
+
+  it("routes configured env proxy policy through a real CONNECT tunnel", async () => {
+    const requests: CapturedRequest[] = [];
+    await withServer(createDeepInfraHandler(requests), async (baseUrl) => {
+      const proxy = await startConnectProxy(baseUrl);
+      try {
+        await withEnvAsync(
+          {
+            HTTP_PROXY: proxy.proxyUrl,
+            http_proxy: undefined,
+            HTTPS_PROXY: undefined,
+            https_proxy: undefined,
+            NO_PROXY: undefined,
+            no_proxy: undefined,
+          },
+          async () => {
+            await generateLocalVideo({
+              baseUrl: `${baseUrl}/v1/openai`,
+              request: {
+                allowPrivateNetwork: true,
+                proxy: { mode: "env-proxy" },
+              },
+            });
+          },
+        );
+
+        expect(proxy.connectTargets).toEqual([new URL(baseUrl).host]);
+        expect(requests).toHaveLength(1);
+      } finally {
+        await proxy.stop();
+      }
+    });
+  });
+
+  it.each([
+    ["default", undefined],
+    ["explicit false", { allowPrivateNetwork: false }],
+  ])("blocks loopback before transport with %s private-network policy", async (_label, request) => {
+    const requests: CapturedRequest[] = [];
+    await withServer(createDeepInfraHandler(requests), async (baseUrl) => {
+      await expect(
+        generateLocalVideo({
+          baseUrl: `${baseUrl}/v1/openai`,
+          request,
+        }),
+      ).rejects.toThrow();
+      expect(requests).toHaveLength(0);
+    });
+  });
+});

--- a/extensions/deepinfra/video-generation-provider.ts
+++ b/extensions/deepinfra/video-generation-provider.ts
@@ -11,6 +11,7 @@ import {
   readProviderJsonResponse,
   resolveProviderHttpRequestConfig,
   resolveProviderOperationTimeoutMs,
+  sanitizeConfiguredModelProviderRequest,
 } from "openclaw/plugin-sdk/provider-http";
 import {
   asSafeIntegerInRange,
@@ -230,7 +231,6 @@ export function buildDeepInfraVideoGenerationProvider(options?: {
         resolveProviderHttpRequestConfig({
           baseUrl: resolveDeepInfraVideoBaseUrl(req),
           defaultBaseUrl: DEEPINFRA_BASE_URL,
-          allowPrivateNetwork: false,
           defaultHeaders: {
             Authorization: `Bearer ${auth.apiKey}`,
             "Content-Type": "application/json",
@@ -238,6 +238,9 @@ export function buildDeepInfraVideoGenerationProvider(options?: {
           provider: "deepinfra",
           capability: "video",
           transport: "http",
+          request: sanitizeConfiguredModelProviderRequest(
+            req.cfg?.models?.providers?.deepinfra?.request,
+          ),
         });
 
       const { response, release } = await postJsonRequest({


### PR DESCRIPTION
## What Problem This Solves

DeepInfra video generation ignored the existing provider request policy. Custom headers and proxy routing never reached the transport, and an explicit private-network opt-in was overridden before the request.

## Why This Change Was Made

The DeepInfra video provider now sanitizes its configured request policy and passes it once to the shared HTTP resolver. The provider no longer forces `allowPrivateNetwork: false`; the shared resolver still denies private-network access when the setting is omitted or false.

The same resolved headers, proxy dispatcher, and private-network decision already feed both the submit request and job polling. This keeps one canonical provider transport path and adds no config, fallback, retry, or feature behavior.

This is an AI-assisted contribution prepared for Alix-007.

## User Impact

Operators can use configured request headers and proxy routing for DeepInfra video generation. Explicit private-network access works when enabled. Omitted and false settings remain blocked before transport.

## Maintainer Decision

Honor the existing operator-controlled private-network opt-in for DeepInfra video generation. This is the established request-policy contract used by sibling provider transports. Current three-way validation remains required before merge.

## Evidence

- Current-main red revision: `894f25427e28732f029dc33f4e5ed913f8db9cca`.
- Exact repaired head: `559fda8a258f0005e39fb69570b4157c8930975a`, rebased onto `ecb6acff90057a31b482f54146ea87e984e06cbc`.
- The rebase is patch-identical: both author commits retain the same stable patch IDs as the proven pre-rebase head.
- Real owner path: `buildDeepInfraVideoGenerationProvider()` called an isolated HTTP endpoint through the production request sanitizer, shared resolver, guarded POST transport, and video data-URL decoder.
- Red: configured `allowPrivateNetwork: true` was rejected before transport on current main. The endpoint received zero requests.
- Green: the configured header reached `POST /v1/openai/videos`, `request.proxy.mode: env-proxy` produced an HTTP `CONNECT` tunnel, and both direct and proxied responses decoded to the expected WebM bytes.
- Fail closed: omitted policy and explicit `allowPrivateNetwork: false` were both rejected before the endpoint received a request.
- Anti-cheat: each request used a revision-bound nonce in the header and prompt. The returned WebM bytes contained the same nonce.
- Focused patch-identical proof: 4/4 real transport tests and 13/13 provider tests passed on Linux with Node 24 after a clean dependency install.
- Changed-scope gates passed conflict-marker, environment-count, max-lines, attribution, wildcard-export, duplicate-coverage, dependency-pin, formatting, Plugin SDK baseline, and deprecated-API checks. The old-base plugin-boundary scan reported unrelated pre-existing compatibility removals; hosted synthetic-merge CI is the merge authority.

## Live proof summary

| Case | Current main | Repaired head |
| --- | --- | --- |
| Configured header and private-network allow | Blocked before transport | Header received and WebM decoded |
| Environment proxy | Blocked before transport | `CONNECT` observed and WebM decoded |
| Policy omitted | Blocked before transport | Blocked before transport |
| `allowPrivateNetwork: false` | Blocked before transport | Blocked before transport |
