### PR TITLE
feat: advertise realtime voice provider voices in talk.catalog

### DIFF
--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -803,6 +803,7 @@ catalog, API-key auth, and dynamic model resolution.
         api.registerRealtimeVoiceProvider({
           id: "acme-ai",
           label: "Acme Realtime Voice",
+          voices: ["nova", "sol"],
           capabilities: {
             transports: ["gateway-relay"],
             inputAudioFormats: [{ encoding: "pcm16", sampleRateHz: 24000, channels: 1 }],
@@ -831,7 +832,13 @@ catalog, API-key auth, and dynamic model resolution.
 
         Declare `capabilities` so `talk.catalog` can expose valid modes,
         transports, audio formats, and feature flags to browser and native Talk
-        clients. Implement `handleBargeIn` when a transport can detect that a
+        clients. List selectable voice ids in `voices` to advertise them through
+        `talk.catalog` the same way speech providers do, so clients can offer a
+        provider-specific voice picker instead of a hard-coded list. The list is
+        provider-wide: advertise the provider's canonical set of known,
+        selectable voice ids, and omit the field when the provider has no fixed
+        voice set. Implement
+        `handleBargeIn` when a transport can detect that a
         human is interrupting assistant playback and the provider supports
         truncating or clearing the active audio response.
         `submitToolResult` may return `void` for synchronous submission, or a

--- a/extensions/google/index.test.ts
+++ b/extensions/google/index.test.ts
@@ -19,6 +19,7 @@ import { registerGoogleGeminiCliProvider } from "./gemini-cli-provider.js";
 import googlePlugin from "./index.js";
 import googleProviderDiscovery from "./provider-discovery.js";
 import { registerGoogleProvider } from "./provider-registration.js";
+import { GOOGLE_TTS_VOICES } from "./speech-provider.js";
 
 const googleProviderPlugin = {
   register(api: Parameters<typeof registerGoogleProvider>[0]) {
@@ -383,6 +384,21 @@ describe("google provider plugin hooks", () => {
 
     expect(googleProvider.buildReplayPolicy).toBe(cliProvider.buildReplayPolicy);
     expect(googleProvider.wrapStreamFn).toBe(cliProvider.wrapStreamFn);
+  });
+
+  it("advertises the shared TTS voice inventory for the realtime catalog", () => {
+    let realtimeProvider: RealtimeVoiceProviderPlugin | undefined;
+    googlePlugin.register(
+      createTestPluginApi({
+        registerRealtimeVoiceProvider(provider) {
+          realtimeProvider = provider;
+        },
+      }),
+    );
+
+    expect(realtimeProvider?.voices).toEqual(GOOGLE_TTS_VOICES);
+    // The bridge's default voice must stay selectable from the advertised list.
+    expect(realtimeProvider?.voices).toContain("Kore");
   });
 
   it("buffers early realtime audio while the lazy Google bridge loads", () => {

--- a/extensions/google/index.ts
+++ b/extensions/google/index.ts
@@ -20,7 +20,7 @@ import {
 } from "./generation-provider-metadata.js";
 import { geminiMemoryEmbeddingProviderAdapter } from "./memory-embedding-adapter.js";
 import { registerGoogleProvider } from "./provider-registration.js";
-import { buildGoogleSpeechProvider } from "./speech-provider.js";
+import { buildGoogleSpeechProvider, GOOGLE_TTS_VOICES } from "./speech-provider.js";
 import { createGeminiWebSearchProvider } from "./src/gemini-web-search-provider.js";
 
 let googleImageGenerationProviderPromise: Promise<ImageGenerationProvider> | null = null;
@@ -311,6 +311,10 @@ function createLazyGoogleRealtimeVoiceProvider(): RealtimeVoiceProviderPlugin {
   return {
     id: "google",
     label: "Google Live Voice",
+    // Live native-audio models accept every Google TTS voice and the realtime
+    // runtime forwards the id unvalidated, so the shared TTS inventory is the
+    // provider-wide voice contract advertised through talk.catalog.
+    voices: GOOGLE_TTS_VOICES,
     autoSelectOrder: 20,
     resolveConfig: ({ cfg, rawConfig }) => resolveGoogleRealtimeProviderConfig(rawConfig, cfg),
     isConfigured: ({ cfg, providerConfig }) =>

--- a/extensions/google/speech-provider.ts
+++ b/extensions/google/speech-provider.ts
@@ -32,7 +32,7 @@ const GOOGLE_TTS_MODELS = [
   "gemini-2.5-pro-preview-tts",
 ] as const;
 
-const GOOGLE_TTS_VOICES = [
+export const GOOGLE_TTS_VOICES = [
   "Zephyr",
   "Puck",
   "Charon",

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -290,6 +290,19 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     const provider = buildOpenAIRealtimeVoiceProvider();
 
     expect(provider.defaultModel).toBe("gpt-realtime-2.1");
+    // Pins the advertised voice set documented in docs/nodes/talk.md.
+    expect(provider.voices).toEqual([
+      "alloy",
+      "ash",
+      "ballad",
+      "coral",
+      "echo",
+      "sage",
+      "shimmer",
+      "verse",
+      "marin",
+      "cedar",
+    ]);
     expect(provider.capabilities).toEqual({
       transports: ["webrtc", "gateway-relay"],
       inputAudioFormats: [

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -47,18 +47,6 @@ import {
   OPENAI_GPT_LIVE_BROWSER_SESSION_UNSUPPORTED_MESSAGE,
 } from "./realtime-quicksilver.js";
 
-type OpenAIRealtimeVoice =
-  | "alloy"
-  | "ash"
-  | "ballad"
-  | "cedar"
-  | "coral"
-  | "echo"
-  | "marin"
-  | "sage"
-  | "shimmer"
-  | "verse";
-
 type OpenAIRealtimeVoiceProviderConfig = {
   apiKey?: string;
   model?: string;
@@ -115,7 +103,8 @@ const OPENAI_REALTIME_VOICES = [
   "verse",
   "marin",
   "cedar",
-] as const satisfies readonly OpenAIRealtimeVoice[];
+] as const;
+type OpenAIRealtimeVoice = (typeof OPENAI_REALTIME_VOICES)[number];
 
 function normalizeOpenAIRealtimeVoice(value: unknown): OpenAIRealtimeVoice | undefined {
   if (typeof value !== "string") {
@@ -1532,6 +1521,10 @@ export function buildOpenAIRealtimeVoiceProvider(): RealtimeVoiceProviderPlugin 
     id: "openai",
     label: "OpenAI Realtime Voice",
     defaultModel: OPENAI_REALTIME_DEFAULT_MODEL,
+    // Advertises exactly the set normalizeOpenAIRealtimeVoice accepts, so
+    // talk.catalog matches config validation. The default gpt-realtime-2.1
+    // accepts all ten (marin/cedar are its recommended voices).
+    voices: OPENAI_REALTIME_VOICES,
     autoSelectOrder: 10,
     capabilities: {
       transports: ["webrtc", "gateway-relay"],

--- a/extensions/xai/realtime-voice-config.ts
+++ b/extensions/xai/realtime-voice-config.ts
@@ -117,7 +117,7 @@ export const XAI_REALTIME_ACTIVE_RESPONSE_ERROR_PREFIX =
 export const XAI_REALTIME_NO_ACTIVE_RESPONSE_CANCEL_ERROR =
   "Cancellation failed: no active response found";
 
-const XAI_REALTIME_VOICES = [
+export const XAI_REALTIME_VOICES = [
   "eve",
   "ara",
   "rex",

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -142,6 +142,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     const provider = buildXaiRealtimeVoiceProvider();
 
     expect(provider.defaultModel).toBe("grok-voice-latest");
+    expect(provider.voices).toEqual(["eve", "ara", "rex", "sal", "leo"]);
     expect(provider.capabilities).toEqual({
       transports: ["gateway-relay"],
       inputAudioFormats: [

--- a/extensions/xai/realtime-voice-provider.ts
+++ b/extensions/xai/realtime-voice-provider.ts
@@ -6,6 +6,7 @@ import {
 import { XaiRealtimeVoiceBridge } from "./realtime-voice-bridge.js";
 import {
   XAI_REALTIME_DEFAULT_MODEL,
+  XAI_REALTIME_VOICES,
   hasXaiRealtimeApiKeyInput,
   normalizeXaiRealtimeBaseUrl,
   normalizeXaiRealtimeProviderConfig,
@@ -18,6 +19,9 @@ export function buildXaiRealtimeVoiceProvider(): RealtimeVoiceProviderPlugin {
     label: "xAI Grok Voice",
     aliases: ["xai-realtime-voice", "grok-voice"],
     defaultModel: XAI_REALTIME_DEFAULT_MODEL,
+    // The canonical Grok voice ids normalizeXaiRealtimeVoice recognizes (it
+    // passes other strings through), advertised as the selectable voice set.
+    voices: XAI_REALTIME_VOICES,
     autoSelectOrder: 25,
     capabilities: {
       transports: ["gateway-relay"],

--- a/src/gateway/server-methods/talk-catalog.ts
+++ b/src/gateway/server-methods/talk-catalog.ts
@@ -1,0 +1,213 @@
+// Builds the talk.catalog projection of speech, transcription, and realtime providers.
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { getVoiceProviderConfig } from "../../../packages/speech-core/voice-models.js";
+import { resolveActiveTalkProviderConfig } from "../../config/talk.js";
+import type { OpenClawConfig } from "../../config/types.js";
+import { resolveProviderRawConfig } from "../../plugin-sdk/provider-selection-runtime.js";
+import { canonicalizeRealtimeTranscriptionProviderId } from "../../realtime-transcription/provider-registry.js";
+import {
+  canonicalizeRealtimeVoiceProviderId,
+  listRealtimeVoiceProviders,
+} from "../../talk/provider-registry.js";
+import { resolveConfiguredRealtimeVoiceProvider } from "../../talk/provider-resolver.js";
+import { canonicalizeSpeechProviderId, listSpeechProviders } from "../../tts/provider-registry.js";
+import { getResolvedSpeechProviderConfig, resolveTtsConfig } from "../../tts/tts.js";
+import {
+  buildTalkRealtimeConfig,
+  buildTalkTranscriptionConfig,
+  configuredOrFalse,
+  listTalkTranscriptionProviders,
+  resolveConfiguredRealtimeTranscriptionProvider,
+} from "./talk-shared.js";
+
+function resolveCatalogProviderSelection(
+  configuredProvider: string | undefined,
+  resolveAutomaticProvider: () => string,
+): { activeProvider?: string; ready: boolean } {
+  // Provider priority belongs to the runtime resolver; catalog consumers must not infer it from row order.
+  try {
+    const resolvedProvider = resolveAutomaticProvider();
+    return {
+      activeProvider: resolvedProvider,
+      ready: true,
+    };
+  } catch {
+    return {
+      ...(configuredProvider ? { activeProvider: configuredProvider } : {}),
+      ready: false,
+    };
+  }
+}
+
+/** Advertise a provider pick-list only when non-empty; empty lists are omitted. */
+function setProviderListEntry(
+  entry: Record<string, unknown>,
+  key: "models" | "aliases" | "voices",
+  values: readonly string[] | undefined,
+): void {
+  if (values?.length) {
+    entry[key] = [...values];
+  }
+}
+
+export function buildTalkCatalog(config: OpenClawConfig) {
+  const ttsConfig = resolveTtsConfig(config);
+  const talkResolved = resolveActiveTalkProviderConfig(config.talk);
+  const activeSpeechProvider = canonicalizeSpeechProviderId(talkResolved?.provider, config);
+  const transcriptionConfig = buildTalkTranscriptionConfig(config);
+  const transcriptionSelection = resolveCatalogProviderSelection(
+    canonicalizeRealtimeTranscriptionProviderId(transcriptionConfig.provider, config),
+    () =>
+      resolveConfiguredRealtimeTranscriptionProvider({
+        config,
+        configuredProviderId: transcriptionConfig.provider,
+        providerConfigs: transcriptionConfig.providers,
+        defaultModel: transcriptionConfig.model,
+      }).provider.id,
+  );
+  const activeTranscriptionProvider = transcriptionSelection.activeProvider;
+  const realtimeConfig = buildTalkRealtimeConfig(config);
+  const realtimeSelection = resolveCatalogProviderSelection(
+    canonicalizeRealtimeVoiceProviderId(realtimeConfig.provider, config),
+    () =>
+      resolveConfiguredRealtimeVoiceProvider({
+        cfg: config,
+        configuredProviderId: realtimeConfig.provider,
+        providerConfigs: realtimeConfig.providers,
+        defaultModel: realtimeConfig.model,
+      }).provider.id,
+  );
+  const activeRealtimeProvider = realtimeSelection.activeProvider;
+
+  return {
+    modes: ["realtime", "stt-tts", "transcription"],
+    transports: ["webrtc", "provider-websocket", "gateway-relay", "managed-room"],
+    brains: ["agent-consult", "direct-tools", "none"],
+    speech: {
+      ...(activeSpeechProvider ? { activeProvider: activeSpeechProvider } : {}),
+      providers: listSpeechProviders(config).map((provider) => {
+        const entry: Record<string, unknown> = {
+          id: provider.id,
+          label: provider.label,
+          configured: configuredOrFalse(() =>
+            provider.isConfigured({
+              cfg: config,
+              providerConfig: getResolvedSpeechProviderConfig(ttsConfig, provider.id, config),
+              timeoutMs: ttsConfig.timeoutMs,
+            }),
+          ),
+          modes: ["stt-tts"],
+          brains: ["agent-consult"],
+        };
+        setProviderListEntry(entry, "models", provider.models);
+        setProviderListEntry(entry, "aliases", provider.aliases);
+        setProviderListEntry(entry, "voices", provider.voices);
+        return entry;
+      }),
+    },
+    transcription: {
+      ready: transcriptionSelection.ready,
+      ...(activeTranscriptionProvider ? { activeProvider: activeTranscriptionProvider } : {}),
+      providers: listTalkTranscriptionProviders(config, [
+        transcriptionConfig.provider,
+        ...Object.keys(transcriptionConfig.providers),
+      ]).map((provider) => {
+        const rawConfig = getVoiceProviderConfig({
+          providerConfigs: transcriptionConfig.providers,
+          provider,
+          configuredProviderId:
+            activeTranscriptionProvider &&
+            normalizeOptionalLowercaseString(provider.id) ===
+              normalizeOptionalLowercaseString(activeTranscriptionProvider)
+              ? transcriptionConfig.provider
+              : undefined,
+        });
+        const rawConfigWithModel =
+          transcriptionConfig.model && rawConfig.model === undefined
+            ? { ...rawConfig, model: transcriptionConfig.model }
+            : rawConfig;
+        const providerConfig =
+          provider.resolveConfig?.({ cfg: config, rawConfig: rawConfigWithModel }) ??
+          rawConfigWithModel;
+        const entry: Record<string, unknown> = {
+          id: provider.id,
+          label: provider.label,
+          configured: configuredOrFalse(() =>
+            provider.isConfigured({ cfg: config, providerConfig }),
+          ),
+          modes: ["transcription"],
+          transports: ["gateway-relay"],
+          brains: ["none"],
+        };
+        if (provider.defaultModel) {
+          entry.defaultModel = provider.defaultModel;
+        }
+        setProviderListEntry(entry, "models", provider.models);
+        setProviderListEntry(entry, "aliases", provider.aliases);
+        return entry;
+      }),
+    },
+    realtime: {
+      ready: realtimeSelection.ready,
+      ...(activeRealtimeProvider ? { activeProvider: activeRealtimeProvider } : {}),
+      providers: listRealtimeVoiceProviders(config).map((provider) => {
+        const rawConfig = resolveProviderRawConfig({
+          providerConfigs: realtimeConfig.providers ?? {},
+          providerId: provider.id,
+          configuredProviderId:
+            provider.id === activeRealtimeProvider ? realtimeConfig.provider : undefined,
+        });
+        const rawConfigWithModel =
+          realtimeConfig.model && rawConfig.model === undefined
+            ? { ...rawConfig, model: realtimeConfig.model }
+            : rawConfig;
+        const providerConfig =
+          provider.resolveConfig?.({ cfg: config, rawConfig: rawConfigWithModel }) ??
+          rawConfigWithModel;
+        const capabilities = provider.capabilities;
+        const entry: Record<string, unknown> = {
+          id: provider.id,
+          label: provider.label,
+          configured: configuredOrFalse(() =>
+            provider.isConfigured({ cfg: config, providerConfig }),
+          ),
+          modes: ["realtime"],
+          brains: capabilities?.supportsToolCalls === false ? ["none"] : ["agent-consult"],
+          supportsBrowserSession: Boolean(
+            capabilities?.supportsBrowserSession ?? provider.createBrowserSession,
+          ),
+        };
+        if (provider.defaultModel) {
+          entry.defaultModel = provider.defaultModel;
+        }
+        setProviderListEntry(entry, "models", provider.models);
+        setProviderListEntry(entry, "aliases", provider.aliases);
+        setProviderListEntry(entry, "voices", provider.voices);
+        if (capabilities?.transports) {
+          entry.transports = [...capabilities.transports];
+        }
+        if (capabilities?.inputAudioFormats) {
+          entry.inputAudioFormats = capabilities.inputAudioFormats.map((format) => ({ ...format }));
+        }
+        if (capabilities?.outputAudioFormats) {
+          entry.outputAudioFormats = capabilities.outputAudioFormats.map((format) => ({
+            ...format,
+          }));
+        }
+        if (capabilities?.supportsBargeIn !== undefined) {
+          entry.supportsBargeIn = capabilities.supportsBargeIn;
+        }
+        if (capabilities?.supportsToolCalls !== undefined) {
+          entry.supportsToolCalls = capabilities.supportsToolCalls;
+        }
+        if (capabilities?.supportsVideoFrames !== undefined) {
+          entry.supportsVideoFrames = capabilities.supportsVideoFrames;
+        }
+        if (capabilities?.supportsSessionResumption !== undefined) {
+          entry.supportsSessionResumption = capabilities.supportsSessionResumption;
+        }
+        return entry;
+      }),
+    },
+  };
+}

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -201,6 +201,14 @@ describe("talk.catalog handler", () => {
         voices: ["voice-1"],
         isConfigured: vi.fn(() => true),
       } as never,
+      {
+        id: "acme",
+        label: "Acme Speech",
+        // Empty model/voice lists must be omitted from the catalog, not advertised.
+        models: [],
+        voices: [],
+        isConfigured: vi.fn(() => false),
+      } as never,
     ]);
     mocks.getResolvedSpeechProviderConfig.mockReturnValue({ apiKey: "speech-key" });
     mocks.listRealtimeTranscriptionProviders.mockReturnValue([
@@ -209,6 +217,7 @@ describe("talk.catalog handler", () => {
         label: "OpenAI Realtime Transcription",
         aliases: ["openai-realtime"],
         defaultModel: "gpt-4o-transcribe",
+        models: ["gpt-4o-transcribe", "gpt-4o-mini-transcribe"],
         resolveConfig: vi.fn(({ rawConfig }) => rawConfig),
         isConfigured: vi.fn(({ providerConfig }) => providerConfig.apiKey === "stt-key"),
       } as never,
@@ -225,6 +234,8 @@ describe("talk.catalog handler", () => {
         id: "google",
         label: "Google Live Voice",
         defaultModel: "gemini-live",
+        models: ["gemini-live", "gemini-live-exp"],
+        voices: ["puck", "aoede"],
         resolveConfig: vi.fn(({ rawConfig }) => rawConfig),
         isConfigured: vi.fn(
           ({ providerConfig }) =>
@@ -248,6 +259,8 @@ describe("talk.catalog handler", () => {
       {
         id: "openai",
         label: "OpenAI Realtime",
+        // Empty voice lists must be omitted from the catalog, not advertised.
+        voices: [],
         resolveConfig: vi.fn(({ rawConfig }) => rawConfig),
         isConfigured: vi.fn(({ providerConfig }) => providerConfig.apiKey === "openai-key"),
         createBridge: vi.fn(),
@@ -317,6 +330,13 @@ describe("talk.catalog handler", () => {
               models: ["eleven_flash_v2_5"],
               voices: ["voice-1"],
             },
+            {
+              id: "acme",
+              label: "Acme Speech",
+              configured: false,
+              modes: ["stt-tts"],
+              brains: ["agent-consult"],
+            },
           ],
         },
         transcription: {
@@ -332,6 +352,7 @@ describe("talk.catalog handler", () => {
               transports: ["gateway-relay"],
               brains: ["none"],
               defaultModel: "gpt-4o-transcribe",
+              models: ["gpt-4o-transcribe", "gpt-4o-mini-transcribe"],
             },
             {
               id: "deepgram",
@@ -353,6 +374,8 @@ describe("talk.catalog handler", () => {
               label: "Google Live Voice",
               configured: true,
               defaultModel: "gemini-live",
+              models: ["gemini-live", "gemini-live-exp"],
+              voices: ["puck", "aoede"],
               modes: ["realtime"],
               transports: ["provider-websocket", "gateway-relay"],
               brains: ["agent-consult"],

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -2,7 +2,6 @@
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeLowercaseStringOrEmpty,
-  normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import {
@@ -19,7 +18,6 @@ import {
   withSpeakerSelectionCompat,
   withSpeakerSelectionFallbackCompat,
 } from "../../../packages/speech-core/speaker.js";
-import { getVoiceProviderConfig } from "../../../packages/speech-core/voice-models.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
 import { redactConfigObject } from "../../config/redact-snapshot.js";
 import {
@@ -33,37 +31,17 @@ import type {
   TalkRealtimeConfig,
 } from "../../config/types.gateway.js";
 import type { OpenClawConfig, TtsConfig, TtsProviderConfigMap } from "../../config/types.js";
-import { resolveProviderRawConfig } from "../../plugin-sdk/provider-selection-runtime.js";
-import { canonicalizeRealtimeTranscriptionProviderId } from "../../realtime-transcription/provider-registry.js";
-import {
-  canonicalizeRealtimeVoiceProviderId,
-  listRealtimeVoiceProviders,
-} from "../../talk/provider-registry.js";
-import { resolveConfiguredRealtimeVoiceProvider } from "../../talk/provider-resolver.js";
-import {
-  canonicalizeSpeechProviderId,
-  getSpeechProvider,
-  listSpeechProviders,
-} from "../../tts/provider-registry.js";
-import {
-  getResolvedSpeechProviderConfig,
-  resolveTtsConfig,
-  synthesizeSpeech,
-  type TtsDirectiveOverrides,
-} from "../../tts/tts.js";
+import { canonicalizeRealtimeVoiceProviderId } from "../../talk/provider-registry.js";
+import { canonicalizeSpeechProviderId, getSpeechProvider } from "../../tts/provider-registry.js";
+import { synthesizeSpeech, type TtsDirectiveOverrides } from "../../tts/tts.js";
 import { ADMIN_SCOPE, TALK_SECRETS_SCOPE } from "../operator-scopes.js";
 import { resolveConfiguredSecretInputString } from "../resolve-configured-secret-input-string.js";
 import { formatForLog } from "../ws-log.js";
 import { inferSpeechMimeType } from "./speech-mime.js";
+import { buildTalkCatalog } from "./talk-catalog.js";
 import { talkClientHandlers } from "./talk-client.js";
 import { talkSessionHandlers } from "./talk-session.js";
-import {
-  buildTalkRealtimeConfig,
-  buildTalkTranscriptionConfig,
-  configuredOrFalse,
-  listTalkTranscriptionProviders,
-  resolveConfiguredRealtimeTranscriptionProvider,
-} from "./talk-shared.js";
+import { buildTalkRealtimeConfig } from "./talk-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
 type TalkSpeakReason =
@@ -77,25 +55,6 @@ type TalkSpeakErrorDetails = {
   reason: TalkSpeakReason;
   fallbackEligible: boolean;
 };
-
-function resolveCatalogProviderSelection(
-  configuredProvider: string | undefined,
-  resolveAutomaticProvider: () => string,
-): { activeProvider?: string; ready: boolean } {
-  // Provider priority belongs to the runtime resolver; catalog consumers must not infer it from row order.
-  try {
-    const resolvedProvider = resolveAutomaticProvider();
-    return {
-      activeProvider: resolvedProvider,
-      ready: true,
-    };
-  } catch {
-    return {
-      ...(configuredProvider ? { activeProvider: configuredProvider } : {}),
-      ready: false,
-    };
-  }
-}
 
 function canReadTalkSecrets(client: { connect?: { scopes?: string[] } } | null): boolean {
   const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
@@ -217,175 +176,6 @@ function buildTalkTtsConfig(
         ...config.messages,
         tts: talkTts,
       },
-    },
-  };
-}
-
-function buildTalkCatalog(config: OpenClawConfig) {
-  const ttsConfig = resolveTtsConfig(config);
-  const talkResolved = resolveActiveTalkProviderConfig(config.talk);
-  const activeSpeechProvider = canonicalizeSpeechProviderId(talkResolved?.provider, config);
-  const transcriptionConfig = buildTalkTranscriptionConfig(config);
-  const transcriptionSelection = resolveCatalogProviderSelection(
-    canonicalizeRealtimeTranscriptionProviderId(transcriptionConfig.provider, config),
-    () =>
-      resolveConfiguredRealtimeTranscriptionProvider({
-        config,
-        configuredProviderId: transcriptionConfig.provider,
-        providerConfigs: transcriptionConfig.providers,
-        defaultModel: transcriptionConfig.model,
-      }).provider.id,
-  );
-  const activeTranscriptionProvider = transcriptionSelection.activeProvider;
-  const realtimeConfig = buildTalkRealtimeConfig(config);
-  const realtimeSelection = resolveCatalogProviderSelection(
-    canonicalizeRealtimeVoiceProviderId(realtimeConfig.provider, config),
-    () =>
-      resolveConfiguredRealtimeVoiceProvider({
-        cfg: config,
-        configuredProviderId: realtimeConfig.provider,
-        providerConfigs: realtimeConfig.providers,
-        defaultModel: realtimeConfig.model,
-      }).provider.id,
-  );
-  const activeRealtimeProvider = realtimeSelection.activeProvider;
-
-  return {
-    modes: ["realtime", "stt-tts", "transcription"],
-    transports: ["webrtc", "provider-websocket", "gateway-relay", "managed-room"],
-    brains: ["agent-consult", "direct-tools", "none"],
-    speech: {
-      ...(activeSpeechProvider ? { activeProvider: activeSpeechProvider } : {}),
-      providers: listSpeechProviders(config).map((provider) => {
-        const entry: Record<string, unknown> = {
-          id: provider.id,
-          label: provider.label,
-          configured: configuredOrFalse(() =>
-            provider.isConfigured({
-              cfg: config,
-              providerConfig: getResolvedSpeechProviderConfig(ttsConfig, provider.id, config),
-              timeoutMs: ttsConfig.timeoutMs,
-            }),
-          ),
-          modes: ["stt-tts"],
-          brains: ["agent-consult"],
-        };
-        if (provider.models) {
-          entry.models = [...provider.models];
-        }
-        if (provider.aliases?.length) {
-          entry.aliases = [...provider.aliases];
-        }
-        if (provider.voices) {
-          entry.voices = [...provider.voices];
-        }
-        return entry;
-      }),
-    },
-    transcription: {
-      ready: transcriptionSelection.ready,
-      ...(activeTranscriptionProvider ? { activeProvider: activeTranscriptionProvider } : {}),
-      providers: listTalkTranscriptionProviders(config, [
-        transcriptionConfig.provider,
-        ...Object.keys(transcriptionConfig.providers),
-      ]).map((provider) => {
-        const rawConfig = getVoiceProviderConfig({
-          providerConfigs: transcriptionConfig.providers,
-          provider,
-          configuredProviderId:
-            activeTranscriptionProvider &&
-            normalizeOptionalLowercaseString(provider.id) ===
-              normalizeOptionalLowercaseString(activeTranscriptionProvider)
-              ? transcriptionConfig.provider
-              : undefined,
-        });
-        const rawConfigWithModel =
-          transcriptionConfig.model && rawConfig.model === undefined
-            ? { ...rawConfig, model: transcriptionConfig.model }
-            : rawConfig;
-        const providerConfig =
-          provider.resolveConfig?.({ cfg: config, rawConfig: rawConfigWithModel }) ??
-          rawConfigWithModel;
-        const entry: Record<string, unknown> = {
-          id: provider.id,
-          label: provider.label,
-          configured: configuredOrFalse(() =>
-            provider.isConfigured({ cfg: config, providerConfig }),
-          ),
-          modes: ["transcription"],
-          transports: ["gateway-relay"],
-          brains: ["none"],
-        };
-        if (provider.defaultModel) {
-          entry.defaultModel = provider.defaultModel;
-        }
-        if (provider.aliases?.length) {
-          entry.aliases = [...provider.aliases];
-        }
-        return entry;
-      }),
-    },
-    realtime: {
-      ready: realtimeSelection.ready,
-      ...(activeRealtimeProvider ? { activeProvider: activeRealtimeProvider } : {}),
-      providers: listRealtimeVoiceProviders(config).map((provider) => {
-        const rawConfig = resolveProviderRawConfig({
-          providerConfigs: realtimeConfig.providers ?? {},
-          providerId: provider.id,
-          configuredProviderId:
-            provider.id === activeRealtimeProvider ? realtimeConfig.provider : undefined,
-        });
-        const rawConfigWithModel =
-          realtimeConfig.model && rawConfig.model === undefined
-            ? { ...rawConfig, model: realtimeConfig.model }
-            : rawConfig;
-        const providerConfig =
-          provider.resolveConfig?.({ cfg: config, rawConfig: rawConfigWithModel }) ??
-          rawConfigWithModel;
-        const capabilities = provider.capabilities;
-        const entry: Record<string, unknown> = {
-          id: provider.id,
-          label: provider.label,
-          configured: configuredOrFalse(() =>
-            provider.isConfigured({ cfg: config, providerConfig }),
-          ),
-          modes: ["realtime"],
-          brains: capabilities?.supportsToolCalls === false ? ["none"] : ["agent-consult"],
-          supportsBrowserSession: Boolean(
-            capabilities?.supportsBrowserSession ?? provider.createBrowserSession,
-          ),
-        };
-        if (provider.defaultModel) {
-          entry.defaultModel = provider.defaultModel;
-        }
-        if (provider.aliases?.length) {
-          entry.aliases = [...provider.aliases];
-        }
-        if (capabilities?.transports) {
-          entry.transports = [...capabilities.transports];
-        }
-        if (capabilities?.inputAudioFormats) {
-          entry.inputAudioFormats = capabilities.inputAudioFormats.map((format) => ({ ...format }));
-        }
-        if (capabilities?.outputAudioFormats) {
-          entry.outputAudioFormats = capabilities.outputAudioFormats.map((format) => ({
-            ...format,
-          }));
-        }
-        if (capabilities?.supportsBargeIn !== undefined) {
-          entry.supportsBargeIn = capabilities.supportsBargeIn;
-        }
-        if (capabilities?.supportsToolCalls !== undefined) {
-          entry.supportsToolCalls = capabilities.supportsToolCalls;
-        }
-        if (capabilities?.supportsVideoFrames !== undefined) {
-          entry.supportsVideoFrames = capabilities.supportsVideoFrames;
-        }
-        if (capabilities?.supportsSessionResumption !== undefined) {
-          entry.supportsSessionResumption = capabilities.supportsSessionResumption;
-        }
-        return entry;
-      }),
     },
   };
 }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2010,6 +2010,8 @@ export type RealtimeVoiceProviderPlugin = {
   aliases?: string[];
   defaultModel?: string;
   models?: readonly string[];
+  /** Selectable voice ids advertised via `talk.catalog` — the provider's canonical set of known voice ids, omitted when the provider has no fixed voice list. */
+  voices?: readonly string[];
   autoSelectOrder?: number;
   capabilities?: RealtimeVoiceProviderCapabilities;
   resolveConfig?: (ctx: RealtimeVoiceProviderResolveConfigContext) => RealtimeVoiceProviderConfig;
@@ -2067,9 +2069,7 @@ export type PluginCommandDiagnosticsSession = {
   threadParentId?: string;
 };
 
-/**
- * Context passed to plugin command handlers.
- */
+/** Context passed to plugin command handlers. */
 export type PluginCommandContext = {
   /** The sender's identifier (for example a channel-scoped user ID) */
   senderId?: string;


### PR DESCRIPTION
Closes #106020

AI assisted with Claude Opus 4.8 and Fable 5

## What Problem This Solves

Resolves a problem where Talk clients could not learn which voices the active realtime voice provider supports. `talk.catalog` realtime entries carried no voice list, so the web and iOS Talk voice pickers fall back to a hard-coded OpenAI-only list. With any other active realtime provider (e.g. Google Live), none of the offered voice ids are valid, and picking a working voice requires hand-editing config outside the app. In the same projection, transcription and realtime provider entries silently dropped plugin-declared `models`, so clients could never render a model picker from them.

## Why This Change Was Made

Mirrors the existing speech-provider seam: `RealtimeVoiceProviderPlugin` gains an optional `voices?: readonly string[]` that core projects into `talk.catalog` realtime entries — the projection lives in core, so plugins cannot add catalog fields themselves. Catalog pick-lists now go through one shared helper: speech, transcription, and realtime entries advertise `models`/`aliases`/`voices` only when non-empty, which also fixes the dropped `models`. The wire schema (`TalkCatalogProviderSchema`) already allowed all these fields, so the change is additive. The OpenAI plugin advertises its canonical voice list (the same set its config validation accepts); the Google plugin advertises the shared 30-name Google TTS voice inventory it already maintains — Google's Live API docs state native-audio models accept every TTS voice, and the realtime runtime forwards the configured voice id unvalidated. The SDK type and docs now pin the field's semantics: a provider-wide set of ids every supported model accepts, omitted when no such set exists. Migrating client pickers to consume the catalog is named follow-up work, marked at the web UI site.

## User Impact

Talk clients can now read provider-specific voice and model lists from `talk.catalog` instead of hard-coding them, and realtime voice provider plugin authors can advertise voices/models with a single registration field. Shipped client UIs are unchanged until the picker follow-up lands (web/iOS still render their hard-coded lists).

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-methods/talk.test.ts extensions/openai/realtime-voice-provider.test.ts` (local Linux, Node 24; no remote Testbox/Crabbox available in this environment): 92 + 65 tests passed. Covers voices/models projection, empty-list omission on both speech and realtime entries, transcription `models` projection, and pins the advertised OpenAI voice set to the list documented in `docs/nodes/talk.md`.
- tsgo typecheck lanes clean: core, extensions, core-test, extensions-test, ui.
- oxfmt/oxlint clean on changed files.
- `plugin-sdk:api:check` OK on the rebased head — the new optional SDK field does not shift the API baseline (type aliases are recorded by name), verified by regenerating before and after.

### Live Gateway proof (updated for the Google voices review finding)

Real setup on this PR head: fresh `pnpm build`, isolated `$OPENCLAW_HOME`, config with `talk.realtime.provider: "openai"` (no credentials configured — the catalog projection is registration-driven), gateway started with `openclaw gateway --bind loopback --allow-unconfigured`, then a real WS RPC via `openclaw gateway call talk.catalog --json`. Response contains no secrets.

The realtime section now shows both bundled providers advertising their voice contracts: Google Live with the shared 30-name TTS inventory and OpenAI with its ten voices; no empty arrays appear anywhere in the response:

```json
"realtime": {
  "ready": false,
  "activeProvider": "openai",
  "providers": [
    {
      "id": "google",
      "label": "Google Live Voice",
      "configured": false,
      "modes": [
        "realtime"
      ],
      "brains": [
        "agent-consult"
      ],
      "supportsBrowserSession": true,
      "voices": [
        "Zephyr",
        "Puck",
        "Charon",
        "Kore",
        "Fenrir",
        "Leda",
        "Orus",
        "Aoede",
        "Callirrhoe",
        "Autonoe",
        "Enceladus",
        "Iapetus",
        "Umbriel",
        "Algieba",
        "Despina",
        "Erinome",
        "Algenib",
        "Rasalgethi",
        "Laomedeia",
        "Achernar",
        "Alnilam",
        "Schedar",
        "Gacrux",
        "Pulcherrima",
        "Achird",
        "Zubenelgenubi",
        "Vindemiatrix",
        "Sadachbia",
        "Sadaltager",
        "Sulafat"
      ]
    },
    {
      "id": "openai",
      "label": "OpenAI Realtime Voice",
      "configured": false,
      "modes": [
        "realtime"
      ],
      "brains": [
        "agent-consult"
      ],
      "supportsBrowserSession": true,
      "defaultModel": "gpt-realtime-2.1",
      "voices": [
        "alloy",
        "ash",
        "ballad",
        "coral",
        "echo",
        "sage",
        "shimmer",
        "verse",
        "marin",
        "cedar"
      ],
      "transports": [
        "webrtc",
        "gateway-relay"
      ],
      "inputAudioFormats": [
        {
          "encoding": "g711_ulaw",
          "sampleRateHz": 8000,
          "channels": 1
        },
        {
          "encoding": "pcm16",
          "sampleRateHz": 24000,
          "channels": 1
        }
      ],
      "outputAudioFormats": [
        {
          "encoding": "g711_ulaw",
          "sampleRateHz": 8000,
          "channels": 1
        },
        {
          "encoding": "pcm16",
          "sampleRateHz": 24000,
          "channels": 1
        }
      ],
      "supportsBargeIn": true,
      "supportsToolCalls": true
    }
  ]
}
}

```

<details>
<summary>Full talk.catalog response (speech providers show models/voices projection, transcription shows defaultModel/models)</summary>

```json
{
  "modes": [
    "realtime",
    "stt-tts",
    "transcription"
  ],
  "transports": [
    "webrtc",
    "provider-websocket",
    "gateway-relay",
    "managed-room"
  ],
  "brains": [
    "agent-consult",
    "direct-tools",
    "none"
  ],
  "speech": {
    "providers": [
      {
        "id": "deepinfra",
        "label": "DeepInfra",
        "configured": false,
        "modes": [
          "stt-tts"
        ],
        "brains": [
          "agent-consult"
        ],
        "models": [
          "hexgrad/Kokoro-82M",
          "Qwen/Qwen3-TTS",
          "ResembleAI/chatterbox-turbo",
          "sesame/csm-1b"
        ],
        "voices": [
          "af_bella"
        ]
      },
      {
        "id": "gradium",
        "label": "Gradium",
        "configured": false,
        "modes": [
          "stt-tts"
        ],
        "brains": [
          "agent-consult"
        ],
        "voices": [
          "YTpq7expH9539ERJ",
          "LFZvm12tW_z0xfGo",
          "Eu9iL_CYe8N-Gkx_",
          "2H4HY2CBNyJHBCrP",
          "jtEKaLYNn6iif5PR",
          "KWJiFWu2O9nMPYcR",
          "3jUdJyOi9pgbxBTK"
        ]
      },
      {
        "id": "inworld",
        "label": "Inworld",
        "configured": false,
        "modes": [
          "stt-tts"
        ],
        "brains": [
          "agent-consult"
        ],
        "models": [
          "inworld-tts-1.5-max",
          "inworld-tts-1.5-mini",
          "inworld-tts-1-max",
          "inworld-tts-1"
        ]
      },
      {
        "id": "azure-speech",
        "label": "Azure Speech",
        "configured": false,
        "modes": [
          "stt-tts"
        ],
        "brains": [
          "agent-consult"
        ],
        "aliases": [
          "azure"
        ]
      },
      {
        "id": "elevenlabs",
        "label": "ElevenLabs",
        "configured": false,
        "modes": [
          "stt-tts"
        ],
        "brains": [
          "agent-consult"
        ],
        "models": [
          "eleven_v3",
          "eleven_multilingual_v2",
          "eleven_flash_v2_5",
          "eleven_flash_v2",
          "eleven_turbo_v2_5",
          "eleven_monolingual_v1"
        ]
      },
      {
        "id": "google",
        "label": "Google",
        "configured": false,
        "modes": [
          "stt-tts"
        ],
        "brains": [
          "agent-consult"
        ],
        "models": [
          "gemini-3.1-flash-tts-preview",
          "gemini-2.5-flash-preview-tts",
          "gemini-2.5-pro-preview-tts"
        ],
        "voices": [
          "Zephyr",
          "Puck",
          "Charon",
          "Kore",
          "Fenrir",
          "Leda",
          "Orus",
          "Aoede",
          "Callirrhoe",
          "Autonoe",
          "Enceladus",
          "Iapetus",
          "Umbriel",
          "Algieba",
          "Despina",
          "Erinome",
          "Algenib",
          "Rasalgethi",
          "Laomedeia",
          "Achernar",
          "Alnilam",
          "Schedar",
          "Gacrux",
          "Pulcherrima",
          "Achird",
          "Zubenelgenubi",
          "Vindemiatrix",
          "Sadachbia",
          "Sadaltager",
          "Sulafat"
        ]
      },
      {
        "id": "microsoft",
        "label": "Microsoft",
        "configured": true,
        "modes": [
          "stt-tts"
        ],
        "brains": [
          "agent-consult"
        ],
        "aliases": [
          "edge"
        ]
      },
      {
        "id": "minimax",
        "label": "MiniMax",
        "configured": false,
        "modes": [
          "stt-tts"
        ],
        "brains": [
          "agent-consult"
        ],
        "models": [
          "speech-2.8-hd",
          "speech-2.8-turbo",
          "speech-2.6-hd",
          "speech-2.6-turbo",
          "speech-02-hd",
          "speech-02-turbo",
          "speech-01-hd",
          "speech-01-turbo",
          "speech-01-240228"
        ],
        "voices": [
          "English_expressive_narrator",
          "Chinese (Mandarin)_Warm_Girl",
          "Chinese (Mandarin)_Lively_Girl",
          "Chinese (Mandarin)_Gentle_Boy",
          "Chinese (Mandarin)_Steady_Boy"
        ]
      },
      {
        "id": "openai",
        "label": "OpenAI",
        "configured": false,
        "modes": [
          "stt-tts"
        ],
        "brains": [
          "agent-consult"
        ],
        "models": [
          "gpt-4o-mini-tts",
          "tts-1",
          "tts-1-hd"
        ],
        "voices": [
          "alloy",
          "ash",
          "ballad",
          "cedar",
          "coral",
          "echo",
          "fable",
          "juniper",
          "marin",
          "onyx",
          "nova",
          "sage",
          "shimmer",
          "verse"
        ]
      },
      {
        "id": "openrouter",
        "label": "OpenRouter",
        "configured": false,
        "modes": [
          "stt-tts"
        ],
        "brains": [
          "agent-consult"
        ],
        "models": [
          "hexgrad/kokoro-82m",
          "google/gemini-3.1-flash-tts-preview",
          "mistralai/voxtral-mini-tts-2603",
          "elevenlabs/eleven-turbo-v2"
        ],
        "voices": [
          "af_alloy"
        ]
      },
      {
        "id": "tts-local-cli",
        "label": "Local CLI",
        "configured": false,
        "modes": [
          "stt-tts"
        ],
        "brains": [
          "agent-consult"
        ],
        "aliases": [
          "cli"
        ]
      },
      {
        "id": "volcengine",
        "label": "Volcengine",
        "configured": false,
        "modes": [
          "stt-tts"
        ],
        "brains": [
          "agent-consult"
        ],
        "aliases": [
          "bytedance",
          "doubao"
        ],
        "voices": [
          "en_female_anna_mars_bigtts",
          "en_male_adam_mars_bigtts",
          "en_female_sarah_mars_bigtts",
          "en_male_smith_mars_bigtts",
          "zh_female_cancan_mars_bigtts",
          "zh_female_qingxinnvsheng_mars_bigtts",
          "zh_female_linjia_mars_bigtts",
          "zh_male_wennuanahu_moon_bigtts",
          "zh_male_shaonianzixin_moon_bigtts",
          "zh_female_shuangkuaisisi_moon_bigtts"
        ]
      },
      {
        "id": "vydra",
        "label": "Vydra",
        "configured": false,
        "modes": [
          "stt-tts"
        ],
        "brains": [
          "agent-consult"
        ],
        "models": [
          "elevenlabs/tts"
        ],
        "voices": [
          "21m00Tcm4TlvDq8ikWAM"
        ]
      },
      {
        "id": "xai",
        "label": "xAI",
        "configured": false,
        "modes": [
          "stt-tts"
        ],
        "brains": [
          "agent-consult"
        ],
        "voices": [
          "ara",
          "eve",
          "leo",
          "rex",
          "sal"
        ]
      },
      {
        "id": "xiaomi",
        "label": "Xiaomi MiMo",
        "configured": false,
        "modes": [
          "stt-tts"
        ],
        "brains": [
          "agent-consult"
        ],
        "models": [
          "mimo-v2.5-tts",
          "mimo-v2-tts",
          "mimo-v2.5-tts-voicedesign"
        ],
        "aliases": [
          "mimo"
        ],
        "voices": [
          "mimo_default",
          "default_zh",
          "default_en",
          "Mia",
          "Chloe",
          "Milo",
          "Dean"
        ]
      }
    ]
  },
  "transcription": {
    "ready": false,
    "providers": [
      {
        "id": "deepgram",
        "label": "Deepgram Realtime Transcription",
        "configured": false,
        "modes": [
          "transcription"
        ],
        "transports": [
          "gateway-relay"
        ],
        "brains": [
          "none"
        ],
        "defaultModel": "nova-3",
        "aliases": [
          "deepgram-realtime",
          "nova-3-streaming"
        ]
      },
      {
        "id": "elevenlabs",
        "label": "ElevenLabs Realtime Transcription",
        "configured": false,
        "modes": [
          "transcription"
        ],
        "transports": [
          "gateway-relay"
        ],
        "brains": [
          "none"
        ],
        "defaultModel": "scribe_v2_realtime",
        "aliases": [
          "elevenlabs-realtime",
          "scribe-v2-realtime"
        ]
      },
      {
        "id": "mistral",
        "label": "Mistral Realtime Transcription",
        "configured": false,
        "modes": [
          "transcription"
        ],
        "transports": [
          "gateway-relay"
        ],
        "brains": [
          "none"
        ],
        "defaultModel": "voxtral-mini-transcribe-realtime-2602",
        "aliases": [
          "mistral-realtime",
          "voxtral-realtime"
        ]
      },
      {
        "id": "openai",
        "label": "OpenAI Realtime Transcription",
        "configured": false,
        "modes": [
          "transcription"
        ],
        "transports": [
          "gateway-relay"
        ],
        "brains": [
          "none"
        ],
        "defaultModel": "gpt-4o-transcribe",
        "aliases": [
          "openai-realtime"
        ]
      },
      {
        "id": "xai",
        "label": "xAI Realtime Transcription",
        "configured": false,
        "modes": [
          "transcription"
        ],
        "transports": [
          "gateway-relay"
        ],
        "brains": [
          "none"
        ],
        "aliases": [
          "xai-realtime",
          "grok-stt-streaming"
        ]
      }
    ]
  },
  "realtime": {
    "ready": false,
    "activeProvider": "openai",
    "providers": [
      {
        "id": "google",
        "label": "Google Live Voice",
        "configured": false,
        "modes": [
          "realtime"
        ],
        "brains": [
          "agent-consult"
        ],
        "supportsBrowserSession": true,
        "voices": [
          "Zephyr",
          "Puck",
          "Charon",
          "Kore",
          "Fenrir",
          "Leda",
          "Orus",
          "Aoede",
          "Callirrhoe",
          "Autonoe",
          "Enceladus",
          "Iapetus",
          "Umbriel",
          "Algieba",
          "Despina",
          "Erinome",
          "Algenib",
          "Rasalgethi",
          "Laomedeia",
          "Achernar",
          "Alnilam",
          "Schedar",
          "Gacrux",
          "Pulcherrima",
          "Achird",
          "Zubenelgenubi",
          "Vindemiatrix",
          "Sadachbia",
          "Sadaltager",
          "Sulafat"
        ]
      },
      {
        "id": "openai",
        "label": "OpenAI Realtime Voice",
        "configured": false,
        "modes": [
          "realtime"
        ],
        "brains": [
          "agent-consult"
        ],
        "supportsBrowserSession": true,
        "defaultModel": "gpt-realtime-2.1",
        "voices": [
          "alloy",
          "ash",
          "ballad",
          "coral",
          "echo",
          "sage",
          "shimmer",
          "verse",
          "marin",
          "cedar"
        ],
        "transports": [
          "webrtc",
          "gateway-relay"
        ],
        "inputAudioFormats": [
          {
            "encoding": "g711_ulaw",
            "sampleRateHz": 8000,
            "channels": 1
          },
          {
            "encoding": "pcm16",
            "sampleRateHz": 24000,
            "channels": 1
          }
        ],
        "outputAudioFormats": [
          {
            "encoding": "g711_ulaw",
            "sampleRateHz": 8000,
            "channels": 1
          },
          {
            "encoding": "pcm16",
            "sampleRateHz": 24000,
            "channels": 1
          }
        ],
        "supportsBargeIn": true,
        "supportsToolCalls": true
      }
    ]
  }
}
```

</details>
