### PR TITLE
fix(sandbox): missing stat paths use locale-independent marker

### DIFF
--- a/src/agents/sandbox/fs-bridge-shell-command-plans.ts
+++ b/src/agents/sandbox/fs-bridge-shell-command-plans.ts
@@ -15,14 +15,31 @@ export type SandboxFsCommandPlan = {
   allowFailure?: boolean;
 };
 
+/**
+ * Locale-independent stdout marker for a missing anchored basename.
+ * Prefer this over parsing localized `stat` stderr (e.g. "No such file or directory").
+ */
+export const SANDBOX_STAT_MISSING_MARKER = "__OPENCLAW_SANDBOX_STAT_MISSING__";
+
 /** Builds a stat command that anchors the path at its canonical parent before reading metadata. */
 export function buildStatPlan(
   target: SandboxResolvedFsPath,
   anchoredTarget: AnchoredSandboxEntry,
 ): SandboxFsCommandPlan {
+  // Emit a reserved marker before invoking `stat` so missing paths do not depend on
+  // English-only coreutils diagnostics under non-C locales.
+  const script = [
+    "set -eu",
+    'cd -- "$1"',
+    'if [ ! -e "$2" ]; then',
+    `  printf '%s\\n' '${SANDBOX_STAT_MISSING_MARKER}'`,
+    "  exit 0",
+    "fi",
+    'stat -c "%F|%s|%y" -- "$2"',
+  ].join("\n");
   return {
     checks: [{ target, options: { action: "stat files" } }],
-    script: 'set -eu\ncd -- "$1"\nstat -c "%F|%s|%y" -- "$2"',
+    script,
     args: [anchoredTarget.canonicalParentPath, anchoredTarget.basename],
     allowFailure: true,
   };

--- a/src/agents/sandbox/fs-bridge-shell-command-plans.ts
+++ b/src/agents/sandbox/fs-bridge-shell-command-plans.ts
@@ -26,16 +26,19 @@ export function buildStatPlan(
   target: SandboxResolvedFsPath,
   anchoredTarget: AnchoredSandboxEntry,
 ): SandboxFsCommandPlan {
-  // Emit a reserved marker before invoking `stat` so missing paths do not depend on
-  // English-only coreutils diagnostics under non-C locales.
+  // Run `stat` first so dangling symlink entries keep GNU metadata. Only after a
+  // failed stat, classify genuine absence with both `-e` and `-L` and emit a
+  // reserved marker (locale-independent; no check-then-use race on the basename).
   const script = [
     "set -eu",
     'cd -- "$1"',
-    'if [ ! -e "$2" ]; then',
-    `  printf '%s\\n' '${SANDBOX_STAT_MISSING_MARKER}'`,
-    "  exit 0",
+    'if ! stat -c "%F|%s|%y" -- "$2"; then',
+    '  if [ ! -e "$2" ] && [ ! -L "$2" ]; then',
+    `    printf '%s\\n' '${SANDBOX_STAT_MISSING_MARKER}'`,
+    "    exit 0",
+    "  fi",
+    "  exit 1",
     "fi",
-    'stat -c "%F|%s|%y" -- "$2"',
   ].join("\n");
   return {
     checks: [{ target, options: { action: "stat files" } }],

--- a/src/agents/sandbox/fs-bridge.anchored-ops.test.ts
+++ b/src/agents/sandbox/fs-bridge.anchored-ops.test.ts
@@ -3,6 +3,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { SANDBOX_STAT_MISSING_MARKER } from "./fs-bridge-shell-command-plans.js";
 import {
   createSandbox,
   createSandboxFsBridge,
@@ -220,6 +221,75 @@ describe("sandbox fs bridge anchored ops", () => {
       expect(getDockerArg(args, 1)).toBe("/workspace/nested");
       expect(getDockerArg(args, 2)).toBe("file.txt");
       expect(args).not.toContain("/workspace/nested/file.txt");
+      const script = getDockerScript(args);
+      expect(script).toContain(`[ ! -e "$2" ]`);
+      expect(script).toContain(SANDBOX_STAT_MISSING_MARKER);
+    });
+  });
+
+  it("returns null for missing paths via locale-independent marker (not English stderr)", async () => {
+    await withTempDir("openclaw-fs-bridge-stat-missing-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      mockedExecDockerRaw.mockImplementation(async (args) => {
+        const script = getDockerScript(args);
+        if (script.includes('readlink -f -- "$cursor"')) {
+          return dockerExecResult(`${getDockerArg(args, 1)}\n`);
+        }
+        if (script.includes(SANDBOX_STAT_MISSING_MARKER) || script.includes('stat -c "%F|%s|%y"')) {
+          // Simulate plan output for absent basename: marker on stdout, exit 0.
+          // Localized stderr must not be required for missing-file handling.
+          return {
+            ...dockerExecResult(`${SANDBOX_STAT_MISSING_MARKER}\n`),
+            stderr: Buffer.from(
+              "stat: impossible d'appliquer stat à 'note.txt': Aucun fichier ou dossier de ce type\n",
+            ),
+            code: 0,
+          };
+        }
+        return dockerExecResult("");
+      });
+
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+        }),
+      });
+
+      await expect(bridge.stat({ filePath: "note.txt" })).resolves.toBeNull();
+    });
+  });
+
+  it("still throws on non-missing stat failures (permission / other stderr)", async () => {
+    await withTempDir("openclaw-fs-bridge-stat-perm-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      mockedExecDockerRaw.mockImplementation(async (args) => {
+        const script = getDockerScript(args);
+        if (script.includes('readlink -f -- "$cursor"')) {
+          return dockerExecResult(`${getDockerArg(args, 1)}\n`);
+        }
+        if (script.includes('stat -c "%F|%s|%y"')) {
+          return {
+            ...dockerExecResult(""),
+            stderr: Buffer.from("stat: permission denied\n"),
+            code: 1,
+          };
+        }
+        return dockerExecResult("");
+      });
+
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+        }),
+      });
+
+      await expect(bridge.stat({ filePath: "secret.txt" })).rejects.toThrow(/permission denied/i);
     });
   });
 

