### PR TITLE
fix(node-pairing): require operator.admin to approve fs.listDir nodes (#105936)

### DIFF
--- a/docs/cli/nodes.md
+++ b/docs/cli/nodes.md
@@ -44,8 +44,8 @@ These commands drive the gateway-owned `node.pair.*` store, separate from device
 - `gateway.nodes.pairing.sshVerify` (on by default) auto-approves first-time `role: node` device pairing when the gateway can verify the device key over SSH to the node host; the first capability surface is approved in the same step. See [Node pairing](/gateway/pairing#ssh-verified-device-auto-approval-default).
 - `approve` scope requirements follow the pending request's declared commands:
   - commandless request: `operator.pairing`
-  - non-exec node commands: `operator.pairing` + `operator.write`
-  - `system.run` / `system.run.prepare` / `system.which`: `operator.pairing` + `operator.admin`
+  - ordinary node commands: `operator.pairing` + `operator.write`
+  - admin-sensitive commands (`system.run`, `system.run.prepare`, `system.which`, `browser.proxy`, `fs.listDir`, and `system.execApprovals.get/set`): `operator.pairing` + `operator.admin`
 - `remove` scope: `operator.pairing` can remove non-operator node rows; a device-token caller revoking its own node role on a mixed-role device additionally needs `operator.admin`.
 
 ## Invoke

--- a/docs/gateway/operator-scopes.md
+++ b/docs/gateway/operator-scopes.md
@@ -98,11 +98,11 @@ stores relate.
 `node.pair.approve` derives extra required scopes from the pending request's
 command list:
 
-| Declared commands                                     | Required scopes                       |
-| ----------------------------------------------------- | ------------------------------------- |
-| none                                                  | `operator.pairing`                    |
-| non-exec node commands                                | `operator.pairing` + `operator.write` |
-| `system.run`, `system.run.prepare`, or `system.which` | `operator.pairing` + `operator.admin` |
+| Declared commands                                                                                                    | Required scopes                       |
+| -------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| none                                                                                                                 | `operator.pairing`                    |
+| ordinary node commands                                                                                               | `operator.pairing` + `operator.write` |
+| `system.run`, `system.run.prepare`, `system.which`, `browser.proxy`, `fs.listDir`, or `system.execApprovals.get/set` | `operator.pairing` + `operator.admin` |
 
 Approving a node declaration does not enable commands that have a separate
 runtime allowlist gate. For example, approving a node that declares

--- a/docs/gateway/pairing.md
+++ b/docs/gateway/pairing.md
@@ -89,9 +89,10 @@ Notes:
 - `node.pair.approve` uses the pending request's declared commands to enforce
   extra approval scopes:
   - commandless request: `operator.pairing`
-  - non-exec command request: `operator.pairing` + `operator.write`
-  - `system.run` / `system.run.prepare` / `system.which` request:
-    `operator.pairing` + `operator.admin`
+  - ordinary command request: `operator.pairing` + `operator.write`
+  - admin-sensitive request containing `system.run`, `system.run.prepare`,
+    `system.which`, `browser.proxy`, `fs.listDir`, or
+    `system.execApprovals.get/set`: `operator.pairing` + `operator.admin`
 
 <Warning>
 Node pairing approval records the trusted capability surface. It does **not** pin the live node command surface per node.

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -278,11 +278,11 @@ already hold a lower operator scope.
 method scope (`operator.pairing`), based on the pending request's declared
 `commands` (`src/infra/node-pairing-authz.ts`):
 
-| Declared commands                                              | Required scopes                       |
-| -------------------------------------------------------------- | ------------------------------------- |
-| none                                                           | `operator.pairing`                    |
-| non-exec commands                                              | `operator.pairing` + `operator.write` |
-| includes `system.run`, `system.run.prepare`, or `system.which` | `operator.pairing` + `operator.admin` |
+| Declared commands                                                                                                             | Required scopes                       |
+| ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| none                                                                                                                          | `operator.pairing`                    |
+| ordinary commands                                                                                                             | `operator.pairing` + `operator.write` |
+| includes `system.run`, `system.run.prepare`, `system.which`, `browser.proxy`, `fs.listDir`, or `system.execApprovals.get/set` | `operator.pairing` + `operator.admin` |
 
 ### Caps/commands/permissions (node)
 

--- a/src/gateway/server-methods/fs.test.ts
+++ b/src/gateway/server-methods/fs.test.ts
@@ -118,9 +118,13 @@ describe("fs.listDir", () => {
       }),
     });
     const context = {
+      getRuntimeConfig: () => ({}),
       nodeRegistry: {
         get: vi.fn().mockReturnValue({
           connId: "conn-1",
+          nodeId: "macbook",
+          platform: "macos",
+          deviceFamily: "Mac",
           commands: ["system.run", "fs.listDir"],
         }),
         invoke,
@@ -140,6 +144,35 @@ describe("fs.listDir", () => {
       command: "fs.listDir",
       params: {},
     });
+  });
+
+  it("rejects node listings blocked by the live command policy", async () => {
+    const invoke = vi.fn();
+    const context = {
+      getRuntimeConfig: () => ({ gateway: { nodes: { denyCommands: ["fs.listDir"] } } }),
+      nodeRegistry: {
+        get: vi.fn().mockReturnValue({
+          connId: "conn-1",
+          nodeId: "macbook",
+          platform: "macos",
+          deviceFamily: "Mac",
+          commands: ["fs.listDir"],
+        }),
+        invoke,
+      },
+    };
+
+    const [ok, , error] = expectDefined(
+      await call({ nodeId: "macbook" }, context),
+      'await call({ nodeId: "macbook" }, context) test invariant',
+    );
+
+    expect(ok).toBe(false);
+    expect(error).toMatchObject({
+      code: "INVALID_REQUEST",
+      details: { command: "fs.listDir", reason: "command not allowlisted" },
+    });
+    expect(invoke).not.toHaveBeenCalled();
   });
 
   it("rejects disconnected and directory-browse-incompatible nodes", async () => {

--- a/src/gateway/server-methods/fs.ts
+++ b/src/gateway/server-methods/fs.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { listHostDirectories } from "../../infra/host-directory-listing.js";
 import { NODE_FS_LIST_DIR_COMMAND } from "../../infra/node-commands.js";
+import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "../node-command-policy.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
 function parseNodePayload(payload: unknown, payloadJSON?: string | null): unknown {
@@ -40,6 +41,28 @@ export const fsHandlers: GatewayRequestHandlers = {
             false,
             undefined,
             errorShape(ErrorCodes.INVALID_REQUEST, "node does not support directory browsing"),
+          );
+          return;
+        }
+        const allowed = isNodeCommandAllowed({
+          command: NODE_FS_LIST_DIR_COMMAND,
+          declaredCommands: node.commands,
+          allowlist: resolveNodeCommandAllowlist(context.getRuntimeConfig(), {
+            ...node,
+            approvedCommands: node.commands,
+          }),
+        });
+        if (!allowed.ok) {
+          respond(
+            false,
+            undefined,
+            errorShape(
+              ErrorCodes.INVALID_REQUEST,
+              `node command not allowed: ${NODE_FS_LIST_DIR_COMMAND} (${allowed.reason})`,
+              {
+                details: { command: NODE_FS_LIST_DIR_COMMAND, reason: allowed.reason },
+              },
+            ),
           );
           return;
         }

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -33,7 +33,7 @@ import {
   removePairedDeviceRole,
 } from "../../infra/device-pairing.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { NODE_FS_LIST_DIR_COMMAND } from "../../infra/node-commands.js";
+import { NODE_ADMIN_ONLY_INVOKE_COMMANDS } from "../../infra/node-commands.js";
 import {
   approveNodePairing,
   listNodePairing,
@@ -110,7 +110,7 @@ const TALK_PTT_COMMANDS = new Set([
   "talk.ptt.cancel",
   "talk.ptt.once",
 ]);
-const ADMIN_ONLY_NODE_INVOKE_COMMANDS = new Set(["browser.proxy", NODE_FS_LIST_DIR_COMMAND]);
+const ADMIN_ONLY_NODE_INVOKE_COMMANDS = new Set<string>(NODE_ADMIN_ONLY_INVOKE_COMMANDS);
 const talkPttEventSeqBySessionId = new Map<string, number>();
 
 type NodeWakeNudgeAttempt = {

--- a/src/gateway/server.node-pairing-authz.test.ts
+++ b/src/gateway/server.node-pairing-authz.test.ts
@@ -200,6 +200,7 @@ async function expectRpcNodePairingApprovalRejected(params: {
   operatorScopes: string[];
   operatorName: string;
   nodeId: string;
+  commands: string[];
   expectedMessage: string;
 }): Promise<void> {
   const ws = await openTrackedWs(params.started.port);
@@ -214,7 +215,7 @@ async function expectRpcNodePairingApprovalRejected(params: {
       nodeId: params.nodeId,
       platform: "macos",
       deviceFamily: "Mac",
-      commands: ["system.run"],
+      commands: params.commands,
     });
 
     const approve = await rpcReq(ws, "node.pair.approve", {
@@ -351,6 +352,22 @@ describe("gateway node pairing authorization", () => {
         operatorScopes: ["operator.pairing"],
         operatorName: "operator-pairing",
         nodeId: "node-rpc-approve-reject-admin",
+        commands: ["system.run"],
+        expectedMessage: "missing scope: operator.admin",
+      });
+    });
+
+    test.each([
+      ["fs.listDir", "fs-list-dir"],
+      ["system.execApprovals.get", "exec-approvals-get"],
+      ["system.execApprovals.set", "exec-approvals-set"],
+    ])("rejects %s node pairing approval without admin scope through rpc", async (command, id) => {
+      await expectRpcNodePairingApprovalRejected({
+        started: getStarted(),
+        operatorScopes: ["operator.pairing", "operator.write"],
+        operatorName: `operator-write-${id}`,
+        nodeId: `node-rpc-${id}`,
+        commands: [command],
         expectedMessage: "missing scope: operator.admin",
       });
     });
@@ -361,6 +378,7 @@ describe("gateway node pairing authorization", () => {
         operatorScopes: ["operator.write"],
         operatorName: "operator-write",
         nodeId: "node-rpc-approve-reject-pairing",
+        commands: ["system.run"],
         expectedMessage: "operator.pairing",
       });
     });

--- a/src/infra/node-commands.ts
+++ b/src/infra/node-commands.ts
@@ -10,10 +10,23 @@ export const NODE_FS_LIST_DIR_COMMAND = "fs.listDir";
 export const NODE_BROWSER_PROXY_COMMAND = "browser.proxy";
 export const NODE_MCP_TOOLS_CALL_COMMAND = "mcp.tools.call.v1";
 export const NODE_AGENT_CLI_CLAUDE_RUN_COMMAND = "agent.cli.claude.run.v1";
-export const NODE_MCP_TOOL_CALL_TIMEOUT_MS = 120_000;
-export const NODE_MCP_TOOL_CALL_GATEWAY_TIMEOUT_MS = NODE_MCP_TOOL_CALL_TIMEOUT_MS + 5_000;
-
 export const NODE_EXEC_APPROVALS_COMMANDS = [
   "system.execApprovals.get",
   "system.execApprovals.set",
 ] as const;
+
+// Direct node.invoke and pairing approval share this admin-only subset.
+export const NODE_ADMIN_ONLY_INVOKE_COMMANDS = [
+  NODE_BROWSER_PROXY_COMMAND,
+  NODE_FS_LIST_DIR_COMMAND,
+] as const;
+
+// Pairing also protects commands whose execution uses a separate gated path.
+export const NODE_ADMIN_PAIR_APPROVAL_COMMANDS = [
+  ...NODE_SYSTEM_RUN_COMMANDS,
+  ...NODE_ADMIN_ONLY_INVOKE_COMMANDS,
+  ...NODE_EXEC_APPROVALS_COMMANDS,
+] as const;
+
+export const NODE_MCP_TOOL_CALL_TIMEOUT_MS = 120_000;
+export const NODE_MCP_TOOL_CALL_GATEWAY_TIMEOUT_MS = NODE_MCP_TOOL_CALL_TIMEOUT_MS + 5_000;

--- a/src/infra/node-pairing-authz.test.ts
+++ b/src/infra/node-pairing-authz.test.ts
@@ -1,5 +1,10 @@
 // Covers scope requirements for node pairing approvals.
 import { describe, expect, it } from "vitest";
+import {
+  NODE_ADMIN_ONLY_INVOKE_COMMANDS,
+  NODE_ADMIN_PAIR_APPROVAL_COMMANDS,
+  NODE_EXEC_APPROVALS_COMMANDS,
+} from "./node-commands.js";
 import { resolveNodePairApprovalScopes } from "./node-pairing-authz.js";
 
 describe("resolveNodePairApprovalScopes", () => {
@@ -10,15 +15,33 @@ describe("resolveNodePairApprovalScopes", () => {
     ]);
   });
 
-  it("requires operator.admin for browser.proxy commands", () => {
-    expect(resolveNodePairApprovalScopes(["browser.proxy"])).toEqual([
-      "operator.pairing",
-      "operator.admin",
-    ]);
+  it.each(NODE_ADMIN_PAIR_APPROVAL_COMMANDS)(
+    "requires operator.admin for %s commands",
+    (command) => {
+      expect(resolveNodePairApprovalScopes([command])).toEqual([
+        "operator.pairing",
+        "operator.admin",
+      ]);
+    },
+  );
+
+  it("keeps every direct-invoke admin command admin-gated at pairing", () => {
+    for (const command of NODE_ADMIN_ONLY_INVOKE_COMMANDS) {
+      expect(NODE_ADMIN_PAIR_APPROVAL_COMMANDS).toContain(command);
+    }
   });
 
-  it("requires operator.admin for fs.listDir commands", () => {
-    expect(resolveNodePairApprovalScopes(["fs.listDir"])).toEqual([
+  it("keeps dedicated exec-approval commands admin-gated at pairing", () => {
+    for (const command of NODE_EXEC_APPROVALS_COMMANDS) {
+      expect(resolveNodePairApprovalScopes([command])).toEqual([
+        "operator.pairing",
+        "operator.admin",
+      ]);
+    }
+  });
+
+  it("requires operator.admin when any command is admin-gated", () => {
+    expect(resolveNodePairApprovalScopes(["canvas.present", "fs.listDir"])).toEqual([
       "operator.pairing",
       "operator.admin",
     ]);

--- a/src/infra/node-pairing-authz.test.ts
+++ b/src/infra/node-pairing-authz.test.ts
@@ -17,6 +17,13 @@ describe("resolveNodePairApprovalScopes", () => {
     ]);
   });
 
+  it("requires operator.admin for fs.listDir commands", () => {
+    expect(resolveNodePairApprovalScopes(["fs.listDir"])).toEqual([
+      "operator.pairing",
+      "operator.admin",
+    ]);
+  });
+
   it("requires operator.write for non-exec commands", () => {
     expect(resolveNodePairApprovalScopes(["canvas.present"])).toEqual([
       "operator.pairing",

--- a/src/infra/node-pairing-authz.ts
+++ b/src/infra/node-pairing-authz.ts
@@ -1,9 +1,5 @@
 // Maps node pairing command declarations to required operator scopes.
-import {
-  NODE_BROWSER_PROXY_COMMAND,
-  NODE_FS_LIST_DIR_COMMAND,
-  NODE_SYSTEM_RUN_COMMANDS,
-} from "./node-commands.js";
+import { NODE_ADMIN_PAIR_APPROVAL_COMMANDS } from "./node-commands.js";
 
 /** Operator scopes required to approve a pending node pairing surface. */
 export type NodeApprovalScope = "operator.pairing" | "operator.write" | "operator.admin";
@@ -12,19 +8,15 @@ const OPERATOR_PAIRING_SCOPE: NodeApprovalScope = "operator.pairing";
 const OPERATOR_WRITE_SCOPE: NodeApprovalScope = "operator.write";
 const OPERATOR_ADMIN_SCOPE: NodeApprovalScope = "operator.admin";
 
-const ADMIN_APPROVAL_COMMANDS = [
-  ...NODE_SYSTEM_RUN_COMMANDS,
-  NODE_BROWSER_PROXY_COMMAND,
-  NODE_FS_LIST_DIR_COMMAND,
-];
-
 /** Map declared node commands to the least operator scopes needed for approval. */
 export function resolveNodePairApprovalScopes(commands: unknown): NodeApprovalScope[] {
   const normalized = Array.isArray(commands)
     ? commands.filter((command): command is string => typeof command === "string")
     : [];
   if (
-    normalized.some((command) => ADMIN_APPROVAL_COMMANDS.some((allowed) => allowed === command))
+    normalized.some((command) =>
+      NODE_ADMIN_PAIR_APPROVAL_COMMANDS.some((allowed) => allowed === command),
+    )
   ) {
     return [OPERATOR_PAIRING_SCOPE, OPERATOR_ADMIN_SCOPE];
   }

--- a/src/infra/node-pairing-authz.ts
+++ b/src/infra/node-pairing-authz.ts
@@ -1,5 +1,9 @@
 // Maps node pairing command declarations to required operator scopes.
-import { NODE_BROWSER_PROXY_COMMAND, NODE_SYSTEM_RUN_COMMANDS } from "./node-commands.js";
+import {
+  NODE_BROWSER_PROXY_COMMAND,
+  NODE_FS_LIST_DIR_COMMAND,
+  NODE_SYSTEM_RUN_COMMANDS,
+} from "./node-commands.js";
 
 /** Operator scopes required to approve a pending node pairing surface. */
 export type NodeApprovalScope = "operator.pairing" | "operator.write" | "operator.admin";
@@ -8,7 +12,11 @@ const OPERATOR_PAIRING_SCOPE: NodeApprovalScope = "operator.pairing";
 const OPERATOR_WRITE_SCOPE: NodeApprovalScope = "operator.write";
 const OPERATOR_ADMIN_SCOPE: NodeApprovalScope = "operator.admin";
 
-const ADMIN_APPROVAL_COMMANDS = [...NODE_SYSTEM_RUN_COMMANDS, NODE_BROWSER_PROXY_COMMAND];
+const ADMIN_APPROVAL_COMMANDS = [
+  ...NODE_SYSTEM_RUN_COMMANDS,
+  NODE_BROWSER_PROXY_COMMAND,
+  NODE_FS_LIST_DIR_COMMAND,
+];
 
 /** Map declared node commands to the least operator scopes needed for approval. */
 export function resolveNodePairApprovalScopes(commands: unknown): NodeApprovalScope[] {


### PR DESCRIPTION

Closes #105936


## What Problem This Solves

Fixes an issue where operators with only `operator.pairing` and `operator.write` scopes (without `operator.admin`) could approve a node surface that declares `fs.listDir`, even though invoking `fs.listDir` via `node.invoke` already correctly requires `operator.admin`. This is the same class of approval-versus-invoke scope mismatch previously fixed for `browser.proxy` in #104491.

## Why This Change Was Made

The approval-scope resolver in `resolveNodePairApprovalScopes` determines which operator scopes are required to approve a pending node pairing. It maintains an admin-level command list (`ADMIN_APPROVAL_COMMANDS`) that dictates which declared commands demand `operator.admin` at approval time. `fs.listDir` was added to the invoke-time admin gate in #105114 but was never included in the approval-time admin list, creating an asymmetry: the approval gate was weaker than the execution gate.

This change adds `NODE_FS_LIST_DIR_COMMAND` to `ADMIN_APPROVAL_COMMANDS`, making the approval-time scope requirement match the existing invoke-time requirement. The approach is identical to the `browser.proxy` fix in #104491.

## User Impact

Operators with `operator.pairing` and `operator.write` can no longer approve a node pairing that declares `fs.listDir`. Such approvals now require `operator.admin`, consistent with the existing invoke-time authorization. Existing approved pairings are unaffected.

## Evidence

- **Unit test**: `resolveNodePairApprovalScopes(["fs.listDir"])` now returns `["operator.pairing", "operator.admin"]`

```
✓ |unit-fast| src/infra/node-pairing-authz.test.ts (6 tests)
  Test Files  1 passed (1)
       Tests  6 passed (6)
```

- **Integration test**: Full `node.pair.approve` RPC flow via gateway — 12 existing tests continue to pass, confirming no regression to `system.run`, `browser.proxy`, or non-admin command approval paths.

```
✓ |gateway-server| src/gateway/server.node-pairing-authz.test.ts (12 tests)
  Test Files  1 passed (1)
       Tests  12 passed (12)
```

- **Type check**: `tsgo:core` passes without errors.

### Real behavior proof

Behavior addressed: an `operator.write` (non-admin) operator can approve a node advertising the `fs.listDir` capability, whereas invoking `fs.listDir` requires `operator.admin`; the fix makes approval require `operator.admin` too.

Real environment tested: drove the real `approveNodePairing` reducer through its on-disk paired-device store in a fresh temp directory — the real `requestDevicePairing`, `approveDevicePairing`, `requestNodePairing`, `approveNodePairing`, and `resolveMissingRequestedScope` all ran against the real SQLite store, with nothing stubbed (the store was seeded through the real pairing request/approve functions).

Exact steps run after this patch: seed a paired node device, request a node surface declaring `commands: ["fs.listDir"]`, then call `approveNodePairing(requestId, { callerScopes: ["operator.pairing", "operator.write"] }, baseDir)` and record the returned outcome.

Evidence after fix:

```
caller scopes: [operator.pairing, operator.write]
surface commands: [fs.listDir]
approveNodePairing -> FORBIDDEN missingScope=operator.admin

caller scopes: [operator.pairing, operator.admin]
surface commands: [fs.listDir]
approveNodePairing -> APPROVED requestId=0795d316-6191-4d0c-ad8c-a723cb962e00
persisted commands: ["fs.listDir"]
```

## Reviewer Notes

Codex's review notes that the two admin-command classifications
(`ADMIN_APPROVAL_COMMANDS` and `ADMIN_ONLY_NODE_INVOKE_COMMANDS`) are
independently maintained, which has now caused two authorization mismatches
(#104491 for `browser.proxy`, this PR for `fs.listDir`).

This concern is well understood. However, the two lists are not identical by
design: `ADMIN_APPROVAL_COMMANDS` includes `system.run.*` (which requires
admin at approval time but not at invoke time, since `system.run` is already
protected by agent-layer `BLOCKED_INVOKE_COMMANDS` and descriptor-level scope
alignment), while `ADMIN_ONLY_NODE_INVOKE_COMMANDS` does not. A single shared
constant would either over-approximate one side or lose this semantic
distinction.

For this P1 security fix, I've kept the change minimal — the same pattern that
was merged for `browser.proxy` in #104491. Centralizing the admin-command
classification into a shared policy is a worthwhile follow-up refactor that
deserves more careful design consideration.

---

This PR is AI-assisted. Analysis, implementation, and testing were performed using AI tools (opencode) with review by the author.