### PR TITLE
fix(ui): allow manual folders on exec-only nodes

### DIFF
--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -699,7 +699,8 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await pathInput.press("Enter");
       expect(
         (await gateway.getRequests("fs.listDir")).filter(
-          (request) => request.params?.nodeId === "old-node",
+          (request) =>
+            (request.params as { nodeId?: string } | undefined)?.nodeId === "old-node",
         ),
       ).toHaveLength(0);
       await page.getByRole("button", { name: "Use this folder" }).click();

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -699,8 +699,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await pathInput.press("Enter");
       expect(
         (await gateway.getRequests("fs.listDir")).filter(
-          (request) =>
-            (request.params as { nodeId?: string } | undefined)?.nodeId === "old-node",
+          (request) => (request.params as { nodeId?: string } | undefined)?.nodeId === "old-node",
         ),
       ).toHaveLength(0);
       await page.getByRole("button", { name: "Use this folder" }).click();

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -24,6 +24,7 @@ const TARGET_REPO = "/tmp/target-repo";
 const NODE_HOME = "/Users/peter";
 const NODE_PICKED = "/Users/peter/Projects";
 const NODE_UNC = "\\\\server\\share\\repo";
+const EXEC_ONLY_PICKED = "C:\\Users\\peter\\repo";
 
 function installRepositorySwitchGateway(page: Page, sessionKey: string) {
   return installMockGateway(page, {
@@ -520,7 +521,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
     }
   });
 
