### PR TITLE
improve(ui): restyle composer send button as filled accent circle

### DIFF
--- a/ui/src/components/icons.ts
+++ b/ui/src/components/icons.ts
@@ -240,6 +240,12 @@ export const icons = {
       <path d="m19 12-7 7-7-7" />
     </svg>
   `,
+  arrowUp: html`
+    <svg viewBox="0 0 24 24">
+      <path d="M12 19V5" />
+      <path d="m5 12 7-7 7 7" />
+    </svg>
+  `,
   arrowLeft: html`
     <svg viewBox="0 0 24 24">
       <path d="m12 19-7-7 7-7" />

--- a/ui/src/components/icons.ts
+++ b/ui/src/components/icons.ts
@@ -234,18 +234,8 @@ export const icons = {
       <path d="M10 18h4" />
     </svg>
   `,
-  arrowDown: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M12 5v14" />
-      <path d="m19 12-7 7-7-7" />
-    </svg>
-  `,
-  arrowUp: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M12 19V5" />
-      <path d="m5 12 7-7 7 7" />
-    </svg>
-  `,
+  arrowDown: html` <svg viewBox="0 0 24 24"><path d="M12 5v14m7-7-7 7-7-7" /></svg> `,
+  arrowUp: html` <svg viewBox="0 0 24 24"><path d="M12 19V5m-7 7 7-7 7 7" /></svg> `,
   arrowLeft: html`
     <svg viewBox="0 0 24 24">
       <path d="m12 19-7-7 7-7" />

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -2129,7 +2129,7 @@ function renderChatPrimaryActions(props: ChatRunControlsProps) {
                       ?disabled=${!props.canSend || props.sending}
                       aria-label=${t("chat.runControls.queueMessage")}
                     >
-                      ${icons.send}
+                      ${icons.arrowUp}
                       <span class="agent-chat__control-label">${t("chat.runControls.queue")}</span>
                     </button>
                   </openclaw-tooltip>
@@ -2159,7 +2159,7 @@ function renderChatPrimaryActions(props: ChatRunControlsProps) {
                     ? t("chat.runControls.queueMessage")
                     : t("chat.runControls.sendMessage")}
                 >
-                  ${icons.send}
+                  ${icons.arrowUp}
                   <span class="agent-chat__control-label"
                     >${props.isBusy
                       ? t("chat.runControls.queue")

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -1179,7 +1179,7 @@ class NewSessionPage extends OpenClawLightDomElement {
                 aria-label=${startLabel}
                 @click=${() => void this.submit()}
               >
-                ${this.submitting ? icons.loader : icons.send}
+                ${this.submitting ? icons.loader : icons.arrowUp}
               </button>
             </openclaw-tooltip>
           </div>

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2201,6 +2201,9 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   }
 }
 
+/* Send is the primary action of the whole surface, so it gets the same solid
+   accent treatment as .btn.primary; variants (--stop, --voice*) override the
+   fill instead of reintroducing borders. */
 .chat-send-btn {
   display: inline-flex;
   align-items: center;
@@ -2209,15 +2212,16 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   min-width: 36px;
   width: 36px;
   height: 36px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--accent);
-  background: transparent;
-  color: var(--accent);
+  border-radius: var(--radius-full);
+  border: none;
+  background: var(--accent);
+  color: var(--primary-foreground);
+  box-shadow: 0 1px 3px var(--accent-subtle);
   flex-shrink: 0;
   transition:
     background var(--duration-fast) ease,
-    border-color var(--duration-fast) ease,
     color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease,
     opacity var(--duration-fast) ease;
   padding: 0;
 }
@@ -2236,19 +2240,18 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 }
 
 .chat-send-btn svg {
-  width: 20px;
-  height: 20px;
+  width: 18px;
+  height: 18px;
   stroke: currentColor;
   fill: none;
-  stroke-width: 1.5px;
+  stroke-width: 2px;
   stroke-linecap: round;
   stroke-linejoin: round;
 }
 
 .chat-send-btn:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--accent) 11%, transparent);
-  border-color: var(--accent-hover);
-  color: var(--accent-hover);
+  background: var(--accent-hover);
+  box-shadow: 0 2px 12px var(--accent-glow);
 }
 
 .chat-send-btn:focus-visible {
@@ -2256,23 +2259,28 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
 }
 
+/* Muted fill (not a ghost outline) while there is nothing to send, so the
+   accent fill itself signals "ready". */
 .chat-send-btn:disabled {
-  border-color: color-mix(in srgb, var(--muted) 45%, transparent);
-  background: transparent;
+  background: color-mix(in srgb, var(--muted) 16%, transparent);
   color: var(--muted);
-  opacity: 0.55;
+  box-shadow: none;
+  opacity: 0.8;
   cursor: not-allowed;
 }
 
