### PR TITLE
improve(gateway): reduce context-cache startup delay

### DIFF
--- a/src/gateway/server-startup-context-cache-prewarm.ts
+++ b/src/gateway/server-startup-context-cache-prewarm.ts
@@ -1,0 +1,58 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
+
+const CONTEXT_CACHE_PREWARM_START_DELAY_MS = 5_000;
+
+type StartupTrace = {
+  measure: <T>(name: string, run: () => T | Promise<T>) => Promise<T>;
+};
+
+export type ContextCachePrewarmHandle = {
+  stop: () => void | Promise<void>;
+};
+
+export function scheduleContextCachePrewarm(params: {
+  cfgAtStart: OpenClawConfig;
+  startupTrace?: StartupTrace;
+  log: { warn: (msg: string) => void };
+}): ContextCachePrewarmHandle {
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const warm = async () => {
+    if (stopped) {
+      return;
+    }
+    const { ensureContextWindowCacheLoaded } = await import("../agents/context.js");
+    if (!stopped) {
+      await ensureContextWindowCacheLoaded(params.cfgAtStart);
+    }
+  };
+
+  // Source-backed provider discovery can consume the main thread. Give
+  // readiness probes and immediate client work a clean event-loop window.
+  timer = setTimeout(() => {
+    timer = undefined;
+    void runWithGatewayIndependentRootWorkAdmission(() =>
+      params.startupTrace
+        ? params.startupTrace.measure("post-ready.context-window-cache", warm)
+        : warm(),
+    ).catch((err: unknown) => {
+      params.log.warn(`post-ready.context-window-cache failed after gateway ready: ${String(err)}`);
+    });
+  }, CONTEXT_CACHE_PREWARM_START_DELAY_MS);
+  timer.unref?.();
+
+  return {
+    stop: () => {
+      stopped = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+    },
+  };
+}
+
+export const testing = {
+  contextCachePrewarmStartDelayMs: CONTEXT_CACHE_PREWARM_START_DELAY_MS,
+};

--- a/src/gateway/server-startup-context-cache-prewarm.ts
+++ b/src/gateway/server-startup-context-cache-prewarm.ts
@@ -7,7 +7,7 @@ type StartupTrace = {
   measure: <T>(name: string, run: () => T | Promise<T>) => Promise<T>;
 };
 
-export type ContextCachePrewarmHandle = {
+type ContextCachePrewarmHandle = {
   stop: () => void | Promise<void>;
 };
 
@@ -52,7 +52,3 @@ export function scheduleContextCachePrewarm(params: {
     },
   };
 }
-
-export const testing = {
-  contextCachePrewarmStartDelayMs: CONTEXT_CACHE_PREWARM_START_DELAY_MS,
-};

