### PR TITLE
fix(extra-params): preserve resolved cacheRetention against undefined own-property clobber

### DIFF
--- a/src/agents/embedded-agent-runner/extra-params.sampling.test.ts
+++ b/src/agents/embedded-agent-runner/extra-params.sampling.test.ts
@@ -517,46 +517,46 @@ describe("createStreamFnWithExtraParams sampling overrides", () => {
     { requestRetention: "none" as const, expected: "none", name: "explicit none" },
     { requestRetention: "short" as const, expected: "short", name: "explicit short" },
     { requestRetention: "long" as const, expected: "long", name: "explicit long" },
-  ])("merges configured cache retention with $name request options", ({
-    requestRetention,
-    expected,
-  }) => {
-    const underlying = vi.fn(() => ({
-      push: vi.fn(),
-      result: vi.fn(async () => undefined),
-      [Symbol.asyncIterator]: vi.fn(async function* () {
-        // empty stream
-      }),
-    })) as unknown as StreamFn;
-    const agent: { streamFn?: StreamFn } = { streamFn: underlying };
+  ])(
+    "merges configured cache retention with $name request options",
+    ({ requestRetention, expected }) => {
+      const underlying = vi.fn(() => ({
+        push: vi.fn(),
+        result: vi.fn(async () => undefined),
+        [Symbol.asyncIterator]: vi.fn(async function* () {
+          // empty stream
+        }),
+      })) as unknown as StreamFn;
+      const agent: { streamFn?: StreamFn } = { streamFn: underlying };
 
-    applyExtraParamsToAgent(
-      agent,
-      undefined,
-      "anthropic",
-      "claude-sonnet-5",
-      { cacheRetention: "long" },
-      undefined,
-      undefined,
-      undefined,
-      { supportsPromptCacheKey: true } as never,
-    );
+      applyExtraParamsToAgent(
+        agent,
+        undefined,
+        "anthropic",
+        "claude-sonnet-5",
+        { cacheRetention: "long" },
+        undefined,
+        undefined,
+        undefined,
+        { supportsPromptCacheKey: true } as never,
+      );
 
-    if (!agent.streamFn) {
-      throw new Error("expected extra params to wrap streamFn");
-    }
+      if (!agent.streamFn) {
+        throw new Error("expected extra params to wrap streamFn");
+      }
 
-    const requestOptions = { cacheRetention: requestRetention };
-    expect(requestOptions).toHaveProperty("cacheRetention");
-    void agent.streamFn(
-      { id: "claude-sonnet-5", api: "anthropic-messages", provider: "anthropic" } as never,
-      { messages: [], tools: [] } as never,
-      requestOptions,
-    );
+      const requestOptions = { cacheRetention: requestRetention };
+      expect(requestOptions).toHaveProperty("cacheRetention");
+      void agent.streamFn(
+        { id: "claude-sonnet-5", api: "anthropic-messages", provider: "anthropic" } as never,
+        { messages: [], tools: [] } as never,
+        requestOptions,
+      );
 
-    expect(underlying).toHaveBeenCalledTimes(1);
-    const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
-      .calls[0]?.[2] as { cacheRetention?: string } | undefined;
-    expect(callOptions?.cacheRetention).toBe(expected);
-  });
+      expect(underlying).toHaveBeenCalledTimes(1);
+      const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
+        .calls[0]?.[2] as { cacheRetention?: string } | undefined;
+      expect(callOptions?.cacheRetention).toBe(expected);
+    },
+  );
 });

--- a/src/agents/embedded-agent-runner/extra-params.sampling.test.ts
+++ b/src/agents/embedded-agent-runner/extra-params.sampling.test.ts
@@ -512,7 +512,15 @@ describe("createStreamFnWithExtraParams sampling overrides", () => {
     expect(second.fastMode).toBe(secondFastMode);
   });
 
-  it("preserves resolved cacheRetention when options carries an own-property undefined (proxy transport clobber)", () => {
+  it.each([
+    { requestRetention: undefined, expected: "long", name: "own undefined" },
+    { requestRetention: "none" as const, expected: "none", name: "explicit none" },
+    { requestRetention: "short" as const, expected: "short", name: "explicit short" },
+    { requestRetention: "long" as const, expected: "long", name: "explicit long" },
+  ])("merges configured cache retention with $name request options", ({
+    requestRetention,
+    expected,
+  }) => {
     const underlying = vi.fn(() => ({
       push: vi.fn(),
       result: vi.fn(async () => undefined),
@@ -538,18 +546,17 @@ describe("createStreamFnWithExtraParams sampling overrides", () => {
       throw new Error("expected extra params to wrap streamFn");
     }
 
-    // Simulate the proxy transport: options carries cacheRetention as an own
-    // property set to undefined, which would clobber the resolved value via
-    // spread without the fix.
+    const requestOptions = { cacheRetention: requestRetention };
+    expect(requestOptions).toHaveProperty("cacheRetention");
     void agent.streamFn(
       { id: "claude-sonnet-5", api: "anthropic-messages", provider: "anthropic" } as never,
       { messages: [], tools: [] } as never,
-      { cacheRetention: undefined },
+      requestOptions,
     );
 
     expect(underlying).toHaveBeenCalledTimes(1);
     const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
       .calls[0]?.[2] as { cacheRetention?: string } | undefined;
-    expect(callOptions?.cacheRetention).toBe("long");
+    expect(callOptions?.cacheRetention).toBe(expected);
   });
 });

--- a/src/agents/embedded-agent-runner/extra-params.sampling.test.ts
+++ b/src/agents/embedded-agent-runner/extra-params.sampling.test.ts
@@ -511,4 +511,45 @@ describe("createStreamFnWithExtraParams sampling overrides", () => {
     expect(first.fastMode).toBe(firstFastMode);
     expect(second.fastMode).toBe(secondFastMode);
   });
+
+  it("preserves resolved cacheRetention when options carries an own-property undefined (proxy transport clobber)", () => {
+    const underlying = vi.fn(() => ({
+      push: vi.fn(),
+      result: vi.fn(async () => undefined),
+      [Symbol.asyncIterator]: vi.fn(async function* () {
+        // empty stream
+      }),
+    })) as unknown as StreamFn;
+    const agent: { streamFn?: StreamFn } = { streamFn: underlying };
+
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "anthropic",
+      "claude-sonnet-5",
+      { cacheRetention: "long" },
+      undefined,
+      undefined,
+      undefined,
+      { supportsPromptCacheKey: true } as never,
+    );
+
+    if (!agent.streamFn) {
+      throw new Error("expected extra params to wrap streamFn");
+    }
+
+    // Simulate the proxy transport: options carries cacheRetention as an own
+    // property set to undefined, which would clobber the resolved value via
+    // spread without the fix.
+    void agent.streamFn(
+      { id: "claude-sonnet-5", api: "anthropic-messages", provider: "anthropic" } as never,
+      { messages: [], tools: [] } as never,
+      { cacheRetention: undefined },
+    );
+
+    expect(underlying).toHaveBeenCalledTimes(1);
+    const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0]?.[2] as { cacheRetention?: string } | undefined;
+    expect(callOptions?.cacheRetention).toBe("long");
+  });
 });

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -558,14 +558,13 @@ function createStreamFnWithExtraParams(
       return underlying(callModel, context, options);
     }
 