-/* Idle voice ring stays muted so the idle -> hover -> recording progression
-   escalates (40% -> 70% -> full ring via --stop); a full-strength idle ring
-   makes recording state indistinguishable at a glance. */
+/* Idle voice fill stays muted so the idle -> hover -> recording progression
+   escalates (10% -> 18% -> live meter + breathing glow); a full-strength idle
+   fill makes recording state indistinguishable at a glance. */
 .chat-send-btn--voice {
-  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  color: var(--accent);
+  box-shadow: none;
 }
 
 .chat-send-btn--voice:hover:not(:disabled) {
-  border-color: color-mix(in srgb, var(--accent) 70%, transparent);
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  box-shadow: none;
 }
 
 /* Live voice input: the level meter itself is the control. Keeping it accent
@@ -2285,8 +2293,9 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   min-width: 64px;
   padding: 0 14px;
   border-radius: var(--radius-full);
-  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
-  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--accent);
+  box-shadow: none;
 }
 
 .chat-send-btn--voice-live::after {
@@ -2301,8 +2310,8 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 }
 
 .chat-send-btn--voice-live:hover:not(:disabled) {
-  border-color: color-mix(in srgb, var(--accent) 75%, transparent);
-  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
+  box-shadow: none;
 }
 
 .chat-send-btn--voice-live .agent-chat__voice-activity {
@@ -2357,13 +2366,12 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   opacity: 0.25;
 }
 
-/* Filled square + soft danger fill so Stop generating reads as the one
-   destructive control; the outline-only square was ambiguous next to other
-   36px icon buttons. */
+/* Soft danger fill so Stop generating reads as the one destructive control
+   next to the accent-filled send button. */
 .chat-send-btn--stop {
-  border-color: color-mix(in srgb, var(--danger) 45%, transparent);
-  background: color-mix(in srgb, var(--danger) 10%, transparent);
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
   color: var(--danger);
+  box-shadow: none;
 }
 
 .chat-send-btn--stop svg {
@@ -2374,9 +2382,9 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 }
 
 .chat-send-btn--stop:hover:not(:disabled) {
-  border-color: var(--danger);
   background: color-mix(in srgb, var(--danger) 18%, transparent);
   color: color-mix(in srgb, var(--danger) 82%, #fff);
+  box-shadow: none;
 }
 
 @media (min-width: 1600px) {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2254,9 +2254,11 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   box-shadow: 0 2px 12px var(--accent-glow);
 }
 
+/* Outline (not box-shadow) so the hover rules' higher-specificity box-shadow
+   overrides can never swallow the keyboard focus indicator. */
 .chat-send-btn:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
 }
 
 /* Muted fill (not a ghost outline) while there is nothing to send, so the


### PR DESCRIPTION
## What Problem This Solves

The composer send button rendered as an outline ghost: transparent background, 1px accent border, and an outlined paper-plane glyph. Every other primary action in the Control UI uses the solid `.btn.primary` accent fill, so the single most important action on the chat surface looked like a secondary control, and the border-around-an-outlined-icon read as double-stroked and wireframe-y next to the rest of the design.

## Why This Change Was Made

Send is the primary action of the whole surface and should carry the same visual weight as `.btn.primary`. The redesign makes the button a solid accent circle with a white arrow-up glyph (the shape/glyph convention users already know from other chat products), keeps a muted fill while there is nothing to send, and drops borders from the stop/voice variants so the whole control family escalates via fill strength instead of outline strength.

## User Impact

- Send button in the chat composer and new-session start screen is now a filled accent circle with an arrow-up glyph; hover uses the accent-hover color plus the same glow as `.btn.primary`.
- Disabled state is a quiet muted fill instead of a ghost outline, so the accent fill itself signals "ready to send".
- Stop generating keeps its soft danger fill, now borderless.
- Voice idle/live states escalate via fill strength (10% -> 18% -> live meter + breathing glow) instead of border strength; behavior is unchanged.

## Evidence

Filled send (chat composer):
![chat filled send](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/composer-send-button/chat-filled-send.png)

Empty composer (voice idle tint):
![chat empty voice](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/composer-send-button/chat-empty-voice.png)

Start screen (disabled muted fill):
![new session disabled](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/composer-send-button/new-session-disabled.png)

Verified against the mock-gateway dev harness (`pnpm dev:ui:mock`) on the chat and `/new` surfaces. Delegated `pnpm check:changed` and the composer unit tests run on Blacksmith Testbox (results posted before merge).


Keyboard focus ring (offset outline, survives hover):
![send focus](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/composer-send-button/send-focus.png) ![send focus hover](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/composer-send-button/send-focus-hover.png)

Autoreview (Codex `gpt-5.6-sol`, xhigh) ran clean on the final diff; an earlier pass caught a hover-vs-focus-ring specificity regression that is fixed in the branch.
