### PR TITLE
fix(ui): catalog sessions select in place and continue from desktop-app sources

### DIFF
--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -57,8 +57,8 @@ import { anthropicMediaUnderstandingProvider } from "./media-understanding-provi
 import {
   createClaudeSessionNodeHostCommands,
   createClaudeSessionNodeInvokePolicies,
-  registerClaudeSessionCatalog,
-} from "./session-catalog.js";
+} from "./session-catalog-node-commands.js";
+import { registerClaudeSessionCatalog } from "./session-catalog.js";
 import { wrapAnthropicProviderStream } from "./stream-wrappers.js";
 import { fetchAnthropicUsage, resolveAnthropicUsageAuth } from "./usage.js";
 

--- a/extensions/anthropic/session-catalog-node-commands.ts
+++ b/extensions/anthropic/session-catalog-node-commands.ts
@@ -1,0 +1,57 @@
+import type {
+  OpenClawPluginNodeHostCommand,
+  OpenClawPluginNodeInvokePolicy,
+} from "openclaw/plugin-sdk/plugin-entry";
+import {
+  CLAUDE_SESSION_READ_COMMAND,
+  CLAUDE_SESSIONS_CAPABILITY,
+  CLAUDE_SESSIONS_LIST_COMMAND,
+  ClaudeCatalogParamsError,
+  claudeProjectsAvailable,
+  listLocalClaudeSessionPage,
+  readLocalClaudeTranscriptPage,
+} from "./session-catalog.js";
+
+function parseNodeParams(paramsJSON?: string | null): unknown {
+  if (!paramsJSON) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(paramsJSON) as unknown;
+  } catch (error) {
+    throw new ClaudeCatalogParamsError("Claude session parameters must be valid JSON", {
+      cause: error,
+    });
+  }
+}
+
+export function createClaudeSessionNodeHostCommands(): OpenClawPluginNodeHostCommand[] {
+  return [
+    {
+      command: CLAUDE_SESSIONS_LIST_COMMAND,
+      cap: CLAUDE_SESSIONS_CAPABILITY,
+      dangerous: false,
+      isAvailable: ({ env }) => claudeProjectsAvailable(env),
+      handle: async (paramsJSON) =>
+        JSON.stringify(await listLocalClaudeSessionPage(parseNodeParams(paramsJSON))),
+    },
+    {
+      command: CLAUDE_SESSION_READ_COMMAND,
+      cap: CLAUDE_SESSIONS_CAPABILITY,
+      dangerous: false,
+      isAvailable: ({ env }) => claudeProjectsAvailable(env),
+      handle: async (paramsJSON) =>
+        JSON.stringify(await readLocalClaudeTranscriptPage(parseNodeParams(paramsJSON))),
+    },
+  ];
+}
+
+export function createClaudeSessionNodeInvokePolicies(): OpenClawPluginNodeInvokePolicy[] {
+  return [
+    {
+      commands: [CLAUDE_SESSIONS_LIST_COMMAND, CLAUDE_SESSION_READ_COMMAND],
+      defaultPlatforms: ["macos", "linux", "windows"],
+      handle: (context) => context.invokeNode(),
+    },
+  ];
+}

