### PR TITLE
fix(cron): avoid ambiguous direct delivery retries

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -148,6 +148,7 @@ import { retireSessionMcpRuntime } from "../../agents/agent-bundle-mcp-tools.js"
 import { countActiveDescendantRuns } from "../../agents/subagent-registry-read.js";
 import { appendAssistantMessageToSessionTranscript } from "../../config/sessions/transcript.runtime.js";
 import { callGateway } from "../../gateway/call.runtime.js";
+import { PlatformMessageNotDispatchedError } from "../../infra/outbound/deliver-types.js";
 import { deliverOutboundPayloads } from "../../infra/outbound/deliver.js";
 import {
   ensureOutboundSessionEntry,
@@ -1774,10 +1775,14 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
   });
 
-  it("retries transient direct announce failures before succeeding", async () => {
+  it("retries proven-not-sent direct announce failures before succeeding", async () => {
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
     vi.mocked(deliverOutboundPayloads)
-      .mockRejectedValueOnce(new Error("ECONNRESET while sending"))
+      .mockRejectedValueOnce(
+        new PlatformMessageNotDispatchedError("upload stopped before final dispatch", {
+          cause: new Error("gateway upload failed"),
+        }),
+      )
       .mockResolvedValueOnce([{ ok: true } as never]);
 
     const params = makeBaseParams({ synthesizedText: "Retry me once." });
@@ -1787,6 +1792,149 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(state.deliveryAttempted).toBe(true);
     expect(state.delivered).toBe(true);
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry ambiguous direct announce send errors", async () => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.mocked(deliverOutboundPayloads).mockRejectedValueOnce(
+      Object.assign(new Error("read ECONNRESET after send"), {
+        code: "ECONNRESET",
+      }),
+    );
+
+    const params = makeBaseParams({ synthesizedText: "Do not duplicate me." });
+    const state = await dispatchCronDelivery(params);
+
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expectResultFields(state.result, {
+      status: "error",
+      error: "Error: read ECONNRESET after send",
+      deliveryAttempted: true,
+    });
+  });
+
+  it("does not retry a batch after an earlier direct announce payload was sent", async () => {
+    mockResolvedOutboundRoute({
+      sessionKey: "agent:main:telegram:direct:123456",
+      baseSessionKey: "agent:main:telegram:direct:123456",
+      to: "telegram:123456",
+    });
+    const notDispatchedError = new PlatformMessageNotDispatchedError(
+      "second payload stopped before final dispatch",
+      {
+        cause: Object.assign(new Error("connect ECONNREFUSED"), {
+          code: "ECONNREFUSED",
+          syscall: "connect",
+        }),
+      },
+    );
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.mocked(deliverOutboundPayloads).mockImplementationOnce(async (deliveryParams) => {
+      deliveryParams.onPayloadDeliveryOutcome?.({
+        index: 0,
+        status: "sent",
+        results: [{ channel: "telegram", messageId: "tg-first" }] as never,
+      });
+      deliveryParams.onPayloadDeliveryOutcome?.({
+        index: 1,
+        status: "failed",
+        error: notDispatchedError,
+        sentBeforeError: false,
+        stage: "platform_send",
+      });
+      return [{ channel: "telegram", messageId: "tg-first" }] as never;
+    });
+
+    const params = makeBaseParams({
+      synthesizedText: undefined,
+      runStartedAt: 1_000,
+    });
+    params.deliveryPayloads = [{ text: "First payload." }, { text: "Second payload." }];
+    params.outputText = "Second payload.";
+    params.summary = "Second payload.";
+    const state = await dispatchCronDelivery(params);
+
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expectResultFields(state.result, {
+      status: "error",
+      error: String(notDispatchedError),
+      deliveryAttempted: true,
+    });
+    expect(enqueueSystemEvent).toHaveBeenCalledExactlyOnceWith(
+      [
+        "A scheduled cron job attempted to deliver to this channel, but delivery failed.",
+        "Job: Test Job",
+        "Target: telegram:123456",
+        "Delivery error: second payload stopped before final dispatch | connect ECONNREFUSED | ECONNREFUSED",
+        "One or more scheduled message payloads may already have been delivered.",
+      ].join("\n"),
+      {
+        sessionKey: "agent:main:telegram:direct:123456",
+        contextKey: "cron-direct-delivery:v1:cron:test-job:1000:telegram::123456::failure",
+      },
+    );
+  });
+
+  it("does not retry after an earlier direct announce payload returned no identity", async () => {
+    mockResolvedOutboundRoute({
+      sessionKey: "agent:main:telegram:direct:123456",
+      baseSessionKey: "agent:main:telegram:direct:123456",
+      to: "telegram:123456",
+    });
+    const notDispatchedError = new PlatformMessageNotDispatchedError(
+      "second payload stopped before final dispatch",
+      {
+        cause: Object.assign(new Error("connect ECONNREFUSED"), {
+          code: "ECONNREFUSED",
+          syscall: "connect",
+        }),
+      },
+    );
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.mocked(deliverOutboundPayloads).mockImplementationOnce(async (deliveryParams) => {
+      deliveryParams.onPayloadDeliveryOutcome?.({
+        index: 0,
+        status: "suppressed",
+        reason: "adapter_returned_no_identity",
+      });
+      deliveryParams.onPayloadDeliveryOutcome?.({
+        index: 1,
+        status: "failed",
+        error: notDispatchedError,
+        sentBeforeError: false,
+        stage: "platform_send",
+      });
+      return [] as never;
+    });
+
+    const params = makeBaseParams({
+      synthesizedText: undefined,
+      runStartedAt: 1_000,
+    });
+    params.deliveryPayloads = [{ text: "First payload." }, { text: "Second payload." }];
+    params.outputText = "Second payload.";
+    params.summary = "Second payload.";
+    const state = await dispatchCronDelivery(params);
+
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expectResultFields(state.result, {
+      status: "error",
+      error: String(notDispatchedError),
+      deliveryAttempted: true,
+    });
+    expect(enqueueSystemEvent).toHaveBeenCalledExactlyOnceWith(
+      [
+        "A scheduled cron job attempted to deliver to this channel, but delivery failed.",
+        "Job: Test Job",
+        "Target: telegram:123456",
+        "Delivery error: second payload stopped before final dispatch | connect ECONNREFUSED | ECONNREFUSED",
+        "One or more scheduled message payloads may already have been delivered.",
+      ].join("\n"),
+      {
+        sessionKey: "agent:main:telegram:direct:123456",
+        contextKey: "cron-direct-delivery:v1:cron:test-job:1000:telegram::123456::failure",
+      },
+    );
   });
 
   it("keeps direct announce delivery idempotent across replay for the same cron execution", async () => {
@@ -2043,10 +2191,17 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expectDeliveryCall(0, { skipQueue: true });
   });
 
-  it("transient retry delivers exactly once with skipQueue on both attempts", async () => {
-    // First call throws a transient error, second call succeeds.
+  it("proven-not-sent retry delivers exactly once with skipQueue on both attempts", async () => {
+    // First call throws before a recipient-visible send, second call succeeds.
     vi.mocked(deliverOutboundPayloads)
-      .mockRejectedValueOnce(new Error("gateway timeout"))
+      .mockRejectedValueOnce(
+        new PlatformMessageNotDispatchedError("gateway stopped before final dispatch", {
+          cause: Object.assign(new Error("connect ECONNREFUSED"), {
+            code: "ECONNREFUSED",
+            syscall: "connect",
+          }),
+        }),
+      )
       .mockResolvedValueOnce([{ ok: true } as never]);
 
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -22,6 +22,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { isSuppressedControlReplyText } from "../../gateway/control-reply-text.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
+import { isProvenDeliveryNotSentError } from "../../infra/delivery-recovery.shared.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type {
   NormalizedOutboundPayload,
@@ -166,17 +167,6 @@ export type DispatchCronDeliveryState = {
   synthesizedText?: string;
   deliveryPayloads: ReplyPayload[];
 };
-
-const TRANSIENT_DIRECT_CRON_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
-  /\berrorcode=unavailable\b/i,
-  /\bstatus\s*[:=]\s*"?unavailable\b/i,
-  /\bUNAVAILABLE\b/,
-  /no active .* listener/i,
-  /gateway not connected/i,
-  /gateway closed \(1006/i,
-  /gateway timeout/i,
-  /\b(econnreset|econnrefused|etimedout|enotfound|ehostunreach|network error)\b/i,
-];
 
 const PERMANENT_DIRECT_CRON_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
   /unsupported channel/i,
@@ -956,9 +946,8 @@ function isTransientDirectCronDeliveryError(error: unknown): boolean {
   if (PERMANENT_DIRECT_CRON_DELIVERY_ERROR_PATTERNS.some((re) => re.test(message))) {
     return false;
   }
-  return TRANSIENT_DIRECT_CRON_DELIVERY_ERROR_PATTERNS.some((re) => re.test(message));
+  return isProvenDeliveryNotSentError(error);
 }
-
 function resolveDirectCronRetryDelaysMs(): readonly number[] {
   return process.env.NODE_ENV === "test" && process.env.OPENCLAW_TEST_FAST === "1"
     ? [0, 0, 0]
@@ -969,6 +958,7 @@ async function retryTransientDirectCronDelivery<T>(params: {
   jobId: string;
   signal?: AbortSignal;
   run: () => Promise<T>;
+  shouldRetryError?: (err: unknown) => boolean;
 }): Promise<T> {
   const retryDelaysMs = resolveDirectCronRetryDelaysMs();
   if (params.signal?.aborted) {
@@ -986,7 +976,9 @@ async function retryTransientDirectCronDelivery<T>(params: {
     maxDelayMs: Math.max(...retryDelaysMs),
     delayMs: ({ attempt }) => retryDelaysMs[attempt - 1] ?? 0,
     shouldRetry: (err) =>
-      params.signal?.aborted !== true && isTransientDirectCronDeliveryError(err),
+      params.signal?.aborted !== true &&
+      isTransientDirectCronDeliveryError(err) &&
+      (params.shouldRetryError?.(err) ?? true),
     onRetry: async ({ attempt, maxAttempts, delayMs, err }) => {
       await logCronDeliveryWarn(
         `[cron:${params.jobId}] transient direct announce delivery failure, retrying ${attempt + 1}/${maxAttempts} in ${Math.round(delayMs / 1000)}s: ${summarizeDirectCronDeliveryError(err)}`,
@@ -998,7 +990,6 @@ async function retryTransientDirectCronDelivery<T>(params: {
     sleep: async (delayMs) => await sleepWithAbort(delayMs, params.signal),
   });
 }
-
 /** Dispatches cron run output through verified message-tool or direct delivery paths. */
 export async function dispatchCronDelivery(
   params: DispatchCronDeliveryParams,
@@ -1201,7 +1192,7 @@ export async function dispatchCronDelivery(
       // Track bestEffort partial failures so we can log them and avoid
       // marking the job as delivered when payloads were silently dropped.
       let hadPartialFailure = false;
-      let partialDeliverySucceededBeforeFailure = false;
+      let payloadMayHaveReachedRecipientBeforeFailure = false;
       // `onPayload` fires after send hooks render the outbound payload, but before
       // platform send. The mirror only consumes this array after full delivery succeeds.
       const attemptedPayloadsForMirror: NormalizedOutboundPayload[] = [];
@@ -1214,7 +1205,6 @@ export async function dispatchCronDelivery(
             );
           }
         : undefined;
-
       const runDelivery = async () => {
         attemptedPayloadsForMirror.length = 0;
         const send = await sendDurableMessageBatch({
@@ -1241,11 +1231,20 @@ export async function dispatchCronDelivery(
           // See: https://github.com/openclaw/openclaw/issues/40545
           skipQueue: true,
         });
+        // No durable id is still ambiguous: the adapter was already invoked.
+        payloadMayHaveReachedRecipientBeforeFailure ||=
+          send.payloadOutcomes?.some(
+            (outcome) =>
+              outcome.status === "sent" ||
+              (outcome.status === "failed" && outcome.sentBeforeError) ||
+              (outcome.status === "suppressed" &&
+                outcome.reason === "adapter_returned_no_identity"),
+          ) ?? false;
         if (send.status === "failed") {
           throw send.error;
         }
         if (send.status === "partial_failed") {
-          partialDeliverySucceededBeforeFailure = send.results.length > 0;
+          payloadMayHaveReachedRecipientBeforeFailure = true;
           if (!params.deliveryBestEffort) {
             throw send.error;
           }
@@ -1261,6 +1260,7 @@ export async function dispatchCronDelivery(
               jobId: params.job.id,
               signal: params.abortSignal,
               run: runDelivery,
+              shouldRetryError: () => !payloadMayHaveReachedRecipientBeforeFailure,
             })
           : await runDelivery();
       } catch (err) {
@@ -1270,7 +1270,7 @@ export async function dispatchCronDelivery(
           to: delivery.to,
           threadId: stringifyRouteThreadId(delivery.threadId),
           error: err,
-          partialDelivered: partialDeliverySucceededBeforeFailure,
+          partialDelivered: payloadMayHaveReachedRecipientBeforeFailure,
         });
         await queueCronAwarenessSystemEvent({
           cfg: params.cfgWithAgentDefaults,


### PR DESCRIPTION
## What Problem This Solves

Fixes #102367.

Cron direct delivery bypasses the durable outbound queue with `skipQueue: true`, but its local retry classifier still retried ambiguous transport errors such as `ECONNRESET` and generic gateway timeouts. Those errors can happen after Slack accepts or finalizes a message, so a retry can post the same scheduled announcement twice.

## Why This Change Was Made

The direct cron retry path now reuses the outbound recovery proof predicate and retries only failures that prove no recipient-visible send happened, such as `PlatformMessageNotDispatchedError` or pre-connect network failures. Ambiguous send/finalization failures remain terminal for that cron delivery attempt, and mixed-payload batches stop retrying once any earlier payload may have reached the recipient, including `adapter_returned_no_identity` outcomes where the adapter was invoked but no durable message id came back.

## User Impact

Scheduled Slack deliveries no longer retry ambiguous post-send transport failures that may already have delivered the message. Proven-not-sent failures still retry, preserving recovery for safe pre-dispatch failures.

## Evidence

- `git diff --check`
- `node --import tsx scripts/check-ts-max-loc.ts --max 500 --base-ref origin/main` — no `delivery-dispatch.ts` LOC ratchet after latest rebase/shrink; current hosted guard failure is unrelated main baseline debt
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean after the post-rebase LOC shrink; no accepted/actionable findings
- Current-head Testbox `tbx_01kxcwxhnnp72exfhyhjpmg8yn` / Actions run `29224842538`: `corepack pnpm test src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts src/infra/outbound/delivery-queue.policy.test.ts` — 120 tests passed

Transcript not included: a local candidate was found, but publishing sanitized agent logs requires explicit maintainer approval.
