### PR TITLE
fix(qa-lab): close transport before gateway teardown

### DIFF
--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -37,24 +37,24 @@ function makeQaSuiteTestLabHandle(): QaLabServerHandle {
 }
 
 describe("qa suite", () => {
-  it("continues ordered cleanup after a resource reports failure", async () => {
+  it("continues transport-before-gateway cleanup after a resource reports failure", async () => {
     const calls: string[] = [];
-    const failure = new Error("gateway pipe failed");
+    const failure = new Error("transport close failed");
 
     const errors = await qaSuiteProgressTesting.runQaSuiteCleanupSteps([
       async () => {
-        calls.push("gateway");
+        calls.push("transport");
         throw failure;
       },
       async () => {
-        calls.push("transport");
+        calls.push("gateway");
       },
       async () => {
         calls.push("lab");
       },
     ]);
 
-    expect(calls).toEqual(["gateway", "transport", "lab"]);
+    expect(calls).toEqual(["transport", "gateway", "lab"]);
     expect(errors).toEqual([failure]);
   });
 

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -37,24 +37,33 @@ function makeQaSuiteTestLabHandle(): QaLabServerHandle {
 }
 
 describe("qa suite", () => {
-  it("continues transport-before-gateway cleanup after a resource reports failure", async () => {
+  it("runs the production cleanup plan in dependency order after a failure", async () => {
     const calls: string[] = [];
     const failure = new Error("transport close failed");
+    const step = (name: string, error?: Error) => async () => {
+      calls.push(name);
+      if (error) {
+        throw error;
+      }
+    };
 
-    const errors = await qaSuiteProgressTesting.runQaSuiteCleanupSteps([
-      async () => {
-        calls.push("transport");
-        throw failure;
-      },
-      async () => {
-        calls.push("gateway");
-      },
-      async () => {
-        calls.push("lab");
-      },
+    const errors = await qaSuiteProgressTesting.runQaFlowSuiteCleanupPlan({
+      closeWebSessions: step("web sessions"),
+      cleanupTransport: step("transport", failure),
+      stopGateway: step("gateway"),
+      disposeAgentHarnesses: step("agent harnesses"),
+      stopProvider: step("provider"),
+      finishLab: step("lab"),
+    });
+
+    expect(calls).toEqual([
+      "web sessions",
+      "transport",
+      "gateway",
+      "agent harnesses",
+      "provider",
+      "lab",
     ]);
-
-    expect(calls).toEqual(["transport", "gateway", "lab"]);
     expect(errors).toEqual([failure]);
   });
 

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -318,6 +318,26 @@ async function runQaSuiteCleanupSteps(steps: ReadonlyArray<() => Promise<void>>)
   return errors;
 }
 
+async function runQaFlowSuiteCleanupPlan(params: {
+  closeWebSessions?: () => Promise<void>;
+  cleanupTransport: () => Promise<void>;
+  stopGateway?: () => Promise<void>;
+  disposeAgentHarnesses: () => Promise<void>;
+  stopProvider?: () => Promise<void>;
+  finishLab: () => Promise<void>;
+}) {
+  return await runQaSuiteCleanupSteps([
+    ...(params.closeWebSessions ? [params.closeWebSessions] : []),
+    // Drain transport HTTP work before stopping the gateway; otherwise a completed suite can
+    // emit an unhandled response-close rejection during delivery.
+    params.cleanupTransport,
+    ...(params.stopGateway ? [params.stopGateway] : []),
+    params.disposeAgentHarnesses,
+    ...(params.stopProvider ? [params.stopProvider] : []),
+    params.finishLab,
+  ]);
+}
+
 function throwQaSuiteCleanupErrors(params: {
   cleanupErrors: unknown[];
   runFailed: boolean;
@@ -2000,40 +2020,31 @@ export async function runQaFlowSuite(params?: QaSuiteRunParams): Promise<QaSuite
     preserveGatewayRuntimeDir = path.join(outputDir, "artifacts", "gateway-runtime");
     throw error;
   } finally {
-    const cleanupSteps: Array<() => Promise<void>> = [];
     const activeEnv = env;
-    if (activeEnv) {
-      cleanupSteps.push(() => closeQaWebSessions(activeEnv.webSessionIds));
-    }
-    // Drain transport HTTP work before stopping the gateway; otherwise a completed suite can
-    // emit an unhandled response-close rejection during delivery.
-    cleanupSteps.push(() => transportFactoryResult.cleanup());
     const keepTemp = process.env.OPENCLAW_QA_KEEP_TEMP === "1" || false;
     const activeGateway = gateway;
-    if (activeGateway) {
-      cleanupSteps.push(() =>
-        activeGateway.stop({
-          keepTemp,
-          preserveToDir: keepTemp ? undefined : preserveGatewayRuntimeDir,
-        }),
-      );
-    }
-    cleanupSteps.push(() => disposeRegisteredAgentHarnesses());
     const activeMock = mock;
-    if (activeMock) {
-      cleanupSteps.push(() => activeMock.stop());
-    }
-    if (ownsLab) {
-      cleanupSteps.push(() => lab.stop());
-    } else {
-      cleanupSteps.push(async () => {
-        lab.setControlUi({
-          controlUiUrl: null,
-          controlUiProxyTarget: null,
-        });
-      });
-    }
-    const cleanupErrors = await runQaSuiteCleanupSteps(cleanupSteps);
+    const cleanupErrors = await runQaFlowSuiteCleanupPlan({
+      closeWebSessions: activeEnv ? () => closeQaWebSessions(activeEnv.webSessionIds) : undefined,
+      cleanupTransport: () => transportFactoryResult.cleanup(),
+      stopGateway: activeGateway
+        ? () =>
+            activeGateway.stop({
+              keepTemp,
+              preserveToDir: keepTemp ? undefined : preserveGatewayRuntimeDir,
+            })
+        : undefined,
+      disposeAgentHarnesses: () => disposeRegisteredAgentHarnesses(),
+      stopProvider: activeMock ? () => activeMock.stop() : undefined,
+      finishLab: ownsLab
+        ? () => lab.stop()
+        : async () => {
+            lab.setControlUi({
+              controlUiUrl: null,
+              controlUiProxyTarget: null,
+            });
+          },
+    });
     throwQaSuiteCleanupErrors({ cleanupErrors, runFailed, runError });
   }
 }
@@ -2050,6 +2061,7 @@ export const qaSuiteProgressTesting = {
   mergeQaRuntimeEnvPatches,
   parseQaSuiteBooleanEnv,
   remapModelRefForForcedRuntime,
+  runQaFlowSuiteCleanupPlan,
   runQaSuiteCleanupSteps,
   throwQaSuiteCleanupErrors,
   resolveQaSuiteControlUiEnabled,

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -2005,6 +2005,9 @@ export async function runQaFlowSuite(params?: QaSuiteRunParams): Promise<QaSuite
     if (activeEnv) {
       cleanupSteps.push(() => closeQaWebSessions(activeEnv.webSessionIds));
     }
+    // Drain transport HTTP work before stopping the gateway; otherwise a completed suite can
+    // emit an unhandled response-close rejection during delivery.
+    cleanupSteps.push(() => transportFactoryResult.cleanup());
     const keepTemp = process.env.OPENCLAW_QA_KEEP_TEMP === "1" || false;
     const activeGateway = gateway;
     if (activeGateway) {
@@ -2015,10 +2018,7 @@ export async function runQaFlowSuite(params?: QaSuiteRunParams): Promise<QaSuite
         }),
       );
     }
-    cleanupSteps.push(
-      () => transportFactoryResult.cleanup(),
-      () => disposeRegisteredAgentHarnesses(),
-    );
+    cleanupSteps.push(() => disposeRegisteredAgentHarnesses());
     const activeMock = mock;
     if (activeMock) {
       cleanupSteps.push(() => activeMock.stop());


### PR DESCRIPTION
Closes #106005

## What Problem This Solves

QA Smoke scenarios could finish successfully while transport work was still delivering an HTTP response. The suite stopped the gateway first, so that delivery could end as an unhandled `HTTP response closed before delivery completed` rejection.

## Why This Change Was Made

Close the transport before stopping the gateway. Transport cleanup drains outstanding provider HTTP work while the gateway can still accept delivery.

The cleanup order now lives in one production-plan helper. Its regression test exercises that exact plan, verifies every dependency boundary, and proves later resources still close when transport cleanup fails.

## User Impact

QA Smoke no longer reports a post-success unhandled rejection caused by its own teardown order. Runtime behavior outside QA Lab is unchanged.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/suite.test.ts`: 1 file, 28 tests passed.
- `node scripts/check-changed.mjs -- extensions/qa-lab/src/suite.ts extensions/qa-lab/src/suite.test.ts`: passed extension production/test types, formatting, lint, plugin boundaries, guardrails, and import-cycle checks on Blacksmith Testbox `tbx_01kxsbnwmep7and94wx80qd1v4` ([run](https://github.com/openclaw/openclaw/actions/runs/29624234046)).
- Real mock-provider QA suite: `channel-chat-baseline` passed 1/1 through the QA Lab gateway and `qa-channel` transport on Blacksmith Testbox `tbx_01kxsbzwran95fx03ampreece7` ([run](https://github.com/openclaw/openclaw/actions/runs/29624440417)); teardown completed without a response-close rejection.
- Exact-head CI on `d85ef465d90fd64983183251ce30d40e9f5c691d`: passed ([run](https://github.com/openclaw/openclaw/actions/runs/29625160726)).
- `git diff --check`: passed.
- Fresh autoreview: no accepted/actionable findings; patch correct (0.98).

## Limitations

The smoke uses the repository's deterministic mock OpenAI provider. No external channel or provider credentials are involved.

AI-assisted: yes. No agent transcript attached (not requested).
