### PR TITLE
fix(ci): make TypeScript LOC growth reviewable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1569,12 +1569,12 @@ jobs:
           case "$TASK" in
             guards)
               pnpm check:no-conflict-markers
+              # The temp-creation report below still needs loc-base; the LOC ratchet checks
+              # only the current tree against its reviewable checked-in baseline.
               if [ -n "$LOC_BASE_SHA" ]; then
                 git fetch --no-tags --depth=1 origin "+${LOC_BASE_SHA}:refs/remotes/origin/loc-base"
-                pnpm check:loc --base-ref refs/remotes/origin/loc-base
-              else
-                pnpm check:loc
               fi
+              pnpm check:loc
               pnpm tool-display:check
               pnpm check:host-env-policy:swift
               pnpm dup:check:coverage

--- a/scripts/check-ts-max-loc.ts
+++ b/scripts/check-ts-max-loc.ts
@@ -13,14 +13,12 @@ function writeStdoutLine(message: string): void {
 }
 
 export type ParsedArgs = {
-  baseRef?: string;
   baselinePath: string;
   maxLines: number;
   writeBaseline: boolean;
 };
 
 export function parseArgs(argv: string[]): ParsedArgs {
-  let baseRef: string | undefined;
   let baselinePath = DEFAULT_BASELINE_PATH;
   let maxLines = 500;
   let writeBaseline = false;
@@ -48,15 +46,6 @@ export function parseArgs(argv: string[]): ParsedArgs {
       index++;
       continue;
     }
-    if (arg === "--base-ref") {
-      const next = argv[index + 1];
-      if (!next || next.startsWith("-") || !/^[A-Za-z0-9_./-]+$/u.test(next)) {
-        throw new Error("--base-ref requires a git ref");
-      }
-      baseRef = next;
-      index++;
-      continue;
-    }
     if (arg === "--write-baseline") {
       writeBaseline = true;
       continue;
@@ -64,7 +53,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     throw new Error(`Unknown argument: ${arg}`);
   }
 
-  return { baseRef, baselinePath, maxLines, writeBaseline };
+  return { baselinePath, maxLines, writeBaseline };
 }
 
 function gitLsFilesAll(): string[] {
@@ -95,10 +84,6 @@ export function countPhysicalLines(content: string): number {
   }
   const splitCount = content.split("\n").length;
   return content.endsWith("\n") ? splitCount - 1 : splitCount;
-}
-
-export function splitNullDelimitedPaths(output: string): string[] {
-  return output.split("\0").filter(Boolean);
 }
 
 async function countLines(filePath: string): Promise<number> {
@@ -155,43 +140,6 @@ export function findLocRatchetViolations(params: {
   );
 }
 
-export function findVersionedBaselineViolations(params: {
-  baseline: LocBaseline;
-  baseBaseline: LocBaseline;
-  baseLinesByChangedPath: ReadonlyMap<string, number | undefined>;
-}): LocRatchetViolation[] {
-  const violations: LocRatchetViolation[] = [];
-  for (const [filePath, lines] of Object.entries(params.baseline)) {
-    if (!params.baseLinesByChangedPath.has(filePath)) {
-      // Unchanged source may reconcile base drift; the current-tree check below still requires
-      // this baseline to equal the file's actual LOC, so arbitrary inflation remains stale.
-      continue;
-    }
-    const baseLines = params.baseLinesByChangedPath.get(filePath);
-    if (baseLines === undefined && params.baseBaseline[filePath] === undefined) {
-      violations.push({ filePath, lines, reason: "baseline-missing" });
-    } else if (baseLines === undefined || lines > baseLines) {
-      violations.push({ filePath, lines, baselineLines: baseLines ?? 0, reason: "grew" });
-    }
-  }
-  return violations.toSorted(
-    (left, right) => right.lines - left.lines || left.filePath.localeCompare(right.filePath),
-  );
-}
-
-export function filterPreexistingBaseDriftViolations(params: {
-  baseline: LocBaseline;
-  baseBaseline: LocBaseline;
-  changedPaths: ReadonlySet<string>;
-  violations: LocRatchetViolation[];
-}): LocRatchetViolation[] {
-  return params.violations.filter(
-    (violation) =>
-      params.changedPaths.has(violation.filePath) ||
-      params.baseline[violation.filePath] !== params.baseBaseline[violation.filePath],
-  );
-}
-
 async function readBaseline(filePath: string): Promise<LocBaseline> {
   return parseBaseline(await readFile(filePath, "utf8"), filePath);
 }
@@ -211,99 +159,7 @@ function parseBaseline(content: string, source: string): LocBaseline {
   return baseline;
 }
 
-function tryGitOutput(args: string[]): string | undefined {
-  try {
-    return execFileSync("git", args, {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-  } catch {
-    return undefined;
-  }
-}
-
-function resolveComparisonBaseRef(
-  baselinePath: string,
-  explicitBaseRef?: string,
-): string | undefined {
-  if (explicitBaseRef) {
-    return explicitBaseRef;
-  }
-  const head = tryGitOutput(["rev-parse", "HEAD"]);
-  const mergeBase = tryGitOutput(["merge-base", "HEAD", "origin/main"]);
-  if (mergeBase && mergeBase !== head) {
-    return mergeBase;
-  }
-  const changedBaselinePath = tryGitOutput(["diff", "--name-only", "HEAD", "--", baselinePath]);
-  if (changedBaselinePath?.split("\n").includes(baselinePath)) {
-    return "HEAD";
-  }
-  return tryGitOutput(["rev-parse", "--verify", "HEAD^"]) ? "HEAD^" : undefined;
-}
-
-function readBaselineAtRef(
-  baseRef: string | undefined,
-  baselinePath: string,
-): LocBaseline | undefined {
-  if (!baseRef) {
-    return undefined;
-  }
-  if (!tryGitOutput(["rev-parse", "--verify", `${baseRef}^{commit}`])) {
-    throw new Error(`Invalid TypeScript LOC comparison ref: ${baseRef}`);
-  }
-  const content = tryGitOutput(["show", `${baseRef}:${baselinePath}`]);
-  return content === undefined ? undefined : parseBaseline(content, `${baseRef}:${baselinePath}`);
-}
-
-function readFileAtRef(baseRef: string, filePath: string): string | undefined {
-  try {
-    return execFileSync("git", ["show", `${baseRef}:${filePath}`], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-  } catch {
-    return undefined;
-  }
-}
-
-function readChangedPaths(baseRef: string): ReadonlySet<string> {
-  const changedPaths = new Set(
-    splitNullDelimitedPaths(
-      execFileSync("git", ["diff", "--name-only", "-z", baseRef, "--"], {
-        encoding: "utf8",
-      }),
-    ),
-  );
-  for (const filePath of splitNullDelimitedPaths(
-    execFileSync("git", ["ls-files", "--others", "--exclude-standard", "-z"], {
-      encoding: "utf8",
-    }),
-  )) {
-    changedPaths.add(filePath);
-  }
-  return changedPaths;
-}
-
-function readBaseLinesForChangedBaselinePaths(
-  baseRef: string,
-  baseline: LocBaseline,
-  changedPaths: ReadonlySet<string>,
-): ReadonlyMap<string, number | undefined> {
-  const baseLinesByChangedPath = new Map<string, number | undefined>();
-  for (const filePath of Object.keys(baseline)) {
-    if (!changedPaths.has(filePath)) {
-      continue;
-    }
-    const baseContent = readFileAtRef(baseRef, filePath);
-    baseLinesByChangedPath.set(
-      filePath,
-      baseContent === undefined ? undefined : countPhysicalLines(baseContent),
-    );
-  }
-  return baseLinesByChangedPath;
-}
-
-function buildBaseline(results: LocResult[], maxLines: number): LocBaseline {
+export function buildLocBaseline(results: LocResult[], maxLines: number): LocBaseline {
   return Object.fromEntries(
     results
       .filter((result) => result.lines > maxLines)
@@ -328,7 +184,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
     throw error;
   });
 
-  const { baseRef, baselinePath, maxLines, writeBaseline } = parseArgs(argv);
+  const { baselinePath, maxLines, writeBaseline } = parseArgs(argv);
   const files = gitLsFilesAll()
     .filter((filePath) => existsSync(filePath))
     .filter(isProductionTypeScriptFile);
@@ -337,62 +193,24 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   );
 
   if (writeBaseline) {
-    const comparisonBaseRef = resolveComparisonBaseRef(baselinePath, baseRef);
-    if (!comparisonBaseRef) {
-      throw new Error("Unable to resolve a comparison ref for the TypeScript LOC baseline update");
-    }
-    const baseBaseline = readBaselineAtRef(comparisonBaseRef, baselinePath);
-    const updatedBaseline = buildBaseline(results, maxLines);
-    const changedPaths = readChangedPaths(comparisonBaseRef);
-    // A missing baseline at a valid base ref is the one-time initialization path.
-    const violations = baseBaseline
-      ? findVersionedBaselineViolations({
-          baseline: updatedBaseline,
-          baseBaseline,
-          baseLinesByChangedPath: readBaseLinesForChangedBaselinePaths(
-            comparisonBaseRef,
-            updatedBaseline,
-            changedPaths,
-          ),
-        })
-      : [];
-    reportViolations(violations);
-    if (violations.length > 0) {
-      return 1;
-    }
+    // Baseline changes are explicit review artifacts. The normal check still
+    // requires exact current LOC and forces every reduction into the baseline.
+    const updatedBaseline = buildLocBaseline(results, maxLines);
     await writeFile(baselinePath, `${JSON.stringify(updatedBaseline, null, 2)}\n`, "utf8");
     writeStdoutLine(`updated ${baselinePath} (${Object.keys(updatedBaseline).length} files)`);
     return 0;
   }
 
   const baseline = await readBaseline(baselinePath);
-  const comparisonBaseRef = resolveComparisonBaseRef(baselinePath, baseRef);
-  const baseBaseline = readBaselineAtRef(comparisonBaseRef, baselinePath);
-  const changedPaths = comparisonBaseRef ? readChangedPaths(comparisonBaseRef) : new Set<string>();
-  const currentViolations = findLocRatchetViolations({ baseline, maxLines, results });
-  const violations = [
-    ...(baseBaseline && comparisonBaseRef
-      ? findVersionedBaselineViolations({
-          baseline,
-          baseBaseline,
-          baseLinesByChangedPath: readBaseLinesForChangedBaselinePaths(
-            comparisonBaseRef,
-            baseline,
-            changedPaths,
-          ),
-        })
-      : []),
-    ...(baseBaseline
-      ? filterPreexistingBaseDriftViolations({
-          baseline,
-          baseBaseline,
-          changedPaths,
-          violations: currentViolations,
-        })
-      : currentViolations),
-  ];
+  const violations = findLocRatchetViolations({ baseline, maxLines, results });
   reportViolations(violations);
-  return violations.length === 0 ? 0 : 1;
+  if (violations.length > 0) {
+    writeStdoutLine(
+      "Split the file, or run `pnpm check:loc:update` and include the baseline diff for review.",
+    );
+    return 1;
+  }
+  return 0;
 }
 
 const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : undefined;

--- a/test/scripts/check-ts-max-loc.test.ts
+++ b/test/scripts/check-ts-max-loc.test.ts
@@ -2,13 +2,10 @@
 import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import {
+  buildLocBaseline,
   countPhysicalLines,
-  filterPreexistingBaseDriftViolations,
   findLocRatchetViolations,
-  findVersionedBaselineViolations,
   isProductionTypeScriptFile,
-  parseArgs,
-  splitNullDelimitedPaths,
 } from "../../scripts/check-ts-max-loc.js";
 
 function runCheckTsMaxLoc(args: string[]) {
@@ -37,21 +34,12 @@ describe("scripts/check-ts-max-loc", () => {
     }
   });
 
-  it("parses a safe comparison base ref", () => {
-    expect(parseArgs(["--base-ref", "refs/remotes/origin/pr-base"])).toMatchObject({
-      baseRef: "refs/remotes/origin/pr-base",
-    });
-    expect(() => parseArgs(["--base-ref", "main^{tree}"])).toThrow("--base-ref requires a git ref");
-  });
-
-  it("fails closed when a comparison ref does not exist", () => {
-    const result = runCheckTsMaxLoc(["--base-ref", "refs/heads/__loc-ratchet-missing__"]);
+  it("rejects the removed comparison flag before scanning files", () => {
+    const result = runCheckTsMaxLoc(["--base-ref", "refs/remotes/origin/pr-base"]);
 
     expect(result.status).toBe(1);
     expect(result.stdout).toBe("");
-    expect(result.stderr).toBe(
-      "Invalid TypeScript LOC comparison ref: refs/heads/__loc-ratchet-missing__\n",
-    );
+    expect(result.stderr).toBe("Unknown argument: --base-ref\n");
   });
 
   it("grandfathers exact legacy sizes and rejects growth or stale baselines", () => {
@@ -94,14 +82,6 @@ describe("scripts/check-ts-max-loc", () => {
     expect(countPhysicalLines("one\ntwo\n")).toBe(2);
   });
 
-  it("parses git paths without quoting or newline ambiguity", () => {
-    expect(splitNullDelimitedPaths("src/normal.ts\0src/café.ts\0src/line\nbreak.ts\0")).toEqual([
-      "src/normal.ts",
-      "src/café.ts",
-      "src/line\nbreak.ts",
-    ]);
-  });
-
   it("excludes repository test and test-support naming conventions", () => {
     expect(isProductionTypeScriptFile("src/runtime.ts")).toBe(true);
     expect(isProductionTypeScriptFile("src/runtime.mts")).toBe(true);
@@ -126,86 +106,19 @@ describe("scripts/check-ts-max-loc", () => {
     expect(isProductionTypeScriptFile("ui/src/i18n/lib/translate.ts")).toBe(true);
   });
 
-  it("allows base drift reconciliation but rejects changed-source growth", () => {
-    const violations = findVersionedBaselineViolations({
-      baseBaseline: {
-        "src/grew.ts": 700,
-        "src/readded.ts": 700,
-        "src/shrank.ts": 700,
-        "src/preexisting-drift.ts": 700,
-      },
-      baseline: {
-        "src/grew.ts": 701,
-        "src/readded.ts": 650,
-        "src/shrank.ts": 650,
-        "src/new.ts": 501,
-        "src/preexisting-drift.ts": 710,
-        "src/preexisting-missing.ts": 510,
-      },
-      baseLinesByChangedPath: new Map([
-        ["src/grew.ts", 700],
-        ["src/readded.ts", undefined],
-        ["src/shrank.ts", 700],
-        ["src/new.ts", undefined],
-      ]),
+  it("builds a reviewable baseline from current oversized files, including growth", () => {
+    expect(
+      buildLocBaseline(
+        [
+          { filePath: "src/grew.ts", lines: 701 },
+          { filePath: "src/new.ts", lines: 501 },
+          { filePath: "src/small.ts", lines: 500 },
+        ],
+        500,
+      ),
+    ).toEqual({
+      "src/grew.ts": 701,
+      "src/new.ts": 501,
     });
-
-    expect(violations).toEqual([
-      { filePath: "src/grew.ts", lines: 701, baselineLines: 700, reason: "grew" },
-      { filePath: "src/readded.ts", lines: 650, baselineLines: 0, reason: "grew" },
-      { filePath: "src/new.ts", lines: 501, reason: "baseline-missing" },
-    ]);
-  });
-
-  it("ignores only drift already present on the comparison base", () => {
-    const violations = filterPreexistingBaseDriftViolations({
-      baseBaseline: {
-        "src/changed.ts": 700,
-        "src/preexisting-growth.ts": 700,
-        "src/preexisting-shrink.ts": 700,
-        "src/removed-entry.ts": 700,
-      },
-      baseline: {
-        "src/changed.ts": 700,
-        "src/preexisting-growth.ts": 700,
-        "src/preexisting-shrink.ts": 700,
-        "src/tampered.ts": 900,
-      },
-      changedPaths: new Set(["src/changed.ts"]),
-      violations: [
-        { filePath: "src/changed.ts", lines: 701, baselineLines: 700, reason: "grew" },
-        {
-          filePath: "src/preexisting-growth.ts",
-          lines: 710,
-          baselineLines: 700,
-          reason: "grew",
-        },
-        {
-          filePath: "src/preexisting-shrink.ts",
-          lines: 690,
-          baselineLines: 700,
-          reason: "baseline-stale",
-        },
-        { filePath: "src/preexisting-new.ts", lines: 510, reason: "baseline-missing" },
-        { filePath: "src/removed-entry.ts", lines: 700, reason: "baseline-missing" },
-        {
-          filePath: "src/tampered.ts",
-          lines: 700,
-          baselineLines: 900,
-          reason: "baseline-stale",
-        },
-      ],
-    });
-
-    expect(violations).toEqual([
-      { filePath: "src/changed.ts", lines: 701, baselineLines: 700, reason: "grew" },
-      { filePath: "src/removed-entry.ts", lines: 700, reason: "baseline-missing" },
-      {
-        filePath: "src/tampered.ts",
-        lines: 700,
-        baselineLines: 900,
-        reason: "baseline-stale",
-      },
-    ]);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The TypeScript maximum-LOC ratchet introduced by #105894 had no legal path for legitimate growth: a changed file above the threshold, or a new oversized file, could not raise or add its checked-in baseline entry because CI compared that entry with the base ref. Snapshot baseline repairs therefore re-broke as `main` moved.

#105991 already excluded generated locale bundles. #106042 tolerates inherited drift, but intentionally still rejects changed-path growth, so it does not provide the missing approval path.

## Why This Change Was Made

Make the checked-in baseline diff the explicit review artifact, matching the repository's other ratchets:

- The normal check still requires every tracked entry to equal the file's current physical LOC.
- Reductions still require lowering or removing the baseline entry.
- `check:loc:update` may record legitimate growth or a new oversized file for reviewer approval.
- The unshipped versioned-comparison machinery and `--base-ref` CI argument are removed.

This is the owner-approved enforcement boundary: CI proves the baseline matches reality; code review approves any increase.

## User Impact

Fresh repo-wide guard runs stop deadlocking on legitimate, reviewed TypeScript growth. The 500-line target and downward ratchet remain enforced.

## Evidence

- AWS Crabbox `run_bf68e8843b92`: `pnpm check:changed` passed on the refreshed patch.
- AWS Crabbox `run_54670c223a72`: focused LOC tests passed 8/8; current `pnpm check:loc` passed.
- Red/green approval proof: a temporary baseline entry lowered by one line failed with `grew`; `--write-baseline` regenerated it; the normal check then passed.
- Blacksmith Testbox `tbx_01kxcydvj62pj0acv44q4qxmae`: `pnpm check:workflows`, scripts/root-test tsgo, formatting, and focused tests passed.
- Two fresh Codex autoreviews: no findings; patch correct.

Refs #105894, #105991, #106042.
