### PR TITLE
feat(ios): guide first launch through pairing explainer and permissions

### DIFF
--- a/apps/.i18n/apple-translation-contradictions.json
+++ b/apps/.i18n/apple-translation-contradictions.json
@@ -382,6 +382,22 @@
       ]
     },
     {
+      "locale": "ar",
+      "source": "Allow",
+      "translations": [
+        "السماح",
+        "سماح"
+      ]
+    },
+    {
+      "locale": "tr",
+      "source": "Allow",
+      "translations": [
+        "İzin Ver",
+        "İzin ver"
+      ]
+    },
+    {
       "locale": "de",
       "source": "Allow Always",
       "translations": [
@@ -1427,6 +1443,22 @@
       "translations": [
         "Безпека з'єднання",
         "Безпека з’єднання"
+      ]
+    },
+    {
+      "locale": "ja-JP",
+      "source": "Continue",
+      "translations": [
+        "続ける",
+        "続行"
+      ]
+    },
+    {
+      "locale": "pl",
+      "source": "Continue",
+      "translations": [
+        "Dalej",
+        "Kontynuuj"
       ]
     },
     {
@@ -2679,27 +2711,11 @@
       ]
     },
     {
-      "locale": "ar",
-      "source": "Enabled",
-      "translations": [
-        "مفعّل",
-        "مُمكّن"
-      ]
-    },
-    {
       "locale": "es",
       "source": "Enabled",
       "translations": [
         "Activado",
         "Habilitado"
-      ]
-    },
-    {
-      "locale": "hi",
-      "source": "Enabled",
-      "translations": [
-        "चालू",
-        "सक्षम"
       ]
     },
     {
@@ -2711,35 +2727,11 @@
       ]
     },
     {
-      "locale": "pl",
-      "source": "Enabled",
-      "translations": [
-        "Włączone",
-        "Włączono"
-      ]
-    },
-    {
       "locale": "pt-BR",
       "source": "Enabled",
       "translations": [
         "Ativado",
         "Habilitado"
-      ]
-    },
-    {
-      "locale": "sv",
-      "source": "Enabled",
-      "translations": [
-        "Aktiverad",
-        "Aktiverat"
-      ]
-    },
-    {
-      "locale": "th",
-      "source": "Enabled",
-      "translations": [
-        "เปิดใช้งานแล้ว",
-        "เปิดใช้แล้ว"
       ]
     },
     {
@@ -3380,6 +3372,198 @@
     },
     {
       "locale": "ja-JP",
+      "source": "Limited",
+      "translations": [
+        "制限あり",
+        "制限付き"
+      ]
+    },
+    {
+      "locale": "pl",
+      "source": "Limited",
+      "translations": [
+        "Ograniczone",
+        "Ograniczony"
+      ]
+    },
+    {
+      "locale": "ru",
+      "source": "Limited",
+      "translations": [
+        "Ограниченный доступ",
+        "Ограничено"
+      ]
+    },
+    {
+      "locale": "sv",
+      "source": "Limited",
+      "translations": [
+        "Begränsad",
+        "Begränsat"
+      ]
+    },
+    {
+      "locale": "vi",
+      "source": "Limited",
+      "translations": [
+        "Giới hạn",
+        "Hạn chế"
+      ]
+    },
+    {
+      "locale": "zh-TW",
+      "source": "Limited",
+      "translations": [
+        "受限",
+        "有限"
+      ]
+    },
+    {
+      "locale": "ar",
+      "source": "List, add, and complete reminders.",
+      "translations": [
+        "اسرد التذكيرات وأضِفها وأكملها.",
+        "عرض التذكيرات وإضافتها وإكمالها."
+      ]
+    },
+    {
+      "locale": "de",
+      "source": "List, add, and complete reminders.",
+      "translations": [
+        "Erinnerungen auflisten, hinzufügen und abschließen.",
+        "Erinnerungen auflisten, hinzufügen und als erledigt markieren."
+      ]
+    },
+    {
+      "locale": "es",
+      "source": "List, add, and complete reminders.",
+      "translations": [
+        "Consulta, añade y completa recordatorios.",
+        "Enumera, añade y completa recordatorios."
+      ]
+    },
+    {
+      "locale": "fa",
+      "source": "List, add, and complete reminders.",
+      "translations": [
+        "فهرست‌کردن، افزودن و تکمیل یادآورها.",
+        "یادآورها را فهرست، اضافه و کامل کنید."
+      ]
+    },
+    {
+      "locale": "fr",
+      "source": "List, add, and complete reminders.",
+      "translations": [
+        "Lister, ajouter et terminer des rappels.",
+        "Répertoriez, ajoutez et terminez des rappels."
+      ]
+    },
+    {
+      "locale": "hi",
+      "source": "List, add, and complete reminders.",
+      "translations": [
+        "रिमाइंडर की सूची देखें, जोड़ें और पूरा करें।",
+        "रिमाइंडर सूचीबद्ध करें, जोड़ें और पूर्ण करें।"
+      ]
+    },
+    {
+      "locale": "id",
+      "source": "List, add, and complete reminders.",
+      "translations": [
+        "Cantumkan, tambahkan, dan selesaikan pengingat.",
+        "Lihat, tambahkan, dan selesaikan pengingat."
+      ]
+    },
+    {
+      "locale": "it",
+      "source": "List, add, and complete reminders.",
+      "translations": [
+        "Elenca, aggiungi e completa i promemoria.",
+        "Elenca, aggiungi e completa promemoria."
+      ]
+    },
+    {
+      "locale": "ja-JP",
+      "source": "List, add, and complete reminders.",
+      "translations": [
+        "リマインダーの一覧表示、追加、完了を行います。",
+        "リマインダーを一覧表示、追加、完了します。"
+      ]
+    },
+    {
+      "locale": "ko",
+      "source": "List, add, and complete reminders.",
+      "translations": [
+        "미리 알림을 나열하고, 추가하고, 완료 처리합니다.",
+        "미리 알림을 조회하고 추가하거나 완료합니다."
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "List, add, and complete reminders.",
+      "translations": [
+        "Bekijk, voeg toe en voltooi herinneringen.",
+        "Geef herinneringen weer, voeg ze toe en voltooi ze."
+      ]
+    },
+    {
+      "locale": "pl",
+      "source": "List, add, and complete reminders.",
+      "translations": [
+        "Wyświetlaj listę przypomnień, dodawaj je i oznaczaj jako wykonane.",
+        "Wyświetlanie, dodawanie i oznaczanie przypomnień jako ukończone."
+      ]
+    },
+    {
+      "locale": "ru",
+      "source": "List, add, and complete reminders.",
+      "translations": [
+        "Просматривайте список напоминаний, добавляйте и отмечайте их как выполненные.",
+        "Просмотр, добавление и выполнение напоминаний."
+      ]
+    },
+    {
+      "locale": "sv",
+      "source": "List, add, and complete reminders.",
+      "translations": [
+        "Lista, lägg till och slutför påminnelser.",
+        "Visa, lägg till och slutför påminnelser."
+      ]
+    },
+    {
+      "locale": "th",
+      "source": "List, add, and complete reminders.",
+      "translations": [
+        "แสดงรายการ เพิ่ม และทำรายการเตือนความจำให้เสร็จ",
+        "แสดงรายการ เพิ่ม และทำรายการเตือนความจำให้เสร็จสิ้น"
+      ]
+    },
+    {
+      "locale": "uk",
+      "source": "List, add, and complete reminders.",
+      "translations": [
+        "Перегляд, додавання та виконання нагадувань.",
+        "Переглядайте список, додавайте й позначайте нагадування як виконані."
+      ]
+    },
+    {
+      "locale": "vi",
+      "source": "List, add, and complete reminders.",
+      "translations": [
+        "Liệt kê, thêm và hoàn thành lời nhắc.",
+        "Liệt kê, thêm và hoàn tất lời nhắc."
+      ]
+    },
+    {
+      "locale": "zh-TW",
+      "source": "List, add, and complete reminders.",
+      "translations": [
+        "列出、新增並完成提醒事項。",
+        "列出、新增及完成提醒事項。"
+      ]
+    },
+    {
+      "locale": "ja-JP",
       "source": "Listening",
       "translations": [
         "リスニング中",
@@ -3571,6 +3755,30 @@
       "translations": [
         "Loading",
         "載入中"
+      ]
+    },
+    {
+      "locale": "fr",
+      "source": "Location",
+      "translations": [
+        "Localisation",
+        "Position"
+      ]
+    },
+    {
+      "locale": "ru",
+      "source": "Location",
+      "translations": [
+        "Геопозиция",
+        "Местоположение"
+      ]
+    },
+    {
+      "locale": "uk",
+      "source": "Location",
+      "translations": [
+        "Геодані",
+        "Місцезнаходження"
       ]
     },
     {
@@ -4529,6 +4737,14 @@
       ]
     },
     {
+      "locale": "de",
+      "source": "Notifications",
+      "translations": [
+        "Benachrichtigungen",
+        "Mitteilungen"
+      ]
+    },
+    {
       "locale": "sv",
       "source": "Notifications",
       "translations": [
@@ -4868,11 +5084,43 @@
       ]
     },
     {
+      "locale": "fr",
+      "source": "Open Settings",
+      "translations": [
+        "Ouvrir Réglages",
+        "Ouvrir les paramètres"
+      ]
+    },
+    {
+      "locale": "hi",
+      "source": "Open Settings",
+      "translations": [
+        "Settings खोलें",
+        "सेटिंग्स खोलें"
+      ]
+    },
+    {
       "locale": "it",
       "source": "Open Settings",
       "translations": [
         "Apri Impostazioni",
         "Apri impostazioni"
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "Open Settings",
+      "translations": [
+        "Instellingen openen",
+        "Open Instellingen"
+      ]
+    },
+    {
+      "locale": "pl",
+      "source": "Open Settings",
+      "translations": [
+        "Otwórz Ustawienia",
+        "Otwórz ustawienia"
       ]
     },
     {
@@ -4884,11 +5132,43 @@
       ]
     },
     {
+      "locale": "ru",
+      "source": "Open Settings",
+      "translations": [
+        "Открыть Настройки",
+        "Открыть настройки"
+      ]
+    },
+    {
+      "locale": "sv",
+      "source": "Open Settings",
+      "translations": [
+        "Öppna Inställningar",
+        "Öppna inställningar"
+      ]
+    },
+    {
+      "locale": "uk",
+      "source": "Open Settings",
+      "translations": [
+        "Відкрити Параметри",
+        "Відкрити налаштування"
+      ]
+    },
+    {
       "locale": "vi",
       "source": "Open Settings",
       "translations": [
         "Mở Cài đặt",
         "Mở cài đặt"
+      ]
+    },
+    {
+      "locale": "zh-TW",
+      "source": "Open Settings",
+      "translations": [
+        "開啟「設定」",
+        "開啟設定"
       ]
     },
     {
@@ -5199,22 +5479,6 @@
       "translations": [
         "配對",
         "配對中"
-      ]
-    },
-    {
-      "locale": "nl",
-      "source": "Photos",
-      "translations": [
-        "Foto's",
-        "Foto’s"
-      ]
-    },
-    {
-      "locale": "sv",
-      "source": "Photos",
-      "translations": [
-        "Bilder",
-        "Foton"
       ]
     },
     {

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -21339,7 +21339,15 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 77,
+      "line": 70,
+      "path": "apps/ios/Sources/Onboarding/OnboardingPermissionsStep.swift",
+      "source": "Limited",
+      "surface": "apple",
+      "id": "native.apple.5f425282ece878eb"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 78,
       "path": "apps/ios/Sources/Onboarding/OnboardingPermissionsStep.swift",
       "source": "Allow",
       "surface": "apple",
@@ -21347,11 +21355,19 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 79,
+      "line": 80,
       "path": "apps/ios/Sources/Onboarding/OnboardingPermissionsStep.swift",
       "source": "Open Settings",
       "surface": "apple",
       "id": "native.apple.f591e16105268e99"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 82,
+      "path": "apps/ios/Sources/Onboarding/OnboardingPermissionsStep.swift",
+      "source": "Manage",
+      "surface": "apple",
+      "id": "native.apple.12ed416835c36555"
     },
     {
       "kind": "conditional-branch",
@@ -21771,7 +21787,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 194,
+      "line": 196,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "QR Scanner Unavailable",
       "surface": "apple",
@@ -21779,7 +21795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 200,
+      "line": 202,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "OK",
       "surface": "apple",
@@ -21787,7 +21803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 305,
+      "line": 307,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Scan Setup Code",
       "surface": "apple",
@@ -21795,7 +21811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 313,
+      "line": 315,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -21803,7 +21819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 320,
+      "line": 322,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Photos",
       "surface": "apple",
@@ -21811,7 +21827,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 361,
+      "line": 363,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Back",
       "surface": "apple",
@@ -21819,7 +21835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 369,
+      "line": 371,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Close",
       "surface": "apple",
@@ -21827,7 +21843,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 395,
+      "line": 397,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Dismiss Keyboard",
       "surface": "apple",
@@ -21835,13 +21851,7 @@
     },
     {
       "kind": "ui-call",
-<<<<<<< HEAD
-      "line": 446,
-||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
-      "line": 444,
-=======
-      "line": 450,
->>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 452,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Mode",
       "surface": "apple",
@@ -21849,13 +21859,7 @@
     },
     {
       "kind": "ui-call",
-<<<<<<< HEAD
-      "line": 447,
-||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
-      "line": 445,
-=======
-      "line": 451,
->>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 453,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Discovery",
       "surface": "apple",
@@ -21863,13 +21867,7 @@
     },
     {
       "kind": "ui-call",
-<<<<<<< HEAD
-      "line": 449,
-||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
-      "line": 447,
-=======
-      "line": 453,
->>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 455,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Status",
       "surface": "apple",
@@ -21877,13 +21875,7 @@
     },
     {
       "kind": "ui-call",
-<<<<<<< HEAD
-      "line": 467,
-||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
-      "line": 465,
-=======
-      "line": 471,
->>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 473,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Choose a mode first.",
       "surface": "apple",
@@ -21891,13 +21883,7 @@
     },
     {
       "kind": "ui-call",
-<<<<<<< HEAD
-      "line": 472,
-||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
-      "line": 470,
-=======
-      "line": 476,
->>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 478,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Back to Mode Selection",
       "surface": "apple",
@@ -21905,13 +21891,7 @@
     },
     {
       "kind": "ui-named-argument",
-<<<<<<< HEAD
-      "line": 516,
-||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
-      "line": 514,
-=======
-      "line": 520,
->>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 522,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Manual Fallback",
       "surface": "apple",
@@ -21919,13 +21899,7 @@
     },
     {
       "kind": "ui-named-argument",
-<<<<<<< HEAD
-      "line": 520,
-||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
-      "line": 518,
-=======
-      "line": 524,
->>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 526,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Domain Settings",
       "surface": "apple",
@@ -21933,13 +21907,7 @@
     },
     {
       "kind": "ui-call",
-<<<<<<< HEAD
-      "line": 531,
-||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
-      "line": 529,
-=======
-      "line": 535,
->>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 537,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Developer Local",
       "surface": "apple",
@@ -21947,13 +21915,7 @@
     },
     {
       "kind": "ui-call",
-<<<<<<< HEAD
-      "line": 534,
-||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
-      "line": 532,
-=======
-      "line": 538,
->>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 540,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Default host is localhost. Use your Mac LAN IP if simulator networking requires it.",
       "surface": "apple",
@@ -21961,13 +21923,7 @@
     },
     {
       "kind": "ui-call",
-<<<<<<< HEAD
-      "line": 562,
-||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
-      "line": 560,
-=======
-      "line": 566,
->>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 568,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway rejected credentials. Scan a fresh setup code or update token/password.",
       "surface": "apple",
@@ -21975,7 +21931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 570,
+      "line": 576,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "OpenClaw is checking gateway and node access.",
       "surface": "apple",
@@ -21983,7 +21939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 584,
+      "line": 590,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Resume After Approval",
       "surface": "apple",
@@ -21991,7 +21947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 590,
+      "line": 596,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Pairing Approval",
       "surface": "apple",
@@ -21999,7 +21955,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 596,
+      "line": 602,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Request ID: %@",
       "surface": "apple",
@@ -22007,7 +21963,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 599,
+      "line": 605,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Request ID: check `openclaw devices list`.",
       "surface": "apple",
@@ -22015,7 +21971,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 603,
+      "line": 609,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Approve this device on the gateway.\n1) `%1$@`\n2) `/pair approve` in your OpenClaw chat\n%2$@\nOpenClaw will also retry automatically when you return to this app.",
       "surface": "apple",
@@ -22023,7 +21979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 620,
+      "line": 626,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Scan Setup Code Again",
       "surface": "apple",
@@ -22031,7 +21987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 633,
+      "line": 639,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Retry Connection",
       "surface": "apple",
@@ -22039,7 +21995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 664,
+      "line": 670,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Enter setup code",
       "surface": "apple",
@@ -22047,7 +22003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 680,
+      "line": 686,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Apply",
       "surface": "apple",
@@ -22055,7 +22011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 698,
+      "line": 704,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Setup Code",
       "surface": "apple",
@@ -22063,7 +22019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 701,
+      "line": 707,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Use this if you have a setup code instead of scanning.",
       "surface": "apple",
@@ -22071,7 +22027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 713,
+      "line": 719,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Host",
       "surface": "apple",
@@ -22079,7 +22035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 714,
+      "line": 720,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Port",
       "surface": "apple",
@@ -22087,7 +22043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 717,
+      "line": 723,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Discovery Domain (optional)",
       "surface": "apple",
@@ -22095,7 +22051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 722,
+      "line": 728,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway Auth Token",
       "surface": "apple",
@@ -22103,7 +22059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 726,
+      "line": 732,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway Password",
       "surface": "apple",
@@ -22111,7 +22067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 756,
+      "line": 762,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Unencrypted",
       "surface": "apple",
@@ -22119,7 +22075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 759,
+      "line": 765,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Secure (TLS)",
       "surface": "apple",
@@ -22127,7 +22083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 763,
+      "line": 769,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connection security",
       "surface": "apple",
@@ -22135,7 +22091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 833,
+      "line": 839,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -22143,7 +22099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 837,
+      "line": 843,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connect",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -21306,6 +21306,54 @@
       "id": "native.apple.1a8232361f3d72fb"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 14,
