### PR TITLE
fix(release): keep reviewed migration residue nonfatal

### DIFF
--- a/extensions/codex/doctor-contract-api.test.ts
+++ b/extensions/codex/doctor-contract-api.test.ts
@@ -894,7 +894,8 @@ describe("codex doctor contract", () => {
     const result = await fixture.migration.migrateLegacyState(fixture.params);
 
     expect(result.changes).toEqual([]);
-    expect(result.warnings).toEqual([expect.stringContaining("owned by agent harness pi")]);
+    expect(result.warnings).toEqual([]);
+    expect(result.notices).toEqual([expect.stringContaining("owned by agent harness pi")]);
     await expect(fs.access(fixture.sidecarPath)).resolves.toBeUndefined();
     await expect(openBindingStore(fixture.env).entries()).resolves.toEqual([]);
 

--- a/extensions/codex/src/migration/session-binding-sidecars.ts
+++ b/extensions/codex/src/migration/session-binding-sidecars.ts
@@ -70,6 +70,7 @@ type SourceMigrationResult = {
   archived: boolean;
   importedKeys: number;
   warning?: string;
+  notice?: string;
 };
 
 // Keep the doctor contract graph independent from the full Codex runtime.
@@ -415,6 +416,11 @@ async function migrateSource(
     importedKeys,
     warning: `Left Codex binding sidecar in place because ${reason}: ${source.sidecarPath}`,
   });
+  const retainNotice = (reason: string): SourceMigrationResult => ({
+    archived: false,
+    importedKeys,
+    notice: `Left Codex binding sidecar in place because ${reason}: ${source.sidecarPath}`,
+  });
   const owner = candidates.length === 1 ? candidates[0] : undefined;
   try {
     return await withFileLock(source.sidecarPath, LEGACY_BINDING_LOCK_OPTIONS, async () => {
@@ -453,7 +459,7 @@ async function migrateSource(
         return retain(`${candidates.length} matching session owners make ownership ambiguous`);
       }
       if (owner?.agentHarnessId && owner.agentHarnessId !== CODEX_AGENT_HARNESS_ID) {
-        return retain(`its session is owned by agent harness ${owner.agentHarnessId}`);
+        return retainNotice(`its session is owned by agent harness ${owner.agentHarnessId}`);
       }
       const sourceSessionFile =
         typeof raw.sessionFile === "string" && raw.sessionFile.trim()
@@ -780,6 +786,7 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
     async migrateLegacyState(params) {
       const changes: string[] = [];
       const warnings: string[] = [];
+      const notices: string[] = [];
       const { sources, surfaces } = await collectLegacyBindingSources(params);
       if (sources.length === 0) {
         return { changes, warnings };
@@ -805,6 +812,9 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
         if (result.warning) {
           warnings.push(result.warning);
         }
+        if (result.notice) {
+          notices.push(result.notice);
+        }
         if (result.archived) {
           migrated++;
         } else {
@@ -821,7 +831,7 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
           `Migrated ${partialImports} safe Codex app-server binding row(s) to plugin state; retained legacy sidecars needing review`,
         );
       }
-      return { changes, warnings };
+      return notices.length > 0 ? { changes, warnings, notices } : { changes, warnings };
     },
   },
 ];

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -2241,7 +2241,8 @@ describe("doctor legacy state migrations", () => {
 
     const result = await runLegacyStateMigrationsForRoot(root);
 
-    expect(result.warnings).toStrictEqual([
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.notices).toStrictEqual([
       "Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: demo",
     ]);
     expect(fs.existsSync(sourcePath)).toBe(true);
@@ -2358,7 +2359,8 @@ describe("doctor legacy state migrations", () => {
 
       const result = await runLegacyStateMigrationsForRoot(root);
 
-      expect(result.warnings).toStrictEqual([
+      expect(result.warnings).toStrictEqual([]);
+      expect(result.notices).toStrictEqual([
         "Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: demo",
       ]);
       expect(fs.existsSync(sourcePath)).toBe(true);

--- a/src/infra/state-migrations.state-dir.test.ts
+++ b/src/infra/state-migrations.state-dir.test.ts
@@ -2,7 +2,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { readPersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
+import {
+  readPersistedInstalledPluginIndex,
+  writePersistedInstalledPluginIndex,
+} from "../plugins/installed-plugin-index-store.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
   autoMigrateLegacyStateDir,
@@ -102,6 +105,51 @@ describe("legacy state dir auto-migration", () => {
       await expect(readPersistedInstalledPluginIndex({ stateDir })).resolves.toMatchObject({
         installRecords: { demo: { source: "npm", spec: "demo@1.0.0" } },
       });
+    });
+  });
+
+  it("reports conflicting plugin install metadata as a notice from the early state-dir pass", async () => {
+    await withStateDirFixture(async (root) => {
+      const stateDir = path.join(root, "custom-state");
+      const sourcePath = path.join(stateDir, "plugins", "installs.json");
+      await writePersistedInstalledPluginIndex(
+        {
+          version: 1,
+          hostContractVersion: "test",
+          compatRegistryVersion: "test",
+          migrationVersion: 1,
+          policyHash: "test",
+          generatedAtMs: 1,
+          installRecords: {
+            demo: { source: "npm", spec: "demo@latest", version: "1.0.0" },
+          },
+          plugins: [],
+          diagnostics: [],
+        },
+        { stateDir },
+      );
+      fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+      fs.writeFileSync(
+        sourcePath,
+        JSON.stringify({
+          records: {
+            demo: { source: "npm", spec: "demo@1.0.0", version: "1.0.0" },
+          },
+        }),
+        "utf8",
+      );
+
+      const result = await autoMigrateLegacyStateDir({
+        env: { OPENCLAW_STATE_DIR: stateDir } as NodeJS.ProcessEnv,
+        homedir: () => root,
+      });
+
+      expect(result.warnings).toStrictEqual([]);
+      expect(result.notices).toStrictEqual([
+        "Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: demo",
+      ]);
+      expect(result.skipped).toBe(false);
+      expect(fs.existsSync(sourcePath)).toBe(true);
     });
   });
 

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -2839,7 +2839,7 @@ async function migrateLegacyPluginStateSidecar(params: {
 
 async function migrateLegacyInstalledPluginIndex(params: {
   stateDir: string;
-}): Promise<{ changes: string[]; warnings: string[] }> {
+}): Promise<MigrationMessages> {
   const sourcePath = resolveLegacyInstalledPluginIndexStorePath({ stateDir: params.stateDir });
   if (!fileExists(sourcePath)) {
     return { changes: [], warnings: [] };
@@ -2875,7 +2875,8 @@ async function migrateLegacyInstalledPluginIndex(params: {
     if (merged.conflicts.length > 0) {
       return {
         changes,
-        warnings: [
+        warnings: [],
+        notices: [
           `Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: ${merged.conflicts.join(", ")}`,
         ],
       };
@@ -3893,20 +3894,23 @@ export async function autoMigrateLegacyStateDir(params: {
   const env = params.env ?? process.env;
   const warnings: string[] = [];
   const changes: string[] = [];
+  const notices: string[] = [];
   const hasCustomStateDir = Boolean(env.OPENCLAW_STATE_DIR?.trim());
   const targetDir = hasCustomStateDir ? resolveStateDir(env, homedir) : resolveNewStateDir(homedir);
   const migratePluginInstallIndex = async () => {
     const result = await migrateLegacyInstalledPluginIndex({ stateDir: targetDir });
     changes.push(...result.changes);
     warnings.push(...result.warnings);
+    notices.push(...(result.notices ?? []));
   };
   if (hasCustomStateDir) {
     await migratePluginInstallIndex();
     return {
       migrated: changes.length > 0,
-      skipped: changes.length === 0 && warnings.length === 0,
+      skipped: changes.length === 0 && warnings.length === 0 && notices.length === 0,
       changes,
       warnings,
+      ...(notices.length > 0 ? { notices } : {}),
     };
   }
 
@@ -3927,7 +3931,13 @@ export async function autoMigrateLegacyStateDir(params: {
   }
   if (!legacyStat) {
     await migratePluginInstallIndex();
-    return { migrated: changes.length > 0, skipped: false, changes, warnings };
+    return {
+      migrated: changes.length > 0,
+      skipped: false,
+      changes,
+      warnings,
+      ...(notices.length > 0 ? { notices } : {}),
+    };
   }
   if (!legacyStat.isDirectory() && !legacyStat.isSymbolicLink()) {
     warnings.push(`Legacy state path is not a directory: ${legacyDir}`);
@@ -3945,7 +3955,13 @@ export async function autoMigrateLegacyStateDir(params: {
     }
     if (path.resolve(legacyTarget) === path.resolve(targetDir)) {
       await migratePluginInstallIndex();
-      return { migrated: changes.length > 0, skipped: false, changes, warnings };
+      return {
+        migrated: changes.length > 0,
+        skipped: false,
+        changes,
+        warnings,
+        ...(notices.length > 0 ? { notices } : {}),
+      };
     }
     if (legacyDirs.some((dir) => path.resolve(dir) === path.resolve(legacyTarget))) {
       legacyDir = legacyTarget;
@@ -3978,13 +3994,25 @@ export async function autoMigrateLegacyStateDir(params: {
   if (isDirPath(targetDir)) {
     if (legacyDir && isLegacyDirSymlinkMirror(legacyDir, targetDir)) {
       await migratePluginInstallIndex();
-      return { migrated: changes.length > 0, skipped: false, changes, warnings };
+      return {
+        migrated: changes.length > 0,
+        skipped: false,
+        changes,
+        warnings,
+        ...(notices.length > 0 ? { notices } : {}),
+      };
     }
     await migratePluginInstallIndex();
     warnings.push(
       `State dir migration skipped: target already exists (${targetDir}). Remove or merge manually.`,
     );
-    return { migrated: changes.length > 0, skipped: false, changes, warnings };
+    return {
+      migrated: changes.length > 0,
+      skipped: false,
+      changes,
+      warnings,
+      ...(notices.length > 0 ? { notices } : {}),
+    };
   }
 
   try {
@@ -4039,7 +4067,13 @@ export async function autoMigrateLegacyStateDir(params: {
   }
 
   await migratePluginInstallIndex();
-  return { migrated: changes.length > 0, skipped: false, changes, warnings };
+  return {
+    migrated: changes.length > 0,
+    skipped: false,
+    changes,
+    warnings,
+    ...(notices.length > 0 ? { notices } : {}),
+  };
 }
 
 export async function autoMigrateLegacyTaskStateSidecars(params: {
@@ -5214,8 +5248,8 @@ export async function runLegacyStateMigrations(params: {
       ...agentDir.warnings,
       ...channelPlans.warnings,
     ],
-    ...(pluginPlans.notices && pluginPlans.notices.length > 0
-      ? { notices: [...pluginPlans.notices] }
+    ...((pluginInstallIndex.notices?.length ?? 0) > 0 || (pluginPlans.notices?.length ?? 0) > 0
+      ? { notices: [...(pluginInstallIndex.notices ?? []), ...(pluginPlans.notices ?? [])] }
       : {}),
   };
 }
@@ -6001,7 +6035,13 @@ export async function autoMigrateLegacyState(params: {
       ...preSessionChannelPlans.warnings,
       ...pluginPlans.warnings,
     ];
-    const notices = [...(stateDirResult.notices ?? []), ...(pluginPlans.notices ?? [])];
+    const notices = [
+      ...new Set([
+        ...(stateDirResult.notices ?? []),
+        ...(pluginInstallIndex.notices ?? []),
+        ...(pluginPlans.notices ?? []),
+      ]),
+    ];
     logMigrationResults(changes, warnings, notices);
     return {
       migrated:
@@ -6180,7 +6220,13 @@ export async function autoMigrateLegacyState(params: {
     ...agentDir.warnings,
     ...channelPlans.warnings,
   ];
-  const notices = [...(stateDirResult.notices ?? []), ...(pluginPlans.notices ?? [])];
+  const notices = [
+    ...new Set([
+      ...(stateDirResult.notices ?? []),
+      ...(pluginInstallIndex.notices ?? []),
+      ...(pluginPlans.notices ?? []),
+    ]),
+  ];
 
   logMigrationResults(changes, warnings, notices);
 


### PR DESCRIPTION
## Summary

- keep canonical SQLite-vs-retired JSON plugin-install conflicts visible as Doctor notices instead of fatal migration warnings
- keep an explicitly non-Codex-owned legacy binding sidecar visible as a Doctor notice without importing or deleting it
- preserve warnings for invalid JSON, failed writes/archives, ambiguous ownership, and other unresolved migration failures

## Root cause

The `release/2026.7.1` startup checkpoint treats every state-migration warning as fatal. Two reviewed, non-converging residue conditions still emitted warnings after `openclaw doctor --fix`: an obsolete JSON plugin-install index that conflicts with newer canonical SQLite rows, and a legacy Codex binding sidecar whose session is explicitly owned by another harness. The next gateway start therefore repeated the same warning and refused readiness indefinitely.

This change preserves both artifacts and their operator visibility while separating them from unresolved migration failures.

Refs #103076 and #90213.

## Verification

- `pnpm test src/infra/state-migrations.state-dir.test.ts src/commands/doctor-state-migrations.test.ts extensions/codex/doctor-contract-api.test.ts` (112 tests passed)
- `pnpm format:check -- src/infra/state-migrations.ts src/infra/state-migrations.state-dir.test.ts src/commands/doctor-state-migrations.test.ts extensions/codex/src/migration/session-binding-sidecars.ts extensions/codex/doctor-contract-api.test.ts`
- `pnpm build`
- independent Codex review; initial P2 notice-propagation finding fixed with a red/green regression test; final review clean with no actionable findings

## Real behavior proof

Behavior addressed: `2026.7.1-beta.6` gateway restart loop after updater completion when Doctor cannot remove reviewed migration residue.

Real environment tested: managed Linux VM upgraded from `2026.6.11` to core and official Codex plugin `2026.7.1-beta.6`; customer identity and addresses withheld.

Exact steps or command run after this patch:

- built an installable beta.6 core artifact with the canonical OpenClaw package helper and installed it over the managed beta.6 service
- installed the official `@openclaw/codex@2026.7.1-beta.6` package, then overlaid the reviewed Codex migration module from this branch so the plugin retained official-install trust
- ran `openclaw doctor --fix --non-interactive`, restarted the managed gateway, and checked systemd state plus both gateway/proxy listeners
- temporarily allowed `codex/gpt-5.6-sol` (without changing the default), then ran a fresh explicit agent session at `thinking=high`; removed the temporary allowlist entry after the smoke

Evidence after fix:

- core: `OpenClaw 2026.7.1-beta.6 (c9ab360)`
- official Codex plugin: `2026.7.1-beta.6`
- gateway: `ActiveState=active`, `SubState=running`, `NRestarts=0`, both managed listeners present
- startup migration output reports the retained plugin-install index and foreign-harness Codex sidecar as `Legacy state migration notes`, not warnings
- SOL smoke returned the exact sentinel `JACKIE_BETA6_SOL_OK`; metadata reported provider `codex`, model `gpt-5.6-sol`, `thinking=high`, one successful attempt, and `fallbackUsed=false`
- post-smoke config readback confirmed the original `openai/gpt-5.5` default/allowlist posture was restored

Observed result after fix: the beta.6 gateway converged and stayed running, the reviewed residue remained intact and visible, and a real GPT-5.6 SOL turn completed through the Codex harness without fallback.

What was not tested: broad repository suite, release publication, or fleet-wide rollout. Those remain remote-CI/release proof.

## Codex dependency contract checked

The sidecar decision was checked against the pinned sibling Codex source: `codex-rs/app-server/README.md`, `codex-rs/app-server-protocol/src/protocol/common.rs`, `codex-rs/app-server-protocol/src/protocol/v2/thread.rs`, and `codex-rs/app-server/src/request_processors/thread_processor.rs`. Codex resume/import is keyed to Codex thread identity and rollout state, so a sidecar explicitly owned by another harness must remain untouched rather than being imported as Codex state.
