### PR TITLE
fix(chat): preserve explicit current-source sends in Control UI history

### DIFF
--- a/src/agents/embedded-agent-message-tool-source-reply.test.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.test.ts
@@ -383,4 +383,50 @@ describe("isDeliveredMessageToolOnlySourceReplyResult", () => {
       }),
     ).toBe(false);
   });
+
+  it("accepts explicit sends with a structured current-source marker", () => {
+    expect(
+      isDeliveredMessageToolOnlySourceReplyResult({
+        sourceReplyDeliveryMode: "message_tool_only",
+        toolName: "message",
+        args: {
+          action: "send",
+          channel: "telegram",
+          target: "8455538490",
+          message: "reply",
+        },
+        result: {
+          content: [{ type: "text", text: '{"ok":true}' }],
+          details: {
+            ok: true,
+            messageId: "telegram-242",
+            sourceReplyRoute: "current-source",
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not trust current-source markers echoed in result text", () => {
+    expect(
+      isDeliveredMessageToolOnlySourceReplyResult({
+        sourceReplyDeliveryMode: "message_tool_only",
+        toolName: "message",
+        args: {
+          action: "send",
+          target: "elsewhere",
+          message: "reply",
+        },
+        result: {
+          content: [
+            {
+              type: "text",
+              text: '{"ok":true,"sourceReplyRoute":"current-source"}',
+            },
+          ],
+          details: { ok: true, messageId: "remote-242" },
+        },
+      }),
+    ).toBe(false);
+  });
 });

--- a/src/agents/embedded-agent-message-tool-source-reply.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.ts
@@ -37,6 +37,10 @@ function asRecord(value: unknown): Record<string, unknown> {
     : {};
 }
 
+function resultConfirmsCurrentSourceRoute(value: unknown): boolean {
+  return asRecord(asRecord(value).details).sourceReplyRoute === "current-source";
+}
+
 function hasStringValue(value: unknown): boolean {
   return typeof value === "string" && value.trim().length > 0;
 }
@@ -563,7 +567,9 @@ export function isDeliveredMessageToolOnlySourceReplyResult(params: {
   if (!isMessageToolSendActionName(args.action) && !sourceRouteReplyAction) {
     return false;
   }
-  if (hasExplicitMessageRoute(args) && params.allowExplicitSourceRoute !== true) {
+  const hasConfirmedExplicitSourceRoute =
+    params.allowExplicitSourceRoute === true || resultConfirmsCurrentSourceRoute(params.result);
+  if (hasExplicitMessageRoute(args) && !hasConfirmedExplicitSourceRoute) {
     return false;
   }
   return isDeliveredMessagingToolResult(params);

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -53,6 +53,7 @@ type ChatDisplayProjectionResult = {
 type PendingMessageToolVisibleReply = {
   toolCallId?: string;
   text: string;
+  requiresSourceRouteConfirmation: boolean;
   anchor: Record<string, unknown>;
   completionAnchor?: Record<string, unknown>;
   deliveryMirrorAnchor?: Record<string, unknown>;
@@ -996,15 +997,17 @@ function extractMessageToolVisibleReplies(
     if (isDryRunMessageToolRecord(args)) {
       continue;
     }
-    if (hasExplicitMessageToolRoute(args)) {
-      continue;
-    }
+    const requiresSourceRouteConfirmation = hasExplicitMessageToolRoute(args);
     const text = readMessageToolVisibleText(args);
     if (!text?.trim()) {
       continue;
     }
     const toolCallId = readToolBlockCallId(record);
-    replies.push({ ...(toolCallId ? { toolCallId } : {}), text });
+    replies.push({
+      ...(toolCallId ? { toolCallId } : {}),
+      text,
+      requiresSourceRouteConfirmation,
+    });
   }
   return replies;
 }
@@ -1099,6 +1102,40 @@ function hasDryRunToolResultValue(value: unknown): boolean {
   });
 }
 
+function hasSuppressedToolResultValue(value: unknown): boolean {
+  const record = readMaybeJsonRecord(value);
+  if (record) {
+    const messageId = normalizeOptionalString(record.messageId)?.toLowerCase();
+    const status = (
+      normalizeOptionalString(record.deliveryStatus) ??
+      normalizeOptionalString(record.delivery_status) ??
+      normalizeOptionalString(record.status)
+    )?.toLowerCase();
+    if (
+      record.delivered === false ||
+      messageId === "skipped" ||
+      messageId === "suppressed" ||
+      status === "skipped" ||
+      status === "suppressed"
+    ) {
+      return true;
+    }
+  }
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  return value.some((block) => {
+    if (hasSuppressedToolResultValue(block)) {
+      return true;
+    }
+    const blockRecord = readRecord(block);
+    return (
+      hasSuppressedToolResultValue(blockRecord?.text) ||
+      hasSuppressedToolResultValue(blockRecord?.content)
+    );
+  });
+}
+
 function isSuccessfulMessageToolResult(
   message: Record<string, unknown>,
   pending: PendingMessageToolVisibleReply,
@@ -1112,10 +1149,17 @@ function isSuccessfulMessageToolResult(
     return false;
   }
   const resultCallId = readMessageToolResultCallId(message);
+  const hasConfirmedSourceRoute =
+    !pending.requiresSourceRouteConfirmation ||
+    readRecord(message.details)?.sourceReplyRoute === "current-source";
   if (pending.toolCallId) {
-    return resultCallId === pending.toolCallId && isSuccessfulMessageToolResultPayload(message);
+    return (
+      resultCallId === pending.toolCallId &&
+      isSuccessfulMessageToolResultPayload(message) &&
+      hasConfirmedSourceRoute
+    );
   }
-  return isSuccessfulMessageToolResultPayload(message);
+  return isSuccessfulMessageToolResultPayload(message) && hasConfirmedSourceRoute;
 }
 
 function isSuccessfulMessageToolResultPayload(message: Record<string, unknown>): boolean {
@@ -1127,6 +1171,15 @@ function isSuccessfulMessageToolResultPayload(message: Record<string, unknown>):
     hasDryRunToolResultValue(message.output) ||
     hasDryRunToolResultValue(message.content) ||
     hasDryRunToolResultValue(message.text)
+  ) {
+    return false;
+  }
+  if (
+    hasSuppressedToolResultValue(message.details) ||
+    hasSuppressedToolResultValue(message.result) ||
+    hasSuppressedToolResultValue(message.output) ||
+    hasSuppressedToolResultValue(message.content) ||
+    hasSuppressedToolResultValue(message.text)
   ) {
     return false;
   }

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -558,6 +558,8 @@ export const sendHandlers: GatewayRequestHandlers = {
           channel,
           actionParams: request.params,
           cfg,
+          accountId,
+          currentAccountId: trustedContext.requesterAccountId,
           sessionKey,
           sessionId: trustedContext.sessionId,
           agentId,

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -1396,6 +1396,125 @@ describe("gateway server chat", () => {
     ).toBe(false);
   });
 
+  test("chat.history keeps confirmed current-source sends before a later final", async () => {
+    const sourceReply = "Visible reply delivered to Telegram.";
+    const laterFinal = "A later run produced this different final.";
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "reply in this Telegram chat" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call-message-current-source",
+            name: "message",
+            arguments: {
+              action: "send",
+              channel: "telegram",
+              target: "8455538490",
+              message: sourceReply,
+            },
+          },
+        ],
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        toolName: "message",
+        toolCallId: "call-message-current-source",
+        content: { ok: true, messageId: "24269", chatId: "8455538490" },
+        details: {
+          ok: true,
+          messageId: "24269",
+          chatId: "8455538490",
+          sourceReplyRoute: "current-source",
+        },
+        timestamp: 3,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "NO_REPLY" }],
+        timestamp: 4,
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "continue" }],
+        timestamp: 5,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: laterFinal }],
+        timestamp: 6,
+      },
+    ]);
+
+    expect(collectHistoryTextValues(historyMessages)).toEqual([
+      "reply in this Telegram chat",
+      sourceReply,
+      "continue",
+      laterFinal,
+    ]);
+    expect(historyMessages).toContainEqual(
+      expect.objectContaining({
+        role: "assistant",
+        content: [{ type: "text", text: sourceReply }],
+        openclawMessageToolMirror: expect.objectContaining({
+          toolCallId: "call-message-current-source",
+        }),
+      }),
+    );
+  });
+
+  test("chat.history does not mirror suppressed current-source sends", async () => {
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "reply here" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call-message-suppressed-current-source",
+            name: "message",
+            arguments: {
+              action: "send",
+              target: "8455538490",
+              message: "Must not appear",
+            },
+          },
+        ],
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        toolName: "message",
+        toolCallId: "call-message-suppressed-current-source",
+        content: { ok: true, messageId: "suppressed" },
+        details: {
+          ok: true,
+          messageId: "suppressed",
+          deliveryStatus: "suppressed",
+          sourceReplyRoute: "current-source",
+        },
+        timestamp: 3,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "NO_REPLY" }],
+        timestamp: 4,
+      },
+    ]);
+
+    expect(collectHistoryTextValues(historyMessages)).toEqual(["reply here"]);
+  });
+
   test("chat.history does not mirror message tool sends from unmatched results", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
       {

--- a/src/infra/outbound/message-action-runner.core-send.test.ts
+++ b/src/infra/outbound/message-action-runner.core-send.test.ts
@@ -37,7 +37,7 @@ const slackConfig = {
   },
 } as OpenClawConfig;
 
-function registerSlackTextPlugin() {
+function registerSlackTextPlugin(accountIds: string[] = ["default"]) {
   const sendText = vi.fn().mockResolvedValue({
     channel: "slack",
     messageId: "m1",
@@ -57,7 +57,7 @@ function registerSlackTextPlugin() {
             },
           }),
           config: {
-            listAccountIds: () => ["default"],
+            listAccountIds: () => accountIds,
             resolveAccount: () => ({ enabled: true }),
             isConfigured: () => true,
           },
@@ -568,6 +568,142 @@ describe("runMessageAction core send routing", () => {
     }
     expect(sendText).toHaveBeenCalledOnce();
     expect(result.to).toBe("channel:C123");
+  });
+
+  it("marks explicit sends to the trusted current source conversation", async () => {
+    registerSlackTextPlugin();
+
+    const result = await runMessageAction({
+      cfg: slackConfig,
+      action: "send",
+      params: {
+        channel: "slack",
+        target: "channel:C123",
+        message: "visible source reply",
+      },
+      toolContext: {
+        currentChannelProvider: "slack",
+        currentChannelId: "channel:C123",
+      },
+      messageActionAuthorization: {
+        requesterAccountId: "default",
+        toolContext: {
+          currentChannelProvider: "slack",
+          currentChannelId: "channel:C123",
+          currentSourceTurnId: "source-turn-1",
+        },
+      },
+      sessionKey: "agent:main:slack:channel:C123",
+      defaultAccountId: "default",
+      sourceReplyDeliveryMode: "message_tool_only",
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect(result.payload).toMatchObject({ sourceReplyRoute: "current-source" });
+  });
+
+  it("does not trust ambient routing when the authorized source differs", async () => {
+    registerSlackTextPlugin();
+
+    const result = await runMessageAction({
+      cfg: slackConfig,
+      action: "send",
+      params: {
+        channel: "slack",
+        target: "channel:C123",
+        message: "not the authorized source",
+      },
+      toolContext: {
+        currentChannelProvider: "slack",
+        currentChannelId: "channel:C123",
+      },
+      messageActionAuthorization: {
+        requesterAccountId: "default",
+        toolContext: {
+          currentChannelProvider: "slack",
+          currentChannelId: "channel:C999",
+          currentSourceTurnId: "source-turn-1",
+        },
+      },
+      sessionKey: "agent:main:slack:channel:C123",
+      defaultAccountId: "default",
+      sourceReplyDeliveryMode: "message_tool_only",
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect((result.payload as { sourceReplyRoute?: unknown }).sourceReplyRoute).toBeUndefined();
+  });
+
+  it("does not mark same-target sends through another account", async () => {
+    registerSlackTextPlugin(["default", "other"]);
+
+    const result = await runMessageAction({
+      cfg: slackConfig,
+      action: "send",
+      params: {
+        channel: "slack",
+        accountId: "other",
+        target: "channel:C123",
+        message: "cross-account reply",
+      },
+      toolContext: {
+        currentChannelProvider: "slack",
+        currentChannelId: "channel:C123",
+      },
+      messageActionAuthorization: {
+        requesterAccountId: "default",
+        toolContext: {
+          currentChannelProvider: "slack",
+          currentChannelId: "channel:C123",
+          currentSourceTurnId: "source-turn-1",
+        },
+      },
+      sessionKey: "agent:main:slack:channel:C123",
+      defaultAccountId: "default",
+      sourceReplyDeliveryMode: "message_tool_only",
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect((result.payload as { sourceReplyRoute?: unknown }).sourceReplyRoute).toBeUndefined();
+  });
+
+  it("does not mark same-target sends to another thread", async () => {
+    registerSlackTextPlugin();
+
+    const result = await runMessageAction({
+      cfg: slackConfig,
+      action: "send",
+      params: {
+        channel: "slack",
+        target: "channel:C123",
+        threadId: "other-thread",
+        message: "thread-only reply",
+      },
+      toolContext: {
+        currentChannelProvider: "slack",
+        currentChannelId: "channel:C123",
+        currentThreadTs: "source-thread",
+      },
+      messageActionAuthorization: {
+        requesterAccountId: "default",
+        toolContext: {
+          currentChannelProvider: "slack",
+          currentChannelId: "channel:C123",
+          currentThreadTs: "source-thread",
+          currentSourceTurnId: "source-turn-1",
+        },
+      },
+      sessionKey: "agent:main:slack:channel:C123:thread:source-thread",
+      defaultAccountId: "default",
+      sourceReplyDeliveryMode: "message_tool_only",
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect((result.payload as { sourceReplyRoute?: unknown }).sourceReplyRoute).toBeUndefined();
   });
 
   it("preserves required delivery when message-tool-only sends target another conversation", async () => {

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -105,6 +105,7 @@ const mocks = vi.hoisted(() => ({
   prepareOutboundMirrorRoute: vi.fn(),
   beginTerminalSourceReplyDelivery: vi.fn(),
   cancelTerminalSourceReplyDelivery: vi.fn(),
+  isDeliveredCurrentSourceReply: vi.fn(() => false),
   reconcileTerminalSourceReplyDelivery: vi.fn(),
 }));
 
@@ -130,6 +131,7 @@ vi.mock("./message.gateway.runtime.js", () => ({
 vi.mock("./source-reply-mirror.js", () => ({
   beginTerminalSourceReplyDelivery: mocks.beginTerminalSourceReplyDelivery,
   cancelTerminalSourceReplyDelivery: mocks.cancelTerminalSourceReplyDelivery,
+  isDeliveredCurrentSourceReply: mocks.isDeliveredCurrentSourceReply,
   reconcileTerminalSourceReplyDelivery: mocks.reconcileTerminalSourceReplyDelivery,
 }));
 

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -114,6 +114,7 @@ import { ensureOutboundSessionEntry, resolveOutboundSessionRoute } from "./outbo
 import {
   beginTerminalSourceReplyDelivery,
   cancelTerminalSourceReplyDelivery,
+  isDeliveredCurrentSourceReply,
   reconcileTerminalSourceReplyDelivery,
 } from "./source-reply-mirror.js";
 import { normalizeTargetForProvider } from "./target-normalization.js";
@@ -255,6 +256,63 @@ export function getToolResult(
   result: MessageActionRunResult,
 ): AgentToolResult<unknown> | undefined {
   return "toolResult" in result ? result.toolResult : undefined;
+}
+
+function asResultRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function markDeliveredCurrentSourceReply<T extends MessageActionRunResult>(
+  result: T,
+  params: {
+    cfg: OpenClawConfig;
+    actionParams: Record<string, unknown>;
+    channel: ChannelId;
+    accountId?: string | null;
+    input: RunMessageActionParams;
+    agentId?: string;
+    replyToIsExplicit: boolean;
+  },
+): T {
+  if (result.kind !== "send" || params.input.sourceReplyDeliveryMode !== "message_tool_only") {
+    return result;
+  }
+  const authorization = params.input.messageActionAuthorization;
+  if (
+    !authorization?.toolContext ||
+    !isDeliveredCurrentSourceReply({
+      action: "send",
+      channel: params.channel,
+      actionParams: params.actionParams,
+      cfg: params.cfg,
+      accountId: params.accountId,
+      currentAccountId: authorization.requesterAccountId ?? params.input.defaultAccountId,
+      sessionKey: params.input.sessionKey,
+      sessionId: params.input.sessionId,
+      agentId: params.agentId,
+      toolContext: authorization.toolContext,
+      deliveredPayload: result.payload,
+      replyToIsExplicit: params.replyToIsExplicit,
+    })
+  ) {
+    return result;
+  }
+  const payload = asResultRecord(result.payload);
+  const details = asResultRecord(result.toolResult?.details);
+  return {
+    ...result,
+    payload: payload ? { ...payload, sourceReplyRoute: "current-source" } : result.payload,
+    ...(result.toolResult
+      ? {
+          toolResult: {
+            ...result.toolResult,
+            details: { ...details, sourceReplyRoute: "current-source" },
+          },
+        }
+      : {}),
+  } as T;
 }
 
 function resolveGatewayActionOptions(gateway?: MessageActionRunnerGateway) {
@@ -825,6 +883,9 @@ async function runGatewayPluginMessageActionOrNull(params: {
     channel: params.channel,
     actionParams: params.params,
     cfg: params.cfg,
+    accountId: params.accountId,
+    currentAccountId:
+      params.input.messageActionAuthorization?.requesterAccountId ?? params.input.defaultAccountId,
     sessionKey: params.input.sessionKey,
     sessionId: params.input.sessionId,
     agentId: params.agentId,
@@ -1421,7 +1482,15 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
         }),
       });
   if (gatewayPluginAction) {
-    return gatewayPluginAction;
+    return markDeliveredCurrentSourceReply(gatewayPluginAction, {
+      cfg,
+      actionParams: params,
+      channel,
+      accountId,
+      input,
+      agentId,
+      replyToIsExplicit,
+    });
   }
 
   const useCorePresentationDelivery = Boolean(
@@ -1510,7 +1579,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     threadId: resolvedThreadId ?? undefined,
   });
 
-  return {
+  const result: MessageActionRunResult = {
     kind: "send",
     channel,
     action,
@@ -1522,6 +1591,15 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     sendResult: send.sendResult,
     dryRun,
   };
+  return markDeliveredCurrentSourceReply(result, {
+    cfg,
+    actionParams: params,
+    channel,
+    accountId,
+    input,
+    agentId,
+    replyToIsExplicit,
+  });
 }
 
 async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {

--- a/src/infra/outbound/source-reply-mirror.ts
+++ b/src/infra/outbound/source-reply-mirror.ts
@@ -18,7 +18,7 @@ import {
   type RestartRecoveryTerminalDeliveryScope,
 } from "../../config/sessions/restart-recovery-receipt.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { normalizeAccountId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { readTrimmedStringAlias } from "../../utils/string-readers.js";
 import { createOutboundPayloadPlan, projectOutboundPayloadPlanForMirror } from "./payloads.js";
 
@@ -27,6 +27,8 @@ type SourceReplyTranscriptMirrorParams = {
   channel: string;
   actionParams: Record<string, unknown>;
   cfg: OpenClawConfig;
+  accountId?: string | null;
+  currentAccountId?: string | null;
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
@@ -35,6 +37,7 @@ type SourceReplyTranscriptMirrorParams = {
   sourceReplyFinal?: boolean;
   toolCallId?: string;
   deliveredPayload?: unknown;
+  replyToIsExplicit?: boolean;
 };
 
 type MirrorableSourceReplyTranscriptParams = SourceReplyTranscriptMirrorParams & {
@@ -102,6 +105,14 @@ function resolveSourceReplyThreadPlacement(
   if (params.actionParams.topLevel === true) {
     return currentThreadId ? "mismatch" : "match";
   }
+  if (
+    params.channel === "slack" &&
+    params.replyToIsExplicit === true &&
+    !currentThreadId &&
+    normalizeOptionalString(params.actionParams.replyTo)
+  ) {
+    return "mismatch";
+  }
   for (const key of ["threadId", "messageThreadId"] as const) {
     if (!Object.hasOwn(params.actionParams, key)) {
       continue;
@@ -133,20 +144,44 @@ function resolveThreadedSourceTarget(
   );
 }
 
-function hasExplicitDeliveryFailure(payload: unknown): boolean {
-  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+function hasExplicitDeliveryFailure(payload: unknown, depth = 0): boolean {
+  if (!payload || typeof payload !== "object" || depth > 4) {
     return false;
   }
+  if (Array.isArray(payload)) {
+    return payload.some((value) => hasExplicitDeliveryFailure(value, depth + 1));
+  }
   const record = payload as Record<string, unknown>;
-  if (record.ok === false) {
+  if (record.ok === false || record.delivered === false || record.dryRun === true) {
+    return true;
+  }
+  const messageId = normalizeOptionalLowercaseString(record.messageId);
+  if (messageId === "skipped" || messageId === "suppressed") {
     return true;
   }
   const status = normalizeOptionalLowercaseString(record.status);
-  if (status === "failed" || status === "error") {
+  if (
+    status === "failed" ||
+    status === "error" ||
+    status === "skipped" ||
+    status === "suppressed" ||
+    status === "dry_run"
+  ) {
     return true;
   }
   const deliveryStatus = normalizeOptionalLowercaseString(record.deliveryStatus);
-  return deliveryStatus === "failed" || deliveryStatus === "error";
+  if (
+    deliveryStatus === "failed" ||
+    deliveryStatus === "error" ||
+    deliveryStatus === "skipped" ||
+    deliveryStatus === "suppressed" ||
+    deliveryStatus === "dry_run"
+  ) {
+    return true;
+  }
+  return ["details", "payload", "result", "results", "sendResult", "toolResult"].some((key) =>
+    hasExplicitDeliveryFailure(record[key], depth + 1),
+  );
 }
 
 function resolveCurrentSourceTurnId(
@@ -269,6 +304,16 @@ function isCurrentSourceConversation(
   if (!toolContext) {
     return false;
   }
+  const accountId = normalizeOptionalString(params.accountId);
+  if (accountId) {
+    const currentAccountId = normalizeOptionalString(params.currentAccountId);
+    if (
+      !currentAccountId ||
+      normalizeAccountId(accountId) !== normalizeAccountId(currentAccountId)
+    ) {
+      return false;
+    }
+  }
   const currentChannel = normalizeOptionalLowercaseString(toolContext.currentChannelProvider);
   if (!currentChannel || currentChannel !== normalizeOptionalLowercaseString(params.channel)) {
     return false;
@@ -315,6 +360,13 @@ function isExactCurrentSourceConversation(
 ): params is MirrorableSourceReplyTranscriptParams {
   return (
     resolveSourceReplyThreadPlacement(params) === "match" && isCurrentSourceConversation(params)
+  );
+}
+
+/** Confirms that a successful send reached the exact trusted source conversation. */
+export function isDeliveredCurrentSourceReply(params: SourceReplyTranscriptMirrorParams): boolean {
+  return (
+    !hasExplicitDeliveryFailure(params.deliveredPayload) && isExactCurrentSourceConversation(params)
   );
 }
 


### PR DESCRIPTION
Related: #104544
Related: #83494

## What Problem This Solves

Fixes an issue where an agent could explicitly send a successful `message` tool reply to the exact current source conversation, while Control UI history omitted that delivered reply and showed only a later, different assistant final.

This PR addresses the explicit current-source `message` send slice of #104544. It does not address missing subagent lifecycle announcements, which are tracked separately in #105517.

## Why This Change Was Made

Explicit routes were excluded from message-tool history projection even when the resolved channel, account, target, and thread matched the current source conversation.

The rewritten fix reuses the existing source-reply mirror's exact-conversation matcher. The outbound owner adds a structured current-source marker only after trusted channel, account, target, thread, and delivery checks pass. History projection and embedded completion trust that structured result marker, not ambient routing fields or marker-shaped text.

Dry-run, skipped, suppressed, failed, cross-channel, cross-account, cross-target, and cross-thread sends remain excluded. Existing transcript delivery mirrors remain authoritative and deduplicated.

## User Impact

Users who receive an explicit agent reply in the current Telegram or Slack source conversation can now see the same reply in Control UI session history. Later assistant output no longer replaces that delivered message in the dashboard.

## Evidence

- Exact patch head: `e1735fb232496b6f1762ab332457a3b6e376805b`
- Replay base: `a941d3ab727e3f0d789f51dd6abfb8c433bcdee6`
- Exact-head upstream CI: https://github.com/openclaw/openclaw/actions/runs/29640061932 (passed)
- Blacksmith focused proof: 85 Gateway/infra/agent tests plus 49 plugin-dispatch sibling tests passed
- Changed gates: core and core-test typechecks, changed-file lint, formatting, import cycles, boundaries, and guards passed
- Autoreview: clean after the implementation rewrite and sibling-test correction

## Risk And Rollback

Risk is limited to read-time history projection and structured result metadata used to prove an exact current-source route. The marker is emitted only after trusted route and delivery validation, and projection continues to reject non-success indicators.

Rollback is a straight revert of this PR. No config, schema, transcript migration, or persisted data rewrite is introduced.

## Documentation

No documentation change is needed. This restores consistency between an existing channel delivery path and the existing Control UI history surface without changing configuration or user-facing commands.
