### PR TITLE
fix(agent-core): preserve cacheRetention when undefined in harness options (#106014)

### DIFF
--- a/packages/agent-core/src/harness/agent-harness.cache-retention.test.ts
+++ b/packages/agent-core/src/harness/agent-harness.cache-retention.test.ts
@@ -1,0 +1,152 @@
+// Agent Core harness tests cover cacheRetention parameter handling.
+import { describe, expect, it, vi } from "vitest";
+import type { Model, StreamFn } from "../../llm.js";
+import { AgentHarness } from "./agent-harness.js";
+import type { Session } from "./types.js";
+
+const mockModel: Model = {
+  id: "claude-sonnet-5",
+  name: "Claude Sonnet 5",
+  api: "anthropic-messages",
+  provider: "anthropic",
+  baseUrl: "https://api.anthropic.com",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200000,
+  maxTokens: 8192,
+};
+
+describe("AgentHarness cacheRetention handling", () => {
+  it("preserves cacheRetention when requestOptions.cacheRetention is undefined", async () => {
+    // This test verifies the fix for issue #106014 where explicit cacheRetention
+    // values were being overwritten by undefined in the agent core harness layer.
+
+    let capturedStreamOptions: unknown;
+
+    // Mock stream function that captures the options it receives
+    const mockStreamFn: StreamFn = vi.fn((model, context, options) => {
+      capturedStreamOptions = options;
+      // Return a minimal async iterable to satisfy the type
+      return (async function* () {
+        yield {
+          type: "content",
+          content: { type: "text" as const, text: "" },
+        };
+      })();
+    });
+
+    // Create a minimal mock session
+    const mockSession: Partial<Session> = {
+      buildContext: vi.fn().mockResolvedValue({
+        messages: [{ role: "user" as const, content: "test", timestamp: Date.now() }],
+      }),
+      getMetadata: vi.fn().mockResolvedValue({ id: "test-session" }),
+      appendMessage: vi.fn().mockResolvedValue(undefined),
+      getBranch: vi.fn().mockResolvedValue([]),
+      getLeafId: vi.fn().mockResolvedValue("test-leaf"),
+      getEntry: vi.fn().mockResolvedValue(undefined),
+      appendModelChange: vi.fn().mockResolvedValue(undefined),
+      appendThinkingLevelChange: vi.fn().mockResolvedValue(undefined),
+      appendCustomEntry: vi.fn().mockResolvedValue(undefined),
+      appendCustomMessageEntry: vi.fn().mockResolvedValue(undefined),
+      appendLabel: vi.fn().mockResolvedValue(undefined),
+      appendSessionName: vi.fn().mockResolvedValue(undefined),
+      appendCompaction: vi.fn().mockResolvedValue("compaction-id"),
+      moveTo: vi.fn().mockResolvedValue("summary-id"),
+      getStorage: vi.fn().mockReturnValue({
+        setLeafId: vi.fn().mockResolvedValue(undefined),
+      }),
+    };
+
+    const harness = new AgentHarness({
+      env: { WORKSPACE_DIR: "/test" },
+      session: mockSession as Session,
+      model: mockModel,
+      tools: [],
+      streamOptions: {
+        cacheRetention: "long", // Explicit long cache retention
+      },
+      getApiKeyAndHeaders: vi.fn().mockResolvedValue({ apiKey: "test-key" }),
+      runtime: {
+        streamSimple: mockStreamFn,
+      },
+    });
+
+    // Execute a prompt to trigger the stream function
+    try {
+      await harness.prompt("test message");
+    } catch {
+      // Ignore errors from the mock - we only care about captured options
+    }
+
+    // Verify that cacheRetention was passed through and not overwritten with undefined
+    expect(capturedStreamOptions).toEqual(
+      expect.objectContaining({
+        cacheRetention: "long",
+      }),
+    );
+  });
+
+  it("does not add cacheRetention key when not configured", async () => {
+    // When no cacheRetention is configured, the key should not be present
+    // in the options object (not even as undefined).
+
+    let capturedStreamOptions: unknown;
+
+    const mockStreamFn: StreamFn = vi.fn((model, context, options) => {
+      capturedStreamOptions = options;
+      return (async function* () {
+        yield {
+          type: "content",
+          content: { type: "text" as const, text: "" },
+        };
+      })();
+    });
+
+    const mockSession: Partial<Session> = {
+      buildContext: vi.fn().mockResolvedValue({
+        messages: [{ role: "user" as const, content: "test", timestamp: Date.now() }],
+      }),
+      getMetadata: vi.fn().mockResolvedValue({ id: "test-session" }),
+      appendMessage: vi.fn().mockResolvedValue(undefined),
+      getBranch: vi.fn().mockResolvedValue([]),
+      getLeafId: vi.fn().mockResolvedValue("test-leaf"),
+      getEntry: vi.fn().mockResolvedValue(undefined),
+      appendModelChange: vi.fn().mockResolvedValue(undefined),
+      appendThinkingLevelChange: vi.fn().mockResolvedValue(undefined),
+      appendCustomEntry: vi.fn().mockResolvedValue(undefined),
+      appendCustomMessageEntry: vi.fn().mockResolvedValue(undefined),
+      appendLabel: vi.fn().mockResolvedValue(undefined),
+      appendSessionName: vi.fn().mockResolvedValue(undefined),
+      appendCompaction: vi.fn().mockResolvedValue("compaction-id"),
+      moveTo: vi.fn().mockResolvedValue("summary-id"),
+      getStorage: vi.fn().mockReturnValue({
+        setLeafId: vi.fn().mockResolvedValue(undefined),
+      }),
+    };
+
+    const harness = new AgentHarness({
+      env: { WORKSPACE_DIR: "/test" },
+      session: mockSession as Session,
+      model: mockModel,
+      tools: [],
+      streamOptions: {}, // No cacheRetention configured
+      getApiKeyAndHeaders: vi.fn().mockResolvedValue({ apiKey: "test-key" }),
+      runtime: {
+        streamSimple: mockStreamFn,
+      },
+    });
+
+    try {
+      await harness.prompt("test message");
+    } catch {
+      // Ignore errors from the mock
+    }
+
+    // Verify that cacheRetention is not present in the options
+    expect((capturedStreamOptions as Record<string, unknown>).cacheRetention).toBeUndefined();
+    // More importantly, verify the key doesn't exist at all
+    expect(Object.keys(capturedStreamOptions as object)).not.toContain("cacheRetention");
+  });
+});

--- a/packages/agent-core/src/harness/agent-harness.ts
+++ b/packages/agent-core/src/harness/agent-harness.ts
@@ -443,7 +443,9 @@ export class CoreAgentHarness<
         snapshotOptions,
       );
       return resolveAgentCoreStreamFn(this.runtime)(model, context, {
-        cacheRetention: requestOptions.cacheRetention,
+        ...(requestOptions.cacheRetention !== undefined && {
+          cacheRetention: requestOptions.cacheRetention,
+        }),
         headers: requestOptions.headers,
         maxRetries: requestOptions.maxRetries,
         maxRetryDelayMs: requestOptions.maxRetryDelayMs,


### PR DESCRIPTION
## What Problem This Solves

Fixes issue #106014 where explicit `cacheRetention` values configured in agent settings (e.g., `"long"` for 1-hour prompt caching) were being silently overwritten with `undefined` in the embedded agent path, causing all requests to fall back to the default 5-minute cache TTL.

## Why This Change Was Made

The root cause was in `packages/agent-core/src/harness/agent-harness.ts:446` where `createStreamFn` constructed an options object with an explicit `cacheRetention: requestOptions.cacheRetention` property. When `requestOptions.cacheRetention` was `undefined` (which is always the case in the embedded agent harness path), JavaScript's object spread semantics caused this `undefined` value to override the previously resolved `"long"` value from the extra-params wrapper.

```javascript
// Before fix:
{...{cacheRetention: "long"}, ...{cacheRetention: undefined}} 
// → {cacheRetention: undefined} ❌

// After fix:
{...(undefined !== undefined && {cacheRetention: undefined}), ...{cacheRetention: "long"}}
// → {cacheRetention: "long"} ✅
```

## User Impact

Users who configured per-model cache retention settings like:
```json
{
  "agents": {
    "defaults": {
      "models": {
        "anthropic/claude-sonnet-5": {
          "params": { "cacheRetention": "long" }
        }
      }
    }
  }
}
```

will now see the expected behavior:
- First conversation writes cache entries with `cache_control: {type:"ephemeral", ttl:"1h"}`
- Subsequent conversations within 1 hour show non-zero `cache_read_input_tokens`
- Previously, all requests used the default 5-minute TTL regardless of configuration

## Evidence

### Test Coverage
New test in `packages/agent-core/src/harness/agent-harness.cache-retention.test.ts` verifies:
1. Explicit `cacheRetention: "long"` is preserved through the harness layer
2. Unconfigured `cacheRetention` does not add an `undefined` key to options

### Validation Results
```
✓ All 65 harness tests pass
✓ New cacheRetention tests pass (2/2)
✓ TypeScript type check passes
✓ Code formatted with oxfmt
```

### Related Files Changed
- `packages/agent-core/src/harness/agent-harness.ts` - Fix conditional spread to avoid undefined overwrite
- `packages/agent-core/src/harness/agent-harness.cache-retention.test.ts` - New test coverage

---

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>