### PR TITLE
fix: sidebar customization check reopens Settings

### DIFF
--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -63,6 +63,15 @@ async function holdUiProof(page: Page, durationMs = 600) {
   }
 }
 
+async function openSettingsFromAgentMenu(sidebar: Locator) {
+  const agentMenuButton = sidebar.getByRole("button", { name: /Agent menu$/ });
+  await expect.poll(() => agentMenuButton.getAttribute("aria-expanded")).toBe("false");
+  await agentMenuButton.click();
+  const agentMenu = sidebar.getByRole("menu", { name: "Agent menu" });
+  await expect.poll(() => agentMenu.isVisible()).toBe(true);
+  await agentMenu.getByRole("menuitem", { name: "Settings" }).click();
+}
+
 async function openSidebarTestPage() {
   const context = await browser.newContext({
     locale: "en-US",
@@ -188,9 +197,7 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await expect.poll(() => roundedWidth(shellNav)).toBe(400);
       // Settings takes over the whole app: the regular sidebar yields to the
       // settings sidebar until "Back to app" (or Escape) exits.
-      const settingsLink = sidebar.getByRole("link", { name: "Settings" });
-      await expect.poll(() => settingsLink.isVisible()).toBe(true);
-      await settingsLink.click();
+      await openSettingsFromAgentMenu(sidebar);
       await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/general");
       const settingsSidebar = page.locator(".settings-sidebar");
       await expect.poll(() => settingsSidebar.isVisible()).toBe(true);
@@ -319,7 +326,7 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await page.keyboard.press("Escape");
       await expect.poll(() => new URL(page.url()).pathname).toBe("/sessions");
       await expect.poll(() => sidebar.isVisible()).toBe(true);
-      await settingsLink.click();
+      await openSettingsFromAgentMenu(sidebar);
       await expect.poll(() => settingsSidebar.isVisible()).toBe(true);
       await expect.poll(() => settingsSearch.inputValue()).toBe("");
       await captureSettingsSidebarProof(settingsSidebar, "01g-settings-search-reset.png");


### PR DESCRIPTION
AI-assisted: Codex implemented and reviewed this change.

## What Problem This Solves

Fixes an issue where the sidebar customization E2E test failed while reopening Settings after the Settings entry moved from a direct sidebar link into the agent-chip menu. The stale accessible-role lookup failed on Linux Chromium as well as the reported macOS/Node 26 setup.

## Why This Change Was Made

The test now follows the current interaction: open the agent menu, wait for its menu state, and activate the Settings menu item. Both Settings entry points in the scenario use the same helper; product behavior remains unchanged.

## User Impact

No runtime behavior changes. The sidebar customization E2E once again validates the current Settings takeover/search flow deterministically across Linux and macOS.

## Evidence

- Before: fresh Blacksmith Testbox Linux/Chromium run on then-current `main` reproduced the same failure: 1 failed, 5 passed; `getByRole("link", { name: "Settings" })` never became visible.
- After, exact branch head `47de398c6a7d47b06c9abccb04df1db44f3445af`: `corepack pnpm test:ui:e2e -- ui/src/e2e/sidebar-customization.e2e.test.ts` — 6 passed, 0 failed, including the 5.4s target scenario. Testbox `tbx_01kxd5m19aynvqrgscr7yf3y1b`; [Actions run](https://github.com/openclaw/openclaw/actions/runs/29231801134).
- Behavior contract: 4 passed, 0 failed, 0 blocked; Settings takeover, search filtering/reset, and navigation-state persistence all passed.
- `git diff --check` — passed.
- Fresh exact-head Codex autoreview — no actionable findings; patch correct (0.95 confidence).
- [Hosted CI run 29231789058](https://github.com/openclaw/openclaw/actions/runs/29231789058) completed with 50 jobs passed, 11 skipped, and 0 failed.

Related: #105777
