### PR TITLE
fix(ci): classify read-only shared state SQLite

### DIFF
--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -47,6 +47,7 @@ const rawSqliteAllowPathGroups = {
     "src/snapshot/local-repository.ts",
   ],
   "agent auth profile read-only bootstrap": ["src/agents/auth-profiles/sqlite.ts"],
+  "read-only shared state database access": ["src/state/openclaw-state-db-readonly.ts"],
   "read-only SQLite status probes": [
     "src/commands/doctor-db-bloat.ts",
     "src/commands/status.scan.shared.ts",


### PR DESCRIPTION
## What Problem This Solves

`main`'s architecture lane rejects `src/state/openclaw-state-db-readonly.ts` as unclassified raw `node:sqlite` access. That helper intentionally owns a narrow read-only database boundary, so the guard failure blocks unrelated pull requests after #106103 merged.

## Why This Change Was Made

Classify the dedicated helper in the existing raw-SQLite allowlist without broadening the exception beyond its single file.

## User Impact

No runtime behavior change. Restores the architecture gate for current `main` and downstream pull requests.

## Evidence

- Blacksmith Testbox `tbx_01kxd3h9m10zggy06rewzh1dk5`: `corepack pnpm check:architecture` passed, including `Kysely guardrails OK` and the database-first legacy-store guard.
- `git diff --check`
- Fresh autoreview: no findings; patch correct (0.96 confidence).

