### PR TITLE
refactor: use built-in glob for package manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Runtime dependencies:** use Node's built-in filesystem globbing for package-manifest resources, removing the direct `glob` dependency and its production `path-scurry` transitive while preserving hidden-path filtering. (#105951)
 - **SQLite snapshots:** add `openclaw backup sqlite create|list|verify|restore` for compact, verified global and per-agent database artifacts with fresh-target-only restore. (#94805) Thanks @giodl73-repo.
 - **GPT-5.6 Ultra and runtime switching:** support Sol, Terra, and Luna across OpenClaw and Codex engines; keep model, runtime, and thinking selection atomic through `/model` and fallback; and add live matrix coverage for both harnesses. (#98021) Thanks @anyech.
 - **OpenAI GPT-5.6 defaults:** use `openai/gpt-5.6` (Sol alias) for fresh API-key setup and exact `openai/gpt-5.6-sol` for fresh Codex/OAuth setup, while preserving existing primaries, fallbacks, aliases, and explicit GPT-5.5 selections. (#103234)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Runtime dependencies:** use Node's built-in filesystem globbing for package-manifest resources, removing the direct `glob` dependency and its production `path-scurry` transitive while preserving hidden-path filtering. (#105951)
 - **SQLite snapshots:** add `openclaw backup sqlite create|list|verify|restore` for compact, verified global and per-agent database artifacts with fresh-target-only restore. (#94805) Thanks @giodl73-repo.
 - **GPT-5.6 Ultra and runtime switching:** support Sol, Terra, and Luna across OpenClaw and Codex engines; keep model, runtime, and thinking selection atomic through `/model` and fallback; and add live matrix coverage for both harnesses. (#98021) Thanks @anyech.
 - **OpenAI GPT-5.6 defaults:** use `openai/gpt-5.6` (Sol alias) for fresh API-key setup and exact `openai/gpt-5.6-sol` for fresh Codex/OAuth setup, while preserving existing primaries, fallbacks, aliases, and explicit GPT-5.5 selections. (#103234)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -37,7 +37,6 @@
         "entities": "8.0.0",
         "express": "5.2.1",
         "file-type": "22.0.1",
-        "glob": "13.0.6",
         "grammy": "1.44.0",
         "highlight.js": "11.11.1",
         "hosted-git-info": "10.1.1",
@@ -1667,23 +1666,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/google-auth-library": {
       "version": "10.9.0",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
@@ -2541,22 +2523,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {

--- a/package.json
+++ b/package.json
@@ -2031,7 +2031,6 @@
     "entities": "8.0.0",
     "express": "5.2.1",
     "file-type": "22.0.1",
-    "glob": "13.0.6",
     "grammy": "1.44.0",
     "highlight.js": "11.11.1",
     "hosted-git-info": "10.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,9 +127,6 @@ importers:
       file-type:
         specifier: 22.0.1
         version: 22.0.1
-      glob:
-        specifier: 13.0.6
-        version: 13.0.6
       grammy:
         specifier: 1.44.0
         version: 1.44.0

--- a/src/agents/sessions/package-manager.test.ts
+++ b/src/agents/sessions/package-manager.test.ts
@@ -60,6 +60,33 @@ describe("DefaultPackageManager", () => {
     expect(skillPaths).not.toContain(outsideSkill);
   });
 
+  it("expands manifest resource globs without hidden paths", async () => {
+    const root = await makeTempDir("openclaw-package-manager-");
+    const packageRoot = join(root, "package");
+    const visibleSkill = join(packageRoot, "skills", "visible", "SKILL.md");
+    const hiddenSkill = join(packageRoot, "skills", ".hidden", "SKILL.md");
+    await mkdir(join(packageRoot, "skills", "visible"), { recursive: true });
+    await mkdir(join(packageRoot, "skills", ".hidden"), { recursive: true });
+    await writeFile(visibleSkill, "# Visible\n", "utf-8");
+    await writeFile(hiddenSkill, "# Hidden\n", "utf-8");
+    await writeFile(
+      join(packageRoot, "package.json"),
+      JSON.stringify({ openclaw: { skills: ["skills/*"] } }),
+      "utf-8",
+    );
+
+    const manager = new DefaultPackageManager({
+      cwd: root,
+      agentDir: join(root, "agent"),
+      settingsManager: SettingsManager.inMemory({ packages: [packageRoot] }),
+    });
+
+    const skillPaths = (await manager.resolve()).skills.map((skill) => skill.path);
+
+    expect(skillPaths).toContain(visibleSkill);
+    expect(skillPaths).not.toContain(hiddenSkill);
+  });
+
   it("keeps convention-discovered resource entries inside the package root", async () => {
     const root = await makeTempDir("openclaw-package-manager-");
     const packageRoot = join(root, "package");

--- a/src/agents/sessions/package-manager.ts
+++ b/src/agents/sessions/package-manager.ts
@@ -4,10 +4,9 @@
  * Resolves extension, skill, prompt, and theme sources from npm, git, local paths, and project manifests.
  */
 import { createHash } from "node:crypto";
-import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { existsSync, globSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { globSync } from "glob";
 import ignore from "ignore";
 import { minimatch } from "minimatch";
 import { addIgnoreRules, toPosixPath, type IgnoreMatcher } from "../../shared/ignore-rules.js";
@@ -1221,12 +1220,9 @@ export class DefaultPackageManager implements PackageManager {
         return [resolve(root, entry)];
       }
 
-      return globSync(entry, {
-        cwd: root,
-        absolute: true,
-        dot: false,
-        nodir: false,
-      }).map((match) => resolve(match));
+      // The supported Node floor has stable fs globbing; its defaults exclude
+      // hidden paths and retain directories, matching package manifests.
+      return globSync(entry, { cwd: root }).map((match) => resolve(root, match));
     });
     return this.collectFilesFromPaths(
       this.filterManifestResourcePaths(resolved, root),


### PR DESCRIPTION
AI-assisted change. Maintainer-requested dependency cleanup.

## What Problem This Solves

OpenClaw carried `glob` as a direct production dependency for one package-manifest resource expansion, even though the supported Node floor provides stable filesystem globbing with the required behavior.

## Why This Change Was Made

Use `node:fs` `globSync` for manifest resource discovery and resolve its relative matches against the package root. A focused regression test covers directory matches and the existing hidden-path exclusion; the direct dependency and generated lock artifacts are removed.

`dotenv` is intentionally retained: its parser is not a drop-in replacement target for `util.parseEnv` under the repository's existing semantics.

## User Impact

No intended behavior change. The published npm dependency tree drops direct `glob` and its production `path-scurry` transitive, while package-manifest resource paths remain absolute and hidden paths remain excluded.

This internal dependency cleanup is documented here rather than in the release-owned changelog. Current runtime-floor installation and security docs were already updated on `main` by #106065 and satisfy the built-in glob prerequisite.

## Evidence

- Patch-equivalent package-manager proof on Node 24.15.0: `pnpm test src/agents/sessions/package-manager.test.ts` — 1 file, 6 tests passed (Testbox `pearl-hermit-45f7`; Actions run 29229347701); the runtime/package diff is unchanged after rebasing.
- Final rebased head `f7e182c0719`: frozen pnpm install and supply-chain policy passed; all 77 npm shrinkwraps are current. A patch-identical synced prep head passed native `pnpm build` and `pnpm check` under Node 24.16.0/npm 11.13.0.
- `pnpm check:docs` — 704 docs formatted/linted, 720 MDX files checked, 5,938 internal links, 0 broken links (Testbox `coral-crayfish-44d2`).
- `pnpm build` — passed all runtime, plugin SDK declaration, and Control UI build phases (Testbox `coral-crayfish-44d2`).
- Two full Testbox attempts reached repository-wide completion and failed only in unrelated current-main surfaces (WhatsApp live-state fixture and MXC package scan); neither touches this five-file package-manager dependency cleanup.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings, patch-correct confidence 0.93.

Hosted CI completion is intentionally waived for this landing at maintainer request.
