### PR TITLE
fix: restore skill experience review CI coverage

### DIFF
--- a/scripts/test-live-shard.mjs
+++ b/scripts/test-live-shard.mjs
@@ -29,6 +29,7 @@ const OPTIONAL_LIVE_SHARD_FILE_ENVS = new Map([
   ["src/agents/subagent-announce.live.test.ts", ["OPENCLAW_LIVE_SUBAGENT_E2E"]],
   ["src/agents/tools/image-tool.ollama.live.test.ts", ["OPENCLAW_LIVE_OLLAMA_IMAGE"]],
   ["src/agents/tools/image-tool.providers.live.test.ts", ["OPENCLAW_LIVE_IMAGE_TOOL_TEST"]],
+  ["src/skills/workshop/experience-review.live.test.ts", ["OPENCLAW_LIVE_SKILL_EXPERIENCE_REVIEW"]],
   ["src/crestodian/rescue-channel.live.test.ts", ["OPENCLAW_LIVE_CRESTODIAN_RESCUE_CHANNEL"]],
   ["src/gateway/android-node.capabilities.live.test.ts", ["OPENCLAW_LIVE_ANDROID_NODE"]],
   ["src/gateway/gateway-acp-bind.live.test.ts", ["OPENCLAW_LIVE_ACP_BIND"]],

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -88,6 +88,9 @@ describe("scripts/test-live-shard", () => {
     expect(selectLiveShardFiles("native-live-src-agents", allFiles)).toContain(
       "src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.live.test.ts",
     );
+    expect(selectLiveShardFiles("native-live-src-agents", allFiles)).toContain(
+      "src/skills/workshop/experience-review.live.test.ts",
+    );
     expect(selectLiveShardFiles("native-live-src-agents-zai-coding", allFiles)).toEqual([
       "src/agents/zai.live.test.ts",
     ]);
@@ -376,6 +379,37 @@ describe("scripts/test-live-shard", () => {
       ok: false,
       reason:
         "Vitest report selected live test files had no passing assertions: src/gateway/gateway-acp-spawn-defaults.live.test.ts",
+    });
+  });
+
+  it("allows the experience review live file to be skipped until its env is enabled", () => {
+    const reviewFile = "src/skills/workshop/experience-review.live.test.ts";
+    const payload = {
+      numPassedTests: 1,
+      numTotalTests: 2,
+      testResults: [
+        {
+          name: path.join(process.cwd(), "src/agents/openai-reasoning-compat.live.test.ts"),
+          assertionResults: [{ status: "passed" }],
+        },
+        {
+          name: path.join(process.cwd(), reviewFile),
+          assertionResults: [{ status: "skipped" }],
+        },
+      ],
+    };
+    const expectedFiles = ["src/agents/openai-reasoning-compat.live.test.ts", reviewFile];
+
+    expect(validateLiveShardReportPayload(payload, expectedFiles, process.cwd(), {})).toEqual({
+      ok: true,
+    });
+    expect(
+      validateLiveShardReportPayload(payload, expectedFiles, process.cwd(), {
+        OPENCLAW_LIVE_SKILL_EXPERIENCE_REVIEW: "1",
+      }),
+    ).toEqual({
+      ok: false,
+      reason: `Vitest report selected live test files had no passing assertions: ${reviewFile}`,
     });
   });
 


### PR DESCRIPTION
Related: #105674

## What Problem This Solves

The release live-test shard now selects the Skill Workshop experience-review test, but its report validator treated the intentionally skipped opt-in test as a failed required test whenever `OPENCLAW_LIVE_SKILL_EXPERIENCE_REVIEW` was not enabled.

## Why This Change Was Made

Registers the experience-review file with its existing opt-in environment variable. Regression coverage verifies both halves of the contract: the file remains assigned to the release shard, is allowed to skip while the opt-in is absent, and must pass once the opt-in is enabled.

## User Impact

No runtime behavior change. Release validation can include all Skill live tests without failing on a deliberately disabled experience-review evaluation, while still requiring real passing proof when that evaluation is enabled.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/test-live-shard.test.ts` — 21/21 passed
- `node scripts/check-deadcode-exports.mjs` — baseline matched 4,076 entries
- `node_modules/.bin/oxfmt --check scripts/test-live-shard.mjs test/scripts/test-live-shard.test.ts` — clean
- `git diff --check` — clean
- Fresh autoreview after the accepted selector finding: clean, no accepted or actionable findings (0.94 confidence)
- Blacksmith delegated leases completed before accepting the command; exact hosted CI is the remaining proof gate
