### PR TITLE
fix(gateway): avoid error logs for superseded config reloads

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -2210,6 +2210,33 @@ describe("startGatewayConfigReloader", () => {
     }
   });
 
+  it("logs expected restart supersession without reporting a reload failure", async () => {
+    const snapshot = makeSnapshot({
+      config: {
+        gateway: { reload: { debounceMs: 0 }, port: 18790 },
+      },
+      hash: "restart-superseded-1",
+    });
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValue(snapshot);
+    const { watcher, onRestart, log, reloader } = createReloaderHarness(readSnapshot);
+    const superseded = new Error("config reload superseded by a newer runtime config source");
+    superseded.name = "GatewayConfigReloadSupersededError";
+    onRestart.mockRejectedValueOnce(superseded);
+
+    watcher.emit("change");
+    await vi.runAllTimersAsync();
+
+    expect(log.info).toHaveBeenCalledWith(
+      "config restart superseded: GatewayConfigReloadSupersededError: config reload superseded by a newer runtime config source",
+    );
+    expect(log.info).toHaveBeenCalledWith(
+      "config reload superseded: GatewayConfigReloadSupersededError: config reload superseded by a newer runtime config source",
+    );
+    expect(log.error).not.toHaveBeenCalled();
+
+    await reloader.stop();
+  });
+
   it("skips invalid external config edits without recovery", async () => {
     const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
       makeSnapshot({

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -156,6 +156,10 @@ class GatewayConfigReloadSupersededError extends Error {
   }
 }
 
+function isGatewayConfigReloadSupersededError(error: unknown): boolean {
+  return error instanceof Error && error.name === "GatewayConfigReloadSupersededError";
+}
+
 function asPluginInstallConfig(records: PluginInstallRecords): OpenClawConfig {
   return {
     plugins: {
@@ -311,7 +315,11 @@ export function startGatewayConfigReloader(opts: {
       // transaction. Only downstream signal delivery may coalesce.
       await opts.onRestart(plan, nextConfig, ownership, sourceConfig);
     } catch (err) {
-      opts.log.error(`config restart failed: ${String(err)}`);
+      if (isGatewayConfigReloadSupersededError(err)) {
+        opts.log.info(`config restart superseded: ${String(err)}`);
+      } else {
+        opts.log.error(`config restart failed: ${String(err)}`);
+      }
       // Failed restart admission must reject the transaction. Otherwise the
       // persisted snapshot becomes the baseline and the same config cannot retry.
       throw err;
@@ -855,7 +863,11 @@ export function startGatewayConfigReloader(opts: {
         await promoteAcceptedSnapshot(snapshot, "valid-config");
       });
     } catch (err) {
-      opts.log.error(`config reload failed: ${String(err)}`);
+      if (isGatewayConfigReloadSupersededError(err)) {
+        opts.log.info(`config reload superseded: ${String(err)}`);
+      } else {
+        opts.log.error(`config reload failed: ${String(err)}`);
+      }
     } finally {
       running = false;
       if (pending) {

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -4043,8 +4043,8 @@ describe("gateway Gmail hot reload handlers", () => {
 
     expect(harness.requestRecoveryRestart).not.toHaveBeenCalled();
     expect(harness.promoteSnapshot).not.toHaveBeenCalled();
-    expect(harness.logReload.error).toHaveBeenCalledWith(
-      "config restart failed: GatewayConfigReloadSupersededError: config reload superseded by a newer runtime config source",
+    expect(harness.logReload.info).toHaveBeenCalledWith(
+      "config restart superseded: GatewayConfigReloadSupersededError: config reload superseded by a newer runtime config source",
     );
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators would see an error-level Gateway log when a config reload was normally superseded by a newer config source.

## Why This Change Was Made

Expected reload supersession now logs at info level at both the restart and outer reload boundaries. Other reload and restart failures remain error-level and preserve existing retry behavior.

## User Impact

Routine config supersession no longer produces a false operational error.

## Evidence

- Blacksmith Testbox: 752 focused tests passed across the config reloader and server reload handler suites.
- Focused format check passed for all three changed files.
- Autoreview clean with no accepted or actionable findings.
