### PR TITLE
fix(ui): restore sidebar icon type import

### DIFF
--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -93,7 +93,7 @@ import {
   sidebarMoreMenuHoldsActiveRoute,
   sidebarPluginTabs,
 } from "./app-sidebar-nav-menus.ts";
-import { icons } from "./icons.ts";
+import { icons, type IconName } from "./icons.ts";
 import {
   LOBSTER_LOGO_VISIT_EVENT,
   LOBSTER_PET_BUILD_MULS,


### PR DESCRIPTION
## What Problem This Solves

Fixes the Control UI production typecheck on current `main`, where the sidebar uses `IconName` for external menu links without importing that type.

## Why This Change Was Made

Restore the type-only import from the existing icons module. This is the smallest correction and does not change runtime behavior.

## User Impact

No user-visible behavior change. Main and pull-request CI can complete the Control UI typecheck again.

## Evidence

- Before: CI run `29231048710`, job `86755242283` failed with `TS2304: Cannot find name 'IconName'` and `TS7053` in `ui/src/components/app-sidebar.ts`.
- `git diff --check`
- `oxfmt --check ui/src/components/app-sidebar.ts`
- Exact-head hosted CI pending.