+      "path": "apps/ios/Sources/Onboarding/OnboardingPermissionsStep.swift",
+      "source": "Allow access",
+      "surface": "apple",
+      "id": "native.apple.9dcd64ab340a6c15"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 15,
+      "path": "apps/ios/Sources/Onboarding/OnboardingPermissionsStep.swift",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "surface": "apple",
+      "id": "native.apple.933a2ac28d1d2aec"
+    },
+    {
+      "kind": "ui-call",
+      "line": 31,
+      "path": "apps/ios/Sources/Onboarding/OnboardingPermissionsStep.swift",
+      "source": "You can change any of these later in Settings.",
+      "surface": "apple",
+      "id": "native.apple.47114a39f7a71c3b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 43,
+      "path": "apps/ios/Sources/Onboarding/OnboardingPermissionsStep.swift",
+      "source": "Continue",
+      "surface": "apple",
+      "id": "native.apple.eabf54e2b640a4a1"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 77,
+      "path": "apps/ios/Sources/Onboarding/OnboardingPermissionsStep.swift",
+      "source": "Allow",
+      "surface": "apple",
+      "id": "native.apple.c5db9e6eae115f7a"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 79,
+      "path": "apps/ios/Sources/Onboarding/OnboardingPermissionsStep.swift",
+      "source": "Open Settings",
+      "surface": "apple",
+      "id": "native.apple.f591e16105268e99"
+    },
+    {
       "kind": "conditional-branch",
       "line": 11,
       "path": "apps/ios/Sources/Onboarding/OnboardingStateStore.swift",
@@ -21597,33 +21645,33 @@
       "kind": "ui-named-argument",
       "line": 245,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
-      "source": "Securely connect this iPhone to your gateway.",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
       "surface": "apple",
-      "id": "native.apple.c9419426ba8c2a2e"
+      "id": "native.apple.9b414850baa618da"
     },
     {
       "kind": "ui-named-argument",
       "line": 252,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
-      "source": "Connect to your gateway",
+      "source": "Your agent runs on your own computer",
       "surface": "apple",
-      "id": "native.apple.3e233ba3ed3181d4"
+      "id": "native.apple.7248e67848beebd9"
     },
     {
       "kind": "ui-named-argument",
       "line": 255,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
-      "source": "Choose device permissions",
+      "source": "Pair this iPhone by scanning a setup code",
       "surface": "apple",
-      "id": "native.apple.b6978424ac0a4d14"
+      "id": "native.apple.acbdc9332988fa64"
     },
     {
       "kind": "ui-named-argument",
       "line": 258,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
-      "source": "Use OpenClaw from your phone",
+      "source": "Chat, talk, and approve actions from anywhere",
       "surface": "apple",
-      "id": "native.apple.4109460a5b8927d8"
+      "id": "native.apple.feb3e155748c2f05"
     },
     {
       "kind": "ui-call",
@@ -21787,7 +21835,13 @@
     },
     {
       "kind": "ui-call",
+<<<<<<< HEAD
       "line": 446,
+||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 444,
+=======
+      "line": 450,
+>>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Mode",
       "surface": "apple",
@@ -21795,7 +21849,13 @@
     },
     {
       "kind": "ui-call",
+<<<<<<< HEAD
       "line": 447,
+||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 445,
+=======
+      "line": 451,
+>>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Discovery",
       "surface": "apple",
@@ -21803,7 +21863,13 @@
     },
     {
       "kind": "ui-call",
+<<<<<<< HEAD
       "line": 449,
+||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 447,
+=======
+      "line": 453,
+>>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Status",
       "surface": "apple",
@@ -21811,7 +21877,13 @@
     },
     {
       "kind": "ui-call",
+<<<<<<< HEAD
       "line": 467,
+||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 465,
+=======
+      "line": 471,
+>>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Choose a mode first.",
       "surface": "apple",
@@ -21819,7 +21891,13 @@
     },
     {
       "kind": "ui-call",
+<<<<<<< HEAD
       "line": 472,
+||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 470,
+=======
+      "line": 476,
+>>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Back to Mode Selection",
       "surface": "apple",
@@ -21827,7 +21905,13 @@
     },
     {
       "kind": "ui-named-argument",
+<<<<<<< HEAD
       "line": 516,
+||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 514,
+=======
+      "line": 520,
+>>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Manual Fallback",
       "surface": "apple",
@@ -21835,7 +21919,13 @@
     },
     {
       "kind": "ui-named-argument",
+<<<<<<< HEAD
       "line": 520,
+||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 518,
+=======
+      "line": 524,
+>>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Domain Settings",
       "surface": "apple",
@@ -21843,7 +21933,13 @@
     },
     {
       "kind": "ui-call",
+<<<<<<< HEAD
       "line": 531,
+||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 529,
+=======
+      "line": 535,
+>>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Developer Local",
       "surface": "apple",
@@ -21851,7 +21947,13 @@
     },
     {
       "kind": "ui-call",
+<<<<<<< HEAD
       "line": 534,
+||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 532,
+=======
+      "line": 538,
+>>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Default host is localhost. Use your Mac LAN IP if simulator networking requires it.",
       "surface": "apple",
@@ -21859,7 +21961,13 @@
     },
     {
       "kind": "ui-call",
+<<<<<<< HEAD
       "line": 562,
+||||||| parent of 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
+      "line": 560,
+=======
+      "line": 566,
+>>>>>>> 57a10efd9a1 (feat(ios): guide first launch through pairing explainer and permissions)
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway rejected credentials. Scan a fresh setup code or update token/password.",
       "surface": "apple",
@@ -22048,6 +22156,158 @@
       "source": "OpenClaw",
       "surface": "apple",
       "id": "native.apple.5b46de1ccb06852b"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 111,
+      "path": "apps/ios/Sources/Permissions/DevicePermissionRow.swift",
+      "source": "Allowed",
+      "surface": "apple",
+      "id": "native.apple.0e07e7044608f954"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 131,
+      "path": "apps/ios/Sources/Permissions/DevicePermissionRow.swift",
+      "source": "Limited",
+      "surface": "apple",
+      "id": "native.apple.86796a6df9d0ff63"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 133,
+      "path": "apps/ios/Sources/Permissions/DevicePermissionRow.swift",
+      "source": "Off in Settings",
+      "surface": "apple",
+      "id": "native.apple.4c7f5404e9c42402"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 60,
+      "path": "apps/ios/Sources/Permissions/DevicePermissions.swift",
+      "source": "Notifications",
+      "surface": "apple",
+      "id": "native.apple.96d65a5563690719"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 61,
+      "path": "apps/ios/Sources/Permissions/DevicePermissions.swift",
+      "source": "Camera",
+      "surface": "apple",
+      "id": "native.apple.d290a46515add091"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 62,
+      "path": "apps/ios/Sources/Permissions/DevicePermissions.swift",
+      "source": "Microphone",
+      "surface": "apple",
+      "id": "native.apple.0eeedbc8aaafcd2c"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 63,
+      "path": "apps/ios/Sources/Permissions/DevicePermissions.swift",
+      "source": "Photos",
+      "surface": "apple",
+      "id": "native.apple.14fadad23dd36e44"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 64,
+      "path": "apps/ios/Sources/Permissions/DevicePermissions.swift",
+      "source": "Contacts",
+      "surface": "apple",
+      "id": "native.apple.f0cfa9dcc57133b7"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 65,
+      "path": "apps/ios/Sources/Permissions/DevicePermissions.swift",
+      "source": "Calendar",
+      "surface": "apple",
+      "id": "native.apple.5ec2597d0b4a06fb"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 66,
+      "path": "apps/ios/Sources/Permissions/DevicePermissions.swift",
+      "source": "Reminders",
+      "surface": "apple",
+      "id": "native.apple.9ed5c19cf1e84490"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 67,
+      "path": "apps/ios/Sources/Permissions/DevicePermissions.swift",
+      "source": "Location",
+      "surface": "apple",
+      "id": "native.apple.866b9df8afcadf07"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 73,
+      "path": "apps/ios/Sources/Permissions/DevicePermissions.swift",
+      "source": "Pairing approvals and replies from your agent.",
+      "surface": "apple",
+      "id": "native.apple.f205ac6778705a7d"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 74,
+      "path": "apps/ios/Sources/Permissions/DevicePermissions.swift",
+      "source": "Scan setup codes and take photos on request.",
+      "surface": "apple",
+      "id": "native.apple.061a17077ee3be94"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 75,
+      "path": "apps/ios/Sources/Permissions/DevicePermissions.swift",
+      "source": "Talk with your agent using voice.",
+      "surface": "apple",
+      "id": "native.apple.c735ac6b282765f9"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 76,
+      "path": "apps/ios/Sources/Permissions/DevicePermissions.swift",
+      "source": "Share recent photos when you ask.",
+      "surface": "apple",
+      "id": "native.apple.ebe8aadcf512ecdb"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 77,
+      "path": "apps/ios/Sources/Permissions/DevicePermissions.swift",
+      "source": "Look up and add people you mention.",
+      "surface": "apple",
+      "id": "native.apple.4c4bc12c0787383c"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 78,
+      "path": "apps/ios/Sources/Permissions/DevicePermissions.swift",
+      "source": "Check and add calendar events.",
+      "surface": "apple",
+      "id": "native.apple.5a4006fbb9b23db1"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 79,
+      "path": "apps/ios/Sources/Permissions/DevicePermissions.swift",
+      "source": "List, add, and complete reminders.",
+      "surface": "apple",
+      "id": "native.apple.2b2a4f1aab6a12ec"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 80,
+      "path": "apps/ios/Sources/Permissions/DevicePermissions.swift",
+      "source": "Answer location and nearby questions.",
+      "surface": "apple",
+      "id": "native.apple.3854ae1f0606bafe"
     },
     {
       "kind": "conditional-branch",
@@ -22474,144 +22734,8 @@
       "id": "native.apple.19fba912c31023b5"
     },
     {
-      "kind": "ui-localized-call",
-      "line": 18,
-      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Add-Only",
-      "surface": "apple",
-      "id": "native.apple.e5a601c8fe47e9ed"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 19,
-      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Allowed",
-      "surface": "apple",
-      "id": "native.apple.32aabe66f916a809"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 20,
-      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Enabled",
-      "surface": "apple",
-      "id": "native.apple.7b551f40d1a6148c"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 21,
-      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Limited",
-      "surface": "apple",
-      "id": "native.apple.94208c3068dae5b9"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 22,
-      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Not Allowed",
-      "surface": "apple",
-      "id": "native.apple.92223852c90e286d"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 23,
-      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Not Set",
-      "surface": "apple",
-      "id": "native.apple.aa6ff8becab99fdc"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 24,
-      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Unknown",
-      "surface": "apple",
-      "id": "native.apple.03e2f7265119d263"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 78,
-      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Contacts",
-      "surface": "apple",
-      "id": "native.apple.4dac301c7e0c921c"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 81,
-      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Search and add contacts from the assistant.",
-      "surface": "apple",
-      "id": "native.apple.01f362d70f6ddb4e"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 87,
-      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Photos",
-      "surface": "apple",
-      "id": "native.apple.eda8d96e40bcc36a"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 96,
-      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Calendar (Add Events)",
-      "surface": "apple",
-      "id": "native.apple.df0159ff34744870"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 99,
-      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Add events with least privilege.",
-      "surface": "apple",
-      "id": "native.apple.c6db4240083c0435"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 105,
-      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Calendar (View Events)",
-      "surface": "apple",
-      "id": "native.apple.dc62e22f0b2726c5"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 108,
-      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "List and read calendar events.",
-      "surface": "apple",
-      "id": "native.apple.650091bc632b3120"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 114,
-      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Reminders",
-      "surface": "apple",
-      "id": "native.apple.7a81d1f17d9d90c0"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 117,
-      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "List, add, and complete reminders.",
-      "surface": "apple",
-      "id": "native.apple.d6fd5e9f85b0e298"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 123,
-      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Health Summaries",
-      "surface": "apple",
-      "id": "native.apple.33df187e4402065a"
-    },
-    {
       "kind": "ui-call",
-      "line": 136,
+      "line": 57,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Privacy & Access",
       "surface": "apple",
@@ -22619,7 +22743,15 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 227,
+      "line": 74,
+      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
+      "source": "Search and add contacts from the assistant.",
+      "surface": "apple",
+      "id": "native.apple.01f362d70f6ddb4e"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 89,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Read photos you select for the assistant.",
       "surface": "apple",
@@ -22627,7 +22759,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 228,
+      "line": 90,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Read recent photos for the assistant.",
       "surface": "apple",
@@ -22635,39 +22767,71 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 236,
+      "line": 92,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Manage Access",
+      "source": "Limited",
       "surface": "apple",
-      "id": "native.apple.ac3ff8e4c6df7a2a"
+      "id": "native.apple.94208c3068dae5b9"
     },
     {
       "kind": "ui-localized-call",
-      "line": 343,
+      "line": 105,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Request Full Access",
+      "source": "Calendar (Add Events)",
       "surface": "apple",
-      "id": "native.apple.c557c95fa2789089"
+      "id": "native.apple.df0159ff34744870"
     },
     {
       "kind": "ui-localized-call",
-      "line": 390,
+      "line": 106,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Request Access",
+      "source": "Add events with least privilege.",
       "surface": "apple",
-      "id": "native.apple.4e50e2ab4c869464"
+      "id": "native.apple.c6db4240083c0435"
     },
     {
       "kind": "ui-localized-call",
-      "line": 392,
+      "line": 120,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
-      "source": "Upgrade to Full Access",
+      "source": "List and read calendar events.",
       "surface": "apple",
-      "id": "native.apple.a9f30d4e86060dca"
+      "id": "native.apple.650091bc632b3120"
     },
     {
       "kind": "ui-localized-call",
-      "line": 394,
+      "line": 135,
+      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
+      "source": "List, add, and complete reminders.",
+      "surface": "apple",
+      "id": "native.apple.d6fd5e9f85b0e298"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 137,
+      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
+      "source": "Add-Only",
+      "surface": "apple",
+      "id": "native.apple.e5a601c8fe47e9ed"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 152,
+      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
+      "source": "Health Summaries",
+      "surface": "apple",
+      "id": "native.apple.33df187e4402065a"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 191,
+      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
+      "source": "Allow",
+      "surface": "apple",
+      "id": "native.apple.0b10201d7e452dc4"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 193,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Open Settings",
       "surface": "apple",
@@ -22675,7 +22839,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 427,
+      "line": 255,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Health data is unavailable on this device.",
       "surface": "apple",
@@ -22683,7 +22847,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 431,
+      "line": 259,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Shares only requested step, sleep, resting heart rate, and workout aggregates through your Gateway with your configured AI provider. Results may remain in chat history.",
       "surface": "apple",
@@ -22691,7 +22855,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 437,
+      "line": 265,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Off by default. Enabling lets requested aggregates leave this iPhone through your Gateway and configured AI provider.",
       "surface": "apple",
@@ -22699,7 +22863,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 446,
+      "line": 274,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Disable",
       "surface": "apple",
@@ -22707,7 +22871,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 447,
+      "line": 275,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Enable & Share Summaries",
       "surface": "apple",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -13339,6 +13339,11 @@
       "translated": "متابعة"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "محدود"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "السماح"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "فتح الإعدادات"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "إدارة"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "السماح بالوصول"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "اختر ما يمكن لوكيلك استخدامه على هذا الـ iPhone. لن يتم تفعيل أي شيء حتى تسمح به."
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "يمكنك تغيير أي من هذه الخيارات لاحقًا في الإعدادات."
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "متابعة"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "السماح"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "فتح الإعدادات"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "الشبكة المنزلية"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "وصّل هذا الـ iPhone بأمان بالـ gateway الخاص بك."
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "وكيلك في جيبك. قم بإقران هذا الـ iPhone بالـ Gateway للبدء."
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "الاتصال بالـ gateway الخاص بك"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "يعمل وكيلك على جهاز الكمبيوتر الخاص بك"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "اختر أذونات الجهاز"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "قم بإقران هذا الـ iPhone عن طريق مسح رمز الإعداد"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "استخدم OpenClaw من هاتفك"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "دردش وتحدث ووافق على الإجراءات من أي مكان"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "مسموح"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "محدود"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "متوقف في الإعدادات"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "الإشعارات"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "الكاميرا"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "الميكروفون"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "الصور"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "جهات الاتصال"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "التقويم"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "التذكيرات"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "الموقع"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "الموافقات على الاقتران والردود من وكيلك."
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "مسح رموز الإعداد ضوئيًا والتقاط الصور عند الطلب."
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "تحدث مع وكيلك باستخدام صوتك."
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "مشاركة الصور الحديثة عندما تطلب ذلك."
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "البحث عن الأشخاص الذين تذكرهم وإضافتهم."
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "التحقق من أحداث التقويم وإضافتها."
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "عرض التذكيرات وإضافتها وإكمالها."
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "الإجابة عن الأسئلة المتعلقة بالموقع والأماكن القريبة."
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "رؤوس مخصصة"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "إضافة فقط"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "مسموح"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "مُمكّن"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "محدود"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "غير مسموح"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "غير معيّن"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "غير معروف"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "جهات الاتصال"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "الخصوصية والوصول"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "ابحث عن جهات الاتصال وأضِفها من المساعد."
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "الصور"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "التقويم (إضافة أحداث)"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "أضِف الأحداث بأقل قدر من الامتيازات."
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "التقويم (عرض الأحداث)"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "سرد أحداث التقويم وقراءتها."
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "التذكيرات"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "اسرد التذكيرات وأضِفها وأكملها."
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "ملخصات الصحة"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "الخصوصية والوصول"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "قراءة الصور الحديثة للمساعد."
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "إدارة الوصول"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "محدود"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "طلب الوصول الكامل"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "التقويم (إضافة أحداث)"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "طلب الوصول"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "أضِف الأحداث بأقل قدر من الامتيازات."
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "الترقية إلى الوصول الكامل"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "سرد أحداث التقويم وقراءتها."
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "اسرد التذكيرات وأضِفها وأكملها."
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "إضافة فقط"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "ملخصات الصحة"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "سماح"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -13339,6 +13339,11 @@
       "translated": "Fortfahren"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "Eingeschränkt"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "Erlauben"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "Einstellungen öffnen"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "Verwalten"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "Zugriff erlauben"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "Wähle aus, was dein Agent auf diesem iPhone verwenden darf. Nichts ist aktiviert, bis du es erlaubst."
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "Du kannst all dies später in den Einstellungen ändern."
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "Fortfahren"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "Erlauben"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "Einstellungen öffnen"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "Heimnetzwerk"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "Verbinden Sie dieses iPhone sicher mit Ihrer Gateway."
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "Dein Agent für unterwegs. Kopple dieses iPhone mit deinem Gateway, um loszulegen."
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "Mit Ihrer Gateway verbinden"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "Dein Agent läuft auf deinem eigenen Computer"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "Geräteberechtigungen auswählen"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "Kopple dieses iPhone, indem du einen Einrichtungscode scannst"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "OpenClaw auf Ihrem Telefon verwenden"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "Chatte, sprich und genehmige Aktionen von überall"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "Erlaubt"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "Eingeschränkt"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "In den Einstellungen deaktiviert"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "Mitteilungen"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "Kamera"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "Mikrofon"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "Fotos"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "Kontakte"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "Kalender"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "Erinnerungen"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "Standort"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "Kopplungsbestätigungen und Antworten von Ihrem Agenten."
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "Einrichtungscodes scannen und auf Anfrage Fotos aufnehmen."
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "Per Sprache mit Ihrem Agenten sprechen."
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "Auf Anfrage kürzlich aufgenommene Fotos teilen."
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "Erwähnte Personen suchen und hinzufügen."
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "Kalendertermine prüfen und hinzufügen."
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "Erinnerungen auflisten, hinzufügen und als erledigt markieren."
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "Fragen zum Standort und zur Umgebung beantworten."
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "Benutzerdefinierte Header"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "Nur hinzufügen"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "Erlaubt"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "Aktiviert"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "Eingeschränkt"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "Nicht erlaubt"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "Nicht festgelegt"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "Unbekannt"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "Kontakte"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "Datenschutz & Zugriff"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "Kontakte über den Assistenten suchen und hinzufügen."
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "Fotos"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "Kalender (Ereignisse hinzufügen)"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "Ereignisse mit geringsten Rechten hinzufügen."
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "Kalender (Ereignisse anzeigen)"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "Kalenderereignisse auflisten und lesen."
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "Erinnerungen"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "Erinnerungen auflisten, hinzufügen und abschließen."
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "Gesundheitszusammenfassungen"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "Datenschutz & Zugriff"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "Lies aktuelle Fotos für den Assistenten."
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "Zugriff verwalten"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "Eingeschränkt"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "Vollzugriff anfordern"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "Kalender (Ereignisse hinzufügen)"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "Zugriff anfordern"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "Ereignisse mit geringsten Rechten hinzufügen."
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "Auf Vollzugriff upgraden"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "Kalenderereignisse auflisten und lesen."
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "Erinnerungen auflisten, hinzufügen und abschließen."
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "Nur hinzufügen"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "Gesundheitszusammenfassungen"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "Erlauben"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "Permitir acceso"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "Elige qué puede usar tu agente en este iPhone. Nada estará activado hasta que lo permitas."
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "Puedes cambiar cualquiera de estas opciones más adelante en Ajustes."
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "Continuar"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "Permitir"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "Abrir Ajustes"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "Red doméstica"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "Conecta de forma segura este iPhone a tu gateway."
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "Tu agente, en tu bolsillo. Empareja este iPhone con tu Gateway para comenzar."
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "Conectar a tu gateway"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "Tu agente se ejecuta en tu propia computadora"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "Elige los permisos del dispositivo"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "Empareja este iPhone escaneando un código de configuración"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "Usa OpenClaw desde tu teléfono"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "Chatea, habla y aprueba acciones desde cualquier lugar"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "Permitido"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "Limitado"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "Desactivado en Ajustes"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "Notificaciones"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "Cámara"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "Micrófono"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "Fotos"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "Contactos"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "Calendario"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "Recordatorios"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "Ubicación"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "Aprobaciones de vinculación y respuestas de tu agente."
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "Escanea códigos de configuración y toma fotos cuando se solicite."
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "Habla con tu agente mediante la voz."
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "Comparte fotos recientes cuando se lo pidas."
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "Busca y añade a las personas que menciones."
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "Consulta y añade eventos del calendario."
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "Consulta, añade y completa recordatorios."
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "Responde preguntas sobre ubicaciones y lugares cercanos."
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "Encabezados personalizados"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "Solo añadir"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "Permitido"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "Activado"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "Limitado"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "No permitido"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "No configurado"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "Desconocido"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "Contactos"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "Privacidad y acceso"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "Busca y añade contactos desde el asistente."
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "Fotos"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "Calendario (Añadir eventos)"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "Añade eventos con el menor privilegio."
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "Calendario (Ver eventos)"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "Enumera y lee eventos del calendario."
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "Recordatorios"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "Enumera, añade y completa recordatorios."
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "Resúmenes de salud"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "Privacidad y acceso"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "Leer fotos recientes para el asistente."
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "Gestionar acceso"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "Limitado"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "Solicitar acceso completo"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "Calendario (Añadir eventos)"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "Solicitar acceso"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "Añade eventos con el menor privilegio."
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "Actualizar a acceso completo"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "Enumera y lee eventos del calendario."
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "Enumera, añade y completa recordatorios."
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "Solo añadir"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "Resúmenes de salud"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "Permitir"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -13339,6 +13339,11 @@
       "translated": "Continuar"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "Limitado"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "Permitir"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "Abrir Ajustes"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "Gestionar"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "اجازه دسترسی"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "انتخاب کنید عامل شما در این iPhone به چه چیزهایی دسترسی داشته باشد. تا زمانی که اجازه ندهید، هیچ‌چیز فعال نیست."
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "بعداً می‌توانید هرکدام از این موارد را در تنظیمات تغییر دهید."
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "ادامه"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "اجازه دادن"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "باز کردن تنظیمات"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "شبکهٔ خانگی"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "این iPhone را به‌صورت امن به Gateway خود متصل کنید."
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "عامل شما، در جیب شما. برای شروع، این iPhone را با gateway خود جفت کنید."
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "اتصال به Gateway شما"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "عامل شما روی رایانه خودتان اجرا می‌شود"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "انتخاب مجوزهای دستگاه"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "این iPhone را با اسکن کد راه‌اندازی جفت کنید"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "استفاده از OpenClaw از طریق تلفن شما"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "از هرجا گپ بزنید، صحبت کنید و اقدامات را تأیید کنید"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "مجاز"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "محدود"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "در تنظیمات غیرفعال است"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "اعلان‌ها"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "دوربین"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "میکروفون"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "عکس‌ها"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "مخاطبان"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "تقویم"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "یادآوری‌ها"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "موقعیت مکانی"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "تأیید درخواست‌های جفت‌سازی و پاسخ‌های عامل شما."
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "اسکن کدهای راه‌اندازی و گرفتن عکس در صورت درخواست."
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "گفت‌وگوی صوتی با عامل شما."
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "اشتراک‌گذاری عکس‌های اخیر در صورت درخواست شما."
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "جست‌وجو و افزودن افرادی که نام می‌برید."
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "بررسی و افزودن رویدادهای تقویم."
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "فهرست‌کردن، افزودن و تکمیل یادآورها."
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "پاسخ به پرسش‌های مربوط به موقعیت مکانی و مکان‌های اطراف."
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "سربرگ‌های سفارشی"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "فقط افزودن"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "مجاز"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "فعال"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "محدود"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "مجاز نیست"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "تنظیم نشده"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "ناشناخته"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "مخاطبین"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "حریم خصوصی و دسترسی"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "از دستیار، مخاطبین را جستجو و اضافه کنید."
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "عکس‌ها"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "تقویم (افزودن رویدادها)"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "رویدادها را با کمترین سطح دسترسی اضافه کنید."
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "تقویم (مشاهده رویدادها)"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "رویدادهای تقویم را فهرست و مطالعه کنید."
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "یادآورها"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "یادآورها را فهرست، اضافه و کامل کنید."
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "خلاصه‌های سلامت"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "حریم خصوصی و دسترسی"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "عکس‌های اخیر را برای دستیار بخواند."
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "مدیریت دسترسی"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "محدود"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "درخواست دسترسی کامل"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "تقویم (افزودن رویدادها)"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "درخواست دسترسی"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "رویدادها را با کمترین سطح دسترسی اضافه کنید."
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "ارتقا به دسترسی کامل"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "رویدادهای تقویم را فهرست و مطالعه کنید."
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "یادآورها را فهرست، اضافه و کامل کنید."
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "فقط افزودن"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "خلاصه‌های سلامت"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "اجازه دادن"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -13339,6 +13339,11 @@
       "translated": "ادامه"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "محدود"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "اجازه دادن"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "باز کردن تنظیمات"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "مدیریت"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "Autoriser l’accès"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "Choisissez ce que votre agent peut utiliser sur cet iPhone. Rien n’est activé tant que vous ne l’autorisez pas."
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "Vous pourrez modifier ces réglages plus tard dans Réglages."
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "Continuer"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "Autoriser"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "Ouvrir Réglages"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "Réseau domestique"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "Connectez cet iPhone à votre Gateway en toute sécurité."
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "Votre agent, dans votre poche. Jumelez cet iPhone avec votre Gateway pour commencer."
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "Se connecter à votre Gateway"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "Votre agent s’exécute sur votre propre ordinateur"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "Choisir les autorisations de l’appareil"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "Jumelez cet iPhone en scannant un code de configuration"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "Utiliser OpenClaw depuis votre téléphone"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "Échangez par écrit ou oralement et approuvez des actions où que vous soyez"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "Autorisé"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "Limité"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "Désactivé dans Réglages"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "Notifications"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "Appareil photo"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "Microphone"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "Contacts"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "Calendrier"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "Rappels"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "Localisation"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "Approbations d’association et réponses de votre agent."
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "Scannez les codes de configuration et prenez des photos sur demande."
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "Parlez avec votre agent à l’aide de votre voix."
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "Partagez des photos récentes lorsque vous le demandez."
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "Recherchez et ajoutez les personnes que vous mentionnez."
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "Consultez et ajoutez des événements au calendrier."
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "Répertoriez, ajoutez et terminez des rappels."
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "Répondez aux questions sur la localisation et les lieux à proximité."
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "En-têtes personnalisés"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "Ajout uniquement"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "Autorisé"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "Activé"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "Limité"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "Non autorisé"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "Non défini"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "Inconnu"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "Contacts"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "Confidentialité et accès"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "Recherchez et ajoutez des contacts depuis l’assistant."
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "Photos"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "Calendrier (Ajouter des événements)"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "Ajoutez des événements avec le moindre privilège."
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "Calendrier (Afficher les événements)"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "Lister et lire les événements du calendrier."
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "Rappels"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "Lister, ajouter et terminer des rappels."
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "Résumés de santé"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "Confidentialité et accès"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "Lire les photos récentes pour l’assistant."
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "Gérer l’accès"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "Limité"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "Demander l’accès complet"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "Calendrier (Ajouter des événements)"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "Demander l’accès"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "Ajoutez des événements avec le moindre privilège."
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "Passer à l’accès complet"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "Lister et lire les événements du calendrier."
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "Lister, ajouter et terminer des rappels."
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "Ajout uniquement"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "Résumés de santé"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "Autoriser"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -13339,6 +13339,11 @@
       "translated": "Continuer"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "Limité"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "Autoriser"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "Ouvrir Réglages"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "Gérer"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "ऐक्सेस की अनुमति दें"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "चुनें कि आपका एजेंट इस iPhone पर किन चीज़ों का उपयोग कर सकता है। आपकी अनुमति के बिना कुछ भी चालू नहीं होगा।"
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "आप बाद में Settings में इनमें से किसी को भी बदल सकते हैं।"
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "जारी रखें"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "अनुमति दें"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "Settings खोलें"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "होम नेटवर्क"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "इस iPhone को अपने gateway से सुरक्षित रूप से कनेक्ट करें।"
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "आपका एजेंट, आपकी जेब में। शुरू करने के लिए इस iPhone को अपने Gateway के साथ पेयर करें।"
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "अपने gateway से कनेक्ट करें"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "आपका एजेंट आपके अपने कंप्यूटर पर चलता है"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "डिवाइस अनुमतियाँ चुनें"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "सेटअप कोड स्कैन करके इस iPhone को पेयर करें"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "अपने फ़ोन से OpenClaw का उपयोग करें"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "कहीं से भी चैट करें, बात करें और कार्रवाइयों को मंज़ूरी दें"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "अनुमति है"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "सीमित"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "Settings में बंद"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "सूचनाएँ"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "कैमरा"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "माइक्रोफ़ोन"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "फ़ोटो"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "संपर्क"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "कैलेंडर"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "रिमाइंडर"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "स्थान"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "आपके एजेंट से पेयरिंग की स्वीकृतियाँ और जवाब।"
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "सेटअप कोड स्कैन करें और अनुरोध पर फ़ोटो लें।"
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "आवाज़ का उपयोग करके अपने एजेंट से बात करें।"
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "आपके कहने पर हाल की फ़ोटो साझा करें।"
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "आपके द्वारा उल्लेखित लोगों को खोजें और जोड़ें।"
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "कैलेंडर ईवेंट जाँचें और जोड़ें।"
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "रिमाइंडर सूचीबद्ध करें, जोड़ें और पूर्ण करें।"
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "स्थान और आस-पास से जुड़े प्रश्नों के उत्तर दें।"
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "कस्टम हेडर"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "केवल जोड़ें"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "अनुमति है"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "चालू"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "सीमित"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "अनुमति नहीं है"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "सेट नहीं है"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "अज्ञात"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "संपर्क"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "गोपनीयता और एक्सेस"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "असिस्टेंट से संपर्क खोजें और जोड़ें।"
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "फ़ोटो"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "कैलेंडर (इवेंट जोड़ें)"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "न्यूनतम विशेषाधिकार के साथ इवेंट जोड़ें।"
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "कैलेंडर (इवेंट देखें)"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "कैलेंडर इवेंट की सूची देखें और उन्हें पढ़ें।"
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "रिमाइंडर"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "रिमाइंडर की सूची देखें, जोड़ें और पूरा करें।"
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "स्वास्थ्य सारांश"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "गोपनीयता और एक्सेस"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "असिस्टेंट के लिए हाल की फ़ोटो पढ़ें।"
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "ऐक्सेस प्रबंधित करें"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "सीमित"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "पूर्ण ऐक्सेस का अनुरोध करें"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "कैलेंडर (इवेंट जोड़ें)"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "ऐक्सेस का अनुरोध करें"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "न्यूनतम विशेषाधिकार के साथ इवेंट जोड़ें।"
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "पूर्ण ऐक्सेस में अपग्रेड करें"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "कैलेंडर इवेंट की सूची देखें और उन्हें पढ़ें।"
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "रिमाइंडर की सूची देखें, जोड़ें और पूरा करें।"
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "केवल जोड़ें"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "स्वास्थ्य सारांश"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "अनुमति दें"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -13339,6 +13339,11 @@
       "translated": "जारी रखें"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "सीमित"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "अनुमति दें"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "Settings खोलें"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "प्रबंधित करें"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -13339,6 +13339,11 @@
       "translated": "Lanjutkan"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "Terbatas"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "Izinkan"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "Buka Pengaturan"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "Kelola"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "Izinkan akses"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "Pilih apa yang dapat digunakan agen Anda di iPhone ini. Tidak ada yang aktif sampai Anda mengizinkannya."
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "Anda dapat mengubah semua ini nanti di Pengaturan."
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "Lanjutkan"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "Izinkan"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "Buka Pengaturan"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "Jaringan Rumah"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "Hubungkan iPhone ini ke gateway Anda dengan aman."
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "Agen Anda, dalam genggaman. Pasangkan iPhone ini dengan gateway Anda untuk memulai."
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "Hubungkan ke gateway Anda"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "Agen Anda berjalan di komputer Anda sendiri"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "Pilih izin perangkat"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "Pasangkan iPhone ini dengan memindai kode penyiapan"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "Gunakan OpenClaw dari ponsel Anda"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "Mengobrol, berbicara, dan menyetujui tindakan dari mana saja"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "Diizinkan"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "Terbatas"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "Dinonaktifkan di Pengaturan"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "Notifikasi"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "Kamera"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "Mikrofon"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "Foto"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "Kontak"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "Kalender"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "Pengingat"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "Lokasi"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "Persetujuan pemasangan dan balasan dari agen Anda."
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "Pindai kode penyiapan dan ambil foto sesuai permintaan."
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "Bicara dengan agen Anda menggunakan suara."
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "Bagikan foto terbaru saat Anda memintanya."
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "Cari dan tambahkan orang yang Anda sebutkan."
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "Periksa dan tambahkan acara kalender."
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "Lihat, tambahkan, dan selesaikan pengingat."
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "Jawab pertanyaan tentang lokasi dan tempat di sekitar."
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "Header Kustom"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "Hanya Tambah"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "Diizinkan"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "Diaktifkan"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "Terbatas"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "Tidak Diizinkan"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "Belum Diatur"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "Tidak diketahui"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "Kontak"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "Privasi & Akses"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "Cari dan tambahkan kontak dari asisten."
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "Foto"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "Kalender (Tambahkan Acara)"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "Tambahkan acara dengan hak akses paling rendah."
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "Kalender (Lihat Acara)"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "Cantumkan dan baca acara kalender."
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "Pengingat"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "Cantumkan, tambahkan, dan selesaikan pengingat."
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "Ringkasan Kesehatan"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "Privasi & Akses"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "Membaca foto terbaru untuk asisten."
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "Kelola Akses"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "Terbatas"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "Minta Akses Penuh"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "Kalender (Tambahkan Acara)"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "Minta Akses"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "Tambahkan acara dengan hak akses paling rendah."
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "Tingkatkan ke Akses Penuh"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "Cantumkan dan baca acara kalender."
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "Cantumkan, tambahkan, dan selesaikan pengingat."
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "Hanya Tambah"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "Ringkasan Kesehatan"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "Izinkan"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -13339,6 +13339,11 @@
       "translated": "Continua"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "Limitato"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "Consenti"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "Apri Impostazioni"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "Gestisci"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "Consenti l'accesso"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "Scegli cosa può usare il tuo agente su questo iPhone. Nessun accesso è attivo finché non lo consenti."
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "Puoi modificare queste opzioni in seguito nelle Impostazioni."
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "Continua"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "Consenti"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "Apri Impostazioni"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "Rete domestica"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "Connetti in modo sicuro questo iPhone al tuo gateway."
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "Il tuo agente, sempre con te. Abbina questo iPhone al tuo gateway per iniziare."
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "Connettiti al tuo gateway"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "Il tuo agente viene eseguito sul tuo computer"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "Scegli le autorizzazioni del dispositivo"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "Abbina questo iPhone scansionando un codice di configurazione"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "Usa OpenClaw dal tuo telefono"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "Chatta, parla e approva azioni ovunque ti trovi"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "Consentito"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "Limitato"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "Disattivato nelle Impostazioni"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "Notifiche"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "Fotocamera"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "Microfono"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "Foto"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "Contatti"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "Calendario"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "Promemoria"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "Posizione"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "Approvazioni di associazione e risposte dal tuo agente."
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "Scansiona i codici di configurazione e scatta foto su richiesta."
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "Parla con il tuo agente usando la voce."
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "Condividi le foto recenti quando lo chiedi."
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "Cerca e aggiungi le persone che menzioni."
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "Controlla e aggiungi eventi del calendario."
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "Elenca, aggiungi e completa i promemoria."
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "Rispondi a domande sulla posizione e sui luoghi nelle vicinanze."
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "Intestazioni personalizzate"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "Solo aggiunta"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "Consentito"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "Abilitato"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "Limitato"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "Non consentito"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "Non impostato"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "Sconosciuto"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "Contatti"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "Privacy e accesso"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "Cerca e aggiungi contatti dall'assistente."
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "Foto"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "Calendario (Aggiungi eventi)"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "Aggiungi eventi con il privilegio minimo."
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "Calendario (Visualizza eventi)"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "Elenca e leggi gli eventi del calendario."
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "Promemoria"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "Elenca, aggiungi e completa promemoria."
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "Riepiloghi salute"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "Privacy e accesso"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "Leggi le foto recenti per l'assistente."
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "Gestisci accesso"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "Limitato"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "Richiedi accesso completo"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "Calendario (Aggiungi eventi)"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "Richiedi accesso"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "Aggiungi eventi con il privilegio minimo."
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "Passa all'accesso completo"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "Elenca e leggi gli eventi del calendario."
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "Elenca, aggiungi e completa promemoria."
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "Solo aggiunta"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "Riepiloghi salute"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "Consenti"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "アクセスを許可"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "このiPhoneでエージェントが使用できる項目を選択してください。許可するまで、どの項目も有効になりません。"
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "これらは後から「設定」でいつでも変更できます。"
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "続ける"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "許可"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "設定を開く"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "ホームネットワーク"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "このiPhoneをGatewayに安全に接続します。"
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "エージェントをポケットに。このiPhoneをGatewayとペアリングして始めましょう。"
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "Gatewayに接続"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "エージェントはご自身のコンピュータ上で動作します"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "デバイスの権限を選択"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "セットアップコードをスキャンして、このiPhoneをペアリングします"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "スマートフォンからOpenClawを使用"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "どこからでもチャットや会話、アクションの承認ができます"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "許可済み"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "制限あり"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "設定でオフ"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "通知"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "カメラ"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "マイク"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "写真"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "連絡先"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "カレンダー"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "リマインダー"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "位置情報"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "エージェントからのペアリング承認依頼と返信。"
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "セットアップコードをスキャンし、リクエストに応じて写真を撮影します。"
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "音声を使ってエージェントと会話します。"
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "依頼に応じて最近の写真を共有します。"
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "名前が挙がった人を検索して連絡先に追加します。"
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "カレンダーの予定を確認、追加します。"
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "リマインダーの一覧表示、追加、完了を行います。"
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "位置情報や周辺に関する質問に回答します。"
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "カスタムヘッダー"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "追加のみ"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "許可済み"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "有効"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "制限付き"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "許可されていません"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "未設定"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "不明"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "連絡先"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "プライバシーとアクセス"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "アシスタントから連絡先を検索して追加します。"
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "写真"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "カレンダー（イベントの追加）"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "最小権限でイベントを追加します。"
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "カレンダー（イベントの表示）"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "カレンダーイベントを一覧表示して読み取ります。"
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "リマインダー"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "リマインダーを一覧表示、追加、完了します。"
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "ヘルスケア概要"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "プライバシーとアクセス"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "最近の写真をアシスタントが読み取ります。"
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "アクセスを管理"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "制限付き"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "フルアクセスをリクエスト"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "カレンダー（イベントの追加）"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "アクセスをリクエスト"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "最小権限でイベントを追加します。"
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "フルアクセスにアップグレード"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "カレンダーイベントを一覧表示して読み取ります。"
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "リマインダーを一覧表示、追加、完了します。"
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "追加のみ"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "ヘルスケア概要"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "許可"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -13339,6 +13339,11 @@
       "translated": "続ける"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "制限あり"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "許可"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "設定を開く"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "管理"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "접근 허용"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "이 iPhone에서 에이전트가 사용할 수 있는 항목을 선택하세요. 허용하기 전에는 아무것도 활성화되지 않습니다."
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "나중에 설정에서 언제든지 변경할 수 있습니다."
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "계속"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "허용"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "설정 열기"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "홈 네트워크"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "이 iPhone을 Gateway에 안전하게 연결하세요."
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "주머니 속의 에이전트. 시작하려면 이 iPhone을 Gateway와 페어링하세요."
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "Gateway에 연결"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "에이전트는 사용자의 컴퓨터에서 실행됩니다"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "기기 권한 선택"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "설정 코드를 스캔하여 이 iPhone을 페어링하세요"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "휴대폰에서 OpenClaw 사용"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "어디서든 채팅하고, 대화하고, 작업을 승인하세요"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "허용됨"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "제한됨"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "설정에서 꺼짐"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "알림"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "카메라"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "마이크"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "사진"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "연락처"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "캘린더"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "미리 알림"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "위치"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "에이전트의 페어링 승인 요청과 답변을 받습니다."
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "설정 코드를 스캔하고 요청 시 사진을 촬영합니다."
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "음성으로 에이전트와 대화합니다."
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "요청 시 최근 사진을 공유합니다."
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "언급한 사람을 검색하고 추가합니다."
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "캘린더 일정을 확인하고 추가합니다."
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "미리 알림을 조회하고 추가하거나 완료합니다."
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "위치 및 주변 지역에 관한 질문에 답변합니다."
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "사용자 지정 헤더"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "추가 전용"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "허용됨"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "활성화됨"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "제한됨"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "허용되지 않음"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "설정되지 않음"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "알 수 없음"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "연락처"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "개인정보 및 접근"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "어시스턴트에서 연락처를 검색하고 추가하세요."
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "사진"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "캘린더(이벤트 추가)"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "최소 권한으로 이벤트를 추가하세요."
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "캘린더(이벤트 보기)"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "캘린더 이벤트를 나열하고 읽습니다."
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "미리 알림"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "미리 알림을 나열하고, 추가하고, 완료 처리합니다."
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "건강 요약"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "개인정보 및 접근"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "어시스턴트가 최근 사진을 읽도록 합니다."
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "접근 권한 관리"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "제한됨"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "전체 접근 권한 요청"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "캘린더(이벤트 추가)"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "접근 권한 요청"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "최소 권한으로 이벤트를 추가하세요."
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "전체 접근 권한으로 업그레이드"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "캘린더 이벤트를 나열하고 읽습니다."
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "미리 알림을 나열하고, 추가하고, 완료 처리합니다."
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "추가 전용"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "건강 요약"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "허용"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -13339,6 +13339,11 @@
       "translated": "계속"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "제한됨"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "허용"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "설정 열기"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "관리"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -13339,6 +13339,11 @@
       "translated": "Doorgaan"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "Beperkt"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "Sta toe"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "Open Instellingen"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "Beheren"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "Toegang toestaan"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "Kies wat je agent op deze iPhone mag gebruiken. Niets is ingeschakeld totdat je toestemming geeft."
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "Je kunt dit later wijzigen in Instellingen."
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "Doorgaan"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "Sta toe"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "Open Instellingen"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "Thuisnetwerk"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "Verbind deze iPhone veilig met je Gateway."
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "Je agent, in je broekzak. Koppel deze iPhone met je gateway om aan de slag te gaan."
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "Verbinden met je Gateway"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "Je agent draait op je eigen computer"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "Apparaatrechten kiezen"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "Koppel deze iPhone door een configuratiecode te scannen"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "Gebruik OpenClaw vanaf je telefoon"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "Chat, praat en keur acties overal vandaan goed"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "Toegestaan"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "Beperkt"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "Uitgeschakeld in Instellingen"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "Meldingen"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "Microfoon"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "Foto's"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "Contacten"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "Agenda"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "Herinneringen"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "Locatie"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "Koppelingsgoedkeuringen en antwoorden van je agent."
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "Scan installatiecodes en maak op verzoek foto's."
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "Praat met je agent via spraak."
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "Deel recente foto's wanneer je daarom vraagt."
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "Zoek mensen die je noemt op en voeg ze toe."
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "Controleer en voeg agenda-afspraken toe."
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "Bekijk, voeg toe en voltooi herinneringen."
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "Beantwoord vragen over locaties en de omgeving."
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "Aangepaste headers"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "Alleen toevoegen"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "Toegestaan"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "Ingeschakeld"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "Beperkt"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "Niet toegestaan"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "Niet ingesteld"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "Onbekend"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "Contacten"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "Privacy en toegang"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "Zoek en voeg contacten toe vanuit de assistent."
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "Foto’s"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "Agenda (gebeurtenissen toevoegen)"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "Voeg gebeurtenissen toe met minimale bevoegdheden."
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "Agenda (gebeurtenissen bekijken)"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "Geef agendagebeurtenissen weer en lees ze."
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "Herinneringen"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "Geef herinneringen weer, voeg ze toe en voltooi ze."
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "Gezondheidsoverzichten"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "Privacy en toegang"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "Lees recente foto’s voor de assistent."
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "Toegang beheren"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "Beperkt"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "Volledige toegang aanvragen"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "Agenda (gebeurtenissen toevoegen)"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "Toegang aanvragen"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "Voeg gebeurtenissen toe met minimale bevoegdheden."
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "Upgraden naar volledige toegang"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "Geef agendagebeurtenissen weer en lees ze."
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "Geef herinneringen weer, voeg ze toe en voltooi ze."
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "Alleen toevoegen"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "Gezondheidsoverzichten"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "Sta toe"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -13339,6 +13339,11 @@
       "translated": "Dalej"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "Ograniczone"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "Zezwól"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "Otwórz Ustawienia"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "Zarządzaj"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "Zezwól na dostęp"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "Wybierz, z czego agent może korzystać na tym iPhonie. Żadna z tych funkcji nie jest aktywna, dopóki na nią nie zezwolisz."
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "Możesz później zmienić dowolne z tych ustawień."
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "Dalej"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "Zezwól"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "Otwórz Ustawienia"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "Sieć domowa"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "Bezpiecznie połącz tego iPhone’a z gateway."
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "Twój agent w kieszeni. Aby rozpocząć, sparuj tego iPhone’a ze swoim gatewayem."
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "Połącz z gateway"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "Twój agent działa na Twoim komputerze"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "Wybierz uprawnienia urządzenia"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "Sparuj tego iPhone’a, skanując kod konfiguracji"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "Korzystaj z OpenClaw na telefonie"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "Czatuj, rozmawiaj i zatwierdzaj działania z dowolnego miejsca"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "Dozwolone"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "Ograniczone"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "Wyłączone w Ustawieniach"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "Powiadomienia"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "Aparat"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "Mikrofon"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "Zdjęcia"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "Kontakty"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "Kalendarz"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "Przypomnienia"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "Lokalizacja"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "Prośby o zatwierdzenie parowania i odpowiedzi od Twojego agenta."
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "Skanowanie kodów konfiguracji i robienie zdjęć na żądanie."
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "Rozmawianie z agentem za pomocą głosu."
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "Udostępnianie ostatnich zdjęć na Twoją prośbę."
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "Wyszukiwanie i dodawanie wspomnianych przez Ciebie osób."
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "Sprawdzanie i dodawanie wydarzeń w kalendarzu."
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "Wyświetlanie, dodawanie i oznaczanie przypomnień jako ukończone."
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "Odpowiadanie na pytania dotyczące lokalizacji i pobliskich miejsc."
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "Niestandardowe nagłówki"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "Tylko dodawanie"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "Dozwolone"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "Włączono"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "Ograniczony"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "Niedozwolone"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "Nie ustawiono"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "Nieznane"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "Kontakty"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "Prywatność i dostęp"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "Wyszukuj i dodawaj kontakty z poziomu asystenta."
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "Zdjęcia"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "Kalendarz (dodawanie wydarzeń)"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "Dodawaj wydarzenia z najmniejszymi niezbędnymi uprawnieniami."
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "Kalendarz (wyświetlanie wydarzeń)"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "Wyświetlaj listę wydarzeń z kalendarza i odczytuj je."
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "Przypomnienia"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "Wyświetlaj listę przypomnień, dodawaj je i oznaczaj jako wykonane."
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "Podsumowania zdrowia"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "Prywatność i dostęp"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "Odczytuj ostatnie zdjęcia dla asystenta."
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "Zarządzaj dostępem"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "Ograniczony"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "Poproś o pełny dostęp"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "Kalendarz (dodawanie wydarzeń)"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "Poproś o dostęp"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "Dodawaj wydarzenia z najmniejszymi niezbędnymi uprawnieniami."
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "Przejdź na pełny dostęp"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "Wyświetlaj listę wydarzeń z kalendarza i odczytuj je."
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "Wyświetlaj listę przypomnień, dodawaj je i oznaczaj jako wykonane."
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "Tylko dodawanie"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "Podsumowania zdrowia"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "Zezwól"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "Permitir acesso"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "Escolha o que seu agente pode usar neste iPhone. Nada será ativado até que você permita."
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "Você pode alterar qualquer uma dessas opções mais tarde em Ajustes."
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "Continuar"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "Permitir"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "Abrir Ajustes"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "Rede doméstica"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "Conecte este iPhone ao seu gateway com segurança."
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "Seu agente no seu bolso. Emparelhe este iPhone com seu gateway para começar."
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "Conectar ao seu gateway"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "Seu agente é executado no seu próprio computador"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "Escolha as permissões do dispositivo"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "Emparelhe este iPhone escaneando um código de configuração"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "Use o OpenClaw pelo seu telefone"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "Converse, fale e aprove ações de qualquer lugar"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "Permitido"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "Limitado"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "Desativado nos Ajustes"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "Notificações"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "Câmera"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "Microfone"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "Fotos"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "Contatos"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "Calendário"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "Lembretes"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "Localização"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "Aprovações de pareamento e respostas do seu agente."
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "Escaneie códigos de configuração e tire fotos quando solicitado."
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "Converse com seu agente usando a voz."
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "Compartilhe fotos recentes quando você pedir."
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "Pesquise e adicione pessoas que você mencionar."
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "Consulte e adicione eventos ao calendário."
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "Liste, adicione e conclua lembretes."
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "Responda a perguntas sobre localização e locais próximos."
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "Cabeçalhos personalizados"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "Somente adição"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "Permitido"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "Ativado"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "Limitado"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "Não permitido"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "Não definido"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "Desconhecido"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "Contatos"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "Privacidade e acesso"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "Pesquise e adicione contatos pelo assistente."
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "Fotos"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "Calendário (Adicionar eventos)"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "Adicione eventos com privilégio mínimo."
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "Calendário (Ver eventos)"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "Liste e leia eventos do calendário."
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "Lembretes"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "Liste, adicione e conclua lembretes."
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "Resumos de Saúde"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "Privacidade e acesso"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "Ler fotos recentes para o assistente."
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "Gerenciar acesso"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "Limitado"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "Solicitar acesso total"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "Calendário (Adicionar eventos)"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "Solicitar acesso"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "Adicione eventos com privilégio mínimo."
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "Fazer upgrade para acesso total"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "Liste e leia eventos do calendário."
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "Liste, adicione e conclua lembretes."
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "Somente adição"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "Resumos de Saúde"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "Permitir"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -13339,6 +13339,11 @@
       "translated": "Continuar"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "Limitado"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "Permitir"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "Abrir Ajustes"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "Gerenciar"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "Разрешить доступ"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "Выберите, что ваш агент может использовать на этом iPhone. По умолчанию доступ ко всему отключён, пока вы его не разрешите."
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "Позже вы сможете изменить любой из этих параметров в Настройках."
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "Продолжить"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "Разрешить"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "Открыть Настройки"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "Домашняя сеть"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "Безопасно подключите этот iPhone к вашему Gateway."
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "Ваш агент у вас в кармане. Чтобы начать, подключите этот iPhone к своему gateway."
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "Подключиться к вашему Gateway"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "Ваш агент работает на вашем компьютере"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "Выберите разрешения устройства"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "Подключите этот iPhone, отсканировав код настройки"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "Используйте OpenClaw с телефона"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "Общайтесь в чате и голосом, а также подтверждайте действия откуда угодно"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "Разрешено"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "Ограниченный доступ"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "Отключено в Настройках"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "Уведомления"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "Камера"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "Микрофон"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "Фото"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "Контакты"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "Календарь"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "Напоминания"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "Местоположение"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "Запросы на сопряжение и ответы от вашего агента."
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "Сканирование кодов настройки и съёмка фотографий по запросу."
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "Общение с вашим агентом с помощью голоса."
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "Предоставление доступа к недавним фотографиям по вашему запросу."
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "Поиск и добавление упомянутых вами людей."
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "Просмотр и добавление событий календаря."
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "Просмотр, добавление и выполнение напоминаний."
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "Ответы на вопросы о местоположении и ближайших местах."
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "Пользовательские заголовки"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "Только добавление"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "Разрешено"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "Включено"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "Ограниченный доступ"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "Не разрешено"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "Не задано"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "Неизвестно"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "Контакты"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "Конфиденциальность и доступ"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "Ищите и добавляйте контакты из ассистента."
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "Фото"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "Календарь (добавление событий)"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "Добавляйте события с минимально необходимыми правами."
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "Календарь (просмотр событий)"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "Просматривайте список событий календаря и читайте их."
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "Напоминания"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "Просматривайте список напоминаний, добавляйте и отмечайте их как выполненные."
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "Сводки о здоровье"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "Конфиденциальность и доступ"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "Читать недавние фотографии для ассистента."
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "Управление доступом"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "Ограниченный доступ"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "Запросить полный доступ"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "Календарь (добавление событий)"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "Запросить доступ"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "Добавляйте события с минимально необходимыми правами."
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "Перейти на полный доступ"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "Просматривайте список событий календаря и читайте их."
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "Просматривайте список напоминаний, добавляйте и отмечайте их как выполненные."
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "Только добавление"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "Сводки о здоровье"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "Разрешить"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -13339,6 +13339,11 @@
       "translated": "Продолжить"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "Ограничено"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "Разрешить"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "Открыть Настройки"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "Управлять"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "Tillåt åtkomst"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "Välj vad din agent får använda på denna iPhone. Inget är aktiverat förrän du tillåter det."
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "Du kan ändra detta senare i Inställningar."
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "Fortsätt"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "Tillåt"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "Öppna Inställningar"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "Hemnätverk"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "Anslut denna iPhone säkert till din gateway."
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "Din agent i fickan. Parkoppla denna iPhone med din gateway för att komma igång."
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "Anslut till din gateway"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "Din agent körs på din egen dator"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "Välj enhetsbehörigheter"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "Parkoppla denna iPhone genom att skanna en installationskod"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "Använd OpenClaw från din telefon"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "Chatta, prata och godkänn åtgärder var du än är"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "Tillåtet"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "Begränsat"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "Avstängt i Inställningar"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "Notiser"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "Kamera"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "Mikrofon"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "Bilder"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "Kontakter"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "Kalender"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "Påminnelser"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "Plats"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "Parkopplingsgodkännanden och svar från din agent."
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "Skanna konfigurationskoder och ta foton på begäran."
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "Prata med din agent med hjälp av rösten."
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "Dela de senaste bilderna när du ber om det."
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "Sök efter och lägg till personer som du nämner."
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "Kontrollera och lägg till kalenderhändelser."
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "Visa, lägg till och slutför påminnelser."
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "Besvara frågor om plats och närområde."
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "Anpassade Headers"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "Endast tillägg"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "Tillåtet"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "Aktiverat"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "Begränsad"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "Inte tillåtet"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "Inte inställt"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "Okänd"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "Kontakter"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "Integritet och åtkomst"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "Sök efter och lägg till kontakter från assistenten."
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "Foton"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "Kalender (lägg till händelser)"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "Lägg till händelser med lägsta behörighet."
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "Kalender (visa händelser)"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "Lista och läs kalenderhändelser."
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "Påminnelser"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "Lista, lägg till och slutför påminnelser."
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "Hälsosammanfattningar"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "Integritet och åtkomst"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "Läs senaste foton för assistenten."
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "Hantera åtkomst"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "Begränsad"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "Begär fullständig åtkomst"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "Kalender (lägg till händelser)"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "Begär åtkomst"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "Lägg till händelser med lägsta behörighet."
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "Uppgradera till fullständig åtkomst"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "Lista och läs kalenderhändelser."
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "Lista, lägg till och slutför påminnelser."
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "Endast tillägg"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "Hälsosammanfattningar"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "Tillåt"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -13339,6 +13339,11 @@
       "translated": "Fortsätt"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "Begränsad"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "Tillåt"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "Öppna Inställningar"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "Hantera"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -13339,6 +13339,11 @@
       "translated": "ดำเนินการต่อ"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "จำกัด"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "อนุญาต"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "เปิดการตั้งค่า"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "จัดการ"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "อนุญาตการเข้าถึง"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "เลือกสิ่งที่เอเจนต์ของคุณสามารถใช้ได้บน iPhone เครื่องนี้ โดยจะไม่มีสิ่งใดเปิดใช้งานจนกว่าคุณจะอนุญาต"
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "คุณสามารถเปลี่ยนแปลงรายการเหล่านี้ภายหลังได้ในการตั้งค่า"
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "ดำเนินการต่อ"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "อนุญาต"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "เปิดการตั้งค่า"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "เครือข่ายภายในบ้าน"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "เชื่อมต่อ iPhone เครื่องนี้กับ Gateway ของคุณอย่างปลอดภัย"
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "เอเจนต์ของคุณในกระเป๋า จับคู่ iPhone เครื่องนี้กับ Gateway ของคุณเพื่อเริ่มต้นใช้งาน"
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "เชื่อมต่อกับ Gateway ของคุณ"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "เอเจนต์ของคุณทำงานบนคอมพิวเตอร์ของคุณเอง"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "เลือกสิทธิ์ของอุปกรณ์"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "จับคู่ iPhone เครื่องนี้โดยสแกนรหัสตั้งค่า"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "ใช้ OpenClaw จากโทรศัพท์ของคุณ"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "แชท พูดคุย และอนุมัติการดำเนินการได้จากทุกที่"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "อนุญาตแล้ว"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "จำกัด"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "ปิดอยู่ในการตั้งค่า"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "การแจ้งเตือน"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "กล้อง"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "ไมโครโฟน"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "รูปภาพ"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "รายชื่อ"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "ปฏิทิน"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "เตือนความจำ"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "ตำแหน่งที่ตั้ง"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "การอนุมัติการจับคู่และการตอบกลับจากเอเจนต์ของคุณ"
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "สแกนรหัสการตั้งค่าและถ่ายรูปเมื่อได้รับคำขอ"
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "พูดคุยกับเอเจนต์ของคุณโดยใช้เสียง"
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "แชร์รูปภาพล่าสุดเมื่อคุณขอ"
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "ค้นหาและเพิ่มบุคคลที่คุณกล่าวถึง"
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "ตรวจสอบและเพิ่มกิจกรรมในปฏิทิน"
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "แสดงรายการ เพิ่ม และทำรายการเตือนความจำให้เสร็จ"
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "ตอบคำถามเกี่ยวกับตำแหน่งที่ตั้งและสถานที่ใกล้เคียง"
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "Headers แบบกำหนดเอง"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "เพิ่มได้เท่านั้น"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "อนุญาตแล้ว"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "เปิดใช้แล้ว"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "จำกัด"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "ไม่อนุญาต"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "ยังไม่ได้ตั้งค่า"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "ไม่ทราบ"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "รายชื่อติดต่อ"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "ความเป็นส่วนตัวและการเข้าถึง"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "ค้นหาและเพิ่มรายชื่อติดต่อจากผู้ช่วย"
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "รูปภาพ"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "ปฏิทิน (เพิ่มกิจกรรม)"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "เพิ่มกิจกรรมด้วยสิทธิ์ขั้นต่ำ"
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "ปฏิทิน (ดูกิจกรรม)"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "แสดงรายการและอ่านกิจกรรมในปฏิทิน"
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "รายการเตือนความจำ"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "แสดงรายการ เพิ่ม และทำรายการเตือนความจำให้เสร็จสิ้น"
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "สรุปข้อมูลสุขภาพ"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "ความเป็นส่วนตัวและการเข้าถึง"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "อ่านรูปภาพล่าสุดสำหรับผู้ช่วย"
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "จัดการสิทธิ์การเข้าถึง"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "จำกัด"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "ขอสิทธิ์การเข้าถึงแบบเต็ม"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "ปฏิทิน (เพิ่มกิจกรรม)"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "ขอสิทธิ์การเข้าถึง"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "เพิ่มกิจกรรมด้วยสิทธิ์ขั้นต่ำ"
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "อัปเกรดเป็นสิทธิ์การเข้าถึงแบบเต็ม"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "แสดงรายการและอ่านกิจกรรมในปฏิทิน"
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "แสดงรายการ เพิ่ม และทำรายการเตือนความจำให้เสร็จสิ้น"
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "เพิ่มได้เท่านั้น"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "สรุปข้อมูลสุขภาพ"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "อนุญาต"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -13339,6 +13339,11 @@
       "translated": "Devam"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "Sınırlı"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "İzin ver"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "Ayarları Aç"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "Yönet"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "Erişime izin ver"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "Aracınızın bu iPhone'da neleri kullanabileceğini seçin. Siz izin verene kadar hiçbirine erişilemez."
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "Bunlardan herhangi birini daha sonra Ayarlar'dan değiştirebilirsiniz."
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "Devam"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "İzin ver"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "Ayarları Aç"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "Ev Ağı"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "Bu iPhone'u gateway'inize güvenli bir şekilde bağlayın."
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "Aracınız cebinizde. Başlamak için bu iPhone'u Gateway'inizle eşleştirin."
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "Gateway'inize bağlanın"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "Aracınız kendi bilgisayarınızda çalışır"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "Cihaz izinlerini seçin"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "Bir kurulum kodunu tarayarak bu iPhone'u eşleştirin"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "OpenClaw'u telefonunuzdan kullanın"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "Her yerden sohbet edin, konuşun ve işlemleri onaylayın"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "İzin verildi"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "Sınırlı"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "Ayarlar'da kapalı"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "Bildirimler"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "Kamera"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "Mikrofon"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "Fotoğraflar"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "Kişiler"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "Takvim"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "Anımsatıcılar"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "Konum"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "Agentinizden gelen eşleştirme onayları ve yanıtları."
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "Kurulum kodlarını tarayın ve istendiğinde fotoğraf çekin."
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "Agentinizle sesli olarak konuşun."
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "İstediğinizde son fotoğrafları paylaşın."
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "Bahsettiğiniz kişileri bulun ve ekleyin."
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "Takvim etkinliklerini kontrol edin ve ekleyin."
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "Anımsatıcıları listeleyin, ekleyin ve tamamlayın."
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "Konum ve yakındaki yerlerle ilgili soruları yanıtlayın."
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "Özel Üst Bilgiler"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "Yalnızca Ekleme"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "İzin Verildi"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "Etkin"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "Sınırlı"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "İzin Verilmiyor"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "Ayarlanmadı"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "Bilinmiyor"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "Kişiler"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "Gizlilik ve Erişim"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "Asistandan kişi arayın ve ekleyin."
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "Fotoğraflar"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "Takvim (Etkinlik Ekle)"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "En az ayrıcalıkla etkinlik ekleyin."
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "Takvim (Etkinlikleri Görüntüle)"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "Takvim etkinliklerini listeleyin ve okuyun."
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "Anımsatıcılar"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "Anımsatıcıları listeleyin, ekleyin ve tamamlayın."
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "Sağlık Özetleri"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "Gizlilik ve Erişim"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "Asistan için son fotoğrafları okuyun."
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "Erişimi Yönet"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "Sınırlı"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "Tam Erişim İste"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "Takvim (Etkinlik Ekle)"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "Erişim İste"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "En az ayrıcalıkla etkinlik ekleyin."
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "Tam Erişime Yükselt"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "Takvim etkinliklerini listeleyin ve okuyun."
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "Anımsatıcıları listeleyin, ekleyin ve tamamlayın."
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "Yalnızca Ekleme"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "Sağlık Özetleri"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "İzin Ver"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -13339,6 +13339,11 @@
       "translated": "Продовжити"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "Обмежено"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "Дозволити"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "Відкрити Параметри"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "Керувати"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "Надати доступ"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "Виберіть, що ваш агент може використовувати на цьому iPhone. Нічого не ввімкнено, доки ви не надасте дозвіл."
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "Згодом ви зможете змінити будь-яке з цих налаштувань у розділі «Параметри»."
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "Продовжити"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "Дозволити"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "Відкрити Параметри"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "Домашня мережа"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "Безпечно підключіть цей iPhone до вашого Gateway."
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "Ваш агент у вашій кишені. Щоб почати, сполучіть цей iPhone зі своїм Gateway."
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "Підключитися до вашого Gateway"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "Ваш агент працює на вашому комп’ютері"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "Виберіть дозволи пристрою"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "Сполучіть цей iPhone, відсканувавши код налаштування"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "Використовуйте OpenClaw зі свого телефона"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "Спілкуйтеся в чаті, розмовляйте й схвалюйте дії звідусіль"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "Дозволено"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "Обмежено"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "Вимкнено в Параметрах"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "Сповіщення"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "Камера"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "Мікрофон"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "Фото"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "Контакти"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "Календар"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "Нагадування"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "Місцезнаходження"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "Схвалення запитів на сполучення та відповіді від вашого агента."
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "Сканування кодів налаштування та створення фотографій на запит."
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "Спілкування з вашим агентом за допомогою голосу."
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "Надсилання нещодавніх фотографій на ваш запит."
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "Пошук і додавання згаданих вами людей."
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "Перевірка та додавання подій календаря."
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "Перегляд, додавання та виконання нагадувань."
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "Відповіді на запитання про місцезнаходження та місця поблизу."
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "Власні заголовки"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "Лише додавання"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "Дозволено"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "Увімкнено"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "Обмежено"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "Не дозволено"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "Не встановлено"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "Невідомо"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "Контакти"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "Конфіденційність і доступ"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "Шукайте й додавайте контакти з помічника."
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "Фото"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "Календар (додавання подій)"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "Додавайте події з мінімальними привілеями."
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "Календар (перегляд подій)"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "Переглядайте список і читайте події календаря."
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "Нагадування"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "Переглядайте список, додавайте й позначайте нагадування як виконані."
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "Підсумки здоров’я"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "Конфіденційність і доступ"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "Читати нещодавні фото для асистента."
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "Керувати доступом"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "Обмежено"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "Запросити повний доступ"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "Календар (додавання подій)"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "Запросити доступ"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "Додавайте події з мінімальними привілеями."
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "Перейти на повний доступ"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "Переглядайте список і читайте події календаря."
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "Переглядайте список, додавайте й позначайте нагадування як виконані."
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "Лише додавання"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "Підсумки здоров’я"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "Дозволити"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "Cho phép truy cập"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "Chọn những gì agent của bạn có thể sử dụng trên iPhone này. Mọi quyền đều tắt cho đến khi bạn cho phép."
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "Bạn có thể thay đổi bất kỳ quyền nào trong số này sau tại Cài đặt."
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "Tiếp tục"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "Cho phép"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "Mở Cài đặt"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "Mạng gia đình"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "Kết nối iPhone này với gateway của bạn một cách an toàn."
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "Agent của bạn, ngay trong túi. Ghép đôi iPhone này với Gateway của bạn để bắt đầu."
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "Kết nối với gateway của bạn"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "Agent của bạn chạy trên máy tính của chính bạn"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "Chọn quyền thiết bị"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "Ghép đôi iPhone này bằng cách quét mã thiết lập"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "Sử dụng OpenClaw từ điện thoại của bạn"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "Trò chuyện, đàm thoại và phê duyệt các hành động từ bất cứ đâu"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "Đã cho phép"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "Hạn chế"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "Đã tắt trong Cài đặt"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "Thông báo"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "Micrô"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "Ảnh"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "Danh bạ"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "Lịch"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "Lời nhắc"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "Vị trí"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "Phê duyệt yêu cầu ghép nối và phản hồi từ tác nhân của bạn."
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "Quét mã thiết lập và chụp ảnh khi được yêu cầu."
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "Trò chuyện với tác nhân của bạn bằng giọng nói."
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "Chia sẻ ảnh gần đây khi bạn yêu cầu."
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "Tìm kiếm và thêm những người bạn đề cập."
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "Kiểm tra và thêm sự kiện lịch."
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "Liệt kê, thêm và hoàn thành lời nhắc."
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "Trả lời các câu hỏi về vị trí và khu vực lân cận."
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "Header tùy chỉnh"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "Chỉ thêm"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "Được phép"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "Đã bật"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "Giới hạn"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "Không được phép"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "Chưa đặt"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "Không xác định"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "Danh bạ"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "Quyền riêng tư & Quyền truy cập"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "Tìm kiếm và thêm liên hệ từ trợ lý."
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "Ảnh"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "Lịch (Thêm sự kiện)"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "Thêm sự kiện với đặc quyền tối thiểu."
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "Lịch (Xem sự kiện)"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "Liệt kê và đọc sự kiện trên lịch."
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "Lời nhắc"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "Liệt kê, thêm và hoàn tất lời nhắc."
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "Tóm tắt sức khỏe"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "Quyền riêng tư & Quyền truy cập"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "Đọc ảnh gần đây cho trợ lý."
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "Quản lý quyền truy cập"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "Giới hạn"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "Yêu cầu quyền truy cập đầy đủ"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "Lịch (Thêm sự kiện)"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "Yêu cầu quyền truy cập"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "Thêm sự kiện với đặc quyền tối thiểu."
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "Nâng cấp lên quyền truy cập đầy đủ"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "Liệt kê và đọc sự kiện trên lịch."
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "Liệt kê, thêm và hoàn tất lời nhắc."
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "Chỉ thêm"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "Tóm tắt sức khỏe"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "Cho phép"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -13339,6 +13339,11 @@
       "translated": "Tiếp tục"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "Hạn chế"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "Cho phép"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "Mở Cài đặt"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "Quản lý"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "允许访问"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "选择您的智能体可以在此 iPhone 上使用的内容。获得您的允许前，所有权限均处于关闭状态。"
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "您稍后可以在“设置”中更改其中任何一项。"
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "继续"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "允许"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "打开设置"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "家庭网络"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "安全地将此 iPhone 连接到您的 Gateway。"
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "您的智能体，随身相伴。将此 iPhone 与您的 Gateway 配对，即可开始使用。"
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "连接到您的 Gateway"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "您的智能体在您自己的电脑上运行"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "选择设备权限"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "扫描设置代码以配对此 iPhone"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "在手机上使用 OpenClaw"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "随时随地聊天、通话和批准操作"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "已允许"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "受限"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "已在设置中关闭"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "通知"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "相机"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "麦克风"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "照片"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "通讯录"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "日历"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "提醒事项"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "位置"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "接收来自智能体的配对批准和回复。"
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "扫描设置代码，并根据请求拍照。"
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "使用语音与智能体交谈。"
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "根据你的请求分享近期照片。"
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "查找并添加你提到的人。"
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "查看并添加日历事件。"
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "列出、添加和完成提醒事项。"
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "回答有关位置和附近地点的问题。"
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "自定义标头"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "仅添加"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "已允许"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "已启用"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "受限"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "不允许"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "未设置"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "未知"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "联系人"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "隐私与访问权限"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "从助手中搜索并添加联系人。"
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "照片"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "日历（添加事件）"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "以最小权限添加事件。"
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "日历（查看事件）"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "列出并读取日历事件。"
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "提醒事项"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "列出、添加和完成提醒事项。"
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "健康摘要"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "隐私与访问权限"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "读取助手使用的最近照片。"
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "管理访问权限"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "受限"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "请求完全访问权限"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "日历（添加事件）"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "请求访问权限"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "以最小权限添加事件。"
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "升级为完全访问权限"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "列出并读取日历事件。"
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "列出、添加和完成提醒事项。"
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "仅添加"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "健康摘要"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "允许"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -13339,6 +13339,11 @@
       "translated": "继续"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "受限"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "允许"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "打开设置"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "管理"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -13339,6 +13339,11 @@
       "translated": "繼續"
     },
     {
+      "id": "native.apple.5f425282ece878eb",
+      "source": "Limited",
+      "translated": "受限"
+    },
+    {
       "id": "native.apple.c5db9e6eae115f7a",
       "source": "Allow",
       "translated": "允許"
@@ -13347,6 +13352,11 @@
       "id": "native.apple.f591e16105268e99",
       "source": "Open Settings",
       "translated": "開啟「設定」"
+    },
+    {
+      "id": "native.apple.12ed416835c36555",
+      "source": "Manage",
+      "translated": "管理"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -13319,6 +13319,36 @@
       "translated": "\\(urlText.prefix(500))…"
     },
     {
+      "id": "native.apple.9dcd64ab340a6c15",
+      "source": "Allow access",
+      "translated": "允許存取"
+    },
+    {
+      "id": "native.apple.933a2ac28d1d2aec",
+      "source": "Choose what your agent can use on this iPhone. Nothing is on until you allow it.",
+      "translated": "選擇您的代理程式可在此 iPhone 上使用的項目。在您允許之前，所有項目皆為關閉狀態。"
+    },
+    {
+      "id": "native.apple.47114a39f7a71c3b",
+      "source": "You can change any of these later in Settings.",
+      "translated": "您稍後可隨時在「設定」中變更這些項目。"
+    },
+    {
+      "id": "native.apple.eabf54e2b640a4a1",
+      "source": "Continue",
+      "translated": "繼續"
+    },
+    {
+      "id": "native.apple.c5db9e6eae115f7a",
+      "source": "Allow",
+      "translated": "允許"
+    },
+    {
+      "id": "native.apple.f591e16105268e99",
+      "source": "Open Settings",
+      "translated": "開啟「設定」"
+    },
+    {
       "id": "native.apple.11687a3d87afd0d7",
       "source": "Home Network",
       "translated": "家用網路"
@@ -13499,24 +13529,24 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.apple.c9419426ba8c2a2e",
-      "source": "Securely connect this iPhone to your gateway.",
-      "translated": "安全地將此 iPhone 連接到你的 Gateway。"
+      "id": "native.apple.9b414850baa618da",
+      "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
+      "translated": "隨身攜帶您的代理程式。將此 iPhone 與您的 Gateway 配對即可開始使用。"
     },
     {
-      "id": "native.apple.3e233ba3ed3181d4",
-      "source": "Connect to your gateway",
-      "translated": "連接到你的 Gateway"
+      "id": "native.apple.7248e67848beebd9",
+      "source": "Your agent runs on your own computer",
+      "translated": "您的代理程式會在您自己的電腦上執行"
     },
     {
-      "id": "native.apple.b6978424ac0a4d14",
-      "source": "Choose device permissions",
-      "translated": "選擇裝置權限"
+      "id": "native.apple.acbdc9332988fa64",
+      "source": "Pair this iPhone by scanning a setup code",
+      "translated": "掃描設定代碼以配對此 iPhone"
     },
     {
-      "id": "native.apple.4109460a5b8927d8",
-      "source": "Use OpenClaw from your phone",
-      "translated": "從你的手機使用 OpenClaw"
+      "id": "native.apple.feb3e155748c2f05",
+      "source": "Chat, talk, and approve actions from anywhere",
+      "translated": "隨時隨地聊天、交談及核准動作"
     },
     {
       "id": "native.apple.cae311a6e975c879",
@@ -13784,6 +13814,101 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.0e07e7044608f954",
+      "source": "Allowed",
+      "translated": "已允許"
+    },
+    {
+      "id": "native.apple.86796a6df9d0ff63",
+      "source": "Limited",
+      "translated": "受限"
+    },
+    {
+      "id": "native.apple.4c7f5404e9c42402",
+      "source": "Off in Settings",
+      "translated": "已在「設定」中關閉"
+    },
+    {
+      "id": "native.apple.96d65a5563690719",
+      "source": "Notifications",
+      "translated": "通知"
+    },
+    {
+      "id": "native.apple.d290a46515add091",
+      "source": "Camera",
+      "translated": "相機"
+    },
+    {
+      "id": "native.apple.0eeedbc8aaafcd2c",
+      "source": "Microphone",
+      "translated": "麥克風"
+    },
+    {
+      "id": "native.apple.14fadad23dd36e44",
+      "source": "Photos",
+      "translated": "照片"
+    },
+    {
+      "id": "native.apple.f0cfa9dcc57133b7",
+      "source": "Contacts",
+      "translated": "聯絡人"
+    },
+    {
+      "id": "native.apple.5ec2597d0b4a06fb",
+      "source": "Calendar",
+      "translated": "行事曆"
+    },
+    {
+      "id": "native.apple.9ed5c19cf1e84490",
+      "source": "Reminders",
+      "translated": "提醒事項"
+    },
+    {
+      "id": "native.apple.866b9df8afcadf07",
+      "source": "Location",
+      "translated": "位置"
+    },
+    {
+      "id": "native.apple.f205ac6778705a7d",
+      "source": "Pairing approvals and replies from your agent.",
+      "translated": "來自您代理程式的配對核准與回覆。"
+    },
+    {
+      "id": "native.apple.061a17077ee3be94",
+      "source": "Scan setup codes and take photos on request.",
+      "translated": "掃描設定代碼，並在要求時拍照。"
+    },
+    {
+      "id": "native.apple.c735ac6b282765f9",
+      "source": "Talk with your agent using voice.",
+      "translated": "使用語音與您的代理程式交談。"
+    },
+    {
+      "id": "native.apple.ebe8aadcf512ecdb",
+      "source": "Share recent photos when you ask.",
+      "translated": "在您要求時分享最近的照片。"
+    },
+    {
+      "id": "native.apple.4c4bc12c0787383c",
+      "source": "Look up and add people you mention.",
+      "translated": "查詢並新增您提到的人物。"
+    },
+    {
+      "id": "native.apple.5a4006fbb9b23db1",
+      "source": "Check and add calendar events.",
+      "translated": "查看並新增行事曆活動。"
+    },
+    {
+      "id": "native.apple.2b2a4f1aab6a12ec",
+      "source": "List, add, and complete reminders.",
+      "translated": "列出、新增及完成提醒事項。"
+    },
+    {
+      "id": "native.apple.3854ae1f0606bafe",
+      "source": "Answer location and nearby questions.",
+      "translated": "回答位置和附近地點的相關問題。"
+    },
+    {
       "id": "native.apple.e5f6435b9cb5a2d8",
       "source": "unknown relay error",
       "translated": "unknown relay error"
@@ -14049,94 +14174,14 @@
       "translated": "自訂標頭"
     },
     {
-      "id": "native.apple.e5a601c8fe47e9ed",
-      "source": "Add-Only",
-      "translated": "僅新增"
-    },
-    {
-      "id": "native.apple.32aabe66f916a809",
-      "source": "Allowed",
-      "translated": "已允許"
-    },
-    {
-      "id": "native.apple.7b551f40d1a6148c",
-      "source": "Enabled",
-      "translated": "已啟用"
-    },
-    {
-      "id": "native.apple.94208c3068dae5b9",
-      "source": "Limited",
-      "translated": "有限"
-    },
-    {
-      "id": "native.apple.92223852c90e286d",
-      "source": "Not Allowed",
-      "translated": "不允許"
-    },
-    {
-      "id": "native.apple.aa6ff8becab99fdc",
-      "source": "Not Set",
-      "translated": "未設定"
-    },
-    {
-      "id": "native.apple.03e2f7265119d263",
-      "source": "Unknown",
-      "translated": "未知"
-    },
-    {
-      "id": "native.apple.4dac301c7e0c921c",
-      "source": "Contacts",
-      "translated": "聯絡人"
+      "id": "native.apple.bb572eab08269809",
+      "source": "Privacy & Access",
+      "translated": "隱私權與存取權"
     },
     {
       "id": "native.apple.01f362d70f6ddb4e",
       "source": "Search and add contacts from the assistant.",
       "translated": "從助理搜尋並新增聯絡人。"
-    },
-    {
-      "id": "native.apple.eda8d96e40bcc36a",
-      "source": "Photos",
-      "translated": "照片"
-    },
-    {
-      "id": "native.apple.df0159ff34744870",
-      "source": "Calendar (Add Events)",
-      "translated": "行事曆（新增事件）"
-    },
-    {
-      "id": "native.apple.c6db4240083c0435",
-      "source": "Add events with least privilege.",
-      "translated": "以最低權限新增事件。"
-    },
-    {
-      "id": "native.apple.dc62e22f0b2726c5",
-      "source": "Calendar (View Events)",
-      "translated": "行事曆（檢視事件）"
-    },
-    {
-      "id": "native.apple.650091bc632b3120",
-      "source": "List and read calendar events.",
-      "translated": "列出並讀取行事曆事件。"
-    },
-    {
-      "id": "native.apple.7a81d1f17d9d90c0",
-      "source": "Reminders",
-      "translated": "提醒事項"
-    },
-    {
-      "id": "native.apple.d6fd5e9f85b0e298",
-      "source": "List, add, and complete reminders.",
-      "translated": "列出、新增並完成提醒事項。"
-    },
-    {
-      "id": "native.apple.33df187e4402065a",
-      "source": "Health Summaries",
-      "translated": "健康摘要"
-    },
-    {
-      "id": "native.apple.bb572eab08269809",
-      "source": "Privacy & Access",
-      "translated": "隱私權與存取權"
     },
     {
       "id": "native.apple.ab998419291361da",
@@ -14149,24 +14194,44 @@
       "translated": "為助理讀取最近的照片。"
     },
     {
-      "id": "native.apple.ac3ff8e4c6df7a2a",
-      "source": "Manage Access",
-      "translated": "管理存取權"
+      "id": "native.apple.94208c3068dae5b9",
+      "source": "Limited",
+      "translated": "有限"
     },
     {
-      "id": "native.apple.c557c95fa2789089",
-      "source": "Request Full Access",
-      "translated": "要求完整存取權"
+      "id": "native.apple.df0159ff34744870",
+      "source": "Calendar (Add Events)",
+      "translated": "行事曆（新增事件）"
     },
     {
-      "id": "native.apple.4e50e2ab4c869464",
-      "source": "Request Access",
-      "translated": "要求存取權"
+      "id": "native.apple.c6db4240083c0435",
+      "source": "Add events with least privilege.",
+      "translated": "以最低權限新增事件。"
     },
     {
-      "id": "native.apple.a9f30d4e86060dca",
-      "source": "Upgrade to Full Access",
-      "translated": "升級至完整存取權"
+      "id": "native.apple.650091bc632b3120",
+      "source": "List and read calendar events.",
+      "translated": "列出並讀取行事曆事件。"
+    },
+    {
+      "id": "native.apple.d6fd5e9f85b0e298",
+      "source": "List, add, and complete reminders.",
+      "translated": "列出、新增並完成提醒事項。"
+    },
+    {
+      "id": "native.apple.e5a601c8fe47e9ed",
+      "source": "Add-Only",
+      "translated": "僅新增"
+    },
+    {
+      "id": "native.apple.33df187e4402065a",
+      "source": "Health Summaries",
+      "translated": "健康摘要"
+    },
+    {
+      "id": "native.apple.0b10201d7e452dc4",
+      "source": "Allow",
+      "translated": "允許"
     },
     {
       "id": "native.apple.3cb9ed2ae352f95c",

--- a/apps/android/app/src/main/res/values-de/strings.xml
+++ b/apps/android/app/src/main/res/values-de/strings.xml
@@ -325,7 +325,7 @@
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Senden fehlgeschlagen: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bridge"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zustellungsfehler"</string>
-    <string name="native_38dcea3e5a6a342e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw auf Ihrem Telefon verwenden"</string>
+    <string name="native_38dcea3e5a6a342e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw von deinem Smartphone verwenden"</string>
     <string name="native_3907fa7f80722a6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Erscheinungsbild"</string>
     <string name="native_3912c65bdd0a4356" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill-Workshop"</string>
     <string name="native_3942b87daebe82bb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Token erforderlich"</string>

--- a/apps/android/app/src/main/res/values-fa/strings.xml
+++ b/apps/android/app/src/main/res/values-fa/strings.xml
@@ -822,7 +822,7 @@
     <string name="native_943a630198a15ae2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"یک گفتگو را شروع کنید تا مکالمه‌های فعال OpenClaw شما اینجا ظاهر شوند."</string>
     <string name="native_944946b3f36d1520" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پوسته در فضای کاری عامل"</string>
     <string name="native_947fd9b8681c972b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s فعال"</string>
-    <string name="native_948cff139c5c153d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"انتخاب مجوزهای دستگاه"</string>
+    <string name="native_948cff139c5c153d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مجوزهای دستگاه را انتخاب کنید"</string>
     <string name="native_94b917998807d655" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مدت آخرین اجرا"</string>
     <string name="native_94da52ecd6c5c3b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عامل پیش‌فرض"</string>
     <string name="native_94f5698f54d7d31a" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s ساعت"</string>

--- a/apps/android/app/src/main/res/values-fr/strings.xml
+++ b/apps/android/app/src/main/res/values-fr/strings.xml
@@ -325,7 +325,7 @@
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Échec de l’envoi : %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pont"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Erreur de livraison"</string>
-    <string name="native_38dcea3e5a6a342e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Utiliser OpenClaw depuis votre téléphone"</string>
+    <string name="native_38dcea3e5a6a342e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Utilisez OpenClaw depuis votre téléphone"</string>
     <string name="native_3907fa7f80722a6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apparence"</string>
     <string name="native_3912c65bdd0a4356" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Atelier de Skills"</string>
     <string name="native_3942b87daebe82bb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Jeton requis"</string>

--- a/apps/android/app/src/main/res/values-ja/strings.xml
+++ b/apps/android/app/src/main/res/values-ja/strings.xml
@@ -822,7 +822,7 @@
     <string name="native_943a630198a15ae2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"チャットを開始すると、アクティブな OpenClaw の会話がここに表示されます。"</string>
     <string name="native_944946b3f36d1520" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"エージェントワークスペース内のシェル"</string>
     <string name="native_947fd9b8681c972b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 件がアクティブ"</string>
-    <string name="native_948cff139c5c153d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"デバイスの権限を選択"</string>
+    <string name="native_948cff139c5c153d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"デバイス権限を選択"</string>
     <string name="native_94b917998807d655" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"前回の所要時間"</string>
     <string name="native_94da52ecd6c5c3b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"デフォルトのエージェント"</string>
     <string name="native_94f5698f54d7d31a" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s時間"</string>

--- a/apps/android/app/src/main/res/values-pl/strings.xml
+++ b/apps/android/app/src/main/res/values-pl/strings.xml
@@ -325,7 +325,7 @@
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wysyłanie nie powiodło się: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Most"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Błąd dostarczenia"</string>
-    <string name="native_38dcea3e5a6a342e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Korzystaj z OpenClaw na telefonie"</string>
+    <string name="native_38dcea3e5a6a342e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Używaj OpenClaw z telefonu"</string>
     <string name="native_3907fa7f80722a6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wygląd"</string>
     <string name="native_3912c65bdd0a4356" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Warsztat Skills"</string>
     <string name="native_3942b87daebe82bb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wymaga tokena"</string>

--- a/apps/android/app/src/main/res/values-ru/strings.xml
+++ b/apps/android/app/src/main/res/values-ru/strings.xml
@@ -127,7 +127,7 @@
     <string name="native_14d9bf289ff83113" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Настройте голос, транспорт и воспроизведение."</string>
     <string name="native_1520b570498730a0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s ожидают подтверждения"</string>
     <string name="native_155106be1173d757" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Имя устройства"</string>
-    <string name="native_15b61974b2707a7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Геопозиция"</string>
+    <string name="native_15b61974b2707a7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Местоположение"</string>
     <string name="native_16196f98cecd6839" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"например America/New_York"</string>
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Целевая сессия"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Проверить навык ClawHub"</string>

--- a/apps/android/app/src/main/res/values-sv/strings.xml
+++ b/apps/android/app/src/main/res/values-sv/strings.xml
@@ -675,7 +675,7 @@
     <string name="native_779aa3df405560c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway utvärderade en annan ClawHub-version. Granska denna skill igen innan du installerar."</string>
     <string name="native_77ab6bb71f77154d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Öppna systemåtkomst"</string>
     <string name="native_7817cd06563196ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bilden är inte tillgänglig"</string>
-    <string name="native_788011833a5a0f22" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aviseringar"</string>
+    <string name="native_788011833a5a0f22" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Notiser"</string>
     <string name="native_78af93f13a7e5044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tillämpa, avvisa och sätt i karantän kräver scope operator.admin. Återanslut med delad gateway-autentisering eller godkänn en scope-uppgradering till operator.admin för enheten för att aktivera livscykelåtgärder."</string>
     <string name="native_78f25f393aa9bcbf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"sticker upload"</string>
     <string name="native_792175fb265c32bc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw devices approve %1$s"</string>

--- a/apps/android/app/src/main/res/values-th/strings.xml
+++ b/apps/android/app/src/main/res/values-th/strings.xml
@@ -984,7 +984,7 @@
     <string name="native_b2e5f1e45872f947" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อุปกรณ์ที่จับคู่แล้ว"</string>
     <string name="native_b3975aa73d16205c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ต้องอนุมัติอีกครั้ง"</string>
     <string name="native_b3e24789bf8dc89b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่ได้กำหนดเวลา"</string>
-    <string name="native_b450645debe2cf0a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รายชื่อติดต่อ"</string>
+    <string name="native_b450645debe2cf0a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รายชื่อ"</string>
     <string name="native_b4739a4f08650db2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังคิด..."</string>
     <string name="native_b485a5fff49d5e50" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โทรศัพท์ของคุณจะไม่ส่งเสียงจนกว่าจะจำเป็น"</string>
     <string name="native_b4a6b1fff2ff63e3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังฟัง · กำลังส่งเสียงที่อยู่ในคิว"</string>

--- a/apps/android/app/src/main/res/values-tr/strings.xml
+++ b/apps/android/app/src/main/res/values-tr/strings.xml
@@ -325,7 +325,7 @@
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gönderilemedi: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Köprü"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Teslim Hatası"</string>
-    <string name="native_38dcea3e5a6a342e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw\'u telefonunuzdan kullanın"</string>
+    <string name="native_38dcea3e5a6a342e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw\'ı telefonunuzdan kullanın"</string>
     <string name="native_3907fa7f80722a6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Görünüm"</string>
     <string name="native_3912c65bdd0a4356" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill Atölyesi"</string>
     <string name="native_3942b87daebe82bb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Belirteç Gerekiyor"</string>

--- a/apps/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -325,7 +325,7 @@
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"傳送失敗：%1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"橋接"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"傳送錯誤"</string>
-    <string name="native_38dcea3e5a6a342e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"從你的手機使用 OpenClaw"</string>
+    <string name="native_38dcea3e5a6a342e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"從您的手機使用 OpenClaw"</string>
     <string name="native_3907fa7f80722a6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"外觀"</string>
     <string name="native_3912c65bdd0a4356" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill 工作坊"</string>
     <string name="native_3942b87daebe82bb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"需要權杖"</string>

--- a/apps/ios/Sources/Design/SettingsProTabSections.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSections.swift
@@ -885,7 +885,7 @@ extension SettingsProTab {
             }
             .contentShape(Rectangle())
         }
