### PR TITLE
fix(agents): route unbound OAuth compaction through auth-aware harness selection

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -1275,6 +1275,76 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     });
   });
 
+  it("routes unbound ChatGPT OAuth direct compaction through auth-aware codex selection", async () => {
+    resolveAgentHarnessPolicyMock.mockReturnValue({
+      runtime: "codex",
+      runtimeSource: "implicit",
+    } as never);
+    // Only ChatGPT OAuth is available — no API-key profile. Auth-aware
+    // selection must pick codex (harness-owned) instead of forced openclaw.
+    ensureAuthProfileStoreMock.mockReturnValue({
+      version: 1,
+      profiles: {
+        "openai:chatgpt": {
+          type: "oauth",
+          provider: "openai",
+          access: "test-auth-token",
+          refresh: "test-auth-token",
+          expires: Date.now() + 10 * 60_000,
+        },
+      },
+      order: { openai: ["openai:chatgpt"] },
+    });
+    getApiKeyForModelMock.mockImplementation(async (params?: { profileId?: string }) => ({
+      apiKey: "test-auth-token",
+      mode: "oauth",
+      source: `profile:${params?.profileId ?? "openai:chatgpt"}`,
+      profileId: params?.profileId ?? "openai:chatgpt",
+    }));
+
+    const result = await compactEmbeddedAgentSessionDirect(
+      wrappedCompactionArgs({
+        provider: "openai",
+        model: "gpt-5.5",
+        // Do not pin provider-level api to openai-responses: that collapses
+        // route resolution to api-key-only and hides ChatGPT OAuth.
+        config: {
+          models: {
+            providers: {
+              openai: { models: [{ id: "gpt-5.5", contextWindow: 350_000 }] },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(maybeCompactAgentHarnessSessionMock).not.toHaveBeenCalled();
+    expect(selectAgentHarnessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentHarnessId: undefined,
+        agentHarnessRuntimeOverride: undefined,
+      }),
+    );
+    expect(selectAgentHarnessMock.mock.results[0]?.value).toEqual(
+      expect.objectContaining({ id: "codex", authBootstrap: "harness" }),
+    );
+    expect(selectAgentHarnessForPreparedModelProvidersMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentHarnessRuntimeOverride: undefined,
+        modelProviders: expect.arrayContaining([
+          expect.objectContaining({
+            preparedAuth: expect.objectContaining({
+              source: "profile",
+              mode: "oauth",
+              requirement: "subscription",
+            }),
+          }),
+        ]),
+      }),
+    );
+  });
+
   it("keeps custom OpenAI-compatible compaction on OpenAI logical context", async () => {
     resolveAgentHarnessPolicyMock.mockReturnValue({ runtime: "codex" });
 
@@ -3157,6 +3227,109 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       runtimeProvider: undefined,
       model: "gpt-5.5",
     });
+  });
+
+  it("routes unbound ChatGPT OAuth queued compaction through auth-aware codex selection", async () => {
+    // Implicit policy may prefer codex, but with no bound/planned harness the
+    // override must stay undefined so prepared OAuth can select the harness.
+    resolveAgentHarnessPolicyMock.mockReturnValue({
+      runtime: "codex",
+      runtimeSource: "implicit",
+    } as never);
+    ensureAuthProfileStoreMock.mockReturnValue({
+      version: 1,
+      profiles: {
+        "openai:chatgpt": {
+          type: "oauth",
+          provider: "openai",
+          access: "test-auth-token",
+          refresh: "test-auth-token",
+          expires: Date.now() + 10 * 60_000,
+        },
+      },
+      order: { openai: ["openai:chatgpt"] },
+    });
+    getApiKeyForModelMock.mockImplementation(async (params?: { profileId?: string }) => ({
+      apiKey: "test-auth-token",
+      mode: "oauth",
+      source: `profile:${params?.profileId ?? "openai:chatgpt"}`,
+      profileId: params?.profileId ?? "openai:chatgpt",
+    }));
+
+    const result = await compactEmbeddedAgentSession(
+      wrappedCompactionArgs({
+        provider: "openai",
+        model: "gpt-5.5",
+        // Do not pin provider-level api to openai-responses: that collapses
+        // route resolution to api-key-only and hides ChatGPT OAuth.
+        config: {
+          models: {
+            providers: {
+              openai: { models: [{ id: "gpt-5.5", contextWindow: 350_000 }] },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(maybeCompactAgentHarnessSessionMock).not.toHaveBeenCalled();
+    expect(selectAgentHarnessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentHarnessId: undefined,
+        agentHarnessRuntimeOverride: undefined,
+      }),
+    );
+    expect(selectAgentHarnessMock.mock.results[0]?.value).toEqual(
+      expect.objectContaining({ id: "codex", authBootstrap: "harness" }),
+    );
+    expect(selectAgentHarnessForPreparedModelProvidersMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentHarnessRuntimeOverride: undefined,
+        modelProviders: expect.arrayContaining([
+          expect.objectContaining({
+            preparedAuth: expect.objectContaining({
+              source: "profile",
+              mode: "oauth",
+              requirement: "subscription",
+            }),
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it("keeps unbound api-key queued compaction on openclaw without native harness compaction", async () => {
+    resolveAgentHarnessPolicyMock.mockReturnValue({
+      runtime: "openclaw",
+      runtimeSource: "implicit",
+    } as never);
+
+    const result = await compactEmbeddedAgentSession(
+      wrappedCompactionArgs({
+        provider: "openai",
+        model: "gpt-5.5",
+        config: {
+          models: {
+            providers: {
+              openai: { models: [{ id: "gpt-5.5", contextWindow: 350_000 }] },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(maybeCompactAgentHarnessSessionMock).not.toHaveBeenCalled();
+    expect(selectAgentHarnessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentHarnessId: undefined,
+        agentHarnessRuntimeOverride: undefined,
+      }),
+    );
+    expect(selectAgentHarnessMock.mock.results[0]?.value).toEqual(
+      expect.objectContaining({ id: "openclaw" }),
+    );
   });
 
   it("uses a prepared harness binding for queued custom OpenAI Responses compaction", async () => {

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -458,18 +458,17 @@ async function compactResolvedContextEngine(
   let preparedHarnessRuntime = selectedHarnessRuntime;
   let preparedParams = params;
   try {
-    if (attemptNativeHarnessCompaction) {
-      await ensureSelectedAgentHarnessPlugin({
-        config: params.config,
-        provider: ceProvider,
-        modelId: ceModelId,
-        agentId: runtimePolicyAgentId,
-        sessionKey: runtimePolicySessionKey,
-        agentHarnessId: params.agentHarnessId,
-        agentHarnessRuntimeOverride: selectedHarnessRuntime,
-        workspaceDir: resolvedWorkspaceDir,
-      });
-    }
+    // Ensure the policy-selected harness plugin so selection can pick implicit codex.
+    await ensureSelectedAgentHarnessPlugin({
+      config: params.config,
+      provider: ceProvider,
+      modelId: ceModelId,
+      agentId: runtimePolicyAgentId,
+      sessionKey: runtimePolicySessionKey,
+      agentHarnessId: params.agentHarnessId,
+      agentHarnessRuntimeOverride: selectedHarnessRuntime,
+      workspaceDir: resolvedWorkspaceDir,
+    });
     const {
       model: ceModel,
       authStorage,
@@ -493,7 +492,8 @@ async function compactResolvedContextEngine(
       })
         ? providedRuntimeAuthPlan
         : undefined;
-    const compactionHarnessRuntimeOverride = selectedHarnessRuntime ?? "openclaw";
+    // Overrides stay unset when no bound/planned/explicit harness resolved so auth-aware
+    // selection can pick the credential-owning harness (codex for ChatGPT OAuth).
     const selectHarnessForPreparedAttempts = (
       attempts: readonly PreparedAgentRuntimeAuthAttempt[],
     ) =>
@@ -511,7 +511,7 @@ async function compactResolvedContextEngine(
         agentId: runtimePolicyAgentId,
         sessionKey: runtimePolicySessionKey,
         agentHarnessId: params.agentHarnessId,
-        agentHarnessRuntimeOverride: compactionHarnessRuntimeOverride,
+        agentHarnessRuntimeOverride: selectedHarnessRuntime,
       });
     const initialHarness = reusableRuntimeAuthPlan
       ? undefined
@@ -523,7 +523,7 @@ async function compactResolvedContextEngine(
           agentId: runtimePolicyAgentId,
           sessionKey: runtimePolicySessionKey,
           agentHarnessId: params.agentHarnessId,
-          agentHarnessRuntimeOverride: compactionHarnessRuntimeOverride,
+          agentHarnessRuntimeOverride: selectedHarnessRuntime,
         });
     const prepareRuntimeAuth = (harness: ReturnType<typeof selectAgentHarness>) =>
       prepareAgentRuntimeAuth({

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -744,18 +744,17 @@ async function compactEmbeddedAgentSessionDirectOnce(
   const modelId = resolvedCompactionTarget.model ?? DEFAULT_MODEL;
   const authProfileId = resolvedCompactionTarget.authProfileId;
   const providedRuntimeAuthPlan = params.runtimeAuthPlan ?? params.runtimePlan?.auth;
-  if (runtimeProvider !== provider || selectedHarnessRuntime) {
-    await ensureSelectedAgentHarnessPlugin({
-      config: params.config,
-      provider,
-      modelId,
-      agentId: runtimePolicyAgentId,
-      sessionKey: runtimePolicySessionKey,
-      agentHarnessId: boundHarnessRuntime,
-      agentHarnessRuntimeOverride: selectedHarnessRuntimeOverride,
-      workspaceDir: resolvedWorkspace,
-    });
-  }
+  // Ensure the policy-selected harness plugin so selection can pick implicit codex.
+  await ensureSelectedAgentHarnessPlugin({
+    config: params.config,
+    provider,
+    modelId,
+    agentId: runtimePolicyAgentId,
+    sessionKey: runtimePolicySessionKey,
+    agentHarnessId: boundHarnessRuntime,
+    agentHarnessRuntimeOverride: selectedHarnessRuntimeOverride,
+    workspaceDir: resolvedWorkspace,
+  });
   let thinkLevel: ThinkLevel = params.thinkLevel ?? "off";
   const attemptedThinking = new Set<ThinkLevel>();
   const fail = (reason: string, err?: unknown): EmbeddedAgentCompactResult => {
@@ -810,8 +809,9 @@ async function compactEmbeddedAgentSessionDirectOnce(
     agentRuntimeAuthPlanMatchesTarget(providedRuntimeAuthPlan, { provider, modelId })
       ? providedRuntimeAuthPlan
       : undefined;
-  const compactionHarnessRuntimeOverride =
-    selectedHarnessRuntimeOverride ?? (selectedHarnessRuntime ? undefined : "openclaw");
+  // Overrides stay unset when no bound/planned/explicit harness resolved so auth-aware
+  // selection can pick the credential-owning harness (codex for ChatGPT OAuth); native
+  // transcript compaction stays gated on selectedHarnessRuntime.
   const selectHarnessForPreparedAttempts = (attempts: readonly PreparedAgentRuntimeAuthAttempt[]) =>
     selectAgentHarnessForPreparedModelProviders({
       provider,
@@ -827,7 +827,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
       agentId: runtimePolicyAgentId,
       sessionKey: runtimePolicySessionKey,
       agentHarnessId: boundHarnessRuntime,
-      agentHarnessRuntimeOverride: compactionHarnessRuntimeOverride,
+      agentHarnessRuntimeOverride: selectedHarnessRuntimeOverride,
     });
   const initialHarness = reusableRuntimeAuthPlan
     ? undefined
@@ -839,7 +839,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
         agentId: runtimePolicyAgentId,
         sessionKey: runtimePolicySessionKey,
         agentHarnessId: boundHarnessRuntime,
-        agentHarnessRuntimeOverride: compactionHarnessRuntimeOverride,
+        agentHarnessRuntimeOverride: selectedHarnessRuntimeOverride,
       });
   const prepareRuntimeAuth = (harness: ReturnType<typeof selectAgentHarness>) =>
     prepareAgentRuntimeAuth({


### PR DESCRIPTION
## What Problem This Solves

Sessions that run on the implicitly selected Codex harness (OpenAI provider + ChatGPT OAuth subscription, no API key) fail every out-of-run compaction: pre-run budget preflight, `/compact`, and subagent-announcement delivery. The failure signature is:

```
Auth profile "openai:..." uses oauth auth, but openai/openai-responses requires an OpenAI API key profile.
```

Because subagent completion announcements retry compaction and then give up, completed subagent work is silently dropped: the child finishes, the parent never wakes. This is the P1 tracked in #90925 (announce path) and the OAuth-only remainder of #98814 (direct compaction; its API-key-backup variant was already fixed by #104685).

## Why This Change Was Made

Root cause: both compaction paths forced harness selection to the core runtime when a session had no bound harness.

- `src/agents/embedded-agent-runner/compact.ts` (direct): `compactionHarnessRuntimeOverride = selectedHarnessRuntimeOverride ?? (selectedHarnessRuntime ? undefined : "openclaw")`
- `src/agents/embedded-agent-runner/compact.queued.ts` (queued/context-engine): `compactionHarnessRuntimeOverride = selectedHarnessRuntime ?? "openclaw"`

When `resolveCompactionHarnessRuntime` finds no bound session harness, no matching prepared runtime plan, and no explicit configured runtime (implicit policy is deliberately filtered), the forced `"openclaw"` override pins `selectAgentHarness` / `selectAgentHarnessForPreparedModelProviders` to the core runtime. Auth preparation then rejects the only available credential via `assertAuthModeAllowedForModel` (`src/agents/model-auth.ts`), because `openai`/`openai-responses` requires an API key. Live turns never force this override — `run.ts` lets policy plus prepared-auth-aware selection resolve implicit Codex — which is why normal turns work while only compaction fails.

The fix removes the forced override (leaving selection auth-aware, exactly like a live run) and loads the policy-selected harness plugin before selection in both paths, since implicit Codex selection otherwise silently falls back to OpenClaw when the plugin is not yet registered (`implicit_plugin_unavailable_openclaw`).

Native transcript compaction is unchanged: `shouldAttemptNativeHarnessCompaction` / `maybeCompactAgentHarnessSession` still key off the bound/planned/explicit harness only, so an unbound session cannot be pulled into native Codex compaction by implicit policy. The existing test pinning that invariant ("does not route queued compaction through implicit Codex policy alone") is untouched and still green.

## User Impact

ChatGPT-OAuth (subscription) users on the Codex runtime get working compaction everywhere: subagent completion announcements are delivered instead of being dropped after retries, and `/compact` plus budget-preflight compaction succeed without an API-key profile. API-key sessions are unaffected (regression-pinned).

Note: a second announce-boundary variant reported in #90925 (CLI codex-bound sessions returning "codex app-server owns automatic compaction" and the announce retry treating that deliberate no-op as fatal) is a separate defect in the announce path and is not addressed here.

## Evidence

- New regression tests in `src/agents/embedded-agent-runner/compact.hooks.test.ts`:
  - unbound ChatGPT-OAuth direct compaction selects codex via auth-aware selection (override stays `undefined`), native compaction not invoked;
  - same for the queued path;
  - unbound api-key compaction stays on openclaw (behavior pin).
  - Verified adversarially: with the prod change reverted, exactly these 3 tests fail (`3 failed | 102 passed`); with it, `105 passed`.
- Focused runs: `compact.hooks.test.ts` + `compaction-runtime-context.test.ts` → 135 passed.
- Affected-surface sweep on Blacksmith Testbox (compact*, compaction*, overflow/timeout-triggered compaction, harness selection/policy, manual boundary, post-compaction loop guard): results in PR checks/comment.
- `check:loc` ratchet: touched files kept at their baselines (`compact.ts` 2021, `compact.queued.ts` 1080). The ratchet currently reports ~28 pre-existing violations on clean `origin/main` (unrelated to this diff; verified by running the check on a clean checkout of `origin/main`).

Fixes #90925
