### PR TITLE
fix(ci): dedupe read-only state allowlist

### DIFF
--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -38,9 +38,7 @@ const rawSqliteAllowPathGroups = {
     "src/infra/sqlite-user-version.ts",
     "src/infra/sqlite-wal.ts",
     "src/state/openclaw-agent-db.ts",
-    "src/state/openclaw-state-db-readonly.ts",
     "src/state/openclaw-state-db.ts",
-    "src/state/openclaw-state-db-readonly.ts",
     "src/state/sqlite-schema-shape.test-support.ts",
   ],
   "backup snapshot maintenance": [


### PR DESCRIPTION
## What Problem This Solves

Concurrent CI repairs left `src/state/openclaw-state-db-readonly.ts` listed three times in the Kysely raw-SQLite allowlist. The guard rejects duplicate paths, so current `main` fails `scripts/check-kysely-guardrails.mjs`.

## Why This Change Was Made

Keep the precise `read-only shared state database access` ownership group added by #106124 and remove the two redundant entries from the broad lifecycle group.

## User Impact

No runtime behavior change. Restores the Kysely architecture guard after the concurrent merges.

## Evidence

- `git diff --check`
- `node scripts/check-kysely-guardrails.mjs` (`Kysely guardrails OK`)
- Autoreview finding inspected and rejected: the dedicated allowlist entry remains present and the executable guard passes.

Follow-up to #106124 and #106126.
