### PR TITLE
fix(cli): rewriteUpdateFlagArgv corrupts positional values containing --update

### DIFF
--- a/src/cli/run-main-policy.ts
+++ b/src/cli/run-main-policy.ts
@@ -4,6 +4,7 @@ import {
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { consumeRootOptionToken, FLAG_TERMINATOR } from "../infra/cli-root-options.js";
 import {
   resolveManifestCommandAliasOwnerInRegistry,
   resolveManifestToolOwnerInRegistry,
@@ -37,14 +38,27 @@ function isBareParentDefaultHelpArgv(argv: string[]): boolean {
 
 export function rewriteUpdateFlagArgv(argv: string[]): string[] {
   // Preserve the old root --update spelling by rewriting before Commander registration.
-  const index = argv.indexOf("--update");
-  if (index === -1) {
+  // Only rewrite --update when it is the first non-root-option token and appears before --.
+  const args = argv.slice(2);
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (!arg || arg === FLAG_TERMINATOR) {
+      return argv;
+    }
+    const consumed = consumeRootOptionToken(args, i);
+    if (consumed > 0) {
+      i += consumed - 1;
+      continue;
+    }
+    if (arg === "--update") {
+      const next = [...argv];
+      next[i + 2] = "update";
+      return next;
+    }
+    // First non-root-option token is not the root --update alias; leave argv unchanged.
     return argv;
   }
-
-  const next = [...argv];
-  next.splice(index, 1, "update");
-  return next;
+  return argv;
 }
 
 export function shouldEnsureCliPath(argv: string[]): boolean {

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -130,6 +130,18 @@ describe("rewriteUpdateFlagArgv", () => {
       "--json",
     ]);
   });
+
+  it("does not rewrite --update after the -- terminator", () => {
+    expect(
+      rewriteUpdateFlagArgv(["node", "entry.js", "config", "set", "foo", "--", "--update"]),
+    ).toEqual(["node", "entry.js", "config", "set", "foo", "--", "--update"]);
+  });
+
+  it("does not rewrite --update when it is a positional value for another command", () => {
+    expect(
+      rewriteUpdateFlagArgv(["node", "entry.js", "config", "set", "update.channel", "--update"]),
+    ).toEqual(["node", "entry.js", "config", "set", "update.channel", "--update"]);
+  });
 });
 
 describe("shouldEnsureCliPath", () => {


### PR DESCRIPTION
Fixes #105923

## What Problem This Solves

Fixes an issue where `openclaw --update` was rewritten to `openclaw update` even when `--update` appeared after the `--` terminator or as a positional value for another command (for example, `openclaw config set some.key --update`). This silently corrupted user input.

## Why This Change Was Made

`rewriteUpdateFlagArgv` used `argv.indexOf("--update")`, which matches `--update` anywhere in the argument list. The intended behavior is to preserve the legacy root-level `--update` spelling only when `--update` is the first non-root-option token and appears before `--`. The fix scans past root options (`--profile`, `--log-level`, `--container`, `--dev`, `--no-color`), stops at `--`, and only rewrites the first matching `--update`.

## User Impact

Users can now safely pass `--update` as a literal value to CLI commands or after `--` without it being rewritten to the `update` subcommand. Root-level `openclaw --update` and `openclaw --profile p --update` continue to work as before.

## Evidence

### Real CLI behavior (after fix)

Using an isolated state dir on the PR branch (`08abe64`):

```text
$ OPENCLAW_STATE_DIR=/tmp/openclaw-proof pnpm openclaw --update --help
OpenClaw 2026.7.2 (08abe64) — All your chats, one OpenClaw.

Usage: openclaw update [options] [command]

Update OpenClaw and inspect update channel status
```

Root-level `--update` is still routed to the `update` subcommand.

```text
$ OPENCLAW_STATE_DIR=/tmp/openclaw-proof pnpm openclaw config set env.vars.TEST -- --update
Updated env.vars.TEST. Restart the gateway to apply.

$ OPENCLAW_STATE_DIR=/tmp/openclaw-proof pnpm openclaw config get env.vars.TEST
--update

$ OPENCLAW_STATE_DIR=/tmp/openclaw-proof cat /tmp/openclaw-proof/openclaw.json
{
  "env": {
    "vars": {
      "TEST": "--update"
    }
  },
  "meta": {
    "lastTouchedVersion": "2026.7.2",
    "lastTouchedAt": "2026-07-13T05:44:33.088Z"
  }
}
```

`--update` passed after `--` is preserved as the literal string value instead of being rewritten to `update`.

### Automated tests

Focused tests added to `src/cli/run-main.test.ts`:

- `does not rewrite --update after the -- terminator`
- `does not rewrite --update when it is a positional value for another command`

Before the fix:

```ts
rewriteUpdateFlagArgv(["node", "entry.js", "config", "set", "foo", "--", "--update"]);
// => ["node", "entry.js", "config", "set", "foo", "--", "update"]

rewriteUpdateFlagArgv(["node", "entry.js", "config", "set", "update.channel", "--update"]);
// => ["node", "entry.js", "config", "set", "update.channel", "update"]
```

After the fix:

```ts
// both leave --update unchanged
```

### Validation run

- `pnpm test src/cli/run-main.test.ts --run` → 38/38 passed
- `pnpm test src/cli --run` → 157 files, 2924 tests passed
- `pnpm format:check src/cli/run-main-policy.ts src/cli/run-main.test.ts` → clean
- `node scripts/run-oxlint.mjs src/cli/run-main-policy.ts src/cli/run-main.test.ts` → 0 warnings, 0 errors
