### PR TITLE
fix(macos): center dashboard traffic lights with the hosted titlebar buttons

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -26163,7 +26163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 643,
+      "line": 665,
       "path": "apps/macos/Sources/OpenClaw/DashboardWindowController.swift",
       "source": "[\\(host)]",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -8,6 +8,20 @@ private final class DashboardWindowContentView: NSView {
     }
 }
 
+/// The dashboard's empty unified toolbar exists only to grow the titlebar to
+/// 52pt so the traffic lights align with the hosted web chrome. `View > Hide
+/// Toolbar` (and ⌥⌘T) would collapse the titlebar while the web inset stays
+/// pinned at `--openclaw-native-titlebar-height`, resurrecting the traffic-light
+/// misalignment. Refusing the toggle keeps the two heights in lockstep.
+private final class DashboardWindow: NSWindow {
+    override func toggleToolbarShown(_: Any?) {}
+
+    override func validateUserInterfaceItem(_ item: NSValidatedUserInterfaceItem) -> Bool {
+        if item.action == #selector(NSWindow.toggleToolbarShown(_:)) { return false }
+        return super.validateUserInterfaceItem(item)
+    }
+}
+
 private final class DashboardWindowDragRegionView: NSView {
     override var mouseDownCanMoveWindow: Bool {
         true
@@ -513,7 +527,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     }
 
     private static func makeWindow(contentView: NSView) -> NSWindow {
-        let window = NSWindow(
+        let window = DashboardWindow(
             contentRect: NSRect(origin: .zero, size: DashboardWindowLayout.windowSize),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
@@ -548,6 +562,12 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         window.title = "OpenClaw"
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
+        // An empty unified toolbar grows the transparent titlebar to 52pt so the
+        // traffic lights sit vertically centered against the web titlebar row
+        // (--openclaw-native-titlebar-height); without it they hug the top edge.
+        window.toolbar = NSToolbar(identifier: "DashboardWindowTitlebar")
+        window.toolbarStyle = .unified
+        window.titlebarSeparatorStyle = .none
         window.isMovableByWindowBackground = true
         window.isReleasedWhenClosed = false
         window.hasShadow = true
@@ -575,7 +595,9 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         // !important selectors also outrank the rules older app builds inject.
         let css = """
         html.openclaw-native-macos {
-          --openclaw-native-titlebar-height: 50px;
+          /* Matches the 52pt unified-toolbar titlebar so the web buttons and the
+             traffic lights share one vertical center. */
+          --openclaw-native-titlebar-height: 52px;
         }
         @media (min-width: 700px) {
           /* Both desktop navigation surfaces must clear AppKit's window controls

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -44,6 +44,15 @@ struct DashboardWindowSmokeTests {
         #expect(controller.window?.styleMask.contains(.closable) == true)
         #expect(controller.window?.contentViewController != nil)
         #expect(controller.window?.standardWindowButton(.closeButton) != nil)
+        // The empty unified toolbar is what grows the titlebar to 52pt so the
+        // traffic lights center against the web titlebar row; without it they
+        // hug the top edge and misalign with the hosted web buttons.
+        #expect(controller.window?.toolbar != nil)
+        #expect(controller.window?.toolbarStyle == .unified)
+        // The toolbar only exists to size the titlebar, so View > Hide Toolbar
+        // (⌥⌘T) must be refused; otherwise hiding it desyncs the 52pt web inset.
+        controller.window?.toggleToolbarShown(nil)
+        #expect(controller.window?.toolbar?.isVisible == true)
         #expect((controller.window?.frame.width ?? 0) >= DashboardWindowLayout.windowMinSize.width)
         #expect((controller.window?.frame.height ?? 0) >= DashboardWindowLayout.windowMinSize.height)
         controller.closeDashboard()
@@ -485,7 +494,10 @@ struct DashboardWindowSmokeTests {
         #expect(chromeScript.source.contains(".sidebar-shell"))
         #expect(chromeScript.source.contains(".settings-sidebar__header"))
         #expect(chromeScript.source.contains("min-width: 700px"))
-        #expect(chromeScript.source.contains("--openclaw-native-titlebar-height"))
+        // Keep the injected titlebar height in lockstep with the 52pt unified
+        // toolbar in makeWindow(); the two must match for the traffic lights and
+        // the hosted web buttons to share one vertical center.
+        #expect(chromeScript.source.contains("--openclaw-native-titlebar-height: 52px"))
         #expect(!chromeScript.source.contains("max-width: 1100px"))
         #expect(chromeScript.source.contains("openclaw-native-web-chrome"))
         #expect(!chromeScript.source.contains("openclaw-native-nav"))

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -129,7 +129,9 @@ html.openclaw-native-web-chrome .sidebar-brand__collapse {
 .macos-titlebar-controls {
   position: fixed;
   top: 0;
-  left: 78px;
+  /* Clear the traffic lights (~74px cluster) with breathing room before the
+     first hosted button, so the two groups read as separate. */
+  left: 92px;
   /* Above app chrome (<=45), below dropdowns/dialogs (>=100). */
   z-index: 50;
   display: flex;


### PR DESCRIPTION
## What Problem This Solves

In the macOS app's dashboard window (the one that hosts the web UI), the macOS traffic-light buttons sat hugging the top edge of the window, visually above the row of web-hosted titlebar controls (sidebar toggle, back/forward). The two button groups didn't share a centerline, and the traffic lights sat almost flush against the first web button with no separation.

## Why This Change Was Made

The dashboard window now carries an empty unified `NSToolbar`, which grows the titlebar to the standard 52pt. AppKit vertically centers the traffic lights in that taller titlebar, so they line up with the web button row (which centers itself in `--openclaw-native-titlebar-height`). That injected height is bumped 50px → 52px to match the toolbar, and the hosted controls' left offset goes 78px → 92px so the traffic-light cluster and the first web button read as two distinct groups.

The toolbar exists only to size the titlebar, so `View > Hide Toolbar` (and ⌥⌘T) are refused via a small `NSWindow` subclass — hiding it would collapse the titlebar while the web inset stayed pinned at 52pt, resurrecting the misalignment.

## User Impact

The dashboard window's traffic lights are now vertically centered against the app's own titlebar buttons, with a comfortable gap between the two groups — a small but visible polish to the desktop chrome. No behavior change beyond appearance.

## Evidence

- Built the ad-hoc-signed app and ran it in a Parallels macOS Tahoe (26.5) VM against a local gateway; confirmed on-screen that the traffic lights and the hosted buttons share one centerline with the wider gap. Before/after screenshots available on request.
- `swift test --filter DashboardWindowSmokeTests` — 27/27 pass, including new assertions for toolbar presence/style, refusal of the hide-toolbar toggle, and the exact injected `--openclaw-native-titlebar-height: 52px`.
- Codex autoreview (`gpt-5.6-sol`, xhigh): clean, "patch is correct".

Related: #105902 (hosting the macOS dashboard titlebar buttons in the web UI).
