### PR TITLE
fix(feishu): explain content-policy delivery rejections

### DIFF
--- a/extensions/feishu/src/message-audit.test.ts
+++ b/extensions/feishu/src/message-audit.test.ts
@@ -1,0 +1,22 @@
+// Feishu tests cover message audit error classification.
+import { describe, expect, it } from "vitest";
+import { isFeishuMessageAuditRejection } from "./message-audit.js";
+
+function sdkError(code: number): Error {
+  return Object.assign(new Error("Request failed with status code 400"), {
+    response: { status: 400, data: { code } },
+  });
+}
+
+describe("isFeishuMessageAuditRejection", () => {
+  it("recognizes code 230028 through the Feishu API wrapper cause", () => {
+    expect(
+      isFeishuMessageAuditRejection(new Error("Feishu send failed", { cause: sdkError(230028) })),
+    ).toBe(true);
+  });
+
+  it("does not classify other Feishu message errors", () => {
+    expect(isFeishuMessageAuditRejection(sdkError(230022))).toBe(false);
+    expect(isFeishuMessageAuditRejection(new Error("send failed"))).toBe(false);
+  });
+});

--- a/extensions/feishu/src/message-audit.ts
+++ b/extensions/feishu/src/message-audit.ts
@@ -1,0 +1,19 @@
+// Feishu plugin module classifies message audit failures.
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+const FEISHU_MESSAGE_AUDIT_REJECTION_CODE = 230028;
+export const MESSAGE_AUDIT_REJECTION_NOTICE =
+  "⚠️ Feishu couldn't deliver this reply because it didn't pass a content policy check.";
+
+export function isFeishuMessageAuditRejection(error: unknown): boolean {
+  if (!isRecord(error)) {
+    return false;
+  }
+  const response = isRecord(error.response) ? error.response : undefined;
+  const data = isRecord(response?.data) ? response.data : undefined;
+  if (data?.code === FEISHU_MESSAGE_AUDIT_REJECTION_CODE) {
+    return true;
+  }
+  const cause = error.cause;
+  return cause !== undefined && cause !== error && isFeishuMessageAuditRejection(cause);
+}

--- a/extensions/feishu/src/reply-dispatcher-fallback.ts
+++ b/extensions/feishu/src/reply-dispatcher-fallback.ts
@@ -29,6 +29,8 @@ export function createFeishuReplyFallbackController(params: ReplyFallbackControl
       await params.closeStreaming(options);
       params.onIdle();
     });
+    // Observe failures immediately so later queue work can continue; callers still
+    // receive the original rejection through the returned task.
     idleSideEffectsPromise = nextIdleSideEffects.catch(() => {});
     return nextIdleSideEffects;
   };