-  it("shows Gateway and every node at the browser super-root and browses a capable node", async () => {
+  it("browses capable nodes and accepts manual paths for exec-only nodes", async () => {
     const context = await browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -651,10 +652,10 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       const oldRoot = roots.getByRole("button", { name: "Old node" });
       expect(await macbookRoot.isEnabled()).toBe(true);
       expect(await macbookRoot.getAttribute("title")).toBeNull();
-      // Disabled rows explain themselves: offline vs. node without browse support.
+      // Offline rows stay disabled; exec-only rows accept a manual path.
       expect(await offlineRoot.isDisabled()).toBe(true);
       expect(await offlineRoot.getAttribute("title")).toBe("Device is offline");
-      expect(await oldRoot.isDisabled()).toBe(true);
+      expect(await oldRoot.isEnabled()).toBe(true);
       expect(await oldRoot.getAttribute("title")).toBe(
         "This device doesn't support folder browsing",
       );
@@ -681,7 +682,8 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
         .toBe("Agent workspace");
       await expect.poll(() => whereLabel.textContent()).toBe("MacBook");
 
-      // Browse back to the custom folder for the final create assertion.
+      // Browse back to the custom folder, then retarget to the exec-only node
+      // with a manual absolute path for the final create assertion.
       await folderSelect.locator("summary").click();
       await roots.getByRole("button", { name: "MacBook" }).click();
       await roots.getByRole("button", { name: "Projects" }).click();
@@ -690,14 +692,30 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
         .poll(() => folderSelect.locator(".new-session-page__trigger-label").textContent())
         .toBe("Projects");
 
+      await folderSelect.locator("summary").click();
+      await roots.getByRole("button", { name: "Old node" }).click();
+      await expect.poll(() => pathInput.inputValue()).toBe("");
+      await pathInput.fill(EXEC_ONLY_PICKED);
+      await pathInput.press("Enter");
+      expect(
+        (await gateway.getRequests("fs.listDir")).filter(
+          (request) => request.params?.nodeId === "old-node",
+        ),
+      ).toHaveLength(0);
+      await page.getByRole("button", { name: "Use this folder" }).click();
+      await expect.poll(() => whereLabel.textContent()).toBe("Old node");
+      await expect
+        .poll(() => folderSelect.locator(".new-session-page__trigger-label").textContent())
+        .toBe("repo");
+
       await page.locator(".new-session-page__message").fill("inspect the remote checkout");
       await page.getByRole("button", { name: "Start session" }).click();
       const createRequest = await gateway.waitForRequest("sessions.create");
       expect(createRequest.params).toMatchObject({
         agentId: "main",
         message: "inspect the remote checkout",
-        execNode: "macbook",
-        cwd: NODE_PICKED,
+        execNode: "old-node",
+        cwd: EXEC_ONLY_PICKED,
       });
       expect(createRequest.params).not.toHaveProperty("worktree");
     } finally {

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -1,5 +1,4 @@
-// Full-page new-session draft: pick agent, exec host, folder, and branch/worktree,
-// then the first message creates the session in one sessions.create call.
+// Full-page draft: pick agent, host, folder, and worktree, then create on first message.
 import { consume } from "@lit/context";
 import { html, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
@@ -42,8 +41,7 @@ type BrowserTarget = { nodeId: string; label: string };
 
 const WORKTREE_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
-/** Last path segment for the folder trigger label; handles both separators.
-    Falls back to the raw path so filesystem roots ("/", "C:\") stay visible. */
+/** Last path segment for the label; raw-path fallback keeps filesystem roots visible. */
 function folderDisplayName(path: string): string {
   return path.split(/[\\/]/).findLast((segment) => segment.length > 0) ?? path;
 }
@@ -79,8 +77,7 @@ class NewSessionPage extends OpenClawLightDomElement {
   @state() private browserError: string | null = null;
   @state() private browserListing: FsListDirResult | null = null;
   @state() private browserTarget: BrowserTarget | null = null;
-  // The head input's live value; a typed absolute path stays applicable via
-  // "Use this folder" even when the host cannot list it (no fs.listDir).
+  // Live head input; absolute paths stay applicable even without fs.listDir.
   @state() private browserPathDraft = "";
 
   private openedFor: string | null = null;
@@ -528,7 +525,7 @@ class NewSessionPage extends OpenClawLightDomElement {
     return this.isAdmin();
   }
 
-  /** Grayed-out device rows must say why: offline vs. node lacks browse support. */
+  /** Unavailable device rows say why; exec-only nodes remain selectable for manual paths. */
   private nodeBrowseBlockedReason(node: DraftNode): string | undefined {
     if (node.canBrowse) {
       return undefined;
@@ -563,12 +560,7 @@ class NewSessionPage extends OpenClawLightDomElement {
     this.browserPathDraft = "";
   }
 
-  /** "Use this folder" applies exactly what the head input shows. The draft
-      syncs to every listed directory, covers hosts that cannot list
-      (fs.listDir missing/failing), and an edited path always wins over a
-      stale listing. A cleared input applies "" — the host's default
-      directory (workspace on the Gateway, home on a node) — matching the
-      clearable folder textbox this browser replaced. Null disables Use. */
+  /** Use applies the live path; empty means host default, null disables. */
   private usableBrowserPath(): string | null {
     const draft = this.browserPathDraft.trim();
     if (draft.length === 0) {
@@ -589,6 +581,14 @@ class NewSessionPage extends OpenClawLightDomElement {
     const client = this.context?.gateway.snapshot.client;
     const target = this.browserTarget;
     if (!client || !target) {
+      return;
+    }
+    // Exec-only nodes still accept a typed cwd; never probe an unsupported fs.listDir.
+    const targetNode = this.nodes.find((node) => node.nodeId === target.nodeId);
+    if (targetNode?.canExec && !targetNode.canBrowse) {
+      this.showBrowserRoot();
+      this.browserTarget = target;
+      this.browserPathDraft = path ?? "";
       return;
     }
     const requestId = ++this.browserRequestToken;
@@ -722,7 +722,7 @@ class NewSessionPage extends OpenClawLightDomElement {
                     <button
                       type="button"
                       class="new-session-page__browser-entry"
-                      ?disabled=${!node.canBrowse}
+                      ?disabled=${!node.canExec}
                       title=${this.nodeBrowseBlockedReason(node) ?? nothing}
                       @click=${() =>
                         this.selectBrowserTarget({


### PR DESCRIPTION
Closes #105967

AI-assisted: yes. I understand and reviewed the change.

## What Problem This Solves

New Session offered connected `system.run` nodes in the Where menu, but the folder picker disabled the same nodes unless they also implemented `fs.listDir`. Users could therefore select an execution-capable node but could not enter its absolute working directory.

## Why This Change Was Made

The picker now keeps connected execution-capable nodes selectable for manual paths. Browse-capable nodes retain directory listing; exec-only nodes expose the existing path field and never receive an unsupported `fs.listDir` request. Offline or non-executable nodes remain disabled.

## User Impact

Users can create a session on lightweight or older nodes that support command execution without filesystem browsing by entering an absolute cwd. The selected node and cwd reach `sessions.create` together.

## Evidence

- Pre-fix real Gateway + Chromium: an exec-only node was enabled in Where but disabled in the folder picker, making manual path entry unreachable.
- Exact head `3cf5d5c249b` on trusted Testbox `tbx_01kxd19qgxe394zrgmdnmzyrk9` ([run 29227975099](https://github.com/openclaw/openclaw/actions/runs/29227975099)): `check:changed` passed and `ui/src/e2e/new-session-page.e2e.test.ts` passed 6/6 in Chromium.
- Regression assertions verify the exec-only node is enabled, pressing Enter sends zero `fs.listDir` calls for it, and `sessions.create` receives `execNode: "old-node"` plus the manual Windows cwd.
- Fresh whole-branch structured autoreview plus post-format patch review: clean, no accepted/actionable findings (0.95 / 0.99 confidence).
- Targeted `oxfmt --check`, `git diff --check`, and the 1,194-line production ratchet: passed.
- No screenshot uploaded because image upload to a public destination was not separately approved; browser assertions provide the UI evidence.
