### PR TITLE
fix(slack): add timeout to startup auth.test requests

### DIFF
--- a/extensions/slack/src/client.test.ts
+++ b/extensions/slack/src/client.test.ts
@@ -18,6 +18,7 @@ vi.mock("@slack/web-api", () => {
 });
 
 let createSlackWebClient: typeof import("./client.js").createSlackWebClient;
+let createSlackStartupAuthClient: typeof import("./client.js").createSlackStartupAuthClient;
 let createSlackLookupClient: typeof import("./client.js").createSlackLookupClient;
 let createSlackWriteClient: typeof import("./client.js").createSlackWriteClient;
 let createSlackTokenCacheKey: typeof import("./client.js").createSlackTokenCacheKey;
@@ -31,8 +32,10 @@ let WebClient: ReturnType<typeof vi.fn>;
 
 const SLACK_API_URL_KEYS = ["SLACK_API_URL", "OPENCLAW_SLACK_API_URL"] as const;
 const PROXY_KEYS = [
+  "ALL_PROXY",
   "HTTPS_PROXY",
   "HTTP_PROXY",
+  "all_proxy",
   "https_proxy",
   "http_proxy",
   "NO_PROXY",
@@ -94,6 +97,7 @@ beforeAll(async () => {
   const slackWebApi = await import("@slack/web-api");
   ({
     createSlackWebClient,
+    createSlackStartupAuthClient,
     createSlackLookupClient,
     createSlackWriteClient,
     createSlackTokenCacheKey,
@@ -183,6 +187,23 @@ describe("slack web client config", () => {
       agent: customAgent,
       retryConfig: SLACK_DEFAULT_RETRY_OPTIONS,
       timeout: 1234,
+    });
+  });
+
+  it("bounds startup auth while preserving listener transport options", () => {
+    const customAgent = {} as never;
+
+    createSlackStartupAuthClient("xoxb-startup", {
+      agent: customAgent,
+      slackApiUrl: "https://slack.test/api/",
+    });
+
+    expect(WebClient).toHaveBeenCalledWith("xoxb-startup", {
+      agent: customAgent,
+      rejectRateLimitedCalls: true,
+      retryConfig: { retries: 0 },
+      slackApiUrl: "https://slack.test/api/",
+      timeout: 10_000,
     });
   });
 

--- a/extensions/slack/src/client.ts
+++ b/extensions/slack/src/client.ts
@@ -29,6 +29,17 @@ export function createSlackWebClient(token: string, options: WebClientOptions = 
   return new WebClient(token, resolveSlackWebClientOptions(options));
 }
 
+export function createSlackStartupAuthClient(token: string, options: WebClientOptions = {}) {
+  // Startup degrades after auth.test fails, so terminate this one-shot request without
+  // imposing the same short deadline on Bolt's long-lived client.
+  return createSlackWebClient(token, {
+    ...options,
+    rejectRateLimitedCalls: true,
+    retryConfig: { retries: 0 },
+    timeout: 10_000,
+  });
+}
+
 export function createSlackLookupClient(token: string, options: SlackLookupClientOptions = {}) {
   return new WebClient(token, resolveSlackLookupClientOptions(options));
 }

--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -16,6 +16,7 @@ type SlackProviderMonitor = (params: {
   runtime?: RuntimeEnv;
   setStatus?: (next: Record<string, unknown>) => void;
 }) => Promise<unknown>;
+type SlackStartupAuthClientFactory = typeof import("./client.js").createSlackStartupAuthClient;
 
 type SlackTestState = {
   config: Record<string, unknown>;
@@ -33,6 +34,8 @@ type SlackTestState = {
     (params: { entries: string[] }) => Promise<Array<{ input: string; resolved: boolean }>>
   >;
   socketModeLogger?: { error: (...args: unknown[]) => void };
+  createSlackStartupAuthClientMock: Mock<SlackStartupAuthClientFactory>;
+  createSlackStartupAuthClientActual?: SlackStartupAuthClientFactory;
 };
 
 const slackTestState: SlackTestState = vi.hoisted(() => ({
@@ -49,6 +52,7 @@ const slackTestState: SlackTestState = vi.hoisted(() => ({
   upsertPairingRequestMock: vi.fn(),
   resolveSlackUserAllowlistMock: vi.fn(),
   socketModeLogger: undefined,
+  createSlackStartupAuthClientMock: vi.fn(),
 }));
 
 const slackInboundDeliveryTestCache = resolveGlobalDedupeCache(
@@ -60,6 +64,14 @@ const slackInboundDeliveryTestCache = resolveGlobalDedupeCache(
 );
 
 export const getSlackTestState = (): SlackTestState => slackTestState;
+
+export function useRealSlackStartupAuthClientOnce(): void {
+  const actual = slackTestState.createSlackStartupAuthClientActual;
+  if (!actual) {
+    throw new Error("real Slack WebClient factory is unavailable");
+  }
+  slackTestState.createSlackStartupAuthClientMock.mockImplementationOnce(actual);
+}
 
 type SlackClient = {
   auth: { test: Mock<(...args: unknown[]) => Promise<Record<string, unknown>>> };
@@ -246,6 +258,9 @@ export function resetSlackTestState(config: Record<string, unknown> = defaultSla
     .mockImplementation(async ({ entries }) =>
       entries.map((input) => ({ input, resolved: false })),
     );
+  slackTestState.createSlackStartupAuthClientMock
+    .mockReset()
+    .mockReturnValue(getSlackClient() as unknown as ReturnType<SlackStartupAuthClientFactory>);
   const client = getSlackClient();
   client.auth.test.mockReset().mockResolvedValue({
     user_id: "bot-user",
@@ -309,6 +324,16 @@ vi.mock("./resolve-users.js", () => ({
   resolveSlackUserAllowlist: (params: { entries: string[] }) =>
     slackTestState.resolveSlackUserAllowlistMock(params),
 }));
+
+vi.mock("./client.js", async () => {
+  const actual = await vi.importActual<typeof import("./client.js")>("./client.js");
+  slackTestState.createSlackStartupAuthClientActual = actual.createSlackStartupAuthClient;
+  return {
+    ...actual,
+    createSlackStartupAuthClient: (...args: Parameters<SlackStartupAuthClientFactory>) =>
+      slackTestState.createSlackStartupAuthClientMock(...args),
+  };
+});
 
 vi.mock("./monitor/send.runtime.js", () => {
   return {

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -9,9 +9,9 @@ import {
   stopSlackMonitor,
 } from "../monitor.test-helpers.js";
 
-const { monitorSlackProvider, SLACK_STARTUP_AUTH_TEST_TIMEOUT_MS } = await import(
-  "./provider.js"
-);
+const { monitorSlackProvider } = await import("./provider.js");
+
+const STARTUP_AUTH_TEST_TIMEOUT_MS = 10_000;
 
 beforeEach(() => {
   resetSlackTestState();
@@ -27,9 +27,7 @@ describe("auth.test boot call", () => {
     // The SDK serializes every property from the call argument into the POST
     // body.  Passing { token } would leak the bot token into the request
     // payload alongside the Authorization header.
-    const firstArg = client.auth.test.mock.calls[0]?.[0] as
-      | Record<string, unknown>
-      | undefined;
+    const firstArg = client.auth.test.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
     if (firstArg != null) {
       expect(firstArg).not.toHaveProperty("token");
     }
@@ -152,7 +150,7 @@ describe("auth.test boot call", () => {
       expect(getSlackClient().auth.test).toHaveBeenCalledTimes(1);
       expect(appStartMock).not.toHaveBeenCalled();
 
-      await vi.advanceTimersByTimeAsync(SLACK_STARTUP_AUTH_TEST_TIMEOUT_MS - 1);
+      await vi.advanceTimersByTimeAsync(STARTUP_AUTH_TEST_TIMEOUT_MS - 1);
       expect(appStartMock).not.toHaveBeenCalled();
 
       await vi.advanceTimersByTimeAsync(1);

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -27,7 +27,9 @@ describe("auth.test boot call", () => {
     // The SDK serializes every property from the call argument into the POST
     // body.  Passing { token } would leak the bot token into the request
     // payload alongside the Authorization header.
-    const firstArg = client.auth.test.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+    const firstArg = client.auth.test.mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
     if (firstArg != null) {
       expect(firstArg).not.toHaveProperty("token");
     }

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -9,7 +9,9 @@ import {
   stopSlackMonitor,
 } from "../monitor.test-helpers.js";
 
-const { monitorSlackProvider } = await import("./provider.js");
+const { monitorSlackProvider, SLACK_STARTUP_AUTH_TEST_TIMEOUT_MS } = await import(
+  "./provider.js"
+);
 
 beforeEach(() => {
   resetSlackTestState();
@@ -124,6 +126,45 @@ describe("auth.test boot call", () => {
         "required-mention channels will fail closed without another trusted activation signal",
       ),
     );
+  });
+
+  it("continues startup after a stalled auth.test reaches the startup timeout", async () => {
+    vi.useFakeTimers();
+    const runtimeLog = vi.fn();
+    const { appStartMock } = getSlackTestState();
+    getSlackClient().auth.test.mockImplementationOnce(
+      () => new Promise<Record<string, unknown>>(() => {}),
+    );
+
+    const monitor = startSlackMonitor(monitorSlackProvider, {
+      runtime: {
+        log: runtimeLog,
+        error: vi.fn(),
+        exit: vi.fn(),
+      },
+    });
+    try {
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(getSlackClient().auth.test).toHaveBeenCalledTimes(1);
+      expect(appStartMock).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(SLACK_STARTUP_AUTH_TEST_TIMEOUT_MS - 1);
+      expect(appStartMock).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await Promise.resolve();
+
+      expect(appStartMock).toHaveBeenCalledTimes(1);
+      expect(runtimeLog).toHaveBeenCalledWith(
+        expect.stringContaining("slack startup auth.test timed out"),
+      );
+    } finally {
+      monitor.controller.abort();
+      await monitor.run;
+      vi.useRealTimers();
+    }
   });
 
   it("preserves workspace startup when auth.test omits app_id", async () => {

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -1,5 +1,7 @@
 // Slack tests cover auth.test token handling during provider boot.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getSlackClient,
   getSlackTestState,
@@ -7,14 +9,61 @@ import {
   runSlackMessageOnce,
   startSlackMonitor,
   stopSlackMonitor,
+  useRealSlackStartupAuthClientOnce,
 } from "../monitor.test-helpers.js";
 
 const { monitorSlackProvider } = await import("./provider.js");
 
-const STARTUP_AUTH_TEST_TIMEOUT_MS = 10_000;
+const PROXY_ENV_KEYS = [
+  "ALL_PROXY",
+  "HTTPS_PROXY",
+  "HTTP_PROXY",
+  "all_proxy",
+  "https_proxy",
+  "http_proxy",
+  "NO_PROXY",
+  "no_proxy",
+] as const;
+
+async function startStalledSlackApiServer(events: string[]) {
+  let requestCount = 0;
+  let requestUrl: string | undefined;
+  const server = createServer((request) => {
+    requestCount += 1;
+    requestUrl = request.url;
+    events.push("request");
+    request.resume();
+    request.socket.once("close", () => {
+      events.push("socket-closed");
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  return {
+    apiUrl: `http://127.0.0.1:${address.port}/api/`,
+    get requestCount() {
+      return requestCount;
+    },
+    get requestUrl() {
+      return requestUrl;
+    },
+    close: async () => {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
 
 beforeEach(() => {
   resetSlackTestState();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 describe("auth.test boot call", () => {
@@ -128,15 +177,15 @@ describe("auth.test boot call", () => {
     );
   });
 
-  it("continues startup after a stalled auth.test reaches the startup timeout", async () => {
-    vi.useFakeTimers();
+  it("continues startup after the startup auth client times out", async () => {
     const runtimeLog = vi.fn();
-    const { appStartMock } = getSlackTestState();
-    let releaseAuthTest = () => {};
-    const stalledAuthTest = new Promise<Record<string, unknown>>((resolve) => {
-      releaseAuthTest = () => resolve({});
-    });
-    getSlackClient().auth.test.mockReturnValueOnce(stalledAuthTest);
+    const { appStartMock, createSlackStartupAuthClientMock } = getSlackTestState();
+    vi.stubEnv("SLACK_API_URL", "https://slack.test/api/");
+    vi.stubEnv("https_proxy", "http://proxy.test:3128");
+    vi.stubEnv("no_proxy", "");
+    getSlackClient().auth.test.mockRejectedValueOnce(
+      new Error("A request error occurred: timeout of 10000ms exceeded"),
+    );
 
     const monitor = startSlackMonitor(monitorSlackProvider, {
       runtime: {
@@ -145,30 +194,58 @@ describe("auth.test boot call", () => {
         exit: vi.fn(),
       },
     });
+    await stopSlackMonitor(monitor);
+
+    expect(createSlackStartupAuthClientMock).toHaveBeenCalledWith(
+      "bot-token",
+      expect.objectContaining({
+        agent: expect.anything(),
+        slackApiUrl: "https://slack.test/api/",
+      }),
+    );
+    expect(getSlackClient().auth.test).toHaveBeenCalledTimes(1);
+    expect(appStartMock).toHaveBeenCalledTimes(1);
+    expect(runtimeLog).toHaveBeenCalledWith(expect.stringContaining("timeout of 10000ms exceeded"));
+  });
+
+  it("settles and closes a real stalled startup auth request before degraded startup", async () => {
+    const events: string[] = [];
+    for (const key of PROXY_ENV_KEYS) {
+      vi.stubEnv(key, "");
+    }
+    const server = await startStalledSlackApiServer(events);
+    vi.stubEnv("SLACK_API_URL", server.apiUrl);
+    useRealSlackStartupAuthClientOnce();
+
+    const runtimeLog = vi.fn((message: string) => {
+      if (message.includes("slack auth.test failed at boot")) {
+        events.push("auth-settled");
+      }
+    });
+    const { appStartMock } = getSlackTestState();
+    appStartMock.mockImplementationOnce(async () => {
+      events.push("app-start");
+    });
+    const monitor = startSlackMonitor(monitorSlackProvider, {
+      runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() },
+    });
     try {
-      await Promise.resolve();
-      await Promise.resolve();
+      await vi.waitFor(() => expect(appStartMock).toHaveBeenCalledTimes(1), { timeout: 12_000 });
+      await vi.waitFor(() => expect(events).toContain("socket-closed"), { timeout: 1_000 });
 
-      expect(getSlackClient().auth.test).toHaveBeenCalledTimes(1);
-      expect(appStartMock).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(STARTUP_AUTH_TEST_TIMEOUT_MS - 1);
-      expect(appStartMock).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
-      await Promise.resolve();
-
-      expect(appStartMock).toHaveBeenCalledTimes(1);
+      expect(server.requestCount).toBe(1);
+      expect(server.requestUrl).toBe("/api/auth.test");
+      expect(events).toContain("auth-settled");
+      expect(events.indexOf("auth-settled")).toBeLessThan(events.indexOf("app-start"));
       expect(runtimeLog).toHaveBeenCalledWith(
-        expect.stringContaining("slack startup auth.test timed out"),
+        expect.stringContaining("timeout of 10000ms exceeded"),
       );
     } finally {
-      releaseAuthTest();
       monitor.controller.abort();
       await monitor.run;
-      vi.useRealTimers();
+      await server.close();
     }
-  });
+  }, 20_000);
 
   it("preserves workspace startup when auth.test omits app_id", async () => {
     getSlackClient().auth.test.mockResolvedValueOnce({

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -217,8 +217,9 @@ describe("auth.test boot call", () => {
     vi.stubEnv("SLACK_API_URL", server.apiUrl);
     useRealSlackStartupAuthClientOnce();
 
-    const runtimeLog = vi.fn((message: string) => {
-      if (message.includes("slack auth.test failed at boot")) {
+    const runtimeLog = vi.fn((...args: unknown[]) => {
+      const message = args[0];
+      if (typeof message === "string" && message.includes("slack auth.test failed at boot")) {
         events.push("auth-settled");
       }
     });

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -132,9 +132,11 @@ describe("auth.test boot call", () => {
     vi.useFakeTimers();
     const runtimeLog = vi.fn();
     const { appStartMock } = getSlackTestState();
-    getSlackClient().auth.test.mockImplementationOnce(
-      () => new Promise<Record<string, unknown>>(() => {}),
-    );
+    let releaseAuthTest = () => {};
+    const stalledAuthTest = new Promise<Record<string, unknown>>((resolve) => {
+      releaseAuthTest = () => resolve({});
+    });
+    getSlackClient().auth.test.mockReturnValueOnce(stalledAuthTest);
 
     const monitor = startSlackMonitor(monitorSlackProvider, {
       runtime: {
@@ -161,6 +163,7 @@ describe("auth.test boot call", () => {
         expect.stringContaining("slack startup auth.test timed out"),
       );
     } finally {
+      releaseAuthTest();
       monitor.controller.abort();
       await monitor.run;
       vi.useRealTimers();

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -379,7 +379,6 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   let botId = "";
   const expectedApiAppIdFromAppToken =
     slackMode === "socket" ? parseApiAppIdFromAppToken(appToken) : undefined;
-  let authTestFailed = false;
   let authTestError: string | undefined;
   let authIdentityWarning: string | undefined;
   let authTestIdentity: SlackAuthTestIdentity | undefined;
@@ -398,23 +397,21 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       accountId: account.accountId,
     });
     if (!authUserId && !enterpriseOrgInstall) {
-      authTestFailed = true;
       authTestError = "auth.test returned no user_id";
     }
   } catch (err) {
-    authTestFailed = true;
     authTestError = err instanceof Error ? err.message : String(err);
   }
   const installationIdentity = resolveSlackInstallationIdentity({
     enterpriseOrgInstall,
-    auth: authTestFailed ? undefined : authTestIdentity,
+    auth: authTestError === undefined ? authTestIdentity : undefined,
     authError: authTestError,
     transportApiAppId: expectedApiAppIdFromAppToken,
   });
   const teamId = installationIdentity.kind === "workspace" ? installationIdentity.teamId : "";
   const apiAppId =
     installationIdentity.kind === "degraded" ? "" : (installationIdentity.apiAppId ?? "");
-  if (authTestFailed) {
+  if (authTestError !== undefined) {
     runtime.log?.(
       warn(
         `[${account.accountId}] slack auth.test failed at boot (${authTestError ?? "unknown error"}); ` +

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -26,7 +26,6 @@ import {
   normalizeOptionalString,
   normalizeStringEntries,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import { installRequestBodyLimitGuard } from "openclaw/plugin-sdk/webhook-request-guards";
 import {
   resolveSlackAccount,
@@ -35,6 +34,7 @@ import {
 } from "../accounts.js";
 import { isSlackAnyNativeApprovalClientEnabled } from "../approval-native-gates.js";
 import { resolveSlackWebClientOptions } from "../client-options.js";
+import { createSlackStartupAuthClient } from "../client.js";
 import { normalizeSlackWebhookPath, registerSlackHttpHandler } from "../http/index.js";
 import { SLACK_TEXT_LIMIT } from "../limits.js";
 import { resolveSlackChannelAllowlist } from "../resolve-channels.js";
@@ -382,9 +382,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   let authIdentityWarning: string | undefined;
   let authTestIdentity: SlackAuthTestIdentity | undefined;
   try {
-    const auth = await withTimeout(app.client.auth.test(), 10_000, {
-      message: "slack startup auth.test timed out",
-    });
+    const auth = await createSlackStartupAuthClient(botToken, clientOptions).auth.test();
     const authUserId = normalizeOptionalString(auth.user_id) ?? "";
     botId = normalizeOptionalString((auth as { bot_id?: string }).bot_id) ?? "";
     // Slack documents bot_id only for bot-token identities. Never treat the user behind a
@@ -413,7 +411,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   if (authTestError !== undefined) {
     runtime.log?.(
       warn(
-        `[${account.accountId}] slack auth.test failed at boot (${authTestError ?? "unknown error"}); ` +
+        `[${account.accountId}] slack auth.test failed at boot (${authTestError}); ` +
           "explicit bot-mention detection will be disabled until restart with a valid bot token; " +
           "required-mention channels will fail closed without another trusted activation signal",
       ),

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -103,7 +103,7 @@ const loadSlackRelaySource = createLazyRuntimeModule(() => import("./relay-sourc
 
 const SLACK_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const SLACK_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
-export const SLACK_STARTUP_AUTH_TEST_TIMEOUT_MS = 10_000;
+const SLACK_STARTUP_AUTH_TEST_TIMEOUT_MS = 10_000;
 
 function resolveStableSlackUserIdEntry(raw: string): string | undefined {
   const trimmed = raw.trim();

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -103,7 +103,6 @@ const loadSlackRelaySource = createLazyRuntimeModule(() => import("./relay-sourc
 
 const SLACK_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const SLACK_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
-const SLACK_STARTUP_AUTH_TEST_TIMEOUT_MS = 10_000;
 
 function resolveStableSlackUserIdEntry(raw: string): string | undefined {
   const trimmed = raw.trim();
@@ -383,7 +382,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   let authIdentityWarning: string | undefined;
   let authTestIdentity: SlackAuthTestIdentity | undefined;
   try {
-    const auth = await withTimeout(app.client.auth.test(), SLACK_STARTUP_AUTH_TEST_TIMEOUT_MS, {
+    const auth = await withTimeout(app.client.auth.test(), 10_000, {
       message: "slack startup auth.test timed out",
     });
     const authUserId = normalizeOptionalString(auth.user_id) ?? "";

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -26,6 +26,7 @@ import {
   normalizeOptionalString,
   normalizeStringEntries,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import { installRequestBodyLimitGuard } from "openclaw/plugin-sdk/webhook-request-guards";
 import {
   resolveSlackAccount,
@@ -102,6 +103,7 @@ const loadSlackRelaySource = createLazyRuntimeModule(() => import("./relay-sourc
 
 const SLACK_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const SLACK_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
+export const SLACK_STARTUP_AUTH_TEST_TIMEOUT_MS = 10_000;
 
 function resolveStableSlackUserIdEntry(raw: string): string | undefined {
   const trimmed = raw.trim();
@@ -382,7 +384,9 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   let authIdentityWarning: string | undefined;
   let authTestIdentity: SlackAuthTestIdentity | undefined;
   try {
-    const auth = await app.client.auth.test();
+    const auth = await withTimeout(app.client.auth.test(), SLACK_STARTUP_AUTH_TEST_TIMEOUT_MS, {
+      message: "slack startup auth.test timed out",
+    });
     const authUserId = normalizeOptionalString(auth.user_id) ?? "";
     botId = normalizeOptionalString((auth as { bot_id?: string }).bot_id) ?? "";
     // Slack documents bot_id only for bot-token identities. Never treat the user behind a


### PR DESCRIPTION
## What Problem This Solves

Slack provider startup could wait indefinitely when the boot-time `auth.test` HTTP request stalled before returning headers.

## Why This Change Was Made

Startup identity validation now uses a dedicated Slack WebClient with a 10-second transport timeout, zero retries, and immediate rate-limit rejection. It preserves the resolved `SLACK_API_URL` and proxy agent, while leaving Bolt's long-lived listener client and its transport policy unchanged.

When the bounded request fails, startup follows the existing degraded path and retains the required-mention fail-closed warning.

This is an AI-assisted contribution prepared for Alix-007.

## User Impact

A stalled Slack identity check terminates after about 10 seconds instead of blocking startup indefinitely. Slack then continues through the existing degraded startup behavior.

## Evidence

- Exact head: `9b03e1d98c9308616d84133e9b7edbbcb09cb1b2`.
- Cleanly rebased onto `main` SHA `18cff45db9e9c4016ca2eb60204902276897d1f7`; the eight-commit range-diff from the prior refreshed head is patch-identical. Later `main` commits through `4a1eedba54a61ddc62bca34ad5aa363d9f1239ac` do not touch the five changed Slack files, so no further rebase is needed.
- Runtime: Node `24.15.0`.
- `node scripts/run-vitest.mjs extensions/slack/src/client.test.ts extensions/slack/src/monitor/provider.auth-test-token.test.ts --reporter verbose`
- Result: 2 files passed, 42 tests passed.
- After the CI type-only follow-up: `node scripts/run-vitest.mjs extensions/slack/src/monitor/provider.auth-test-token.test.ts --reporter verbose` passed 1 file / 9 tests on the exact head.
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs extensions/slack/src/client.ts extensions/slack/src/client.test.ts extensions/slack/src/monitor.test-helpers.ts extensions/slack/src/monitor/provider.ts extensions/slack/src/monitor/provider.auth-test-token.test.ts`
- Result: passed.
- `oxfmt --check` on the same five files passed on the patch-identical pre-refresh head; `git diff --check upstream/main...HEAD` passed on the refreshed exact head.
- Refreshed-head autoreview against current `main`: `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --engine claude --model claude-sonnet-4-6 --thinking high`; clean, no accepted/actionable findings, overall correctness 0.92. The reviewer explicitly checked coexistence with the newly landed Slack identity-health/degraded-status behavior.
- Previous-head CI isolated one test-only logger mock variance error; the exact head now implements the runtime contract as `(...args: unknown[]) => void` and safely narrows the first argument before inspecting the message.
- GitHub CI for the refreshed exact head passed [run `29459929560`](https://github.com/openclaw/openclaw/actions/runs/29459929560) with 35 successful jobs, 0 failures, 0 pending jobs, and `openclaw/ci-gate` green.
- ClawSweeper exact review passed [run `29459930491`](https://github.com/openclaw/clawsweeper/actions/runs/29459930491): patch correct, no review findings, real-behavior proof sufficient, and no contributor action required.

## Proof

The committed regression test uses the real startup-scoped `@slack/web-api` WebClient against a loopback `node:http` server configured through `SLACK_API_URL`. The server accepts the request and deliberately never returns response headers.

Observed on the exact head:

```text
POST /api/auth.test requests: 1
web-api warning: http request failed timeout of 10000ms exceeded
stalled transport test duration: 10078ms
socket close: observed before server cleanup
startup order: auth-settled before app-start
```

The test also proves the request uses `/api/auth.test`, the socket closes within one second of the timeout, and degraded startup proceeds only after the auth request settles. A companion client test proves that the startup policy preserves the supplied proxy agent and Slack API root while forcing `timeout: 10000`, `retries: 0`, and `rejectRateLimitedCalls: true`.

Dependency source was inspected directly: Slack WebClient passes `timeout` to Axios and `agent`/`slackApiUrl` to its HTTP configuration; `rejectRateLimitedCalls` prevents an in-attempt `Retry-After` sleep. Bolt forwards its client options to its long-lived WebClient, which is why this deadline is isolated to the one-shot startup client.

Blacksmith Testbox/Crabbox was unavailable for this worktree, so the repository-approved local wrapper fallback was used with Node 24.15.0. No live Slack credentials or public Slack outage path was exercised; the proof is controlled local HTTP transport behavior.



