### PR TITLE
fix(imessage): narrow recovered projection

### DIFF
--- a/extensions/imessage/src/monitor/conversation-repair.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.ts
@@ -229,7 +229,8 @@ export async function repairIMessageConversationAnchor(
     }
   }
 
-  if (matchedProjections.length === 0) {
+  const projection = matchedProjections[0];
+  if (!projection) {
     runtime?.error?.(`imessage: dropping anchorless message GUID=${guid}; no recent chat matched`);
     return null;
   }
@@ -242,7 +243,6 @@ export async function repairIMessageConversationAnchor(
     return null;
   }
 
-  const projection = matchedProjections[0];
   if (projection.is_from_me) {
     runtime?.error?.(
       `imessage: dropping anchorless message GUID=${guid}; recovered authoritative row is from-me`,


### PR DESCRIPTION
## What Problem This Solves

The iMessage anchor-recovery change from #104218 left `matchedProjections[0]` typed as possibly `undefined`, breaking the production, extension-package, and test typecheck lanes on `main`.

## Why This Change Was Made

Read the first projection before the empty-result guard and narrow that value directly. Runtime behavior stays unchanged: no match still logs and returns `null`; matched and conflicting projections retain their existing paths.

## User Impact

No user-visible behavior change. Restores green TypeScript checks for the iMessage plugin.

## Evidence

- Blacksmith Testbox `tbx_01kxcwady8vytdycxa25rvte70` / Actions run 29224451701
- `pnpm test extensions/imessage/src/monitor/conversation-repair.test.ts` — 14 tests passed
- `pnpm tsgo:extensions`
- `pnpm check:changed -- extensions/imessage/src/monitor/conversation-repair.ts`
- Autoreview: clean, confidence 0.99
