### PR TITLE
fix(ui): order model-dependent chat settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI model settings:** order model-dependent reasoning and speed updates after pending model switches so provider-specific values are validated against the newly selected model instead of the previous one.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.
 - **Gateway source watch:** hand the configured port off from the installed service before starting the tmux watcher, preserve failed panes for attach/capture, and keep explicit alternate-port watches side by side with the managed Gateway.
 - **Claude CLI max-turn diagnostics:** preserve terminal max-turn results with OpenClaw and Claude session context, warn when tool actions may already have run, and stop unsafe auth-profile or model replay for potentially side-effecting turns. (#94130) Thanks @zhangguiping-xydt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI model settings:** order model-dependent reasoning and speed updates after pending model switches so provider-specific values are validated against the newly selected model instead of the previous one.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.
 - **Gateway source watch:** hand the configured port off from the installed service before starting the tmux watcher, preserve failed panes for attach/capture, and keep explicit alternate-port watches side by side with the managed Gateway.
 - **Claude CLI max-turn diagnostics:** preserve terminal max-turn results with OpenClaw and Claude session context, warn when tool actions may already have run, and stop unsafe auth-profile or model replay for potentially side-effecting turns. (#94130) Thanks @zhangguiping-xydt.

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -2785,6 +2785,110 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
+  it("applies provider-specific reasoning after the selected model is saved", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const sessionKey = "agent:main:session-a";
+    const fableSession = {
+      key: sessionKey,
+      kind: "direct",
+      label: "Session A",
+      model: "claude-fable-5",
+      modelProvider: "anthropic",
+      thinkingDefault: "high",
+      thinkingLevel: "high",
+      thinkingLevels: [
+        { id: "off", label: "off" },
+        { id: "adaptive", label: "adaptive" },
+        { id: "high", label: "high" },
+        { id: "xhigh", label: "xhigh" },
+        { id: "max", label: "max" },
+      ],
+      updatedAt: 2,
+    };
+    const solSession = {
+      ...fableSession,
+      model: "gpt-5.6-sol",
+      modelProvider: "openai",
+      thinkingLevels: [
+        { id: "off", label: "off" },
+        { id: "low", label: "low" },
+        { id: "medium", label: "medium" },
+        { id: "high", label: "high" },
+        { id: "ultra", label: "ultra" },
+      ],
+    };
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["sessions.patch"],
+      methodResponses: {
+        "sessions.list": chatSessionListResponse([fableSession]),
+      },
+      models: [
+        { id: "claude-fable-5", name: "Claude Fable 5", provider: "anthropic" },
+        { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" },
+      ],
+      sessionKey,
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+
+      const main = page.getByRole("main");
+      await main.locator('[data-chat-model-select="true"]').click();
+      await main.locator('[data-chat-model-provider="openai"]').click();
+      await main.locator('[data-chat-model-option="openai/gpt-5.6-sol"]').click();
+
+      const modelPatch = await gateway.waitForRequest("sessions.patch");
+      expect(requireRecord(modelPatch.params)).toMatchObject({
+        key: sessionKey,
+        model: "openai/gpt-5.6-sol",
+      });
+      const thinkingSlider = main.locator('[data-chat-thinking-slider="true"]');
+      await expect.poll(() => thinkingSlider.isDisabled()).toBe(true);
+      await thinkingSlider.evaluate((input) => {
+        const slider = input as HTMLInputElement;
+        slider.value = slider.max;
+        slider.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+      await expectRequestCountStable(gateway, "sessions.patch", 1);
+
+      await gateway.setMethodResponse("sessions.list", chatSessionListResponse([solSession]));
+      await gateway.resolveDeferred("sessions.patch");
+      await expect
+        .poll(() => thinkingSlider.getAttribute("data-chat-thinking-values"))
+        .toContain("ultra");
+      await expect.poll(() => thinkingSlider.isEnabled()).toBe(true);
+
+      await thinkingSlider.evaluate((input) => {
+        const slider = input as HTMLInputElement;
+        const values = (slider.dataset.chatThinkingValues ?? "").split(",");
+        slider.value = String(values.indexOf("ultra"));
+        slider.dispatchEvent(new Event("input", { bubbles: true }));
+        slider.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+      const patches = await waitForRequests(gateway, "sessions.patch", 2);
+      expect(requireRecord(patches[1]?.params)).toMatchObject({
+        key: sessionKey,
+        thinkingLevel: "ultra",
+      });
+      await expect.poll(() => page.getByText(/not supported for/u).count()).toBe(0);
+
+      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      if (artifactDir) {
+        await page.screenshot({
+          path: `${artifactDir}/model-thinking-sync.png`,
+          fullPage: true,
+        });
+      }
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
   it("keeps send pending until reasoning and speed patches finish", async () => {
     const context = await newBrowserContext({
       locale: "en-US",

--- a/ui/src/pages/chat/chat-session.ts
+++ b/ui/src/pages/chat/chat-session.ts
@@ -6,7 +6,6 @@ import {
   scopedAgentParamsForSession,
   scopedAgentListParamsForRefreshTarget,
   scopedAgentListParamsForSession,
-  resolveSessionKey,
   type SessionCapability,
   type SessionListOptions,
   type SessionRefreshTarget,
@@ -14,18 +13,17 @@ import {
 } from "../../lib/sessions/index.ts";
 import {
   areUiSessionKeysEquivalent,
-  DEFAULT_AGENT_ID,
-  DEFAULT_MAIN_KEY,
   isUiGlobalSessionKey,
-  normalizeAgentId,
-  normalizeSessionKeyForUiComparison,
-  resolveUiConfiguredMainKey,
-  resolveUiDefaultAgentId,
   resolveUiGlobalAliasAgentId,
-  resolveUiSelectedGlobalAgentId,
 } from "../../lib/sessions/session-key.ts";
 import { normalizeOptionalString } from "../../lib/string-coerce.ts";
 import type { ChatHistoryResult } from "./chat-history.ts";
+import {
+  getPendingChatModelSwitch,
+  trackPendingChatModelSwitch,
+  trackPendingChatPickerPatch,
+} from "./chat-settings-patches.ts";
+export { getPendingChatPickerPatch, trackPendingChatPickerPatch } from "./chat-settings-patches.ts";
 
 const CHAT_SESSION_LIST_ACTIVE_MINUTES = 0;
 const CHAT_SESSION_LIST_LIMIT = 50;
@@ -235,78 +233,6 @@ function setChatError(host: ChatModelSettingsHost, error: string | null, request
   }
 }
 
-const pendingChatPickerPatches = new WeakMap<SessionCapability, Map<string, Promise<boolean>>>();
-
-type ChatPickerPatchHost = SessionScopeHost & { sessions: SessionCapability };
-
-function resolveChatPickerPatchKey(
-  host: ChatPickerPatchHost,
-  sessionKey: string,
-  agentId?: string,
-): string {
-  const normalizedKey = normalizeSessionKeyForUiComparison(sessionKey);
-  const match = /^agent:([^:]+):(.*)$/u.exec(normalizedKey);
-  const body = match?.[2] ?? normalizedKey;
-  const isGlobal = isUiGlobalSessionKey(sessionKey);
-  const isMainAlias = [DEFAULT_MAIN_KEY, resolveUiConfiguredMainKey(host)].includes(
-    body.toLowerCase(),
-  );
-  const defaultAgentId = resolveUiDefaultAgentId(host);
-  const parsedAgentId = match?.[1];
-  // Match the Gateway's legacy default-main remap only when the live agent
-  // catalog proves that "main" is not a real agent.
-  const isLegacyDefaultMainAlias =
-    isMainAlias &&
-    normalizeAgentId(parsedAgentId ?? "") === DEFAULT_AGENT_ID &&
-    defaultAgentId !== DEFAULT_AGENT_ID &&
-    host.agentsList?.agents != null &&
-    !host.agentsList.agents.some(
-      (candidate) => normalizeAgentId(candidate.id) === DEFAULT_AGENT_ID,
-    );
-  // Main aliases share the literal global store only in global session scope.
-  const isGlobalMain = host.agentsList?.scope
-    ? host.agentsList.scope === "global"
-    : isUiGlobalSessionKey(resolveSessionKey(DEFAULT_MAIN_KEY, host.hello));
-  const resolvedAgentId =
-    (isLegacyDefaultMainAlias ? defaultAgentId : agentId?.trim() || parsedAgentId) ||
-    (isGlobal ? resolveUiSelectedGlobalAgentId(host) : defaultAgentId);
-  const settingsKey =
-    isGlobal || (isMainAlias && isGlobalMain) ? "global" : isMainAlias ? DEFAULT_MAIN_KEY : body;
-  return `agent:${normalizeAgentId(resolvedAgentId)}:${settingsKey}`;
-}
-
-export function getPendingChatPickerPatch(
-  host: ChatPickerPatchHost,
-  sessionKey: string,
-  agentId?: string,
-): Promise<boolean> | undefined {
-  const patchKey = resolveChatPickerPatchKey(host, sessionKey, agentId);
-  return pendingChatPickerPatches.get(host.sessions)?.get(patchKey);
-}
-
-export function trackPendingChatPickerPatch(
-  host: ChatPickerPatchHost,
-  sessionKey: string,
-  patchPromise: Promise<boolean>,
-) {
-  const pendingBySession =
-    pendingChatPickerPatches.get(host.sessions) ?? new Map<string, Promise<boolean>>();
-  pendingChatPickerPatches.set(host.sessions, pendingBySession);
-  const patchKey = resolveChatPickerPatchKey(host, sessionKey);
-  const previous = pendingBySession.get(patchKey);
-  // Aggregate every picker patch across the shared capability; overlapping
-  // Gateway handlers can overtake pane-local or latest-only tracking.
-  const pending = Promise.all([previous ?? true, patchPromise]).then(
-    ([previousReady, patchReady]) => previousReady && patchReady,
-  );
-  pendingBySession.set(patchKey, pending);
-  void pending.finally(() => {
-    if (pendingBySession.get(patchKey) === pending) {
-      pendingBySession.delete(patchKey);
-    }
-  });
-}
-
 // Immediate-apply pickers can overlap patches for the same session. Mirror the
 // pendingModelPatches token guard in sessions/index.ts: only the latest patch
 // may re-assert or roll back the optimistic row, so a slow earlier request
@@ -366,6 +292,7 @@ export function switchChatFastMode(
   const activeRow = host.sessionsResult?.sessions?.find((row) => row.key === targetSessionKey);
   const previousFastMode = activeRow?.fastMode;
   const previousEffectiveFastMode = activeRow?.effectiveFastMode;
+  const pendingModelSwitch = getPendingChatModelSwitch(host, targetSessionKey);
   const next: FastMode | undefined =
     nextFastMode === "" ? undefined : nextFastMode === "auto" ? "auto" : nextFastMode === "on";
   if (previousFastMode === next) {
@@ -386,6 +313,13 @@ export function switchChatFastMode(
   };
   const patchPromise = (async () => {
     try {
+      // Speed support belongs to the selected model. A stale picker event can
+      // arrive before the model-switch render lock, so let that switch commit
+      // before the Gateway validates this model-dependent patch.
+      if (pendingModelSwitch && !(await pendingModelSwitch)) {
+        rollback();
+        return false;
+      }
       const patched = await host.sessions.patch(
         targetSessionKey,
         {
@@ -436,6 +370,7 @@ export async function switchChatModel(
     return true;
   }
   const previousModelOverride = host.sessions.state.modelOverrides[targetSessionKey];
+  const previousModelSwitch = getPendingChatModelSwitch(host, targetSessionKey);
   setChatError(host, null, true);
   const switchPromiseRef: { current?: Promise<boolean> } = {};
   const clearPendingSwitch = () => {
@@ -447,6 +382,11 @@ export async function switchChatModel(
   };
   const switchPromise: Promise<boolean> = (async () => {
     try {
+      // Rapid selections can enter before the disabled state renders. Preserve
+      // user order so an older model response cannot overwrite the newer one.
+      if (previousModelSwitch) {
+        await previousModelSwitch;
+      }
       const patched = await host.sessions.patch(
         targetSessionKey,
         {
@@ -474,6 +414,7 @@ export async function switchChatModel(
     ...host.chatModelSwitchPromises,
     [targetSessionKey]: switchPromise,
   };
+  trackPendingChatModelSwitch(host, targetSessionKey, switchPromise);
   trackPendingChatPickerPatch(host, targetSessionKey, switchPromise);
   host.requestUpdate?.();
   return switchPromise;
@@ -489,6 +430,7 @@ export function switchChatThinkingLevel(
   }
   const activeRow = host.sessionsResult?.sessions?.find((row) => row.key === targetSessionKey);
   const previousThinkingLevel = activeRow?.thinkingLevel;
+  const pendingModelSwitch = getPendingChatModelSwitch(host, targetSessionKey);
   const normalizedNext =
     (normalizeThinkLevel(nextThinkingLevel) ?? nextThinkingLevel.trim()) || undefined;
   const normalizedPrev =
@@ -514,6 +456,12 @@ export function switchChatThinkingLevel(
   };
   const patchPromise = (async () => {
     try {
+      // Thinking levels are model-specific. The renderer locks this control
+      // during a switch, but an already-dispatched event still needs ordering.
+      if (pendingModelSwitch && !(await pendingModelSwitch)) {
+        rollback();
+        return false;
+      }
       const patched = await host.sessions.patch(
         targetSessionKey,
         {

--- a/ui/src/pages/chat/chat-session.ts
+++ b/ui/src/pages/chat/chat-session.ts
@@ -20,10 +20,11 @@ import { normalizeOptionalString } from "../../lib/string-coerce.ts";
 import type { ChatHistoryResult } from "./chat-history.ts";
 import {
   getPendingChatModelSwitch,
+  getPendingChatPickerPatch,
   trackPendingChatModelSwitch,
   trackPendingChatPickerPatch,
 } from "./chat-settings-patches.ts";
-export { getPendingChatPickerPatch, trackPendingChatPickerPatch } from "./chat-settings-patches.ts";
+export { getPendingChatPickerPatch, trackPendingChatPickerPatch };
 
 const CHAT_SESSION_LIST_ACTIVE_MINUTES = 0;
 const CHAT_SESSION_LIST_LIMIT = 50;
@@ -370,7 +371,7 @@ export async function switchChatModel(
     return true;
   }
   const previousModelOverride = host.sessions.state.modelOverrides[targetSessionKey];
-  const previousModelSwitch = getPendingChatModelSwitch(host, targetSessionKey);
+  const previousPickerPatch = getPendingChatPickerPatch(host, targetSessionKey);
   setChatError(host, null, true);
   const switchPromiseRef: { current?: Promise<boolean> } = {};
   const clearPendingSwitch = () => {
@@ -383,9 +384,9 @@ export async function switchChatModel(
   const switchPromise: Promise<boolean> = (async () => {
     try {
       // Rapid selections can enter before the disabled state renders. Preserve
-      // user order so an older model response cannot overwrite the newer one.
-      if (previousModelSwitch) {
-        await previousModelSwitch;
+      // user order across both model and model-dependent settings patches.
+      if (previousPickerPatch) {
+        await previousPickerPatch;
       }
       const patched = await host.sessions.patch(
         targetSessionKey,

--- a/ui/src/pages/chat/chat-settings-patches.ts
+++ b/ui/src/pages/chat/chat-settings-patches.ts
@@ -1,0 +1,121 @@
+import {
+  resolveSessionKey,
+  type SessionCapability,
+  type SessionScopeHost,
+} from "../../lib/sessions/index.ts";
+import {
+  DEFAULT_AGENT_ID,
+  DEFAULT_MAIN_KEY,
+  isUiGlobalSessionKey,
+  normalizeAgentId,
+  normalizeSessionKeyForUiComparison,
+  resolveUiConfiguredMainKey,
+  resolveUiDefaultAgentId,
+  resolveUiSelectedGlobalAgentId,
+} from "../../lib/sessions/session-key.ts";
+
+type ChatPickerPatchHost = SessionScopeHost & { sessions: SessionCapability };
+type PendingPatchStore = WeakMap<SessionCapability, Map<string, Promise<boolean>>>;
+
+const pendingChatPickerPatches: PendingPatchStore = new WeakMap();
+const pendingChatModelSwitches: PendingPatchStore = new WeakMap();
+
+function resolveChatPickerPatchKey(
+  host: ChatPickerPatchHost,
+  sessionKey: string,
+  agentId?: string,
+): string {
+  const normalizedKey = normalizeSessionKeyForUiComparison(sessionKey);
+  const match = /^agent:([^:]+):(.*)$/u.exec(normalizedKey);
+  const body = match?.[2] ?? normalizedKey;
+  const isGlobal = isUiGlobalSessionKey(sessionKey);
+  const isMainAlias = [DEFAULT_MAIN_KEY, resolveUiConfiguredMainKey(host)].includes(
+    body.toLowerCase(),
+  );
+  const defaultAgentId = resolveUiDefaultAgentId(host);
+  const parsedAgentId = match?.[1];
+  // Match the Gateway's legacy default-main remap only when the live agent
+  // catalog proves that "main" is not a real agent.
+  const isLegacyDefaultMainAlias =
+    isMainAlias &&
+    normalizeAgentId(parsedAgentId ?? "") === DEFAULT_AGENT_ID &&
+    defaultAgentId !== DEFAULT_AGENT_ID &&
+    host.agentsList?.agents != null &&
+    !host.agentsList.agents.some(
+      (candidate) => normalizeAgentId(candidate.id) === DEFAULT_AGENT_ID,
+    );
+  // Main aliases share the literal global store only in global session scope.
+  const isGlobalMain = host.agentsList?.scope
+    ? host.agentsList.scope === "global"
+    : isUiGlobalSessionKey(resolveSessionKey(DEFAULT_MAIN_KEY, host.hello));
+  const resolvedAgentId =
+    (isLegacyDefaultMainAlias ? defaultAgentId : agentId?.trim() || parsedAgentId) ||
+    (isGlobal ? resolveUiSelectedGlobalAgentId(host) : defaultAgentId);
+  const settingsKey =
+    isGlobal || (isMainAlias && isGlobalMain) ? "global" : isMainAlias ? DEFAULT_MAIN_KEY : body;
+  return `agent:${normalizeAgentId(resolvedAgentId)}:${settingsKey}`;
+}
+
+function getPendingPatch(
+  store: PendingPatchStore,
+  host: ChatPickerPatchHost,
+  sessionKey: string,
+  agentId?: string,
+): Promise<boolean> | undefined {
+  const patchKey = resolveChatPickerPatchKey(host, sessionKey, agentId);
+  return store.get(host.sessions)?.get(patchKey);
+}
+
+function trackLatestPatch(
+  store: PendingPatchStore,
+  host: ChatPickerPatchHost,
+  sessionKey: string,
+  patchPromise: Promise<boolean>,
+): void {
+  const pendingBySession = store.get(host.sessions) ?? new Map<string, Promise<boolean>>();
+  store.set(host.sessions, pendingBySession);
+  const patchKey = resolveChatPickerPatchKey(host, sessionKey);
+  pendingBySession.set(patchKey, patchPromise);
+  void patchPromise.finally(() => {
+    if (pendingBySession.get(patchKey) === patchPromise) {
+      pendingBySession.delete(patchKey);
+    }
+  });
+}
+
+export function getPendingChatPickerPatch(
+  host: ChatPickerPatchHost,
+  sessionKey: string,
+  agentId?: string,
+): Promise<boolean> | undefined {
+  return getPendingPatch(pendingChatPickerPatches, host, sessionKey, agentId);
+}
+
+export function trackPendingChatPickerPatch(
+  host: ChatPickerPatchHost,
+  sessionKey: string,
+  patchPromise: Promise<boolean>,
+): void {
+  const previous = getPendingChatPickerPatch(host, sessionKey);
+  // Aggregate every picker patch across the shared capability; overlapping
+  // Gateway handlers can overtake pane-local or latest-only tracking.
+  const pending = Promise.all([previous ?? true, patchPromise]).then(
+    ([previousReady, patchReady]) => previousReady && patchReady,
+  );
+  trackLatestPatch(pendingChatPickerPatches, host, sessionKey, pending);
+}
+
+export function getPendingChatModelSwitch(
+  host: ChatPickerPatchHost,
+  sessionKey: string,
+): Promise<boolean> | undefined {
+  return getPendingPatch(pendingChatModelSwitches, host, sessionKey);
+}
+
+export function trackPendingChatModelSwitch(
+  host: ChatPickerPatchHost,
+  sessionKey: string,
+  switchPromise: Promise<boolean>,
+): void {
+  trackLatestPatch(pendingChatModelSwitches, host, sessionKey, switchPromise);
+}

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5094,6 +5094,102 @@ describe("chat model controls", () => {
     expect(speedToggle?.disabled).toBe(true);
   });
 
+  it("orders model-dependent patches after a pending model switch", async () => {
+    const modelPatch = createDeferred<unknown>();
+    const patches: Array<Record<string, unknown>> = [];
+    const patchResult = {
+      ok: true,
+      path: "",
+      key: "main",
+      entry: { sessionId: "main" },
+    };
+    const sessions = {
+      state: { modelOverrides: {} },
+      patch: vi.fn((_key: string, patch: Record<string, unknown>) => {
+        patches.push(patch);
+        return Object.hasOwn(patch, "model") ? modelPatch.promise : Promise.resolve(patchResult);
+      }),
+      refresh: async () => {},
+      setModelOverride: vi.fn(),
+    };
+    const host = {
+      client: {},
+      connected: true,
+      sessionKey: "main",
+      chatModelCatalog: [],
+      chatModelSwitchPromises: {},
+      chatThinkingLevel: "high",
+      sessions,
+      sessionsResult: createSessionsResultFromRows([
+        {
+          key: "main",
+          kind: "direct",
+          updatedAt: 1,
+          model: "claude-fable-5",
+          modelProvider: "anthropic",
+          thinkingLevel: "high",
+          fastMode: false,
+          effectiveFastMode: false,
+        },
+      ]),
+    } as unknown as Parameters<typeof switchChatModel>[0];
+
+    const modelSwitch = switchChatModel(host, "openai/gpt-5.6-sol");
+    const thinkingPatch = switchChatThinkingLevel(host, "ultra");
+    const fastModePatch = switchChatFastMode(host, "on");
+
+    expect(patches).toEqual([{ model: "openai/gpt-5.6-sol" }]);
+    modelPatch.resolve(patchResult);
+    await expect(modelSwitch).resolves.toBe(true);
+    await expect(Promise.all([thinkingPatch, fastModePatch])).resolves.toEqual([true, true]);
+    expect(patches).toHaveLength(3);
+    expect(patches.slice(1)).toEqual(
+      expect.arrayContaining([{ thinkingLevel: "ultra" }, { fastMode: true }]),
+    );
+  });
+
+  it("drops model-dependent patches when the pending model switch fails", async () => {
+    const modelPatch = createDeferred<unknown>();
+    const patches: Array<Record<string, unknown>> = [];
+    const sessions = {
+      state: { modelOverrides: {} },
+      patch: vi.fn((_key: string, patch: Record<string, unknown>) => {
+        patches.push(patch);
+        return modelPatch.promise;
+      }),
+      refresh: async () => {},
+      setModelOverride: vi.fn(),
+    };
+    const host = {
+      client: {},
+      connected: true,
+      sessionKey: "main",
+      chatModelCatalog: [],
+      chatModelSwitchPromises: {},
+      chatThinkingLevel: "high",
+      sessions,
+      sessionsResult: createSessionsResultFromRows([
+        {
+          key: "main",
+          kind: "direct",
+          updatedAt: 1,
+          model: "claude-fable-5",
+          modelProvider: "anthropic",
+          thinkingLevel: "high",
+        },
+      ]),
+    } as unknown as Parameters<typeof switchChatModel>[0];
+
+    const modelSwitch = switchChatModel(host, "openai/gpt-5.6-sol");
+    const thinkingPatch = switchChatThinkingLevel(host, "ultra");
+    modelPatch.resolve(null);
+
+    await expect(modelSwitch).resolves.toBe(false);
+    await expect(thinkingPatch).resolves.toBe(false);
+    expect(patches).toEqual([{ model: "openai/gpt-5.6-sol" }]);
+    expect(host.chatThinkingLevel).toBe("high");
+  });
+
   it("keeps the newest speed selection when an older patch fails late", async () => {
     const pendingPatches: Array<{ resolve: () => void; reject: (error: Error) => void }> = [];
     // Minimal host: the factory's mock gateway rebuilds session rows on every

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5096,6 +5096,7 @@ describe("chat model controls", () => {
 
   it("orders model-dependent patches after a pending model switch", async () => {
     const modelPatch = createDeferred<unknown>();
+    const thinkingUpdate = createDeferred<unknown>();
     const patches: Array<Record<string, unknown>> = [];
     const patchResult = {
       ok: true,
@@ -5107,7 +5108,13 @@ describe("chat model controls", () => {
       state: { modelOverrides: {} },
       patch: vi.fn((_key: string, patch: Record<string, unknown>) => {
         patches.push(patch);
-        return Object.hasOwn(patch, "model") ? modelPatch.promise : Promise.resolve(patchResult);
+        if (Object.hasOwn(patch, "model")) {
+          return modelPatch.promise;
+        }
+        if (Object.hasOwn(patch, "thinkingLevel")) {
+          return thinkingUpdate.promise;
+        }
+        return Promise.resolve(patchResult);
       }),
       refresh: async () => {},
       setModelOverride: vi.fn(),
@@ -5137,13 +5144,21 @@ describe("chat model controls", () => {
     const modelSwitch = switchChatModel(host, "openai/gpt-5.6-sol");
     const thinkingPatch = switchChatThinkingLevel(host, "ultra");
     const fastModePatch = switchChatFastMode(host, "on");
+    const laterModelSwitch = switchChatModel(host, "google/gemini-3-pro");
 
     expect(patches).toEqual([{ model: "openai/gpt-5.6-sol" }]);
     modelPatch.resolve(patchResult);
     await expect(modelSwitch).resolves.toBe(true);
-    await expect(Promise.all([thinkingPatch, fastModePatch])).resolves.toEqual([true, true]);
-    expect(patches).toHaveLength(3);
-    expect(patches.slice(1)).toEqual(
+    await vi.waitFor(() => expect(patches).toHaveLength(3));
+    expect(patches).not.toContainEqual({ model: "google/gemini-3-pro" });
+    thinkingUpdate.resolve(patchResult);
+    await expect(Promise.all([thinkingPatch, fastModePatch, laterModelSwitch])).resolves.toEqual([
+      true,
+      true,
+      true,
+    ]);
+    expect(patches.at(-1)).toEqual({ model: "google/gemini-3-pro" });
+    expect(patches.slice(1, -1)).toEqual(
       expect.arrayContaining([{ thinkingLevel: "ultra" }, { fastMode: true }]),
     );
   });


### PR DESCRIPTION
Related: #102871, #103253

## What Problem This Solves

Control UI could show a newly selected model while a reasoning or speed update was still validated against the previous model. Switching from Anthropic Claude Fable 5 to OpenAI GPT-5.6 Sol and choosing Sol's `ultra` reasoning level could therefore fail with an error claiming `ultra` was unsupported for Fable.

## Why This Change Was Made

The immediate-apply picker sent model, reasoning, and speed changes as independent overlapping `sessions.patch` requests. The renderer disabled model-dependent controls during a switch, but an already-dispatched event could still cross that render boundary, and rapid model selections could be applied by the Gateway out of user order.

Control UI now tracks pending model switches by the same canonical session identity used for its existing pending-settings gate. Model-dependent reasoning and speed updates wait for the selected model to commit, failed model switches drop and roll back dependent settings, and rapid model switches preserve selection order. The shared coordination moved into a focused module, bringing `chat-session.ts` below the repository's 500-line production-file limit.

Gateway validation remains strict. This fixes the client ordering bug instead of weakening provider-specific thinking-level checks or adding a fallback.

## User Impact

The model picker can switch between providers with different reasoning labels without reporting the previous provider's validation error. GPT-5.6 Sol's Ultra level is applied only after Sol is the committed session model; failed model changes do not leak dependent settings.

## Evidence

- Blacksmith Testbox `tbx_01kxcz354kck4w7xjcg9d66ggf`, exact head `2f40164f154`:
  - `pnpm check:changed` — passed, including LOC ratchet, formatting, core-test/UI typechecks, and lint.
  - Focused rapid-switch ordering and failed-switch rollback tests — 2 passed.
- Same rebased patch before the final rapid-switch hardening (`fe9dbe242e2`), Blacksmith Testbox `tbx_01kxcz354kck4w7xjcg9d66ggf`:
  - `pnpm test ui/src/pages/chat/chat-view.test.ts ui/src/pages/chat/chat-send.test.ts` — 390 passed.
  - `pnpm test:ui:e2e ui/src/e2e/chat-flow.e2e.test.ts -t "applies provider-specific reasoning after the selected model is saved"` — 1 passed.
  - `pnpm build` — passed, including the production Control UI build.
- Mocked browser proof delayed the model response, verified reasoning stayed locked, swapped Fable's label set for Sol's, selected Ultra, and observed no unsupported-level error.
- Fresh Codex autoreview: no accepted or actionable findings, overall confidence 0.93.

AI-assisted: yes, Codex.