@@ -58,6 +60,7 @@ export function createFeishuReplyFallbackController(params: ReplyFallbackControl
     const idleTask = queueIdleSideEffects({ markClosedForReply: false });
     if (shouldQueueAuditNotice) {
       await queueMessageAuditNotice();
+      await idleTask;
       return;
     }
     await idleTask;

--- a/extensions/feishu/src/reply-dispatcher-fallback.ts
+++ b/extensions/feishu/src/reply-dispatcher-fallback.ts
@@ -1,0 +1,89 @@
+// Feishu plugin module owns reply fallback sequencing.
+import { isFeishuMessageAuditRejection, MESSAGE_AUDIT_REJECTION_NOTICE } from "./message-audit.js";
+
+const NO_VISIBLE_REPLY_FALLBACK_TEXT =
+  "⚠️ This reply completed without visible content. The turn may have been interrupted; please retry or ask me to recover from recent context.";
+
+type VisibleReplyState = {
+  visibleReplySent: boolean;
+  skippedFinalReason: string | null;
+};
+
+type ReplyFallbackControllerParams = {
+  accountId: string;
+  closeStreaming: (options?: { markClosedForReply?: boolean }) => Promise<void>;
+  getVisibleReplyState: () => VisibleReplyState;
+  log?: (message: string) => void;
+  error?: (message: string) => void;
+  markVisibleReplySent: () => void;
+  onIdle: () => void;
+  sendText: (text: string) => Promise<void>;
+};
+
+export function createFeishuReplyFallbackController(params: ReplyFallbackControllerParams) {
+  let messageAuditNoticeQueued = false;
+  let idleSideEffectsPromise: Promise<void> = Promise.resolve();
+
+  const queueIdleSideEffects = (options?: { markClosedForReply?: boolean }): Promise<void> => {
+    const nextIdleSideEffects = idleSideEffectsPromise.then(async () => {
+      await params.closeStreaming(options);
+      params.onIdle();
+    });
+    idleSideEffectsPromise = nextIdleSideEffects.catch(() => {});
+    return nextIdleSideEffects;
+  };
+
+  const queueMessageAuditNotice = (): Promise<void> => {
+    // Keep the notice in the idle chain so fallback evaluation cannot race it.
+    const nextIdleSideEffects = idleSideEffectsPromise.then(async () => {
+      try {
+        await params.sendText(MESSAGE_AUDIT_REJECTION_NOTICE);
+        params.markVisibleReplySent();
+      } catch (noticeError) {
+        params.error?.(
+          `feishu[${params.accountId}]: failed to send message audit rejection notice: ${String(noticeError)}`,
+        );
+      }
+    });
+    idleSideEffectsPromise = nextIdleSideEffects;
+    return nextIdleSideEffects;
+  };
+
+  const handleReplyError = async (error: unknown): Promise<void> => {
+    const shouldQueueAuditNotice =
+      !messageAuditNoticeQueued && isFeishuMessageAuditRejection(error);
+    if (shouldQueueAuditNotice) {
+      messageAuditNoticeQueued = true;
+    }
+    const idleTask = queueIdleSideEffects({ markClosedForReply: false });
+    if (shouldQueueAuditNotice) {
+      await queueMessageAuditNotice();
+      return;
+    }
+    await idleTask;
+  };
+
+  const ensureNoVisibleReplyFallback = async (reason: string): Promise<boolean> => {
+    await idleSideEffectsPromise;
+    const state = params.getVisibleReplyState();
+    if (state.visibleReplySent) {
+      return false;
+    }
+    if (state.skippedFinalReason === "silent") {
+      params.log?.(
+        `feishu[${params.accountId}]: no-visible-reply fallback skipped for intentional silence (${reason})`,
+      );
+      return false;
+    }
+    await params.sendText(NO_VISIBLE_REPLY_FALLBACK_TEXT);
+    params.markVisibleReplySent();
+    params.error?.(`feishu[${params.accountId}]: sent no-visible-reply fallback (${reason})`);
+    return true;
+  };
+
+  return {
+    ensureNoVisibleReplyFallback,
+    handleReplyError,
+    onIdle: () => queueIdleSideEffects(),
+  };
+}

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1993,6 +1993,40 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     );
   });
 
+  it("sends the audit rejection notice before propagating streaming cleanup failures", async () => {
+    const originalPush = streamingInstances.push.bind(streamingInstances);
+    streamingInstances.push = (...args: StreamingSessionStub[]) => {
+      const firstInstance = args[0];
+      if (firstInstance && streamingInstances.length === 0) {
+        firstInstance.close = vi.fn(async () => {
+          firstInstance.active = false;
+          throw new Error("close failed");
+        });
+      }
+      return originalPush(...args);
+    };
+
+    try {
+      const { options } = createDispatcherHarness({ runtime: createRuntimeLogger() });
+      const sdkError = Object.assign(new Error("Request failed with status code 400"), {
+        response: { status: 400, data: { code: 230028 } },
+      });
+      const wrappedError = new Error("Feishu send failed", { cause: sdkError });
+
+      await options.deliver({ text: "```md\nfirst\n```" }, { kind: "final" });
+      await expect(options.onError?.(wrappedError, { kind: "final" })).rejects.toThrow(
+        "close failed",
+      );
+
+      expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+      expect(firstMockArg(sendMessageFeishuMock, "send message params").text).toBe(
+        "⚠️ Feishu couldn't deliver this reply because it didn't pass a content policy check.",
+      );
+    } finally {
+      streamingInstances.push = originalPush;
+    }
+  });
+
   it("explains an audit rejection after an earlier reply chunk was delivered", async () => {
     useNonStreamingAutoAccount();
     const runtime = createRuntimeLogger();

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1963,6 +1963,35 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     );
   });
 
