### PR TITLE
fix(ci): keep Periphery scope checks off shared API quota

### DIFF
--- a/.github/workflows/ios-periphery.yml
+++ b/.github/workflows/ios-periphery.yml
@@ -40,43 +40,45 @@ jobs:
 
       - name: Detect changed paths
         id: scope
-        shell: bash
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          EVENT_NAME: ${{ github.event_name }}
-          PR_DRAFT: ${{ github.event.pull_request.draft && 'true' || 'false' }}
-        run: |
-          set -euo pipefail
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "should-scan=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ "$PR_DRAFT" = "true" ]; then
-            echo "should-scan=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            if (context.eventName === "workflow_dispatch") {
+              core.setOutput("should-scan", "true");
+              return;
+            }
+            if (context.payload.pull_request?.draft) {
+              core.setOutput("should-scan", "false");
+              return;
+            }
 
-          if git diff --quiet "$BASE_SHA" HEAD -- \
-            apps/ios/ \
-            apps/shared/OpenClawKit/Sources/ \
-            apps/swabble/Sources/SwabbleKit/ \
-            .github/workflows/ios-periphery.yml \
-            .github/workflows/ios-periphery-comment.yml \
-            config/swiftformat \
-            config/swiftlint.yml \
-            scripts/check-swift-tools.sh \
-            scripts/format-swift.sh \
-            scripts/install-swift-tools.sh \
-            scripts/ios-write-swift-filelist.mjs \
-            scripts/lint-swift.sh; then
-            echo "should-scan=false" >> "$GITHUB_OUTPUT"
-          else
-            diff_status="$?"
-            if [ "$diff_status" -ne 1 ]; then
-              exit "$diff_status"
-            fi
-            echo "should-scan=true" >> "$GITHUB_OUTPUT"
-          fi
+            const baseSha = context.payload.pull_request?.base?.sha;
+            if (!baseSha) {
+              throw new Error("missing pull request base SHA");
+            }
+            const result = await exec.getExecOutput("git", [
+              "diff",
+              "--quiet",
+              baseSha,
+              "HEAD",
+              "--",
+              "apps/ios/",
+              "apps/shared/OpenClawKit/Sources/",
+              "apps/swabble/Sources/SwabbleKit/",
+              ".github/workflows/ios-periphery.yml",
+              ".github/workflows/ios-periphery-comment.yml",
+              "config/swiftformat",
+              "config/swiftlint.yml",
+              "scripts/check-swift-tools.sh",
+              "scripts/format-swift.sh",
+              "scripts/install-swift-tools.sh",
+              "scripts/ios-write-swift-filelist.mjs",
+              "scripts/lint-swift.sh",
+            ], { ignoreReturnCode: true, silent: true });
+            if (result.exitCode !== 0 && result.exitCode !== 1) {
+              throw new Error(`git diff failed with exit code ${result.exitCode}`);
+            }
+            core.setOutput("should-scan", String(result.exitCode === 1));
 
   scan:
     name: Scan iOS dead code

--- a/.github/workflows/ios-periphery.yml
+++ b/.github/workflows/ios-periphery.yml
@@ -14,7 +14,6 @@ env:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   scope:
@@ -23,46 +22,61 @@ jobs:
     outputs:
       should-scan: ${{ steps.scope.outputs.should-scan }}
     steps:
