### PR TITLE
fix(twitch): send channel-prefixed targets to Twitch channels

### DIFF
--- a/extensions/twitch/src/plugin.test.ts
+++ b/extensions/twitch/src/plugin.test.ts
@@ -11,6 +11,24 @@ describe("twitchPlugin pairing", () => {
 });
 
 describe("twitchPlugin outbound session routing", () => {
+  it("normalizes channel-prefixed Twitch targets for message sends", () => {
+    expect(twitchPlugin.messaging?.targetPrefixes).toEqual(["twitch", "twitch-chat"]);
+    expect(twitchPlugin.messaging?.normalizeTarget?.("  twitch:channel:OpenClaw  ")).toBe(
+      "openclaw",
+    );
+    expect(twitchPlugin.messaging?.normalizeTarget?.("twitch-chat:group:OpenClaw")).toBe(
+      "openclaw",
+    );
+    expect(twitchPlugin.messaging?.normalizeTarget?.("#OpenClaw")).toBe("openclaw");
+  });
+
+  it.each(["twitch:user:alice", "twitch:dm:alice"])(
+    "normalizes unsupported direct target %s to an empty target",
+    (target) => {
+      expect(twitchPlugin.messaging?.normalizeTarget?.(target)).toBe("");
+    },
+  );
+
   it("reproduces the canonical inbound channel session", async () => {
     const route = await twitchPlugin.messaging?.resolveOutboundSessionRoute?.({
       cfg: {},

--- a/extensions/twitch/src/plugin.ts
+++ b/extensions/twitch/src/plugin.ts
@@ -97,6 +97,8 @@ export const twitchPlugin: ChannelPlugin<ResolvedTwitchAccount> =
         chatTypes: ["group"],
       },
       messaging: {
+        targetPrefixes: ["twitch", "twitch-chat"],
+        normalizeTarget: normalizeTwitchMessagingTarget,
         resolveOutboundSessionRoute: ({ cfg, agentId, accountId, target }) => {
           const channel = normalizeTwitchMessagingTarget(target);
           if (!channel) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending Twitch messages to a channel-prefixed target such as `twitch:channel:OpenClaw` or `twitch-chat:group:OpenClaw` could fail to deliver to the intended Twitch channel.

Twitch already accepted those canonical channel targets when building outbound session routes. For example, `twitch:channel:OpenClaw` is routed as the `openclaw` group conversation in `extensions/twitch/src/plugin.test.ts`. However, the normal message-send target normalization path did not expose Twitch's existing target normalizer through the plugin messaging metadata. As a result, ordinary message sends could pass the raw prefixed string into Twitch outbound delivery instead of the actual channel name.

Concrete example before this fix:

- User/model target: `twitch:channel:OpenClaw`
- Expected Twitch channel: `openclaw`
- Actual send target could remain effectively prefixed because the shared message target normalizer had no Twitch `normalizeTarget` hook.

## Why This Change Was Made

This change exposes Twitch's existing `normalizeTwitchMessagingTarget` through the standard channel messaging metadata and declares the supported Twitch target prefixes (`twitch`, `twitch-chat`).

That keeps the normal message tool path aligned with Twitch's existing outbound session routing behavior. It does not add a new target format; it makes the already-supported `twitch:channel:*` and `twitch-chat:group:*` forms work consistently for real message sends.

## User Impact

Users can now send Twitch messages using the same prefixed target forms OpenClaw already uses for routed Twitch conversations:

- `twitch:channel:OpenClaw`
- `twitch-chat:group:OpenClaw`
- `#OpenClaw`

All of these normalize to the actual Twitch channel `openclaw` before delivery.

Unsupported Twitch direct-message-style targets still do not become valid channel targets. The regression test keeps `twitch:user:alice` and `twitch:dm:alice` normalized to an empty target, matching the plugin's group-channel-only behavior.

## Evidence

Code evidence:

- `extensions/twitch/src/plugin.ts` already had `normalizeTwitchMessagingTarget`, which strips `twitch` / `twitch-chat` provider prefixes and channel/group kind prefixes before normalizing the Twitch channel.
- The same file's outbound session route already used that helper to route `twitch:channel:OpenClaw` as `openclaw`.
- The fix wires that existing helper into `messaging.normalizeTarget` and declares `messaging.targetPrefixes`.

Regression coverage added in `extensions/twitch/src/plugin.test.ts`:

- `twitch:channel:OpenClaw` normalizes to `openclaw`
- `twitch-chat:group:OpenClaw` normalizes to `openclaw`
- `#OpenClaw` normalizes to `openclaw`
- `twitch:user:alice` and `twitch:dm:alice` remain unsupported direct targets

Validation run:

```bash
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/twitch/src/plugin.test.ts
```

Result:

```text
[test] passed 1 Vitest shard
```

Also checked:

```bash
git diff --check
```

Proof gap:

- Blacksmith/Testbox prewarm was unavailable in this environment because the Crabbox wrapper failed its basic sanity check.
- Autoreview could not run here because the `codex` executable is not installed in this environment.
