### PR TITLE
refactor(gateway): remove transcript archive re-export

### DIFF
--- a/src/gateway/session-utils.fs-anchor.ts
+++ b/src/gateway/session-utils.fs-anchor.ts
@@ -1,9 +1,9 @@
 import { materializeSessionArchiveForRead } from "../config/sessions/archive-compression.js";
+import { resolveSessionTranscriptResetArchiveCandidatesAsync } from "./session-transcript-files.fs.js";
 import { readSessionTranscriptIndex } from "./session-transcript-index.fs.js";
 import {
   findExistingTranscriptPath,
   indexedTranscriptEntryToMessages,
-  resolveSessionTranscriptResetArchiveCandidatesAsync,
   type ReadRecentSessionMessagesResult,
 } from "./session-utils.fs.js";
 

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -959,7 +959,6 @@ export {
   archiveSessionTranscripts,
   cleanupArchivedSessionTranscripts,
   resolveSessionTranscriptCandidates,
-  resolveSessionTranscriptResetArchiveCandidatesAsync,
 } from "./session-transcript-files.fs.js";
 
 export function capArrayByJsonBytes<T>(


### PR DESCRIPTION
## What Problem This Solves

Removes an obsolete gateway barrel export for a transcript reset-archive helper that is owned and used internally by the transcript filesystem module. Keeping the re-export widens the apparent gateway API and leaves a redundant dependency path.

## Why This Change Was Made

The anchored transcript reader now imports `resolveSessionTranscriptResetArchiveCandidatesAsync` directly from its defining module. The unused `session-utils.fs.ts` re-export is removed.

This is intentionally behavior-preserving. The helper implementation and both runtime call sites are unchanged.

## User Impact

No user-visible behavior changes. The internal gateway ownership boundary is narrower and future callers are directed to the canonical transcript-files module.

## Evidence

- Fresh Testbox `tbx_01kxd5c8g5nd84kz8xhk9j7naq` ([run 29231574253](https://github.com/openclaw/openclaw/actions/runs/29231574253)):
  - `pnpm test:serial src/gateway/session-transcript-readers.test.ts src/gateway/session-utils.fs.test.ts` - 444 tests passed
  - exact two-path `pnpm check:changed` - passed
  - `pnpm deadcode:exports` - matched 4,870 baseline entries
- `git diff --check` - passed
- Fresh `gpt-5.6-sol` medium autoreview - clean, confidence 0.95

Live overlap audit found no open PR touching either changed gateway file. The open archive-containment fix #103044 changes the defining module's archive policy but does not overlap this import/export boundary.