-        .accessibilityLabel(Text(title))
+        .accessibilityLabel(title)
     }
 
     func toggleCard(title: LocalizedStringKey, isOn: Binding<Bool>) -> some View {
@@ -1411,7 +1411,7 @@ extension SettingsProTab {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(Text(title))
+        .accessibilityLabel(title)
         .accessibilityValue(isOn.wrappedValue
             ? String(localized: "On")
             : String(localized: "Off"))

--- a/apps/ios/Sources/Design/SettingsProTabSections.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSections.swift
@@ -885,7 +885,7 @@ extension SettingsProTab {
             }
             .contentShape(Rectangle())
         }
-        .accessibilityLabel(title)
+        .accessibilityLabel(Text(title))
     }
 
     func toggleCard(title: LocalizedStringKey, isOn: Binding<Bool>) -> some View {
@@ -1411,7 +1411,7 @@ extension SettingsProTab {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(title)
+        .accessibilityLabel(Text(title))
         .accessibilityValue(isOn.wrappedValue
             ? String(localized: "On")
             : String(localized: "Off"))

--- a/apps/ios/Sources/Onboarding/OnboardingPermissionsStep.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingPermissionsStep.swift
@@ -67,6 +67,7 @@ struct OnboardingPermissionsStep: View {
             detail: kind.detail,
             grant: grant,
             isRequesting: self.permissions.requesting.contains(kind),
+            statusLabel: grant == .limited ? LocalizedStringResource("Limited") : nil,
             actionTitle: Self.actionTitle(for: grant),
             action: self.action(for: kind, grant: grant))
     }
@@ -77,7 +78,9 @@ struct OnboardingPermissionsStep: View {
             LocalizedStringResource("Allow")
         case .denied:
             LocalizedStringResource("Open Settings")
-        case .granted, .limited:
+        case .limited:
+            LocalizedStringResource("Manage")
+        case .granted:
             nil
         }
     }
