### PR TITLE
fix(clickclack): accept prefixed mixed-case message targets

### DIFF
--- a/extensions/clickclack/src/outbound.test.ts
+++ b/extensions/clickclack/src/outbound.test.ts
@@ -73,6 +73,17 @@ describe("sendClickClackText routing", () => {
     expect(createThreadReply).not.toHaveBeenCalled();
   });
 
+  it("accepts provider-prefixed mixed-case channel targets", async () => {
+    await sendClickClackText({ cfg, to: "ClickClack:Channel:General", text: "hi" });
+
+    expect(createChannelMessage).toHaveBeenCalledWith(
+      "General",
+      "hi",
+      expect.objectContaining({ quotedMessageId: undefined }),
+    );
+    expect(createThreadReply).not.toHaveBeenCalled();
+  });
+
   it("uses the inbound correlation id for outbound ClickClack HTTP calls", async () => {
     await sendClickClackText({
       cfg,

--- a/extensions/clickclack/src/session-route.test.ts
+++ b/extensions/clickclack/src/session-route.test.ts
@@ -18,6 +18,32 @@ describe("ClickClack outbound session routing", () => {
     expect(channelRoute?.recipientSessionExact).toBe(false);
   });
 
+  it("routes provider-prefixed mixed-case targets to canonical sessions", async () => {
+    const dmRoute = await clickClackPlugin.messaging?.resolveOutboundSessionRoute?.({
+      cfg: {},
+      agentId: "main",
+      target: "cc:DM:usr_1",
+    });
+    const channelRoute = await clickClackPlugin.messaging?.resolveOutboundSessionRoute?.({
+      cfg: {},
+      agentId: "main",
+      target: "ClickClack:Channel:General",
+    });
+
+    expect(dmRoute).toMatchObject({
+      to: "dm:usr_1",
+      chatType: "direct",
+      recipientSessionExact: true,
+      peer: { kind: "direct", id: "dm:usr_1" },
+    });
+    expect(channelRoute).toMatchObject({
+      to: "channel:General",
+      chatType: "group",
+      recipientSessionExact: false,
+      peer: { kind: "channel", id: "channel:General" },
+    });
+  });
+
   it("keeps threaded DMs on the inbound base session", async () => {
     const route = await clickClackPlugin.messaging?.resolveOutboundSessionRoute?.({
       cfg: { session: { dmScope: "per-channel-peer" } },

--- a/extensions/clickclack/src/target.test.ts
+++ b/extensions/clickclack/src/target.test.ts
@@ -13,12 +13,26 @@ describe("ClickClack targets", () => {
       kind: "channel",
       id: "general",
     });
+    expect(parseClickClackTarget("ClickClack:Channel:General")).toEqual({
+      chatType: "group",
+      kind: "channel",
+      id: "General",
+    });
     expect(normalizeClickClackTarget("general")).toBe("channel:general");
+    expect(normalizeClickClackTarget("CC:Channel:General")).toBe("channel:General");
   });
 
   it("parses thread and dm targets", () => {
     expect(buildClickClackTarget(parseClickClackTarget("thread:msg_1"))).toBe("thread:msg_1");
+    expect(buildClickClackTarget(parseClickClackTarget("clickclack:Thread:msg_1"))).toBe(
+      "thread:msg_1",
+    );
     expect(parseClickClackTarget("dm:usr_1")).toEqual({
+      chatType: "direct",
+      kind: "dm",
+      id: "usr_1",
+    });
+    expect(parseClickClackTarget("CC:DM:usr_1")).toEqual({
       chatType: "direct",
       kind: "dm",
       id: "usr_1",

--- a/extensions/clickclack/src/target.ts
+++ b/extensions/clickclack/src/target.ts
@@ -1,25 +1,27 @@
 /**
  * Parser and formatter for ClickClack outbound target strings.
  */
+import { stripChannelTargetPrefix } from "openclaw/plugin-sdk/channel-core";
 import type { ClickClackTarget } from "./types.js";
 
 /**
  * Parses `channel:name`, `thread:msg_id`, `dm:usr_id`, or a bare channel name.
  */
 export function parseClickClackTarget(raw: string): ClickClackTarget {
-  const value = raw.trim();
+  const value = stripChannelTargetPrefix(raw, "clickclack", "cc");
   if (!value) {
     throw new Error("ClickClack target is required");
   }
   const [prefix, ...rest] = value.split(":");
+  const kind = prefix?.toLowerCase();
   const body = rest.join(":").trim();
-  if (prefix === "channel" && body) {
+  if (kind === "channel" && body) {
     return { chatType: "group", kind: "channel", id: body };
   }
-  if (prefix === "thread" && body) {
+  if (kind === "thread" && body) {
     return { chatType: "group", kind: "thread", id: body };
   }
-  if (prefix === "dm" && body) {
+  if (kind === "dm" && body) {
     return { chatType: "direct", kind: "dm", id: body };
   }
   if (!body) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending ClickClack messages could hit an unsupported target error when the target included the ClickClack provider prefix or used mixed-case target kinds.

The broken case is a mismatch between ClickClack's advertised target contract and its private target parser:

- ClickClack already declares `targetPrefixes: ["clickclack", "cc"]`.
- ClickClack already wires `normalizeTarget: normalizeClickClackTarget`.
- The parser only accepted lowercase, unprefixed target kinds before this change.

That means a target like `ClickClack:Channel:General` looked like a valid ClickClack target to OpenClaw's provider-target layer, but the ClickClack parser treated `ClickClack` as the target kind and rejected the whole value.

Before this fix:

```text
Input target:       ClickClack:Channel:General
Parsed target kind: ClickClack
Result:            Unsupported ClickClack target
```

After this fix:

```text
Input target:       ClickClack:Channel:General
Canonical target:   channel:General
Channel id used:    General
```

This matters for users who type a target manually, copy a value from another tool, or generate targets through scripts/integrations that preserve display-style casing such as `ClickClack:` or `Channel:`.

The same mismatch affected direct messages and thread targets:

```text
cc:DM:usr_1
clickclack:Thread:msg_1
```

## Why This Change Was Made

The existing ClickClack target contract already allows provider-qualified targets through `clickclack:` and `cc:`. This change makes the ClickClack parser follow that same contract for:

```text
clickclack:
cc:
channel:
thread:
dm:
```

The fix is intentionally narrow:

- It stays inside the ClickClack plugin boundary.
- It changes only prefix matching, not the accepted target syntax.
- It does not add config, dependencies, migrations, or fallback behavior.
- It preserves the target id text after stripping the provider/kind prefixes.

The parser is the right place for the fix because it feeds normalization, outbound delivery, and session routing. Fixing only the send call site would leave normalized target behavior and session route behavior inconsistent.

This is the narrowest correct owner-boundary fix because all ClickClack send, route, and normalize paths already funnel through `parseClickClackTarget`. Fixing the parser makes the behavior consistent for:

- message-tool target normalization through `normalizeClickClackTarget`
- outbound HTTP delivery through `sendClickClackText`
- outbound session routing through `resolveOutboundSessionRoute`

The change deliberately does not modify shared outbound target policy or session-key generation. Existing canonical ClickClack targets keep the same behavior, and session routing keeps its current route/session-key semantics.

## User Impact

Users and agents can now send ClickClack messages when the target comes from a provider-qualified form or mixed-case user input. These examples now resolve to the intended canonical target:

| User-provided target | Canonical target after parsing |
| --- | --- |
| `ClickClack:Channel:General` | `channel:General` |
| `CC:Channel:General` | `channel:General` |
| `cc:DM:usr_1` | `dm:usr_1` |
| `clickclack:Thread:msg_1` | `thread:msg_1` |

Lowercase inputs continue to behave the same:

| Existing target | Canonical target |
| --- | --- |
| `channel:general` | `channel:general` |
| `dm:usr_1` | `dm:usr_1` |
| `thread:msg_1` | `thread:msg_1` |

That removes a user-visible delivery failure without requiring users to know that ClickClack's internal parser previously only accepted lower-case, unprefixed target syntax.

## Evidence

### Code-path proof

- `extensions/clickclack/src/channel.ts` already declares `targetPrefixes: ["clickclack", "cc"]`, `normalizeTarget: normalizeClickClackTarget`, and sends outbound session targets through `parseClickClackTarget`.
- `extensions/clickclack/src/outbound.ts` calls `parseClickClackTarget(params.to)` before choosing channel, thread, or DM delivery.
- `extensions/clickclack/src/channel.ts` calls the same parser from `resolveOutboundSessionRoute()` before building the outbound session route.
- `src/agents/embedded-agent-subscribe.tools.ts` normalizes message-tool targets through `normalizeTargetForProvider`, so the ClickClack normalizer is on the real agent message-send path.
- `src/plugin-sdk/core.ts` provides `stripChannelTargetPrefix`, which strips known provider prefixes case-insensitively while preserving the remaining target text.

Because these call sites share `parseClickClackTarget()`, stripping provider prefixes and comparing target kinds case-insensitively aligns detection, normalization, session routing, and message sending without adding a second path.

### Before/after behavior covered by tests

The parser regression test in `extensions/clickclack/src/target.test.ts` proves provider-prefixed and mixed-case targets normalize while preserving the target id:

```text
parseClickClackTarget("ClickClack:Channel:General") -> { kind: "channel", id: "General" }
normalizeClickClackTarget("CC:Channel:General") -> "channel:General"
buildClickClackTarget(parseClickClackTarget("clickclack:Thread:msg_1")) -> "thread:msg_1"
parseClickClackTarget("CC:DM:usr_1") -> { kind: "dm", id: "usr_1" }
```

The send-path regression test in `extensions/clickclack/src/outbound.test.ts` proves the actual outbound message path uses the stripped channel id:

```text
sendClickClackText({ to: "ClickClack:Channel:General", text: "hi", ... })
```

The mocked ClickClack client is asserted against:

```text
createChannelMessage("General", "hi", ...)
```

The session-route regression test in `extensions/clickclack/src/session-route.test.ts` proves provider-prefixed mixed-case targets become canonical route targets:

```text
cc:DM:usr_1 -> to: "dm:usr_1", chatType: "direct"
ClickClack:Channel:General -> to: "channel:General", chatType: "group"
```

### Validation run

Focused ClickClack tests:

```bash
env OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs extensions/clickclack/src/target.test.ts -- --reporter=verbose
```

Result:

```text
[test] passed 1 Vitest shard in 13.33s
```

```bash
env OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs extensions/clickclack/src/outbound.test.ts -- --reporter=verbose
```

Result:

```text
[test] passed 1 Vitest shard in 12.54s
```

```bash
env OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs extensions/clickclack/src/session-route.test.ts -- --reporter=verbose
```

Result:

```text
[test] passed 1 Vitest shard in 19.82s
```

Diff whitespace check:

```bash
git diff --check
```

Result: passed.

### Validation notes

Remote Testbox validation could not be completed from this checkout earlier because the Crabbox wrapper failed its basic binary sanity check before running tests. The focused local fallback above was used for the touched ClickClack surface.

Autoreview could not be completed in this environment because `python3` is Python 3.6 and the script requires a newer parser; running it with `python3.13` reached the review helper but failed because the `codex` executable is not installed.