+  it("keeps the original error path alive when the audit rejection notice also fails", async () => {
+    useNonStreamingAutoAccount();
+    const runtime = createRuntimeLogger();
+    const { result, options } = createDispatcherHarness({ runtime });
+    const sdkError = Object.assign(new Error("Request failed with status code 400"), {
+      response: { status: 400, data: { code: 230028 } },
+    });
+    const wrappedError = new Error("Feishu send failed", { cause: sdkError });
+    sendMessageFeishuMock
+      .mockRejectedValueOnce(wrappedError)
+      .mockRejectedValueOnce(new Error("notice send failed"))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(options.deliver({ text: "Original reply" }, { kind: "final" })).rejects.toBe(
+      wrappedError,
+    );
+    await expect(options.onError?.(wrappedError, { kind: "final" })).resolves.toBeUndefined();
+    await expect(result.ensureNoVisibleReplyFallback("failed-final")).resolves.toBe(true);
+
+    expect(sendMessageFeishuMock.mock.calls.map((call) => call[0]?.text)).toEqual([
+      "Original reply",
+      "⚠️ Feishu couldn't deliver this reply because it didn't pass a content policy check.",
+      expect.stringContaining("without visible content"),
+    ]);
+    expect(runtime.error).toHaveBeenCalledWith(
+      "feishu[main]: failed to send message audit rejection notice: Error: notice send failed",
+    );
+  });
+
   it("explains an audit rejection after an earlier reply chunk was delivered", async () => {
     useNonStreamingAutoAccount();
     const runtime = createRuntimeLogger();

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1937,6 +1937,60 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("explains a Feishu content-policy rejection without changing the rejected reply", async () => {
+    useNonStreamingAutoAccount();
+    const runtime = createRuntimeLogger();
+    const { result, options } = createDispatcherHarness({ runtime });
+    const sdkError = Object.assign(new Error("Request failed with status code 400"), {
+      response: {
+        status: 400,
+        data: { code: 230028, msg: "The messages do NOT pass the audit" },
+      },
+    });
+    const wrappedError = new Error("Feishu send failed", { cause: sdkError });
+    sendMessageFeishuMock.mockRejectedValueOnce(wrappedError);
+
+    await expect(options.deliver({ text: "Original reply" }, { kind: "final" })).rejects.toBe(
+      wrappedError,
+    );
+    await options.onError?.(wrappedError, { kind: "final" });
+    await expect(result.ensureNoVisibleReplyFallback("failed-final")).resolves.toBe(false);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(2);
+    expect(sendMessageFeishuMock.mock.calls[0]?.[0]?.text).toBe("Original reply");
+    expect(sendMessageFeishuMock.mock.calls[1]?.[0]?.text).toBe(
+      "⚠️ Feishu couldn't deliver this reply because it didn't pass a content policy check.",
+    );
+  });
+
+  it("explains an audit rejection after an earlier reply chunk was delivered", async () => {
+    useNonStreamingAutoAccount();
+    const runtime = createRuntimeLogger();
+    const { result, options } = createDispatcherHarness({ runtime });
+    const core = getFeishuRuntimeMock();
+    core.channel.text.chunkTextWithMode.mockReturnValue(["First chunk", "Rejected chunk"]);
+    const sdkError = Object.assign(new Error("Request failed with status code 400"), {
+      response: { status: 400, data: { code: 230028 } },
+    });
+    const wrappedError = new Error("Feishu send failed", { cause: sdkError });
+    sendMessageFeishuMock
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(wrappedError)
+      .mockResolvedValueOnce(undefined);
+
+    await expect(options.deliver({ text: "Original reply" }, { kind: "final" })).rejects.toBe(
+      wrappedError,
+    );
+    await options.onError?.(wrappedError, { kind: "final" });
+    await expect(result.ensureNoVisibleReplyFallback("failed-final")).resolves.toBe(false);
+
+    expect(sendMessageFeishuMock.mock.calls.map((call) => call[0]?.text)).toEqual([
+      "First chunk",
+      "Rejected chunk",
+      "⚠️ Feishu couldn't deliver this reply because it didn't pass a content policy check.",
+    ]);
+  });
+
   it("does not send no-visible-reply fallback after an intentional silent final", async () => {
     const runtime = createRuntimeLogger();
     const { result, options } = createDispatcherHarness({ runtime, sessionKey: "main" });

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -222,7 +222,8 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   }
 
   function createRuntimeLogger() {
-    return { log: vi.fn(), error: vi.fn() } as never;
+    const runtime = { log: vi.fn(), error: vi.fn() };
+    return runtime as typeof runtime & ReplyDispatcherArgs["runtime"];
   }
 
   function createDispatcherHarness(overrides: Partial<ReplyDispatcherArgs> = {}) {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -1,8 +1,8 @@
 // Feishu plugin module implements reply dispatcher behavior.
 import { formatReasoningMessage } from "openclaw/plugin-sdk/agent-runtime";
 import { logTypingFailure } from "openclaw/plugin-sdk/channel-feedback";
-import { createChannelMessageReplyPipeline } from "openclaw/plugin-sdk/channel-outbound";
 import {
+  createChannelMessageReplyPipeline,
   formatChannelProgressDraftLineForEntry,
   isChannelProgressDraftWorkToolName,
   resolveChannelPreviewStreamMode,
@@ -20,6 +20,7 @@ import { createFeishuClient } from "./client.js";
 import { resolveFeishuIdentityEmoji } from "./identity-header.js";
 import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.js";
 import type { MentionTarget } from "./mention-target.types.js";
+import * as messageAudit from "./message-audit.js";
 import {
   createReplyPrefixContext,
   type ClawdbotConfig,
@@ -282,6 +283,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streamingCloseErroredForReply = false;
   let visibleReplySent = false;
   let skippedFinalReason: string | null = null;
+  let messageAuditNoticeSent = false;
   let idleSideEffectsPromise: Promise<void> = Promise.resolve();
   let replyLifecycleStateInitialized = false;
   type StreamTextUpdateMode = "snapshot" | "delta";
@@ -847,12 +849,27 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         }
       },
       onError: async (error, info) => {
+        const shouldSendAuditNotice =
+          !messageAuditNoticeSent && messageAudit.isFeishuMessageAuditRejection(error);
         streamingCloseErroredForReply = true;
         streamingClosedForReply = false;
         params.runtime.error?.(
           `feishu[${account.accountId}] ${info.kind} reply failed: ${String(error)}`,
         );
         await queueIdleSideEffects({ markClosedForReply: false });
+        if (shouldSendAuditNotice) {
+          messageAuditNoticeSent = true;
+          await sendMessageFeishu({
+            cfg,
+            to: sendTarget,
+            text: messageAudit.MESSAGE_AUDIT_REJECTION_NOTICE,
+            replyToMessageId: sendReplyToMessageId,
+            replyInThread: effectiveReplyInThread,
+            allowTopLevelReplyFallback,
+            accountId,
+          });
+          markVisibleReplySent();
+        }
       },
       onIdle: () => queueIdleSideEffects(),
       onCleanup: () => {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -283,7 +283,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streamingCloseErroredForReply = false;
   let visibleReplySent = false;
   let skippedFinalReason: string | null = null;
-  let messageAuditNoticeSent = false;
+  let messageAuditNoticeQueued = false;
   let idleSideEffectsPromise: Promise<void> = Promise.resolve();
   let replyLifecycleStateInitialized = false;
   type StreamTextUpdateMode = "snapshot" | "delta";
@@ -629,6 +629,30 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     return nextIdleSideEffects;
   };
 
+  const queueMessageAuditNotice = (): Promise<void> => {
+    // Keep the notice in the idle chain so fallback evaluation cannot race it.
+    const nextIdleSideEffects = idleSideEffectsPromise.then(async () => {
+      try {
+        await sendMessageFeishu({
+          cfg,
+          to: sendTarget,
+          text: messageAudit.MESSAGE_AUDIT_REJECTION_NOTICE,
+          replyToMessageId: sendReplyToMessageId,
+          replyInThread: effectiveReplyInThread,
+          allowTopLevelReplyFallback,
+          accountId,
+        });
+        markVisibleReplySent();
+      } catch (noticeError) {
+        params.runtime.error?.(
+          `feishu[${account.accountId}]: failed to send message audit rejection notice: ${String(noticeError)}`,
+        );
+      }
+    });
+    idleSideEffectsPromise = nextIdleSideEffects;
+    return nextIdleSideEffects;
+  };
+
   const { dispatcher, replyOptions, markDispatchIdle } =
     core.channel.reply.createReplyDispatcherWithTyping({
       responsePrefix: prefixContext.responsePrefix,
@@ -849,27 +873,22 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         }
       },
       onError: async (error, info) => {
-        const shouldSendAuditNotice =
-          !messageAuditNoticeSent && messageAudit.isFeishuMessageAuditRejection(error);
+        const shouldQueueAuditNotice =
+          !messageAuditNoticeQueued && messageAudit.isFeishuMessageAuditRejection(error);
+        if (shouldQueueAuditNotice) {
+          messageAuditNoticeQueued = true;
+        }
         streamingCloseErroredForReply = true;
         streamingClosedForReply = false;
         params.runtime.error?.(
           `feishu[${account.accountId}] ${info.kind} reply failed: ${String(error)}`,
         );
-        await queueIdleSideEffects({ markClosedForReply: false });
-        if (shouldSendAuditNotice) {
-          messageAuditNoticeSent = true;
-          await sendMessageFeishu({
-            cfg,
-            to: sendTarget,
-            text: messageAudit.MESSAGE_AUDIT_REJECTION_NOTICE,
-            replyToMessageId: sendReplyToMessageId,
-            replyInThread: effectiveReplyInThread,
-            allowTopLevelReplyFallback,
-            accountId,
-          });
-          markVisibleReplySent();
+        const idleTask = queueIdleSideEffects({ markClosedForReply: false });
+        if (shouldQueueAuditNotice) {
+          await queueMessageAuditNotice();
+          return;
         }
+        await idleTask;
       },
       onIdle: () => queueIdleSideEffects(),
       onCleanup: () => {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -20,7 +20,7 @@ import { createFeishuClient } from "./client.js";
 import { resolveFeishuIdentityEmoji } from "./identity-header.js";
 import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.js";
 import type { MentionTarget } from "./mention-target.types.js";
-import * as messageAudit from "./message-audit.js";
+import { createFeishuReplyFallbackController } from "./reply-dispatcher-fallback.js";
 import {
   createReplyPrefixContext,
   type ClawdbotConfig,
@@ -62,8 +62,6 @@ function mergeStreamingFinalText(
 const TYPING_INDICATOR_MAX_AGE_MS = 2 * 60_000;
 const MS_EPOCH_MIN = 1_000_000_000_000;
 const STREAMING_START_FAILURE_BACKOFF_MS = 60_000;
-const NO_VISIBLE_REPLY_FALLBACK_TEXT =
-  "⚠️ This reply completed without visible content. The turn may have been interrupted; please retry or ask me to recover from recent context.";
 
 function isStreamingStartBackedOff(accountId: string, now = Date.now()): boolean {
   const backoffUntil = streamingStartBackoffUntilByAccount.get(accountId);
@@ -283,8 +281,6 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streamingCloseErroredForReply = false;
   let visibleReplySent = false;
   let skippedFinalReason: string | null = null;
-  let messageAuditNoticeQueued = false;
-  let idleSideEffectsPromise: Promise<void> = Promise.resolve();
   let replyLifecycleStateInitialized = false;
   type StreamTextUpdateMode = "snapshot" | "delta";
 
@@ -593,65 +589,26 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     });
   };
 
-  const ensureNoVisibleReplyFallback = async (reason: string): Promise<boolean> => {
-    await idleSideEffectsPromise;
-    if (visibleReplySent) {
-      return false;
-    }
-    if (skippedFinalReason === "silent") {
-      params.runtime.log?.(
-        `feishu[${account.accountId}]: no-visible-reply fallback skipped for intentional silence (${reason})`,
-      );
-      return false;
-    }
-    await sendMessageFeishu({
-      cfg,
-      to: sendTarget,
-      text: NO_VISIBLE_REPLY_FALLBACK_TEXT,
-      replyToMessageId: sendReplyToMessageId,
-      replyInThread: effectiveReplyInThread,
-      allowTopLevelReplyFallback,
-      accountId,
-    });
-    markVisibleReplySent();
-    params.runtime.error?.(
-      `feishu[${account.accountId}]: sent no-visible-reply fallback (${reason})`,
-    );
-    return true;
-  };
-
-  const queueIdleSideEffects = (options?: { markClosedForReply?: boolean }): Promise<void> => {
-    const nextIdleSideEffects = idleSideEffectsPromise.then(async () => {
-      await closeStreaming(options);
-      typingCallbacks?.onIdle?.();
-    });
-    idleSideEffectsPromise = nextIdleSideEffects.catch(() => {});
-    return nextIdleSideEffects;
-  };
-
-  const queueMessageAuditNotice = (): Promise<void> => {
-    // Keep the notice in the idle chain so fallback evaluation cannot race it.
-    const nextIdleSideEffects = idleSideEffectsPromise.then(async () => {
-      try {
-        await sendMessageFeishu({
-          cfg,
-          to: sendTarget,
-          text: messageAudit.MESSAGE_AUDIT_REJECTION_NOTICE,
-          replyToMessageId: sendReplyToMessageId,
-          replyInThread: effectiveReplyInThread,
-          allowTopLevelReplyFallback,
-          accountId,
-        });
-        markVisibleReplySent();
-      } catch (noticeError) {
-        params.runtime.error?.(
-          `feishu[${account.accountId}]: failed to send message audit rejection notice: ${String(noticeError)}`,
-        );
-      }
-    });
-    idleSideEffectsPromise = nextIdleSideEffects;
-    return nextIdleSideEffects;
-  };
+  const replyFallback = createFeishuReplyFallbackController({
+    accountId: account.accountId,
+    closeStreaming,
+    getVisibleReplyState: () => ({ visibleReplySent, skippedFinalReason }),
+    log: params.runtime.log,
+    error: params.runtime.error,
+    markVisibleReplySent,
+    onIdle: () => typingCallbacks?.onIdle?.(),
+    sendText: async (text) => {
+      await sendMessageFeishu({
+        cfg,
+        to: sendTarget,
+        text,
+        replyToMessageId: sendReplyToMessageId,
+        replyInThread: effectiveReplyInThread,
+        allowTopLevelReplyFallback,
+        accountId,
+      });
+    },
+  });
 
   const { dispatcher, replyOptions, markDispatchIdle } =
     core.channel.reply.createReplyDispatcherWithTyping({
@@ -873,24 +830,14 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         }
       },
       onError: async (error, info) => {
-        const shouldQueueAuditNotice =
-          !messageAuditNoticeQueued && messageAudit.isFeishuMessageAuditRejection(error);
-        if (shouldQueueAuditNotice) {
-          messageAuditNoticeQueued = true;
-        }
         streamingCloseErroredForReply = true;
         streamingClosedForReply = false;
         params.runtime.error?.(
           `feishu[${account.accountId}] ${info.kind} reply failed: ${String(error)}`,
         );
-        const idleTask = queueIdleSideEffects({ markClosedForReply: false });
-        if (shouldQueueAuditNotice) {
-          await queueMessageAuditNotice();
-          return;
-        }
-        await idleTask;
+        await replyFallback.handleReplyError(error);
       },
-      onIdle: () => queueIdleSideEffects(),
+      onIdle: replyFallback.onIdle,
       onCleanup: () => {
         typingCallbacks?.onCleanup?.();
       },
@@ -976,7 +923,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         : undefined,
     },
     markDispatchIdle,
-    ensureNoVisibleReplyFallback,
+    ensureNoVisibleReplyFallback: replyFallback.ensureNoVisibleReplyFallback,
     getVisibleReplyState: () => ({
       visibleReplySent,
       skippedFinalReason,


### PR DESCRIPTION
Closes #105976

## What Problem This Solves

Fixes an issue where Feishu users would receive the generic “reply completed without visible content” fallback when Feishu rejected the assistant reply with message API code `230028`. That fallback incorrectly suggested an interrupted or empty turn instead of a delivery policy failure.

## Why This Change Was Made

The Feishu plugin now recognizes the documented `230028` error through the SDK's Axios error shape and OpenClaw's existing error `cause` wrapper. Its error path sends one neutral notice saying that Feishu could not deliver the reply because it did not pass a content policy check, including when an earlier chunk was delivered before a later chunk was rejected.

The notice is serialized after streaming cleanup. Notice delivery failures remain isolated so the existing generic fallback can still run, while streaming cleanup failures retain their original rejection semantics.

This deliberately does not redact or otherwise modify the original reply, retry altered content, send a file, or switch transports. Other delivery errors retain the existing generic fallback.

## User Impact

Users get a neutral, accurate reason when Feishu blocks a reply under code `230028`, without OpenClaw weakening or bypassing the channel's content-policy decision.

## Evidence

- `node scripts/run-vitest.mjs extensions/feishu/src/message-audit.test.ts extensions/feishu/src/reply-dispatcher.test.ts` — 2 files, 92 tests passed.
- Targeted `oxfmt`, targeted `oxlint`, and `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean; no accepted/actionable findings, confidence 0.94.
- Exact GitHub merge tree `e47644ccb31ec7e392d225abee2ca7204f71fd73` combines PR head `2998e6c3cb9419dd0fdac5fe383d1d5198adcabb` with main `a418bf9bef063e0594f6f7990b3a17ff80c12ee1`.
- Exact-head CI run https://github.com/openclaw/openclaw/actions/runs/29313758993 — passed, including LOC ratchet, lint, `check-test-types`, build, QA smoke, and Node test shards.
- CodeQL Critical Quality run https://github.com/openclaw/openclaw/actions/runs/29313759082 — passed.
- Exact dependency contract inspected: `@larksuiteoapi/node-sdk@1.68.0` sends message create/reply through Axios, rethrowing the Axios error; OpenClaw's `requestFeishuApi` preserves it as `cause`.
- Feishu documents HTTP 400 / code `230028` as a message audit failure: https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/reply
- #92445 contains the original real-environment reproduction. This PR does not repeat a live DLP rejection because intentionally triggering a tenant content-policy failure is not needed to validate the error-to-prompt mapping.

Known proof gap: the local Crabbox wrapper could not access a working Blacksmith Testbox binary, so the focused tests used the documented narrow local fallback. GitHub's Linux Node 24 exact-merge CI supplies the full type, lint, build, and test-shard proof.

AI-assisted: yes. I reviewed the implementation and validation results.
