### PR TITLE
improve(ios): make gateway QR pairing prominent in Settings

### DIFF
--- a/apps/.i18n/apple-translation-contradictions.json
+++ b/apps/.i18n/apple-translation-contradictions.json
@@ -2036,38 +2036,6 @@
       ]
     },
     {
-      "locale": "ko",
-      "source": "Discovered Gateways",
-      "translations": [
-        "검색된 Gateway",
-        "발견된 Gateway"
-      ]
-    },
-    {
-      "locale": "nl",
-      "source": "Discovered Gateways",
-      "translations": [
-        "Gevonden Gateways",
-        "Ontdekte Gateways"
-      ]
-    },
-    {
-      "locale": "th",
-      "source": "Discovered Gateways",
-      "translations": [
-        "Gateway ที่ค้นพบ",
-        "Gateway ที่พบ"
-      ]
-    },
-    {
-      "locale": "zh-CN",
-      "source": "Discovered Gateways",
-      "translations": [
-        "发现的 Gateway",
-        "已发现的 Gateway"
-      ]
-    },
-    {
       "locale": "es",
       "source": "Discovery",
       "translations": [
@@ -6737,22 +6705,6 @@
       "translations": [
         "Configurar",
         "Configuração"
-      ]
-    },
-    {
-      "locale": "de",
-      "source": "Setup Code",
-      "translations": [
-        "Einrichtungscode",
-        "Setup-Code"
-      ]
-    },
-    {
-      "locale": "zh-TW",
-      "source": "Setup Code",
-      "translations": [
-        "設定代碼",
-        "設定碼"
       ]
     },
     {

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -17259,7 +17259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 35,
+      "line": 47,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Checks",
       "surface": "apple",
@@ -17267,7 +17267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 38,
+      "line": 50,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Last Run",
       "surface": "apple",
@@ -17275,7 +17275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 44,
+      "line": 56,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway Link",
       "surface": "apple",
@@ -17283,7 +17283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 50,
+      "line": 62,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Discovery",
       "surface": "apple",
@@ -17291,7 +17291,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 56,
+      "line": 68,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Talk Config",
       "surface": "apple",
@@ -17299,7 +17299,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 62,
+      "line": 74,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Notifications",
       "surface": "apple",
@@ -17307,7 +17307,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 63,
+      "line": 75,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Approval and event alert channel",
       "surface": "apple",
@@ -17315,7 +17315,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 68,
+      "line": 80,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Screen Capture",
       "surface": "apple",
@@ -17323,7 +17323,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 69,
+      "line": 81,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Live foreground capture state",
       "surface": "apple",
@@ -17331,7 +17331,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 71,
+      "line": 83,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "live",
       "surface": "apple",
@@ -17339,7 +17339,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 72,
+      "line": 84,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "idle",
       "surface": "apple",
@@ -17347,7 +17347,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 76,
+      "line": 88,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Voice Wake",
       "surface": "apple",
@@ -17355,7 +17355,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 79,
+      "line": 91,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "on",
       "surface": "apple",
@@ -17363,7 +17363,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 80,
+      "line": 92,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "off",
       "surface": "apple",
@@ -17371,7 +17371,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 127,
+      "line": 139,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Switching to %@…",
       "surface": "apple",
@@ -17379,7 +17379,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 145,
+      "line": 157,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Could not forget %@.",
       "surface": "apple",
@@ -17387,7 +17387,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 154,
+      "line": 166,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Forgot %@.",
       "surface": "apple",
@@ -17395,7 +17395,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 169,
+      "line": 181,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Saved endpoint unavailable",
       "surface": "apple",
@@ -17403,7 +17403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 171,
+      "line": 183,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "\\(endpoint) • TLS",
       "surface": "apple",
@@ -17411,7 +17411,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 174,
+      "line": 186,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Discovered • TLS",
       "surface": "apple",
@@ -17419,7 +17419,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 175,
+      "line": 187,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Discovered",
       "surface": "apple",
@@ -17427,7 +17427,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 318,
+      "line": 330,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "TLS",
       "surface": "apple",
@@ -17435,7 +17435,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 318,
+      "line": 330,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "plain",
       "surface": "apple",
@@ -17443,7 +17443,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 321,
+      "line": 333,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup link loaded for %@:%@ (%@). Tap Connect to apply.",
       "surface": "apple",
@@ -17451,7 +17451,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 332,
+      "line": 344,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Paste a setup code to continue.",
       "surface": "apple",
@@ -17459,7 +17459,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 347,
+      "line": 359,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup code not recognized or uses an insecure ws:// gateway URL.",
       "surface": "apple",
@@ -17467,7 +17467,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 392,
+      "line": 404,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Opening QR scanner...",
       "surface": "apple",
@@ -17475,7 +17475,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 398,
+      "line": 410,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "QR loaded. Closing scanner...",
       "surface": "apple",
@@ -17483,7 +17483,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 428,
+      "line": 440,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Apple Review demo mode enabled.",
       "surface": "apple",
@@ -17491,7 +17491,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 479,
+      "line": 491,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Failed: host required",
       "surface": "apple",
@@ -17499,7 +17499,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 487,
+      "line": 499,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Failed: invalid port",
       "surface": "apple",
@@ -17507,7 +17507,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 545,
+      "line": 557,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Tailscale is off on this device. Turn it on, then try again.",
       "surface": "apple",
@@ -17515,7 +17515,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 922,
+      "line": 934,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway",
       "surface": "apple",
@@ -17523,7 +17523,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 923,
+      "line": 935,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Apple Watch",
       "surface": "apple",
@@ -17531,7 +17531,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 924,
+      "line": 936,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Approvals",
       "surface": "apple",
@@ -17539,7 +17539,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 925,
+      "line": 937,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Permissions",
       "surface": "apple",
@@ -17547,7 +17547,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 926,
+      "line": 938,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Channels",
       "surface": "apple",
@@ -17555,7 +17555,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 927,
+      "line": 939,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Skills",
       "surface": "apple",
@@ -17563,7 +17563,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 928,
+      "line": 940,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Voice & Talk",
       "surface": "apple",
@@ -17571,7 +17571,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 929,
+      "line": 941,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Diagnostics",
       "surface": "apple",
@@ -17579,7 +17579,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 930,
+      "line": 942,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Privacy",
       "surface": "apple",
@@ -17587,7 +17587,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 932,
+      "line": 944,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Licenses",
       "surface": "apple",
@@ -17595,7 +17595,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 933,
+      "line": 945,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "About",
       "surface": "apple",
@@ -17603,7 +17603,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 940,
+      "line": 952,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Preparing one-time setup…",
       "surface": "apple",
@@ -17611,7 +17611,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 945,
+      "line": 957,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "surface": "apple",
@@ -17619,7 +17619,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 947,
+      "line": 959,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
       "surface": "apple",
@@ -17627,7 +17627,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1037,
+      "line": 1049,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "This gateway is on your tailnet. Turn on Tailscale on this device, then tap Connect.",
       "surface": "apple",
@@ -17635,7 +17635,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1044,
+      "line": 1056,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Pairing required. Run /pair approve in your OpenClaw chat, then connect again.",
       "surface": "apple",
@@ -17643,7 +17643,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1047,
+      "line": 1059,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Secure handshake failed. Check Tailscale, then connect again.",
       "surface": "apple",
@@ -17651,7 +17651,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1056,
+      "line": 1068,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connection timed out. Make sure Tailscale is connected, then try again.",
       "surface": "apple",
@@ -17659,7 +17659,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1060,
+      "line": 1072,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connected, but some controls are restricted for nodes. This is expected.",
       "surface": "apple",
@@ -17667,7 +17667,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1067,
+      "line": 1079,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup code applied. Connecting...",
       "surface": "apple",
@@ -17675,7 +17675,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1068,
+      "line": 1080,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Checking gateway reachability...",
       "surface": "apple",
@@ -17683,7 +17683,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1069,
+      "line": 1081,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "QR loaded. Connecting to %@:%@...",
       "surface": "apple",
@@ -17691,7 +17691,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1132,
+      "line": 1144,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not loaded",
       "surface": "apple",
@@ -17699,7 +17699,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1135,
+      "line": 1147,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Configured",
       "surface": "apple",
@@ -17707,7 +17707,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1136,
+      "line": 1148,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not configured",
       "surface": "apple",
@@ -17715,7 +17715,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1143,
+      "line": 1155,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not active",
       "surface": "apple",
@@ -17723,7 +17723,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1173,
+      "line": 1191,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Apple Review demo mode",
       "surface": "apple",
@@ -17731,7 +17731,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1176,
+      "line": 1194,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connected",
       "surface": "apple",
@@ -17739,7 +17739,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1182,
+      "line": 1200,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "offline",
       "surface": "apple",
@@ -17747,7 +17747,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1182,
+      "line": 1200,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "online",
       "surface": "apple",
@@ -17755,7 +17755,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1200,
+      "line": 1218,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Live gateway requests are disabled in demo mode.",
       "surface": "apple",
@@ -17763,7 +17763,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1204,
+      "line": 1222,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Foreground approvals still appear while OpenClaw is connected.",
       "surface": "apple",
@@ -17771,7 +17771,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1207,
+      "line": 1225,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway requests will appear here.",
       "surface": "apple",
@@ -17779,7 +17779,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1208,
+      "line": 1226,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connect to the gateway.",
       "surface": "apple",
@@ -17787,7 +17787,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1212,
+      "line": 1230,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Demo mode only",
       "surface": "apple",
@@ -17795,7 +17795,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1219,
+      "line": 1237,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "loaded",
       "surface": "apple",
@@ -17803,7 +17803,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1220,
+      "line": 1238,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "missing",
       "surface": "apple",
@@ -17811,7 +17811,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1229,
+      "line": 1247,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Waiting for gateway",
       "surface": "apple",
@@ -17819,7 +17819,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1246,
+      "line": 1264,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "1 waiting",
       "surface": "apple",
@@ -17827,7 +17827,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1249,
+      "line": 1267,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "%@ waiting",
       "surface": "apple",
@@ -17835,7 +17835,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1260,
+      "line": 1278,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Review gateway action",
       "surface": "apple",
@@ -17843,7 +17843,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1262,
+      "line": 1280,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Agent: %@",
       "surface": "apple",
@@ -17851,7 +17851,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1271,
+      "line": 1289,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Resolving",
       "surface": "apple",
@@ -17859,7 +17859,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1272,
+      "line": 1290,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "High",
       "surface": "apple",
@@ -17867,7 +17867,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1278,
+      "line": 1296,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Permission can be saved",
       "surface": "apple",
@@ -17875,7 +17875,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1279,
+      "line": 1297,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "One-time approval",
       "surface": "apple",
@@ -17883,7 +17883,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1282,
+      "line": 1300,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Medium",
       "surface": "apple",
@@ -17891,7 +17891,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1283,
+      "line": 1301,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Review",
       "surface": "apple",
@@ -17899,7 +17899,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1289,
+      "line": 1307,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Talk + Wake",
       "surface": "apple",
@@ -17907,7 +17907,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1290,
+      "line": 1308,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Talk on",
       "surface": "apple",
@@ -17915,7 +17915,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1291,
+      "line": 1309,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Wake on",
       "surface": "apple",
@@ -17923,7 +17923,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1292,
+      "line": 1310,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Off",
       "surface": "apple",
@@ -17931,7 +17931,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1296,
+      "line": 1314,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "demo",
       "surface": "apple",
@@ -17939,7 +17939,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1297,
+      "line": 1315,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "ready",
       "surface": "apple",
@@ -17947,7 +17947,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1298,
+      "line": 1316,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "check",
       "surface": "apple",
@@ -17955,7 +17955,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1299,
+      "line": 1317,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "partial",
       "surface": "apple",
@@ -17963,7 +17963,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1303,
+      "line": 1321,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "pending",
       "surface": "apple",
@@ -17971,7 +17971,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1305,
+      "line": 1323,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "pass",
       "surface": "apple",
@@ -17979,7 +17979,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1316,
+      "line": 1334,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Requesting iOS location permission…",
       "surface": "apple",
@@ -17987,7 +17987,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1382,
+      "line": 1400,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "This build uses OpenClaw's hosted push relay at %@ for notification delivery data.",
       "surface": "apple",
@@ -17995,7 +17995,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1386,
+      "line": 1404,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "This build is not configured to use OpenClaw's hosted push relay.",
       "surface": "apple",
@@ -18003,7 +18003,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1391,
+      "line": 1409,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Enabling this sends delivery data through OpenClaw's hosted push relay.",
       "surface": "apple",
@@ -18106,16 +18106,8 @@
       "id": "native.apple.529c06f7f7f6e428"
     },
     {
-      "kind": "ui-named-argument",
-      "line": 293,
-      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
-      "source": "Gateway",
-      "surface": "apple",
-      "id": "native.apple.5c4427c5a67068d6"
-    },
-    {
       "kind": "ui-call",
-      "line": 299,
+      "line": 328,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Address",
       "surface": "apple",
@@ -18123,7 +18115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 300,
+      "line": 329,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Server",
       "surface": "apple",
@@ -18131,7 +18123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 301,
+      "line": 330,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovered",
       "surface": "apple",
@@ -18139,15 +18131,31 @@
     },
     {
       "kind": "ui-call",
-      "line": 307,
+      "line": 336,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Agents",
       "surface": "apple",
       "id": "native.apple.8e3656d85f092897"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 361,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "Gateway",
+      "surface": "apple",
+      "id": "native.apple.5c4427c5a67068d6"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 365,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "Scan QR to Pair",
+      "surface": "apple",
+      "id": "native.apple.34444b9c6d74f472"
+    },
+    {
       "kind": "ui-modifier",
-      "line": 366,
+      "line": 396,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Switch Gateway",
       "surface": "apple",
@@ -18155,7 +18163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 373,
+      "line": 403,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Approvals",
       "surface": "apple",
@@ -18163,7 +18171,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 375,
+      "line": 405,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Out-of-app approval alerts need notification permission.",
       "surface": "apple",
@@ -18171,7 +18179,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 377,
+      "line": 407,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No gateway actions are waiting for review.",
       "surface": "apple",
@@ -18179,7 +18187,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 378,
+      "line": 408,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Review pending gateway actions.",
       "surface": "apple",
@@ -18187,7 +18195,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 380,
+      "line": 410,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Alerts Off",
       "surface": "apple",
@@ -18195,7 +18203,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 382,
+      "line": 412,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "clear",
       "surface": "apple",
@@ -18203,7 +18211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 400,
+      "line": 430,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Apple Watch",
       "surface": "apple",
@@ -18211,7 +18219,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 403,
+      "line": 433,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Relay remains available; direct mode adds an independent Gateway node.",
       "surface": "apple",
@@ -18219,7 +18227,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 405,
+      "line": 435,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Install the OpenClaw watch app before enabling direct mode.",
       "surface": "apple",
@@ -18227,7 +18235,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 408,
+      "line": 438,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Reachable",
       "surface": "apple",
@@ -18235,7 +18243,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 410,
+      "line": 440,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Installed",
       "surface": "apple",
@@ -18243,7 +18251,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 411,
+      "line": 441,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Unavailable",
       "surface": "apple",
@@ -18251,7 +18259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 418,
+      "line": 448,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Enable Direct Gateway Connection",
       "surface": "apple",
@@ -18259,7 +18267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 434,
+      "line": 464,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "The watch receives a one-time pairing code and stores its own device token. A reachable secure Gateway URL is required away from the iPhone.",
       "surface": "apple",
@@ -18267,7 +18275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 442,
+      "line": 472,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Direct node features",
       "surface": "apple",
@@ -18275,7 +18283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 452,
+      "line": 482,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Notifications are off",
       "surface": "apple",
@@ -18283,7 +18291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 454,
+      "line": 484,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Enable Notifications to receive approval alerts while OpenClaw is not open.",
       "surface": "apple",
@@ -18291,7 +18299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 463,
+      "line": 493,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Open Notifications",
       "surface": "apple",
@@ -18299,7 +18307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 473,
+      "line": 503,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Pending approvals",
       "surface": "apple",
@@ -18307,7 +18315,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 490,
+      "line": 520,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Review exec approval",
       "surface": "apple",
@@ -18315,7 +18323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 497,
+      "line": 527,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Reviewing",
       "surface": "apple",
@@ -18323,7 +18331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 531,
+      "line": 561,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Allow Once",
       "surface": "apple",
@@ -18331,7 +18339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 540,
+      "line": 570,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Allow Always",
       "surface": "apple",
@@ -18339,7 +18347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 549,
+      "line": 579,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Deny",
       "surface": "apple",
@@ -18347,7 +18355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 560,
+      "line": 590,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Dismiss",
       "surface": "apple",
@@ -18355,7 +18363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 570,
+      "line": 600,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No approvals waiting",
       "surface": "apple",
@@ -18363,7 +18371,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 600,
+      "line": 630,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Camera",
       "surface": "apple",
@@ -18371,7 +18379,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 606,
+      "line": 636,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Keep Awake",
       "surface": "apple",
@@ -18379,7 +18387,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 617,
+      "line": 647,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice & Talk",
       "surface": "apple",
@@ -18387,7 +18395,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 632,
+      "line": 662,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Health Check",
       "surface": "apple",
@@ -18395,7 +18403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 633,
+      "line": 663,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run app, permission, and gateway-adjacent checks without editing setup.",
       "surface": "apple",
@@ -18403,7 +18411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 641,
+      "line": 671,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run Diagnostics",
       "surface": "apple",
@@ -18411,7 +18419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 651,
+      "line": 681,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Platform",
       "surface": "apple",
@@ -18419,7 +18427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 654,
+      "line": 684,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "App",
       "surface": "apple",
@@ -18427,7 +18435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 657,
+      "line": 687,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Model",
       "surface": "apple",
@@ -18435,7 +18443,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 669,
+      "line": 699,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Camera Access",
       "surface": "apple",
@@ -18443,7 +18451,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 675,
+      "line": 705,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Background Listening",
       "surface": "apple",
@@ -18451,7 +18459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 700,
+      "line": 730,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Notifications",
       "surface": "apple",
@@ -18459,7 +18467,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 709,
+      "line": 739,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Turns OpenClaw notification delivery on or off",
       "surface": "apple",
@@ -18467,7 +18475,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 729,
+      "line": 759,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Reconnect",
       "surface": "apple",
@@ -18475,7 +18483,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 739,
+      "line": 769,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Diagnose",
       "surface": "apple",
@@ -18483,7 +18491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 755,
+      "line": 785,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "License files are not available in this build.",
       "surface": "apple",
@@ -18491,7 +18499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 772,
+      "line": 802,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "apple",
@@ -18499,7 +18507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 812,
+      "line": 842,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -18507,7 +18515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 814,
+      "line": 844,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Personal AI on your devices",
       "surface": "apple",
@@ -18515,7 +18523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 831,
+      "line": 861,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "iOS",
       "surface": "apple",
@@ -18523,7 +18531,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 838,
+      "line": 868,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Website",
       "surface": "apple",
@@ -18531,7 +18539,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 843,
+      "line": 873,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Docs",
       "surface": "apple",
@@ -18539,7 +18547,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 848,
+      "line": 878,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "GitHub",
       "surface": "apple",
@@ -18547,7 +18555,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 853,
+      "line": 883,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discord",
       "surface": "apple",
@@ -18555,7 +18563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 858,
+      "line": 888,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "© 2026 OpenClaw Foundation — MIT License.",
       "surface": "apple",
@@ -18563,7 +18571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 864,
+      "line": 894,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Title",
       "surface": "apple",
@@ -18571,7 +18579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 904,
+      "line": 934,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Location",
       "surface": "apple",
@@ -18579,7 +18587,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 922,
+      "line": 952,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Location Sharing",
       "surface": "apple",
@@ -18587,7 +18595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 935,
+      "line": 965,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Access Level",
       "surface": "apple",
@@ -18595,7 +18603,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 957,
+      "line": 987,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Chooses While Using the App or Always",
       "surface": "apple",
@@ -18603,7 +18611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 977,
+      "line": 1007,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default Agent",
       "surface": "apple",
@@ -18611,7 +18619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 978,
+      "line": 1008,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default",
       "surface": "apple",
@@ -18619,15 +18627,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 988,
+      "line": 1018,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Used for new Chat and Talk sessions.",
       "surface": "apple",
       "id": "native.apple.3de045f17ea3c6d0"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 1028,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "Scan QR",
+      "surface": "apple",
+      "id": "native.apple.19552e71de246322"
+    },
+    {
       "kind": "ui-call",
-      "line": 995,
+      "line": 1036,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Paste setup code",
       "surface": "apple",
@@ -18635,15 +18651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1001,
-      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
-      "source": "Scan QR",
-      "surface": "apple",
-      "id": "native.apple.19552e71de246322"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 1011,
+      "line": 1042,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connect",
       "surface": "apple",
@@ -18651,23 +18659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1020,
-      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
-      "source": "Setup Code",
-      "surface": "apple",
-      "id": "native.apple.d8a5510f1a2e1701"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1033,
-      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
-      "source": "Discovered Gateways",
-      "surface": "apple",
-      "id": "native.apple.adb22453596f1d78"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1035,
+      "line": 1051,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "surface": "apple",
@@ -18675,7 +18667,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 1049,
+      "line": 1060,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "Add Gateway",
+      "surface": "apple",
+      "id": "native.apple.784220b48f5c4af8"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1075,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Pair a gateway to make it available here.",
       "surface": "apple",
@@ -18683,7 +18683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1058,
+      "line": 1084,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Paired Gateways",
       "surface": "apple",
@@ -18691,7 +18691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1061,
+      "line": 1087,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Switch gateways without pairing again.",
       "surface": "apple",
@@ -18699,7 +18699,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1091,
+      "line": 1117,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Active Gateway",
       "surface": "apple",
@@ -18707,7 +18707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1103,
+      "line": 1129,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Forget",
       "surface": "apple",
@@ -18715,7 +18715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1115,
+      "line": 1141,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Forget Gateway",
       "surface": "apple",
@@ -18723,7 +18723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1168,
+      "line": 1194,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Manual Gateway",
       "surface": "apple",
@@ -18731,7 +18731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1169,
+      "line": 1195,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Use Manual Gateway",
       "surface": "apple",
@@ -18739,7 +18739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1170,
+      "line": 1196,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Host",
       "surface": "apple",
@@ -18747,7 +18747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1174,
+      "line": 1200,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Port",
       "surface": "apple",
@@ -18755,7 +18755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1178,
+      "line": 1204,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Unencrypted",
       "surface": "apple",
@@ -18763,7 +18763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1181,
+      "line": 1207,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Secure (TLS)",
       "surface": "apple",
@@ -18771,7 +18771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1185,
+      "line": 1211,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connection security",
       "surface": "apple",
@@ -18779,7 +18779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1196,
+      "line": 1222,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connect Manual",
       "surface": "apple",
@@ -18787,7 +18787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1226,
+      "line": 1252,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Auto-connect on launch",
       "surface": "apple",
@@ -18795,7 +18795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1227,
+      "line": 1253,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Auth Token",
       "surface": "apple",
@@ -18803,7 +18803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1228,
+      "line": 1254,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Password",
       "surface": "apple",
@@ -18811,7 +18811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1233,
+      "line": 1259,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Custom Headers",
       "surface": "apple",
@@ -18819,7 +18819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1240,
+      "line": 1266,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Reset Onboarding",
       "surface": "apple",
@@ -18827,7 +18827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1270,
+      "line": 1296,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice Wake",
       "surface": "apple",
@@ -18835,7 +18835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1273,
+      "line": 1299,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Talk Mode",
       "surface": "apple",
@@ -18843,7 +18843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1281,
+      "line": 1307,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Speech Language",
       "surface": "apple",
@@ -18851,7 +18851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1288,
+      "line": 1314,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Speakerphone",
       "surface": "apple",
@@ -18859,7 +18859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1292,
+      "line": 1318,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Wake Words",
       "surface": "apple",
@@ -18867,7 +18867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1314,
+      "line": 1340,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice",
       "surface": "apple",
@@ -18875,7 +18875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1315,
+      "line": 1341,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Provider",
       "surface": "apple",
@@ -18883,7 +18883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1322,
+      "line": 1348,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Realtime Voice",
       "surface": "apple",
@@ -18891,7 +18891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1323,
+      "line": 1349,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Default",
       "surface": "apple",
@@ -18899,7 +18899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1330,
+      "line": 1356,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice Mode",
       "surface": "apple",
@@ -18907,7 +18907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1333,
+      "line": 1359,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Active Voice",
       "surface": "apple",
@@ -18915,7 +18915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1337,
+      "line": 1363,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Last Voice Issue",
       "surface": "apple",
@@ -18923,7 +18923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1339,
+      "line": 1365,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Transport",
       "surface": "apple",
@@ -18931,7 +18931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1342,
+      "line": 1368,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "API Key",
       "surface": "apple",
@@ -18939,7 +18939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1349,
+      "line": 1375,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Show Talk Control",
       "surface": "apple",
@@ -18947,7 +18947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1350,
+      "line": 1376,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default Share Instruction",
       "surface": "apple",
@@ -18955,7 +18955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1357,
+      "line": 1383,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run Share Self-Test",
       "surface": "apple",
@@ -18963,7 +18963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1374,
+      "line": 1400,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovery Debug Logs",
       "surface": "apple",
@@ -18971,7 +18971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1377,
+      "line": 1403,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Debug Screen Status",
       "surface": "apple",
@@ -18979,7 +18979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1381,
+      "line": 1407,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovery Logs",
       "surface": "apple",
@@ -18987,7 +18987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1389,
+      "line": 1415,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Device",
       "surface": "apple",
@@ -18995,7 +18995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1390,
+      "line": 1416,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Device Name",
       "surface": "apple",
@@ -19003,7 +19003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1392,
+      "line": 1418,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Instance ID",
       "surface": "apple",
@@ -19011,7 +19011,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1416,
+      "line": 1442,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "On",
       "surface": "apple",
@@ -19019,7 +19019,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1417,
+      "line": 1443,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Off",
       "surface": "apple",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -11319,11 +11319,6 @@
       "translated": "التراخيص"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "العنوان"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "الوكلاء"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "امسح رمز QR للإقران"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "يُستخدم لجلسات الدردشة والتحدث الجديدة."
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "الصق رمز الإعداد"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "مسح QR"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "الصق رمز الإعداد"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "اتصال"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "رمز الإعداد"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "بوابات Gateway المكتشفة"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "لم يتم العثور على أي بوابات حتى الآن. استخدم الإعداد اليدوي إذا كان Bonjour محظورًا."
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "إضافة Gateway"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -11319,11 +11319,6 @@
       "translated": "Lizenzen"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "Adresse"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "Agenten"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "QR-Code zum Koppeln scannen"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "Wird für neue Chat- und Talk-Sitzungen verwendet."
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "Einrichtungscode einfügen"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "QR scannen"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "Einrichtungscode einfügen"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "Verbinden"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "Einrichtungscode"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "Gefundene Gateways"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "Noch keine Gateways gefunden. Verwenden Sie die manuelle Einrichtung, wenn Bonjour blockiert ist."
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "Gateway hinzufügen"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -11319,11 +11319,6 @@
       "translated": "Licencias"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "Dirección"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "Agentes"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "Escanear QR para enlazar"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "Se usa para nuevas sesiones de Chat y Talk."
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "Pegar código de configuración"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "Escanear QR"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "Pegar código de configuración"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "Conectar"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "Código de configuración"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "Gateways descubiertos"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "Aún no se encontraron gateways. Usa la configuración manual si Bonjour está bloqueado."
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "Añadir Gateway"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -11319,11 +11319,6 @@
       "translated": "مجوزها"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "نشانی"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "عامل‌ها"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "برای جفت‌سازی، کد QR را اسکن کنید"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "برای جلسه‌های جدید Chat و Talk استفاده می‌شود."
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "کد راه‌اندازی را جای‌گذاری کنید"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "اسکن QR"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "کد راه‌اندازی را جای‌گذاری کنید"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "اتصال"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "کد راه‌اندازی"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "Gatewayهای کشف‌شده"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "هنوز Gatewayی پیدا نشده است. اگر Bonjour مسدود شده است، از راه‌اندازی دستی استفاده کنید."
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "افزودن Gateway"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -11319,11 +11319,6 @@
       "translated": "Licences"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "Adresse"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "Agents"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "Scanner le code QR pour jumeler"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "Utilisé pour les nouvelles sessions Chat et Talk."
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "Coller le code de configuration"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "Scanner le QR code"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "Coller le code de configuration"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "Connecter"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "Code de configuration"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "Gateways découverts"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "Aucun Gateway trouvé pour le moment. Utilisez la configuration manuelle si Bonjour est bloqué."
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "Ajouter un Gateway"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -11319,11 +11319,6 @@
       "translated": "लाइसेंस"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "पता"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "एजेंट"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "पेयर करने के लिए QR स्कैन करें"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "नए Chat और Talk सत्रों के लिए उपयोग किया जाता है।"
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "Setup Code पेस्ट करें"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "QR स्कैन करें"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "Setup Code पेस्ट करें"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "कनेक्ट करें"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "Setup Code"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "खोजे गए Gateways"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "अभी तक कोई gateway नहीं मिला। यदि Bonjour ब्लॉक है, तो मैनुअल सेटअप का उपयोग करें।"
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "Gateway जोड़ें"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -11319,11 +11319,6 @@
       "translated": "Lisensi"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "Alamat"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "Agen"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "Pindai QR untuk Memasangkan"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "Digunakan untuk sesi Chat dan Talk baru."
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "Tempel kode penyiapan"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "Pindai QR"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "Tempel kode penyiapan"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "Hubungkan"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "Kode Penyiapan"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "Gateway yang Ditemukan"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "Belum ada gateway yang ditemukan. Gunakan penyiapan manual jika Bonjour diblokir."
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "Tambahkan Gateway"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -11319,11 +11319,6 @@
       "translated": "Licenze"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "Indirizzo"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "Agenti"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "Scansiona il codice QR per abbinare"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "Usato per nuove sessioni di Chat e Talk."
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "Incolla il codice di configurazione"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "Scansiona QR"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "Incolla il codice di configurazione"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "Connetti"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "Codice di configurazione"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "Gateway rilevati"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "Nessun gateway trovato ancora. Usa la configurazione manuale se Bonjour è bloccato."
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "Aggiungi Gateway"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -11319,11 +11319,6 @@
       "translated": "ライセンス"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "アドレス"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "エージェント"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "QRコードをスキャンしてペアリング"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "新しいChatおよびTalkセッションに使用されます。"
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "セットアップコードを貼り付け"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "QRをスキャン"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "セットアップコードを貼り付け"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "接続"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "セットアップコード"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "検出されたGateway"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "Gatewayがまだ見つかりません。Bonjourがブロックされている場合は手動セットアップを使用してください。"
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "Gatewayを追加"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -11319,11 +11319,6 @@
       "translated": "라이선스"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "주소"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "에이전트"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "페어링하려면 QR 코드를 스캔하세요"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "새 Chat 및 Talk 세션에 사용됩니다."
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "설정 코드 붙여넣기"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "QR 스캔"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "설정 코드 붙여넣기"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "연결"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "설정 코드"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "발견된 Gateway"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "아직 Gateway를 찾을 수 없습니다. Bonjour가 차단된 경우 수동 설정을 사용하세요."
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "Gateway 추가"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -11319,11 +11319,6 @@
       "translated": "Licenties"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "Adres"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "Agenten"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "Scan QR-code om te koppelen"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "Gebruikt voor nieuwe Chat- en Talk-sessies."
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "Installatiecode plakken"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "QR-code scannen"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "Installatiecode plakken"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "Verbinden"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "Installatiecode"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "Ontdekte Gateways"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "Nog geen gateways gevonden. Gebruik handmatige installatie als Bonjour is geblokkeerd."
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "Gateway toevoegen"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -11319,11 +11319,6 @@
       "translated": "Licencje"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "Adres"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "Agenci"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "Zeskanuj kod QR, aby sparować"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "Używane dla nowych sesji Chat i Talk."
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "Wklej kod konfiguracji"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "Skanuj QR"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "Wklej kod konfiguracji"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "Połącz"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "Kod konfiguracji"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "Wykryte Gateway"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "Nie znaleziono jeszcze żadnych Gateway. Użyj konfiguracji ręcznej, jeśli Bonjour jest zablokowany."
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "Dodaj Gateway"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -11319,11 +11319,6 @@
       "translated": "Licenças"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "Endereço"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "Agentes"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "Escanear QR para emparelhar"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "Usado para novas sessões de Chat e Talk."
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "Colar código de configuração"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "Escanear QR"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "Colar código de configuração"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "Conectar"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "Código de configuração"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "Gateways descobertos"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "Nenhum gateway encontrado ainda. Use a configuração manual se o Bonjour estiver bloqueado."
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "Adicionar Gateway"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -11319,11 +11319,6 @@
       "translated": "Лицензии"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "Адрес"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "Агенты"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "Отсканируйте QR-код для сопряжения"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "Используется для новых сеансов Chat и Talk."
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "Вставьте код настройки"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "Сканировать QR"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "Вставьте код настройки"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "Подключиться"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "Код настройки"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "Обнаруженные Gateway"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "Gateway пока не найдены. Используйте ручную настройку, если Bonjour заблокирован."
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "Добавить Gateway"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -11319,11 +11319,6 @@
       "translated": "Licenser"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "Adress"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "Agenter"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "Skanna QR-koden för att parkoppla"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "Används för nya chatt- och samtalssessioner."
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "Klistra in installationskod"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "Skanna QR"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "Klistra in installationskod"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "Anslut"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "Installationskod"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "Upptäckta Gateways"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "Inga gateways hittades ännu. Använd manuell konfiguration om Bonjour är blockerat."
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "Lägg till Gateway"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -11319,11 +11319,6 @@
       "translated": "ใบอนุญาต"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "ที่อยู่"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "เอเจนต์"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "สแกนคิวอาร์โค้ดเพื่อจับคู่"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "ใช้สำหรับเซสชัน Chat และ Talk ใหม่"
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "วางรหัสตั้งค่า"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "สแกน QR"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "วางรหัสตั้งค่า"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "เชื่อมต่อ"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "รหัสตั้งค่า"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "Gateway ที่ค้นพบ"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "ยังไม่พบ Gateway ใช้การตั้งค่าด้วยตนเองหาก Bonjour ถูกบล็อก"
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "เพิ่ม Gateway"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -11319,11 +11319,6 @@
       "translated": "Lisanslar"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "Adres"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "Aracılar"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "Eşleştirmek için QR Kodunu Tara"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "Yeni Chat ve Talk oturumları için kullanılır."
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "Kurulum kodunu yapıştır"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "QR'ı Tara"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "Kurulum kodunu yapıştır"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "Bağlan"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "Kurulum Kodu"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "Keşfedilen Gateway'ler"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "Henüz gateway bulunamadı. Bonjour engelleniyorsa manuel kurulumu kullanın."
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "Gateway Ekle"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -11319,11 +11319,6 @@
       "translated": "Ліцензії"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "Адреса"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "Агенти"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "Відскануйте QR-код для сполучення"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "Використовується для нових сеансів Chat і Talk."
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "Вставте код налаштування"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "Сканувати QR-код"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "Вставте код налаштування"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "Підключитися"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "Код налаштування"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "Виявлені Gateway"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "Gateway ще не знайдено. Використайте ручне налаштування, якщо Bonjour заблоковано."
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "Додати Gateway"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -11319,11 +11319,6 @@
       "translated": "Giấy phép"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "Địa chỉ"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "Tác nhân"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "Quét mã QR để ghép đôi"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "Được dùng cho các phiên Chat và Talk mới."
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "Dán mã thiết lập"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "Quét QR"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "Dán mã thiết lập"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "Kết nối"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "Mã thiết lập"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "Gateway đã phát hiện"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "Chưa tìm thấy gateway nào. Dùng thiết lập thủ công nếu Bonjour bị chặn."
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "Thêm Gateway"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -11319,11 +11319,6 @@
       "translated": "许可证"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "地址"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "代理"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "扫描二维码以配对"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "用于新的聊天和通话会话。"
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "粘贴设置代码"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "扫描二维码"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "粘贴设置代码"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "连接"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "设置代码"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "发现的 Gateway"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "尚未找到 Gateway。如果 Bonjour 被阻止，请使用手动设置。"
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "添加 Gateway"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -11319,11 +11319,6 @@
       "translated": "授權"
     },
     {
-      "id": "native.apple.5c4427c5a67068d6",
-      "source": "Gateway",
-      "translated": "Gateway"
-    },
-    {
       "id": "native.apple.800b6502b5b49941",
       "source": "Address",
       "translated": "位址"
@@ -11342,6 +11337,16 @@
       "id": "native.apple.8e3656d85f092897",
       "source": "Agents",
       "translated": "代理程式"
+    },
+    {
+      "id": "native.apple.5c4427c5a67068d6",
+      "source": "Gateway",
+      "translated": "Gateway"
+    },
+    {
+      "id": "native.apple.34444b9c6d74f472",
+      "source": "Scan QR to Pair",
+      "translated": "掃描 QR Code 以配對"
     },
     {
       "id": "native.apple.88835de05348122a",
@@ -11644,14 +11649,14 @@
       "translated": "用於新的 Chat 和 Talk 工作階段。"
     },
     {
-      "id": "native.apple.313eb24efcb8d4a0",
-      "source": "Paste setup code",
-      "translated": "貼上設定代碼"
-    },
-    {
       "id": "native.apple.19552e71de246322",
       "source": "Scan QR",
       "translated": "掃描 QR"
+    },
+    {
+      "id": "native.apple.313eb24efcb8d4a0",
+      "source": "Paste setup code",
+      "translated": "貼上設定代碼"
     },
     {
       "id": "native.apple.f4afcfbe4e4a72f8",
@@ -11659,19 +11664,14 @@
       "translated": "連線"
     },
     {
-      "id": "native.apple.d8a5510f1a2e1701",
-      "source": "Setup Code",
-      "translated": "設定代碼"
-    },
-    {
-      "id": "native.apple.adb22453596f1d78",
-      "source": "Discovered Gateways",
-      "translated": "已探索到的 Gateway"
-    },
-    {
       "id": "native.apple.64b89f4aa3a81aef",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "translated": "尚未找到 Gateway。如果 Bonjour 被封鎖，請使用手動設定。"
+    },
+    {
+      "id": "native.apple.784220b48f5c4af8",
+      "source": "Add Gateway",
+      "translated": "新增 Gateway"
     },
     {
       "id": "native.apple.75c61c4ee1ecc6d8",

--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -10,7 +10,10 @@ extension SettingsProTab {
         title: OpenClawTextValue,
         detail: OpenClawTextValue,
         value: OpenClawTextValue,
-        color: Color) -> some View
+        color: Color,
+        actionTitle: LocalizedStringKey? = nil,
+        actionSystemImage: String = "arrow.right",
+        action: (() -> Void)? = nil) -> some View
     {
         Section {
             HStack(spacing: 12) {
@@ -27,6 +30,15 @@ extension SettingsProTab {
                 value.text
                     .font(OpenClawType.subheadMedium)
                     .foregroundStyle(color)
+            }
+            if let action, let actionTitle {
+                Button(action: action) {
+                    Label(actionTitle, systemImage: actionSystemImage)
+                        .font(OpenClawType.subheadSemiBold)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(OpenClawBrand.accent)
             }
         }
     }
@@ -1166,6 +1178,12 @@ extension SettingsProTab {
     var gatewayConnected: Bool {
         !self.appModel.isAppleReviewDemoModeEnabled &&
             GatewayStatusBuilder.build(appModel: self.appModel) == .connected
+    }
+
+    /// First-run state: no paired gateways yet (demo mode fakes a pairing), so
+    /// the status card surfaces Scan QR as the primary action.
+    var gatewayNeedsPairing: Bool {
+        self.gatewayRegistry.entries.isEmpty && !self.appModel.isAppleReviewDemoModeEnabled
     }
 
     var gatewayStatusDetail: String {

--- a/apps/ios/Sources/Design/SettingsProTabSections.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSections.swift
@@ -282,32 +282,27 @@ extension SettingsProTab {
                         .font(OpenClawType.headline)
                         .foregroundStyle(.primary)
                 }
+                if route == .gateway {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button {
+                            self.openGatewayQRScanner()
+                        } label: {
+                            Image(systemName: "qrcode.viewfinder")
+                                .font(OpenClawType.subheadSemiBold)
+                        }
+                        .disabled(self.connectingGateway != nil)
+                        .accessibilityLabel("Scan QR")
+                    }
+                }
             }
         }
     }
 
+    /// Ordered by intent: connection state, then pairing (the first-run action),
+    /// then facts/preferences; manual entry and credentials are plumbing at the end.
     var gatewayDestination: some View {
         Group {
-            self.detailStatusCard(
-                icon: "antenna.radiowaves.left.and.right",
-                title: "Gateway",
-                detail: .verbatim(self.gatewayStatusDetail),
-                value: .verbatim(self.gatewayStatusValue),
-                color: self.gatewayStatusColor)
-
-            self.detailListCard {
-                SettingsDetailRow("Address", value: .verbatim(self.gatewayAddress))
-                SettingsDetailRow("Server", value: .verbatim(self.gatewayServer))
-                SettingsDetailRow(
-                    "Discovered",
-                    value: .verbatim(self.gatewayController.gateways.count.formatted()))
-                SettingsDetailRow(
-                    "Default Agent",
-                    value: .verbatim(self.appModel.activeAgentName))
-                SettingsDetailRow(
-                    "Agents",
-                    value: .verbatim(self.appModel.gatewayAgents.count.formatted()))
-            }
+            self.gatewayStatusCard
 
             Section {
                 Button {
@@ -326,15 +321,50 @@ extension SettingsProTab {
                 .disabled(self.isRefreshingGateway)
             }
 
-            self.manualGatewayCard
-            self.pairedGatewaysCard
-            self.deviceIdentityCard
-            self.agentSelectionCard
             self.gatewaySetupCard
-            self.discoveredGatewaysCard
+            self.pairedGatewaysCard
+
+            self.detailListCard {
+                SettingsDetailRow("Address", value: .verbatim(self.gatewayAddress))
+                SettingsDetailRow("Server", value: .verbatim(self.gatewayServer))
+                SettingsDetailRow(
+                    "Discovered",
+                    value: .verbatim(self.gatewayController.gateways.count.formatted()))
+                SettingsDetailRow(
+                    "Default Agent",
+                    value: .verbatim(self.appModel.activeAgentName))
+                SettingsDetailRow(
+                    "Agents",
+                    value: .verbatim(self.appModel.gatewayAgents.count.formatted()))
+            }
+
+            self.agentSelectionCard
+            self.deviceIdentityCard
+            self.manualGatewayCard
             self.gatewayAdvancedCard
         }
         .font(OpenClawType.body)
+    }
+
+    private var gatewayStatusCard: some View {
+        // Hero pairing action honors the same connect lock as the other scanner
+        // entry points; an in-flight attempt must not race a second scan.
+        let showScanHero = self.gatewayNeedsPairing && self.connectingGateway == nil
+        // Unapplied `self.openGatewayQRScanner` in a ternary crashes the Swift 6
+        // type checker ("failed to produce diagnostic"); build the optional closure imperatively.
+        var scanAction: (() -> Void)?
+        if showScanHero {
+            scanAction = { self.openGatewayQRScanner() }
+        }
+        return self.detailStatusCard(
+            icon: "antenna.radiowaves.left.and.right",
+            title: "Gateway",
+            detail: .verbatim(self.gatewayStatusDetail),
+            value: .verbatim(self.gatewayStatusValue),
+            color: self.gatewayStatusColor,
+            actionTitle: showScanHero ? "Scan QR to Pair" : nil,
+            actionSystemImage: "qrcode.viewfinder",
+            action: scanAction)
     }
 
     var gatewayQuickSwitchMenu: some View {
@@ -990,13 +1020,10 @@ extension SettingsProTab {
         }
     }
 
+    /// One section owns the whole pairing story: scan, paste, and discovered
+    /// gateways; splitting these across the page hid Scan QR below plumbing.
     var gatewaySetupCard: some View {
         Section {
-            TextField("Paste setup code", text: self.$setupCode)
-                .font(OpenClawType.body)
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled()
-                .disabled(self.connectingGateway != nil)
             self.gatewayActionButton(
                 title: "Scan QR",
                 icon: "qrcode.viewfinder",
@@ -1006,31 +1033,20 @@ extension SettingsProTab {
             {
                 self.openGatewayQRScanner()
             }
-
+            TextField("Paste setup code", text: self.$setupCode)
+                .font(OpenClawType.body)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .disabled(self.connectingGateway != nil)
             self.gatewayActionButton(
                 title: "Connect",
                 icon: "bolt.horizontal.circle",
                 color: OpenClawBrand.accent,
-                isBusy: self.connectingGateway == .manual,
+                isBusy: self.setupAttemptID != nil,
                 isDisabled: !self.canApplyGatewaySetup || self.connectingGateway != nil)
             {
                 Task { await self.applySetupCodeAndConnect() }
             }
-        } header: {
-            Text("Setup Code")
-                .font(OpenClawType.subheadSemiBold)
-        } footer: {
-            if let warning = self.tailnetWarningText {
-                Text(warning).font(OpenClawType.footnote).foregroundStyle(OpenClawBrand.warn)
-            } else if let status = self.setupStatusLine {
-                Text(status)
-                    .font(OpenClawType.footnote)
-            }
-        }
-    }
-
-    var discoveredGatewaysCard: some View {
-        Section("Discovered Gateways") {
             if self.gatewayController.gateways.isEmpty {
                 Text("No gateways found yet. Use manual setup if Bonjour is blocked.")
                     .font(OpenClawType.subhead)
@@ -1039,6 +1055,16 @@ extension SettingsProTab {
                 ForEach(self.gatewayController.gateways) { gateway in
                     self.discoveredGatewayRow(gateway)
                 }
+            }
+        } header: {
+            Text("Add Gateway")
+                .font(OpenClawType.subheadSemiBold)
+        } footer: {
+            if let warning = self.tailnetWarningText {
+                Text(warning).font(OpenClawType.footnote).foregroundStyle(OpenClawBrand.warn)
+            } else if let status = self.setupStatusLine {
+                Text(status)
+                    .font(OpenClawType.footnote)
             }
         }
     }

--- a/apps/ios/Tests/RootTabsSourceGuardTests+GatewaySupport.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests+GatewaySupport.swift
@@ -66,8 +66,14 @@ extension RootTabsSourceGuardTests {
         #expect(sectionsSource.contains("self.gatewayActions"))
         #expect(sectionsSource.contains("self.manualGatewayCard"))
         #expect(sectionsSource.contains("self.gatewaySetupCard"))
-        #expect(sectionsSource.contains("self.discoveredGatewaysCard"))
         #expect(sectionsSource.contains("self.gatewayAdvancedCard"))
+        // Pairing stays reachable without scrolling: nav-bar scanner button on the
+        // gateway route plus a status-card hero while nothing is paired. The hero
+        // honors the same connect lock as the other scanner entry points.
+        #expect(sectionsSource.contains("if route == .gateway {"))
+        #expect(sectionsSource.contains(
+            "let showScanHero = self.gatewayNeedsPairing && self.connectingGateway == nil"))
+        #expect(sectionsSource.contains("actionTitle: showScanHero ? \"Scan QR to Pair\" : nil"))
         #expect(sectionsSource.contains("title: \"Reconnect\""))
         #expect(sectionsSource.contains("Task { await self.reconnectGateway() }"))
         #expect(sectionsSource.contains("title: \"Diagnose\""))


### PR DESCRIPTION
Closes #106013

## What Problem This Solves

Resolves a problem where pairing a phone with a gateway — the first-run action for every new device — was buried on the iOS Settings → Gateway screen. Scan QR sat inside a section titled "Setup Code" at position 8 of 10, below Manual Gateway plumbing, device identity, and the Default Agent picker, and the pairing story was smeared across three non-adjacent sections (Manual Gateway, Setup Code, Discovered Gateways).

## Why This Change Was Made

The Control UI pairing flow shows a QR code and asks the phone to scan it; the phone-side entry point should be reachable without scrolling and should read as pairing, not "Setup Code". The screen is now ordered by intent instead of accretion:

- **Nav-bar scan button**: `qrcode.viewfinder` top-right on the Gateway route, always reachable, disabled while a connect attempt runs.
- **Section order**: status → Reconnect/Diagnose → **Add Gateway** (Scan QR first, paste setup code, Connect, discovered gateways merged in) → Paired Gateways → facts → Default Agent → Device → Manual Gateway → Advanced.
- **First-run hero**: while no gateway is paired and no connect attempt is running, the status card shows a prominent "Scan QR to Pair" button (the design previews in `SettingsProTabSupport.swift` already mocked this state; it was never wired up). The hero honors the same `connectingGateway` lock as the other scanner entry points.
- Drive-by fix: the setup-code Connect row computed its busy spinner from `connectingGateway == .manual`, which misses the `.setupCode` phase of the attempt; it now keys off `setupAttemptID`.

The `RootTabsSourceGuardTests` gateway-surface guard was updated for the merged section and now pins the nav-bar scanner button and the hero's connect lock.

New user-visible strings ("Add Gateway", "Scan QR to Pair") went through the native i18n pipeline: inventory sync, per-locale translation for all 21 locales, and iOS catalog projection.

## User Impact

iOS users pairing a new gateway find Scan QR immediately: in the nav bar, on the status card while unpaired, and as the first row of the first setup section. No behavior changes to connecting, discovery, or credentials; existing sections were reordered, not removed.

## Evidence

- `swiftlint --strict` and `swiftformat --lint` clean on touched files.
- `native-app-i18n check`, `apple-app-i18n check`, `android-app-i18n check` all pass.
- Local `xcodebuild` Debug build for iOS Simulator succeeds.
- Focused `OpenClawTests/RootTabsSourceGuardTests` (61 tests incl. gateway surface guards): passed on iPhone 17 / iOS 26.5 simulator.
- Autoreview (Codex `gpt-5.6-sol`, xhigh): clean, no actionable findings on the final diff.
- Known pre-existing, unrelated: `OpenClawTypographyTests` "branded font boundaries" fails identically on current `origin/main` (two `.accessibilityLabel(Text(title))` offenders in this file; the apple-i18n checker requires exactly that form, so the two suites contradict — not CI-gated, follow-up tracked separately).
