### PR TITLE
fix(infra): return undefined for bigint exceeding MAX_SAFE_INTEGER in normalizeSqliteNumber

### DIFF
--- a/src/infra/sqlite-number.test.ts
+++ b/src/infra/sqlite-number.test.ts
@@ -38,4 +38,12 @@ describe("normalizeSqliteNumber", () => {
   it("converts negative bigint", () => {
     expect(normalizeSqliteNumber(BigInt(-1))).toBe(-1);
   });
+
+  it("returns undefined for bigint exceeding MAX_SAFE_INTEGER", () => {
+    expect(normalizeSqliteNumber(BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1))).toBeUndefined();
+  });
+
+  it("returns undefined for bigint below -MAX_SAFE_INTEGER", () => {
+    expect(normalizeSqliteNumber(BigInt(-Number.MAX_SAFE_INTEGER) - BigInt(1))).toBeUndefined();
+  });
 });

--- a/src/infra/sqlite-number.test.ts
+++ b/src/infra/sqlite-number.test.ts
@@ -1,4 +1,5 @@
 // Tests for SQLite number normalization.
+import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 import { normalizeSqliteNumber } from "./sqlite-number.js";
 
@@ -39,11 +40,18 @@ describe("normalizeSqliteNumber", () => {
     expect(normalizeSqliteNumber(BigInt(-1))).toBe(-1);
   });
 
-  it("returns undefined for bigint exceeding MAX_SAFE_INTEGER", () => {
-    expect(normalizeSqliteNumber(BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1))).toBeUndefined();
-  });
-
-  it("returns undefined for bigint below -MAX_SAFE_INTEGER", () => {
-    expect(normalizeSqliteNumber(BigInt(-Number.MAX_SAFE_INTEGER) - BigInt(1))).toBeUndefined();
+  it.each([
+    BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1),
+    BigInt(-Number.MAX_SAFE_INTEGER) - BigInt(1),
+  ])("returns undefined for unsafe bigint row %s", (value) => {
+    const database = new DatabaseSync(":memory:");
+    try {
+      const statement = database.prepare("SELECT ? AS value");
+      statement.setReadBigInts(true);
+      const row = statement.get(value) as { value: bigint };
+      expect(normalizeSqliteNumber(row.value)).toBeUndefined();
+    } finally {
+      database.close();
+    }
   });
 });

--- a/src/infra/sqlite-number.ts
+++ b/src/infra/sqlite-number.ts
@@ -1,10 +1,9 @@
-/** Converts a SQLite number or bigint column into a JavaScript number.
- *  Returns undefined when the value is null, non-numeric, or a bigint that
- *  exceeds Number.MAX_SAFE_INTEGER (2^53-1) where Number() would silently
- *  lose precision or return Infinity. */
+const MAX_SAFE_INTEGER_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
+
+/** Converts a SQLite number or safely representable bigint column into a JavaScript number. */
 export function normalizeSqliteNumber(value: number | bigint | null): number | undefined {
   if (typeof value === "bigint") {
-    if (value > Number.MAX_SAFE_INTEGER || value < -Number.MAX_SAFE_INTEGER) {
+    if (value > MAX_SAFE_INTEGER_BIGINT || value < -MAX_SAFE_INTEGER_BIGINT) {
       return undefined;
     }
     return Number(value);

--- a/src/infra/sqlite-number.ts
+++ b/src/infra/sqlite-number.ts
@@ -1,6 +1,12 @@
-/** Converts a SQLite number or bigint column into a JavaScript number. */
+/** Converts a SQLite number or bigint column into a JavaScript number.
+ *  Returns undefined when the value is null, non-numeric, or a bigint that
+ *  exceeds Number.MAX_SAFE_INTEGER (2^53-1) where Number() would silently
+ *  lose precision or return Infinity. */
 export function normalizeSqliteNumber(value: number | bigint | null): number | undefined {
   if (typeof value === "bigint") {
+    if (value > Number.MAX_SAFE_INTEGER || value < -Number.MAX_SAFE_INTEGER) {
+      return undefined;
+    }
     return Number(value);
   }
   return typeof value === "number" ? value : undefined;


### PR DESCRIPTION
## What Problem This Solves

`normalizeSqliteNumber` converted bigint rows to JavaScript numbers without checking the safe-integer range. A bigint outside `Number.MAX_SAFE_INTEGER` loses precision when converted.

## Fix

Return `undefined` for bigint values outside the inclusive JavaScript safe-integer range. Keep the bound as a bigint constant so the conversion decision is exact and centralized.

## User Impact

Corrupt or externally produced SQLite integer rows can no longer silently become imprecise timestamps, sequence values, revisions, counts, or byte values at callers of the shared decoder.

## Evidence

- Real SQLite regression: `StatementSync.setReadBigInts(true)` reads the first positive and negative unsafe SQLite integers as bigint values; both now normalize to `undefined`.
- `node scripts/run-vitest.mjs src/infra/sqlite-number.test.ts`
  - PASS: 1 shard, 11 tests.
- `node scripts/check-changed.mjs -- src/infra/sqlite-number.ts src/infra/sqlite-number.test.ts`
  - PASS: typechecks, lint, formatting, boundaries, import cycles, and repository guards.
  - Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29632468162
- Structured autoreview: clean, correctness 0.98.

## Test plan

- [x] Preserve safe positive, negative, zero, number, and null behavior.
- [x] Reject the first bigint above the positive safe boundary.
- [x] Reject the first bigint below the negative safe boundary.
- [x] Exercise the unsafe values through a real node:sqlite statement.
