### PR TITLE
feat(onepassword): optional 1Password secrets broker plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -358,6 +358,12 @@
           - "extensions/vault/**"
           - "docs/plugins/vault.md"
           - "docs/plugins/reference/vault.md"
+"extensions: onepassword":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/onepassword/**"
+          - "docs/plugins/onepassword.md"
+          - "docs/plugins/reference/onepassword.md"
 "extensions: webhooks":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1292,6 +1292,7 @@
                   "plugins/admin-http-rpc",
                   "plugins/voice-call",
                   "plugins/vault",
+                  "plugins/onepassword",
                   "plugins/memory-wiki",
                   "plugins/llama-cpp",
                   "plugins/memory-lancedb",

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -5927,6 +5927,19 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Safety
   - H2: Related
 
+## plugins/onepassword.md
+
+- Route: /plugins/onepassword
+- Headings:
+  - H1: 1Password secrets broker
+  - H2: Security model
+  - H2: Before you begin
+  - H2: Configure registered secrets
+  - H2: Use the agent tool
+  - H2: Policy tiers and approvals
+  - H2: Inspect status and audit history
+  - H2: 1Password CLI behavior
+
 ## plugins/plugin-inventory.md
 
 - Route: /plugins/plugin-inventory
@@ -6706,6 +6719,15 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Route: /plugins/reference/ollama
 - Headings:
   - H1: Ollama plugin
+  - H2: Distribution
+  - H2: Surface
+  - H2: Related docs
+
+## plugins/reference/onepassword.md
+
+- Route: /plugins/reference/onepassword
+- Headings:
+  - H1: Onepassword plugin
   - H2: Distribution
   - H2: Surface
   - H2: Related docs

--- a/docs/plugins/onepassword.md
+++ b/docs/plugins/onepassword.md
@@ -151,7 +151,8 @@ grant for that agent and slug to SQLite; other agents must receive their own
 approval. OpenClaw offers allow always only when the caller has a concrete agent
 identity. The grant expires after `grantTtlHours`, which defaults to 720 hours.
 An unresolved or timed-out approval denies the request; the maximum approval
-wait is 600 seconds.
+wait is 600 seconds. The plugin retains up to 1,024 standing grants; at that
+bound, the oldest grant is evicted and its agent must approve the next access.
 
 The in-memory cache defaults to 300 seconds and is bounded by the configured
 slug registry. Set `cacheTtlSeconds` to `0` to disable it. Policy is evaluated

--- a/docs/plugins/onepassword.md
+++ b/docs/plugins/onepassword.md
@@ -106,8 +106,8 @@ Add plugin config to `openclaw.json`:
 
 Slugs use lowercase letters, numbers, and hyphens, start with a letter or
 number, and contain at most 64 characters. A registry can contain up to 32
-slugs; descriptions can contain up to 200 characters. `field` defaults to
-`credential`.
+slugs; descriptions can contain up to 200 characters. `field` accepts one field
+label or ID, must not contain a comma, and defaults to `credential`.
 An item-level `vault` overrides the default vault. `opBin` can set an absolute
 path to the `op` executable; otherwise the plugin resolves `op` from `PATH`.
 Item titles must not start with a hyphen.
@@ -147,9 +147,11 @@ field label.
   always, or deny.
 
 Allow once authorizes only the current tool call. Allow always writes a standing
-grant for that slug to SQLite. The grant expires after `grantTtlHours`, which
-defaults to 720 hours. An unresolved or timed-out approval denies the request;
-the maximum approval wait is 600 seconds.
+grant for that agent and slug to SQLite; other agents must receive their own
+approval. OpenClaw offers allow always only when the caller has a concrete agent
+identity. The grant expires after `grantTtlHours`, which defaults to 720 hours.
+An unresolved or timed-out approval denies the request; the maximum approval
+wait is 600 seconds.
 
 The in-memory cache defaults to 300 seconds and is bounded by the configured
 slug registry. Set `cacheTtlSeconds` to `0` to disable it. Policy is evaluated
@@ -180,8 +182,9 @@ value to the audit log.
 
 ## 1Password CLI behavior
 
-Each cache miss runs `op item get` with the configured item and vault, JSON
-output, a bounded timeout, and `--cache=false`. Only
+Each cache miss runs `op item get` with the configured item, vault, and exact
+field selector, JSON output, a bounded timeout, and `--cache=false`. The child
+receives only that field rather than the full item. Only
 `OP_SERVICE_ACCOUNT_TOKEN` and `HOME` are present in the child environment.
 
 The plugin makes one attempt. `RATE_LIMITED` errors should be handled by waiting

--- a/docs/plugins/onepassword.md
+++ b/docs/plugins/onepassword.md
@@ -156,7 +156,10 @@ bound, the oldest grant is evicted and its agent must approve the next access.
 
 The in-memory cache defaults to 300 seconds and is bounded by the configured
 slug registry. Set `cacheTtlSeconds` to `0` to disable it. Policy is evaluated
-before every cache lookup, and cache hits are audited.
+before every cache lookup, and cache hits are audited. Runtime config reloads
+take effect at each policy and execution boundary; disabling the plugin or
+removing, denying, or retargeting a slug invalidates pending authorization and
+cached values.
 
 ## Inspect status and audit history
 

--- a/docs/plugins/onepassword.md
+++ b/docs/plugins/onepassword.md
@@ -1,0 +1,190 @@
+---
+summary: "Use the optional 1Password plugin as an audited agent secrets broker"
+read_when:
+  - You want agents to request curated 1Password secrets
+  - You need per-secret approval policy and audit history
+  - You are configuring a 1Password service account for OpenClaw
+title: "1Password secrets broker"
+---
+
+# 1Password secrets broker
+
+The bundled `onepassword` plugin gives agents one policy-controlled tool for
+reading a curated set of 1Password fields. It is disabled by default and does
+nothing until `plugins.entries.onepassword.config` is present.
+
+This is an agent tool, not a SecretRef provider. It does not inject environment
+variables or resolve OpenClaw config secrets.
+
+## Security model
+
+- Service-account authentication only. The token stays in a local credentials
+  file and is never accepted in `openclaw.json`.
+- Curated registry only. Agents can list configured slugs, but the plugin never
+  enumerates a 1Password vault.
+- Per-slug `auto`, `approve`, or `deny` policy.
+- Approval grants expire. A cached value never bypasses current policy.
+- Every access attempt is recorded in OpenClaw's shared SQLite state. Audit
+  rows include the supplied reason; keep reasons non-sensitive. The broker
+  never copies a fetched value or the service token into an audit row.
+- After the current tool execution, OpenClaw-owned transcript persistence
+  replaces a successful `get` value with redacted metadata.
+- The value is model-visible for that execution. If the model copies it into a
+  later tool call or reply, that separate record is outside this plugin's
+  persistence hook. Keep policies narrow and do not ask the model to echo a
+  value.
+- The plugin invokes `op` once per cache miss. It does not retry rate limits or
+  other failures.
+
+Give the service account read access only to the vaults and items registered in
+the plugin config.
+
+## Before you begin
+
+You need:
+
+- the 1Password CLI (`op`) installed on the Gateway host
+- a 1Password service account with access to the selected items
+- a dedicated service-account token file
+
+Enable the bundled plugin:
+
+```bash
+openclaw plugins enable onepassword
+```
+
+Create the token directory and file under the OpenClaw state directory:
+
+```bash
+mkdir -p ~/.openclaw/credentials/onepassword
+chmod 700 ~/.openclaw/credentials/onepassword
+printf '%s' "$OP_SERVICE_ACCOUNT_TOKEN" > \
+  ~/.openclaw/credentials/onepassword/service-account-token
+chmod 600 ~/.openclaw/credentials/onepassword/service-account-token
+unset OP_SERVICE_ACCOUNT_TOKEN
+```
+
+When `OPENCLAW_STATE_DIR` is set, replace `~/.openclaw` with that directory.
+The plugin warns once when the token file is readable or writable by group or
+other users.
+
+## Configure registered secrets
+
+Add plugin config to `openclaw.json`:
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "onepassword": {
+        "enabled": true,
+        "config": {
+          "vault": "Automation",
+          "defaultPolicy": "approve",
+          "cacheTtlSeconds": 300,
+          "grantTtlHours": 720,
+          "opTimeoutMs": 15000,
+          "items": {
+            "repository-token": {
+              "item": "Repository automation token",
+              "field": "credential",
+              "policy": "approve",
+              "description": "Token for repository automation",
+            },
+            "model-key": {
+              "item": "Model provider key",
+              "vault": "Agent credentials",
+              "policy": "auto",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+Slugs use lowercase letters, numbers, and hyphens, start with a letter or
+number, and contain at most 64 characters. A registry can contain up to 32
+slugs; descriptions can contain up to 200 characters. `field` defaults to
+`credential`.
+An item-level `vault` overrides the default vault. `opBin` can set an absolute
+path to the `op` executable; otherwise the plugin resolves `op` from `PATH`.
+Item titles must not start with a hyphen.
+
+## Use the agent tool
+
+The tool name is `onepassword`.
+
+List registered slugs:
+
+```json
+{ "action": "list" }
+```
+
+The result contains only the slug, description, policy, and whether a standing
+grant is active. It never contains a secret value and does not query 1Password.
+
+Request one secret:
+
+```json
+{
+  "action": "get",
+  "slug": "repository-token",
+  "reason": "Authenticate the requested repository operation"
+}
+```
+
+`reason` is required, must be non-empty, and is limited to 300 characters. A
+successful `get` returns the value plus the configured slug, item title, and
+field label.
+
+## Policy tiers and approvals
+
+- `auto`: fetch immediately and audit the request.
+- `deny`: block and audit the request.
+- `approve`: use an unexpired standing grant, or ask a human to allow once,
+  always, or deny.
+
+Allow once authorizes only the current tool call. Allow always writes a standing
+grant for that slug to SQLite. The grant expires after `grantTtlHours`, which
+defaults to 720 hours. An unresolved or timed-out approval denies the request;
+the maximum approval wait is 600 seconds.
+
+The in-memory cache defaults to 300 seconds and is bounded by the configured
+slug registry. Set `cacheTtlSeconds` to `0` to disable it. Policy is evaluated
+before every cache lookup, and cache hits are audited.
+
+## Inspect status and audit history
+
+Show readiness and registry counts:
+
+```bash
+openclaw onepassword status
+```
+
+This reports whether the token file exists, whether `op` resolved and its path,
+the registered item count, and per-policy counts. It never reads or prints the
+token or secret values.
+
+Show the 50 most recent audit rows:
+
+```bash
+openclaw onepassword audit
+openclaw onepassword audit --limit 100
+```
+
+Rows are newest first and show timestamp, agent, slug, outcome, and a truncated
+reason. The reason is stored as supplied; the broker never adds the fetched
+value to the audit log.
+
+## 1Password CLI behavior
+
+Each cache miss runs `op item get` with the configured item and vault, JSON
+output, a bounded timeout, and `--cache=false`. Only
+`OP_SERVICE_ACCOUNT_TOKEN` and `HOME` are present in the child environment.
+
+The plugin makes one attempt. `RATE_LIMITED` errors should be handled by waiting
+before a later agent request; the plugin does not create an automatic retry
+loop. Other stable error codes distinguish missing tokens or binaries, missing
+items or fields, authentication failures, timeouts, and other `op` failures.

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,7 +51,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-64 plugins
+65 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
@@ -132,6 +132,8 @@ Each entry lists the package, distribution route, and description.
 - **[oc-path](/plugins/reference/oc-path)** (`@openclaw/oc-path`) - included in OpenClaw. Adds the openclaw path CLI for oc:// workspace file addressing.
 
 - **[ollama](/plugins/reference/ollama)** (`@openclaw/ollama-provider`) - included in OpenClaw. Adds Ollama, Ollama Cloud model provider support to OpenClaw.
+
+- **[onepassword](/plugins/reference/onepassword)** (`@openclaw/onepassword`) - included in OpenClaw. Curated 1Password secrets broker with approval policy and SQLite audit history.
 
 - **[open-prose](/plugins/reference/open-prose)** (`@openclaw/open-prose`) - included in OpenClaw. OpenProse VM skill pack with a /prose slash command.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 137
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 138
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 136
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 137
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/onepassword.md
+++ b/docs/plugins/reference/onepassword.md
@@ -1,0 +1,23 @@
+---
+summary: "Curated 1Password secrets broker with approval policy and SQLite audit history."
+read_when:
+  - You are installing, configuring, or auditing the onepassword plugin
+title: "Onepassword plugin"
+---
+
+# Onepassword plugin
+
+Curated 1Password secrets broker with approval policy and SQLite audit history.
+
+## Distribution
+
+- Package: `@openclaw/onepassword`
+- Install route: included in OpenClaw
+
+## Surface
+
+contracts: tools
+
+## Related docs
+
+- [onepassword](/plugins/onepassword)

--- a/docs/plugins/reference/qa-lab.md
+++ b/docs/plugins/reference/qa-lab.md
@@ -16,4 +16,4 @@ OpenClaw QA lab plugin with private debugger UI and scenario runner.
 
 ## Surface
 
-contracts: webSearchProviders, workerProviders
+contracts: tools, webSearchProviders, workerProviders

--- a/extensions/onepassword/index.test.ts
+++ b/extensions/onepassword/index.test.ts
@@ -44,4 +44,91 @@ describe("onepassword plugin", () => {
     expect(registerCli).toHaveBeenCalledTimes(1);
     expect(registerTool).not.toHaveBeenCalled();
   });
+
+  it("evaluates enablement and before-tool policy from live plugin config", async () => {
+    const pluginConfig = (policy: "auto" | "deny") => ({
+      vault: "Automation",
+      items: {
+        deploy: {
+          item: "Deploy token",
+          field: "credential",
+          policy,
+        },
+      },
+    });
+    let livePolicy: "auto" | "deny" = "auto";
+    let liveEnabled = true;
+    const current = () => ({
+      plugins: {
+        entries: {
+          onepassword: {
+            enabled: liveEnabled,
+            config: pluginConfig(livePolicy),
+          },
+        },
+      },
+    });
+    const store = {
+      register: vi.fn(async () => undefined),
+      lookup: vi.fn(async () => undefined),
+      delete: vi.fn(async () => undefined),
+      entries: vi.fn(async () => []),
+    };
+    const on = vi.fn();
+
+    plugin.register(
+      createTestPluginApi({
+        id: "onepassword",
+        name: "1Password",
+        source: "test",
+        config: current(),
+        pluginConfig: pluginConfig("auto"),
+        runtime: {
+          config: { current },
+          state: {
+            openKeyedStore: () => store,
+            resolveStateDir: () => "/tmp/openclaw-onepassword-test",
+          },
+        } as never,
+        registerCli: vi.fn(),
+        registerTool: vi.fn(),
+        on,
+      }),
+    );
+
+    const beforeToolCall = on.mock.calls.find(([name]) => name === "before_tool_call")?.[1] as
+      | ((
+          event: { toolName: string; toolCallId: string; params: Record<string, unknown> },
+          context: { toolName: string; toolCallId: string; agentId: string },
+        ) => Promise<{ block?: boolean } | void>)
+      | undefined;
+    if (!beforeToolCall) {
+      throw new Error("missing before_tool_call hook");
+    }
+
+    liveEnabled = false;
+    await expect(
+      beforeToolCall(
+        {
+          toolName: "onepassword",
+          toolCallId: "live-enabled-1",
+          params: { action: "get", slug: "deploy", reason: "test live enablement" },
+        },
+        { toolName: "onepassword", toolCallId: "live-enabled-1", agentId: "agent-a" },
+      ),
+    ).resolves.toMatchObject({ block: true });
+
+    liveEnabled = true;
+    livePolicy = "deny";
+    await expect(
+      beforeToolCall(
+        {
+          toolName: "onepassword",
+          toolCallId: "live-policy-1",
+          params: { action: "get", slug: "deploy", reason: "test live policy" },
+        },
+        { toolName: "onepassword", toolCallId: "live-policy-1", agentId: "agent-a" },
+      ),
+    ).resolves.toMatchObject({ block: true });
+  });
 });

--- a/extensions/onepassword/index.test.ts
+++ b/extensions/onepassword/index.test.ts
@@ -1,0 +1,47 @@
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+
+describe("onepassword plugin", () => {
+  it("opens bounded fail-closed grant and audit stores", () => {
+    const store = {
+      register: vi.fn(),
+      lookup: vi.fn(),
+      delete: vi.fn(),
+      entries: vi.fn(async () => []),
+    };
+    const openKeyedStore = vi.fn(() => store);
+    const registerCli = vi.fn();
+    const registerTool = vi.fn();
+
+    plugin.register(
+      createTestPluginApi({
+        id: "onepassword",
+        name: "1Password",
+        source: "test",
+        config: {},
+        runtime: {
+          state: {
+            openKeyedStore,
+            resolveStateDir: () => "/tmp/openclaw-onepassword-test",
+          },
+        } as never,
+        registerCli,
+        registerTool,
+      }),
+    );
+
+    expect(openKeyedStore).toHaveBeenNthCalledWith(1, {
+      namespace: "grants",
+      maxEntries: 1_024,
+      overflowPolicy: "evict-oldest",
+    });
+    expect(openKeyedStore).toHaveBeenNthCalledWith(2, {
+      namespace: "audit",
+      maxEntries: 40_000,
+      overflowPolicy: "evict-oldest",
+    });
+    expect(registerCli).toHaveBeenCalledTimes(1);
+    expect(registerTool).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/onepassword/index.ts
+++ b/extensions/onepassword/index.ts
@@ -1,0 +1,68 @@
+import path from "node:path";
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import type { AuditRow, StandingGrant } from "./src/broker.js";
+import { OnePasswordBroker } from "./src/broker.js";
+import { MAX_REGISTERED_ITEMS, parseOnePasswordConfig } from "./src/config.js";
+import { OpClient } from "./src/op-client.js";
+import { createOnePasswordTool, redactPersistedOnePasswordResult } from "./src/tool.js";
+
+const MAX_AUDIT_ROWS = 40_000;
+
+export default definePluginEntry({
+  id: "onepassword",
+  name: "1Password",
+  description: "Curated 1Password secrets broker with approval policy and SQLite audit history.",
+  register(api) {
+    const config = parseOnePasswordConfig(api.pluginConfig);
+    const grants = api.runtime.state.openKeyedStore<StandingGrant>({
+      namespace: "grants",
+      maxEntries: MAX_REGISTERED_ITEMS,
+      overflowPolicy: "reject-new",
+    });
+    const audit = api.runtime.state.openKeyedStore<AuditRow>({
+      namespace: "audit",
+      maxEntries: MAX_AUDIT_ROWS,
+      overflowPolicy: "evict-oldest",
+    });
+    const tokenFile = path.join(
+      api.runtime.state.resolveStateDir(process.env),
+      "credentials",
+      "onepassword",
+      "service-account-token",
+    );
+    const opClient = new OpClient({
+      opBin: config?.opBin,
+      tokenFile,
+      timeoutMs: config?.opTimeoutMs ?? 15_000,
+      warn: (message) => api.logger.warn(message),
+    });
+    const broker = config
+      ? new OnePasswordBroker({ config, opClient, stores: { audit, grants } })
+      : undefined;
+
+    api.registerCli(
+      async ({ program }) => {
+        const { registerOnePasswordCommands } = await import("./src/cli.js");
+        registerOnePasswordCommands({ program, config, opClient, auditStore: audit });
+      },
+      {
+        descriptors: [
+          {
+            name: "onepassword",
+            description: "Inspect the 1Password secrets broker",
+            hasSubcommands: true,
+          },
+        ],
+      },
+    );
+
+    if (!broker) {
+      return;
+    }
+    api.registerTool((context) => createOnePasswordTool(broker, context), {
+      name: "onepassword",
+    });
+    api.on("before_tool_call", (event, ctx) => broker.beforeToolCall(event, ctx));
+    api.on("tool_result_persist", redactPersistedOnePasswordResult);
+  },
+});

--- a/extensions/onepassword/index.ts
+++ b/extensions/onepassword/index.ts
@@ -7,6 +7,7 @@ import { OpClient } from "./src/op-client.js";
 import { createOnePasswordTool, redactPersistedOnePasswordResult } from "./src/tool.js";
 
 const MAX_AUDIT_ROWS = 40_000;
+const MAX_STANDING_GRANTS = MAX_REGISTERED_ITEMS * 32;
 
 export default definePluginEntry({
   id: "onepassword",
@@ -16,8 +17,10 @@ export default definePluginEntry({
     const config = parseOnePasswordConfig(api.pluginConfig);
     const grants = api.runtime.state.openKeyedStore<StandingGrant>({
       namespace: "grants",
-      maxEntries: MAX_REGISTERED_ITEMS,
-      overflowPolicy: "reject-new",
+      // Evicting the oldest grant is fail-closed: that agent must approve again.
+      // Keep enough room for 32 agents holding every registered slug.
+      maxEntries: MAX_STANDING_GRANTS,
+      overflowPolicy: "evict-oldest",
     });
     const audit = api.runtime.state.openKeyedStore<AuditRow>({
       namespace: "audit",

--- a/extensions/onepassword/index.ts
+++ b/extensions/onepassword/index.ts
@@ -1,4 +1,10 @@
 import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  normalizePluginsConfig,
+  resolveEffectiveEnableState,
+  resolveLivePluginConfigObject,
+} from "openclaw/plugin-sdk/plugin-config-runtime";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import type { AuditRow, StandingGrant } from "./src/broker.js";
 import { OnePasswordBroker } from "./src/broker.js";
@@ -14,7 +20,28 @@ export default definePluginEntry({
   name: "1Password",
   description: "Curated 1Password secrets broker with approval policy and SQLite audit history.",
   register(api) {
-    const config = parseOnePasswordConfig(api.pluginConfig);
+    const startupConfig = parseOnePasswordConfig(api.pluginConfig);
+    const resolveCurrentConfig = () => {
+      const liveConfig = api.runtime.config?.current
+        ? (api.runtime.config.current() as OpenClawConfig)
+        : undefined;
+      if (!liveConfig) {
+        return startupConfig;
+      }
+      const livePluginConfig = resolveLivePluginConfigObject(
+        () => liveConfig,
+        "onepassword",
+        api.pluginConfig as Record<string, unknown> | undefined,
+      );
+      const enabled = resolveEffectiveEnableState({
+        id: "onepassword",
+        origin: "bundled",
+        config: normalizePluginsConfig(liveConfig.plugins),
+        rootConfig: liveConfig,
+        enabledByDefault: livePluginConfig !== undefined,
+      }).enabled;
+      return enabled ? parseOnePasswordConfig(livePluginConfig) : undefined;
+    };
     const grants = api.runtime.state.openKeyedStore<StandingGrant>({
       namespace: "grants",
       // Evicting the oldest grant is fail-closed: that agent must approve again.
@@ -33,20 +60,41 @@ export default definePluginEntry({
       "onepassword",
       "service-account-token",
     );
-    const opClient = new OpClient({
-      opBin: config?.opBin,
-      tokenFile,
-      timeoutMs: config?.opTimeoutMs ?? 15_000,
-      warn: (message) => api.logger.warn(message),
-    });
-    const broker = config
-      ? new OnePasswordBroker({ config, opClient, stores: { audit, grants } })
+    let cachedOpClient: { key: string; client: OpClient } | undefined;
+    const resolveCurrentOpClient = () => {
+      const config = resolveCurrentConfig();
+      const key = JSON.stringify([config?.opBin ?? null, config?.opTimeoutMs ?? 15_000]);
+      if (cachedOpClient?.key === key) {
+        return cachedOpClient.client;
+      }
+      const client = new OpClient({
+        opBin: config?.opBin,
+        tokenFile,
+        timeoutMs: config?.opTimeoutMs ?? 15_000,
+        warn: (message) => api.logger.warn(message),
+      });
+      cachedOpClient = { key, client };
+      return client;
+    };
+    const broker = startupConfig
+      ? new OnePasswordBroker({
+          resolveConfig: resolveCurrentConfig,
+          opClient: {
+            getItem: (params) => resolveCurrentOpClient().getItem(params),
+          },
+          stores: { audit, grants },
+        })
       : undefined;
 
     api.registerCli(
       async ({ program }) => {
         const { registerOnePasswordCommands } = await import("./src/cli.js");
-        registerOnePasswordCommands({ program, config, opClient, auditStore: audit });
+        registerOnePasswordCommands({
+          program,
+          resolveConfig: resolveCurrentConfig,
+          resolveOpClient: resolveCurrentOpClient,
+          auditStore: audit,
+        });
       },
       {
         descriptors: [

--- a/extensions/onepassword/npm-shrinkwrap.json
+++ b/extensions/onepassword/npm-shrinkwrap.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/onepassword",
+  "version": "2026.7.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openclaw/onepassword",
+      "version": "2026.7.2"
+    }
+  }
+}

--- a/extensions/onepassword/openclaw.plugin.json
+++ b/extensions/onepassword/openclaw.plugin.json
@@ -1,0 +1,94 @@
+{
+  "id": "onepassword",
+  "name": "1Password",
+  "description": "Curated 1Password secrets broker with approval policy and SQLite audit history.",
+  "activation": {
+    "onStartup": false,
+    "onCommands": ["onepassword"],
+    "onConfigPaths": ["plugins.entries.onepassword.config"]
+  },
+  "commandAliases": [
+    {
+      "name": "onepassword",
+      "kind": "cli"
+    }
+  ],
+  "contracts": {
+    "tools": ["onepassword"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["vault", "items"],
+    "properties": {
+      "vault": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^(?!\\s*-)"
+      },
+      "opBin": {
+        "type": "string",
+        "minLength": 1
+      },
+      "defaultPolicy": {
+        "type": "string",
+        "enum": ["auto", "approve", "deny"],
+        "default": "approve"
+      },
+      "cacheTtlSeconds": {
+        "type": "integer",
+        "minimum": 0,
+        "default": 300
+      },
+      "grantTtlHours": {
+        "type": "number",
+        "exclusiveMinimum": 0,
+        "default": 720
+      },
+      "opTimeoutMs": {
+        "type": "integer",
+        "minimum": 1,
+        "default": 15000
+      },
+      "items": {
+        "type": "object",
+        "minProperties": 1,
+        "maxProperties": 32,
+        "propertyNames": {
+          "pattern": "^[a-z0-9][a-z0-9-]{0,63}$"
+        },
+        "additionalProperties": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["item"],
+          "properties": {
+            "item": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^(?!\\s*-)"
+            },
+            "vault": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^(?!\\s*-)"
+            },
+            "field": {
+              "type": "string",
+              "minLength": 1,
+              "default": "credential"
+            },
+            "policy": {
+              "type": "string",
+              "enum": ["auto", "approve", "deny"]
+            },
+            "description": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/onepassword/openclaw.plugin.json
+++ b/extensions/onepassword/openclaw.plugin.json
@@ -75,6 +75,7 @@
             "field": {
               "type": "string",
               "minLength": 1,
+              "pattern": "^[^,]+$",
               "default": "credential"
             },
             "policy": {

--- a/extensions/onepassword/package.json
+++ b/extensions/onepassword/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/onepassword",
+  "version": "2026.7.2",
+  "private": true,
+  "description": "1Password secrets broker for OpenClaw",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/onepassword/src/broker.test.ts
+++ b/extensions/onepassword/src/broker.test.ts
@@ -51,6 +51,7 @@ function configuredItem(configured: OnePasswordConfig, slug: string): OnePasswor
 
 function setup(nowValue = 1_000, configured = config()) {
   let now = nowValue;
+  let currentConfig: OnePasswordConfig | undefined = configured;
   const audit = new MemoryKeyedStore<AuditRow>(() => now);
   const grants = new MemoryKeyedStore<StandingGrant>(() => now);
   const getItem = vi.fn(async () => ({
@@ -59,7 +60,7 @@ function setup(nowValue = 1_000, configured = config()) {
     fieldLabel: "credential",
   }));
   const broker = new OnePasswordBroker({
-    config: configured,
+    resolveConfig: () => currentConfig,
     opClient: { getItem },
     stores: { audit, grants },
     now: () => now,
@@ -69,6 +70,9 @@ function setup(nowValue = 1_000, configured = config()) {
     audit,
     grants,
     getItem,
+    setConfig: (next: OnePasswordConfig | undefined) => {
+      currentConfig = next;
+    },
     advance: (ms: number) => {
       now += ms;
     },
@@ -380,6 +384,94 @@ describe("OnePasswordBroker validation and policy", () => {
     expect(remapped?.requireApproval).toBeDefined();
   });
 
+  it("fails closed when live policy changes after authorization", async () => {
+    const configured = config();
+    const { broker, audit, getItem, setConfig } = setup(1_000, configured);
+    await before(broker, "live-deny-1", {
+      action: "get",
+      slug: "automatic",
+      reason: "authorized before reload",
+    });
+    const reloaded = structuredClone(configured);
+    configuredItem(reloaded, "automatic").policy = "deny";
+    setConfig(reloaded);
+
+    await expect(
+      broker.get(
+        "live-deny-1",
+        { action: "get", slug: "automatic", reason: "authorized before reload" },
+        invocation,
+      ),
+    ).rejects.toMatchObject({ code: "POLICY_CHANGED" });
+    expect(getItem).not.toHaveBeenCalled();
+    expect((await audit.entries()).at(-1)?.value).toMatchObject({
+      outcome: "policy-denied",
+    });
+  });
+
+  it("rejects a retargeted authorization and never reuses its cached value", async () => {
+    const configured = config();
+    const { broker, getItem, setConfig } = setup(1_000, configured);
+    await before(broker, "live-target-1", {
+      action: "get",
+      slug: "automatic",
+      reason: "prime original target",
+    });
+    await broker.get(
+      "live-target-1",
+      { action: "get", slug: "automatic", reason: "prime original target" },
+      invocation,
+    );
+
+    await before(broker, "live-target-2", {
+      action: "get",
+      slug: "automatic",
+      reason: "authorized before retarget",
+    });
+    const reloaded = structuredClone(configured);
+    configuredItem(reloaded, "automatic").item = "Replacement target";
+    setConfig(reloaded);
+    await expect(
+      broker.get(
+        "live-target-2",
+        { action: "get", slug: "automatic", reason: "authorized before retarget" },
+        invocation,
+      ),
+    ).rejects.toMatchObject({ code: "POLICY_CHANGED" });
+
+    await before(broker, "live-target-3", {
+      action: "get",
+      slug: "automatic",
+      reason: "authorize replacement target",
+    });
+    await broker.get(
+      "live-target-3",
+      { action: "get", slug: "automatic", reason: "authorize replacement target" },
+      invocation,
+    );
+    expect(getItem).toHaveBeenCalledTimes(2);
+    expect(getItem).toHaveBeenLastCalledWith(
+      expect.objectContaining({ item: "Replacement target" }),
+    );
+  });
+
+  it("blocks access after live plugin config removal", async () => {
+    const { broker, audit, getItem, setConfig } = setup();
+    setConfig(undefined);
+    await expect(
+      before(broker, "live-remove-1", {
+        action: "get",
+        slug: "automatic",
+        reason: "after removal",
+      }),
+    ).resolves.toMatchObject({ block: true });
+    expect(getItem).not.toHaveBeenCalled();
+    expect((await audit.entries()).at(-1)?.value).toMatchObject({
+      outcome: "error",
+      errorCode: "POLICY_CHANGED",
+    });
+  });
+
   it("prunes grants for removed slugs before persisting a replacement", async () => {
     const { broker, grants } = setup();
     for (const slug of ["removed-a", "removed-b"]) {
@@ -483,7 +575,7 @@ describe("OnePasswordBroker cache and audit", () => {
       fieldLabel: "credential",
     }));
     const broker = new OnePasswordBroker({
-      config: cfg,
+      resolveConfig: () => cfg,
       opClient: { getItem },
       stores: { audit, grants },
     });

--- a/extensions/onepassword/src/broker.test.ts
+++ b/extensions/onepassword/src/broker.test.ts
@@ -1,11 +1,6 @@
 import type { PluginHookBeforeToolCallResult } from "openclaw/plugin-sdk/types";
 import { describe, expect, it, vi } from "vitest";
-import {
-  fingerprintOnePasswordTarget,
-  OnePasswordBroker,
-  type AuditRow,
-  type StandingGrant,
-} from "./broker.js";
+import { OnePasswordBroker, type AuditRow, type StandingGrant } from "./broker.js";
 import type { OnePasswordConfig, OnePasswordItemConfig } from "./config.js";
 import { MemoryKeyedStore } from "./memory-store.test-support.js";
 
@@ -93,21 +88,21 @@ async function before(
 
 describe("OnePasswordBroker validation and policy", () => {
   it("lists only registry metadata and active grant state", async () => {
-    const configured = config();
-    const { broker, grants, getItem } = setup(1_000, configured);
-    await grants.register("approval", {
+    const { broker, getItem } = setup();
+    const approval = await before(broker, "list-grant", {
+      action: "get",
       slug: "approval",
-      grantedAtMs: 900,
-      expiresAtMs: 2_000,
-      targetFingerprint: fingerprintOnePasswordTarget(configuredItem(configured, "approval")),
+      reason: "create listing fixture",
     });
-    await grants.register("automatic", {
-      slug: "automatic",
-      grantedAtMs: 900,
-      expiresAtMs: 2_000,
-      targetFingerprint: "stale-target",
-    });
-    const items = await broker.list();
+    await approval?.requireApproval?.onResolution?.("allow-always");
+    await broker.get(
+      "list-grant",
+      { action: "get", slug: "approval", reason: "create listing fixture" },
+      invocation,
+    );
+    getItem.mockClear();
+
+    const items = await broker.list(invocation);
     expect(items).toEqual([
       {
         slug: "approval",
@@ -267,7 +262,7 @@ describe("OnePasswordBroker validation and policy", () => {
   });
 
   it("persists allow-always grants and expires them", async () => {
-    const { broker, audit, getItem, advance } = setup();
+    const { broker, audit, grants, getItem, advance } = setup();
     const first = await before(broker, "grant-1", {
       action: "get",
       slug: "approval",
@@ -283,6 +278,7 @@ describe("OnePasswordBroker validation and policy", () => {
       },
       invocation,
     );
+    expect((await grants.entries()).map((entry) => entry.value.agentId)).toEqual(["agent-a"]);
 
     advance(300_001);
     const second = await before(broker, "grant-2", {
@@ -309,6 +305,55 @@ describe("OnePasswordBroker validation and policy", () => {
       "approved",
       "grant",
     ]);
+  });
+
+  it("scopes standing grants and list state to the approved agent", async () => {
+    const { broker } = setup();
+    const approved = await before(broker, "agent-grant-1", {
+      action: "get",
+      slug: "approval",
+      reason: "agent a access",
+    });
+    await approved?.requireApproval?.onResolution?.("allow-always");
+    await broker.get(
+      "agent-grant-1",
+      { action: "get", slug: "approval", reason: "agent a access" },
+      invocation,
+    );
+
+    const otherAgent = {
+      agentId: "agent-b",
+      sessionKey: "session-b",
+      sessionId: "conversation-b",
+    };
+    const otherRequest = await broker.beforeToolCall(
+      {
+        toolName: "onepassword",
+        toolCallId: "agent-grant-2",
+        params: { action: "get", slug: "approval", reason: "agent b access" },
+      },
+      { toolName: "onepassword", toolCallId: "agent-grant-2", ...otherAgent },
+    );
+    expect(otherRequest?.requireApproval).toBeDefined();
+    expect((await broker.list(invocation)).find((item) => item.slug === "approval")).toMatchObject({
+      standingGrantActive: true,
+    });
+    expect((await broker.list(otherAgent)).find((item) => item.slug === "approval")).toMatchObject({
+      standingGrantActive: false,
+    });
+  });
+
+  it("does not offer a durable grant without an agent identity", async () => {
+    const { broker } = setup();
+    const result = await broker.beforeToolCall(
+      {
+        toolName: "onepassword",
+        toolCallId: "unknown-agent",
+        params: { action: "get", slug: "approval", reason: "one call only" },
+      },
+      { toolName: "onepassword", toolCallId: "unknown-agent" },
+    );
+    expect(result?.requireApproval?.allowedDecisions).toEqual(["allow-once", "deny"]);
   });
 
   it("invalidates a standing grant when its configured target changes", async () => {
@@ -339,6 +384,7 @@ describe("OnePasswordBroker validation and policy", () => {
     const { broker, grants } = setup();
     for (const slug of ["removed-a", "removed-b"]) {
       await grants.register(slug, {
+        agentId: "agent-a",
         slug,
         grantedAtMs: 900,
         expiresAtMs: 10_000,
@@ -356,7 +402,7 @@ describe("OnePasswordBroker validation and policy", () => {
       { action: "get", slug: "approval", reason: "replace removed grants" },
       invocation,
     );
-    expect((await grants.entries()).map((entry) => entry.key)).toEqual(["approval"]);
+    expect((await grants.entries()).map((entry) => entry.value.slug)).toEqual(["approval"]);
   });
 
   it("rechecks a standing grant before serving a cached value", async () => {

--- a/extensions/onepassword/src/broker.test.ts
+++ b/extensions/onepassword/src/broker.test.ts
@@ -1,0 +1,476 @@
+import type { PluginHookBeforeToolCallResult } from "openclaw/plugin-sdk/types";
+import { describe, expect, it, vi } from "vitest";
+import {
+  fingerprintOnePasswordTarget,
+  OnePasswordBroker,
+  type AuditRow,
+  type StandingGrant,
+} from "./broker.js";
+import type { OnePasswordConfig, OnePasswordItemConfig } from "./config.js";
+import { MemoryKeyedStore } from "./memory-store.test-support.js";
+
+const invocation = {
+  agentId: "agent-a",
+  sessionKey: "session-a",
+  sessionId: "conversation-a",
+} as const;
+
+function config(): OnePasswordConfig {
+  return {
+    vault: "Automation",
+    defaultPolicy: "approve",
+    cacheTtlSeconds: 300,
+    grantTtlHours: 1,
+    opTimeoutMs: 15_000,
+    items: {
+      automatic: {
+        item: "Automatic",
+        vault: "Automation",
+        field: "credential",
+        policy: "auto",
+        description: "Automatic item",
+      },
+      approval: {
+        item: "Approval",
+        vault: "Automation",
+        field: "credential",
+        policy: "approve",
+      },
+      blocked: {
+        item: "Blocked",
+        vault: "Automation",
+        field: "credential",
+        policy: "deny",
+      },
+    },
+  };
+}
+
+function configuredItem(configured: OnePasswordConfig, slug: string): OnePasswordItemConfig {
+  const item = configured.items[slug];
+  if (!item) {
+    throw new Error(`Missing test config item: ${slug}`);
+  }
+  return item;
+}
+
+function setup(nowValue = 1_000, configured = config()) {
+  let now = nowValue;
+  const audit = new MemoryKeyedStore<AuditRow>(() => now);
+  const grants = new MemoryKeyedStore<StandingGrant>(() => now);
+  const getItem = vi.fn(async () => ({
+    value: ["fixture", "value"].join("-"),
+    itemTitle: "Item title",
+    fieldLabel: "credential",
+  }));
+  const broker = new OnePasswordBroker({
+    config: configured,
+    opClient: { getItem },
+    stores: { audit, grants },
+    now: () => now,
+  });
+  return {
+    broker,
+    audit,
+    grants,
+    getItem,
+    advance: (ms: number) => {
+      now += ms;
+    },
+  };
+}
+
+async function before(
+  broker: OnePasswordBroker,
+  toolCallId: string,
+  params: Record<string, unknown>,
+): Promise<PluginHookBeforeToolCallResult | void> {
+  return broker.beforeToolCall(
+    { toolName: "onepassword", params, toolCallId },
+    { toolName: "onepassword", toolCallId, ...invocation },
+  );
+}
+
+describe("OnePasswordBroker validation and policy", () => {
+  it("lists only registry metadata and active grant state", async () => {
+    const configured = config();
+    const { broker, grants, getItem } = setup(1_000, configured);
+    await grants.register("approval", {
+      slug: "approval",
+      grantedAtMs: 900,
+      expiresAtMs: 2_000,
+      targetFingerprint: fingerprintOnePasswordTarget(configuredItem(configured, "approval")),
+    });
+    await grants.register("automatic", {
+      slug: "automatic",
+      grantedAtMs: 900,
+      expiresAtMs: 2_000,
+      targetFingerprint: "stale-target",
+    });
+    const items = await broker.list();
+    expect(items).toEqual([
+      {
+        slug: "approval",
+        description: "",
+        policy: "approve",
+        standingGrantActive: true,
+      },
+      {
+        slug: "automatic",
+        description: "Automatic item",
+        policy: "auto",
+        standingGrantActive: false,
+      },
+      {
+        slug: "blocked",
+        description: "",
+        policy: "deny",
+        standingGrantActive: false,
+      },
+    ]);
+    expect(getItem).not.toHaveBeenCalled();
+  });
+
+  it("requires a non-empty bounded reason before policy evaluation", async () => {
+    const { broker, audit, getItem } = setup();
+    const missing = await before(broker, "call-1", { action: "get", slug: "blocked" });
+    const empty = await before(broker, "call-2", {
+      action: "get",
+      slug: "blocked",
+      reason: "   ",
+    });
+    const long = await before(broker, "call-3", {
+      action: "get",
+      slug: "blocked",
+      reason: "x".repeat(301),
+    });
+    expect(missing).toMatchObject({ block: true });
+    expect(empty).toMatchObject({ block: true });
+    expect(long).toMatchObject({ block: true });
+    expect(getItem).not.toHaveBeenCalled();
+    expect((await audit.entries()).map((entry) => entry.value.errorCode)).toEqual([
+      "INVALID_REASON",
+      "INVALID_REASON",
+      "INVALID_REASON",
+    ]);
+  });
+
+  it("rejects invalid and unknown slugs", async () => {
+    const { broker, audit } = setup();
+    expect(
+      await before(broker, "call-1", { action: "get", slug: "Bad", reason: "test" }),
+    ).toMatchObject({ block: true });
+    expect(
+      await before(broker, "call-2", { action: "get", slug: "unknown", reason: "test" }),
+    ).toMatchObject({ block: true });
+    expect(
+      await before(broker, "call-3", { action: "get", slug: "constructor", reason: "test" }),
+    ).toMatchObject({ block: true });
+    expect((await audit.entries()).map((entry) => entry.value.errorCode)).toEqual([
+      "INVALID_SLUG",
+      "UNKNOWN_SLUG",
+      "UNKNOWN_SLUG",
+    ]);
+  });
+
+  it("allows auto, blocks deny, and audits one row per attempt", async () => {
+    const { broker, audit, getItem } = setup();
+    expect(
+      await before(broker, "auto-1", { action: "get", slug: "automatic", reason: "test" }),
+    ).toBeUndefined();
+    await expect(
+      broker.get("auto-1", { action: "get", slug: "automatic", reason: "test" }, invocation),
+    ).resolves.toMatchObject({ value: ["fixture", "value"].join("-") });
+    expect(
+      await before(broker, "deny-1", { action: "get", slug: "blocked", reason: "test" }),
+    ).toMatchObject({ block: true });
+    expect(getItem).toHaveBeenCalledTimes(1);
+    expect((await audit.entries()).map((entry) => entry.value.outcome)).toEqual([
+      "auto",
+      "policy-denied",
+    ]);
+  });
+
+  it("handles allow-once, deny, and timeout decisions", async () => {
+    const { broker, audit, getItem } = setup();
+    const approved = await before(broker, "approve-1", {
+      action: "get",
+      slug: "approval",
+      reason: "one use",
+    });
+    expect(approved?.requireApproval).toMatchObject({
+      title: "1Password: approval",
+      description: "Agent agent-a requests approval. Reason: one use",
+      severity: "warning",
+      timeoutMs: 600_000,
+      allowedDecisions: ["allow-once", "allow-always", "deny"],
+    });
+    await approved?.requireApproval?.onResolution?.("allow-once");
+    await broker.get(
+      "approve-1",
+      { action: "get", slug: "approval", reason: "one use" },
+      invocation,
+    );
+
+    const denied = await before(broker, "approve-2", {
+      action: "get",
+      slug: "approval",
+      reason: "deny",
+    });
+    await denied?.requireApproval?.onResolution?.("deny");
+    const timedOut = await before(broker, "approve-3", {
+      action: "get",
+      slug: "approval",
+      reason: "timeout",
+    });
+    await timedOut?.requireApproval?.onResolution?.("timeout");
+
+    expect(getItem).toHaveBeenCalledTimes(1);
+    expect((await audit.entries()).map((entry) => entry.value.outcome)).toEqual([
+      "approved",
+      "denied",
+      "timeout",
+    ]);
+  });
+
+  it("isolates identical tool call ids across sessions", async () => {
+    const { broker, audit } = setup();
+    const sessionA = { agentId: "agent-a", sessionKey: "session-a", sessionId: "conversation-a" };
+    const sessionB = { agentId: "agent-b", sessionKey: "session-b", sessionId: "conversation-b" };
+    for (const [scope, reason] of [
+      [sessionA, "first session"],
+      [sessionB, "second session"],
+    ] as const) {
+      await broker.beforeToolCall(
+        {
+          toolName: "onepassword",
+          params: { action: "get", slug: "automatic", reason },
+          toolCallId: "call-1",
+        },
+        { toolName: "onepassword", toolCallId: "call-1", ...scope },
+      );
+    }
+    await expect(
+      broker.get("call-1", { action: "get", slug: "automatic", reason: "first session" }, sessionA),
+    ).resolves.toMatchObject({ slug: "automatic" });
+    await expect(
+      broker.get(
+        "call-1",
+        { action: "get", slug: "automatic", reason: "second session" },
+        sessionB,
+      ),
+    ).resolves.toMatchObject({ slug: "automatic" });
+    expect((await audit.entries()).map((entry) => entry.value.sessionKey)).toEqual([
+      "session-a",
+      "session-b",
+    ]);
+  });
+
+  it("persists allow-always grants and expires them", async () => {
+    const { broker, audit, getItem, advance } = setup();
+    const first = await before(broker, "grant-1", {
+      action: "get",
+      slug: "approval",
+      reason: "standing access",
+    });
+    await first?.requireApproval?.onResolution?.("allow-always");
+    await broker.get(
+      "grant-1",
+      {
+        action: "get",
+        slug: "approval",
+        reason: "standing access",
+      },
+      invocation,
+    );
+
+    advance(300_001);
+    const second = await before(broker, "grant-2", {
+      action: "get",
+      slug: "approval",
+      reason: "second access",
+    });
+    expect(second).toBeUndefined();
+    await broker.get(
+      "grant-2",
+      { action: "get", slug: "approval", reason: "second access" },
+      invocation,
+    );
+    expect(getItem).toHaveBeenCalledTimes(2);
+
+    advance(60 * 60 * 1000 + 1);
+    const expired = await before(broker, "grant-3", {
+      action: "get",
+      slug: "approval",
+      reason: "expired access",
+    });
+    expect(expired?.requireApproval).toBeDefined();
+    expect((await audit.entries()).map((entry) => entry.value.outcome)).toEqual([
+      "approved",
+      "grant",
+    ]);
+  });
+
+  it("invalidates a standing grant when its configured target changes", async () => {
+    const configured = config();
+    const { broker } = setup(1_000, configured);
+    const first = await before(broker, "grant-remap-1", {
+      action: "get",
+      slug: "approval",
+      reason: "approve original target",
+    });
+    await first?.requireApproval?.onResolution?.("allow-always");
+    await broker.get(
+      "grant-remap-1",
+      { action: "get", slug: "approval", reason: "approve original target" },
+      invocation,
+    );
+
+    configuredItem(configured, "approval").item = "Replacement target";
+    const remapped = await before(broker, "grant-remap-2", {
+      action: "get",
+      slug: "approval",
+      reason: "request remapped target",
+    });
+    expect(remapped?.requireApproval).toBeDefined();
+  });
+
+  it("prunes grants for removed slugs before persisting a replacement", async () => {
+    const { broker, grants } = setup();
+    for (const slug of ["removed-a", "removed-b"]) {
+      await grants.register(slug, {
+        slug,
+        grantedAtMs: 900,
+        expiresAtMs: 10_000,
+        targetFingerprint: "removed-target",
+      });
+    }
+    const approval = await before(broker, "grant-prune-1", {
+      action: "get",
+      slug: "approval",
+      reason: "replace removed grants",
+    });
+    await approval?.requireApproval?.onResolution?.("allow-always");
+    await broker.get(
+      "grant-prune-1",
+      { action: "get", slug: "approval", reason: "replace removed grants" },
+      invocation,
+    );
+    expect((await grants.entries()).map((entry) => entry.key)).toEqual(["approval"]);
+  });
+
+  it("rechecks a standing grant before serving a cached value", async () => {
+    const configured = config();
+    configured.grantTtlHours = 0.001;
+    const { broker, audit, getItem, advance } = setup(1_000, configured);
+    const first = await before(broker, "grant-cache-1", {
+      action: "get",
+      slug: "approval",
+      reason: "create grant",
+    });
+    await first?.requireApproval?.onResolution?.("allow-always");
+    await broker.get(
+      "grant-cache-1",
+      {
+        action: "get",
+        slug: "approval",
+        reason: "create grant",
+      },
+      invocation,
+    );
+
+    const second = await before(broker, "grant-cache-2", {
+      action: "get",
+      slug: "approval",
+      reason: "use grant",
+    });
+    expect(second).toBeUndefined();
+    advance(3_601);
+    await expect(
+      broker.get(
+        "grant-cache-2",
+        {
+          action: "get",
+          slug: "approval",
+          reason: "use grant",
+        },
+        invocation,
+      ),
+    ).rejects.toMatchObject({ code: "GRANT_EXPIRED" });
+    expect(getItem).toHaveBeenCalledTimes(1);
+    expect((await audit.entries()).at(-1)?.value).toMatchObject({
+      outcome: "error",
+      errorCode: "GRANT_EXPIRED",
+    });
+  });
+});
+
+describe("OnePasswordBroker cache and audit", () => {
+  it("honors cache TTL, audits hits, and refetches after expiry", async () => {
+    const { broker, audit, getItem, advance } = setup();
+    for (const [id, reason] of [
+      ["cache-1", "first"],
+      ["cache-2", "second"],
+    ] as const) {
+      await before(broker, id, { action: "get", slug: "automatic", reason });
+      await broker.get(id, { action: "get", slug: "automatic", reason }, invocation);
+    }
+    expect(getItem).toHaveBeenCalledTimes(1);
+    advance(300_001);
+    await before(broker, "cache-3", { action: "get", slug: "automatic", reason: "third" });
+    await broker.get("cache-3", { action: "get", slug: "automatic", reason: "third" }, invocation);
+    expect(getItem).toHaveBeenCalledTimes(2);
+    expect((await audit.entries()).map((entry) => entry.value.outcome)).toEqual([
+      "auto",
+      "cache-hit",
+      "auto",
+    ]);
+  });
+
+  it("never lets a cache entry bypass a changed deny policy", async () => {
+    const cfg = config();
+    const audit = new MemoryKeyedStore<AuditRow>();
+    const grants = new MemoryKeyedStore<StandingGrant>();
+    const getItem = vi.fn(async () => ({
+      value: ["fixture", "value"].join("-"),
+      itemTitle: "Item",
+      fieldLabel: "credential",
+    }));
+    const broker = new OnePasswordBroker({
+      config: cfg,
+      opClient: { getItem },
+      stores: { audit, grants },
+    });
+    await before(broker, "deny-cache-1", {
+      action: "get",
+      slug: "automatic",
+      reason: "prime cache",
+    });
+    await broker.get(
+      "deny-cache-1",
+      {
+        action: "get",
+        slug: "automatic",
+        reason: "prime cache",
+      },
+      invocation,
+    );
+    const automatic = cfg.items.automatic;
+    if (!automatic) {
+      throw new Error("automatic test item missing");
+    }
+    automatic.policy = "deny";
+    expect(
+      await before(broker, "deny-cache-2", {
+        action: "get",
+        slug: "automatic",
+        reason: "blocked",
+      }),
+    ).toMatchObject({ block: true });
+    expect(getItem).toHaveBeenCalledTimes(1);
+    expect((await audit.entries()).map((entry) => entry.value.outcome)).toEqual([
+      "auto",
+      "policy-denied",
+    ]);
+  });
+});

--- a/extensions/onepassword/src/broker.ts
+++ b/extensions/onepassword/src/broker.ts
@@ -37,6 +37,7 @@ export type AuditRow = {
 };
 
 export type StandingGrant = {
+  agentId: string;
   slug: string;
   grantedAtMs: number;
   expiresAtMs: number;
@@ -140,6 +141,12 @@ export function fingerprintOnePasswordTarget(item: OnePasswordItemConfig): strin
     .digest("hex");
 }
 
+function standingGrantKey(agentId: string, slug: string): string {
+  return createHash("sha256")
+    .update(JSON.stringify([agentId, slug]))
+    .digest("hex");
+}
+
 export function parseToolInput(params: Record<string, unknown>): ParsedToolInput {
   if (params.action === "list") {
     return { action: "list" };
@@ -240,10 +247,12 @@ export class OnePasswordBroker {
   private async pruneStaleGrants(): Promise<void> {
     const now = this.now();
     for (const entry of await this.stores.grants.entries()) {
-      const item = this.config.items[entry.key];
+      const item = Object.hasOwn(this.config.items, entry.value.slug)
+        ? this.config.items[entry.value.slug]
+        : undefined;
       if (
-        !Object.hasOwn(this.config.items, entry.key) ||
         !item ||
+        entry.key !== standingGrantKey(entry.value.agentId, entry.value.slug) ||
         entry.value.expiresAtMs <= now ||
         entry.value.targetFingerprint !== fingerprintOnePasswordTarget(item)
       ) {
@@ -305,9 +314,13 @@ export class OnePasswordBroker {
       return;
     }
 
-    const grant = await this.stores.grants.lookup(input.slug);
+    const grantKey =
+      context.agentId === "unknown" ? undefined : standingGrantKey(context.agentId, input.slug);
+    const grant = grantKey ? await this.stores.grants.lookup(grantKey) : undefined;
     if (
       grant &&
+      grant.agentId === context.agentId &&
+      grant.slug === input.slug &&
       grant.expiresAtMs > this.now() &&
       grant.targetFingerprint === fingerprintOnePasswordTarget(item)
     ) {
@@ -319,8 +332,8 @@ export class OnePasswordBroker {
       });
       return;
     }
-    if (grant) {
-      await this.stores.grants.delete(input.slug);
+    if (grant && grantKey) {
+      await this.stores.grants.delete(grantKey);
     }
 
     return {
@@ -329,7 +342,12 @@ export class OnePasswordBroker {
         description: `Agent ${context.agentId} requests ${input.slug}. Reason: ${input.reason}`,
         severity: "warning",
         timeoutMs: APPROVAL_TIMEOUT_MS,
-        allowedDecisions: ["allow-once", "allow-always", "deny"],
+        // Durable grants must bind to a concrete core-provided agent identity.
+        // Unknown callers can still receive one-call approval, never shared access.
+        allowedDecisions:
+          context.agentId === "unknown"
+            ? ["allow-once", "deny"]
+            : ["allow-once", "allow-always", "deny"],
         // Core fires onResolution without awaiting it; the synchronous pending.set
         // below is what guarantees the authorization exists before the tool
         // handler runs. Do not move it behind an await.
@@ -338,7 +356,7 @@ export class OnePasswordBroker {
             this.pending.set(this.pendingKey(context), {
               ...context,
               outcome: "approved",
-              persistGrant: decision === "allow-always",
+              persistGrant: decision === "allow-always" && context.agentId !== "unknown",
               expiresAtMs: this.now() + PENDING_AUTHORIZATION_TTL_MS,
             });
             return;
@@ -357,21 +375,24 @@ export class OnePasswordBroker {
     };
   }
 
-  async list(): Promise<ListedItem[]> {
+  async list(invocation: ToolInvocationContext): Promise<ListedItem[]> {
     const grants = new Map(
       (await this.stores.grants.entries()).map((entry) => [entry.key, entry.value]),
     );
     const now = this.now();
+    const agentId = invocation.agentId;
     return Object.entries(this.config.items)
       .toSorted(([left], [right]) => left.localeCompare(right))
       .map(([slug, item]) => {
-        const grant = grants.get(slug);
+        const grant = agentId ? grants.get(standingGrantKey(agentId, slug)) : undefined;
         return {
           slug,
           description: item.description ?? "",
           policy: item.policy,
           standingGrantActive: Boolean(
             grant &&
+            grant.agentId === agentId &&
+            grant.slug === slug &&
             grant.expiresAtMs > now &&
             grant.targetFingerprint === fingerprintOnePasswordTarget(item),
           ),
@@ -428,9 +449,13 @@ export class OnePasswordBroker {
       throw internalError("POLICY_CHANGED", "1Password policy changed before tool execution");
     }
     if (authorization.outcome === "grant") {
-      const grant = await this.stores.grants.lookup(input.slug);
+      const grant = await this.stores.grants.lookup(
+        standingGrantKey(authorization.agentId, input.slug),
+      );
       if (
         !grant ||
+        grant.agentId !== authorization.agentId ||
+        grant.slug !== input.slug ||
         grant.expiresAtMs <= this.now() ||
         grant.targetFingerprint !== fingerprintOnePasswordTarget(item)
       ) {
@@ -448,8 +473,9 @@ export class OnePasswordBroker {
       try {
         await this.pruneStaleGrants();
         await this.stores.grants.register(
-          input.slug,
+          standingGrantKey(authorization.agentId, input.slug),
           {
+            agentId: authorization.agentId,
             slug: input.slug,
             grantedAtMs,
             expiresAtMs: grantedAtMs + ttlMs,

--- a/extensions/onepassword/src/broker.ts
+++ b/extensions/onepassword/src/broker.ts
@@ -1,0 +1,493 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import type {
+  PluginHookBeforeToolCallEvent,
+  PluginHookBeforeToolCallResult,
+  PluginHookToolContext,
+} from "openclaw/plugin-sdk/types";
+import {
+  SLUG_PATTERN,
+  type OnePasswordConfig,
+  type OnePasswordItemConfig,
+  type OnePasswordPolicy,
+} from "./config.js";
+import { OnePasswordError, type OnePasswordErrorCode } from "./errors.js";
+import type { OpClient, ResolvedSecret } from "./op-client.js";
+
+export type AuditOutcome =
+  | "auto"
+  | "approved"
+  | "grant"
+  | "denied"
+  | "policy-denied"
+  | "timeout"
+  | "error"
+  | "cache-hit";
+
+export type AuditRow = {
+  timestampMs: number;
+  agentId: string;
+  sessionKey: string;
+  toolCallId: string;
+  slug: string;
+  reason: string;
+  outcome: AuditOutcome;
+  approvalId?: string;
+  errorCode?: AuditErrorCode;
+};
+
+export type StandingGrant = {
+  slug: string;
+  grantedAtMs: number;
+  expiresAtMs: number;
+  targetFingerprint: string;
+};
+
+export type AuditInternalErrorCode =
+  | "INVALID_ACTION"
+  | "INVALID_REASON"
+  | "INVALID_SLUG"
+  | "UNKNOWN_SLUG"
+  | "TOOL_CALL_ID_MISSING"
+  | "POLICY_NOT_EVALUATED"
+  | "POLICY_CHANGED"
+  | "GRANT_EXPIRED"
+  | "APPROVAL_CANCELLED";
+
+export type AuditErrorCode = OnePasswordErrorCode | AuditInternalErrorCode;
+
+export type BrokerStores = {
+  audit: PluginStateKeyedStore<AuditRow>;
+  grants: PluginStateKeyedStore<StandingGrant>;
+};
+
+export type BrokerOptions = {
+  config: OnePasswordConfig;
+  opClient: Pick<OpClient, "getItem">;
+  stores: BrokerStores;
+  now?: () => number;
+};
+
+type AccessContext = {
+  agentId: string;
+  sessionKey: string;
+  sessionId: string;
+  toolCallId: string;
+  slug: string;
+  reason: string;
+};
+
+type PendingAuthorization = AccessContext & {
+  outcome: "auto" | "approved" | "grant";
+  persistGrant: boolean;
+  expiresAtMs: number;
+};
+
+type CacheEntry = ResolvedSecret & {
+  expiresAtMs: number;
+};
+
+type ParsedGet = {
+  action: "get";
+  slug: string;
+  reason: string;
+};
+
+export type ToolInvocationContext = {
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+};
+
+type ParsedList = {
+  action: "list";
+};
+
+export type ParsedToolInput = ParsedGet | ParsedList;
+
+export type ListedItem = {
+  slug: string;
+  description: string;
+  policy: OnePasswordPolicy;
+  standingGrantActive: boolean;
+};
+
+const APPROVAL_TIMEOUT_MS = 600_000;
+const PENDING_AUTHORIZATION_TTL_MS = APPROVAL_TIMEOUT_MS;
+
+function textParam(params: Record<string, unknown>, key: string): string | undefined {
+  const value = params[key];
+  return typeof value === "string" ? value.trim() : undefined;
+}
+
+class BrokerError extends Error {
+  readonly code: AuditInternalErrorCode;
+
+  constructor(code: AuditInternalErrorCode, message: string) {
+    super(message);
+    this.name = "BrokerError";
+    this.code = code;
+  }
+}
+
+function internalError(code: AuditInternalErrorCode, message: string): BrokerError {
+  return new BrokerError(code, message);
+}
+
+export function fingerprintOnePasswordTarget(item: OnePasswordItemConfig): string {
+  return createHash("sha256")
+    .update(JSON.stringify([item.vault, item.item, item.field]))
+    .digest("hex");
+}
+
+export function parseToolInput(params: Record<string, unknown>): ParsedToolInput {
+  if (params.action === "list") {
+    return { action: "list" };
+  }
+  if (params.action !== "get") {
+    throw internalError("INVALID_ACTION", "action must be list or get");
+  }
+  const reason = textParam(params, "reason");
+  if (!reason || reason.length > 300) {
+    throw internalError("INVALID_REASON", "reason is required and must be at most 300 characters");
+  }
+  const slug = textParam(params, "slug");
+  if (!slug || !SLUG_PATTERN.test(slug)) {
+    throw internalError("INVALID_SLUG", "slug must match ^[a-z0-9][a-z0-9-]{0,63}$");
+  }
+  return { action: "get", slug, reason };
+}
+
+function errorCode(error: unknown): AuditErrorCode | undefined {
+  if (error instanceof OnePasswordError) {
+    return error.code;
+  }
+  if (error instanceof BrokerError) {
+    return error.code;
+  }
+  return undefined;
+}
+
+export class OnePasswordBroker {
+  private readonly config: OnePasswordConfig;
+  private readonly opClient: Pick<OpClient, "getItem">;
+  private readonly stores: BrokerStores;
+  private readonly now: () => number;
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly pending = new Map<string, PendingAuthorization>();
+
+  constructor(options: BrokerOptions) {
+    this.config = options.config;
+    this.opClient = options.opClient;
+    this.stores = options.stores;
+    this.now = options.now ?? Date.now;
+  }
+
+  private context(
+    event: PluginHookBeforeToolCallEvent,
+    ctx: PluginHookToolContext,
+    input: Partial<ParsedGet>,
+  ): AccessContext {
+    return {
+      agentId: ctx.agentId ?? "unknown",
+      sessionKey: ctx.sessionKey ?? "unknown",
+      sessionId: ctx.sessionId ?? "unknown",
+      toolCallId: event.toolCallId ?? ctx.toolCallId ?? "unknown",
+      slug: input.slug ?? "unknown",
+      reason: input.reason ?? "",
+    };
+  }
+
+  private pendingKey(
+    context: Pick<AccessContext, "agentId" | "sessionKey" | "sessionId" | "toolCallId">,
+  ): string {
+    return JSON.stringify([
+      context.agentId,
+      context.sessionKey,
+      context.sessionId,
+      context.toolCallId,
+    ]);
+  }
+
+  private async audit(
+    context: AccessContext,
+    outcome: AuditOutcome,
+    options: { errorCode?: AuditErrorCode } = {},
+  ): Promise<void> {
+    const timestampMs = this.now();
+    const key = `${String(timestampMs).padStart(16, "0")}:${context.toolCallId}:${randomUUID()}`;
+    await this.stores.audit.register(key, {
+      timestampMs,
+      agentId: context.agentId,
+      sessionKey: context.sessionKey,
+      toolCallId: context.toolCallId,
+      slug: context.slug,
+      reason: context.reason,
+      outcome,
+      ...(options.errorCode ? { errorCode: options.errorCode } : {}),
+    });
+  }
+
+  private sweepPending(): void {
+    const now = this.now();
+    for (const [key, authorization] of this.pending) {
+      if (authorization.expiresAtMs <= now) {
+        this.pending.delete(key);
+      }
+    }
+  }
+
+  private async pruneStaleGrants(): Promise<void> {
+    const now = this.now();
+    for (const entry of await this.stores.grants.entries()) {
+      const item = this.config.items[entry.key];
+      if (
+        !Object.hasOwn(this.config.items, entry.key) ||
+        !item ||
+        entry.value.expiresAtMs <= now ||
+        entry.value.targetFingerprint !== fingerprintOnePasswordTarget(item)
+      ) {
+        await this.stores.grants.delete(entry.key);
+      }
+    }
+  }
+
+  async beforeToolCall(
+    event: PluginHookBeforeToolCallEvent,
+    ctx: PluginHookToolContext,
+  ): Promise<PluginHookBeforeToolCallResult | void> {
+    if (event.toolName !== "onepassword") {
+      return;
+    }
+    let input: ParsedToolInput;
+    try {
+      input = parseToolInput(event.params);
+    } catch (error) {
+      const context = this.context(event, ctx, {
+        slug: textParam(event.params, "slug"),
+        reason: textParam(event.params, "reason"),
+      });
+      await this.audit(context, "error", { errorCode: errorCode(error) ?? "INVALID_ACTION" });
+      return {
+        block: true,
+        blockReason: error instanceof Error ? error.message : "Invalid request",
+      };
+    }
+    if (input.action === "list") {
+      return;
+    }
+    const context = this.context(event, ctx, input);
+    if (!Object.hasOwn(this.config.items, input.slug)) {
+      await this.audit(context, "error", { errorCode: "UNKNOWN_SLUG" });
+      return { block: true, blockReason: `Unknown 1Password slug: ${input.slug}` };
+    }
+    const item = this.config.items[input.slug];
+    if (!item) {
+      throw new Error(`Missing 1Password config for registered slug: ${input.slug}`);
+    }
+    if (!event.toolCallId && !ctx.toolCallId) {
+      await this.audit(context, "error", { errorCode: "TOOL_CALL_ID_MISSING" });
+      return { block: true, blockReason: "1Password request is missing a tool call id" };
+    }
+    if (item.policy === "deny") {
+      await this.audit(context, "policy-denied");
+      return { block: true, blockReason: `1Password access denied by policy for ${input.slug}` };
+    }
+
+    this.sweepPending();
+    if (item.policy === "auto") {
+      this.pending.set(this.pendingKey(context), {
+        ...context,
+        outcome: "auto",
+        persistGrant: false,
+        expiresAtMs: this.now() + PENDING_AUTHORIZATION_TTL_MS,
+      });
+      return;
+    }
+
+    const grant = await this.stores.grants.lookup(input.slug);
+    if (
+      grant &&
+      grant.expiresAtMs > this.now() &&
+      grant.targetFingerprint === fingerprintOnePasswordTarget(item)
+    ) {
+      this.pending.set(this.pendingKey(context), {
+        ...context,
+        outcome: "grant",
+        persistGrant: false,
+        expiresAtMs: this.now() + PENDING_AUTHORIZATION_TTL_MS,
+      });
+      return;
+    }
+    if (grant) {
+      await this.stores.grants.delete(input.slug);
+    }
+
+    return {
+      requireApproval: {
+        title: `1Password: ${input.slug}`,
+        description: `Agent ${context.agentId} requests ${input.slug}. Reason: ${input.reason}`,
+        severity: "warning",
+        timeoutMs: APPROVAL_TIMEOUT_MS,
+        allowedDecisions: ["allow-once", "allow-always", "deny"],
+        // Core fires onResolution without awaiting it; the synchronous pending.set
+        // below is what guarantees the authorization exists before the tool
+        // handler runs. Do not move it behind an await.
+        onResolution: async (decision) => {
+          if (decision === "allow-once" || decision === "allow-always") {
+            this.pending.set(this.pendingKey(context), {
+              ...context,
+              outcome: "approved",
+              persistGrant: decision === "allow-always",
+              expiresAtMs: this.now() + PENDING_AUTHORIZATION_TTL_MS,
+            });
+            return;
+          }
+          if (decision === "deny") {
+            await this.audit(context, "denied");
+            return;
+          }
+          if (decision === "timeout") {
+            await this.audit(context, "timeout");
+            return;
+          }
+          await this.audit(context, "error", { errorCode: "APPROVAL_CANCELLED" });
+        },
+      },
+    };
+  }
+
+  async list(): Promise<ListedItem[]> {
+    const grants = new Map(
+      (await this.stores.grants.entries()).map((entry) => [entry.key, entry.value]),
+    );
+    const now = this.now();
+    return Object.entries(this.config.items)
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([slug, item]) => {
+        const grant = grants.get(slug);
+        return {
+          slug,
+          description: item.description ?? "",
+          policy: item.policy,
+          standingGrantActive: Boolean(
+            grant &&
+            grant.expiresAtMs > now &&
+            grant.targetFingerprint === fingerprintOnePasswordTarget(item),
+          ),
+        };
+      });
+  }
+
+  async get(
+    toolCallId: string,
+    input: ParsedGet,
+    invocation: ToolInvocationContext,
+  ): Promise<ResolvedSecret & { slug: string }> {
+    this.sweepPending();
+    const fallbackContext: AccessContext = {
+      agentId: invocation.agentId ?? "unknown",
+      sessionKey: invocation.sessionKey ?? "unknown",
+      sessionId: invocation.sessionId ?? "unknown",
+      toolCallId,
+      slug: input.slug,
+      reason: input.reason,
+    };
+    const key = this.pendingKey(fallbackContext);
+    const authorization = this.pending.get(key);
+    this.pending.delete(key);
+    if (
+      !authorization ||
+      authorization.slug !== input.slug ||
+      authorization.reason !== input.reason
+    ) {
+      await this.audit(fallbackContext, "error", { errorCode: "POLICY_NOT_EVALUATED" });
+      throw internalError(
+        "POLICY_NOT_EVALUATED",
+        "1Password policy was not evaluated for this request",
+      );
+    }
+
+    if (!Object.hasOwn(this.config.items, input.slug)) {
+      await this.audit(authorization, "error", { errorCode: "UNKNOWN_SLUG" });
+      throw internalError("UNKNOWN_SLUG", `Unknown 1Password slug: ${input.slug}`);
+    }
+    const item = this.config.items[input.slug];
+    if (!item) {
+      throw new Error(`Missing 1Password config for registered slug: ${input.slug}`);
+    }
+    if (item.policy === "deny") {
+      await this.audit(authorization, "policy-denied");
+      throw internalError("POLICY_CHANGED", `1Password access denied by policy for ${input.slug}`);
+    }
+    if (
+      (authorization.outcome === "auto" && item.policy !== "auto") ||
+      (authorization.outcome !== "auto" && item.policy !== "approve")
+    ) {
+      await this.audit(authorization, "error", { errorCode: "POLICY_CHANGED" });
+      throw internalError("POLICY_CHANGED", "1Password policy changed before tool execution");
+    }
+    if (authorization.outcome === "grant") {
+      const grant = await this.stores.grants.lookup(input.slug);
+      if (
+        !grant ||
+        grant.expiresAtMs <= this.now() ||
+        grant.targetFingerprint !== fingerprintOnePasswordTarget(item)
+      ) {
+        await this.audit(authorization, "error", { errorCode: "GRANT_EXPIRED" });
+        throw internalError(
+          "GRANT_EXPIRED",
+          "1Password standing grant expired before tool execution",
+        );
+      }
+    }
+
+    if (authorization.persistGrant) {
+      const grantedAtMs = this.now();
+      const ttlMs = Math.round(this.config.grantTtlHours * 60 * 60 * 1000);
+      try {
+        await this.pruneStaleGrants();
+        await this.stores.grants.register(
+          input.slug,
+          {
+            slug: input.slug,
+            grantedAtMs,
+            expiresAtMs: grantedAtMs + ttlMs,
+            targetFingerprint: fingerprintOnePasswordTarget(item),
+          },
+          { ttlMs },
+        );
+      } catch (error) {
+        await this.audit(authorization, "error", { errorCode: errorCode(error) });
+        throw error;
+      }
+    }
+
+    const cached = this.cache.get(input.slug);
+    if (cached && cached.expiresAtMs > this.now()) {
+      await this.audit(authorization, "cache-hit");
+      return {
+        slug: input.slug,
+        value: cached.value,
+        itemTitle: cached.itemTitle,
+        fieldLabel: cached.fieldLabel,
+      };
+    }
+    this.cache.delete(input.slug);
+
+    try {
+      const secret = await this.opClient.getItem(item);
+      await this.audit(authorization, authorization.outcome);
+      if (this.config.cacheTtlSeconds > 0) {
+        this.cache.set(input.slug, {
+          ...secret,
+          expiresAtMs: this.now() + this.config.cacheTtlSeconds * 1000,
+        });
+      }
+      return { slug: input.slug, ...secret };
+    } catch (error) {
+      await this.audit(authorization, "error", { errorCode: errorCode(error) });
+      throw error;
+    }
+  }
+}

--- a/extensions/onepassword/src/broker.ts
+++ b/extensions/onepassword/src/broker.ts
@@ -14,7 +14,7 @@ import {
 import { OnePasswordError, type OnePasswordErrorCode } from "./errors.js";
 import type { OpClient, ResolvedSecret } from "./op-client.js";
 
-export type AuditOutcome =
+type AuditOutcome =
   | "auto"
   | "approved"
   | "grant"
@@ -57,12 +57,12 @@ type AuditInternalErrorCode =
 
 type AuditErrorCode = OnePasswordErrorCode | AuditInternalErrorCode;
 
-export type BrokerStores = {
+type BrokerStores = {
   audit: PluginStateKeyedStore<AuditRow>;
   grants: PluginStateKeyedStore<StandingGrant>;
 };
 
-export type BrokerOptions = {
+type BrokerOptions = {
   resolveConfig: () => OnePasswordConfig | undefined;
   opClient: Pick<OpClient, "getItem">;
   stores: BrokerStores;
@@ -97,7 +97,7 @@ type ParsedGet = {
   reason: string;
 };
 
-export type ToolInvocationContext = {
+type ToolInvocationContext = {
   agentId?: string;
   sessionKey?: string;
   sessionId?: string;
@@ -107,9 +107,9 @@ type ParsedList = {
   action: "list";
 };
 
-export type ParsedToolInput = ParsedGet | ParsedList;
+type ParsedToolInput = ParsedGet | ParsedList;
 
-export type ListedItem = {
+type ListedItem = {
   slug: string;
   description: string;
   policy: OnePasswordPolicy;
@@ -138,7 +138,7 @@ function internalError(code: AuditInternalErrorCode, message: string): BrokerErr
   return new BrokerError(code, message);
 }
 
-export function fingerprintOnePasswordTarget(item: OnePasswordItemConfig): string {
+function fingerprintOnePasswordTarget(item: OnePasswordItemConfig): string {
   return createHash("sha256")
     .update(JSON.stringify([item.vault, item.item, item.field]))
     .digest("hex");

--- a/extensions/onepassword/src/broker.ts
+++ b/extensions/onepassword/src/broker.ts
@@ -63,7 +63,7 @@ export type BrokerStores = {
 };
 
 export type BrokerOptions = {
-  config: OnePasswordConfig;
+  resolveConfig: () => OnePasswordConfig | undefined;
   opClient: Pick<OpClient, "getItem">;
   stores: BrokerStores;
   now?: () => number;
@@ -81,10 +81,13 @@ type AccessContext = {
 type PendingAuthorization = AccessContext & {
   outcome: "auto" | "approved" | "grant";
   persistGrant: boolean;
+  configFingerprint: string;
+  targetFingerprint: string;
   expiresAtMs: number;
 };
 
 type CacheEntry = ResolvedSecret & {
+  targetFingerprint: string;
   expiresAtMs: number;
 };
 
@@ -176,18 +179,40 @@ function errorCode(error: unknown): AuditErrorCode | undefined {
 }
 
 export class OnePasswordBroker {
-  private readonly config: OnePasswordConfig;
+  private readonly resolveConfig: () => OnePasswordConfig | undefined;
   private readonly opClient: Pick<OpClient, "getItem">;
   private readonly stores: BrokerStores;
   private readonly now: () => number;
   private readonly cache = new Map<string, CacheEntry>();
   private readonly pending = new Map<string, PendingAuthorization>();
+  private lastConfigFingerprint: string | null | undefined;
 
   constructor(options: BrokerOptions) {
-    this.config = options.config;
+    this.resolveConfig = options.resolveConfig;
     this.opClient = options.opClient;
     this.stores = options.stores;
     this.now = options.now ?? Date.now;
+  }
+
+  private observeConfigFingerprint(fingerprint: string | null): void {
+    if (this.lastConfigFingerprint !== undefined && this.lastConfigFingerprint !== fingerprint) {
+      // A reload can revoke policy or retarget a slug. Cached secrets and
+      // in-flight authorizations must not survive that ownership boundary.
+      this.cache.clear();
+      this.pending.clear();
+    }
+    this.lastConfigFingerprint = fingerprint;
+  }
+
+  private currentConfig(): { config: OnePasswordConfig; fingerprint: string } {
+    const config = this.resolveConfig();
+    if (!config) {
+      this.observeConfigFingerprint(null);
+      throw internalError("POLICY_CHANGED", "1Password broker is no longer configured");
+    }
+    const fingerprint = createHash("sha256").update(JSON.stringify(config)).digest("hex");
+    this.observeConfigFingerprint(fingerprint);
+    return { config, fingerprint };
   }
 
   private context(
@@ -244,11 +269,11 @@ export class OnePasswordBroker {
     }
   }
 
-  private async pruneStaleGrants(): Promise<void> {
+  private async pruneStaleGrants(config: OnePasswordConfig): Promise<void> {
     const now = this.now();
     for (const entry of await this.stores.grants.entries()) {
-      const item = Object.hasOwn(this.config.items, entry.value.slug)
-        ? this.config.items[entry.value.slug]
+      const item = Object.hasOwn(config.items, entry.value.slug)
+        ? config.items[entry.value.slug]
         : undefined;
       if (
         !item ||
@@ -286,11 +311,22 @@ export class OnePasswordBroker {
       return;
     }
     const context = this.context(event, ctx, input);
-    if (!Object.hasOwn(this.config.items, input.slug)) {
+    let config: OnePasswordConfig;
+    let configFingerprint: string;
+    try {
+      ({ config, fingerprint: configFingerprint } = this.currentConfig());
+    } catch (error) {
+      await this.audit(context, "error", { errorCode: errorCode(error) });
+      return {
+        block: true,
+        blockReason: error instanceof Error ? error.message : "1Password broker is unavailable",
+      };
+    }
+    if (!Object.hasOwn(config.items, input.slug)) {
       await this.audit(context, "error", { errorCode: "UNKNOWN_SLUG" });
       return { block: true, blockReason: `Unknown 1Password slug: ${input.slug}` };
     }
-    const item = this.config.items[input.slug];
+    const item = config.items[input.slug];
     if (!item) {
       throw new Error(`Missing 1Password config for registered slug: ${input.slug}`);
     }
@@ -309,6 +345,8 @@ export class OnePasswordBroker {
         ...context,
         outcome: "auto",
         persistGrant: false,
+        configFingerprint,
+        targetFingerprint: fingerprintOnePasswordTarget(item),
         expiresAtMs: this.now() + PENDING_AUTHORIZATION_TTL_MS,
       });
       return;
@@ -328,6 +366,8 @@ export class OnePasswordBroker {
         ...context,
         outcome: "grant",
         persistGrant: false,
+        configFingerprint,
+        targetFingerprint: fingerprintOnePasswordTarget(item),
         expiresAtMs: this.now() + PENDING_AUTHORIZATION_TTL_MS,
       });
       return;
@@ -357,6 +397,8 @@ export class OnePasswordBroker {
               ...context,
               outcome: "approved",
               persistGrant: decision === "allow-always" && context.agentId !== "unknown",
+              configFingerprint,
+              targetFingerprint: fingerprintOnePasswordTarget(item),
               expiresAtMs: this.now() + PENDING_AUTHORIZATION_TTL_MS,
             });
             return;
@@ -376,12 +418,13 @@ export class OnePasswordBroker {
   }
 
   async list(invocation: ToolInvocationContext): Promise<ListedItem[]> {
+    const { config } = this.currentConfig();
     const grants = new Map(
       (await this.stores.grants.entries()).map((entry) => [entry.key, entry.value]),
     );
     const now = this.now();
     const agentId = invocation.agentId;
-    return Object.entries(this.config.items)
+    return Object.entries(config.items)
       .toSorted(([left], [right]) => left.localeCompare(right))
       .map(([slug, item]) => {
         const grant = agentId ? grants.get(standingGrantKey(agentId, slug)) : undefined;
@@ -429,11 +472,19 @@ export class OnePasswordBroker {
       );
     }
 
-    if (!Object.hasOwn(this.config.items, input.slug)) {
+    let config: OnePasswordConfig;
+    let configFingerprint: string;
+    try {
+      ({ config, fingerprint: configFingerprint } = this.currentConfig());
+    } catch (error) {
+      await this.audit(authorization, "error", { errorCode: errorCode(error) });
+      throw error;
+    }
+    if (!Object.hasOwn(config.items, input.slug)) {
       await this.audit(authorization, "error", { errorCode: "UNKNOWN_SLUG" });
       throw internalError("UNKNOWN_SLUG", `Unknown 1Password slug: ${input.slug}`);
     }
-    const item = this.config.items[input.slug];
+    const item = config.items[input.slug];
     if (!item) {
       throw new Error(`Missing 1Password config for registered slug: ${input.slug}`);
     }
@@ -443,7 +494,9 @@ export class OnePasswordBroker {
     }
     if (
       (authorization.outcome === "auto" && item.policy !== "auto") ||
-      (authorization.outcome !== "auto" && item.policy !== "approve")
+      (authorization.outcome !== "auto" && item.policy !== "approve") ||
+      authorization.configFingerprint !== configFingerprint ||
+      authorization.targetFingerprint !== fingerprintOnePasswordTarget(item)
     ) {
       await this.audit(authorization, "error", { errorCode: "POLICY_CHANGED" });
       throw internalError("POLICY_CHANGED", "1Password policy changed before tool execution");
@@ -469,9 +522,9 @@ export class OnePasswordBroker {
 
     if (authorization.persistGrant) {
       const grantedAtMs = this.now();
-      const ttlMs = Math.round(this.config.grantTtlHours * 60 * 60 * 1000);
+      const ttlMs = Math.round(config.grantTtlHours * 60 * 60 * 1000);
       try {
-        await this.pruneStaleGrants();
+        await this.pruneStaleGrants(config);
         await this.stores.grants.register(
           standingGrantKey(authorization.agentId, input.slug),
           {
@@ -490,7 +543,12 @@ export class OnePasswordBroker {
     }
 
     const cached = this.cache.get(input.slug);
-    if (cached && cached.expiresAtMs > this.now()) {
+    const targetFingerprint = fingerprintOnePasswordTarget(item);
+    if (
+      cached &&
+      cached.expiresAtMs > this.now() &&
+      cached.targetFingerprint === targetFingerprint
+    ) {
       await this.audit(authorization, "cache-hit");
       return {
         slug: input.slug,
@@ -504,10 +562,11 @@ export class OnePasswordBroker {
     try {
       const secret = await this.opClient.getItem(item);
       await this.audit(authorization, authorization.outcome);
-      if (this.config.cacheTtlSeconds > 0) {
+      if (config.cacheTtlSeconds > 0) {
         this.cache.set(input.slug, {
           ...secret,
-          expiresAtMs: this.now() + this.config.cacheTtlSeconds * 1000,
+          targetFingerprint,
+          expiresAtMs: this.now() + config.cacheTtlSeconds * 1000,
         });
       }
       return { slug: input.slug, ...secret };

--- a/extensions/onepassword/src/broker.ts
+++ b/extensions/onepassword/src/broker.ts
@@ -44,7 +44,7 @@ export type StandingGrant = {
   targetFingerprint: string;
 };
 
-export type AuditInternalErrorCode =
+type AuditInternalErrorCode =
   | "INVALID_ACTION"
   | "INVALID_REASON"
   | "INVALID_SLUG"
@@ -55,7 +55,7 @@ export type AuditInternalErrorCode =
   | "GRANT_EXPIRED"
   | "APPROVAL_CANCELLED";
 
-export type AuditErrorCode = OnePasswordErrorCode | AuditInternalErrorCode;
+type AuditErrorCode = OnePasswordErrorCode | AuditInternalErrorCode;
 
 export type BrokerStores = {
   audit: PluginStateKeyedStore<AuditRow>;

--- a/extensions/onepassword/src/cli.test.ts
+++ b/extensions/onepassword/src/cli.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AuditRow } from "./broker.js";
-import { buildStatus, readAuditRows } from "./cli.js";
+import { registerOnePasswordCommands } from "./cli.js";
 import type { OnePasswordConfig } from "./config.js";
 import { MemoryKeyedStore } from "./memory-store.test-support.js";
 
@@ -17,12 +17,70 @@ const config: OnePasswordConfig = {
   },
 };
 
-describe("1Password CLI output", () => {
-  it("status contains readiness and counts without token or item values", async () => {
-    const status = await buildStatus(config, {
+type CommandAction = (options: Record<string, unknown>) => void | Promise<void>;
+
+class TestCommand {
+  private readonly children = new Map<string, TestCommand>();
+  private handler: CommandAction | undefined;
+
+  command(name: string): TestCommand {
+    const key = name.split(/[ <]/u)[0] ?? name;
+    const child = new TestCommand();
+    this.children.set(key, child);
+    return child;
+  }
+
+  description(_value: string): TestCommand {
+    return this;
+  }
+
+  option(_flags: string, _description: string, _defaultValue?: string): TestCommand {
+    return this;
+  }
+
+  action<TOptions>(fn: (options: TOptions) => void | Promise<void>): TestCommand {
+    this.handler = fn as CommandAction;
+    return this;
+  }
+
+  child(name: string): TestCommand {
+    const child = this.children.get(name);
+    if (!child) {
+      throw new Error(`Missing test command: ${name}`);
+    }
+    return child;
+  }
+
+  async run(options: Record<string, unknown> = {}): Promise<void> {
+    if (!this.handler) {
+      throw new Error("Missing test command action");
+    }
+    await this.handler(options);
+  }
+}
+
+function setupCommands(auditStore = new MemoryKeyedStore<AuditRow>()) {
+  const program = new TestCommand();
+  const write = vi.fn<(message: string) => void>();
+  registerOnePasswordCommands({
+    program,
+    resolveConfig: () => config,
+    resolveOpClient: () => ({
       opBin: "/usr/local/bin/op",
       tokenFilePresent: async () => true,
-    });
+    }),
+    auditStore,
+    write,
+  });
+  return { onepassword: program.child("onepassword"), write };
+}
+
+describe("1Password CLI output", () => {
+  it("status contains readiness and counts without token or item values", async () => {
+    const { onepassword, write } = setupCommands();
+    await onepassword.child("status").run();
+    const status = JSON.parse(String(write.mock.calls[0]?.[0])) as Record<string, unknown>;
+
     expect(status).toEqual({
       tokenFilePresent: true,
       opBinaryResolved: true,
@@ -53,7 +111,10 @@ describe("1Password CLI output", () => {
       reason: `prefix-${"x".repeat(100)}`,
       outcome: "approved",
     });
-    const rows = await readAuditRows(store, 1);
+    const { onepassword, write } = setupCommands(store);
+    await onepassword.child("audit").run({ limit: "1" });
+    const rows = JSON.parse(String(write.mock.calls[0]?.[0])) as Array<Record<string, unknown>>;
+
     expect(rows).toEqual([
       {
         timestamp: "1970-01-01T00:00:02.000Z",

--- a/extensions/onepassword/src/cli.test.ts
+++ b/extensions/onepassword/src/cli.test.ts
@@ -30,16 +30,16 @@ class TestCommand {
     return child;
   }
 
-  description(_value: string): TestCommand {
+  description(_value: string): this {
     return this;
   }
 
-  option(_flags: string, _description: string, _defaultValue?: string): TestCommand {
+  option(_flags: string, _description: string, _defaultValue?: string): this {
     return this;
   }
 
-  action<TOptions>(fn: (options: TOptions) => void | Promise<void>): TestCommand {
-    this.handler = fn as CommandAction;
+  action(fn: CommandAction): this {
+    this.handler = fn;
     return this;
   }
 
@@ -63,7 +63,7 @@ function setupCommands(auditStore = new MemoryKeyedStore<AuditRow>()) {
   const program = new TestCommand();
   const write = vi.fn<(message: string) => void>();
   registerOnePasswordCommands({
-    program,
+    program: program as unknown as Parameters<typeof registerOnePasswordCommands>[0]["program"],
     resolveConfig: () => config,
     resolveOpClient: () => ({
       opBin: "/usr/local/bin/op",

--- a/extensions/onepassword/src/cli.test.ts
+++ b/extensions/onepassword/src/cli.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { AuditRow } from "./broker.js";
+import { buildStatus, readAuditRows } from "./cli.js";
+import type { OnePasswordConfig } from "./config.js";
+import { MemoryKeyedStore } from "./memory-store.test-support.js";
+
+const config: OnePasswordConfig = {
+  vault: "Automation",
+  defaultPolicy: "approve",
+  cacheTtlSeconds: 300,
+  grantTtlHours: 720,
+  opTimeoutMs: 15_000,
+  items: {
+    alpha: { item: "Sensitive title", vault: "Automation", field: "credential", policy: "auto" },
+    beta: { item: "Other", vault: "Automation", field: "credential", policy: "approve" },
+    gamma: { item: "Third", vault: "Automation", field: "credential", policy: "deny" },
+  },
+};
+
+describe("1Password CLI output", () => {
+  it("status contains readiness and counts without token or item values", async () => {
+    const status = await buildStatus(config, {
+      opBin: "/usr/local/bin/op",
+      tokenFilePresent: async () => true,
+    });
+    expect(status).toEqual({
+      tokenFilePresent: true,
+      opBinaryResolved: true,
+      opBinaryPath: "/usr/local/bin/op",
+      itemCount: 3,
+      policyCounts: { auto: 1, approve: 1, deny: 1 },
+    });
+    expect(JSON.stringify(status)).not.toContain("Sensitive title");
+  });
+
+  it("audit output is deterministic, limited, truncated, and value-free", async () => {
+    const store = new MemoryKeyedStore<AuditRow>();
+    await store.register("first", {
+      timestampMs: 1000,
+      agentId: "agent-a",
+      sessionKey: "session-a",
+      toolCallId: "call-a",
+      slug: "alpha",
+      reason: "short",
+      outcome: "auto",
+    });
+    await store.register("second", {
+      timestampMs: 2000,
+      agentId: "agent-b",
+      sessionKey: "session-b",
+      toolCallId: "call-b",
+      slug: "beta",
+      reason: `prefix-${"x".repeat(100)}`,
+      outcome: "approved",
+    });
+    const rows = await readAuditRows(store, 1);
+    expect(rows).toEqual([
+      {
+        timestamp: "1970-01-01T00:00:02.000Z",
+        agent: "agent-b",
+        slug: "beta",
+        outcome: "approved",
+        reason: expect.stringMatching(/^prefix-.+\.\.\.$/),
+      },
+    ]);
+    expect(rows[0]?.reason).toHaveLength(80);
+    expect(JSON.stringify(rows)).not.toContain(["fixture", "value"].join("-"));
+  });
+});

--- a/extensions/onepassword/src/cli.ts
+++ b/extensions/onepassword/src/cli.ts
@@ -10,7 +10,7 @@ type CommandLike = {
   action<TOptions>(fn: (options: TOptions) => void | Promise<void>): CommandLike;
 };
 
-export type OnePasswordCliContext = {
+type OnePasswordCliContext = {
   program: CommandLike;
   resolveConfig: () => OnePasswordConfig | undefined;
   resolveOpClient: () => Pick<OpClient, "opBin" | "tokenFilePresent">;
@@ -33,7 +33,7 @@ function truncateReason(reason: string): string {
   return reason.length <= 80 ? reason : `${reason.slice(0, 77)}...`;
 }
 
-export async function buildStatus(
+async function buildStatus(
   config: OnePasswordConfig | undefined,
   opClient: Pick<OpClient, "opBin" | "tokenFilePresent">,
 ) {
@@ -50,7 +50,7 @@ export async function buildStatus(
   };
 }
 
-export async function readAuditRows(auditStore: PluginStateKeyedStore<AuditRow>, limit: number) {
+async function readAuditRows(auditStore: PluginStateKeyedStore<AuditRow>, limit: number) {
   return (await auditStore.entries())
     .toSorted(
       (left, right) =>

--- a/extensions/onepassword/src/cli.ts
+++ b/extensions/onepassword/src/cli.ts
@@ -12,8 +12,8 @@ type CommandLike = {
 
 export type OnePasswordCliContext = {
   program: CommandLike;
-  config?: OnePasswordConfig;
-  opClient: Pick<OpClient, "opBin" | "tokenFilePresent">;
+  resolveConfig: () => OnePasswordConfig | undefined;
+  resolveOpClient: () => Pick<OpClient, "opBin" | "tokenFilePresent">;
   auditStore: PluginStateKeyedStore<AuditRow>;
   write?: (message: string) => void;
 };
@@ -75,7 +75,13 @@ export function registerOnePasswordCommands(context: OnePasswordCliContext): voi
     .command("status")
     .description("Show broker readiness without secret values")
     .action(async () => {
-      write(JSON.stringify(await buildStatus(context.config, context.opClient), null, 2));
+      write(
+        JSON.stringify(
+          await buildStatus(context.resolveConfig(), context.resolveOpClient()),
+          null,
+          2,
+        ),
+      );
     });
   command
     .command("audit")

--- a/extensions/onepassword/src/cli.ts
+++ b/extensions/onepassword/src/cli.ts
@@ -1,0 +1,89 @@
+import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import type { AuditRow } from "./broker.js";
+import type { OnePasswordConfig } from "./config.js";
+import type { OpClient } from "./op-client.js";
+
+type CommandLike = {
+  command(name: string): CommandLike;
+  description(value: string): CommandLike;
+  option(flags: string, description: string, defaultValue?: string): CommandLike;
+  action<TOptions>(fn: (options: TOptions) => void | Promise<void>): CommandLike;
+};
+
+export type OnePasswordCliContext = {
+  program: CommandLike;
+  config?: OnePasswordConfig;
+  opClient: Pick<OpClient, "opBin" | "tokenFilePresent">;
+  auditStore: PluginStateKeyedStore<AuditRow>;
+  write?: (message: string) => void;
+};
+
+function parseLimit(value: unknown): number {
+  if (value === undefined) {
+    return 50;
+  }
+  const parsed = typeof value === "string" ? Number(value) : Number.NaN;
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 1000) {
+    throw new Error("--limit must be an integer from 1 to 1000");
+  }
+  return parsed;
+}
+
+function truncateReason(reason: string): string {
+  return reason.length <= 80 ? reason : `${reason.slice(0, 77)}...`;
+}
+
+export async function buildStatus(
+  config: OnePasswordConfig | undefined,
+  opClient: Pick<OpClient, "opBin" | "tokenFilePresent">,
+) {
+  const policies = { auto: 0, approve: 0, deny: 0 };
+  for (const item of Object.values(config?.items ?? {})) {
+    policies[item.policy] += 1;
+  }
+  return {
+    tokenFilePresent: await opClient.tokenFilePresent(),
+    opBinaryResolved: Boolean(opClient.opBin),
+    opBinaryPath: opClient.opBin ?? null,
+    itemCount: Object.keys(config?.items ?? {}).length,
+    policyCounts: policies,
+  };
+}
+
+export async function readAuditRows(auditStore: PluginStateKeyedStore<AuditRow>, limit: number) {
+  return (await auditStore.entries())
+    .toSorted(
+      (left, right) =>
+        right.value.timestampMs - left.value.timestampMs || right.key.localeCompare(left.key),
+    )
+    .slice(0, limit)
+    .map(({ value }) => ({
+      timestamp: new Date(value.timestampMs).toISOString(),
+      agent: value.agentId,
+      slug: value.slug,
+      outcome: value.outcome,
+      reason: truncateReason(value.reason),
+    }));
+}
+
+export function registerOnePasswordCommands(context: OnePasswordCliContext): void {
+  const write = context.write ?? ((message: string) => process.stdout.write(`${message}\n`));
+  const command = context.program
+    .command("onepassword")
+    .description("Inspect the 1Password broker");
+  command
+    .command("status")
+    .description("Show broker readiness without secret values")
+    .action(async () => {
+      write(JSON.stringify(await buildStatus(context.config, context.opClient), null, 2));
+    });
+  command
+    .command("audit")
+    .description("Show recent 1Password access audit rows")
+    .option("--limit <number>", "Maximum rows to print", "50")
+    .action(async (options: { limit?: string }) => {
+      write(
+        JSON.stringify(await readAuditRows(context.auditStore, parseLimit(options.limit)), null, 2),
+      );
+    });
+}

--- a/extensions/onepassword/src/config.test.ts
+++ b/extensions/onepassword/src/config.test.ts
@@ -18,6 +18,12 @@ describe("parseOnePasswordConfig", () => {
         items: { token: { item: "Token", vault: "-Other" } },
       }),
     ).toThrow("token vault must not start with a hyphen");
+    expect(() =>
+      parseOnePasswordConfig({
+        vault: "Automation",
+        items: { token: { item: "Token", field: "username,password" } },
+      }),
+    ).toThrow("field must not contain commas");
   });
 
   it("applies defaults and item overrides", () => {

--- a/extensions/onepassword/src/config.test.ts
+++ b/extensions/onepassword/src/config.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { MAX_DESCRIPTION_LENGTH, MAX_REGISTERED_ITEMS, parseOnePasswordConfig } from "./config.js";
+
+describe("parseOnePasswordConfig", () => {
+  it("rejects invalid slug grammar", () => {
+    expect(() =>
+      parseOnePasswordConfig({ vault: "Automation", items: { Bad_Slug: { item: "Token" } } }),
+    ).toThrow("Invalid 1Password item slug");
+    expect(() =>
+      parseOnePasswordConfig({ vault: "Automation", items: { token: { item: "--help" } } }),
+    ).toThrow("must not start with a hyphen");
+    expect(() =>
+      parseOnePasswordConfig({ vault: "-Automation", items: { token: { item: "Token" } } }),
+    ).toThrow("vault must not start with a hyphen");
+    expect(() =>
+      parseOnePasswordConfig({
+        vault: "Automation",
+        items: { token: { item: "Token", vault: "-Other" } },
+      }),
+    ).toThrow("token vault must not start with a hyphen");
+  });
+
+  it("applies defaults and item overrides", () => {
+    expect(
+      parseOnePasswordConfig({
+        vault: "Automation",
+        items: {
+          token: { item: "Token" },
+          denied: { item: "Denied", vault: "Other", field: "password", policy: "deny" },
+        },
+      }),
+    ).toMatchObject({
+      defaultPolicy: "approve",
+      cacheTtlSeconds: 300,
+      grantTtlHours: 720,
+      opTimeoutMs: 15_000,
+      items: {
+        token: { vault: "Automation", field: "credential", policy: "approve" },
+        denied: { vault: "Other", field: "password", policy: "deny" },
+      },
+    });
+  });
+
+  it("bounds listable registry metadata", () => {
+    const tooMany = Object.fromEntries(
+      Array.from({ length: MAX_REGISTERED_ITEMS + 1 }, (_, index) => [
+        `token-${index}`,
+        { item: `Token ${index}` },
+      ]),
+    );
+    expect(() => parseOnePasswordConfig({ vault: "Automation", items: tooMany })).toThrow(
+      `at most ${MAX_REGISTERED_ITEMS}`,
+    );
+    expect(() =>
+      parseOnePasswordConfig({
+        vault: "Automation",
+        items: {
+          token: { item: "Token", description: "x".repeat(MAX_DESCRIPTION_LENGTH + 1) },
+        },
+      }),
+    ).toThrow(`at most ${MAX_DESCRIPTION_LENGTH}`);
+  });
+});

--- a/extensions/onepassword/src/config.test.ts
+++ b/extensions/onepassword/src/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { MAX_DESCRIPTION_LENGTH, MAX_REGISTERED_ITEMS, parseOnePasswordConfig } from "./config.js";
+import { MAX_REGISTERED_ITEMS, parseOnePasswordConfig } from "./config.js";
 
 describe("parseOnePasswordConfig", () => {
   it("rejects invalid slug grammar", () => {
@@ -61,9 +61,9 @@ describe("parseOnePasswordConfig", () => {
       parseOnePasswordConfig({
         vault: "Automation",
         items: {
-          token: { item: "Token", description: "x".repeat(MAX_DESCRIPTION_LENGTH + 1) },
+          token: { item: "Token", description: "x".repeat(201) },
         },
       }),
-    ).toThrow(`at most ${MAX_DESCRIPTION_LENGTH}`);
+    ).toThrow("at most 200");
   });
 });

--- a/extensions/onepassword/src/config.ts
+++ b/extensions/onepassword/src/config.ts
@@ -116,10 +116,16 @@ export function parseOnePasswordConfig(value: unknown): OnePasswordConfig | unde
         `1Password config item ${slug} description must be at most ${MAX_DESCRIPTION_LENGTH} characters`,
       );
     }
+    const field = optionalString(rawItem, "field") ?? "credential";
+    // op treats commas in --fields as multiple selectors. Reject them so one
+    // registry entry can never load more than its single configured field.
+    if (field.includes(",")) {
+      throw new Error(`1Password config item ${slug} field must not contain commas`);
+    }
     items[slug] = {
       item,
       vault: itemVault,
-      field: optionalString(rawItem, "field") ?? "credential",
+      field,
       policy: readPolicy(rawItem.policy, `items.${slug}.policy`, defaultPolicy),
       ...(description ? { description } : {}),
     };

--- a/extensions/onepassword/src/config.ts
+++ b/extensions/onepassword/src/config.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 
 export const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
 export const MAX_REGISTERED_ITEMS = 32;
-export const MAX_DESCRIPTION_LENGTH = 200;
+const MAX_DESCRIPTION_LENGTH = 200;
 
 export type OnePasswordPolicy = "auto" | "approve" | "deny";
 

--- a/extensions/onepassword/src/config.ts
+++ b/extensions/onepassword/src/config.ts
@@ -1,0 +1,151 @@
+import path from "node:path";
+
+export const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
+export const MAX_REGISTERED_ITEMS = 32;
+export const MAX_DESCRIPTION_LENGTH = 200;
+
+export type OnePasswordPolicy = "auto" | "approve" | "deny";
+
+export type OnePasswordItemConfig = {
+  item: string;
+  vault: string;
+  field: string;
+  policy: OnePasswordPolicy;
+  description?: string;
+};
+
+export type OnePasswordConfig = {
+  vault: string;
+  opBin?: string;
+  defaultPolicy: OnePasswordPolicy;
+  cacheTtlSeconds: number;
+  grantTtlHours: number;
+  opTimeoutMs: number;
+  items: Record<string, OnePasswordItemConfig>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function requiredString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`1Password config ${key} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function optionalString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`1Password config ${key} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function readPolicy(value: unknown, label: string, fallback: OnePasswordPolicy): OnePasswordPolicy {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (value === "auto" || value === "approve" || value === "deny") {
+    return value;
+  }
+  throw new Error(`1Password config ${label} must be auto, approve, or deny`);
+}
+
+function readNumber(
+  record: Record<string, unknown>,
+  key: string,
+  fallback: number,
+  options: { integer: boolean; allowZero: boolean },
+): number {
+  const value = record[key] ?? fallback;
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    (options.integer && !Number.isInteger(value)) ||
+    (options.allowZero ? value < 0 : value <= 0)
+  ) {
+    throw new Error(`1Password config ${key} must be a valid positive number`);
+  }
+  return value;
+}
+
+export function parseOnePasswordConfig(value: unknown): OnePasswordConfig | undefined {
+  if (!isRecord(value) || Object.keys(value).length === 0) {
+    return undefined;
+  }
+  const vault = requiredString(value, "vault");
+  if (vault.startsWith("-")) {
+    throw new Error("1Password config vault must not start with a hyphen");
+  }
+  const defaultPolicy = readPolicy(value.defaultPolicy, "defaultPolicy", "approve");
+  if (!isRecord(value.items) || Object.keys(value.items).length === 0) {
+    throw new Error("1Password config items must contain at least one registered slug");
+  }
+  if (Object.keys(value.items).length > MAX_REGISTERED_ITEMS) {
+    throw new Error(
+      `1Password config items must contain at most ${MAX_REGISTERED_ITEMS} registered slugs`,
+    );
+  }
+
+  const items: Record<string, OnePasswordItemConfig> = Object.create(null);
+  for (const [slug, rawItem] of Object.entries(value.items)) {
+    if (!SLUG_PATTERN.test(slug)) {
+      throw new Error(`Invalid 1Password item slug: ${slug}`);
+    }
+    if (!isRecord(rawItem)) {
+      throw new Error(`1Password config item ${slug} must be an object`);
+    }
+    const item = requiredString(rawItem, "item");
+    // Item and vault land in op argv; a leading hyphen would parse as a CLI flag.
+    if (item.startsWith("-")) {
+      throw new Error(`1Password config item ${slug} item must not start with a hyphen`);
+    }
+    const itemVault = optionalString(rawItem, "vault") ?? vault;
+    if (itemVault.startsWith("-")) {
+      throw new Error(`1Password config item ${slug} vault must not start with a hyphen`);
+    }
+    const description = optionalString(rawItem, "description");
+    if (description && description.length > MAX_DESCRIPTION_LENGTH) {
+      throw new Error(
+        `1Password config item ${slug} description must be at most ${MAX_DESCRIPTION_LENGTH} characters`,
+      );
+    }
+    items[slug] = {
+      item,
+      vault: itemVault,
+      field: optionalString(rawItem, "field") ?? "credential",
+      policy: readPolicy(rawItem.policy, `items.${slug}.policy`, defaultPolicy),
+      ...(description ? { description } : {}),
+    };
+  }
+
+  const opBin = optionalString(value, "opBin");
+  if (opBin && !path.isAbsolute(opBin)) {
+    throw new Error("1Password config opBin must be an absolute path");
+  }
+
+  return {
+    vault,
+    ...(opBin ? { opBin } : {}),
+    defaultPolicy,
+    cacheTtlSeconds: readNumber(value, "cacheTtlSeconds", 300, {
+      integer: true,
+      allowZero: true,
+    }),
+    grantTtlHours: readNumber(value, "grantTtlHours", 720, {
+      integer: false,
+      allowZero: false,
+    }),
+    opTimeoutMs: readNumber(value, "opTimeoutMs", 15_000, {
+      integer: true,
+      allowZero: false,
+    }),
+    items,
+  };
+}

--- a/extensions/onepassword/src/errors.ts
+++ b/extensions/onepassword/src/errors.ts
@@ -1,0 +1,19 @@
+export type OnePasswordErrorCode =
+  | "TOKEN_MISSING"
+  | "OP_NOT_FOUND"
+  | "ITEM_NOT_FOUND"
+  | "FIELD_NOT_FOUND"
+  | "RATE_LIMITED"
+  | "AUTH_FAILED"
+  | "TIMEOUT"
+  | "OP_ERROR";
+
+export class OnePasswordError extends Error {
+  readonly code: OnePasswordErrorCode;
+
+  constructor(code: OnePasswordErrorCode, message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "OnePasswordError";
+    this.code = code;
+  }
+}

--- a/extensions/onepassword/src/memory-store.test-support.ts
+++ b/extensions/onepassword/src/memory-store.test-support.ts
@@ -1,0 +1,58 @@
+import type {
+  PluginStateEntry,
+  PluginStateKeyedStore,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
+
+export class MemoryKeyedStore<T> implements PluginStateKeyedStore<T> {
+  private readonly values = new Map<string, PluginStateEntry<T>>();
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  async register(key: string, value: T, opts?: { ttlMs?: number }): Promise<void> {
+    const createdAt = this.now();
+    this.values.set(key, {
+      key,
+      value,
+      createdAt,
+      ...(opts?.ttlMs ? { expiresAt: createdAt + opts.ttlMs } : {}),
+    });
+  }
+
+  async registerIfAbsent(key: string, value: T, opts?: { ttlMs?: number }): Promise<boolean> {
+    if (await this.lookup(key)) {
+      return false;
+    }
+    await this.register(key, value, opts);
+    return true;
+  }
+
+  async lookup(key: string): Promise<T | undefined> {
+    const entry = this.values.get(key);
+    if (entry?.expiresAt !== undefined && entry.expiresAt <= this.now()) {
+      this.values.delete(key);
+      return undefined;
+    }
+    return entry?.value;
+  }
+
+  async consume(key: string): Promise<T | undefined> {
+    const value = await this.lookup(key);
+    this.values.delete(key);
+    return value;
+  }
+
+  async delete(key: string): Promise<boolean> {
+    return this.values.delete(key);
+  }
+
+  async entries(): Promise<PluginStateEntry<T>[]> {
+    for (const key of this.values.keys()) {
+      await this.lookup(key);
+    }
+    return [...this.values.values()];
+  }
+
+  async clear(): Promise<void> {
+    this.values.clear();
+  }
+}

--- a/extensions/onepassword/src/op-client.test.ts
+++ b/extensions/onepassword/src/op-client.test.ts
@@ -1,9 +1,11 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { OnePasswordError } from "./errors.js";
 import { OpClient, type OpProcessRunner } from "./op-client.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("OpClient", () => {
   let root = "";
@@ -13,27 +15,23 @@ describe("OpClient", () => {
   const rightFixture = ["right", "fixture"].join("-");
 
   beforeEach(async () => {
-    root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-onepassword-")));
+    root = await fs.realpath(tempDirs.make("openclaw-onepassword-"));
     opBin = path.join(root, "op");
     tokenFile = path.join(root, "service-account-token");
     await fs.writeFile(opBin, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
     await fs.writeFile(tokenFile, `  ${fixtureAuth}\n`, { mode: 0o600 });
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     vi.restoreAllMocks();
-    await fs.rm(root, { recursive: true, force: true });
   });
 
   it("constructs one cache-disabled request with minimal environment and trims the token", async () => {
     const runner = vi.fn<OpProcessRunner>(async () => ({
       stdout: JSON.stringify({
-        title: "Repository token",
-        fields: [
-          { id: "credential", label: "legacy", value: ["wrong", "fixture"].join("-") },
-          { id: "new", label: "credential", value: rightFixture },
-          { id: "duplicate", label: "credential", value: ["later", "fixture"].join("-") },
-        ],
+        id: "new",
+        label: "credential",
+        value: rightFixture,
       }),
       stderr: "",
     }));
@@ -55,6 +53,8 @@ describe("OpClient", () => {
         "Repository token",
         "--vault",
         "Automation",
+        "--fields",
+        "credential",
         "--format",
         "json",
         "--cache=false",
@@ -67,12 +67,9 @@ describe("OpClient", () => {
     );
   });
 
-  it("falls back from label to field id", async () => {
+  it("accepts a response selected by field id", async () => {
     const runner: OpProcessRunner = async () => ({
-      stdout: JSON.stringify({
-        title: "Token",
-        fields: [{ id: "credential", label: "password", value: "by-id" }],
-      }),
+      stdout: JSON.stringify({ id: "credential", label: "password", value: "by-id" }),
       stderr: "",
     });
     const client = new OpClient({ opBin, tokenFile, timeoutMs: 1000, runner });
@@ -81,14 +78,12 @@ describe("OpClient", () => {
     ).resolves.toMatchObject({ value: "by-id", fieldLabel: "password" });
   });
 
-  it("reports available labels without values when a field is absent", async () => {
+  it("rejects a mismatched field response without exposing its value", async () => {
     const runner: OpProcessRunner = async () => ({
       stdout: JSON.stringify({
-        title: "Token",
-        fields: [
-          { id: "one", label: "username", value: ["private", "user"].join("-") },
-          { id: "two", label: "password", value: ["private", "pass"].join("-") },
-        ],
+        id: "one",
+        label: "username",
+        value: ["private", "user"].join("-"),
       }),
       stderr: "",
     });
@@ -98,7 +93,6 @@ describe("OpClient", () => {
       .catch((caught: unknown) => caught);
     expect(error).toBeInstanceOf(OnePasswordError);
     expect(error).toMatchObject({ code: "FIELD_NOT_FOUND" });
-    expect(String(error)).toContain("password, username");
     expect(String(error)).not.toContain("private-");
   });
 
@@ -121,10 +115,7 @@ describe("OpClient", () => {
     await fs.chmod(tokenFile, 0o644);
     const warn = vi.fn();
     const runner: OpProcessRunner = async () => ({
-      stdout: JSON.stringify({
-        title: "Token",
-        fields: [{ label: "credential", value: "value" }],
-      }),
+      stdout: JSON.stringify({ label: "credential", value: "value" }),
       stderr: "",
     });
     const client = new OpClient({ opBin, tokenFile, timeoutMs: 1000, runner, warn });
@@ -137,6 +128,7 @@ describe("OpClient", () => {
     ["RATE_LIMITED", { stderr: "request failed: 429 rate limit", code: 1 }],
     ["ITEM_NOT_FOUND", { stderr: "item is not found", code: 1 }],
     ["ITEM_NOT_FOUND", { stderr: `"Token" isn't an item in the "Automation" vault`, code: 1 }],
+    ["FIELD_NOT_FOUND", { stderr: `"credential" isn't a field in the "Token" item`, code: 1 }],
     ["AUTH_FAILED", { stderr: "unauthorized service account", code: 1 }],
     ["TIMEOUT", { stderr: "", killed: true, signal: "SIGTERM" }],
     ["OP_ERROR", { stderr: "unexpected failure", code: 1 }],

--- a/extensions/onepassword/src/op-client.test.ts
+++ b/extensions/onepassword/src/op-client.test.ts
@@ -3,7 +3,9 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { OnePasswordError } from "./errors.js";
-import { OpClient, type OpProcessRunner } from "./op-client.js";
+import { OpClient } from "./op-client.js";
+
+type OpProcessRunner = NonNullable<ConstructorParameters<typeof OpClient>[0]["runner"]>;
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 

--- a/extensions/onepassword/src/op-client.test.ts
+++ b/extensions/onepassword/src/op-client.test.ts
@@ -1,13 +1,13 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { OnePasswordError } from "./errors.js";
 import { OpClient } from "./op-client.js";
 
 type OpProcessRunner = NonNullable<ConstructorParameters<typeof OpClient>[0]["runner"]>;
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const tempDirs: string[] = [];
 
 describe("OpClient", () => {
   let root = "";
@@ -17,15 +17,19 @@ describe("OpClient", () => {
   const rightFixture = ["right", "fixture"].join("-");
 
   beforeEach(async () => {
-    root = await fs.realpath(tempDirs.make("openclaw-onepassword-"));
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-onepassword-"));
+    tempDirs.push(root);
     opBin = path.join(root, "op");
     tokenFile = path.join(root, "service-account-token");
     await fs.writeFile(opBin, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
     await fs.writeFile(tokenFile, `  ${fixtureAuth}\n`, { mode: 0o600 });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.restoreAllMocks();
+    await Promise.all(
+      tempDirs.splice(0).map((tempDir) => fs.rm(tempDir, { recursive: true, force: true })),
+    );
   });
 
   it("constructs one cache-disabled request with minimal environment and trims the token", async () => {

--- a/extensions/onepassword/src/op-client.test.ts
+++ b/extensions/onepassword/src/op-client.test.ts
@@ -1,0 +1,167 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OnePasswordError } from "./errors.js";
+import { OpClient, type OpProcessRunner } from "./op-client.js";
+
+describe("OpClient", () => {
+  let root = "";
+  let opBin = "";
+  let tokenFile = "";
+  const fixtureAuth = ["fixture", "auth"].join("-");
+  const rightFixture = ["right", "fixture"].join("-");
+
+  beforeEach(async () => {
+    root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-onepassword-")));
+    opBin = path.join(root, "op");
+    tokenFile = path.join(root, "service-account-token");
+    await fs.writeFile(opBin, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+    await fs.writeFile(tokenFile, `  ${fixtureAuth}\n`, { mode: 0o600 });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("constructs one cache-disabled request with minimal environment and trims the token", async () => {
+    const runner = vi.fn<OpProcessRunner>(async () => ({
+      stdout: JSON.stringify({
+        title: "Repository token",
+        fields: [
+          { id: "credential", label: "legacy", value: ["wrong", "fixture"].join("-") },
+          { id: "new", label: "credential", value: rightFixture },
+          { id: "duplicate", label: "credential", value: ["later", "fixture"].join("-") },
+        ],
+      }),
+      stderr: "",
+    }));
+    const client = new OpClient({ opBin, tokenFile, timeoutMs: 1234, runner, home: root });
+
+    await expect(
+      client.getItem({ item: "Repository token", vault: "Automation", field: "credential" }),
+    ).resolves.toEqual({
+      value: rightFixture,
+      itemTitle: "Repository token",
+      fieldLabel: "credential",
+    });
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(runner).toHaveBeenCalledWith(
+      opBin,
+      [
+        "item",
+        "get",
+        "Repository token",
+        "--vault",
+        "Automation",
+        "--format",
+        "json",
+        "--cache=false",
+      ],
+      {
+        env: { OP_SERVICE_ACCOUNT_TOKEN: fixtureAuth, HOME: root },
+        timeoutMs: 1234,
+        maxBufferBytes: 1024 * 1024,
+      },
+    );
+  });
+
+  it("falls back from label to field id", async () => {
+    const runner: OpProcessRunner = async () => ({
+      stdout: JSON.stringify({
+        title: "Token",
+        fields: [{ id: "credential", label: "password", value: "by-id" }],
+      }),
+      stderr: "",
+    });
+    const client = new OpClient({ opBin, tokenFile, timeoutMs: 1000, runner });
+    await expect(
+      client.getItem({ item: "Token", vault: "Automation", field: "credential" }),
+    ).resolves.toMatchObject({ value: "by-id", fieldLabel: "password" });
+  });
+
+  it("reports available labels without values when a field is absent", async () => {
+    const runner: OpProcessRunner = async () => ({
+      stdout: JSON.stringify({
+        title: "Token",
+        fields: [
+          { id: "one", label: "username", value: ["private", "user"].join("-") },
+          { id: "two", label: "password", value: ["private", "pass"].join("-") },
+        ],
+      }),
+      stderr: "",
+    });
+    const client = new OpClient({ opBin, tokenFile, timeoutMs: 1000, runner });
+    const error = await client
+      .getItem({ item: "Token", vault: "Automation", field: "credential" })
+      .catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(OnePasswordError);
+    expect(error).toMatchObject({ code: "FIELD_NOT_FOUND" });
+    expect(String(error)).toContain("password, username");
+    expect(String(error)).not.toContain("private-");
+  });
+
+  it("surfaces missing and empty token files as TOKEN_MISSING", async () => {
+    await fs.rm(tokenFile);
+    const runner = vi.fn<OpProcessRunner>();
+    const client = new OpClient({ opBin, tokenFile, timeoutMs: 1000, runner });
+    await expect(
+      client.getItem({ item: "Token", vault: "Automation", field: "credential" }),
+    ).rejects.toMatchObject({ code: "TOKEN_MISSING" });
+    expect(runner).not.toHaveBeenCalled();
+
+    await fs.writeFile(tokenFile, " \n", { mode: 0o600 });
+    await expect(
+      client.getItem({ item: "Token", vault: "Automation", field: "credential" }),
+    ).rejects.toMatchObject({ code: "TOKEN_MISSING" });
+  });
+
+  it("warns once for token file permissions broader than 0600", async () => {
+    await fs.chmod(tokenFile, 0o644);
+    const warn = vi.fn();
+    const runner: OpProcessRunner = async () => ({
+      stdout: JSON.stringify({
+        title: "Token",
+        fields: [{ label: "credential", value: "value" }],
+      }),
+      stderr: "",
+    });
+    const client = new OpClient({ opBin, tokenFile, timeoutMs: 1000, runner, warn });
+    await client.getItem({ item: "Token", vault: "Automation", field: "credential" });
+    await client.getItem({ item: "Token", vault: "Automation", field: "credential" });
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["RATE_LIMITED", { stderr: "request failed: 429 rate limit", code: 1 }],
+    ["ITEM_NOT_FOUND", { stderr: "item is not found", code: 1 }],
+    ["ITEM_NOT_FOUND", { stderr: `"Token" isn't an item in the "Automation" vault`, code: 1 }],
+    ["AUTH_FAILED", { stderr: "unauthorized service account", code: 1 }],
+    ["TIMEOUT", { stderr: "", killed: true, signal: "SIGTERM" }],
+    ["OP_ERROR", { stderr: "unexpected failure", code: 1 }],
+  ] as const)("maps process failure to %s without retry", async (expectedCode, failure) => {
+    const runner = vi.fn<OpProcessRunner>(async () => {
+      throw Object.assign(new Error("op failed"), failure);
+    });
+    const client = new OpClient({ opBin, tokenFile, timeoutMs: 1000, runner });
+    await expect(
+      client.getItem({ item: "Token", vault: "Automation", field: "credential" }),
+    ).rejects.toMatchObject({ code: expectedCode });
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an unresolved binary without invoking a runner", async () => {
+    const runner = vi.fn<OpProcessRunner>();
+    const client = new OpClient({
+      opBin: path.join(root, "missing-op"),
+      tokenFile,
+      timeoutMs: 1000,
+      runner,
+    });
+    await expect(
+      client.getItem({ item: "Token", vault: "Automation", field: "credential" }),
+    ).rejects.toMatchObject({ code: "OP_NOT_FOUND" });
+    expect(runner).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/onepassword/src/op-client.test.ts
+++ b/extensions/onepassword/src/op-client.test.ts
@@ -17,6 +17,7 @@ describe("OpClient", () => {
   const rightFixture = ["right", "fixture"].join("-");
 
   beforeEach(async () => {
+    // openclaw-temp-dir: allow plugin tests cannot import the core-only tracker.
     root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-onepassword-"));
     tempDirs.push(root);
     opBin = path.join(root, "op");

--- a/extensions/onepassword/src/op-client.test.ts
+++ b/extensions/onepassword/src/op-client.test.ts
@@ -128,7 +128,12 @@ describe("OpClient", () => {
     ["RATE_LIMITED", { stderr: "request failed: 429 rate limit", code: 1 }],
     ["ITEM_NOT_FOUND", { stderr: "item is not found", code: 1 }],
     ["ITEM_NOT_FOUND", { stderr: `"Token" isn't an item in the "Automation" vault`, code: 1 }],
+    [
+      "ITEM_NOT_FOUND",
+      { stderr: `"Rate limit token" isn't an item in the "Automation" vault`, code: 1 },
+    ],
     ["FIELD_NOT_FOUND", { stderr: `"credential" isn't a field in the "Token" item`, code: 1 }],
+    ["FIELD_NOT_FOUND", { stderr: `"429 credential" isn't a field in the "Token" item`, code: 1 }],
     ["AUTH_FAILED", { stderr: "unauthorized service account", code: 1 }],
     ["TIMEOUT", { stderr: "", killed: true, signal: "SIGTERM" }],
     ["OP_ERROR", { stderr: "unexpected failure", code: 1 }],

--- a/extensions/onepassword/src/op-client.ts
+++ b/extensions/onepassword/src/op-client.ts
@@ -1,0 +1,286 @@
+import { execFile } from "node:child_process";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { OnePasswordError } from "./errors.js";
+
+const MAX_STDOUT_BYTES = 1024 * 1024;
+
+export type OpProcessResult = {
+  stdout: string;
+  stderr: string;
+};
+
+export type OpProcessOptions = {
+  env: NodeJS.ProcessEnv;
+  timeoutMs: number;
+  maxBufferBytes: number;
+};
+
+export type OpProcessRunner = (
+  file: string,
+  args: string[],
+  options: OpProcessOptions,
+) => Promise<OpProcessResult>;
+
+export type ResolvedSecret = {
+  value: string;
+  itemTitle: string;
+  fieldLabel: string;
+};
+
+export type OpClientOptions = {
+  opBin?: string;
+  tokenFile: string;
+  timeoutMs: number;
+  runner?: OpProcessRunner;
+  home?: string;
+  pathEnv?: string;
+  warn?: (message: string) => void;
+};
+
+type OpField = {
+  id?: unknown;
+  label?: unknown;
+  value?: unknown;
+};
+
+type OpItem = {
+  title?: unknown;
+  fields?: unknown;
+};
+
+function defaultRunner(
+  file: string,
+  args: string[],
+  options: OpProcessOptions,
+): Promise<OpProcessResult> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      file,
+      args,
+      {
+        env: options.env,
+        timeout: options.timeoutMs,
+        maxBuffer: options.maxBufferBytes,
+        encoding: "utf8",
+        windowsHide: true,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(
+            Object.assign(new Error("1Password CLI process failed"), {
+              stderr,
+              code: error.code,
+              killed: error.killed,
+              signal: error.signal,
+            }),
+          );
+          return;
+        }
+        resolve({ stdout, stderr });
+      },
+    );
+  });
+}
+
+function isExecutable(filePath: string): boolean {
+  try {
+    fsSync.accessSync(filePath, fsSync.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function resolveOpBinary(
+  configuredPath: string | undefined,
+  pathEnv: string,
+): string | undefined {
+  if (configuredPath) {
+    return isExecutable(configuredPath) ? configuredPath : undefined;
+  }
+  const executable = process.platform === "win32" ? "op.exe" : "op";
+  for (const directory of pathEnv.split(path.delimiter)) {
+    if (!directory) {
+      continue;
+    }
+    const candidate = path.resolve(directory, executable);
+    if (isExecutable(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function errorRecord(error: unknown): Record<string, unknown> {
+  return error && typeof error === "object" ? (error as Record<string, unknown>) : {};
+}
+
+function classifyOpError(error: unknown): OnePasswordError {
+  if (error instanceof OnePasswordError) {
+    return error;
+  }
+  const record = errorRecord(error);
+  const stderr = typeof record.stderr === "string" ? record.stderr : "";
+  const normalized = stderr.toLowerCase();
+  if (record.code === "ENOENT") {
+    return new OnePasswordError("OP_NOT_FOUND", "1Password CLI executable was not found");
+  }
+  if (record.killed === true || record.code === "ETIMEDOUT" || record.signal === "SIGTERM") {
+    return new OnePasswordError("TIMEOUT", "1Password CLI request timed out");
+  }
+  if (/\b429\b|rate[ -]?limit|too many requests/u.test(normalized)) {
+    return new OnePasswordError("RATE_LIMITED", "1Password rate limit reached");
+  }
+  if (
+    /item.+(is not found|isn't found|not found|does not exist)|could not find.+item|isn't an item\b/u.test(
+      normalized,
+    )
+  ) {
+    return new OnePasswordError("ITEM_NOT_FOUND", "1Password item was not found");
+  }
+  if (
+    /unauthorized|authentication|not signed in|invalid service account|permission denied/u.test(
+      normalized,
+    )
+  ) {
+    return new OnePasswordError("AUTH_FAILED", "1Password service account authentication failed");
+  }
+  return new OnePasswordError("OP_ERROR", "1Password CLI request failed");
+}
+
+function parseItem(stdout: string): OpItem {
+  try {
+    const parsed: unknown = JSON.parse(stdout);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("item response is not an object");
+    }
+    return parsed as OpItem;
+  } catch (error) {
+    throw new OnePasswordError("OP_ERROR", "1Password CLI returned invalid JSON", {
+      cause: error,
+    });
+  }
+}
+
+function normalizeFields(item: OpItem): OpField[] {
+  return Array.isArray(item.fields)
+    ? item.fields.filter(
+        (field): field is OpField =>
+          Boolean(field) && typeof field === "object" && !Array.isArray(field),
+      )
+    : [];
+}
+
+function extractSecret(item: OpItem, requestedField: string): ResolvedSecret {
+  const fields = normalizeFields(item);
+  const exactLabel = fields.find((field) => field.label === requestedField);
+  const selected = exactLabel ?? fields.find((field) => field.id === requestedField);
+  if (!selected || typeof selected.value !== "string") {
+    const labels = fields
+      .map((field) => (typeof field.label === "string" ? field.label : undefined))
+      .filter((label): label is string => Boolean(label))
+      .toSorted();
+    const suffix = labels.length > 0 ? ` Available fields: ${labels.join(", ")}` : "";
+    throw new OnePasswordError(
+      "FIELD_NOT_FOUND",
+      `1Password field ${requestedField} was not found.${suffix}`,
+    );
+  }
+  return {
+    value: selected.value,
+    itemTitle: typeof item.title === "string" ? item.title : "",
+    fieldLabel: typeof selected.label === "string" ? selected.label : requestedField,
+  };
+}
+
+export class OpClient {
+  readonly opBin: string | undefined;
+  readonly tokenFile: string;
+  private readonly timeoutMs: number;
+  private readonly runner: OpProcessRunner;
+  private readonly home: string;
+  private readonly warn: (message: string) => void;
+  private permissionWarningEmitted = false;
+
+  constructor(options: OpClientOptions) {
+    this.opBin = resolveOpBinary(options.opBin, options.pathEnv ?? process.env.PATH ?? "");
+    this.tokenFile = options.tokenFile;
+    this.timeoutMs = options.timeoutMs;
+    this.runner = options.runner ?? defaultRunner;
+    this.home = options.home ?? os.homedir();
+    this.warn = options.warn ?? (() => undefined);
+  }
+
+  async tokenFilePresent(): Promise<boolean> {
+    try {
+      await fs.access(this.tokenFile, fsSync.constants.R_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async readToken(): Promise<string> {
+    let contents: string;
+    try {
+      const [raw, stat] = await Promise.all([
+        fs.readFile(this.tokenFile, "utf8"),
+        fs.stat(this.tokenFile),
+      ]);
+      contents = raw.trim();
+      if (
+        !this.permissionWarningEmitted &&
+        process.platform !== "win32" &&
+        (stat.mode & 0o077) !== 0
+      ) {
+        this.permissionWarningEmitted = true;
+        this.warn("1Password service account token file permissions are broader than 0600");
+      }
+    } catch (error) {
+      throw new OnePasswordError(
+        "TOKEN_MISSING",
+        "1Password service account token file is missing",
+        {
+          cause: error,
+        },
+      );
+    }
+    if (!contents) {
+      throw new OnePasswordError("TOKEN_MISSING", "1Password service account token file is empty");
+    }
+    return contents;
+  }
+
+  async getItem(params: { item: string; vault: string; field: string }): Promise<ResolvedSecret> {
+    if (!this.opBin) {
+      throw new OnePasswordError("OP_NOT_FOUND", "1Password CLI executable was not found");
+    }
+    const token = await this.readToken();
+    const args = [
+      "item",
+      "get",
+      params.item,
+      "--vault",
+      params.vault,
+      "--format",
+      "json",
+      "--cache=false",
+    ];
+    try {
+      const result = await this.runner(this.opBin, args, {
+        env: {
+          OP_SERVICE_ACCOUNT_TOKEN: token,
+          HOME: this.home,
+        },
+        timeoutMs: this.timeoutMs,
+        maxBufferBytes: MAX_STDOUT_BYTES,
+      });
+      return extractSecret(parseItem(result.stdout), params.field);
+    } catch (error) {
+      throw classifyOpError(error);
+    }
+  }
+}

--- a/extensions/onepassword/src/op-client.ts
+++ b/extensions/onepassword/src/op-client.ts
@@ -126,9 +126,6 @@ function classifyOpError(error: unknown): OnePasswordError {
   if (record.killed === true || record.code === "ETIMEDOUT" || record.signal === "SIGTERM") {
     return new OnePasswordError("TIMEOUT", "1Password CLI request timed out");
   }
-  if (/\b429\b|rate[ -]?limit|too many requests/u.test(normalized)) {
-    return new OnePasswordError("RATE_LIMITED", "1Password rate limit reached");
-  }
   if (
     /item.+(is not found|isn't found|not found|does not exist)|could not find.+item|isn't an item\b/u.test(
       normalized,
@@ -147,6 +144,9 @@ function classifyOpError(error: unknown): OnePasswordError {
     )
   ) {
     return new OnePasswordError("AUTH_FAILED", "1Password service account authentication failed");
+  }
+  if (/\b429\b|rate[ -]?limit|too many requests/u.test(normalized)) {
+    return new OnePasswordError("RATE_LIMITED", "1Password rate limit reached");
   }
   return new OnePasswordError("OP_ERROR", "1Password CLI request failed");
 }

--- a/extensions/onepassword/src/op-client.ts
+++ b/extensions/onepassword/src/op-client.ts
@@ -46,11 +46,6 @@ type OpField = {
   value?: unknown;
 };
 
-type OpItem = {
-  title?: unknown;
-  fields?: unknown;
-};
-
 function defaultRunner(
   file: string,
   args: string[],
@@ -142,6 +137,11 @@ function classifyOpError(error: unknown): OnePasswordError {
     return new OnePasswordError("ITEM_NOT_FOUND", "1Password item was not found");
   }
   if (
+    /isn't a field\b|field.+(?:is not found|isn't found|not found|does not exist)/u.test(normalized)
+  ) {
+    return new OnePasswordError("FIELD_NOT_FOUND", "1Password field was not found");
+  }
+  if (
     /unauthorized|authentication|not signed in|invalid service account|permission denied/u.test(
       normalized,
     )
@@ -151,48 +151,32 @@ function classifyOpError(error: unknown): OnePasswordError {
   return new OnePasswordError("OP_ERROR", "1Password CLI request failed");
 }
 
-function parseItem(stdout: string): OpItem {
+function parseField(stdout: string, requestedField: string, itemTitle: string): ResolvedSecret {
+  let field: OpField;
   try {
     const parsed: unknown = JSON.parse(stdout);
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      throw new Error("item response is not an object");
+      throw new Error("field response is not an object");
     }
-    return parsed as OpItem;
+    field = parsed as OpField;
   } catch (error) {
     throw new OnePasswordError("OP_ERROR", "1Password CLI returned invalid JSON", {
       cause: error,
     });
   }
-}
-
-function normalizeFields(item: OpItem): OpField[] {
-  return Array.isArray(item.fields)
-    ? item.fields.filter(
-        (field): field is OpField =>
-          Boolean(field) && typeof field === "object" && !Array.isArray(field),
-      )
-    : [];
-}
-
-function extractSecret(item: OpItem, requestedField: string): ResolvedSecret {
-  const fields = normalizeFields(item);
-  const exactLabel = fields.find((field) => field.label === requestedField);
-  const selected = exactLabel ?? fields.find((field) => field.id === requestedField);
-  if (!selected || typeof selected.value !== "string") {
-    const labels = fields
-      .map((field) => (typeof field.label === "string" ? field.label : undefined))
-      .filter((label): label is string => Boolean(label))
-      .toSorted();
-    const suffix = labels.length > 0 ? ` Available fields: ${labels.join(", ")}` : "";
+  if (
+    (field.label !== requestedField && field.id !== requestedField) ||
+    typeof field.value !== "string"
+  ) {
     throw new OnePasswordError(
       "FIELD_NOT_FOUND",
-      `1Password field ${requestedField} was not found.${suffix}`,
+      `1Password field ${requestedField} was not found`,
     );
   }
   return {
-    value: selected.value,
-    itemTitle: typeof item.title === "string" ? item.title : "",
-    fieldLabel: typeof selected.label === "string" ? selected.label : requestedField,
+    value: field.value,
+    itemTitle,
+    fieldLabel: typeof field.label === "string" ? field.label : requestedField,
   };
 }
 
@@ -265,6 +249,8 @@ export class OpClient {
       params.item,
       "--vault",
       params.vault,
+      "--fields",
+      params.field,
       "--format",
       "json",
       "--cache=false",
@@ -278,7 +264,7 @@ export class OpClient {
         timeoutMs: this.timeoutMs,
         maxBufferBytes: MAX_STDOUT_BYTES,
       });
-      return extractSecret(parseItem(result.stdout), params.field);
+      return parseField(result.stdout, params.field, params.item);
     } catch (error) {
       throw classifyOpError(error);
     }

--- a/extensions/onepassword/src/op-client.ts
+++ b/extensions/onepassword/src/op-client.ts
@@ -7,18 +7,18 @@ import { OnePasswordError } from "./errors.js";
 
 const MAX_STDOUT_BYTES = 1024 * 1024;
 
-export type OpProcessResult = {
+type OpProcessResult = {
   stdout: string;
   stderr: string;
 };
 
-export type OpProcessOptions = {
+type OpProcessOptions = {
   env: NodeJS.ProcessEnv;
   timeoutMs: number;
   maxBufferBytes: number;
 };
 
-export type OpProcessRunner = (
+type OpProcessRunner = (
   file: string,
   args: string[],
   options: OpProcessOptions,
@@ -30,7 +30,7 @@ export type ResolvedSecret = {
   fieldLabel: string;
 };
 
-export type OpClientOptions = {
+type OpClientOptions = {
   opBin?: string;
   tokenFile: string;
   timeoutMs: number;
@@ -89,10 +89,7 @@ function isExecutable(filePath: string): boolean {
   }
 }
 
-export function resolveOpBinary(
-  configuredPath: string | undefined,
-  pathEnv: string,
-): string | undefined {
+function resolveOpBinary(configuredPath: string | undefined, pathEnv: string): string | undefined {
   if (configuredPath) {
     return isExecutable(configuredPath) ? configuredPath : undefined;
   }

--- a/extensions/onepassword/src/tool.test.ts
+++ b/extensions/onepassword/src/tool.test.ts
@@ -1,0 +1,76 @@
+import type { PluginHookToolResultPersistEvent } from "openclaw/plugin-sdk/types";
+import { describe, expect, it } from "vitest";
+import { redactPersistedOnePasswordResult } from "./tool.js";
+
+function event(
+  details: Record<string, unknown>,
+  contentText = JSON.stringify(details),
+): PluginHookToolResultPersistEvent {
+  return {
+    toolName: "onepassword",
+    toolCallId: "call-1",
+    message: {
+      role: "toolResult",
+      toolName: "onepassword",
+      toolCallId: "call-1",
+      isError: false,
+      timestamp: 1,
+      content: [{ type: "text", text: contentText }],
+      details,
+    },
+  };
+}
+
+describe("redactPersistedOnePasswordResult", () => {
+  it("removes a successful get value from persisted content and details", () => {
+    const fixtureValue = ["fixture", "value"].join("-");
+    const result = redactPersistedOnePasswordResult(
+      event({
+        ok: true,
+        slug: "repository-token",
+        value: fixtureValue,
+        itemTitle: "Repository token",
+        fieldLabel: "credential",
+      }),
+    );
+    expect(result?.message).toMatchObject({
+      role: "toolResult",
+      details: {
+        ok: true,
+        redacted: true,
+        slug: "repository-token",
+        itemTitle: "Repository token",
+        fieldLabel: "credential",
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain(fixtureValue);
+  });
+
+  it("uses the persisted message tool name when event correlation is absent", () => {
+    const fixtureValue = ["uncorrelated", "fixture"].join("-");
+    const persistedEvent = event({ ok: true, value: fixtureValue });
+    delete persistedEvent.toolName;
+    const result = redactPersistedOnePasswordResult(persistedEvent);
+    expect(result?.message).toMatchObject({ details: { ok: true, redacted: true } });
+    expect(JSON.stringify(result)).not.toContain(fixtureValue);
+  });
+
+  it("leaves list and error results unchanged", () => {
+    expect(redactPersistedOnePasswordResult(event({ ok: true, items: [] }))).toBeUndefined();
+    expect(
+      redactPersistedOnePasswordResult(event({ ok: false, error: { code: "OP_ERROR" } })),
+    ).toBeUndefined();
+  });
+
+  it("redacts get content after oversized details are capped", () => {
+    const fixtureValue = ["oversized", "fixture"].join("-");
+    const result = redactPersistedOnePasswordResult(
+      event(
+        { persistedDetailsTruncated: true },
+        JSON.stringify({ ok: true, slug: "repository-token", value: fixtureValue }),
+      ),
+    );
+    expect(result?.message).toMatchObject({ details: { ok: true, redacted: true } });
+    expect(JSON.stringify(result)).not.toContain(fixtureValue);
+  });
+});

--- a/extensions/onepassword/src/tool.ts
+++ b/extensions/onepassword/src/tool.ts
@@ -1,0 +1,115 @@
+import type { AnyAgentTool, OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
+import { jsonResult } from "openclaw/plugin-sdk/tool-results";
+import type {
+  PluginHookToolResultPersistEvent,
+  PluginHookToolResultPersistResult,
+} from "openclaw/plugin-sdk/types";
+import { parseToolInput, type OnePasswordBroker } from "./broker.js";
+import { OnePasswordError } from "./errors.js";
+
+const OnePasswordToolSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["action"],
+  properties: {
+    action: {
+      type: "string",
+      enum: ["list", "get"],
+      description: "List registered secret slugs or get one registered secret.",
+    },
+    slug: {
+      type: "string",
+      pattern: "^[a-z0-9][a-z0-9-]{0,63}$",
+      description: "Registered secret slug. Required for get.",
+    },
+    reason: {
+      type: "string",
+      minLength: 1,
+      maxLength: 300,
+      description: "Why the agent needs this secret. Required for get.",
+    },
+  },
+} as unknown as AnyAgentTool["parameters"];
+
+function errorResult(error: unknown) {
+  const code =
+    error instanceof OnePasswordError
+      ? error.code
+      : error && typeof error === "object" && "code" in error && typeof error.code === "string"
+        ? error.code
+        : "OP_ERROR";
+  const message = error instanceof Error ? error.message : "1Password request failed";
+  return jsonResult({ ok: false, error: { code, message } });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function redactPersistedOnePasswordResult(
+  event: PluginHookToolResultPersistEvent,
+): PluginHookToolResultPersistResult | undefined {
+  if (
+    event.message.role !== "toolResult" ||
+    (event.toolName ?? event.message.toolName) !== "onepassword"
+  ) {
+    return undefined;
+  }
+  const details = event.message.details;
+  const contentText = event.message.content
+    .filter(
+      (part): part is Extract<(typeof event.message.content)[number], { type: "text" }> =>
+        part.type === "text",
+    )
+    .map((part) => part.text)
+    .join("\n");
+  const hasSecretValue =
+    (isRecord(details) && typeof details.value === "string") || /"value"\s*:/.test(contentText);
+  if (!hasSecretValue) {
+    return undefined;
+  }
+  const safeDetails = isRecord(details) ? details : {};
+  const persisted = {
+    ok: true,
+    redacted: true,
+    ...(typeof safeDetails.slug === "string" ? { slug: safeDetails.slug } : {}),
+    ...(typeof safeDetails.itemTitle === "string" ? { itemTitle: safeDetails.itemTitle } : {}),
+    ...(typeof safeDetails.fieldLabel === "string" ? { fieldLabel: safeDetails.fieldLabel } : {}),
+  };
+  return {
+    message: {
+      ...event.message,
+      content: [{ type: "text", text: JSON.stringify(persisted, null, 2) }],
+      details: persisted,
+    },
+  };
+}
+
+export function createOnePasswordTool(
+  broker: OnePasswordBroker,
+  invocation: OpenClawPluginToolContext,
+): AnyAgentTool {
+  return {
+    name: "onepassword",
+    label: "1Password",
+    description:
+      "List curated 1Password secret slugs or retrieve one secret under its configured access policy.",
+    parameters: OnePasswordToolSchema,
+    execute: async (toolCallId, rawParams) => {
+      const params =
+        rawParams && typeof rawParams === "object" && !Array.isArray(rawParams)
+          ? (rawParams as Record<string, unknown>)
+          : {};
+      try {
+        const input = parseToolInput(params);
+        if (input.action === "list") {
+          return jsonResult({ ok: true, items: await broker.list() });
+        }
+        const secret = await broker.get(toolCallId, input, invocation);
+        return jsonResult({ ok: true, ...secret });
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  };
+}

--- a/extensions/onepassword/src/tool.ts
+++ b/extensions/onepassword/src/tool.ts
@@ -103,7 +103,7 @@ export function createOnePasswordTool(
       try {
         const input = parseToolInput(params);
         if (input.action === "list") {
-          return jsonResult({ ok: true, items: await broker.list() });
+          return jsonResult({ ok: true, items: await broker.list(invocation) });
         }
         const secret = await broker.get(toolCallId, input, invocation);
         return jsonResult({ ok: true, ...secret });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1321,6 +1321,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  'extensions/onepassword':
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/open-prose:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/src/plugins/contracts/boundary-invariants.test.ts
+++ b/src/plugins/contracts/boundary-invariants.test.ts
@@ -22,6 +22,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_FILES = [
   "extensions/matrix/subagent-hooks-api.ts",
   "extensions/memory-core/src/dreaming.ts",
   "extensions/memory-lancedb/index.ts",
+  "extensions/onepassword/index.ts",
   "extensions/thread-ownership/index.ts",
   "extensions/workboard/index.ts",
 ] as const;
@@ -35,6 +36,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   "extensions/matrix/subagent-hooks-api.ts": ["subagent_delivery_target", "subagent_ended"],
   "extensions/memory-core/src/dreaming.ts": ["before_agent_reply", "gateway_start", "gateway_stop"],
   "extensions/memory-lancedb/index.ts": ["agent_end", "before_prompt_build", "session_end"],
+  "extensions/onepassword/index.ts": ["before_tool_call", "tool_result_persist"],
   "extensions/thread-ownership/index.ts": ["message_received", "message_sending"],
   "extensions/workboard/index.ts": ["subagent_ended"],
 } as const satisfies Record<

--- a/src/plugins/contracts/boundary-invariants.test.ts
+++ b/src/plugins/contracts/boundary-invariants.test.ts
@@ -57,6 +57,12 @@ const BUNDLED_LIVE_CONFIG_HOOK_GUARDS = {
     "api.runtime.config?.current?.() ?? api.config",
   ],
   "extensions/memory-lancedb/index.ts": ["resolveLivePluginConfigObject(", '"memory-lancedb"'],
+  "extensions/onepassword/index.ts": [
+    "resolveLivePluginConfigObject(",
+    "resolveEffectiveEnableState(",
+    '"onepassword"',
+    "api.runtime.config?.current",
+  ],
   "extensions/thread-ownership/index.ts": [
     "resolveLivePluginConfigObject(",
     '"thread-ownership"',


### PR DESCRIPTION
## What Problem This Solves

Agents that need credentials can otherwise shell out to the 1Password CLI without a policy layer, approval gate, or durable audit record. OpenClaw's existing SecretRef flow covers config-time resolution, not governed agent-facing secret access.

Closes #105924.

## Why This Change Was Made

Adds an optional bundled `onepassword` plugin, inactive until configured, with:

- A curated-registry-only `onepassword` tool: `list` exposes metadata, while `get` requires a registered slug and reason.
- Per-slug `auto`, `approve`, or `deny` policy through the existing generic approval seam.
- Agent-scoped, TTL-bounded standing grants that bind the configured vault/item/field target and fail closed after config changes.
- Shared-SQLite audit and grant state, bounded retention, plus value-free `openclaw onepassword status|audit` diagnostics.
- One exact configured-field `op item get` request per cache miss, a minimal child environment, no retries, and no broad vault enumeration.
- Transcript persistence redaction: the model receives the value for the active turn, while stored tool results retain only safe metadata.
- Live disable, removal, deny-policy, and target-change revocation across authorization and execution boundaries.

The plugin boundary is intentional: core remains provider-agnostic, while the plugin uses public approval, config, state, and tool-result hooks. Official 1Password SDK/MCP options were checked; the installed CLI remains the smallest adequate runtime dependency for this bounded broker.

## User Impact

Opt-in only; existing installations are unchanged. Operators who enable the plugin gain policy-controlled agent secret access, per-agent standing grants, durable audit records, and approval prompts through existing OpenClaw surfaces. Setup, policy, revocation, and threat-model details live in `docs/plugins/onepassword.md`.

Release note: adds an optional bundled 1Password secrets broker with curated access, approval policy, audit history, and persistence-safe redaction.

## Evidence

- Exact head `a03c9c90ad83ec9273b768de069948564374551c`.
- Exact-head Testbox run `29241276150`: bundled-extension lint, extension-test public-boundary check, 6 focused files / 43 tests, extension test types, deadcode export ratchet, and plugin-SDK surface budget tests all passed.
- Patch-identical Testbox run `29238344552`: full build passed. Run `29239695160`: full format check and the complete affected boundary shard passed.
- Live 1Password CLI 2.34.1 service-account contract probe, redacted output only: `--fields <label>` returned exactly the requested concealed field object, its returned ID differed from the configured label, and a missing field failed closed.
- Source-blind behavior validation passed status, empty audit, redaction, and invalid multi-field configuration probes.
- Fresh fix-only autoreview: no accepted/actionable findings.
- Hosted exact-head CI: `29241235491` passed, including security, dependency, workflow-sanity, CodeQL, OpenGrep, and periphery gates.
- `git diff --check` clean. Root changelog intentionally unchanged; release-note context is recorded here.
