### PR TITLE
fix(ci): unblock stable release validation

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -525,14 +525,14 @@ jobs:
                 break
               fi
               poll_count=$((poll_count + 1))
-              if (( poll_count % 2 == 0 )); then
+              if (( poll_count % 5 == 0 )); then
                 fail_fast_failed_jobs
               fi
               if (( poll_count % 10 == 0 )); then
                 echo "Still waiting on ${workflow}: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
                 fetch_child_jobs | jq 'select(.status != "completed") | {name, status, url: .html_url}' || true
               fi
-              sleep 30
+              sleep 60
             done
             trap - EXIT INT TERM
 
@@ -715,14 +715,14 @@ jobs:
                 break
               fi
               poll_count=$((poll_count + 1))
-              if (( poll_count % 2 == 0 )); then
+              if (( poll_count % 5 == 0 )); then
                 fail_fast_failed_jobs
               fi
               if (( poll_count % 10 == 0 )); then
                 echo "Still waiting on ${workflow}: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
                 fetch_child_jobs | jq 'select(.status != "completed") | {name, status, url: .html_url}' || true
               fi
-              sleep 30
+              sleep 60
             done
             trap - EXIT INT TERM
 
@@ -966,14 +966,14 @@ jobs:
                 break
               fi
               poll_count=$((poll_count + 1))
-              if (( poll_count % 2 == 0 )); then
+              if (( poll_count % 5 == 0 )); then
                 fail_fast_failed_jobs
               fi
               if (( poll_count % 10 == 0 )); then
                 echo "Still waiting on ${workflow}: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
                 fetch_child_jobs | jq 'select(.status != "completed") | {name, status, url: .html_url}' || true
               fi
-              sleep 30
+              sleep 60
             done
             trap - EXIT INT TERM
 
@@ -1211,14 +1211,14 @@ jobs:
               break
             fi
             poll_count=$((poll_count + 1))
-            if (( poll_count % 2 == 0 )); then
+            if (( poll_count % 5 == 0 )); then
               fail_fast_failed_jobs
             fi
             if (( poll_count % 10 == 0 )); then
               echo "Still waiting on npm-telegram-beta-e2e.yml: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
               gh_with_retry run view "$run_id" --json jobs --jq '.jobs[] | select(.status != "completed") | {name, status, url}' || true
             fi
-            sleep 30
+            sleep 60
           done
           trap - EXIT INT TERM
 
@@ -1381,7 +1381,7 @@ jobs:
               echo "Still waiting on openclaw-performance.yml: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
               gh_with_retry run view "$run_id" --json jobs --jq '.jobs[] | select(.status != "completed") | {name, status, url}' || true
             fi
-            sleep 30
+            sleep 60
           done
           trap - EXIT INT TERM
 


### PR DESCRIPTION
## What Problem This Solves

Full release validation can exhaust the shared GitHub App REST quota while monitoring long, high-fanout child workflows. Parent run 29221957117 attempt 3 failed on rate-limit errors even though release-checks child 29225319039 and plugin child 29225321611 completed successfully.

Current `main` also rejects the intentional read-only state database boundary added by #106103 because that file was omitted from the explicit raw SQLite allowlist.

## Why This Change Was Made

Poll child workflow status every 60 seconds instead of every 30 seconds, scan child jobs for fail-fast failures every five minutes, and emit active-job summaries every ten minutes. Completion detection, cancellation, and failure propagation stay unchanged while expensive job-list pagination drops substantially.

Declare `src/state/openclaw-state-db-readonly.ts` in the existing read-only SQLite probe allowlist. The module deliberately owns a short-lived `DatabaseSync(..., { readOnly: true })` boundary and already routes query execution through Kysely helpers.

## User Impact

Release validation remains fail-fast, but its parent monitors are much less likely to fail because unrelated GitHub API traffic consumed the installation quota. The second change only restores current-main architecture CI for the already-landed read-only database path.

## Evidence

- `git diff --check` passes.
- `node scripts/check-kysely-guardrails.mjs` passes.
- `oxfmt --check scripts/check-kysely-guardrails.mjs` passes.
- `actionlint` reports only the same pre-existing SC2016 info present on `origin/main`.
- Autoreview completed with no accepted/actionable findings for both commits.
- Failure proof: parent run 29221957117 attempt 3 exhausted the installation API quota while its release and plugin child workflows later finished green.
- Failure proof: exact-head CI run 29229601637 rejected `src/state/openclaw-state-db-readonly.ts` as missing from the explicit raw SQLite allowlist.
