### PR TITLE
fix(googlechat): keep accounts.default streaming when doctor migrates named accounts [AI-assisted]

### DIFF
--- a/extensions/googlechat/src/doctor-contract.test.ts
+++ b/extensions/googlechat/src/doctor-contract.test.ts
@@ -110,4 +110,56 @@ describe("googlechat doctor contract", () => {
     const second = normalizeCompatibilityConfig({ cfg: result.config });
     expect(second.changes).toEqual([]);
   });
+
+  it("seeds named accounts from accounts.default over root (layered inheritance)", () => {
+    // Regression for #105940: doctor must not drop accounts.default block
+    // streaming when materializing a named account that only had chunkMode.
+    // Google Chat runtime resolves named accounts as {...accounts.default, ...named}
+    // (accounts.ts), so a materialized named-account streaming object must
+    // inherit accounts.default.streaming fields, not only the root streaming.
+    const result = normalizeCompatibilityConfig({
+      cfg: {
+        channels: {
+          googlechat: {
+            accounts: {
+              default: { blockStreaming: true },
+              support: { chunkMode: "newline" },
+            },
+          },
+        },
+      } as never,
+    });
+    const googlechat = result.config.channels?.googlechat as unknown as Record<string, unknown>;
+    const accounts = googlechat.accounts as Record<string, Record<string, unknown>>;
+    expect(accounts.default?.streaming).toEqual({ block: { enabled: true } });
+    expect(accounts.support?.streaming).toEqual({
+      chunkMode: "newline",
+      block: { enabled: true },
+    });
+    // Idempotent: a second pass makes no further changes.
+    const second = normalizeCompatibilityConfig({ cfg: result.config });
+    expect(second.changes).toEqual([]);
+  });
+
+  it("resolves the default account case-insensitively when seeding named accounts", () => {
+    const result = normalizeCompatibilityConfig({
+      cfg: {
+        channels: {
+          googlechat: {
+            accounts: {
+              Default: { blockStreaming: true },
+              support: { chunkMode: "newline" },
+            },
+          },
+        },
+      } as never,
+    });
+    const googlechat = result.config.channels?.googlechat as unknown as Record<string, unknown>;
+    const accounts = googlechat.accounts as Record<string, Record<string, unknown>>;
+    expect(accounts.Default?.streaming).toEqual({ block: { enabled: true } });
+    expect(accounts.support?.streaming).toEqual({
+      chunkMode: "newline",
+      block: { enabled: true },
+    });
+  });
 });

--- a/extensions/googlechat/src/doctor-contract.ts
+++ b/extensions/googlechat/src/doctor-contract.ts
@@ -8,16 +8,18 @@ import { asObjectRecord, defineChannelAliasMigration } from "openclaw/plugin-sdk
 
 type GoogleChatChannelsConfig = NonNullable<OpenClawConfig["channels"]>;
 
-// Google Chat's nested streaming schema is delivery-only ({chunkMode, block});
+// Googlechat's nested streaming schema is delivery-only ({chunkMode, block});
 // it has no preview mode (legacy streamMode is removed outright above), so
 // only the delivery flat aliases migrate. Account merge replaces the root
 // streaming object wholesale (resolveMergedAccountConfig without a streaming
-// deep-merge), so migration seeds materialized account objects with the
-// inherited root settings.
+// deep-merge), and named accounts layer as {...accounts.default, ...named}
+// (accounts.ts), so a materialized named-account streaming object must inherit
+// accounts.default fields over root ones. Seeding is handled below instead of
+// via accountStreamingReplacesRoot because the generic root-only seed would
+// drop accounts.default block-streaming when a named account only had chunkMode.
 const streamingAliasMigration = defineChannelAliasMigration({
   channelId: "googlechat",
   streaming: { defaultMode: "partial", deliveryOnly: true },
-  accountStreamingReplacesRoot: true,
 });
 
 function hasLegacyGoogleChatStreamMode(value: unknown): boolean {
@@ -189,14 +191,132 @@ function normalizeRetiredGoogleChatKeys(cfg: OpenClawConfig): ChannelDoctorConfi
   };
 }
 