--- a/src/agents/sandbox/fs-bridge.anchored-ops.test.ts
+++ b/src/agents/sandbox/fs-bridge.anchored-ops.test.ts
@@ -222,7 +222,11 @@ describe("sandbox fs bridge anchored ops", () => {
       expect(getDockerArg(args, 2)).toBe("file.txt");
       expect(args).not.toContain("/workspace/nested/file.txt");
       const script = getDockerScript(args);
-      expect(script).toContain(`[ ! -e "$2" ]`);
+      // CS: stat first; missing marker only after failure when neither -e nor -L.
+      const statIdx = script.indexOf('stat -c "%F|%s|%y" -- "$2"');
+      const missingCheckIdx = script.indexOf('[ ! -e "$2" ] && [ ! -L "$2" ]');
+      expect(statIdx).toBeGreaterThanOrEqual(0);
+      expect(missingCheckIdx).toBeGreaterThan(statIdx);
       expect(script).toContain(SANDBOX_STAT_MISSING_MARKER);
     });
   });
@@ -238,7 +242,7 @@ describe("sandbox fs bridge anchored ops", () => {
           return dockerExecResult(`${getDockerArg(args, 1)}\n`);
         }
         if (script.includes(SANDBOX_STAT_MISSING_MARKER) || script.includes('stat -c "%F|%s|%y"')) {
-          // Simulate plan output for absent basename: marker on stdout, exit 0.
+          // Simulate post-stat missing classification: marker on stdout, exit 0.
           // Localized stderr must not be required for missing-file handling.
           return {
             ...dockerExecResult(`${SANDBOX_STAT_MISSING_MARKER}\n`),
@@ -262,6 +266,38 @@ describe("sandbox fs bridge anchored ops", () => {
     });
   });
 
+  it("preserves dangling symlink stats (does not treat as missing)", async () => {
+    await withTempDir("openclaw-fs-bridge-stat-dangle-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      mockedExecDockerRaw.mockImplementation(async (args) => {
+        const script = getDockerScript(args);
+        if (script.includes('readlink -f -- "$cursor"')) {
+          return dockerExecResult(`${getDockerArg(args, 1)}\n`);
+        }
+        if (script.includes('stat -c "%F|%s|%y"')) {
+          // GNU stat without -L reports the symlink entry even when the target is gone.
+          return dockerExecResult("symbolic link|11|1710000000.0\n");
+        }
+        return dockerExecResult("");
+      });
+
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+        }),
+      });
+
+      // Bridge coerces GNU "symbolic link" to type "other"; must not return null.
+      await expect(bridge.stat({ filePath: "dangle" })).resolves.toMatchObject({
+        type: "other",
+        size: 11,
+      });
+    });
+  });
+
   it("still throws on non-missing stat failures (permission / other stderr)", async () => {
     await withTempDir("openclaw-fs-bridge-stat-perm-", async (stateDir) => {
       const workspaceDir = path.join(stateDir, "workspace");
@@ -273,6 +309,7 @@ describe("sandbox fs bridge anchored ops", () => {
           return dockerExecResult(`${getDockerArg(args, 1)}\n`);
         }
         if (script.includes('stat -c "%F|%s|%y"')) {
+          // Existing entry, non-missing failure: plan rethrows (no missing marker).
           return {
             ...dockerExecResult(""),
             stderr: Buffer.from("stat: permission denied\n"),

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -17,7 +17,11 @@ import {
   buildPinnedWritePlan,
 } from "./fs-bridge-mutation-helper.js";
 import { SandboxFsPathGuard } from "./fs-bridge-path-safety.js";
-import { buildStatPlan, type SandboxFsCommandPlan } from "./fs-bridge-shell-command-plans.js";
+import {
+  buildStatPlan,
+  SANDBOX_STAT_MISSING_MARKER,
+  type SandboxFsCommandPlan,
+} from "./fs-bridge-shell-command-plans.js";
 import { parseSandboxStatMtimeMs, parseSandboxStatSize } from "./fs-bridge-stat-parse.js";
 import type { SandboxFsBridge, SandboxFsStat, SandboxResolvedPath } from "./fs-bridge.types.js";
 import {
@@ -206,15 +210,16 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       buildStatPlan(target, anchoredTarget),
       params.signal,
     );
+    const text = result.stdout.toString("utf8").trim();
+    // Command plan prints a fixed marker for absent basenames (locale-independent).
+    if (text === SANDBOX_STAT_MISSING_MARKER) {
+      return null;
+    }
     if (result.code !== 0) {
       const stderr = result.stderr.toString("utf8");
-      if (stderr.includes("No such file or directory")) {
-        return null;
-      }
       const message = stderr.trim() || `stat failed with code ${result.code}`;
       throw new Error(`stat failed for ${target.containerPath}: ${message}`);
     }
-    const text = result.stdout.toString("utf8").trim();
     const [typeRaw, sizeRaw, mtimeRaw] = text.split("|");
     return {
       type: coerceStatType(typeRaw),


### PR DESCRIPTION
Closes #105187

## What Problem This Solves

Fixes an issue where users running sandbox containers with a non-English locale would get a thrown `stat failed` error for a missing file instead of the bridge returning `null` when the container's `stat` diagnostics are localized.

## Why This Change Was Made

ClawSweeper's preferred fix is a structured, locale-independent missing-path result from the stat command plan—not English stderr matching and not `LC_ALL=C` alone. The plan runs GNU `stat` first so dangling symlink entries keep their existing metadata, then emits a reserved marker only when `stat` fails and both `[ ! -e ]` and `[ ! -L ]` confirm there is no basename entry. The bridge maps only that marker to `null`. Permission and other nonzero failures still throw. Linked open PR #105263 explores `LC_ALL=C`; this follows the issue review's best-solution shape and the durable CS rank-up (stat-first + `-L` entry check).

**Fix quality:** compatibility — preserve dangling-symlink entry semantics and one canonical missing-path path, no dual English-stderr shim; performance — no pre-stat existence race; usability — missing files stay null across locales; security — path-safety checks and non-missing failures unchanged.

## User Impact

Sandbox-backed file checks return the expected missing-file (`null`) result regardless of container locale. Dangling symlinks remain stat-able (not treated as absent). Permission and other filesystem failures remain visible errors.

## Evidence

Verification host: local macOS (Crabbox bypass; Docker not available on this host for live non-English container)

```text
$ node scripts/run-vitest.mjs src/agents/sandbox/fs-bridge.anchored-ops.test.ts src/agents/sandbox/fs-bridge.shell.test.ts
Test Files  2 passed (2)
     Tests  21 passed (21)
[test] passed 1 Vitest shard

$ pnpm exec oxfmt --check src/agents/sandbox/fs-bridge.ts src/agents/sandbox/fs-bridge-shell-command-plans.ts src/agents/sandbox/fs-bridge.anchored-ops.test.ts
All matched files use the correct format.

$ git diff --check
(clean)
```

New / updated coverage:
- plan runs `stat` first; missing marker only after failure when neither `-e` nor `-L`
- missing path returns `null` when stdout is the marker even if French-style stderr is present
- dangling symlink mock returns GNU `symbolic link|…` and bridge resolves non-null (`type: "other"`)
- non-missing failures (permission denied) still throw

## Real behavior proof

- Behavior addressed: sandbox `stat` of a missing path returns `null` without English stderr matching; dangling symlink entries are not classified as missing; permission failures still throw.
- Environment: local macOS openclaw checkout at HEAD after CS follow-up patch; focused Vitest with docker-exec mocks (agent-solo unit-or-source). Live non-English container not run on this host (no Docker binary).
- Current-main contrast: `fs-bridge.ts` only treated missing files when stderr included the English phrase `No such file or directory`, so localized containers threw instead of returning null. Earlier PR revision used a `test -e` precheck that would treat dangling symlinks as absent.
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs src/agents/sandbox/fs-bridge.anchored-ops.test.ts src/agents/sandbox/fs-bridge.shell.test.ts`
  2. Missing-path test injects French-style missing-file stderr plus the reserved marker and expects `null`.
  3. Dangling-symlink test injects successful GNU `symbolic link|11|…` output and expects non-null stat (`type: "other"`, size 11).
  4. Control test injects permission-denied stderr + nonzero code and expects throw.
  5. Plan structure test asserts `stat` appears before the `[ ! -e ] && [ ! -L ]` missing classification.
- Evidence after fix: 21/21 focused tests pass; missing-marker → null; dangling symlink → non-null; permission → reject `/permission denied/i`.
- Control check: only the post-stat missing-marker path returns null; dangling symlink and permission/other failures do not; existing anchored stat size/path tests still pass.
- Observed result after fix: missing paths are classified by the plan marker after `stat` fails, not by precheck `-e` alone and not by locale-specific diagnostics.
- What was not tested: live non-English Docker container end-to-end (Docker unavailable on verification host). Host-backend path uses the same plan when shell is used.

## AI disclosure

This fix was authored with AI assistance (Grok). Human operator did not manually write the patch; proof is the focused Vitest transcript above. ClawSweeper follow-up round addressed CS P1/P2 shell-plan findings (stat-first + `-L`) and dangling-symlink regression coverage.