### PR TITLE
fix(ui): preserve sidebar collapsed state when group rename/delete fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,7 +137,6 @@ Docs: https://docs.openclaw.ai
 - **Feishu mention forwarding:** fail closed when the bot Open ID is unavailable so group messages cannot be misclassified as explicit bot mentions. (#100891) Thanks @zhangguiping-xydt.
 - **Cron edit delivery:** preserve each job's implicit delivery mode when applying partial delivery updates, so disabling best-effort delivery no longer turns detached job announcements off. (#100846) Thanks @machine3at.
 - **Control UI session creation:** keep newly created sessions at the front of the stable sidebar order after selecting another session. Thanks @shakkernerd.
-- **Control UI session groups:** preserve collapsed sidebar groups when rename or delete requests fail or finish after a Gateway disconnect. (#105974) Thanks @wuqxuan.
 - **Control UI file previews:** keep large Skill Workshop files responsive with cached, offscreen-contained text chunks while preserving wrapped content, stable file switching, full-file copy, and clean focus behavior. (#101319) Thanks @xianshishan and @shakkernerd.
 - **FTS-only memory startup:** skip plugin capability discovery when `memorySearch.provider` is explicitly `none`, avoiding an unnecessary cold-start scan.
 - **Control UI agent model labels:** show each selected agent's effective model in the Default picker option instead of the global model. (#100719, #77690, #77440) Thanks @hyspacex.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ Docs: https://docs.openclaw.ai
 - **Feishu mention forwarding:** fail closed when the bot Open ID is unavailable so group messages cannot be misclassified as explicit bot mentions. (#100891) Thanks @zhangguiping-xydt.
 - **Cron edit delivery:** preserve each job's implicit delivery mode when applying partial delivery updates, so disabling best-effort delivery no longer turns detached job announcements off. (#100846) Thanks @machine3at.
 - **Control UI session creation:** keep newly created sessions at the front of the stable sidebar order after selecting another session. Thanks @shakkernerd.
+- **Control UI session groups:** preserve collapsed sidebar groups when rename or delete requests fail or finish after a Gateway disconnect. (#105974) Thanks @wuqxuan.
 - **Control UI file previews:** keep large Skill Workshop files responsive with cached, offscreen-contained text chunks while preserving wrapped content, stable file switching, full-file copy, and clean focus behavior. (#101319) Thanks @xianshishan and @shakkernerd.
 - **FTS-only memory startup:** skip plugin capability discovery when `memorySearch.provider` is explicitly `none`, avoiding an unnecessary cold-start scan.
 - **Control UI agent model labels:** show each selected agent's effective model in the Default picker option instead of the global model. (#100719, #77690, #77440) Thanks @hyspacex.

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -17,10 +17,7 @@ import {
   type ApplicationGatewaySnapshot,
 } from "../app/context.ts";
 import { CATALOG_SESSION_CONTINUED_EVENT } from "../lib/sessions/catalog-key.ts";
-import type {
-  SessionCapability,
-  SessionState,
-} from "../lib/sessions/index.ts";
+import type { SessionCapability, SessionState } from "../lib/sessions/index.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import "./app-sidebar.ts";
 import {

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -17,7 +17,11 @@ import {
   type ApplicationGatewaySnapshot,
 } from "../app/context.ts";
 import { CATALOG_SESSION_CONTINUED_EVENT } from "../lib/sessions/catalog-key.ts";
-import type { SessionCapability, SessionState } from "../lib/sessions/index.ts";
+import type {
+  SessionCapability,
+  SessionGroupMutationResult,
+  SessionState,
+} from "../lib/sessions/index.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import "./app-sidebar.ts";
 import {
@@ -140,8 +144,8 @@ function createSessionsHarness(agentId: string, keys: string[]) {
   let canonicalListRevision = 1;
   const listeners = new Set<(next: SessionState) => void>();
   const groupsPut = vi.fn(() => Promise.resolve());
-  const groupsRename = vi.fn(() => Promise.resolve());
-  const groupsDelete = vi.fn(() => Promise.resolve());
+  const groupsRename = vi.fn(() => Promise.resolve<SessionGroupMutationResult>("completed"));
+  const groupsDelete = vi.fn(() => Promise.resolve<SessionGroupMutationResult>("completed"));
   const patch = vi.fn(() => Promise.resolve(null));
   const deleteMany = vi.fn(() =>
     Promise.resolve({ deleted: [] as string[], errors: [], preservedWorktrees: [] }),
@@ -1988,8 +1992,8 @@ describe("AppSidebar group mutation collapsed state", () => {
   const COLLAPSED_STORAGE_KEY = "openclaw:sidebar:sessions:collapsed-sections";
 
   async function mountCollapsedGroup(options: {
-    groupsRename?: () => Promise<void>;
-    groupsDelete?: () => Promise<void>;
+    groupsRename?: () => Promise<SessionGroupMutationResult>;
+    groupsDelete?: () => Promise<SessionGroupMutationResult>;
   }) {
     localStorage.setItem(COLLAPSED_STORAGE_KEY, JSON.stringify(["category:Alpha"]));
     const gatewayHarness = createGatewayHarness({} as GatewayBrowserClient);
@@ -2041,7 +2045,7 @@ describe("AppSidebar group mutation collapsed state", () => {
 
   it("rewrites collapsed keys only after group rename succeeds", async () => {
     const { sidebar, harness } = await mountCollapsedGroup({
-      groupsRename: () => Promise.resolve(),
+      groupsRename: () => Promise.resolve("completed"),
     });
     const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Beta");
     const menu = await openGroupMenu(sidebar);
@@ -2056,9 +2060,9 @@ describe("AppSidebar group mutation collapsed state", () => {
     promptSpy.mockRestore();
   });
 
-  it("ignores a successful group rename after its Gateway disconnects", async () => {
-    let resolveRename!: () => void;
-    const rename = new Promise<void>((resolve) => {
+  it("ignores a stale group rename after its Gateway reconnects with the same client", async () => {
+    let resolveRename!: (result: SessionGroupMutationResult) => void;
+    const rename = new Promise<SessionGroupMutationResult>((resolve) => {
       resolveRename = resolve;
     });
     const { sidebar, harness, gatewayHarness } = await mountCollapsedGroup({
@@ -2070,7 +2074,8 @@ describe("AppSidebar group mutation collapsed state", () => {
     await vi.waitFor(() => expect(harness.groupsRename).toHaveBeenCalledWith("Alpha", "Beta"));
 
     gatewayHarness.publish({ connected: false });
-    resolveRename();
+    gatewayHarness.publish({ connected: true });
+    resolveRename("stale");
     await Promise.resolve();
     await Promise.resolve();
 
@@ -2096,7 +2101,7 @@ describe("AppSidebar group mutation collapsed state", () => {
 
   it("drops collapsed keys only after group delete succeeds", async () => {
     const { sidebar, harness } = await mountCollapsedGroup({
-      groupsDelete: () => Promise.resolve(),
+      groupsDelete: () => Promise.resolve("completed"),
     });
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     const menu = await openGroupMenu(sidebar);

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -1992,7 +1992,7 @@ describe("AppSidebar group mutation collapsed state", () => {
     groupsDelete?: () => Promise<void>;
   }) {
     localStorage.setItem(COLLAPSED_STORAGE_KEY, JSON.stringify(["category:Alpha"]));
-    const gateway = createGateway({} as GatewayBrowserClient);
+    const gatewayHarness = createGatewayHarness({} as GatewayBrowserClient);
     const harness = createSessionsHarness("main", ["agent:main:main"]);
     if (options.groupsRename) {
       harness.groupsRename.mockImplementation(options.groupsRename);
@@ -2000,11 +2000,11 @@ describe("AppSidebar group mutation collapsed state", () => {
     if (options.groupsDelete) {
       harness.groupsDelete.mockImplementation(options.groupsDelete);
     }
-    const { sidebar } = await mountSidebar(gateway, harness.sessions);
+    const { sidebar } = await mountSidebar(gatewayHarness.gateway, harness.sessions);
     sidebar.connected = true;
     harness.publish({ groups: ["Alpha"] });
     await sidebar.updateComplete;
-    return { sidebar, harness };
+    return { sidebar, harness, gatewayHarness };
   }
 
   async function openGroupMenu(sidebar: SidebarLifecycleState) {
@@ -2053,6 +2053,28 @@ describe("AppSidebar group mutation collapsed state", () => {
     expect(JSON.parse(localStorage.getItem(COLLAPSED_STORAGE_KEY) ?? "[]")).toEqual([
       "category:Beta",
     ]);
+    promptSpy.mockRestore();
+  });
+
+  it("ignores a successful group rename after its Gateway disconnects", async () => {
+    let resolveRename!: () => void;
+    const rename = new Promise<void>((resolve) => {
+      resolveRename = resolve;
+    });
+    const { sidebar, harness, gatewayHarness } = await mountCollapsedGroup({
+      groupsRename: () => rename,
+    });
+    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Beta");
+    const menu = await openGroupMenu(sidebar);
+    menu.querySelectorAll<HTMLButtonElement>(".session-menu__item")[0]?.click();
+    await vi.waitFor(() => expect(harness.groupsRename).toHaveBeenCalledWith("Alpha", "Beta"));
+
+    gatewayHarness.publish({ connected: false });
+    resolveRename();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(localStorage.getItem(COLLAPSED_STORAGE_KEY)).toBe(JSON.stringify(["category:Alpha"]));
     promptSpy.mockRestore();
   });
 

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -19,7 +19,6 @@ import {
 import { CATALOG_SESSION_CONTINUED_EVENT } from "../lib/sessions/catalog-key.ts";
 import type {
   SessionCapability,
-  SessionGroupMutationResult,
   SessionState,
 } from "../lib/sessions/index.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
@@ -29,6 +28,8 @@ import {
   createLobsterPetLook,
   type LobsterLogoVisitDetail,
 } from "./lobster-pet.ts";
+
+type SessionGroupMutationResult = Awaited<ReturnType<SessionCapability["groupsRename"]>>;
 
 // Keep the attention widget inert: it fires its own health RPCs (cron.list,
 // models.authStatus) on connect, which would interleave with the nth-call

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -140,6 +140,8 @@ function createSessionsHarness(agentId: string, keys: string[]) {
   let canonicalListRevision = 1;
   const listeners = new Set<(next: SessionState) => void>();
   const groupsPut = vi.fn(() => Promise.resolve());
+  const groupsRename = vi.fn(() => Promise.resolve());
+  const groupsDelete = vi.fn(() => Promise.resolve());
   const patch = vi.fn(() => Promise.resolve(null));
   const deleteMany = vi.fn(() =>
     Promise.resolve({ deleted: [] as string[], errors: [], preservedWorktrees: [] }),
@@ -158,6 +160,8 @@ function createSessionsHarness(agentId: string, keys: string[]) {
     subscribeCreated: () => () => undefined,
     groupsLoad: () => Promise.resolve(),
     groupsPut,
+    groupsRename,
+    groupsDelete,
     patch,
     deleteMany,
     refresh: () => Promise.resolve(),
@@ -171,6 +175,8 @@ function createSessionsHarness(agentId: string, keys: string[]) {
   return {
     sessions,
     groupsPut,
+    groupsRename,
+    groupsDelete,
     patch,
     deleteMany,
     publish,
@@ -1794,7 +1800,6 @@ describe("AppSidebar custom group reordering", () => {
     expect(harness.groupsPut).toHaveBeenCalledWith(["Gamma", "Alpha", "Beta"]);
   });
 });
-
 describe("AppSidebar catalog session rows", () => {
   const catalogList = (
     sessions: Array<Record<string, unknown>>,
@@ -1977,5 +1982,109 @@ describe("AppSidebar catalog session rows", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+describe("AppSidebar group mutation collapsed state", () => {
+  const COLLAPSED_STORAGE_KEY = "openclaw:sidebar:sessions:collapsed-sections";
+
+  async function mountCollapsedGroup(options: {
+    groupsRename?: () => Promise<void>;
+    groupsDelete?: () => Promise<void>;
+  }) {
+    localStorage.setItem(COLLAPSED_STORAGE_KEY, JSON.stringify(["category:Alpha"]));
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const harness = createSessionsHarness("main", ["agent:main:main"]);
+    if (options.groupsRename) {
+      harness.groupsRename.mockImplementation(options.groupsRename);
+    }
+    if (options.groupsDelete) {
+      harness.groupsDelete.mockImplementation(options.groupsDelete);
+    }
+    const { sidebar } = await mountSidebar(gateway, harness.sessions);
+    sidebar.connected = true;
+    harness.publish({ groups: ["Alpha"] });
+    await sidebar.updateComplete;
+    return { sidebar, harness };
+  }
+
+  async function openGroupMenu(sidebar: SidebarLifecycleState) {
+    const actions = sidebar.querySelector<HTMLButtonElement>(
+      '[data-session-section="category:Alpha"] .sidebar-session-group-actions',
+    );
+    if (!actions) {
+      throw new Error("expected group actions trigger");
+    }
+    actions.click();
+    await sidebar.updateComplete;
+    const menu = sidebar.querySelector(".sidebar-session-group-menu");
+    if (!menu) {
+      throw new Error("expected group menu");
+    }
+    return menu;
+  }
+
+  it("keeps collapsed keys when group rename is rejected", async () => {
+    const { sidebar, harness } = await mountCollapsedGroup({
+      groupsRename: () => Promise.reject(new Error("rename failed")),
+    });
+    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Beta");
+    const menu = await openGroupMenu(sidebar);
+    const rename = menu.querySelectorAll<HTMLButtonElement>(".session-menu__item")[0];
+    rename?.click();
+    await vi.waitFor(() => expect(harness.groupsRename).toHaveBeenCalledWith("Alpha", "Beta"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(localStorage.getItem(COLLAPSED_STORAGE_KEY)).toBe(JSON.stringify(["category:Alpha"]));
+    promptSpy.mockRestore();
+  });
+
+  it("rewrites collapsed keys only after group rename succeeds", async () => {
+    const { sidebar, harness } = await mountCollapsedGroup({
+      groupsRename: () => Promise.resolve(),
+    });
+    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Beta");
+    const menu = await openGroupMenu(sidebar);
+    menu.querySelectorAll<HTMLButtonElement>(".session-menu__item")[0]?.click();
+    await vi.waitFor(() => expect(harness.groupsRename).toHaveBeenCalledWith("Alpha", "Beta"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(JSON.parse(localStorage.getItem(COLLAPSED_STORAGE_KEY) ?? "[]")).toEqual([
+      "category:Beta",
+    ]);
+    promptSpy.mockRestore();
+  });
+
+  it("keeps collapsed keys when group delete is rejected", async () => {
+    const { sidebar, harness } = await mountCollapsedGroup({
+      groupsDelete: () => Promise.reject(new Error("delete failed")),
+    });
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const menu = await openGroupMenu(sidebar);
+    const items = menu.querySelectorAll<HTMLButtonElement>(".session-menu__item");
+    items[items.length - 1]?.click();
+    await vi.waitFor(() => expect(harness.groupsDelete).toHaveBeenCalledWith("Alpha"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(localStorage.getItem(COLLAPSED_STORAGE_KEY)).toBe(JSON.stringify(["category:Alpha"]));
+    confirmSpy.mockRestore();
+  });
+
+  it("drops collapsed keys only after group delete succeeds", async () => {
+    const { sidebar, harness } = await mountCollapsedGroup({
+      groupsDelete: () => Promise.resolve(),
+    });
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const menu = await openGroupMenu(sidebar);
+    const items = menu.querySelectorAll<HTMLButtonElement>(".session-menu__item");
+    items[items.length - 1]?.click();
+    await vi.waitFor(() => expect(harness.groupsDelete).toHaveBeenCalledWith("Alpha"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(JSON.parse(localStorage.getItem(COLLAPSED_STORAGE_KEY) ?? "[]")).toEqual([]);
+    confirmSpy.mockRestore();
   });
 });

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -1627,8 +1627,8 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     // Collapse keys follow the confirmed Gateway rename only and stay scoped
     // to the connection that issued it; stale completions must not rewrite storage.
     void context.sessions.groupsRename(group, next).then(
-      () => {
-        if (!this.isCurrentSessionGroupMutation(context, client)) {
+      (outcome) => {
+        if (outcome !== "completed" || !this.isCurrentSessionGroupMutation(context, client)) {
           return;
         }
         const from = `category:${group}`;
@@ -1654,8 +1654,8 @@ class AppSidebar extends OpenClawLightDomContentsElement {
       return;
     }
     void context.sessions.groupsDelete(group).then(
-      () => {
-        if (!this.isCurrentSessionGroupMutation(context, client)) {
+      (outcome) => {
+        if (outcome !== "completed" || !this.isCurrentSessionGroupMutation(context, client)) {
           return;
         }
         const collapsed = new Set(this.collapsedSessionSections);

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -1616,18 +1616,21 @@ class AppSidebar extends OpenClawLightDomContentsElement {
 
   private renameSessionGroupFromMenu(group: string) {
     const context = this.context;
-    if (!context || !this.connected) {
+    const client = context?.gateway.snapshot.client;
+    if (!context || !client || !this.connected || !context.gateway.snapshot.connected) {
       return;
     }
     const next = window.prompt(t("sessionsView.renameGroupPrompt"), group)?.trim();
     if (!next || next === group) {
       return;
     }
-    // Collapse keys follow the confirmed Gateway rename only. Using finally
-    // rewrote local storage even when the RPC rejected and the old group remained.
-    void context.sessions
-      .groupsRename(group, next)
-      .then(() => {
+    // Collapse keys follow the confirmed Gateway rename only and stay scoped
+    // to the connection that issued it; stale completions must not rewrite storage.
+    void context.sessions.groupsRename(group, next).then(
+      () => {
+        if (!this.isCurrentSessionGroupMutation(context, client)) {
+          return;
+        }
         const from = `category:${group}`;
         if (this.collapsedSessionSections.has(from)) {
           const collapsed = new Set(this.collapsedSessionSections);
@@ -1636,34 +1639,42 @@ class AppSidebar extends OpenClawLightDomContentsElement {
           this.saveCollapsedSessionSections(collapsed);
         }
         this.requestUpdate();
-      })
-      .catch(() => {
-        // Session capability / Sessions page surface mutation errors; leave
-        // persisted collapsed state byte-for-byte unchanged on rejection.
-      });
+      },
+      () => undefined,
+    );
   }
 
   private deleteSessionGroupFromMenu(group: string) {
     const context = this.context;
-    if (!context || !this.connected) {
+    const client = context?.gateway.snapshot.client;
+    if (!context || !client || !this.connected || !context.gateway.snapshot.connected) {
       return;
     }
     if (!window.confirm(t("sessionsView.deleteGroupConfirm", { group }))) {
       return;
     }
-    // Same success-only contract as rename: a failed delete must not drop the
-    // group's collapsed preference while the catalog entry still exists.
-    void context.sessions
-      .groupsDelete(group)
-      .then(() => {
+    void context.sessions.groupsDelete(group).then(
+      () => {
+        if (!this.isCurrentSessionGroupMutation(context, client)) {
+          return;
+        }
         const collapsed = new Set(this.collapsedSessionSections);
         collapsed.delete(`category:${group}`);
         this.saveCollapsedSessionSections(collapsed);
         this.requestUpdate();
-      })
-      .catch(() => {
-        // Leave collapsed state alone when the Gateway rejects the delete.
-      });
+      },
+      () => undefined,
+    );
+  }
+
+  private isCurrentSessionGroupMutation(
+    context: ApplicationContext<RouteId>,
+    client: GatewayBrowserClient,
+  ) {
+    const snapshot = context.gateway.snapshot;
+    return (
+      this.context === context && this.connected && snapshot.connected && snapshot.client === client
+    );
   }
 
   private saveCollapsedSessionSections(sections: ReadonlySet<string>) {

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -1623,17 +1623,24 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     if (!next || next === group) {
       return;
     }
-    // The gateway renames the catalog entry and repoints member sessions.
-    void context.sessions.groupsRename(group, next).finally(() => {
-      const from = `category:${group}`;
-      if (this.collapsedSessionSections.has(from)) {
-        const collapsed = new Set(this.collapsedSessionSections);
-        collapsed.delete(from);
-        collapsed.add(`category:${next}`);
-        this.saveCollapsedSessionSections(collapsed);
-      }
-      this.requestUpdate();
-    });
+    // Collapse keys follow the confirmed Gateway rename only. Using finally
+    // rewrote local storage even when the RPC rejected and the old group remained.
+    void context.sessions
+      .groupsRename(group, next)
+      .then(() => {
+        const from = `category:${group}`;
+        if (this.collapsedSessionSections.has(from)) {
+          const collapsed = new Set(this.collapsedSessionSections);
+          collapsed.delete(from);
+          collapsed.add(`category:${next}`);
+          this.saveCollapsedSessionSections(collapsed);
+        }
+        this.requestUpdate();
+      })
+      .catch(() => {
+        // Session capability / Sessions page surface mutation errors; leave
+        // persisted collapsed state byte-for-byte unchanged on rejection.
+      });
   }
 
   private deleteSessionGroupFromMenu(group: string) {
@@ -1644,12 +1651,19 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     if (!window.confirm(t("sessionsView.deleteGroupConfirm", { group }))) {
       return;
     }
-    void context.sessions.groupsDelete(group).finally(() => {
-      const collapsed = new Set(this.collapsedSessionSections);
-      collapsed.delete(`category:${group}`);
-      this.saveCollapsedSessionSections(collapsed);
-      this.requestUpdate();
-    });
+    // Same success-only contract as rename: a failed delete must not drop the
+    // group's collapsed preference while the catalog entry still exists.
+    void context.sessions
+      .groupsDelete(group)
+      .then(() => {
+        const collapsed = new Set(this.collapsedSessionSections);
+        collapsed.delete(`category:${group}`);
+        this.saveCollapsedSessionSections(collapsed);
+        this.requestUpdate();
+      })
+      .catch(() => {
+        // Leave collapsed state alone when the Gateway rejects the delete.
+      });
   }
 
   private saveCollapsedSessionSections(sections: ReadonlySet<string>) {

--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -17,6 +17,7 @@ const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const collapsedSessionSectionsStorageKey = "openclaw:sidebar:sessions:collapsed-sections";
 
 let browser: Browser;
 let server: ControlUiE2eServer;
@@ -818,6 +819,85 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
       await page.getByRole("menuitemradio", { name: "None" }).click();
       await expect.poll(() => groups.count()).toBe(1);
       await expect.poll(() => groups.first().locator(".sidebar-recent-session").count()).toBe(4);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("preserves a collapsed sidebar group when its rename is rejected", async () => {
+    const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await page.addInitScript(
+      ({ key, value }) => {
+        try {
+          if (localStorage.getItem(key) === null) {
+            localStorage.setItem(key, value);
+          }
+        } catch {
+          // The opaque initial document has no storage; the app origin does.
+        }
+      },
+      {
+        key: collapsedSessionSectionsStorageKey,
+        value: JSON.stringify(["category:Research"]),
+      },
+    );
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["sessions.groups.rename"],
+      featureMethods: ["chat.metadata", "chat.startup", "sessions.groups.list"],
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          sessionRow("agent:main:main", "Main", baseTime),
+          sessionRow("agent:main:paper", "Paper", baseTime - 60_000, {
+            category: "Research",
+          }),
+        ]),
+      },
+      sessionGroups: ["Research"],
+      sessionKey: "agent:main:main",
+    });
+    const pageErrors: string[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const researchGroup = page.locator('[data-session-section="category:Research"]');
+      await researchGroup.waitFor({ state: "visible", timeout: 10_000 });
+      await expect.poll(() => researchGroup.locator(".sidebar-recent-session").count()).toBe(0);
+      await researchGroup.locator(".sidebar-recent-sessions__head").hover();
+      await researchGroup.getByRole("button", { name: "Group options for Research" }).click();
+      page.once("dialog", (dialog) => void dialog.accept("Projects"));
+      await page.getByRole("menuitem", { name: "Rename group…" }).click();
+      await gateway.waitForRequest("sessions.groups.rename");
+      await gateway.rejectDeferred("sessions.groups.rename", {
+        code: "INVALID_REQUEST",
+        message: "rejected group rename",
+      });
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
+
+      expect(
+        await page.evaluate((key) => localStorage.getItem(key), collapsedSessionSectionsStorageKey),
+      ).toBe(JSON.stringify(["category:Research"]));
+      await researchGroup.waitFor({ state: "visible" });
+      expect(await page.locator('[data-session-section="category:Projects"]').count()).toBe(0);
+      expect(pageErrors).toEqual([]);
+
+      await page.reload();
+      await researchGroup.waitFor({ state: "visible", timeout: 10_000 });
+      await expect.poll(() => researchGroup.locator(".sidebar-recent-session").count()).toBe(0);
+      expect(
+        await page.evaluate((key) => localStorage.getItem(key), collapsedSessionSectionsStorageKey),
+      ).toBe(JSON.stringify(["category:Research"]));
     } finally {
       await context.close();
     }

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -220,6 +220,40 @@ describe("createSessionCapability", () => {
     sessions.dispose();
   });
 
+  it.each(["rename", "delete"] as const)(
+    "keeps a confirmed group %s completed when its row refresh outlives the connection",
+    async (operation) => {
+      const refreshed = deferred<SessionsListResult>();
+      const method =
+        operation === "rename" ? "sessions.groups.rename" : "sessions.groups.delete";
+      const request = vi.fn(async (requestedMethod: string) => {
+        if (requestedMethod === method) {
+          return { groups: [{ name: operation === "rename" ? "Beta" : "Other" }] };
+        }
+        if (requestedMethod === "sessions.list") {
+          return await refreshed.promise;
+        }
+        throw new Error(`Unexpected request: ${requestedMethod}`);
+      });
+      const client = { request } as unknown as GatewayBrowserClient;
+      const { gateway, publish } = createGatewayHarness(client, [method]);
+      const sessions = createSessionCapability(gateway);
+
+      const mutation =
+        operation === "rename"
+          ? sessions.groupsRename("Alpha", "Beta")
+          : sessions.groupsDelete("Alpha");
+      await vi.waitFor(() =>
+        expect(request).toHaveBeenCalledWith("sessions.list", expect.any(Object)),
+      );
+      publish(false);
+      refreshed.resolve(sessionsResult([], 2));
+
+      await expect(mutation).resolves.toBe("completed");
+      sessions.dispose();
+    },
+  );
+
   it("does not probe for a group catalog when the method is explicitly absent", async () => {
     const request = vi.fn();
     const client = { request } as unknown as GatewayBrowserClient;

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -192,6 +192,34 @@ describe("createSessionCapability", () => {
     sessions.dispose();
   });
 
+  it("reports a group rename as stale after a same-client reconnect", async () => {
+    const renamed = deferred<{ groups: Array<{ name: string }> }>();
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.groups.rename") {
+        return await renamed.promise;
+      }
+      if (method === "sessions.subscribe") {
+        return {};
+      }
+      if (method === "sessions.list") {
+        return sessionsResult([], 2);
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { gateway, publish } = createGatewayHarness(client, ["sessions.groups.rename"]);
+    const sessions = createSessionCapability(gateway);
+
+    const operation = sessions.groupsRename("Alpha", "Beta");
+    publish(false);
+    publish(true);
+    renamed.resolve({ groups: [{ name: "Beta" }] });
+
+    await expect(operation).resolves.toBe("stale");
+    expect(sessions.state.groups).toEqual([]);
+    sessions.dispose();
+  });
+
   it("does not probe for a group catalog when the method is explicitly absent", async () => {
     const request = vi.fn();
     const client = { request } as unknown as GatewayBrowserClient;

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -160,6 +160,38 @@ describe("createSessionCapability", () => {
     sessions.dispose();
   });
 
+  it("publishes state.error when group rename is rejected", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.groups.rename") {
+        throw new Error("rename failed");
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { gateway } = createGatewayHarness(client, ["sessions.groups.rename"]);
+    const sessions = createSessionCapability(gateway);
+
+    await expect(sessions.groupsRename("Alpha", "Beta")).rejects.toThrow("rename failed");
+    expect(sessions.state.error).toBe("Error: rename failed");
+    sessions.dispose();
+  });
+
+  it("publishes state.error when group delete is rejected", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.groups.delete") {
+        throw new Error("delete failed");
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { gateway } = createGatewayHarness(client, ["sessions.groups.delete"]);
+    const sessions = createSessionCapability(gateway);
+
+    await expect(sessions.groupsDelete("Alpha")).rejects.toThrow("delete failed");
+    expect(sessions.state.error).toBe("Error: delete failed");
+    sessions.dispose();
+  });
+
   it("does not probe for a group catalog when the method is explicitly absent", async () => {
     const request = vi.fn();
     const client = { request } as unknown as GatewayBrowserClient;

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -224,8 +224,7 @@ describe("createSessionCapability", () => {
     "keeps a confirmed group %s completed when its row refresh outlives the connection",
     async (operation) => {
       const refreshed = deferred<SessionsListResult>();
-      const method =
-        operation === "rename" ? "sessions.groups.rename" : "sessions.groups.delete";
+      const method = operation === "rename" ? "sessions.groups.rename" : "sessions.groups.delete";
       const request = vi.fn(async (requestedMethod: string) => {
         if (requestedMethod === method) {
           return { groups: [{ name: operation === "rename" ? "Beta" : "Other" }] };

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -1007,8 +1007,10 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         return "stale";
       }
       publishGroups(readGroupNames(result));
-      await refresh({ ...lastListOptions, force: true });
-      return isCurrentConnection(scope) ? "completed" : "stale";
+      // The mutation response is the commit point. Reconcile member rows in
+      // the background so a later disconnect cannot downgrade confirmed work.
+      void refresh({ ...lastListOptions, force: true });
+      return "completed";
     } catch (error) {
       if (!isCurrentConnection(scope)) {
         return "stale";
@@ -1029,8 +1031,10 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         return "stale";
       }
       publishGroups(readGroupNames(result));
-      await refresh({ ...lastListOptions, force: true });
-      return isCurrentConnection(scope) ? "completed" : "stale";
+      // See groupsRename: collapsed-state consumers must observe confirmed
+      // completion before an unrelated refresh can outlive the connection.
+      void refresh({ ...lastListOptions, force: true });
+      return "completed";
     } catch (error) {
       if (!isCurrentConnection(scope)) {
         return "stale";

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -62,6 +62,8 @@ export type SessionState = {
   groups: readonly string[];
 };
 
+export type SessionGroupMutationResult = "completed" | "stale";
+
 export type SessionListOptions = {
   agentId?: string;
   activeMinutes?: number;
@@ -240,10 +242,10 @@ export type SessionCapability = {
   groupsLoad: () => Promise<void>;
   /** Replaces the gateway-owned group catalog (order included). */
   groupsPut: (names: readonly string[]) => Promise<void>;
-  /** Renames a group; the gateway repoints member sessions server-side. */
-  groupsRename: (from: string, to: string) => Promise<void>;
-  /** Deletes a group; the gateway clears member categories server-side. */
-  groupsDelete: (name: string) => Promise<void>;
+  /** Renames a group; stale means the initiating connection retired before reconciliation. */
+  groupsRename: (from: string, to: string) => Promise<SessionGroupMutationResult>;
+  /** Deletes a group; stale means the initiating connection retired before reconciliation. */
+  groupsDelete: (name: string) => Promise<SessionGroupMutationResult>;
   subscribeCreated: (listener: (key: string) => void) => () => void;
   subscribe: (listener: (state: SessionState) => void) => () => void;
   dispose: () => void;
@@ -994,42 +996,46 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     }
   };
 
-  const groupsRename = async (from: string, to: string) => {
+  const groupsRename = async (from: string, to: string): Promise<SessionGroupMutationResult> => {
     const scope = captureConnection();
     if (!scope) {
-      return;
+      return "stale";
     }
     try {
       const result = await scope.client.request("sessions.groups.rename", { name: from, to });
       if (!isCurrentConnection(scope)) {
-        return;
+        return "stale";
       }
       publishGroups(readGroupNames(result));
       await refresh({ ...lastListOptions, force: true });
+      return isCurrentConnection(scope) ? "completed" : "stale";
     } catch (error) {
-      if (isCurrentConnection(scope)) {
-        publish({ ...state, error: String(error) });
+      if (!isCurrentConnection(scope)) {
+        return "stale";
       }
+      publish({ ...state, error: String(error) });
       throw error;
     }
   };
 
-  const groupsDelete = async (name: string) => {
+  const groupsDelete = async (name: string): Promise<SessionGroupMutationResult> => {
     const scope = captureConnection();
     if (!scope) {
-      return;
+      return "stale";
     }
     try {
       const result = await scope.client.request("sessions.groups.delete", { name });
       if (!isCurrentConnection(scope)) {
-        return;
+        return "stale";
       }
       publishGroups(readGroupNames(result));
       await refresh({ ...lastListOptions, force: true });
+      return isCurrentConnection(scope) ? "completed" : "stale";
     } catch (error) {
-      if (isCurrentConnection(scope)) {
-        publish({ ...state, error: String(error) });
+      if (!isCurrentConnection(scope)) {
+        return "stale";
       }
+      publish({ ...state, error: String(error) });
       throw error;
     }
   };

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -999,12 +999,19 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     if (!scope) {
       return;
     }
-    const result = await scope.client.request("sessions.groups.rename", { name: from, to });
-    if (!isCurrentConnection(scope)) {
-      return;
+    try {
+      const result = await scope.client.request("sessions.groups.rename", { name: from, to });
+      if (!isCurrentConnection(scope)) {
+        return;
+      }
+      publishGroups(readGroupNames(result));
+      await refresh({ ...lastListOptions, force: true });
+    } catch (error) {
+      if (isCurrentConnection(scope)) {
+        publish({ ...state, error: String(error) });
+      }
+      throw error;
     }
-    publishGroups(readGroupNames(result));
-    await refresh({ ...lastListOptions, force: true });
   };
 
   const groupsDelete = async (name: string) => {
@@ -1012,12 +1019,19 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     if (!scope) {
       return;
     }
-    const result = await scope.client.request("sessions.groups.delete", { name });
-    if (!isCurrentConnection(scope)) {
-      return;
+    try {
+      const result = await scope.client.request("sessions.groups.delete", { name });
+      if (!isCurrentConnection(scope)) {
+        return;
+      }
+      publishGroups(readGroupNames(result));
+      await refresh({ ...lastListOptions, force: true });
+    } catch (error) {
+      if (isCurrentConnection(scope)) {
+        publish({ ...state, error: String(error) });
+      }
+      throw error;
     }
-    publishGroups(readGroupNames(result));
-    await refresh({ ...lastListOptions, force: true });
   };
 
   const patch = async (

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -62,7 +62,7 @@ export type SessionState = {
   groups: readonly string[];
 };
 
-export type SessionGroupMutationResult = "completed" | "stale";
+type SessionGroupMutationResult = "completed" | "stale";
 
 export type SessionListOptions = {
   agentId?: string;


### PR DESCRIPTION
Closes #105974

## What Problem This Solves

Rejected custom-group rename and delete requests left the Gateway catalog unchanged but still rewrote the sidebar's persisted collapsed-group keys. A failed rename could therefore expand the surviving group after reload, while a failed delete could discard its preference entirely.

## Why This Change Was Made

Collapsed-state cleanup ran from `Promise.finally`, so it executed after both successful and rejected RPCs. The sidebar now updates persisted keys only after an explicit completed outcome from the initiating Gateway connection generation. Rejections and completions retired by disconnect/reconnect preserve the existing key byte-for-byte, while the session capability retains current-connection errors for presentation surfaces.

This keeps one authoritative boundary: the Gateway confirms catalog mutations; the sidebar mirrors confirmed results. No new config, migration, protocol, dependency, or compatibility shim.

## User Impact

- Failed rename/delete: the original group and collapsed preference remain intact across reload.
- Successful rename: the collapsed key follows the new group name.
- Successful delete: the obsolete collapsed key is removed.
- A completion from a disconnected, reconnected, or replaced Gateway cannot mutate the new page's browser state.

Sidebar-wide visible mutation feedback remains tracked by #105973; this PR preserves the capability error required by that surface without claiming the dedicated Sessions page automatically displays actions initiated elsewhere.

## Evidence

### Real Gateway reproduction before the fix

Playwright drove the actual Control UI connected to Gateway `2026.7.2` with a real OpenAI-backed disposable session:

1. Created a disposable session and custom group, moved the session into it, and collapsed the group.
2. Renamed the group to a 513-character label so the real Gateway rejected the protocol-invalid request.
3. Observed the server group still present, the original collapsed key missing, the rejected-name key persisted, no danger callout, and one unhandled browser page error.
4. Deleted all disposable session/group/browser state afterward.

### After-fix proof

- Head: `2453ef9fc1a03cd77fb1ad777dd3218abed01471`
- Exact-head real-Gateway proof: Playwright served the CI-built `dist-runtime-build` artifact from run `29250560948` and connected it to the isolated live Gateway `2026.7.2`:
  - Rename rejection: a 513-character target produced a real `INVALID_REQUEST`; the original group stayed visible, its collapsed key stayed present before and after reload, no replacement group appeared, and the browser reported zero page errors.
  - Delete rejection: a temporary SQLite write lock on this disposable Gateway state produced a real `UNAVAILABLE`; the original group and collapsed key stayed present before and after reload with zero page errors. The transaction was rolled back and the lock released immediately after the response.
  - Stale completion: the real Gateway committed a valid rename while Playwright held its response; the application installed a replacement Gateway client before the old response was released. The server contained the renamed group, but the replacement page and a reload retained the original collapsed key and did not add the renamed key. Two WebSocket generations were observed and the browser reported zero page errors.
  - Cleanup: all disposable proof groups were deleted; a direct SQLite count confirmed zero matching rows.
- Sanitized AWS Crabbox on behavior-equivalent head `d0e736169c4406d74d96397664302687bd3407ae` (public network, no Tailscale, no IAM role, no credentials; lease `cbx_12a019d28349` released after proof):
  - [run `run_a68b6eef01a5`](https://crabbox.openclaw.ai/portal/runs/run_a68b6eef01a5): 76/76 targeted capability and AppSidebar unit tests passed. Browser setup then stopped before E2E because the isolated temporary home lacked Chromium system libraries.
  - [run `run_db8c8595a506`](https://crabbox.openclaw.ai/portal/runs/run_db8c8595a506): targeted Chromium Control UI E2E passed 1/1 after installing the required public browser libraries. The rejected rename preserved `category:Research` through reload with no replacement group or page error.
- Exact-tree Blacksmith Testbox proof on lease `tbx_01kxdq2n67txytbz95w3bs0snh` (stopped after validation):
  - 84/84 targeted capability and AppSidebar unit tests passed.
  - 14/14 Chromium session-management E2E tests passed, including rejected rename persistence and same-client reconnect coverage.
  - The production Control UI build, precompressed-asset verification, and performance budgets passed.
  - After applying current `oxfmt`, 28/28 focused capability tests and the complete `check:changed` UI/core-test gate passed, including format, typecheck, and lint.
- Source-blind behavior contract: PASS for all user tasks and anti-cheat probes; target was the secretless browser flow above.
- Exact-head hosted CI: [run 29250560948](https://github.com/openclaw/openclaw/actions/runs/29250560948) completed successfully, including the Control UI, build-artifact, typecheck, lint, contract, QA smoke, and Node test lanes.
- Exact-head full-branch autoreview: no accepted/actionable findings, confidence 0.90.
- Static: targeted `oxfmt`; `git diff --check` clean.

Known proof gaps: sidebar-wide visible mutation feedback is deliberately not claimed here and remains the separately tracked #105973 behavior.

## AI disclosure

The contributor disclosed AI-assisted authorship. Maintainer review corrected the error-surface claim, added stale-connection and browser persistence coverage, and supplied real Gateway reproduction plus isolated after-fix proof.
