### PR TITLE
refactor(ui): align plugin filter chips with the hub tab strip

### DIFF
--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:04:09.156Z",
+  "generatedAt": "2026-07-13T15:00:03.071Z",
   "locale": "ar",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:03:54.991Z",
+  "generatedAt": "2026-07-13T15:00:00.793Z",
   "locale": "de",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:03:56.815Z",
+  "generatedAt": "2026-07-13T15:00:01.149Z",
   "locale": "es",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:04:31.897Z",
+  "generatedAt": "2026-07-13T15:00:05.921Z",
   "locale": "fa",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:04:03.646Z",
+  "generatedAt": "2026-07-13T15:00:02.336Z",
   "locale": "fr",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/hi.meta.json
+++ b/ui/src/i18n/.i18n/hi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:04:07.008Z",
+  "generatedAt": "2026-07-13T15:00:02.722Z",
   "locale": "hi",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:04:19.573Z",
+  "generatedAt": "2026-07-13T15:00:04.449Z",
   "locale": "id",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:04:12.681Z",
+  "generatedAt": "2026-07-13T15:00:03.516Z",
   "locale": "it",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:03:58.809Z",
+  "generatedAt": "2026-07-13T15:00:01.552Z",
   "locale": "ja-JP",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:04:01.608Z",
+  "generatedAt": "2026-07-13T15:00:01.896Z",
   "locale": "ko",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:04:28.960Z",
+  "generatedAt": "2026-07-13T15:00:05.655Z",
   "locale": "nl",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:04:21.543Z",
+  "generatedAt": "2026-07-13T15:00:04.801Z",
   "locale": "pl",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:03:53.069Z",
+  "generatedAt": "2026-07-13T15:00:00.321Z",
   "locale": "pt-BR",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ru.meta.json
+++ b/ui/src/i18n/.i18n/ru.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:04:33.986Z",
+  "generatedAt": "2026-07-13T15:00:06.340Z",
   "locale": "ru",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:04:23.414Z",
+  "generatedAt": "2026-07-13T15:00:05.119Z",
   "locale": "th",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:04:15.640Z",
+  "generatedAt": "2026-07-13T15:00:03.828Z",
   "locale": "tr",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:04:17.752Z",
+  "generatedAt": "2026-07-13T15:00:04.131Z",
   "locale": "uk",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:04:25.712Z",
+  "generatedAt": "2026-07-13T15:00:05.416Z",
   "locale": "vi",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:03:49.381Z",
+  "generatedAt": "2026-07-13T14:59:58.949Z",
   "locale": "zh-CN",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T13:03:51.239Z",
+  "generatedAt": "2026-07-13T14:59:59.835Z",
   "locale": "zh-TW",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "25fdb9fb6a03b9783294692e789b6f9542ee14c288b260214e83ff01aa7034f8",