+/** Deep-fills fields missing from target with copies of source values. */
+function fillMissingStreamingFields(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): { value: Record<string, unknown>; filled: boolean } {
+  let filled = false;
+  const value = { ...target };
+  for (const [key, sourceValue] of Object.entries(source)) {
+    if (sourceValue === undefined) {
+      continue;
+    }
+    const existing = value[key];
+    if (existing === undefined) {
+      value[key] = structuredClone(sourceValue);
+      filled = true;
+      continue;
+    }
+    const existingRecord = asObjectRecord(existing);
+    const sourceRecord = asObjectRecord(sourceValue);
+    if (!existingRecord || !sourceRecord) {
+      continue;
+    }
+    const merged = fillMissingStreamingFields(existingRecord, sourceRecord);
+    if (merged.filled) {
+      value[key] = merged.value;
+      filled = true;
+    }
+  }
+  return { value, filled };
+}
+
+// The runtime merge replaces `streaming` wholesale per layer (named account >
+// accounts.default > root), while the retired flat keys resolved per key
+// across those layers. Account objects that migration materializes must carry
+// the settings the account previously inherited, or `doctor --fix` silently
+// changes effective delivery behavior for that account.
+function seedMigratedAccountStreaming(params: {
+  cfg: OpenClawConfig;
+  accountsWithoutStreamingBefore: ReadonlySet<string>;
+  changes: string[];
+}): OpenClawConfig {
+  const channels = params.cfg.channels as Record<string, unknown> | undefined;
+  const entry = asObjectRecord(channels?.googlechat);
+  const accounts = asObjectRecord(entry?.accounts);
+  if (!entry || !accounts) {
+    return params.cfg;
+  }
+  const rootStreaming = asObjectRecord(entry.streaming);
+  // Account lookup treats keys case-insensitively (resolveAccountEntry), so
+  // `accounts.Default` is the default account too.
+  const defaultKey = Object.hasOwn(accounts, "default")
+    ? "default"
+    : Object.keys(accounts).find((key) => key.trim().toLowerCase() === "default");
+
+  let accountsChanged = false;
+  const nextAccounts = { ...accounts };
+  // Seed the default account first: its final object is the inheritance
+  // source for named accounts (default replaces root wholesale when set).
+  const seedOrder = Object.keys(accounts).toSorted((left, right) =>
+    left === defaultKey ? -1 : right === defaultKey ? 1 : left.localeCompare(right),
+  );
+  for (const accountId of seedOrder) {
+    const account = asObjectRecord(nextAccounts[accountId]);
+    const created = asObjectRecord(account?.streaming);
+    if (!account || !created || !params.accountsWithoutStreamingBefore.has(accountId)) {
+      continue;
+    }
+    const defaultStreaming = defaultKey
+      ? asObjectRecord(asObjectRecord(nextAccounts[defaultKey])?.streaming)
+      : null;
+    const inheritedSource =
+      accountId === defaultKey ? rootStreaming : (defaultStreaming ?? rootStreaming);
+    if (!inheritedSource) {
+      continue;
+    }
+    const seeded = fillMissingStreamingFields(created, inheritedSource);
+    if (!seeded.filled) {
+      continue;
+    }
+    nextAccounts[accountId] = { ...account, streaming: seeded.value };
+    accountsChanged = true;
+    const sourcePath =
+      accountId === defaultKey
+        ? "channels.googlechat.streaming"
+        : "effective channels.googlechat streaming defaults";
+    params.changes.push(
+      `Copied ${sourcePath} into channels.googlechat.accounts.${accountId}.streaming to keep inherited settings while migrating flat streaming keys.`,
+    );
+  }
+  if (!accountsChanged) {
+    return params.cfg;
+  }
+  return {
+    ...params.cfg,
+    channels: {
+      ...channels,
+      googlechat: { ...entry, accounts: nextAccounts },
+    },
+  } as OpenClawConfig;
+}
+
 export function normalizeCompatibilityConfig({
   cfg,
 }: {
   cfg: OpenClawConfig;
 }): ChannelDoctorConfigMutation {
   const retired = normalizeRetiredGoogleChatKeys(cfg);
-  return streamingAliasMigration.normalizeChannelConfig({
+  const accountsBefore = asObjectRecord(
+    asObjectRecord((retired.config.channels as Record<string, unknown> | undefined)?.googlechat)
+      ?.accounts,
+  );
+  const accountsWithoutStreamingBefore = new Set(
+    Object.entries(accountsBefore ?? {})
+      .filter(([, account]) => asObjectRecord(account)?.streaming === undefined)
+      .map(([accountId]) => accountId),
+  );
+  const aliases = streamingAliasMigration.normalizeChannelConfig({
     cfg: retired.config,
     changes: retired.changes,
   });
+  return {
+    config: seedMigratedAccountStreaming({
+      cfg: aliases.config,
+      accountsWithoutStreamingBefore,
+      changes: aliases.changes,
+    }),
+    changes: aliases.changes,
+  };
 }


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

Closes #105940

## What Problem This Solves

Fixes an issue where `openclaw doctor --fix` silently drops an inherited Google Chat block-streaming setting from named accounts. When `channels.googlechat.accounts.default.blockStreaming: true` is combined with a named account that has a flat streaming key to migrate (e.g. `accounts.support.chunkMode: "newline"`), the migration materializes `accounts.support.streaming` from the named account's `chunkMode` only and seeds the rest from the **root** `channels.googlechat.streaming` - which has no `block` field. At runtime, named-account resolution layers `{...accounts.default, ...named}` and replaces `streaming` wholesale, so `block.enabled` disappears and block streaming is silently disabled for that account.

## Why This Change Was Made

Google Chat's doctor contract used the generic `accountStreamingReplacesRoot: true` seed, which only copies root `streaming` fields into a materialized account object. It never consulted `channels.googlechat.accounts.default.streaming`, even though the runtime (`extensions/googlechat/src/accounts.ts`) layers `accounts.default` between root and the named account. WhatsApp's doctor contract already solves this exact `accounts.default` inheritance shape (#105709) with a custom `seedMigratedAccountStreaming` that seeds the default account first (from root), then seeds named accounts from the default (falling back to root), case-insensitively, and only for accounts that had no `streaming` object before migration.

This PR ports that already-merged WhatsApp pattern to Google Chat:
- Drops `accountStreamingReplacesRoot: true` from `defineChannelAliasMigration`.
- Adds `fillMissingStreamingFields` + `seedMigratedAccountStreaming` (mirroring `extensions/whatsapp/src/doctor-contract.ts`), scoped to `channels.googlechat`.
- Wraps `normalizeCompatibilityConfig` to record which accounts lacked `streaming` before the alias migration, run the alias migration, then seed those materialized objects.

The change is local to `extensions/googlechat/src/doctor-contract.ts`; the shared `channel-compat-normalization.ts` and the other five channels' migrations are untouched, so deep-merge channels (slack, imessage) and the existing root-only seed path are unaffected.

## User Impact

Operators running `openclaw doctor --fix` on a Google Chat config that sets `accounts.default.blockStreaming` keep block streaming enabled on named accounts after migration, instead of silently losing it. Configs without `accounts.default` streaming behave exactly as before (root seed).

## Evidence

Real behavior captured by driving the real `normalizeCompatibilityConfig` against a config with `accounts.default.blockStreaming: true` + `accounts.support.chunkMode: "newline"`. Regression tests live in `extensions/googlechat/src/doctor-contract.test.ts` (both new tests fail on `main`, pass with the fix - failing-first).

**Before fix (current `main`)** - the named `support` account's materialized `streaming` only carries its own `chunkMode`; `block.enabled` from `accounts.default` is lost. Actual `result.config.channels.googlechat.accounts.support.streaming` returned by `normalizeCompatibilityConfig`:

```
{
  "changes": [
    "Moved channels.googlechat.accounts.default.blockStreaming -> channels.googlechat.accounts.default.streaming.block.enabled.",
    "Moved channels.googlechat.accounts.support.chunkMode -> channels.googlechat.accounts.support.streaming.chunkMode."
  ],
  "defaultStreaming": { "block": { "enabled": true } },
  "supportStreaming": { "chunkMode": "newline" }
}
```

**After fix** - the named `support` account inherits `block.enabled` from `accounts.default`, matching the pre-migration effective delivery settings. Actual return value:

```
{
  "changes": [
    "Moved channels.googlechat.accounts.default.blockStreaming -> channels.googlechat.accounts.default.streaming.block.enabled.",
    "Moved channels.googlechat.accounts.support.chunkMode -> channels.googlechat.accounts.support.streaming.chunkMode.",
    "Copied effective channels.googlechat streaming defaults into channels.googlechat.accounts.support.streaming to keep inherited settings while migrating flat streaming keys."
  ],
  "defaultStreaming": { "block": { "enabled": true } },
  "supportStreaming": { "chunkMode": "newline", "block": { "enabled": true } }
}
```

A second `normalizeCompatibilityConfig` pass returns no changes (idempotent), and the default account is resolved case-insensitively (`Default` seeds named accounts the same way). The existing root-seeding test (`moves flat delivery aliases at root and account level with root seeding`) still passes - configs without `accounts.default` keep the prior root-only behavior.

Local verification:

- `node scripts/run-vitest.mjs extensions/googlechat/src/doctor-contract.test.ts` - 6/6 pass (2 new regression tests fail on `main`, pass after the fix; 4 existing tests unchanged).
- `node scripts/run-vitest.mjs extensions/whatsapp/src/doctor-contract.test.ts` - 5/5 pass (the pattern this ports from is unchanged).
- `oxlint` + `oxfmt --check` on changed files - pass.
- `pnpm tsgo:extensions` + `pnpm tsgo:extensions:test` - pass (no type errors).

Not tested: the live `openclaw doctor --fix` CLI invocation and a real Google Chat account run (the proof drives the real `normalizeCompatibilityConfig` function directly against the exact config shape the issue describes; the migration is a pure config-to-config transform with no Google Chat runtime dependency).
