### PR TITLE
fix(qa-lab): report authoritative Crabline readiness artifact

### DIFF
--- a/extensions/qa-lab/src/crabline-artifacts.ts
+++ b/extensions/qa-lab/src/crabline-artifacts.ts
@@ -1,7 +1,7 @@
 // Qa Lab plugin module resolves Crabline artifact paths reported by completed generations.
 import type { OpenClawCrablineChannelDriverSelection } from "@openclaw/crabline";
 
-export type QaCrablineChannelDriverArtifactPaths = {
+type QaCrablineChannelDriverArtifactPaths = {
   capabilityMatrixPath: string;
   providerReadinessArtifactPath?: string;
   smokeArtifactPath: string;

--- a/extensions/qa-lab/src/crabline-artifacts.ts
+++ b/extensions/qa-lab/src/crabline-artifacts.ts
@@ -1,0 +1,48 @@
+// Qa Lab plugin module resolves Crabline artifact paths reported by completed generations.
+import type { OpenClawCrablineChannelDriverSelection } from "@openclaw/crabline";
+
+export type QaCrablineChannelDriverArtifactPaths = {
+  capabilityMatrixPath: string;
+  providerReadinessArtifactPath?: string;
+  smokeArtifactPath: string;
+};
+
+export type QaSuiteChannelDriverSelection = Omit<
+  OpenClawCrablineChannelDriverSelection,
+  "capabilityMatrixPath" | "providerReadinessArtifactPath" | "smokeArtifactPath"
+> &
+  QaCrablineChannelDriverArtifactPaths;
+
+export function hasQaCrablineArtifactPath(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function readArtifactPath(value: unknown) {
+  return hasQaCrablineArtifactPath(value) ? value.trim() : undefined;
+}
+
+export function resolveQaCrablineChannelDriverArtifactPaths(params: {
+  result?: {
+    capabilityMatrixPath?: unknown;
+    providerReadinessArtifactPath?: unknown;
+    smokeArtifactPath?: unknown;
+  };
+  selection?: OpenClawCrablineChannelDriverSelection | null;
+}): QaCrablineChannelDriverArtifactPaths | undefined {
+  if (!params.selection) {
+    return undefined;
+  }
+  const smokeArtifactPath = readArtifactPath(params.result?.smokeArtifactPath);
+  return {
+    capabilityMatrixPath:
+      readArtifactPath(params.result?.capabilityMatrixPath) ??
+      params.selection.capabilityMatrixPath,
+    providerReadinessArtifactPath:
+      readArtifactPath(params.result?.providerReadinessArtifactPath) ??
+      // Legacy results expose the completed readiness generation through smokeArtifactPath.
+      smokeArtifactPath ??
+      params.selection.providerReadinessArtifactPath ??
+      params.selection.smokeArtifactPath,
+    smokeArtifactPath: smokeArtifactPath ?? params.selection.smokeArtifactPath,
+  };
+}

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -533,9 +533,7 @@ describe("qa suite", () => {
       "smoke.json",
     );
     const providerReadinessArtifactPath = path.join(
-      outputDir,
-      "crabline-generations",
-      "generation-1",
+      path.dirname(smokeArtifactPath),
       "provider-readiness.json",
     );
     await fs.mkdir(path.dirname(capabilityMatrixPath), { recursive: true });

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -532,9 +532,20 @@ describe("qa suite", () => {
       "generation-11111111-1111-4111-8111-111111111111",
       "smoke.json",
     );
+    const providerReadinessArtifactPath = path.join(
+      outputDir,
+      "crabline-generations",
+      "generation-1",
+      "provider-readiness.json",
+    );
     await fs.mkdir(path.dirname(capabilityMatrixPath), { recursive: true });
     await fs.writeFile(capabilityMatrixPath, "authoritative capabilities\n", "utf8");
     await fs.writeFile(smokeArtifactPath, "authoritative smoke\n", "utf8");
+    await fs.writeFile(
+      providerReadinessArtifactPath,
+      "authoritative provider readiness\n",
+      "utf8",
+    );
 
     const artifacts = await qaSuiteProgressTesting.writeQaSuiteArtifacts({
       outputDir,
@@ -579,7 +590,7 @@ describe("qa suite", () => {
           "manifest.json",
         ),
         providerReadiness: {},
-        providerReadinessArtifactPath: smokeArtifactPath,
+        providerReadinessArtifactPath,
         smoke: {},
         smokeArtifactPath,
       })),
@@ -589,6 +600,9 @@ describe("qa suite", () => {
       "authoritative capabilities\n",
     );
     await expect(fs.readFile(smokeArtifactPath, "utf8")).resolves.toBe("authoritative smoke\n");
+    await expect(fs.readFile(providerReadinessArtifactPath, "utf8")).resolves.toBe(
+      "authoritative provider readiness\n",
+    );
     await expect(
       fs.access(path.join(outputDir, "crabline-fake-provider-capabilities.json")),
     ).rejects.toMatchObject({ code: "ENOENT" });
@@ -617,7 +631,7 @@ describe("qa suite", () => {
     });
     expect(artifacts.report).toContain(`Generation capability filename: ${capabilityMatrixPath}.`);
     expect(artifacts.report).toContain(
-      `Generation provider-readiness filename: ${smokeArtifactPath}.`,
+      `Generation provider-readiness filename: ${providerReadinessArtifactPath}.`,
     );
     expect(artifacts.report).not.toContain("crabline-fake-provider-capabilities.json");
     expect(artifacts.report).not.toContain("crabline-fake-provider-smoke.json");

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -539,11 +539,7 @@ describe("qa suite", () => {
     await fs.mkdir(path.dirname(capabilityMatrixPath), { recursive: true });
     await fs.writeFile(capabilityMatrixPath, "authoritative capabilities\n", "utf8");
     await fs.writeFile(smokeArtifactPath, "authoritative smoke\n", "utf8");
-    await fs.writeFile(
-      providerReadinessArtifactPath,
-      "authoritative provider readiness\n",
-      "utf8",
-    );
+    await fs.writeFile(providerReadinessArtifactPath, "authoritative provider readiness\n", "utf8");
 
     const artifacts = await qaSuiteProgressTesting.writeQaSuiteArtifacts({
       outputDir,

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -5,6 +5,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import {
   createOpenClawCrablineChannelReportNotes,
   runOpenClawCrablineChannelDriverSmoke,
+  type OpenClawCrablineChannelDriverSelection,
 } from "@openclaw/crabline";
 import { disposeRegisteredAgentHarnesses } from "openclaw/plugin-sdk/agent-harness";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -1098,9 +1098,7 @@ async function writeQaSuiteArtifacts(params: {
             crablineChannelDriverSelection.providerReadinessArtifactPath ??
             crablineChannelDriverSelection.smokeArtifactPath,
           smokeArtifactPath:
-            authoritativeSmokeArtifactPath ??
-            authoritativeProviderReadinessArtifactPath ??
-            crablineChannelDriverSelection.smokeArtifactPath,
+            authoritativeSmokeArtifactPath ?? crablineChannelDriverSelection.smokeArtifactPath,
         }
       : crablineChannelDriverSelection;
   const report = renderQaMarkdownReport({

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -5,7 +5,6 @@ import { setTimeout as sleep } from "node:timers/promises";
 import {
   createOpenClawCrablineChannelReportNotes,
   runOpenClawCrablineChannelDriverSmoke,
-  type OpenClawCrablineChannelDriverSelection,
 } from "@openclaw/crabline";
 import { disposeRegisteredAgentHarnesses } from "openclaw/plugin-sdk/agent-harness";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -1094,6 +1094,8 @@ async function writeQaSuiteArtifacts(params: {
             crablineChannelDriverSelection.capabilityMatrixPath,
           providerReadinessArtifactPath:
             authoritativeProviderReadinessArtifactPath ??
+            // Legacy results expose the completed readiness generation through smokeArtifactPath.
+            // It outranks the selection's pre-run filename, which may never be materialized.
             authoritativeSmokeArtifactPath ??
             crablineChannelDriverSelection.providerReadinessArtifactPath ??
             crablineChannelDriverSelection.smokeArtifactPath,

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -19,6 +19,11 @@ import {
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { assertQaSuiteArtifactWritten } from "./artifact-assertion.js";
 import {
+  hasQaCrablineArtifactPath,
+  resolveQaCrablineChannelDriverArtifactPaths,
+  type QaSuiteChannelDriverSelection,
+} from "./crabline-artifacts.js";
+import {
   buildQaSuiteEvidenceSummary,
   QA_EVIDENCE_FILENAME,
   type QaEvidenceSummaryJson,
@@ -100,20 +105,6 @@ type QaSuiteStep = {
 type QaCrablineChannelDriverSmokeResult = Awaited<
   ReturnType<typeof runOpenClawCrablineChannelDriverSmoke>
 >;
-
-type QaSuiteChannelDriverSelection = Omit<
-  OpenClawCrablineChannelDriverSelection,
-  "capabilityMatrixPath" | "providerReadinessArtifactPath" | "smokeArtifactPath"
-> & {
-  capabilityMatrixPath: string;
-  providerReadinessArtifactPath?: string;
-  smokeArtifactPath: string;
-};
-
-function readQaSuiteArtifactPath(value: unknown) {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
 function resolveQaSuiteControlUiEnabled(params: {
   explicit?: boolean;
   scenarios: ReturnType<typeof readQaBootstrapScenarioCatalog>["scenarios"];
@@ -1076,31 +1067,15 @@ async function writeQaSuiteArtifacts(params: {
           selection: crablineChannelDriverSelection,
         })
       : undefined;
-  const authoritativeCapabilityMatrixPath = readQaSuiteArtifactPath(
-    crablineChannelDriverSmoke?.capabilityMatrixPath,
-  );
-  const authoritativeProviderReadinessArtifactPath = readQaSuiteArtifactPath(
-    crablineChannelDriverSmoke?.providerReadinessArtifactPath,
-  );
-  const authoritativeSmokeArtifactPath = readQaSuiteArtifactPath(
-    crablineChannelDriverSmoke?.smokeArtifactPath,
-  );
+  const crablineChannelDriverArtifactPaths = resolveQaCrablineChannelDriverArtifactPaths({
+    result: crablineChannelDriverSmoke,
+    selection: crablineChannelDriverSelection,
+  });
   const effectiveChannelDriverSelection: QaSuiteChannelDriverSelection | null | undefined =
-    crablineChannelDriverSelection
+    crablineChannelDriverSelection && crablineChannelDriverArtifactPaths
       ? {
           ...crablineChannelDriverSelection,
-          capabilityMatrixPath:
-            authoritativeCapabilityMatrixPath ??
-            crablineChannelDriverSelection.capabilityMatrixPath,
-          providerReadinessArtifactPath:
-            authoritativeProviderReadinessArtifactPath ??
-            // Legacy results expose the completed readiness generation through smokeArtifactPath.
-            // It outranks the selection's pre-run filename, which may never be materialized.
-            authoritativeSmokeArtifactPath ??
-            crablineChannelDriverSelection.providerReadinessArtifactPath ??
-            crablineChannelDriverSelection.smokeArtifactPath,
-          smokeArtifactPath:
-            authoritativeSmokeArtifactPath ?? crablineChannelDriverSelection.smokeArtifactPath,
+          ...crablineChannelDriverArtifactPaths,
         }
       : crablineChannelDriverSelection;
   const report = renderQaMarkdownReport({
@@ -1153,7 +1128,7 @@ async function writeQaSuiteArtifacts(params: {
   if (
     crablineChannelDriverSelection &&
     crablineChannelDriverSmoke &&
-    !authoritativeCapabilityMatrixPath
+    !hasQaCrablineArtifactPath(crablineChannelDriverSmoke.capabilityMatrixPath)
   ) {
     await fs.writeFile(
       path.join(params.outputDir, crablineChannelDriverSelection.capabilityMatrixPath),
@@ -1175,7 +1150,7 @@ async function writeQaSuiteArtifacts(params: {
   if (
     crablineChannelDriverSelection &&
     crablineChannelDriverSmoke &&
-    !authoritativeSmokeArtifactPath
+    !hasQaCrablineArtifactPath(crablineChannelDriverSmoke.smokeArtifactPath)
   ) {
     await fs.writeFile(
       path.join(params.outputDir, crablineChannelDriverSelection.smokeArtifactPath),


### PR DESCRIPTION
Related: #105983

## What Problem This Solves

Fixes an issue where QA operators could be directed to the channel smoke artifact instead of Crabline's authoritative provider-readiness artifact when a generation returned distinct paths.

## Why This Change Was Made

Carry `providerReadinessArtifactPath` through the QA artifact selection independently from `smokeArtifactPath`, while retaining the legacy completed-generation fallback for older Crabline results. The regression fixture uses distinct files so field swaps cannot pass unnoticed.

## User Impact

QA reports now identify the authoritative provider-readiness artifact without changing the existing smoke artifact recorded in summaries and evidence.

## Evidence

- Blacksmith Testbox `tbx_01kxcwvd7j2rzzhk1b6dw4r4xx`: `pnpm test extensions/qa-lab/src/suite.test.ts` — 29 passed.
- Same Testbox: `pnpm tsgo:extensions:test` — passed.
- Fresh branch autoreview on `8a2da4b1bf1555fe0bfaf705eb57300c673c81be` — clean, no accepted/actionable findings.
- `git diff --check` — passed.
