### PR TITLE
chore(ci): remove stale transcript export baseline

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -3630,7 +3630,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/gateway/session-transcript-readers.ts: readRecentSessionUsageFromTranscriptAsync",
   "src/gateway/session-transcript-readers.ts: readSessionMessageCount",
   "src/gateway/session-transcript-readers.ts: readSessionMessages",
-  "src/gateway/session-transcript-readers.ts: ResolvedTranscriptReadTarget",
   "src/gateway/session-transcript-readers.ts: visitSessionMessages",
   "src/gateway/session-utils.fs.ts: archiveFileOnDisk",
   "src/gateway/session-utils.fs.ts: archiveSessionTranscripts",


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails `node scripts/check-deadcode-exports.mjs` because #106052 added a baseline entry for `ResolvedTranscriptReadTarget` after #105913 made that export live again. The stale entry blocks the dependency lane for unrelated pull requests.

## Why This Change Was Made

Remove only the stale baseline row. The source export is still used, so no runtime or API change is needed.

## User Impact

No runtime impact. OpenClaw pull requests can pass the unused-export dependency gate again.

## Evidence

- Before on `d13e3c6adfe`: checker exits 1 with the single stale `ResolvedTranscriptReadTarget` entry.
- After: `node scripts/check-deadcode-exports.mjs` passes with 5,503 entries.
- `git diff --check` passes.
