### PR TITLE
fix(cron): batch pending-media snapshot in session reaper to avoid O(SxT) loop

### DIFF
--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -453,4 +453,35 @@ describe("sweepCronRunSessions", () => {
       listSpy.mockRestore();
     }
   });
+
+  it("does not build the pending-media snapshot when no cron continuations exist", async () => {
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      "agent:main:cron:job1:run:recent-1": {
+        sessionId: "recent-1",
+        updatedAt: now - 1 * 3_600_000, // 1h ago — not expired
+      },
+      "agent:main:cron:job1:run:recent-2": {
+        sessionId: "recent-2",
+        updatedAt: now - 2 * 3_600_000, // 2h ago — not expired
+      },
+      "agent:main:telegram:dm:123": {
+        sessionId: "regular-dm",
+        updatedAt: now - 50 * 3_600_000, // old, but not cron run
+      },
+    };
+    await seedSessionEntries(storePath, store);
+    taskStatusMocks.buildPendingSet.mockClear();
+
+    const result = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+    });
+
+    expect(result.pruned).toBe(0);
+    // Lazy snapshot: no continuation rows → buildPendingSet never called.
+    expect(taskStatusMocks.buildPendingSet).not.toHaveBeenCalled();
+  });
 });

--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -14,10 +14,14 @@ import { resetReaperThrottle } from "./session-reaper.test-support.js";
 
 const { listSessionEntries, patchSessionEntry, replaceSessionEntry } = sessionAccessor;
 
