### PR TITLE
fix(ci): preserve default live-shard proof for opt-in skill review

### DIFF
--- a/scripts/test-live-shard.mjs
+++ b/scripts/test-live-shard.mjs
@@ -38,6 +38,7 @@ const OPTIONAL_LIVE_SHARD_FILE_ENVS = new Map([
   ["src/gateway/gateway-codex-harness.live.test.ts", ["OPENCLAW_LIVE_CODEX_HARNESS"]],
   ["src/gateway/gateway-trajectory-export.live.test.ts", ["OPENCLAW_LIVE_CODEX_HARNESS"]],
   ["src/infra/push-apns-http2.live.test.ts", ["OPENCLAW_LIVE_APNS_REACHABILITY"]],
+  ["src/skills/workshop/experience-review.live.test.ts", ["OPENCLAW_LIVE_SKILL_EXPERIENCE_REVIEW"]],
   ["test/image-generation.infer-cli.live.test.ts", ["OPENCLAW_LIVE_INFER_CLI_TEST"]],
 ]);
 const SKIPPED_ASSERTION_STATUSES = new Set(["disabled", "pending", "skipped", "todo"]);

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -345,6 +345,38 @@ describe("scripts/test-live-shard", () => {
     });
   });
 
+  it("treats the skill experience review as opt-in release proof", () => {
+    const skillReviewFile = "src/skills/workshop/experience-review.live.test.ts";
+    const payload = {
+      numPassedTests: 1,
+      numTotalTests: 2,
+      testResults: [
+        {
+          name: path.join(process.cwd(), "src/agents/openai-reasoning-compat.live.test.ts"),
+          assertionResults: [{ status: "passed" }],
+        },
+        {
+          name: path.join(process.cwd(), skillReviewFile),
+          assertionResults: [{ status: "skipped" }],
+        },
+      ],
+    };
+    const expectedFiles = ["src/agents/openai-reasoning-compat.live.test.ts", skillReviewFile];
+
+    expect(validateLiveShardReportPayload(payload, expectedFiles, process.cwd(), {})).toEqual({
+      ok: true,
+    });
+    expect(
+      validateLiveShardReportPayload(payload, expectedFiles, process.cwd(), {
+        OPENCLAW_LIVE_SKILL_EXPERIENCE_REVIEW: "1",
+      }),
+    ).toEqual({
+      ok: false,
+      reason:
+        "Vitest report selected live test files had no passing assertions: src/skills/workshop/experience-review.live.test.ts",
+    });
+  });
+
   it("allows gateway core opt-in live files to be skipped until their env is enabled", () => {
     const payload = {
       numPassedTests: 1,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the default `native-live-src-agents` release proof would fail after the opt-in skill experience review test joined that shard, because the disabled test was treated as missing passing evidence.

## Why This Change Was Made

Registers the skill experience review test with its existing `OPENCLAW_LIVE_SKILL_EXPERIENCE_REVIEW` opt-in and adds regression coverage for both disabled and enabled validation. The broader experience-review CI failures were fixed directly on `main`; this PR now contains only the remaining live-proof invariant.

## User Impact

No product behavior change. Default release live-shard validation can run without the optional OpenAI skill-review evaluation, while explicitly enabled runs still require it to pass.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/test-live-shard.test.ts` — 21/21 passed.
- Targeted `oxfmt --check` — passed.
- Fresh autoreview — no accepted/actionable findings; correctness confidence 0.98.
- Blacksmith Testbox warmup was unavailable because GitHub returned HTTP 502 fetching the workflow; the repo-approved narrow local fallback was used.
