### PR TITLE
fix(codex): update managed app-server to 0.144.3 [AI]

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -130,7 +130,7 @@ flags, and plugin allow/deny references into this block. Explicit canonical
 ## App-server transport
 
 For ordinary harness turns, OpenClaw starts the managed Codex binary shipped
-with the official plugin (currently `@openai/codex` `0.144.1`):
+with the official plugin (currently `@openai/codex` `0.144.2`):
 
 ```bash
 codex app-server --listen stdio://
@@ -586,7 +586,7 @@ If discovery fails or times out, OpenClaw uses a bundled fallback catalog:
 | `gpt-5.4-mini` | GPT-5.4-Mini | low, medium, high, xhigh |
 
 <Note>
-The current bundled harness is `@openai/codex` `0.144.1`. A `model/list` probe
+The current bundled harness is `@openai/codex` `0.144.2`. A `model/list` probe
 against that bundled app-server returned these public picker rows:
 
 | Model id        | Input modalities | Reasoning efforts                    |

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -130,7 +130,7 @@ flags, and plugin allow/deny references into this block. Explicit canonical
 ## App-server transport
 
 For ordinary harness turns, OpenClaw starts the managed Codex binary shipped
-with the official plugin (currently `@openai/codex` `0.144.2`):
+with the official plugin (currently `@openai/codex` `0.144.3`):
 
 ```bash
 codex app-server --listen stdio://
@@ -586,7 +586,7 @@ If discovery fails or times out, OpenClaw uses a bundled fallback catalog:
 | `gpt-5.4-mini` | GPT-5.4-Mini | low, medium, high, xhigh |
 
 <Note>
-The current bundled harness is `@openai/codex` `0.144.2`. A `model/list` probe
+The current bundled harness is `@openai/codex` `0.144.3`. A `model/list` probe
 against that bundled app-server returned these public picker rows:
 
 | Model id        | Input modalities | Reasoning efforts                    |

