### PR TITLE
feat(goals): continue active session goals while idle

### DIFF
--- a/src/agents/goal-driver/driver.test.ts
+++ b/src/agents/goal-driver/driver.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createGoalContinuationDriver,
+  type GoalDriverConfig,
+  type GoalDriverGoalSnapshot,
+  type GoalDriverTarget,
+} from "./driver.js";
+
+const target: GoalDriverTarget = {
+  agentId: "main",
+  sessionKey: "agent:main:main",
+  storePath: "/tmp/openclaw-main/sessions.json",
+};
+
+function activeGoal(
+  overrides: Partial<GoalDriverGoalSnapshot> = {},
+): GoalDriverGoalSnapshot {
+  return {
+    id: "goal-1",
+    objective: "Land deterministic goal continuation",
+    status: "active",
+    continuationTurns: 0,
+    ...overrides,
+  };
+}
+
+function createHarness(overrides: {
+  config?: Partial<GoalDriverConfig>;
+  goal?: GoalDriverGoalSnapshot | undefined;
+  activeRun?: boolean;
+  queuedTurns?: boolean;
+  systemEvents?: boolean;
+} = {}) {
+  let config: GoalDriverConfig = {
+    enabled: true,
+    idleDelayMs: 1_000,
+    maxContinuationTurns: 3,
+    ...overrides.config,
+  };
+  let goal = Object.hasOwn(overrides, "goal") ? overrides.goal : activeGoal();
+  let activeRun = overrides.activeRun ?? false;
+  let queuedTurns = overrides.queuedTurns ?? false;
+  let systemEvents = overrides.systemEvents ?? false;
+
+  const readGoal = vi.fn(() => goal);
+  const recordContinuation = vi.fn(async () => {
+    if (!goal || goal.status !== "active") {
+      return undefined;
+    }
+    goal = { ...goal, continuationTurns: goal.continuationTurns + 1 };
+    return goal;
+  });
+  const rollbackContinuation = vi.fn(async () => true);
+  const pauseGoal = vi.fn(async () => undefined);
+  const enqueueContinuation = vi.fn(() => true);
+  const requestWake = vi.fn();
+
+  const driver = createGoalContinuationDriver({
+    getConfig: () => config,
+    readGoal,
+    hasActiveRun: () => activeRun,
+    hasQueuedTurns: () => queuedTurns,
+    hasSystemEvents: () => systemEvents,
+    recordContinuation,
+    rollbackContinuation,
+    pauseGoal,
+    enqueueContinuation,
+    requestWake,
+  });
+
+  return {
+    driver,
+    readGoal,
+    recordContinuation,
+    rollbackContinuation,
+    pauseGoal,
+    enqueueContinuation,
+    requestWake,
+    setConfig: (next: Partial<GoalDriverConfig>) => {
+      config = { ...config, ...next };
+    },
+    setActiveRun: (value: boolean) => {
+      activeRun = value;
+    },
+    setQueuedTurns: (value: boolean) => {
+      queuedTurns = value;
+    },
+    setSystemEvents: (value: boolean) => {
+      systemEvents = value;
+    },
+  };
+}
+
+describe("goal continuation driver", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("is a zero-effect no-op while the experiment is disabled", async () => {
+    const harness = createHarness({ config: { enabled: false } });
+
+    harness.driver.arm(target);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(harness.driver.pendingCount()).toBe(0);
+    expect(harness.readGoal).not.toHaveBeenCalled();
+    expect(harness.recordContinuation).not.toHaveBeenCalled();
+    expect(harness.requestWake).not.toHaveBeenCalled();
+  });
+
+  it("uses the exact configured delay and keeps one timer per durable target", async () => {
+    const harness = createHarness();
+
+    harness.driver.arm(target);
+    harness.driver.arm({ ...target });
+    expect(harness.driver.pendingCount()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(harness.recordContinuation).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(harness.recordContinuation).toHaveBeenCalledOnce();
+    expect(harness.requestWake).toHaveBeenCalledOnce();
+    expect(harness.driver.pendingCount()).toBe(0);
+  });
+
+  it.each([
+    ["an active run", { activeRun: true }],
+    ["queued user work", { queuedTurns: true }],
+    ["a queued system event", { systemEvents: true }],
+  ])("lets %s win without polling or self-rearming", async (_label, state) => {
+    const harness = createHarness(state);
+
+    harness.driver.arm(target);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(harness.recordContinuation).not.toHaveBeenCalled();
+    expect(harness.requestWake).not.toHaveBeenCalled();
+    expect(harness.driver.pendingCount()).toBe(0);
+  });
+
+  it.each(["paused", "blocked", "usage_limited", "budget_limited", "complete"] as const)(
+    "disarms when the durable goal is %s",
+    async (status) => {
+      const harness = createHarness({ goal: activeGoal({ status }) });
+
+      harness.driver.arm(target);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(harness.recordContinuation).not.toHaveBeenCalled();
+      expect(harness.requestWake).not.toHaveBeenCalled();
+      expect(harness.driver.pendingCount()).toBe(0);
+    },
+  );
+
+  it("auto-pauses at the persisted continuation ceiling without enqueueing", async () => {
+    const harness = createHarness({ goal: activeGoal({ continuationTurns: 3 }) });
+
+    harness.driver.arm(target);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(harness.pauseGoal).toHaveBeenCalledWith(
+      target,
+      expect.stringContaining("continuation"),
+    );
+    expect(harness.recordContinuation).not.toHaveBeenCalled();
+    expect(harness.enqueueContinuation).not.toHaveBeenCalled();
+    expect(harness.requestWake).not.toHaveBeenCalled();
+  });
+
+  it("does not enqueue or wake when the durable reservation fails", async () => {
+    const harness = createHarness();
+    harness.recordContinuation.mockRejectedValueOnce(new Error("store unavailable"));
+
+    harness.driver.arm(target);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(harness.enqueueContinuation).not.toHaveBeenCalled();
+    expect(harness.requestWake).not.toHaveBeenCalled();
+  });
+
+  it("rolls back when user work wins the race after the durable reservation", async () => {
+    const harness = createHarness();
+    harness.recordContinuation.mockImplementationOnce(async () => {
+      harness.setQueuedTurns(true);
+      return activeGoal({ continuationTurns: 1 });
+    });
+
+    harness.driver.arm(target);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(harness.rollbackContinuation).toHaveBeenCalledWith(target, {
+      goalId: "goal-1",
+      expectedContinuationTurns: 1,
+    });
+    expect(harness.enqueueContinuation).not.toHaveBeenCalled();
+    expect(harness.requestWake).not.toHaveBeenCalled();
+  });
+
+  it("rolls back a rejected enqueue and wakes only after enqueue succeeds", async () => {
+    const harness = createHarness();
+    harness.enqueueContinuation.mockReturnValueOnce(false);
+
+    harness.driver.arm(target);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(harness.rollbackContinuation).toHaveBeenCalledWith(target, {
+      goalId: "goal-1",
+      expectedContinuationTurns: 1,
+    });
+    expect(harness.requestWake).not.toHaveBeenCalled();
+
+    harness.driver.arm(target);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(harness.requestWake).toHaveBeenCalledOnce();
+    expect(harness.driver.pendingCount()).toBe(0);
+  });
+
+  it("disarms a pending timer when config is disabled and stop cancels all targets", async () => {
+    const harness = createHarness();
+    const otherTarget = {
+      ...target,
+      sessionKey: "agent:main:telegram:direct:123",
+    };
+
+    harness.driver.rearm([target, otherTarget]);
+    expect(harness.driver.pendingCount()).toBe(2);
+    harness.setConfig({ enabled: false });
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(harness.recordContinuation).not.toHaveBeenCalled();
+    expect(harness.driver.pendingCount()).toBe(0);
+
+    harness.setConfig({ enabled: true });
+    harness.driver.rearm([target, otherTarget]);
+    harness.driver.stop();
+    expect(harness.driver.pendingCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(harness.recordContinuation).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/goal-driver/service.test.ts
+++ b/src/agents/goal-driver/service.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  discoverPersistedActiveGoalTargets,
+  resolveGoalDriverConfig,
+} from "./service.js";
+
+describe("goal driver service", () => {
+  it("is default-off and resolves only deterministic bounded settings", () => {
+    expect(resolveGoalDriverConfig({})).toEqual({
+      enabled: false,
+      idleDelayMs: 20_000,
+      maxContinuationTurns: 3,
+    });
+    expect(
+      resolveGoalDriverConfig({
+        tools: {
+          experimental: {
+            goalDriver: {
+              enabled: true,
+              idleDelayMs: 7_500,
+              maxContinuationTurns: 5,
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      enabled: true,
+      idleDelayMs: 7_500,
+      maxContinuationTurns: 5,
+    });
+  });
+
+  it("recovers active goals from every agent store and refuses bare global keys", () => {
+    const config: OpenClawConfig = {
+      agents: { list: [{ id: "alpha" }, { id: "beta" }] },
+    };
+    const resolveStoreTargets = vi.fn(() => [
+      { agentId: "alpha", storePath: "/state/agents/alpha/sessions/sessions.json" },
+      { agentId: "beta", storePath: "/state/agents/beta/sessions/sessions.json" },
+    ]);
+    const listEntries = vi.fn(({ storePath }: { storePath: string }) => {
+      const agentId = storePath.includes("/alpha/") ? "alpha" : "beta";
+      return [
+        {
+          sessionKey: `agent:${agentId}:main`,
+          entry: {
+            sessionId: `${agentId}-session`,
+            updatedAt: 1,
+            goal: {
+              schemaVersion: 1 as const,
+              id: `${agentId}-goal`,
+              objective: `Finish ${agentId}`,
+              status: "active" as const,
+              createdAt: 1,
+              updatedAt: 1,
+              tokenStart: 0,
+              tokenStartFresh: true,
+              tokensUsed: 0,
+              continuationTurns: 0,
+            },
+          },
+        },
+        {
+          sessionKey: `agent:${agentId}:paused`,
+          entry: {
+            sessionId: `${agentId}-paused`,
+            updatedAt: 1,
+            goal: {
+              schemaVersion: 1 as const,
+              id: `${agentId}-paused-goal`,
+              objective: "Do not rearm",
+              status: "paused" as const,
+              createdAt: 1,
+              updatedAt: 1,
+              tokenStart: 0,
+              tokenStartFresh: true,
+              tokensUsed: 0,
+              continuationTurns: 0,
+            },
+          },
+        },
+        {
+          // Both stores intentionally contain this key. Current-main system-event
+          // queues cannot distinguish the owner, so the safe behavior is refusal.
+          sessionKey: "global",
+          entry: {
+            sessionId: `${agentId}-global`,
+            updatedAt: 1,
+            goal: {
+              schemaVersion: 1 as const,
+              id: `${agentId}-global-goal`,
+              objective: "Must not cross agent stores",
+              status: "active" as const,
+              createdAt: 1,
+              updatedAt: 1,
+              tokenStart: 0,
+              tokenStartFresh: true,
+              tokensUsed: 0,
+              continuationTurns: 0,
+            },
+          },
+        },
+      ];
+    });
+
+    const targets = discoverPersistedActiveGoalTargets(config, {
+      resolveStoreTargets,
+      listEntries,
+    });
+
+    expect(targets).toEqual([
+      {
+        agentId: "alpha",
+        sessionKey: "agent:alpha:main",
+        storePath: "/state/agents/alpha/sessions/sessions.json",
+      },
+      {
+        agentId: "beta",
+        sessionKey: "agent:beta:main",
+        storePath: "/state/agents/beta/sessions/sessions.json",
+      },
+    ]);
+    expect(resolveStoreTargets).toHaveBeenCalledWith(config);
+    expect(listEntries).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/config/sessions/goals.continuation.test.ts
+++ b/src/config/sessions/goals.continuation.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  createSessionGoal,
+  getSessionGoal,
+  recordSessionGoalContinuation,
+  rollbackSessionGoalContinuation,
+  updateSessionGoalStatus,
+} from "./goals.js";
+import { upsertSessionEntry } from "./session-accessor.js";
+import { useTempSessionsFixture } from "./test-helpers.js";
+import type { SessionGoalStatus } from "./types.js";
+
+describe("session goal continuation reservations", () => {
+  const fixture = useTempSessionsFixture("openclaw-session-goal-continuation-");
+  const sessionKey = "agent:main:main";
+
+  async function createGoal() {
+    const storePath = fixture.storePath();
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId: "session-1",
+        updatedAt: 1,
+        totalTokens: 0,
+        totalTokensFresh: true,
+      },
+    );
+    const goal = await createSessionGoal({
+      sessionKey,
+      storePath,
+      objective: "Land deterministic continuation",
+      now: 10,
+    });
+    return { goal, storePath };
+  }
+
+  it("atomically reserves a bounded continuation only for the current active goal", async () => {
+    const { goal, storePath } = await createGoal();
+
+    const reservations = await Promise.all(
+      [20, 30, 40].map((now) =>
+        recordSessionGoalContinuation({
+          sessionKey,
+          storePath,
+          goalId: goal.id,
+          maxContinuationTurns: 2,
+          now,
+        }),
+      ),
+    );
+    const staleGoal = await recordSessionGoalContinuation({
+      sessionKey,
+      storePath,
+      goalId: "replaced-goal",
+      maxContinuationTurns: 3,
+      now: 50,
+    });
+
+    expect(
+      reservations
+        .filter((reservation) => reservation !== undefined)
+        .map((reservation) => reservation.continuationTurns)
+        .sort(),
+    ).toEqual([1, 2]);
+    expect(reservations.filter((reservation) => reservation === undefined)).toHaveLength(1);
+    expect(staleGoal).toBeUndefined();
+    expect((await getSessionGoal({ sessionKey, storePath, persist: false })).goal)
+      .toMatchObject({ id: goal.id, status: "active", continuationTurns: 2 });
+  });
+
+  it("conditionally rolls back only the reservation it still owns", async () => {
+    const { goal, storePath } = await createGoal();
+    await recordSessionGoalContinuation({
+      sessionKey,
+      storePath,
+      goalId: goal.id,
+      maxContinuationTurns: 3,
+    });
+
+    const stale = await rollbackSessionGoalContinuation({
+      sessionKey,
+      storePath,
+      goalId: goal.id,
+      expectedContinuationTurns: 2,
+    });
+    const owned = await rollbackSessionGoalContinuation({
+      sessionKey,
+      storePath,
+      goalId: goal.id,
+      expectedContinuationTurns: 1,
+    });
+    const duplicate = await rollbackSessionGoalContinuation({
+      sessionKey,
+      storePath,
+      goalId: goal.id,
+      expectedContinuationTurns: 1,
+    });
+
+    expect(stale).toBe(false);
+    expect(owned).toBe(true);
+    expect(duplicate).toBe(false);
+    expect((await getSessionGoal({ sessionKey, storePath, persist: false })).goal)
+      .toMatchObject({ continuationTurns: 0 });
+  });
+
+  it.each([
+    "paused",
+    "blocked",
+    "usage_limited",
+    "budget_limited",
+  ] satisfies SessionGoalStatus[])(
+    "starts a fresh continuation window when an operator resumes a %s goal",
+    async (status) => {
+      const { goal, storePath } = await createGoal();
+      await recordSessionGoalContinuation({
+        sessionKey,
+        storePath,
+        goalId: goal.id,
+        maxContinuationTurns: 3,
+      });
+      if (status === "usage_limited" || status === "budget_limited") {
+        const snapshot = await getSessionGoal({ sessionKey, storePath, persist: false });
+        await upsertSessionEntry(
+          { sessionKey, storePath },
+          {
+            sessionId: "session-1",
+            updatedAt: 20,
+            totalTokens: 0,
+            totalTokensFresh: true,
+            goal: { ...snapshot.goal!, status },
+          },
+        );
+      } else {
+        await updateSessionGoalStatus({ sessionKey, storePath, status, now: 20 });
+      }
+
+      const resumed = await updateSessionGoalStatus({
+        sessionKey,
+        storePath,
+        status: "active",
+        now: 30,
+      });
+
+      expect(resumed.status).toBe("active");
+      expect(resumed.continuationTurns).toBe(0);
+    },
+  );
+
+  it("does not reset the window on an idempotent active-to-active status write", async () => {
+    const { goal, storePath } = await createGoal();
+    await recordSessionGoalContinuation({
+      sessionKey,
+      storePath,
+      goalId: goal.id,
+      maxContinuationTurns: 3,
+    });
+
+    const active = await updateSessionGoalStatus({
+      sessionKey,
+      storePath,
+      status: "active",
+      now: 30,
+    });
+
+    expect(active.continuationTurns).toBe(1);
+  });
+});

--- a/src/gateway/server-runtime-subscriptions.goal-driver.test.ts
+++ b/src/gateway/server-runtime-subscriptions.goal-driver.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { emitAgentEvent, resetAgentEventsForTest } from "../infra/agent-events.js";
+import type { SubsystemLogger } from "../logging/subsystem.js";
+import { resetTaskRegistryForTests } from "../tasks/task-registry.js";
+import { installInMemoryTaskRegistryRuntime } from "../test-utils/task-registry-runtime.js";
+import {
+  createChatRunState,
+  createSessionEventSubscriberRegistry,
+  createSessionMessageSubscriberRegistry,
+  createToolEventRecipientRegistry,
+} from "./server-chat-state.js";
+
+const state = vi.hoisted(() => ({
+  onRunTerminal: vi.fn<(sessionKey: string) => void>(),
+  rearmPersistedActiveGoals: vi.fn<() => void>(),
+  stop: vi.fn<() => void>(),
+  start: vi.fn(),
+  agentHandlerOptions: undefined as
+    | {
+        markTrackedRunTerminalPersisted?: (params: {
+          runId: string;
+          clientRunId: string;
+          sessionKey: string;
+        }) => void;
+      }
+    | undefined,
+}));
+
+vi.mock("../agents/goal-driver/service.js", () => ({
+  startGoalDriverService: (...args: unknown[]) => {
+    state.start(...args);
+    return {
+      onRunTerminal: state.onRunTerminal,
+      rearmPersistedActiveGoals: state.rearmPersistedActiveGoals,
+      pendingCount: () => 0,
+      stop: state.stop,
+    };
+  },
+}));
+
+vi.mock("../audit/audit-config.js", () => ({
+  isAuditLedgerEnabled: () => false,
+  resolveAuditMessageMode: () => "off",
+}));
+
+vi.mock("../audit/audit-recorder.js", () => ({
+  createAuditEventRecorder: () => ({
+    record: vi.fn(),
+    recordTool: vi.fn(),
+    recordMessage: vi.fn(),
+    stop: vi.fn(async () => undefined),
+  }),
+}));
+
+vi.mock("./server-chat.js", () => ({
+  createAgentEventHandler: (options: typeof state.agentHandlerOptions) => {
+    state.agentHandlerOptions = options;
+    return () => undefined;
+  },
+}));
+
+vi.mock("./server-session-key.js", () => ({
+  resolveSessionKeyForRun: () => "agent:main:main",
+}));
+
+vi.mock("./server-session-events.js", () => ({
+  createTranscriptUpdateBroadcastHandler: () => () => undefined,
+  createLifecycleEventBroadcastHandler: () => () => undefined,
+}));
+
+const { startGatewayEventSubscriptions } = await import("./server-runtime-subscriptions.js");
+type SubscriptionParams = Parameters<typeof startGatewayEventSubscriptions>[0];
+
+const mockLog: SubsystemLogger = {
+  subsystem: "gateway-goal-driver-test",
+  isEnabled: () => true,
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  raw: vi.fn(),
+  child: () => mockLog,
+};
+
+function createParams(): SubscriptionParams {
+  return {
+    log: mockLog,
+    broadcast: vi.fn(),
+    broadcastToConnIds: vi.fn(),
+    nodeSendToSession: vi.fn(),
+    agentRunSeq: new Map(),
+    chatRunState: createChatRunState(),
+    toolEventRecipients: createToolEventRecipientRegistry(),
+    sessionEventSubscribers: createSessionEventSubscriberRegistry(),
+    sessionMessageSubscribers: createSessionMessageSubscriberRegistry(),
+    chatAbortControllers: new Map(),
+    chatQueuedTurns: new Map(),
+    restartRecoveryCandidates: new Map(),
+  };
+}
+
+describe("gateway goal-driver terminal wiring", () => {
+  let unsubs: ReturnType<typeof startGatewayEventSubscriptions> | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.agentHandlerOptions = undefined;
+    installInMemoryTaskRegistryRuntime();
+  });
+
+  afterEach(async () => {
+    await unsubs?.agentUnsub();
+    unsubs?.heartbeatUnsub();
+    unsubs?.transcriptUnsub();
+    unsubs?.lifecycleUnsub();
+    void unsubs?.taskUnsub();
+    resetAgentEventsForTest();
+    resetTaskRegistryForTests({ persist: false });
+  });
+
+  it("rearms at startup, arms only after terminal persistence, and stops with subscriptions", async () => {
+    unsubs = startGatewayEventSubscriptions(createParams());
+
+    expect(state.start).toHaveBeenCalledOnce();
+    expect(state.rearmPersistedActiveGoals).toHaveBeenCalledOnce();
+
+    emitAgentEvent({
+      runId: "goal-run",
+      sessionKey: "agent:main:main",
+      agentId: "main",
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
+    await vi.waitFor(() => expect(state.agentHandlerOptions).toBeDefined());
+
+    // The raw terminal event is intentionally too early: the durable lifecycle
+    // write has not resolved yet, so a continuation cannot be armed from it.
+    expect(state.onRunTerminal).not.toHaveBeenCalled();
+
+    state.agentHandlerOptions?.markTrackedRunTerminalPersisted?.({
+      runId: "goal-run",
+      clientRunId: "goal-run",
+      sessionKey: "agent:main:main",
+    });
+
+    expect(state.onRunTerminal).toHaveBeenCalledOnce();
+    expect(state.onRunTerminal).toHaveBeenCalledWith("agent:main:main");
+
+    await unsubs.agentUnsub();
+    expect(state.stop).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Related: #102260

This is the focused current-main replacement for the deterministic goal-driver slice discussed in #102261 and #103586. It deliberately does not carry forward their unrelated question, plan, judge, wait-barrier, UI, generated, or Hermes-labelled scope.

## What Problem This Solves

OpenClaw can persist, display, budget, pause, block, resume, and complete a session goal, but an active goal still stops whenever a turn ends. Operators must send another message to keep an otherwise idle goal moving.

## Why This Change Was Made

This adds a default-off, deterministic gateway driver that uses the existing session goal, active-run, queued-turn, system-event, heartbeat, context, UI, and `goal_changed` paths. It reserves each bounded continuation durably before enqueueing a wake, lets user work win races, and auto-pauses at the configured ceiling.

The driver is intentionally limited to agent-scoped session keys. Current-main system-event queues cannot safely distinguish the same bare `global` key in multiple agent stores, and expanding queue identity belongs in a separate change. The durable-owner repair in #104265 is also kept separate rather than duplicated here.

## User Impact

Operators who explicitly enable `tools.experimental.goalDriver.enabled` can let an active session goal continue after a fixed idle delay without sending a synthetic user message. Existing goal controls and status UI remain the source of truth. The feature remains inert by default.

## Evidence

- RED contract: fork CI at exact test-only SHA `b5c2f60d959a3714af01be27eddd00b46aa6e7e6` reported the expected missing driver, service, goal reservation/rollback, and gateway-wiring symbols: https://github.com/100yenadmin/openclaw/actions/runs/29228761335
- Tests cover exact delay/no jitter, one timer per durable target, active/user/system queue precedence, persistence failure, race rollback, rejected enqueue, no self-rearm, dynamic disable, startup recovery, unsafe bare-key refusal, bounded concurrent reservations, resume reset, and terminal-persistence ordering.
- Structured pre-commit review of the tests-only contract completed with no actionable findings.
- GREEN exact-head CI and non-repository visual evidence will be added before this draft is marked ready.
