### PR TITLE
fix(macos): prevent launch stalls with many Node versions

### DIFF
--- a/apps/macos/Sources/OpenClaw/CLIInstaller.swift
+++ b/apps/macos/Sources/OpenClaw/CLIInstaller.swift
@@ -160,8 +160,9 @@ enum CLIInstaller {
     }
 
     static func status() async -> Status {
+        let preferredPaths = await CommandResolver.preferredPathsAsync()
         let locations = self.installedLocations(
-            searchPaths: CommandResolver.preferredPaths(),
+            searchPaths: preferredPaths,
             fileManager: .default)
         guard !locations.isEmpty else {
             return .missing(location: self.managedExecutableLocation())
@@ -169,7 +170,10 @@ enum CLIInstaller {
 
         var fallbackStatus: Status?
         for location in locations {
-            let status = await self.status(location: location)
+            let status = await self.status(
+                location: location,
+                expectedVersion: GatewayEnvironment.expectedGatewayVersionString(),
+                preferredPaths: preferredPaths)
             if status.isReady {
                 self.rememberValidated(status)
                 return status
@@ -189,7 +193,11 @@ enum CLIInstaller {
             return .missing(location: location)
         }
 
-        let status = await self.status(location: location, expectedVersion: expectedVersion)
+        let preferredPaths = await CommandResolver.preferredPathsAsync()
+        let status = await self.status(
+            location: location,
+            expectedVersion: expectedVersion,
+            preferredPaths: preferredPaths)
         if status.isReady {
             self.rememberValidated(status)
         }
@@ -197,13 +205,21 @@ enum CLIInstaller {
     }
 
     static func status(location: String) async -> Status {
-        await self.status(
+        let preferredPaths = await CommandResolver.preferredPathsAsync()
+        return await self.status(
             location: location,
-            expectedVersion: GatewayEnvironment.expectedGatewayVersionString())
+            expectedVersion: GatewayEnvironment.expectedGatewayVersionString(),
+            preferredPaths: preferredPaths)
     }
 
-    private static func status(location: String, expectedVersion: String?) async -> Status {
-        let environment = self.probeEnvironment(location: location)
+    private static func status(
+        location: String,
+        expectedVersion: String?,
+        preferredPaths: [String]) async -> Status
+    {
+        let environment = self.probeEnvironment(
+            location: location,
+            preferredPaths: preferredPaths)
         let response = await ShellExecutor.runDetailed(
             command: [location, "--version"],
             cwd: nil,

--- a/apps/macos/Sources/OpenClaw/CommandResolver.swift
+++ b/apps/macos/Sources/OpenClaw/CommandResolver.swift
@@ -81,6 +81,13 @@ enum CommandResolver {
             validatedExecutable: validatedExecutable)
     }
 
+    /// Version-manager trees can make discovery arbitrarily slow. Async callers
+    /// must leave their actor before touching the filesystem or the UI can stall.
+    @concurrent
+    static func preferredPathsAsync() async -> [String] {
+        self.preferredPaths()
+    }
+
     static func preferredPaths(
         home: URL,
         current: [String],


### PR DESCRIPTION
Closes #106082

## What Problem This Solves

Fixes an issue where macOS app users with many Node versions could see the entire app stall for minutes immediately after launch while CLI PATH discovery scanned version-manager directories on the main thread.

## Why This Change Was Made

CLI status checks now cross an explicit Swift 6.2 `@concurrent` boundary before filesystem discovery and reuse one discovered PATH snapshot for every executable probe in that status pass. This keeps the launch-time main actor free without introducing a stale process-wide cache or changing CLI resolution behavior.

Release note: Fixed macOS app launch stalls when large Node version-manager directories make CLI discovery slow.

## User Impact

The macOS app remains responsive while it discovers CLI and Node version-manager paths during startup. Existing `nvm`, `fnm`, `asdf`, and Volta discovery continues to feed the same CLI status checks.

## Evidence

- Before: an observed process sample repeatedly held the main thread in `MacNodeModeCoordinator` -> `CLIInstaller.status()` -> `CommandResolver.versionedNodeBinPaths()` -> filesystem metadata syscalls; main-queue timers did not fire.
- `swiftformat --lint apps/macos/Sources/OpenClaw/CommandResolver.swift apps/macos/Sources/OpenClaw/CLIInstaller.swift --config config/swiftformat` (pass)
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcrun swiftc -frontend -parse apps/macos/Sources/OpenClaw/CommandResolver.swift apps/macos/Sources/OpenClaw/CLIInstaller.swift` (pass)
- Fresh autoreview after the accepted return fix: 0 actionable findings; patch correct, confidence 0.94.
- Local focused `swift test` is blocked before the touched target: Command Line Tools lacks the SwiftUI macro plugin, while the only installed full Xcode is a Swift 6.4 beta that fails unchanged Peekaboo concurrency code. Exact-head macOS CI is the compatible-toolchain test authority.
- Signed-app behavior validation remains blocked: the available Tart VM rejected guest-agent SSH key injection, so no live before/after trace is claimed.

AI-assisted: yes (Codex).
