### PR TITLE
ci: consolidate SMS webhook test reset

### DIFF
--- a/extensions/sms/src/webhook.test.ts
+++ b/extensions/sms/src/webhook.test.ts
@@ -7,7 +7,6 @@ import { computeTwilioSignature, parseTwilioFormBody } from "./twilio.js";
 import type { ResolvedSmsAccount } from "./types.js";
 import {
   createSmsWebhookHandler,
-  resetSmsWebhookRateLimiterForTest,
   createSmsWebhookReplayGuard,
   resetSmsWebhookReplayGuardsForTest,
 } from "./webhook.js";
@@ -116,7 +115,6 @@ function createMessageSid(index: number): string {
 describe("createSmsWebhookHandler", () => {
   beforeEach(() => {
     dispatchSmsInboundEvent.mockClear();
-    resetSmsWebhookRateLimiterForTest();
     resetSmsWebhookReplayGuardsForTest();
   });
 

--- a/extensions/sms/src/webhook.ts
+++ b/extensions/sms/src/webhook.ts
@@ -104,6 +104,8 @@ function resolveSmsWebhookReplayGuard(account: ResolvedSmsAccount): SmsWebhookRe
 
 export function resetSmsWebhookReplayGuardsForTest(): void {
   replayGuardsByAccount.clear();
+  invalidRequestRateLimiter.clear();
+  callbackDispatchRateLimiter.clear();
 }
 
 type SmsWebhookLog = {
@@ -150,11 +152,6 @@ function rejectInvalidRequestRateLimit(params: {
   params.log?.warn?.(`SMS webhook invalid-request rate limit exceeded for ${params.key}`);
   respondTwiml(params.res, 429, "Rate limit exceeded");
   return true;
-}
-
-export function resetSmsWebhookRateLimiterForTest(): void {
-  invalidRequestRateLimiter.clear();
-  callbackDispatchRateLimiter.clear();
 }
 
 // Each account route owns its guard so one saturated account cannot block sibling accounts.

--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -1018,7 +1018,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "extensions/sms/src/twilio.ts: parseTwilioFormBody",
   "extensions/sms/src/twilio.ts: TwilioSmsApiError",
   "extensions/sms/src/webhook.ts: createSmsWebhookReplayGuard",
-  "extensions/sms/src/webhook.ts: resetSmsWebhookRateLimiterForTest",
   "extensions/sms/src/webhook.ts: resetSmsWebhookReplayGuardsForTest",
   "extensions/synology-chat/src/channel.ts: createSynologyChatPlugin",
   "extensions/synology-chat/src/channel.ts: synologyChatMessageAdapter",


### PR DESCRIPTION
## What Problem This Solves

`checks-dependencies` inherited an unnecessary second test-only export for resetting SMS webhook rate limiters. The extra export expanded the dead-export baseline and left two reset calls that must stay synchronized.

## Why This Change Was Made

The existing webhook test reset now clears replay guards and both rate limiters. The redundant exported helper and its stale baseline entry are removed, leaving one canonical module-state reset for the test suite.

This is AI-assisted maintainer work. The final branch diff passed the repository autoreview workflow with no accepted or actionable findings.

## User Impact

No shipped runtime behavior changes. The dependency ratchet stays exact and SMS webhook tests reset all module state through one path.

## Evidence

- `fnm exec --using=24.16.0 node scripts/run-vitest.mjs extensions/sms/src/webhook.test.ts`: 8/8 passed
- `fnm exec --using=24.16.0 node scripts/check-deadcode-exports.mjs`: matched all 4,986 baseline entries
- Node 24 CI-like Control UI run with three workers: 236 files / 3,742 tests passed while investigating the concurrent `checks-ui` failure
- Fresh branch autoreview against `origin/main`: clean, 0.98 confidence
- Blacksmith Testbox allocation was attempted twice; both leases shut down before the command could start, so the focused proof used the documented local Node fallback
