### PR TITLE
fix(ci): allow read-only state database boundary

### DIFF
--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -38,6 +38,7 @@ const rawSqliteAllowPathGroups = {
     "src/infra/sqlite-user-version.ts",
     "src/infra/sqlite-wal.ts",
     "src/state/openclaw-agent-db.ts",
+    "src/state/openclaw-state-db-readonly.ts",
     "src/state/openclaw-state-db.ts",
     "src/state/sqlite-schema-shape.test-support.ts",
   ],


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails the Kysely architecture guard because the intentional read-only state database boundary from #106103 was omitted from the explicit raw SQLite allowlist.

## Why This Change Was Made

Adds `src/state/openclaw-state-db-readonly.ts` to the database lifecycle/schema/transaction/PRAGMA allowlist group. This keeps the guard fail-closed for new raw SQLite access while recognizing the existing short-lived read-only database lifecycle owner.

This is the clean, narrow replacement for the allowlist portion of #106104; that branch also contains unrelated release-monitor polling changes and cannot be updated by maintainers.

## User Impact

No runtime behavior changes. Architecture CI can validate unrelated changes again without weakening the Kysely/raw-SQL guard.

## Evidence

- `git diff --check`
- `oxfmt --check scripts/check-kysely-guardrails.mjs`
- Testbox `tbx_01kxd3s3086e3wk1sxv78e66s0`, run https://github.com/openclaw/openclaw/actions/runs/29230099877: `node scripts/check-kysely-guardrails.mjs` passes
- Fresh autoreview: no findings, confidence 0.94

