### PR TITLE
feat(control-ui): one-row automations toolbar, failing drill-down, visible row actions

### DIFF
--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:16:54.313Z",
+  "generatedAt": "2026-07-13T08:35:08.861Z",
   "locale": "ar",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:16:43.333Z",
+  "generatedAt": "2026-07-13T08:35:06.016Z",
   "locale": "de",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:16:45.274Z",
+  "generatedAt": "2026-07-13T08:35:06.393Z",
   "locale": "es",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:17:11.888Z",
+  "generatedAt": "2026-07-13T08:35:19.374Z",
   "locale": "fa",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:16:50.572Z",
+  "generatedAt": "2026-07-13T08:35:07.850Z",
   "locale": "fr",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/hi.meta.json
+++ b/ui/src/i18n/.i18n/hi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:16:53.027Z",
+  "generatedAt": "2026-07-13T08:35:08.469Z",
   "locale": "hi",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:17:01.232Z",
+  "generatedAt": "2026-07-13T08:35:11.608Z",
   "locale": "id",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:16:55.830Z",
+  "generatedAt": "2026-07-13T08:35:09.240Z",
   "locale": "it",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:16:46.864Z",
+  "generatedAt": "2026-07-13T08:35:06.895Z",
   "locale": "ja-JP",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:16:49.146Z",
+  "generatedAt": "2026-07-13T08:35:07.392Z",
   "locale": "ko",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:17:10.043Z",
+  "generatedAt": "2026-07-13T08:35:18.775Z",
   "locale": "nl",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:17:04.033Z",
+  "generatedAt": "2026-07-13T08:35:13.094Z",
   "locale": "pl",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:16:41.702Z",
+  "generatedAt": "2026-07-13T08:35:05.623Z",
   "locale": "pt-BR",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ru.meta.json
+++ b/ui/src/i18n/.i18n/ru.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:17:13.690Z",
+  "generatedAt": "2026-07-13T08:35:19.866Z",
   "locale": "ru",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:17:06.913Z",
+  "generatedAt": "2026-07-13T08:35:15.582Z",
   "locale": "th",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:16:57.685Z",
+  "generatedAt": "2026-07-13T08:35:09.659Z",
   "locale": "tr",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:16:59.328Z",
+  "generatedAt": "2026-07-13T08:35:10.335Z",
   "locale": "uk",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:17:08.466Z",
+  "generatedAt": "2026-07-13T08:35:17.598Z",
   "locale": "vi",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:16:38.737Z",
+  "generatedAt": "2026-07-13T08:35:04.516Z",
   "locale": "zh-CN",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:16:40.436Z",
+  "generatedAt": "2026-07-13T08:35:05.137Z",
   "locale": "zh-TW",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "a286fe6d3e569ef88ea4b97c7a4f0317678d026eaf15befe23cc0a460da235b5",
-  "totalKeys": 3113,
-  "translatedKeys": 3113,
+  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
+  "totalKeys": 3112,
+  "translatedKeys": 3112,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -3542,7 +3542,6 @@ export const ar: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "المجدول",
       tasks: "المهام",
       failing: "متعطّلة",
       nextWake: "التشغيل التالي",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -3602,7 +3602,6 @@ export const de: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "Zeitplaner",
       tasks: "Aufgaben",
       failing: "Fehlgeschlagen",
       nextWake: "Nächste Ausführung",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3547,7 +3547,6 @@ export const en: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "Scheduler",
       tasks: "Automations",
       failing: "Failing",
       nextWake: "Next wake",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -3602,7 +3602,6 @@ export const es: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "Programador",
       tasks: "Tareas",
       failing: "Con errores",
       nextWake: "Próxima activación",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -3566,7 +3566,6 @@ export const fa: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "زمان‌بند",
       tasks: "وظایف",
       failing: "ناموفق",
       nextWake: "بیداری بعدی",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -3625,7 +3625,6 @@ export const fr: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "Planificateur",
       tasks: "Tâches",
       failing: "En échec",
       nextWake: "Prochain réveil",

--- a/ui/src/i18n/locales/hi.ts
+++ b/ui/src/i18n/locales/hi.ts
@@ -3538,7 +3538,6 @@ export const hi: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "शेड्यूलर",
       tasks: "कार्य",
       failing: "विफल",
       nextWake: "अगला वेक",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -3574,7 +3574,6 @@ export const id: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "Penjadwal",
       tasks: "Tugas",
       failing: "Gagal",
       nextWake: "Bangun berikutnya",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -3606,7 +3606,6 @@ export const it: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "Pianificatore",
       tasks: "Attività",
       failing: "Con errori",
       nextWake: "Prossima attivazione",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -3580,7 +3580,6 @@ export const ja_JP: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "スケジューラー",
       tasks: "タスク",
       failing: "失敗中",
       nextWake: "次回の起動",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -3557,7 +3557,6 @@ export const ko: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "스케줄러",
       tasks: "작업",
       failing: "실패 중",
       nextWake: "다음 실행",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -3585,7 +3585,6 @@ export const nl: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "Planner",
       tasks: "Taken",
       failing: "Mislukt",
       nextWake: "Volgende activering",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -3591,7 +3591,6 @@ export const pl: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "Harmonogram",
       tasks: "Zadania",
       failing: "Nieudane",
       nextWake: "Następne uruchomienie",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -3580,7 +3580,6 @@ export const pt_BR: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "Agendador",
       tasks: "Tarefas",
       failing: "Com falha",
       nextWake: "Próximo despertar",

