### PR TITLE
fix(ci): reduce release validation API polling

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -525,14 +525,14 @@ jobs:
                 break
               fi
               poll_count=$((poll_count + 1))
-              if (( poll_count % 2 == 0 )); then
+              if (( poll_count % 5 == 0 )); then
                 fail_fast_failed_jobs
               fi
               if (( poll_count % 10 == 0 )); then
                 echo "Still waiting on ${workflow}: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
                 fetch_child_jobs | jq 'select(.status != "completed") | {name, status, url: .html_url}' || true
               fi
-              sleep 30
+              sleep 60
             done
             trap - EXIT INT TERM
 
@@ -715,14 +715,14 @@ jobs:
                 break
               fi
               poll_count=$((poll_count + 1))
-              if (( poll_count % 2 == 0 )); then
+              if (( poll_count % 5 == 0 )); then
                 fail_fast_failed_jobs
               fi
               if (( poll_count % 10 == 0 )); then
                 echo "Still waiting on ${workflow}: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
                 fetch_child_jobs | jq 'select(.status != "completed") | {name, status, url: .html_url}' || true
               fi
-              sleep 30
+              sleep 60
             done
             trap - EXIT INT TERM
 
@@ -966,14 +966,14 @@ jobs:
                 break
               fi
               poll_count=$((poll_count + 1))
-              if (( poll_count % 2 == 0 )); then
+              if (( poll_count % 5 == 0 )); then
                 fail_fast_failed_jobs
               fi
               if (( poll_count % 10 == 0 )); then
                 echo "Still waiting on ${workflow}: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
                 fetch_child_jobs | jq 'select(.status != "completed") | {name, status, url: .html_url}' || true
               fi
-              sleep 30
+              sleep 60
             done
             trap - EXIT INT TERM
 
@@ -1211,14 +1211,14 @@ jobs:
               break
             fi
             poll_count=$((poll_count + 1))
-            if (( poll_count % 2 == 0 )); then
+            if (( poll_count % 5 == 0 )); then
               fail_fast_failed_jobs
             fi
             if (( poll_count % 10 == 0 )); then
               echo "Still waiting on npm-telegram-beta-e2e.yml: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
               gh_with_retry run view "$run_id" --json jobs --jq '.jobs[] | select(.status != "completed") | {name, status, url}' || true
             fi
-            sleep 30
+            sleep 60
           done
           trap - EXIT INT TERM
 
@@ -1381,7 +1381,7 @@ jobs:
               echo "Still waiting on openclaw-performance.yml: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
               gh_with_retry run view "$run_id" --json jobs --jq '.jobs[] | select(.status != "completed") | {name, status, url}' || true
             fi
-            sleep 30
+            sleep 60
           done
           trap - EXIT INT TERM
 


### PR DESCRIPTION
Related: #106104

## What Problem This Solves

Fixes stable full-release validation monitors exhausting the shared GitHub App REST quota while waiting for otherwise-successful child workflows.

## Why This Change Was Made

Poll child completion every 60 seconds, scan child jobs every five polls, and retain ten-poll progress summaries across all five monitor loops. Completion, cancellation, and failure propagation remain unchanged.

## User Impact

Release operators can complete full stable validation without the parent monitor dying from its own API polling load. No product runtime behavior changes.

## Evidence

- Failure: full release validation run `29221957117`, attempt 3 exhausted GitHub App REST quota; child runs `29225319039` and `29225321611` later succeeded.
- `git diff --check origin/main...HEAD`
- `actionlint .github/workflows/full-release-validation.yml`
- Fresh autoreview: clean, confidence 0.96.
- Exact-head hosted CI pending.