### PR TITLE
refactor(ui): direct enable/disable and remove actions on plugin cards

### DIFF
--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:32:39.671Z",
+  "generatedAt": "2026-07-13T07:37:56.120Z",
   "locale": "ar",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:31:59.031Z",
+  "generatedAt": "2026-07-13T07:37:54.197Z",
   "locale": "de",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:32:06.985Z",
+  "generatedAt": "2026-07-13T07:37:54.518Z",
   "locale": "es",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:32:45.549Z",
+  "generatedAt": "2026-07-13T07:37:58.555Z",
   "locale": "fa",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:32:37.794Z",
+  "generatedAt": "2026-07-13T07:37:55.400Z",
   "locale": "fr",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/hi.meta.json
+++ b/ui/src/i18n/.i18n/hi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:32:39.001Z",
+  "generatedAt": "2026-07-13T07:37:55.737Z",
   "locale": "hi",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:32:42.215Z",
+  "generatedAt": "2026-07-13T07:37:57.240Z",
   "locale": "id",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:32:40.331Z",
+  "generatedAt": "2026-07-13T07:37:56.424Z",
   "locale": "it",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:32:21.417Z",
+  "generatedAt": "2026-07-13T07:37:54.797Z",
   "locale": "ja-JP",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:32:27.786Z",
+  "generatedAt": "2026-07-13T07:37:55.111Z",
   "locale": "ko",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:32:44.665Z",
+  "generatedAt": "2026-07-13T07:37:58.231Z",
   "locale": "nl",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:32:42.835Z",
+  "generatedAt": "2026-07-13T07:37:57.472Z",
   "locale": "pl",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:31:50.904Z",
+  "generatedAt": "2026-07-13T07:37:53.897Z",
   "locale": "pt-BR",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ru.meta.json
+++ b/ui/src/i18n/.i18n/ru.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:32:46.084Z",
+  "generatedAt": "2026-07-13T07:37:58.907Z",
   "locale": "ru",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:32:43.279Z",
+  "generatedAt": "2026-07-13T07:37:57.714Z",
   "locale": "th",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:32:41.046Z",
+  "generatedAt": "2026-07-13T07:37:56.718Z",
   "locale": "tr",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:32:41.650Z",
+  "generatedAt": "2026-07-13T07:37:56.970Z",
   "locale": "uk",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:32:43.873Z",
+  "generatedAt": "2026-07-13T07:37:57.963Z",
   "locale": "vi",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:31:26.886Z",
+  "generatedAt": "2026-07-13T07:37:53.325Z",
   "locale": "zh-CN",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T07:31:39.321Z",
+  "generatedAt": "2026-07-13T07:37:53.615Z",
   "locale": "zh-TW",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0ed1e5b749603e9e6d9d0bfb4143228ab0e0445b40b11666267e301ea696b738",
