### PR TITLE
fix(ui): retry groups hydration after transient sessions.groups.list rejection [AI-assisted]

### DIFF
--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -737,4 +737,34 @@ describe("createSessionCapability", () => {
     expect(request).toHaveBeenCalledTimes(2);
     sessions.dispose();
   });
+
+  it("retries groups hydration after a transient sessions.groups.list rejection", async () => {
+    // Regression for #106141: a transient sessions.groups.list rejection must
+    // not be latched as "loaded" for the connection - a later groupsLoad() on
+    // the same connection should retry and publish the authoritative groups.
+    let groupsListCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.groups.list") {
+        groupsListCalls += 1;
+        if (groupsListCalls === 1) {
+          throw new Error("transient groups list failure");
+        }
+        return { groups: [{ name: "Alpha" }, { name: "Beta" }] };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { gateway } = createGatewayHarness(client);
+    const sessions = createSessionCapability(gateway);
+
+    // First load: RPC rejects transiently. groups stay empty.
+    await sessions.groupsLoad();
+    expect(sessions.state.groups).toEqual([]);
+
+    // Second load on the same connection: should retry, not short-circuit.
+    await sessions.groupsLoad();
+    expect(sessions.state.groups).toEqual(["Alpha", "Beta"]);
+    expect(groupsListCalls).toBe(2);
+    sessions.dispose();
+  });
 });

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -877,11 +877,11 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     }
   };
 
-  const loadGroups = async (scope: SessionConnectionScope) => {
+  const loadGroups = async (scope: SessionConnectionScope): Promise<boolean> => {
     try {
       const listed = await scope.client.request("sessions.groups.list", {});
       if (!isCurrentConnection(scope)) {
-        return;
+        return false;
       }
       let names = readGroupNames(listed);
       // One-time migration: browser-local catalogs predate the gateway store.
@@ -889,7 +889,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       if (names.length === 0 && legacy.length > 0) {
         const put = await scope.client.request("sessions.groups.put", { names: legacy });
         if (!isCurrentConnection(scope)) {
-          return;
+          return false;
         }
         names = readGroupNames(put);
       }
@@ -901,8 +901,12 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         }
       }
       publishGroups(names);
+      return true;
     } catch {
       // Older gateways without the groups RPC keep observed-category grouping.
+      // A transient rejection (gateway advertises sessions.groups.list but the
+      // call failed) must stay retryable, so do not record a loaded epoch here.
+      return false;
     }
   };
 
@@ -912,8 +916,11 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     if (!scope || groupsLoadedEpoch === scope.epoch) {
       return;
     }
-    groupsLoadedEpoch = scope.epoch;
-    await loadGroups(scope);
+    // Only mark the connection's groups as loaded once the catalog hydration
+    // succeeds; a transient rejection stays retryable on the next call.
+    if (await loadGroups(scope)) {
+      groupsLoadedEpoch = scope.epoch;
+    }
   };
 
   const groupsPut = async (names: readonly string[]) => {


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

Closes #106141

## What Problem This Solves

Fixes an issue where a transient `sessions.groups.list` rejection is latched as a successful load for the entire Control UI connection, so the gateway-owned custom session group catalog stays empty (groups and their move targets disappear, catalog ordering falls back to row-discovered categories) until reconnect or an external group mutation resets the epoch.

## Why This Change Was Made

`groupsLoad()` marked the connection epoch as loaded (`groupsLoadedEpoch = scope.epoch`) **before** awaiting `loadGroups()`, and `loadGroups()` caught every rejection silently. So when the first `sessions.groups.list` call failed transiently, the epoch was already recorded as loaded and every later `groupsLoad()` on the same connection short-circuited at the `groupsLoadedEpoch === scope.epoch` guard without sending another request.

The fix records the loaded epoch only after `loadGroups()` succeeds. `loadGroups()` now returns a `boolean` (`true` once `publishGroups(names)` has run, `false` on any rejection or when the connection is no longer current), and `groupsLoad()` sets `groupsLoadedEpoch` only when it returns `true`. A transient rejection leaves the epoch unset, so the next `groupsLoad()` retries the catalog hydration and publishes the authoritative groups.

The change is local to the `groupsLoad`/`loadGroups` pair in `ui/src/lib/sessions/index.ts`; the public `groupsLoad()` contract, the legacy browser-local catalog migration, and the `groupsPut`/`groupsDelete` paths are unchanged.

## User Impact

Control UI users whose first group-catalog hydration hits a transient failure now see their custom session groups appear on the next sidebar sync, instead of an empty catalog for the rest of the connection. Gateways that do not advertise `sessions.groups.list` keep the prior observed-category grouping behavior.

## Evidence

Regression test in `ui/src/lib/sessions/index.test.ts` (`retries groups hydration after a transient sessions.groups.list rejection`): it drives the real `createSessionCapability` with a mock `client.request` whose first `sessions.groups.list` call rejects with a transient error and whose second returns `{ groups: [{ name: "Alpha" }, { name: "Beta" }] }`, then calls `sessions.groupsLoad()` twice. The test fails on `main` and passes with the fix (failing-first).

**Before fix (current `main`)** - the first `groupsLoad()` rejects transiently but records the epoch as loaded, so the second `groupsLoad()` short-circuits and never sends a second RPC; `state.groups` stays empty:

```
await sessions.groupsLoad();   // first call: RPC rejects transiently, epoch marked loaded
expect(sessions.state.groups).toEqual([]);   // passes (still empty)

await sessions.groupsLoad();   // second call: short-circuits at epoch guard, no RPC sent
expect(sessions.state.groups).toEqual(["Alpha", "Beta"]);
// AssertionError: expected [] to deeply equal [ "Alpha", "Beta" ]
// groupsListCalls === 1 (second call never sent the RPC)
```

**After fix** - the epoch is recorded only on success, so the second `groupsLoad()` retries the RPC and publishes the groups:

```
await sessions.groupsLoad();   // first call: RPC rejects transiently, epoch NOT marked
expect(sessions.state.groups).toEqual([]);   // passes (still empty)

await sessions.groupsLoad();   // second call: retries RPC, succeeds
expect(sessions.state.groups).toEqual(["Alpha", "Beta"]);   // passes
expect(groupsListCalls).toBe(2);   // second RPC was sent
```

Local verification:

- `node scripts/run-vitest.mjs ui/src/lib/sessions/index.test.ts` - 18/18 pass (1 new regression test fails on `main`, passes after the fix; 17 existing tests unchanged).
- `oxlint` + `oxfmt --check` on changed files - pass.
- `pnpm tsgo:ui` (UI prod types) + `pnpm tsgo:test:ui` (UI test types) - pass.

Not tested: the live Control UI in a browser against a real gateway (the proof drives the real `createSessionCapability` session store directly with a mock gateway client, exercising the exact `groupsLoad` -> `loadGroups` -> `sessions.groups.list` path the issue describes; no browser or live gateway is involved in this state transition).