@@ -86,9 +89,9 @@ struct OnboardingPermissionsStep: View {
         switch grant {
         case .notRequested:
             { Task { await self.permissions.request(kind) } }
-        case .denied:
+        case .denied, .limited:
             { self.openSystemSettings() }
-        case .granted, .limited:
+        case .granted:
             nil
         }
     }

--- a/apps/ios/Sources/Onboarding/OnboardingPermissionsStep.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingPermissionsStep.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+/// First-run permissions page: one tap per grant, live status, always skippable.
+/// System prompts fire only from the row actions; product opt-ins stay in Settings.
+struct OnboardingPermissionsStep: View {
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var permissions = DevicePermissionsModel()
+    let onContinue: () -> Void
+
+    var body: some View {
+        OnboardingActivationCanvas {
+            VStack(alignment: .leading, spacing: 0) {
+                OnboardingHeroHeader(
+                    title: "Allow access",
+                    subtitle: "Choose what your agent can use on this iPhone. Nothing is on until you allow it.")
+                    .padding(.top, 18)
+
+                OnboardingIntroPanel {
+                    VStack(alignment: .leading, spacing: 2) {
+                        ForEach(DevicePermissionKind.allCases) { kind in
+                            self.row(for: kind)
+                            if kind != DevicePermissionKind.allCases.last {
+                                Divider()
+                                    .padding(.leading, 48)
+                            }
+                        }
+                    }
+                }
+                .padding(.top, 30)
+
+                Text("You can change any of these later in Settings.")
+                    .font(OpenClawType.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 14)
+
+                Spacer(minLength: 32)
+
+                Button {
+                    self.onContinue()
+                } label: {
+                    Text("Continue")
+                        .font(OpenClawType.subheadSemiBold)
+                }
+                .buttonStyle(OpenClawPrimaryActionButtonStyle())
+                .padding(.top, 22)
+            }
+        }
+        .task {
+            await self.permissions.refresh()
+        }
+        .onChange(of: self.scenePhase) { _, phase in
+            guard phase == .active else { return }
+            Task { await self.permissions.refresh() }
+        }
+    }
+
+    private func row(for kind: DevicePermissionKind) -> some View {
+        let grant = self.permissions.grant(for: kind)
+        return DevicePermissionRow(
+            identifierPrefix: "onboarding-permission",
+            identifier: kind.rawValue,
+            symbol: kind.symbol,
+            tint: kind.tint,
+            title: kind.title,
+            detail: kind.detail,
+            grant: grant,
+            isRequesting: self.permissions.requesting.contains(kind),
+            actionTitle: Self.actionTitle(for: grant),
+            action: self.action(for: kind, grant: grant))
+    }
+
+    private static func actionTitle(for grant: DevicePermissionGrant) -> LocalizedStringResource? {
+        switch grant {
+        case .notRequested:
+            LocalizedStringResource("Allow")
+        case .denied:
+            LocalizedStringResource("Open Settings")
+        case .granted, .limited:
+            nil
+        }
+    }
+
+    private func action(for kind: DevicePermissionKind, grant: DevicePermissionGrant) -> (() -> Void)? {
+        switch grant {
+        case .notRequested:
+            { Task { await self.permissions.request(kind) } }
+        case .denied:
+            { self.openSystemSettings() }
+        case .granted, .limited:
+            nil
+        }
+    }
+
+    private func openSystemSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+    }
+}

