### PR TITLE
fix(ui): report WhatsApp logout no-ops

### DIFF
--- a/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
+++ b/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
@@ -1,0 +1,101 @@
+// Control UI tests cover WhatsApp logout feedback against a mocked Gateway.
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+const QR_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlY9Z8AAAAASUVORK5CYII=";
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+describeControlUiE2e("Control UI WhatsApp logout mocked Gateway E2E", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("keeps the QR visible and explains a no-op logout", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 1000, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "channels.status": {
+          ts: Date.now(),
+          channelOrder: ["whatsapp"],
+          channelLabels: { whatsapp: "WhatsApp" },
+          channels: {
+            whatsapp: {
+              configured: true,
+              linked: true,
+              running: true,
+              connected: true,
+              reconnectAttempts: 0,
+            },
+          },
+          channelAccounts: {},
+          channelDefaultAccountId: {},
+        },
+        "web.login.start": {
+          connected: false,
+          message: "Scan this QR.",
+          qrDataUrl: QR_DATA_URL,
+        },
+        "channels.logout": {
+          channel: "whatsapp",
+          accountId: "default",
+          cleared: false,
+          loggedOut: false,
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}settings/channels`);
+      expect(response?.status()).toBe(200);
+      const card = page.locator(".card", { hasText: "WhatsApp" }).first();
+      await card.waitFor();
+
+      await card.getByRole("button", { name: "Relink" }).click();
+      const qr = card.getByRole("img", { name: "WhatsApp QR" });
+      await qr.waitFor();
+      await expect(qr.getAttribute("src")).resolves.toBe(QR_DATA_URL);
+
+      await card.getByRole("button", { name: "Logout" }).click();
+      await expect
+        .poll(async () => card.locator(".callout").allTextContents())
+        .toContain(
+          "WhatsApp logout did not clear a stored session. It may already be absent, or the configured auth directory could not be cleared.",
+        );
+      await expect(qr.getAttribute("src")).resolves.toBe(QR_DATA_URL);
+      await expect(card.getByText("Logged out.", { exact: true }).count()).resolves.toBe(0);
+      await expect.poll(async () => gateway.getRequests("channels.logout")).toHaveLength(1);
+      await expect.poll(async () => gateway.getRequests("channels.status")).toHaveLength(3);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
+++ b/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
@@ -76,22 +76,24 @@ describeControlUiE2e("Control UI WhatsApp logout mocked Gateway E2E", () => {
     try {
       const response = await page.goto(`${server.baseUrl}settings/channels`);
       expect(response?.status()).toBe(200);
-      const card = page.locator(".card", { hasText: "WhatsApp" }).first();
-      await card.waitFor();
+      const channel = page.locator(".channels-item", { hasText: "WhatsApp" }).first();
+      await channel.click();
+      const detail = page.locator(".channels-detail");
+      await detail.waitFor();
 
-      await card.getByRole("button", { name: "Relink" }).click();
-      const qr = card.getByRole("img", { name: "WhatsApp QR" });
+      await detail.getByRole("button", { name: "Relink" }).click();
+      const qr = detail.getByRole("img", { name: "WhatsApp QR" });
       await qr.waitFor();
       await expect(qr.getAttribute("src")).resolves.toBe(QR_DATA_URL);
 
-      await card.getByRole("button", { name: "Logout" }).click();
+      await detail.getByRole("button", { name: "Logout" }).click();
       await expect
-        .poll(async () => card.locator(".callout").allTextContents())
+        .poll(async () => detail.locator(".settings-row__desc").allTextContents())
         .toContain(
-          "WhatsApp logout did not clear a stored session. It may already be absent, or the configured auth directory could not be cleared.",
+          "No stored WhatsApp session was cleared. It may already be absent, or its auth directory may require manual cleanup.",
         );
       await expect(qr.getAttribute("src")).resolves.toBe(QR_DATA_URL);
-      await expect(card.getByText("Logged out.", { exact: true }).count()).resolves.toBe(0);
+      await expect(detail.getByText("Logged out.", { exact: true }).count()).resolves.toBe(0);
       await expect.poll(async () => gateway.getRequests("channels.logout")).toHaveLength(1);
       await expect.poll(async () => gateway.getRequests("channels.status")).toHaveLength(3);
     } finally {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -224,6 +224,9 @@ export const en: TranslationMap = {
     whatsapp: {
       title: "WhatsApp",
       subtitle: "Link WhatsApp Web and monitor connection health.",
+      loggedOut: "Logged out.",
+      logoutNotCleared:
+        "No stored WhatsApp session was cleared. It may already be absent, or its auth directory may require manual cleanup.",
     },
     gatewayUrlConfirmation: {
       title: "Change Gateway URL",

--- a/ui/src/lib/channels/index.test.ts
+++ b/ui/src/lib/channels/index.test.ts
@@ -131,6 +131,84 @@ describe("channels controller WhatsApp wait", () => {
   });
 });
 
+describe("channels controller WhatsApp logout", () => {
+  it("preserves login state when no stored session was cleared", async () => {
+    const request = vi.fn(async (method: string) =>
+      method === "channels.logout"
+        ? { cleared: false, loggedOut: false }
+        : createChannelsSnapshot("refreshed"),
+    );
+    const channels = createChannelCapability({
+      snapshot: { client: { request }, connected: true },
+      subscribe: () => () => undefined,
+    } as never);
+    channels.state.whatsappLoginMessage = "Scan this QR.";
+    channels.state.whatsappLoginQrDataUrl = "data:image/png;base64,current-qr";
+    channels.state.whatsappLoginConnected = true;
+
+    await channels.logoutWhatsApp("work");
+
+    expect(request).toHaveBeenCalledWith("channels.logout", {
+      channel: "whatsapp",
+      accountId: "work",
+    });
+    expect(request.mock.calls.filter(([method]) => method === "channels.status")).toHaveLength(1);
+    expect(channels.state.whatsappLoginMessage).toBe(
+      "No stored WhatsApp session was cleared. It may already be absent, or its auth directory may require manual cleanup.",
+    );
+    expect(channels.state.whatsappLoginQrDataUrl).toBe("data:image/png;base64,current-qr");
+    expect(channels.state.whatsappLoginConnected).toBe(true);
+    expect(channels.state.whatsappBusy).toBe(false);
+    channels.dispose();
+  });
+
+  it("clears login state only when the Gateway confirms session clearance", async () => {
+    const request = vi.fn(async (method: string) =>
+      method === "channels.logout"
+        ? { cleared: true, loggedOut: true }
+        : createChannelsSnapshot("refreshed"),
+    );
+    const channels = createChannelCapability({
+      snapshot: { client: { request }, connected: true },
+      subscribe: () => () => undefined,
+    } as never);
+    channels.state.whatsappLoginMessage = "Scan this QR.";
+    channels.state.whatsappLoginQrDataUrl = "data:image/png;base64,current-qr";
+    channels.state.whatsappLoginConnected = true;
+
+    await channels.logoutWhatsApp();
+
+    expect(channels.state.whatsappLoginMessage).toBe("Logged out.");
+    expect(channels.state.whatsappLoginQrDataUrl).toBeNull();
+    expect(channels.state.whatsappLoginConnected).toBeNull();
+    expect(channels.state.whatsappBusy).toBe(false);
+    channels.dispose();
+  });
+
+  it("reports a Gateway failure without discarding login state", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "channels.logout") {
+        throw new Error("credential cleanup failed");
+      }
+      return createChannelsSnapshot("refreshed");
+    });
+    const channels = createChannelCapability({
+      snapshot: { client: { request }, connected: true },
+      subscribe: () => () => undefined,
+    } as never);
+    channels.state.whatsappLoginQrDataUrl = "data:image/png;base64,current-qr";
+    channels.state.whatsappLoginConnected = true;
+
+    await channels.logoutWhatsApp();
+
+    expect(channels.state.whatsappLoginMessage).toBe("Error: credential cleanup failed");
+    expect(channels.state.whatsappLoginQrDataUrl).toBe("data:image/png;base64,current-qr");
+    expect(channels.state.whatsappLoginConnected).toBe(true);
+    expect(request.mock.calls.filter(([method]) => method === "channels.status")).toHaveLength(1);
+    channels.dispose();
+  });
+});
+
 describe("channel refresh sequencing", () => {
   it("keeps a stale slow probe from replacing a newer runtime snapshot", async () => {
     const slowProbe = createDeferred<ChannelsStatusSnapshot | null>();

--- a/ui/src/lib/channels/index.ts
+++ b/ui/src/lib/channels/index.ts
@@ -9,6 +9,10 @@ type ChannelGatewayClient = {
   request<T = unknown>(method: string, params?: unknown): Promise<T>;
 };
 
+type ChannelLogoutResult = {
+  cleared: boolean;
+};
+
 type ChannelGatewaySnapshot = {
   client: ChannelGatewayClient | null;
   connected: boolean;
@@ -43,7 +47,7 @@ export type ChannelCapability = {
   refresh: (probe?: boolean, options?: LoadChannelsOptions) => Promise<void>;
   startWhatsApp: (force: boolean, accountId?: string) => Promise<void>;
   waitWhatsApp: (accountId?: string) => Promise<void>;
-  logoutWhatsApp: () => Promise<void>;
+  logoutWhatsApp: (accountId?: string) => Promise<void>;
   subscribe: (listener: (state: ChannelsState) => void) => () => void;
   dispose: () => void;
 };
@@ -261,19 +265,26 @@ async function waitWhatsAppLogin(state: ChannelsState, accountId?: string): Prom
   return true;
 }
 
-async function logoutWhatsApp(state: ChannelsState): Promise<boolean> {
+async function logoutWhatsApp(state: ChannelsState, accountId?: string): Promise<boolean> {
   const operation = beginWhatsAppOperation(state);
   if (!operation) {
     return false;
   }
   try {
-    await operation.client.request("channels.logout", { channel: "whatsapp" });
+    const result = await operation.client.request<ChannelLogoutResult>("channels.logout", {
+      channel: "whatsapp",
+      ...(accountId ? { accountId } : {}),
+    });
     if (!isCurrentWhatsAppOperation(state, operation)) {
       return false;
     }
-    state.whatsappLoginMessage = "Logged out.";
-    state.whatsappLoginQrDataUrl = null;
-    state.whatsappLoginConnected = null;
+    if (result.cleared) {
+      state.whatsappLoginMessage = t("channels.whatsapp.loggedOut");
+      state.whatsappLoginQrDataUrl = null;
+      state.whatsappLoginConnected = null;
+    } else {
+      state.whatsappLoginMessage = t("channels.whatsapp.logoutNotCleared");
+    }
   } catch (err) {
     if (!isCurrentWhatsAppOperation(state, operation)) {
       return false;
@@ -398,9 +409,9 @@ export function createChannelCapability(gateway: ChannelGateway): ChannelCapabil
           await loadChannels(state, true);
         }
       }),
-    logoutWhatsApp: () =>
+    logoutWhatsApp: (accountId) =>
       run(async () => {
-        if (await logoutWhatsApp(state)) {
+        if (await logoutWhatsApp(state, accountId)) {
           await loadChannels(state, true);
         }
       }),

--- a/ui/src/pages/channels/channels-page.ts
+++ b/ui/src/pages/channels/channels-page.ts
@@ -475,7 +475,8 @@ class ChannelsPage extends OpenClawLightDomElement {
             void context.channels.startWhatsApp(force, this.wizardHost.whatsappAccountId),
           onWhatsAppWait: () =>
             void context.channels.waitWhatsApp(this.wizardHost.whatsappAccountId),
-          onWhatsAppLogout: () => void context.channels.logoutWhatsApp(),
+          onWhatsAppLogout: () =>
+            void context.channels.logoutWhatsApp(this.wizardHost.whatsappAccountId),
           onConfigPatch: (path, value) => context.runtimeConfig.patchForm(path, value),
           onConfigSave: () => void this.saveChannelConfig(),
           onConfigReload: () => void this.reloadChannelConfig(),


### PR DESCRIPTION
Closes #105926

AI-assisted: yes. I understand and reviewed the change.

## What Problem This Solves

Fixes an issue where users logging out of WhatsApp in Settings → Channels would see “Logged out.” and lose the visible QR/connection state when the Gateway reported that no stored session was cleared.

## Why This Change Was Made

The Control UI now treats only the existing `cleared: true` Gateway result as confirmed credential removal. A semantic no-op or RPC failure preserves recovery state and reports the outcome accurately; logout also targets the same selected account used by the adjacent start/wait flow.

## User Impact

Users no longer receive false confirmation that WhatsApp credentials were removed. If no session exists or safe credential cleanup is refused, the UI retains useful recovery state, explains the no-op, and refreshes channel status.

## Evidence

- Exact head `02642902897a9d6aadec3ba6900e957f56fd732c`, trusted Testbox `tbx_01kxwff3v2cccmt6342xkg5895`, Actions run `29675774760`: 30/30 focused controller, Gateway, and real auth-store filesystem tests passed.
- Same exact head/Testbox/run: 1/1 Chromium mocked-Gateway E2E passed through the Channels hub/detail/logout path, verifying preserved QR, accurate feedback, absence of success copy, and post-action status refresh.
- Same exact head/Testbox/run: the five-file changed gate passed formatting, i18n, typecheck, lint, dependency, conflict, and boundary checks.
- Fresh structured autoreview after the final rebase: clean, no accepted/actionable findings, 0.91 confidence.
- `git diff --check origin/main...HEAD`: passed.
- No destructive personal-account logout was run. The mocked-Gateway browser contract and real auth-store filesystem tests cover the UI and cleanup boundaries without touching maintainer credentials.
- No before/after screenshot: this changes outcome copy/state rather than layout, and the Chromium assertions cover the rendered path without publishing account or device imagery.
