### PR TITLE
fix(slack): bound userCache growth with pruneMapToMaxSize

### DIFF
--- a/extensions/slack/src/monitor/context.test.ts
+++ b/extensions/slack/src/monitor/context.test.ts
@@ -200,4 +200,41 @@ describe("createSlackMonitorContext channel metadata cache", () => {
 
     await expect(ctx.resolveChannelName("C0OLDEST")).resolves.toEqual({});
   });
+
+  it("evicts the oldest user name when the bounded user cache fills", async () => {
+    const usersInfo = vi.fn().mockResolvedValue({
+      user: { profile: { display_name: "test-user" } },
+    });
+    const ctx = createTestContext({
+      appClient: { users: { info: usersInfo } } as unknown as App["client"],
+    });
+    await ctx.resolveUserName("U0OLDEST");
+    for (let index = 0; index < 2048; index += 1) {
+      await ctx.resolveUserName(`U${index}`);
+    }
+    // U0OLDEST should have been evicted by the fill. Re-requesting it must
+    // call users.info again (cache miss) instead of returning a stale entry.
+    await ctx.resolveUserName("U0OLDEST");
+    expect(usersInfo).toHaveBeenCalledTimes(2050);
+  });
+
+  it("keeps a recently re-resolved user while older entries are evicted", async () => {
+    const usersInfo = vi.fn().mockImplementation(async ({ user }: { user: string }) => ({
+      user: { profile: { display_name: `name-${user}` } },
+    }));
+    const ctx = createTestContext({
+      appClient: { users: { info: usersInfo } } as unknown as App["client"],
+    });
+    await ctx.resolveUserName("U0KEEP");
+    for (let index = 0; index < 2047; index += 1) {
+      await ctx.resolveUserName(`U${index}`);
+    }
+    // Touch U0KEEP so it becomes newest before the final insert that would
+    // otherwise push the original insertion past the 2048-entry bound.
+    await ctx.resolveUserName("U0KEEP");
+    await ctx.resolveUserName("U_NEW");
+    const before = usersInfo.mock.calls.length;
+    await expect(ctx.resolveUserName("U0KEEP")).resolves.toEqual({ name: "name-U0KEEP" });
+    expect(usersInfo).toHaveBeenCalledTimes(before);
+  });
 });

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -3,7 +3,6 @@ import type { App } from "@slack/bolt";
 import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import { formatAllowlistMatchMeta } from "openclaw/plugin-sdk/allow-from";
 import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
