### PR TITLE
fix(ui): stop Workboard sidebar E2E timeout

### DIFF
--- a/ui/src/pages/plugins/plugins.e2e.test.ts
+++ b/ui/src/pages/plugins/plugins.e2e.test.ts
@@ -515,7 +515,11 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       if ((await moreButton.getAttribute("aria-expanded")) !== "true") {
         await moreButton.click();
       }
-      await sidebar.getByRole("link", { name: "Workboard" }).waitFor({ state: "visible" });
+      const workboardMenuItem = sidebar
+        .getByRole("menu", { exact: true, name: "More" })
+        .getByRole("menuitem", { exact: true, name: "Workboard" });
+      await workboardMenuItem.waitFor({ state: "visible" });
+      expect(await workboardMenuItem.getAttribute("href")).toBe("/workboard");
     } finally {
       await context.close();
     }


### PR DESCRIPTION
## What Problem This Solves

Related: #105906

The Plugins Control UI E2E timed out after enabling Workboard because its final sidebar assertion still queried the unpinned route as a `link`. The More-menu refactor intentionally exposes those routes as `menuitem` elements, so Playwright could no longer match the old role even though Workboard was rendered correctly.

## Why This Change Was Made

Scope the assertion to the open More menu, locate Workboard by its current `menuitem` accessibility role, and verify that it still targets `/workboard`.

The product state flow remains correct: enabling the plugin refreshes authoritative config, Workboard enters the enabled route set, and the sidebar renders it in the More menu. Changing runtime markup or reverting the menu role would conflict with the current accessible menu contract and the sibling sidebar E2E coverage, so the stale test locator is the right repair surface.

## User Impact

No runtime behavior change. Restores regression coverage for enabling Workboard and finding its sidebar destination after the More-menu refactor.

## Evidence

- Before: `ui/src/pages/plugins/plugins.e2e.test.ts` failed on main at the final `getByRole("link", { name: "Workboard" })` assertion with a 30-second timeout.
- After: fresh Blacksmith Testbox on patch-identical pre-sync head tree `871ff5e6a96d` passes the focused UI E2E: 1 file, 3 tests.
- Final verified PR head `4faea1043b4e` is the same one-file patch synced cleanly onto current `main`.
- `pnpm check:changed`: passes on the tree-identical clean local rebase lineage.
- Autoreview on that clean local rebase commit: clean, no accepted/actionable findings.
- Pre-sync exact-head release gate: 116/117 jobs passed. The sole failure is the unrelated `MacNodeModeCoordinatorTests.swift` worker-restart timeout, reproduced after a failed-job rerun and identically present on `main` ancestor `1eb3956`; that macOS surface is unchanged between the baseline commit and current `main`.
- AI-assisted: yes.
