### PR TITLE
fix(memory): backfill provider.model with resolved model name

### DIFF
--- a/extensions/memory-core/src/memory/embeddings.test.ts
+++ b/extensions/memory-core/src/memory/embeddings.test.ts
@@ -313,4 +313,23 @@ describe("createEmbeddingProvider", () => {
     expect(model).toBe("generic-default");
     expect(mockEmbeddingRegistry.genericLookupConfigs).toEqual([options.config]);
   });
+
+  it("backfills empty provider.model with resolved model name (#90042)", async () => {
+    registerMemoryEmbeddingProvider({
+      id: "openai",
+      transport: "remote",
+      defaultModel: "text-embedding-3-small",
+      create: async () => ({
+        provider: {
+          id: "openai",
+          model: "",
+          embedQuery: async () => [1],
+          embedBatch: async (texts) => texts.map(() => [1]),
+        },
+      }),
+    });
+
+    const result = await createEmbeddingProvider(createOptions("openai"));
+    expect(result.provider?.model).toBe("text-embedding-3-small");
+  });
 });

--- a/extensions/memory-core/src/memory/embeddings.ts
+++ b/extensions/memory-core/src/memory/embeddings.ts
@@ -242,6 +242,9 @@ async function createWithAdapter(
     model: resolveProviderModel(adapter, options.model),
   };
   const result = await adapter.create(createOptions);
+  if (result.provider && !result.provider.model) {
+    result.provider.model = createOptions.model;
+  }
   return {
     provider: result.provider,
     requestedProvider: options.provider,


### PR DESCRIPTION
## Summary

When an adapter returns an empty provider.model, backfill it with the resolved model name from resolveProviderModel.

- Problem: Adapter can return empty provider.model even though creation resolved a default; downstream identity code consumes empty value → broken vector search
- Solution: After adapter.create(), if result.provider exists and has no model, set it to createOptions.model
- What changed: `extensions/memory-core/src/memory/embeddings.ts` (+3 lines), `extensions/memory-core/src/memory/embeddings.test.ts` (+19 lines)
- What did NOT change: No behavior change when provider.model is already set

## Change Type

- [x] Bug fix

## Scope

- [x] Memory / storage

## Linked Issue

- Fixes #90042
- [x] This PR fixes a bug or regression

## Motivation

Memory embedding provider can return an empty provider.model string, causing downstream identity mismatch and broken vector search (#90042).

## Real behavior proof

- Behavior addressed: Empty provider.model after adapter.create()
- Real environment tested: Linux, Node 24.13, branch `fix/provider-model-backfill-90042-reborn`
- Exact steps or command run after this patch:

```console
$ node scripts/run-vitest.mjs run extensions/memory-core/src/memory/embeddings.test.ts
```

- Evidence after fix (rebased onto upstream/main @ f12b4af0214):

```console
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

- Observed result after fix: New test "backfills empty provider.model with resolved model name (#90042)" passes — adapter returning `model: ""` gets backfilled to `"text-embedding-3-small"`.
- What was not tested: Live vector search with real embedding provider

## Root Cause

`createWithAdapter` in embeddings.ts did not backfill provider.model when the adapter returned an empty value, even though `resolveProviderModel` had resolved the correct model name.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — direct property assignment after adapter.create() is the minimal fix point
- **Alternative considered**: Spreading result.provider (would lose prototype-defined methods on plugin provider objects)

## AI Assistance

- **AI-assisted**: Yes
- **AI model**: deepseek-v4-flash
- **Human confirmed understanding of code changes**: Yes

---

Fixes #90042