### PR TITLE
fix(qa): preserve Crabline generation artifact paths

### DIFF
--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -487,12 +487,12 @@ describe("qa suite", () => {
       if (typeof capabilityMatrixPath !== "string" || typeof smokeArtifactPath !== "string") {
         throw new Error("Crabline generation artifact paths missing from QA summary.");
       }
-      expect(capabilityMatrixPath).toMatch(
-        /^\.crabline-smoke-artifacts\/generation-[^/]+\/crabline-fake-provider-capabilities\.json$/u,
-      );
-      expect(smokeArtifactPath).toMatch(
-        /^\.crabline-smoke-artifacts\/generation-[^/]+\/crabline-fake-provider-smoke\.json$/u,
-      );
+      const artifactGenerationDirectory = path.dirname(capabilityMatrixPath);
+      expect(path.dirname(artifactGenerationDirectory)).toBe(".crabline-smoke-artifacts");
+      expect(path.basename(artifactGenerationDirectory)).toMatch(/^generation-[^/\\]+$/u);
+      expect(path.basename(capabilityMatrixPath)).toBe("crabline-fake-provider-capabilities.json");
+      expect(path.dirname(smokeArtifactPath)).toBe(artifactGenerationDirectory);
+      expect(path.basename(smokeArtifactPath)).toBe("crabline-fake-provider-smoke.json");
       const matrix = JSON.parse(
         await fs.readFile(path.resolve(outputDir, capabilityMatrixPath), "utf8"),
       ) as {
@@ -564,6 +564,7 @@ describe("qa suite", () => {
         capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
         channel: "telegram",
         channelDriver: "crabline",
+        providerReadinessArtifactPath: "crabline-fake-provider-smoke.json",
         smokeArtifactPath: "crabline-fake-provider-smoke.json",
       },
       runCrablineChannelDriverSmoke: vi.fn(async () => ({

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -99,21 +99,20 @@ type QaSuiteStep = {
 
 type QaCrablineChannelDriverSmokeResult = Awaited<
   ReturnType<typeof runOpenClawCrablineChannelDriverSmoke>
-> & {
-  capabilityMatrixPath?: unknown;
-  smokeArtifactPath?: unknown;
-};
-
-type QaCrablineChannelDriverArtifactPaths = {
-  capabilityMatrixPath: string;
-  smokeArtifactPath: string;
-};
+>;
 
 type QaSuiteChannelDriverSelection = Omit<
   OpenClawCrablineChannelDriverSelection,
-  "capabilityMatrixPath" | "smokeArtifactPath"
-> &
-  QaCrablineChannelDriverArtifactPaths;
+  "capabilityMatrixPath" | "providerReadinessArtifactPath" | "smokeArtifactPath"
+> & {
+  capabilityMatrixPath: string;
+  providerReadinessArtifactPath?: string;
+  smokeArtifactPath: string;
+};
+
+function readQaSuiteArtifactPath(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
 
 function resolveQaSuiteControlUiEnabled(params: {
   explicit?: boolean;
@@ -1077,31 +1076,31 @@ async function writeQaSuiteArtifacts(params: {
           selection: crablineChannelDriverSelection,
         })
       : undefined;
-  const authoritativeCapabilityMatrixPath =
-    typeof crablineChannelDriverSmoke?.capabilityMatrixPath === "string" &&
-    crablineChannelDriverSmoke.capabilityMatrixPath.trim().length > 0
-      ? crablineChannelDriverSmoke.capabilityMatrixPath.trim()
-      : undefined;
-  const authoritativeSmokeArtifactPath =
-    typeof crablineChannelDriverSmoke?.smokeArtifactPath === "string" &&
-    crablineChannelDriverSmoke.smokeArtifactPath.trim().length > 0
-      ? crablineChannelDriverSmoke.smokeArtifactPath.trim()
-      : undefined;
-  const crablineChannelDriverArtifactPaths: QaCrablineChannelDriverArtifactPaths | undefined =
+  const authoritativeCapabilityMatrixPath = readQaSuiteArtifactPath(
+    crablineChannelDriverSmoke?.capabilityMatrixPath,
+  );
+  const authoritativeProviderReadinessArtifactPath = readQaSuiteArtifactPath(
+    crablineChannelDriverSmoke?.providerReadinessArtifactPath,
+  );
+  const authoritativeSmokeArtifactPath = readQaSuiteArtifactPath(
+    crablineChannelDriverSmoke?.smokeArtifactPath,
+  );
+  const effectiveChannelDriverSelection: QaSuiteChannelDriverSelection | null | undefined =
     crablineChannelDriverSelection
       ? {
+          ...crablineChannelDriverSelection,
           capabilityMatrixPath:
             authoritativeCapabilityMatrixPath ??
             crablineChannelDriverSelection.capabilityMatrixPath,
+          providerReadinessArtifactPath:
+            authoritativeProviderReadinessArtifactPath ??
+            authoritativeSmokeArtifactPath ??
+            crablineChannelDriverSelection.providerReadinessArtifactPath ??
+            crablineChannelDriverSelection.smokeArtifactPath,
           smokeArtifactPath:
-            authoritativeSmokeArtifactPath ?? crablineChannelDriverSelection.smokeArtifactPath,
-        }
-      : undefined;
-  const effectiveChannelDriverSelection: QaSuiteChannelDriverSelection | null | undefined =
-    crablineChannelDriverSelection && crablineChannelDriverArtifactPaths
-      ? {
-          ...crablineChannelDriverSelection,
-          ...crablineChannelDriverArtifactPaths,
+            authoritativeSmokeArtifactPath ??
+            authoritativeProviderReadinessArtifactPath ??
+            crablineChannelDriverSelection.smokeArtifactPath,
         }
       : crablineChannelDriverSelection;
   const report = renderQaMarkdownReport({
@@ -1126,15 +1125,15 @@ async function writeQaSuiteArtifacts(params: {
           artifactPaths: [
             { kind: "summary", path: path.basename(summaryPath) },
             { kind: "report", path: path.basename(reportPath) },
-            ...(crablineChannelDriverArtifactPaths
+            ...(effectiveChannelDriverSelection
               ? [
                   {
                     kind: "channel-capability-matrix",
-                    path: crablineChannelDriverArtifactPaths.capabilityMatrixPath,
+                    path: effectiveChannelDriverSelection.capabilityMatrixPath,
                   },
                   {
                     kind: "channel-driver-smoke",
-                    path: crablineChannelDriverArtifactPaths.smokeArtifactPath,
+                    path: effectiveChannelDriverSelection.smokeArtifactPath,
                   },
                 ]
               : []),

--- a/scripts/ts-max-loc-baseline-v2.json
+++ b/scripts/ts-max-loc-baseline-v2.json
@@ -294,7 +294,7 @@
   "extensions/qa-lab/src/scorecard-taxonomy.ts": 1162,
   "extensions/qa-lab/src/suite-launch.runtime.ts": 785,
   "extensions/qa-lab/src/suite-runtime-agent-process.ts": 602,
-  "extensions/qa-lab/src/suite.ts": 2085,
+  "extensions/qa-lab/src/suite.ts": 2084,
   "extensions/qa-lab/src/test-file-scenario-runner.ts": 614,
   "extensions/qa-lab/src/tool-search-gateway.fixture.ts": 517,
   "extensions/qa-lab/web/src/app.ts": 1771,


### PR DESCRIPTION
Related: #105983

## What Problem This Solves

Fixes an issue where QA Lab reports could keep Crabline's legacy provider-readiness filename after Crabline published generation-scoped artifacts. The accompanying artifact-path test also assumed POSIX separators and failed deterministically on Windows.

## Why This Change Was Made

QA Lab now carries Crabline's authoritative capability, provider-readiness, and smoke artifact paths through one effective selection used by reports and evidence. The test validates path components with `node:path`, and the LOC ratchet records the resulting one-line reduction.

## User Impact

QA evidence points to artifacts that actually exist, and the suite remains portable across Linux, macOS, and Windows. There is no end-user runtime behavior change.

## Evidence

- Blacksmith Testbox `tbx_01kxcwpp6hjb5m203hx5vpdjwf`: `pnpm test:serial extensions/qa-lab/src/suite.test.ts` passed 29 tests.
- Same Testbox: `pnpm test:extensions:package-boundary:compile` passed all 119 plugin packages.
- `pnpm check:changed` reached only pre-existing current-main LOC drift in unrelated agent/Codex files; https://github.com/openclaw/openclaw/pull/105981 tracks that repair.
- `git diff --check` and `oxfmt --check` passed.
- Fresh autoreview: no accepted/actionable findings; patch correct at 0.97 confidence after direct Crabline 0.1.11 contract verification.

AI-assisted; implementation and dependency contract were manually reviewed.