+    const effectiveCacheRetention = options?.cacheRetention ?? cacheRetention;
     return underlying(callModel, context, {
       ...streamParams,
-      ...(cacheRetention ? { cacheRetention } : {}),
       ...options,
-      // Re-assert the resolved cacheRetention when the caller's options carries
-      // an own-property undefined that would otherwise clobber it via spread
-      // (e.g. the proxy transport always emits cacheRetention as an own key).
-      ...(cacheRetention && options?.cacheRetention == null ? { cacheRetention } : {}),
+      // Callers can carry an own undefined value; treat nullish as absent while
+      // preserving explicit request-level none/short/long overrides.
+      ...(effectiveCacheRetention ? { cacheRetention: effectiveCacheRetention } : {}),
     });
   };
 

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -553,17 +553,14 @@ function createStreamFnWithExtraParams(
       typeof callModel.id === "string" ? callModel.id : undefined,
       readSupportsPromptCacheKey(callModel),
     );
-    const hasStreamParams = Object.keys(streamParams).length > 0 || cacheRetention;
-    if (!hasStreamParams) {
+    if (Object.keys(streamParams).length === 0 && !cacheRetention) {
       return underlying(callModel, context, options);
     }
-
     const effectiveCacheRetention = options?.cacheRetention ?? cacheRetention;
     return underlying(callModel, context, {
       ...streamParams,
       ...options,
-      // Callers can carry an own undefined value; treat nullish as absent while
-      // preserving explicit request-level none/short/long overrides.
+      // Own undefined means no request override; explicit none/short/long still wins.
       ...(effectiveCacheRetention ? { cacheRetention: effectiveCacheRetention } : {}),
     });
   };

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -562,6 +562,10 @@ function createStreamFnWithExtraParams(
       ...streamParams,
       ...(cacheRetention ? { cacheRetention } : {}),
       ...options,
+      // Re-assert the resolved cacheRetention when the caller's options carries
+      // an own-property undefined that would otherwise clobber it via spread
+      // (e.g. the proxy transport always emits cacheRetention as an own key).
+      ...(cacheRetention && options?.cacheRetention == null ? { cacheRetention } : {}),
     });
   };
 


### PR DESCRIPTION
## What Problem This Solves

Per-model `params.cacheRetention` is silently ignored on the embedded-agent path. The extra-params wrapper correctly resolves the per-model `cacheRetention` (e.g. `"long"`), but the proxy transport always emits `cacheRetention` as an own property set to `undefined`. JS spread semantics (`...options` last) cause the resolved value to be overwritten by `undefined`, so Anthropic requests always fall back to the default 5-minute cache TTL. Fixes #106014.

## Why This Change Was Made

The root cause is a spread ordering issue in `createStreamFnWithExtraParams`:
1. `resolveCacheRetention` correctly picks up per-model `params.cacheRetention`
2. The proxy transport's `buildProxyRequestOptions` includes `cacheRetention: options.cacheRetention` — an own property, even when undefined
3. `{ ...{cacheRetention: "long"}, ...{cacheRetention: undefined} }` → `{cacheRetention: undefined}`

The fix re-asserts the resolved `cacheRetention` after the spread when the caller's options carries a nullish own-property value, so the resolved per-model config takes precedence.

## Evidence

```
$ npx vitest run src/agents/embedded-agent-runner/extra-params.sampling.test.ts --no-coverage -t "preserves resolved cacheRetention"

 Test Files  2 passed (2)
      Tests  2 passed | 26 skipped (28)
```

The new regression test simulates the proxy transport path (options with `cacheRetention: undefined` as own property) and verifies the resolved `"long"` survives in the underlying streamFn call.

## Merge Risk

Low. The change only affects the case where both:
1. A resolved `cacheRetention` is present (from per-model params)
2. The caller's options carries `cacheRetention` as a nullish own-property

When the caller explicitly sets a non-nullish `cacheRetention`, it still wins. This is a narrow guard against the JS spread own-property-undefined quirk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)