### PR TITLE
fix(nodes): reject malformed camera content lengths

### DIFF
--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -306,6 +306,15 @@ describe("nodes camera helpers", () => {
       expectedMessage: /exceeds max/i,
     },
     {
+      name: "malformed content-length",
+      url: "https://198.51.100.42/weird.bin",
+      response: new Response("tiny", {
+        status: 200,
+        headers: { "content-length": "0x3" },
+      }),
+      expectedMessage: /invalid content-length header: 0x3/i,
+    },
+    {
       name: "non-ok status",
       url: "https://198.51.100.42/down.bin",
       response: new Response("down", { status: 503, statusText: "Service Unavailable" }),
@@ -343,6 +352,15 @@ describe("nodes camera helpers", () => {
           headers: { "content-length": String(999_999_999) },
         }),
       expectedMessage: /exceeds max/i,
+    },
+    {
+      name: "malformed content-length",
+      response: () =>
+        cancelTrackedResponse({
+          status: 200,
+          headers: { "content-length": "0x3" },
+        }),
+      expectedMessage: /invalid content-length/i,
     },
   ] as const)(
     "cancels rejected url response bodies: $name",

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -2,10 +2,10 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { canonicalizeBase64, estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
+import { parseMediaContentLength } from "@openclaw/media-core/content-length";
 import { toErrorObject } from "../infra/errors.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { normalizeHostname } from "../infra/net/hostname.js";
-import { parseStrictNonNegativeInteger } from "../infra/parse-finite-number.js";
 import { resolveCliName } from "./cli-name.js";
 import {
   asBoolean,
@@ -144,13 +144,14 @@ export async function writeUrlToFile(
       throw new Error(`failed to download ${url}: ${res.status} ${res.statusText}`);
     }
 
-    const contentLengthRaw = res.headers.get("content-length");
-    const contentLength = parseStrictNonNegativeInteger(contentLengthRaw);
-    if (
-      typeof contentLength === "number" &&
-      Number.isFinite(contentLength) &&
-      contentLength > MAX_CAMERA_URL_DOWNLOAD_BYTES
-    ) {
+    let contentLength: number | null;
+    try {
+      contentLength = parseMediaContentLength(res.headers.get("content-length"));
+    } catch (err) {
+      await cancelIgnoredResponseBody(res);
+      throw err;
+    }
+    if (contentLength !== null && contentLength > MAX_CAMERA_URL_DOWNLOAD_BYTES) {
       await cancelIgnoredResponseBody(res);
       throw new Error(
         `writeUrlToFile: content-length ${contentLength} exceeds max ${MAX_CAMERA_URL_DOWNLOAD_BYTES}`,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users saving URL-backed node camera, photo, or clip media could accept a malformed `Content-Length` response header and continue as though no size header was present.

## Why This Change Was Made

The node media URL download boundary now parses `Content-Length` with the shared strict media parser before reading the response body, and cancels rejected response bodies on malformed headers. This keeps the change inside the node-hosted media download path used by camera CLI commands and agent node media actions without changing valid downloads, config, provider behavior, schemas, or public APIs.

## User Impact

Malformed node-hosted media responses are rejected before the payload is copied to disk, while valid URL-backed camera media continues to use the existing size limits and stream guard.

## Evidence

- Claim proved: the production `fetchWithSsrFGuard` -> `writeUrlToFile` HTTPS download path still accepts missing and valid `Content-Length` headers, and rejects malformed media lengths before opening/copying the output file.
- Current-head runtime proof at `aef555613389229e08cafc57157a415df05f0783`: loopback HTTPS responder called by `writeUrlToFile` via `node --import tsx --input-type=module -`.

```text
HEAD=aef555613389229e08cafc57157a415df05f0783
missing-header: PASS bytes=11 payload=url-content
valid-header: PASS bytes=11 payload=url-content
malformed-header: PASS header=9007199254740992 rejected="invalid content-length header: 9007199254740992" outputExists=false
requests=/missing,/valid,/malformed
result=PASS
```

- Focused regression proof: `node scripts/run-vitest.mjs src/cli/nodes-camera.test.ts` passed with 31 tests, including the `content-length: 0x3` rejection/cancellation case.
- PR diff hygiene: `git diff --check upstream/main...HEAD` passed.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode branch --base upstream/main` passed with no accepted/actionable findings on this head.