### PR TITLE
fix(cli): stop rewriteUpdateFlagArgv from corrupting positional --update values

### DIFF
--- a/src/cli/run-main-policy.ts
+++ b/src/cli/run-main-policy.ts
@@ -37,8 +37,31 @@ function isBareParentDefaultHelpArgv(argv: string[]): boolean {
 
 export function rewriteUpdateFlagArgv(argv: string[]): string[] {
   // Preserve the old root --update spelling by rewriting before Commander registration.
+  // Only rewrite when --update is used as a root-level command (before any subcommand
+  // and before the -- end-of-options marker).  --update after -- or as a positional
+  // argument to another command must be left alone.
+  const endOfOptions = argv.indexOf("--");
+  const searchEnd = endOfOptions === -1 ? argv.length : endOfOptions;
+
   const index = argv.indexOf("--update");
-  if (index === -1) {
+  if (index === -1 || index >= searchEnd) {
+    return argv;
+  }
+
+  // Find the first non-flag, non-flag-value word (the subcommand slot).
+  // If a subcommand already exists before --update, then --update is a
+  // positional argument to that command, not a root-level flag.
+  for (let i = 2; i < index; i++) {
+    const arg = argv[i];
+    if (arg.startsWith("-")) {
+      // Skip the flag value when the flag starts with -- (long form).
+      if (arg.startsWith("--") && i + 1 < index && !argv[i + 1]!.startsWith("-")) {
+        i++;
+      }
+      continue;
+    }
+    // A non-flag word appears before --update: it's a subcommand.
+    // --update is therefore a positional argument, not a root command.
     return argv;
   }
 

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -130,6 +130,27 @@ describe("rewriteUpdateFlagArgv", () => {
       "--json",
     ]);
   });
+
+  it("does not rewrite --update after the -- end-of-options marker", () => {
+    expect(
+      rewriteUpdateFlagArgv(["node", "entry.js", "config", "set", "foo", "--", "--update"]),
+    ).toEqual(["node", "entry.js", "config", "set", "foo", "--", "--update"]);
+  });
+
+  it("does not rewrite --update used as a positional value for a subcommand", () => {
+    expect(
+      rewriteUpdateFlagArgv(["node", "entry.js", "config", "set", "update.channel", "--update"]),
+    ).toEqual(["node", "entry.js", "config", "set", "update.channel", "--update"]);
+  });
+
+  it("does not rewrite --update when a subcommand precedes it", () => {
+    expect(rewriteUpdateFlagArgv(["node", "entry.js", "status", "--update"])).toEqual([
+      "node",
+      "entry.js",
+      "status",
+      "--update",
+    ]);
+  });
 });
 
 describe("shouldEnsureCliPath", () => {


### PR DESCRIPTION
## What Problem This Solves

`rewriteUpdateFlagArgv` rewrites any occurrence of `--update` to `update`, even when `--update` appears:
- After the `--` end-of-options marker (where it's a positional value)
- After a subcommand like `config set` (where it's a value, not a root flag)

This corrupts user input and can silently change values passed to commands like `openclaw config set`. Fixes #105923.

## Why This Change Was Made

The function is meant to support the old root-level `--update` spelling (equivalent to the `update` subcommand). The fix constrains rewriting to only when `--update` is used as a root-level command — before any subcommand and before `--`.

The fix:
1. Finds the `--` end-of-options marker and only searches for `--update` before it
2. Checks for a subcommand (first non-flag, non-flag-value word) before `--update`; if one exists, `--update` is a positional argument, not a root command
3. Skips long-flag value pairs (`--flag value`) when scanning for subcommands

## Evidence

```
$ npx vitest run src/cli/run-main.test.ts --no-coverage -t "rewriteUpdateFlagArgv"

 Test Files  1 passed (1)
      Tests  7 passed | 36 skipped (43)
```

All 7 tests pass (4 existing + 3 new regression tests):
- `--update` after `--` is not rewritten
- `--update` as a positional value for a subcommand is not rewritten
- `--update` after a subcommand is not rewritten

## Merge Risk

Low. The change only affects the `rewriteUpdateFlagArgv` function used during CLI startup. Existing behavior for root-level `--update` is preserved. The only behavioral change is that `--update` used as a positional value (after `--` or after a subcommand) is no longer incorrectly rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)