### PR TITLE
refactor: standardize test HTTP mocking on MockAgent

### DIFF
--- a/src/infra/clawhub.promotions.test.ts
+++ b/src/infra/clawhub.promotions.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
+import { useMockHttp } from "../test-utils/mock-http.js";
 import {
   fetchClawHubPromotion,
   fetchClawHubPromotions,
@@ -6,6 +7,9 @@ import {
   parseClawHubPromotion,
   parseClawHubPromotionsFeed,
 } from "./clawhub.js";
+
+const CLAWHUB_URL = "https://clawhub.ai";
+const mockHttp = useMockHttp();
 
 const validPromotion = {
   slug: "spring-models",
@@ -20,13 +24,6 @@ const validPromotion = {
   models: [{ modelRef: "openrouter/example/model-alpha", alias: "Alpha", suggestedDefault: true }],
   signupUrl: "https://signup.example.com",
 };
-
-function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}) {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "content-type": "application/json", ...headers },
-  });
-}
 
 describe("parseClawHubPromotion", () => {
   it("parses a full promotion payload", () => {
@@ -92,24 +89,29 @@ describe("parseClawHubPromotion", () => {
 
 describe("promotion fetches", () => {
   it("fetches and validates the active promotions list", async () => {
-    const fetchImpl = vi.fn(async (..._args: unknown[]) =>
-      jsonResponse({ promotions: [validPromotion] }),
-    );
-    const promotions = await fetchClawHubPromotions({ fetchImpl });
+    mockHttp.intercept({
+      url: `${CLAWHUB_URL}/api/v1/promotions`,
+      reply: { json: { promotions: [validPromotion] } },
+    });
+    const promotions = await fetchClawHubPromotions();
     expect(promotions).toHaveLength(1);
-    expect(String(fetchImpl.mock.calls[0]?.[0])).toContain("/api/v1/promotions");
   });
 
   it("rejects a list response without a promotions array", async () => {
-    const fetchImpl = vi.fn(async (..._args: unknown[]) => jsonResponse({ nope: true }));
-    await expect(fetchClawHubPromotions({ fetchImpl })).rejects.toThrow(/promotions array/);
+    mockHttp.intercept({
+      url: `${CLAWHUB_URL}/api/v1/promotions`,
+      reply: { json: { nope: true } },
+    });
+    await expect(fetchClawHubPromotions()).rejects.toThrow(/promotions array/);
   });
 
   it("fetches a single promotion by slug", async () => {
-    const fetchImpl = vi.fn(async (..._args: unknown[]) => jsonResponse(validPromotion));
-    const promotion = await fetchClawHubPromotion({ slug: "spring-models", fetchImpl });
+    mockHttp.intercept({
+      url: `${CLAWHUB_URL}/api/v1/promotions/spring-models`,
+      reply: { json: validPromotion },
+    });
+    const promotion = await fetchClawHubPromotion({ slug: "spring-models" });
     expect(promotion.title).toBe("Free Example models");
-    expect(String(fetchImpl.mock.calls[0]?.[0])).toContain("/api/v1/promotions/spring-models");
   });
 });
 
@@ -169,33 +171,41 @@ describe("parseClawHubPromotionsFeed", () => {
 
 describe("fetchClawHubPromotionsFeed", () => {
   it("fetches without auth, returns the parsed feed and etag", async () => {
-    const fetchImpl = vi.fn(async (..._args: unknown[]) =>
-      jsonResponse(validFeed, 200, { etag: '"seq-3"' }),
-    );
-    const result = await fetchClawHubPromotionsFeed({ fetchImpl });
+    mockHttp.intercept({
+      url: `${CLAWHUB_URL}/api/v1/feeds/promotions`,
+      requestHeaders: (headers) =>
+        !Object.keys(headers).some((name) => name.toLowerCase() === "authorization"),
+      reply: { json: validFeed, headers: { etag: '"seq-3"' } },
+    });
+    const result = await fetchClawHubPromotionsFeed();
     expect(result.status).toBe("ok");
     if (result.status === "ok") {
       expect(result.feed.sequence).toBe(3);
       expect(result.etag).toBe('"seq-3"');
     }
-    expect(String(fetchImpl.mock.calls[0]?.[0])).toContain("/api/v1/feeds/promotions");
-    const init = fetchImpl.mock.calls[0]?.[1] as RequestInit;
-    expect(new Headers(init?.headers).get("authorization")).toBeNull();
   });
 
   it("sends If-None-Match and maps 304 to not-modified", async () => {
-    const fetchImpl = vi.fn(async (..._args: unknown[]) => new Response(null, { status: 304 }));
-    const result = await fetchClawHubPromotionsFeed({ etag: '"seq-3"', fetchImpl });
+    mockHttp.intercept({
+      url: `${CLAWHUB_URL}/api/v1/feeds/promotions`,
+      requestHeaders: { "if-none-match": '"seq-3"' },
+      reply: { status: 304 },
+    });
+    const result = await fetchClawHubPromotionsFeed({ etag: '"seq-3"' });
     expect(result.status).toBe("not-modified");
-    const init = fetchImpl.mock.calls[0]?.[1] as RequestInit;
-    expect(new Headers(init?.headers).get("if-none-match")).toBe('"seq-3"');
   });
 
   it("does not extend the interactive feed timeout with transient retries", async () => {
-    const fetchImpl = vi.fn().mockRejectedValue(new Error("offline"));
+    mockHttp.intercept({
+      url: `${CLAWHUB_URL}/api/v1/feeds/promotions`,
+      reply: new Error("offline"),
+    });
 
-    await expect(fetchClawHubPromotionsFeed({ fetchImpl })).rejects.toThrow("offline");
+    await expect(fetchClawHubPromotionsFeed()).rejects.toMatchObject({
+      message: "fetch failed",
+      cause: expect.objectContaining({ message: "offline" }),
+    });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(mockHttp.requests()).toHaveLength(1);
   });
 });

--- a/src/infra/promotions-feed.test.ts
+++ b/src/infra/promotions-feed.test.ts
@@ -1,11 +1,12 @@
 // Covers the promotions feed cache: refresh cadence, 304 revalidation,
 // sequence monotonicity, notified markers, and claim provenance.
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
+import { useMockHttp } from "../test-utils/mock-http.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -21,6 +22,8 @@ import {
 } from "./promotions-feed.js";
 
 const NOW = Date.parse("2026-07-05T12:00:00.000Z");
+const FEED_URL = "https://clawhub.ai/api/v1/feeds/promotions";
+const mockHttp = useMockHttp();
 
 function feedPayload(overrides: Record<string, unknown> = {}) {
   return {
@@ -46,16 +49,6 @@ function feedPayload(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function feedResponse(body: unknown, init: { status?: number; etag?: string } = {}) {
-  return new Response(init.status === 304 ? null : JSON.stringify(body), {
-    status: init.status ?? 200,
-    headers: {
-      "content-type": "application/json",
-      ...(init.etag ? { etag: init.etag } : {}),
-    },
-  });
-}
-
 describe("promotions feed state", () => {
   let testState: OpenClawTestState;
 
@@ -72,9 +65,12 @@ describe("promotions feed state", () => {
   });
 
   it("caches a fetched snapshot and round-trips it from storage", async () => {
-    const fetchImpl = vi.fn(async () => feedResponse(feedPayload(), { etag: '"v4"' }));
-    const state = await maybeRefreshPromotionsFeed({ nowMs: NOW, fetchImpl });
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    mockHttp.intercept({
+      url: FEED_URL,
+      reply: { json: feedPayload(), headers: { etag: '"v4"' } },
+    });
+    const state = await maybeRefreshPromotionsFeed({ nowMs: NOW, fetchImpl: globalThis.fetch });
+    expect(mockHttp.requests()).toHaveLength(1);
     expect(state.sequence).toBe(4);
     expect(state.etag).toBe('"v4"');
     expect(state.expiresAtMs).toBe(Date.parse("2026-07-06T00:00:00.000Z"));
@@ -89,83 +85,117 @@ describe("promotions feed state", () => {
   });
 
   it("skips the network while the last check is fresh", async () => {
-    const fetchImpl = vi.fn(async () => feedResponse(feedPayload()));
-    await maybeRefreshPromotionsFeed({ nowMs: NOW, fetchImpl });
-    const second = await maybeRefreshPromotionsFeed({ nowMs: NOW + 60_000, fetchImpl });
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    mockHttp.intercept({ url: FEED_URL, reply: { json: feedPayload() } });
+    await maybeRefreshPromotionsFeed({ nowMs: NOW, fetchImpl: globalThis.fetch });
+    const second = await maybeRefreshPromotionsFeed({
+      nowMs: NOW + 60_000,
+      fetchImpl: globalThis.fetch,
+    });
+    expect(mockHttp.requests()).toHaveLength(1);
     expect(second.entries).toHaveLength(1);
   });
 
   it("refreshes at feed expiry and keeps an expired 304 snapshot hidden without retrying", async () => {
     const expiresAt = new Date(NOW + 60_000).toISOString();
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(feedResponse(feedPayload({ expiresAt }), { etag: '"v4"' }))
-      .mockResolvedValueOnce(feedResponse(null, { status: 304 }));
-    await maybeRefreshPromotionsFeed({ nowMs: NOW, fetchImpl });
+    mockHttp.intercept({
+      url: FEED_URL,
+      reply: { json: feedPayload({ expiresAt }), headers: { etag: '"v4"' } },
+    });
+    mockHttp.intercept({ url: FEED_URL, reply: { status: 304 } });
+    await maybeRefreshPromotionsFeed({ nowMs: NOW, fetchImpl: globalThis.fetch });
 
-    const expired = await maybeRefreshPromotionsFeed({ nowMs: NOW + 60_000, fetchImpl });
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const expired = await maybeRefreshPromotionsFeed({
+      nowMs: NOW + 60_000,
+      fetchImpl: globalThis.fetch,
+    });
+    expect(mockHttp.requests()).toHaveLength(2);
     expect(listLivePromotionEntries(expired, NOW + 60_000)).toHaveLength(0);
 
-    const cached = await maybeRefreshPromotionsFeed({ nowMs: NOW + 61_000, fetchImpl });
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const cached = await maybeRefreshPromotionsFeed({
+      nowMs: NOW + 61_000,
+      fetchImpl: globalThis.fetch,
+    });
+    expect(mockHttp.requests()).toHaveLength(2);
     expect(listLivePromotionEntries(cached, NOW + 61_000)).toHaveLength(0);
   });
 
   it("keeps an expired snapshot hidden after a failed expiry refresh without retrying", async () => {
     const expiresAt = new Date(NOW + 60_000).toISOString();
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(feedResponse(feedPayload({ expiresAt })))
-      .mockRejectedValueOnce(new Error("offline"));
-    await maybeRefreshPromotionsFeed({ nowMs: NOW, fetchImpl });
+    mockHttp.intercept({ url: FEED_URL, reply: { json: feedPayload({ expiresAt }) } });
+    mockHttp.intercept({ url: FEED_URL, reply: new Error("offline") });
+    await maybeRefreshPromotionsFeed({ nowMs: NOW, fetchImpl: globalThis.fetch });
 
-    const expired = await maybeRefreshPromotionsFeed({ nowMs: NOW + 60_000, fetchImpl });
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const expired = await maybeRefreshPromotionsFeed({
+      nowMs: NOW + 60_000,
+      fetchImpl: globalThis.fetch,
+    });
+    expect(mockHttp.requests()).toHaveLength(2);
     expect(listLivePromotionEntries(expired, NOW + 60_000)).toHaveLength(0);
 
-    const cached = await maybeRefreshPromotionsFeed({ nowMs: NOW + 61_000, fetchImpl });
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const cached = await maybeRefreshPromotionsFeed({
+      nowMs: NOW + 61_000,
+      fetchImpl: globalThis.fetch,
+    });
+    expect(mockHttp.requests()).toHaveLength(2);
     expect(listLivePromotionEntries(cached, NOW + 61_000)).toHaveLength(0);
   });
 
   it("replaces an expired snapshot when ClawHub publishes a newer sequence", async () => {
     const firstExpiry = new Date(NOW + 60_000).toISOString();
     const nextExpiry = new Date(NOW + 86_400_000).toISOString();
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(feedResponse(feedPayload({ expiresAt: firstExpiry, sequence: 4 })))
-      .mockResolvedValueOnce(feedResponse(feedPayload({ expiresAt: nextExpiry, sequence: 5 })));
-    await maybeRefreshPromotionsFeed({ nowMs: NOW, fetchImpl });
+    mockHttp.intercept({
+      url: FEED_URL,
+      reply: { json: feedPayload({ expiresAt: firstExpiry, sequence: 4 }) },
+    });
+    mockHttp.intercept({
+      url: FEED_URL,
+      reply: { json: feedPayload({ expiresAt: nextExpiry, sequence: 5 }) },
+    });
+    await maybeRefreshPromotionsFeed({ nowMs: NOW, fetchImpl: globalThis.fetch });
 
-    const refreshed = await maybeRefreshPromotionsFeed({ nowMs: NOW + 60_000, fetchImpl });
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const refreshed = await maybeRefreshPromotionsFeed({
+      nowMs: NOW + 60_000,
+      fetchImpl: globalThis.fetch,
+    });
+    expect(mockHttp.requests()).toHaveLength(2);
     expect(refreshed.sequence).toBe(5);
     expect(refreshed.expiresAtMs).toBe(Date.parse(nextExpiry));
     expect(listLivePromotionEntries(refreshed, NOW + 60_000)).toHaveLength(1);
   });
 
   it("revalidates with If-None-Match and keeps the cache on 304", async () => {
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(feedResponse(feedPayload(), { etag: '"v4"' }))
-      .mockResolvedValueOnce(feedResponse(null, { status: 304 }));
-    await maybeRefreshPromotionsFeed({ nowMs: NOW, fetchImpl });
-    const state = await maybeRefreshPromotionsFeed({ nowMs: NOW + 60_000, force: true, fetchImpl });
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
-    const secondInit = fetchImpl.mock.calls[1]?.[1] as RequestInit;
-    expect(new Headers(secondInit.headers).get("if-none-match")).toBe('"v4"');
+    mockHttp.intercept({
+      url: FEED_URL,
+      reply: { json: feedPayload(), headers: { etag: '"v4"' } },
+    });
+    mockHttp.intercept({
+      url: FEED_URL,
+      requestHeaders: { "if-none-match": '"v4"' },
+      reply: { status: 304 },
+    });
+    await maybeRefreshPromotionsFeed({ nowMs: NOW, fetchImpl: globalThis.fetch });
+    const state = await maybeRefreshPromotionsFeed({
+      nowMs: NOW + 60_000,
+      force: true,
+      fetchImpl: globalThis.fetch,
+    });
+    expect(mockHttp.requests()).toHaveLength(2);
     expect(state.entries).toHaveLength(1);
     expect(readPromotionsFeedState().lastCheckedAtMs).toBe(NOW + 60_000);
   });
 
   it("drops a stale validator when the cached payload is invalid", async () => {
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(feedResponse(feedPayload(), { etag: '"v4"' }))
-      .mockResolvedValueOnce(feedResponse(feedPayload({ sequence: 5 }), { etag: '"v5"' }));
-    await maybeRefreshPromotionsFeed({ nowMs: NOW, fetchImpl });
+    mockHttp.intercept({
+      url: FEED_URL,
+      reply: { json: feedPayload(), headers: { etag: '"v4"' } },
+    });
+    mockHttp.intercept({
+      url: FEED_URL,
+      requestHeaders: (headers) =>
+        !Object.keys(headers).some((name) => name.toLowerCase() === "if-none-match"),
+      reply: { json: feedPayload({ sequence: 5 }), headers: { etag: '"v5"' } },
+    });
+    await maybeRefreshPromotionsFeed({ nowMs: NOW, fetchImpl: globalThis.fetch });
     runOpenClawStateWriteTransaction(({ db }) => {
       const kysely =
         getNodeSqliteKysely<Pick<OpenClawStateKyselyDatabase, "clawhub_promotions_feed_state">>(db);
@@ -180,34 +210,39 @@ describe("promotions feed state", () => {
 
     const state = await maybeRefreshPromotionsFeed({
       nowMs: NOW + 60_000,
-      fetchImpl,
+      fetchImpl: globalThis.fetch,
     });
 
-    const secondInit = fetchImpl.mock.calls[1]?.[1] as RequestInit;
-    expect(new Headers(secondInit.headers).get("if-none-match")).toBeNull();
     expect(state.sequence).toBe(5);
     expect(state.etag).toBe('"v5"');
     expect(state.entries).toHaveLength(1);
   });
 
   it("never replaces the cache with an older snapshot sequence", async () => {
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(feedResponse(feedPayload({ sequence: 4 })))
-      .mockResolvedValueOnce(feedResponse(feedPayload({ sequence: 2, entries: [] })));
-    await maybeRefreshPromotionsFeed({ nowMs: NOW, fetchImpl });
-    const state = await maybeRefreshPromotionsFeed({ nowMs: NOW + 60_000, force: true, fetchImpl });
+    mockHttp.intercept({ url: FEED_URL, reply: { json: feedPayload({ sequence: 4 }) } });
+    mockHttp.intercept({
+      url: FEED_URL,
+      reply: { json: feedPayload({ sequence: 2, entries: [] }) },
+    });
+    await maybeRefreshPromotionsFeed({ nowMs: NOW, fetchImpl: globalThis.fetch });
+    const state = await maybeRefreshPromotionsFeed({
+      nowMs: NOW + 60_000,
+      force: true,
+      fetchImpl: globalThis.fetch,
+    });
     expect(state.sequence).toBe(4);
     expect(state.entries).toHaveLength(1);
   });
 
   it("fails silent on network errors and keeps the cached snapshot", async () => {
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(feedResponse(feedPayload()))
-      .mockRejectedValueOnce(new Error("offline"));
-    await maybeRefreshPromotionsFeed({ nowMs: NOW, fetchImpl });
-    const state = await maybeRefreshPromotionsFeed({ nowMs: NOW + 60_000, force: true, fetchImpl });
+    mockHttp.intercept({ url: FEED_URL, reply: { json: feedPayload() } });
+    mockHttp.intercept({ url: FEED_URL, reply: new Error("offline") });
+    await maybeRefreshPromotionsFeed({ nowMs: NOW, fetchImpl: globalThis.fetch });
+    const state = await maybeRefreshPromotionsFeed({
+      nowMs: NOW + 60_000,
+      force: true,
+      fetchImpl: globalThis.fetch,
+    });
     expect(state.entries).toHaveLength(1);
     // The failed attempt still stamps the check time so offline runs do not
     // retry on every command.

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
+import { useMockHttp } from "../test-utils/mock-http.js";
 import {
   checkDepsStatus,
   checkUpdateStatus,
@@ -18,6 +19,12 @@ import {
   resolveExtendedStablePackage,
   resolveNpmChannelTag,
 } from "./update-check.js";
+
+const mockHttp = useMockHttp();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("compareSemverStrings", () => {
   it("handles stable and prerelease precedence for both legacy and beta formats", () => {
@@ -73,10 +80,6 @@ describe("resolveNpmChannelTag", () => {
       };
     });
     runCommand = runCommandMock as unknown as NpmMetadataCommandRunner;
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
   });
 
   it("delegates package target metadata to npm view with global config scope", async () => {
@@ -196,19 +199,15 @@ describe("resolveNpmChannelTag", () => {
   });
 
   it("uses the public registry when no npm command is available", async () => {
-    const fetch = vi.fn(async () => {
-      return new Response(
-        JSON.stringify({
+    mockHttp.intercept({
+      url: "https://registry.npmjs.org/openclaw/latest",
+      reply: {
+        json: {
           version: "2026.6.8",
           engines: { node: ">=22.19.0" },
-        }),
-        {
-          status: 200,
-          headers: { "content-type": "application/json" },
         },
-      );
+      },
     });
-    vi.stubGlobal("fetch", fetch);
 
     await expect(
       fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 1000 }),
@@ -217,18 +216,14 @@ describe("resolveNpmChannelTag", () => {
       version: "2026.6.8",
       nodeEngine: ">=22.19.0",
     });
-    expect(fetch).toHaveBeenCalledWith(
-      "https://registry.npmjs.org/openclaw/latest",
-      expect.objectContaining({ signal: expect.any(AbortSignal) }),
-    );
   });
 
   it("cancels public registry HTTP failure bodies", async () => {
-    const cancel = vi.fn(async () => undefined);
-    const fetch = vi.fn(
-      async () => ({ ok: false, status: 503, body: { cancel } }) as unknown as Response,
-    );
-    vi.stubGlobal("fetch", fetch);
+    const cancel = vi.spyOn(ReadableStream.prototype, "cancel");
+    mockHttp.intercept({
+      url: "https://registry.npmjs.org/openclaw/latest",
+      reply: { status: 503, body: "unavailable" },
+    });
 
     await expect(
       fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 1000 }),
@@ -243,19 +238,13 @@ describe("resolveNpmChannelTag", () => {
 
   it("returns error on oversized public registry response exceeding 16 MiB", async () => {
     const ONE_MIB = 1024 * 1024;
-    const fetch = vi.fn(async () => {
-      const oversizedBody = new Uint8Array(16 * ONE_MIB + 1).fill(0x41);
-      return new Response(
-        new ReadableStream({
-          start(controller) {
-            controller.enqueue(oversizedBody);
-            controller.close();
-          },
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      );
+    mockHttp.intercept({
+      url: "https://registry.npmjs.org/openclaw/latest",
+      reply: {
+        body: Buffer.alloc(16 * ONE_MIB + 1, 0x41),
+        headers: { "content-type": "application/json" },
+      },
     });
-    vi.stubGlobal("fetch", fetch);
 
     const result = await fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 5000 });
     expect(result.version).toBeNull();
@@ -269,13 +258,10 @@ describe("resolveNpmChannelTag", () => {
     const innerLen = targetSize - 14; // '{"version":"'.length(12) + '"}"'.length(2)
     const body = `{"version":"${"0".repeat(innerLen)}"}`;
 
-    const fetch = vi.fn(async () => {
-      return new Response(body, {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
+    mockHttp.intercept({
+      url: "https://registry.npmjs.org/openclaw/latest",
+      reply: { body, headers: { "content-type": "application/json" } },
     });
-    vi.stubGlobal("fetch", fetch);
 
     const result = await fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 5000 });
     // The version field is a giant string — it exists, confirming parse succeeded
@@ -285,13 +271,13 @@ describe("resolveNpmChannelTag", () => {
   });
 
   it("returns error on malformed JSON from registry", async () => {
-    const fetch = vi.fn(async () => {
-      return new Response("not-json-at-all{{{", {
-        status: 200,
+    mockHttp.intercept({
+      url: "https://registry.npmjs.org/openclaw/latest",
+      reply: {
+        body: "not-json-at-all{{{",
         headers: { "content-type": "application/json" },
-      });
+      },
     });
-    vi.stubGlobal("fetch", fetch);
 
     const result = await fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 1000 });
     expect(result.version).toBeNull();
@@ -299,13 +285,10 @@ describe("resolveNpmChannelTag", () => {
   });
 
   it("returns error on non-200 status from registry", async () => {
-    const fetch = vi.fn(async () => {
-      return new Response(null, {
-        status: 404,
-        headers: { "content-type": "application/json" },
-      });
+    mockHttp.intercept({
+      url: "https://registry.npmjs.org/openclaw/latest",
+      reply: { status: 404 },
     });
-    vi.stubGlobal("fetch", fetch);
 
     const result = await fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 1000 });
     expect(result.version).toBeNull();
@@ -414,26 +397,15 @@ describe("resolveNpmChannelTag", () => {
 });
 
 describe("resolveExtendedStablePackage", () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
   it("resolves and verifies an exact public package without falling back", async () => {
-    const fetch = vi
-      .fn()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ version: "2026.6.33" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ version: "2026.6.33" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      );
-    vi.stubGlobal("fetch", fetch);
+    mockHttp.intercept({
+      url: "https://registry.npmjs.org/openclaw/extended-stable",
+      reply: { json: { version: "2026.6.33" } },
+    });
+    mockHttp.intercept({
+      url: "https://registry.npmjs.org/openclaw/2026.6.33",
+      reply: { json: { version: "2026.6.33" } },
+    });
 
     await expect(
       resolveExtendedStablePackage({ installKind: "package", timeoutMs: 1000, env: {} }),
@@ -443,28 +415,17 @@ describe("resolveExtendedStablePackage", () => {
       version: "2026.6.33",
       packageSpec: "openclaw@2026.6.33",
     });
-    expect(fetch.mock.calls.map((call) => call[0])).toEqual([
-      "https://registry.npmjs.org/openclaw/extended-stable",
-      "https://registry.npmjs.org/openclaw/2026.6.33",
-    ]);
   });
 
   it("supports an explicit scoped-package override on a loopback test registry", async () => {
-    const fetch = vi
-      .fn()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ version: "2000.4.34" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ version: "2000.4.34" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      );
-    vi.stubGlobal("fetch", fetch);
+    mockHttp.intercept({
+      url: "http://127.0.0.1:4873/%40kevins8%2Fopenclaw/extended-stable",
+      reply: { json: { version: "2000.4.34" } },
+    });
+    mockHttp.intercept({
+      url: "http://127.0.0.1:4873/%40kevins8%2Fopenclaw/2000.4.34",
+      reply: { json: { version: "2000.4.34" } },
+    });
 
     await expect(
       resolveExtendedStablePackage({
@@ -482,28 +443,17 @@ describe("resolveExtendedStablePackage", () => {
       version: "2000.4.34",
       packageSpec: "@kevins8/openclaw@2000.4.34",
     });
-    expect(fetch.mock.calls.map((call) => call[0])).toEqual([
-      "http://127.0.0.1:4873/%40kevins8%2Fopenclaw/extended-stable",
-      "http://127.0.0.1:4873/%40kevins8%2Fopenclaw/2000.4.34",
-    ]);
   });
 
   it("ignores package overrides that do not use a loopback registry", async () => {
-    const fetch = vi
-      .fn()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ version: "2026.6.33" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ version: "2026.6.33" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      );
-    vi.stubGlobal("fetch", fetch);
+    mockHttp.intercept({
+      url: "https://registry.npmjs.org/openclaw/extended-stable",
+      reply: { json: { version: "2026.6.33" } },
+    });
+    mockHttp.intercept({
+      url: "https://registry.npmjs.org/openclaw/2026.6.33",
+      reply: { json: { version: "2026.6.33" } },
+    });
 
     await expect(
       resolveExtendedStablePackage({
@@ -519,71 +469,53 @@ describe("resolveExtendedStablePackage", () => {
       status: "resolved",
       packageSpec: "openclaw@2026.6.33",
     });
-    expect(fetch.mock.calls.map((call) => call[0])).toEqual([
-      "https://registry.npmjs.org/openclaw/extended-stable",
-      "https://registry.npmjs.org/openclaw/2026.6.33",
-    ]);
   });
 
   it("returns selector_missing for an absent public selector", async () => {
-    const fetch = vi.fn(async () => new Response("not found", { status: 404 }));
-    vi.stubGlobal("fetch", fetch);
+    mockHttp.intercept({
+      url: "https://registry.npmjs.org/openclaw/extended-stable",
+      reply: { status: 404, body: "not found" },
+    });
 
     await expect(
       resolveExtendedStablePackage({ installKind: "package", timeoutMs: 1000 }),
     ).resolves.toEqual({ status: "failed", reason: "selector_missing" });
-    expect(fetch).toHaveBeenCalledTimes(1);
   });
 
   it("returns selector_query_failed for unusable selector metadata", async () => {
-    const fetch = vi.fn(
-      async () =>
-        new Response("{", {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-    );
-    vi.stubGlobal("fetch", fetch);
+    mockHttp.intercept({
+      url: "https://registry.npmjs.org/openclaw/extended-stable",
+      reply: { body: "{", headers: { "content-type": "application/json" } },
+    });
 
     await expect(
       resolveExtendedStablePackage({ installKind: "package", timeoutMs: 1000 }),
     ).resolves.toEqual({ status: "failed", reason: "selector_query_failed" });
-    expect(fetch).toHaveBeenCalledTimes(1);
   });
 
   it("returns exact_package_mismatch when exact readback differs", async () => {
-    const fetch = vi
-      .fn()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ version: "2026.6.33" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ version: "2026.6.34" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      );
-    vi.stubGlobal("fetch", fetch);
+    mockHttp.intercept({
+      url: "https://registry.npmjs.org/openclaw/extended-stable",
+      reply: { json: { version: "2026.6.33" } },
+    });
+    mockHttp.intercept({
+      url: "https://registry.npmjs.org/openclaw/2026.6.33",
+      reply: { json: { version: "2026.6.34" } },
+    });
 
     await expect(
       resolveExtendedStablePackage({ installKind: "package", timeoutMs: 1000 }),
     ).resolves.toEqual({ status: "failed", reason: "exact_package_mismatch" });
-    expect(fetch.mock.calls.map((call) => String(call[0]))).not.toContain(
+    expect(mockHttp.requests().map((request) => request.fullUrl)).not.toContain(
       "https://registry.npmjs.org/openclaw/latest",
     );
   });
 
   it("rejects Git installs before making a registry request", async () => {
-    const fetch = vi.fn();
-    vi.stubGlobal("fetch", fetch);
-
     await expect(
       resolveExtendedStablePackage({ installKind: "git", timeoutMs: 1000 }),
     ).resolves.toEqual({ status: "failed", reason: "unsupported_git_channel" });
-    expect(fetch).not.toHaveBeenCalled();
+    expect(mockHttp.requests()).toHaveLength(0);
   });
 });
 
@@ -784,27 +716,21 @@ describe("checkUpdateStatus", () => {
         "utf8",
       );
       await runCommandWithTimeout(["git", "init"], { cwd: root, timeoutMs: 1000 });
-      const fetch = vi.fn();
-      vi.stubGlobal("fetch", fetch);
-      try {
-        const status = await checkUpdateStatus({
-          root,
-          includeRegistry: true,
-          registryChannel: "extended-stable",
-          fetchGit: false,
-          timeoutMs: 1000,
-        });
+      const status = await checkUpdateStatus({
+        root,
+        includeRegistry: true,
+        registryChannel: "extended-stable",
+        fetchGit: false,
+        timeoutMs: 1000,
+      });
 
-        expect(status.registry).toEqual({
-          latestVersion: null,
-          tag: "extended-stable",
-          error: "unsupported_git_channel",
-          reason: "unsupported_git_channel",
-        });
-        expect(fetch).not.toHaveBeenCalled();
-      } finally {
-        vi.unstubAllGlobals();
-      }
+      expect(status.registry).toEqual({
+        latestVersion: null,
+        tag: "extended-stable",
+        error: "unsupported_git_channel",
+        reason: "unsupported_git_channel",
+      });
+      expect(mockHttp.requests()).toHaveLength(0);
     });
   });
 });

--- a/src/test-utils/mock-http.test.ts
+++ b/src/test-utils/mock-http.test.ts
@@ -1,0 +1,75 @@
+import { getGlobalDispatcher, request } from "undici";
+import { describe, expect, it } from "vitest";
+import { createMockHttp, useMockHttp } from "./mock-http.js";
+
+describe("useMockHttp", () => {
+  const mockHttp = useMockHttp();
+
+  it("routes Node global fetch through the mock dispatcher", async () => {
+    mockHttp.intercept({
+      url: "https://example.test/global-fetch",
+      reply: { json: { source: "global-fetch" } },
+    });
+
+    const response = await globalThis.fetch("https://example.test/global-fetch");
+
+    await expect(response.json()).resolves.toEqual({ source: "global-fetch" });
+  });
+
+  it("matches undici requests by URL, method, headers, and body", async () => {
+    mockHttp.intercept({
+      url: "https://example.test/undici-request?mode=test",
+      method: "POST",
+      requestHeaders: { "content-type": "application/json" },
+      requestBody: JSON.stringify({ ready: true }),
+      reply: { status: 201, body: "created" },
+    });
+
+    const response = await request("https://example.test/undici-request?mode=test", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ready: true }),
+    });
+
+    expect(response.statusCode).toBe(201);
+    await expect(response.body.text()).resolves.toBe("created");
+  });
+
+  it("returns per-request replies in registration order", async () => {
+    mockHttp.intercept({
+      url: "https://example.test/sequence",
+      reply: { json: { sequence: 1 } },
+    });
+    mockHttp.intercept({
+      url: "https://example.test/sequence",
+      reply: { json: { sequence: 2 } },
+    });
+
+    const first = await globalThis.fetch("https://example.test/sequence");
+    const second = await globalThis.fetch("https://example.test/sequence");
+
+    await expect(first.json()).resolves.toEqual({ sequence: 1 });
+    await expect(second.json()).resolves.toEqual({ sequence: 2 });
+    expect(mockHttp.requests().map((entry) => entry.fullUrl)).toEqual([
+      "https://example.test/sequence",
+      "https://example.test/sequence",
+    ]);
+  });
+});
+
+describe("createMockHttp", () => {
+  it("reports unused interceptors while restoring the previous dispatcher", async () => {
+    const previousDispatcher = getGlobalDispatcher();
+    const previousFetch = globalThis.fetch;
+    const mockHttp = createMockHttp();
+    mockHttp.setup();
+    mockHttp.intercept({
+      url: "https://example.test/unused",
+      reply: { status: 204 },
+    });
+
+    await expect(mockHttp.cleanup()).rejects.toThrow(/interceptor is pending/);
+    expect(getGlobalDispatcher()).toBe(previousDispatcher);
+    expect(globalThis.fetch).toBe(previousFetch);
+  });
+});

--- a/src/test-utils/mock-http.ts
+++ b/src/test-utils/mock-http.ts
@@ -1,0 +1,139 @@
+import {
+  fetch as undiciFetch,
+  getGlobalDispatcher,
+  MockAgent,
+  type MockCallHistoryLog,
+  setGlobalDispatcher,
+} from "undici";
+import { afterEach, beforeEach } from "vitest";
+
+type MockHttpValueMatcher = string | RegExp | ((value: string) => boolean);
+type MockHttpHeaderMatcher =
+  | Record<string, MockHttpValueMatcher>
+  | ((headers: Record<string, string>) => boolean);
+type MockHttpHeaders = Record<string, string | string[]>;
+type MockHttpBody = string | Buffer | Uint8Array | ArrayBuffer;
+
+export type MockHttpReply =
+  | {
+      status?: number;
+      body?: MockHttpBody;
+      json?: never;
+      headers?: MockHttpHeaders;
+    }
+  | {
+      status?: number;
+      body?: never;
+      json: unknown;
+      headers?: MockHttpHeaders;
+    };
+
+export type MockHttpInterceptor = {
+  url: string | URL;
+  method?: string;
+  requestBody?: MockHttpValueMatcher;
+  requestHeaders?: MockHttpHeaderMatcher;
+  reply: MockHttpReply | Error;
+  times?: number;
+};
+
+export type MockHttp = {
+  setup: () => void;
+  intercept: (params: MockHttpInterceptor) => void;
+  requests: () => MockCallHistoryLog[];
+  cleanup: () => Promise<void>;
+};
+
+function replyHeaders(reply: MockHttpReply): MockHttpHeaders {
+  const headers = { ...reply.headers };
+  if (
+    "json" in reply &&
+    !Object.keys(headers).some((name) => name.toLowerCase() === "content-type")
+  ) {
+    headers["content-type"] = "application/json";
+  }
+  return headers;
+}
+
+/** Creates an explicit lifecycle for tests that cannot use Vitest hooks. */
+export function createMockHttp(): MockHttp {
+  let agent: MockAgent | undefined;
+  let previousDispatcher: ReturnType<typeof getGlobalDispatcher> | undefined;
+  let previousFetch: typeof globalThis.fetch | undefined;
+
+  const requireAgent = (): MockAgent => {
+    if (!agent) {
+      throw new Error("Mock HTTP is not set up for this test");
+    }
+    return agent;
+  };
+
+  return {
+    setup() {
+      if (agent) {
+        throw new Error("Mock HTTP is already set up for this test");
+      }
+      previousDispatcher = getGlobalDispatcher();
+      previousFetch = globalThis.fetch;
+      agent = new MockAgent({ enableCallHistory: true });
+      agent.disableNetConnect();
+      setGlobalDispatcher(agent);
+      // Node's DOM fetch type and root undici's fetch type use different iterator declarations.
+      globalThis.fetch = undiciFetch as unknown as typeof globalThis.fetch;
+    },
+    intercept(params) {
+      const currentAgent = requireAgent();
+      const url = new URL(params.url);
+      if (url.hash) {
+        throw new Error(`Mock HTTP URLs cannot include fragments: ${url.toString()}`);
+      }
+      const interceptor = currentAgent.get(url.origin).intercept({
+        path: `${url.pathname}${url.search}`,
+        method: params.method ?? "GET",
+        ...(params.requestBody === undefined ? {} : { body: params.requestBody }),
+        ...(params.requestHeaders === undefined ? {} : { headers: params.requestHeaders }),
+      });
+      const scope =
+        params.reply instanceof Error
+          ? interceptor.replyWithError(params.reply)
+          : interceptor.reply(
+              params.reply.status ?? 200,
+              "json" in params.reply ? JSON.stringify(params.reply.json) : params.reply.body,
+              { headers: replyHeaders(params.reply) },
+            );
+      if (params.times !== undefined) {
+        scope.times(params.times);
+      }
+    },
+    requests() {
+      return requireAgent().getCallHistory()?.calls() ?? [];
+    },
+    async cleanup() {
+      const currentAgent = agent;
+      const dispatcher = previousDispatcher;
+      const fetch = previousFetch;
+      agent = undefined;
+      previousDispatcher = undefined;
+      previousFetch = undefined;
+      if (!currentAgent || !dispatcher || !fetch) {
+        return;
+      }
+      try {
+        currentAgent.assertNoPendingInterceptors();
+      } finally {
+        // Global dispatcher state outlives Vitest modules under --isolate=false.
+        globalThis.fetch = fetch;
+        setGlobalDispatcher(dispatcher);
+        await currentAgent.close();
+      }
+    },
+  };
+}
+
+/** Installs a fresh, network-disabled MockAgent for every test in the current suite. */
+export function useMockHttp(): MockHttp {
+  const mockHttp = createMockHttp();
+  beforeEach(() => mockHttp.setup());
+  afterEach(() => mockHttp.cleanup());
+  return mockHttp;
+}


### PR DESCRIPTION
Closes #105900

## What Problem This Solves

OpenClaw tests currently mix global `fetch` stubs, hand-built `Response` objects, and partial helpers that do not verify request URLs, methods, or unconsumed expectations. That fragmentation makes HTTP tests easier to pass with the wrong request and harder to clean up safely under `--isolate=false`.

## Why This Change Was Made

Adds one root-`undici` `MockAgent` helper with exact URL/method/header/body matching, ordered per-request replies, call history, pending-interceptor assertions, disabled real networking, and full dispatcher/global-fetch restoration. Migrates the largest update-check suite plus two promotions suites as the first bounded pattern; existing helpers remain until their remaining callers are migrated.

## User Impact

No runtime or user-visible behavior changes. Contributors get stricter, zero-new-dependency HTTP tests that fail on unexpected requests and unused mocks.

## Evidence

- Blacksmith Testbox `tbx_01kxcqmg3nrd97qeamsb85jp5q`: `corepack pnpm test src/test-utils/mock-http.test.ts src/infra/update-check.test.ts src/infra/promotions-feed.test.ts src/infra/clawhub.promotions.test.ts` — 65 tests passed across unit-fast and infra lanes at commit `9a12f61ced0` rebased onto `cb5fc0ea8a5`. [Run](https://github.com/openclaw/openclaw/actions/runs/29221355317)
- Helper contract proves both global `fetch` (routed through root `undici.fetch`) and direct `undici.request`, ordered responses, request matching, pending-interceptor failure, and exact global restoration.
- `corepack pnpm check:changed` completed all formatting, dependency, SDK baseline, core/core-test typecheck, lint, database, import-cycle, and guard stages on the same code before the latest unrelated main changes.
- Current-main rerun is blocked at the repository-wide TypeScript LOC ratchet by files unchanged in this PR; the same baseline drift is present on `origin/main`, and none of the five changed files appears in the report.
- Fresh `autoreview --mode local`: no accepted/actionable findings; overall correctness 0.91.

AI-assisted: Codex implemented and validated this change under maintainer direction.
