### PR TITLE
fix(imessage): preserve recovered projection invariant

### DIFF
--- a/extensions/imessage/src/monitor/conversation-repair.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.ts
@@ -242,7 +242,7 @@ export async function repairIMessageConversationAnchor(
     return null;
   }
 
-  const projection = matchedProjections[0];
+  const projection = matchedProjections[0]!;
   if (projection.is_from_me) {
     runtime?.error?.(
       `imessage: dropping anchorless message GUID=${guid}; recovered authoritative row is from-me`,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the extension typecheck failed after anchorless iMessage recovery began collecting authoritative projections in an array.

## Why This Change Was Made

The existing empty-array guard proves the first projection exists. This change carries that invariant through TypeScript's indexed-access check without altering runtime behavior.

## User Impact

No user-visible behavior changes. Current `main` returns to a clean extension typecheck.

## Evidence

- `pnpm test:serial extensions/imessage/src/monitor/conversation-repair.test.ts` - 14 passed
- `pnpm check:changed` - passed extension production/test typechecks, lint, database-first guard, runtime-sidecar guard, and cycle check
- `autoreview --mode local` - no findings, correctness confidence 0.98
