### PR TITLE
fix: prevent QA and terminal validation failures [AI]

### DIFF
--- a/extensions/qa-lab/src/crabline-transport.test.ts
+++ b/extensions/qa-lab/src/crabline-transport.test.ts
@@ -836,9 +836,9 @@ describe("crabline transport", () => {
       });
 
       try {
-        await transport.state.addInboundMessage({
+        const inbound = await transport.state.addInboundMessage({
           conversation: {
-            id: "-1001234567890",
+            id: "telegram-command-room",
             kind: "channel",
           },
           senderId: "100001",
@@ -856,7 +856,7 @@ describe("crabline transport", () => {
           url: `${telegram?.apiRoot}/bot${telegram?.botToken}/sendMessage`,
           init: {
             body: JSON.stringify({
-              chat_id: -1001234567890,
+              chat_id: inbound.conversation.id,
               text: "assistant via fake telegram",
             }),
             headers: { "content-type": "application/json" },
@@ -870,14 +870,14 @@ describe("crabline transport", () => {
 
         await expect(
           transport.waitForOutbound({
-            conversation: { id: "-1001234567890", kind: "group" },
+            conversation: { id: "telegram-command-room", kind: "channel" },
             textIncludes: "assistant via fake telegram",
             timeoutMs: 1_000,
           }),
         ).resolves.toMatchObject({
           conversation: {
-            id: "-1001234567890",
-            kind: "group",
+            id: "telegram-command-room",
+            kind: "channel",
           },
           direction: "outbound",
           text: "assistant via fake telegram",

--- a/extensions/qa-lab/src/crabline-transport.ts
+++ b/extensions/qa-lab/src/crabline-transport.ts
@@ -50,6 +50,11 @@ type QaCrablineTransportState = QaTransportState & {
   rememberProviderTarget: (providerTargetKey: string, qaTarget: string) => void;
 };
 
+function formatLogicalQaTarget({ conversation, threadId }: QaBusInboundMessageInput) {
+  const prefix = conversation.kind === "direct" ? "dm" : conversation.kind;
+  return threadId ? `thread:${conversation.id}/${threadId}` : `${prefix}:${conversation.id}`;
+}
+
 const TELEGRAM_LIFECYCLE_METHOD_RE = /\/(sendMessage|editMessageText|deleteMessage)$/u;
 
 function resolveTelegramQaSenderId(senderId: string) {
@@ -303,7 +308,9 @@ function createCrablineState(params: {
           senderId: providerSenderId,
         },
       });
-      targetByProviderTarget.set(providerInbound.providerTargetKey, providerInbound.qaTarget);
+      // Providers may coerce channel conversations to groups; preserve the scenario's logical
+      // target so outbound waits and assertions still match the original input.
+      targetByProviderTarget.set(providerInbound.providerTargetKey, formatLogicalQaTarget(input));
       const providerMessageId = await postCrablineInbound({
         adapter: params.adapter,
         providerInbound,

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -14,19 +14,13 @@ type CreateOptions = {
 type CreateGhosttyTerminalMock = Mock<
   (options: CreateOptions) => Promise<ReturnType<typeof createTerminalController>>
 >;
+type TerminalFactory = typeof import("./terminal-runtime.ts").createIsolatedGhosttyTerminal;
 
-// Vitest resets this test module but can retain terminal-panel.ts. Reuse one
-// mock so retained imports and the current test graph share the same identity.
-const createGhosttyTerminalMock = vi.hoisted(() => {
-  const scope = globalThis as typeof globalThis & {
-    openclawTestCreateGhosttyTerminalMock?: CreateGhosttyTerminalMock;
-  };
-  return (scope.openclawTestCreateGhosttyTerminalMock ??=
-    vi.fn<(options: CreateOptions) => Promise<ReturnType<typeof createTerminalController>>>());
-});
+const createGhosttyTerminalMock: CreateGhosttyTerminalMock = vi.fn();
 
 function createTerminalController(dispose: () => void = vi.fn()) {
   return {
+    readOnly: false,
     terminal: {
       cols: 100,
       rows: 30,
@@ -36,6 +30,9 @@ function createTerminalController(dispose: () => void = vi.fn()) {
     },
     write: vi.fn(),
     fit: vi.fn(),
+    resize: vi.fn(),
+    setReadOnly: vi.fn(),
+    attach: vi.fn(),
     dispose,
   };
 }
@@ -58,17 +55,15 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
-vi.mock("./terminal-runtime.ts", () => {
-  return { createIsolatedGhosttyTerminal: createGhosttyTerminalMock };
-});
-
 import { OpenClawTerminalPanel } from "./terminal-panel.ts";
 
 const TERMINAL_PANEL_ELEMENT_NAME = `test-openclaw-terminal-panel-${crypto.randomUUID()}`;
 
-// Keep the mounted panel and i18n manager in the current module graph when
-// the non-isolated runner has retained an earlier production registration.
-class TestTerminalPanel extends OpenClawTerminalPanel {}
+// The full non-isolated UI suite can import the production panel before this
+// test. Override its factory instead of relying on a module mock import order.
+class TestTerminalPanel extends OpenClawTerminalPanel {
+  protected override createTerminal = createGhosttyTerminalMock as unknown as TerminalFactory;
+}
 
 customElements.define(TERMINAL_PANEL_ELEMENT_NAME, TestTerminalPanel);
 
@@ -89,18 +84,7 @@ describe("OpenClawTerminalPanel", () => {
     let createOptions: CreateOptions | undefined;
     createGhosttyTerminalMock.mockImplementation(async (options: CreateOptions) => {
       createOptions = options;
-      return {
-        terminal: {
-          cols: 100,
-          rows: 30,
-          viewportY: 0,
-          write: vi.fn(),
-          focus: vi.fn(),
-        },
-        write: vi.fn(),
-        fit: vi.fn(),
-        dispose: vi.fn(),
-      };
+      return createTerminalController();
     });
     const requests: Array<{ method: string; params: unknown }> = [];
     const client: TerminalGatewayClient = {
@@ -156,20 +140,7 @@ describe("OpenClawTerminalPanel", () => {
   });
 
   it("fullscreen mode auto-opens without dock chrome and survives last-tab close", async () => {
-    createGhosttyTerminalMock.mockImplementation(async () => {
-      return {
-        terminal: {
-          cols: 100,
-          rows: 30,
-          viewportY: 0,
-          write: vi.fn(),
-          focus: vi.fn(),
-        },
-        write: vi.fn(),
-        fit: vi.fn(),
-        dispose: vi.fn(),
-      };
-    });
+    createGhosttyTerminalMock.mockImplementation(async () => createTerminalController());
     const requests: Array<{ method: string; params: unknown }> = [];
     const client: TerminalGatewayClient = {
       request: async <T>(method: string, params?: unknown) => {

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -147,6 +147,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
   private lifecycleSyncToken = 0;
   private resizeCleanup: (() => void) | null = null;
   private tabSeq = 0;
+  protected createTerminal = createIsolatedGhosttyTerminal;
   private readonly onGlobalKeyDown = (event: KeyboardEvent) => this.handleGlobalKey(event);
   private readonly onToggleRequest = (event: Event) => this.handleToggleRequest(event);
   // Re-clamp a dock sized on a larger window so the header/resizer never end
@@ -419,8 +420,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
     rows: number;
   }> {
     const connection = this.connectionFor(operation);
-    // Captured so the cancelled-open cleanup can close the session even if a
-    // teardown swaps this.connection while the open/attach RPC is in flight.
+    // Preserve the connection so cancelled-open cleanup still closes the in-flight session.
     const host = document.createElement("div");
     host.className = "tp-host";
     const id = `tab-${++this.tabSeq}`;
@@ -438,7 +438,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
     const tabRef = { current: undefined as TerminalTabState | undefined };
     let controller: GhosttyTerminalController;
     try {
-      controller = await createIsolatedGhosttyTerminal({
+      controller = await this.createTerminal({
         parent: host,
         readOnly: false,
         terminalOptions: {


### PR DESCRIPTION
## What Problem This Solves

Resolves two pre-existing validation failures that can keep required `main` checks red: QA Lab's Crabline transport loses a scenario's logical `channel:` target when a provider normalizes the conversation to `group`, and the terminal panel test can retain a stale module-mock identity when the full UI suite imports production code first.

## Why This Change Was Made

The Crabline adapter now records the scenario's logical target separately from its provider-normalized delivery target. The terminal panel keeps its production factory as the default while exposing a protected test seam, so tests no longer depend on Vitest module-cache import order.

This is AI-assisted maintainer work. The final patch was reviewed with the repository's autoreview workflow; no actionable findings remained.

## User Impact

No shipped product behavior changes. Required QA and UI validation becomes deterministic again, unblocking the repository merge queue.

## Evidence

- Blacksmith Testbox `tbx_01kxcy2e4ns9bbqyyj4sa28pam` / [run `29225604892`](https://github.com/openclaw/openclaw/actions/runs/29225604892)
- Focused QA + terminal tests: 25/25 passed
- Full UI suite: 236 files, 3,742 tests passed
- Changed-surface gate passed for all four touched files, including type, lint, LOC, dependency, SDK, database-first, sidecar, and import-cycle checks
- Fresh autoreview: clean, no accepted/actionable findings