+      - name: Checkout
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 1
+          fetch-tags: false
+          persist-credentials: false
+          submodules: false
+
+      - name: Ensure base commit
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Detect changed paths
         id: scope
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            if (context.eventName === "workflow_dispatch") {
-              core.setOutput("should-scan", "true");
-              return;
-            }
-            if (context.payload.pull_request?.draft) {
-              core.setOutput("should-scan", "false");
-              return;
-            }
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_DRAFT: ${{ github.event.pull_request.draft && 'true' || 'false' }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "should-scan=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$PR_DRAFT" = "true" ]; then
+            echo "should-scan=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-            const isScanPath = (filename) =>
-              typeof filename === "string" && (
-                filename.startsWith("apps/ios/") ||
-                filename.startsWith("apps/shared/OpenClawKit/Sources/") ||
-                filename.startsWith("apps/swabble/Sources/SwabbleKit/") ||
-                filename === ".github/workflows/ios-periphery.yml" ||
-                filename === ".github/workflows/ios-periphery-comment.yml" ||
-                filename === "config/swiftformat" ||
-                filename === "config/swiftlint.yml" ||
-                filename === "scripts/check-swift-tools.sh" ||
-                filename === "scripts/format-swift.sh" ||
-                filename === "scripts/install-swift-tools.sh" ||
-                filename === "scripts/ios-write-swift-filelist.mjs" ||
-                filename === "scripts/lint-swift.sh"
-              );
-            const shouldScan = files.some(
-              ({ filename, previous_filename: previousFilename }) =>
-                isScanPath(filename) || isScanPath(previousFilename)
-            );
-            core.setOutput("should-scan", String(shouldScan));
+          if git diff --quiet "$BASE_SHA" HEAD -- \
+            apps/ios/ \
+            apps/shared/OpenClawKit/Sources/ \
+            apps/swabble/Sources/SwabbleKit/ \
+            .github/workflows/ios-periphery.yml \
+            .github/workflows/ios-periphery-comment.yml \
+            config/swiftformat \
+            config/swiftlint.yml \
+            scripts/check-swift-tools.sh \
+            scripts/format-swift.sh \
+            scripts/install-swift-tools.sh \
+            scripts/ios-write-swift-filelist.mjs \
+            scripts/lint-swift.sh; then
+            echo "should-scan=false" >> "$GITHUB_OUTPUT"
+          else
+            diff_status="$?"
+            if [ "$diff_status" -ne 1 ]; then
+              exit "$diff_status"
+            fi
+            echo "should-scan=true" >> "$GITHUB_OUTPUT"
+          fi
 
   scan:
     name: Scan iOS dead code

--- a/.github/workflows/macos-periphery.yml
+++ b/.github/workflows/macos-periphery.yml
@@ -14,7 +14,6 @@ env:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   scope:
@@ -23,38 +22,53 @@ jobs:
     outputs:
       should-scan: ${{ steps.scope.outputs.should-scan }}
     steps:
+      - name: Checkout
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 1
+          fetch-tags: false
+          persist-credentials: false
+          submodules: false
+
+      - name: Ensure base commit
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Detect changed paths
         id: scope
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            if (context.eventName === "workflow_dispatch") {
-              core.setOutput("should-scan", "true");
-              return;
-            }
-            if (context.payload.pull_request?.draft) {
-              core.setOutput("should-scan", "false");
-              return;
-            }
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_DRAFT: ${{ github.event.pull_request.draft && 'true' || 'false' }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "should-scan=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$PR_DRAFT" = "true" ]; then
+            echo "should-scan=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-            const isScanPath = (filename) =>
-              typeof filename === "string" && (
-                filename.startsWith("apps/macos/") ||
-                filename === ".github/workflows/macos-periphery.yml" ||
-                filename === ".github/workflows/ios-periphery-comment.yml" ||
-                filename === "apps/macos/.periphery.yml"
-              );
-            const shouldScan = files.some(
-              ({ filename, previous_filename: previousFilename }) =>
-                isScanPath(filename) || isScanPath(previousFilename)
-            );
-            core.setOutput("should-scan", String(shouldScan));
+          if git diff --quiet "$BASE_SHA" HEAD -- \
+            apps/macos/ \
+            .github/workflows/macos-periphery.yml \
+            .github/workflows/ios-periphery-comment.yml \
+            apps/macos/.periphery.yml; then
+            echo "should-scan=false" >> "$GITHUB_OUTPUT"
+          else
+            diff_status="$?"
+            if [ "$diff_status" -ne 1 ]; then
+              exit "$diff_status"
+            fi
+            echo "should-scan=true" >> "$GITHUB_OUTPUT"
+          fi
 
   scan:
     name: Scan macOS dead code

--- a/.github/workflows/macos-periphery.yml
+++ b/.github/workflows/macos-periphery.yml
@@ -40,35 +40,37 @@ jobs:
 
       - name: Detect changed paths
         id: scope
-        shell: bash
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          EVENT_NAME: ${{ github.event_name }}
-          PR_DRAFT: ${{ github.event.pull_request.draft && 'true' || 'false' }}
-        run: |
-          set -euo pipefail
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "should-scan=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ "$PR_DRAFT" = "true" ]; then
-            echo "should-scan=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            if (context.eventName === "workflow_dispatch") {
+              core.setOutput("should-scan", "true");
+              return;
+            }
+            if (context.payload.pull_request?.draft) {
+              core.setOutput("should-scan", "false");
+              return;
+            }
 
