### PR TITLE
fix(cli): use startsWith for loopback IPv4 check in container proxy

### DIFF
--- a/src/cli/container-target.ts
+++ b/src/cli/container-target.ts
@@ -184,7 +184,7 @@ function isLoopbackProxyHostname(hostname: string): boolean {
     return true;
   }
   if (isIP(normalizedHostname) === 4) {
-    return normalizedHostname.split(".", 1)[0] === "127";
+    return normalizedHostname.startsWith("127.");
   }
   const ipv6Hostname = normalizedHostname.replace(/^\[|\]$/g, "");
   if (isIP(ipv6Hostname) !== 6) {


### PR DESCRIPTION
## What Problem This Solves

`isLoopbackProxyHostname` in `container-target.ts` used `normalizedHostname.split(".", 1)[0] === "127"` to check for loopback IPv4 addresses. While functionally correct (since `isIP()` already validates the format), `startsWith("127.")` is more direct, more readable, and avoids the unnecessary string split operation.

## Fix

Replace `split(".", 1)[0] === "127"` with `startsWith("127.")`. Behavior is identical because `isIP(normalizedHostname) === 4` already guarantees the input is a valid IPv4 address (four decimal octets separated by dots), so `127.x.x.x` is the only pattern where `startsWith("127.")` is true.

## Evidence

### Before and after behavior

```
// Both expressions produce identical results for valid IPv4:
"127.0.0.1".split(".", 1)[0] === "127"  → true
"127.0.0.1".startsWith("127.")          → true

"192.168.1.1".split(".", 1)[0] === "127"  → false
"192.168.1.1".startsWith("127.")          → false

"10.0.0.1".split(".", 1)[0] === "127"  → false
"10.0.0.1".startsWith("127.")          → false
```

Since `isIP() === 4` guarantees valid IPv4 format, `startsWith("127.")` cannot false-positive on non-loopback addresses. No address like `1270.0.0.1` passes `isIP() === 4`.

### Rebased to latest main

This PR has been rebased onto the latest `origin/main` to resolve a stale export-count CI failure.

## Test plan

- [x] Existing `container-target` tests (32 tests) pass — behavior unchanged
- [x] `isLoopbackProxyHostname` logic is identical for all valid IPv4 inputs