### PR TITLE
fix(ai): reject noncanonical array indices in local schema refs

### DIFF
--- a/packages/ai/src/providers/agent-tools-parameter-schema.ts
+++ b/packages/ai/src/providers/agent-tools-parameter-schema.ts
@@ -465,8 +465,6 @@ function decodeJsonPointerSegment(segment: string): string {
   return segment.replaceAll("~1", "/").replaceAll("~0", "~");
 }
 
-const CANONICAL_JSON_POINTER_ARRAY_INDEX = /^(0|[1-9]\d*)$/;
-
 function resolveJsonPointerPath(value: unknown, segments: string[]): unknown {
   let current = value;
   for (const segment of segments) {
@@ -475,12 +473,8 @@ function resolveJsonPointerPath(value: unknown, segments: string[]): unknown {
     }
     const key = decodeJsonPointerSegment(segment);
     if (Array.isArray(current)) {
-      // RFC 6901 array indices are base-10 digits without leading zeros.
-      if (!CANONICAL_JSON_POINTER_ARRAY_INDEX.test(key)) {
-        return undefined;
-      }
-      const index = Number(key);
-      if (!Number.isInteger(index) || index < 0 || index >= current.length) {
+      const index = /^(?:0|[1-9]\d*)$/.test(key) ? Number(key) : -1;
+      if (index < 0 || index >= current.length) {
         return undefined;
       }
       current = current[index];

--- a/packages/ai/src/providers/agent-tools-parameter-schema.ts
+++ b/packages/ai/src/providers/agent-tools-parameter-schema.ts
@@ -465,6 +465,8 @@ function decodeJsonPointerSegment(segment: string): string {
   return segment.replaceAll("~1", "/").replaceAll("~0", "~");
 }
 
+const CANONICAL_JSON_POINTER_ARRAY_INDEX = /^(0|[1-9]\d*)$/;
+
 function resolveJsonPointerPath(value: unknown, segments: string[]): unknown {
   let current = value;
   for (const segment of segments) {
@@ -473,6 +475,10 @@ function resolveJsonPointerPath(value: unknown, segments: string[]): unknown {
     }
     const key = decodeJsonPointerSegment(segment);
     if (Array.isArray(current)) {
+      // RFC 6901 array indices are base-10 digits without leading zeros.
+      if (!CANONICAL_JSON_POINTER_ARRAY_INDEX.test(key)) {
+        return undefined;
+      }
       const index = Number(key);
       if (!Number.isInteger(index) || index < 0 || index >= current.length) {
         return undefined;

--- a/src/agents/agent-tools.schema.test.ts
+++ b/src/agents/agent-tools.schema.test.ts
@@ -344,6 +344,10 @@ describe("normalizeToolParameterSchema", () => {
         hexadecimal: { $ref: "#/$defs/Choice/anyOf/0x1" },
         exponent: { $ref: "#/$defs/Choice/anyOf/1e0" },
         leadingZero: { $ref: "#/$defs/Choice/anyOf/01" },
+        plusZero: { $ref: "#/$defs/Choice/anyOf/+0" },
+        negativeZero: { $ref: "#/$defs/Choice/anyOf/-0" },
+        empty: { $ref: "#/$defs/Choice/anyOf/" },
+        whitespace: { $ref: "#/$defs/Choice/anyOf/ " },
         escapedObjectKey: { $ref: "#/$defs/Escaped/properties/a~1b" },
       },
       $defs: {
@@ -371,6 +375,18 @@ describe("normalizeToolParameterSchema", () => {
     });
     expect(normalized.properties?.leadingZero).toEqual({
       $ref: "#/$defs/Choice/anyOf/01",
+    });
+    expect(normalized.properties?.plusZero).toEqual({
+      $ref: "#/$defs/Choice/anyOf/+0",
+    });
+    expect(normalized.properties?.negativeZero).toEqual({
+      $ref: "#/$defs/Choice/anyOf/-0",
+    });
+    expect(normalized.properties?.empty).toEqual({
+      $ref: "#/$defs/Choice/anyOf/",
+    });
+    expect(normalized.properties?.whitespace).toEqual({
+      $ref: "#/$defs/Choice/anyOf/ ",
     });
     expect(normalized.properties?.escapedObjectKey).toEqual({ type: "boolean" });
   });

--- a/src/agents/agent-tools.schema.test.ts
+++ b/src/agents/agent-tools.schema.test.ts
@@ -335,6 +335,46 @@ describe("normalizeToolParameterSchema", () => {
     });
   });
 
+  it("rejects noncanonical array indices in local $ref paths", () => {
+    const normalized = normalizeToolParameterSchema({
+      type: "object",
+      properties: {
+        canonicalZero: { $ref: "#/$defs/Choice/anyOf/0" },
+        canonicalOne: { $ref: "#/$defs/Choice/anyOf/1" },
+        hexadecimal: { $ref: "#/$defs/Choice/anyOf/0x1" },
+        exponent: { $ref: "#/$defs/Choice/anyOf/1e0" },
+        leadingZero: { $ref: "#/$defs/Choice/anyOf/01" },
+        escapedObjectKey: { $ref: "#/$defs/Escaped/properties/a~1b" },
+      },
+      $defs: {
+        Choice: {
+          anyOf: [{ type: "string" }, { type: "number" }],
+        },
+        Escaped: {
+          type: "object",
+          properties: {
+            "a/b": { type: "boolean" },
+          },
+        },
+      },
+    }) as {
+      properties?: Record<string, unknown>;
+    };
+
+    expect(normalized.properties?.canonicalZero).toEqual({ type: "string" });
+    expect(normalized.properties?.canonicalOne).toEqual({ type: "number" });
+    expect(normalized.properties?.hexadecimal).toEqual({
+      $ref: "#/$defs/Choice/anyOf/0x1",
+    });
+    expect(normalized.properties?.exponent).toEqual({
+      $ref: "#/$defs/Choice/anyOf/1e0",
+    });
+    expect(normalized.properties?.leadingZero).toEqual({
+      $ref: "#/$defs/Choice/anyOf/01",
+    });
+    expect(normalized.properties?.escapedObjectKey).toEqual({ type: "boolean" });
+  });
+
   it("inlines local refs in tuple array items", () => {
     expect(
       normalizeToolParameterSchema({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where tools with local JSON Schema refs could expose the wrong parameter shape to a model when an array path segment used hexadecimal, exponent, or leading-zero notation. JavaScript number coercion previously treated values such as `0x1` and `1e0` as array index `1`, silently inlining a different schema branch.

## Why This Change Was Made

Array tokens are now checked against the canonical RFC 6901 unsigned base-10 grammar before conversion. The check applies only while traversing arrays, so ordinary object keys and escaped JSON Pointer tokens keep their existing behavior.

AI-assisted.

## User Impact

Model-facing tool schemas no longer silently reinterpret noncanonical local refs as a different array element. Canonical `0` and `1` refs continue to inline, and escaped object-property refs remain supported.

## Evidence

### Real registered-tool → model request proof

The contributor proof below validated the original implementation head `dd9b70c4a99c1d4706dca264b24b6301303988b5`. Maintainer head `cc42b830c9401a59998c10647b51055efbbc458b` preserves that behavior, removes the extra production constant/comment to stay within the LOC ratchet, and adds the remaining coercion-boundary regressions.

The temporary fixture was packaged and installed through the real plugin lifecycle, then exercised by a real local agent turn:

```text
$ pnpm openclaw plugins install npm-pack:<fixture.tgz> --force
Installed plugin: pr-105922-schema-proof

$ pnpm openclaw plugins inspect pr-105922-schema-proof --runtime --json
"status": "loaded"
"toolNames": ["pr_105922_schema_probe"]

$ pnpm openclaw agent --local --agent main \
    --session-id pr-105922-schema-proof \
    --model openai/gpt-5.6-luna \
    --message "Return PR_105922_MODEL_PATH_OK without calling tools." \
    --thinking off --timeout 60 --json
[model-fetch] POST http://127.0.0.1:<mock-port>/v1/responses
[model-fetch] response status=200
"finalAssistantVisibleText": "PR_105922_MODEL_PATH_OK"
```

The repository mock OpenAI HTTP server captured the actual `/v1/responses` payload emitted by the production plugin loader, embedded agent runtime, tool policy, OpenAI Responses projection, and provider transport. Only the remote model response was mocked; tool registration and model-facing request construction were real.

Redacted extraction of the registered tool from that one captured request:

```json
{
  "type": "function",
  "name": "pr_105922_schema_probe",
  "parameters": {
    "type": "object",
    "properties": {
      "canonicalOne": { "type": "number" },
      "noncanonicalHex": { "$ref": "#/$defs/Choice/anyOf/0x1" },
      "escapedObjectKey": { "type": "boolean" }
    }
  }
}
```

This proves the real model-facing payload still resolves canonical array index `1`, leaves noncanonical `0x1` unresolved instead of exposing the wrong `number` branch, and preserves escaped object-key resolution.

### Focused regression and static checks

- Before fix on current main: `node scripts/run-vitest.mjs src/agents/agent-tools.schema.test.ts` failed because `#/$defs/Choice/anyOf/0x1` became `{ type: "number" }` (45 passed, 1 failed).
- Blacksmith Testbox run [29266838390](https://github.com/openclaw/openclaw/actions/runs/29266838390): all 46 focused tests passed; changed gates passed after the LOC-neutral refactor.
- Maintainer coverage adds rejected `+0`, `-0`, empty, and whitespace array tokens alongside canonical `0`/`1`, rejected `0x1`/`1e0`/`01`, and the escaped object-key control.
- `pnpm format:check -- packages/ai/src/providers/agent-tools-parameter-schema.ts src/agents/agent-tools.schema.test.ts`
- `git diff --check`
- Fresh maintainer autoreview of the final tree: clean, no accepted/actionable findings; correctness confidence 0.99.
- Exact-head CI: [run 29272339992](https://github.com/openclaw/openclaw/actions/runs/29272339992) (maintainer-approved; final result is the merge gate).

No external provider credential or user state was used; the proof ran with an isolated state directory and a dummy key accepted only by the local mock endpoint.

## Release-note context

Fixes local tool-schema refs so noncanonical array tokens cannot silently select another schema branch. Thanks @wahaha1223.

## Risk / Compatibility

Low. Only noncanonical local `$ref` array tokens change behavior; canonical indices and object-key JSON Pointer escaping remain unchanged.
