### PR TITLE
fix(ci): register experience review live opt-in

### DIFF
--- a/scripts/test-live-shard.mjs
+++ b/scripts/test-live-shard.mjs
@@ -38,6 +38,10 @@ const OPTIONAL_LIVE_SHARD_FILE_ENVS = new Map([
   ["src/gateway/gateway-codex-harness.live.test.ts", ["OPENCLAW_LIVE_CODEX_HARNESS"]],
   ["src/gateway/gateway-trajectory-export.live.test.ts", ["OPENCLAW_LIVE_CODEX_HARNESS"]],
   ["src/infra/push-apns-http2.live.test.ts", ["OPENCLAW_LIVE_APNS_REACHABILITY"]],
+  [
+    "src/skills/workshop/experience-review.live.test.ts",
+    ["OPENCLAW_LIVE_SKILL_EXPERIENCE_REVIEW"],
+  ],
   ["test/image-generation.infer-cli.live.test.ts", ["OPENCLAW_LIVE_INFER_CLI_TEST"]],
 ]);
 const SKIPPED_ASSERTION_STATUSES = new Set(["disabled", "pending", "skipped", "todo"]);

--- a/scripts/test-live-shard.mjs
+++ b/scripts/test-live-shard.mjs
@@ -38,10 +38,7 @@ const OPTIONAL_LIVE_SHARD_FILE_ENVS = new Map([
   ["src/gateway/gateway-codex-harness.live.test.ts", ["OPENCLAW_LIVE_CODEX_HARNESS"]],
   ["src/gateway/gateway-trajectory-export.live.test.ts", ["OPENCLAW_LIVE_CODEX_HARNESS"]],
   ["src/infra/push-apns-http2.live.test.ts", ["OPENCLAW_LIVE_APNS_REACHABILITY"]],
-  [
-    "src/skills/workshop/experience-review.live.test.ts",
-    ["OPENCLAW_LIVE_SKILL_EXPERIENCE_REVIEW"],
-  ],
+  ["src/skills/workshop/experience-review.live.test.ts", ["OPENCLAW_LIVE_SKILL_EXPERIENCE_REVIEW"]],
   ["test/image-generation.infer-cli.live.test.ts", ["OPENCLAW_LIVE_INFER_CLI_TEST"]],
 ]);
 const SKIPPED_ASSERTION_STATUSES = new Set(["disabled", "pending", "skipped", "todo"]);

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -325,10 +325,7 @@ describe("scripts/test-live-shard", () => {
           assertionResults: [{ status: "skipped" }],
         },
         {
-          name: path.join(
-            process.cwd(),
-            "src/skills/workshop/experience-review.live.test.ts",
-          ),
+          name: path.join(process.cwd(), "src/skills/workshop/experience-review.live.test.ts"),
           assertionResults: [{ status: "skipped" }],
         },
       ],

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -314,7 +314,7 @@ describe("scripts/test-live-shard", () => {
   it("allows explicitly opt-in live shard files to be skipped until their env is enabled", () => {
     const payload = {
       numPassedTests: 1,
-      numTotalTests: 2,
+      numTotalTests: 3,
       testResults: [
         {
           name: path.join(process.cwd(), "src/gateway/gateway-codex-harness.live.test.ts"),
@@ -324,11 +324,19 @@ describe("scripts/test-live-shard", () => {
           name: path.join(process.cwd(), "src/gateway/gateway-cli-backend.live.test.ts"),
           assertionResults: [{ status: "skipped" }],
         },
+        {
+          name: path.join(
+            process.cwd(),
+            "src/skills/workshop/experience-review.live.test.ts",
+          ),
+          assertionResults: [{ status: "skipped" }],
+        },
       ],
     };
     const expectedFiles = [
       "src/gateway/gateway-codex-harness.live.test.ts",
       "src/gateway/gateway-cli-backend.live.test.ts",
+      "src/skills/workshop/experience-review.live.test.ts",
     ];
 
     expect(validateLiveShardReportPayload(payload, expectedFiles, process.cwd(), {})).toEqual({
@@ -342,6 +350,15 @@ describe("scripts/test-live-shard", () => {
       ok: false,
       reason:
         "Vitest report selected live test files had no passing assertions: src/gateway/gateway-cli-backend.live.test.ts",
+    });
+    expect(
+      validateLiveShardReportPayload(payload, expectedFiles, process.cwd(), {
+        OPENCLAW_LIVE_SKILL_EXPERIENCE_REVIEW: "1",
+      }),
+    ).toEqual({
+      ok: false,
+      reason:
+        "Vitest report selected live test files had no passing assertions: src/skills/workshop/experience-review.live.test.ts",
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

The current `main` repair routes `src/skills/workshop/experience-review.live.test.ts` into the release `native-live-src-agents` shard, but the shard runner does not know that this eval is opt-in. Without its env flag, Vitest reports the file as skipped and live-shard evidence validation rejects the release run.

## Why This Change Was Made

Register the file in `OPTIONAL_LIVE_SHARD_FILE_ENVS` with `OPENCLAW_LIVE_SKILL_EXPERIENCE_REVIEW`. Extend the existing validator test to prove the skipped file is accepted when disabled and rejected when the opt-in is explicitly enabled without passing assertions.

## User Impact

Release live validation can run the native agent shard without enabling the OpenAI-backed experience-review eval, while still requiring real passing evidence whenever that eval is enabled.

## Evidence

- `node --check scripts/test-live-shard.mjs` — passed
- `node scripts/test-live-shard.mjs native-live-src-agents --list` — includes the experience-review live test
- `git diff --check` — passed
- Fresh autoreview — clean, no accepted/actionable findings
- Blacksmith Testbox unavailable: gitmon returned HTTP 429
- Linked-worktree Vitest fallback unavailable: `node_modules` is not installed; exact hosted PR CI is the acceptance gate
