### PR TITLE
fix: prevent channel allowlists from granting owner access

### DIFF
--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -542,7 +542,7 @@ Group owners can toggle per-group activation with a standalone message:
 - `/activation mention`
 - `/activation always`
 
-`/activation` is a core owner-gated command and only applies in group chats. Owner means the sender matches the channel's `allowFrom` / `commands.ownerAllowFrom` (when no allowlist is configured, the account's own id counts as owner). The stored mode overrides that group's `requireMention` on channels that consult it (Google Chat, QQBot, Telegram, WhatsApp), and the group system-prompt intro reflects the active mode everywhere.
+`/activation` is a core owner-gated command and only applies in group chats. Owner means the sender matches `commands.ownerAllowFrom`; channel `allowFrom` lists only control ordinary channel and command access. The stored mode overrides that group's `requireMention` on channels that consult it (Google Chat, QQBot, Telegram, WhatsApp), and the group system-prompt intro reflects the active mode everywhere.
 
 ## Context fields
 

--- a/scripts/ts-max-loc-baseline-v2.json
+++ b/scripts/ts-max-loc-baseline-v2.json
@@ -670,7 +670,7 @@
   "src/agents/worktrees/service.ts": 851,
   "src/audit/audit-event-store.ts": 703,
   "src/auto-reply/chunk.ts": 557,
-  "src/auto-reply/command-auth.ts": 710,
+  "src/auto-reply/command-auth.ts": 699,
   "src/auto-reply/commands-registry.shared.ts": 1061,
   "src/auto-reply/dispatch.ts": 737,
   "src/auto-reply/reply/abort.ts": 524,

--- a/src/auto-reply/command-auth.owner-default.test.ts
+++ b/src/auto-reply/command-auth.owner-default.test.ts
@@ -78,6 +78,30 @@ describe("senderIsOwner only reflects explicit owner authorization", () => {
     expect(auth.isAuthorizedSender).toBe(true);
   });
 