--- a/extensions/codex/npm-shrinkwrap.json
+++ b/extensions/codex/npm-shrinkwrap.json
@@ -8,7 +8,7 @@
       "name": "@openclaw/codex",
       "version": "2026.7.2",
       "dependencies": {
-        "@openai/codex": "0.144.2",
+        "@openai/codex": "0.144.3",
         "semver": "7.8.5",
         "smol-toml": "1.7.0",
         "typebox": "1.3.3",
@@ -17,9 +17,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.144.2",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2.tgz",
-      "integrity": "sha512-2eJ6OvuVjJL6XlbHWvHUh6mYRCrR80IB/j8Z1gMzwh0B/uHG+atEaTkYt3JeYFuifflgI2ppec7TI7Y5lhE+vw==",
+      "version": "0.144.3",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3.tgz",
+      "integrity": "sha512-8Re3wp5CdYiM7nsF4StFa5js6IT11N7srhxfvwtol7ENHDht05C+HS4e1CTmYjqkhgsUzl2R1gB27iN2pdbVnA==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -28,19 +28,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.2-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.2-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.2-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.2-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.2-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.2-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.3-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.3-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.3-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.3-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.3-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.3-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.2-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-darwin-arm64.tgz",
-      "integrity": "sha512-/RvmNpFKsi0uo7Or424timagvR/5tdR9b+fFRZ4uwXeSqCs2N0UiEKdJlHd2G709A3N61Tg5i62jHRKvqcB8Rw==",
+      "version": "0.144.3-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3-darwin-arm64.tgz",
+      "integrity": "sha512-v/yT1wqslBcwquUvUPZvAdYyiZcCBIUL+pE4ymHpbUMVduwDJBw1EjLroOhe9FkYFDHzWGyv7YEw7iIV4k+0dA==",
       "cpu": [
         "arm64"
       ],
@@ -55,9 +55,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.144.2-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-darwin-x64.tgz",
-      "integrity": "sha512-gd4vOeZ7SZdSEPtlVdLDCqNkBHnRVJLvWh7lv+hxDF1Ceqo7h5Lb1ypHfEmFHkvm3V1oWjMSYaV0SjNdBI8PjA==",
+      "version": "0.144.3-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3-darwin-x64.tgz",
+      "integrity": "sha512-308U0s7AeRg3AlnxJtmJk03yRRriEplC6ceFoB3OpWh+przqt8/u6MKDVU3KHdjb+vasa0IpmDWv5VrFw3oJAw==",
       "cpu": [
         "x64"
       ],
@@ -72,9 +72,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.2-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-linux-arm64.tgz",
-      "integrity": "sha512-SiAhn4Us7USSyUOpwBR57AihEdS2BVQ/Dw+qheTjHv2yFW1Qhh6r9wy3yMcY6YFj2HA04cBg4CijAUXieF20ig==",
+      "version": "0.144.3-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3-linux-arm64.tgz",
+      "integrity": "sha512-mJgDUmoPMry9a7g6ywsMQ4uQko2K0uHLqzEITUJMXiNNbCRBQKS+PxDWBlSK0bF0v72uAhWRRRGvPXslwhIdyg==",
       "cpu": [
         "arm64"
       ],
@@ -89,9 +89,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.144.2-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-linux-x64.tgz",
-      "integrity": "sha512-wlrMbKNBWi9T6RWy61ZNmYhSa73FGyZWSWI8F+FJGKXcjCdTI1VOercTcVtZ2cr2W70s/veIEu17HfQjrUYj6g==",
+      "version": "0.144.3-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3-linux-x64.tgz",
+      "integrity": "sha512-xtDY5sWQPbYBj2lLWZJvc0jBre0XQ7ZmN4VbSEvazbQ2X7uHhm1D/0oZ7AI+SgC/VfZrUhvxRHd43/AmXSaAzA==",
       "cpu": [
         "x64"
       ],
@@ -106,9 +106,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.2-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-win32-arm64.tgz",
-      "integrity": "sha512-hkv9xHjnvzGrrAXI1sr9FMT1z31OPrjZeHqDBobIAHk0RbLgg7eeCUZVi7Z94JjRm6nK3hMW177NdWt0qax9jg==",
+      "version": "0.144.3-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3-win32-arm64.tgz",
+      "integrity": "sha512-uvgBLuBX58GIq58CquhvhEmwLlH9Lc46rLmE5/CkEf1vQiCvWqVHxL28t7P9cmWGoeMuxsrIwqJgyzmRu6wZMQ==",
       "cpu": [
         "arm64"
       ],
@@ -123,9 +123,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.144.2-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-win32-x64.tgz",
-      "integrity": "sha512-1oXU+Ky/3x75V71Tseu3QxSwcqsR/B3REZS9mO1dk2WQ+Xd0bQ52StqgyumGRAUlgC5tkv1crj/ayTUw4yQtrw==",
+      "version": "0.144.3-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3-win32-x64.tgz",
+      "integrity": "sha512-0o8LpbZuBvqcAdIqMh96pECFTtfkgMT2sP/Q2IKYUOOlSudq3ulvdDW6zARq04HhbOxSsU9TBYDkdqtDs2YcYQ==",
       "cpu": [
         "x64"
       ],

--- a/extensions/codex/npm-shrinkwrap.json
+++ b/extensions/codex/npm-shrinkwrap.json
@@ -8,7 +8,7 @@
       "name": "@openclaw/codex",
       "version": "2026.7.2",
       "dependencies": {
-        "@openai/codex": "0.144.1",
+        "@openai/codex": "0.144.2",
         "semver": "7.8.5",
         "smol-toml": "1.7.0",
         "typebox": "1.3.3",
@@ -17,9 +17,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.144.1",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1.tgz",
-      "integrity": "sha512-Xir1zqPfpenhdoAoshN53uonzbBXj18COyzRkFlVZpSNyEl5XtkuYu9oddELePFN7K/0sXUcSO34Ad5IeCXPbw==",
+      "version": "0.144.2",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2.tgz",
+      "integrity": "sha512-2eJ6OvuVjJL6XlbHWvHUh6mYRCrR80IB/j8Z1gMzwh0B/uHG+atEaTkYt3JeYFuifflgI2ppec7TI7Y5lhE+vw==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -28,19 +28,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.1-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.1-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.1-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.1-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.1-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.1-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.2-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.2-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.2-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.2-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.2-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.2-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.1-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-arm64.tgz",
-      "integrity": "sha512-dABeDK+ATqMG54MGBd3VjpKfh5EOoqx9PKVQB2QYDaEXx3F6CdUCXue5QIMfr4OxziUj8pUcLAQyd+KFqiTUFw==",
+      "version": "0.144.2-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-darwin-arm64.tgz",
+      "integrity": "sha512-/RvmNpFKsi0uo7Or424timagvR/5tdR9b+fFRZ4uwXeSqCs2N0UiEKdJlHd2G709A3N61Tg5i62jHRKvqcB8Rw==",
       "cpu": [
         "arm64"
       ],
@@ -55,9 +55,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.144.1-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-x64.tgz",
-      "integrity": "sha512-K2g3Q3tNxzFhV0SuzO6HcsYK7EQrp/o4HyeReyhkwVrwwUPoYwyIbB0IRjHIiDzRhbKriDccid2iyF5aPqdTcg==",
+      "version": "0.144.2-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-darwin-x64.tgz",
+      "integrity": "sha512-gd4vOeZ7SZdSEPtlVdLDCqNkBHnRVJLvWh7lv+hxDF1Ceqo7h5Lb1ypHfEmFHkvm3V1oWjMSYaV0SjNdBI8PjA==",
       "cpu": [
         "x64"
       ],
@@ -72,9 +72,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.1-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-arm64.tgz",
-      "integrity": "sha512-451o15+XtaXCCb35t/KCyyPqXHnTPxPxtdqEYOnE3e4sH5AfnI/uVJwfdjOksMG6vRLy6R+fLvSDOMguRFLmQw==",
+      "version": "0.144.2-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-linux-arm64.tgz",
+      "integrity": "sha512-SiAhn4Us7USSyUOpwBR57AihEdS2BVQ/Dw+qheTjHv2yFW1Qhh6r9wy3yMcY6YFj2HA04cBg4CijAUXieF20ig==",
       "cpu": [
         "arm64"
       ],
@@ -89,9 +89,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.144.1-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-x64.tgz",
-      "integrity": "sha512-HNGVI+BulrOaC/0IzBvd6EL62j7LrlbFKibrhw6hZjjCjAeUYzRB2jB4qDzXN1NfqDi6Xrvniof3kwbwab24lg==",
+      "version": "0.144.2-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-linux-x64.tgz",
+      "integrity": "sha512-wlrMbKNBWi9T6RWy61ZNmYhSa73FGyZWSWI8F+FJGKXcjCdTI1VOercTcVtZ2cr2W70s/veIEu17HfQjrUYj6g==",
       "cpu": [
         "x64"
       ],
@@ -106,9 +106,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.1-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-arm64.tgz",
-      "integrity": "sha512-L4aDVEh9o1u7WYoxpSyv3un9Bz26YZYocOFqE2oHdEQDL2s6/LdtutLQc3oUZruLlEbkNsjSU0HI1OKsP0+Ctg==",
+      "version": "0.144.2-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-win32-arm64.tgz",
+      "integrity": "sha512-hkv9xHjnvzGrrAXI1sr9FMT1z31OPrjZeHqDBobIAHk0RbLgg7eeCUZVi7Z94JjRm6nK3hMW177NdWt0qax9jg==",
       "cpu": [
         "arm64"
       ],
@@ -123,9 +123,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.144.1-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-x64.tgz",
-      "integrity": "sha512-qv2HOp6v/nVP31p5I5GxYyL0wa79PMzim1+W9CKSV0UldjFV9AMbualA8PeXcYhbvvh9Y1UASXxwjuQdlyfAvw==",
+      "version": "0.144.2-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-win32-x64.tgz",
+      "integrity": "sha512-1oXU+Ky/3x75V71Tseu3QxSwcqsR/B3REZS9mO1dk2WQ+Xd0bQ52StqgyumGRAUlgC5tkv1crj/ayTUw4yQtrw==",
       "cpu": [
         "x64"
       ],

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@openai/codex": "0.144.2",
+    "@openai/codex": "0.144.3",
     "semver": "7.8.5",
     "smol-toml": "1.7.0",
     "typebox": "1.3.3",

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@openai/codex": "0.144.1",
+    "@openai/codex": "0.144.2",
     "semver": "7.8.5",
     "smol-toml": "1.7.0",
     "typebox": "1.3.3",

--- a/extensions/codex/src/manifest.test.ts
+++ b/extensions/codex/src/manifest.test.ts
@@ -22,7 +22,7 @@ describe("codex package manifest", () => {
     ) as CodexPackageManifest;
 
     expect(packageJson.devDependencies).toHaveProperty("@openclaw/plugin-sdk");
-    expect(packageJson.dependencies?.["@openai/codex"]).toBe("0.144.1");
+    expect(packageJson.dependencies?.["@openai/codex"]).toBe("0.144.2");
     expect(packageJson.openclaw?.release?.requireLatestDependencies).toEqual(["@openai/codex"]);
     expect(packageJson.openclaw?.install?.requiredPlatformPackages).toEqual([
       "@openai/codex-linux-x64",

--- a/extensions/codex/src/manifest.test.ts
+++ b/extensions/codex/src/manifest.test.ts
@@ -22,7 +22,7 @@ describe("codex package manifest", () => {
     ) as CodexPackageManifest;
 
     expect(packageJson.devDependencies).toHaveProperty("@openclaw/plugin-sdk");
-    expect(packageJson.dependencies?.["@openai/codex"]).toBe("0.144.2");
+    expect(packageJson.dependencies?.["@openai/codex"]).toBe("0.144.3");
     expect(packageJson.openclaw?.release?.requireLatestDependencies).toEqual(["@openai/codex"]);
     expect(packageJson.openclaw?.install?.requiredPlatformPackages).toEqual([
       "@openai/codex-linux-x64",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -549,8 +549,8 @@ importers:
   extensions/codex:
     dependencies:
       '@openai/codex':
-        specifier: 0.144.1
-        version: 0.144.1
+        specifier: 0.144.2
+        version: 0.144.2
       semver:
         specifier: 7.8.5
         version: 7.8.5
@@ -3425,43 +3425,43 @@ packages:
     resolution: {integrity: sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  '@openai/codex@0.144.1':
-    resolution: {integrity: sha512-Xir1zqPfpenhdoAoshN53uonzbBXj18COyzRkFlVZpSNyEl5XtkuYu9oddELePFN7K/0sXUcSO34Ad5IeCXPbw==}
+  '@openai/codex@0.144.2':
+    resolution: {integrity: sha512-2eJ6OvuVjJL6XlbHWvHUh6mYRCrR80IB/j8Z1gMzwh0B/uHG+atEaTkYt3JeYFuifflgI2ppec7TI7Y5lhE+vw==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.144.1-darwin-arm64':
-    resolution: {integrity: sha512-dABeDK+ATqMG54MGBd3VjpKfh5EOoqx9PKVQB2QYDaEXx3F6CdUCXue5QIMfr4OxziUj8pUcLAQyd+KFqiTUFw==}
+  '@openai/codex@0.144.2-darwin-arm64':
+    resolution: {integrity: sha512-/RvmNpFKsi0uo7Or424timagvR/5tdR9b+fFRZ4uwXeSqCs2N0UiEKdJlHd2G709A3N61Tg5i62jHRKvqcB8Rw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.144.1-darwin-x64':
-    resolution: {integrity: sha512-K2g3Q3tNxzFhV0SuzO6HcsYK7EQrp/o4HyeReyhkwVrwwUPoYwyIbB0IRjHIiDzRhbKriDccid2iyF5aPqdTcg==}
+  '@openai/codex@0.144.2-darwin-x64':
+    resolution: {integrity: sha512-gd4vOeZ7SZdSEPtlVdLDCqNkBHnRVJLvWh7lv+hxDF1Ceqo7h5Lb1ypHfEmFHkvm3V1oWjMSYaV0SjNdBI8PjA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.144.1-linux-arm64':
-    resolution: {integrity: sha512-451o15+XtaXCCb35t/KCyyPqXHnTPxPxtdqEYOnE3e4sH5AfnI/uVJwfdjOksMG6vRLy6R+fLvSDOMguRFLmQw==}
+  '@openai/codex@0.144.2-linux-arm64':
+    resolution: {integrity: sha512-SiAhn4Us7USSyUOpwBR57AihEdS2BVQ/Dw+qheTjHv2yFW1Qhh6r9wy3yMcY6YFj2HA04cBg4CijAUXieF20ig==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.144.1-linux-x64':
-    resolution: {integrity: sha512-HNGVI+BulrOaC/0IzBvd6EL62j7LrlbFKibrhw6hZjjCjAeUYzRB2jB4qDzXN1NfqDi6Xrvniof3kwbwab24lg==}
+  '@openai/codex@0.144.2-linux-x64':
+    resolution: {integrity: sha512-wlrMbKNBWi9T6RWy61ZNmYhSa73FGyZWSWI8F+FJGKXcjCdTI1VOercTcVtZ2cr2W70s/veIEu17HfQjrUYj6g==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.144.1-win32-arm64':
-    resolution: {integrity: sha512-L4aDVEh9o1u7WYoxpSyv3un9Bz26YZYocOFqE2oHdEQDL2s6/LdtutLQc3oUZruLlEbkNsjSU0HI1OKsP0+Ctg==}
+  '@openai/codex@0.144.2-win32-arm64':
+    resolution: {integrity: sha512-hkv9xHjnvzGrrAXI1sr9FMT1z31OPrjZeHqDBobIAHk0RbLgg7eeCUZVi7Z94JjRm6nK3hMW177NdWt0qax9jg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.144.1-win32-x64':
-    resolution: {integrity: sha512-qv2HOp6v/nVP31p5I5GxYyL0wa79PMzim1+W9CKSV0UldjFV9AMbualA8PeXcYhbvvh9Y1UASXxwjuQdlyfAvw==}
+  '@openai/codex@0.144.2-win32-x64':
+    resolution: {integrity: sha512-1oXU+Ky/3x75V71Tseu3QxSwcqsR/B3REZS9mO1dk2WQ+Xd0bQ52StqgyumGRAUlgC5tkv1crj/ayTUw4yQtrw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -9603,31 +9603,31 @@ snapshots:
 
   '@npmcli/redact@4.0.0': {}
 
-  '@openai/codex@0.144.1':
+  '@openai/codex@0.144.2':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.144.1-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.144.1-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.144.1-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.144.1-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.144.1-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.144.1-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.144.2-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.144.2-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.144.2-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.144.2-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.144.2-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.144.2-win32-x64'
 
-  '@openai/codex@0.144.1-darwin-arm64':
+  '@openai/codex@0.144.2-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.144.1-darwin-x64':
+  '@openai/codex@0.144.2-darwin-x64':
     optional: true
 
-  '@openai/codex@0.144.1-linux-arm64':
+  '@openai/codex@0.144.2-linux-arm64':
     optional: true
 
-  '@openai/codex@0.144.1-linux-x64':
+  '@openai/codex@0.144.2-linux-x64':
     optional: true
 
-  '@openai/codex@0.144.1-win32-arm64':
+  '@openai/codex@0.144.2-win32-arm64':
     optional: true
 
-  '@openai/codex@0.144.1-win32-x64':
+  '@openai/codex@0.144.2-win32-x64':
     optional: true
 
   '@openclaw/crabline@0.1.11':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -549,8 +549,8 @@ importers:
   extensions/codex:
     dependencies:
       '@openai/codex':
-        specifier: 0.144.2
-        version: 0.144.2
+        specifier: 0.144.3
+        version: 0.144.3
       semver:
         specifier: 7.8.5
         version: 7.8.5
@@ -3425,43 +3425,43 @@ packages:
     resolution: {integrity: sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  '@openai/codex@0.144.2':
-    resolution: {integrity: sha512-2eJ6OvuVjJL6XlbHWvHUh6mYRCrR80IB/j8Z1gMzwh0B/uHG+atEaTkYt3JeYFuifflgI2ppec7TI7Y5lhE+vw==}
+  '@openai/codex@0.144.3':
+    resolution: {integrity: sha512-8Re3wp5CdYiM7nsF4StFa5js6IT11N7srhxfvwtol7ENHDht05C+HS4e1CTmYjqkhgsUzl2R1gB27iN2pdbVnA==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.144.2-darwin-arm64':
-    resolution: {integrity: sha512-/RvmNpFKsi0uo7Or424timagvR/5tdR9b+fFRZ4uwXeSqCs2N0UiEKdJlHd2G709A3N61Tg5i62jHRKvqcB8Rw==}
+  '@openai/codex@0.144.3-darwin-arm64':
+    resolution: {integrity: sha512-v/yT1wqslBcwquUvUPZvAdYyiZcCBIUL+pE4ymHpbUMVduwDJBw1EjLroOhe9FkYFDHzWGyv7YEw7iIV4k+0dA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.144.2-darwin-x64':
-    resolution: {integrity: sha512-gd4vOeZ7SZdSEPtlVdLDCqNkBHnRVJLvWh7lv+hxDF1Ceqo7h5Lb1ypHfEmFHkvm3V1oWjMSYaV0SjNdBI8PjA==}
+  '@openai/codex@0.144.3-darwin-x64':
+    resolution: {integrity: sha512-308U0s7AeRg3AlnxJtmJk03yRRriEplC6ceFoB3OpWh+przqt8/u6MKDVU3KHdjb+vasa0IpmDWv5VrFw3oJAw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.144.2-linux-arm64':
-    resolution: {integrity: sha512-SiAhn4Us7USSyUOpwBR57AihEdS2BVQ/Dw+qheTjHv2yFW1Qhh6r9wy3yMcY6YFj2HA04cBg4CijAUXieF20ig==}
+  '@openai/codex@0.144.3-linux-arm64':
+    resolution: {integrity: sha512-mJgDUmoPMry9a7g6ywsMQ4uQko2K0uHLqzEITUJMXiNNbCRBQKS+PxDWBlSK0bF0v72uAhWRRRGvPXslwhIdyg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.144.2-linux-x64':
-    resolution: {integrity: sha512-wlrMbKNBWi9T6RWy61ZNmYhSa73FGyZWSWI8F+FJGKXcjCdTI1VOercTcVtZ2cr2W70s/veIEu17HfQjrUYj6g==}
+  '@openai/codex@0.144.3-linux-x64':
+    resolution: {integrity: sha512-xtDY5sWQPbYBj2lLWZJvc0jBre0XQ7ZmN4VbSEvazbQ2X7uHhm1D/0oZ7AI+SgC/VfZrUhvxRHd43/AmXSaAzA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.144.2-win32-arm64':
-    resolution: {integrity: sha512-hkv9xHjnvzGrrAXI1sr9FMT1z31OPrjZeHqDBobIAHk0RbLgg7eeCUZVi7Z94JjRm6nK3hMW177NdWt0qax9jg==}
+  '@openai/codex@0.144.3-win32-arm64':
+    resolution: {integrity: sha512-uvgBLuBX58GIq58CquhvhEmwLlH9Lc46rLmE5/CkEf1vQiCvWqVHxL28t7P9cmWGoeMuxsrIwqJgyzmRu6wZMQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.144.2-win32-x64':
-    resolution: {integrity: sha512-1oXU+Ky/3x75V71Tseu3QxSwcqsR/B3REZS9mO1dk2WQ+Xd0bQ52StqgyumGRAUlgC5tkv1crj/ayTUw4yQtrw==}
+  '@openai/codex@0.144.3-win32-x64':
+    resolution: {integrity: sha512-0o8LpbZuBvqcAdIqMh96pECFTtfkgMT2sP/Q2IKYUOOlSudq3ulvdDW6zARq04HhbOxSsU9TBYDkdqtDs2YcYQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -9603,31 +9603,31 @@ snapshots:
 
   '@npmcli/redact@4.0.0': {}
 
-  '@openai/codex@0.144.2':
+  '@openai/codex@0.144.3':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.144.2-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.144.2-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.144.2-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.144.2-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.144.2-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.144.2-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.144.3-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.144.3-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.144.3-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.144.3-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.144.3-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.144.3-win32-x64'
 
-  '@openai/codex@0.144.2-darwin-arm64':
+  '@openai/codex@0.144.3-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.144.2-darwin-x64':
+  '@openai/codex@0.144.3-darwin-x64':
     optional: true
 
-  '@openai/codex@0.144.2-linux-arm64':
+  '@openai/codex@0.144.3-linux-arm64':
     optional: true
 
-  '@openai/codex@0.144.2-linux-x64':
+  '@openai/codex@0.144.3-linux-x64':
     optional: true
 
-  '@openai/codex@0.144.2-win32-arm64':
+  '@openai/codex@0.144.3-win32-arm64':
     optional: true
 
-  '@openai/codex@0.144.2-win32-x64':
+  '@openai/codex@0.144.3-win32-x64':
     optional: true
 
   '@openclaw/crabline@0.1.11':


### PR DESCRIPTION
## What Problem This Solves

The bundled Codex app-server was pinned to `@openai/codex` 0.144.1, whose backend requests are now rejected. This blocks the Codex plugin before the next OpenClaw release.

## Why This Change Was Made

- Pin the managed Codex runtime and every platform artifact to 0.144.3.
- Regenerate the root pnpm lock and plugin npm shrinkwrap, including registry integrities.
- Align the manifest assertion and harness reference version. The live 0.144.3 `model/list` catalog is unchanged, so the existing seven-row snapshot remains current.

Direct upstream source inspection confirms this is the correct owner boundary: Codex builds its backend `User-Agent` from `CARGO_PKG_VERSION` in `codex-rs/login/src/auth/default_client.rs:141-164`, then installs that value on authenticated backend requests in `codex-rs/backend-client/src/client.rs:179-182,212-219`. OpenClaw should therefore upgrade the managed package, not spoof a backend header. The 0.144.2-to-0.144.3 comparison has no app-server protocol, protocol, exec, login-user-agent, backend-client, or CLI contract changes; its relevant app-server runtime delta is the compatible persisted reasoning-effort resume fix in `codex-rs/app-server/src/request_processors/thread_processor.rs:2785-2814`.

## User Impact

Codex harness requests use backend-visible version 0.144.3, restoring compatibility for the release. No OpenClaw API, config, protocol, or picker-catalog shape changes.

## Evidence

- Blacksmith Testbox `tbx_01kxd5c8haz92bc9vfadvdfq7g`: fresh isolated `corepack pnpm --config.minimum-release-age=0 dlx @openai/codex@0.144.3 --version` returned `codex-cli 0.144.3`.
- Same Testbox: authenticated 0.144.3 app-server `model/list` succeeded; public picker rows exactly match `docs/plugins/codex-harness-reference.md`.
- Same Testbox: `corepack pnpm test extensions/codex` passed 106 files and 2,490 tests.
- Same Testbox: `corepack pnpm deps:shrinkwrap:changed:check`, selected-plugin npm release checks, and full `corepack pnpm check:changed` passed ([run 29232316676](https://github.com/openclaw/openclaw/actions/runs/29232316676)).
- Exact prepared-head CI is green at `92ed0c43a984be36d3a8b5e7b08eab38203cb54c` ([run 29234980974](https://github.com/openclaw/openclaw/actions/runs/29234980974)).
- Fresh structured autoreview of prepared head `92ed0c43a98`: no findings, patch correct at 0.97 confidence.