-import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import type {
   OpenClawConfig,
   SlackReactionNotificationMode,
@@ -31,6 +30,7 @@ import { normalizeSlackChannelType } from "./channel-type.js";
 import { resolveSessionKey } from "./config.runtime.js";
 import type { SlackInstallationIdentity } from "./enterprise-install.js";
 import type { SlackEventScope } from "./event-scope.js";
+import { readLruMapEntry, writeLruMapEntry } from "./lru-map-cache.js";
 import { isSlackChannelAllowedByPolicy } from "./policy.js";
 
 export { normalizeSlackChannelType, resolveSlackChatType } from "./channel-type.js";
@@ -64,6 +64,7 @@ type SlackChannelCacheEntry = {
 
 const SLACK_ASSISTANT_THREAD_CONTEXT_METADATA_EVENT = "assistant_thread_context";
 const SLACK_CHANNEL_CACHE_MAX_ENTRIES = 1024;
+const SLACK_USER_CACHE_MAX_ENTRIES = 2048;
 const SLACK_CHANNEL_DENIAL_WARNING_TTL_MS = 5 * 60_000;
 const SLACK_CHANNEL_DENIAL_WARNING_MAX_ENTRIES = 1024;
 
@@ -288,22 +289,6 @@ export function createSlackMonitorContext(params: {
   const scopedKey = (key: string, eventScope?: SlackEventScope) =>
     eventScope ? `${params.accountId}:${eventScope.teamId}:${key}` : key;
 
-  const readCachedChannel = (cacheKey: string): SlackChannelCacheEntry | undefined => {
-    const cached = channelCache.get(cacheKey);
-    if (cached) {
-      // Active rooms stay resident while the bounded cache evicts the oldest entry.
-      channelCache.delete(cacheKey);
-      channelCache.set(cacheKey, cached);
-    }
-    return cached;
-  };
-
-  const writeCachedChannel = (cacheKey: string, entry: SlackChannelCacheEntry): void => {
-    channelCache.delete(cacheKey);
-    channelCache.set(cacheKey, entry);
-    pruneMapToMaxSize(channelCache, SLACK_CHANNEL_CACHE_MAX_ENTRIES);
-  };
-
   const rememberSlackChannelType = (
     channelId: string | null | undefined,
     channelType: string | null | undefined,
@@ -321,16 +306,21 @@ export function createSlackMonitorContext(params: {
       return;
     }
     const cacheKey = scopedKey(id, eventScope);
-    const cached = readCachedChannel(cacheKey);
+    const cached = readLruMapEntry(channelCache, cacheKey);
     const type = normalizeSlackChannelType(normalizedType, id);
     if (cached?.info.type === type) {
       return;
     }
     // Type-only entries must not suppress a later conversations.info metadata fill.
-    writeCachedChannel(cacheKey, {
-      info: { ...cached?.info, type },
-      metadataLoaded: cached?.metadataLoaded ?? false,
-    });
+    writeLruMapEntry(
+      channelCache,
+      cacheKey,
+      {
+        info: { ...cached?.info, type },
+        metadataLoaded: cached?.metadataLoaded ?? false,
+      },
+      SLACK_CHANNEL_CACHE_MAX_ENTRIES,
+    );
   };
 
   const recallSlackChannelType = (
@@ -338,7 +328,7 @@ export function createSlackMonitorContext(params: {
     eventScope?: SlackEventScope,
   ): SlackMessageEvent["channel_type"] | undefined => {
     const id = normalizeOptionalString(channelId);
-    return id ? readCachedChannel(scopedKey(id, eventScope))?.info.type : undefined;
+    return id ? readLruMapEntry(channelCache, scopedKey(id, eventScope))?.info.type : undefined;
   };
 
   const markMessageSeen = (
@@ -508,7 +498,7 @@ export function createSlackMonitorContext(params: {
 
   const resolveChannelName = async (channelId: string, eventScope?: SlackEventScope) => {
     const cacheKey = scopedKey(channelId, eventScope);
-    const cached = readCachedChannel(cacheKey);
+    const cached = readLruMapEntry(channelCache, cacheKey);
     if (cached?.metadataLoaded) {
       return cached.info;
     }
@@ -537,7 +527,7 @@ export function createSlackMonitorContext(params: {
         info: { name, type: cached?.info.type ?? type, topic, purpose },
         metadataLoaded: true,
       };
-      writeCachedChannel(cacheKey, entry);
+      writeLruMapEntry(channelCache, cacheKey, entry, SLACK_CHANNEL_CACHE_MAX_ENTRIES);
       return entry.info;
     } catch {
       return cached?.info ?? {};
@@ -546,7 +536,7 @@ export function createSlackMonitorContext(params: {
 
   const resolveUserName = async (userId: string, eventScope?: SlackEventScope) => {
     const cacheKey = scopedKey(userId, eventScope);
-    const cached = userCache.get(cacheKey);
+    const cached = readLruMapEntry(userCache, cacheKey);
     if (cached) {
       return cached;
     }
@@ -558,7 +548,7 @@ export function createSlackMonitorContext(params: {
       const profile = info.user?.profile;
       const name = profile?.display_name || profile?.real_name || info.user?.name || undefined;
       const entry = { name };
-      userCache.set(cacheKey, entry);
+      writeLruMapEntry(userCache, cacheKey, entry, SLACK_USER_CACHE_MAX_ENTRIES);
       return entry;
     } catch {
       return {};

--- a/extensions/slack/src/monitor/lru-map-cache.ts
+++ b/extensions/slack/src/monitor/lru-map-cache.ts
@@ -1,0 +1,22 @@
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
+
+/** LRU-touch read: move hit to newest so pruneMapToMaxSize keeps active keys. */
+export function readLruMapEntry<T>(cache: Map<string, T>, cacheKey: string): T | undefined {
+  const cached = cache.get(cacheKey);
+  if (cached) {
+    cache.delete(cacheKey);
+    cache.set(cacheKey, cached);
+  }
+  return cached;
+}
+
+export function writeLruMapEntry<T>(
+  cache: Map<string, T>,
+  cacheKey: string,
+  entry: T,
+  maxEntries: number,
+): void {
+  cache.delete(cacheKey);
+  cache.set(cacheKey, entry);
+  pruneMapToMaxSize(cache, maxEntries);
+}


### PR DESCRIPTION
## What Problem This Solves

The Slack monitor's process-lifetime `userCache` stored every successful unique `users.info` lookup without a bound. Long-running monitors spanning many users or Enterprise Grid teams could therefore retain names indefinitely. The neighboring channel cache was already bounded.

## Why This Change Was Made

This applies the existing channel-cache policy to user names: cache hits refresh insertion order, successful misses write through a small plugin-local LRU helper, and `pruneMapToMaxSize` caps the map at 2,048 entries.

The cache stays in its existing Slack monitor owner. No configuration, persistence, API request, or failure behavior changes. Slack's documented [`users.info`](https://docs.slack.dev/reference/methods/users.info/) request and optional profile fields remain unchanged.

Alternatives rejected:

- TTL-only eviction adds clock policy and still permits unbounded bursts.
- A shared core cache would cross the Slack plugin ownership boundary.
- Replacing keyed lookups with `users.list` would broaden API, data, and rate-limit behavior.

## User Impact

- Slack user-name cache growth is capped at 2,048 entries.
- Recently used names remain resident.
- Evicted users resolve normally through `users.info` on their next lookup.
- Failed lookups remain uncached, preserving the existing retry-on-next-lookup behavior.

## Evidence

Head: `9271eedffc89ff58e0ac09e8ac402252de90d7b3`, rebased onto current main when published.

- Blacksmith Testbox: `extensions/slack/src/monitor/context.test.ts`, 11/11 passed.
- Full path-scoped `check:changed` passed, including extension source/test typechecks, formatting, lint, LOC, dependency, SDK, database-first, sidecar, and import-cycle gates.
- Regression tests fill beyond the cap, prove oldest-entry eviction, and prove a recently touched entry survives.
- Redacted live Slack proof exercised successful lookup, cache hit, bounded fill, eviction, and refetch.
- A historical exact-head CI failure was unrelated TUI test-type drift; fresh exact-head hosted CI is required before merge.

Previously exposed proof credentials were confirmed revoked/rotated by the operator. No credential values or suffixes remain in this body.

## AI disclosure

The contributor used Cursor. Maintainer review traced the owner/callers/siblings, checked the Slack SDK and current API docs, rebased the focused patch, and ran fresh remote proof.
