### PR TITLE
ci(apple-i18n): restore the Text-wrapped title contract to match the accessibilityLabel bypass ban

### DIFF
--- a/scripts/apple-app-i18n.ts
+++ b/scripts/apple-app-i18n.ts
@@ -182,7 +182,9 @@ const LOCALIZED_WRAPPER_CONTRACTS: Record<string, readonly string[]> = {
     "func gatewaySecureField(\n        _ placeholder: LocalizedStringKey",
     "func settingsToggle(\n        _ title: LocalizedStringKey",
     ".accessibilityLabel(Text(placeholder))",
-    ".accessibilityLabel(title)",
+    // Text(...) wrapping keeps this contract disjoint from the substring ban
+    // on .accessibilityLabel(title) in RAW_LOCALIZATION_BYPASSES below.
+    ".accessibilityLabel(Text(title))",
   ],
   "apps/ios/Sources/Gateway/GatewayConnectionController+Capabilities.swift": [
     'String(localized: "Secure connection is required for this host.")',


### PR DESCRIPTION
## What Problem This Solves

`main` is red again on the apple-i18n gate: two fixes for the same drift crossed. Direct commit 0aabf562423 pointed the wrapper contract at `.accessibilityLabel(title)` while #105859 (c81ae0412cb) moved the Swift back to `.accessibilityLabel(Text(title))` AND added `.accessibilityLabel(title)` to `RAW_LOCALIZATION_BYPASSES` — so the contract table now requires the exact substring the bypass table bans, and the check fails on every commit.

## Why This Change Was Made

One-line reconciliation matching the newest iOS intent (#105859): the wrapper contract requires `.accessibilityLabel(Text(title))` again, which is disjoint from the banned raw substring. A comment marks that coupling so the next drift doesn't recross. Supersedes #105864 (same drift, earlier crossing).

## User Impact

None at runtime. Unblocks CI.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/apple-app-i18n.test.ts`: red on plain main ("bypasses localized string lookup: .accessibilityLabel(title)"), 13/13 green with this change.
- `pnpm native:i18n:check`: clean (entries=4200 changed=false).