--- a/src/gateway/server-startup-early.test.ts
+++ b/src/gateway/server-startup-early.test.ts
@@ -128,7 +128,7 @@ describe("startGatewayEarlyRuntime", () => {
 
     expect(mocks.setSkillsRemoteRegistry).toHaveBeenCalledWith(nodeRegistry);
     await Promise.resolve();
-    expect(mocks.ensureContextWindowCacheLoaded).toHaveBeenCalledWith({});
+    expect(mocks.ensureContextWindowCacheLoaded).not.toHaveBeenCalled();
     expect(mocks.primeRemoteSkillsCache).toHaveBeenCalledTimes(1);
     expect(mocks.ensureTaskRuntimeStateReady).toHaveBeenCalledTimes(1);
     expect(mocks.configureTaskRegistryMaintenance).toHaveBeenCalledTimes(1);
@@ -144,22 +144,6 @@ describe("startGatewayEarlyRuntime", () => {
 
     earlyRuntime.skillsChangeUnsub();
     expect(mocks.skillsChangeUnsub).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not block gateway early runtime on context-window cache warmup", async () => {
-    const pendingWarmup = new Promise<void>(() => {});
-    mocks.ensureContextWindowCacheLoaded.mockReturnValueOnce(pendingWarmup);
-
-    const earlyRuntime = await startGatewayEarlyRuntime(
-      earlyRuntimeInput({
-        minimalTestGateway: false,
-        cfgAtStart: { agents: { defaults: { model: "openai/gpt-5.5" } } } as never,
-      }),
-    );
-
-    await Promise.resolve();
-    expect(mocks.ensureContextWindowCacheLoaded).toHaveBeenCalledTimes(1);
-    expect(earlyRuntime).toHaveProperty("startMaintenance");
   });
 
   it("fails before discovery and task maintenance when task state cannot restore", async () => {

--- a/src/gateway/server-startup-early.ts
+++ b/src/gateway/server-startup-early.ts
@@ -123,14 +123,6 @@ export async function startGatewayEarlyRuntime(params: {
   let getActiveTaskCount = () => 0;
 
   if (!params.minimalTestGateway) {
-    void import("../agents/context.js")
-      .then(({ ensureContextWindowCacheLoaded }) =>
-        ensureContextWindowCacheLoaded(params.cfgAtStart),
-      )
-      .catch((err: unknown) => {
-        params.log.warn(`Context-window cache warmup failed to start: ${String(err)}`);
-      });
-
     const [{ primeRemoteSkillsCache, setSkillsRemoteRegistry }, taskRegistryMaintenance] =
       await measureStartup(params.startupTrace, "runtime.early.lazy-runtime-imports", () =>
         Promise.all([

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -255,8 +255,7 @@ vi.mock("./server-tailscale.js", () => ({
 
 const { startGatewayPostAttachRuntime, startGatewaySidecars, testing } =
   await import("./server-startup-post-attach.js");
-const { scheduleContextCachePrewarm, testing: contextCachePrewarmTesting } =
-  await import("./server-startup-context-cache-prewarm.js");
+const { scheduleContextCachePrewarm } = await import("./server-startup-context-cache-prewarm.js");
 const { STARTUP_UNAVAILABLE_GATEWAY_METHODS } = await import("./methods/core-descriptors.js");
 const { createGatewayCloseHandler } = await import("./server-close.js");
 const { createChatRunState } = await import("./server-chat-state.js");
@@ -1232,7 +1231,6 @@ describe("startGatewayPostAttachRuntime", () => {
 
   it("defers context-window cache prewarm to a post-ready sidecar", async () => {
     vi.useFakeTimers();
-    expect(contextCachePrewarmTesting.contextCachePrewarmStartDelayMs).toBe(5_000);
     const cfg = { agents: { defaults: { model: "openai/gpt-5.5" } } } as never;
     const sidecar = scheduleContextCachePrewarm({
       cfgAtStart: cfg,
@@ -1240,7 +1238,9 @@ describe("startGatewayPostAttachRuntime", () => {
     });
 
     expect(hoisted.ensureContextWindowCacheLoaded).not.toHaveBeenCalled();
-    await vi.runAllTimersAsync();
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(hoisted.ensureContextWindowCacheLoaded).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
     await vi.dynamicImportSettled();
     await vi.waitFor(() => {
       expect(hoisted.ensureContextWindowCacheLoaded).toHaveBeenCalledWith(cfg);

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -69,6 +69,7 @@ const hoisted = vi.hoisted(() => {
   }));
   const ensureOpenClawModelsJson = vi.fn(async () => {});
   const ensureRuntimePluginsLoaded = vi.fn();
+  const ensureContextWindowCacheLoaded = vi.fn(async () => {});
   const clearCurrentProviderAuthState = vi.fn();
   const warmCurrentProviderAuthStateOffMainThread = vi.fn(
     async (_cfg?: unknown, _options?: unknown) => {},
@@ -108,6 +109,7 @@ const hoisted = vi.hoisted(() => {
     getModelRefStatus,
     ensureOpenClawModelsJson,
     ensureRuntimePluginsLoaded,
+    ensureContextWindowCacheLoaded,
     clearCurrentProviderAuthState,
     warmCurrentProviderAuthStateOffMainThread,
     setAuthProfileFailureHook,
@@ -217,6 +219,10 @@ vi.mock("../agents/runtime-plugins.js", () => ({
   ensureRuntimePluginsLoaded: hoisted.ensureRuntimePluginsLoaded,
 }));
 
+vi.mock("../agents/context.js", () => ({
+  ensureContextWindowCacheLoaded: hoisted.ensureContextWindowCacheLoaded,
+}));
+
 vi.mock("../agents/model-provider-auth.js", () => ({
   warmCurrentProviderAuthStateOffMainThread: hoisted.warmCurrentProviderAuthStateOffMainThread,
 }));
@@ -249,6 +255,8 @@ vi.mock("./server-tailscale.js", () => ({
 
 const { startGatewayPostAttachRuntime, startGatewaySidecars, testing } =
   await import("./server-startup-post-attach.js");
+const { scheduleContextCachePrewarm, testing: contextCachePrewarmTesting } =
+  await import("./server-startup-context-cache-prewarm.js");
 const { STARTUP_UNAVAILABLE_GATEWAY_METHODS } = await import("./methods/core-descriptors.js");
 const { createGatewayCloseHandler } = await import("./server-close.js");
 const { createChatRunState } = await import("./server-chat-state.js");
@@ -359,6 +367,8 @@ describe("startGatewayPostAttachRuntime", () => {
     hoisted.ensureOpenClawModelsJson.mockReset();
     hoisted.ensureOpenClawModelsJson.mockResolvedValue(undefined);
     hoisted.ensureRuntimePluginsLoaded.mockReset();
+    hoisted.ensureContextWindowCacheLoaded.mockReset();
+    hoisted.ensureContextWindowCacheLoaded.mockResolvedValue(undefined);
     hoisted.clearCurrentProviderAuthState.mockClear();
     hoisted.warmCurrentProviderAuthStateOffMainThread.mockReset();
     hoisted.warmCurrentProviderAuthStateOffMainThread.mockResolvedValue(undefined);
@@ -1138,7 +1148,7 @@ describe("startGatewayPostAttachRuntime", () => {
       await vi.advanceTimersToNextTimerAsync();
       expect(postReadyRequestTurn).toHaveBeenCalledTimes(1);
       expect(onPostReadySidecars.mock.calls[0]?.[0]).toHaveLength(0);
-      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(2);
+      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(3);
       await vi.dynamicImportSettled();
       await vi.waitFor(() => {
         expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
@@ -1170,7 +1180,7 @@ describe("startGatewayPostAttachRuntime", () => {
       await vi.waitFor(() => {
         expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
       });
-      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(2);
+      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(3);
 
       await vi.advanceTimersByTimeAsync(10_000);
       expect(hoisted.warmCurrentProviderAuthStateOffMainThread).not.toHaveBeenCalled();
@@ -1220,6 +1230,36 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(testing.agentRuntimePluginPrewarmStartDelayMs).toBe(0);
   });
 
+  it("defers context-window cache prewarm to a post-ready sidecar", async () => {
+    vi.useFakeTimers();
+    expect(contextCachePrewarmTesting.contextCachePrewarmStartDelayMs).toBe(5_000);
+    const cfg = { agents: { defaults: { model: "openai/gpt-5.5" } } } as never;
+    const sidecar = scheduleContextCachePrewarm({
+      cfgAtStart: cfg,
+      log: { warn: vi.fn() },
+    });
+
+    expect(hoisted.ensureContextWindowCacheLoaded).not.toHaveBeenCalled();
+    await vi.runAllTimersAsync();
+    await vi.dynamicImportSettled();
+    await vi.waitFor(() => {
+      expect(hoisted.ensureContextWindowCacheLoaded).toHaveBeenCalledWith(cfg);
+    });
+    await sidecar.stop();
+  });
+
+  it("cancels context-window cache prewarm when the gateway stops first", async () => {
+    vi.useFakeTimers();
+    const sidecar = scheduleContextCachePrewarm({
+      cfgAtStart: {} as never,
+      log: { warn: vi.fn() },
+    });
+
+    await sidecar.stop();
+    await vi.runAllTimersAsync();
+    expect(hoisted.ensureContextWindowCacheLoaded).not.toHaveBeenCalled();
+  });
+
   it("keeps provider auth prewarm alive when Gmail post-ready sidecars stop", async () => {
     vi.useFakeTimers();
     const onPostReadySidecars = vi.fn();
@@ -1263,7 +1303,7 @@ describe("startGatewayPostAttachRuntime", () => {
         | { stop: () => void }[]
         | undefined;
       expect(gmailSidecars).toHaveLength(1);
-      expect(lifetimeSidecars).toHaveLength(2);
+      expect(lifetimeSidecars).toHaveLength(3);
 
       for (const sidecar of gmailSidecars ?? []) {
         sidecar.stop();
@@ -1325,7 +1365,7 @@ describe("startGatewayPostAttachRuntime", () => {
       | Array<{ stop: () => Promise<void> | void }>
       | undefined;
     expect(gmailSidecars).toHaveLength(1);
-    expect(lifetimeSidecars).toHaveLength(2);
+    expect(lifetimeSidecars).toHaveLength(3);
 
     await vi.waitFor(() => {
       expect(hoisted.transcriptsAutoStartService.start).toHaveBeenCalledTimes(1);
@@ -1820,7 +1860,7 @@ describe("startGatewayPostAttachRuntime", () => {
       name: "sidecars.ready",
       metrics: [
         ["loadedPluginCount", 2],
-        ["postReadySidecarCount", 1],
+        ["postReadySidecarCount", 2],
       ],
     });
   });

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -26,6 +26,7 @@ import {
 import { STARTUP_UNAVAILABLE_GATEWAY_METHODS } from "./methods/core-descriptors.js";
 import type { refreshLatestUpdateRestartSentinel } from "./server-restart-sentinel.js";
 import type { GatewaySidecarStartupMode } from "./server-sidecar-startup-mode.js";
+import { scheduleContextCachePrewarm } from "./server-startup-context-cache-prewarm.js";
 import type { logGatewayStartup } from "./server-startup-log.js";
 import {
   createGatewayStartupOutcomeRecorder,
@@ -45,7 +46,6 @@ const DEFERRED_SIDECAR_START_DELAY_MS = 100;
 const SESSION_LOCK_CLEANUP_CONCURRENCY = 4;
 const SKIP_STARTUP_MODEL_PREWARM_ENV = "OPENCLAW_SKIP_STARTUP_MODEL_PREWARM";
 const QMD_STARTUP_IDLE_DELAY_MS = 120_000;
-
 type Awaitable<T> = T | Promise<T>;
 
 type GatewayStartupTrace = {
@@ -75,9 +75,7 @@ const loadGatewayRestartSentinelModule = createLazyRuntimeModule(
   () => import("./server-restart-sentinel.js"),
 );
 
-export type GatewayPostReadySidecarHandle = {
-  stop: () => Awaitable<void>;
-};
+export type GatewayPostReadySidecarHandle = { stop: () => Awaitable<void> };
 
 /** Stop sidecars immediately when shutdown has already started before they are reported. */
 export function stopPostReadySidecarsAfterCloseStarted(params: {
@@ -1328,7 +1326,7 @@ export async function startGatewayPostAttachRuntime(
           reportPluginServices(result.pluginServices);
         }
         const postReadySidecars = [...result.postReadySidecars];
-        const gatewayLifetimeSidecars: GatewayPostReadySidecarHandle[] = [];
+        const gatewayLifetimeSidecars = [scheduleContextCachePrewarm(params)];
         if (workerEnvironmentSidecar) {
           gatewayLifetimeSidecars.push(workerEnvironmentSidecar);
         }


### PR DESCRIPTION
Closes #106076

## What Problem This Solves

Gateway startup could spend roughly 1.3 seconds on optional context-window catalog discovery before the readiness endpoint could respond. The source-backed catalog path loads package exports and Jiti on the main thread even though the resulting cache is not required to serve the Gateway.

## Why This Change Was Made

Move the existing context-window cache warmup from early startup into a lifecycle-owned post-ready sidecar with a five-second grace period. The cache implementation, provider behavior, and lookup semantics stay unchanged; Gateway shutdown can cancel the deferred work before it starts.

## User Impact

The Gateway becomes serviceable sooner, especially for source and development starts. Repeated turns keep the same warmed context-window cache behavior after startup settles.

## Evidence

- V8 startup profile: the prewarm path spent about 776 ms resolving Node package exports and 614 ms in Jiti before readiness.
- Same Testbox, five-run medians: default `/readyz` improved from 3639.5 ms to 2378.0 ms, a 34.7% reduction. Final range: 2346.9-2460.6 ms.
- Stress cases: 50 startup-lazy plugins improved from 4743.5 ms to 4170.5 ms; 50 manifest-only plugins stayed essentially unchanged, isolating the remaining cost to plugin bootstrap.
- Final branch contents: focused Gateway tests passed 126/126 and the dead-export baseline matched on Testbox `tbx_01kxd3kbwcvmnsdcq0xfvntnnt`; run https://github.com/openclaw/openclaw/actions/runs/29229952125.
- Broad proof: full build passed, and `check:changed` passed after the first rebase on Testbox `tbx_01kxd36j0vybgecnjm3fxr1v3p` in 3m16s. The only subsequent code change narrows two exports and was covered by the focused and dead-export reruns above.
- Live AWS Crabbox run: three demanding `openai/gpt-5.6` turns built, tested, and benchmarked a no-dependency static-site generator; all exited 0. Run: https://crabbox.openclaw.ai/portal/runs/run_84b5616a2163.
- Fresh pre-commit autoreview: no accepted or actionable findings.