-  "totalKeys": 3105,
-  "translatedKeys": 3105,
+  "sourceHash": "5c8cc82a0a8d2870bc0bfa1c479d93f8b36504649ca760dde2040f5516586622",
+  "totalKeys": 3103,
+  "translatedKeys": 3103,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -1719,8 +1719,6 @@ export const ar: TranslationMap = {
     cancel: "إلغاء",
     removedRestart: "تمت إزالة {name}. يلزم إعادة تشغيل Gateway لتطبيق التغيير.",
     verifiedSource: "مصدر موثّق",
-    menuLabel: "إجراءات {name}",
-    menuDetails: "عرض التفاصيل",
     enableAction: "تمكين",
     disableAction: "تعطيل",
     working: "جارٍ العمل…",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -1749,8 +1749,6 @@ export const de: TranslationMap = {
     removedRestart:
       "{name} wurde entfernt. Ein Neustart der Gateway ist erforderlich, um die Änderung anzuwenden.",
     verifiedSource: "Verifizierte Quelle",
-    menuLabel: "{name}-Aktionen",
-    menuDetails: "Details anzeigen",
     enableAction: "Aktivieren",
     disableAction: "Deaktivieren",
     working: "Wird ausgeführt…",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1719,8 +1719,6 @@ export const en: TranslationMap = {
     cancel: "Cancel",
     removedRestart: "Removed {name}. A Gateway restart is required to apply the change.",
     verifiedSource: "Verified source",
-    menuLabel: "{name} actions",
-    menuDetails: "View details",
     enableAction: "Enable",
     disableAction: "Disable",
     working: "Working…",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -1748,8 +1748,6 @@ export const es: TranslationMap = {
     cancel: "Cancelar",
     removedRestart: "Se eliminó {name}. Es necesario reiniciar Gateway para aplicar el cambio.",
     verifiedSource: "Fuente verificada",
-    menuLabel: "Acciones de {name}",
-    menuDetails: "Ver detalles",
     enableAction: "Activar",
     disableAction: "Desactivar",
     working: "Procesando…",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -1726,8 +1726,6 @@ export const fa: TranslationMap = {
     cancel: "لغو",
     removedRestart: "{name} حذف شد. برای اعمال تغییر، راه‌اندازی مجدد Gateway لازم است.",
     verifiedSource: "منبع تأییدشده",
-    menuLabel: "اقدامات {name}",
-    menuDetails: "مشاهده جزئیات",
     enableAction: "فعال کردن",
     disableAction: "غیرفعال کردن",
     working: "در حال انجام…",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -1758,8 +1758,6 @@ export const fr: TranslationMap = {
     removedRestart:
       "{name} supprimé. Un redémarrage de Gateway est nécessaire pour appliquer la modification.",
     verifiedSource: "Source vérifiée",
-    menuLabel: "Actions de {name}",
-    menuDetails: "Voir les détails",
     enableAction: "Activer",
     disableAction: "Désactiver",
     working: "Traitement en cours…",

--- a/ui/src/i18n/locales/hi.ts
+++ b/ui/src/i18n/locales/hi.ts
@@ -1717,8 +1717,6 @@ export const hi: TranslationMap = {
     cancel: "रद्द करें",
     removedRestart: "{name} हटा दिया गया। परिवर्तन लागू करने के लिए Gateway को पुनः प्रारंभ करना आवश्यक है।",
     verifiedSource: "सत्यापित स्रोत",
-    menuLabel: "{name} कार्रवाइयाँ",
-    menuDetails: "विवरण देखें",
     enableAction: "सक्षम करें",
     disableAction: "अक्षम करें",
     working: "काम हो रहा है…",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -1730,8 +1730,6 @@ export const id: TranslationMap = {
     cancel: "Batal",
     removedRestart: "{name} dihapus. Gateway perlu dimulai ulang untuk menerapkan perubahan.",
     verifiedSource: "Sumber terverifikasi",
-    menuLabel: "Tindakan {name}",
-    menuDetails: "Lihat detail",
     enableAction: "Aktifkan",
     disableAction: "Nonaktifkan",
     working: "Memproses…",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -1750,8 +1750,6 @@ export const it: TranslationMap = {
     cancel: "Annulla",
     removedRestart: "{name} rimosso. È necessario riavviare il Gateway per applicare la modifica.",
     verifiedSource: "Fonte verificata",
-    menuLabel: "Azioni {name}",
-    menuDetails: "Visualizza dettagli",
     enableAction: "Abilita",
     disableAction: "Disabilita",
     working: "Elaborazione…",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -1739,8 +1739,6 @@ export const ja_JP: TranslationMap = {
     cancel: "キャンセル",
     removedRestart: "{name}を削除しました。変更を適用するにはGatewayの再起動が必要です。",
     verifiedSource: "確認済みのソース",
-    menuLabel: "{name} のアクション",
-    menuDetails: "詳細を表示",
     enableAction: "有効にする",
     disableAction: "無効にする",
     working: "処理中…",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -1725,8 +1725,6 @@ export const ko: TranslationMap = {
     removedRestart:
       "{name}이(가) 제거되었습니다. 변경 사항을 적용하려면 Gateway를 다시 시작해야 합니다.",
     verifiedSource: "인증된 출처",
-    menuLabel: "{name} 작업",
-    menuDetails: "세부 정보 보기",
     enableAction: "활성화",
     disableAction: "비활성화",
     working: "작업 중…",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -1737,8 +1737,6 @@ export const nl: TranslationMap = {
     removedRestart:
       "{name} verwijderd. Een herstart van de Gateway is vereist om de wijziging toe te passen.",
     verifiedSource: "Geverifieerde bron",
-    menuLabel: "{name}-acties",
-    menuDetails: "Details bekijken",
     enableAction: "Inschakelen",
     disableAction: "Uitschakelen",
     working: "Bezig…",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -1742,8 +1742,6 @@ export const pl: TranslationMap = {
     removedRestart:
       "Usunięto {name}. Aby zastosować zmianę, wymagane jest ponowne uruchomienie Gateway.",
     verifiedSource: "Zweryfikowane źródło",
-    menuLabel: "Działania dla {name}",
-    menuDetails: "Zobacz szczegóły",
     enableAction: "Włącz",
     disableAction: "Wyłącz",
     working: "Przetwarzanie…",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -1731,8 +1731,6 @@ export const pt_BR: TranslationMap = {
     cancel: "Cancelar",
     removedRestart: "{name} removido. É necessário reiniciar o Gateway para aplicar a alteração.",
     verifiedSource: "Fonte verificada",
-    menuLabel: "Ações de {name}",
-    menuDetails: "Ver detalhes",
     enableAction: "Ativar",
     disableAction: "Desativar",
     working: "Trabalhando…",

--- a/ui/src/i18n/locales/ru.ts
+++ b/ui/src/i18n/locales/ru.ts
@@ -1746,8 +1746,6 @@ export const ru: TranslationMap = {
     cancel: "Отмена",
     removedRestart: "{name} удален. Для применения изменения требуется перезапуск Gateway.",
     verifiedSource: "Проверенный источник",
-    menuLabel: "Действия для {name}",
-    menuDetails: "Просмотреть сведения",
     enableAction: "Включить",
     disableAction: "Отключить",
     working: "Выполняется…",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -1708,8 +1708,6 @@ export const th: TranslationMap = {
     cancel: "ยกเลิก",
     removedRestart: "ลบ {name} แล้ว ต้องรีสตาร์ท Gateway เพื่อใช้การเปลี่ยนแปลง",
     verifiedSource: "แหล่งที่มายืนยันแล้ว",
-    menuLabel: "การดำเนินการของ {name}",
-    menuDetails: "ดูรายละเอียด",
     enableAction: "เปิดใช้งาน",
     disableAction: "ปิดใช้งาน",
     working: "กำลังดำเนินการ…",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -1747,8 +1747,6 @@ export const tr: TranslationMap = {
     removedRestart:
       "{name} kaldırıldı. Değişikliği uygulamak için Gateway yeniden başlatılmalıdır.",
     verifiedSource: "Doğrulanmış kaynak",
-    menuLabel: "{name} eylemleri",
-    menuDetails: "Ayrıntıları görüntüle",
     enableAction: "Etkinleştir",
     disableAction: "Devre dışı bırak",
     working: "Çalışıyor…",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -1739,8 +1739,6 @@ export const uk: TranslationMap = {
     cancel: "Скасувати",
     removedRestart: "Видалено {name}. Щоб застосувати зміну, потрібен перезапуск Gateway.",
     verifiedSource: "Перевірене джерело",
-    menuLabel: "Дії для {name}",
-    menuDetails: "Переглянути деталі",
     enableAction: "Увімкнути",
     disableAction: "Вимкнути",
     working: "Обробка…",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -1729,8 +1729,6 @@ export const vi: TranslationMap = {
     cancel: "Hủy",
     removedRestart: "Đã gỡ bỏ {name}. Cần khởi động lại Gateway để áp dụng thay đổi.",
     verifiedSource: "Nguồn đã xác minh",
-    menuLabel: "Thao tác {name}",
-    menuDetails: "Xem chi tiết",
     enableAction: "Bật",
     disableAction: "Tắt",
     working: "Đang xử lý…",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -1703,8 +1703,6 @@ export const zh_CN: TranslationMap = {
     cancel: "取消",
     removedRestart: "已移除 {name}。需要重启 Gateway 才能应用更改。",
     verifiedSource: "已验证来源",
-    menuLabel: "{name} 操作",
-    menuDetails: "查看详情",
     enableAction: "启用",
     disableAction: "禁用",
     working: "处理中…",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -1706,8 +1706,6 @@ export const zh_TW: TranslationMap = {
     cancel: "取消",
     removedRestart: "已移除 {name}。需要重新啟動 Gateway 才能套用變更。",
     verifiedSource: "已驗證來源",
-    menuLabel: "{name} 動作",
-    menuDetails: "檢視詳細資料",
     enableAction: "啟用",
     disableAction: "停用",
     working: "處理中…",

--- a/ui/src/pages/plugins/plugins-page.test.ts
+++ b/ui/src/pages/plugins/plugins-page.test.ts
@@ -210,13 +210,13 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
-async function clickMenuItem(page: TestPluginsPage, pluginSelector: string, label: string) {
-  page.querySelector<HTMLButtonElement>(`${pluginSelector} .plugins-kebab`)?.click();
-  await page.updateComplete;
-  const item = [
-    ...page.querySelectorAll<HTMLButtonElement>(`${pluginSelector} .plugins-menu__item`),
-  ].find((element) => element.textContent?.includes(label));
-  item?.click();
+async function clickRowAction(page: TestPluginsPage, pluginSelector: string, label: string) {
+  const button = [
+    ...page.querySelectorAll<HTMLButtonElement>(`${pluginSelector} button`),
+  ].find((element) =>
+    (element.getAttribute("aria-label") ?? element.textContent ?? "").includes(label),
+  );
+  button?.click();
   await page.updateComplete;
 }
 
@@ -419,7 +419,7 @@ describe("PluginsPage", () => {
       },
     );
 
-    await clickMenuItem(page, '[data-plugin-id="workboard"]', "Enable");
+    await clickRowAction(page, '[data-plugin-id="workboard"]', "Enable");
 
     await vi.waitFor(() => expect(page.result?.plugins[0]?.enabled).toBe(true));
     await vi.waitFor(() => expect(refreshConfig).toHaveBeenCalledOnce());
@@ -452,12 +452,12 @@ describe("PluginsPage", () => {
       },
     );
 
-    await clickMenuItem(page, '[data-plugin-id="workboard"]', "Enable");
+    await clickRowAction(page, '[data-plugin-id="workboard"]', "Enable");
     await vi.waitFor(() =>
       expect(page.querySelector('[role="alert"]')?.textContent).toContain("Enable failed"),
     );
 
-    await clickMenuItem(page, '[data-plugin-id="workboard"]', "Enable");
+    await clickRowAction(page, '[data-plugin-id="workboard"]', "Enable");
     await vi.waitFor(() => {
       const calls = request.mock.calls.filter(([method]) => method === "plugins.setEnabled");
       expect(calls).toHaveLength(2);
@@ -543,7 +543,7 @@ describe("PluginsPage", () => {
     page.querySelector<HTMLButtonElement>(".plugins-refresh")?.click();
     await page.updateComplete;
     expect(page.loading).toBe(true);
-    await clickMenuItem(page, '[data-plugin-id="workboard"]', "Enable");
+    await clickRowAction(page, '[data-plugin-id="workboard"]', "Enable");
 
     await vi.waitFor(() => expect(page.busy["plugin:workboard"]).toBeUndefined());
     expect(page.loading).toBe(false);
@@ -585,7 +585,7 @@ describe("PluginsPage", () => {
       },
     );
 
-    await clickMenuItem(page, '[data-plugin-id="workboard"]', "Enable");
+    await clickRowAction(page, '[data-plugin-id="workboard"]', "Enable");
     await vi.waitFor(() =>
       expect(page.querySelector(".plugins-page-error")?.textContent).toContain(
         "Could not refresh Control UI configuration: config.get failed",
@@ -634,13 +634,13 @@ describe("PluginsPage", () => {
       error: null,
     });
 
-    await clickMenuItem(page, '[data-plugin-id="workboard"]', "Enable");
+    await clickRowAction(page, '[data-plugin-id="workboard"]', "Enable");
     expect(page.busy["plugin:workboard"]).toBe(true);
 
     harness.emit(replacementClient, true);
     await vi.waitFor(() => expect(replacementListCount).toBe(1));
     await page.updateComplete;
-    await clickMenuItem(page, '[data-plugin-id="workboard"]', "Enable");
+    await clickRowAction(page, '[data-plugin-id="workboard"]', "Enable");
     expect(page.busy["plugin:workboard"]).toBe(true);
 
     staleMutation.resolve({ ok: true, plugin: enabledPlugin, restartRequired: false });
@@ -690,7 +690,7 @@ describe("PluginsPage", () => {
       },
     );
 
-    await clickMenuItem(page, '[data-plugin-id="community-thing"]', "Remove");
+    await clickRowAction(page, '[data-plugin-id="community-thing"]', "Remove");
     page
       .querySelector<HTMLButtonElement>(
         '[data-plugin-id="community-thing"] .plugins-remove-confirm .btn.danger',
@@ -814,7 +814,7 @@ describe("PluginsPage", () => {
     );
 
     expect(page.querySelector('[data-mcp-name="github"]')).not.toBeNull();
-    await clickMenuItem(page, '[data-mcp-name="github"]', "Remove");
+    await clickRowAction(page, '[data-mcp-name="github"]', "Remove");
 
     await vi.waitFor(() => expect(configHarness.runtimeConfig.patch).toHaveBeenCalledOnce());
     const patchArgs = expectDefined(

--- a/ui/src/pages/plugins/plugins-page.test.ts
+++ b/ui/src/pages/plugins/plugins-page.test.ts
@@ -211,10 +211,8 @@ function deferred<T>() {
 }
 
 async function clickRowAction(page: TestPluginsPage, pluginSelector: string, label: string) {
-  const button = [
-    ...page.querySelectorAll<HTMLButtonElement>(`${pluginSelector} button`),
-  ].find((element) =>
-    (element.getAttribute("aria-label") ?? element.textContent ?? "").includes(label),
+  const button = [...page.querySelectorAll<HTMLButtonElement>(`${pluginSelector} button`)].find(
+    (element) => (element.getAttribute("aria-label") ?? element.textContent ?? "").includes(label),
   );
   button?.click();
   await page.updateComplete;

--- a/ui/src/pages/plugins/plugins-page.ts
+++ b/ui/src/pages/plugins/plugins-page.ts
@@ -153,7 +153,6 @@ class PluginsPage extends OpenClawLightDomElement {
   @state() private busy: Record<string, boolean> = {};
   @state() private messages: Record<string, PluginRowMessage> = {};
   @state() private pendingRemoval: Record<string, boolean> = {};
-  @state() private openMenuKey: string | null = null;
   @state() private detailPluginId: string | null = null;
   @state() private pageNotice: PluginRowMessage | null = null;
   @state() private mcpServers: McpServerSummary[] | null = null;
@@ -201,12 +200,10 @@ class PluginsPage extends OpenClawLightDomElement {
 
   override connectedCallback() {
     super.connectedCallback();
-    document.addEventListener("pointerdown", this.handleDocumentPointerDown, true);
     document.addEventListener("keydown", this.handleDocumentKeydown, true);
   }
 
   override disconnectedCallback() {
-    document.removeEventListener("pointerdown", this.handleDocumentPointerDown, true);
     document.removeEventListener("keydown", this.handleDocumentKeydown, true);
     this.subscriptions.clear();
     this.clearSearchTimer();
@@ -214,22 +211,8 @@ class PluginsPage extends OpenClawLightDomElement {
     super.disconnectedCallback();
   }
 
-  private readonly handleDocumentPointerDown = (event: PointerEvent) => {
-    if (!this.openMenuKey) {
-      return;
-    }
-    if (!(event.target as HTMLElement | null)?.closest(".plugins-actions-menu")) {
-      this.openMenuKey = null;
-    }
-  };
-
   private readonly handleDocumentKeydown = (event: KeyboardEvent) => {
     if (event.key !== "Escape") {
-      return;
-    }
-    if (this.openMenuKey) {
-      this.openMenuKey = null;
-      event.stopPropagation();
       return;
     }
     if (this.detailPluginId) {
@@ -261,7 +244,6 @@ class PluginsPage extends OpenClawLightDomElement {
         this.error = null;
         this.messages = {};
         this.pendingRemoval = {};
-        this.openMenuKey = null;
         this.detailPluginId = null;
         this.pageNotice = null;
         this.mcpMessage = null;
@@ -428,7 +410,6 @@ class PluginsPage extends OpenClawLightDomElement {
 
   private changeTab(tab: PluginsTab) {
     this.activeTab = tab;
-    this.openMenuKey = null;
     this.clearSearchTimer();
     this.searchRequestGeneration += 1;
     this.searchLoading = false;
@@ -885,7 +866,6 @@ class PluginsPage extends OpenClawLightDomElement {
           busy: this.busy,
           messages: this.messages,
           pendingRemoval: this.pendingRemoval,
-          openMenuKey: this.openMenuKey,
           detailPluginId: this.detailPluginId,
           canMutate: this.canMutate(),
           mutationBlockedReason: blockedReason,
@@ -900,11 +880,7 @@ class PluginsPage extends OpenClawLightDomElement {
             this.installedFilter = filter;
           },
           onRefresh: () => void this.refreshPage(),
-          onToggleMenu: (key) => {
-            this.openMenuKey = key;
-          },
           onShowDetails: (pluginId) => {
-            this.openMenuKey = null;
             this.detailPluginId = pluginId;
           },
           onSetEnabled: (pluginId, enabled, rowKey) =>

--- a/ui/src/pages/plugins/plugins.e2e.test.ts
+++ b/ui/src/pages/plugins/plugins.e2e.test.ts
@@ -212,10 +212,8 @@ async function waitForNextRequest(
   throw new Error(`Timed out waiting for the next ${method} request`);
 }
 
-async function clickRowMenuItem(page: Page, rowSelector: string, itemName: string): Promise<void> {
-  const row = page.locator(rowSelector);
-  await row.locator(".plugins-kebab").click();
-  await page.getByRole("menuitem", { name: itemName, exact: true }).click();
+async function clickRowAction(page: Page, rowSelector: string, buttonName: string): Promise<void> {
+  await page.locator(rowSelector).getByRole("button", { name: buttonName, exact: true }).click();
 }
 
 async function captureScreenshot(page: Page, name: string): Promise<void> {
@@ -321,7 +319,7 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       const workboardCard = page.locator('[data-plugin-id="workboard"]');
       await page.getByRole("heading", { name: "Tools" }).waitFor();
       await page.getByRole("heading", { name: "MCP servers" }).waitFor();
-      expect(await workboardCard.textContent()).toContain("Disabled");
+      await workboardCard.getByRole("button", { name: "Enable", exact: true }).waitFor();
       await captureScreenshot(page, "01-installed-desktop.png");
 
       // Rows open a detail overlay; close it before continuing.
@@ -419,8 +417,10 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       await gateway.resolveDeferred("plugins.list", installedInventory);
       await gateway.resolveDeferred("config.get", configSnapshot(false));
       await expect.poll(() => searchRow.getAttribute("aria-busy")).toBe("false");
-      // Installed search results swap Install for an enabled state chip + menu.
-      await searchRow.locator(".plugins-state--enabled").waitFor({ state: "attached" });
+      // Installed search results swap Install for the enable/disable toggle.
+      await page
+        .locator('[data-package-name="calendar-plus"][data-plugin-status="enabled"]')
+        .waitFor({ state: "attached" });
 
       await page.getByRole("tab", { name: /^Installed/u }).click();
       await page.getByRole("searchbox", { name: "Search plugins" }).fill("");
@@ -430,7 +430,7 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       const enableCountBefore = (await gateway.getRequests("plugins.setEnabled")).length;
       await gateway.deferNext("plugins.list");
       await gateway.deferNext("config.get");
-      await clickRowMenuItem(page, '[data-plugin-id="workboard"]', "Enable");
+      await clickRowAction(page, '[data-plugin-id="workboard"]', "Enable");
 
       const enableRequest = await waitForNextRequest(
         gateway,
@@ -454,13 +454,15 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       await gateway.resolveDeferred("config.get", configSnapshot(true));
       await expect.poll(() => workboardCard.getAttribute("aria-busy")).toBe("false");
 
-      await workboardCard.locator(".plugins-state--enabled").waitFor({ state: "attached" });
+      await page
+        .locator('[data-plugin-id="workboard"][data-plugin-status="enabled"]')
+        .waitFor({ state: "attached" });
       const calendarRow = page.locator('[data-plugin-id="calendar-plus"]');
       await calendarRow.waitFor({ state: "visible" });
       await captureScreenshot(page, "05-enabled-installed-desktop.png");
 
-      // Removable installs expose a menu-driven, confirm-guarded uninstall.
-      await clickRowMenuItem(page, '[data-plugin-id="calendar-plus"]', "Remove");
+      // Removable installs expose a confirm-guarded uninstall behind the trash button.
+      await clickRowAction(page, '[data-plugin-id="calendar-plus"]', "Remove Calendar Plus");
       const uninstallCountBefore = (await gateway.getRequests("plugins.uninstall")).length;
       const listCountBeforeRemove = (await gateway.getRequests("plugins.list")).length;
       const configCountBeforeRemove = (await gateway.getRequests("config.get")).length;
@@ -535,11 +537,9 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       const workboardCard = page.locator('[data-plugin-id="workboard"]');
       await workboardCard.waitFor({ state: "visible" });
       expect(await page.getByRole("note").textContent()).toContain("operator.admin");
-      await workboardCard.locator(".plugins-kebab").click();
-      expect(await page.getByRole("menuitem", { name: "Enable", exact: true }).isDisabled()).toBe(
-        true,
-      );
-      await page.keyboard.press("Escape");
+      expect(
+        await workboardCard.getByRole("button", { name: "Enable", exact: true }).isDisabled(),
+      ).toBe(true);
 
       await page.getByRole("tab", { name: /^Discover/u }).click();
       await page.getByRole("searchbox", { name: "Search plugins" }).fill("calendar");
@@ -598,7 +598,7 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       await gateway.resolveDeferred("plugins.list", finalInventory);
       await error.waitFor({ state: "detached" });
       await page
-        .locator('[data-plugin-id="workboard"] .plugins-state--enabled')
+        .locator('[data-plugin-id="workboard"][data-plugin-status="enabled"]')
         .waitFor({ state: "attached" });
     } finally {
       await context.close();

--- a/ui/src/pages/plugins/view.test.ts
+++ b/ui/src/pages/plugins/view.test.ts
@@ -54,7 +54,6 @@ function createProps(overrides: Partial<PluginsViewProps> = {}): PluginsViewProp
     busy: {},
     messages: {},
     pendingRemoval: {},
-    openMenuKey: null,
     detailPluginId: null,
     canMutate: true,
     mutationBlockedReason: null,
@@ -67,7 +66,6 @@ function createProps(overrides: Partial<PluginsViewProps> = {}): PluginsViewProp
     onQueryChange: () => undefined,
     onFilterChange: () => undefined,
     onRefresh: () => undefined,
-    onToggleMenu: () => undefined,
     onShowDetails: () => undefined,
     onSetEnabled: () => undefined,
     onInstall: () => undefined,
@@ -95,10 +93,10 @@ function normalizedText(element: Element | null): string {
   return element?.textContent?.replace(/\s+/gu, " ").trim() ?? "";
 }
 
-function menuItem(container: Element, label: string): HTMLButtonElement | null {
+function actionButton(container: Element, label: string): HTMLButtonElement | null {
   return (
-    [...container.querySelectorAll<HTMLButtonElement>(".plugins-menu__item")].find((item) =>
-      item.textContent?.includes(label),
+    [...container.querySelectorAll<HTMLButtonElement>("button")].find((button) =>
+      (button.getAttribute("aria-label") ?? normalizedText(button)).includes(label),
     ) ?? null
   );
 }
@@ -168,10 +166,9 @@ describe("renderPlugins", () => {
     expect(onFilterChange).toHaveBeenCalledWith("issues");
   });
 
-  it("offers enable and remove through the row actions menu", () => {
+  it("offers enable and remove through direct row actions", () => {
     const onSetEnabled = vi.fn();
     const onRequestUninstall = vi.fn();
-    const onToggleMenu = vi.fn();
     const removableKey = pluginRowKey("community-thing");
     const plugins = [
       createPlugin(),
@@ -183,37 +180,19 @@ describe("renderPlugins", () => {
         featured: false,
       }),
     ];
-    const closedMenus = mount(createProps({ result: createResult(plugins), onToggleMenu }));
-    const kebab = closedMenus.querySelector<HTMLButtonElement>(
-      '[data-plugin-id="community-thing"] .plugins-kebab',
-    );
-    expect(kebab?.getAttribute("aria-expanded")).toBe("false");
-    kebab?.click();
-    expect(onToggleMenu).toHaveBeenCalledWith(removableKey);
-
     const container = mount(
-      createProps({
-        result: createResult(plugins),
-        openMenuKey: removableKey,
-        onSetEnabled,
-        onRequestUninstall,
-      }),
+      createProps({ result: createResult(plugins), onSetEnabled, onRequestUninstall }),
     );
     const row = container.querySelector<HTMLElement>('[data-plugin-id="community-thing"]')!;
-    expect(normalizedText(row.querySelector(".plugins-state"))).toBe("Disabled");
-    menuItem(row, "Enable")?.click();
+    actionButton(row, "Enable")?.click();
     expect(onSetEnabled).toHaveBeenCalledWith("community-thing", true, removableKey);
-    menuItem(row, "Remove")?.click();
+    actionButton(row, "Remove Community Thing")?.click();
     expect(onRequestUninstall).toHaveBeenCalledWith(removableKey);
 
-    // Bundled plugins expose no Remove item, only enable/disable and details.
-    const bundledMenu = mount(
-      createProps({ result: createResult(plugins), openMenuKey: pluginRowKey("workboard") }),
-    );
-    const bundledRow = bundledMenu.querySelector<HTMLElement>('[data-plugin-id="workboard"]')!;
-    expect(menuItem(bundledRow, "Remove")).toBeNull();
-    expect(menuItem(bundledRow, "Enable")).not.toBeNull();
-    expect(menuItem(bundledRow, "View details")).not.toBeNull();
+    // Bundled plugins cannot be removed; the row still offers enable/disable.
+    const bundledRow = container.querySelector<HTMLElement>('[data-plugin-id="workboard"]')!;
+    expect(actionButton(bundledRow, "Remove")).toBeNull();
+    expect(actionButton(bundledRow, "Enable")).not.toBeNull();
   });
 
   it("confirms removal before uninstalling", () => {
@@ -270,14 +249,13 @@ describe("renderPlugins", () => {
     expect(onShowDetails).toHaveBeenCalledWith(null);
   });
 
-  it("lists MCP servers with menu-driven toggle and remove plus the add form", () => {
+  it("lists MCP servers with direct toggle and remove plus the add form", () => {
     const onMcpToggle = vi.fn();
     const onMcpRemove = vi.fn();
     const onMcpAdd = vi.fn();
     const container = mount(
       createProps({
         mcpFormOpen: true,
-        openMenuKey: "mcp:github",
         mcpServers: [
           {
             name: "github",
@@ -296,9 +274,9 @@ describe("renderPlugins", () => {
     const row = container.querySelector<HTMLElement>('[data-mcp-name="github"]')!;
     expect(normalizedText(row)).toContain("github");
     expect(normalizedText(row)).toContain("OAuth");
-    menuItem(row, "Disable")?.click();
+    actionButton(row, "Disable")?.click();
     expect(onMcpToggle).toHaveBeenCalledWith("github", false);
-    menuItem(row, "Remove")?.click();
+    actionButton(row, "Remove github")?.click();
     expect(onMcpRemove).toHaveBeenCalledWith("github");
 
     const form = container.querySelector<HTMLFormElement>(".plugins-mcp-form")!;
@@ -458,7 +436,6 @@ describe("renderPlugins", () => {
         result: createResult([createPlugin(), available]),
         canMutate: false,
         mutationBlockedReason: "Browsing only. Plugin changes require operator.admin access.",
-        openMenuKey: pluginRowKey("workboard"),
         onInstall,
         onSetEnabled,
       }),
@@ -469,7 +446,7 @@ describe("renderPlugins", () => {
       container.querySelector<HTMLButtonElement>('[aria-label="Install Lobster"]')?.disabled,
     ).toBe(true);
     const workboardRow = container.querySelector<HTMLElement>('[data-plugin-id="workboard"]')!;
-    const enableItem = menuItem(workboardRow, "Enable");
+    const enableItem = actionButton(workboardRow, "Enable");
     expect(enableItem?.disabled).toBe(true);
     enableItem?.click();
     expect(onInstall).not.toHaveBeenCalled();
@@ -539,7 +516,6 @@ describe("renderPlugins", () => {
         activeTab: "discover",
         query: "calendar",
         result: createResult([installed]),
-        openMenuKey: clawHubRowKey(packageName),
         searchResults: [
           {
             score: 0.9,
@@ -559,8 +535,7 @@ describe("renderPlugins", () => {
     const row = container.querySelector<HTMLElement>(`[data-package-name="${packageName}"]`)!;
     expect(row.querySelector("h3")?.textContent).toBe("Calendar Plus");
     expect(row.querySelector(".plugins-install")).toBeNull();
-    expect(normalizedText(row.querySelector(".plugins-state"))).toBe("Enabled");
-    menuItem(row, "Disable")?.click();
+    actionButton(row, "Disable")?.click();
     expect(onSetEnabled).toHaveBeenCalledWith(
       "calendar-runtime",
       false,

--- a/ui/src/pages/plugins/view.ts
+++ b/ui/src/pages/plugins/view.ts
@@ -62,7 +62,6 @@ export type PluginsViewProps = {
   busy: Readonly<Record<string, boolean>>;
   messages: Readonly<Record<string, PluginRowMessage>>;
   pendingRemoval: Readonly<Record<string, boolean>>;
-  openMenuKey: string | null;
   detailPluginId: string | null;
   canMutate: boolean;
   mutationBlockedReason: string | null;
@@ -75,7 +74,6 @@ export type PluginsViewProps = {
   onQueryChange: (query: string) => void;
   onFilterChange: (filter: InstalledFilter) => void;
   onRefresh: () => void;
-  onToggleMenu: (key: string | null) => void;
   onShowDetails: (pluginId: string | null) => void;
   onSetEnabled: (pluginId: string, enabled: boolean, rowKey: string) => void;
   onInstall: (rowKey: string, request: PluginInstallRequest) => void;
@@ -357,103 +355,53 @@ function stateChip(plugin: PluginCatalogItem) {
   >`;
 }
 
-type PluginMenuItem = {
-  key: string;
-  label: string;
-  icon: TemplateResult;
-  danger?: boolean;
-  disabled?: boolean;
-  onSelect: () => void;
-};
-
-function renderActionsMenu(
-  menuKey: string,
-  label: string,
-  items: readonly PluginMenuItem[],
+function renderToggleButton(
   props: PluginsViewProps,
+  busy: boolean,
+  options: { enabled: boolean; onToggle: (enabled: boolean) => void },
 ) {
-  const open = props.openMenuKey === menuKey;
+  const enable = !options.enabled;
   return html`
-    <span class="plugins-actions-menu">
-      <button
-        type="button"
-        class="btn btn--sm btn--icon plugins-kebab"
-        aria-label=${label}
-        aria-haspopup="menu"
-        aria-expanded=${open ? "true" : "false"}
-        @click=${(event: Event) => {
-          event.stopPropagation();
-          props.onToggleMenu(open ? null : menuKey);
-        }}
-      >
-        ${icons.moreHorizontal}
-      </button>
-      ${open
-        ? html`
-            <div class="plugins-menu" role="menu" aria-label=${label}>
-              ${items.map(
-                (item) => html`
-                  <button
-                    type="button"
-                    role="menuitem"
-                    class="plugins-menu__item ${item.danger ? "plugins-menu__item--danger" : ""}"
-                    ?disabled=${item.disabled}
-                    @click=${(event: Event) => {
-                      event.stopPropagation();
-                      props.onToggleMenu(null);
-                      item.onSelect();
-                    }}
-                  >
-                    <span class="plugins-menu__icon" aria-hidden="true">${item.icon}</span>
-                    ${item.label}
-                  </button>
-                `,
-              )}
-            </div>
-          `
-        : nothing}
-    </span>
+    <button
+      type="button"
+      class="btn btn--sm ${enable ? "primary" : ""}"
+      title=${props.mutationBlockedReason ?? ""}
+      ?disabled=${!props.canMutate || busy}
+      @click=${(event: Event) => {
+        event.stopPropagation();
+        options.onToggle(enable);
+      }}
+    >
+      ${busy
+        ? t("pluginsPage.working")
+        : enable
+          ? t("pluginsPage.enableAction")
+          : t("pluginsPage.disableAction")}
+    </button>
   `;
 }
 
-function pluginMenuItems(
-  plugin: PluginCatalogItem,
+function renderRemoveButton(
   props: PluginsViewProps,
-  rowKey: string,
-  options: { details: boolean },
-): PluginMenuItem[] {
-  const blocked = !props.canMutate || (props.busy[rowKey] ?? false);
-  const items: PluginMenuItem[] = [];
-  if (options.details) {
-    items.push({
-      key: "details",
-      label: t("pluginsPage.menuDetails"),
-      icon: icons.eye,
-      onSelect: () => props.onShowDetails(plugin.id),
-    });
-  }
-  items.push({
-    key: "toggle",
-    label: plugin.enabled ? t("pluginsPage.disableAction") : t("pluginsPage.enableAction"),
-    icon: plugin.enabled ? circleIcon() : icons.check,
-    disabled: blocked,
-    onSelect: () => props.onSetEnabled(plugin.id, !plugin.enabled, rowKey),
-  });
-  if (plugin.removable) {
-    items.push({
-      key: "remove",
-      label: t("pluginsPage.remove"),
-      icon: icons.trash,
-      danger: true,
-      disabled: blocked,
-      onSelect: () => props.onRequestUninstall(rowKey),
-    });
-  }
-  return items;
-}
-
-function circleIcon(): TemplateResult {
-  return icons.circle;
+  busy: boolean,
+  name: string,
+  onRemove: () => void,
+) {
+  return html`
+    <button
+      type="button"
+      class="btn btn--sm btn--icon plugins-remove"
+      aria-label=${t("pluginsPage.removeNamed", { name })}
+      title=${props.mutationBlockedReason ?? t("pluginsPage.removeNamed", { name })}
+      ?disabled=${!props.canMutate || busy}
+      @click=${(event: Event) => {
+        event.stopPropagation();
+        onRemove();
+      }}
+    >
+      ${icons.trash}
+    </button>
+  `;
 }
 
 function renderInstallButton(
@@ -524,7 +472,6 @@ function renderCatalogActions(
   props: PluginsViewProps,
   busy: boolean,
   rowKey: string,
-  options: { details: boolean },
 ) {
   if (props.pendingRemoval[rowKey]) {
     return renderRemoveConfirm(plugin, props, busy, rowKey);
@@ -536,13 +483,13 @@ function renderCatalogActions(
       : html`<span class="plugins-action-note">${t("pluginsPage.unavailable")}</span>`;
   }
   return html`
-    ${stateChip(plugin)}
-    ${renderActionsMenu(
-      rowKey,
-      t("pluginsPage.menuLabel", { name: plugin.name }),
-      pluginMenuItems(plugin, props, rowKey, options),
-      props,
-    )}
+    ${renderToggleButton(props, busy, {
+      enabled: plugin.enabled,
+      onToggle: (enabled) => props.onSetEnabled(plugin.id, enabled, rowKey),
+    })}
+    ${plugin.removable
+      ? renderRemoveButton(props, busy, plugin.name, () => props.onRequestUninstall(rowKey))
+      : nothing}
   `;
 }
 
@@ -653,9 +600,7 @@ function renderInstalledRow(plugin: PluginCatalogItem, props: PluginsViewProps):
             : nothing}
         </div>
       </div>
-      <div class="plugins-row__actions">
-        ${renderCatalogActions(plugin, props, busy, key, { details: true })}
-      </div>
+      <div class="plugins-row__actions">${renderCatalogActions(plugin, props, busy, key)}</div>
       ${plugin.error
         ? html`<div class="plugins-row-message plugins-row-message--error" role="alert">
             ${plugin.error}
@@ -664,27 +609,6 @@ function renderInstalledRow(plugin: PluginCatalogItem, props: PluginsViewProps):
       ${renderRowMessage(key, props.messages[key], busy, props)}
     </article>
   `;
-}
-
-function mcpMenuItems(server: McpServerSummary, props: PluginsViewProps): PluginMenuItem[] {
-  const blocked = !props.canMutate || props.mcpBusy;
-  return [
-    {
-      key: "toggle",
-      label: server.enabled ? t("pluginsPage.disableAction") : t("pluginsPage.enableAction"),
-      icon: server.enabled ? circleIcon() : icons.check,
-      disabled: blocked,
-      onSelect: () => props.onMcpToggle(server.name, !server.enabled),
-    },
-    {
-      key: "remove",
-      label: t("pluginsPage.remove"),
-      icon: icons.trash,
-      danger: true,
-      disabled: blocked,
-      onSelect: () => props.onMcpRemove(server.name),
-    },
-  ];
 }
 
 function renderMcpSection(props: PluginsViewProps) {
@@ -760,14 +684,12 @@ function renderMcpRow(server: McpServerSummary, props: PluginsViewProps): Templa
         <div class="plugins-row__meta"><span>${server.transport}</span></div>
       </div>
       <div class="plugins-row__actions">
-        <span class="plugins-state ${server.enabled ? "plugins-state--enabled" : ""}"
-          >${server.enabled ? t("pluginsPage.enabled") : t("pluginsPage.disabled")}</span
-        >
-        ${renderActionsMenu(
-          `mcp:${server.name}`,
-          t("pluginsPage.menuLabel", { name: server.name }),
-          mcpMenuItems(server, props),
-          props,
+        ${renderToggleButton(props, props.mcpBusy, {
+          enabled: server.enabled,
+          onToggle: (enabled) => props.onMcpToggle(server.name, enabled),
+        })}
+        ${renderRemoveButton(props, props.mcpBusy, server.name, () =>
+          props.onMcpRemove(server.name),
         )}
       </div>
     </article>
@@ -884,9 +806,7 @@ function renderCatalogCard(plugin: PluginCatalogItem, props: PluginsViewProps): 
           ${plugin.origin ? html`<span>${originLabel(plugin.origin)}</span>` : nothing}
         </div>
       </div>
-      <div class="plugins-card__footer">
-        ${renderCatalogActions(plugin, props, busy, key, { details: true })}
-      </div>
+      <div class="plugins-card__footer">${renderCatalogActions(plugin, props, busy, key)}</div>
       ${plugin.error
         ? html`<div class="plugins-row-message plugins-row-message--error" role="alert">
             ${plugin.error}
@@ -1057,7 +977,7 @@ function renderClawHubResult(item: PluginSearchResult, props: PluginsViewProps):
       </div>
       <div class="plugins-row__actions">
         ${installed
-          ? renderCatalogActions(installed, props, busy, key, { details: true })
+          ? renderCatalogActions(installed, props, busy, key)
           : renderInstallButton(props, busy, key, pkg.displayName, {
               source: "clawhub",
               packageName: pkg.name,

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -50,8 +50,7 @@
 .plugins-empty__icon svg,
 .plugins-readonly svg,
 .plugins-refresh svg,
-.plugins-menu__icon svg,
-.plugins-kebab svg,
+.plugins-remove svg,
 .plugins-downloads svg,
 .plugins-badge svg,
 .plugins-group__actions svg,
@@ -750,82 +749,16 @@
   height: 13px;
 }
 
-/* ---------- actions menu ---------- */
-
-.plugins-actions-menu {
-  position: relative;
-  display: inline-flex;
-}
-
-.plugins-kebab {
+.plugins-remove {
   width: 30px;
   height: 30px;
-  padding: 6px;
+  padding: 7px;
   color: var(--muted);
 }
 
-.plugins-kebab[aria-expanded="true"] {
-  background: var(--bg-hover);
-  color: var(--text-strong);
-}
-
-.plugins-menu {
-  position: absolute;
-  top: calc(100% + 4px);
-  right: 0;
-  z-index: 30;
-  display: grid;
-  min-width: 168px;
-  gap: 2px;
-  border: 1px solid var(--border-strong);
-  border-radius: var(--radius-md);
-  padding: 4px;
-  background: var(--popover);
-  box-shadow: var(--shadow-lg);
-  animation: scale-in var(--duration-fast) var(--ease-out);
-}
-
-.plugins-menu__item {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  min-height: 32px;
-  border: 0;
-  border-radius: var(--radius-sm);
-  padding: 0 10px;
-  background: transparent;
-  color: var(--text-strong);
-  font-size: var(--control-ui-text-sm);
-  text-align: left;
-  cursor: pointer;
-  white-space: nowrap;
-}
-
-.plugins-menu__item:hover:not(:disabled),
-.plugins-menu__item:focus-visible {
-  background: var(--bg-hover);
-  outline: none;
-}
-
-.plugins-menu__item:disabled {
-  color: var(--muted);
-  cursor: not-allowed;
-  opacity: 0.55;
-}
-
-.plugins-menu__item--danger {
-  color: var(--danger);
-}
-
-.plugins-menu__item--danger:hover:not(:disabled) {
+.plugins-remove:hover:not(:disabled) {
   background: var(--danger-subtle);
-}
-
-.plugins-menu__icon {
-  display: inline-flex;
-  width: 14px;
-  height: 14px;
-  flex: 0 0 auto;
+  color: var(--danger);
 }
 
 /* ---------- detail overlay ---------- */


### PR DESCRIPTION
## What Problem This Solves

Plugin cards and rows in the Control UI Plugins page showed a passive state pill ("Disabled"/"Enabled") next to a `…` kebab menu. The primary action (enable/disable) was hidden behind the menu, and the menu duplicated "View details" even though clicking anywhere on the card/row already opens the detail overlay. Two extra clicks for the most common action, plus redundant chrome on every card.

## Why This Change Was Made

Direct actions are clearer than a status pill plus an overflow menu:

- The state pill + kebab is replaced by a direct **Enable**/**Disable** button (App Store-style: the button label communicates the state — "Enable" means it is currently disabled).
- Removable plugins and MCP servers get a trash icon button; plugin removal keeps the existing inline confirm step.
- "View details" is dropped from the menu — the whole card/row remains clickable and opens the detail overlay.
- With no menu items left, the entire kebab/menu machinery is deleted: `renderActionsMenu`, menu item builders, `openMenuKey` state, the document `pointerdown` listener, the Escape-closes-menu branch, and the menu CSS. Net **-240 LOC** (code + generated locales).

Surfaces covered: Discover catalog cards, Installed rows, ClawHub search results, MCP server rows. The detail overlay's actions are unchanged. Unused i18n keys `pluginsPage.menuLabel` / `pluginsPage.menuDetails` removed from `en.ts` with the generated locale bundles pruned in the same change.

## User Impact

- One click to enable/disable a plugin from any card or row (was: open menu, pick item).
- Remove is one click to the existing confirm (plugins) or immediate (MCP servers — same behavior as the old menu item).
- Read-only operators see the same buttons disabled with the block reason tooltip, as before.

## Screenshots

| Installed row | Discover cards |
| --- | --- |
| ![installed](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-plugin-card-actions/01-installed-desktop.png) | ![discover](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-plugin-card-actions/03-discover-desktop.png) |

More: [detail overlay](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-plugin-card-actions/02-detail-desktop.png), [ClawHub search](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-plugin-card-actions/04-search-desktop.png), [enabled state](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-plugin-card-actions/05-enabled-installed-desktop.png), [mobile](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-plugin-card-actions/06-installed-mobile.png)

## Evidence

- Unit/view/page tests updated to drive the direct buttons (`ui/src/pages/plugins/view.test.ts`, `plugins-page.test.ts`); e2e flow updated (`plugins.e2e.test.ts`) including the read-only operator gate asserting the disabled Enable button.
- Plugins e2e run locally with real Chromium: the full browse → install → enable → remove flow passes and produced the screenshots above. The one failing assertion in that file (sidebar "Workboard" link after enable, `plugins.e2e.test.ts:518`) times out identically on current `origin/main` — pre-existing sidebar breakage, not from this change; the ui-e2e lane is not part of PR CI.
- `terminal-panel.test.ts` failure seen on an earlier head was main breakage from #106003 (fails 8/8 at plain `origin/main` locally) and is fixed by #106061; green after rebase.
- Codex autoreview (gpt-5.5, xhigh): clean, no accepted findings.
- Hosted CI green on head except the security-scan lanes, which failed on GitHub installation API rate limits during SARIF upload (infra) and went green on rerun (attempt 2).