-          if git diff --quiet "$BASE_SHA" HEAD -- \
-            apps/macos/ \
-            .github/workflows/macos-periphery.yml \
-            .github/workflows/ios-periphery-comment.yml \
-            apps/macos/.periphery.yml; then
-            echo "should-scan=false" >> "$GITHUB_OUTPUT"
-          else
-            diff_status="$?"
-            if [ "$diff_status" -ne 1 ]; then
-              exit "$diff_status"
-            fi
-            echo "should-scan=true" >> "$GITHUB_OUTPUT"
-          fi
+            const baseSha = context.payload.pull_request?.base?.sha;
+            if (!baseSha) {
+              throw new Error("missing pull request base SHA");
+            }
+            const result = await exec.getExecOutput("git", [
+              "diff",
+              "--quiet",
+              baseSha,
+              "HEAD",
+              "--",
+              "apps/macos/",
+              ".github/workflows/macos-periphery.yml",
+              ".github/workflows/ios-periphery-comment.yml",
+              "apps/macos/.periphery.yml",
+            ], { ignoreReturnCode: true, silent: true });
+            if (result.exitCode !== 0 && result.exitCode !== 1) {
+              throw new Error(`git diff failed with exit code ${result.exitCode}`);
+            }
+            core.setOutput("should-scan", String(result.exitCode === 1));
 
   scan:
     name: Scan macOS dead code

--- a/.github/workflows/shared-openclawkit-periphery.yml
+++ b/.github/workflows/shared-openclawkit-periphery.yml
@@ -40,40 +40,42 @@ jobs:
 
       - name: Detect changed paths
         id: scope
-        shell: bash
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          EVENT_NAME: ${{ github.event_name }}
-          PR_DRAFT: ${{ github.event.pull_request.draft && 'true' || 'false' }}
-        run: |
-          set -euo pipefail
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "should-scan=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ "$PR_DRAFT" = "true" ]; then
-            echo "should-scan=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            if (context.eventName === "workflow_dispatch") {
+              core.setOutput("should-scan", "true");
+              return;
+            }
+            if (context.payload.pull_request?.draft) {
+              core.setOutput("should-scan", "false");
+              return;
+            }
 
-          if git diff --quiet "$BASE_SHA" HEAD -- \
-            apps/ios/ \
-            apps/macos/ \
-            apps/shared/OpenClawKit/ \
-            .github/workflows/shared-openclawkit-periphery.yml \
-            scripts/periphery-intersection.mjs \
-            scripts/ios-configure-signing.sh \
-            scripts/ios-write-swift-filelist.mjs \
-            scripts/ios-write-version-xcconfig.sh \
-            test/scripts/periphery-intersection.test.ts; then
-            echo "should-scan=false" >> "$GITHUB_OUTPUT"
-          else
-            diff_status="$?"
-            if [ "$diff_status" -ne 1 ]; then
-              exit "$diff_status"
-            fi
-            echo "should-scan=true" >> "$GITHUB_OUTPUT"
-          fi
+            const baseSha = context.payload.pull_request?.base?.sha;
+            if (!baseSha) {
+              throw new Error("missing pull request base SHA");
+            }
+            const result = await exec.getExecOutput("git", [
+              "diff",
+              "--quiet",
+              baseSha,
+              "HEAD",
+              "--",
+              "apps/ios/",
+              "apps/macos/",
+              "apps/shared/OpenClawKit/",
+              ".github/workflows/shared-openclawkit-periphery.yml",
+              "scripts/periphery-intersection.mjs",
+              "scripts/ios-configure-signing.sh",
+              "scripts/ios-write-swift-filelist.mjs",
+              "scripts/ios-write-version-xcconfig.sh",
+              "test/scripts/periphery-intersection.test.ts",
+            ], { ignoreReturnCode: true, silent: true });
+            if (result.exitCode !== 0 && result.exitCode !== 1) {
+              throw new Error(`git diff failed with exit code ${result.exitCode}`);
+            }
+            core.setOutput("should-scan", String(result.exitCode === 1));
 
   scan-ios:
     name: Scan shared kit from iOS

--- a/.github/workflows/shared-openclawkit-periphery.yml
+++ b/.github/workflows/shared-openclawkit-periphery.yml
@@ -14,7 +14,6 @@ env:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   scope:
@@ -23,43 +22,58 @@ jobs:
     outputs:
       should-scan: ${{ steps.scope.outputs.should-scan }}
     steps:
+      - name: Checkout
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 1
+          fetch-tags: false
+          persist-credentials: false
+          submodules: false
+
+      - name: Ensure base commit
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Detect changed paths
         id: scope
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            if (context.eventName === "workflow_dispatch") {
-              core.setOutput("should-scan", "true");
-              return;
-            }
-            if (context.payload.pull_request?.draft) {
-              core.setOutput("should-scan", "false");
-              return;
-            }
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_DRAFT: ${{ github.event.pull_request.draft && 'true' || 'false' }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "should-scan=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$PR_DRAFT" = "true" ]; then
+            echo "should-scan=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-            const isScanPath = (filename) =>
-              typeof filename === "string" && (
-                filename.startsWith("apps/ios/") ||
-                filename.startsWith("apps/macos/") ||
-                filename.startsWith("apps/shared/OpenClawKit/") ||
-                filename === ".github/workflows/shared-openclawkit-periphery.yml" ||
-                filename === "scripts/periphery-intersection.mjs" ||
-                filename === "scripts/ios-configure-signing.sh" ||
-                filename === "scripts/ios-write-swift-filelist.mjs" ||
-                filename === "scripts/ios-write-version-xcconfig.sh" ||
-                filename === "test/scripts/periphery-intersection.test.ts"
-              );
-            const shouldScan = files.some(
-              ({ filename, previous_filename: previousFilename }) =>
-                isScanPath(filename) || isScanPath(previousFilename)
-            );
-            core.setOutput("should-scan", String(shouldScan));
+          if git diff --quiet "$BASE_SHA" HEAD -- \
+            apps/ios/ \
+            apps/macos/ \
+            apps/shared/OpenClawKit/ \
+            .github/workflows/shared-openclawkit-periphery.yml \
+            scripts/periphery-intersection.mjs \
+            scripts/ios-configure-signing.sh \
+            scripts/ios-write-swift-filelist.mjs \
+            scripts/ios-write-version-xcconfig.sh \
+            test/scripts/periphery-intersection.test.ts; then
+            echo "should-scan=false" >> "$GITHUB_OUTPUT"
+          else
+            diff_status="$?"
+            if [ "$diff_status" -ne 1 ]; then
+              exit "$diff_status"
+            fi
+            echo "should-scan=true" >> "$GITHUB_OUTPUT"
+          fi
 
   scan-ios:
     name: Scan shared kit from iOS