+  it("keeps channel allowlist senders authorized without owner status", () => {
+    const cfg = {
+      channels: { telegram: { allowFrom: ["200482621"] } },
+    } as OpenClawConfig;
+
+    const ctx = {
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "direct",
+      From: "telegram:200482621",
+      SenderId: "200482621",
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(auth.ownerList).toEqual([]);
+    expect(auth.senderIsOwner).toBe(false);
+    expect(auth.isAuthorizedSender).toBe(true);
+  });
+
   it("senderIsOwner is false when ownerAllowFrom is configured and sender does not match", () => {
     const cfg = {
       channels: { discord: {} },
@@ -147,7 +171,7 @@ describe("senderIsOwner only reflects explicit owner authorization", () => {
     expect(auth.senderIsOwner).toBe(true);
   });
 
-  it("senderIsOwner is true when ownerAllowFrom is wildcard (*)", () => {
+  it("ignores ownerAllowFrom wildcards", () => {
     const cfg = {
       channels: { discord: {} },
       commands: { ownerAllowFrom: ["*"] },
@@ -166,7 +190,9 @@ describe("senderIsOwner only reflects explicit owner authorization", () => {
       commandAuthorized: true,
     });
 
-    expect(auth.senderIsOwner).toBe(true);
+    expect(auth.ownerList).toEqual([]);
+    expect(auth.senderIsOwner).toBe(false);
+    expect(auth.isAuthorizedSender).toBe(true);
   });
 
   it("senderIsOwner is true for internal operator.admin sessions", () => {

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -49,11 +49,8 @@ type ProviderAllowFromResolution = {
 };
 
 type OwnerAuthorizationState = {
-  allowAll: boolean;
-  ownerAllowAll: boolean;
-  ownerCandidatesForCommands: string[];
+  commandOwnerCandidates: string[];
   explicitOwners: string[];
-  ownerList: string[];
 };
 
 function resolveProviderFromContext(
@@ -400,7 +397,7 @@ function resolveOwnerAuthorizationState(params: {
   const allowAll =
     !params.hadResolutionError &&
     (params.allowFromList.length === 0 || hasWildcardAllowFrom(params.allowFromList));
-  const ownerCandidatesForCommands = resolveOwnerCandidatesForCommands({
+  const channelCommandOwners = resolveOwnerCandidatesForCommands({
     plugin: params.plugin,
     cfg: params.cfg,
     accountId: params.accountId,
@@ -408,26 +405,22 @@ function resolveOwnerAuthorizationState(params: {
     allowAll,
     allowFromList: params.allowFromList,
   });
-  const ownerAllowAll = hasWildcardAllowFrom(configOwnerAllowFromList);
-  const explicitOwners = stripWildcardAllowFrom(configOwnerAllowFromList);
-  const explicitOverrides = stripWildcardAllowFrom(contextOwnerAllowFromList);
-  const ownerList = Array.from(
+  const explicitOwners = Array.from(new Set(stripWildcardAllowFrom(configOwnerAllowFromList)));
+  const contextCommandOwners = stripWildcardAllowFrom(contextOwnerAllowFromList);
+  // Channel and context lists can authorize commands within one transport, but only the global
+  // owner list grants owner-only command and action authority.
+  const commandOwnerCandidates = Array.from(
     new Set(
       explicitOwners.length > 0
         ? explicitOwners
-        : ownerAllowAll
-          ? []
-          : explicitOverrides.length > 0
-            ? explicitOverrides
-            : ownerCandidatesForCommands,
+        : contextCommandOwners.length > 0
+          ? contextCommandOwners
+          : channelCommandOwners,
     ),
   );
   return {
-    allowAll,
-    ownerAllowAll,
-    ownerCandidatesForCommands,
+    commandOwnerCandidates,
     explicitOwners,
-    ownerList,
   };
 }
 
@@ -659,15 +652,13 @@ export function resolveCommandAuthorization(params: {
     from,
     chatType: ctx.ChatType,
   });
-  const matchedSender = ownerState.ownerList.length
-    ? senderCandidates.find((candidate) => ownerState.ownerList.includes(candidate))
+  const matchedSender = ownerState.explicitOwners.length
+    ? senderCandidates.find((candidate) => ownerState.explicitOwners.includes(candidate))
     : undefined;
-  const matchedCommandOwner = ownerState.ownerCandidatesForCommands.length
-    ? senderCandidates.find((candidate) =>
-        ownerState.ownerCandidatesForCommands.includes(candidate),
-      )
+  const matchedCommandOwner = ownerState.commandOwnerCandidates.length
+    ? senderCandidates.find((candidate) => ownerState.commandOwnerCandidates.includes(candidate))
     : undefined;
-  const senderId = matchedSender ?? senderCandidates[0];
+  const senderId = matchedSender ?? matchedCommandOwner ?? senderCandidates[0];
 
   const enforceOwner = Boolean(plugin?.commands?.enforceOwnerForCommands);
   const senderIsOwnerByIdentity = Boolean(matchedSender);
@@ -675,16 +666,14 @@ export function resolveCommandAuthorization(params: {
     isInternalMessageChannel(ctx.Provider) &&
     Array.isArray(ctx.GatewayClientScopes) &&
     ctx.GatewayClientScopes.includes("operator.admin");
-  const ownerAllowlistConfigured = ownerState.ownerAllowAll || ownerState.explicitOwners.length > 0;
-  const senderIsOwner = senderIsOwnerByIdentity || senderIsOwnerByScope || ownerState.ownerAllowAll;
+  const ownerAllowlistConfigured = ownerState.explicitOwners.length > 0;
+  const senderIsOwner = senderIsOwnerByIdentity || senderIsOwnerByScope;
   const requireOwner = enforceOwner || ownerAllowlistConfigured;
   const isOwnerForCommands = !requireOwner
     ? true
-    : ownerState.ownerAllowAll
-      ? true
-      : ownerAllowlistConfigured
-        ? senderIsOwner
-        : senderIsOwnerByScope || Boolean(matchedCommandOwner);
+    : ownerAllowlistConfigured
+      ? senderIsOwner
+      : senderIsOwnerByScope || Boolean(matchedCommandOwner);
   const nativeCommandAuthorized =
     commandAuthorized && isNativeCommandTurn(resolveCommandTurnContext(ctx)) && !requireOwner;
   const isAuthorizedSender = resolveCommandSenderAuthorization({
@@ -700,7 +689,7 @@ export function resolveCommandAuthorization(params: {
 
   return {
     providerId,
-    ownerList: ownerState.ownerList,
+    ownerList: ownerState.explicitOwners,
     senderId: senderId || undefined,
     senderIsOwner,
     isAuthorizedSender,

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -310,7 +310,7 @@ describe("resolveCommandAuthorization", () => {
     expect(otherAuth.isAuthorizedSender).toBe(false);
   });
 
-  it("uses owner allowlist override from context when configured", () => {
+  it("uses context owner candidates for command authorization without granting owner status", () => {
     setActivePluginRegistry(
       createTestRegistry([
         {
@@ -341,8 +341,9 @@ describe("resolveCommandAuthorization", () => {
       commandAuthorized: true,
     });
 
-    expect(auth.senderIsOwner).toBe(true);
-    expect(auth.ownerList).toEqual(["123"]);
+    expect(auth.senderIsOwner).toBe(false);
+    expect(auth.ownerList).toEqual([]);
+    expect(auth.isAuthorizedSender).toBe(true);
   });
 
   it("suppresses inherited owner status when the context forbids it", () => {
@@ -510,8 +511,8 @@ describe("resolveCommandAuthorization", () => {
       commandAuthorized: true,
     });
 
-    expect(auth.ownerList).toEqual(["123"]);
-    expect(auth.senderIsOwner).toBe(true);
+    expect(auth.ownerList).toEqual([]);
+    expect(auth.senderIsOwner).toBe(false);
     expect(auth.isAuthorizedSender).toBe(true);
   });
 
@@ -977,7 +978,8 @@ describe("resolveCommandAuthorization", () => {
         commandAuthorized: true,
       });
 
-      expect(auth.ownerList).toEqual(["123"]);
+      expect(auth.ownerList).toEqual([]);
+      expect(auth.senderIsOwner).toBe(false);
       expect(auth.isAuthorizedSender).toBe(true);
     });
 

--- a/src/commands/doctor-command-owner.test.ts
+++ b/src/commands/doctor-command-owner.test.ts
@@ -23,6 +23,10 @@ describe("command owner health", () => {
     expect(hasConfiguredCommandOwners({ commands: { ownerAllowFrom: ["telegram:123"] } })).toBe(
       true,
     );
+    expect(hasConfiguredCommandOwners({ commands: { ownerAllowFrom: ["*"] } })).toBe(false);
+    expect(hasConfiguredCommandOwners({ commands: { ownerAllowFrom: ["telegram:*"] } })).toBe(
+      false,
+    );
   });
 
   it("formats pairing senders as channel-scoped command owners", () => {

--- a/src/commands/doctor-command-owner.ts
+++ b/src/commands/doctor-command-owner.ts
@@ -11,7 +11,9 @@ function resolveConfiguredCommandOwners(cfg: OpenClawConfig): string[] {
   if (!Array.isArray(owners)) {
     return [];
   }
-  return normalizeStringEntries(owners.map((entry) => String(entry ?? "")));
+  return normalizeStringEntries(owners.map((entry) => String(entry ?? ""))).filter(
+    (entry) => entry !== "*" && !entry.endsWith(":*"),
+  );
 }
 
 /** Returns true when at least one owner sender id is configured. */


### PR DESCRIPTION
Closes #104984

## What Problem This Solves

Fixes an issue where a sender allowed to use one channel could be treated as a global command owner. With config commands enabled, that incorrectly allowed owner-gated mutations such as `/allowlist` and `/config`.

## Why This Change Was Made

The shared command authorization resolver now keeps transport-level command access separate from global owner authority. Only an explicit `commands.ownerAllowFrom` identity or an internal `operator.admin` session grants owner status; channel/context allowlists continue to authorize ordinary commands. Owner wildcards are ignored consistently with the documented contract, and doctor treats wildcard-only owner configuration as missing.

This central fix applies to every privileged command using the existing owner gate instead of adding command- or channel-specific authorization branches.

## User Impact

Channel allowlists still let approved senders talk to the bot and use ordinary commands. Owner-only commands now require an explicit command owner, preventing a channel-scoped identity from changing authorization or configuration globally.

Existing one-owner setups remain straightforward: the first approved DM pairing bootstraps `commands.ownerAllowFrom`, and doctor explains how to configure an owner when none exists.

## Evidence

- Blacksmith Testbox `tbx_01kxcy550168g8hy9w42rgyx65`: 99 focused authorization, `/allowlist`, command-gating, and doctor tests passed.
- `pnpm check:changed`: passed on the same current-main Testbox run, including formatting, TypeScript production/test checks, lint, import-cycle, and repository guards.
- Fresh structured Codex autoreview: no accepted/actionable findings; patch correct, confidence 0.94.
- AI-assisted: implementation and review performed with Codex; author reviewed the resulting code and validation.