--- a/extensions/anthropic/session-catalog-node-commands.ts
+++ b/extensions/anthropic/session-catalog-node-commands.ts
@@ -1,16 +1,29 @@
+import { statSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type {
   OpenClawPluginNodeHostCommand,
   OpenClawPluginNodeInvokePolicy,
 } from "openclaw/plugin-sdk/plugin-entry";
 import {
   CLAUDE_SESSION_READ_COMMAND,
-  CLAUDE_SESSIONS_CAPABILITY,
   CLAUDE_SESSIONS_LIST_COMMAND,
-  ClaudeCatalogParamsError,
-  claudeProjectsAvailable,
   listLocalClaudeSessionPage,
   readLocalClaudeTranscriptPage,
 } from "./session-catalog.js";
+
+const CLAUDE_SESSIONS_CAPABILITY = "claude-sessions";
+
+// Nodes advertise the catalog commands only when this machine has a Claude
+// Code session store; without it the gateway skips the node entirely.
+function claudeProjectsAvailable(env: NodeJS.ProcessEnv): boolean {
+  const homeDir = env.HOME?.trim() || env.USERPROFILE?.trim() || os.homedir();
+  try {
+    return statSync(path.join(homeDir, ".claude", "projects")).isDirectory();
+  } catch {
+    return false;
+  }
+}
 
 function parseNodeParams(paramsJSON?: string | null): unknown {
   if (!paramsJSON) {
@@ -19,9 +32,7 @@ function parseNodeParams(paramsJSON?: string | null): unknown {
   try {
     return JSON.parse(paramsJSON) as unknown;
   } catch (error) {
-    throw new ClaudeCatalogParamsError("Claude session parameters must be valid JSON", {
-      cause: error,
-    });
+    throw new Error("Claude session parameters must be valid JSON", { cause: error });
   }
 }
 

--- a/extensions/anthropic/session-catalog.test.ts
+++ b/extensions/anthropic/session-catalog.test.ts
@@ -154,6 +154,77 @@ describe("Claude session catalog", () => {
     );
   });
 
+  it("continues a local Desktop-app row and lists it as continuable", async () => {
+    const home = await createHome();
+    process.env.HOME = home;
+    const sessionId = "desktop-source-session";
+    await writeProject({
+      home,
+      entries: [
+        {
+          sessionId,
+          fullPath: path.join(home, ".claude", "projects", "-workspace", `${sessionId}.jsonl`),
+          summary: "Index title",
+          projectPath: "/work/desktop",
+        },
+      ],
+      transcripts: { [sessionId]: [message(sessionId, "user", "desktop prompt", 1)] },
+    });
+    await writeDesktopMetadata(home, "active", {
+      cliSessionId: sessionId,
+      title: "Desktop title",
+      cwd: "/desktop/cwd",
+      isArchived: false,
+    });
+    const createSessionEntry = vi.fn(async (params: Record<string, unknown>) => ({
+      key: `agent:main:${String(params.key)}`,
+      agentId: "main",
+      sessionId: "openclaw-adopted",
+      entry: { sessionId: "openclaw-adopted", updatedAt: Date.now() },
+    }));
+    let provider: SessionCatalogProvider | undefined;
+    const api = {
+      id: "anthropic",
+      config: {},
+      runtime: {
+        config: { current: () => ({}) },
+        nodes: { list: async () => ({ nodes: [] }) },
+        agent: {
+          session: {
+            listSessionEntries: () => [],
+            createSessionEntry,
+          },
+        },
+      },
+      registerSessionCatalog: (candidate: SessionCatalogProvider) => {
+        provider = candidate;
+      },
+    } as unknown as OpenClawPluginApi;
+    registerClaudeSessionCatalog(api);
+
+    const hosts = await provider?.list({});
+    expect(hosts?.[0]?.sessions).toEqual([
+      expect.objectContaining({
+        threadId: sessionId,
+        source: "claude-desktop",
+        canContinue: true,
+        canArchive: false,
+      }),
+    ]);
+    await expect(
+      provider?.continueSession?.({ hostId: "gateway:local", threadId: sessionId }),
+    ).resolves.toEqual({
+      sessionKey: expect.stringContaining("plugin:anthropic:catalog-adopt:claude:"),
+    });
+    expect(createSessionEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialEntry: expect.objectContaining({
+          cliSessionBinding: { sessionId, forceReuse: true, forkNextResume: true },
+        }),
+      }),
+    );
+  });
+
   it("merges CLI indexes with active Desktop metadata and hides archived Desktop sessions", async () => {
     const home = await createHome();
     await writeProject({

--- a/extensions/anthropic/session-catalog.test.ts
+++ b/extensions/anthropic/session-catalog.test.ts
@@ -5,10 +5,10 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import type { SessionCatalogProvider } from "openclaw/plugin-sdk/session-catalog";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createClaudeSessionNodeHostCommands } from "./session-catalog-node-commands.js";
 import {
   CLAUDE_SESSIONS_LIST_COMMAND,
   CLAUDE_SESSION_READ_COMMAND,
-  createClaudeSessionNodeHostCommands,
   listClaudeSessionCatalog,
   listLocalClaudeSessionPage,
   readLocalClaudeTranscriptPage,

--- a/extensions/anthropic/session-catalog.ts
+++ b/extensions/anthropic/session-catalog.ts
@@ -6,11 +6,7 @@ import path from "node:path";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { listAgentIds, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import type {
-  OpenClawPluginApi,
-  OpenClawPluginNodeHostCommand,
-  OpenClawPluginNodeInvokePolicy,
-} from "openclaw/plugin-sdk/plugin-entry";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import type {
   SessionCatalogHost,
@@ -25,7 +21,7 @@ export const CLAUDE_SESSIONS_LIST_COMMAND = "anthropic.claude.sessions.list.v1";
 export const CLAUDE_SESSION_READ_COMMAND = "anthropic.claude.sessions.read.v1";
 import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_DEFAULT_MODEL_REF } from "./cli-constants.js";
 
-const CLAUDE_SESSIONS_CAPABILITY = "claude-sessions";
+export const CLAUDE_SESSIONS_CAPABILITY = "claude-sessions";
 const CLAUDE_LOCAL_SESSION_HOST_ID = "gateway:local";
 const DEFAULT_PAGE_LIMIT = 50;
 const MAX_PAGE_LIMIT = 100;
@@ -139,7 +135,7 @@ type CatalogRecord = ClaudeSessionCatalogSession & {
   filePath: string;
 };
 
-class ClaudeCatalogParamsError extends Error {}
+export class ClaudeCatalogParamsError extends Error {}
 
 function optionalString(value: unknown, maxLength = MAX_STRING_LENGTH): string | undefined {
   if (typeof value !== "string") {
@@ -216,7 +212,7 @@ function currentHomeDir(env: NodeJS.ProcessEnv = process.env): string {
   return env.HOME?.trim() || env.USERPROFILE?.trim() || os.homedir();
 }
 
-function claudeProjectsAvailable(env: NodeJS.ProcessEnv): boolean {
+export function claudeProjectsAvailable(env: NodeJS.ProcessEnv): boolean {
   const homeDir = currentHomeDir(env);
   try {
     return statSync(projectsDir(homeDir)).isDirectory();
@@ -618,19 +614,6 @@ export async function listLocalClaudeSessionPage(
     sessions: page,
     ...(nextOffset < records.length ? { nextCursor: encodeOffset(nextOffset) } : {}),
   };
-}
-
-function parseNodeParams(paramsJSON?: string | null): unknown {
-  if (!paramsJSON) {
-    return undefined;
-  }
-  try {
-    return JSON.parse(paramsJSON) as unknown;
-  } catch (error) {
-    throw new ClaudeCatalogParamsError("Claude session parameters must be valid JSON", {
-      cause: error,
-    });
-  }
 }
 
 function transcriptItemType(role: string, content: unknown): string {
@@ -1172,37 +1155,6 @@ async function readClaudeSessionTranscript(params: {
       ? { nextCursor: optionalString(page.nextCursor, MAX_CURSOR_LENGTH) }
       : {}),
   };
-}
-
-export function createClaudeSessionNodeHostCommands(): OpenClawPluginNodeHostCommand[] {
-  return [
-    {
-      command: CLAUDE_SESSIONS_LIST_COMMAND,
-      cap: CLAUDE_SESSIONS_CAPABILITY,
-      dangerous: false,
-      isAvailable: ({ env }) => claudeProjectsAvailable(env),
-      handle: async (paramsJSON) =>
-        JSON.stringify(await listLocalClaudeSessionPage(parseNodeParams(paramsJSON))),
-    },
-    {
-      command: CLAUDE_SESSION_READ_COMMAND,
-      cap: CLAUDE_SESSIONS_CAPABILITY,
-      dangerous: false,
-      isAvailable: ({ env }) => claudeProjectsAvailable(env),
-      handle: async (paramsJSON) =>
-        JSON.stringify(await readLocalClaudeTranscriptPage(parseNodeParams(paramsJSON))),
-    },
-  ];
-}
-
-export function createClaudeSessionNodeInvokePolicies(): OpenClawPluginNodeInvokePolicy[] {
-  return [
-    {
-      commands: [CLAUDE_SESSIONS_LIST_COMMAND, CLAUDE_SESSION_READ_COMMAND],
-      defaultPlatforms: ["macos", "linux", "windows"],
-      handle: (context) => context.invokeNode(),
-    },
-  ];
 }
 
 function adoptedSessionKey(threadId: string): string {

--- a/extensions/anthropic/session-catalog.ts
+++ b/extensions/anthropic/session-catalog.ts
@@ -51,6 +51,13 @@ const CLAUDE_HISTORY_IMPORT_MAX_BYTES = 512 * 1024;
 
 type ClaudeSessionSource = "claude-cli" | "claude-desktop";
 
+// Desktop-app sessions live in the same ~/.claude/projects store as CLI
+// sessions (records without a projects JSONL are dropped during discovery),
+// so `claude --resume --fork-session` continues both alike.
+function isResumableClaudeSource(source: string | undefined): boolean {
+  return source === "claude-cli" || source === "claude-desktop";
+}
+
 export type ClaudeSessionCatalogSession = {
   threadId: string;
   name?: string | null;
@@ -1342,8 +1349,8 @@ async function continueClaudeSession(
     const record = (await listClaudeSessions()).find(
       (candidate) => candidate.threadId === threadId,
     );
-    if (!record || record.source !== "claude-cli") {
-      throw new ClaudeCatalogParamsError("only local Claude CLI sessions can be continued");
+    if (!record || !isResumableClaudeSource(record.source)) {
+      throw new ClaudeCatalogParamsError("only local Claude Code sessions can be continued");
     }
     const source = await fs.stat(record.filePath).catch(() => undefined);
     if (!source?.isFile()) {
@@ -1439,9 +1446,9 @@ function toGenericClaudeHost(
     connected: host.connected,
     ...(host.nodeId ? { nodeId: host.nodeId } : {}),
     sessions: host.sessions.map((session) => {
-      const localCli =
-        host.hostId === CLAUDE_LOCAL_SESSION_HOST_ID && session.source === "claude-cli";
-      const openClawSessionKey = localCli ? adopted.get(session.threadId) : undefined;
+      const localResumable =
+        host.hostId === CLAUDE_LOCAL_SESSION_HOST_ID && isResumableClaudeSource(session.source);
+      const openClawSessionKey = localResumable ? adopted.get(session.threadId) : undefined;
       return {
         threadId: session.threadId,
         ...(session.name ? { name: session.name } : {}),
@@ -1456,7 +1463,7 @@ function toGenericClaudeHost(
         ...(session.gitBranch ? { gitBranch: session.gitBranch } : {}),
         archived: session.archived,
         ...(openClawSessionKey ? { openClawSessionKey } : {}),
-        canContinue: localCli,
+        canContinue: localResumable,
         canArchive: false,
       };
     }),

--- a/extensions/anthropic/session-catalog.ts
+++ b/extensions/anthropic/session-catalog.ts
@@ -1,5 +1,4 @@
 import { createHash } from "node:crypto";
-import { statSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -21,7 +20,6 @@ export const CLAUDE_SESSIONS_LIST_COMMAND = "anthropic.claude.sessions.list.v1";
 export const CLAUDE_SESSION_READ_COMMAND = "anthropic.claude.sessions.read.v1";
 import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_DEFAULT_MODEL_REF } from "./cli-constants.js";
 
-export const CLAUDE_SESSIONS_CAPABILITY = "claude-sessions";
 const CLAUDE_LOCAL_SESSION_HOST_ID = "gateway:local";
 const DEFAULT_PAGE_LIMIT = 50;
 const MAX_PAGE_LIMIT = 100;
@@ -135,7 +133,7 @@ type CatalogRecord = ClaudeSessionCatalogSession & {
   filePath: string;
 };
 
-export class ClaudeCatalogParamsError extends Error {}
+class ClaudeCatalogParamsError extends Error {}
 
 function optionalString(value: unknown, maxLength = MAX_STRING_LENGTH): string | undefined {
   if (typeof value !== "string") {
@@ -210,15 +208,6 @@ function desktopSessionsDir(homeDir: string): string {
 
 function currentHomeDir(env: NodeJS.ProcessEnv = process.env): string {
   return env.HOME?.trim() || env.USERPROFILE?.trim() || os.homedir();
-}
-
-export function claudeProjectsAvailable(env: NodeJS.ProcessEnv): boolean {
-  const homeDir = currentHomeDir(env);
-  try {
-    return statSync(projectsDir(homeDir)).isDirectory();
-  } catch {
-    return false;
-  }
 }
 
 async function readDesktopMetadata(homeDir: string): Promise<{

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -1,0 +1,205 @@
+import { html, nothing } from "lit";
+import type {
+  SessionCatalog,
+  SessionCatalogHost,
+  SessionCatalogSession,
+} from "../../../packages/gateway-protocol/src/index.ts";
+import type { GatewaySessionRow } from "../api/types.ts";
+import { pathForRoute } from "../app-route-paths.ts";
+import { t } from "../i18n/index.ts";
+import { formatRelativeTimestamp } from "../lib/format.ts";
+import type { CatalogSessionContinuedDetail } from "../lib/sessions/catalog-key.ts";
+import { buildCatalogSessionKey } from "../lib/sessions/catalog-key.ts";
+import { searchForSession } from "../lib/sessions/index.ts";
+import { shouldHandleNavigationClick } from "./app-sidebar-nav-menus.ts";
+import { icons } from "./icons.ts";
+
+export function formatSidebarTimestamp(timestampMs: number | null | undefined): string {
+  const value = formatRelativeTimestamp(timestampMs, { fallback: "" });
+  if (value === "just now") {
+    return "now";
+  }
+  return value.endsWith(" ago") ? value.slice(0, -" ago".length) : value;
+}
+
+/** Session keys already adopted into OpenClaw sessions; the regular list hides
+    these so each adopted session stays a single selectable catalog row. */
+export function adoptedCatalogSessionKeys(catalogs: readonly SessionCatalog[]): Set<string> {
+  const keys = new Set<string>();
+  for (const catalog of catalogs) {
+    for (const host of catalog.hosts) {
+      for (const session of host.sessions) {
+        if (session.openClawSessionKey) {
+          keys.add(session.openClawSessionKey);
+        }
+      }
+    }
+  }
+  return keys;
+}
+
+/** Stamps a freshly adopted session key onto its catalog row so the sidebar
+    binds it before the next catalog poll confirms the adoption. */
+export function bindAdoptedCatalogSession(
+  catalogs: readonly SessionCatalog[],
+  detail: CatalogSessionContinuedDetail,
+): SessionCatalog[] {
+  return catalogs.map((catalog) =>
+    catalog.id === detail.catalogId
+      ? {
+          ...catalog,
+          hosts: catalog.hosts.map((host) =>
+            host.hostId === detail.hostId
+              ? {
+                  ...host,
+                  sessions: host.sessions.map((session) =>
+                    session.threadId === detail.threadId
+                      ? { ...session, openClawSessionKey: detail.sessionKey }
+                      : session,
+                  ),
+                }
+              : host,
+          ),
+        }
+      : catalog,
+  );
+}
+
+export type SessionCatalogGroupsParams = {
+  catalogs: readonly SessionCatalog[];
+  basePath: string;
+  routeSessionKey: string;
+  collapsedSections: ReadonlySet<string>;
+  loadingMoreCatalogIds: ReadonlySet<string>;
+  liveRows: readonly GatewaySessionRow[];
+  renderLiveRow: (row: GatewaySessionRow) => unknown;
+  onToggleSection: (sectionId: string) => void;
+  onLoadMore: (catalogId: string) => void;
+  onNavigate: (search: string) => void;
+};
+
+export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
+  // Adopted rows reuse the live session row so activity, unread state, and
+  // the session menu behave exactly like the regular list.
+  const liveRowsByKey = new Map<string, GatewaySessionRow>();
+  for (const row of params.liveRows) {
+    if (!liveRowsByKey.has(row.key)) {
+      liveRowsByKey.set(row.key, row);
+    }
+  }
+  return params.catalogs.map((catalog) => {
+    const sectionId = `catalog:${catalog.id}`;
+    const collapsed = params.collapsedSections.has(sectionId);
+    const rows = catalog.hosts.flatMap((host) =>
+      host.sessions.map((session) => ({ host, session })),
+    );
+    const loadingMore = params.loadingMoreCatalogIds.has(catalog.id);
+    const hasMore = catalog.hosts.some((host) => Boolean(host.nextCursor));
+    return html`
+      <div class="sidebar-recent-sessions__group" data-session-section=${sectionId}>
+        <div class="sidebar-recent-sessions__head">
+          <button
+            type="button"
+            class="sidebar-session-group-toggle"
+            aria-expanded=${String(!collapsed)}
+            aria-label=${catalog.label}
+            @click=${() => params.onToggleSection(sectionId)}
+          >
+            <span class="sidebar-session-group-toggle__icon" aria-hidden="true"
+              >${collapsed ? icons.chevronRight : icons.chevronDown}</span
+            >
+            <span class="sidebar-recent-sessions__label-text">${catalog.label}</span>
+            <span class="sidebar-session-group-count">${rows.length}</span>
+          </button>
+        </div>
+        ${collapsed
+          ? nothing
+          : html`<div class="sidebar-recent-sessions__list">
+                ${rows.map(({ host, session }) =>
+                  renderCatalogSessionRow(catalog, host, session, liveRowsByKey, params),
+                )}
+              </div>
+              ${hasMore
+                ? html`<button
+                    type="button"
+                    class="sidebar-session-catalog-load-more"
+                    data-session-catalog-load-more=${catalog.id}
+                    ?disabled=${loadingMore}
+                    aria-busy=${String(loadingMore)}
+                    @click=${() => params.onLoadMore(catalog.id)}
+                  >
+                    ${t("chat.selectors.loadMoreSessions")}
+                  </button>`
+                : nothing}`}
+      </div>
+    `;
+  });
+}
+
+function renderCatalogSessionRow(
+  catalog: SessionCatalog,
+  host: SessionCatalogHost,
+  session: SessionCatalogSession,
+  liveRowsByKey: ReadonlyMap<string, GatewaySessionRow>,
+  params: SessionCatalogGroupsParams,
+) {
+  const adoptedRow = session.openClawSessionKey
+    ? liveRowsByKey.get(session.openClawSessionKey)
+    : undefined;
+  if (adoptedRow) {
+    return params.renderLiveRow(adoptedRow);
+  }
+  const key =
+    session.openClawSessionKey ??
+    buildCatalogSessionKey({
+      catalogId: catalog.id,
+      hostId: host.hostId,
+      threadId: session.threadId,
+    });
+  const search = searchForSession(key);
+  const href = `${pathForRoute("chat", params.basePath)}${search}`;
+  // The catalog header already names the source; only a paired node's
+  // machine name adds signal on the row itself.
+  const hostSubtitle = host.kind === "node" ? host.label : undefined;
+  const active = params.routeSessionKey !== "" && key === params.routeSessionKey;
+  const rawTimestamp = session.recencyAt ?? session.updatedAt ?? session.createdAt;
+  const timestamp =
+    typeof rawTimestamp === "number" && rawTimestamp < 1_000_000_000_000
+      ? rawTimestamp * 1000
+      : rawTimestamp;
+  return html`
+    <div
+      class="sidebar-recent-session session-row-host ${active
+        ? "sidebar-recent-session--active"
+        : ""}"
+      data-session-key=${key}
+    >
+      <a
+        href=${href}
+        class="sidebar-recent-session__link"
+        title=${hostSubtitle
+          ? `${session.name || session.threadId} · ${hostSubtitle}`
+          : session.name || session.threadId}
+        @click=${(event: MouseEvent) => {
+          if (!shouldHandleNavigationClick(event)) {
+            return;
+          }
+          event.preventDefault();
+          params.onNavigate(search);
+        }}
+      >
+        <span class="sidebar-recent-session__text">
+          <span class="sidebar-recent-session__name hover-marquee"
+            >${session.name || session.threadId}</span
+          >
+          ${hostSubtitle
+            ? html`<span class="sidebar-recent-session__subtitle">${hostSubtitle}</span>`
+            : nothing}
+        </span>
+        <span class="sidebar-recent-session__aside session-row-aside">
+          <span class="session-row-trail">${formatSidebarTimestamp(timestamp)}</span>
+        </span>
+      </a>
+    </div>
+  `;
+}

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -65,7 +65,7 @@ export function bindAdoptedCatalogSession(
   );
 }
 
-export type SessionCatalogGroupsParams = {
+type SessionCatalogGroupsParams = {
   catalogs: readonly SessionCatalog[];
   basePath: string;
   routeSessionKey: string;

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -16,6 +16,7 @@ import {
   type ApplicationGateway,
   type ApplicationGatewaySnapshot,
 } from "../app/context.ts";
+import { CATALOG_SESSION_CONTINUED_EVENT } from "../lib/sessions/catalog-key.ts";
 import type { SessionCapability, SessionState } from "../lib/sessions/index.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import "./app-sidebar.ts";
@@ -1513,5 +1514,190 @@ describe("AppSidebar custom group reordering", () => {
     dispatchDragEvent(alphaSection, "drop", dataTransfer);
 
     expect(harness.groupsPut).toHaveBeenCalledWith(["Gamma", "Alpha", "Beta"]);
+  });
+});
+
+describe("AppSidebar catalog session rows", () => {
+  const catalogList = (
+    sessions: Array<Record<string, unknown>>,
+    hosts?: SessionCatalog["hosts"],
+  ): SessionsCatalogListResult => ({
+    catalogs: [
+      {
+        id: "codex",
+        label: "Codex",
+        capabilities: { continueSession: true, archive: true },
+        hosts: hosts ?? [
+          {
+            hostId: "gateway:local",
+            label: "Local Codex",
+            kind: "gateway" as const,
+            connected: true,
+            sessions: sessions.map((session) => ({
+              status: "idle",
+              archived: false,
+              canContinue: true,
+              canArchive: true,
+              ...session,
+            })) as SessionCatalog["hosts"][number]["sessions"],
+          },
+        ],
+      },
+    ],
+  });
+
+  async function mountWithCatalog(result: SessionsCatalogListResult, sessionKeys: string[]) {
+    const request = vi.fn().mockResolvedValue(result);
+    const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+    gateway.publish({
+      hello: {
+        features: { methods: ["sessions.catalog.list"] },
+      } as ApplicationGatewaySnapshot["hello"],
+    });
+    const { sidebar } = await mountSidebar(gateway.gateway, createSessions("main", sessionKeys));
+    sidebar.connected = true;
+    await sidebar.updateComplete;
+    await vi.advanceTimersByTimeAsync(0);
+    await sidebar.updateComplete;
+    return { sidebar, request };
+  }
+
+  it("shows a host subtitle only for paired-node rows", async () => {
+    vi.useFakeTimers();
+    try {
+      const { sidebar } = await mountWithCatalog(
+        catalogList(
+          [],
+          [
+            {
+              hostId: "gateway:local",
+              label: "Local Codex",
+              kind: "gateway",
+              connected: true,
+              sessions: [
+                {
+                  threadId: "thread-local",
+                  name: "Local session",
+                  status: "idle",
+                  archived: false,
+                  canContinue: true,
+                  canArchive: true,
+                },
+              ],
+            },
+            {
+              hostId: "node:devbox",
+              label: "Dev Box",
+              kind: "node",
+              nodeId: "devbox",
+              connected: true,
+              sessions: [
+                {
+                  threadId: "thread-node",
+                  name: "Node session",
+                  status: "stored",
+                  archived: false,
+                  canContinue: false,
+                  canArchive: false,
+                },
+              ],
+            },
+          ],
+        ),
+        ["agent:main:main"],
+      );
+
+      const subtitles = [
+        ...sidebar.querySelectorAll(
+          '[data-session-section="catalog:codex"] .sidebar-recent-session__subtitle',
+        ),
+      ].map((node) => node.textContent?.trim());
+      expect(subtitles).toEqual(["Dev Box"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("marks the routed catalog session row active without a phantom chat row", async () => {
+    vi.useFakeTimers();
+    try {
+      const { sidebar } = await mountWithCatalog(
+        catalogList([{ threadId: "thread-1", name: "Release checklist" }]),
+        ["agent:main:main"],
+      );
+      (sidebar as unknown as { activeRouteId: string }).activeRouteId = "chat";
+      sidebar.sessionKey = "catalog:codex:gateway%3Alocal:thread-1";
+      await sidebar.updateComplete;
+
+      const active = sidebar.querySelectorAll(".sidebar-recent-session--active");
+      expect(active).toHaveLength(1);
+      expect(active[0]?.getAttribute("data-session-key")).toBe(
+        "catalog:codex:gateway%3Alocal:thread-1",
+      );
+      // The raw catalog key must not surface as a synthesized chat row.
+      const chatRows = [
+        ...sidebar.querySelectorAll(
+          '.sidebar-recent-sessions__group:not([data-session-section^="catalog:"]) [data-session-key]',
+        ),
+      ].map((row) => row.getAttribute("data-session-key"));
+      expect(chatRows).not.toContain("catalog:codex:gateway%3Alocal:thread-1");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("renders an adopted catalog session as its live row and hides the duplicate", async () => {
+    vi.useFakeTimers();
+    try {
+      const { sidebar } = await mountWithCatalog(
+        catalogList([
+          {
+            threadId: "thread-1",
+            name: "Release checklist",
+            openClawSessionKey: "agent:main:adopted-codex",
+          },
+        ]),
+        ["agent:main:main", "agent:main:adopted-codex"],
+      );
+
+      const rows = [...sidebar.querySelectorAll('[data-session-key="agent:main:adopted-codex"]')];
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.closest('[data-session-section="catalog:codex"]')).not.toBeNull();
+      // Live-row parity: the adopted row exposes the regular session actions.
+      expect(rows[0]?.querySelector("[data-session-menu]")).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("binds the adopted session immediately on the catalog-continued event", async () => {
+    vi.useFakeTimers();
+    try {
+      const { sidebar } = await mountWithCatalog(
+        catalogList([{ threadId: "thread-1", name: "Release checklist" }]),
+        ["agent:main:main", "agent:main:adopted-codex"],
+      );
+      expect(
+        sidebar.querySelectorAll('[data-session-key="agent:main:adopted-codex"]'),
+      ).toHaveLength(1);
+
+      document.dispatchEvent(
+        new CustomEvent(CATALOG_SESSION_CONTINUED_EVENT, {
+          detail: {
+            catalogId: "codex",
+            hostId: "gateway:local",
+            threadId: "thread-1",
+            sessionKey: "agent:main:adopted-codex",
+          },
+        }),
+      );
+      await sidebar.updateComplete;
+
+      const rows = [...sidebar.querySelectorAll('[data-session-key="agent:main:adopted-codex"]')];
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.closest('[data-session-section="catalog:codex"]')).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -49,7 +49,11 @@ import {
   resolveSessionDisplayName,
   resolveSessionWorkSubtitle,
 } from "../lib/session-display.ts";
-import { buildCatalogSessionKey } from "../lib/sessions/catalog-key.ts";
+import {
+  buildCatalogSessionKey,
+  CATALOG_SESSION_CONTINUED_EVENT,
+  type CatalogSessionContinuedDetail,
+} from "../lib/sessions/catalog-key.ts";
 import { reorderSessionCustomGroups } from "../lib/sessions/custom-groups.ts";
 import {
   readSessionDragData,
@@ -376,7 +380,21 @@ class AppSidebar extends OpenClawLightDomContentsElement {
       );
   }
 
+  override connectedCallback() {
+    super.connectedCallback();
+    // Document listener: the chat pane announces catalog adoptions so the
+    // catalog row binds to the new session key before the next catalog poll.
+    document.addEventListener(
+      CATALOG_SESSION_CONTINUED_EVENT,
+      this.handleCatalogSessionContinued as EventListener,
+    );
+  }
+
   override disconnectedCallback() {
+    document.removeEventListener(
+      CATALOG_SESSION_CONTINUED_EVENT,
+      this.handleCatalogSessionContinued as EventListener,
+    );
     this.dismissTransientMenus();
     this.gatewaySource = null;
     this.gatewayClient = null;
@@ -409,6 +427,41 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     }
     void this.refreshSessionCatalogs();
   }
+
+  private readonly handleCatalogSessionContinued = (
+    event: CustomEvent<CatalogSessionContinuedDetail>,
+  ) => {
+    const detail = event.detail;
+    if (!detail?.sessionKey) {
+      return;
+    }
+    this.sessionCatalogs = this.sessionCatalogs.map((catalog) =>
+      catalog.id === detail.catalogId
+        ? {
+            ...catalog,
+            hosts: catalog.hosts.map((host) =>
+              host.hostId === detail.hostId
+                ? {
+                    ...host,
+                    sessions: host.sessions.map((session) =>
+                      session.threadId === detail.threadId
+                        ? { ...session, openClawSessionKey: detail.sessionKey }
+                        : session,
+                    ),
+                  }
+                : host,
+            ),
+          }
+        : catalog,
+    );
+    // Invalidate in-flight polls and load-more merges so a pre-adoption
+    // snapshot cannot clobber the patched rows; the 30s poll reconfirms.
+    this.sessionCatalogRevision += 1;
+    this.sessionCatalogRevisions.set(
+      detail.catalogId,
+      (this.sessionCatalogRevisions.get(detail.catalogId) ?? 0) + 1,
+    );
+  };
 
   private async refreshSessionCatalogs() {
     const client = this.context?.gateway.snapshot.client;
@@ -2573,11 +2626,15 @@ class AppSidebar extends OpenClawLightDomContentsElement {
   private selectedAgentSessionRows(
     navigationState: ReturnType<AppSidebar["getSessionNavigationState"]>,
   ): SidebarRecentSession[] {
+    // Adopted catalog sessions render inside their catalog group; hiding them
+    // here keeps one selectable row per session instead of a duplicate that
+    // jumps to the top of the regular list.
+    const adopted = this.adoptedCatalogSessionKeys();
     const selected = this.expandedAgentId();
     const loadedAgentId = normalizeAgentId(this.sessionsAgentId ?? "");
     const routeAgentId = normalizeAgentId(navigationState.selectedAgentId);
     if (selected === routeAgentId && selected === loadedAgentId) {
-      return navigationState.visibleSessions;
+      return navigationState.visibleSessions.filter((row) => !adopted.has(row.key));
     }
     const rows =
       selected === loadedAgentId
@@ -2592,7 +2649,22 @@ class AppSidebar extends OpenClawLightDomContentsElement {
       filterByAgent: true,
     })
       .toSorted(this.compareSidebarSessionRows)
+      .filter((row) => !adopted.has(row.key))
       .map(navigationState.toSidebarSession);
+  }
+
+  private adoptedCatalogSessionKeys(): ReadonlySet<string> {
+    const keys = new Set<string>();
+    for (const catalog of this.sessionCatalogs) {
+      for (const host of catalog.hosts) {
+        for (const session of host.sessions) {
+          if (session.openClawSessionKey) {
+            keys.add(session.openClawSessionKey);
+          }
+        }
+      }
+    }
+    return keys;
   }
 
   private agentUnreadCount(agentId: string): number {
@@ -2720,7 +2792,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
               normalizeAgentId(this.draftSessionAgentId) === expandedAgentId,
             showFallback: true,
           })}
-          ${this.renderSessionCatalogs()}
+          ${this.renderSessionCatalogs(navigationState)}
         </div>
       </section>
     `;
@@ -2730,7 +2802,21 @@ class AppSidebar extends OpenClawLightDomContentsElement {
   // .sidebar-sessions sections would form a second scroll-less region that
   // flex-squeezes under the shell body's overflow clip and paints rows over
   // the following section.
-  private renderSessionCatalogs() {
+  private renderSessionCatalogs(
+    navigationState: ReturnType<AppSidebar["getSessionNavigationState"]>,
+  ) {
+    // Adopted rows reuse the live session row so activity, unread state, and
+    // the session menu behave exactly like the regular list.
+    const liveRows = new Map<string, SessionsListResult["sessions"][number]>();
+    for (const row of [
+      ...(this.sessionsResult?.sessions ?? []),
+      ...Object.values(this.sessionRowsByAgent).flat(),
+    ]) {
+      if (!liveRows.has(row.key)) {
+        liveRows.set(row.key, row);
+      }
+    }
+    const routeSessionKey = this.activeRouteId === "chat" ? this.getRouteSessionKey() : "";
     return this.sessionCatalogs.map((catalog) => {
       const sectionId = `catalog:${catalog.id}`;
       const collapsed = this.collapsedSessionSections.has(sectionId);
@@ -2759,7 +2845,11 @@ class AppSidebar extends OpenClawLightDomContentsElement {
             ? nothing
             : html`<div class="sidebar-recent-sessions__list">
                   ${rows.map(({ host, session }) =>
-                    this.renderCatalogSession(catalog, host, session),
+                    this.renderCatalogSession(catalog, host, session, {
+                      navigationState,
+                      liveRows,
+                      routeSessionKey,
+                    }),
                   )}
                 </div>
                 ${hasMore
@@ -2783,7 +2873,18 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     catalog: SessionCatalog,
     host: SessionCatalogHost,
     session: SessionCatalogSession,
+    context: {
+      navigationState: ReturnType<AppSidebar["getSessionNavigationState"]>;
+      liveRows: ReadonlyMap<string, SessionsListResult["sessions"][number]>;
+      routeSessionKey: string;
+    },
   ) {
+    const adoptedRow = session.openClawSessionKey
+      ? context.liveRows.get(session.openClawSessionKey)
+      : undefined;
+    if (adoptedRow) {
+      return this.renderRecentSession(context.navigationState.toSidebarSession(adoptedRow));
+    }
     const key =
       session.openClawSessionKey ??
       buildCatalogSessionKey({
@@ -2792,18 +2893,28 @@ class AppSidebar extends OpenClawLightDomContentsElement {
         threadId: session.threadId,
       });
     const href = `${pathForRoute("chat", this.basePath)}${searchForSession(key)}`;
-    const hostSubtitle = catalog.hosts.length > 1 || host.kind === "node" ? host.label : undefined;
+    // The catalog header already names the source; only a paired node's
+    // machine name adds signal on the row itself.
+    const hostSubtitle = host.kind === "node" ? host.label : undefined;
+    const active = context.routeSessionKey !== "" && key === context.routeSessionKey;
     const rawTimestamp = session.recencyAt ?? session.updatedAt ?? session.createdAt;
     const timestamp =
       typeof rawTimestamp === "number" && rawTimestamp < 1_000_000_000_000
         ? rawTimestamp * 1000
         : rawTimestamp;
     return html`
-      <div class="sidebar-recent-session session-row-host" data-session-key=${key}>
+      <div
+        class="sidebar-recent-session session-row-host ${active
+          ? "sidebar-recent-session--active"
+          : ""}"
+        data-session-key=${key}
+      >
         <a
           href=${href}
           class="sidebar-recent-session__link"
-          title=${`${session.name || session.threadId} · ${host.label}`}
+          title=${hostSubtitle
+            ? `${session.name || session.threadId} · ${hostSubtitle}`
+            : session.name || session.threadId}
           @click=${(event: MouseEvent) => {
             if (!shouldHandleNavigationClick(event)) {
               return;

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -40,7 +40,6 @@ import { normalizeAgentLabel, resolveAgentTextAvatar } from "../lib/agents/displ
 import { resolveAgentAvatarUrl } from "../lib/avatar.ts";
 import { editorOpenUrl } from "../lib/editor-links.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../lib/external-link.ts";
-import { formatRelativeTimestamp } from "../lib/format.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import { startHoverMarquee, stopHoverMarquee } from "../lib/hover-marquee.ts";
 import {
@@ -50,7 +49,6 @@ import {
   resolveSessionWorkSubtitle,
 } from "../lib/session-display.ts";
 import {
-  buildCatalogSessionKey,
   CATALOG_SESSION_CONTINUED_EVENT,
   type CatalogSessionContinuedDetail,
 } from "../lib/sessions/catalog-key.ts";
@@ -97,6 +95,12 @@ import {
   sidebarMoreMenuHoldsActiveRoute,
   sidebarPluginTabs,
 } from "./app-sidebar-nav-menus.ts";
+import {
+  adoptedCatalogSessionKeys,
+  bindAdoptedCatalogSession,
+  formatSidebarTimestamp,
+  renderSessionCatalogGroups,
+} from "./app-sidebar-session-catalogs.ts";
 import { icons, type IconName } from "./icons.ts";
 import {
   LOBSTER_LOGO_VISIT_EVENT,
@@ -224,14 +228,6 @@ const AGENT_MENU_LINKS: ReadonlyArray<{ href: string; icon: IconName; label: () 
     label: () => t("agentChip.viewChangelog"),
   },
 ];
-
-function formatSidebarTimestamp(timestampMs: number | null | undefined): string {
-  const value = formatRelativeTimestamp(timestampMs, { fallback: "" });
-  if (value === "just now") {
-    return "now";
-  }
-  return value.endsWith(" ago") ? value.slice(0, -" ago".length) : value;
-}
 
 function sessionCatalogHostKey(catalogId: string, hostId: string): string {
   return `${catalogId}\u0000${hostId}`;
@@ -435,25 +431,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     if (!detail?.sessionKey) {
       return;
     }
-    this.sessionCatalogs = this.sessionCatalogs.map((catalog) =>
-      catalog.id === detail.catalogId
-        ? {
-            ...catalog,
-            hosts: catalog.hosts.map((host) =>
-              host.hostId === detail.hostId
-                ? {
-                    ...host,
-                    sessions: host.sessions.map((session) =>
-                      session.threadId === detail.threadId
-                        ? { ...session, openClawSessionKey: detail.sessionKey }
-                        : session,
-                    ),
-                  }
-                : host,
-            ),
-          }
-        : catalog,
-    );
+    this.sessionCatalogs = bindAdoptedCatalogSession(this.sessionCatalogs, detail);
     // Invalidate in-flight polls and load-more merges so a pre-adoption
     // snapshot cannot clobber the patched rows; the 30s poll reconfirms.
     this.sessionCatalogRevision += 1;
@@ -2629,7 +2607,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     // Adopted catalog sessions render inside their catalog group; hiding them
     // here keeps one selectable row per session instead of a duplicate that
     // jumps to the top of the regular list.
-    const adopted = this.adoptedCatalogSessionKeys();
+    const adopted = adoptedCatalogSessionKeys(this.sessionCatalogs);
     const selected = this.expandedAgentId();
     const loadedAgentId = normalizeAgentId(this.sessionsAgentId ?? "");
     const routeAgentId = normalizeAgentId(navigationState.selectedAgentId);
@@ -2651,20 +2629,6 @@ class AppSidebar extends OpenClawLightDomContentsElement {
       .toSorted(this.compareSidebarSessionRows)
       .filter((row) => !adopted.has(row.key))
       .map(navigationState.toSidebarSession);
-  }
-
-  private adoptedCatalogSessionKeys(): ReadonlySet<string> {
-    const keys = new Set<string>();
-    for (const catalog of this.sessionCatalogs) {
-      for (const host of catalog.hosts) {
-        for (const session of host.sessions) {
-          if (session.openClawSessionKey) {
-            keys.add(session.openClawSessionKey);
-          }
-        }
-      }
-    }
-    return keys;
   }
 
   private agentUnreadCount(agentId: string): number {
@@ -2805,138 +2769,21 @@ class AppSidebar extends OpenClawLightDomContentsElement {
   private renderSessionCatalogs(
     navigationState: ReturnType<AppSidebar["getSessionNavigationState"]>,
   ) {
-    // Adopted rows reuse the live session row so activity, unread state, and
-    // the session menu behave exactly like the regular list.
-    const liveRows = new Map<string, SessionsListResult["sessions"][number]>();
-    for (const row of [
-      ...(this.sessionsResult?.sessions ?? []),
-      ...Object.values(this.sessionRowsByAgent).flat(),
-    ]) {
-      if (!liveRows.has(row.key)) {
-        liveRows.set(row.key, row);
-      }
-    }
-    const routeSessionKey = this.activeRouteId === "chat" ? this.getRouteSessionKey() : "";
-    return this.sessionCatalogs.map((catalog) => {
-      const sectionId = `catalog:${catalog.id}`;
-      const collapsed = this.collapsedSessionSections.has(sectionId);
-      const hosts = catalog.hosts;
-      const rows = hosts.flatMap((host) => host.sessions.map((session) => ({ host, session })));
-      const loadingMore = this.loadingMoreSessionCatalogIds.has(catalog.id);
-      const hasMore = hosts.some((host) => Boolean(host.nextCursor));
-      return html`
-        <div class="sidebar-recent-sessions__group" data-session-section=${sectionId}>
-          <div class="sidebar-recent-sessions__head">
-            <button
-              type="button"
-              class="sidebar-session-group-toggle"
-              aria-expanded=${String(!collapsed)}
-              aria-label=${catalog.label}
-              @click=${() => this.toggleSessionSection(sectionId)}
-            >
-              <span class="sidebar-session-group-toggle__icon" aria-hidden="true"
-                >${collapsed ? icons.chevronRight : icons.chevronDown}</span
-              >
-              <span class="sidebar-recent-sessions__label-text">${catalog.label}</span>
-              <span class="sidebar-session-group-count">${rows.length}</span>
-            </button>
-          </div>
-          ${collapsed
-            ? nothing
-            : html`<div class="sidebar-recent-sessions__list">
-                  ${rows.map(({ host, session }) =>
-                    this.renderCatalogSession(catalog, host, session, {
-                      navigationState,
-                      liveRows,
-                      routeSessionKey,
-                    }),
-                  )}
-                </div>
-                ${hasMore
-                  ? html`<button
-                      type="button"
-                      class="sidebar-session-catalog-load-more"
-                      data-session-catalog-load-more=${catalog.id}
-                      ?disabled=${loadingMore}
-                      aria-busy=${String(loadingMore)}
-                      @click=${() => void this.loadMoreSessionCatalog(catalog.id)}
-                    >
-                      ${t("chat.selectors.loadMoreSessions")}
-                    </button>`
-                  : nothing}`}
-        </div>
-      `;
+    return renderSessionCatalogGroups({
+      catalogs: this.sessionCatalogs,
+      basePath: this.basePath,
+      routeSessionKey: this.activeRouteId === "chat" ? this.getRouteSessionKey() : "",
+      collapsedSections: this.collapsedSessionSections,
+      loadingMoreCatalogIds: this.loadingMoreSessionCatalogIds,
+      liveRows: [
+        ...(this.sessionsResult?.sessions ?? []),
+        ...Object.values(this.sessionRowsByAgent).flat(),
+      ],
+      renderLiveRow: (row) => this.renderRecentSession(navigationState.toSidebarSession(row)),
+      onToggleSection: (sectionId) => this.toggleSessionSection(sectionId),
+      onLoadMore: (catalogId) => void this.loadMoreSessionCatalog(catalogId),
+      onNavigate: (search) => this.onNavigate?.("chat", { search }),
     });
-  }
-
-  private renderCatalogSession(
-    catalog: SessionCatalog,
-    host: SessionCatalogHost,
-    session: SessionCatalogSession,
-    context: {
-      navigationState: ReturnType<AppSidebar["getSessionNavigationState"]>;
-      liveRows: ReadonlyMap<string, SessionsListResult["sessions"][number]>;
-      routeSessionKey: string;
-    },
-  ) {
-    const adoptedRow = session.openClawSessionKey
-      ? context.liveRows.get(session.openClawSessionKey)
-      : undefined;
-    if (adoptedRow) {
-      return this.renderRecentSession(context.navigationState.toSidebarSession(adoptedRow));
-    }
-    const key =
-      session.openClawSessionKey ??
-      buildCatalogSessionKey({
-        catalogId: catalog.id,
-        hostId: host.hostId,
-        threadId: session.threadId,
-      });
-    const href = `${pathForRoute("chat", this.basePath)}${searchForSession(key)}`;
-    // The catalog header already names the source; only a paired node's
-    // machine name adds signal on the row itself.
-    const hostSubtitle = host.kind === "node" ? host.label : undefined;
-    const active = context.routeSessionKey !== "" && key === context.routeSessionKey;
-    const rawTimestamp = session.recencyAt ?? session.updatedAt ?? session.createdAt;
-    const timestamp =
-      typeof rawTimestamp === "number" && rawTimestamp < 1_000_000_000_000
-        ? rawTimestamp * 1000
-        : rawTimestamp;
-    return html`
-      <div
-        class="sidebar-recent-session session-row-host ${active
-          ? "sidebar-recent-session--active"
-          : ""}"
-        data-session-key=${key}
-      >
-        <a
-          href=${href}
-          class="sidebar-recent-session__link"
-          title=${hostSubtitle
-            ? `${session.name || session.threadId} · ${hostSubtitle}`
-            : session.name || session.threadId}
-          @click=${(event: MouseEvent) => {
-            if (!shouldHandleNavigationClick(event)) {
-              return;
-            }
-            event.preventDefault();
-            this.onNavigate?.("chat", { search: searchForSession(key) });
-          }}
-        >
-          <span class="sidebar-recent-session__text">
-            <span class="sidebar-recent-session__name hover-marquee"
-              >${session.name || session.threadId}</span
-            >
-            ${hostSubtitle
-              ? html`<span class="sidebar-recent-session__subtitle">${hostSubtitle}</span>`
-              : nothing}
-          </span>
-          <span class="sidebar-recent-session__aside session-row-aside">
-            <span class="session-row-trail">${formatSidebarTimestamp(timestamp)}</span>
-          </span>
-        </a>
-      </div>
-    `;
   }
 
   private renderMoreRow() {

--- a/ui/src/lib/sessions/catalog-key.ts
+++ b/ui/src/lib/sessions/catalog-key.ts
@@ -27,7 +27,7 @@ export function announceCatalogSessionContinued(detail: CatalogSessionContinuedD
 const CATALOG_SESSION_LOOKUP_PAGE_LIMIT = 100;
 const CATALOG_SESSION_LOOKUP_MAX_PAGES = 100;
 
-export type CatalogSessionLookup = {
+type CatalogSessionLookup = {
   host: SessionCatalogHost | null;
   session: SessionCatalogSession | null;
 };

--- a/ui/src/lib/sessions/catalog-key.ts
+++ b/ui/src/lib/sessions/catalog-key.ts
@@ -4,6 +4,13 @@ export type CatalogSessionKey = {
   threadId: string;
 };
 
+/** Fired on `document` when a catalog session is adopted into an OpenClaw
+    session, so the sidebar can bind the row to its session key immediately
+    instead of waiting for the next catalog poll. */
+export const CATALOG_SESSION_CONTINUED_EVENT = "openclaw-session-catalog-continued";
+
+export type CatalogSessionContinuedDetail = CatalogSessionKey & { sessionKey: string };
+
 export function buildCatalogSessionKey(key: CatalogSessionKey): string {
   return `catalog:${encodeURIComponent(key.catalogId)}:${encodeURIComponent(key.hostId)}:${encodeURIComponent(key.threadId)}`;
 }

--- a/ui/src/lib/sessions/catalog-key.ts
+++ b/ui/src/lib/sessions/catalog-key.ts
@@ -1,3 +1,10 @@
+import type {
+  SessionCatalogHost,
+  SessionCatalogSession,
+  SessionsCatalogListResult,
+} from "../../../../packages/gateway-protocol/src/index.ts";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+
 export type CatalogSessionKey = {
   catalogId: string;
   hostId: string;
@@ -10,6 +17,58 @@ export type CatalogSessionKey = {
 export const CATALOG_SESSION_CONTINUED_EVENT = "openclaw-session-catalog-continued";
 
 export type CatalogSessionContinuedDetail = CatalogSessionKey & { sessionKey: string };
+
+export function announceCatalogSessionContinued(detail: CatalogSessionContinuedDetail): void {
+  document.dispatchEvent(
+    new CustomEvent<CatalogSessionContinuedDetail>(CATALOG_SESSION_CONTINUED_EVENT, { detail }),
+  );
+}
+
+const CATALOG_SESSION_LOOKUP_PAGE_LIMIT = 100;
+const CATALOG_SESSION_LOOKUP_MAX_PAGES = 100;
+
+export type CatalogSessionLookup = {
+  host: SessionCatalogHost | null;
+  session: SessionCatalogSession | null;
+};
+
+/** Resolves a catalog row's metadata (host + per-session capability flags).
+    A sidebar row can come from any loaded page, so this follows the host's
+    cursor until the thread is found; `null` means the caller went stale. */
+export async function lookupCatalogSession(params: {
+  client: Pick<GatewayBrowserClient, "request">;
+  key: CatalogSessionKey;
+  isCurrent: () => boolean;
+}): Promise<CatalogSessionLookup | null> {
+  const { client, key } = params;
+  let cursor: string | undefined;
+  const seenCursors = new Set<string>();
+  let host: SessionCatalogHost | null = null;
+  for (let pageIndex = 0; pageIndex < CATALOG_SESSION_LOOKUP_MAX_PAGES; pageIndex += 1) {
+    const listed = await client.request<SessionsCatalogListResult>("sessions.catalog.list", {
+      catalogId: key.catalogId,
+      hostIds: [key.hostId],
+      limitPerHost: CATALOG_SESSION_LOOKUP_PAGE_LIMIT,
+      ...(cursor ? { cursors: { [key.hostId]: cursor } } : {}),
+    });
+    if (!params.isCurrent()) {
+      return null;
+    }
+    const catalog = listed.catalogs.find((candidate) => candidate.id === key.catalogId);
+    host = catalog?.hosts.find((candidate) => candidate.hostId === key.hostId) ?? null;
+    const session = host?.sessions.find((candidate) => candidate.threadId === key.threadId) ?? null;
+    if (session) {
+      return { host, session };
+    }
+    const nextCursor = host?.nextCursor;
+    if (!nextCursor || seenCursors.has(nextCursor)) {
+      break;
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+  return { host, session: null };
+}
 
 export function buildCatalogSessionKey(key: CatalogSessionKey): string {
   return `catalog:${encodeURIComponent(key.catalogId)}:${encodeURIComponent(key.hostId)}:${encodeURIComponent(key.threadId)}`;

--- a/ui/src/lib/sessions/navigation.test.ts
+++ b/ui/src/lib/sessions/navigation.test.ts
@@ -49,6 +49,22 @@ describe("resolveSessionNavigation", () => {
     expect(navigation.activeRowKey).toBe("agent:main:session-b");
   });
 
+  it("does not synthesize a session row for a catalog session key", () => {
+    const rows = [
+      { key: "agent:main:recent-0", kind: "direct" as const, updatedAt: 100 },
+      { key: "agent:main:recent-1", kind: "direct" as const, updatedAt: 90 },
+    ];
+    const navigation = resolveSessionNavigation({
+      result: sessionsResult(rows),
+      resultAgentId: "main",
+      sessionKey: "catalog:claude:gateway%3Alocal:thread-1",
+    });
+
+    expect(navigation.visibleSessions.map((row) => row.key)).toEqual(rows.map((row) => row.key));
+    expect(navigation.activeRowKey).toBeNull();
+    expect(navigation.selectedSession).toBeUndefined();
+  });
+
   it("keeps a deep-linked session ahead of every returned active row", () => {
     const navigation = resolveSessionNavigation({
       result: sessionsResult(

--- a/ui/src/lib/sessions/navigation.ts
+++ b/ui/src/lib/sessions/navigation.ts
@@ -6,6 +6,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../string-coerce.ts";
+import { parseCatalogSessionKey } from "./catalog-key.ts";
 import {
   areUiSessionKeysEquivalent,
   isUiGlobalSessionKey,
@@ -276,8 +277,12 @@ export function resolveSessionNavigation(input: SessionNavigationInput): Session
     areUiSessionKeysEquivalent(row.key, currentSessionKey) ||
     (resultScopeMatches && uiSessionRowMatchesSelectedChat(input, row.key, currentSessionKey));
   const selectedSession = input.result?.sessions.find(matchesCurrentSession);
+  // Catalog sessions select their own sidebar rows; synthesizing a session row
+  // here would surface the raw catalog key as a phantom chat entry.
   const activeSession =
-    currentSessionKey && currentSessionKey.toLowerCase() !== "unknown"
+    currentSessionKey &&
+    currentSessionKey.toLowerCase() !== "unknown" &&
+    !parseCatalogSessionKey(currentSessionKey)
       ? { ...(selectedSession ?? { kind: "direct", updatedAt: null }), key: currentSessionKey }
       : undefined;
   const sortedSessions = getVisibleSessionRows(input.result, {

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -1819,10 +1819,11 @@ class ChatPane extends OpenClawLightDomElement {
         (row) => row.archived === true && areUiSessionKeysEquivalent(row.key, state.sessionKey),
       ) === true;
     const disabledReason = selectedSessionArchived ? t("chat.archivedSessionDisabled") : null;
-    // Claim view-only only once loaded catalog metadata proves it, so a
-    // continuable session never flashes a wrong "view-only" banner.
+    // Never flash "view-only" while metadata loads; after loading, anything
+    // short of a continuable session (including a failed lookup) explains the
+    // disabled composer instead of leaving it silently inert.
     const catalogDisabledReason =
-      catalogKey && !this.catalogLoading && this.catalogSession?.canContinue === false
+      catalogKey && !this.catalogLoading && this.catalogSession?.canContinue !== true
         ? this.catalogHost?.kind === "node"
           ? t("chat.catalog.remoteViewOnly")
           : t("chat.catalog.unsupportedViewOnly")

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -1819,9 +1819,8 @@ class ChatPane extends OpenClawLightDomElement {
         (row) => row.archived === true && areUiSessionKeysEquivalent(row.key, state.sessionKey),
       ) === true;
     const disabledReason = selectedSessionArchived ? t("chat.archivedSessionDisabled") : null;
-    // Never flash "view-only" while metadata loads; after loading, anything
-    // short of a continuable session (including a failed lookup) explains the
-    // disabled composer instead of leaving it silently inert.
+    // Never flash "view-only" while metadata loads; after loading, anything short
+    // of a continuable session (failed lookups too) explains the disabled composer.
     const catalogDisabledReason =
       catalogKey && !this.catalogLoading && this.catalogSession?.canContinue !== true
         ? this.catalogHost?.kind === "node"

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -6,7 +6,6 @@ import type {
   SessionCatalogSession,
   SessionCatalogTranscriptItem,
   SessionsCatalogContinueResult,
-  SessionsCatalogListResult,
   SessionsCatalogReadResult,
   TaskSuggestion,
   TaskSuggestionEvent,
@@ -43,10 +42,10 @@ import { clampText } from "../../lib/format.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { resolveSessionDisplayName } from "../../lib/session-display.ts";
 import {
+  announceCatalogSessionContinued,
   buildCatalogSessionKey,
-  CATALOG_SESSION_CONTINUED_EVENT,
+  lookupCatalogSession,
   parseCatalogSessionKey,
-  type CatalogSessionContinuedDetail,
   type CatalogSessionKey,
 } from "../../lib/sessions/catalog-key.ts";
 import { resolveSessionKey, scopedAgentParamsForSession } from "../../lib/sessions/index.ts";
@@ -220,9 +219,6 @@ type ChatPaneConnectionScope = {
   generation: number;
   sessions: ChatPageContext["sessions"];
 };
-
-const CATALOG_SESSION_LOOKUP_PAGE_LIMIT = 100;
-const CATALOG_SESSION_LOOKUP_MAX_PAGES = 100;
 
 const CHAT_OPEN_DETAILS_SELECTOR =
   ".chat-controls__inline-select[open], .context-usage details[open], .agent-chat__talk-select[open], .agent-chat__attach-menu[open], .chat-pr__checks[open]";
@@ -860,34 +856,12 @@ class ChatPane extends OpenClawLightDomElement {
     }
     try {
       if (!older) {
-        let cursor: string | undefined;
-        const seenCursors = new Set<string>();
-        // A sidebar row can come from any loaded page. Follow that host's cursor
-        // so continuation metadata is not lost when the selected row is past page one.
-        for (let pageIndex = 0; pageIndex < CATALOG_SESSION_LOOKUP_MAX_PAGES; pageIndex += 1) {
-          const listed = await client.request<SessionsCatalogListResult>("sessions.catalog.list", {
-            catalogId: key.catalogId,
-            hostIds: [key.hostId],
-            limitPerHost: CATALOG_SESSION_LOOKUP_PAGE_LIMIT,
-            ...(cursor ? { cursors: { [key.hostId]: cursor } } : {}),
-          });
-          if (!isCurrent()) {
-            return false;
-          }
-          const catalog = listed.catalogs.find((candidate) => candidate.id === key.catalogId);
-          this.catalogHost = catalog?.hosts.find((host) => host.hostId === key.hostId) ?? null;
-          this.catalogSession =
-            this.catalogHost?.sessions.find((session) => session.threadId === key.threadId) ?? null;
-          if (this.catalogSession) {
-            break;
-          }
-          const nextCursor = this.catalogHost?.nextCursor;
-          if (!nextCursor || seenCursors.has(nextCursor)) {
-            break;
-          }
-          seenCursors.add(nextCursor);
-          cursor = nextCursor;
+        const lookup = await lookupCatalogSession({ client, key, isCurrent });
+        if (!lookup) {
+          return false;
         }
+        this.catalogHost = lookup.host;
+        this.catalogSession = lookup.session;
       }
       const requestedOlderCursor = older ? this.catalogCursor : undefined;
       if (requestedOlderCursor) {
@@ -1151,11 +1125,7 @@ class ChatPane extends OpenClawLightDomElement {
         "sessions.catalog.continue",
         key,
       );
-      document.dispatchEvent(
-        new CustomEvent<CatalogSessionContinuedDetail>(CATALOG_SESSION_CONTINUED_EVENT, {
-          detail: { ...key, sessionKey: result.sessionKey },
-        }),
-      );
+      announceCatalogSessionContinued({ ...key, sessionKey: result.sessionKey });
       this.onPaneSessionChange?.(this.paneId, result.sessionKey);
       this.switchPaneSession(result.sessionKey);
       state.handleChatDraftChange(draft);
@@ -1849,9 +1819,8 @@ class ChatPane extends OpenClawLightDomElement {
         (row) => row.archived === true && areUiSessionKeysEquivalent(row.key, state.sessionKey),
       ) === true;
     const disabledReason = selectedSessionArchived ? t("chat.archivedSessionDisabled") : null;
-    // Claim view-only only once catalog metadata proves it; while loading (or
-    // after a failed lookup) the composer stays disabled without a banner so a
-    // continuable session never flashes a wrong "view-only" message.
+    // Claim view-only only once loaded catalog metadata proves it, so a
+    // continuable session never flashes a wrong "view-only" banner.
     const catalogDisabledReason =
       catalogKey && !this.catalogLoading && this.catalogSession?.canContinue === false
         ? this.catalogHost?.kind === "node"

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -44,7 +44,9 @@ import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { resolveSessionDisplayName } from "../../lib/session-display.ts";
 import {
   buildCatalogSessionKey,
+  CATALOG_SESSION_CONTINUED_EVENT,
   parseCatalogSessionKey,
+  type CatalogSessionContinuedDetail,
   type CatalogSessionKey,
 } from "../../lib/sessions/catalog-key.ts";
 import { resolveSessionKey, scopedAgentParamsForSession } from "../../lib/sessions/index.ts";
@@ -1149,6 +1151,11 @@ class ChatPane extends OpenClawLightDomElement {
         "sessions.catalog.continue",
         key,
       );
+      document.dispatchEvent(
+        new CustomEvent<CatalogSessionContinuedDetail>(CATALOG_SESSION_CONTINUED_EVENT, {
+          detail: { ...key, sessionKey: result.sessionKey },
+        }),
+      );
       this.onPaneSessionChange?.(this.paneId, result.sessionKey);
       this.switchPaneSession(result.sessionKey);
       state.handleChatDraftChange(draft);
@@ -1842,13 +1849,15 @@ class ChatPane extends OpenClawLightDomElement {
         (row) => row.archived === true && areUiSessionKeysEquivalent(row.key, state.sessionKey),
       ) === true;
     const disabledReason = selectedSessionArchived ? t("chat.archivedSessionDisabled") : null;
-    const catalogDisabledReason = catalogKey
-      ? this.catalogSession?.canContinue
-        ? null
-        : this.catalogHost?.kind === "node"
+    // Claim view-only only once catalog metadata proves it; while loading (or
+    // after a failed lookup) the composer stays disabled without a banner so a
+    // continuable session never flashes a wrong "view-only" message.
+    const catalogDisabledReason =
+      catalogKey && !this.catalogLoading && this.catalogSession?.canContinue === false
+        ? this.catalogHost?.kind === "node"
           ? t("chat.catalog.remoteViewOnly")
           : t("chat.catalog.unsupportedViewOnly")
-      : null;
+        : null;
     const canOpenRealtimeTalkSettings = hasOperatorAdminAccess(
       this.context.gateway.snapshot.hello?.auth ?? null,
     );


### PR DESCRIPTION
## What Problem This Solves

External Codex/Claude Code sessions surfaced in the Control UI sidebar ("session catalog") were effectively unusable:

1. **Wrongly view-only.** Almost every real Claude Code session on the gateway host showed "This external session source is view-only." Two causes:
   - Sessions driven through the Claude Code **desktop app** are recorded with `source: "claude-desktop"` during catalog discovery, and the anthropic plugin hard-required `source === "claude-cli"` for `canContinue`/continue — even though desktop sessions live in the same `~/.claude/projects` JSONL store (discovery drops desktop records without one) and `claude --resume --fork-session` continues them identically.
   - The chat pane showed the view-only banner whenever catalog metadata wasn't loaded yet, so even continuable sessions flashed "view-only" while loading.
2. **Selection lifted the session into the chats block.** Clicking a catalog row synthesized a phantom row in the regular sessions list labeled with the raw `catalog:claude:gateway%3Alocal:…` key (deep-link fallback in `resolveSessionNavigation`), and previously adopted sessions rendered twice — once in the catalog group and once in the regular list, jumping to the top on activity. Catalog rows also never showed a selected state.
3. **"Local Codex" / "Local Claude" noise.** Rows carried the gateway-host label as subtitle whenever a catalog had more than one host, adding no signal (the group header already names the source).

## Why This Change Was Made

Catalog sessions should feel like regular sessions that happen to run through Codex/Claude Code: click → selected in place, transcript shown, type → continue with streaming. All gating keys off the provider-reported per-session `canContinue`, so paired-node continuation (PR #105833) lights up in this UI automatically once it lands.

## User Impact

- Local Claude Code sessions (CLI **and** desktop app) are continuable from the web UI: type into the transcript view, the session is adopted, and the reply streams in as a normal session run.
- The view-only banner never flashes during load; after metadata loads, any non-continuable state (including a failed lookup) shows the explanatory banner instead of a silently disabled composer.
- Clicking a catalog session selects it in place. No phantom `catalog:…` row, no duplicate entry jumping to the top of the chats list. Adopted sessions render as full live session rows (run spinner, unread dot, pin/menu actions) inside their catalog group, bound immediately on adoption via a document-level `openclaw-session-catalog-continued` event instead of waiting for the next 30s catalog poll.
- Host subtitles only show a paired node's machine name; "Local Codex"/"Local Claude" subtitles are gone.
- Structure: sidebar catalog rendering moved to `app-sidebar-session-catalogs.ts`, the catalog metadata lookup to `catalog-key.ts`, and the Claude node-host commands to `session-catalog-node-commands.ts` (mirrors the codex plugin layout).

## Evidence

- Live verification against a scratch gateway built from this branch on a Mac with 40 real Claude Code sessions (mixed CLI/desktop):
  - Before: every session showed the view-only banner, and clicking created the phantom raw-key row.
  - After: `sessions.catalog.list` reports `canContinue: true` for desktop-source sessions, rows select in place with the active highlight, the composer is enabled, and sending ran the full flow — `sessions.catalog.continue` succeeded (adoption + history import), `chat.send` started a run through the claude-cli backend with `useResume=true` (gateway log), and the adopted row stayed inside the catalog group with the live run spinner and no duplicate in the chats block. (The CLI turn itself returned empty on that box because ~20 concurrent agent sessions were contending the local `claude` OAuth — standalone `claude -p` reproduced "Not logged in" in isolation; the resume path is the same shipped one used for `claude-cli`-source adoption.)
- Tests (all passing locally via `node scripts/run-vitest.mjs`):
  - `extensions/anthropic/session-catalog.test.ts` (8) — incl. new: desktop-source rows list as continuable and adopt with the same one-shot fork binding.
  - `ui/src/lib/sessions/navigation.test.ts` (12) — incl. new: no synthesized row for catalog session keys.
  - `ui/src/components/app-sidebar.test.ts` (54 with navigation shard) — incl. new: node-only host subtitles; in-place active highlight without a phantom chat row; adopted rows render once (as live rows) inside the catalog group; catalog-continued event binds the adopted key immediately.
  - `ui/src/e2e/codex-sessions.e2e.test.ts` + `ui/src/e2e/claude-sessions.e2e.test.ts` (3) — existing catalog flows still pass.
- `pnpm tsgo:ui` and `pnpm tsgo:extensions` pass locally.
- Autoreview (Codex `gpt-5.6-sol`, thinking xhigh, branch vs origin/main): one P2 finding (silent disabled composer after failed lookup) — fixed in 47591dfeaf9; rerun clean: "patch is correct", no actionable findings.
