### PR TITLE
fix(ui): hide empty native session categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI native sessions:** hide exhausted Codex and Claude Code sidebar categories when they contain no sessions while keeping paginated catalogs reachable.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.
 - **Gateway source watch:** hand the configured port off from the installed service before starting the tmux watcher, preserve failed panes for attach/capture, and keep explicit alternate-port watches side by side with the managed Gateway.
 - **Claude CLI max-turn diagnostics:** preserve terminal max-turn results with OpenClaw and Claude session context, warn when tool actions may already have run, and stop unsafe auth-profile or model replay for potentially side-effecting turns. (#94130) Thanks @zhangguiping-xydt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI native sessions:** hide exhausted Codex and Claude Code sidebar categories when they contain no sessions while keeping paginated catalogs reachable.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.
 - **Gateway source watch:** hand the configured port off from the installed service before starting the tmux watcher, preserve failed panes for attach/capture, and keep explicit alternate-port watches side by side with the managed Gateway.
 - **Claude CLI max-turn diagnostics:** preserve terminal max-turn results with OpenClaw and Claude session context, warn when tool actions may already have run, and stop unsafe auth-profile or model replay for potentially side-effecting turns. (#94130) Thanks @zhangguiping-xydt.

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -95,6 +95,9 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
     );
     const loadingMore = params.loadingMoreCatalogIds.has(catalog.id);
     const hasMore = catalog.hosts.some((host) => Boolean(host.nextCursor));
+    if (rows.length === 0 && !hasMore) {
+      return nothing;
+    }
     return html`
       <div class="sidebar-recent-sessions__group" data-session-section=${sectionId}>
         <div class="sidebar-recent-sessions__head">

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -90,14 +90,23 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
   return params.catalogs.map((catalog) => {
     const sectionId = `catalog:${catalog.id}`;
     const collapsed = params.collapsedSections.has(sectionId);
-    const rows = catalog.hosts.flatMap((host) =>
+    const hosts = catalog.hosts;
+    const rows = hosts.flatMap((host) =>
       host.sessions.map((session) => ({ host, session })),
     );
     const loadingMore = params.loadingMoreCatalogIds.has(catalog.id);
-    const hasMore = catalog.hosts.some((host) => Boolean(host.nextCursor));
-    if (rows.length === 0 && !hasMore) {
+    const hasMore = hosts.some((host) => Boolean(host.nextCursor));
+    const errorMessages = [
+      ...(catalog.error ? [catalog.error.message] : []),
+      ...hosts.flatMap((host) => (host.error ? [host.error.message] : [])),
+    ];
+    const hasError = errorMessages.length > 0;
+    // Keep provider failures distinguishable from successful empty results.
+    // Hiding both states would silently mask unavailable session sources.
+    if (rows.length === 0 && !hasMore && !hasError) {
       return nothing;
     }
+    const errorMessage = errorMessages.join("; ");
     return html`
       <div class="sidebar-recent-sessions__group" data-session-section=${sectionId}>
         <div class="sidebar-recent-sessions__head">
@@ -105,14 +114,22 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
             type="button"
             class="sidebar-session-group-toggle"
             aria-expanded=${String(!collapsed)}
-            aria-label=${catalog.label}
+            aria-label=${hasError ? `${catalog.label}: ${errorMessage}` : catalog.label}
+            title=${hasError ? errorMessage : nothing}
             @click=${() => params.onToggleSection(sectionId)}
           >
             <span class="sidebar-session-group-toggle__icon" aria-hidden="true"
               >${collapsed ? icons.chevronRight : icons.chevronDown}</span
             >
             <span class="sidebar-recent-sessions__label-text">${catalog.label}</span>
-            <span class="sidebar-session-group-count">${rows.length}</span>
+            <span
+              class="sidebar-session-group-count ${hasError
+                ? "sidebar-session-group-count--error"
+                : ""}"
+              data-session-catalog-error=${hasError ? catalog.id : nothing}
+              aria-hidden="true"
+              >${hasError ? icons.alertTriangle : rows.length}</span
+            >
           </button>
         </div>
         ${collapsed

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -91,9 +91,7 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
     const sectionId = `catalog:${catalog.id}`;
     const collapsed = params.collapsedSections.has(sectionId);
     const hosts = catalog.hosts;
-    const rows = hosts.flatMap((host) =>
-      host.sessions.map((session) => ({ host, session })),
-    );
+    const rows = hosts.flatMap((host) => host.sessions.map((session) => ({ host, session })));
     const loadingMore = params.loadingMoreCatalogIds.has(catalog.id);
     const hasMore = hosts.some((host) => Boolean(host.nextCursor));
     const errorMessages = [

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -589,6 +589,60 @@ describe("AppSidebar session catalog pagination", () => {
     }
   });
 
+  it("shows catalog errors as warnings instead of empty counts", async () => {
+    vi.useFakeTimers();
+    try {
+      const hostError = catalogErrorPage("Claude host unavailable", "claude").catalogs[0];
+      const request = vi.fn().mockResolvedValue({
+        catalogs: [
+          {
+            id: "codex",
+            label: "Codex",
+            capabilities: { continueSession: true, archive: true },
+            hosts: [],
+            error: { code: "unavailable", message: "Codex provider unavailable" },
+          },
+          hostError,
+        ],
+      });
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+
+      const codexSection = sidebar.querySelector('[data-session-section="catalog:codex"]');
+      const claudeSection = sidebar.querySelector('[data-session-section="catalog:claude"]');
+      expect(codexSection).not.toBeNull();
+      expect(claudeSection).not.toBeNull();
+      expect(codexSection?.querySelector(".sidebar-session-group-count")?.textContent).not.toBe(
+        "0",
+      );
+      expect(claudeSection?.querySelector(".sidebar-session-group-count")?.textContent).not.toBe(
+        "0",
+      );
+      expect(
+        codexSection?.querySelector(".sidebar-session-group-toggle")?.getAttribute("aria-label"),
+      ).toContain("Codex provider unavailable");
+      expect(
+        claudeSection?.querySelector(".sidebar-session-group-toggle")?.getAttribute("aria-label"),
+      ).toContain("Claude host unavailable");
+      expect(codexSection?.querySelector('[data-session-catalog-error="codex"]')).not.toBeNull();
+      expect(claudeSection?.querySelector('[data-session-catalog-error="claude"]')).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps an empty catalog reachable while a later page remains", async () => {
     vi.useFakeTimers();
     try {

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -559,6 +559,68 @@ describe("AppSidebar session catalog pagination", () => {
     }
   });
 
+  it("hides catalog groups that have no sessions", async () => {
+    vi.useFakeTimers();
+    try {
+      const codex = catalogPage([]);
+      const claude = catalogPage([], undefined, "claude");
+      const request = vi.fn().mockResolvedValue({
+        catalogs: [...codex.catalogs, ...claude.catalogs],
+      });
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+
+      expect(sidebar.querySelector('[data-session-section="catalog:codex"]')).toBeNull();
+      expect(sidebar.querySelector('[data-session-section="catalog:claude"]')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps an empty catalog reachable while a later page remains", async () => {
+    vi.useFakeTimers();
+    try {
+      const request = vi
+        .fn()
+        .mockResolvedValueOnce(catalogPage([], "page-2"))
+        .mockResolvedValueOnce(catalogPage([{ threadId: "thread-1", name: "Later session" }]));
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+
+      expect(sidebar.querySelector('[data-session-section="catalog:codex"]')).not.toBeNull();
+      sidebar.querySelector<HTMLButtonElement>('[data-session-catalog-load-more="codex"]')?.click();
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+      expect(sidebar.textContent).toContain("Later session");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("appends host pages and keeps them through the next poll refresh", async () => {
     vi.useFakeTimers();
     try {

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -30,6 +30,55 @@ suite("Codex native session catalog", () => {
     await server?.close();
   });
 
+  it("omits empty native session catalogs from the sidebar", async () => {
+    const page = await browser.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "sessions.catalog.list"],
+      methodResponses: {
+        "sessions.catalog.list": {
+          catalogs: [
+            {
+              id: "codex",
+              label: "Codex",
+              capabilities: { continueSession: true, archive: true },
+              hosts: [
+                {
+                  hostId: "gateway:codex",
+                  label: "Local Codex",
+                  kind: "gateway",
+                  connected: true,
+                  sessions: [],
+                },
+              ],
+            },
+            {
+              id: "claude",
+              label: "Claude Code",
+              capabilities: { continueSession: true, archive: false },
+              hosts: [
+                {
+                  hostId: "gateway:claude",
+                  label: "Local Claude",
+                  kind: "gateway",
+                  connected: true,
+                  sessions: [],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    await page.goto(`${server.baseUrl}chat`);
+    await expect
+      .poll(async () => (await gateway.getRequests("sessions.catalog.list")).length)
+      .toBeGreaterThan(0);
+    expect(await page.locator('[data-session-section="catalog:codex"]').count()).toBe(0);
+    expect(await page.locator('[data-session-section="catalog:claude"]').count()).toBe(0);
+    await page.close();
+  });
+
   it("adopts from the native chat composer, navigates, and auto-sends", async () => {
     const page = await browser.newPage();
     const gateway = await installMockGateway(page, {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1310,6 +1310,21 @@ html.openclaw-native-web-chrome .sidebar-brand__collapse {
   text-align: center;
 }
 
+.sidebar-session-group-count--error {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--warning);
+}
+
+.sidebar-session-group-count--error svg {
+  width: 12px;
+  height: 12px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.8px;
+}
+
 .sidebar-session-catalog-load-more {
   display: block;
   width: calc(100% - 20px);


### PR DESCRIPTION
Related: #104717

## What Problem This Solves

Fixes an issue where users with no Codex or Claude Code sessions would see empty native-session categories and a `0` count in the Control UI sidebar.

## Why This Change Was Made

Suppress exhausted empty catalogs in the shared sidebar catalog renderer. Empty pages with continuation cursors remain visible and loadable, while provider or host failures remain visible as accessible warning states instead of being mistaken for successful empty results.

## User Impact

Empty Codex and Claude Code categories no longer occupy sidebar space. Populated and paginated native-session categories continue to work as before, and catalog failures remain visible without a misleading zero count.

## Evidence

- Before: the regression test failed against the prior implementation because the empty Codex section rendered with count `0`.
- Exact current tree: the approved local fallback passed 45 sidebar component tests and 2 Chromium native-session E2E tests.
- Exact-head hosted CI: [run 29235277756](https://github.com/openclaw/openclaw/actions/runs/29235277756) completed with 51 successful jobs, 10 intentional skips, and zero failures for `24d20b8a6d43`.
- Fresh branch-mode autoreview against current `main` reported no accepted or actionable findings.

AI-assisted: yes.
