### PR TITLE
refactor(plugin-sdk): prune eligible deprecated exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Plugin SDK compatibility cleanup:** remove unshipped pairing and approval-reaction compatibility exports, migrate bundled Zalo delivery to `OutboundDeliveryResult`, and deprecate the legacy raw send result shape ahead of the next plugin-SDK major release.
 - **SQLite snapshots:** add `openclaw backup sqlite create|list|verify|restore` for compact, verified global and per-agent database artifacts with fresh-target-only restore. (#94805) Thanks @giodl73-repo.
 - **GPT-5.6 Ultra and runtime switching:** support Sol, Terra, and Luna across OpenClaw and Codex engines; keep model, runtime, and thinking selection atomic through `/model` and fallback; and add live matrix coverage for both harnesses. (#98021) Thanks @anyech.
 - **OpenAI GPT-5.6 defaults:** use `openai/gpt-5.6` (Sol alias) for fresh API-key setup and exact `openai/gpt-5.6-sol` for fresh Codex/OAuth setup, while preserving existing primaries, fallbacks, aliases, and explicit GPT-5.5 selections. (#103234)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Plugin SDK compatibility cleanup:** remove unshipped pairing and approval-reaction compatibility exports, migrate bundled Zalo delivery to `OutboundDeliveryResult`, and deprecate the legacy raw send result shape ahead of the next plugin-SDK major release.
 - **SQLite snapshots:** add `openclaw backup sqlite create|list|verify|restore` for compact, verified global and per-agent database artifacts with fresh-target-only restore. (#94805) Thanks @giodl73-repo.
 - **GPT-5.6 Ultra and runtime switching:** support Sol, Terra, and Luna across OpenClaw and Codex engines; keep model, runtime, and thinking selection atomic through `/model` and fallback; and add live matrix coverage for both harnesses. (#98021) Thanks @anyech.
 - **OpenAI GPT-5.6 defaults:** use `openai/gpt-5.6` (Sol alias) for fresh API-key setup and exact `openai/gpt-5.6-sol` for fresh Codex/OAuth setup, while preserving existing primaries, fallbacks, aliases, and explicit GPT-5.5 selections. (#103234)

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-8bb175b965c6fab4512f110cd584ba601074885fb49375f2dd18e832882d61a5  plugin-sdk-api-baseline.json
-5a1548ecb0cf8dffb67591b41b9e1a3c04ee7fe0cb22ac2f3bcfa24e319f4f47  plugin-sdk-api-baseline.jsonl
+598c5f1bb39362de6b11b4cd3403551f99fb7c3bbf85d5e3dcf1b1408a8cec24  plugin-sdk-api-baseline.json
+d87a296d6d449c2e01b63eeb1e1743d1f11dcdf4091520328c54798ac18f149f  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -791,6 +791,18 @@ major release. Every entry maps the old API to its canonical replacement.
 
   </Accordion>
 
+  <Accordion title="Raw channel send results -> OutboundDeliveryResult">
+    **Old**: return `{ ok, messageId, error }` through
+    `ChannelSendRawResult` and normalize it with
+    `createRawChannelSendResultAdapter(...)`.
+
+    **New**: return `OutboundDeliveryResult` fields and attach the channel with
+    `createAttachedChannelResultAdapter(...)`. Failed sends should throw instead
+    of returning an error string. The raw result type remains available until
+    the next plugin-SDK major release.
+
+  </Accordion>
+
   <Accordion title="Subagent session messages types renamed">
     Two legacy type aliases still exported from `src/plugins/runtime/types.ts`:
 

--- a/extensions/telegram/src/inline-buttons.test.ts
+++ b/extensions/telegram/src/inline-buttons.test.ts
@@ -1,5 +1,5 @@
 // Telegram tests cover inline buttons plugin behavior.
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it } from "vitest";
 import { buildTelegramInteractiveButtons } from "./button-types.js";
 import { describeTelegramInteractiveButtonBehavior } from "./button-types.test-helpers.js";

--- a/extensions/zalo/src/channel.ts
+++ b/extensions/zalo/src/channel.ts
@@ -16,7 +16,7 @@ import {
 } from "openclaw/plugin-sdk/channel-core";
 import {
   defineChannelMessageAdapter,
-  type ChannelMessageSendResult,
+  type MessageReceipt,
 } from "openclaw/plugin-sdk/channel-outbound";
 import {
   buildOpenGroupPolicyRestrictSendersWarning,
@@ -85,48 +85,32 @@ const zaloSetupWizard = createZaloSetupWizardProxy(
 );
 const zaloTextChunkLimit = 2000;
 
-type ZaloRawSendResult = {
-  ok: boolean;
-  messageId?: string;
-  receipt: ChannelMessageSendResult["receipt"];
-  error?: string;
-};
-
-function requireSuccessfulZaloSend(
-  result: ZaloRawSendResult,
-  fallbackError: string,
-): ChannelMessageSendResult {
+async function sendZaloDelivery(ctx: {
+  cfg: OpenClawConfig;
+  to: string;
+  text: string;
+  accountId?: string | null;
+  mediaUrl?: string;
+}): Promise<{ messageId: string; receipt: MessageReceipt }> {
+  const result = await (
+    await loadZaloChannelRuntime()
+  ).sendZaloText({
+    to: ctx.to,
+    text: ctx.text,
+    accountId: ctx.accountId ?? undefined,
+    mediaUrl: ctx.mediaUrl,
+    cfg: ctx.cfg,
+  });
   if (!result.ok) {
-    throw new Error(result.error ?? fallbackError);
+    throw new Error(result.error ?? `Failed to send Zalo ${ctx.mediaUrl ? "media" : "message"}`);
   }
   return { messageId: result.messageId ?? "", receipt: result.receipt };
 }
 
 const zaloSendResultAdapter = createAttachedChannelResultAdapter({
   channel: "zalo",
-  sendText: async ({ to, text, accountId, cfg }) => {
-    const result = await (
-      await loadZaloChannelRuntime()
-    ).sendZaloText({
-      to,
-      text,
-      accountId: accountId ?? undefined,
-      cfg,
-    });
-    return requireSuccessfulZaloSend(result, "Failed to send Zalo message");
-  },
-  sendMedia: async ({ to, text, mediaUrl, accountId, cfg }) => {
-    const result = await (
-      await loadZaloChannelRuntime()
-    ).sendZaloText({
-      to,
-      text,
-      accountId: accountId ?? undefined,
-      mediaUrl,
-      cfg,
-    });
-    return requireSuccessfulZaloSend(result, "Failed to send Zalo media");
-  },
+  sendText: sendZaloDelivery,
+  sendMedia: sendZaloDelivery,
 });
 
 export const zaloMessageAdapter = defineChannelMessageAdapter({
@@ -139,31 +123,8 @@ export const zaloMessageAdapter = defineChannelMessageAdapter({
     },
   },
   send: {
-    text: async ({ to, text, accountId, cfg }) =>
-      requireSuccessfulZaloSend(
-        await (
-          await loadZaloChannelRuntime()
-        ).sendZaloText({
-          to,
-          text,
-          accountId: accountId ?? undefined,
-          cfg,
-        }),
-        "Failed to send Zalo message",
-      ),
-    media: async ({ to, text, mediaUrl, accountId, cfg }) =>
-      requireSuccessfulZaloSend(
-        await (
-          await loadZaloChannelRuntime()
-        ).sendZaloText({
-          to,
-          text,
-          accountId: accountId ?? undefined,
-          mediaUrl,
-          cfg,
-        }),
-        "Failed to send Zalo media",
-      ),
+    text: sendZaloDelivery,
+    media: sendZaloDelivery,
   },
 });
 

--- a/extensions/zalo/src/channel.ts
+++ b/extensions/zalo/src/channel.ts
@@ -21,8 +21,8 @@ import {
   createOpenProviderGroupPolicyWarningCollector,
 } from "openclaw/plugin-sdk/channel-policy";
 import {
+  createAttachedChannelResultAdapter,
   createEmptyChannelResult,
-  createRawChannelSendResultAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
 import { buildTokenChannelStatusSummary } from "openclaw/plugin-sdk/channel-status";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -82,19 +82,24 @@ const zaloSetupWizard = createZaloSetupWizardProxy(
 );
 const zaloTextChunkLimit = 2000;
 
-const zaloRawSendResultAdapter = createRawChannelSendResultAdapter({
+const zaloSendResultAdapter = createAttachedChannelResultAdapter({
   channel: "zalo",
-  sendText: async ({ to, text, accountId, cfg }) =>
-    await (
+  sendText: async ({ to, text, accountId, cfg }) => {
+    const result = await (
       await loadZaloChannelRuntime()
     ).sendZaloText({
       to,
       text,
       accountId: accountId ?? undefined,
       cfg,
-    }),
-  sendMedia: async ({ to, text, mediaUrl, accountId, cfg }) =>
-    await (
+    });
+    if (!result.ok) {
+      throw new Error(result.error ?? "Failed to send Zalo message");
+    }
+    return { messageId: result.messageId ?? "", receipt: result.receipt };
+  },
+  sendMedia: async ({ to, text, mediaUrl, accountId, cfg }) => {
+    const result = await (
       await loadZaloChannelRuntime()
     ).sendZaloText({
       to,
@@ -102,7 +107,12 @@ const zaloRawSendResultAdapter = createRawChannelSendResultAdapter({
       accountId: accountId ?? undefined,
       mediaUrl,
       cfg,
-    }),
+    });
+    if (!result.ok) {
+      throw new Error(result.error ?? "Failed to send Zalo media");
+    }
+    return { messageId: result.messageId ?? "", receipt: result.receipt };
+  },
 });
 
 export const zaloMessageAdapter = defineChannelMessageAdapter({
@@ -303,11 +313,11 @@ export const zaloPlugin: ChannelPlugin<ResolvedZaloAccount, ZaloProbeResult> =
           ctx,
           textChunkLimit: zaloTextChunkLimit,
           chunker: chunkTextForOutbound,
-          sendText: (nextCtx) => zaloRawSendResultAdapter.sendText!(nextCtx),
-          sendMedia: (nextCtx) => zaloRawSendResultAdapter.sendMedia!(nextCtx),
+          sendText: (nextCtx) => zaloSendResultAdapter.sendText!(nextCtx),
+          sendMedia: (nextCtx) => zaloSendResultAdapter.sendMedia!(nextCtx),
           emptyResult: createEmptyChannelResult("zalo"),
           onResult: ctx.onDeliveryResult,
         }),
-      ...zaloRawSendResultAdapter,
+      ...zaloSendResultAdapter,
     },
   });

--- a/extensions/zalo/src/channel.ts
+++ b/extensions/zalo/src/channel.ts
@@ -14,7 +14,10 @@ import {
   createChatChannelPlugin,
   type ChannelPlugin,
 } from "openclaw/plugin-sdk/channel-core";
-import { defineChannelMessageAdapter } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  defineChannelMessageAdapter,
+  type ChannelMessageSendResult,
+} from "openclaw/plugin-sdk/channel-outbound";
 import {
   buildOpenGroupPolicyRestrictSendersWarning,
   buildOpenGroupPolicyWarning,
@@ -82,6 +85,23 @@ const zaloSetupWizard = createZaloSetupWizardProxy(
 );
 const zaloTextChunkLimit = 2000;
 
+type ZaloRawSendResult = {
+  ok: boolean;
+  messageId?: string;
+  receipt: ChannelMessageSendResult["receipt"];
+  error?: string;
+};
+
+function requireSuccessfulZaloSend(
+  result: ZaloRawSendResult,
+  fallbackError: string,
+): ChannelMessageSendResult {
+  if (!result.ok) {
+    throw new Error(result.error ?? fallbackError);
+  }
+  return { messageId: result.messageId ?? "", receipt: result.receipt };
+}
+
 const zaloSendResultAdapter = createAttachedChannelResultAdapter({
   channel: "zalo",
   sendText: async ({ to, text, accountId, cfg }) => {
@@ -93,10 +113,7 @@ const zaloSendResultAdapter = createAttachedChannelResultAdapter({
       accountId: accountId ?? undefined,
       cfg,
     });
-    if (!result.ok) {
-      throw new Error(result.error ?? "Failed to send Zalo message");
-    }
-    return { messageId: result.messageId ?? "", receipt: result.receipt };
+    return requireSuccessfulZaloSend(result, "Failed to send Zalo message");
   },
   sendMedia: async ({ to, text, mediaUrl, accountId, cfg }) => {
     const result = await (
@@ -108,10 +125,7 @@ const zaloSendResultAdapter = createAttachedChannelResultAdapter({
       mediaUrl,
       cfg,
     });
-    if (!result.ok) {
-      throw new Error(result.error ?? "Failed to send Zalo media");
-    }
-    return { messageId: result.messageId ?? "", receipt: result.receipt };
+    return requireSuccessfulZaloSend(result, "Failed to send Zalo media");
   },
 });
 
@@ -126,24 +140,30 @@ export const zaloMessageAdapter = defineChannelMessageAdapter({
   },
   send: {
     text: async ({ to, text, accountId, cfg }) =>
-      await (
-        await loadZaloChannelRuntime()
-      ).sendZaloText({
-        to,
-        text,
-        accountId: accountId ?? undefined,
-        cfg,
-      }),
+      requireSuccessfulZaloSend(
+        await (
+          await loadZaloChannelRuntime()
+        ).sendZaloText({
+          to,
+          text,
+          accountId: accountId ?? undefined,
+          cfg,
+        }),
+        "Failed to send Zalo message",
+      ),
     media: async ({ to, text, mediaUrl, accountId, cfg }) =>
-      await (
-        await loadZaloChannelRuntime()
-      ).sendZaloText({
-        to,
-        text,
-        accountId: accountId ?? undefined,
-        mediaUrl,
-        cfg,
-      }),
+      requireSuccessfulZaloSend(
+        await (
+          await loadZaloChannelRuntime()
+        ).sendZaloText({
+          to,
+          text,
+          accountId: accountId ?? undefined,
+          mediaUrl,
+          cfg,
+        }),
+        "Failed to send Zalo media",
+      ),
   },
 });
 

--- a/extensions/zalo/src/outbound-payload.contract.test.ts
+++ b/extensions/zalo/src/outbound-payload.contract.test.ts
@@ -6,9 +6,16 @@ import {
 } from "openclaw/plugin-sdk/channel-contract-testing";
 import {
   createMessageReceiptFromOutboundResults,
+  sendDurableMessageBatch,
   verifyChannelMessageAdapterCapabilityProofs,
 } from "openclaw/plugin-sdk/channel-outbound";
-import { describe, expect, it, vi } from "vitest";
+import {
+  createEmptyPluginRegistry,
+  createTestRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { zaloMessageAdapter, zaloPlugin } from "./channel.js";
 
 const { sendZaloTextMock } = vi.hoisted(() => ({
@@ -82,6 +89,11 @@ function createZaloHarness(params: OutboundPayloadHarnessParams) {
   };
 }
 
+afterEach(() => {
+  resetPluginRuntimeStateForTest();
+  setActivePluginRegistry(createEmptyPluginRegistry());
+});
+
 describe("Zalo outbound payload contract", () => {
   installChannelOutboundPayloadContractSuite({
     channel: "zalo",
@@ -100,6 +112,40 @@ describe("Zalo outbound payload contract", () => {
       requireZaloOutboundTextSender()({ cfg: {}, to: "123456789", text: "hello" }),
     ).rejects.toThrow("Zalo rejected the message");
   });
+
+  it.each([
+    { kind: "text", payload: { text: "hello" } },
+    {
+      kind: "media",
+      payload: { text: "image", mediaUrl: "https://example.com/image.png" },
+    },
+  ] as const)(
+    "reports $kind message-adapter failures to durable delivery",
+    async ({ kind, payload }) => {
+      setActivePluginRegistry(
+        createTestRegistry([{ pluginId: "zalo", source: "test", plugin: zaloPlugin }]),
+      );
+      sendZaloTextMock.mockReset().mockResolvedValue({
+        ok: false,
+        error: `Zalo rejected the ${kind}`,
+        receipt: createMessageReceiptFromOutboundResults({ results: [], kind }),
+      });
+
+      const result = await sendDurableMessageBatch({
+        cfg: {},
+        channel: "zalo",
+        to: "123456789",
+        payloads: [payload],
+        skipQueue: true,
+      });
+
+      expect(result.status).toBe("failed");
+      if (result.status !== "failed") {
+        throw new Error(`Expected failed Zalo ${kind} delivery`);
+      }
+      expect(result.error).toMatchObject({ message: `Zalo rejected the ${kind}` });
+    },
+  );
 
   it("declares message adapter durable text and media with receipt proofs", async () => {
     sendZaloTextMock.mockReset().mockImplementation(async (ctx: { mediaUrl?: string }) =>

--- a/extensions/zalo/src/outbound-payload.contract.test.ts
+++ b/extensions/zalo/src/outbound-payload.contract.test.ts
@@ -47,9 +47,21 @@ function requireZaloMediaSender(): NonNullable<ZaloMessageSender["media"]> {
   return media;
 }
 
+function requireZaloOutboundTextSender(): NonNullable<ZaloOutbound["sendText"]> {
+  const sendText = zaloPlugin.outbound?.sendText;
+  if (!sendText) {
+    throw new Error("Expected Zalo outbound text sender");
+  }
+  return sendText;
+}
+
 function createZaloHarness(params: OutboundPayloadHarnessParams) {
   const sendZalo = vi.fn();
-  primeChannelOutboundSendMock(sendZalo, { ok: true, messageId: "zl-1" }, params.sendResults);
+  primeChannelOutboundSendMock(
+    sendZalo,
+    { ok: true, messageId: "zl-1" },
+    params.sendResults?.map((result) => ({ ok: true, ...result })),
+  );
   sendZaloTextMock.mockReset().mockImplementation(
     async (nextCtx: { to: string; text: string; mediaUrl?: string }) =>
       await sendZalo(nextCtx.to, nextCtx.text, {
@@ -75,6 +87,18 @@ describe("Zalo outbound payload contract", () => {
     channel: "zalo",
     chunking: { mode: "split", longTextLength: 3000, maxChunkLength: 2000 },
     createHarness: createZaloHarness,
+  });
+
+  it("throws legacy raw send failures at the typed delivery boundary", async () => {
+    sendZaloTextMock.mockReset().mockResolvedValue({
+      ok: false,
+      error: "Zalo rejected the message",
+      receipt: createMessageReceiptFromOutboundResults({ results: [], kind: "text" }),
+    });
+
+    await expect(
+      requireZaloOutboundTextSender()({ cfg: {}, to: "123456789", text: "hello" }),
+    ).rejects.toThrow("Zalo rejected the message");
   });
 
   it("declares message adapter durable text and media with receipt proofs", async () => {

--- a/scripts/check-pairing-account-scope.mjs
+++ b/scripts/check-pairing-account-scope.mjs
@@ -55,14 +55,6 @@ function findViolations(content, filePath) {
             reason: "readChannelAllowFromStore call must pass explicit accountId as 3rd arg",
           });
         }
-      } else if (
-        callName === "readLegacyChannelAllowFromStore" ||
-        callName === "readLegacyChannelAllowFromStoreSync"
-      ) {
-        violations.push({
-          line: toLine(sourceFile, node),
-          reason: `${callName} is legacy-only; use account-scoped readChannelAllowFromStore* APIs`,
-        });
       } else if (callName === "upsertChannelPairingRequest") {
         const firstArg = node.arguments[0];
         if (!firstArg || !hasRequiredAccountIdProperty(firstArg)) {

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -124,6 +124,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "ssrf-runtime": 1,
   "media-runtime": 2,
   "text-runtime": 191,
+  "agent-core": 1,
   "agent-runtime": 7,
   "plugin-runtime": 13,
   "channel-secret-runtime": 23,
@@ -213,7 +214,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
-      3281,
+      3282,
       env,
     ),
     publicWildcardReexports: readPluginSdkSurfaceBudgetEnv(

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -104,7 +104,6 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "channel-streaming": 49,
   "approval-gateway-runtime": 1,
   "approval-handler-runtime": 1,
-  "approval-reaction-runtime": 1,
   "approval-reply-runtime": 3,
   "approval-runtime": 1,
   "config-runtime": 123,
@@ -158,6 +157,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   // landed on main (#105802) without entrypoint pins; not touched by this PR.
   "channel-pairing": 1,
   "conversation-runtime": 4,
+  "channel-send-result": 1,
   "channel-policy": 8,
   "channel-route": 5,
   "session-store-runtime": 4,
@@ -203,20 +203,17 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
-      10644,
+      10640,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS",
-      5358,
+      5354,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
-      // 3279 + 5 deprecated pairing/conversation exports added on main by the
-      // SQLite pairing migration (#105802) without a pin bump (its changed-path
-      // set skipped this lane); sources are byte-identical to main here.
-      3284,
+      3281,
       env,
     ),
     publicWildcardReexports: readPluginSdkSurfaceBudgetEnv(

--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -210,28 +210,12 @@ async function updateAllowFromStoreEntry(params: {
   }, sqliteOptionsForEnv(env));
 }
 
-/** @deprecated Reads the canonical default-account SQLite rows. */
-export async function readLegacyChannelAllowFromStore(
-  channel: PairingChannel,
-  env: NodeJS.ProcessEnv = process.env,
-): Promise<string[]> {
-  return readAllowFromState(channel, env, DEFAULT_ACCOUNT_ID);
-}
-
 export async function readChannelAllowFromStore(
   channel: PairingChannel,
   env: NodeJS.ProcessEnv = process.env,
   accountId?: string,
 ): Promise<string[]> {
   return readAllowFromState(channel, env, accountId);
-}
-
-/** @deprecated Reads the canonical default-account SQLite rows. */
-export function readLegacyChannelAllowFromStoreSync(
-  channel: PairingChannel,
-  env: NodeJS.ProcessEnv = process.env,
-): string[] {
-  return readAllowFromState(channel, env, DEFAULT_ACCOUNT_ID);
 }
 
 export function readChannelAllowFromStoreSync(
@@ -241,9 +225,6 @@ export function readChannelAllowFromStoreSync(
 ): string[] {
   return readAllowFromState(channel, env, accountId);
 }
-
-/** @deprecated SQLite reads are uncached; retained for the shipped SDK test surface. */
-export function clearPairingAllowFromReadCacheForTest(): void {}
 
 type AllowFromStoreEntryUpdateParams = {
   channel: PairingChannel;

--- a/src/plugin-sdk/approval-reaction-runtime.test.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.test.ts
@@ -14,7 +14,6 @@ import {
   listApprovalReactionBindings,
   normalizeApprovalReactionEmoji,
   resolveApprovalReactionDecision,
-  resolveApprovalReactionTarget,
   resolveTypedApprovalReactionTarget,
   shouldSuppressLocalNativeExecApprovalPrompt,
 } from "./approval-reaction-runtime.js";
@@ -140,23 +139,6 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
     ).toEqual({
       approvalId,
       approvalKind: "exec",
-      decision: "deny",
-      normalizedEmoji: "👎",
-    });
-  });
-
-  it("preserves deprecated id-based kind inference", () => {
-    expect(
-      resolveApprovalReactionTarget({
-        target: {
-          approvalId: "plugin:legacy-id",
-          allowedDecisions: ["deny"],
-        },
-        reactionKey: "👎",
-      }),
-    ).toEqual({
-      approvalId: "plugin:legacy-id",
-      approvalKind: "plugin",
       decision: "deny",
       normalizedEmoji: "👎",
     });

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -242,20 +242,6 @@ function resolveApprovalReactionTargetInternal<TRoute>(params: {
   };
 }
 
-/**
- * Resolve a stored target while retaining shipped id-based ownership inference.
- * @deprecated Use resolveTypedApprovalReactionTarget with an explicit approvalKind.
- */
-export function resolveApprovalReactionTarget<TRoute = unknown>(params: {
-  target: ApprovalReactionTargetRecord<TRoute> | null | undefined;
-  reactionKey: string;
-}): ApprovalReactionTargetResolution<TRoute> | null {
-  return resolveApprovalReactionTargetInternal({
-    ...params,
-    allowLegacyKindInference: true,
-  });
-}
-
 /** Resolve an explicitly typed target without deriving ownership from its id. */
 export function resolveTypedApprovalReactionTarget<TRoute = unknown>(params: {
   target:

--- a/src/plugin-sdk/channel-send-result.ts
+++ b/src/plugin-sdk/channel-send-result.ts
@@ -6,7 +6,11 @@ import type { OutboundDeliveryResult } from "../infra/outbound/deliver.js";
 export type { ChannelOutboundAdapter } from "../channels/plugins/outbound.types.js";
 export type { OutboundDeliveryResult } from "../infra/outbound/deliver.js";
 
-/** Legacy raw send result shape accepted from channel SDK adapters. */
+/**
+ * Legacy raw send result shape accepted from channel SDK adapters.
+ * @deprecated Return `OutboundDeliveryResult` and use
+ * `createAttachedChannelResultAdapter`. Removal with the next plugin-SDK major.
+ */
 export type ChannelSendRawResult = {
   /** Whether the channel send operation succeeded. */
   ok: boolean;


### PR DESCRIPTION
Closes #105980

AI-assisted: yes. The complete diff, consumer inventory, release-tag boundary, and final generated surface were manually audited; fresh Codex autoreview is clean.

## What Problem This Solves

The public plugin SDK surface gate carried removable, unshipped compatibility exports while bundled code still used deprecated entrypoints and the legacy raw channel send result shape. That kept exact export budgets higher than necessary and encouraged new callers to copy compatibility-only APIs.

## Why This Change Was Made

This change audits consumers and tag history before removal, preserves shipped compatibility entrypoints through their documented major-version window, removes four eligible entrypoint-qualified exports, and migrates bundled Telegram and Zalo callers to canonical SDK contracts. Zalo now returns typed delivery results with receipts and converts failed raw sends into failed durable delivery at both outbound and normal message-adapter boundaries; `ChannelSendRawResult` remains available but is deprecated until the next plugin-SDK major.

## User Impact

Plugin authors get a smaller, better-guarded public surface without breaking shipped compatibility paths. Bundled Zalo delivery now follows the canonical `OutboundDeliveryResult` contract while preserving message receipts and explicit send failures.

## Evidence

- Actual current-main surface: 10,644 public exports, 5,358 callable exports, and 3,285 deprecated exports (including the inherited unbudgeted `agent-core` export). This branch ratchets the exact counts to 10,640 / 5,354 / 3,282, a net reduction of 4 / 4 / 3.
- `pnpm plugin-sdk:surface:check` and `pnpm plugin-sdk:api:check` pass with the regenerated hash on AWS run `run_55e627bf0035`: https://crabbox.openclaw.ai/portal/runs/run_55e627bf0035
- 74 focused tests pass across six Vitest shards: pairing store, approval reactions, channel pairing, channel send results, SDK package subpaths, Telegram, and Zalo durable text/media failures.
- `pnpm build` passes, including the public plugin SDK declaration graph and Control UI build, on Testbox `tbx_01kxd5rv1ttfaxqzrk06w36kft`.
- Core, core-test, production-extension, and extension-test TypeScript lanes pass. Targeted oxfmt and oxlint pass; the complete changed gate also passed before the final conflict-free main rebase.
- Fresh autoreview: clean, no actionable findings, correctness confidence 0.94.
