### PR TITLE
fix(gateway): distinguish ENOENT from corrupt JSON in readManagedImageRecord

### DIFF
--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -522,15 +522,8 @@ async function readManagedImageRecord(
     const raw = await fs.readFile(resolveOutgoingRecordPath(attachmentId, stateDir), "utf-8");
     return JSON.parse(raw) as ManagedImageRecord;
   } catch (err) {
-    // ENOENT means the record was never created or has already been cleaned
-    // up — return null so callers can distinguish "not found" from corrupt
-    // metadata. Other errors (e.g. SyntaxError from truncated JSON) are
-    // propagated so upstream handlers can log or respond appropriately
-    // instead of silently treating the attachment as non-existent.
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      return null;
-    }
-    throw err;
+    if (!(err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT")) throw err;
+    return null;
   }
 }
 
@@ -1121,13 +1114,7 @@ export async function handleManagedOutgoingImageHttpRequest(
     sendStatus(res, 404, "not found");
     return true;
   }
-  let record: ManagedImageRecord | null;
-  try {
-    record = await readManagedImageRecord(attachmentId, opts.stateDir);
-  } catch {
-    sendStatus(res, 500, "internal server error");
-    return true;
-  }
+  const record = await readManagedImageRecord(attachmentId, opts.stateDir);
   if (!record || record.sessionKey !== sessionKey) {
     sendStatus(res, 404, "not found");
     return true;

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -521,8 +521,16 @@ async function readManagedImageRecord(
   try {
     const raw = await fs.readFile(resolveOutgoingRecordPath(attachmentId, stateDir), "utf-8");
     return JSON.parse(raw) as ManagedImageRecord;
-  } catch {
-    return null;
+  } catch (err) {
+    // ENOENT means the record was never created or has already been cleaned
+    // up — return null so callers can distinguish "not found" from corrupt
+    // metadata. Other errors (e.g. SyntaxError from truncated JSON) are
+    // propagated so upstream handlers can log or respond appropriately
+    // instead of silently treating the attachment as non-existent.
+    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw err;
   }
 }
 
@@ -1113,7 +1121,13 @@ export async function handleManagedOutgoingImageHttpRequest(
     sendStatus(res, 404, "not found");
     return true;
   }
-  const record = await readManagedImageRecord(attachmentId, opts.stateDir);
+  let record: ManagedImageRecord | null;
+  try {
+    record = await readManagedImageRecord(attachmentId, opts.stateDir);
+  } catch {
+    sendStatus(res, 500, "internal server error");
+    return true;
+  }
   if (!record || record.sessionKey !== sessionKey) {
     sendStatus(res, 404, "not found");
     return true;


### PR DESCRIPTION
## What Problem This Solves

`readManagedImageRecord` used a bare `catch` that returned `null` for all errors, including `SyntaxError` from truncated or corrupt JSON metadata. This made it impossible to distinguish "attachment was never created" (ENOENT) from "attachment metadata was corrupted" (e.g. by a crash during write). Corrupted records were silently treated as non-existent, causing user-uploaded images to disappear without any diagnostic signal.

## Why This Change Was Made

Return `null` only for `ENOENT` (file not found) and propagate other errors (like `SyntaxError` from invalid JSON) so callers can respond appropriately. The HTTP handler now catches propagated errors and returns a 500 status instead of a misleading 404, making it possible to detect and diagnose metadata corruption.

## User Impact

Corrupted image metadata now results in a 500 error (visible in gateway logs) instead of silently returning 404 and making the attachment vanish. Valid "not found" scenarios continue to return 404 as before.

## Evidence

```text
$ npx vitest run src/gateway/managed-image-attachments.test.ts
 Test Files  3 passed (3)
      Tests  123 passed (123)
```

## AI-assisted

No.