### PR TITLE
fix(memory-lancedb): make table initialization atomic

### DIFF
--- a/extensions/memory-lancedb/lancedb-store.ts
+++ b/extensions/memory-lancedb/lancedb-store.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
 import type * as LanceDB from "@lancedb/lancedb";
+import { Field, FixedSizeList, Float32, Float64, Schema, Utf8 } from "apache-arrow";
 import type { MemoryCategory } from "./config.js";
 import { loadLanceDbModule } from "./lancedb-runtime.js";
 import {
@@ -10,8 +12,8 @@ import {
   quoteLanceSqlString,
 } from "./lancedb-schema.js";
 
-const SCHEMA_SENTINEL_ID = "__schema__";
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const TABLE_INITIALIZATION_ATTEMPTS = 3;
 
 export type MemoryEntry = {
   id: string;
@@ -50,6 +52,47 @@ type MemoryQueryOptions = {
 type StoredMemoryRow = MemoryEntry & {
   agentId: string;
 };
+
+function createMemoryTableSchema(vectorDim: number): Schema {
+  return new Schema([
+    new Field("id", new Utf8(), true),
+    new Field("text", new Utf8(), true),
+    new Field("vector", new FixedSizeList(vectorDim, new Field("item", new Float32(), true)), true),
+    new Field("importance", new Float64(), true),
+    new Field("category", new Utf8(), true),
+    new Field("createdAt", new Float64(), true),
+    new Field("agentId", new Utf8(), true),
+  ]);
+}
+
+async function openOrCreateMemoryTable(
+  db: LanceDB.Connection,
+  vectorDim: number,
+): Promise<LanceDB.Table> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= TABLE_INITIALIZATION_ATTEMPTS; attempt += 1) {
+    let table: LanceDB.Table | null = null;
+    try {
+      const tables = await db.tableNames();
+      table = tables.includes(MEMORY_TABLE_NAME)
+        ? await db.openTable(MEMORY_TABLE_NAME)
+        : await db.createEmptyTable(MEMORY_TABLE_NAME, createMemoryTableSchema(vectorDim), {
+            existOk: true,
+          });
+      // A concurrent create can expose the table name before its first version
+      // is readable. Probe the schema and retry the whole dependency boundary.
+      await table.schema();
+      return table;
+    } catch (error) {
+      table?.close();
+      lastError = error;
+      if (attempt < TABLE_INITIALIZATION_ATTEMPTS) {
+        await delay(attempt * 10);
+      }
+    }
+  }
+  throw lastError;
+}
 
 function formatQueryFilter(filter: MemoryQueryFilter): string {
   if (filter.operator === "LIKE" && typeof filter.value !== "string") {
@@ -102,36 +145,9 @@ export class MemoryDB {
     const db = await lancedb.connect(this.dbPath, connectionOptions);
     let table: LanceDB.Table | null = null;
     try {
-      const tables = await db.tableNames();
-
-      if (tables.includes(MEMORY_TABLE_NAME)) {
-        table = await db.openTable(MEMORY_TABLE_NAME);
-        if (!hasAgentScopeColumn(await table.schema())) {
-          throw legacyMemorySchemaError();
-        }
-      } else {
-        // The tableNames() check is advisory across processes. LanceDB's
-        // existOk mode makes creation tolerant when another initializer wins
-        // the race between the check and createTable().
-        table = await db.createTable(
-          MEMORY_TABLE_NAME,
-          [
-            {
-              id: SCHEMA_SENTINEL_ID,
-              text: "",
-              vector: Array.from({ length: this.vectorDim }).fill(0),
-              importance: 0,
-              category: "other",
-              createdAt: 0,
-              agentId: SCHEMA_SENTINEL_ID,
-            },
-          ],
-          { existOk: true },
-        );
-        if (!hasAgentScopeColumn(await table.schema())) {
-          throw legacyMemorySchemaError();
-        }
-        await table.delete(`id = ${quoteLanceSqlString(SCHEMA_SENTINEL_ID)}`);
+      table = await openOrCreateMemoryTable(db, this.vectorDim);
+      if (!hasAgentScopeColumn(await table.schema())) {
+        throw legacyMemorySchemaError();
       }
 
       this.db = db;

--- a/extensions/memory-lancedb/lancedb-store.ts
+++ b/extensions/memory-lancedb/lancedb-store.ts
@@ -110,17 +110,27 @@ export class MemoryDB {
           throw legacyMemorySchemaError();
         }
       } else {
-        table = await db.createTable(MEMORY_TABLE_NAME, [
-          {
-            id: SCHEMA_SENTINEL_ID,
-            text: "",
-            vector: Array.from({ length: this.vectorDim }).fill(0),
-            importance: 0,
-            category: "other",
-            createdAt: 0,
-            agentId: SCHEMA_SENTINEL_ID,
-          },
-        ]);
+        // The tableNames() check is advisory across processes. LanceDB's
+        // existOk mode makes creation tolerant when another initializer wins
+        // the race between the check and createTable().
+        table = await db.createTable(
+          MEMORY_TABLE_NAME,
+          [
+            {
+              id: SCHEMA_SENTINEL_ID,
+              text: "",
+              vector: Array.from({ length: this.vectorDim }).fill(0),
+              importance: 0,
+              category: "other",
+              createdAt: 0,
+              agentId: SCHEMA_SENTINEL_ID,
+            },
+          ],
+          { existOk: true },
+        );
+        if (!hasAgentScopeColumn(await table.schema())) {
+          throw legacyMemorySchemaError();
+        }
         await table.delete(`id = ${quoteLanceSqlString(SCHEMA_SENTINEL_ID)}`);
       }
 

--- a/extensions/memory-lancedb/memory-lancedb.concurrent.test.ts
+++ b/extensions/memory-lancedb/memory-lancedb.concurrent.test.ts
@@ -1,0 +1,56 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+function initializeInChild(dbPath: string): Promise<void> {
+  const moduleUrl = new URL("./lancedb-store.ts", import.meta.url).href;
+  const source = `
+    import { MemoryDB } from ${JSON.stringify(moduleUrl)};
+    const db = new MemoryDB(process.argv[1], 4);
+    await db.count("concurrent-test-agent");
+  `;
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "--eval", source, dbPath],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`memory-lancedb initializer exited ${String(code)}: ${stderr.trim()}`));
+    });
+  });
+}
+
+describe("memory-lancedb concurrent initialization", () => {
+  test("atomically creates the memories table across processes", async () => {
+    const dbPath = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-lancedb-race-"));
+    tempDirs.push(dbPath);
+
+    await Promise.all(Array.from({ length: 6 }, () => initializeInChild(dbPath)));
+
+    const lancedb = await import("@lancedb/lancedb");
+    const connection = await lancedb.connect(dbPath);
+    await expect(connection.tableNames()).resolves.toEqual(["memories"]);
+    const table = await connection.openTable("memories");
+    await expect(table.countRows()).resolves.toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #105680

## What Problem This Solves

The bundled LanceDB memory plugin checked whether the `memories` table existed and then created it in a separate operation. Two OpenClaw processes initializing the same database could both observe the table as absent, race during creation, and fail startup with a duplicate-create error.

## Why This Change Was Made

Keep the existing fast path for an already-present table, but make the absent-table path use the LanceDB 0.30.0 atomic `existOk` create mode. This keeps concurrency ownership in the database dependency, avoids a filesystem lock that would not fit remote storage URIs, and keeps schema-row cleanup idempotent.

The regression test starts six independent Node processes against one fresh LanceDB directory and requires every process to complete initialization successfully. The same scenario fails against the previous implementation.

LanceDB documents that `existOk: true` suppresses the existing-table error in create mode and ignores the losing caller supplied data: https://lancedb.github.io/lancedb/js/interfaces/CreateTableOptions/

## User Impact

Gateway and worker processes can initialize the same memory-lancedb store concurrently without intermittent duplicate-create startup failures.

## Evidence

Final-head validation:

- Candidate head: `4e1bc84e3e1`; rebased onto `origin/main` at `652266b8b6c`.
- Production diff after the current TypeScript LOC ratchet: `12 additions / 13 deletions`; the legacy production file no longer grows.

### Standalone concurrent-process behavior proof

Environment: macOS arm64, Node 24.15.0, exact `@lancedb/lancedb@0.30.0`, one fresh temporary local LanceDB directory. This proof ran outside Vitest. The temporary driver started six independent Node processes; each imported the production `extensions/memory-lancedb/index.ts` module and called `testing.createMemoryDb(dbPath, 4).count()`.

Pre-fix control: the same final-head snapshot with only `{ existOk: true }` removed while retaining the test access hook:

```text
initializer 2: failed (1)
initializer 3: failed (1)
initializer 4: failed (1)
initializer 5: failed (1)
initializer 1: failed (1)
initializer 6: ok
Error: Table memories already exists
before_exit=1
```

Final head:

```text
initializer 5: ok
initializer 1: ok
initializer 3: ok
initializer 6: ok
initializer 4: ok
initializer 2: ok
tables: memories
rows: 0
after_exit=0
```

The final table is usable, all six initializers return successfully, and the temporary schema row is removed.

### Tests and gates

- `node scripts/run-vitest.mjs extensions/memory-lancedb/index.test.ts extensions/memory-lancedb/memory-lancedb.concurrent.test.ts` under Node 24.15.0 — 2 files and 126 tests passed.
- `check:changed` passed conflict markers, the TypeScript LOC ratchet, attributions, extension export guards, duplicate coverage, dependency pins, and formatting. Its repository-wide Plugin SDK API baseline reports a hash mismatch; the exact baseline command reproduces the same mismatch on a clean detached `origin/main` snapshot, so this PR does not introduce it.
- `git diff --check origin/main...HEAD` — passed.
- Earlier exact-head failures were deterministic regressions on the old `main` baseline and did not reference either memory-lancedb file. The current `main` repair at [`2c95bd2387c`](https://github.com/openclaw/openclaw/commit/2c95bd2387cdcfab5b3736f3ab6d08a4ad23cb65) is included; fresh exact-head CI run [29386264145](https://github.com/openclaw/openclaw/actions/runs/29386264145) passed with 46 checks green, including `openclaw/ci-gate`.

Remote Testbox delegation was unavailable because the installed Crabbox binary is 0.16.0 while the current flow requires 0.22.0 or newer. The proof above is secretless local execution, and GitHub CI remains the remote verification lane.




<!-- exact-head-follow-up-6604 -->
### Exact-head follow-up — 6604ba454b7

Rebased onto origin/main 64c82812a5e. GitHub now reports the PR mergeable; main advanced again after the push, so the exact-merge checks are validating head 6604ba454b7 against the live base.

The first rebased implementation exposed two additional LanceDB-native races during focused repetition:

- Concurrent sentinel deletion could fail with Delete transaction incompatible with concurrent transaction Overwrite.
- createEmptyTable with existOk could briefly expose the table name before its first version was readable.

The final implementation creates the empty table with an explicit Arrow schema, so there is no sentinel cleanup transaction, and retries the complete list/open-or-create/schema-ready dependency boundary up to three times without matching error strings.

Standalone six-process control on current origin/main:

```text
initializer 1: failed (1)
initializer 2: failed (1)
initializer 3: ok
initializer 4: failed (1)
initializer 5: failed (1)
initializer 6: failed (1)
failure: [Error: Table memories already exists] { code: GenericFailure }
tables: memories
rows: 0
before_exit=1
```

Standalone six-process exact-head result:

```text
initializer 1: ok
initializer 2: ok
initializer 3: ok
initializer 4: ok
initializer 5: ok
initializer 6: ok
tables: memories
rows: 0
after_exit=0
```

Focused validation:

- Concurrent six-process Vitest regression: 20 consecutive rounds passed.
- lancedb-store tests: 2 passed.
- Targeted oxfmt, oxlint, and git diff --check passed.
- Fresh structured autoreview: no accepted or actionable findings; patch correctness 0.93.
- Local check-changed remote delegation could not finish because registry downloads for optional cross-platform binaries repeatedly failed; exact-head GitHub CI is the wide validation lane.
