### PR TITLE
fix(ui): allow session creation during refresh

### DIFF
--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -268,6 +268,82 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
     }
   });
 
+  it("creates a session while a canonical session refresh is pending", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const sessionKey = "agent:main:refresh-overlap-e2e";
+    const listResponse = {
+      count: 0,
+      path: "",
+      sessions: [],
+      ts: Date.now(),
+    };
+    const gateway = await installMockGateway(page, {
+      workspaceGit: true,
+      methodResponses: {
+        "agents.list": {
+          agents: [
+            {
+              id: "main",
+              identity: { name: "Main" },
+              name: "Main",
+              workspace: WORKSPACE,
+              workspaceGit: true,
+            },
+          ],
+          defaultId: "main",
+          mainKey: "main",
+          scope: "agent",
+        },
+        "sessions.create": { key: sessionKey },
+        "sessions.list": listResponse,
+        "worktrees.branches": {
+          branches: [{ kind: "local", name: "main" }],
+          defaultBranch: "main",
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}new`);
+      const message = page.locator(".new-session-page__message");
+      await message.waitFor({ state: "visible", timeout: 10_000 });
+      const listCalls = (await gateway.getRequests("sessions.list")).length;
+
+      await gateway.deferNext("sessions.list");
+      await gateway.emitGatewayEvent("sessions.changed", {
+        key: "agent:main:other-client",
+        kind: "direct",
+        reason: "update",
+        sessionKey: "agent:main:other-client",
+        updatedAt: Date.now(),
+      });
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.list")).length)
+        .toBe(listCalls + 1);
+
+      await message.fill("create during refresh");
+      await page.getByRole("button", { name: "Start session" }).click();
+      const create = await gateway.waitForRequest("sessions.create");
+      expect(create.params).toMatchObject({
+        agentId: "main",
+        message: "create during refresh",
+      });
+      expect(new URL(page.url()).pathname).toBe("/new");
+
+      await gateway.resolveDeferred("sessions.list", listResponse);
+      await expect
+        .poll(() => new URL(page.url()).search)
+        .toContain(`session=${encodeURIComponent(sessionKey)}`);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("locks the submitted draft until creation settles and restores it after failure", async () => {
     const context = await browser.newContext({
       locale: "en-US",

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -229,6 +229,43 @@ describe("createSessionCapability", () => {
     sessions.dispose();
   });
 
+  it("creates a session while a list refresh is in flight", async () => {
+    const pendingList = deferred<SessionsListResult>();
+    let listCalls = 0;
+    const key = "agent:main:created";
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        listCalls += 1;
+        return listCalls === 1
+          ? await pendingList.promise
+          : sessionsResult([{ key, kind: "direct", updatedAt: 2 }], 2);
+      }
+      if (method === "sessions.create") {
+        return { key };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { gateway } = createGatewayHarness(client);
+    const sessions = createSessionCapability(gateway);
+
+    const refresh = sessions.refresh({ force: true });
+    expect(sessions.state.loading).toBe(true);
+
+    const created = sessions.create({ agentId: "main" });
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith("sessions.create", { agentId: "main" }),
+    );
+
+    pendingList.resolve(sessionsResult([], 1));
+    await expect(created).resolves.toBe(key);
+    await refresh;
+
+    expect(listCalls).toBe(2);
+    expect(sessions.state.result?.sessions[0]?.key).toBe(key);
+    sessions.dispose();
+  });
+
   it("returns the initial-run rejection without discarding the created session key", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.create") {

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -805,7 +805,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
 
   const createResult = async (params: SessionCreateParams = {}) => {
     const scope = captureConnection();
-    if (!scope || state.loading) {
+    if (!scope) {
       return null;
     }
     try {
@@ -821,8 +821,8 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       if (!isCurrentConnection(scope)) {
         return null;
       }
-      // Creation can originate outside the sidebar. Notify presentation owners
-      // after refresh so they can reconcile the new row without guessing from list churn.
+      // Creation may overlap read-only list loading. Notify presentation owners
+      // after its queued refresh so they never guess from stale list churn.
       for (const listener of createdListeners) {
         listener(result.key);
       }


### PR DESCRIPTION
## What Problem This Solves

Submitting New Session while the shared session list was refreshing returned a local failure without ever sending `sessions.create`. Users had to retry even though the Gateway was healthy.

Closes #105968.

## Why This Change Was Made

Session creation is a write and does not depend on completion of a read-only `sessions.list`. The capability already queues its forced post-create refresh behind any in-flight list request, so creation can proceed while retaining authoritative post-write state and connection-epoch checks.

## User Impact

New Session and fork actions no longer fail spuriously when they overlap a canonical session refresh. The UI still waits for the queued authoritative refresh before navigating or notifying presentation owners.

## Evidence

- Deterministic capability regression: a held `sessions.list` no longer suppresses `sessions.create`; the queued follow-up list wins and publishes the created row.
- Exact rebased head `468122ab621`; its UI patch is byte-identical to trusted Testbox head `ea89e62e837` on `tbx_01kxd4pz0mztyt8n787a4zd1g1` ([run 29230914079](https://github.com/openclaw/openclaw/actions/runs/29230914079)): `check:changed` passed, the session capability suite passed 18/18, and New Session Chromium passed 7/7. The final rebases only adopted repaired current-main CI/sidebar baselines; `node scripts/check-kysely-guardrails.mjs` and `git diff --check` pass at the final head.
- The browser journey holds a canonical refresh after an external `sessions.changed` event, observes `sessions.create` before releasing it, verifies the page remains on `/new`, then verifies navigation to the created key.
- Behavior contract anti-cheat rerun — 1/1 Chromium passed.
- Fresh whole-branch structured autoreview — clean, no accepted/actionable findings, 0.94 confidence.

No screenshot uploaded because public image upload was not separately approved.
