### PR TITLE
fix(imessage): narrow recovered projection before use

### DIFF
--- a/extensions/imessage/src/monitor/conversation-repair.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.ts
@@ -229,7 +229,8 @@ export async function repairIMessageConversationAnchor(
     }
   }
 
-  if (matchedProjections.length === 0) {
+  const [projection] = matchedProjections;
+  if (!projection) {
     runtime?.error?.(`imessage: dropping anchorless message GUID=${guid}; no recent chat matched`);
     return null;
   }
@@ -242,7 +243,6 @@ export async function repairIMessageConversationAnchor(
     return null;
   }
 
-  const projection = matchedProjections[0];
   if (projection.is_from_me) {
     runtime?.error?.(
       `imessage: dropping anchorless message GUID=${guid}; recovered authoritative row is from-me`,


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails the extension typecheck after #104218 because `noUncheckedIndexedAccess` leaves the first recovered projection typed as possibly undefined even after a separate array-length check.

## Why This Change Was Made

Destructure the first projection before the existing empty-result guard. The same guard now narrows the value for all later authoritative-projection checks without changing runtime behavior.

## User Impact

Restores extension typecheck and package-boundary CI for iMessage. Runtime recovery behavior is unchanged.

## Evidence

- `pnpm test extensions/imessage/src/monitor/conversation-repair.test.ts`: 14/14 passed.
- `pnpm tsgo:extensions`: passed.
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29224232673.
- Exact-branch autoreview: clean, no actionable findings (0.99 confidence).
- `git diff --check`: clean.