--- a/ui/src/i18n/locales/ru.ts
+++ b/ui/src/i18n/locales/ru.ts
@@ -3595,7 +3595,6 @@ export const ru: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "Планировщик",
       tasks: "Задачи",
       failing: "С ошибками",
       nextWake: "Следующее пробуждение",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -3514,7 +3514,6 @@ export const th: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "ตัวกำหนดเวลา",
       tasks: "งาน",
       failing: "ล้มเหลว",
       nextWake: "ปลุกครั้งถัดไป",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -3591,7 +3591,6 @@ export const tr: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "Zamanlayıcı",
       tasks: "Görevler",
       failing: "Başarısız",
       nextWake: "Sonraki uyanma",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -3578,7 +3578,6 @@ export const uk: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "Планувальник",
       tasks: "Завдання",
       failing: "З помилками",
       nextWake: "Наступне пробудження",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -3561,7 +3561,6 @@ export const vi: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "Bộ lập lịch",
       tasks: "Tác vụ",
       failing: "Đang lỗi",
       nextWake: "Lần chạy tiếp theo",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -3500,7 +3500,6 @@ export const zh_CN: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "调度器",
       tasks: "任务",
       failing: "失败",
       nextWake: "下次唤醒",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -3506,7 +3506,6 @@ export const zh_TW: TranslationMap = {
       },
     },
     stats: {
-      scheduler: "排程器",
       tasks: "任務",
       failing: "失敗中",
       nextWake: "下次喚醒",

--- a/ui/src/pages/cron/cron-page.test.ts
+++ b/ui/src/pages/cron/cron-page.test.ts
@@ -168,6 +168,25 @@ describe("CronPage editor state sync", () => {
     await vi.waitFor(() => expect(page.cron.cronCreateOpen).toBe(false));
   });
 
+  it("drills from the failing stat into run history filtered to errors", async () => {
+    const request = createRequest();
+    const client = { request } as unknown as GatewayBrowserClient;
+    const gateway = createGateway(client, true);
+    const page = createPage(createContext(gateway), { render: true });
+
+    await vi.waitFor(() =>
+      expect(page.querySelector('[data-test-id="cron-stat-failing"]')).not.toBeNull(),
+    );
+    (page.querySelector('[data-test-id="cron-stat-failing"]') as HTMLButtonElement).click();
+
+    await vi.waitFor(() => expect(page.querySelector(".cron-activity")).not.toBeNull());
+    expect(page.cron.cronRunsStatuses).toEqual(["error"]);
+    expect(request).toHaveBeenCalledWith(
+      "cron.runs",
+      expect.objectContaining({ statuses: ["error"] }),
+    );
+  });
+
   it("syncs form enabled after header pause and resets runs scope after remove", async () => {
     const job = {
       id: "job-1",

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -421,17 +421,6 @@ class CronPage extends OpenClawLightDomElement {
           onListTabChange: (tab) => {
             this.listTab = tab;
           },
-          onShowFailingRuns: () => {
-            // Failing stat card drills into run history pre-filtered to errors.
-            this.listTab = "activity";
-            void this.runCronTask(async (cronState) => {
-              updateCronRunsFilter(cronState, { cronRunsStatuses: ["error"] });
-              await loadCronRuns(
-                cronState,
-                cronState.cronRunsScope === "all" ? null : cronState.cronRunsJobId,
-              );
-            });
-          },
           onDetailTabChange: (tab) => {
             this.detailTab = tab;
           },

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -421,6 +421,17 @@ class CronPage extends OpenClawLightDomElement {
           onListTabChange: (tab) => {
             this.listTab = tab;
           },
+          onShowFailingRuns: () => {
+            // Failing stat card drills into run history pre-filtered to errors.
+            this.listTab = "activity";
+            void this.runCronTask(async (cronState) => {
+              updateCronRunsFilter(cronState, { cronRunsStatuses: ["error"] });
+              await loadCronRuns(
+                cronState,
+                cronState.cronRunsScope === "all" ? null : cronState.cronRunsJobId,
+              );
+            });
+          },
           onDetailTabChange: (tab) => {
             this.detailTab = tab;
           },

--- a/ui/src/pages/cron/view-runs.ts
+++ b/ui/src/pages/cron/view-runs.ts
@@ -1,0 +1,321 @@
+// Run-history rendering for the Automations screen: the compact filter row
+// plus run entries, shared by the list view's Run history tab and the job
+// detail history tab.
+import { html, nothing } from "lit";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import type { CronRunLogEntry } from "../../api/types.ts";
+import type { CronDeliveryStatus, CronRunsStatusValue, CronSortDir } from "../../api/types.ts";
+import { pathForRoute } from "../../app-route-paths.ts";
+import { icon } from "../../components/icons.ts";
+import { toSanitizedMarkdownHtml } from "../../components/markdown.ts";
+import { t } from "../../i18n/index.ts";
+import { formatRelativeTimestamp, formatMs } from "../../lib/format.ts";
+import { searchForSession } from "../../lib/sessions/index.ts";
+import type { CronProps } from "./view.ts";
+
+function getRunStatusOptions(): Array<{ value: CronRunsStatusValue; label: string }> {
+  return [
+    { value: "ok", label: t("cron.runs.runStatusOk") },
+    { value: "error", label: t("cron.runs.runStatusError") },
+    { value: "skipped", label: t("cron.runs.runStatusSkipped") },
+  ];
+}
+
+function getRunDeliveryOptions(): Array<{ value: CronDeliveryStatus; label: string }> {
+  return [
+    { value: "delivered", label: t("cron.runs.deliveryDelivered") },
+    { value: "not-delivered", label: t("cron.runs.deliveryNotDelivered") },
+    { value: "unknown", label: t("cron.runs.deliveryUnknown") },
+    { value: "not-requested", label: t("cron.runs.deliveryNotRequested") },
+  ];
+}
+
+function toggleSelection<T extends string>(selected: T[], value: T, checked: boolean): T[] {
+  const set = new Set(selected);
+  if (checked) {
+    set.add(value);
+  } else {
+    set.delete(value);
+  }
+  return Array.from(set);
+}
+
+function summarizeSelection(selectedLabels: string[], allLabel: string) {
+  if (selectedLabels.length === 0) {
+    return allLabel;
+  }
+  if (selectedLabels.length <= 2) {
+    return selectedLabels.join(", ");
+  }
+  return `${selectedLabels[0]} +${selectedLabels.length - 1}`;
+}
+
+function renderFilterDropdown(params: {
+  id: string;
+  title: string;
+  summary: string;
+  options: Array<{ value: string; label: string }>;
+  selected: string[];
+  onToggle: (value: string, checked: boolean) => void;
+  onClear: () => void;
+}) {
+  return html`
+    <div class="cron-filter-dropdown" data-filter=${params.id}>
+      <details class="cron-filter-dropdown__details">
+        <summary
+          class="btn btn--sm cron-filter-dropdown__trigger ${params.selected.length > 0
+            ? "active"
+            : ""}"
+          title=${params.title}
+          aria-label=${params.title}
+        >
+          <span>${params.summary}</span>
+          ${icon("chevronDown")}
+        </summary>
+        <div class="cron-filter-dropdown__panel">
+          <div class="cron-filter-dropdown__list">
+            ${params.options.map(
+              (option) => html`
+                <label class="cron-filter-dropdown__option">
+                  <input
+                    type="checkbox"
+                    value=${option.value}
+                    .checked=${params.selected.includes(option.value)}
+                    @change=${(event: Event) => {
+                      const target = event.target as HTMLInputElement;
+                      params.onToggle(option.value, target.checked);
+                    }}
+                  />
+                  <span>${option.label}</span>
+                </label>
+              `,
+            )}
+          </div>
+          <div class="row">
+            <button class="btn" type="button" @click=${params.onClear}>
+              ${t("cron.runs.clear")}
+            </button>
+          </div>
+        </div>
+      </details>
+    </div>
+  `;
+}
+
+export function renderRunsSection(props: CronProps) {
+  const runs = props.runs.toSorted((a, b) =>
+    props.runsSortDir === "asc" ? a.ts - b.ts : b.ts - a.ts,
+  );
+  const hasRunFilters =
+    props.runsQuery.trim().length > 0 ||
+    props.runsStatuses.length > 0 ||
+    props.runsDeliveryStatuses.length > 0;
+  const runStatusOptions = getRunStatusOptions();
+  const runDeliveryOptions = getRunDeliveryOptions();
+  const selectedStatusLabels = runStatusOptions
+    .filter((option) => props.runsStatuses.includes(option.value))
+    .map((option) => option.label);
+  const selectedDeliveryLabels = runDeliveryOptions
+    .filter((option) => props.runsDeliveryStatuses.includes(option.value))
+    .map((option) => option.label);
+  const statusSummary = summarizeSelection(selectedStatusLabels, t("cron.runs.allStatuses"));
+  const deliverySummary = summarizeSelection(selectedDeliveryLabels, t("cron.runs.allDelivery"));
+  return html`
+    <div class="cron-runs">
+      <div class="cron-run-filters">
+        <div class="cron-search-box cron-run-filter-search">
+          <span class="cron-search-box__icon" aria-hidden="true">${icon("search")}</span>
+          <input
+            type="search"
+            .value=${props.runsQuery}
+            aria-label=${t("cron.runs.searchRuns")}
+            placeholder=${t("cron.runs.searchPlaceholder")}
+            @input=${(e: Event) =>
+              props.onRunsFiltersChange({ cronRunsQuery: (e.target as HTMLInputElement).value })}
+          />
+        </div>
+        ${renderFilterDropdown({
+          id: "status",
+          title: t("cron.runs.status"),
+          summary: statusSummary,
+          options: runStatusOptions,
+          selected: props.runsStatuses,
+          onToggle: (value, checked) => {
+            const next = toggleSelection(props.runsStatuses, value as CronRunsStatusValue, checked);
+            void props.onRunsFiltersChange({ cronRunsStatuses: next });
+          },
+          onClear: () => {
+            void props.onRunsFiltersChange({ cronRunsStatuses: [] });
+          },
+        })}
+        ${renderFilterDropdown({
+          id: "delivery",
+          title: t("cron.runs.delivery"),
+          summary: deliverySummary,
+          options: runDeliveryOptions,
+          selected: props.runsDeliveryStatuses,
+          onToggle: (value, checked) => {
+            const next = toggleSelection(
+              props.runsDeliveryStatuses,
+              value as CronDeliveryStatus,
+              checked,
+            );
+            void props.onRunsFiltersChange({ cronRunsDeliveryStatuses: next });
+          },
+          onClear: () => {
+            void props.onRunsFiltersChange({ cronRunsDeliveryStatuses: [] });
+          },
+        })}
+        <select
+          class="cron-run-sort"
+          aria-label=${t("cron.jobs.sort")}
+          title=${t("cron.jobs.sort")}
+          .value=${props.runsSortDir}
+          @change=${(e: Event) =>
+            props.onRunsFiltersChange({
+              cronRunsSortDir: (e.target as HTMLSelectElement).value as CronSortDir,
+            })}
+        >
+          <option value="desc">${t("cron.runs.newestFirst")}</option>
+          <option value="asc">${t("cron.runs.oldestFirst")}</option>
+        </select>
+      </div>
+      ${runs.length === 0
+        ? hasRunFilters
+          ? html`<div class="muted cron-runs__empty">${t("cron.runs.noMatching")}</div>`
+          : html`
+              <div class="cron-empty-state">
+                <div class="cron-empty-state__title">${t("cron.runs.emptyTitle")}</div>
+                <div class="cron-empty-state__copy">${t("cron.runs.emptyHint")}</div>
+              </div>
+            `
+        : html`
+            <div class="cron-runs__list">
+              ${runs.map((entry) => renderRun(entry, props.basePath, props.onNavigateToChat))}
+            </div>
+          `}
+      ${props.runsHasMore
+        ? html`
+            <button
+              class="btn btn--sm cron-load-more"
+              ?disabled=${props.runsLoadingMore}
+              @click=${props.onLoadMoreRuns}
+            >
+              ${props.runsLoadingMore ? t("cron.list.loading") : t("cron.runs.loadMore")}
+            </button>
+          `
+        : nothing}
+    </div>
+  `;
+}
+
+function formatRunNextLabel(nextRunAtMs: number, nowMs = Date.now()) {
+  const rel = formatRelativeTimestamp(nextRunAtMs);
+  return nextRunAtMs > nowMs ? t("cron.runEntry.next", { rel }) : t("cron.runEntry.due", { rel });
+}
+
+export function runStatusLabel(value: string): string {
+  switch (value) {
+    case "ok":
+      return t("cron.runs.runStatusOk");
+    case "error":
+      return t("cron.runs.runStatusError");
+    case "skipped":
+      return t("cron.runs.runStatusSkipped");
+    default:
+      return t("cron.runs.runStatusUnknown");
+  }
+}
+
+function runDeliveryLabel(value: string): string {
+  switch (value) {
+    case "delivered":
+      return t("cron.runs.deliveryDelivered");
+    case "not-delivered":
+      return t("cron.runs.deliveryNotDelivered");
+    case "not-requested":
+      return t("cron.runs.deliveryNotRequested");
+    default:
+      return t("cron.runs.deliveryUnknown");
+  }
+}
+
+function renderRun(
+  entry: CronRunLogEntry,
+  basePath: string,
+  onNavigateToChat?: (sessionKey: string) => void,
+) {
+  const chatUrl =
+    typeof entry.sessionKey === "string" && entry.sessionKey.trim().length > 0
+      ? `${pathForRoute("chat", basePath)}${searchForSession(entry.sessionKey)}`
+      : null;
+  const status = runStatusLabel(entry.status ?? "unknown");
+  const delivery = runDeliveryLabel(entry.deliveryStatus ?? "not-requested");
+  const usage = entry.usage;
+  const usageSummary =
+    usage && typeof usage.total_tokens === "number"
+      ? `${usage.total_tokens} tokens`
+      : usage && typeof usage.input_tokens === "number" && typeof usage.output_tokens === "number"
+        ? `${usage.input_tokens} in / ${usage.output_tokens} out`
+        : null;
+  const bodySource = entry.summary || entry.error || t("cron.runEntry.noSummary");
+  const showErrorInMeta = Boolean(entry.error) && Boolean(entry.summary);
+  return html`
+    <div class="list-item cron-run-entry">
+      <div class="cron-run-entry__header">
+        <div class="list-main cron-run-entry__main">
+          <div class="list-title cron-run-entry__title">
+            ${entry.jobName ?? entry.jobId}
+            <span class="muted"> · ${status}</span>
+          </div>
+          <div class="chip-row" style="margin-top: 4px;">
+            <span class="chip">${delivery}</span>
+            ${entry.model ? html`<span class="chip">${entry.model}</span>` : nothing}
+            ${entry.provider ? html`<span class="chip">${entry.provider}</span>` : nothing}
+            ${usageSummary ? html`<span class="chip">${usageSummary}</span>` : nothing}
+          </div>
+        </div>
+        <div class="list-meta cron-run-entry__meta">
+          <div>${formatMs(entry.ts)}</div>
+          ${typeof entry.runAtMs === "number"
+            ? html`<div class="muted">${t("cron.runEntry.runAt")} ${formatMs(entry.runAtMs)}</div>`
+            : nothing}
+          <div class="muted">${entry.durationMs ?? 0}ms</div>
+          ${typeof entry.nextRunAtMs === "number"
+            ? html`<div class="muted">${formatRunNextLabel(entry.nextRunAtMs)}</div>`
+            : nothing}
+          ${chatUrl
+            ? html`<div>
+                <a
+                  class="session-link"
+                  href=${chatUrl}
+                  @click=${(e: MouseEvent) => {
+                    if (
+                      e.defaultPrevented ||
+                      e.button !== 0 ||
+                      e.metaKey ||
+                      e.ctrlKey ||
+                      e.shiftKey ||
+                      e.altKey
+                    ) {
+                      return;
+                    }
+                    if (onNavigateToChat && entry.sessionKey) {
+                      e.preventDefault();
+                      onNavigateToChat(entry.sessionKey);
+                    }
+                  }}
+                  >${t("cron.runEntry.openRunChat")}</a
+                >
+              </div>`
+            : nothing}
+          ${showErrorInMeta ? html`<div class="muted">${entry.error}</div>` : nothing}
+          ${entry.deliveryError ? html`<div class="muted">${entry.deliveryError}</div>` : nothing}
+        </div>
+      </div>
+      <div class="cron-run-entry__body chat-text">
+        ${unsafeHTML(toSanitizedMarkdownHtml(bodySource))}
+      </div>
+    </div>
+  `;
+}

--- a/ui/src/pages/cron/view-runs.ts
+++ b/ui/src/pages/cron/view-runs.ts
@@ -11,7 +11,28 @@ import { toSanitizedMarkdownHtml } from "../../components/markdown.ts";
 import { t } from "../../i18n/index.ts";
 import { formatRelativeTimestamp, formatMs } from "../../lib/format.ts";
 import { searchForSession } from "../../lib/sessions/index.ts";
-import type { CronProps } from "./view.ts";
+
+// Leaf contract: the slice of the cron view props this module needs. Keeping
+// it local (instead of importing CronProps from view.ts) avoids a module
+// cycle between view.ts and view-runs.ts.
+type CronRunsSectionProps = {
+  basePath: string;
+  runs: CronRunLogEntry[];
+  runsHasMore: boolean;
+  runsLoadingMore: boolean;
+  runsStatuses: CronRunsStatusValue[];
+  runsDeliveryStatuses: CronDeliveryStatus[];
+  runsQuery: string;
+  runsSortDir: CronSortDir;
+  onLoadMoreRuns: () => void;
+  onRunsFiltersChange: (patch: {
+    cronRunsStatuses?: CronRunsStatusValue[];
+    cronRunsDeliveryStatuses?: CronDeliveryStatus[];
+    cronRunsQuery?: string;
+    cronRunsSortDir?: CronSortDir;
+  }) => void | Promise<void>;
+  onNavigateToChat?: (sessionKey: string) => void;
+};
 
 function getRunStatusOptions(): Array<{ value: CronRunsStatusValue; label: string }> {
   return [
@@ -102,7 +123,7 @@ function renderFilterDropdown(params: {
   `;
 }
 
-export function renderRunsSection(props: CronProps) {
+export function renderRunsSection(props: CronRunsSectionProps) {
   const runs = props.runs.toSorted((a, b) =>
     props.runsSortDir === "asc" ? a.ts - b.ts : b.ts - a.ts,
   );

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -64,7 +64,6 @@ function createProps(overrides: Partial<CronProps> = {}): CronProps {
     deliveryToSuggestions: [],
     accountSuggestions: [],
     onListTabChange: () => undefined,
-    onShowFailingRuns: () => undefined,
     onDetailTabChange: () => undefined,
     onFormChange: () => undefined,
     onRefresh: () => undefined,
@@ -291,12 +290,14 @@ describe("cron view list pane", () => {
   });
 
   it("shows the global failing count and drills into failing run history", () => {
-    const onShowFailingRuns = vi.fn();
-    const container = renderView({ failingCount: 3, onShowFailingRuns });
+    const onListTabChange = vi.fn();
+    const onRunsFiltersChange = vi.fn();
+    const container = renderView({ failingCount: 3, onListTabChange, onRunsFiltersChange });
     const value = getElement(container, ".cron-stat__value--danger", HTMLSpanElement);
     expect(value.textContent?.trim()).toBe("3");
     getElement(container, '[data-test-id="cron-stat-failing"]', HTMLButtonElement).click();
-    expect(onShowFailingRuns).toHaveBeenCalledTimes(1);
+    expect(onListTabChange).toHaveBeenCalledWith("activity");
+    expect(onRunsFiltersChange).toHaveBeenCalledWith({ cronRunsStatuses: ["error"] });
 
     const unknown = renderView({ failingCount: null });
     expect(unknown.querySelector(".cron-stat__value--danger")).toBeNull();

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -64,6 +64,7 @@ function createProps(overrides: Partial<CronProps> = {}): CronProps {
     deliveryToSuggestions: [],
     accountSuggestions: [],
     onListTabChange: () => undefined,
+    onShowFailingRuns: () => undefined,
     onDetailTabChange: () => undefined,
     onFormChange: () => undefined,
     onRefresh: () => undefined,
@@ -206,17 +207,30 @@ describe("cron view list pane", () => {
     expect(onSelectJob).toHaveBeenCalledWith(paused);
   });
 
-  it("keeps row menu actions from selecting the row", () => {
+  it("keeps inline row actions from selecting the row", () => {
     const onSelectJob = vi.fn();
     const onRun = vi.fn();
+    const onToggle = vi.fn();
     const job = createJob("job-1");
-    const container = renderView({ jobs: [job], onSelectJob, onRun });
+    const container = renderView({ jobs: [job], onSelectJob, onRun, onToggle });
 
-    const runNow = Array.from(
-      container.querySelectorAll(".cron-table__row .cron-job-menu__item"),
-    ).find((item) => item.textContent?.trim() === "Run now") as HTMLButtonElement;
-    runNow.click();
+    getElement(container, '[data-test-id="cron-row-run-job-1"]', HTMLButtonElement).click();
     expect(onRun).toHaveBeenCalledWith(job, "force");
+
+    const toggle = getElement(
+      container,
+      '[data-test-id="cron-row-toggle-job-1"]',
+      HTMLButtonElement,
+    );
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+    toggle.click();
+    expect(onToggle).toHaveBeenCalledWith(job, false);
+
+    const runIfDue = Array.from(
+      container.querySelectorAll(".cron-table__row .cron-job-menu__item"),
+    ).find((item) => item.textContent?.trim() === "Run if due") as HTMLButtonElement;
+    runIfDue.click();
+    expect(onRun).toHaveBeenCalledWith(job, "due");
     expect(onSelectJob).not.toHaveBeenCalled();
   });
 
@@ -260,23 +274,29 @@ describe("cron view list pane", () => {
     expect(renderView().querySelector(".cron-suggestions")).not.toBeNull();
   });
 
-  it("shows scheduler status in the stats and counts in the table footer", () => {
-    const container = renderView({
+  it("shows a scheduler banner only while the scheduler is off", () => {
+    const off = renderView({
       status: { enabled: false, jobs: 2 },
       jobs: [createJob("job-1")],
       jobsTotal: 2,
     });
-    const stats = getElement(container, ".cron-stats", HTMLDivElement);
-    expect(stats.textContent).toContain("Scheduler disabled");
-    expect(stats.textContent).toContain("2");
-    const footer = getElement(container, ".cron-table__footer", HTMLDivElement);
+    const banner = getElement(off, '[data-test-id="cron-scheduler-banner"]', HTMLDivElement);
+    expect(banner.textContent).toContain("Scheduler disabled");
+    expect(getElement(off, ".cron-stats", HTMLDivElement).textContent).not.toContain("Scheduler");
+    const footer = getElement(off, ".cron-table__footer", HTMLDivElement);
     expect(footer.textContent).toContain("1 of 2");
+
+    const on = renderView({ status: { enabled: true, jobs: 2 } });
+    expect(on.querySelector('[data-test-id="cron-scheduler-banner"]')).toBeNull();
   });
 
-  it("shows the global failing count and degrades to n/a when unknown", () => {
-    const container = renderView({ failingCount: 3 });
+  it("shows the global failing count and drills into failing run history", () => {
+    const onShowFailingRuns = vi.fn();
+    const container = renderView({ failingCount: 3, onShowFailingRuns });
     const value = getElement(container, ".cron-stat__value--danger", HTMLSpanElement);
     expect(value.textContent?.trim()).toBe("3");
+    getElement(container, '[data-test-id="cron-stat-failing"]', HTMLButtonElement).click();
+    expect(onShowFailingRuns).toHaveBeenCalledTimes(1);
 
     const unknown = renderView({ failingCount: null });
     expect(unknown.querySelector(".cron-stat__value--danger")).toBeNull();

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -4,7 +4,6 @@
 import { html, nothing } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { repeat } from "lit/directives/repeat.js";
-import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { ChannelUiMetaEntry, CronJob, CronRunLogEntry, CronStatus } from "../../api/types.ts";
 import "../../styles/chat/text.css";
 import "../../styles/cron.css";
@@ -15,9 +14,7 @@ import type {
   CronJobsSortBy,
   CronSortDir,
 } from "../../api/types.ts";
-import { pathForRoute } from "../../app-route-paths.ts";
 import { icon } from "../../components/icons.ts";
-import { toSanitizedMarkdownHtml } from "../../components/markdown.ts";
 import "../../components/tooltip.ts";
 import { t } from "../../i18n/index.ts";
 import { isCronJobActiveFailure, resolveCronJobLastRunStatus } from "../../lib/cron-status.ts";
@@ -30,16 +27,16 @@ import type {
 import type { CronFormState } from "../../lib/cron/index.ts";
 import { formatRelativeTimestamp, formatMs } from "../../lib/format.ts";
 import { formatCronSchedule, formatNextRun } from "../../lib/presenter.ts";
-import { searchForSession } from "../../lib/sessions/index.ts";
 import { normalizeStringEntries, uniqueStrings } from "../../lib/string-coerce.ts";
 import { CRON_SUGGESTIONS, suggestionFormPatch } from "./suggestions.ts";
+import { renderRunsSection, runStatusLabel } from "./view-runs.ts";
 
 type CronPanelMode = "overview" | "create" | "job";
 
 export type CronListTab = "tasks" | "activity";
 export type CronDetailTab = "settings" | "history";
 
-type CronProps = {
+export type CronProps = {
   basePath: string;
   loading: boolean;
   jobsLoadingMore: boolean;
@@ -81,7 +78,6 @@ type CronProps = {
   deliveryToSuggestions: string[];
   accountSuggestions: string[];
   onListTabChange: (tab: CronListTab) => void;
-  onShowFailingRuns: () => void;
   onDetailTabChange: (tab: CronDetailTab) => void;
   onFormChange: (patch: Partial<CronFormState>) => void;
   onRefresh: () => void;
@@ -116,43 +112,6 @@ type CronProps = {
 
 // ── Shared option helpers ──
 
-function getRunStatusOptions(): Array<{ value: CronRunsStatusValue; label: string }> {
-  return [
-    { value: "ok", label: t("cron.runs.runStatusOk") },
-    { value: "error", label: t("cron.runs.runStatusError") },
-    { value: "skipped", label: t("cron.runs.runStatusSkipped") },
-  ];
-}
-
-function getRunDeliveryOptions(): Array<{ value: CronDeliveryStatus; label: string }> {
-  return [
-    { value: "delivered", label: t("cron.runs.deliveryDelivered") },
-    { value: "not-delivered", label: t("cron.runs.deliveryNotDelivered") },
-    { value: "unknown", label: t("cron.runs.deliveryUnknown") },
-    { value: "not-requested", label: t("cron.runs.deliveryNotRequested") },
-  ];
-}
-
-function toggleSelection<T extends string>(selected: T[], value: T, checked: boolean): T[] {
-  const set = new Set(selected);
-  if (checked) {
-    set.add(value);
-  } else {
-    set.delete(value);
-  }
-  return Array.from(set);
-}
-
-function summarizeSelection(selectedLabels: string[], allLabel: string) {
-  if (selectedLabels.length === 0) {
-    return allLabel;
-  }
-  if (selectedLabels.length <= 2) {
-    return selectedLabels.join(", ");
-  }
-  return `${selectedLabels[0]} +${selectedLabels.length - 1}`;
-}
-
 function buildChannelOptions(props: CronProps): string[] {
   const options = ["last", ...props.channels.filter(Boolean)];
   const current = props.form.deliveryChannel?.trim();
@@ -178,58 +137,6 @@ function resolveChannelLabel(props: CronProps, channel: string): string {
     return meta.label;
   }
   return props.channelLabels?.[channel] ?? channel;
-}
-
-function renderFilterDropdown(params: {
-  id: string;
-  title: string;
-  summary: string;
-  options: Array<{ value: string; label: string }>;
-  selected: string[];
-  onToggle: (value: string, checked: boolean) => void;
-  onClear: () => void;
-}) {
-  return html`
-    <div class="cron-filter-dropdown" data-filter=${params.id}>
-      <details class="cron-filter-dropdown__details">
-        <summary
-          class="btn btn--sm cron-filter-dropdown__trigger ${params.selected.length > 0
-            ? "active"
-            : ""}"
-          title=${params.title}
-          aria-label=${params.title}
-        >
-          <span>${params.summary}</span>
-          ${icon("chevronDown")}
-        </summary>
-        <div class="cron-filter-dropdown__panel">
-          <div class="cron-filter-dropdown__list">
-            ${params.options.map(
-              (option) => html`
-                <label class="cron-filter-dropdown__option">
-                  <input
-                    type="checkbox"
-                    value=${option.value}
-                    .checked=${params.selected.includes(option.value)}
-                    @change=${(event: Event) => {
-                      const target = event.target as HTMLInputElement;
-                      params.onToggle(option.value, target.checked);
-                    }}
-                  />
-                  <span>${option.label}</span>
-                </label>
-              `,
-            )}
-          </div>
-          <div class="row">
-            <button class="btn" type="button" @click=${params.onClear}>
-              ${t("cron.runs.clear")}
-            </button>
-          </div>
-        </div>
-      </details>
-    </div>
-  `;
 }
 
 function renderSuggestionList(id: string, options: string[]) {
@@ -487,7 +394,11 @@ function renderStats(props: CronProps) {
         class="cron-stat cron-stat--action card"
         data-test-id="cron-stat-failing"
         title=${t("cron.list.activityTab")}
-        @click=${props.onShowFailingRuns}
+        @click=${() => {
+          // Drill into run history pre-filtered to errors.
+          props.onListTabChange("activity");
+          void props.onRunsFiltersChange({ cronRunsStatuses: ["error"] });
+        }}
       >
         <span class="cron-stat__label">${t("cron.stats.failing")}</span>
         <span
@@ -1890,225 +1801,5 @@ function renderFailureAlertRows(props: CronProps, channelOptions: string[]) {
           })}
         `
       : nothing}
-  `;
-}
-
-// ── Run history ──
-
-function renderRunsSection(props: CronProps) {
-  const runs = props.runs.toSorted((a, b) =>
-    props.runsSortDir === "asc" ? a.ts - b.ts : b.ts - a.ts,
-  );
-  const hasRunFilters =
-    props.runsQuery.trim().length > 0 ||
-    props.runsStatuses.length > 0 ||
-    props.runsDeliveryStatuses.length > 0;
-  const runStatusOptions = getRunStatusOptions();
-  const runDeliveryOptions = getRunDeliveryOptions();
-  const selectedStatusLabels = runStatusOptions
-    .filter((option) => props.runsStatuses.includes(option.value))
-    .map((option) => option.label);
-  const selectedDeliveryLabels = runDeliveryOptions
-    .filter((option) => props.runsDeliveryStatuses.includes(option.value))
-    .map((option) => option.label);
-  const statusSummary = summarizeSelection(selectedStatusLabels, t("cron.runs.allStatuses"));
-  const deliverySummary = summarizeSelection(selectedDeliveryLabels, t("cron.runs.allDelivery"));
-  return html`
-    <div class="cron-runs">
-      <div class="cron-run-filters">
-        <div class="cron-search-box cron-run-filter-search">
-          <span class="cron-search-box__icon" aria-hidden="true">${icon("search")}</span>
-          <input
-            type="search"
-            .value=${props.runsQuery}
-            aria-label=${t("cron.runs.searchRuns")}
-            placeholder=${t("cron.runs.searchPlaceholder")}
-            @input=${(e: Event) =>
-              props.onRunsFiltersChange({ cronRunsQuery: (e.target as HTMLInputElement).value })}
-          />
-        </div>
-        ${renderFilterDropdown({
-          id: "status",
-          title: t("cron.runs.status"),
-          summary: statusSummary,
-          options: runStatusOptions,
-          selected: props.runsStatuses,
-          onToggle: (value, checked) => {
-            const next = toggleSelection(props.runsStatuses, value as CronRunsStatusValue, checked);
-            void props.onRunsFiltersChange({ cronRunsStatuses: next });
-          },
-          onClear: () => {
-            void props.onRunsFiltersChange({ cronRunsStatuses: [] });
-          },
-        })}
-        ${renderFilterDropdown({
-          id: "delivery",
-          title: t("cron.runs.delivery"),
-          summary: deliverySummary,
-          options: runDeliveryOptions,
-          selected: props.runsDeliveryStatuses,
-          onToggle: (value, checked) => {
-            const next = toggleSelection(
-              props.runsDeliveryStatuses,
-              value as CronDeliveryStatus,
-              checked,
-            );
-            void props.onRunsFiltersChange({ cronRunsDeliveryStatuses: next });
-          },
-          onClear: () => {
-            void props.onRunsFiltersChange({ cronRunsDeliveryStatuses: [] });
-          },
-        })}
-        <select
-          class="cron-run-sort"
-          aria-label=${t("cron.jobs.sort")}
-          title=${t("cron.jobs.sort")}
-          .value=${props.runsSortDir}
-          @change=${(e: Event) =>
-            props.onRunsFiltersChange({
-              cronRunsSortDir: (e.target as HTMLSelectElement).value as CronSortDir,
-            })}
-        >
-          <option value="desc">${t("cron.runs.newestFirst")}</option>
-          <option value="asc">${t("cron.runs.oldestFirst")}</option>
-        </select>
-      </div>
-      ${runs.length === 0
-        ? hasRunFilters
-          ? html`<div class="muted cron-runs__empty">${t("cron.runs.noMatching")}</div>`
-          : html`
-              <div class="cron-empty-state">
-                <div class="cron-empty-state__title">${t("cron.runs.emptyTitle")}</div>
-                <div class="cron-empty-state__copy">${t("cron.runs.emptyHint")}</div>
-              </div>
-            `
-        : html`
-            <div class="cron-runs__list">
-              ${runs.map((entry) => renderRun(entry, props.basePath, props.onNavigateToChat))}
-            </div>
-          `}
-      ${props.runsHasMore
-        ? html`
-            <button
-              class="btn btn--sm cron-load-more"
-              ?disabled=${props.runsLoadingMore}
-              @click=${props.onLoadMoreRuns}
-            >
-              ${props.runsLoadingMore ? t("cron.list.loading") : t("cron.runs.loadMore")}
-            </button>
-          `
-        : nothing}
-    </div>
-  `;
-}
-
-function formatRunNextLabel(nextRunAtMs: number, nowMs = Date.now()) {
-  const rel = formatRelativeTimestamp(nextRunAtMs);
-  return nextRunAtMs > nowMs ? t("cron.runEntry.next", { rel }) : t("cron.runEntry.due", { rel });
-}
-
-function runStatusLabel(value: string): string {
-  switch (value) {
-    case "ok":
-      return t("cron.runs.runStatusOk");
-    case "error":
-      return t("cron.runs.runStatusError");
-    case "skipped":
-      return t("cron.runs.runStatusSkipped");
-    default:
-      return t("cron.runs.runStatusUnknown");
-  }
-}
-
-function runDeliveryLabel(value: string): string {
-  switch (value) {
-    case "delivered":
-      return t("cron.runs.deliveryDelivered");
-    case "not-delivered":
-      return t("cron.runs.deliveryNotDelivered");
-    case "not-requested":
-      return t("cron.runs.deliveryNotRequested");
-    default:
-      return t("cron.runs.deliveryUnknown");
-  }
-}
-
-function renderRun(
-  entry: CronRunLogEntry,
-  basePath: string,
-  onNavigateToChat?: (sessionKey: string) => void,
-) {
-  const chatUrl =
-    typeof entry.sessionKey === "string" && entry.sessionKey.trim().length > 0
-      ? `${pathForRoute("chat", basePath)}${searchForSession(entry.sessionKey)}`
-      : null;
-  const status = runStatusLabel(entry.status ?? "unknown");
-  const delivery = runDeliveryLabel(entry.deliveryStatus ?? "not-requested");
-  const usage = entry.usage;
-  const usageSummary =
-    usage && typeof usage.total_tokens === "number"
-      ? `${usage.total_tokens} tokens`
-      : usage && typeof usage.input_tokens === "number" && typeof usage.output_tokens === "number"
-        ? `${usage.input_tokens} in / ${usage.output_tokens} out`
-        : null;
-  const bodySource = entry.summary || entry.error || t("cron.runEntry.noSummary");
-  const showErrorInMeta = Boolean(entry.error) && Boolean(entry.summary);
-  return html`
-    <div class="list-item cron-run-entry">
-      <div class="cron-run-entry__header">
-        <div class="list-main cron-run-entry__main">
-          <div class="list-title cron-run-entry__title">
-            ${entry.jobName ?? entry.jobId}
-            <span class="muted"> · ${status}</span>
-          </div>
-          <div class="chip-row" style="margin-top: 4px;">
-            <span class="chip">${delivery}</span>
-            ${entry.model ? html`<span class="chip">${entry.model}</span>` : nothing}
-            ${entry.provider ? html`<span class="chip">${entry.provider}</span>` : nothing}
-            ${usageSummary ? html`<span class="chip">${usageSummary}</span>` : nothing}
-          </div>
-        </div>
-        <div class="list-meta cron-run-entry__meta">
-          <div>${formatMs(entry.ts)}</div>
-          ${typeof entry.runAtMs === "number"
-            ? html`<div class="muted">${t("cron.runEntry.runAt")} ${formatMs(entry.runAtMs)}</div>`
-            : nothing}
-          <div class="muted">${entry.durationMs ?? 0}ms</div>
-          ${typeof entry.nextRunAtMs === "number"
-            ? html`<div class="muted">${formatRunNextLabel(entry.nextRunAtMs)}</div>`
-            : nothing}
-          ${chatUrl
-            ? html`<div>
-                <a
-                  class="session-link"
-                  href=${chatUrl}
-                  @click=${(e: MouseEvent) => {
-                    if (
-                      e.defaultPrevented ||
-                      e.button !== 0 ||
-                      e.metaKey ||
-                      e.ctrlKey ||
-                      e.shiftKey ||
-                      e.altKey
-                    ) {
-                      return;
-                    }
-                    if (onNavigateToChat && entry.sessionKey) {
-                      e.preventDefault();
-                      onNavigateToChat(entry.sessionKey);
-                    }
-                  }}
-                  >${t("cron.runEntry.openRunChat")}</a
-                >
-              </div>`
-            : nothing}
-          ${showErrorInMeta ? html`<div class="muted">${entry.error}</div>` : nothing}
-          ${entry.deliveryError ? html`<div class="muted">${entry.deliveryError}</div>` : nothing}
-        </div>
-      </div>
-      <div class="cron-run-entry__body chat-text">
-        ${unsafeHTML(toSanitizedMarkdownHtml(bodySource))}
-      </div>
-    </div>
   `;
 }

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -36,7 +36,7 @@ type CronPanelMode = "overview" | "create" | "job";
 export type CronListTab = "tasks" | "activity";
 export type CronDetailTab = "settings" | "history";
 
-export type CronProps = {
+type CronProps = {
   basePath: string;
   loading: boolean;
   jobsLoadingMore: boolean;

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -81,6 +81,7 @@ type CronProps = {
   deliveryToSuggestions: string[];
   accountSuggestions: string[];
   onListTabChange: (tab: CronListTab) => void;
+  onShowFailingRuns: () => void;
   onDetailTabChange: (tab: CronDetailTab) => void;
   onFormChange: (patch: Partial<CronFormState>) => void;
   onRefresh: () => void;
@@ -189,11 +190,17 @@ function renderFilterDropdown(params: {
   onClear: () => void;
 }) {
   return html`
-    <div class="field cron-filter-dropdown" data-filter=${params.id}>
-      <span>${params.title}</span>
+    <div class="cron-filter-dropdown" data-filter=${params.id}>
       <details class="cron-filter-dropdown__details">
-        <summary class="btn cron-filter-dropdown__trigger">
+        <summary
+          class="btn btn--sm cron-filter-dropdown__trigger ${params.selected.length > 0
+            ? "active"
+            : ""}"
+          title=${params.title}
+          aria-label=${params.title}
+        >
           <span>${params.summary}</span>
+          ${icon("chevronDown")}
         </summary>
         <div class="cron-filter-dropdown__panel">
           <div class="cron-filter-dropdown__list">
@@ -447,8 +454,16 @@ const ENABLED_TABS: Array<{ value: CronJobsEnabledFilter; labelKey: string }> = 
 function renderListView(props: CronProps) {
   return html`
     <section class="cron-page" data-panel-mode="overview">
-      ${renderStats(props)} ${renderListTabs(props)}
+      ${renderStats(props)}
+      ${props.status && !props.status.enabled
+        ? html`
+            <div class="cron-error-banner" data-test-id="cron-scheduler-banner">
+              <strong>${t("cron.list.schedulerOff")}</strong> ${t("cron.runNotStarted.stopped")}
+            </div>
+          `
+        : nothing}
       ${props.error ? html`<div class="cron-error-banner">${props.error}</div>` : nothing}
+      ${renderToolbar(props)}
       ${props.listTab === "activity"
         ? html`<div class="cron-activity card">${renderRunsSection(props)}</div>`
         : renderTasksPanel(props)}
@@ -467,7 +482,13 @@ function renderStats(props: CronProps) {
         <span class="cron-stat__label">${t("cron.stats.tasks")}</span>
         <span class="cron-stat__value">${total}</span>
       </div>
-      <div class="cron-stat card">
+      <button
+        type="button"
+        class="cron-stat cron-stat--action card"
+        data-test-id="cron-stat-failing"
+        title=${t("cron.list.activityTab")}
+        @click=${props.onShowFailingRuns}
+      >
         <span class="cron-stat__label">${t("cron.stats.failing")}</span>
         <span
           class="cron-stat__value ${typeof failing === "number" && failing > 0
@@ -476,17 +497,8 @@ function renderStats(props: CronProps) {
         >
           ${failing ?? t("common.na")}
         </span>
-      </div>
-      <div class="cron-stat card">
-        <span class="cron-stat__label">${t("cron.stats.scheduler")}</span>
-        <span class="cron-stat__value cron-stat__value--chip">
-          ${props.status
-            ? props.status.enabled
-              ? html`<span class="chip chip-ok">${t("common.enabled")}</span>`
-              : html`<span class="chip chip-danger">${t("cron.list.schedulerOff")}</span>`
-            : t("common.na")}
-        </span>
-      </div>
+        <span class="cron-stat__go" aria-hidden="true">${icon("chevronRight")}</span>
+      </button>
       <div class="cron-stat card">
         <span class="cron-stat__label">${t("cron.stats.nextWake")}</span>
         <span class="cron-stat__value cron-stat__value--time">
@@ -497,91 +509,107 @@ function renderStats(props: CronProps) {
   `;
 }
 
-function renderListTabs(props: CronProps) {
-  const tabs: Array<{ value: CronListTab; label: string; testId: string }> = [
+// One toolbar row for both list tabs: view switch on the left, tab-specific
+// filters in the middle, refresh + New automation pinned right.
+function renderToolbar(props: CronProps) {
+  const viewTabs: Array<{ value: CronListTab; label: string; testId: string }> = [
     { value: "tasks", label: t("cron.list.tasksTab"), testId: "cron-list-tab-tasks" },
     { value: "activity", label: t("cron.list.activityTab"), testId: "cron-list-tab-activity" },
   ];
-  return html`
-    <div class="cron-tabs cron-view-tabs" role="tablist">
-      ${tabs.map(
-        (tab) => html`
-          <button
-            type="button"
-            role="tab"
-            class="cron-tab ${props.listTab === tab.value ? "cron-tab--active" : ""}"
-            aria-selected=${props.listTab === tab.value ? "true" : "false"}
-            data-test-id=${tab.testId}
-            @click=${() => props.onListTabChange(tab.value)}
-          >
-            ${tab.label}
-          </button>
-        `,
-      )}
-    </div>
-  `;
-}
-
-function renderTasksPanel(props: CronProps) {
   const hasAdvancedJobsFilters =
     props.jobsScheduleKindFilter !== "all" ||
     props.jobsLastStatusFilter !== "all" ||
     props.jobsSortBy !== "nextRunAtMs" ||
     props.jobsSortDir !== "asc";
-  const hasAnyJobsFilters =
-    hasAdvancedJobsFilters ||
-    props.jobsQuery.trim().length > 0 ||
-    props.jobsEnabledFilter !== "all";
   return html`
     <div class="cron-toolbar">
       <div class="cron-tabs" role="tablist">
-        ${ENABLED_TABS.map(
+        ${viewTabs.map(
           (tab) => html`
             <button
               type="button"
               role="tab"
-              class="cron-tab ${props.jobsEnabledFilter === tab.value ? "cron-tab--active" : ""}"
-              aria-selected=${props.jobsEnabledFilter === tab.value ? "true" : "false"}
-              data-test-id=${`cron-tab-${tab.value}`}
-              @click=${() => props.onJobsFiltersChange({ cronJobsEnabledFilter: tab.value })}
+              class="cron-tab ${props.listTab === tab.value ? "cron-tab--active" : ""}"
+              aria-selected=${props.listTab === tab.value ? "true" : "false"}
+              data-test-id=${tab.testId}
+              @click=${() => props.onListTabChange(tab.value)}
             >
-              ${t(tab.labelKey)}
+              ${tab.label}
             </button>
           `,
         )}
       </div>
-      <div class="cron-search-box">
-        <span class="cron-search-box__icon" aria-hidden="true">${icon("search")}</span>
-        <input
-          type="search"
-          .value=${props.jobsQuery}
-          placeholder=${t("cron.list.searchPlaceholder")}
-          @input=${(e: Event) =>
-            props.onJobsFiltersChange({
-              cronJobsQuery: (e.target as HTMLInputElement).value,
-            })}
-        />
+      ${props.listTab === "tasks"
+        ? html`
+            <div class="cron-tabs" role="tablist">
+              ${ENABLED_TABS.map(
+                (tab) => html`
+                  <button
+                    type="button"
+                    role="tab"
+                    class="cron-tab ${props.jobsEnabledFilter === tab.value
+                      ? "cron-tab--active"
+                      : ""}"
+                    aria-selected=${props.jobsEnabledFilter === tab.value ? "true" : "false"}
+                    data-test-id=${`cron-tab-${tab.value}`}
+                    @click=${() => props.onJobsFiltersChange({ cronJobsEnabledFilter: tab.value })}
+                  >
+                    ${t(tab.labelKey)}
+                  </button>
+                `,
+              )}
+            </div>
+            <div class="cron-search-box">
+              <span class="cron-search-box__icon" aria-hidden="true">${icon("search")}</span>
+              <input
+                type="search"
+                .value=${props.jobsQuery}
+                aria-label=${t("cron.list.searchPlaceholder")}
+                placeholder=${t("cron.list.searchPlaceholder")}
+                @input=${(e: Event) =>
+                  props.onJobsFiltersChange({
+                    cronJobsQuery: (e.target as HTMLInputElement).value,
+                  })}
+              />
+            </div>
+            ${renderJobsFilterPopover(props, hasAdvancedJobsFilters)}
+          `
+        : nothing}
+      <div class="cron-toolbar__end">
+        <button
+          type="button"
+          class="btn btn--sm btn--ghost cron-refresh ${props.loading
+            ? "cron-refresh--loading"
+            : ""}"
+          ?disabled=${props.loading}
+          title=${props.loading ? t("cron.list.refreshing") : t("cron.list.refresh")}
+          aria-label=${t("cron.list.refresh")}
+          @click=${props.onRefresh}
+        >
+          ${icon("refresh")}
+        </button>
+        <button
+          type="button"
+          class="btn primary btn--sm cron-new-task"
+          data-test-id="cron-new-task"
+          @click=${() => props.onOpenCreate()}
+        >
+          ${icon("plus")} ${t("cron.list.newTask")}
+        </button>
       </div>
-      ${renderJobsFilterPopover(props, hasAdvancedJobsFilters)}
-      <button
-        type="button"
-        class="btn btn--sm btn--ghost cron-refresh ${props.loading ? "cron-refresh--loading" : ""}"
-        ?disabled=${props.loading}
-        title=${props.loading ? t("cron.list.refreshing") : t("cron.list.refresh")}
-        aria-label=${t("cron.list.refresh")}
-        @click=${props.onRefresh}
-      >
-        ${icon("refresh")}
-      </button>
-      <button
-        type="button"
-        class="btn primary btn--sm cron-new-task"
-        data-test-id="cron-new-task"
-        @click=${() => props.onOpenCreate()}
-      >
-        ${icon("plus")} ${t("cron.list.newTask")}
-      </button>
     </div>
+  `;
+}
+
+function renderTasksPanel(props: CronProps) {
+  const hasAnyJobsFilters =
+    props.jobsScheduleKindFilter !== "all" ||
+    props.jobsLastStatusFilter !== "all" ||
+    props.jobsSortBy !== "nextRunAtMs" ||
+    props.jobsSortDir !== "asc" ||
+    props.jobsQuery.trim().length > 0 ||
+    props.jobsEnabledFilter !== "all";
+  return html`
     ${renderJobsTable(props, hasAnyJobsFilters)}
     ${hasAnyJobsFilters ? nothing : renderSuggestions(props)}
   `;
@@ -761,7 +789,22 @@ function renderJobRow(job: CronJob, props: CronProps) {
         @click=${(e: Event) => e.stopPropagation()}
         @keydown=${(e: Event) => e.stopPropagation()}
       >
-        ${renderJobMenu(props, job, { rowActions: true })}
+        <button
+          type="button"
+          class="btn btn--sm btn--ghost cron-row-run"
+          data-test-id=${`cron-row-run-${job.id}`}
+          title=${t("cron.actions.runNow")}
+          aria-label=${t("cron.actions.runNow")}
+          ?disabled=${props.busy}
+          @click=${() => props.onRun(job, "force")}
+        >
+          ${icon("play")}
+        </button>
+        ${renderEnabledSwitch(props, job, {
+          compact: true,
+          testId: `cron-row-toggle-${job.id}`,
+        })}
+        ${renderJobMenu(props, job)}
       </span>
     </div>
   `;
@@ -794,7 +837,9 @@ function renderLastRunCell(job: CronJob) {
   `;
 }
 
-function renderJobMenu(props: CronProps, job: CronJob, opts: { rowActions: boolean }) {
+// Run now and pause/resume are visible controls (rows and detail header);
+// the menu only carries the low-traffic actions.
+function renderJobMenu(props: CronProps, job: CronJob) {
   return html`
     <details class="cron-job-menu">
       <summary
@@ -807,17 +852,7 @@ function renderJobMenu(props: CronProps, job: CronJob, opts: { rowActions: boole
         ${icon("moreHorizontal")}
       </summary>
       <div class="cron-job-menu__panel" role="menu">
-        ${opts.rowActions
-          ? html`
-              ${renderMenuItem(props, t("cron.actions.runNow"), () => props.onRun(job, "force"))}
-              ${renderMenuItem(props, t("cron.actions.runIfDue"), () => props.onRun(job, "due"))}
-              ${renderMenuItem(
-                props,
-                job.enabled ? t("cron.actions.pause") : t("cron.actions.resume"),
-                () => props.onToggle(job, !job.enabled),
-              )}
-            `
-          : renderMenuItem(props, t("cron.actions.runIfDue"), () => props.onRun(job, "due"))}
+        ${renderMenuItem(props, t("cron.actions.runIfDue"), () => props.onRun(job, "due"))}
         ${renderMenuItem(props, t("cron.actions.clone"), () => props.onClone(job))}
         ${renderMenuItem(props, t("cron.actions.remove"), () => props.onRemove(job), {
           danger: true,
@@ -920,7 +955,7 @@ function renderDetailHeader(props: CronProps, mode: CronPanelMode, selectedJob?:
               >
                 ${icon("play")} ${t("cron.actions.runNow")}
               </button>
-              ${renderJobMenu(props, selectedJob, { rowActions: false })}
+              ${renderJobMenu(props, selectedJob)}
             `
           : nothing}
       </div>
@@ -928,23 +963,29 @@ function renderDetailHeader(props: CronProps, mode: CronPanelMode, selectedJob?:
   `;
 }
 
-function renderEnabledSwitch(props: CronProps, job: CronJob) {
+function renderEnabledSwitch(
+  props: CronProps,
+  job: CronJob,
+  opts?: { compact?: boolean; testId?: string },
+) {
+  const stateLabel = job.enabled ? t("cron.detail.active") : t("cron.detail.paused");
+  const actionLabel = job.enabled ? t("cron.actions.pause") : t("cron.actions.resume");
   return html`
     <button
       type="button"
       class="cron-switch ${job.enabled ? "cron-switch--on" : ""}"
       role="switch"
       aria-checked=${job.enabled ? "true" : "false"}
-      data-test-id="cron-toggle-enabled"
+      aria-label=${opts?.compact ? actionLabel : nothing}
+      title=${opts?.compact ? actionLabel : nothing}
+      data-test-id=${opts?.testId ?? "cron-toggle-enabled"}
       ?disabled=${props.busy}
       @click=${() => props.onToggle(job, !job.enabled)}
     >
       <span class="cron-switch__track" aria-hidden="true">
         <span class="cron-switch__thumb"></span>
       </span>
-      <span class="cron-switch__label">
-        ${job.enabled ? t("cron.detail.active") : t("cron.detail.paused")}
-      </span>
+      ${opts?.compact ? nothing : html`<span class="cron-switch__label">${stateLabel}</span>`}
     </button>
   `;
 }
@@ -1875,15 +1916,17 @@ function renderRunsSection(props: CronProps) {
   return html`
     <div class="cron-runs">
       <div class="cron-run-filters">
-        <label class="field cron-run-filter-search">
-          <span>${t("cron.runs.searchRuns")}</span>
+        <div class="cron-search-box cron-run-filter-search">
+          <span class="cron-search-box__icon" aria-hidden="true">${icon("search")}</span>
           <input
+            type="search"
             .value=${props.runsQuery}
+            aria-label=${t("cron.runs.searchRuns")}
             placeholder=${t("cron.runs.searchPlaceholder")}
             @input=${(e: Event) =>
               props.onRunsFiltersChange({ cronRunsQuery: (e.target as HTMLInputElement).value })}
           />
-        </label>
+        </div>
         ${renderFilterDropdown({
           id: "status",
           title: t("cron.runs.status"),
@@ -1916,19 +1959,19 @@ function renderRunsSection(props: CronProps) {
             void props.onRunsFiltersChange({ cronRunsDeliveryStatuses: [] });
           },
         })}
-        <label class="field">
-          <span>${t("cron.jobs.sort")}</span>
-          <select
-            .value=${props.runsSortDir}
-            @change=${(e: Event) =>
-              props.onRunsFiltersChange({
-                cronRunsSortDir: (e.target as HTMLSelectElement).value as CronSortDir,
-              })}
-          >
-            <option value="desc">${t("cron.runs.newestFirst")}</option>
-            <option value="asc">${t("cron.runs.oldestFirst")}</option>
-          </select>
-        </label>
+        <select
+          class="cron-run-sort"
+          aria-label=${t("cron.jobs.sort")}
+          title=${t("cron.jobs.sort")}
+          .value=${props.runsSortDir}
+          @change=${(e: Event) =>
+            props.onRunsFiltersChange({
+              cronRunsSortDir: (e.target as HTMLSelectElement).value as CronSortDir,
+            })}
+        >
+          <option value="desc">${t("cron.runs.newestFirst")}</option>
+          <option value="asc">${t("cron.runs.oldestFirst")}</option>
+        </select>
       </div>
       ${runs.length === 0
         ? hasRunFilters

--- a/ui/src/styles/cron.css
+++ b/ui/src/styles/cron.css
@@ -11,7 +11,7 @@
 
 .cron-stats {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 12px;
 }
 
@@ -21,6 +21,46 @@
   gap: 8px;
   padding: 14px 16px;
   min-width: 0;
+}
+
+/* Failing card is a drill-down into run history filtered to errors. */
+.cron-stat--action {
+  position: relative;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    background var(--duration-fast) var(--ease-out);
+}
+
+.cron-stat--action:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+}
+
+.cron-stat__go {
+  position: absolute;
+  top: 50%;
+  right: 12px;
+  transform: translateY(-50%);
+  display: inline-flex;
+  color: var(--muted);
+  opacity: 0;
+  transition: opacity var(--duration-fast) var(--ease-out);
+}
+
+.cron-stat__go svg {
+  width: 14px;
+  height: 14px;
+  stroke: currentColor;
+  fill: none;
+}
+
+.cron-stat--action:hover .cron-stat__go,
+.cron-stat--action:focus-visible .cron-stat__go {
+  opacity: 1;
 }
 
 .cron-stat__label {
@@ -133,8 +173,25 @@
   padding-left: 32px;
 }
 
-.cron-new-task {
+/* The global :focus-visible outline draws an offset accent rectangle around
+   the input, and the accent is red — it reads as an error state. Focus is a
+   quiet border tint instead. */
+.cron-search-box input:focus,
+.cron-search-box input:focus-visible {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 46%, var(--border));
+  background: color-mix(in srgb, var(--bg-elevated) 88%, transparent);
+}
+
+.cron-toolbar__end {
   margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.cron-new-task {
   flex: 0 0 auto;
   gap: 6px;
 }
@@ -235,7 +292,7 @@
   grid-template-columns: minmax(180px, 1.6fr) minmax(150px, 1.1fr) minmax(110px, 0.8fr) minmax(
       140px,
       0.9fr
-    ) 44px;
+    ) 116px;
   gap: 12px;
   align-items: center;
   padding: 0 16px;
@@ -371,7 +428,22 @@
 
 .cron-table__actions {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
+  gap: 6px;
+}
+
+.cron-row-run {
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+
+.cron-row-run svg {
+  width: 12px;
+  height: 12px;
 }
 
 .cron-table__footer {
@@ -1106,17 +1178,33 @@
 }
 
 .cron-run-filters {
-  display: grid;
-  grid-template-columns: minmax(200px, 1fr) minmax(140px, 180px) minmax(140px, 180px) minmax(
-      130px,
-      160px
-    );
-  gap: 10px;
-  align-items: end;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 .cron-run-filter-search {
-  min-width: 0;
+  flex: 1 1 220px;
+}
+
+/* Match the .btn--sm dropdown triggers beside it instead of the native look. */
+.cron-run-sort {
+  flex: 0 0 auto;
+  width: auto;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  cursor: pointer;
+}
+
+.cron-run-sort:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
 }
 
 .cron-runs__empty {
@@ -1131,6 +1219,7 @@
 
 .cron-filter-dropdown {
   min-width: 0;
+  flex: 0 0 auto;
 }
 
 .cron-filter-dropdown__details {
@@ -1146,9 +1235,16 @@
 }
 
 .cron-filter-dropdown__trigger {
-  width: 100%;
   justify-content: space-between;
   text-align: left;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.cron-filter-dropdown__trigger svg {
+  width: 12px;
+  height: 12px;
+  color: var(--muted);
 }
 
 .cron-filter-dropdown__panel {
@@ -1287,14 +1383,6 @@
 /* ── Responsive ── */
 
 @media (max-width: 1100px) {
-  .cron-stats {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .cron-run-filters {
-    grid-template-columns: 1fr;
-  }
-
   .cron-filter-dropdown__panel {
     width: 100%;
     max-width: none;
@@ -1329,7 +1417,7 @@
   }
 
   .cron-table__row {
-    grid-template-columns: minmax(0, 1fr) 44px;
+    grid-template-columns: minmax(0, 1fr) 116px;
     row-gap: 4px;
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #106043. The Automations page had five usability problems: the search box's focus ring rendered as an offset red rectangle (reads as a validation error), the `Automations | Run history` tabs occupied their own row above the toolbar, the Failing stat card was inert, a permanent "Scheduler: Enabled" chip card conveyed nothing actionable, and the most common per-job actions (Run now, Pause/Resume) were hidden behind the row's ⋯ menu.

## Why This Change Was Made

Daily-use feedback (maintainer): controls should be one row, the failing count should be a drill-down, scheduler state only matters when it is off, and pause/run-now belong on the row, not in a menu.

## User Impact

- **One toolbar row** for both list tabs: view pills + All/Active/Paused + search + filter popover, with refresh and New automation pinned right (`ui/src/pages/cron/view.ts`).
- **Quiet search focus**: cron search inputs replace the global offset outline with a subtle accent border tint (`ui/src/styles/cron.css`).
- **Failing card is a button**: clicking it opens Run history pre-filtered to `status=error` (`onShowFailingRuns` in `ui/src/pages/cron/cron-page.ts`).
- **Scheduler card removed**: a danger banner ("Scheduler disabled — The scheduler is stopped.") appears above the toolbar only while `cron.status.enabled` is false; stats grid is now 3 cards.
- **Visible row actions**: every row gets a Run now (▶) button and an enabled switch; the ⋯ menu keeps Run if due / Clone / Remove. The detail-header switch behavior is unchanged.
- **Run history filters** compacted into a single unlabeled row (search box, status/delivery dropdowns, sort select) used by both the Run history tab and the job detail history tab.
- i18n: removed the now-unused `cron.stats.scheduler` key; generated bundles pruned via `sync --write` (fallbacks=0, removal only — no new keys).

### Screenshots

| List (one-row toolbar, 3 stat cards, row actions) | Search focus | Failing → Run history |
| --- | --- | --- |
| ![list](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/automations-redesign-2026-07/cron-list.png) | ![focus](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/automations-redesign-2026-07/cron-search-focus.png) | ![failing](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/automations-redesign-2026-07/cron-failing-history.png) |

## Evidence

- Mock-gateway Playwright screenshots above (dark, 1440×860) show the merged toolbar, the quiet focus ring, per-row ▶ + switch + ⋯, and the failing-card drill-down landing on Run history with the Error status filter applied.
- `pnpm test ui/src/pages/cron` (view + page tests) green on Blacksmith Testbox, including new coverage: failing-card click → activity tab + `cron.runs` called with `statuses: ["error"]`; inline row Run now / toggle wiring; scheduler banner only when `enabled: false`.
- `pnpm check:changed` green on Testbox.
- i18n: `sync --write` output `fallbacks=0` for all 20 locales; diff is exactly one deleted key per bundle.

### Follow-up in this PR

- Run-history rendering extracted to `ui/src/pages/cron/view-runs.ts` with a local leaf props contract (no module cycle; `view.ts` 2069 → 1803 lines).
- Autoreview (Codex, branch vs origin/main): clean, no actionable findings.
