### PR TITLE
fix(ci): deduplicate read-only SQLite allowlist

### DIFF
--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -38,7 +38,6 @@ const rawSqliteAllowPathGroups = {
     "src/infra/sqlite-user-version.ts",
     "src/infra/sqlite-wal.ts",
     "src/state/openclaw-agent-db.ts",
-    "src/state/openclaw-state-db-readonly.ts",
     "src/state/openclaw-state-db.ts",
     "src/state/openclaw-state-db-readonly.ts",
     "src/state/sqlite-schema-shape.test-support.ts",
@@ -49,7 +48,6 @@ const rawSqliteAllowPathGroups = {
     "src/snapshot/local-repository.ts",
   ],
   "agent auth profile read-only bootstrap": ["src/agents/auth-profiles/sqlite.ts"],
-  "read-only shared state database access": ["src/state/openclaw-state-db-readonly.ts"],
   "read-only SQLite status probes": [
     "src/commands/doctor-db-bloat.ts",
     "src/commands/status.scan.shared.ts",


### PR DESCRIPTION
## What Problem This Solves

Concurrent repairs for the read-only shared-state SQLite guard landed overlapping allowlist entries. Current `main` lists `src/state/openclaw-state-db-readonly.ts` three times, so the guard throws `Duplicate raw SQLite allowlist path` before architecture checks can run. This blocks unrelated PR CI, including #106098.

## Why This Change Was Made

Retains one canonical entry in the existing database lifecycle/schema/transaction/PRAGMA group and removes the two redundant entries. The effective allowed path set is unchanged; duplicate detection remains fail-closed.

## User Impact

No runtime behavior change. Restores the architecture lane and merge queue after the overlapping CI repairs.

## Evidence

- Before: [CI run 29230550342](https://github.com/openclaw/openclaw/actions/runs/29230550342) fails `check:architecture` with `Duplicate raw SQLite allowlist path: src/state/openclaw-state-db-readonly.ts`.
- Blacksmith Testbox `tbx_01kxd4jdytxadqm5ha9r3cq1r8`: frozen install and full `corepack pnpm check:architecture` passed, including `Kysely guardrails OK` and the database-first legacy-store guard.
- `git diff --check` passed.
- Fresh structured autoreview: no findings; patch correct at 0.99 confidence.
