### PR TITLE
fix(googlechat): keep accounts.default streaming when doctor migrates named accounts

### DIFF
--- a/extensions/googlechat/src/doctor-contract.test.ts
+++ b/extensions/googlechat/src/doctor-contract.test.ts
@@ -1,5 +1,6 @@
 // Googlechat tests cover doctor contract plugin behavior.
 import { describe, expect, it } from "vitest";
+import { resolveGoogleChatAccount } from "./accounts.js";
 import { legacyConfigRules, normalizeCompatibilityConfig } from "./doctor-contract.js";
 
 describe("googlechat doctor contract", () => {
@@ -111,16 +112,27 @@ describe("googlechat doctor contract", () => {
     expect(second.changes).toEqual([]);
   });
 
-  it("seeds named accounts from accounts.default over root (layered inheritance)", () => {
-    // Regression for #105940: doctor must not drop accounts.default block
-    // streaming when materializing a named account that only had chunkMode.
+  it("materializes accounts.default streaming for migrated named accounts", () => {
     const result = normalizeCompatibilityConfig({
       cfg: {
         channels: {
           googlechat: {
+            streaming: {
+              block: { enabled: false },
+            },
             accounts: {
-              default: { blockStreaming: true },
-              support: { chunkMode: "newline" },
+              default: {
+                streaming: {
+                  block: {
+                    enabled: true,
+                    coalesce: { minChars: 20, maxChars: 100 },
+                  },
+                },
+              },
+              support: {
+                chunkMode: "newline",
+                blockStreamingCoalesce: { maxChars: 80 },
+              },
             },
           },
         },
@@ -130,12 +142,23 @@ describe("googlechat doctor contract", () => {
     const googlechat = result.config.channels?.googlechat as unknown as Record<string, unknown>;
     const accounts = googlechat.accounts as Record<string, Record<string, unknown>>;
     expect(accounts.default?.streaming).toEqual({
-      block: { enabled: true },
+      block: { enabled: true, coalesce: { minChars: 20, maxChars: 100 } },
     });
     expect(accounts.support?.streaming).toEqual({
       chunkMode: "newline",
-      block: { enabled: true },
+      block: {
+        enabled: true,
+        coalesce: { minChars: 20, maxChars: 80 },
+      },
     });
+    expect(accounts.support?.chunkMode).toBeUndefined();
+    expect(accounts.support?.blockStreamingCoalesce).toBeUndefined();
+
+    const resolved = resolveGoogleChatAccount({
+      cfg: result.config,
+      accountId: "support",
+    });
+    expect(resolved.config.streaming).toEqual(accounts.support?.streaming);
 
     const second = normalizeCompatibilityConfig({ cfg: result.config });
     expect(second.changes).toEqual([]);

--- a/extensions/googlechat/src/doctor-contract.test.ts
+++ b/extensions/googlechat/src/doctor-contract.test.ts
@@ -110,4 +110,56 @@ describe("googlechat doctor contract", () => {
     const second = normalizeCompatibilityConfig({ cfg: result.config });
     expect(second.changes).toEqual([]);
   });
+
+  it("seeds named accounts from accounts.default over root (layered inheritance)", () => {
+    // Regression for #105940: doctor must not drop accounts.default block
+    // streaming when materializing a named account that only had chunkMode.
+    const result = normalizeCompatibilityConfig({
+      cfg: {
+        channels: {
+          googlechat: {
+            accounts: {
+              default: { blockStreaming: true },
+              support: { chunkMode: "newline" },
+            },
+          },
+        },
+      } as never,
+    });
+
+    const googlechat = result.config.channels?.googlechat as unknown as Record<string, unknown>;
+    const accounts = googlechat.accounts as Record<string, Record<string, unknown>>;
+    expect(accounts.default?.streaming).toEqual({
+      block: { enabled: true },
+    });
+    expect(accounts.support?.streaming).toEqual({
+      chunkMode: "newline",
+      block: { enabled: true },
+    });
+
+    const second = normalizeCompatibilityConfig({ cfg: result.config });
+    expect(second.changes).toEqual([]);
+  });
+
+  it("resolves the default account case-insensitively when seeding named accounts", () => {
+    const result = normalizeCompatibilityConfig({
+      cfg: {
+        channels: {
+          googlechat: {
+            accounts: {
+              Default: { blockStreaming: true },
+              support: { chunkMode: "newline" },
+            },
+          },
+        },
+      } as never,
+    });
+
+    const googlechat = result.config.channels?.googlechat as unknown as Record<string, unknown>;
+    const accounts = googlechat.accounts as Record<string, Record<string, unknown>>;
+    expect(accounts.support?.streaming).toEqual({
+      chunkMode: "newline",
+      block: { enabled: true },
+    });
+  });
 });

--- a/extensions/googlechat/src/doctor-contract.ts
+++ b/extensions/googlechat/src/doctor-contract.ts
@@ -1,20 +1,19 @@
 // Googlechat plugin module implements doctor contract behavior.
+import { isDeepStrictEqual } from "node:util";
 import type {
   ChannelDoctorConfigMutation,
   ChannelDoctorLegacyConfigRule,
 } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { mergeDeep } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { asObjectRecord, defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor";
 
 type GoogleChatChannelsConfig = NonNullable<OpenClawConfig["channels"]>;
 
 // Google Chat's nested streaming schema is delivery-only ({chunkMode, block});
 // it has no preview mode (legacy streamMode is removed outright above), so
-// only the delivery flat aliases migrate. Seeding is handled below instead of
-// via accountStreamingReplacesRoot because Google Chat resolution layers
-// accounts.default shared config between the channel root and named accounts
-// (accounts.ts), so a materialized named-account streaming object must inherit
-// default-account settings over root ones — same shape as WhatsApp.
+// only the delivery flat aliases migrate. The plugin doctor below then
+// materializes Google Chat's root < accounts.default < named precedence.
 const streamingAliasMigration = defineChannelAliasMigration({
   channelId: "googlechat",
   streaming: { defaultMode: "partial", deliveryOnly: true },
@@ -189,45 +188,12 @@ function normalizeRetiredGoogleChatKeys(cfg: OpenClawConfig): ChannelDoctorConfi
   };
 }
 
-/** Deep-fills fields missing from target with copies of source values. */
-function fillMissingStreamingFields(
-  target: Record<string, unknown>,
-  source: Record<string, unknown>,
-): { value: Record<string, unknown>; filled: boolean } {
-  let filled = false;
-  const value = { ...target };
-  for (const [key, sourceValue] of Object.entries(source)) {
-    if (sourceValue === undefined) {
-      continue;
-    }
-    const existing = value[key];
-    if (existing === undefined) {
-      value[key] = structuredClone(sourceValue);
-      filled = true;
-      continue;
-    }
-    const existingRecord = asObjectRecord(existing);
-    const sourceRecord = asObjectRecord(sourceValue);
-    if (!existingRecord || !sourceRecord) {
-      continue;
-    }
-    const merged = fillMissingStreamingFields(existingRecord, sourceRecord);
-    if (merged.filled) {
-      value[key] = merged.value;
-      filled = true;
-    }
-  }
-  return { value, filled };
-}
-
-// The runtime merge replaces `streaming` wholesale per layer (named account >
-// accounts.default > root), while the retired flat keys resolved per key
-// across those layers. Account objects that migration materializes must carry
-// the settings the account previously inherited, or `doctor --fix` silently
-// changes effective delivery behavior for that account.
-function seedMigratedAccountStreaming(params: {
+// Runtime replaces streaming at each layer. When doctor creates an object from
+// flat aliases, materialize the effective root < accounts.default < named value
+// so the canonical runtime path preserves the pre-migration behavior.
+function materializeMigratedAccountStreaming(params: {
   cfg: OpenClawConfig;
-  accountsWithoutStreamingBefore: ReadonlySet<string>;
+  accountsBefore: Record<string, unknown> | null;
   changes: string[];
 }): OpenClawConfig {
   const channels = params.cfg.channels as Record<string, unknown> | undefined;
@@ -237,43 +203,43 @@ function seedMigratedAccountStreaming(params: {
     return params.cfg;
   }
   const rootStreaming = asObjectRecord(entry.streaming);
-  // Account lookup treats keys case-insensitively (resolveAccountEntry), so
-  // `accounts.Default` is the default account too.
   const defaultKey = Object.hasOwn(accounts, "default")
     ? "default"
     : Object.keys(accounts).find((key) => key.trim().toLowerCase() === "default");
 
   let accountsChanged = false;
   const nextAccounts = { ...accounts };
-  // Seed the default account first: its final object is the inheritance
-  // source for named accounts (default replaces root wholesale when set).
-  const seedOrder = Object.keys(accounts).toSorted((left, right) =>
+  const accountIds = Object.keys(accounts).toSorted((left, right) =>
     left === defaultKey ? -1 : right === defaultKey ? 1 : left.localeCompare(right),
   );
-  for (const accountId of seedOrder) {
+  for (const accountId of accountIds) {
+    const accountBefore = asObjectRecord(params.accountsBefore?.[accountId]);
+    if (accountBefore?.streaming !== undefined) {
+      continue;
+    }
     const account = asObjectRecord(nextAccounts[accountId]);
     const created = asObjectRecord(account?.streaming);
-    if (!account || !created || !params.accountsWithoutStreamingBefore.has(accountId)) {
+    if (!account || !created) {
       continue;
     }
     const defaultStreaming = defaultKey
       ? asObjectRecord(asObjectRecord(nextAccounts[defaultKey])?.streaming)
       : null;
-    const inheritedSource =
+    const inherited =
       accountId === defaultKey ? rootStreaming : (defaultStreaming ?? rootStreaming);
-    if (!inheritedSource) {
+    if (!inherited) {
       continue;
     }
-    const seeded = fillMissingStreamingFields(created, inheritedSource);
-    if (!seeded.filled) {
+    const materialized = asObjectRecord(mergeDeep(inherited, created));
+    if (!materialized || isDeepStrictEqual(materialized, created)) {
       continue;
     }
-    nextAccounts[accountId] = { ...account, streaming: seeded.value };
+    nextAccounts[accountId] = { ...account, streaming: materialized };
     accountsChanged = true;
     const sourcePath =
-      accountId === defaultKey
-        ? "channels.googlechat.streaming"
-        : "effective channels.googlechat streaming defaults";
+      accountId !== defaultKey && defaultKey && defaultStreaming
+        ? `channels.googlechat.accounts.${defaultKey}.streaming`
+        : "channels.googlechat.streaming";
     params.changes.push(
       `Copied ${sourcePath} into channels.googlechat.accounts.${accountId}.streaming to keep inherited settings while migrating flat streaming keys.`,
     );
@@ -300,19 +266,14 @@ export function normalizeCompatibilityConfig({
     asObjectRecord((retired.config.channels as Record<string, unknown> | undefined)?.googlechat)
       ?.accounts,
   );
-  const accountsWithoutStreamingBefore = new Set(
-    Object.entries(accountsBefore ?? {})
-      .filter(([, account]) => asObjectRecord(account)?.streaming === undefined)
-      .map(([accountId]) => accountId),
-  );
   const aliases = streamingAliasMigration.normalizeChannelConfig({
     cfg: retired.config,
     changes: retired.changes,
   });
   return {
-    config: seedMigratedAccountStreaming({
+    config: materializeMigratedAccountStreaming({
       cfg: aliases.config,
-      accountsWithoutStreamingBefore,
+      accountsBefore,
       changes: aliases.changes,
     }),
     changes: aliases.changes,

--- a/extensions/googlechat/src/doctor-contract.ts
+++ b/extensions/googlechat/src/doctor-contract.ts
@@ -10,14 +10,14 @@ type GoogleChatChannelsConfig = NonNullable<OpenClawConfig["channels"]>;
 
 // Google Chat's nested streaming schema is delivery-only ({chunkMode, block});
 // it has no preview mode (legacy streamMode is removed outright above), so
-// only the delivery flat aliases migrate. Account merge replaces the root
-// streaming object wholesale (resolveMergedAccountConfig without a streaming
-// deep-merge), so migration seeds materialized account objects with the
-// inherited root settings.
+// only the delivery flat aliases migrate. Seeding is handled below instead of
+// via accountStreamingReplacesRoot because Google Chat resolution layers
+// accounts.default shared config between the channel root and named accounts
+// (accounts.ts), so a materialized named-account streaming object must inherit
+// default-account settings over root ones — same shape as WhatsApp.
 const streamingAliasMigration = defineChannelAliasMigration({
   channelId: "googlechat",
   streaming: { defaultMode: "partial", deliveryOnly: true },
-  accountStreamingReplacesRoot: true,
 });
 
 function hasLegacyGoogleChatStreamMode(value: unknown): boolean {
@@ -189,14 +189,132 @@ function normalizeRetiredGoogleChatKeys(cfg: OpenClawConfig): ChannelDoctorConfi
   };
 }
 
+/** Deep-fills fields missing from target with copies of source values. */
+function fillMissingStreamingFields(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): { value: Record<string, unknown>; filled: boolean } {
+  let filled = false;
+  const value = { ...target };
+  for (const [key, sourceValue] of Object.entries(source)) {
+    if (sourceValue === undefined) {
+      continue;
+    }
+    const existing = value[key];
+    if (existing === undefined) {
+      value[key] = structuredClone(sourceValue);
+      filled = true;
+      continue;
+    }
+    const existingRecord = asObjectRecord(existing);
+    const sourceRecord = asObjectRecord(sourceValue);
+    if (!existingRecord || !sourceRecord) {
+      continue;
+    }
+    const merged = fillMissingStreamingFields(existingRecord, sourceRecord);
+    if (merged.filled) {
+      value[key] = merged.value;
+      filled = true;
+    }
+  }
+  return { value, filled };
+}
+
+// The runtime merge replaces `streaming` wholesale per layer (named account >
+// accounts.default > root), while the retired flat keys resolved per key
+// across those layers. Account objects that migration materializes must carry
+// the settings the account previously inherited, or `doctor --fix` silently
+// changes effective delivery behavior for that account.
+function seedMigratedAccountStreaming(params: {
+  cfg: OpenClawConfig;
+  accountsWithoutStreamingBefore: ReadonlySet<string>;
+  changes: string[];
+}): OpenClawConfig {
+  const channels = params.cfg.channels as Record<string, unknown> | undefined;
+  const entry = asObjectRecord(channels?.googlechat);
+  const accounts = asObjectRecord(entry?.accounts);
+  if (!entry || !accounts) {
+    return params.cfg;
+  }
+  const rootStreaming = asObjectRecord(entry.streaming);
+  // Account lookup treats keys case-insensitively (resolveAccountEntry), so
+  // `accounts.Default` is the default account too.
+  const defaultKey = Object.hasOwn(accounts, "default")
+    ? "default"
+    : Object.keys(accounts).find((key) => key.trim().toLowerCase() === "default");
+
+  let accountsChanged = false;
+  const nextAccounts = { ...accounts };
+  // Seed the default account first: its final object is the inheritance
+  // source for named accounts (default replaces root wholesale when set).
+  const seedOrder = Object.keys(accounts).toSorted((left, right) =>
+    left === defaultKey ? -1 : right === defaultKey ? 1 : left.localeCompare(right),
+  );
+  for (const accountId of seedOrder) {
+    const account = asObjectRecord(nextAccounts[accountId]);
+    const created = asObjectRecord(account?.streaming);
+    if (!account || !created || !params.accountsWithoutStreamingBefore.has(accountId)) {
+      continue;
+    }
+    const defaultStreaming = defaultKey
+      ? asObjectRecord(asObjectRecord(nextAccounts[defaultKey])?.streaming)
+      : null;
+    const inheritedSource =
+      accountId === defaultKey ? rootStreaming : (defaultStreaming ?? rootStreaming);
+    if (!inheritedSource) {
+      continue;
+    }
+    const seeded = fillMissingStreamingFields(created, inheritedSource);
+    if (!seeded.filled) {
+      continue;
+    }
+    nextAccounts[accountId] = { ...account, streaming: seeded.value };
+    accountsChanged = true;
+    const sourcePath =
+      accountId === defaultKey
+        ? "channels.googlechat.streaming"
+        : "effective channels.googlechat streaming defaults";
+    params.changes.push(
+      `Copied ${sourcePath} into channels.googlechat.accounts.${accountId}.streaming to keep inherited settings while migrating flat streaming keys.`,
+    );
+  }
+  if (!accountsChanged) {
+    return params.cfg;
+  }
+  return {
+    ...params.cfg,
+    channels: {
+      ...channels,
+      googlechat: { ...entry, accounts: nextAccounts },
+    },
+  } as OpenClawConfig;
+}
+
 export function normalizeCompatibilityConfig({
   cfg,
 }: {
   cfg: OpenClawConfig;
 }): ChannelDoctorConfigMutation {
   const retired = normalizeRetiredGoogleChatKeys(cfg);
-  return streamingAliasMigration.normalizeChannelConfig({
+  const accountsBefore = asObjectRecord(
+    asObjectRecord((retired.config.channels as Record<string, unknown> | undefined)?.googlechat)
+      ?.accounts,
+  );
+  const accountsWithoutStreamingBefore = new Set(
+    Object.entries(accountsBefore ?? {})
+      .filter(([, account]) => asObjectRecord(account)?.streaming === undefined)
+      .map(([accountId]) => accountId),
+  );
+  const aliases = streamingAliasMigration.normalizeChannelConfig({
     cfg: retired.config,
     changes: retired.changes,
   });
+  return {
+    config: seedMigratedAccountStreaming({
+      cfg: aliases.config,
+      accountsWithoutStreamingBefore,
+      changes: aliases.changes,
+    }),
+    changes: aliases.changes,
+  };
 }


### PR DESCRIPTION
Closes #105940

## What Problem This Solves

`openclaw doctor --fix` could silently change effective Google Chat streaming behavior. If a named account used a retired flat key such as `chunkMode`, doctor materialized a partial `streaming` object. Runtime treats that object as a wholesale account-layer replacement, so settings inherited from `accounts.default` disappeared.

## Why This Change Was Made

Google Chat resolves streaming with a strict `channels.googlechat` → `accounts.default` → named-account precedence. This keeps migration ownership in the Google Chat doctor contract: first normalize the retired flat aliases, then materialize the effective canonical streaming object only for accounts whose object was created by that migration. Runtime continues to read the canonical shape without aliases, shims, or fallback readers.

The materialization is ordered so `accounts.default` is completed from root before named accounts inherit from it. Named-account values remain authoritative, including nested coalescing fields.

## User Impact

Multi-account Google Chat configurations retain their effective block-streaming and coalescing settings after `openclaw doctor --fix`. The persisted canonical config now exactly matches what the runtime resolver consumes.

## Evidence

- `node scripts/run-vitest.mjs extensions/googlechat/src/doctor-contract.test.ts extensions/googlechat/src/setup.test.ts` — 34 tests passed.
- `node scripts/run-vitest.mjs extensions/googlechat/src/doctor-contract.test.ts src/channels/plugins/doctor-contract-api.fast-path.test.ts` — 10 tests passed.
- Regression coverage proves root/default/named precedence, nested named-account overrides, removal of retired flat keys, doctor idempotency, and equality between persisted canonical streaming and `resolveGoogleChatAccount()`.
- `node scripts/check-changed.mjs -- extensions/googlechat/src/doctor-contract.ts extensions/googlechat/src/doctor-contract.test.ts` — passed all extension production/test typechecks, formatting, lint, plugin-boundary, SDK-baseline, legacy-store, and import-cycle gates on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29669099590
- Fresh maintainer autoreview: no accepted or actionable findings.

Co-authored-by: tiffanychum <71036662+tiffanychum@users.noreply.github.com>
