### PR TITLE
fix(ios): typography audit rejects localized accessibility labels

### DIFF
--- a/apps/ios/Tests/OpenClawTypographyTests.swift
+++ b/apps/ios/Tests/OpenClawTypographyTests.swift
@@ -476,7 +476,7 @@ struct OpenClawTypographyTests {
     private static func unbrandedTextCallOffenders() throws -> [String] {
         let fontTokens = ["OpenClawType", "OpenClawChatTypography"]
         // Accessibility-only Text is spoken, never rendered, so no branded font applies.
-        let allowedFragments = [".navigationTitle(", ".alert(\"", ".tabItem { Label(", ".accessibilityLabel(Text("]
+        let allowedFragments = [".navigationTitle(", ".alert(\"", ".tabItem { Label("]
         return try self.swiftSourcesForTypographyAudit().flatMap { url -> [String] in
             let source = try String(contentsOf: url, encoding: .utf8)
             let lines = source.components(separatedBy: .newlines)

--- a/apps/ios/Tests/OpenClawTypographyTests.swift
+++ b/apps/ios/Tests/OpenClawTypographyTests.swift
@@ -355,6 +355,22 @@ struct OpenClawTypographyTests {
         #expect(offenders.isEmpty, Comment(rawValue: offenders.joined(separator: "\n")))
     }
 
+    @Test func `accessibility metadata text does not require visual typography`() throws {
+        let accessibilityTextSamples = [
+            ".accessibilityLabel(Text(title))",
+            ".accessibilityValue(\n    Text(value))",
+            ".accessibilityHint(\n\n    Text(hint))",
+        ]
+        for source in accessibilityTextSamples {
+            let lines = source.components(separatedBy: .newlines)
+            let idx = try #require(lines.firstIndex { Self.isTextOrLabelCall($0) })
+            #expect(Self.isAccessibilityMetadataTextCall(at: idx, in: lines))
+        }
+
+        #expect(!Self.isAccessibilityMetadataTextCall(at: 0, in: ["Text(title)"]))
+        #expect(!Self.isAccessibilityMetadataTextCall(at: 0, in: [".accessibilityLabel(title)"]))
+    }
+
     @Test func `secure fields do not use platform placeholder text`() throws {
         let offenders = try Self.swiftSourcesForTypographyAudit().flatMap { url -> [String] in
             let source = try String(contentsOf: url, encoding: .utf8)
@@ -454,7 +470,10 @@ struct OpenClawTypographyTests {
                 let hasLocalFont = fontTokens.contains { window.contains($0) }
                     || self.hasAllowedBrandedFontParameter(window, line: rawLine, in: url)
 
-                if self.isTextOrLabelCall(rawLine), !hasLocalFont {
+                if self.isTextOrLabelCall(rawLine),
+                   !self.isAccessibilityMetadataTextCall(at: idx, in: lines),
+                   !hasLocalFont
+                {
                     return "\(self.relativePath(url)):\(idx + 1): \(line)"
                 }
 
@@ -469,6 +488,23 @@ struct OpenClawTypographyTests {
 
     private static func isTextOrLabelCall(_ line: String) -> Bool {
         line.range(of: #"\b(Text|Label)\s*\("#, options: .regularExpression) != nil
+    }
+
+    private static func isAccessibilityMetadataTextCall(at idx: Int, in lines: [String]) -> Bool {
+        let line = lines[idx]
+        guard let textCall = line.range(of: #"\bText\s*\("#, options: .regularExpression) else { return false }
+
+        let contextStart = max(lines.startIndex, idx - 4)
+        let precedingLines = lines[contextStart..<idx].joined(separator: "\n")
+        let currentLinePrefix = line[..<textCall.upperBound]
+        let context = precedingLines.isEmpty
+            ? String(currentLinePrefix)
+            : precedingLines + "\n" + String(currentLinePrefix)
+
+        // Accessibility metadata is announced, not rendered; localized Text overloads need no visual font.
+        return context.range(
+            of: #"\.accessibility(?:Label|Value|Hint)\s*\(\s*Text\s*\($"#,
+            options: .regularExpression) != nil
     }
 
     private static func isShorthandControlCall(_ line: String) -> Bool {

--- a/apps/ios/Tests/OpenClawTypographyTests.swift
+++ b/apps/ios/Tests/OpenClawTypographyTests.swift
@@ -361,6 +361,7 @@ struct OpenClawTypographyTests {
             "Image(systemName: \"circle\").accessibilityLabel(Text(title))",
             ".accessibilityLabel(Text(title)).accessibilityIdentifier(\"status\")",
             "Image(systemName: \"circle\").accessibilityLabel(Text(title)).accessibilityHint(Text(hint))",
+            ".accessibilityLabel(Text(self.statusLabel ?? LocalizedStringResource(\"Allowed\")))",
             ".accessibilityLabel(Text(title))\n)",
             ".accessibilityLabel(\n    Text(title)\n)",
             "Image(systemName: \"circle\")\n    .accessibilityLabel(\n        Text(title)\n    )",
@@ -492,6 +493,7 @@ struct OpenClawTypographyTests {
         return try self.swiftSourcesForTypographyAudit().flatMap { url -> [String] in
             let source = try String(contentsOf: url, encoding: .utf8)
             let lines = source.components(separatedBy: .newlines)
+            let accessibilityMetadataTextLines = self.accessibilityMetadataTextLines(in: lines)
             return lines.indices.compactMap { idx -> String? in
                 let rawLine = lines[idx]
                 let line = rawLine.trimmingCharacters(in: .whitespaces)
@@ -503,7 +505,7 @@ struct OpenClawTypographyTests {
                     || self.hasAllowedBrandedFontParameter(window, line: rawLine, in: url)
 
                 if self.isTextOrLabelCall(rawLine),
-                   !self.isAccessibilityMetadataTextCall(at: idx, in: lines),
+                   !accessibilityMetadataTextLines.contains(idx),
                    !hasLocalFont
                 {
                     return "\(self.relativePath(url)):\(idx + 1): \(line)"
@@ -523,40 +525,167 @@ struct OpenClawTypographyTests {
     }
 
     private static func isAccessibilityMetadataTextCall(at idx: Int, in lines: [String]) -> Bool {
-        let rawLine = lines[idx]
-        let textArgument = #"(?:[^()"\\]|\\.|"(?:\\.|[^"\\])*")*"#
-        let inlineAccessibilityText =
-            #"\.accessibility(?:Label|Value|Hint)\s*\(\s*Text\s*\(\#(textArgument)\)\s*\)"#
+        self.accessibilityMetadataTextLines(in: lines).contains(idx)
+    }
 
-        var inlineRemainder = rawLine
-        var removedInlineMetadata = false
-        while let range = inlineRemainder.range(of: inlineAccessibilityText, options: .regularExpression) {
-            inlineRemainder.removeSubrange(range)
-            removedInlineMetadata = true
-        }
-        if removedInlineMetadata {
-            // Do not let metadata Text hide a visual Text or Label sharing the audited line.
-            return !self.isTextOrLabelCall(inlineRemainder)
-        }
+    private static func accessibilityMetadataTextLines(in lines: [String]) -> Set<Int> {
+        let code = self.maskedSwiftCode(lines.joined(separator: "\n"))
+        let textToken = Array("Text".utf8)
+        let labelToken = Array("Label".utf8)
+        let modifiers = [
+            Array(".accessibilityLabel".utf8),
+            Array(".accessibilityValue".utf8),
+            Array(".accessibilityHint".utf8),
+        ]
+        var callCounts: [Int: Int] = [:]
+        var metadataCallCounts: [Int: Int] = [:]
+        var line = 0
 
-        let directText = #"^\s*Text\s*\(\#(textArgument)\)"#
-        guard let range = rawLine.range(of: directText, options: .regularExpression) else { return false }
-        let remainder = rawLine.replacingCharacters(in: range, with: "")
-        guard !self.isTextOrLabelCall(remainder) else { return false }
-
-        let contextStart = max(lines.startIndex, idx - 4)
-        // Comment text cannot open a metadata modifier for a following visual Text.
-        let leadingContext = lines[contextStart..<idx]
-            .map { line in
-                guard let comment = line.range(of: "//") else { return line }
-                return String(line[..<comment.lowerBound])
+        for offset in code.indices {
+            if code[offset] == 10 {
+                line += 1
+                continue
             }
-            .joined(separator: "\n")
-        let accessibilityOpener =
-            #"(?s)(?:^|\n)[^\n]*\.accessibility(?:Label|Value|Hint)\s*\(\s*$"#
+            if self.callOpeningParenthesis(after: textToken, at: offset, in: code) != nil ||
+                self.callOpeningParenthesis(after: labelToken, at: offset, in: code) != nil
+            {
+                callCounts[line, default: 0] += 1
+            }
 
-        // Direct accessibility metadata is announced, not rendered. Complex expressions fail closed.
-        return leadingContext.range(of: accessibilityOpener, options: .regularExpression) != nil
+            for modifier in modifiers {
+                guard let modifierOpen = self.callOpeningParenthesis(after: modifier, at: offset, in: code)
+                else { continue }
+                let textOffset = self.skippingWhitespace(in: code, after: modifierOpen)
+                guard let textOpen = self.callOpeningParenthesis(after: textToken, at: textOffset, in: code),
+                      let textClose = self.matchingParenthesis(in: code, openingAt: textOpen)
+                else { continue }
+                let metadataClose = self.skippingWhitespace(in: code, after: textClose)
+                guard metadataClose < code.count, code[metadataClose] == 41 else { continue }
+
+                // Exempt only the direct Text argument; visible calls sharing its source line stay audited.
+                let textLine = line + code[offset..<textOffset].count(where: { $0 == 10 })
+                metadataCallCounts[textLine, default: 0] += 1
+            }
+        }
+
+        return Set(metadataCallCounts.compactMap { line, count in
+            callCounts[line] == count ? line : nil
+        })
+    }
+
+    private static func callOpeningParenthesis(
+        after token: [UInt8],
+        at offset: Int,
+        in code: [UInt8]) -> Int?
+    {
+        guard offset + token.count <= code.count,
+              code[offset..<(offset + token.count)].elementsEqual(token),
+              token.first == 46 || offset == 0 || !self.isSwiftIdentifierByte(code[offset - 1])
+        else { return nil }
+        let afterToken = offset + token.count
+        guard afterToken == code.count || !self.isSwiftIdentifierByte(code[afterToken]) else { return nil }
+        let opening = self.skippingWhitespace(in: code, after: afterToken - 1)
+        return opening < code.count && code[opening] == 40 ? opening : nil
+    }
+
+    private static func skippingWhitespace(in code: [UInt8], after offset: Int) -> Int {
+        var cursor = offset + 1
+        while cursor < code.count, code[cursor] == 9 || code[cursor] == 10 || code[cursor] == 13 || code[cursor] == 32 {
+            cursor += 1
+        }
+        return cursor
+    }
+
+    private static func matchingParenthesis(in code: [UInt8], openingAt offset: Int) -> Int? {
+        var depth = 0
+        for cursor in offset..<code.count {
+            if code[cursor] == 40 {
+                depth += 1
+            } else if code[cursor] == 41 {
+                depth -= 1
+                if depth == 0 { return cursor }
+            }
+        }
+        return nil
+    }
+
+    private static func isSwiftIdentifierByte(_ byte: UInt8) -> Bool {
+        byte == 95 || (48...57).contains(byte) || (65...90).contains(byte) || (97...122).contains(byte) || byte >= 128
+    }
+
+    private static func maskedSwiftCode(_ source: String) -> [UInt8] {
+        let sourceBytes = Array(source.utf8)
+        var code = sourceBytes
+        var cursor = 0
+
+        func mask(_ range: Range<Int>) {
+            for offset in range where code[offset] != 10 && code[offset] != 13 {
+                code[offset] = 32
+            }
+        }
+
+        while cursor < sourceBytes.count {
+            if cursor + 1 < sourceBytes.count, sourceBytes[cursor] == 47, sourceBytes[cursor + 1] == 47 {
+                let start = cursor
+                while cursor < sourceBytes.count, sourceBytes[cursor] != 10 {
+                    cursor += 1
+                }
+                mask(start..<cursor)
+                continue
+            }
+            if cursor + 1 < sourceBytes.count, sourceBytes[cursor] == 47, sourceBytes[cursor + 1] == 42 {
+                let start = cursor
+                var depth = 1
+                cursor += 2
+                while cursor < sourceBytes.count, depth > 0 {
+                    if cursor + 1 < sourceBytes.count, sourceBytes[cursor] == 47, sourceBytes[cursor + 1] == 42 {
+                        depth += 1
+                        cursor += 2
+                    } else if cursor + 1 < sourceBytes.count,
+                              sourceBytes[cursor] == 42,
+                              sourceBytes[cursor + 1] == 47
+                    {
+                        depth -= 1
+                        cursor += 2
+                    } else {
+                        cursor += 1
+                    }
+                }
+                mask(start..<cursor)
+                continue
+            }
+
+            let start = cursor
+            var hashCount = 0
+            while cursor < sourceBytes.count, sourceBytes[cursor] == 35 {
+                hashCount += 1
+                cursor += 1
+            }
+            guard cursor < sourceBytes.count, sourceBytes[cursor] == 34 else {
+                cursor = start + 1
+                continue
+            }
+            let quoteCount = cursor + 2 < sourceBytes.count &&
+                sourceBytes[cursor + 1] == 34 && sourceBytes[cursor + 2] == 34 ? 3 : 1
+            cursor += quoteCount
+            while cursor < sourceBytes.count {
+                if hashCount == 0, quoteCount == 1, sourceBytes[cursor] == 92 {
+                    cursor = min(sourceBytes.count, cursor + 2)
+                    continue
+                }
+                let closingEnd = cursor + quoteCount + hashCount
+                if closingEnd <= sourceBytes.count,
+                   sourceBytes[cursor..<(cursor + quoteCount)].allSatisfy({ $0 == 34 }),
+                   sourceBytes[(cursor + quoteCount)..<closingEnd].allSatisfy({ $0 == 35 })
+                {
+                    cursor = closingEnd
+                    break
+                }
+                cursor += 1
+            }
+            mask(start..<cursor)
+        }
+        return code
     }
 
     private static func isShorthandControlCall(_ line: String) -> Bool {

--- a/apps/ios/Tests/OpenClawTypographyTests.swift
+++ b/apps/ios/Tests/OpenClawTypographyTests.swift
@@ -358,8 +358,12 @@ struct OpenClawTypographyTests {
     @Test func `accessibility metadata text does not require visual typography`() throws {
         let accessibilityTextSamples = [
             ".accessibilityLabel(Text(title))",
+            "Image(systemName: \"circle\").accessibilityLabel(Text(title))",
+            ".accessibilityLabel(Text(title)).accessibilityIdentifier(\"status\")",
+            "Image(systemName: \"circle\").accessibilityLabel(Text(title)).accessibilityHint(Text(hint))",
             ".accessibilityLabel(Text(title))\n)",
             ".accessibilityLabel(\n    Text(title)\n)",
+            "Image(systemName: \"circle\")\n    .accessibilityLabel(\n        Text(title)\n    )",
             ".accessibilityValue(\n    Text(value))",
             ".accessibilityHint(\n\n    Text(hint))",
         ]
@@ -391,6 +395,12 @@ struct OpenClawTypographyTests {
             "Text(body)",
         ]
         #expect(!Self.isAccessibilityMetadataTextCall(at: 1, in: modifierTextInString))
+
+        let modifierTextInComment = [
+            "// Example: .accessibilityLabel(",
+            "Text(body)",
+        ]
+        #expect(!Self.isAccessibilityMetadataTextCall(at: 1, in: modifierTextInComment))
     }
 
     @Test func `secure fields do not use platform placeholder text`() throws {
@@ -513,23 +523,40 @@ struct OpenClawTypographyTests {
     }
 
     private static func isAccessibilityMetadataTextCall(at idx: Int, in lines: [String]) -> Bool {
-        let contextStart = max(lines.startIndex, idx - 4)
+        let rawLine = lines[idx]
         let textArgument = #"(?:[^()"\\]|\\.|"(?:\\.|[^"\\])*")*"#
-        let accessibilityExpression =
-            #"(?s)(?:^|\n)\s*\.accessibility(?:Label|Value|Hint)\s*\(\s*Text\s*\(\#(textArgument)\)\s*\)\s*$"#
+        let inlineAccessibilityText =
+            #"\.accessibility(?:Label|Value|Hint)\s*\(\s*Text\s*\(\#(textArgument)\)\s*\)"#
 
-        // Direct accessibility metadata is announced, not rendered. Complex expressions fail closed.
-        let context = lines[contextStart...idx].joined(separator: "\n")
-        if context.range(of: accessibilityExpression, options: .regularExpression) != nil {
-            return true
+        var inlineRemainder = rawLine
+        var removedInlineMetadata = false
+        while let range = inlineRemainder.range(of: inlineAccessibilityText, options: .regularExpression) {
+            inlineRemainder.removeSubrange(range)
+            removedInlineMetadata = true
+        }
+        if removedInlineMetadata {
+            // Do not let metadata Text hide a visual Text or Label sharing the audited line.
+            return !self.isTextOrLabelCall(inlineRemainder)
         }
 
-        // Only extend an incomplete modifier; a following ")" can instead close an outer expression.
-        guard idx + 1 < lines.endIndex,
-              lines[idx + 1].trimmingCharacters(in: .whitespaces) == ")"
-        else { return false }
-        let extendedContext = lines[contextStart...idx + 1].joined(separator: "\n")
-        return extendedContext.range(of: accessibilityExpression, options: .regularExpression) != nil
+        let directText = #"^\s*Text\s*\(\#(textArgument)\)"#
+        guard let range = rawLine.range(of: directText, options: .regularExpression) else { return false }
+        let remainder = rawLine.replacingCharacters(in: range, with: "")
+        guard !self.isTextOrLabelCall(remainder) else { return false }
+
+        let contextStart = max(lines.startIndex, idx - 4)
+        // Comment text cannot open a metadata modifier for a following visual Text.
+        let leadingContext = lines[contextStart..<idx]
+            .map { line in
+                guard let comment = line.range(of: "//") else { return line }
+                return String(line[..<comment.lowerBound])
+            }
+            .joined(separator: "\n")
+        let accessibilityOpener =
+            #"(?s)(?:^|\n)[^\n]*\.accessibility(?:Label|Value|Hint)\s*\(\s*$"#
+
+        // Direct accessibility metadata is announced, not rendered. Complex expressions fail closed.
+        return leadingContext.range(of: accessibilityOpener, options: .regularExpression) != nil
     }
 
     private static func isShorthandControlCall(_ line: String) -> Bool {

--- a/apps/ios/Tests/OpenClawTypographyTests.swift
+++ b/apps/ios/Tests/OpenClawTypographyTests.swift
@@ -358,6 +358,8 @@ struct OpenClawTypographyTests {
     @Test func `accessibility metadata text does not require visual typography`() throws {
         let accessibilityTextSamples = [
             ".accessibilityLabel(Text(title))",
+            ".accessibilityLabel(Text(title))\n)",
+            ".accessibilityLabel(\n    Text(title)\n)",
             ".accessibilityValue(\n    Text(value))",
             ".accessibilityHint(\n\n    Text(hint))",
         ]
@@ -512,13 +514,22 @@ struct OpenClawTypographyTests {
 
     private static func isAccessibilityMetadataTextCall(at idx: Int, in lines: [String]) -> Bool {
         let contextStart = max(lines.startIndex, idx - 4)
-        let context = lines[contextStart...idx].joined(separator: "\n")
         let textArgument = #"(?:[^()"\\]|\\.|"(?:\\.|[^"\\])*")*"#
         let accessibilityExpression =
             #"(?s)(?:^|\n)\s*\.accessibility(?:Label|Value|Hint)\s*\(\s*Text\s*\(\#(textArgument)\)\s*\)\s*$"#
 
         // Direct accessibility metadata is announced, not rendered. Complex expressions fail closed.
-        return context.range(of: accessibilityExpression, options: .regularExpression) != nil
+        let context = lines[contextStart...idx].joined(separator: "\n")
+        if context.range(of: accessibilityExpression, options: .regularExpression) != nil {
+            return true
+        }
+
+        // Only extend an incomplete modifier; a following ")" can instead close an outer expression.
+        guard idx + 1 < lines.endIndex,
+              lines[idx + 1].trimmingCharacters(in: .whitespaces) == ")"
+        else { return false }
+        let extendedContext = lines[contextStart...idx + 1].joined(separator: "\n")
+        return extendedContext.range(of: accessibilityExpression, options: .regularExpression) != nil
     }
 
     private static func isShorthandControlCall(_ line: String) -> Bool {

--- a/apps/ios/Tests/OpenClawTypographyTests.swift
+++ b/apps/ios/Tests/OpenClawTypographyTests.swift
@@ -369,6 +369,12 @@ struct OpenClawTypographyTests {
 
         #expect(!Self.isAccessibilityMetadataTextCall(at: 0, in: ["Text(title)"]))
         #expect(!Self.isAccessibilityMetadataTextCall(at: 0, in: [".accessibilityLabel(title)"]))
+
+        let nearbyVisualText = [
+            ".accessibilityLabel(Text(title))",
+            "Text(body)",
+        ]
+        #expect(!Self.isAccessibilityMetadataTextCall(at: 1, in: nearbyVisualText))
     }
 
     @Test func `secure fields do not use platform placeholder text`() throws {

--- a/apps/ios/Tests/OpenClawTypographyTests.swift
+++ b/apps/ios/Tests/OpenClawTypographyTests.swift
@@ -375,6 +375,20 @@ struct OpenClawTypographyTests {
             "Text(body)",
         ]
         #expect(!Self.isAccessibilityMetadataTextCall(at: 1, in: nearbyVisualText))
+
+        let sameLineVisualLabel = [
+            "Label(\"Status\", systemImage: \"circle\").accessibilityLabel(Text(status))",
+        ]
+        #expect(!Self.isAccessibilityMetadataTextCall(at: 0, in: sameLineVisualLabel))
+
+        let trailingVisualText = [".accessibilityLabel(Text(status)); Text(body)"]
+        #expect(!Self.isAccessibilityMetadataTextCall(at: 0, in: trailingVisualText))
+
+        let modifierTextInString = [
+            "let sample = \".accessibilityLabel(\"",
+            "Text(body)",
+        ]
+        #expect(!Self.isAccessibilityMetadataTextCall(at: 1, in: modifierTextInString))
     }
 
     @Test func `secure fields do not use platform placeholder text`() throws {
@@ -497,20 +511,14 @@ struct OpenClawTypographyTests {
     }
 
     private static func isAccessibilityMetadataTextCall(at idx: Int, in lines: [String]) -> Bool {
-        let line = lines[idx]
-        guard let textCall = line.range(of: #"\bText\s*\("#, options: .regularExpression) else { return false }
-
         let contextStart = max(lines.startIndex, idx - 4)
-        let precedingLines = lines[contextStart..<idx].joined(separator: "\n")
-        let currentLinePrefix = line[..<textCall.upperBound]
-        let context = precedingLines.isEmpty
-            ? String(currentLinePrefix)
-            : precedingLines + "\n" + String(currentLinePrefix)
+        let context = lines[contextStart...idx].joined(separator: "\n")
+        let textArgument = #"(?:[^()"\\]|\\.|"(?:\\.|[^"\\])*")*"#
+        let accessibilityExpression =
+            #"(?s)(?:^|\n)\s*\.accessibility(?:Label|Value|Hint)\s*\(\s*Text\s*\(\#(textArgument)\)\s*\)\s*$"#
 
-        // Accessibility metadata is announced, not rendered; localized Text overloads need no visual font.
-        return context.range(
-            of: #"\.accessibility(?:Label|Value|Hint)\s*\(\s*Text\s*\($"#,
-            options: .regularExpression) != nil
+        // Direct accessibility metadata is announced, not rendered. Complex expressions fail closed.
+        return context.range(of: accessibilityExpression, options: .regularExpression) != nil
     }
 
     private static func isShorthandControlCall(_ line: String) -> Bool {


### PR DESCRIPTION
Related: #105859

AI-assisted: yes (Codex)

## What Problem This Solves

Fixes an issue where the iOS branded-typography test rejected localized accessibility labels that use SwiftUI `Text`, even though those labels are accessibility metadata and are not visually rendered. The Apple localization checker requires that typed form, leaving the two checks contradictory on current `main`.

## Why This Change Was Made

The typography scanner now excludes `Text` calls used directly by `accessibilityLabel`, `accessibilityValue`, and `accessibilityHint`, including multiline formatting and nested localized constructors. A small Swift lexical mask plus balanced-parenthesis scan keeps strings/comments from influencing classification. Ordinary visual `Text` and `Label` calls remain subject to the branded-font audit, including when they share a line with accessibility metadata.

## User Impact

No runtime UI behavior changes. Maintainers can keep localized VoiceOver labels in their canonical SwiftUI form without making the typography test fail or weakening visual typography coverage.

## Evidence

- Before-fix scanner reproduction: `SettingsProTabSections.swift:877` and `SettingsProTabSections.swift:1403` reported as unbranded offenders.
- After-fix scanner reproduction: no unbranded `Text`/`Label` offenders; accessibility metadata classifier positive and negative samples pass.
- `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' test -only-testing:OpenClawTests/OpenClawTypographyTests` — pass, 11 tests in the focused suite.
- `node --import tsx scripts/apple-app-i18n.ts check` — pass on Blacksmith Testbox `tbx_01kxdgdkf1frraa2gfw4dnedb5` ([run 29242957328](https://github.com/openclaw/openclaw/actions/runs/29242957328)).
- `pnpm check:changed` — pass on the same synced Testbox checkout.
- `swiftformat --lint --config config/swiftformat apps/ios/Tests/OpenClawTypographyTests.swift` — pass.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean, no accepted/actionable findings (0.88 confidence).