--- a/test/scripts/ios-periphery-comment-workflow.test.ts
+++ b/test/scripts/ios-periphery-comment-workflow.test.ts
@@ -97,6 +97,7 @@ function scopeScript(): string {
 }
 
 async function runScope(options: {
+  diffExitCode?: number;
   draft?: boolean;
   eventName?: string;
   files?: Array<string | { filename: string; previous_filename?: string }>;
@@ -111,6 +112,7 @@ async function runScope(options: {
     eventName: options.eventName ?? "pull_request",
     payload: {
       pull_request: {
+        base: { sha: "base-sha" },
         draft: options.draft ?? false,
         number: 123,
       },
@@ -120,25 +122,35 @@ async function runScope(options: {
       repo: "openclaw",
     },
   };
-  const github = {
-    rest: {
-      pulls: {
-        listFiles() {},
-      },
-    },
-    async paginate() {
-      return (options.files ?? []).map((file) =>
-        typeof file === "string" ? { filename: file } : file,
+  const exec = {
+    async getExecOutput(command: string, args: string[]) {
+      if (command !== "git" || args.slice(0, 5).join(" ") !== "diff --quiet base-sha HEAD --") {
+        throw new Error(`unexpected scope command: ${command} ${args.join(" ")}`);
+      }
+      if (options.diffExitCode !== undefined) {
+        return { exitCode: options.diffExitCode };
+      }
+      const pathspecs = args.slice(5);
+      const filenames = (options.files ?? []).flatMap((file) =>
+        typeof file === "string"
+          ? [file]
+          : [file.filename, file.previous_filename].filter((name): name is string => Boolean(name)),
       );
+      const changed = filenames.some((filename) =>
+        pathspecs.some((pathspec) =>
+          pathspec.endsWith("/") ? filename.startsWith(pathspec) : filename === pathspec,
+        ),
+      );
+      return { exitCode: changed ? 1 : 0 };
     },
   };
   const execute = compileFunction(`return (async () => {\n${scopeScript()}\n})();`, [
     "context",
     "core",
-    "github",
-  ]) as (context: unknown, core: unknown, github: unknown) => Promise<void>;
+    "exec",
+  ]) as (context: unknown, core: unknown, exec: unknown) => Promise<void>;
 
-  await execute(context, core, github);
+  await execute(context, core, exec);
   return outputs.get("should-scan");
 }
 
@@ -465,9 +477,11 @@ describe("iOS Periphery comment workflow", () => {
       compileFunction(`return (async () => {\n${scopeScript()}\n})();`, [
         "context",
         "core",
-        "github",
+        "exec",
       ]),
     ).not.toThrow();
+    expect(scopeScript()).toContain("exec.getExecOutput");
+    expect(scopeScript()).not.toContain("pulls.listFiles");
   });
 
   it.each([
@@ -508,6 +522,12 @@ describe("iOS Periphery comment workflow", () => {
     },
   ])("sets scope output for $name", async ({ expected, files, options }) => {
     await expect(runScope({ ...options, files })).resolves.toBe(expected);
+  });
+
+  it("fails closed when git cannot compare the base and head", async () => {
+    await expect(runScope({ diffExitCode: 128 })).rejects.toThrow(
+      "git diff failed with exit code 128",
+    );
   });
 
   it("accepts a valid small Periphery artifact", async () => {

--- a/test/scripts/periphery-intersection.test.ts
+++ b/test/scripts/periphery-intersection.test.ts
@@ -129,8 +129,8 @@ describe("shared OpenClawKit Periphery workflow", () => {
     const execute = compileFunction(`return (async () => {\n${script}\n})();`, [
       "context",
       "core",
-      "github",
-    ]) as (context: unknown, core: unknown, github: unknown) => Promise<void>;
+      "exec",
+    ]) as (context: unknown, core: unknown, exec: unknown) => Promise<void>;
 
     for (const filename of [
       "apps/ios/Sources/App.swift",
@@ -142,13 +142,20 @@ describe("shared OpenClawKit Periphery workflow", () => {
       await execute(
         {
           eventName: "pull_request",
-          payload: { pull_request: { draft: false, number: 1 } },
+          payload: { pull_request: { base: { sha: "base-sha" }, draft: false, number: 1 } },
           repo: {},
         },
         { setOutput: (name: string, value: string) => outputs.set(name, value) },
         {
-          paginate: async () => [{ filename }],
-          rest: { pulls: { listFiles() {} } },
+          async getExecOutput(command: string, args: string[]) {
+            expect(command).toBe("git");
+            expect(args.slice(0, 5)).toEqual(["diff", "--quiet", "base-sha", "HEAD", "--"]);
+            const pathspecs = args.slice(5);
+            const changed = pathspecs.some((pathspec) =>
+              pathspec.endsWith("/") ? filename.startsWith(pathspec) : filename === pathspec,
+            );
+            return { exitCode: changed ? 1 : 0 };
+          },
         },
       );
       expect(outputs.get("should-scan"), filename).toBe("true");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where unrelated pull requests could receive three red Periphery checks when the shared GitHub Actions installation exhausted its core API quota. Each scope job called the pull-request files API solely to decide whether its scan should run, so quota exhaustion failed the detector before it could skip an unrelated scan.

## Why This Change Was Made

The three scope jobs now use a credential-free shallow checkout, the existing bounded base-commit fetch action, and a local fail-closed `git diff` over the same path sets. Manual dispatch still scans, draft pull requests still skip, rename-away changes remain visible to the diff, and the no-longer-needed `pull-requests: read` permission is removed.

## User Impact

No product behavior changes. Pull-request validation no longer depends on shared API quota merely to determine Periphery scope.

## Evidence

- Before: runs [`29226761911`](https://github.com/openclaw/openclaw/actions/runs/29226761911), [`29226761962`](https://github.com/openclaw/openclaw/actions/runs/29226761962), and [`29226761901`](https://github.com/openclaw/openclaw/actions/runs/29226761901) all failed at the same files-list request with HTTP 403 and `x-ratelimit-remaining: 0`.
- `actionlint` passed for all three changed workflows.
- `git diff --check` passed.
- Local committed-diff probes selected each workflow's scan path set and rejected an unrelated `README.md` path.
- Fresh autoreview: no findings; patch correct at 0.94 confidence.
- Exact-head workflow runs are the live end-to-end proof: changing each workflow intentionally selects all three Periphery scan lanes without calling the pull-request files API.