-const taskStatusMocks = vi.hoisted(() => ({ hasPendingGeneratedMediaTask: vi.fn() }));
+const taskStatusMocks = vi.hoisted(() => ({
+  hasPendingGeneratedMediaTask: vi.fn(),
+  buildPendingSet: vi.fn<() => Set<string>>(() => new Set()),
+}));
 
 vi.mock("../tasks/task-status-access.js", () => ({
   hasPendingGeneratedMediaTaskForSessionKey: taskStatusMocks.hasPendingGeneratedMediaTask,
+  buildPendingGeneratedMediaSessionKeySet: taskStatusMocks.buildPendingSet,
 }));
 
 function createTestLogger(): Logger {
@@ -77,6 +81,7 @@ describe("sweepCronRunSessions", () => {
   beforeEach(async () => {
     resetReaperThrottle();
     taskStatusMocks.hasPendingGeneratedMediaTask.mockReset().mockReturnValue(false);
+    taskStatusMocks.buildPendingSet.mockReset().mockReturnValue(new Set());
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cron-reaper-"));
     storePath = path.join(tmpDir, "sessions.json");
   });
@@ -177,7 +182,7 @@ describe("sweepCronRunSessions", () => {
       },
     };
     await seedSessionEntries(storePath, store);
-    taskStatusMocks.hasPendingGeneratedMediaTask.mockReturnValue(true);
+    taskStatusMocks.buildPendingSet.mockReturnValue(new Set([sessionKey]));
 
     const result = await sweepCronRunSessions({
       sessionStorePath: storePath,
@@ -205,7 +210,7 @@ describe("sweepCronRunSessions", () => {
         },
       },
     });
-    taskStatusMocks.hasPendingGeneratedMediaTask.mockReturnValue(true);
+    taskStatusMocks.buildPendingSet.mockReturnValue(new Set([sessionKey]));
 
     const result = await sweepCronRunSessions({
       sessionStorePath: storePath,

--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -15,12 +15,10 @@ import { resetReaperThrottle } from "./session-reaper.test-support.js";
 const { listSessionEntries, patchSessionEntry, replaceSessionEntry } = sessionAccessor;
 
 const taskStatusMocks = vi.hoisted(() => ({
-  hasPendingGeneratedMediaTask: vi.fn(),
   buildPendingSet: vi.fn<() => Set<string>>(() => new Set()),
 }));
 
 vi.mock("../tasks/task-status-access.js", () => ({
-  hasPendingGeneratedMediaTaskForSessionKey: taskStatusMocks.hasPendingGeneratedMediaTask,
   buildPendingGeneratedMediaSessionKeySet: taskStatusMocks.buildPendingSet,
 }));
 
@@ -80,7 +78,6 @@ describe("sweepCronRunSessions", () => {
 
   beforeEach(async () => {
     resetReaperThrottle();
-    taskStatusMocks.hasPendingGeneratedMediaTask.mockReset().mockReturnValue(false);
     taskStatusMocks.buildPendingSet.mockReset().mockReturnValue(new Set());
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cron-reaper-"));
     storePath = path.join(tmpDir, "sessions.json");
@@ -454,16 +451,17 @@ describe("sweepCronRunSessions", () => {
     }
   });
 
-  it("does not build the pending-media snapshot when no cron continuations exist", async () => {
+  it("does not build the pending-media snapshot without an expired continuation", async () => {
     const now = Date.now();
     const store: Record<string, SessionEntry> = {
       "agent:main:cron:job1:run:recent-1": {
         sessionId: "recent-1",
         updatedAt: now - 1 * 3_600_000, // 1h ago — not expired
+        cronRunContinuation: { lifecycleRevision: "revision-1", phase: "ready" },
       },
-      "agent:main:cron:job1:run:recent-2": {
-        sessionId: "recent-2",
-        updatedAt: now - 2 * 3_600_000, // 2h ago — not expired
+      "agent:main:cron:job1:run:expired": {
+        sessionId: "expired",
+        updatedAt: now - 25 * 3_600_000,
       },
       "agent:main:telegram:dm:123": {
         sessionId: "regular-dm",
@@ -480,8 +478,38 @@ describe("sweepCronRunSessions", () => {
       force: true,
     });
 
-    expect(result.pruned).toBe(0);
-    // Lazy snapshot: no continuation rows → buildPendingSet never called.
+    expect(result.pruned).toBe(1);
     expect(taskStatusMocks.buildPendingSet).not.toHaveBeenCalled();
+  });
+
+  it("builds one pending-media snapshot for multiple expired continuations", async () => {
+    const now = Date.now();
+    const keptKey = "agent:main:cron:job1:run:kept";
+    const prunedKey = "agent:main:cron:job1:run:pruned";
+    const continuation = { lifecycleRevision: "revision-1", phase: "ready" } as const;
+    await seedSessionEntries(storePath, {
+      [keptKey]: {
+        sessionId: "kept",
+        updatedAt: now - 25 * 3_600_000,
+        cronRunContinuation: continuation,
+      },
+      [prunedKey]: {
+        sessionId: "pruned",
+        updatedAt: now - 25 * 3_600_000,
+        cronRunContinuation: continuation,
+      },
+    });
+    taskStatusMocks.buildPendingSet.mockReturnValue(new Set([keptKey]));
+
+    const result = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+    });
+
+    expect(result.pruned).toBe(1);
+    expect(taskStatusMocks.buildPendingSet).toHaveBeenCalledOnce();
+    expect(Object.keys(readSessionEntries(storePath))).toEqual([keptKey]);
   });
 });

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -78,16 +78,22 @@ export async function sweepCronRunSessions(params: {
   let transcriptCleanupError: unknown;
   try {
     const cutoff = now - retentionMs;
-    const pendingMediaSessionKeys = buildPendingGeneratedMediaSessionKeySet();
+    // Lazily built on the first continuation row so idle sweeps (deployments
+    // with no cron jobs) skip the task-registry snapshot entirely. Once built,
+    // every subsequent continuation row uses O(1) Set.has() instead of
+    // repeating the full listTaskRecords() clone+sort for each row.
+    let pendingMediaSessionKeys: Set<string> | undefined;
     const removals: SessionEntryLifecycleRemoval[] = [];
     for (const { sessionKey, entry } of listSessionEntries({ storePath })) {
       if (!isCronRunSessionKey(sessionKey)) {
         continue;
       }
       const continuation = entry.cronRunContinuation;
-      const hasPendingMedia = Boolean(continuation && pendingMediaSessionKeys.has(sessionKey));
-      if (continuation && hasPendingMedia) {
-        continue;
+      if (continuation) {
+        pendingMediaSessionKeys ??= buildPendingGeneratedMediaSessionKeySet();
+        if (pendingMediaSessionKeys.has(sessionKey)) {
+          continue;
+        }
       }
       const updatedAt = entry.updatedAt ?? 0;
       if (updatedAt < cutoff) {

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -78,33 +78,31 @@ export async function sweepCronRunSessions(params: {
   let transcriptCleanupError: unknown;
   try {
     const cutoff = now - retentionMs;
-    // Lazily built on the first continuation row so idle sweeps (deployments
-    // with no cron jobs) skip the task-registry snapshot entirely. Once built,
-    // every subsequent continuation row uses O(1) Set.has() instead of
-    // repeating the full listTaskRecords() clone+sort for each row.
     let pendingMediaSessionKeys: Set<string> | undefined;
     const removals: SessionEntryLifecycleRemoval[] = [];
     for (const { sessionKey, entry } of listSessionEntries({ storePath })) {
       if (!isCronRunSessionKey(sessionKey)) {
         continue;
       }
-      const continuation = entry.cronRunContinuation;
-      if (continuation) {
+      const updatedAt = entry.updatedAt ?? 0;
+      if (updatedAt >= cutoff) {
+        continue;
+      }
+      if (entry.cronRunContinuation) {
+        // Build one unordered snapshot only when an expired continuation needs it.
+        // Fresh rows and stores without continuations never touch the task registry.
         pendingMediaSessionKeys ??= buildPendingGeneratedMediaSessionKeySet();
         if (pendingMediaSessionKeys.has(sessionKey)) {
           continue;
         }
       }
-      const updatedAt = entry.updatedAt ?? 0;
-      if (updatedAt < cutoff) {
-        removals.push({
-          sessionKey,
-          expectedEntry: entry,
-          ...(entry.sessionId ? { expectedSessionId: entry.sessionId } : {}),
-          expectedUpdatedAt: entry.updatedAt,
-          archiveRemovedTranscript: true,
-        });
-      }
+      removals.push({
+        sessionKey,
+        expectedEntry: entry,
+        ...(entry.sessionId ? { expectedSessionId: entry.sessionId } : {}),
+        expectedUpdatedAt: entry.updatedAt,
+        archiveRemovedTranscript: true,
+      });
     }
     if (removals.length > 0) {
       // Archive-age cleanup follows the session maintenance retention knob:

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -9,7 +9,7 @@ import { resolveMaintenanceConfig } from "../config/sessions/store-maintenance-r
 import type { CronConfig } from "../config/types.cron.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
-import { hasPendingGeneratedMediaTaskForSessionKey } from "../tasks/task-status-access.js";
+import { buildPendingGeneratedMediaSessionKeySet } from "../tasks/task-status-access.js";
 import type { Logger } from "./service/state.js";
 
 const DEFAULT_RETENTION_MS = 24 * 3_600_000; // 24 hours
@@ -78,15 +78,14 @@ export async function sweepCronRunSessions(params: {
   let transcriptCleanupError: unknown;
   try {
     const cutoff = now - retentionMs;
+    const pendingMediaSessionKeys = buildPendingGeneratedMediaSessionKeySet();
     const removals: SessionEntryLifecycleRemoval[] = [];
     for (const { sessionKey, entry } of listSessionEntries({ storePath })) {
       if (!isCronRunSessionKey(sessionKey)) {
         continue;
       }
       const continuation = entry.cronRunContinuation;
-      const hasPendingMedia = Boolean(
-        continuation && hasPendingGeneratedMediaTaskForSessionKey(sessionKey),
-      );
+      const hasPendingMedia = Boolean(continuation && pendingMediaSessionKeys.has(sessionKey));
       if (continuation && hasPendingMedia) {
         continue;
       }

--- a/src/tasks/generated-media-task-activity.ts
+++ b/src/tasks/generated-media-task-activity.ts
@@ -47,6 +47,11 @@ export function listActiveGeneratedMediaTaskIdsForSessionKey(sessionKey: string)
   return runIds;
 }
 
+/** Returns the set of all session keys with in-process generated-media activity. */
+export function getAllActiveGeneratedMediaSessionKeys(): Set<string> {
+  return new Set(getActiveGeneratedMediaTasks().values());
+}
+
 /** Returns the latest admitted run id even after that task became terminal. */
 export function getLatestGeneratedMediaTaskAdmissionIdForSessionKey(
   sessionKey: string,

--- a/src/tasks/task-status-access.test.ts
+++ b/src/tasks/task-status-access.test.ts
@@ -11,12 +11,16 @@ import {
   hasPendingGeneratedMediaTaskForSessionKey,
 } from "./task-status-access.js";
 
-const mocks = vi.hoisted(() => ({ listTaskRecords: vi.fn() }));
+const mocks = vi.hoisted(() => ({
+  listTaskRecords: vi.fn(),
+  listTaskRecordsUnsorted: vi.fn(),
+}));
 
 vi.mock("./task-registry.js", () => ({
   findTaskByRunId: vi.fn(),
   getTaskById: vi.fn(),
   listTaskRecords: mocks.listTaskRecords,
+  listTaskRecordsUnsorted: mocks.listTaskRecordsUnsorted,
   listTasksForAgentId: vi.fn(),
   listTasksForSessionKey: vi.fn(),
 }));
@@ -27,6 +31,7 @@ describe("generated media task snapshots", () => {
   beforeEach(() => {
     resetGeneratedMediaTaskActivityForTests();
     mocks.listTaskRecords.mockReset();
+    mocks.listTaskRecordsUnsorted.mockReset();
   });
 
   it("detects only media admitted by the current exact-run attempt", () => {
@@ -78,50 +83,33 @@ describe("buildPendingGeneratedMediaSessionKeySet", () => {
 
   beforeEach(() => {
     resetGeneratedMediaTaskActivityForTests();
-    mocks.listTaskRecords.mockReset();
+    mocks.listTaskRecordsUnsorted.mockReset();
   });
 
   it("returns an empty set when no active media and no persisted tasks", () => {
-    mocks.listTaskRecords.mockReturnValue([]);
+    mocks.listTaskRecordsUnsorted.mockReturnValue([]);
     expect(buildPendingGeneratedMediaSessionKeySet()).toEqual(new Set());
   });
 
-  it("includes in-process active generated-media session keys", () => {
-    mocks.listTaskRecords.mockReturnValue([]);
-    registerGeneratedMediaTaskActivity("tool:image_generate:run-1", sessionKey);
-    expect(buildPendingGeneratedMediaSessionKeySet()).toEqual(new Set([sessionKey]));
-  });
-
-  it("includes requester session keys from non-terminal generated-media tasks", () => {
-    mocks.listTaskRecords.mockReturnValue([
+  it("combines active, requester, and owner session keys in one unsorted snapshot", () => {
+    registerGeneratedMediaTaskActivity("tool:image_generate:run-1", "active-key");
+    mocks.listTaskRecordsUnsorted.mockReturnValue([
       {
         taskId: "img-task",
         taskKind: "image_generation",
         status: "queued",
         requesterSessionKey: sessionKey,
-        ownerKey: "other-owner",
+        ownerKey: "owner-key",
       },
     ]);
-    expect(buildPendingGeneratedMediaSessionKeySet()).toEqual(new Set([sessionKey, "other-owner"]));
+    expect(buildPendingGeneratedMediaSessionKeySet()).toEqual(
+      new Set(["active-key", sessionKey, "owner-key"]),
+    );
+    expect(mocks.listTaskRecordsUnsorted).toHaveBeenCalledOnce();
   });
 
-  it("includes owner keys from non-terminal generated-media tasks", () => {
-    mocks.listTaskRecords.mockReturnValue([
-      {
-        taskId: "vid-task",
-        taskKind: "video_generation",
-        status: "running",
-        requesterSessionKey: "other-requester",
-        ownerKey: sessionKey,
-      },
-    ]);
-    const result = buildPendingGeneratedMediaSessionKeySet();
-    expect(result.has(sessionKey)).toBe(true);
-    expect(result.has("other-requester")).toBe(true);
-  });
-
-  it("excludes terminal generated-media tasks", () => {
-    mocks.listTaskRecords.mockReturnValue([
+  it("excludes terminal and non-generated-media tasks", () => {
+    mocks.listTaskRecordsUnsorted.mockReturnValue([
       {
         taskId: "done-task",
         taskKind: "image_generation",
@@ -129,12 +117,6 @@ describe("buildPendingGeneratedMediaSessionKeySet", () => {
         requesterSessionKey: sessionKey,
         ownerKey: sessionKey,
       },
-    ]);
-    expect(buildPendingGeneratedMediaSessionKeySet()).toEqual(new Set());
-  });
-
-  it("excludes non-generated-media tasks", () => {
-    mocks.listTaskRecords.mockReturnValue([
       {
         taskId: "chat-task",
         taskKind: "chat",
@@ -144,21 +126,5 @@ describe("buildPendingGeneratedMediaSessionKeySet", () => {
       },
     ]);
     expect(buildPendingGeneratedMediaSessionKeySet()).toEqual(new Set());
-  });
-
-  it("combines active media and persisted tasks in one scan", () => {
-    registerGeneratedMediaTaskActivity("tool:in-proc:run-1", "active-key");
-    mocks.listTaskRecords.mockReturnValue([
-      {
-        taskId: "persisted-task",
-        taskKind: "music_generation",
-        status: "processing",
-        requesterSessionKey: "persisted-key",
-        ownerKey: "owner-key",
-      },
-    ]);
-    expect(buildPendingGeneratedMediaSessionKeySet()).toEqual(
-      new Set(["active-key", "persisted-key", "owner-key"]),
-    );
   });
 });

--- a/src/tasks/task-status-access.test.ts
+++ b/src/tasks/task-status-access.test.ts
@@ -5,6 +5,7 @@ import {
 } from "./generated-media-task-activity.js";
 import { resetGeneratedMediaTaskActivityForTests } from "./task-runtime.test-helpers.js";
 import {
+  buildPendingGeneratedMediaSessionKeySet,
   getGeneratedMediaTaskIdsForSessionKey,
   hasNewGeneratedMediaTaskForSessionKey,
   hasPendingGeneratedMediaTaskForSessionKey,
@@ -69,5 +70,95 @@ describe("generated media task snapshots", () => {
     clearGeneratedMediaTaskActivity("tool:image_generate:run-1");
     expect(hasNewGeneratedMediaTaskForSessionKey(sessionKey, before)).toBe(true);
     expect(hasPendingGeneratedMediaTaskForSessionKey(sessionKey)).toBe(false);
+  });
+});
+
+describe("buildPendingGeneratedMediaSessionKeySet", () => {
+  const sessionKey = "agent:main:cron:job:run:run-id";
+
+  beforeEach(() => {
+    resetGeneratedMediaTaskActivityForTests();
+    mocks.listTaskRecords.mockReset();
+  });
+
+  it("returns an empty set when no active media and no persisted tasks", () => {
+    mocks.listTaskRecords.mockReturnValue([]);
+    expect(buildPendingGeneratedMediaSessionKeySet()).toEqual(new Set());
+  });
+
+  it("includes in-process active generated-media session keys", () => {
+    mocks.listTaskRecords.mockReturnValue([]);
+    registerGeneratedMediaTaskActivity("tool:image_generate:run-1", sessionKey);
+    expect(buildPendingGeneratedMediaSessionKeySet()).toEqual(new Set([sessionKey]));
+  });
+
+  it("includes requester session keys from non-terminal generated-media tasks", () => {
+    mocks.listTaskRecords.mockReturnValue([
+      {
+        taskId: "img-task",
+        taskKind: "image_generation",
+        status: "queued",
+        requesterSessionKey: sessionKey,
+        ownerKey: "other-owner",
+      },
+    ]);
+    expect(buildPendingGeneratedMediaSessionKeySet()).toEqual(new Set([sessionKey, "other-owner"]));
+  });
+
+  it("includes owner keys from non-terminal generated-media tasks", () => {
+    mocks.listTaskRecords.mockReturnValue([
+      {
+        taskId: "vid-task",
+        taskKind: "video_generation",
+        status: "running",
+        requesterSessionKey: "other-requester",
+        ownerKey: sessionKey,
+      },
+    ]);
+    const result = buildPendingGeneratedMediaSessionKeySet();
+    expect(result.has(sessionKey)).toBe(true);
+    expect(result.has("other-requester")).toBe(true);
+  });
+
+  it("excludes terminal generated-media tasks", () => {
+    mocks.listTaskRecords.mockReturnValue([
+      {
+        taskId: "done-task",
+        taskKind: "image_generation",
+        status: "succeeded",
+        requesterSessionKey: sessionKey,
+        ownerKey: sessionKey,
+      },
+    ]);
+    expect(buildPendingGeneratedMediaSessionKeySet()).toEqual(new Set());
+  });
+
+  it("excludes non-generated-media tasks", () => {
+    mocks.listTaskRecords.mockReturnValue([
+      {
+        taskId: "chat-task",
+        taskKind: "chat",
+        status: "running",
+        requesterSessionKey: sessionKey,
+        ownerKey: sessionKey,
+      },
+    ]);
+    expect(buildPendingGeneratedMediaSessionKeySet()).toEqual(new Set());
+  });
+
+  it("combines active media and persisted tasks in one scan", () => {
+    registerGeneratedMediaTaskActivity("tool:in-proc:run-1", "active-key");
+    mocks.listTaskRecords.mockReturnValue([
+      {
+        taskId: "persisted-task",
+        taskKind: "music_generation",
+        status: "processing",
+        requesterSessionKey: "persisted-key",
+        ownerKey: "owner-key",
+      },
+    ]);
+    expect(buildPendingGeneratedMediaSessionKeySet()).toEqual(
+      new Set(["active-key", "persisted-key", "owner-key"]),
+    );
   });
 });

--- a/src/tasks/task-status-access.ts
+++ b/src/tasks/task-status-access.ts
@@ -1,5 +1,6 @@
 import { parseCronRunScopeSuffix } from "../sessions/session-key-utils.js";
 import {
+  getAllActiveGeneratedMediaSessionKeys,
   getLatestGeneratedMediaTaskAdmissionIdForSessionKey,
   listActiveGeneratedMediaTaskIdsForSessionKey,
 } from "./generated-media-task-activity.js";
@@ -95,4 +96,27 @@ export function hasPendingGeneratedMediaTaskForSessionKey(sessionKey: string): b
     (task) =>
       GENERATED_MEDIA_TASK_KINDS.has(task.taskKind ?? "") && !isTerminalTaskStatus(task.status),
   );
+}
+
+/**
+ * Builds a one-shot snapshot of all session keys with pending generated-media
+ * work. Consume this once per reaper sweep for O(1) per-row lookups instead of
+ * repeating global task and activity scans for every cron continuation row.
+ */
+export function buildPendingGeneratedMediaSessionKeySet(): Set<string> {
+  const keys = new Set<string>();
+  for (const key of getAllActiveGeneratedMediaSessionKeys()) {
+    keys.add(key);
+  }
+  for (const task of listTaskRecords()) {
+    if (GENERATED_MEDIA_TASK_KINDS.has(task.taskKind ?? "") && !isTerminalTaskStatus(task.status)) {
+      if (task.requesterSessionKey) {
+        keys.add(task.requesterSessionKey);
+      }
+      if (task.ownerKey) {
+        keys.add(task.ownerKey);
+      }
+    }
+  }
+  return keys;
 }

--- a/src/tasks/task-status-access.ts
+++ b/src/tasks/task-status-access.ts
@@ -10,6 +10,7 @@ import {
   findTaskByRunId,
   getTaskById,
   listTaskRecords,
+  listTaskRecordsUnsorted,
   listTasksForAgentId,
   listTasksForSessionKey,
 } from "./task-registry.js";
@@ -104,11 +105,8 @@ export function hasPendingGeneratedMediaTaskForSessionKey(sessionKey: string): b
  * repeating global task and activity scans for every cron continuation row.
  */
 export function buildPendingGeneratedMediaSessionKeySet(): Set<string> {
-  const keys = new Set<string>();
-  for (const key of getAllActiveGeneratedMediaSessionKeys()) {
-    keys.add(key);
-  }
-  for (const task of listTaskRecords()) {
+  const keys = getAllActiveGeneratedMediaSessionKeys();
+  for (const task of listTaskRecordsUnsorted()) {
     if (GENERATED_MEDIA_TASK_KINDS.has(task.taskKind ?? "") && !isTerminalTaskStatus(task.status)) {
       if (task.requesterSessionKey) {
         keys.add(task.requesterSessionKey);


### PR DESCRIPTION
#### What Problem This Solves

Closes #105694.

The cron session reaper previously called the per-session generated-media pending check for every continuation row. Each call scanned in-process activity and cloned, sorted, and filtered the full task registry. With many continuation rows and tasks, sweep cost grew multiplicatively and could block the gateway event loop.

#### Why This Change Was Made

The reaper now builds one sweep-scoped set of session keys with pending generated-media work, then uses constant-time membership checks for expired continuation rows.

Maintainer review tightened the implementation:

- the snapshot is built only after the first expired continuation is found, so fresh rows and expired rows without continuations never touch the task registry;
- the task registry uses its existing unsorted snapshot because the reaper does not consume task order;
- requester session keys, owner keys, and in-process generated-media activity retain the prior matching contract;
- the same snapshot is reused across every later expired continuation in the sweep.

This changes sweep complexity from repeated global scans to one O(tasks + active media) snapshot plus O(1) lookups.

#### User Impact

Cron session pruning keeps the same preservation/removal decisions while avoiding event-loop work that scaled with both session and task counts. No config, CLI, SDK, migration, or operator action changes.

#### Evidence

- `node scripts/run-vitest.mjs src/cron/session-reaper.test.ts src/tasks/task-status-access.test.ts src/tasks/cron-run-continuation-cleanup.test.ts`
  - 31 tests passed across two Vitest shards.
  - Repeated after the final rebase with the same result.
- Regression coverage proves:
  - no snapshot for fresh continuations or expired rows without continuations;
  - exactly one snapshot for multiple expired continuations;
  - preservation of in-process activity, requester keys, and owner keys;
  - exclusion of terminal and non-generated-media tasks;
  - unchanged immediate continuation-cleanup behavior.
- `git diff --check` passed.
- Targeted formatting passed.
- Fresh maintainer autoreview of both the edits and full branch reported no actionable findings.
- Exact-head hosted CI: [run 29619935453](https://github.com/openclaw/openclaw/actions/runs/29619935453) passed all required checks at `353f7b9adf573a70c58534be2f969fd4b8e5db69`.

Human contributor credit: @wm0018.
