### PR TITLE
refactor(test): use shared timeout helper

### DIFF
--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { WebSocketServer, type RawData, type WebSocket } from "ws";
 import { installGatewayTestHooks, startServer } from "../../../src/gateway/test-helpers.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../../src/infra/agent-events.js";
+import { withTimeout } from "../../../src/utils/with-timeout.js";
 import { GatewayClientTransport, OpenClaw } from "./index.js";
 
 type JsonObject = Record<string, unknown>;
@@ -53,22 +54,6 @@ async function reservePort(): Promise<number> {
     server.close((error) => (error ? reject(error) : resolve()));
   });
   return port;
-}
-
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
-  let timer: NodeJS.Timeout | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<never>((_resolve, reject) => {
-        timer = setTimeout(() => reject(new Error(message)), timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
-  }
 }
 
 async function createFakeGateway(port = 0): Promise<FakeGateway> {
@@ -410,7 +395,7 @@ describe("OpenClaw SDK websocket e2e", () => {
       })();
 
       const [seen, result] = await Promise.all([
-        withTimeout(seenPromise, 2_000, "timed out waiting for SDK run events"),
+        withTimeout(seenPromise, 2_000, { message: "timed out waiting for SDK run events" }),
         run.wait({ timeoutMs: 2_000 }),
       ]);
 
@@ -635,11 +620,9 @@ describe("OpenClaw SDK real Gateway e2e", () => {
         data: { phase: "end", endedAt: 222 },
       });
 
-      const { seen, sessionKeys } = await withTimeout(
-        eventsPromise,
-        2_000,
-        "timed out waiting for real Gateway SDK events",
-      );
+      const { seen, sessionKeys } = await withTimeout(eventsPromise, 2_000, {
+        message: "timed out waiting for real Gateway SDK events",
+      });
       expect(seen).toEqual(["run.started", "assistant.delta", "run.completed"]);
       expect(sessionKeys).toEqual([
         "agent:main:dashboard:sdk-real-gateway",
@@ -721,11 +704,9 @@ liveGatewayDescribe("OpenClaw SDK live Gateway e2e", () => {
       })();
 
       const result = await run.wait({ timeoutMs: 180_000 });
-      const events = await withTimeout(
-        eventsPromise,
-        5_000,
-        "timed out waiting for live SDK run events",
-      );
+      const events = await withTimeout(eventsPromise, 5_000, {
+        message: "timed out waiting for live SDK run events",
+      });
 
       expect(result.status).toBe("completed");
       expect(events.terminal).toBe("run.completed");

--- a/src/agents/bash-tools.exec-gateway-approval.e2e.test.ts
+++ b/src/agents/bash-tools.exec-gateway-approval.e2e.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../gateway/test-helpers.e2e.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import { withTimeout } from "../utils/with-timeout.js";
 import type { ExecApprovalFollowupOutcome } from "./bash-tools.exec-types.js";
 import { createExecTool } from "./bash-tools.exec.js";
 
@@ -39,21 +40,6 @@ const GATEWAY_CONNECT_TIMEOUT_MS = 120_000;
 const EXEC_APPROVAL_E2E_TIMEOUT_MS = 180_000;
 
 type Cleanup = () => Promise<void> | void;
-
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
-  let timeout: NodeJS.Timeout | undefined;
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timeout = setTimeout(() => reject(new Error(`timed out waiting for ${label}`)), timeoutMs);
-    timeout.unref();
-  });
-  try {
-    return await Promise.race([promise, timeoutPromise]);
-  } finally {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-  }
-}
 
 describe("gateway-hosted exec approvals", () => {
   const cleanup: Cleanup[] = [];
@@ -177,7 +163,9 @@ describe("gateway-hosted exec approvals", () => {
         { timeoutMs: 10_000 },
       );
 
-      const outcome = await withTimeout(outcomePromise, 15_000, "approved exec outcome");
+      const outcome = await withTimeout(outcomePromise, 15_000, {
+        message: "timed out waiting for approved exec outcome",
+      });
       expect(outcome.status).toBe("completed");
       expect(outcome.exitCode).toBe(0);
       expect(outcome.aggregated).toBe("smoke");

--- a/src/cron/service.read-ops-nonblocking.test.ts
+++ b/src/cron/service.read-ops-nonblocking.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { withTimeout } from "../utils/with-timeout.js";
 import { CronService } from "./service.js";
 import { writeCronStoreSnapshot } from "./service.test-harness.js";
 
@@ -18,22 +19,6 @@ type IsolatedRunResult = {
   summary?: string;
   error?: string;
 };
-
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
-  let timeout: NodeJS.Timeout | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<T>((_resolve, reject) => {
-        timeout = setTimeout(() => reject(new Error(`${label} timed out`)), timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-  }
-}
 
 async function makeStorePath() {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-"));
@@ -211,12 +196,19 @@ describe("CronService read ops while job is running", () => {
       await isolatedRun.runStarted;
 
       await expect(
-        withTimeout(cron.list({ includeDisabled: true }), 300, "cron.list during cron.run"),
+        withTimeout(cron.list({ includeDisabled: true }), 300, {
+          message: "cron.list during cron.run timed out",
+        }),
       ).resolves.toHaveLength(1);
-      expectCronStatus(await withTimeout(cron.status(), 300, "cron.status during cron.run"), {
-        storePath: store.storePath,
-        jobs: 1,
-      });
+      expectCronStatus(
+        await withTimeout(cron.status(), 300, {
+          message: "cron.status during cron.run timed out",
+        }),
+        {
+          storePath: store.storePath,
+          jobs: 1,
+        },
+      );
 
       isolatedRun.completeRun({ status: "ok", summary: "manual done" });
       await expect(runPromise).resolves.toEqual({ ok: true, ran: true });
@@ -273,12 +265,19 @@ describe("CronService read ops while job is running", () => {
       expect(isolatedRun.runIsolatedAgentJob).not.toHaveBeenCalled();
 
       await expect(
-        withTimeout(cron.list({ includeDisabled: true }), 300, "cron.list during startup"),
+        withTimeout(cron.list({ includeDisabled: true }), 300, {
+          message: "cron.list during startup timed out",
+        }),
       ).resolves.toHaveLength(1);
-      expectCronStatus(await withTimeout(cron.status(), 300, "cron.status during startup"), {
-        storePath: store.storePath,
-        jobs: 1,
-      });
+      expectCronStatus(
+        await withTimeout(cron.status(), 300, {
+          message: "cron.status during startup timed out",
+        }),
+        {
+          storePath: store.storePath,
+          jobs: 1,
+        },
+      );
 
       const jobs = await cron.list({ includeDisabled: true });
       expect(jobs[0]?.state.lastStatus).toBeUndefined();

--- a/src/daemon/launchd.integration.e2e.test.ts
+++ b/src/daemon/launchd.integration.e2e.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { withTimeout } from "../utils/with-timeout.js";
 import {
   installLaunchAgent,
   readLaunchAgentRuntime,
@@ -41,26 +42,6 @@ const describeLaunchdIntegration = canRunLaunchdIntegration() ? describe : descr
 
 function resolveGuiDomain(): string {
   return `gui/${process.getuid?.() ?? 501}`;
-}
-
-async function withTimeout<T>(params: {
-  run: () => Promise<T>;
-  timeoutMs: number;
-  message: string;
-}): Promise<T> {
-  let timer: NodeJS.Timeout | undefined;
-  try {
-    return await Promise.race([
-      params.run(),
-      new Promise<T>((_, reject) => {
-        timer = setTimeout(() => reject(new Error(params.message)), params.timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
-  }
 }
 
 async function waitForRunningRuntime(params: {
@@ -125,18 +106,18 @@ function launchEnvOrThrow(env: GatewayServiceEnv | undefined): GatewayServiceEnv
 }
 
 async function initializeLaunchdRuntime(launchEnv: GatewayServiceEnv, stdout: PassThrough) {
-  await withTimeout({
-    run: async () => {
+  await withTimeout(
+    (async () => {
       await installLaunchAgent({
         env: launchEnv,
         stdout,
         programArguments: [process.execPath, "-e", "setInterval(() => {}, 1000);"],
       });
       await waitForRunningRuntime({ env: launchEnv });
-    },
-    timeoutMs: STARTUP_TIMEOUT_MS,
-    message: "Timed out initializing launchd integration runtime",
-  });
+    })(),
+    STARTUP_TIMEOUT_MS,
+    { message: "Timed out initializing launchd integration runtime" },
+  );
 }
 
 async function writeLaunchAgentProbeScript(params: {
@@ -265,11 +246,11 @@ describeLaunchdIntegration("launchd integration", () => {
     await fs.access(resolveLaunchAgentPlistPath(launchEnv));
     await fs.writeFile(eventsPath, "", "utf8");
 
-    const repair = await withTimeout({
-      run: async () => repairLaunchAgentBootstrap({ env: launchEnv }),
-      timeoutMs: STARTUP_TIMEOUT_MS,
-      message: "Timed out repairing launchd integration runtime",
-    });
+    const repair = await withTimeout(
+      repairLaunchAgentBootstrap({ env: launchEnv }),
+      STARTUP_TIMEOUT_MS,
+      { message: "Timed out repairing launchd integration runtime" },
+    );
     expect(repair).toEqual({ ok: true, status: "repaired" });
     await waitForRunningRuntime({ env: launchEnv });
 

--- a/src/gateway/server.plugin-node-capability-auth.test.ts
+++ b/src/gateway/server.plugin-node-capability-auth.test.ts
@@ -5,9 +5,11 @@ import { connect, type Socket } from "node:net";
 import type { Duplex } from "node:stream";
 import { describe, expect, test } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
+import { withTimeout } from "../utils/with-timeout.js";
 import { createAuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import { PLUGIN_NODE_CAPABILITY_PATH_PREFIX } from "./plugin-node-capability.js";
+import { MAX_PREAUTH_PAYLOAD_BYTES } from "./server-constants.js";
 import { attachGatewayUpgradeHandler, createGatewayHttpServer } from "./server-http.js";
 import { createPreauthConnectionBudget } from "./server/preauth-connection-budget.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
@@ -53,22 +55,6 @@ async function fetchCanvas(input: string, init?: RequestInit): Promise<Response>
   throw new Error("unreachable");
 }
 
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<never>((_, reject) => {
-        timer = setTimeout(() => reject(new Error(`${label} timed out`)), timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
-  }
-}
-
 async function listen(
   server: ReturnType<typeof createGatewayHttpServer>,
   host = "127.0.0.1",
@@ -101,7 +87,7 @@ async function listen(
           server.close((err) => (err ? reject(err) : resolve()));
         }),
         SERVER_CLOSE_TIMEOUT_MS,
-        "gateway test server close",
+        { message: "gateway test server close timed out" },
       );
     },
   };
@@ -316,7 +302,10 @@ async function withCanvasGatewayHarness(params: {
   }) => Promise<void>;
 }) {
   const clients = new Set<GatewayWsClient>();
-  const canvasWss = new WebSocketServer({ noServer: true });
+  const canvasWss = new WebSocketServer({
+    noServer: true,
+    maxPayload: MAX_PREAUTH_PAYLOAD_BYTES,
+  });
   const canvasHandler: CanvasHostHandler = {
     rootDir: "test",
     basePath: "/canvas",
@@ -358,7 +347,10 @@ async function withCanvasGatewayHarness(params: {
     rateLimiter: params.rateLimiter,
   });
 
-  const wss = new WebSocketServer({ noServer: true });
+  const wss = new WebSocketServer({
+    noServer: true,
+    maxPayload: MAX_PREAUTH_PAYLOAD_BYTES,
+  });
   attachGatewayUpgradeHandler({
     httpServer,
     wss,


### PR DESCRIPTION
## What Problem This Solves

Five test files carried near-identical local `withTimeout` implementations, making timeout cleanup and error-message behavior easy to drift between suites.

## Why This Change Was Made

Reuse the existing `src/utils/with-timeout.ts` production helper in all five tests, including the SDK E2E suite. Exact timeout messages and durations remain unchanged through the helper's custom-message option; no new test-only abstraction is needed.

The precise security scan also exposed two pre-existing unlimited `noServer` WebSocket fixtures in the touched Gateway test. Both now use the existing production pre-auth payload cap.

## User Impact

No user-visible behavior changes. Test timeout behavior now has one maintained implementation instead of five copies.

## Evidence

- Blacksmith Testbox through Crabbox `tbx_01kxcra0ty3dac3v4c3ac84p1c`: targeted `oxfmt --check`, precise Opengrep, plus all five requested test files.
- Result: zero scan findings; 26 assertions passed; six environment-gated cases skipped (five macOS-only launchd cases on Linux and one live SDK case).
- Autoreview: clean, no accepted/actionable findings (0.97 confidence).
- `git diff --check`: clean.

AI-assisted change; implementation and proof reviewed before submission.
