### PR TITLE
fix: set identity from the selected agent workspace

### DIFF
--- a/src/agents/identity-file.test.ts
+++ b/src/agents/identity-file.test.ts
@@ -57,6 +57,11 @@ describe("parseIdentityMarkdown", () => {
     const parsed = parseIdentityMarkdown(content);
     expect(parsed).toStrictEqual({});
   });
+
+  it("ignores an italic not-set placeholder", () => {
+    const parsed = parseIdentityMarkdown("- **Avatar:** *(not set yet)*");
+    expect(parsed).toStrictEqual({});
+  });
 });
 
 describe("mergeIdentityMarkdownContent", () => {

--- a/src/agents/identity-file.ts
+++ b/src/agents/identity-file.ts
@@ -28,6 +28,7 @@ const WRITABLE_IDENTITY_FIELDS = [
 const RICH_IDENTITY_LABELS = new Set(["name", "creature", "vibe", "theme", "emoji", "avatar"]);
 
 const IDENTITY_PLACEHOLDER_VALUES = new Set([
+  "not set yet",
   "pick something you like",
   "ai? robot? familiar? ghost in the machine? something weirder?",
   "how do you come across? sharp? warm? chaotic? calm?",

--- a/src/commands/agents.commands.identity.ts
+++ b/src/commands/agents.commands.identity.ts
@@ -85,6 +85,7 @@ export async function agentsSetIdentityCommand(
   const identityFileRaw = normalizeOptionalString(opts.identityFile);
   const workspaceRaw = normalizeOptionalString(opts.workspace);
   const wantsIdentityFile = Boolean(opts.fromIdentity || identityFileRaw || !hasExplicitIdentity);
+  let agentId = agentRaw ? normalizeAgentId(agentRaw) : undefined;
 
   let identityFilePath: string | undefined;
   let workspaceDir: string | undefined;
@@ -94,11 +95,12 @@ export async function agentsSetIdentityCommand(
     workspaceDir = path.dirname(identityFilePath);
   } else if (workspaceRaw) {
     workspaceDir = normalizeWorkspacePath(workspaceRaw);
-  } else if (wantsIdentityFile || !agentRaw) {
+  } else if (agentId && wantsIdentityFile) {
+    workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+  } else if (wantsIdentityFile || !agentId) {
     workspaceDir = path.resolve(process.cwd());
   }
 
-  let agentId = agentRaw ? normalizeAgentId(agentRaw) : undefined;
   if (!agentId) {
     if (!workspaceDir) {
       runtime.error("Select an agent with --agent or provide a workspace via --workspace.");

--- a/src/commands/agents.identity.test.ts
+++ b/src/commands/agents.identity.test.ts
@@ -103,6 +103,25 @@ describe("agents set-identity command", () => {
     });
   });
 
+  it("resolves --from-identity against the selected agent workspace", async () => {
+    const { root, workspace } = await createIdentityWorkspace();
+    await writeIdentityFile(workspace, ["- Name: Workspace Agent"]);
+
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: { agents: { list: [{ id: "main", workspace }] } },
+    });
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(root);
+
+    try {
+      await agentsSetIdentityCommand({ agent: "main", fromIdentity: true }, runtime);
+    } finally {
+      cwdSpy.mockRestore();
+    }
+
+    expect(getWrittenMainIdentity()).toEqual({ name: "Workspace Agent" });
+  });
+
   it("errors when multiple agents match the same workspace", async () => {
     const { workspace } = await createIdentityWorkspace("shared");
     await writeIdentityFile(workspace, ["- Name: Echo"]);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw agents set-identity --agent <id> --from-identity` from outside the agent workspace would read `IDENTITY.md` from the shell working directory. Remote invocations such as SSH sessions from `$HOME` therefore failed with `No identity data found` even when the selected agent had a configured workspace.

It also prevents the common italic placeholder `*(not set yet)*` from becoming a persisted avatar value.

## Why This Change Was Made

When an agent is explicitly selected and identity-file input is needed, the command now uses the existing agent workspace resolver. Explicit `--identity-file` and `--workspace` options retain precedence. The identity parser's normalized placeholder allowlist now includes `not set yet`.

AI-assisted: Codex implemented the change and ran the repository's structured autoreview gate.

## User Impact

Operators can sync a selected agent's identity from any working directory, including remote SSH shells. Placeholder avatar text is ignored instead of being written into agent config.

## Evidence

- Before-fix Testbox regression proof:
  - selected-agent workspace test failed because no config write occurred
  - parser test returned `{ avatar: "(not set yet)" }`
- After-fix focused proof: `corepack pnpm test src/commands/agents.identity.test.ts src/agents/identity-file.test.ts` — 16/16 tests passed across two Vitest shards.
- Changed gate: `corepack pnpm check:changed` — formatting, core production/test typechecks, lint, and guards passed.
- Black-box CLI proof via `openclaw.mjs` from two unrelated working directories:
  - configured agent workspace resolved
  - identity name persisted and changed with the fixture
  - italic placeholder avatar omitted from JSON output and persisted config
- Testbox-through-Crabbox: `tbx_01kxd0fspdmceavmwdye3gvmgk`; [Actions run 29227350470](https://github.com/openclaw/openclaw/actions/runs/29227350470).
- Autoreview: clean, no accepted/actionable findings; 0.96 correctness confidence.
