### PR TITLE
refactor(whatsapp): reuse pinned Baileys helpers

### DIFF
--- a/extensions/whatsapp/src/inbound/extract.ts
+++ b/extensions/whatsapp/src/inbound/extract.ts
@@ -9,108 +9,8 @@ import { jidToE164 } from "../text-runtime.js";
 import { parseVcard } from "../vcard.js";
 import type { WhatsAppStructuredContactContext } from "./types.js";
 
-const MESSAGE_WRAPPER_KEYS = [
-  "botInvokeMessage",
-  "ephemeralMessage",
-  "viewOnceMessage",
-  "viewOnceMessageV2",
-  "viewOnceMessageV2Extension",
-  "documentWithCaptionMessage",
-  "groupMentionedMessage",
-] as const;
-
-const MESSAGE_CONTENT_KEYS = [
-  "conversation",
-  "extendedTextMessage",
-  "imageMessage",
-  "videoMessage",
-  "audioMessage",
-  "documentMessage",
-  "stickerMessage",
-  "locationMessage",
-  "liveLocationMessage",
-  "contactMessage",
-  "contactsArrayMessage",
-  "buttonsResponseMessage",
-  "listResponseMessage",
-  "templateButtonReplyMessage",
-  "interactiveResponseMessage",
-  "buttonsMessage",
-  "listMessage",
-] as const;
-
-function fallbackNormalizeMessageContent(
-  message: proto.IMessage | undefined,
-): proto.IMessage | undefined {
-  let current = message as unknown;
-  while (current && typeof current === "object") {
-    let unwrapped = false;
-    for (const key of MESSAGE_WRAPPER_KEYS) {
-      const candidate = (current as Record<string, unknown>)[key];
-      if (
-        candidate &&
-        typeof candidate === "object" &&
-        "message" in (candidate as Record<string, unknown>) &&
-        (candidate as { message?: unknown }).message
-      ) {
-        current = (candidate as { message: unknown }).message;
-        unwrapped = true;
-        break;
-      }
-    }
-    if (!unwrapped) {
-      break;
-    }
-  }
-  return current as proto.IMessage | undefined;
-}
-
-function normalizeMessage(message: proto.IMessage | undefined): proto.IMessage | undefined {
-  if (typeof normalizeMessageContent === "function") {
-    return normalizeMessageContent(message);
-  }
-  return fallbackNormalizeMessageContent(message);
-}
-
-function fallbackGetContentType(
-  message: proto.IMessage | undefined,
-): keyof proto.IMessage | undefined {
-  const normalized = fallbackNormalizeMessageContent(message);
-  if (!normalized || typeof normalized !== "object") {
-    return undefined;
-  }
-  for (const key of MESSAGE_CONTENT_KEYS) {
-    if ((normalized as Record<string, unknown>)[key] != null) {
-      return key as keyof proto.IMessage;
-    }
-  }
-  return undefined;
-}
-
-function getMessageContentType(
-  message: proto.IMessage | undefined,
-): keyof proto.IMessage | undefined {
-  if (typeof getContentType === "function") {
-    return getContentType(message);
-  }
-  return fallbackGetContentType(message);
-}
-
-function extractMessage(message: proto.IMessage | undefined): proto.IMessage | undefined {
-  if (typeof extractMessageContent === "function") {
-    return extractMessageContent(message);
-  }
-  const normalized = fallbackNormalizeMessageContent(message);
-  const contentType = fallbackGetContentType(normalized);
-  if (!normalized || !contentType || contentType === "conversation") {
-    return normalized;
-  }
-  const candidate = (normalized as Record<string, unknown>)[contentType];
-  return candidate && typeof candidate === "object" ? (candidate as proto.IMessage) : normalized;
-}
-
 function getFutureProofInnerMessage(message: proto.IMessage): proto.IMessage | undefined {
-  const contentType = getMessageContentType(message);
+  const contentType = getContentType(message);
   const candidate = contentType ? (message as Record<string, unknown>)[contentType] : undefined;
   if (
     candidate &&
@@ -119,9 +19,9 @@ function getFutureProofInnerMessage(message: proto.IMessage): proto.IMessage | u
     (candidate as { message?: unknown }).message &&
     typeof (candidate as { message: unknown }).message === "object"
   ) {
-    const inner = normalizeMessage((candidate as { message: proto.IMessage }).message);
+    const inner = normalizeMessageContent((candidate as { message: proto.IMessage }).message);
     if (inner) {
-      const innerType = getMessageContentType(inner);
+      const innerType = getContentType(inner);
       if (innerType && innerType !== contentType) {
         return inner;
       }
@@ -132,7 +32,7 @@ function getFutureProofInnerMessage(message: proto.IMessage): proto.IMessage | u
 
 function buildMessageChain(message: proto.IMessage | undefined): proto.IMessage[] {
   const chain: proto.IMessage[] = [];
-  let current = normalizeMessage(message);
+  let current = normalizeMessageContent(message);
   while (current && chain.length < 4) {
     chain.push(current);
     current = getFutureProofInnerMessage(current);
@@ -146,7 +46,7 @@ function unwrapMessage(message: proto.IMessage | undefined): proto.IMessage | un
 }
 
 function extractContextInfoFromMessage(message: proto.IMessage): proto.IContextInfo | undefined {
-  const contentType = getMessageContentType(message);
+  const contentType = getContentType(message);
   const candidate = contentType ? (message as Record<string, unknown>)[contentType] : undefined;
   const contextInfo =
     candidate && typeof candidate === "object" && "contextInfo" in candidate
@@ -236,7 +136,7 @@ export function extractText(rawMessage: proto.IMessage | undefined): string | un
   if (!message) {
     return undefined;
   }
-  const extracted = extractMessage(message);
+  const extracted = extractMessageContent(message);
   const candidates = [message, extracted && extracted !== message ? extracted : undefined];
   for (const candidate of candidates) {
     if (!candidate) {
@@ -429,7 +329,7 @@ export function describeReplyContext(
     return null;
   }
   const contextInfo = extractContextInfo(message);
-  const quoted = normalizeMessage(contextInfo?.quotedMessage as proto.IMessage | undefined);
+  const quoted = normalizeMessageContent(contextInfo?.quotedMessage as proto.IMessage | undefined);
   if (!quoted) {
     return null;
   }
@@ -441,7 +341,7 @@ export function describeReplyContext(
     body = extractMediaPlaceholder(quoted);
   }
   if (!body) {
-    const quotedType = quoted ? getMessageContentType(quoted) : undefined;
+    const quotedType = quoted ? getContentType(quoted) : undefined;
     logVerbose(
       `Quoted message missing extractable body${quotedType ? ` (type ${quotedType})` : ""}`,
     );

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -106,7 +106,7 @@ import type {
   WebListenerCloseReason,
 } from "./types.js";
 
-const LOGGED_OUT_STATUS = DisconnectReason?.loggedOut ?? 401;
+const LOGGED_OUT_STATUS = DisconnectReason.loggedOut;
 const RECONNECT_IN_PROGRESS_ERROR = "no active socket - reconnection in progress";
 const GROUP_META_TTL_MS = 5 * 60 * 1000;
 const BAILEYS_MESSAGE_TTL_MS = 10 * 60 * 1000;
@@ -258,10 +258,6 @@ function logWhatsAppVerbose(enabled: boolean | undefined, message: string) {
     return;
   }
   defaultRuntime.log(message);
-}
-
-function isGroupJid(jid: string): boolean {
-  return (typeof isJidGroup === "function" ? isJidGroup(jid) : jid.endsWith("@g.us")) === true;
 }
 
 function isDirectUserJid(jid: string): boolean {
@@ -923,7 +919,7 @@ export async function attachWebInboxToSocket(
     jid: string,
     text: string,
   ): Promise<{ text: string; mentionedJids: string[] }> => {
-    if (!isGroupJid(jid) || !mayContainWhatsAppOutboundMention(text)) {
+    if (isJidGroup(jid) !== true || !mayContainWhatsAppOutboundMention(text)) {
       return { text, mentionedJids: [] };
     }
     const meta = await getGroupMeta(jid);
@@ -981,7 +977,7 @@ export async function attachWebInboxToSocket(
       return null;
     }
 
-    const group = isGroupJid(remoteJid);
+    const group = isJidGroup(remoteJid) === true;
     // Drop echoes of messages the gateway itself sent (tracked by sendTrackedMessage).
     // Applies to both groups and DMs/self-chat — without this, self-chat mode
     // re-processes the bot's own replies as new inbound user messages.


### PR DESCRIPTION
Closes #106123

## What Problem This Solves

The WhatsApp inbound path carries local fallback copies of helpers that are guaranteed by the exact pinned Baileys package. Those unreachable branches add maintenance surface and can drift from the dependency behavior they duplicate.

## Why This Change Was Made

Call Baileys' public message, JID, and disconnect helpers directly while retaining OpenClaw's separate future-envelope traversal. This removes 104 net lines without changing the production path.

## User Impact

No intended user-visible behavior change. WhatsApp inbound handling now has less duplicated code and follows the pinned dependency contract directly.

## Evidence

- `corepack pnpm test:extension whatsapp`: 89 files and 1,062 tests passed.
- `corepack pnpm check:changed`: passed on current `main`, including extension production/test typechecks, targeted lint, formatting, dependency guards, and import-cycle checks.
- Blacksmith Testbox: `tbx_01kxd5f8ahss209k574359zyf2` (`pearl-prawn-6349`), Actions run `29231661768`.
- Fresh isolated autoreview: clean; no accepted or actionable findings (0.94 correctness).
- Exact `baileys@7.0.0-rc.13` runtime source and declarations inspected for every reused export.

AI-assisted: yes — dependency audit, implementation, and verification were performed with Codex.