-  "totalKeys": 3133,
-  "translatedKeys": 3133,
+  "sourceHash": "cdc7191e32cd9df9a33a9ecb0051af6232b7ce85db254b19d30413a82967de11",
+  "totalKeys": 3132,
+  "translatedKeys": 3132,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -1742,7 +1742,6 @@ export const ar: TranslationMap = {
     filterAll: "الكل",
     filterIssues: "المشكلات",
     filterLabel: "تصفية المكونات الإضافية المثبتة",
-    pulseLabel: "{enabled} مفعّل، {disabled} معطّل، {issues} به مشكلات",
     categoryChannels: "القنوات",
     categoryProviders: "موفرو النماذج",
     categoryMemory: "الذاكرة",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -1770,7 +1770,6 @@ export const de: TranslationMap = {
     filterAll: "Alle",
     filterIssues: "Probleme",
     filterLabel: "Installierte Plugins filtern",
-    pulseLabel: "{enabled} aktiviert, {disabled} deaktiviert, {issues} mit Problemen",
     categoryChannels: "Kanäle",
     categoryProviders: "Modellanbieter",
     categoryMemory: "Speicher",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1715,7 +1715,6 @@ export const en: TranslationMap = {
     filterAll: "All",
     filterIssues: "Issues",
     filterLabel: "Filter installed plugins",
-    pulseLabel: "{enabled} enabled, {disabled} disabled, {issues} with issues",
     categoryChannels: "Channels",
     categoryProviders: "Model providers",
     categoryMemory: "Memory",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -1770,7 +1770,6 @@ export const es: TranslationMap = {
     filterAll: "Todos",
     filterIssues: "Problemas",
     filterLabel: "Filtrar plugins instalados",
-    pulseLabel: "{enabled} habilitados, {disabled} deshabilitados, {issues} con problemas",
     categoryChannels: "Canales",
     categoryProviders: "Proveedores de modelos",
     categoryMemory: "Memoria",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -1748,7 +1748,6 @@ export const fa: TranslationMap = {
     filterAll: "همه",
     filterIssues: "مشکلات",
     filterLabel: "فیلتر کردن افزونه‌های نصب‌شده",
-    pulseLabel: "{enabled} فعال، {disabled} غیرفعال، {issues} دارای مشکل",
     categoryChannels: "کانال‌ها",
     categoryProviders: "ارائه‌دهندگان مدل",
     categoryMemory: "حافظه",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -1780,7 +1780,6 @@ export const fr: TranslationMap = {
     filterAll: "Tous",
     filterIssues: "Problèmes",
     filterLabel: "Filtrer les plugins installés",
-    pulseLabel: "{enabled} activés, {disabled} désactivés, {issues} avec des problèmes",
     categoryChannels: "Canaux",
     categoryProviders: "Fournisseurs de modèles",
     categoryMemory: "Mémoire",

--- a/ui/src/i18n/locales/hi.ts
+++ b/ui/src/i18n/locales/hi.ts
@@ -1739,7 +1739,6 @@ export const hi: TranslationMap = {
     filterAll: "सभी",
     filterIssues: "समस्याएँ",
     filterLabel: "इंस्टॉल किए गए प्लगइन्स फ़िल्टर करें",
-    pulseLabel: "{enabled} सक्षम, {disabled} अक्षम, {issues} में समस्याएँ",
     categoryChannels: "चैनल",
     categoryProviders: "मॉडल प्रदाता",
     categoryMemory: "मेमोरी",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -1752,7 +1752,6 @@ export const id: TranslationMap = {
     filterAll: "Semua",
     filterIssues: "Masalah",
     filterLabel: "Filter plugin terinstal",
-    pulseLabel: "{enabled} diaktifkan, {disabled} dinonaktifkan, {issues} bermasalah",
     categoryChannels: "Saluran",
     categoryProviders: "Penyedia model",
     categoryMemory: "Memori",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -1773,7 +1773,6 @@ export const it: TranslationMap = {
     filterAll: "Tutti",
     filterIssues: "Problemi",
     filterLabel: "Filtra i plugin installati",
-    pulseLabel: "{enabled} abilitati, {disabled} disabilitati, {issues} con problemi",
     categoryChannels: "Canali",
     categoryProviders: "Provider di modelli",
     categoryMemory: "Memoria",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -1760,7 +1760,6 @@ export const ja_JP: TranslationMap = {
     filterAll: "すべて",
     filterIssues: "問題",
     filterLabel: "インストール済みプラグインをフィルター",
-    pulseLabel: "有効 {enabled} 件、無効 {disabled} 件、問題あり {issues} 件",
     categoryChannels: "チャンネル",
     categoryProviders: "モデルプロバイダー",
     categoryMemory: "メモリ",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -1745,7 +1745,6 @@ export const ko: TranslationMap = {
     filterAll: "전체",
     filterIssues: "문제",
     filterLabel: "설치된 플러그인 필터링",
-    pulseLabel: "활성화 {enabled}개, 비활성화 {disabled}개, 문제 있음 {issues}개",
     categoryChannels: "채널",
     categoryProviders: "모델 제공업체",
     categoryMemory: "메모리",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -1758,7 +1758,6 @@ export const nl: TranslationMap = {
     filterAll: "Alle",
     filterIssues: "Problemen",
     filterLabel: "Geïnstalleerde plugins filteren",
-    pulseLabel: "{enabled} ingeschakeld, {disabled} uitgeschakeld, {issues} met problemen",
     categoryChannels: "Kanalen",
     categoryProviders: "Modelproviders",
     categoryMemory: "Geheugen",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -1762,7 +1762,6 @@ export const pl: TranslationMap = {
     filterAll: "Wszystkie",
     filterIssues: "Problemy",
     filterLabel: "Filtruj zainstalowane wtyczki",
-    pulseLabel: "{enabled} włączone, {disabled} wyłączone, {issues} z problemami",
     categoryChannels: "Kanały",
     categoryProviders: "Dostawcy modeli",
     categoryMemory: "Pamięć",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -1754,7 +1754,6 @@ export const pt_BR: TranslationMap = {
     filterAll: "Todos",
     filterIssues: "Problemas",
     filterLabel: "Filtrar plugins instalados",
-    pulseLabel: "{enabled} habilitados, {disabled} desabilitados, {issues} com problemas",
     categoryChannels: "Canais",
     categoryProviders: "Provedores de modelo",
     categoryMemory: "Memória",

--- a/ui/src/i18n/locales/ru.ts
+++ b/ui/src/i18n/locales/ru.ts
@@ -1770,7 +1770,6 @@ export const ru: TranslationMap = {
     filterAll: "Все",
     filterIssues: "Проблемы",
     filterLabel: "Фильтр установленных плагинов",
-    pulseLabel: "{enabled} включено, {disabled} отключено, {issues} с проблемами",
     categoryChannels: "Каналы",
     categoryProviders: "Поставщики моделей",
     categoryMemory: "Память",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -1730,7 +1730,6 @@ export const th: TranslationMap = {
     filterAll: "ทั้งหมด",
     filterIssues: "ปัญหา",
     filterLabel: "กรองปลั๊กอินที่ติดตั้ง",
-    pulseLabel: "เปิดใช้งาน {enabled} รายการ, ปิดใช้งาน {disabled} รายการ, มีปัญหา {issues} รายการ",
     categoryChannels: "ช่องทาง",
     categoryProviders: "ผู้ให้บริการโมเดล",
     categoryMemory: "หน่วยความจำ",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -1767,7 +1767,6 @@ export const tr: TranslationMap = {
     filterAll: "Tümü",
     filterIssues: "Sorunlar",
     filterLabel: "Yüklü eklentileri filtrele",
-    pulseLabel: "{enabled} etkin, {disabled} devre dışı, {issues} sorunlu",
     categoryChannels: "Kanallar",
     categoryProviders: "Model sağlayıcıları",
     categoryMemory: "Bellek",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -1763,7 +1763,6 @@ export const uk: TranslationMap = {
     filterAll: "Усі",
     filterIssues: "Проблеми",
     filterLabel: "Фільтрувати встановлені плагіни",
-    pulseLabel: "{enabled} увімкнено, {disabled} вимкнено, {issues} з проблемами",
     categoryChannels: "Канали",
     categoryProviders: "Постачальники моделей",
     categoryMemory: "Пам’ять",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -1754,7 +1754,6 @@ export const vi: TranslationMap = {
     filterAll: "Tất cả",
     filterIssues: "Sự cố",
     filterLabel: "Lọc plugin đã cài đặt",
-    pulseLabel: "{enabled} đã bật, {disabled} đã tắt, {issues} có sự cố",
     categoryChannels: "Kênh",
     categoryProviders: "Nhà cung cấp mô hình",
     categoryMemory: "Bộ nhớ",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -1723,7 +1723,6 @@ export const zh_CN: TranslationMap = {
     filterAll: "全部",
     filterIssues: "问题",
     filterLabel: "筛选已安装插件",
-    pulseLabel: "{enabled} 个已启用，{disabled} 个已禁用，{issues} 个存在问题",
     categoryChannels: "渠道",
     categoryProviders: "模型提供商",
     categoryMemory: "记忆",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -1726,7 +1726,6 @@ export const zh_TW: TranslationMap = {
     filterAll: "全部",
     filterIssues: "問題",
     filterLabel: "篩選已安裝的外掛",
-    pulseLabel: "{enabled} 個已啟用，{disabled} 個已停用，{issues} 個有問題",
     categoryChannels: "頻道",
     categoryProviders: "模型供應商",
     categoryMemory: "記憶體",

--- a/ui/src/pages/plugins/view.test.ts
+++ b/ui/src/pages/plugins/view.test.ts
@@ -138,11 +138,10 @@ describe("renderPlugins", () => {
     expect(groups.map((group) => group.label)).toEqual(["Channels", "Tools"]);
 
     const container = mount(createProps({ result: createResult(plugins) }));
-    const pulse = container.querySelector(".plugins-pulse");
-    expect(normalizedText(pulse)).toContain("All 3");
-    expect(normalizedText(pulse)).toContain("Enabled 1");
-    expect(normalizedText(pulse)).toContain("Issues 1");
-    expect(pulse?.querySelectorAll(".plugins-pulse__segment")).toHaveLength(3);
+    const filters = container.querySelector(".plugins-filters");
+    expect(normalizedText(filters)).toContain("All 3");
+    expect(normalizedText(filters)).toContain("Enabled 1");
+    expect(normalizedText(filters)).toContain("Issues 1");
     expect(
       container.querySelector('[data-plugin-id="broken"] [role="alert"]')?.textContent,
     ).toContain("manifest invalid");

--- a/ui/src/pages/plugins/view.ts
+++ b/ui/src/pages/plugins/view.ts
@@ -496,72 +496,37 @@ function renderCatalogActions(
 
 /* ---------------------------------- installed tab ---------------------------------- */
 
-/**
- * One compact strip instead of stat cards: a segmented distribution meter and
- * filter chips that double as the legend and the counts.
- */
-function renderInventoryPulse(props: PluginsViewProps) {
+/** Filter chips that double as the inventory legend and the counts. */
+function renderInstalledFilters(props: PluginsViewProps) {
   const installed = (props.result?.plugins ?? []).filter((plugin) => plugin.installed);
   const issues = installed.filter((plugin) => plugin.state === "error").length;
   const enabled = installed.filter((plugin) => plugin.enabled && plugin.state !== "error").length;
-  const disabled = installed.length - enabled - issues;
   const counts: Record<InstalledFilter, number> = {
     all: installed.length,
     enabled,
-    disabled,
+    disabled: installed.length - enabled - issues,
     issues,
   };
-  const segments = (
-    [
-      ["enabled", enabled],
-      ["disabled", disabled],
-      ["issues", issues],
-    ] as const
-  ).filter(([, value]) => value > 0);
   return html`
-    <div class="plugins-pulse">
-      ${segments.length > 0
-        ? html`
-            <div
-              class="plugins-pulse__meter"
-              role="img"
-              aria-label=${t("pluginsPage.pulseLabel", {
-                enabled: String(enabled),
-                disabled: String(disabled),
-                issues: String(issues),
-              })}
-            >
-              ${segments.map(
-                ([key, value]) => html`
-                  <span
-                    class="plugins-pulse__segment plugins-pulse__segment--${key}"
-                    style=${`flex-grow:${value}`}
-                  ></span>
-                `,
-              )}
-            </div>
-          `
-        : nothing}
-      <div class="plugins-filters" role="group" aria-label=${t("pluginsPage.filterLabel")}>
-        ${INSTALLED_FILTERS.map(
-          (filter) => html`
-            <button
-              type="button"
-              class=${props.installedFilter === filter ? "active" : ""}
-              @click=${() => props.onFilterChange(filter)}
-            >
-              ${filter === "all"
-                ? nothing
-                : html`<span
-                    class="plugins-filters__dot plugins-filters__dot--${filter}"
-                    aria-hidden="true"
-                  ></span>`}
-              ${filterLabel(filter)}
-              <span class="plugins-filters__count">${counts[filter]}</span>
-            </button>
-          `,
-        )}
-      </div>
+    <div class="plugins-filters" role="group" aria-label=${t("pluginsPage.filterLabel")}>
+      ${INSTALLED_FILTERS.map(
+        (filter) => html`
+          <button
+            type="button"
+            class=${props.installedFilter === filter ? "active" : ""}
+            @click=${() => props.onFilterChange(filter)}
+          >
+            ${filter === "all"
+              ? nothing
+              : html`<span
+                  class="plugins-filters__dot plugins-filters__dot--${filter}"
+                  aria-hidden="true"
+                ></span>`}
+            ${filterLabel(filter)}
+            <span class="plugins-filters__count">${counts[filter]}</span>
+          </button>
+        `,
+      )}
     </div>
   `;
 }
@@ -741,7 +706,7 @@ function renderInstalled(props: PluginsViewProps) {
   const plugins = installedPlugins(props.result?.plugins ?? [], props.query, props.installedFilter);
   const groups = groupInstalledByCategory(plugins);
   return html`
-    ${renderInventoryPulse(props)}
+    ${renderInstalledFilters(props)}
     ${groups.length === 0
       ? renderEmpty(
           props.query || props.installedFilter !== "all"

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -195,73 +195,40 @@
   margin-top: 14px;
 }
 
-/* ---------- inventory pulse ---------- */
-
-.plugins-pulse {
-  display: grid;
-  gap: 10px;
-  margin-bottom: 18px;
-}
-
-.plugins-pulse__meter {
-  display: flex;
-  height: 6px;
-  gap: 3px;
-  overflow: hidden;
-  border-radius: var(--radius-full);
-}
-
-.plugins-pulse__segment {
-  min-width: 6px;
-  border-radius: var(--radius-full);
-  transition: flex-grow var(--duration-slow) var(--ease-out);
-}
-
-.plugins-pulse__segment--enabled {
-  background: var(--ok);
-}
-
-.plugins-pulse__segment--disabled {
-  background: var(--border-strong);
-}
-
-.plugins-pulse__segment--issues {
-  background: var(--danger);
-}
-
 /* ---------- filter chips ---------- */
 
+/* Match the hub tab strip above: same radius, hover, and active treatment. */
 .plugins-filters {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 4px;
+  margin-bottom: 18px;
 }
 
 .plugins-filters button {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-full);
-  padding: 5px 12px;
+  gap: 7px;
+  min-height: 32px;
+  border: 0;
+  border-radius: var(--radius-md);
+  padding: 0 11px;
   background: transparent;
   color: var(--muted);
-  font-size: var(--control-ui-text-xs);
-  font-weight: 580;
+  font-size: var(--control-ui-text-sm);
+  font-weight: 560;
   cursor: pointer;
   transition:
     color var(--duration-fast) var(--ease-out),
-    background var(--duration-fast) var(--ease-out),
-    border-color var(--duration-fast) var(--ease-out);
+    background var(--duration-fast) var(--ease-out);
 }
 
 .plugins-filters button:hover {
-  border-color: var(--border-hover);
+  background: var(--bg-hover);
   color: var(--text-strong);
 }
 
 .plugins-filters button.active {
-  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
   background: var(--accent-subtle);
   color: var(--text-strong);
 }
@@ -286,12 +253,15 @@
 }
 
 .plugins-filters__count {
-  color: var(--muted);
+  min-width: 20px;
+  border-radius: var(--radius-full);
+  padding: 2px 6px;
+  background: color-mix(in srgb, currentColor 11%, transparent);
+  color: inherit;
+  font-size: var(--control-ui-text-xs);
   font-variant-numeric: tabular-nums;
-}
-
-.plugins-filters button.active .plugins-filters__count {
-  color: var(--text-strong);
+  line-height: 1.2;
+  text-align: center;
 }
 
 /* ---------- groups / shelves ---------- */


### PR DESCRIPTION
## What Problem This Solves

On the Plugins page, the installed-inventory filter row used pill-shaped chips (`--radius-full`) directly under the tab strip, which uses soft rounded rectangles (`--radius-md`) — two competing corner radii in adjacent controls. A thin segmented distribution meter sat between them, reading as a stray line without an obvious meaning.

Follow-up to #106040.

## Why This Change Was Made

- The segmented inventory meter is removed; the filter chips already carry the same information as legend (colored dots) and counts.
- The filter chips now match the tab strip above them: borderless, `--radius-md` corners, same hover (`--bg-hover`) and active (`--accent-subtle`) treatment, and the same rounded count badges.
- The now-unused `pluginsPage.pulseLabel` key is removed from `en.ts` with generated locale bundles pruned in the same change. Net -87 LOC.

## User Impact

One consistent visual language for the tab strip and the filter row; no behavior change — the same four filters (All/Enabled/Disabled/Issues) with counts and state dots.

## Screenshots

![installed filters aligned](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-plugin-filter-chips/installed-filters.png)

## Evidence

- `ui/src/pages/plugins/view.test.ts` updated (counts assertion now targets `.plugins-filters`); full plugins view suite passes locally.
- Plugins mocked-gateway Chromium e2e: browse/read-only/list-failure flows pass and regenerated the screenshot above; the one failing assertion (sidebar Workboard link, `plugins.e2e.test.ts:518`) is pre-existing on `main` (see #106040 evidence) and untouched by this diff.
- Keyless `control-ui-i18n sync` prune (`fallbacks=0`, pure deletions); `check` clean.
- Codex autoreview: result noted in PR checks/comment trail.
