### PR TITLE
fix(ci): remove reintroduced transcript export baseline

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -3114,7 +3114,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/gateway/session-transcript-readers.ts: readRecentSessionUsageFromTranscriptAsync",
   "src/gateway/session-transcript-readers.ts: readSessionMessageCount",
   "src/gateway/session-transcript-readers.ts: readSessionMessages",
-  "src/gateway/session-transcript-readers.ts: ResolvedTranscriptReadTarget",
   "src/gateway/session-transcript-readers.ts: visitSessionMessages",
   "src/gateway/session-utils.fs.ts: archiveFileOnDisk",
   "src/gateway/session-utils.fs.ts: archiveSessionTranscripts",


### PR DESCRIPTION
## What Problem This Solves

PR #105961 regenerated the production dead-export baseline from a stale branch and reintroduced `ResolvedTranscriptReadTarget`, which current production Knip no longer reports. That makes `pnpm deadcode:exports` fail on current main and blocks unrelated PR dependency gates.

## Why This Change Was Made

Remove the single stale allowance again. The underlying export was already removed; no runtime code changes.

## User Impact

None. This restores the shrink-only dead-export ratchet and unblocks CI.

## Evidence

- `node scripts/check-deadcode-exports.mjs` — 4,986 entries matched
- `git diff --check`
- Diff is one baseline deletion, matching the earlier repair in `125ad94d6d4`