--- a/apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift
@@ -5,7 +5,7 @@ private enum OnboardingVisual {
     static let maxWidth: CGFloat = 430
 }
 
-private struct OnboardingActivationCanvas<Content: View>: View {
+struct OnboardingActivationCanvas<Content: View>: View {
     @ViewBuilder let content: Content
 
     var body: some View {
@@ -31,7 +31,7 @@ private struct OnboardingHeroGlyph: View {
     }
 }
 
-private struct OnboardingHeroHeader: View {
+struct OnboardingHeroHeader: View {
     let title: LocalizedStringKey
     let subtitle: LocalizedStringKey?
 
@@ -83,7 +83,7 @@ private enum OnboardingIntroPanelStyle {
     static let stroke = OpenClawBrand.activationNeutralStroke
 }
 
-private struct OnboardingIntroPanel<Content: View>: View {
+struct OnboardingIntroPanel<Content: View>: View {
     @ViewBuilder let content: Content
 
     var body: some View {
@@ -242,20 +242,20 @@ struct OnboardingIntroStep: View {
             VStack(alignment: .leading, spacing: 0) {
                 OnboardingHeroHeader(
                     title: "OpenClaw",
-                    subtitle: "Securely connect this iPhone to your gateway.")
+                    subtitle: "Your agent, in your pocket. Pair this iPhone with your gateway to get started.")
                     .padding(.top, 18)
 
                 OnboardingIntroPanel {
                     VStack(alignment: .leading, spacing: 14) {
                         OnboardingSafetyRow(
-                            symbol: "link",
-                            title: "Connect to your gateway")
+                            symbol: "desktopcomputer",
+                            title: "Your agent runs on your own computer")
                         OnboardingSafetyRow(
-                            symbol: "hand.raised",
-                            title: "Choose device permissions")
+                            symbol: "qrcode.viewfinder",
+                            title: "Pair this iPhone by scanning a setup code")
                         OnboardingSafetyRow(
                             symbol: "message.fill",
-                            title: "Use OpenClaw from your phone")
+                            title: "Chat, talk, and approve actions from anywhere")
                     }
                 }
                 .padding(.top, 44)

--- a/apps/ios/Sources/Onboarding/OnboardingWizardTypes.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardTypes.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 enum OnboardingStep: Int, CaseIterable {
     case intro
+    case permissions
     case welcome
     case mode
     case connect
@@ -23,6 +24,7 @@ enum OnboardingStep: Int, CaseIterable {
     var title: LocalizedStringKey {
         switch self {
         case .intro: "Welcome"
+        case .permissions: "Permissions"
         case .welcome: "Connect Gateway"
         case .mode: "Gateway Setup"
         case .connect: "Gateway Details"
@@ -32,7 +34,12 @@ enum OnboardingStep: Int, CaseIterable {
     }
 
     var canGoBack: Bool {
-        self != .intro && self != .welcome && self != .success
+        switch self {
+        case .intro, .permissions, .welcome, .success:
+            false
+        case .mode, .connect, .auth:
+            true
+        }
     }
 }
 

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -74,7 +74,7 @@ struct OnboardingWizardView: View {
     }
 
     private var isFullScreenStep: Bool {
-        self.step == .intro || self.step == .welcome || self.step == .success
+        self.step == .intro || self.step == .permissions || self.step == .welcome || self.step == .success
     }
 
     private var currentProblem: GatewayConnectionProblem? {
@@ -142,6 +142,8 @@ struct OnboardingWizardView: View {
                 switch self.step {
                 case .intro:
                     self.introStep
+                case .permissions:
+                    self.permissionsStep
                 case .welcome:
                     self.welcomeStep
                 case .success:
@@ -402,6 +404,10 @@ struct OnboardingWizardView: View {
 
     private var introStep: some View {
         OnboardingIntroStep(onContinue: self.advanceFromIntro)
+    }
+
+    private var permissionsStep: some View {
+        OnboardingPermissionsStep(onContinue: self.advanceFromPermissions)
     }
 
     private var welcomeStep: some View {
@@ -1138,13 +1144,20 @@ extension OnboardingWizardView {
 
     private func advanceFromIntro() {
         OnboardingStateStore.markFirstRunIntroSeen()
+        self.statusLine = ""
+        self.navigate(to: .permissions)
+    }
+
+    private func advanceFromPermissions() {
         self.requestLocalNetworkAccess(reason: "onboarding_continue")
         self.statusLine = ""
         self.navigate(to: .welcome)
     }
 
     private func requestLocalNetworkAccessIfPastIntro(reason: String) {
-        guard self.step != .intro else { return }
+        // The local-network prompt waits until pairing starts so it never stacks
+        // on top of the permission prompts users trigger on the permissions step.
+        guard self.step != .intro, self.step != .permissions else { return }
         self.requestLocalNetworkAccess(reason: reason)
     }
 

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -1143,12 +1143,14 @@ extension OnboardingWizardView {
     }
 
     private func advanceFromIntro() {
-        OnboardingStateStore.markFirstRunIntroSeen()
         self.statusLine = ""
         self.navigate(to: .permissions)
     }
 
     private func advanceFromPermissions() {
+        // Marked here, not on the intro Continue: an interrupted first run must
+        // replay intro + permissions on relaunch instead of skipping them forever.
+        OnboardingStateStore.markFirstRunIntroSeen()
         self.requestLocalNetworkAccess(reason: "onboarding_continue")
         self.statusLine = ""
         self.navigate(to: .welcome)

--- a/apps/ios/Sources/Permissions/DevicePermissionRow.swift
+++ b/apps/ios/Sources/Permissions/DevicePermissionRow.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+
+/// Capsule action used by permission rows: filled for the initial "Allow",
+/// bordered for repair actions like "Open Settings" or "Upgrade".
+struct DevicePermissionActionButtonStyle: ButtonStyle {
+    let prominent: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(OpenClawType.footnoteSemiBold)
+            .padding(.horizontal, 14)
+            .frame(height: 32)
+            .foregroundStyle(
+                self.prominent
+                    ? OpenClawBrand.activationPrimaryActionText
+                    : OpenClawBrand.activationPrimaryAction)
+            .background {
+                if self.prominent {
+                    Capsule(style: .continuous)
+                        .fill(OpenClawBrand.activationPrimaryGradient)
+                } else {
+                    Capsule(style: .continuous)
+                        .fill(OpenClawBrand.activationNeutralSurface)
+                }
+            }
+            .overlay {
+                Capsule(style: .continuous)
+                    .stroke(
+                        self.prominent
+                            ? Color.white.opacity(0.26)
+                            : OpenClawBrand.activationNeutralStroke,
+                        lineWidth: 0.5)
+            }
+            .opacity(configuration.isPressed ? 0.86 : 1)
+            .scaleEffect(configuration.isPressed ? 0.97 : 1)
+            .animation(.smooth(duration: 0.12), value: configuration.isPressed)
+    }
+}
+
+/// One device permission with an icon tile, explanation, and a single clear
+/// affordance: Allow when unset, a green check when granted, a repair action otherwise.
+struct DevicePermissionRow: View {
+    let identifierPrefix: String
+    let identifier: String
+    let symbol: String
+    let tint: Color
+    let title: LocalizedStringResource
+    let detail: LocalizedStringResource
+    let grant: DevicePermissionGrant
+    var isRequesting: Bool = false
+    var statusLabel: LocalizedStringResource?
+    var actionTitle: LocalizedStringResource?
+    var action: (() -> Void)?
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            self.iconTile
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(self.title)
+                    .font(OpenClawType.subheadSemiBold)
+                Text(self.detail)
+                    .font(OpenClawType.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 8)
+
+            self.trailingControl
+        }
+        .padding(.vertical, 6)
+    }
+
+    private var isGrantedTile: Bool {
+        self.grant == .granted || self.grant == .limited
+    }
+
+    private var iconTile: some View {
+        Image(systemName: self.symbol)
+            .font(OpenClawType.subheadSemiBold)
+            .foregroundStyle(self.isGrantedTile ? Color.white : self.tint)
+            .frame(width: 36, height: 36)
+            .background {
+                RoundedRectangle(cornerRadius: 11, style: .continuous)
+                    .fill(self.isGrantedTile ? AnyShapeStyle(self.tint) : AnyShapeStyle(self.tint.opacity(0.14)))
+            }
+            .accessibilityHidden(true)
+    }
+
+    @ViewBuilder
+    private var trailingControl: some View {
+        if self.isRequesting {
+            ProgressView()
+                .progressViewStyle(.circular)
+                .controlSize(.small)
+                .frame(height: 32)
+        } else {
+            VStack(alignment: .trailing, spacing: 4) {
+                if let actionTitle = self.actionTitle, let action = self.action {
+                    Button(action: action) {
+                        Text(actionTitle)
+                            .font(OpenClawType.footnoteSemiBold)
+                    }
+                    .buttonStyle(DevicePermissionActionButtonStyle(prominent: self.grant == .notRequested))
+                    .accessibilityIdentifier("\(self.identifierPrefix)-\(self.identifier)-action")
+                } else if self.grant == .granted || self.grant == .limited {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(OpenClawType.title3SemiBold)
+                        .foregroundStyle(OpenClawBrand.ok)
+                        .accessibilityLabel(Text(self.statusLabel ?? LocalizedStringResource("Allowed")))
+                        .accessibilityIdentifier("\(self.identifierPrefix)-\(self.identifier)-status")
+                }
+
+                if let statusCaption {
+                    Text(statusCaption)
+                        .font(OpenClawType.caption2Medium)
+                        .foregroundStyle(self.statusCaptionColor)
+                        .accessibilityIdentifier("\(self.identifierPrefix)-\(self.identifier)-status")
+                }
+            }
+        }
+    }
+
+    /// Shown under the action for partial or blocked states so the row explains
+    /// why a repair action (Upgrade / Open Settings) is offered.
+    private var statusCaption: LocalizedStringResource? {
+        guard self.actionTitle != nil else { return nil }
+        switch self.grant {
+        case .limited:
+            return self.statusLabel ?? LocalizedStringResource("Limited")
+        case .denied:
+            return self.statusLabel ?? LocalizedStringResource("Off in Settings")
+        case .granted, .notRequested:
+            return nil
+        }
+    }
+
+    private var statusCaptionColor: Color {
+        self.grant == .denied ? OpenClawBrand.danger : OpenClawBrand.warn
+    }
+}

--- a/apps/ios/Sources/Permissions/DevicePermissions.swift
+++ b/apps/ios/Sources/Permissions/DevicePermissions.swift
@@ -1,0 +1,239 @@
+import AVFoundation
+import Contacts
+import CoreLocation
+import EventKit
+import Photos
+import SwiftUI
+import UserNotifications
+
+/// Closed grant state for one device permission, shared by onboarding and Settings rows.
+enum DevicePermissionGrant: Equatable {
+    case granted
+    case limited
+    case notRequested
+    case denied
+}
+
+/// Device permissions the connected agent can use from this iPhone.
+enum DevicePermissionKind: String, CaseIterable, Identifiable {
+    case notifications
+    case camera
+    case microphone
+    case photos
+    case contacts
+    case calendar
+    case reminders
+    case location
+
+    var id: String {
+        self.rawValue
+    }
+
+    var symbol: String {
+        switch self {
+        case .notifications: "bell.badge.fill"
+        case .camera: "camera.fill"
+        case .microphone: "mic.fill"
+        case .photos: "photo.on.rectangle"
+        case .contacts: "person.crop.circle.fill"
+        case .calendar: "calendar"
+        case .reminders: "checklist"
+        case .location: "location.fill"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .notifications: .red
+        case .camera: .indigo
+        case .microphone: .pink
+        case .photos: .orange
+        case .contacts: .blue
+        case .calendar: .teal
+        case .reminders: .green
+        case .location: .purple
+        }
+    }
+
+    var title: LocalizedStringResource {
+        switch self {
+        case .notifications: LocalizedStringResource("Notifications")
+        case .camera: LocalizedStringResource("Camera")
+        case .microphone: LocalizedStringResource("Microphone")
+        case .photos: LocalizedStringResource("Photos")
+        case .contacts: LocalizedStringResource("Contacts")
+        case .calendar: LocalizedStringResource("Calendar")
+        case .reminders: LocalizedStringResource("Reminders")
+        case .location: LocalizedStringResource("Location")
+        }
+    }
+
+    var detail: LocalizedStringResource {
+        switch self {
+        case .notifications: LocalizedStringResource("Pairing approvals and replies from your agent.")
+        case .camera: LocalizedStringResource("Scan setup codes and take photos on request.")
+        case .microphone: LocalizedStringResource("Talk with your agent using voice.")
+        case .photos: LocalizedStringResource("Share recent photos when you ask.")
+        case .contacts: LocalizedStringResource("Look up and add people you mention.")
+        case .calendar: LocalizedStringResource("Check and add calendar events.")
+        case .reminders: LocalizedStringResource("List, add, and complete reminders.")
+        case .location: LocalizedStringResource("Answer location and nearby questions.")
+        }
+    }
+}
+
+/// Pure status→grant maps so onboarding and Settings agree on one vocabulary.
+enum DevicePermissionStatusMap {
+    static func contacts(_ status: CNAuthorizationStatus) -> DevicePermissionGrant {
+        switch status {
+        case .authorized: .granted
+        case .limited: .limited
+        case .notDetermined: .notRequested
+        case .denied, .restricted: .denied
+        @unknown default: .denied
+        }
+    }
+
+    static func photos(_ status: PHAuthorizationStatus) -> DevicePermissionGrant {
+        switch status {
+        case .authorized: .granted
+        case .limited: .limited
+        case .notDetermined: .notRequested
+        case .denied, .restricted: .denied
+        @unknown default: .denied
+        }
+    }
+
+    /// Full read access; `.writeOnly` surfaces as `.limited` ("Add-Only").
+    static func eventKitRead(_ status: EKAuthorizationStatus) -> DevicePermissionGrant {
+        switch status {
+        case .authorized, .fullAccess: .granted
+        case .writeOnly: .limited
+        case .notDetermined: .notRequested
+        case .denied, .restricted: .denied
+        @unknown default: .denied
+        }
+    }
+
+    /// Add-events access; `.writeOnly` already satisfies it.
+    static func eventKitWrite(_ status: EKAuthorizationStatus) -> DevicePermissionGrant {
+        switch status {
+        case .authorized, .fullAccess, .writeOnly: .granted
+        case .notDetermined: .notRequested
+        case .denied, .restricted: .denied
+        @unknown default: .denied
+        }
+    }
+
+    static func capture(_ status: AVAuthorizationStatus) -> DevicePermissionGrant {
+        switch status {
+        case .authorized: .granted
+        case .notDetermined: .notRequested
+        case .denied, .restricted: .denied
+        @unknown default: .denied
+        }
+    }
+
+    static func microphone(_ permission: AVAudioApplication.recordPermission) -> DevicePermissionGrant {
+        switch permission {
+        case .granted: .granted
+        case .undetermined: .notRequested
+        case .denied: .denied
+        @unknown default: .denied
+        }
+    }
+
+    static func notifications(_ status: UNAuthorizationStatus) -> DevicePermissionGrant {
+        switch status {
+        case .authorized, .ephemeral, .provisional: .granted
+        case .notDetermined: .notRequested
+        case .denied: .denied
+        @unknown default: .denied
+        }
+    }
+
+    static func location(_ status: CLAuthorizationStatus) -> DevicePermissionGrant {
+        switch status {
+        case .authorizedAlways, .authorizedWhenInUse: .granted
+        case .notDetermined: .notRequested
+        case .denied, .restricted: .denied
+        @unknown default: .denied
+        }
+    }
+}
+
+/// Live grant state + request plumbing for the onboarding permissions step.
+/// Requests only raise the system prompts; product opt-ins (push relay serving,
+/// Health sharing) remain explicit choices in Settings.
+@MainActor
+@Observable
+final class DevicePermissionsModel {
+    private(set) var grants: [DevicePermissionKind: DevicePermissionGrant] = [:]
+    private(set) var requesting: Set<DevicePermissionKind> = []
+    /// Owns its manager so authorization callbacks resolve without the app-wide service.
+    private let locationService = LocationService()
+
+    func grant(for kind: DevicePermissionKind) -> DevicePermissionGrant {
+        self.grants[kind] ?? .notRequested
+    }
+
+    func refresh() async {
+        var next: [DevicePermissionKind: DevicePermissionGrant] = [
+            .camera: DevicePermissionStatusMap.capture(AVCaptureDevice.authorizationStatus(for: .video)),
+            .microphone: DevicePermissionStatusMap.microphone(AVAudioApplication.shared.recordPermission),
+            .photos: DevicePermissionStatusMap.photos(PhotoLibraryAccess.authorizationStatus()),
+            .contacts: DevicePermissionStatusMap.contacts(CNContactStore.authorizationStatus(for: .contacts)),
+            .calendar: DevicePermissionStatusMap.eventKitRead(EKEventStore.authorizationStatus(for: .event)),
+            .reminders: DevicePermissionStatusMap.eventKitRead(EKEventStore.authorizationStatus(for: .reminder)),
+            .location: DevicePermissionStatusMap.location(self.locationService.locationManager.authorizationStatus),
+        ]
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        next[.notifications] = DevicePermissionStatusMap.notifications(settings.authorizationStatus)
+        self.grants = next
+    }
+
+    func request(_ kind: DevicePermissionKind) async {
+        guard self.grant(for: kind) == .notRequested, !self.requesting.contains(kind) else { return }
+        self.requesting.insert(kind)
+        defer { self.requesting.remove(kind) }
+
+        switch kind {
+        case .notifications:
+            _ = try? await UNUserNotificationCenter.current().requestAuthorization(options: [
+                .alert,
+                .badge,
+                .sound,
+            ])
+        case .camera:
+            _ = await PermissionRequestBridge.awaitRequest { completion in
+                AVCaptureDevice.requestAccess(for: .video, completionHandler: completion)
+            }
+        case .microphone:
+            _ = await TalkModeManager.requestMicrophonePermission()
+        case .photos:
+            _ = await PhotoLibraryAccess.requestReadWrite()
+        case .contacts:
+            _ = await PermissionRequestBridge.awaitRequest { completion in
+                CNContactStore().requestAccess(for: .contacts) { granted, _ in
+                    completion(granted)
+                }
+            }
+        case .calendar:
+            _ = await PermissionRequestBridge.awaitRequest { completion in
+                EKEventStore().requestFullAccessToEvents { granted, _ in
+                    completion(granted)
+                }
+            }
+        case .reminders:
+            _ = await PermissionRequestBridge.awaitRequest { completion in
+                EKEventStore().requestFullAccessToReminders { granted, _ in
+                    completion(granted)
+                }
+            }
+        case .location:
+            _ = await self.locationService.ensureAuthorization(mode: .whileUsing)
+        }
+
+        await self.refresh()
+    }
+}

--- a/apps/ios/Sources/Settings/PrivacyAccessSectionView.swift
+++ b/apps/ios/Sources/Settings/PrivacyAccessSectionView.swift
@@ -4,39 +4,6 @@ import Photos
 import SwiftUI
 import UIKit
 
-private enum PrivacyPermissionStatus {
-    case addOnly
-    case allowed
-    case enabled
-    case limited
-    case notAllowed
-    case notSet
-    case unknown
-
-    var resource: LocalizedStringResource {
-        switch self {
-        case .addOnly: LocalizedStringResource("Add-Only")
-        case .allowed: LocalizedStringResource("Allowed")
-        case .enabled: LocalizedStringResource("Enabled")
-        case .limited: LocalizedStringResource("Limited")
-        case .notAllowed: LocalizedStringResource("Not Allowed")
-        case .notSet: LocalizedStringResource("Not Set")
-        case .unknown: LocalizedStringResource("Unknown")
-        }
-    }
-
-    var tone: OpenClawStatusTone {
-        switch self {
-        case .allowed, .enabled, .limited:
-            .ok
-        case .addOnly, .notSet:
-            .warn
-        case .notAllowed, .unknown:
-            .danger
-        }
-    }
-}
-
 struct PrivacyGatewayPermissionSnapshot: Equatable {
     let contacts: Bool
     let photos: Bool
@@ -68,64 +35,18 @@ struct PrivacyAccessSectionView: View {
     @State private var photosStatus = PhotoLibraryAccess.authorizationStatus()
     @State private var healthEnabled = HealthAuthorization.isEnabled
     @State private var healthError: String?
+    @State private var requestingIdentifiers: Set<String> = []
 
     @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         DisclosureGroup {
-            self.permissionRow(
-                identifier: "contacts",
-                title: "Contacts",
-                icon: "person.crop.circle",
-                status: self.permissionStatus(for: self.contactsStatus),
-                detail: "Search and add contacts from the assistant.",
-                actionTitle: self.actionTitle(for: self.contactsStatus),
-                action: self.handleContactsAction)
-
-            self.permissionRow(
-                identifier: "photos",
-                title: "Photos",
-                icon: "photo.on.rectangle",
-                status: self.photosPermissionStatus,
-                detail: self.photosDetail,
-                actionTitle: self.photosActionTitle,
-                action: self.handlePhotosAction)
-
-            self.permissionRow(
-                identifier: "calendar-add",
-                title: "Calendar (Add Events)",
-                icon: "calendar.badge.plus",
-                status: self.calendarWritePermissionStatus,
-                detail: "Add events with least privilege.",
-                actionTitle: self.calendarWriteActionTitle,
-                action: self.handleCalendarWriteAction)
-
-            self.permissionRow(
-                identifier: "calendar-view",
-                title: "Calendar (View Events)",
-                icon: "calendar",
-                status: self.calendarReadPermissionStatus,
-                detail: "List and read calendar events.",
-                actionTitle: self.calendarReadActionTitle,
-                action: self.handleCalendarReadAction)
-
-            self.permissionRow(
-                identifier: "reminders",
-                title: "Reminders",
-                icon: "checklist",
-                status: self.remindersPermissionStatus,
-                detail: "List, add, and complete reminders.",
-                actionTitle: self.remindersActionTitle,
-                action: self.handleRemindersAction)
-
-            self.permissionRow(
-                identifier: "health",
-                title: "Health Summaries",
-                icon: "heart.text.clipboard",
-                status: self.healthPermissionStatus,
-                detail: self.healthDetail,
-                actionTitle: self.healthActionTitle,
-                action: self.handleHealthAction)
+            self.contactsRow
+            self.photosRow
+            self.calendarAddRow
+            self.calendarViewRow
+            self.remindersRow
+            self.healthRow
 
             if let healthError {
                 Text(healthError)
@@ -145,281 +66,188 @@ struct PrivacyAccessSectionView: View {
         }
     }
 
+    private var contactsRow: some View {
+        let grant = DevicePermissionStatusMap.contacts(self.contactsStatus)
+        return self.permissionRow(
+            identifier: "contacts",
+            kind: .contacts,
+            detail: LocalizedStringResource("Search and add contacts from the assistant."),
+            grant: grant,
+            statusLabel: grant == .limited ? LocalizedStringResource("Limited") : nil,
+            actionTitle: self.standardActionTitle(for: grant, limitedTitle: "Manage Access"),
+            action: self.standardAction(identifier: "contacts", for: grant) {
+                await self.requestContacts()
+            })
+    }
+
+    private var photosRow: some View {
+        let grant = DevicePermissionStatusMap.photos(self.photosStatus)
+        return self.permissionRow(
+            identifier: "photos",
+            kind: .photos,
+            detail: grant == .limited
+                ? LocalizedStringResource("Read photos you select for the assistant.")
+                : LocalizedStringResource("Read recent photos for the assistant."),
+            grant: grant,
+            statusLabel: grant == .limited ? LocalizedStringResource("Limited") : nil,
+            actionTitle: self.standardActionTitle(for: grant, limitedTitle: "Manage Access"),
+            action: self.standardAction(identifier: "photos", for: grant) {
+                await self.updatePhotosStatus(PhotoLibraryAccess.requestReadWrite())
+            })
+    }
+
+    private var calendarAddRow: some View {
+        let grant = DevicePermissionStatusMap.eventKitWrite(self.calendarStatus)
+        return self.permissionRow(
+            identifier: "calendar-add",
+            kind: .calendar,
+            symbol: "calendar.badge.plus",
+            title: LocalizedStringResource("Calendar (Add Events)"),
+            detail: LocalizedStringResource("Add events with least privilege."),
+            grant: grant,
+            actionTitle: self.standardActionTitle(for: grant),
+            action: self.standardAction(identifier: "calendar-add", for: grant) {
+                _ = await self.requestCalendarWriteOnly()
+                self.applyCalendarStatus()
+            })
+    }
+
+    private var calendarViewRow: some View {
+        let grant = DevicePermissionStatusMap.eventKitRead(self.calendarStatus)
+        return self.permissionRow(
+            identifier: "calendar-view",
+            kind: .calendar,
+            detail: LocalizedStringResource("List and read calendar events."),
+            grant: grant,
+            statusLabel: grant == .limited ? LocalizedStringResource("Add-Only") : nil,
+            actionTitle: self.standardActionTitle(for: grant, limitedTitle: "Upgrade"),
+            action: self.standardAction(identifier: "calendar-view", for: grant, limitedRequests: true) {
+                _ = await self.requestCalendarFull()
+                self.applyCalendarStatus()
+            })
+    }
+
+    private var remindersRow: some View {
+        let grant = DevicePermissionStatusMap.eventKitRead(self.remindersStatus)
+        return self.permissionRow(
+            identifier: "reminders",
+            kind: .reminders,
+            detail: LocalizedStringResource("List, add, and complete reminders."),
+            grant: grant,
+            statusLabel: grant == .limited ? LocalizedStringResource("Add-Only") : nil,
+            actionTitle: self.standardActionTitle(for: grant, limitedTitle: "Upgrade"),
+            action: self.standardAction(identifier: "reminders", for: grant, limitedRequests: true) {
+                _ = await self.requestRemindersFull()
+                self.remindersStatus = EKEventStore.authorizationStatus(for: .reminder)
+                self.refreshAll()
+            })
+    }
+
+    private var healthRow: some View {
+        DevicePermissionRow(
+            identifierPrefix: "privacy-access",
+            identifier: "health",
+            symbol: "heart.text.clipboard",
+            tint: .red,
+            title: LocalizedStringResource("Health Summaries"),
+            detail: self.healthDetail,
+            grant: self.healthGrant,
+            isRequesting: self.requestingIdentifiers.contains("health"),
+            actionTitle: self.healthActionTitle,
+            action: HealthAuthorization.isAvailable ? { self.handleHealthAction() } : nil)
+    }
+
     private func permissionRow(
         identifier: String,
-        title: LocalizedStringResource,
-        icon: String,
-        status: PrivacyPermissionStatus,
+        kind: DevicePermissionKind,
+        symbol: String? = nil,
+        title: LocalizedStringResource? = nil,
         detail: LocalizedStringResource,
+        grant: DevicePermissionGrant,
+        statusLabel: LocalizedStringResource? = nil,
         actionTitle: LocalizedStringResource?,
         action: (() -> Void)?) -> some View
     {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Label {
-                    Text(title)
-                } icon: {
-                    Image(systemName: icon)
-                }
-                .font(OpenClawType.subheadSemiBold)
-                Spacer()
-                OpenClawStatusBadge(
-                    label: .verbatim(String(localized: status.resource)),
-                    tone: status.tone)
-                    .accessibilityIdentifier("privacy-access-\(identifier)-status")
-            }
-            Text(detail)
-                .font(OpenClawType.footnote)
-                .foregroundStyle(.secondary)
-            if let actionTitle, let action {
-                Button(action: action) {
-                    Text(actionTitle)
-                        .font(OpenClawType.footnoteSemiBold)
-                }
-                .buttonStyle(.bordered)
-                .accessibilityIdentifier("privacy-access-\(identifier)-action")
-            }
-        }
-        .padding(.vertical, 2)
+        DevicePermissionRow(
+            identifierPrefix: "privacy-access",
+            identifier: identifier,
+            symbol: symbol ?? kind.symbol,
+            tint: kind.tint,
+            title: title ?? kind.title,
+            detail: detail,
+            grant: grant,
+            isRequesting: self.requestingIdentifiers.contains(identifier),
+            statusLabel: statusLabel,
+            actionTitle: actionTitle,
+            action: action)
     }
 
-    private func permissionStatus(for cnStatus: CNAuthorizationStatus) -> PrivacyPermissionStatus {
-        switch cnStatus {
-        case .authorized, .limited:
-            .allowed
-        case .notDetermined:
-            .notSet
-        case .denied, .restricted:
-            .notAllowed
-        @unknown default:
-            .unknown
-        }
-    }
-
-    private func actionTitle(for cnStatus: CNAuthorizationStatus) -> LocalizedStringResource? {
-        switch cnStatus {
-        case .notDetermined:
-            LocalizedStringResource("Request Access")
-        case .denied, .restricted:
+    private func standardActionTitle(
+        for grant: DevicePermissionGrant,
+        limitedTitle: LocalizedStringResource? = nil) -> LocalizedStringResource?
+    {
+        switch grant {
+        case .notRequested:
+            LocalizedStringResource("Allow")
+        case .denied:
             LocalizedStringResource("Open Settings")
-        default:
-            nil
-        }
-    }
-
-    private var photosPermissionStatus: PrivacyPermissionStatus {
-        switch self.photosStatus {
-        case .authorized:
-            .allowed
         case .limited:
-            .limited
-        case .notDetermined:
-            .notSet
-        case .denied, .restricted:
-            .notAllowed
-        @unknown default:
-            .unknown
+            limitedTitle
+        case .granted:
+            nil
         }
     }
 
-    private var photosDetail: LocalizedStringResource {
-        self.photosStatus == .limited
-            ? LocalizedStringResource("Read photos you select for the assistant.")
-            : LocalizedStringResource("Read recent photos for the assistant.")
-    }
-
-    private var photosActionTitle: LocalizedStringResource? {
-        switch self.photosStatus {
-        case .notDetermined:
-            LocalizedStringResource("Request Access")
+    /// `limitedRequests`: a limited grant re-requests (EventKit write-only → full)
+    /// instead of routing to Settings like Photos/Contacts limited access does.
+    private func standardAction(
+        identifier: String,
+        for grant: DevicePermissionGrant,
+        limitedRequests: Bool = false,
+        request: @escaping () async -> Void) -> (() -> Void)?
+    {
+        let run: () -> Void = {
+            guard !self.requestingIdentifiers.contains(identifier) else { return }
+            Task {
+                self.requestingIdentifiers.insert(identifier)
+                defer { self.requestingIdentifiers.remove(identifier) }
+                await request()
+            }
+        }
+        switch grant {
+        case .notRequested:
+            return run
         case .limited:
-            LocalizedStringResource("Manage Access")
-        case .denied, .restricted:
-            LocalizedStringResource("Open Settings")
-        default:
-            nil
+            return limitedRequests ? run : { self.openSettings() }
+        case .denied:
+            return { self.openSettings() }
+        case .granted:
+            return nil
         }
     }
 
-    private func handlePhotosAction() {
-        switch self.photosStatus {
-        case .notDetermined:
-            Task {
-                let status = await PhotoLibraryAccess.requestReadWrite()
-                await MainActor.run { self.updatePhotosStatus(status) }
+    private func requestContacts() async {
+        let granted = await PermissionRequestBridge.awaitRequest { completion in
+            let store = CNContactStore()
+            store.requestAccess(for: .contacts) { granted, _ in
+                completion(granted)
             }
-        case .limited, .denied, .restricted:
-            self.openSettings()
-        default:
-            break
+        }
+        self.refreshAll()
+        if granted {
+            self.contactsStatus = CNContactStore.authorizationStatus(for: .contacts)
         }
     }
 
-    private func handleContactsAction() {
-        switch self.contactsStatus {
-        case .notDetermined:
-            Task {
-                let granted = await PermissionRequestBridge.awaitRequest { completion in
-                    let store = CNContactStore()
-                    store.requestAccess(for: .contacts) { granted, _ in
-                        completion(granted)
-                    }
-                }
-                await MainActor.run {
-                    self.refreshAll()
-                    if granted {
-                        self.contactsStatus = .authorized
-                    }
-                }
-            }
-        case .denied, .restricted:
-            self.openSettings()
-        default:
-            break
-        }
+    private func applyCalendarStatus() {
+        self.calendarStatus = EKEventStore.authorizationStatus(for: .event)
+        self.refreshAll()
     }
 
-    private var calendarWritePermissionStatus: PrivacyPermissionStatus {
-        switch self.calendarStatus {
-        case .authorized, .fullAccess, .writeOnly:
-            .allowed
-        case .notDetermined:
-            .notSet
-        case .denied, .restricted:
-            .notAllowed
-        @unknown default:
-            .unknown
-        }
-    }
-
-    private var calendarWriteActionTitle: LocalizedStringResource? {
-        switch self.calendarStatus {
-        case .notDetermined:
-            LocalizedStringResource("Request Access")
-        case .denied, .restricted:
-            LocalizedStringResource("Open Settings")
-        default:
-            nil
-        }
-    }
-
-    private func handleCalendarWriteAction() {
-        switch self.calendarStatus {
-        case .notDetermined:
-            Task {
-                let granted = await self.requestCalendarWriteOnly()
-                await MainActor.run {
-                    self.refreshAll()
-                    if granted {
-                        self.calendarStatus = .writeOnly
-                    }
-                }
-            }
-        case .denied, .restricted:
-            self.openSettings()
-        default:
-            break
-        }
-    }
-
-    private var calendarReadPermissionStatus: PrivacyPermissionStatus {
-        switch self.calendarStatus {
-        case .authorized, .fullAccess:
-            .allowed
-        case .writeOnly:
-            .addOnly
-        case .notDetermined:
-            .notSet
-        case .denied, .restricted:
-            .notAllowed
-        @unknown default:
-            .unknown
-        }
-    }
-
-    private var calendarReadActionTitle: LocalizedStringResource? {
-        switch self.calendarStatus {
-        case .notDetermined:
-            LocalizedStringResource("Request Full Access")
-        case .writeOnly:
-            LocalizedStringResource("Upgrade to Full Access")
-        case .denied, .restricted:
-            LocalizedStringResource("Open Settings")
-        default:
-            nil
-        }
-    }
-
-    private func handleCalendarReadAction() {
-        switch self.calendarStatus {
-        case .notDetermined, .writeOnly:
-            Task {
-                let granted = await self.requestCalendarFull()
-                await MainActor.run {
-                    self.refreshAll()
-                    if granted {
-                        self.calendarStatus = .fullAccess
-                    }
-                }
-            }
-        case .denied, .restricted:
-            self.openSettings()
-        default:
-            break
-        }
-    }
-
-    private var remindersPermissionStatus: PrivacyPermissionStatus {
-        switch self.remindersStatus {
-        case .authorized, .fullAccess:
-            .allowed
-        case .writeOnly:
-            .addOnly
-        case .notDetermined:
-            .notSet
-        case .denied, .restricted:
-            .notAllowed
-        @unknown default:
-            .unknown
-        }
-    }
-
-    private var remindersActionTitle: LocalizedStringResource? {
-        switch self.remindersStatus {
-        case .notDetermined:
-            LocalizedStringResource("Request Access")
-        case .writeOnly:
-            LocalizedStringResource("Upgrade to Full Access")
-        case .denied, .restricted:
-            LocalizedStringResource("Open Settings")
-        default:
-            nil
-        }
-    }
-
-    private func handleRemindersAction() {
-        switch self.remindersStatus {
-        case .notDetermined, .writeOnly:
-            Task {
-                let granted = await self.requestRemindersFull()
-                await MainActor.run {
-                    self.refreshAll()
-                    if granted {
-                        self.remindersStatus = .fullAccess
-                    }
-                }
-            }
-        case .denied, .restricted:
-            self.openSettings()
-        default:
-            break
-        }
-    }
-
-    private var healthPermissionStatus: PrivacyPermissionStatus {
-        guard HealthAuthorization.isAvailable else { return .notAllowed }
+    private var healthGrant: DevicePermissionGrant {
+        guard HealthAuthorization.isAvailable else { return .denied }
         // HealthKit hides read authorization; this is only OpenClaw's sharing switch.
-        return self.healthEnabled ? .enabled : .notSet
+        return self.healthEnabled ? .granted : .notRequested
     }
 
     private var healthDetail: LocalizedStringResource {
@@ -456,7 +284,10 @@ struct PrivacyAccessSectionView: View {
             return
         }
 
+        guard !self.requestingIdentifiers.contains("health") else { return }
         Task { @MainActor in
+            self.requestingIdentifiers.insert("health")
+            defer { self.requestingIdentifiers.remove("health") }
             do {
                 try await HealthAuthorization.enable()
                 self.healthEnabled = true

--- a/apps/ios/Tests/DevicePermissionsTests.swift
+++ b/apps/ios/Tests/DevicePermissionsTests.swift
@@ -1,0 +1,61 @@
+import AVFoundation
+import Contacts
+import EventKit
+import Photos
+import Testing
+import UserNotifications
+@testable import OpenClaw
+
+struct DevicePermissionsTests {
+    @Test func `contacts statuses map to shared grants`() {
+        #expect(DevicePermissionStatusMap.contacts(.authorized) == .granted)
+        #expect(DevicePermissionStatusMap.contacts(.limited) == .limited)
+        #expect(DevicePermissionStatusMap.contacts(.notDetermined) == .notRequested)
+        #expect(DevicePermissionStatusMap.contacts(.denied) == .denied)
+        #expect(DevicePermissionStatusMap.contacts(.restricted) == .denied)
+    }
+
+    @Test func `photos statuses map to shared grants`() {
+        #expect(DevicePermissionStatusMap.photos(.authorized) == .granted)
+        #expect(DevicePermissionStatusMap.photos(.limited) == .limited)
+        #expect(DevicePermissionStatusMap.photos(.notDetermined) == .notRequested)
+        #expect(DevicePermissionStatusMap.photos(.denied) == .denied)
+    }
+
+    @Test func `event kit write-only is limited for read but granted for add`() {
+        #expect(DevicePermissionStatusMap.eventKitRead(.writeOnly) == .limited)
+        #expect(DevicePermissionStatusMap.eventKitWrite(.writeOnly) == .granted)
+        #expect(DevicePermissionStatusMap.eventKitRead(.fullAccess) == .granted)
+        #expect(DevicePermissionStatusMap.eventKitWrite(.fullAccess) == .granted)
+        #expect(DevicePermissionStatusMap.eventKitRead(.notDetermined) == .notRequested)
+        #expect(DevicePermissionStatusMap.eventKitRead(.denied) == .denied)
+    }
+
+    @Test func `capture microphone notification and location statuses map to shared grants`() {
+        #expect(DevicePermissionStatusMap.capture(.authorized) == .granted)
+        #expect(DevicePermissionStatusMap.capture(.notDetermined) == .notRequested)
+        #expect(DevicePermissionStatusMap.capture(.denied) == .denied)
+
+        #expect(DevicePermissionStatusMap.microphone(.granted) == .granted)
+        #expect(DevicePermissionStatusMap.microphone(.undetermined) == .notRequested)
+        #expect(DevicePermissionStatusMap.microphone(.denied) == .denied)
+
+        #expect(DevicePermissionStatusMap.notifications(.authorized) == .granted)
+        #expect(DevicePermissionStatusMap.notifications(.provisional) == .granted)
+        #expect(DevicePermissionStatusMap.notifications(.notDetermined) == .notRequested)
+        #expect(DevicePermissionStatusMap.notifications(.denied) == .denied)
+
+        #expect(DevicePermissionStatusMap.location(.authorizedWhenInUse) == .granted)
+        #expect(DevicePermissionStatusMap.location(.authorizedAlways) == .granted)
+        #expect(DevicePermissionStatusMap.location(.notDetermined) == .notRequested)
+        #expect(DevicePermissionStatusMap.location(.restricted) == .denied)
+    }
+
+    @Test func `first-run onboarding inserts permissions between intro and pairing`() {
+        #expect(OnboardingStep.permissions.previous == .intro)
+        #expect(OnboardingStep.welcome.previous == .permissions)
+        #expect(!OnboardingStep.permissions.canGoBack)
+        // Permissions is a first-run page, not part of the manual connect progress trail.
+        #expect(OnboardingStep.permissions.manualProgressTitle.isEmpty)
+    }
+}

--- a/apps/ios/Tests/OpenClawTypographyTests.swift
+++ b/apps/ios/Tests/OpenClawTypographyTests.swift
@@ -439,7 +439,8 @@ struct OpenClawTypographyTests {
 
     private static func unbrandedTextCallOffenders() throws -> [String] {
         let fontTokens = ["OpenClawType", "OpenClawChatTypography"]
-        let allowedFragments = [".navigationTitle(", ".alert(\"", ".tabItem { Label("]
+        // Accessibility-only Text is spoken, never rendered, so no branded font applies.
+        let allowedFragments = [".navigationTitle(", ".alert(\"", ".tabItem { Label(", ".accessibilityLabel(Text("]
         return try self.swiftSourcesForTypographyAudit().flatMap { url -> [String] in
             let source = try String(contentsOf: url, encoding: .utf8)
             let lines = source.components(separatedBy: .newlines)

--- a/apps/ios/Tests/OpenClawTypographyTests.swift
+++ b/apps/ios/Tests/OpenClawTypographyTests.swift
@@ -315,8 +315,11 @@ struct OpenClawTypographyTests {
 
         #expect(!privacyAccess.contains("DisclosureGroup(\"Privacy & Access\")"))
         #expect(privacyAccess.contains("Text(\"Privacy & Access\")"))
-        #expect(privacyAccess.contains("Text(actionTitle)"))
-        #expect(privacyAccess.contains(".font(OpenClawType.footnoteSemiBold)"))
+        let permissionRow = try String(
+            contentsOf: Self.sourceURL("Permissions/DevicePermissionRow.swift"),
+            encoding: .utf8)
+        #expect(permissionRow.contains("Text(actionTitle)"))
+        #expect(permissionRow.contains(".font(OpenClawType.footnoteSemiBold)"))
 
         #expect(!skillWorkshop.contains("Button(\"Done\")"))
         #expect(skillWorkshop.contains("Label(\"Refresh\", systemImage: \"arrow.clockwise\")"))

--- a/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
+++ b/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
@@ -302,6 +302,7 @@ struct SwiftUIRenderSmokeTests {
     @Test @MainActor func `onboarding activation screens build across appearance and type size`() {
         let screens: [AnyView] = [
             AnyView(OnboardingIntroStep(onContinue: {})),
+            AnyView(OnboardingPermissionsStep(onContinue: {})),
             AnyView(OnboardingWelcomeStep(
                 statusLine: "",
                 isConnecting: false,

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -417,6 +417,8 @@ final class OpenClawSnapshotUITests: XCTestCase {
 
         XCTAssertTrue(app.buttons["Continue"].waitForExistence(timeout: 8))
         app.buttons["Continue"].tap()
+        XCTAssertTrue(app.staticTexts["Allow access"].waitForExistence(timeout: 8))
+        app.buttons["Continue"].tap()
         app.tap()
 
         let copySetupCommand = app.buttons["Copy setup code command"]
@@ -674,6 +676,8 @@ final class OpenClawSnapshotUITests: XCTestCase {
 
         XCTAssertTrue(app.buttons["Continue"].waitForExistence(timeout: 8))
         app.buttons["Continue"].tap()
+        XCTAssertTrue(app.staticTexts["Allow access"].waitForExistence(timeout: 8))
+        app.buttons["Continue"].tap()
         app.tap()
         XCTAssertTrue(app.buttons["Connect Manually"].waitForExistence(timeout: 8))
         app.buttons["Connect Manually"].tap()
@@ -731,7 +735,7 @@ final class OpenClawSnapshotUITests: XCTestCase {
         XCTAssertTrue(privacy.waitForExistence(timeout: 8))
         privacy.tap()
 
-        let request = try XCTUnwrap(self.app?.buttons["privacy-access-Photos-action"])
+        let request = try XCTUnwrap(self.app?.buttons["privacy-access-photos-action"])
         XCTAssertTrue(request.waitForExistence(timeout: 5))
         request.tap()
         self.app?.tap()
@@ -746,10 +750,10 @@ final class OpenClawSnapshotUITests: XCTestCase {
         let limitedStatus = try XCTUnwrap(self.app?.staticTexts.matching(
             NSPredicate(
                 format: "identifier == %@ AND label == %@",
-                "privacy-access-Photos-status",
+                "privacy-access-photos-status",
                 "Limited")).firstMatch)
         XCTAssertTrue(limitedStatus.waitForExistence(timeout: 8))
-        XCTAssertEqual(self.app?.buttons["privacy-access-Photos-action"].label, "Manage Access")
+        XCTAssertEqual(self.app?.buttons["privacy-access-photos-action"].label, "Manage Access")
         self.attachScreenshot(named: "photos-limited-access")
     }
 
@@ -825,6 +829,8 @@ final class OpenClawSnapshotUITests: XCTestCase {
         self.app = app
 
         XCTAssertTrue(app.buttons["Continue"].waitForExistence(timeout: 8))
+        app.buttons["Continue"].tap()
+        XCTAssertTrue(app.staticTexts["Allow access"].waitForExistence(timeout: 8))
         app.buttons["Continue"].tap()
         app.tap()
         XCTAssertTrue(app.buttons["Connect Manually"].waitForExistence(timeout: 8))

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -30,6 +30,11 @@ Availability: iPhone app builds are distributed through Apple channels when enab
 
 ## Quick start (pair + connect)
 
+On first launch the app walks through a short pairing explainer and a
+permissions page (notifications, camera, microphone, photos, contacts,
+calendar, reminders, location). Every grant is optional and can be changed
+later in **Settings** -> **Permissions**, or in the iOS Settings app.
+
 1. Start an authenticated Gateway with a route your phone can reach. Tailscale
    Serve is the recommended remote path:
 

--- a/scripts/apple-app-i18n.ts
+++ b/scripts/apple-app-i18n.ts
@@ -245,11 +245,17 @@ const LOCALIZED_WRAPPER_CONTRACTS: Record<string, readonly string[]> = {
     "Text(verbatim: primaryActionTitle)",
   ],
   "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift": [
-    "title: LocalizedStringResource",
-    "status: PrivacyPermissionStatus",
     "detail: LocalizedStringResource",
+    "statusLabel: LocalizedStringResource? = nil",
     "actionTitle: LocalizedStringResource?",
-    "String(localized: status.resource)",
+  ],
+  "apps/ios/Sources/Permissions/DevicePermissionRow.swift": [
+    "title: LocalizedStringResource",
+    "detail: LocalizedStringResource",
+    "statusLabel: LocalizedStringResource?",
+    "actionTitle: LocalizedStringResource?",
+    "Text(self.title)",
+    "Text(actionTitle)",
   ],
   "apps/ios/Sources/LiveActivity/LiveActivityManager.swift": [
     'String(localized: "Connecting...")',


### PR DESCRIPTION
## What Problem This Solves

Fixes #106118.

First launch of the iOS app dropped users straight into gateway connection: no explanation of how pairing works, and no place to grant device permissions — they popped up ad-hoc (camera mid-QR-scan, microphone on first talk) or hid behind Settings. The Settings "Privacy & Access" rows used status-badge pills ("Not Set" / "Allowed") with plain bordered buttons.

## Why This Change Was Made

First-run flow is now: pairing explainer → permissions page → connect wizard, mirroring the macOS app's "Grant permissions" onboarding page. One shared row component (tinted icon tile, one-line benefit copy, a single clear affordance — filled **Allow** capsule / green check / **Open Settings** / **Manage**) is used by both onboarding and the redesigned Settings section, replacing the badge pills.

Details:
- `DevicePermissionsModel` + `DevicePermissionStatusMap` (new `apps/ios/Sources/Permissions/DevicePermissions.swift`): one closed grant vocabulary (granted / limited / notRequested / denied) and request plumbing for notifications, camera, microphone, photos, contacts, calendar, reminders, location. Requests only raise the system prompts; product opt-ins (push relay serving, Health sharing) stay explicit in Settings.
- `OnboardingPermissionsStep` (new): first-run-only page between intro and connect; every grant optional, page skippable, live status refresh on scene activation, limited grants show a "Limited" caption + **Manage**.
- Onboarding intro rewritten as a pairing explainer ("agent runs on your own computer" / "pair by scanning a setup code" / "chat, talk, approve from anywhere"). First-run marker now persists only after the permissions step so an interrupted first launch replays the flow. The local-network prompt is deferred until pairing starts so it never stacks on permission prompts.
- `PrivacyAccessSectionView` rebuilt on the shared rows (−169 LOC); keeps calendar add/view least-privilege split, add-only "Upgrade" path, Health enable/disable, and the gateway-registration refresh on grant changes. Two pre-existing bare `.accessibilityLabel(Text(...))` typography offenders in `SettingsProTabSections.swift` fixed (that suite doesn't run in CI and was red on main).

## User Impact

New users get a guided first launch: what pairing is, then one screen to grant exactly what they want their agent to use, then QR pairing. Permission state is finally glanceable — granted rows show a filled tile + green check, limited access is labeled and manageable, denied rows deep-link to iOS Settings.

| Explainer | Permissions | System prompt | Granted |
| --- | --- | --- | --- |
| ![intro](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ios-onboarding-permissions/01-intro.png) | ![permissions](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ios-onboarding-permissions/02-permissions.png) | ![prompt](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ios-onboarding-permissions/03-prompt.png) | ![granted](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ios-onboarding-permissions/04-granted.png) |

## Evidence

- `pnpm ios:build` (simulator Debug): **BUILD SUCCEEDED** on the final head.
- Focused simulator tests on iPhone 16 Pro: `OpenClawTests/DevicePermissionsTests` (new status-map + step-order tests), `SwiftUIRenderSmokeTests` (new permissions step added to the onboarding render matrix), `OnboardingStateStoreTests`, `OpenClawTypographyTests` — 46 tests, all passing.
- Live simulator walkthrough (screenshots above): reset onboarding → explainer → permissions page → tapped Allow on Notifications → iOS prompt → row flips to filled tile + green check.
- `pnpm native:i18n:check` green: inventory synced and all 21 native locales translated (30 new entries each).
- swiftformat lint clean on all touched files; autoreview (Codex gpt-5.6-sol, xhigh) run on the diff — both accepted findings (resumable first-run marker, limited-grant display) fixed in the follow-up commit.
- UITest flows (`--openclaw-reset-onboarding` paths) updated for the new step; stale `privacy-access-Photos-*` identifier casing fixed to match the code (`photos`).
