### PR TITLE
fix(zalo): strip target prefixes before Bot API sends

### DIFF
--- a/extensions/zalo/src/send.test.ts
+++ b/extensions/zalo/src/send.test.ts
@@ -106,6 +106,42 @@ describe("zalo send", () => {
     expect(successful.receipt.parts[0]?.kind).toBe("media");
   });
 
+  it("normalizes provider and target-kind prefixes before calling the Bot API", async () => {
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      result: { message_id: "z-msg-prefixed" },
+    });
+    sendPhotoMock.mockResolvedValueOnce({
+      ok: true,
+      result: { message_id: "z-photo-prefixed" },
+    });
+
+    await sendMessageZalo("zalo:group:dm-chat-prefixed-text", "hello", {
+      token: "zalo-token",
+    });
+    await sendPhotoZalo("zl:user:dm-chat-prefixed-photo", "https://example.com/photo.jpg", {
+      token: "zalo-token",
+    });
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      "zalo-token",
+      {
+        chat_id: "dm-chat-prefixed-text",
+        text: "hello",
+      },
+      undefined,
+    );
+    expect(sendPhotoMock).toHaveBeenCalledWith(
+      "zalo-token",
+      {
+        chat_id: "dm-chat-prefixed-photo",
+        photo: "https://example.com/photo.jpg",
+        caption: undefined,
+      },
+      undefined,
+    );
+  });
+
   it("fails fast for missing token or blank photo URLs", async () => {
     const missingToken = await sendMessageZalo("dm-chat-3", "hello", {});
     expectFailedSend(missingToken, "No Zalo bot token configured");

--- a/extensions/zalo/src/send.test.ts
+++ b/extensions/zalo/src/send.test.ts
@@ -119,8 +119,9 @@ describe("zalo send", () => {
     await sendMessageZalo("zalo:group:dm-chat-prefixed-text", "hello", {
       token: "zalo-token",
     });
-    await sendPhotoZalo("zl:user:dm-chat-prefixed-photo", "https://example.com/photo.jpg", {
+    await sendMessageZalo("zl:user:dm-chat-prefixed-photo", "", {
       token: "zalo-token",
+      mediaUrl: "https://example.com/photo.jpg",
     });
 
     expect(sendMessageMock).toHaveBeenCalledWith(

--- a/extensions/zalo/src/send.ts
+++ b/extensions/zalo/src/send.ts
@@ -4,6 +4,7 @@ import {
   type MessageReceipt,
   type MessageReceiptPartKind,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { stripChannelTargetPrefix, stripTargetKindPrefix } from "openclaw/plugin-sdk/core";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -119,11 +120,15 @@ function resolveValidatedSendContext(
   if (!token) {
     return { ok: false, error: "No Zalo bot token configured" };
   }
-  const trimmedChatId = chatId?.trim();
+  const trimmedChatId = normalizeZaloSendChatId(chatId);
   if (!trimmedChatId) {
     return { ok: false, error: "No chat_id provided" };
   }
   return { ok: true, chatId: trimmedChatId, token, fetcher };
+}
+
+function normalizeZaloSendChatId(chatId: string): string {
+  return stripTargetKindPrefix(stripChannelTargetPrefix(chatId, "zalo", "zl"));
 }
 
 function resolveSendContextOrFailure(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending a Zalo message with an explicit Zalo target could have OpenClaw accept and route the target, but the Bot API send path still used the provider or target-kind prefix as part of the `chat_id`.

The broken case is a mismatch between Zalo session routing and Zalo delivery:

- Zalo session routing accepts targets such as `zalo:group:<chatId>`, `group:<chatId>`, `zalo:user:<chatId>`, and `user:<chatId>`.
- The router strips the provider/kind prefixes to build the outbound session around the real peer id.
- The actual Bot API send path only trimmed the target and then sent it as `chat_id`.

Before this fix:

```text
Input target:        zalo:group:123456789
Session peer id:     123456789
Bot API chat_id:     group:123456789
```

For direct/user-style targets, the same mismatch could happen:

```text
Input target:        zl:user:987654321
Session peer id:     987654321
Bot API chat_id:     user:987654321
```

After this fix:

```text
Input target:        zalo:group:123456789
Session peer id:     123456789
Bot API chat_id:     123456789
```

This matters when users type explicit targets, copy targets from docs or logs, or when the agent/model chooses the explicit `group:` / `user:` form that the Zalo routing layer already supports.

## Why This Change Was Made

The fix normalizes the Zalo send target at the shared low-level send context before calling the Bot API. It removes the Zalo provider prefixes (`zalo:` and `zl:`) and then removes the generic target-kind prefix (`group:`, `user:`, `dm:`, etc.) using the same Plugin SDK helpers already used by Zalo outbound session routing.

The fix is intentionally narrow:

- It stays inside the Zalo plugin send path.
- It does not change the accepted target syntax.
- It does not add config, dependencies, migrations, or fallback behavior.
- It keeps ordinary chat ids unchanged, including opaque ids such as `123456789`, `abc.xyz`, or `3becaa50ae12474c1e03`.
- It covers both text and media sends because `sendMessageZalo()` and `sendPhotoZalo()` share the same validated send context.

Fixing this at `sendMessageZalo()` / `sendPhotoZalo()` is the right boundary because both Zalo plugin action sends and Zalo outbound adapter sends eventually call that shared send context. Fixing only one higher-level call site would leave another send path with the same mismatch.

## User Impact

Users can now use explicit Zalo targets without accidentally sending prefixed values to the Zalo Bot API.

Examples that now resolve to the intended Bot API `chat_id`:

| User-provided target | Bot API `chat_id` after stripping |
| --- | --- |
| `zalo:group:123456789` | `123456789` |
| `group:123456789` | `123456789` |
| `zl:user:987654321` | `987654321` |
| `user:987654321` | `987654321` |

Existing plain chat ids continue to behave the same:

| Existing target | Bot API `chat_id` |
| --- | --- |
| `123456789` | `123456789` |
| `abc.xyz` | `abc.xyz` |
| `3becaa50ae12474c1e03` | `3becaa50ae12474c1e03` |

This avoids a user-visible failure mode where OpenClaw appears to understand the Zalo target for session/mirror purposes, but the actual outbound message fails because the Bot API receives a `chat_id` containing `group:` or `user:`.

## Evidence

### Code-path proof

- `extensions/zalo/src/session-route.ts` strips `zalo:` / `zl:` provider prefixes with `stripChannelTargetPrefix()` before route resolution.
- `extensions/zalo/src/session-route.ts` also strips target-kind prefixes with `stripTargetKindPrefix()` and uses the stripped value as `peer.id`.
- `extensions/zalo/src/actions.ts` reads the message tool `to` parameter and passes it directly to `sendMessageZalo()`.
- `extensions/zalo/src/channel.ts` also passes `to` directly through the Zalo message adapter and outbound adapter into `sendZaloText()`.
- `extensions/zalo/src/channel.runtime.ts` passes `params.to` directly to `sendMessageZalo()`.
- Before this change, `extensions/zalo/src/send.ts` only trimmed `chatId` before using it as the Bot API `chat_id`.

Because all Zalo send paths converge on `extensions/zalo/src/send.ts`, normalizing there aligns plugin action sends, outbound text sends, and outbound media sends with the target grammar that session routing already accepts.

### Before/after behavior covered by tests

The regression test in `extensions/zalo/src/send.test.ts` proves the actual Bot API payload strips both provider and target-kind prefixes:

```text
sendMessageZalo("zalo:group:dm-chat-prefixed-text", "hello", ...)
```

The mocked `sendMessage()` call is asserted against:

```text
chat_id: "dm-chat-prefixed-text"
```

The same test proves media/photo delivery uses the same normalized send context:

```text
sendPhotoZalo("zl:user:dm-chat-prefixed-photo", "https://example.com/photo.jpg", ...)
```

The mocked `sendPhoto()` call is asserted against:

```text
chat_id: "dm-chat-prefixed-photo"
```

### Validation run

Focused Zalo send test:

```bash
env OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs extensions/zalo/src/send.test.ts -- --reporter=verbose
```

Result:

```text
[test] passed 1 Vitest shard in 39.39s
```

Diff whitespace check:

```bash
git diff --check
```

Result: passed.

### Validation notes

Remote Testbox validation could not be started from this checkout because the Crabbox wrapper failed its basic binary sanity check before running tests:

```text
selected binary failed basic --version/--help sanity checks
```

The focused local fallback above was used for the touched Zalo send surface.
