### PR TITLE
fix: narrow execSchema.yieldMs from Type.Number to Type.Integer({minimum:0})

### DIFF
--- a/_validate-yieldms.mts
+++ b/_validate-yieldms.mts
@@ -1,0 +1,62 @@
+/**
+ * Proof script for #105930: execSchema.yieldMs Type.Number → Type.Integer({ minimum: 0 })
+ *
+ * Validates the actual production schema exported from bash-tools.schemas.ts.
+ * Run: npx tsx _validate-yieldms.mts
+ */
+
+import { Value } from "typebox/value";
+import { execSchema } from "./src/agents/bash-tools.schemas.js";
+
+console.log("=== execSchema.yieldMs (production, Integer({ minimum: 0 })) ===\n");
+
+const cases: Array<{ label: string; input: Record<string, unknown>; expect: boolean }> = [
+  {
+    label: "valid integer yieldMs",
+    input: { command: "echo hi", yieldMs: 10000 },
+    expect: true,
+  },
+  {
+    label: "yieldMs=0 (min boundary)",
+    input: { command: "echo hi", yieldMs: 0 },
+    expect: true,
+  },
+  {
+    label: "float yieldMs — rejected",
+    input: { command: "echo hi", yieldMs: 10.5 },
+    expect: false,
+  },
+  {
+    label: "negative yieldMs — rejected",
+    input: { command: "echo hi", yieldMs: -100 },
+    expect: false,
+  },
+  {
+    label: "yieldMs omitted (optional)",
+    input: { command: "echo hi" },
+    expect: true,
+  },
+  {
+    label: "yieldMs with background flag",
+    input: { command: "long-task", yieldMs: 5000, background: true },
+    expect: true,
+  },
+];
+
+let passed = 0;
+let failed = 0;
+
+for (const { label, input, expect: expected } of cases) {
+  const result = Value.Check(execSchema, input);
+  const marker = result === expected ? "✓" : "✗";
+  if (result === expected) {
+    passed++;
+    console.log(`  ${marker} ${label}: ${JSON.stringify(input)} → ${result}`);
+  } else {
+    failed++;
+    console.log(`  ${marker} ${label}: ${JSON.stringify(input)} → ${result} (expected ${expected})`);
+  }
+}
+
+console.log(`\n${failed === 0 ? "✅" : "❌"} ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/src/agents/bash-tools.exec-yieldms-schema.test.ts
+++ b/src/agents/bash-tools.exec-yieldms-schema.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { Value } from "typebox/value";
+import { execSchema } from "./bash-tools.schemas.js";
+
+describe("execSchema yieldMs (production)", () => {
+  it("accepts valid positive integer yieldMs", () => {
+    const result = Value.Check(execSchema, {
+      command: "echo hi",
+      yieldMs: 10000,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("accepts yieldMs=0 (minimum boundary)", () => {
+    const result = Value.Check(execSchema, {
+      command: "echo hi",
+      yieldMs: 0,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("rejects float yieldMs", () => {
+    const result = Value.Check(execSchema, {
+      command: "echo hi",
+      yieldMs: 10.5,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("rejects negative yieldMs (below minimum 0)", () => {
+    const result = Value.Check(execSchema, {
+      command: "echo hi",
+      yieldMs: -100,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("accepts omitted yieldMs (optional)", () => {
+    const result = Value.Check(execSchema, { command: "echo hi" });
+    expect(result).toBe(true);
+  });
+
+  it("accepts yieldMs with background flag", () => {
+    const result = Value.Check(execSchema, {
+      command: "long-task",
+      yieldMs: 5000,
+      background: true,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("still validates required command", () => {
+    const result = Value.Check(execSchema, { yieldMs: 5000 });
+    expect(result).toBe(false);
+  });
+
+  it("rejects invalid command type with valid yieldMs", () => {
+    const result = Value.Check(execSchema, {
+      command: 123,
+      yieldMs: 5000,
+    });
+    expect(result).toBe(false);
+  });
+});

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -22,6 +22,7 @@ export const execSchema = Type.Object({
   yieldMs: Type.Optional(
     Type.Integer({
       description: "Milliseconds to wait before backgrounding (default 10000)",
+      minimum: 0,
     }),
   ),
   background: Type.Optional(Type.Boolean({ description: "Run in background immediately" })),
@@ -90,8 +91,8 @@ export const processSchema = Type.Object({
   text: Type.Optional(Type.String({ description: "Text to paste for paste" })),
   bracketed: Type.Optional(Type.Boolean({ description: "Wrap paste in bracketed mode" })),
   eof: Type.Optional(Type.Boolean({ description: "Close stdin after write" })),
-  offset: Type.Optional(Type.Integer({ description: "Log offset" })),
-  limit: Type.Optional(Type.Integer({ description: "Log length" })),
+  offset: Type.Optional(Type.Number({ description: "Log offset" })),
+  limit: Type.Optional(Type.Number({ description: "Log length" })),
   timeout: Type.Optional(
     Type.Number({
       description:

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -20,7 +20,7 @@ export const execSchema = Type.Object({
   ),
   env: Type.Optional(Type.Record(Type.String(), Type.String())),
   yieldMs: Type.Optional(
-    Type.Number({
+    Type.Integer({
       description: "Milliseconds to wait before backgrounding (default 10000)",
     }),
   ),
@@ -90,8 +90,8 @@ export const processSchema = Type.Object({
   text: Type.Optional(Type.String({ description: "Text to paste for paste" })),
   bracketed: Type.Optional(Type.Boolean({ description: "Wrap paste in bracketed mode" })),
   eof: Type.Optional(Type.Boolean({ description: "Close stdin after write" })),
-  offset: Type.Optional(Type.Number({ description: "Log offset" })),
-  limit: Type.Optional(Type.Number({ description: "Log length" })),
+  offset: Type.Optional(Type.Integer({ description: "Log offset" })),
+  limit: Type.Optional(Type.Integer({ description: "Log length" })),
   timeout: Type.Optional(
     Type.Number({
       description:


### PR DESCRIPTION
## Summary

**Problem**: `execSchema.yieldMs` accepts floating-point values via `Type.Number()`, but milliseconds is inherently an integer field. Float values like `yieldMs=10.5` silently pass schema validation and reach runtime with nonsensical values. Negative values also pass through.

**Solution**: Tighten `yieldMs` to `Type.Integer({ minimum: 0 })` — the schema layer now rejects float and negative values before they reach the exec tool runtime.

**What changed / NOT changed**: One type annotation changed in `src/agents/bash-tools.schemas.ts`. The `yieldMs` field now includes `minimum: 0` to reject negative values. Runtime behavior is unchanged for valid integer inputs. **Note**: `processSchema.offset` and `processSchema.limit` are NOT changed in this PR — they are covered by the canonical PR #105560 which already handles pagination fields with `Type.Integer({ minimum: 0 })`. This PR focuses exclusively on the `yieldMs` field which has no canonical coverage elsewhere. No config, CLI, or public API surface changed. No dependencies added or updated.

**merge-risk declaration**: Schema-only change to an internal tool parameter type. The `yieldMs` field is documented as accepting milliseconds — integer semantics are consistent with the existing description. No session state, auth, message delivery, or security boundary involved. This is a compatibility tightening: callers passing valid integer values work identically; callers passing float or negative values now get a clear schema validation error.

## Real behavior proof

**Behavior addressed**: Schema-level validation tightening — reject float and negative values for `execSchema.yieldMs` at the TypeBox parameter parsing stage.

**Real environment tested**: Linux x86_64 (local workstation)

**Exact steps or command run after this patch**: Validation against the actual production `execSchema` (imported from `src/agents/bash-tools.schemas.js`) via TypeBox `Value.Check()`:

```
$ npx tsx _validate-yieldms.mts
=== execSchema.yieldMs (production, Integer({ minimum: 0 })) ===

  ✓ valid integer yieldMs: {"command":"echo hi","yieldMs":10000} → true
  ✓ yieldMs=0 (min boundary): {"command":"echo hi","yieldMs":0} → true
  ✓ float yieldMs — rejected: {"command":"echo hi","yieldMs":10.5} → false
  ✓ negative yieldMs — rejected: {"command":"echo hi","yieldMs":-100} → false
  ✓ yieldMs omitted (optional): {"command":"echo hi"} → true
  ✓ yieldMs with background flag: {"command":"long-task","yieldMs":5000,"background":true} → true

✅ 6 passed, 0 failed
```

Also ran focused regression tests against the actual production schema:

```
$ vitest run src/agents/bash-tools.exec-yieldms-schema.test.ts
 ✓ execSchema yieldMs (production) > accepts valid positive integer yieldMs
 ✓ execSchema yieldMs (production) > accepts yieldMs=0 (minimum boundary)
 ✓ execSchema yieldMs (production) > rejects float yieldMs
 ✓ execSchema yieldMs (production) > rejects negative yieldMs (below minimum 0)
 ✓ execSchema yieldMs (production) > accepts omitted yieldMs (optional)
 ✓ execSchema yieldMs (production) > accepts yieldMs with background flag
 ✓ execSchema yieldMs (production) > still validates required command
 ✓ execSchema yieldMs (production) > rejects invalid command type with valid yieldMs
 Tests  8 passed (8)
```

**After-fix evidence**: TypeBox `Value.Check()` confirms that `yieldMs=10.5` and `yieldMs=-100` return `false` (rejected at schema validation) while valid integers, `yieldMs=0`, and omitted optionals return `true`.

**Observed result after the fix**: Float and negative values correctly rejected at schema layer. Valid integer values and omitted optional fields continue to pass validation.

**What was not tested**: End-to-end LLM exec tool invocation with float/negative yieldMs values. The schema change is validated at the TypeBox parsing layer and does not alter runtime execution paths.

## Tests and validation

- `pnpm build:ci-artifacts` → exit 0 ✓ (compilation succeeds with new schema type)
- Existing exec tool tests continue to pass (schema tightening does not break valid callers)
- Focused regression: `vitest run src/agents/bash-tools.exec-yieldms-schema.test.ts` → 8/8 passed ✓
  - Covers: valid int, minimum boundary, float rejection, negative rejection, optional omission, background flag, required command, invalid command type
  - All tests validate against actual production `execSchema` from `bash-tools.schemas.ts`

## Risk checklist

- [x] This change is backwards compatible — existing callers passing non-negative integer values continue to work identically; callers passing float or negative values now get a clear schema validation error
- [x] This change has been tested with existing configurations — built and tested with default config
- [x] New regression tests added — `src/agents/bash-tools.exec-yieldms-schema.test.ts` covers valid, float, negative, boundary, and optional values
- [ ] I have updated relevant documentation — not needed, internal schema type change with no user-visible surface
- [ ] Breaking changes (if any) are documented in Summary — no breaking changes

## Related PRs

- **#105560** (lzyyzznl): Covers `processSchema.offset` and `processSchema.limit` with `Type.Integer({ minimum: 0 })` — canonical for pagination fields. This PR complements by handling the remaining `execSchema.yieldMs` field.

/cc @openclaw/clawsweeper