### PR TITLE
fix(telegram): preserve authored links whose label matches a file-ref hostname [AI-assisted]

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -9,6 +9,7 @@ import {
   renderTelegramHtmlText,
   splitTelegramHtmlChunks,
   telegramHtmlToPlainTextFallback,
+  wrapFileReferencesInHtml,
 } from "./format.js";
 
 describe("markdownToTelegramHtml", () => {
@@ -471,6 +472,34 @@ describe("markdownToTelegramHtml", () => {
     const res = markdownToTelegramHtml("See README.md. Also (backup.sh).");
     expect(res).toContain("<code>README.md</code>.");
     expect(res).toContain("(<code>backup.sh</code>).");
+  });
+
+  it("preserves authored links whose label matches a file-ref hostname (#105679)", () => {
+    // Authored markdown links are real navigations and must survive even when the
+    // visible label coincidentally looks like a file reference with a TLD extension.
+    expect(markdownToTelegramHtml("[foo.go](https://foo.go)")).toBe(
+      '<a href="https://foo.go">foo.go</a>',
+    );
+    expect(markdownToTelegramHtml("[README.md](https://README.md)")).toBe(
+      '<a href="https://README.md">README.md</a>',
+    );
+    // http:// authored symmetric links remain a known narrow edge case (treated as
+    // autolinks); the common https:// authored form is what #105679 restores.
+    expect(markdownToTelegramHtml("[docs](https://example.com)")).toBe(
+      '<a href="https://example.com">docs</a>',
+    );
+  });
+
+  it("does not de-linkify authored https anchors in the html safety-net (#105679)", () => {
+    // Authored https:// symmetric anchors must pass through wrapFileReferencesInHtml.
+    expect(wrapFileReferencesInHtml('<a href="https://foo.go">foo.go</a>')).toBe(
+      '<a href="https://foo.go">foo.go</a>',
+    );
+    // Defense-in-depth preserved: a linkifier-generated http://<label> autolink is
+    // still folded back into a code tag so Telegram shows plain text, not a link.
+    expect(wrapFileReferencesInHtml('<a href="http://README.md">README.md</a>')).toBe(
+      "<code>README.md</code>",
+    );
   });
 
   it("renders spoiler tags", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -70,9 +70,14 @@ function buildTelegramLink(link: MarkdownLinkSpan, text: string) {
   if (!isTelegramRichLinkHref(href)) {
     return null;
   }
-  // Suppress auto-linkified file references (e.g. README.md → http://README.md)
+  // Suppress auto-linkified file references (e.g. bare `README.md` that the
+  // markdown-it linkifier turns into an http://README.md autolink). Restrict the
+  // suppression to the linkifier's canonical http:// form so authored links whose
+  // label coincidentally matches a file-ref hostname (e.g. [foo.go](https://foo.go))
+  // are preserved — the linkifier only ever emits http://, real links use https://
+  // or carry a path. See #105679.
   const label = text.slice(link.start, link.end);
-  if (isAutoLinkedFileRef(href, label)) {
+  if (href.startsWith("http://") && isAutoLinkedFileRef(href, label)) {
     return null;
   }
   const safeHref = escapeHtmlAttr(href);
@@ -199,7 +204,9 @@ function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-const AUTO_LINKED_ANCHOR_PATTERN = /<a\s+href="https?:\/\/([^"]+)"[^>]*>\1<\/a>/gi;
+// Safety-net de-linkifier targets auto-generated anchors where href="http://<label>"
+// (the linkifier's canonical form). Authored https:// anchors are left intact (#105679).
+const AUTO_LINKED_ANCHOR_PATTERN = /<a\s+href="http:\/\/([^"]+)"[^>]*>\1<\/a>/gi;
 const HTML_TAG_PATTERN = /(<\/?)([a-zA-Z][a-zA-Z0-9-]*)\b[^>]*?>/gi;
 const HTML_MODE_TAG_PATTERN = /^<(\/?)([a-zA-Z][a-zA-Z0-9-]*)([^<>]*)>$/;
 const ESCAPED_HTML_TAG_PATTERN = /&lt;(\/?)([a-zA-Z][a-zA-Z0-9-]*)(.*?)&gt;/g;


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

Closes #105679

## What Problem This Solves

Fixes an issue where Telegram recipients silently lose authored navigation links whose visible label coincidentally looks like a file reference with a TLD extension — for example `[foo.go](https://foo.go)` or `[README.md](https://README.md)`. Instead of a clickable link, Telegram received plain code text (`<code>foo.go</code>`), discarding the link target the author wrote. Any authored link whose label matches a tracked file-ref hostname (`md`, `go`, `py`, `pl`, `sh`, `am`, `at`, `be`, `cc`) is affected.

## Why This Change Was Made

The formatter suppresses "auto-linkified" bare file references: when the markdown-it linkifier turns bare text like `README.md` into an `http://README.md` autolink, the formatter folds it back to `<code>` so Telegram shows plain text instead of a bogus domain-registrar link preview. That suppression is meant to target only the linkifier's canonical `http://<label>` form (the code comments already document `http://`, not `https://`).

The suppression lives at two sites, and both accepted `https://` as readily as `http://`:

1. `buildTelegramLink` — runs during markdown→IR conversion (the user-facing path); and
2. the `wrapFileReferencesInHtml` safety-net — the raw-HTML defense-in-depth path.

`isAutoLinkedFileRef(href, label)` returns true whenever `(href minus scheme) == label` and the label has a tracked extension, so an **authored** symmetric link (`[foo.go](https://foo.go)`) was indistinguishable from a genuine autolink and got destroyed — at site 1 in the normal pipeline, and at site 2 for raw-HTML anchors.

The linkifier only ever emits `http://` (it normalizes schemeless domains to `http://`); real authored links use `https://` or carry a path. So the scheme is the reliable discriminator. This PR narrows **both** suppression sites to `http://` only, matching the documented intent. Genuine `http://README.md` autolinks are still folded to `<code>`; authored `https://` links are preserved. This is behavior-loosening (preserves more links, never adds suppression), so it cannot regress cases that previously rendered links.

## User Impact

Authors can now share links like `[foo.go](https://foo.go)` in Telegram-bound messages and have them arrive as working clickable links instead of being silently replaced with unclickable code text. File-reference pretty-printing for bare tokens mentioned in prose (e.g. `README.md` → `<code>README.md</code>`) is unchanged.

## Evidence

Real behavior proof — the production formatter (`markdownToTelegramHtml` / `wrapFileReferencesInHtml`) run on the repro inputs via the repo's vitest runner.

**Before (unpatched `main`):**

```
markdownToTelegramHtml("[foo.go](https://foo.go)")            => <code>foo.go</code>          [LINK LOST]
markdownToTelegramHtml("[README.md](https://README.md)")      => <code>README.md</code>       [LINK LOST]
wrapFileReferencesInHtml('<a href="https://foo.go">foo.go</a>')   => <code>foo.go</code>       [LINK LOST]
```

**After (this PR):**

```
markdownToTelegramHtml("[foo.go](https://foo.go)")            => <a href="https://foo.go">foo.go</a>          [link ok]
markdownToTelegramHtml("[README.md](https://README.md)")      => <a href="https://README.md">README.md</a>    [link ok]
wrapFileReferencesInHtml('<a href="https://foo.go">foo.go</a>')   => <a href="https://foo.go">foo.go</a>      [link ok]
```

**Defense preserved (regression guards) — unchanged before vs after:**

```
markdownToTelegramHtml("See README.md.")                              => See <code>README.md</code>.
wrapFileReferencesInHtml('<a href="http://README.md">README.md</a>')      => <code>README.md</code>   [de-linkified, intended]
wrapFileReferencesInHtml('<a href="https://example.com">docs</a>')        => <a href="https://example.com">docs</a>
```

Regression tests added in `extensions/telegram/src/format.test.ts`:

- `preserves authored links whose label matches a file-ref hostname (#105679)`
- `does not de-linkify authored https anchors in the html safety-net (#105679)`

Both fail on unpatched `main` and pass with this PR; the full `format.test.ts` suite is green (71/71).

### What was not tested

- Telegram *client* rendering was not screenshotted (no Telegram Desktop session). The proof is the HTML payload the formatter emits — which is what Telegram receives and what determines whether a clickable link renders. The `<a>` structure is directly verifiable in formatter output.
- On Windows, 5 tests in `bot.create-telegram-bot.test.ts` fail with `EBUSY: resource busy or locked ... openclaw-agent.sqlite` during temp-dir teardown — a pre-existing Windows file-locking flake in the test harness, unrelated to this change (those tests exercise bot command dispatch, not the formatter).
