### PR TITLE
fix(discord): hydrate missing reply references

### DIFF
--- a/extensions/discord/src/monitor/message-handler.hydration.test.ts
+++ b/extensions/discord/src/monitor/message-handler.hydration.test.ts
@@ -128,6 +128,52 @@ describe("hydrateDiscordMessageIfNeeded", () => {
     expect(hydrated.referencedMessage?.content).toBe("the replied-to message");
   });
 
+  it("fetches the referenced message when the hydrated reply still omits it", async () => {
+    const client = createInternalTestClient();
+    const rest = createFakeRestClient([
+      createDefaultReplyPayload(),
+      createReferencedMessagePayload("the directly fetched message"),
+    ]);
+    const message = new Message(client, createDefaultReplyPayload());
+
+    const hydrated = await hydrateDiscordMessageIfNeeded({
+      client: { rest },
+      message,
+      messageChannelId: "c1",
+    });
+
+    expect(rest.calls.map((call) => call.path)).toEqual([
+      "/channels/c1/messages/m1",
+      "/channels/c1/messages/m0",
+    ]);
+    expect(hydrated.referencedMessage?.content).toBe("the directly fetched message");
+  });
+
+  it("uses the referenced channel when directly hydrating a cross-channel reply", async () => {
+    const client = createInternalTestClient();
+    const reply = createDefaultReplyPayload({
+      message_reference: {
+        type: MessageReferenceType.Default,
+        message_id: "m0",
+        channel_id: "c2",
+      },
+    });
+    const rest = createFakeRestClient([
+      reply,
+      createReferencedMessagePayload("the cross-channel message"),
+    ]);
+    const message = new Message(client, reply);
+
+    const hydrated = await hydrateDiscordMessageIfNeeded({
+      client: { rest },
+      message,
+      messageChannelId: "c1",
+    });
+
+    expect(rest.calls[1]?.path).toBe("/channels/c2/messages/m0");
+    expect(hydrated.referencedMessage?.content).toBe("the cross-channel message");
+  });
+
   it("keeps the original reply message when hydration fetch fails", async () => {
     const client = createInternalTestClient();
     const rest = createFakeRestClient();

--- a/extensions/discord/src/monitor/message-handler.hydration.test.ts
+++ b/extensions/discord/src/monitor/message-handler.hydration.test.ts
@@ -5,7 +5,9 @@ import {
   createFakeRestClient,
   createInternalTestClient,
 } from "../internal/test-builders.test-support.js";
+import { buildDiscordMessageProcessContext } from "./message-handler.context.js";
 import { hydrateDiscordMessageIfNeeded } from "./message-handler.hydration.js";
+import { createBaseDiscordMessageContext } from "./message-handler.test-harness.js";
 
 const TEST_TIMESTAMP = "2026-01-01T00:00:00.000Z";
 
@@ -147,6 +149,24 @@ describe("hydrateDiscordMessageIfNeeded", () => {
       "/channels/c1/messages/m0",
     ]);
     expect(hydrated.referencedMessage?.content).toBe("the directly fetched message");
+
+    const ctx = await createBaseDiscordMessageContext({
+      message: hydrated,
+      author: hydrated.author,
+      baseText: hydrated.content,
+      messageText: hydrated.content,
+    });
+    const result = await buildDiscordMessageProcessContext({
+      ctx,
+      text: hydrated.content,
+      mediaList: [],
+    });
+    if (!result) {
+      throw new Error("expected a built Discord message context");
+    }
+
+    expect(result.ctxPayload.ReplyToId).toBe("m0");
+    expect(result.ctxPayload.ReplyToBody).toBe("the directly fetched message");
   });
 
   it("uses the referenced channel when directly hydrating a cross-channel reply", async () => {

--- a/extensions/discord/src/monitor/message-handler.hydration.ts
+++ b/extensions/discord/src/monitor/message-handler.hydration.ts
@@ -189,6 +189,43 @@ function hasMissingReferencedMessagePayload(message: Message): boolean {
   return !Object.hasOwn(readMessageRawData(message), "referenced_message");
 }
 
+async function hydrateDiscordReplyReference(params: {
+  client: { rest: Parameters<typeof getChannelMessage>[0] };
+  message: Message;
+  messageChannelId: string;
+}): Promise<Message> {
+  if (!hasMissingReferencedMessagePayload(params.message)) {
+    return params.message;
+  }
+  const reference = params.message.messageReference;
+  const referencedMessageId = reference?.message_id;
+  if (!referencedMessageId) {
+    return params.message;
+  }
+  const referencedChannelId = reference.channel_id ?? params.messageChannelId;
+  try {
+    const referenced = (await getChannelMessage(
+      params.client.rest,
+      referencedChannelId,
+      referencedMessageId,
+    )) as APIMessage | null | undefined;
+    if (!referenced) {
+      return params.message;
+    }
+    // Discord may omit referenced_message from both Gateway and REST reply payloads.
+    // Attach the canonical referenced fetch so downstream reply context stays bounded.
+    return mergeFetchedDiscordMessage(params.message, {
+      ...readMessageRawData(params.message),
+      referenced_message: referenced,
+    } as APIMessage);
+  } catch (err) {
+    logVerbose(
+      `discord: failed to hydrate referenced message ${referencedMessageId}: ${String(err)}`,
+    );
+    return params.message;
+  }
+}
+
 export async function hydrateDiscordMessageIfNeeded(params: {
   client: { rest: Parameters<typeof getChannelMessage>[0] };
   message: Message;
@@ -199,19 +236,24 @@ export async function hydrateDiscordMessageIfNeeded(params: {
   if (!shouldHydrateDiscordMessage({ message: params.message })) {
     return params.message;
   }
+  let hydrated = params.message;
   try {
     const fetched = (await getChannelMessage(
       params.client.rest,
       params.messageChannelId,
       params.message.id,
     )) as APIMessage | null | undefined;
-    if (!fetched) {
-      return params.message;
+    if (fetched) {
+      logVerbose(`discord: hydrated inbound payload via REST for ${params.message.id}`);
+      hydrated = mergeFetchedDiscordMessage(params.message, fetched);
     }
-    logVerbose(`discord: hydrated inbound payload via REST for ${params.message.id}`);
-    return mergeFetchedDiscordMessage(params.message, fetched);
   } catch (err) {
     logVerbose(`discord: failed to hydrate message ${params.message.id}: ${String(err)}`);
     return params.message;
   }
+  return hydrateDiscordReplyReference({
+    client: params.client,
+    message: hydrated,
+    messageChannelId: params.messageChannelId,
+  });
 }


### PR DESCRIPTION
Closes #105862

## What Problem This Solves

A normal Discord reply can arrive with a valid `message_reference.message_id` but without a nested `referenced_message`. OpenClaw currently re-fetches the inbound reply, but if Discord REST also omits the nested payload, downstream reply context still cannot see the referenced message body.

## Why This Change Was Made

Preserve the existing inbound hydration first. When that successful REST result still lacks `referenced_message`, fetch the referenced message directly using the reference channel and message IDs and attach it through the existing Discord `Message` wrapper path.

The fallback remains limited to ordinary Discord replies. Known-deleted references and forwarded messages are unchanged, cross-channel references use their own channel ID, and API failures continue normal inbound delivery without logging referenced content.

## User Impact

Agents can receive the bounded quoted-message context for native Discord replies even when Discord omits the nested referenced payload from both the Gateway event and the hydrated reply response.

## Evidence

Final-head validation after rebasing onto current `main`:

- Candidate head: `3526d95eed`; based on `origin/main` at `9c94864746`.
- Production-path integration proof: the regression test starts with an ordinary reply whose Gateway-shaped payload omits `referenced_message`, verifies the two real REST routes (`/channels/c1/messages/m1` then `/channels/c1/messages/m0`), passes the hydrated Discord `Message` through `buildDiscordMessageProcessContext`, and asserts the actual inbound agent payload contains `ReplyToId === "m0"` and `ReplyToBody === "the directly fetched message"`.
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.hydration.test.ts extensions/discord/src/monitor/message-handler.context.test.ts extensions/discord/src/monitor/message-utils.test.ts extensions/discord/src/monitor/message-handler.preflight.test.ts` under Node 24.15.0 — 4 files and 110 tests passed.
- `node_modules/.bin/oxfmt --check extensions/discord/src/monitor/message-handler.hydration.ts extensions/discord/src/monitor/message-handler.hydration.test.ts` — passed.
- `git diff --check origin/main...HEAD` — passed.
- `check:changed` passed its scoped conflict-marker, attribution, extension export, duplicate coverage, dependency pin, and formatting lanes. Its repository-wide Plugin SDK API baseline check reports the same hash mismatch on a clean detached `origin/main` worktree, so that drift is not introduced by this PR.

Discord documents that an absent `referenced_message` means its backend did not attempt to resolve it, and documents Get Channel Message as the supported endpoint for retrieving a specific readable message: https://docs.discord.com/developers/resources/message

### Proof boundary

This is deterministic, secretless integration proof through the actual Discord message-context builder, not a live Discord capture. This machine has no configured Discord account or token, so a redacted real Gateway/REST transcript cannot be truthfully produced locally. The test deliberately exercises the reported double-omission and verifies the recovered body at the final agent-context boundary rather than stopping at the REST wrapper.