### PR TITLE
fix(gateway): drain parked restart emit hooks on hooked emissions

### DIFF
--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -15,6 +15,7 @@ import {
   testing,
   consumeGatewaySigusr1RestartIntent,
   consumeGatewaySigusr1RestartAuthorization,
+  deferGatewayRestartUntilIdle,
   emitGatewayRestart,
   isGatewaySigusr1RestartExternallyAllowed,
   markGatewaySigusr1RestartHandled,
@@ -662,6 +663,175 @@ describe("infra runtime", () => {
       expect(beforeEmit).toHaveBeenCalledTimes(1);
       expect(afterEmitRejected).toHaveBeenCalledTimes(1);
       expect(isGatewayWorkAdmissionClosed()).toBe(false);
+    });
+
+    it("drains parked emit hooks when a hooked deferral wins the emission race", async () => {
+      // Gateway-tool parks sentinel/continuation hooks; config-reload deferral
+      // can emit first with its own hooks. Both preparations must run, and
+      // session ownership must clear so a later session can claim the slot.
+      const parkedBeforeEmit = vi.fn(async () => {});
+      const callerBeforeEmit = vi.fn(async () => {});
+      const callerEmitRestart = vi.fn(() => ({ status: "emitted" as const }));
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      try {
+        const scheduled = scheduleGatewaySigusr1Restart({
+          delayMs: 60_000,
+          reason: "gateway.tool.restart",
+          sessionKey: "agent:main:session-A",
+          emitHooks: { beforeEmit: parkedBeforeEmit },
+        });
+        expect(scheduled.emitHooksQueued).toBe(true);
+
+        deferGatewayRestartUntilIdle({
+          getPendingCount: () => 0,
+          reason: "config.reload",
+          emitHooks: {
+            beforeEmit: callerBeforeEmit,
+            emitRestart: callerEmitRestart,
+          },
+        });
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(parkedBeforeEmit).toHaveBeenCalledTimes(1);
+        expect(callerBeforeEmit).toHaveBeenCalledTimes(1);
+        expect(callerEmitRestart).toHaveBeenCalledTimes(1);
+        // Caller preflight precedes the parked drain so late-parked hooks are
+        // captured by the drain's tail re-read before emission.
+        expect(callerBeforeEmit.mock.invocationCallOrder[0]).toBeLessThan(
+          parkedBeforeEmit.mock.invocationCallOrder[0] ?? Number.NEGATIVE_INFINITY,
+        );
+        expect(parkedBeforeEmit.mock.invocationCallOrder[0]).toBeLessThan(
+          callerEmitRestart.mock.invocationCallOrder[0] ?? Number.NEGATIVE_INFINITY,
+        );
+
+        const followUp = scheduleGatewaySigusr1Restart({
+          delayMs: 1_000,
+          reason: "session-B",
+          sessionKey: "agent:main:session-B",
+          emitHooks: { beforeEmit: vi.fn(async () => {}) },
+        });
+        expect(followUp.emitHooksQueued).toBe(true);
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
+    it("rejects parked emit hooks when a hooked emission is not emitted", async () => {
+      const parkedBeforeEmit = vi.fn(async () => {});
+      const parkedAfterEmitRejected = vi.fn(async () => {});
+      const callerBeforeEmit = vi.fn(async () => {});
+      const callerAfterEmitRejected = vi.fn(async () => {});
+      const callerEmitRestart = vi.fn(() => ({ status: "coalesced" as const }));
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      try {
+        scheduleGatewaySigusr1Restart({
+          delayMs: 60_000,
+          reason: "gateway.tool.restart",
+          sessionKey: "agent:main:session-A",
+          emitHooks: {
+            beforeEmit: parkedBeforeEmit,
+            afterEmitRejected: parkedAfterEmitRejected,
+          },
+        });
+
+        deferGatewayRestartUntilIdle({
+          getPendingCount: () => 0,
+          reason: "config.reload",
+          emitHooks: {
+            beforeEmit: callerBeforeEmit,
+            afterEmitRejected: callerAfterEmitRejected,
+            emitRestart: callerEmitRestart,
+          },
+        });
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(parkedBeforeEmit).toHaveBeenCalledTimes(1);
+        expect(callerBeforeEmit).toHaveBeenCalledTimes(1);
+        expect(callerEmitRestart).toHaveBeenCalledTimes(1);
+        expect(parkedAfterEmitRejected).toHaveBeenCalledTimes(1);
+        expect(callerAfterEmitRejected).toHaveBeenCalledTimes(1);
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
+    it("re-drains hooks accepted while caller preparation awaits", async () => {
+      // scheduleGatewaySigusr1Restart is not fence-gated: a session can park
+      // hooks (emitHooksQueued: true) while the emitting caller's beforeEmit
+      // awaits. Those hooks must ride this restart, not be silently dropped.
+      const lateBeforeEmit = vi.fn(async () => {});
+      const callerEmitRestart = vi.fn(() => ({ status: "emitted" as const }));
+      let lateQueued: boolean | undefined;
+      const callerBeforeEmit = vi.fn(async () => {
+        if (lateQueued === undefined) {
+          lateQueued = scheduleGatewaySigusr1Restart({
+            delayMs: 60_000,
+            reason: "late.session",
+            sessionKey: "agent:main:session-late",
+            emitHooks: { beforeEmit: lateBeforeEmit },
+          }).emitHooksQueued;
+        }
+      });
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      try {
+        deferGatewayRestartUntilIdle({
+          getPendingCount: () => 0,
+          reason: "config.reload",
+          emitHooks: {
+            beforeEmit: callerBeforeEmit,
+            emitRestart: callerEmitRestart,
+          },
+        });
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(lateQueued).toBe(true);
+        expect(lateBeforeEmit).toHaveBeenCalledTimes(1);
+        expect(callerEmitRestart).toHaveBeenCalledTimes(1);
+        expect(lateBeforeEmit.mock.invocationCallOrder[0]).toBeLessThan(
+          callerEmitRestart.mock.invocationCallOrder[0] ?? Number.NEGATIVE_INFINITY,
+        );
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
+    it("runs every afterEmitFailed callback even when an earlier one throws", async () => {
+      const parkedAfterEmitFailed = vi.fn(async () => {
+        throw new Error("sentinel cleanup failed");
+      });
+      const callerAfterEmitFailed = vi.fn(async () => {});
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      try {
+        scheduleGatewaySigusr1Restart({
+          delayMs: 60_000,
+          reason: "gateway.tool.restart",
+          sessionKey: "agent:main:session-A",
+          emitHooks: {
+            beforeEmit: vi.fn(async () => {}),
+            afterEmitFailed: parkedAfterEmitFailed,
+          },
+        });
+
+        deferGatewayRestartUntilIdle({
+          getPendingCount: () => 0,
+          reason: "config.reload",
+          emitHooks: {
+            beforeEmit: vi.fn(async () => {}),
+            afterEmitFailed: callerAfterEmitFailed,
+            emitRestart: () => ({ status: "failed" as const }),
+          },
+        });
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(parkedAfterEmitFailed).toHaveBeenCalledTimes(1);
+        expect(callerAfterEmitFailed).toHaveBeenCalledTimes(1);
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
     });
 
     it("still emits restart when preparation fails", async () => {

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -616,6 +616,16 @@ async function rejectPreparedRestartHook(hooks: RestartEmitHooks | undefined): P
   } catch {}
 }
 
+async function rejectPreparedRestartHooks(hooksList: readonly RestartEmitHooks[]): Promise<void> {
+  for (const hooks of hooksList) {
+    await rejectPreparedRestartHook(hooks);
+  }
+}
+
+// Single-flight: only emitPreparedGatewayRestart calls this, after synchronously
+// taking the restart-signal admission fence. A concurrent emission attempt blocks
+// in tryBeginGatewayIndependentRootWorkAdmission (restartSignalPending), so two
+// bodies never interleave and a detached parked hook cannot be bypassed mid-await.
 async function emitPreparedGatewayRestartUnderAdmission(
   hooks?: RestartEmitHooks,
   reasonOverride?: string,
@@ -627,46 +637,91 @@ async function emitPreparedGatewayRestartUnderAdmission(
   if (!isCurrent()) {
     return null;
   }
-  let nextHooks = hooks ?? pendingRestartEmitHooks;
-  // Keep pendingRestartSessionKey alive across the await beforeEmit() window:
-  // a different-session caller that coalesces while preparation runs would
-  // otherwise slip past the updatePendingRestartEmitHooks session guard and
-  // chain its own hooks (#86742, the CWE-200 in-flight preparation race).
-  if (!hooks) {
-    pendingRestartEmitHooks = undefined;
-  }
-  let preparedHooks: RestartEmitHooks | undefined;
-  while (nextHooks) {
-    if (preparedHooks) {
-      await rejectPreparedRestartHook(preparedHooks);
-      preparedHooks = undefined;
-      if (!isCurrent()) {
-        return null;
-      }
-    }
+
+  // Caller preflight runs before the parked drain: the drain loop's tail
+  // re-read then also captures hooks accepted (emitHooksQueued: true) while
+  // this await was in flight, leaving no async window before emission where
+  // parked continuations could be silently dropped.
+  let callerPrepared = false;
+  if (hooks) {
     try {
-      await nextHooks.beforeEmit?.();
-      preparedHooks = nextHooks;
+      await hooks.beforeEmit?.();
+      callerPrepared = true;
     } catch (err) {
       restartLog.warn(
         `restart preparation failed; restart will continue without it: ${String(err)}`,
       );
     }
     if (!isCurrent()) {
-      await rejectPreparedRestartHook(preparedHooks);
+      if (callerPrepared) {
+        await rejectPreparedRestartHook(hooks);
+      }
       return null;
     }
-    if (hooks) {
-      break;
+  }
+
+  // Drain parked emit hooks even when the caller supplies its own. Reload
+  // deferral can win the emission race; without this drain the gateway-tool
+  // sentinel/continuation is never written and session ownership goes stale.
+  // Keep pendingRestartSessionKey until the slot is fully consumed so
+  // different-session coalesces during preparation still hit the #86742 guard.
+  // Timing note: with an empty slot this stays await-free; mid-flight intent
+  // and deferral consumers observe hookless emission at original latency.
+  let nextParked = pendingRestartEmitHooks;
+  pendingRestartEmitHooks = undefined;
+  let preparedParked: RestartEmitHooks | undefined;
+  const rejectCallerOnBail = async () => {
+    if (hooks && callerPrepared) {
+      await rejectPreparedRestartHook(hooks);
     }
-    nextHooks = pendingRestartEmitHooks;
+  };
+  while (nextParked) {
+    if (preparedParked) {
+      await rejectPreparedRestartHook(preparedParked);
+      preparedParked = undefined;
+      if (!isCurrent()) {
+        await rejectCallerOnBail();
+        return null;
+      }
+    }
+    try {
+      await nextParked.beforeEmit?.();
+      preparedParked = nextParked;
+    } catch (err) {
+      restartLog.warn(
+        `restart preparation failed; restart will continue without it: ${String(err)}`,
+      );
+    }
+    if (!isCurrent()) {
+      await rejectPreparedRestartHook(preparedParked);
+      await rejectCallerOnBail();
+      return null;
+    }
+    nextParked = pendingRestartEmitHooks;
     pendingRestartEmitHooks = undefined;
   }
-  if (!hooks) {
-    pendingRestartSessionKey = undefined;
+
+  // Slot settled and no awaits remain before emission — release ownership for
+  // every emission attempt, not only hookless ones, so a later session can
+  // claim continuation hooks for the next restart cycle.
+  pendingRestartSessionKey = undefined;
+
+  // Track every successfully prepared hook set (parked + caller) so non-emitted
+  // outcomes can roll back both the gateway-tool sentinel and reload preflight.
+  const preparedHooksList: RestartEmitHooks[] = [];
+  if (preparedParked) {
+    preparedHooksList.push(preparedParked);
   }
+  if (hooks && callerPrepared) {
+    preparedHooksList.push(hooks);
+  }
+  // With caller hooks, emission stays the caller's (or falls back to the core
+  // signal path if its preparation failed); parked hooks never own emission
+  // when a caller is present.
+  const emitOwner = hooks ? (callerPrepared ? hooks : undefined) : preparedParked;
+
   if (!isCurrent()) {
-    await rejectPreparedRestartHook(preparedHooks);
+    await rejectPreparedRestartHooks(preparedHooksList);
     return null;
   }
 
@@ -678,14 +733,20 @@ async function emitPreparedGatewayRestartUnderAdmission(
   const resolvedReason = preferredReason ?? reasonOverride;
   const resolvedIntent =
     preferredReason && intent ? { ...intent, reason: preferredReason } : intent;
-  const emitResult = preparedHooks?.emitRestart
-    ? preparedHooks.emitRestart(resolvedReason, resolvedIntent)
+  const emitResult = emitOwner?.emitRestart
+    ? emitOwner.emitRestart(resolvedReason, resolvedIntent)
     : requestGatewayRestartWithSignalAdmission(resolvedReason, resolvedIntent);
   if (emitResult.status !== "emitted") {
-    await rejectPreparedRestartHook(preparedHooks);
+    await rejectPreparedRestartHooks(preparedHooksList);
   }
   if (emitResult.status === "failed") {
-    await preparedHooks?.afterEmitFailed?.();
+    // Isolate each failure callback: one throwing hook set must not skip the
+    // other's cleanup or reject this fire-and-forget emission promise.
+    for (const prepared of preparedHooksList) {
+      try {
+        await prepared.afterEmitFailed?.();
+      } catch {}
+    }
   }
   return emitResult;
 }


### PR DESCRIPTION
## What Problem This Solves

`gateway` tool restarts queue a continuation (restart sentinel written in an emit hook, recovered on boot as a resume turn). When a config-reload restart deferral (`server-reload-handlers.ts` → `deferGatewayRestartUntilIdle` with its own `emitHooks`) wins the emission race, `emitPreparedGatewayRestartUnderAdmission` runs only the caller's hooks and never drains the parked `pendingRestartEmitHooks` — the sentinel is never written, so the promised continuation silently disappears and the session stays dead until a human pings it. Observed in production (see issue): the agent reported `continuationQueued: true`, told the user the task would "resume automatically after restart", restarted, and never resumed. Two follow-on leaks on the same path: the orphaned hooks' `afterEmitRejected` never fires, and `pendingRestartSessionKey` is never cleared, so stale ownership survives in-process restarts and can reject a *different* session's future continuation.

Fixes #106138

## Why This Change Was Made

The tool-restart path and the config-watcher path are two deferral polls racing for one emission; only the hookless winner preserved queued continuations. The bounded fix makes the emission point honor the parked hooks regardless of who emits: the caller's `beforeEmit` (reload secrets preflight) runs first, then the parked-hook drain loop runs with its original replace/reject semantics — its tail re-read also captures hooks accepted (`emitHooksQueued: true`) while the caller's preparation awaited, so no async window remains before emission where a queued continuation could be dropped. Session ownership (`pendingRestartSessionKey`) now clears exactly when the slot is consumed on every emission attempt (previously leaked on hooked emissions, and — because container restarts are in-process — across gateway generations), every prepared hook set is rolled back via `afterEmitRejected` on non-emitted outcomes, and `afterEmitFailed` callbacks are error-isolated so one throwing hook set cannot skip another's cleanup. The empty-slot path stays await-free because mid-flight intent/deferral consumers observe hookless emission latency. Merging the two restart state machines was deliberately left out of scope — this restores the invariant `continuationQueued: true` ⇒ continuation survives, without touching reload-handler semantics.

Concurrent-emitter interleaving (two emissions racing mid-`beforeEmit`) was reviewed and is already impossible: every emission path goes through `emitPreparedGatewayRestart`, which synchronously takes the restart-signal admission fence (`beginGatewayRestartSignalAdmission` sets `restartSignalPending` with no await between admission entry and fence), and a concurrent attempt blocks in `tryBeginGatewayIndependentRootWorkAdmission`. This single-flight contract is now documented at `emitPreparedGatewayRestartUnderAdmission`.

## User Impact

Agent-initiated gateway restarts (`gateway` tool `action: "restart"` with `continuationMessage`) now reliably resume after the restart even when a restart-required config change (e.g. `browser.noSandbox`) armed the config watcher's own deferral in the same window — the exact "config set, then restart" sequence agents commonly run. No config, protocol, or tool-surface changes.

## Evidence

- Production trace (issue #106138): reload deferral won the emission (`all operations and replies completed; restarting gateway now`), no sentinel recovery/notice/continuation followed, while an earlier tool-side emission in the same session delivered its continuation correctly.
- New tests in `src/infra/infra-runtime.test.ts` (+4): hooked emission drains parked hooks and emits once via the caller's `emitRestart` with ownership cleared for the next session; hooks accepted while caller preparation awaits ride the same emission; parked hooks get `afterEmitRejected` on non-emitted outcomes; every `afterEmitFailed` runs even when an earlier one throws. Existing #86742 different-session rejection cases and mid-flight timing probes unchanged and green.
- Validation (Blacksmith Testbox, synced worktree on current `main`): `node scripts/run-vitest.mjs` over `src/infra/infra-runtime.test.ts`, `restart.deferral-timeout`, `restart-suspension`, `restart-coordinator`, `restart-sentinel`, `src/agents/tools/gateway-tool.test.ts`, `src/gateway/server-reload-handlers.test.ts`, `src/auto-reply/reply/commands-session-restart.test.ts`, `src/gateway/server-methods/update.test.ts` — all shards pass; `tsgo` core lane clean; core test-types lane has 0 non-`ui/` errors (the 2 `ui/app-sidebar.ts` errors reproduce identically on clean `main` with the diff stashed — pre-existing, unrelated).
- **Live A/B behavior proof** (real gateway, mock Telegram + mock LLM, real `gateway` tool call, config-watcher deferral winning the emission): after-fix run delivers exactly one sentinel recovery (`Gateway restart ok`) and exactly one continuation turn; before-fix run (`src/infra/restart.ts` reverted to `main`, rebuilt) loses both despite `continuationQueued: true`. Full logs: https://github.com/openclaw/openclaw/pull/106174#issuecomment-4956370473
- Codex autoreview: clean, "patch is correct (0.88)", no actionable findings.
