### PR TITLE
docs(release): add a release-train scope contract

### DIFF
--- a/.agents/skills/release-openclaw-maintainer/SKILL.md
+++ b/.agents/skills/release-openclaw-maintainer/SKILL.md
@@ -57,6 +57,17 @@ GHSA-specific advisory work outside this skill.
   ## Approved exceptions
   ```
 
+- Under `Approved exceptions`, record one decision per PR using exactly one of
+  these forms. An optional Markdown list marker is allowed:
+
+  ```md
+  #PR: pending (https://github.com/...decision...)
+  #PR: approved by @captain (https://github.com/...decision...)
+  #PR: rejected by @captain (https://github.com/...decision...)
+  ```
+
+  Use `None.` when no exception entries exist. Unknown, negated, duplicate,
+  missing-approver, or missing-link forms are incomplete and never approved.
 - The allowed classes are exactly `release-preparation`, `release-blocker`,
   `exact-backport`, `release-infrastructure`, `changelog-only`, and `exception`.
   Pull requests targeting `release/**` use this copyable metadata block:

--- a/.agents/skills/release-openclaw-maintainer/SKILL.md
+++ b/.agents/skills/release-openclaw-maintainer/SKILL.md
@@ -31,6 +31,55 @@ GHSA-specific advisory work outside this skill.
   user-facing documentation contract changed.
 - Normal release work happens on a branch cut from `main`, not directly on
   `main`. Use `release/YYYY.M.PATCH` for the branch name.
+- Before creating a new `release/YYYY.M.PATCH` branch, create one
+  maintainer-owned GitHub issue for that train. This prospective scope contract
+  complements the Code SHA / Release SHA evidence model; it does not freeze
+  `main`, and normal development continues there.
+- The train issue is authoritative and records: release train, release captain,
+  goal, non-goals, cut SHA, allowed change classes, exit criteria, and approved
+  exceptions. Use this copyable template:
+
+  ```md
+  ## Release train
+
+  ## Release captain
+
+  ## Goal
+
+  ## Non-goals
+
+  ## Cut SHA
+
+  ## Allowed change classes
+
+  ## Exit criteria
+
+  ## Approved exceptions
+  ```
+
+- The allowed classes are exactly `release-preparation`, `release-blocker`,
+  `exact-backport`, `release-infrastructure`, `changelog-only`, and `exception`.
+  Pull requests targeting `release/**` use this copyable metadata block:
+
+  ```md
+  Release train: #issue
+  Release class: <class>
+  Blocker: #issue | not applicable
+  Source on main: full SHA and PR | not applicable
+  Exception decision: contract link | not required
+  ```
+
+- Explicit metadata and the train issue are authoritative; commit prefixes are
+  signals only. Apply classes deterministically: `release-preparation` is
+  restricted to expected version and generated release surfaces;
+  `release-blocker` cites its blocker issue; `exact-backport` cites a full SHA
+  on `main` and must be patch-equivalent; `release-infrastructure` covers
+  release-owned operational machinery; `changelog-only` changes exactly
+  `CHANGELOG.md`; and `exception` requires the named release captain's approval
+  plus a listing in the train issue.
+- The initial ClawSweeper integration is advisory. A ClawSweeper required
+  check needs a completed shadow train and separate maintainer approval before
+  it can become required.
 - If the operator asks for a release without saying stable/full, default to
   beta only. Continue from beta to stable only when the operator explicitly asks
   for the full release or an automated beta-and-stable train.

--- a/.agents/skills/release-openclaw-maintainer/SKILL.md
+++ b/.agents/skills/release-openclaw-maintainer/SKILL.md
@@ -58,7 +58,7 @@ GHSA-specific advisory work outside this skill.
   ```
 
 - Under `Approved exceptions`, record one decision per PR using exactly one of
-  these forms. An optional Markdown list marker is allowed:
+  these forms. Only an optional `-` or `*` Markdown list marker is accepted:
 
   ```md
   #PR: pending (https://github.com/...decision...)

--- a/.agents/skills/release-openclaw-maintainer/SKILL.md
+++ b/.agents/skills/release-openclaw-maintainer/SKILL.md
@@ -61,13 +61,16 @@ GHSA-specific advisory work outside this skill.
   these forms. Only an optional `-` or `*` Markdown list marker is accepted:
 
   ```md
-  #PR: pending (https://github.com/...decision...)
-  #PR: approved by @captain (https://github.com/...decision...)
-  #PR: rejected by @captain (https://github.com/...decision...)
+  #PR: pending (https://github.com/OWNER/REPO/issues/NUMBER#issuecomment-ID)
+  #PR: approved by @captain (https://github.com/OWNER/REPO/issues/NUMBER#issuecomment-ID)
+  #PR: rejected by @captain (https://github.com/OWNER/REPO/pull/NUMBER#issuecomment-ID)
   ```
 
-  Use `None.` when no exception entries exist. Unknown, negated, duplicate,
-  missing-approver, or missing-link forms are incomplete and never approved.
+  The link must be a GitHub issue or pull request decision-comment URL ending in
+  `#issuecomment-ID`. Use `None.` when no exception entries exist. Unknown,
+  negated, duplicate, missing-approver, or missing-link forms are incomplete and
+  never approved.
+
 - The allowed classes are exactly `release-preparation`, `release-blocker`,
   `exact-backport`, `release-infrastructure`, `changelog-only`, and `exception`.
   Pull requests targeting `release/**` use this copyable metadata block:
@@ -77,7 +80,7 @@ GHSA-specific advisory work outside this skill.
   Release class: <class>
   Blocker: #issue | not applicable
   Source on main: full SHA and PR | not applicable
-  Exception decision: contract link | not required
+  Exception decision: same decision-comment URL listed in the train issue | not required
   ```
 
 - Explicit metadata and the train issue are authoritative; commit prefixes are
@@ -87,7 +90,8 @@ GHSA-specific advisory work outside this skill.
   on `main` and must be patch-equivalent; `release-infrastructure` covers
   release-owned operational machinery; `changelog-only` changes exactly
   `CHANGELOG.md`; and `exception` requires the named release captain's approval
-  plus a listing in the train issue.
+  plus a listing in the train issue, with the PR repeating the same
+  decision-comment URL.
 - The initial ClawSweeper integration is advisory. A ClawSweeper required
   check needs a completed shadow train and separate maintainer approval before
   it can become required.

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -8430,6 +8430,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H2: Version naming
   - H2: Release cadence
+  - H2: Release-train scope contract
   - H2: Monthly npm-only extended-stable publication
   - H2: Regular release operator checklist
   - H2: Stable main closeout

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -73,6 +73,18 @@ must include this copyable template:
 ## Approved exceptions
 ```
 
+Under `Approved exceptions`, record one decision per PR using exactly one of
+these forms. An optional Markdown list marker is allowed:
+
+```md
+#PR: pending (https://github.com/...decision...)
+#PR: approved by @captain (https://github.com/...decision...)
+#PR: rejected by @captain (https://github.com/...decision...)
+```
+
+Use `None.` when no exception entries exist. Unknown, negated, duplicate,
+missing-approver, or missing-link forms are incomplete and never approved.
+
 The allowed classes are exactly:
 
 - `release-preparation`

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -77,13 +77,15 @@ Under `Approved exceptions`, record one decision per PR using exactly one of
 these forms. Only an optional `-` or `*` Markdown list marker is accepted:
 
 ```md
-#PR: pending (https://github.com/...decision...)
-#PR: approved by @captain (https://github.com/...decision...)
-#PR: rejected by @captain (https://github.com/...decision...)
+#PR: pending (https://github.com/OWNER/REPO/issues/NUMBER#issuecomment-ID)
+#PR: approved by @captain (https://github.com/OWNER/REPO/issues/NUMBER#issuecomment-ID)
+#PR: rejected by @captain (https://github.com/OWNER/REPO/pull/NUMBER#issuecomment-ID)
 ```
 
-Use `None.` when no exception entries exist. Unknown, negated, duplicate,
-missing-approver, or missing-link forms are incomplete and never approved.
+The link must be a GitHub issue or pull request decision-comment URL ending in
+`#issuecomment-ID`. Use `None.` when no exception entries exist. Unknown,
+negated, duplicate, missing-approver, or missing-link forms are incomplete and
+never approved.
 
 The allowed classes are exactly:
 
@@ -101,7 +103,7 @@ Release train: #issue
 Release class: <class>
 Blocker: #issue | not applicable
 Source on main: full SHA and PR | not applicable
-Exception decision: contract link | not required
+Exception decision: same decision-comment URL listed in the train issue | not required
 ```
 
 The explicit metadata and the train issue are authoritative; commit prefixes
@@ -114,7 +116,7 @@ are signals only. Apply the classes deterministically:
 - `release-infrastructure` covers release-owned operational machinery.
 - `changelog-only` changes exactly `CHANGELOG.md`.
 - `exception` requires the named release captain's approval and a listing in the
-  train issue.
+  train issue; the PR repeats the same decision-comment URL.
 
 The initial ClawSweeper integration is advisory. A ClawSweeper required check
 needs a completed shadow train and separate maintainer approval before it can

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -44,6 +44,70 @@ Tideclaw alpha builds are a separate internal prerelease track (npm dist-tag `al
 - If a beta tag has been pushed or published and needs a fix, maintainers cut the next `-beta.N` tag instead of deleting or recreating the old one
 - Detailed release procedure, approvals, credentials, and recovery notes are maintainer-only
 
+## Release-train scope contract
+
+This prospective maintainer-owned contract applies only to a named
+`release/YYYY.M.PATCH` branch. It complements the existing Code SHA and
+Release SHA evidence model; it does not change that model or freeze `main`.
+Normal development continues on `main`.
+
+Before creating a new `release/YYYY.M.PATCH` branch, create one maintainer-owned
+GitHub issue for that train. The issue is the authoritative scope record and
+must include this copyable template:
+
+```md
+## Release train
+
+## Release captain
+
+## Goal
+
+## Non-goals
+
+## Cut SHA
+
+## Allowed change classes
+
+## Exit criteria
+
+## Approved exceptions
+```
+
+The allowed classes are exactly:
+
+- `release-preparation`
+- `release-blocker`
+- `exact-backport`
+- `release-infrastructure`
+- `changelog-only`
+- `exception`
+
+Pull requests targeting `release/**` include this copyable metadata block:
+
+```md
+Release train: #issue
+Release class: <class>
+Blocker: #issue | not applicable
+Source on main: full SHA and PR | not applicable
+Exception decision: contract link | not required
+```
+
+The explicit metadata and the train issue are authoritative; commit prefixes
+are signals only. Apply the classes deterministically:
+
+- `release-preparation` is restricted to expected version and generated release
+  surfaces.
+- `release-blocker` cites its blocker issue.
+- `exact-backport` cites a full SHA on `main` and must be patch-equivalent.
+- `release-infrastructure` covers release-owned operational machinery.
+- `changelog-only` changes exactly `CHANGELOG.md`.
+- `exception` requires the named release captain's approval and a listing in the
+  train issue.
+
+The initial ClawSweeper integration is advisory. A ClawSweeper required check
+needs a completed shadow train and separate maintainer approval before it can
+become required.
+
 ## Monthly npm-only extended-stable publication
 
 This is a dedicated exception to the regular release procedure below. For a

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -74,7 +74,7 @@ must include this copyable template:
 ```
 
 Under `Approved exceptions`, record one decision per PR using exactly one of
-these forms. An optional Markdown list marker is allowed:
+these forms. Only an optional `-` or `*` Markdown list marker is accepted:
 
 ```md
 #PR: pending (https://github.com/...decision...)


### PR DESCRIPTION
Related: #73537. Companion read-only audit draft: openclaw/clawsweeper#536.

## What problem this solves

OpenClaw’s release workflow now distinguishes Code SHA and Release SHA evidence clearly, but a release train does not yet have one prospective scope record that states its goal, non-goals, allowed change classes, exit criteria, captain, and approved exceptions.

This can make an otherwise well-validated release harder to reason about when changes are considered between branch cut and publication.

## What this adds

This adds a small maintainer-owned release-train contract before a new `release/YYYY.M.PATCH` branch is created, plus explicit metadata for pull requests targeting `release/**`. The public release reference and maintainer skill use the same copyable fields, six change classes, and explicit exception-decision grammar.

The policy is prospective and advisory-first:

- normal development continues on `main`;
- `2026.7.1` remains retrospective evidence and is not gated;
- PR metadata is authoritative while title/path heuristics are signals only;
- incomplete evidence never means clear;
- release inclusion and exception decisions remain maintainer-owned;
- any required ClawSweeper check needs one complete shadow train plus separate maintainer-admin approval.

## Staged proof

The companion ClawSweeper draft adds only the deterministic read-only audit foundation. Report publishing, advisory Check Runs, and the shadow-train evaluation remain dependency-ordered stages. This documentation is the shared contract needed to exercise that shadow; it does not itself enable a workflow, Check Run, ruleset, or release gate.

## Evidence

- `pnpm docs:list`
- `pnpm check:docs`
- `git diff --check e460ad1536e6e038847702ae09be704325182187..c8417a6d5064cebbc7b44225e137e9c263661085`
- generated `docs/docs_map.md` is current against the rebased base
- two sequential read-only reviews: architecture/correctness, then workflow/permissions/safety

Changed only:

- `docs/reference/RELEASING.md`
- `.agents/skills/release-openclaw-maintainer/SKILL.md`
- generated `docs/docs_map.md`

There is no runtime, package, changelog, update-channel, publication, current-train, or ruleset change in this PR. Passing docs checks establishes documentation PR readiness only; it does not approve a merge or release.
