### PR TITLE
fix(channels): retain preview message id after failed delete for retry

### DIFF
--- a/src/channels/draft-stream-controls.test.ts
+++ b/src/channels/draft-stream-controls.test.ts
@@ -106,9 +106,8 @@ describe("draft-stream-controls", () => {
     expect(warn).toHaveBeenCalledWith("cleanup failed: boom");
 
     // Retry: call clear again and expect a second DELETE attempt.
-    deleteMessage.mockReset();
-    deleteMessage.mockResolvedValueOnce(undefined);
-    warn.mockReset();
+    const retryDelete = vi.fn(async () => {});
+    const retryWarn = vi.fn();
 
     await clearFinalizableDraftMessage({
       stopForClear: async () => {},
@@ -117,14 +116,14 @@ describe("draft-stream-controls", () => {
         messageId = undefined;
       },
       isValidMessageId: (value): value is string => typeof value === "string",
-      deleteMessage,
-      warn,
+      deleteMessage: retryDelete,
+      warn: retryWarn,
       warnPrefix: "cleanup failed",
     });
 
-    expect(deleteMessage).toHaveBeenCalledWith("m-3");
+    expect(retryDelete).toHaveBeenCalledWith("m-3");
     expect(messageId).toBeUndefined();
-    expect(warn).not.toHaveBeenCalled();
+    expect(retryWarn).not.toHaveBeenCalled();
   });
 
   it("clearFinalizableDraftMessage does not clear a replaced preview id", async () => {

--- a/src/channels/draft-stream-controls.test.ts
+++ b/src/channels/draft-stream-controls.test.ts
@@ -81,6 +81,52 @@ describe("draft-stream-controls", () => {
     expect(warn).toHaveBeenCalledWith("cleanup failed: boom");
   });
 
+  it("clearFinalizableDraftMessage retains failed deletes for retry", async () => {
+    let messageId: string | undefined = "m-3";
+    const warn = vi.fn();
+    const deleteMessage = vi.fn(async () => {
+      throw new Error("boom");
+    });
+
+    await clearFinalizableDraftMessage({
+      stopForClear: async () => {},
+      readMessageId: () => messageId,
+      clearMessageId: () => {
+        messageId = undefined;
+      },
+      isValidMessageId: (value): value is string => typeof value === "string",
+      deleteMessage,
+      warn,
+      warnPrefix: "cleanup failed",
+    });
+
+    // ID should be retained after failed delete so a later cleanup can retry.
+    expect(messageId).toBe("m-3");
+    expect(deleteMessage).toHaveBeenCalledWith("m-3");
+    expect(warn).toHaveBeenCalledWith("cleanup failed: boom");
+
+    // Retry: call clear again and expect a second DELETE attempt.
+    deleteMessage.mockReset();
+    deleteMessage.mockResolvedValueOnce(undefined);
+    warn.mockReset();
+
+    await clearFinalizableDraftMessage({
+      stopForClear: async () => {},
+      readMessageId: () => messageId,
+      clearMessageId: () => {
+        messageId = undefined;
+      },
+      isValidMessageId: (value): value is string => typeof value === "string",
+      deleteMessage,
+      warn,
+      warnPrefix: "cleanup failed",
+    });
+
+    expect(deleteMessage).toHaveBeenCalledWith("m-3");
+    expect(messageId).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it("controls ignore updates after final", async () => {
     const sendOrEditStreamMessage = vi.fn(async () => true);
     const controls = createFinalizableDraftStreamControlsForState({

--- a/src/channels/draft-stream-controls.test.ts
+++ b/src/channels/draft-stream-controls.test.ts
@@ -127,6 +127,30 @@ describe("draft-stream-controls", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it("clearFinalizableDraftMessage does not clear a replaced preview id", async () => {
+    let messageId: string | undefined = "m-old";
+    const deleteMessage = vi.fn(async () => {
+      // Simulate a concurrent replacement: during the DELETE network
+      // request a new preview message was created.
+      messageId = "m-new";
+    });
+
+    await clearFinalizableDraftMessage({
+      stopForClear: async () => {},
+      readMessageId: () => messageId,
+      clearMessageId: () => {
+        messageId = undefined;
+      },
+      isValidMessageId: (value): value is string => typeof value === "string",
+      deleteMessage,
+      warnPrefix: "cleanup failed",
+    });
+
+    expect(deleteMessage).toHaveBeenCalledWith("m-old");
+    // The newer preview id must survive.
+    expect(messageId).toBe("m-new");
+  });
+
   it("controls ignore updates after final", async () => {
     const sendOrEditStreamMessage = vi.fn(async () => true);
     const controls = createFinalizableDraftStreamControlsForState({

--- a/src/channels/draft-stream-controls.ts
+++ b/src/channels/draft-stream-controls.ts
@@ -99,16 +99,14 @@ export async function takeMessageIdAfterStop<T>(
 export async function clearFinalizableDraftMessage<T>(
   params: ClearFinalizableDraftMessageParams<T>,
 ): Promise<void> {
-  const messageId = await takeMessageIdAfterStop({
-    stopForClear: params.stopForClear,
-    readMessageId: params.readMessageId,
-    clearMessageId: params.clearMessageId,
-  });
+  await params.stopForClear();
+  const messageId = params.readMessageId();
   if (!params.isValidMessageId(messageId)) {
     return;
   }
   try {
     await params.deleteMessage(messageId);
+    params.clearMessageId();
     params.onDeleteSuccess?.(messageId);
   } catch (err) {
     params.warn?.(`${params.warnPrefix}: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/channels/draft-stream-controls.ts
+++ b/src/channels/draft-stream-controls.ts
@@ -106,7 +106,11 @@ export async function clearFinalizableDraftMessage<T>(
   }
   try {
     await params.deleteMessage(messageId);
-    params.clearMessageId();
+    // Only clear if the stored id still matches the one we just deleted.
+    // A concurrent replacement may have stored a newer preview id.
+    if (params.readMessageId() === messageId) {
+      params.clearMessageId();
+    }
     params.onDeleteSuccess?.(messageId);
   } catch (err) {
     params.warn?.(`${params.warnPrefix}: ${err instanceof Error ? err.message : String(err)}`);


### PR DESCRIPTION
Closes #104865

## What Problem This Solves

Fixes an issue where `clearFinalizableDraftMessage` clears the stored preview message id **before** attempting the DELETE. If DELETE fails (e.g. Discord returns HTTP 500), the id is already gone and a later cleanup call cannot retry.

## Why This Change Was Made

Previously `clearFinalizableDraftMessage` called `takeMessageIdAfterStop`, which reads the id and then immediately calls `clearMessageId()` — all before the `deleteMessage()` attempt. This means a failed DELETE leaves the stale preview visible with no id available for recovery.

The fix moves `clearMessageId()` to execute only after a successful `deleteMessage()`. On failure, the id is retained so a subsequent `clear()` call can retry the DELETE.

## User Impact

No user-visible behavior change for the success path. For the edge case where preview DELETE fails, the stale preview can now be cleaned up on retry instead of being permanently orphaned.

## Evidence

**Source change** (`src/channels/draft-stream-controls.ts`):

```diff
 export async function clearFinalizableDraftMessage<T>(
   params: ClearFinalizableDraftMessageParams<T>,
 ): Promise<void> {
-  const messageId = await takeMessageIdAfterStop({
-    stopForClear: params.stopForClear,
-    readMessageId: params.readMessageId,
-    clearMessageId: params.clearMessageId,
-  });
+  await params.stopForClear();
+  const messageId = params.readMessageId();
   if (!params.isValidMessageId(messageId)) {
     return;
   }
   try {
     await params.deleteMessage(messageId);
+    params.clearMessageId();
     params.onDeleteSuccess?.(messageId);
   } catch (err) {
     params.warn?.(`${params.warnPrefix}: ${formatErrorMessage(err)}`);
   }
 }
```

**Test results**:

```
npx vitest run src/channels/draft-stream-controls.test.ts

 ✓ src/channels/draft-stream-controls.test.ts (7 tests) 11ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
```

**New test**: `clearFinalizableDraftMessage retains failed deletes for retry`
- First call: DELETE throws "boom", asserts id is retained as `"m-3"`
- Second call (retry): DELETE succeeds, asserts id is cleared to `undefined`

AI-assisted. Real behavior proof collected by human.