### PR TITLE
fix(sqlite): prevent plugin metadata reads from mutating state

### DIFF
--- a/src/plugins/installed-plugin-index-record-reader.ts
+++ b/src/plugins/installed-plugin-index-record-reader.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { tryReadJsonSync } from "../infra/json-files.js";
-import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { withOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import { resolveDefaultPluginNpmDir, validatePluginId } from "./install-paths.js";
 import {
   getInstalledPluginIndexInstallRecordsCache,
@@ -269,25 +269,24 @@ function readPersistedInstalledPluginIndexForRecords(
     return tryReadJsonSync(options.filePath);
   }
   try {
-    const database = openOpenClawStateDatabase(
-      resolveInstalledPluginIndexStateDatabaseOptions(options),
-    );
-    const row = database.db
-      .prepare(
-        `
-          SELECT install_records_json, plugins_json
-            FROM installed_plugin_index
-           WHERE index_key = ?
-        `,
-      )
-      .get("installed-plugin-index") as InstalledPluginIndexRecordRow | undefined;
-    if (!row) {
-      return null;
-    }
-    return {
-      installRecords: parseJsonColumn(row.install_records_json),
-      plugins: parseJsonColumn(row.plugins_json),
-    };
+    return withOpenClawStateDatabaseReadOnly(({ db }) => {
+      const row = db
+        .prepare(
+          `
+            SELECT install_records_json, plugins_json
+              FROM installed_plugin_index
+             WHERE index_key = ?
+          `,
+        )
+        .get("installed-plugin-index") as InstalledPluginIndexRecordRow | undefined;
+      if (!row) {
+        return null;
+      }
+      return {
+        installRecords: parseJsonColumn(row.install_records_json),
+        plugins: parseJsonColumn(row.plugins_json),
+      };
+    }, resolveInstalledPluginIndexStateDatabaseOptions(options));
   } catch {
     return null;
   }

--- a/src/plugins/installed-plugin-index-store.test.ts
+++ b/src/plugins/installed-plugin-index-store.test.ts
@@ -2,11 +2,13 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import {
   closeOpenClawStateDatabaseForTest,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
 import type { PluginCandidate } from "./discovery.js";
+import { readPersistedInstalledPluginIndexInstallRecords } from "./installed-plugin-index-records.js";
 import {
   inspectPersistedInstalledPluginIndex,
   readPersistedInstalledPluginIndex,
@@ -226,6 +228,43 @@ describe("installed plugin index persistence", () => {
     expect(persisted.policyHash).toBe(index.policyHash);
     expectPluginIds(persisted, ["demo"]);
     expectPluginFields(persisted, "demo", { packageBuild: { bundledDist: false } });
+  });
+
+  it("does not repair shared state schema while reading the index", async () => {
+    const stateDir = makeTempDir();
+    const filePath = resolveInstalledPluginIndexStorePath({ stateDir });
+    await writePersistedInstalledPluginIndex(createIndex(), { stateDir });
+    closeOpenClawStateDatabaseForTest();
+
+    const sqlite = requireNodeSqlite();
+    const mutate = new sqlite.DatabaseSync(filePath);
+    mutate.exec("DROP INDEX idx_operator_approvals_resolution_ref;");
+    mutate.close();
+
+    const expectCanonicalIndexMissing = () => {
+      const verify = new sqlite.DatabaseSync(filePath, { readOnly: true });
+      try {
+        expect(
+          verify
+            .prepare(
+              "SELECT 1 FROM sqlite_schema WHERE type = 'index' AND name = 'idx_operator_approvals_resolution_ref'",
+            )
+            .get(),
+        ).toBeUndefined();
+      } finally {
+        verify.close();
+      }
+    };
+
+    await expect(readPersistedInstalledPluginIndex({ stateDir })).resolves.toMatchObject({
+      version: 1,
+    });
+    expectCanonicalIndexMissing();
+
+    await expect(readPersistedInstalledPluginIndexInstallRecords({ stateDir })).resolves.toEqual(
+      {},
+    );
+    expectCanonicalIndexMissing();
   });
 
   it("preserves startup config paths across persisted index roundtrips", async () => {

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -2,10 +2,8 @@
 import { existsSync, readFileSync } from "node:fs";
 import { z } from "zod";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
-import {
-  openOpenClawStateDatabase,
-  runOpenClawStateWriteTransaction,
-} from "../state/openclaw-state-db.js";
+import { withOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import { safeParseWithSchema } from "../utils/zod-parse.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
@@ -294,21 +292,20 @@ function readPersistedInstalledPluginIndexFromSqlite(
     return null;
   }
   try {
-    const database = openOpenClawStateDatabase(
-      resolveInstalledPluginIndexStateDatabaseOptions(options),
-    );
-    const row = database.db
-      .prepare(
-        `
-          SELECT version, warning, host_contract_version, compat_registry_version,
-                 migration_version, policy_hash, generated_at_ms, refresh_reason,
-                 install_records_json, plugins_json, diagnostics_json
-            FROM installed_plugin_index
-           WHERE index_key = ?
-        `,
-      )
-      .get(INSTALLED_PLUGIN_INDEX_SQLITE_KEY) as InstalledPluginIndexSqliteRow | undefined;
-    return parseInstalledPluginIndexSqliteRow(row);
+    return withOpenClawStateDatabaseReadOnly(({ db }) => {
+      const row = db
+        .prepare(
+          `
+            SELECT version, warning, host_contract_version, compat_registry_version,
+                   migration_version, policy_hash, generated_at_ms, refresh_reason,
+                   install_records_json, plugins_json, diagnostics_json
+              FROM installed_plugin_index
+             WHERE index_key = ?
+          `,
+        )
+        .get(INSTALLED_PLUGIN_INDEX_SQLITE_KEY) as InstalledPluginIndexSqliteRow | undefined;
+      return parseInstalledPluginIndexSqliteRow(row);
+    }, resolveInstalledPluginIndexStateDatabaseOptions(options));
   } catch {
     return null;
   }

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -1,0 +1,56 @@
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { clearNodeSqliteKyselyCacheForDatabase } from "../infra/kysely-sync.js";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import {
+  createNewerSqliteSchemaVersionError,
+  readSqliteUserVersion,
+} from "../infra/sqlite-user-version.js";
+import {
+  OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+  OPENCLAW_STATE_SCHEMA_VERSION,
+  type OpenClawStateDatabaseOptions,
+} from "./openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
+
+type OpenClawStateReadOnlyDatabase = {
+  db: DatabaseSync;
+  path: string;
+};
+
+function assertSupportedSchemaVersion(db: DatabaseSync, pathname: string): void {
+  const userVersion = readSqliteUserVersion(db);
+  if (userVersion > OPENCLAW_STATE_SCHEMA_VERSION) {
+    throw createNewerSqliteSchemaVersionError(
+      "OpenClaw state database",
+      pathname,
+      userVersion,
+      OPENCLAW_STATE_SCHEMA_VERSION,
+    );
+  }
+}
+
+/**
+ * Read shared state without joining the writable lifecycle.
+ *
+ * CLI metadata reads can overlap a live Gateway. Keep them off schema repair,
+ * journal-mode setup, checkpoints, and permission mutation owned by writers.
+ */
+export function withOpenClawStateDatabaseReadOnly<T>(
+  operation: (database: OpenClawStateReadOnlyDatabase) => T,
+  options: OpenClawStateDatabaseOptions = {},
+): T {
+  const pathname = path.resolve(
+    options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env),
+  );
+  const sqlite = requireNodeSqlite();
+  const db = new sqlite.DatabaseSync(pathname, { readOnly: true });
+  try {
+    db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
+    assertSupportedSchemaVersion(db, pathname);
+    return operation({ db, path: pathname });
+  } finally {
+    clearNodeSqliteKyselyCacheForDatabase(db);
+    db.close();
+  }
+}


### PR DESCRIPTION
Related: #101290

## What Problem This Solves

Fixes an issue where CLI/config/plugin metadata reads could join the shared state's writable lifecycle while a live Gateway owned the database. A nominal read could repair canonical indexes, configure WAL maintenance, checkpoint, or mutate file permissions.

## Why This Change Was Made

Plugin index reads now use a short-lived `DatabaseSync` handle opened with `readOnly: true`. The helper preserves state-path resolution, busy timeout, newer-schema rejection, and deterministic close behavior while leaving schema repair and WAL lifecycle work to writable owners.

Both persisted plugin-index read paths moved to the read-only helper. Writable refreshes still use the existing state transaction path.

## User Impact

CLI and configuration flows that inspect installed plugin metadata no longer mutate or repair the shared state database. This reduces cross-process SQLite ownership overlap while a Gateway is running without changing plugin-index results.

## Evidence

- Red proof before the implementation: the new regression test failed because reading the plugin index recreated a deliberately removed canonical index. Blacksmith Testbox Actions run `29227894730`.
- Exact-head focused proof on Blacksmith Testbox `tbx_01kxd2m9558776fyy9p4btxt3s`: 77 tests passed across shared-state and plugin-index suites.
- The full core/core-test `pnpm check:changed` lane passed on the same Testbox, including typechecks, lint, import-cycle checks, database-first guards, and formatting. Current `main` independently regenerates a different Plugin SDK API hash; that hash was reconciled only inside the disposable Testbox worktree so the unrelated remaining gates could run, and no generated file is part of this PR.
- Fresh pre-commit autoreview: clean, no accepted or actionable findings.
- Upstream Node source inspection confirmed `DatabaseSync(path, { readOnly: true })` opens SQLite with `SQLITE_OPEN_READONLY`; the default constructor uses writable/create flags.
