### PR TITLE
fix(config): warn on JSON5 comment loss after successful config write

### DIFF
--- a/src/config/io.parse.test.ts
+++ b/src/config/io.parse.test.ts
@@ -1,6 +1,7 @@
 // Covers config file parsing errors and JSON5 compatibility behavior.
 import { describe, expect, it, vi } from "vitest";
 import { parseConfigJson5 } from "./config.js";
+import { hasJSON5Comments } from "./io.js";
 
 describe("parseConfigJson5", () => {
   it("uses native JSON parsing before JSON5 fallback", () => {
@@ -19,5 +20,61 @@ describe("parseConfigJson5", () => {
 
     expect(result).toEqual({ ok: true, parsed: { gateway: { mode: "local" } } });
     expect(json5.parse).toHaveBeenCalledOnce();
+  });
+});
+
+describe("hasJSON5Comments", () => {
+  it("detects line comments outside strings", () => {
+    expect(hasJSON5Comments("// top-level comment\n{ a: 1 }")).toBe(true);
+    expect(hasJSON5Comments("{ a: 1 // inline\n}")).toBe(true);
+    expect(hasJSON5Comments("{ a: 1 } // trailing")).toBe(true);
+  });
+
+  it("detects block comments outside strings", () => {
+    expect(hasJSON5Comments("/* header */\n{ a: 1 }")).toBe(true);
+    expect(hasJSON5Comments("{ a: /* inline */ 1 }")).toBe(true);
+    expect(hasJSON5Comments("{ /*\n multi-line\n*/ a: 1 }")).toBe(true);
+  });
+
+  it("ignores comment markers inside double-quoted strings", () => {
+    expect(hasJSON5Comments('{ "url": "http://example.com" }')).toBe(false);
+    expect(hasJSON5Comments('{ "key": "// not a comment" }')).toBe(false);
+    expect(hasJSON5Comments('{ "key": "/* not a comment */" }')).toBe(false);
+  });
+
+  it("ignores comment markers inside single-quoted strings", () => {
+    expect(hasJSON5Comments("{ url: 'http://example.com' }")).toBe(false);
+    expect(hasJSON5Comments("{ key: '// not a comment' }")).toBe(false);
+    expect(hasJSON5Comments("{ key: '/* not a comment */' }")).toBe(false);
+  });
+
+  it("returns false for plain JSON without comments", () => {
+    expect(hasJSON5Comments('{ "a": 1 }')).toBe(false);
+    expect(hasJSON5Comments('{ "a": 1, "b": [2, 3] }')).toBe(false);
+    expect(hasJSON5Comments("{}")).toBe(false);
+  });
+
+  it("returns false for empty or whitespace-only input", () => {
+    expect(hasJSON5Comments("")).toBe(false);
+    expect(hasJSON5Comments("   \n  \t  ")).toBe(false);
+  });
+
+  it("handles escaped quotes inside strings", () => {
+    expect(hasJSON5Comments('{ "key": "escaped \\" quote", "b": 1 }')).toBe(false);
+    expect(hasJSON5Comments('{ "key": "escaped \\\\ backslash" // real comment }')).toBe(true);
+  });
+
+  it("ignores comment markers across JSON5 line continuations (U+2028 / U+2029)", () => {
+    // A string continued across a line/paragraph separator; the // after it stays inside the string.
+    const ls = String.fromCodePoint(0x2028);
+    const ps = String.fromCodePoint(0x2029);
+    expect(hasJSON5Comments(`{ "key": "continued\\${ls}// still string" }`)).toBe(false);
+    expect(hasJSON5Comments(`{ "key": "continued\\${ps}// still string" }`)).toBe(false);
+  });
+
+  it("ignores comment markers across standard JSON5 line continuations (LF / CR / CRLF)", () => {
+    expect(hasJSON5Comments('{ "key": "continued\\\n// still string" }')).toBe(false);
+    expect(hasJSON5Comments('{ "key": "continued\\\r// still string" }')).toBe(false);
+    expect(hasJSON5Comments('{ "key": "continued\\\r\n// still string" }')).toBe(false);
   });
 });

--- a/src/config/io.parse.test.ts
+++ b/src/config/io.parse.test.ts
@@ -64,6 +64,15 @@ describe("hasJSON5Comments", () => {
     expect(hasJSON5Comments('{ "key": "escaped \\\\ backslash" // real comment }')).toBe(true);
   });
 
+  it("detects comments immediately adjacent to closing quotes", () => {
+    // Scanner backtracks after the closing quote (i-- then for-loop i++)
+    // so the character after the quote is not skipped.
+    expect(hasJSON5Comments('{"a":"x"/* note */}')).toBe(true);
+    expect(hasJSON5Comments('{"a":"x"// note\n}')).toBe(true);
+    expect(hasJSON5Comments('{"a":"x","b":"y"/* note */}')).toBe(true);
+    expect(hasJSON5Comments('{"a":"x"/*note*/}')).toBe(true);
+  });
+
   it("ignores comment markers across JSON5 line continuations (U+2028 / U+2029)", () => {
     // A string continued across a line/paragraph separator; the // after it stays inside the string.
     const ls = String.fromCodePoint(0x2028);

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1486,8 +1486,12 @@ export function hasJSON5Comments(raw: string): boolean {
     }
     if (ch === "/") {
       const next = raw[i + 1];
-      if (next === "/") return true;
-      if (next === "*") return true;
+      if (next === "/") {
+        return true;
+      }
+      if (next === "*") {
+        return true;
+      }
       continue;
     }
     // Entered a string literal — consume it including escapes.
@@ -1507,10 +1511,14 @@ export function hasJSON5Comments(raw: string): boolean {
           }
           if (escaped === "\r") {
             i++;
-            if (i < raw.length && raw[i] === "\n") i++;
+            if (i < raw.length && raw[i] === "\n") {
+              i++;
+            }
             continue;
           }
-          if (escaped === " " || escaped === " ") {
+          // U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR)
+          // are valid JSON5 line terminators in escape sequences.
+          if (escaped === "\u2028" || escaped === "\u2029") {
             i++;
             continue;
           }

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1471,6 +1471,67 @@ function createConfigFileSnapshot(params: {
   };
 }
 
+/**
+ * Returns true when `raw` contains JSON5 comments (// or /*) outside of string
+ * literals. Uses a character-by-character lexical scan that handles every JSON5
+ * escape sequence including U+2028 / U+2029 line continuations, so comment-like
+ * text inside strings never produces a false positive.
+ */
+export function hasJSON5Comments(raw: string): boolean {
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    // Fast path: skip non-comment, non-string characters.
+    if (ch !== "/" && ch !== '"' && ch !== "'" && ch !== "`") {
+      continue;
+    }
+    if (ch === "/") {
+      const next = raw[i + 1];
+      if (next === "/") return true;
+      if (next === "*") return true;
+      continue;
+    }
+    // Entered a string literal — consume it including escapes.
+    const quote = ch;
+    i++;
+    while (i < raw.length) {
+      const c = raw[i];
+      if (c === "\\") {
+        i++;
+        // JSON5 line continuation: backslash + line terminator skips both.
+        // Terminators: LF (U+000A), CR (U+000D), CRLF, LS (U+2028), PS (U+2029).
+        if (i < raw.length) {
+          const escaped = raw[i];
+          if (escaped === "\n") {
+            i++;
+            continue;
+          }
+          if (escaped === "\r") {
+            i++;
+            if (i < raw.length && raw[i] === "\n") i++;
+            continue;
+          }
+          if (escaped === " " || escaped === " ") {
+            i++;
+            continue;
+          }
+          // Standard escape: consume the escaped character and continue.
+          i++;
+          continue;
+        }
+        continue;
+      }
+      if (c === quote) {
+        i++;
+        break;
+      }
+      i++;
+    }
+    // Back up one because the for-loop increment will advance past the closing quote.
+    i--;
+  }
+  return false;
+}
+
 async function finalizeReadConfigSnapshotInternalResult(
   deps: Required<ConfigIoDeps>,
   result: ReadConfigFileSnapshotInternalResult,
@@ -2610,6 +2671,16 @@ export function createConfigIO(
           changedPathCount,
         }),
       );
+      // JSON5 comments are stripped by the parse-modify-stringify roundtrip.
+      // Warn only after a successful write so a later rejection or failure
+      // does not alarm users about a file that was never changed.
+      if (typeof snapshot.raw === "string" && hasJSON5Comments(snapshot.raw)) {
+        deps.logger.warn(
+          `Config write removed JSON5 comments from ${configPath}. ` +
+            `A pre-write backup was saved to the config directory; ` +
+            `diff it against the current file to recover commented-out settings.`,
+        );
+      }
     };
     const logConfigWriteAnomalies = () => {
       if (suspiciousReasons.length === 0) {

--- a/src/config/mutate.test.ts
+++ b/src/config/mutate.test.ts
@@ -2552,4 +2552,85 @@ describe("config mutate helpers", () => {
       setRuntimeConfigSnapshotRefreshHandler(null);
     }
   });
+
+  it("warns when a single-file $include write removes JSON5 comments", async () => {
+    const home = await suiteRootTracker.make("include-comment-loss");
+    const configPath = path.join(home, ".openclaw", "openclaw.json");
+    const pluginsPath = path.join(home, ".openclaw", "config", "plugins.json5");
+    await fs.mkdir(path.dirname(pluginsPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify({ plugins: { $include: "./config/plugins.json5" } }, null, 2)}\n`,
+      "utf-8",
+    );
+    // Write the include file with JSON5 comments
+    const commentedRaw =
+      [
+        "// Plugin entries managed by setup wizard",
+        "{",
+        '  "entries": { "demo": { "enabled": true } }',
+        "}",
+      ].join("\n") + "\n";
+    await fs.writeFile(pluginsPath, commentedRaw, "utf-8");
+
+    const snapshot: ConfigFileSnapshot = {
+      ...createSnapshot({
+        hash: "hash-include-comment-loss",
+        path: configPath,
+        parsed: { plugins: { $include: "./config/plugins.json5" } },
+        sourceConfig: { plugins: { entries: { demo: { enabled: true } } } },
+      }),
+      raw: `${JSON.stringify({ plugins: { $include: "./config/plugins.json5" } }, null, 2)}\n`,
+    };
+    const includeHash = hashConfigIncludeRaw(commentedRaw);
+    ioMocks.readConfigFileSnapshotForWrite
+      .mockResolvedValueOnce({
+        snapshot,
+        writeOptions: {
+          expectedConfigPath: configPath,
+          includeFileHashesForWrite: { [pluginsPath]: includeHash },
+          assertConfigPathForWrite: allowConfigPathWrite,
+          includeFileTargetsForWrite: { [pluginsPath]: await resolveIncludeTarget(pluginsPath) },
+        },
+      })
+      .mockResolvedValueOnce({
+        snapshot: createSnapshot({
+          hash: "hash-include-comment-loss-refreshed",
+          path: configPath,
+          parsed: { plugins: { $include: "./config/plugins.json5" } },
+          sourceConfig: {
+            plugins: { entries: { demo: { enabled: true }, extra: { enabled: true } } },
+          },
+        }),
+        writeOptions: { expectedConfigPath: configPath },
+      });
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const prevLog = process.env.OPENCLAW_TEST_CONFIG_OVERWRITE_LOG;
+    process.env.OPENCLAW_TEST_CONFIG_OVERWRITE_LOG = "1";
+    try {
+      await replaceConfigFile({
+        baseHash: snapshot.hash,
+        nextConfig: {
+          plugins: {
+            entries: { demo: { enabled: true }, extra: { enabled: true } },
+          },
+        },
+        io: {
+          readConfigFileSnapshotForWrite: ioMocks.readConfigFileSnapshotForWrite,
+          writeConfigFile: ioMocks.writeConfigFile,
+        },
+      });
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("removed JSON5 comments"));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(pluginsPath));
+    } finally {
+      if (prevLog === undefined) {
+        delete process.env.OPENCLAW_TEST_CONFIG_OVERWRITE_LOG;
+      } else {
+        process.env.OPENCLAW_TEST_CONFIG_OVERWRITE_LOG = prevLog;
+      }
+      warn.mockRestore();
+    }
+  });
 });

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -808,13 +808,21 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
           }
         : undefined,
     onCommitted: (previousRaw) => {
-      if (previousRaw === null) return;
-      if (params.writeOptions?.skipOutputLogs) return;
-      if (!hasJSON5Comments(previousRaw)) return;
-      const writeEnv = params.io?.env ?? process.env;
-      const isVitest = writeEnv.VITEST === "true";
-      const shouldLogInVitest = writeEnv.OPENCLAW_TEST_CONFIG_OVERWRITE_LOG === "1";
-      if (isVitest && !shouldLogInVitest) return;
+      if (previousRaw === null) {
+        return;
+      }
+      if (params.writeOptions?.skipOutputLogs) {
+        return;
+      }
+      if (!hasJSON5Comments(previousRaw)) {
+        return;
+      }
+      const logEnv = params.io?.env ?? process.env;
+      const isVitest = logEnv.VITEST === "true";
+      const shouldLogInVitest = logEnv.OPENCLAW_TEST_CONFIG_OVERWRITE_LOG === "1";
+      if (isVitest && !shouldLogInVitest) {
+        return;
+      }
       console.warn(
         `Config write removed JSON5 comments from ${expectedIncludeTarget}. ` +
           `A pre-write backup was saved to the config directory; ` +

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -30,6 +30,7 @@ import {
 import { createInvalidConfigError, formatInvalidConfigDetails } from "./io.invalid-config.js";
 import {
   createConfigIO,
+  hasJSON5Comments,
   readConfigFileSnapshotForWrite,
   restoreEnvChangesIfUnchanged,
   resolveConfigSnapshotHash,
@@ -556,6 +557,8 @@ async function writeRootBoundJsonFile(params: {
   rootSnapshot: ConfigFileSnapshot;
   assertConfigPathForWrite: () => void;
   preCommitRuntimePreflight?: () => Promise<unknown>;
+  /** Called after a successful atomic write with the previous raw content. */
+  onCommitted?: (previousRaw: string | null) => void;
 }): Promise<void> {
   params.assertConfigPathForWrite();
   const targetBeforeBackup = await resolveExpectedRootBoundIncludeFile({
@@ -605,6 +608,7 @@ async function writeRootBoundJsonFile(params: {
     });
     throw error;
   }
+  params.onCommitted?.(currentRaw);
 }
 
 async function tryWriteSingleTopLevelIncludeMutation(params: {
@@ -803,6 +807,20 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
             await callerPreCommit?.(runtimeConfigToWrite);
           }
         : undefined,
+    onCommitted: (previousRaw) => {
+      if (previousRaw === null) return;
+      if (params.writeOptions?.skipOutputLogs) return;
+      if (!hasJSON5Comments(previousRaw)) return;
+      const writeEnv = params.io?.env ?? process.env;
+      const isVitest = writeEnv.VITEST === "true";
+      const shouldLogInVitest = writeEnv.OPENCLAW_TEST_CONFIG_OVERWRITE_LOG === "1";
+      if (isVitest && !shouldLogInVitest) return;
+      console.warn(
+        `Config write removed JSON5 comments from ${expectedIncludeTarget}. ` +
+          `A pre-write backup was saved to the config directory; ` +
+          `diff it against the current file to recover commented-out settings.`,
+      );
+    },
   });
   const envBeforePostWriteRead = { ...writeEnv };
   let envAfterPostWriteRead = envBeforePostWriteRead;


### PR DESCRIPTION
#### What Problem This Solves

Close #105683

Fixes silent JSON5 comment loss when `openclaw.json` and its `$include`-referenced files are written. OpenClaw parses JSON5 (supporting `//` and `/* */`), but `JSON.stringify` strips all user-authored comments on every automatic config mutation.

#### Why This Change Was Made

- **Lexical scanner** replaces regex — full JSON5 escape coverage including U+2028/U+2029 line continuations. Scanner uses `i--` backoff after the while-loop so adjacent comments (`{"a":"x"/* note */}`) are never skipped.
- **Post-commit warning** in `logConfigOverwrite()` — only fires after `replaceFileAtomic` succeeds
- **Both write paths covered** — root writer (`replaceFileAtomic`) and `$include` writer (`writeRootBoundJsonFile`)
- Recovery guidance points to the `.bak` backup

#### User Impact

Users with JSON5 comments in `openclaw.json` or included files see a post-commit warning with recovery instructions. No false positives (URLs, `//` in strings, all line continuations handled). Plain JSON produces no warning.

#### Evidence

- **Type check:** `tsgo` passes
- **Tests:**
  - `io.parse.test.ts` — 12 tests (+10: lexical scanner covers line/block comments, strings, escaped quotes, adjacent comments, U+2028/U+2029/LF/CR/CRLF continuations, plain JSON, empty input)
  - `io.write-config.test.ts` — 103 tests (no regression)
  - `io.audit.test.ts` — all tests (no regression)
  - `mutate.test.ts` — 46 tests (+1: include-file warning test)
- **Change scope:** 4 files, +252 lines
  - `src/config/io.ts` — `hasJSON5Comments()` + warning in `logConfigOverwrite`
  - `src/config/mutate.ts` — `onCommitted` callback in `writeRootBoundJsonFile`
  - `src/config/io.parse.test.ts` — 10 focused tests
  - `src/config/mutate.test.ts` — 1 include-writer test
  - No new dependencies, no config/CLI/SDK/docs surface

- **Real behavior proof — root writer:**
```
Config Write — JSON5 Comment-Loss Warning Proof
[setup] 317 bytes, 3 line comments, 1 block comment
[read]  hash=422ddd0dd094 valid=true size=317
  ✓ config file found
  ✓ raw has // line comments
  ✓ raw has /* */ block comments
  ✓ raw has inline // comment
[write] mutating config (adding plugins.entries.demo)...
[write] file on disk (256 bytes):
        | { "gateway": { "mode": "local", "port": 18789 }, ... }
[check] comment-loss warning: PRESENT
  Config write removed JSON5 comments from .../openclaw.json.
  A pre-write backup was saved to the config directory; diff it against the
  current file to recover commented-out settings.
  ✓ warning emitted after successful write
  ✓ warning names the config file
  ✓ warning tells user about backup
  ✓ written file is plain JSON
  ✓ new plugin entry persisted
[check] backup: .../openclaw.json.bak — exists: true, 317 bytes, has //: true
  ✓ backup is byte-identical to original commented file
[recovery] cp .../openclaw.json.bak .../openclaw.json
Passed: 13 | Failed: 0
```

- **Real behavior proof — $include writer (`plugins.json5` via `replaceConfigFile`):**
```
$include File Write — Comment-Loss Warning Proof
[setup] include: .../plugins.json5 (155 bytes, 3 comments)
  ✓ root config found
  ✓ plugins.json5 has comments
[write] replaceConfigFile — adding plugins.entries.extra
  Config write removed JSON5 comments from .../plugins.json5.
  A pre-write backup was saved to the config directory...
  ✓ include writer emits comment-loss warning
  ✓ warning names the include file path
  ✓ written file is plain JSON
  ✓ mutation persisted
  ✓ pre-write backup exists
  ✓ backup byte-identical to original
[recovery] cp .../plugins.json5.bak .../plugins.json5
Passed: 9 | Failed: 0
```

- [P2] scanner finding from prior review: the `i--` after the while-loop backtracks past the closing quote, and the `for` increment lands on the character immediately after it — adjacent `{"a":"x"/* note */}` and `{"a":"x"// note\n}` patterns are correctly detected. Explicit test coverage added for all four variants.
