### PR TITLE
fix(discord): hydrate missing reply references

### DIFF
--- a/extensions/discord/src/monitor/message-handler.hydration.test.ts
+++ b/extensions/discord/src/monitor/message-handler.hydration.test.ts
@@ -128,6 +128,52 @@ describe("hydrateDiscordMessageIfNeeded", () => {
     expect(hydrated.referencedMessage?.content).toBe("the replied-to message");
   });
 
+  it("fetches the referenced message when the hydrated reply still omits it", async () => {
+    const client = createInternalTestClient();
+    const rest = createFakeRestClient([
+      createDefaultReplyPayload(),
+      createReferencedMessagePayload("the directly fetched message"),
+    ]);
+    const message = new Message(client, createDefaultReplyPayload());
+
+    const hydrated = await hydrateDiscordMessageIfNeeded({
+      client: { rest },
+      message,
+      messageChannelId: "c1",
+    });
+
+    expect(rest.calls.map((call) => call.path)).toEqual([
+      "/channels/c1/messages/m1",
+      "/channels/c1/messages/m0",
+    ]);
+    expect(hydrated.referencedMessage?.content).toBe("the directly fetched message");
+  });
+
+  it("uses the referenced channel when directly hydrating a cross-channel reply", async () => {
+    const client = createInternalTestClient();
+    const reply = createDefaultReplyPayload({
+      message_reference: {
+        type: MessageReferenceType.Default,
+        message_id: "m0",
+        channel_id: "c2",
+      },
+    });
+    const rest = createFakeRestClient([
+      reply,
+      createReferencedMessagePayload("the cross-channel message"),
+    ]);
+    const message = new Message(client, reply);
+
+    const hydrated = await hydrateDiscordMessageIfNeeded({
+      client: { rest },
+      message,
+      messageChannelId: "c1",
+    });
+
+    expect(rest.calls[1]?.path).toBe("/channels/c2/messages/m0");
+    expect(hydrated.referencedMessage?.content).toBe("the cross-channel message");
+  });
+
   it("keeps the original reply message when hydration fetch fails", async () => {
     const client = createInternalTestClient();
     const rest = createFakeRestClient();

--- a/extensions/discord/src/monitor/message-handler.hydration.test.ts
+++ b/extensions/discord/src/monitor/message-handler.hydration.test.ts
@@ -5,7 +5,9 @@ import {
   createFakeRestClient,
   createInternalTestClient,
 } from "../internal/test-builders.test-support.js";
+import { buildDiscordMessageProcessContext } from "./message-handler.context.js";
 import { hydrateDiscordMessageIfNeeded } from "./message-handler.hydration.js";
+import { createBaseDiscordMessageContext } from "./message-handler.test-harness.js";
 
 const TEST_TIMESTAMP = "2026-01-01T00:00:00.000Z";
 
@@ -147,6 +149,24 @@ describe("hydrateDiscordMessageIfNeeded", () => {
       "/channels/c1/messages/m0",
     ]);
     expect(hydrated.referencedMessage?.content).toBe("the directly fetched message");
+
+    const ctx = await createBaseDiscordMessageContext({
+      message: hydrated,
+      author: hydrated.author,
+      baseText: hydrated.content,
+      messageText: hydrated.content,
+    });
+    const result = await buildDiscordMessageProcessContext({
+      ctx,
+      text: hydrated.content,
+      mediaList: [],
+    });
+    if (!result) {
+      throw new Error("expected a built Discord message context");
+    }
+
+    expect(result.ctxPayload.ReplyToId).toBe("m0");
+    expect(result.ctxPayload.ReplyToBody).toBe("the directly fetched message");
   });
 
   it("uses the referenced channel when directly hydrating a cross-channel reply", async () => {

--- a/extensions/discord/src/monitor/message-handler.hydration.test.ts
+++ b/extensions/discord/src/monitor/message-handler.hydration.test.ts
@@ -111,14 +111,29 @@ describe("hydrateDiscordMessageIfNeeded", () => {
     expect(hydrated.referencedMessage?.content).toBe("earlier");
   });
 
-  it("hydrates reply references when Discord omits referenced_message", async () => {
+  it("uses referenced messages supplied by current-message hydration", async () => {
     const client = createInternalTestClient();
     const rest = createFakeRestClient([
       createDefaultReplyPayload({
+        content: "hello <@123>",
+        mentions: [
+          {
+            id: "123",
+            username: "bob",
+            global_name: null,
+            discriminator: "0",
+            avatar: null,
+          },
+        ],
         referenced_message: createReferencedMessagePayload("the replied-to message"),
       }),
     ]);
-    const message = new Message(client, createDefaultReplyPayload());
+    const message = new Message(
+      client,
+      createDefaultReplyPayload({
+        content: "hello <@123>",
+      }),
+    );
 
     const hydrated = await hydrateDiscordMessageIfNeeded({
       client: { rest },
@@ -126,14 +141,13 @@ describe("hydrateDiscordMessageIfNeeded", () => {
       messageChannelId: "c1",
     });
 
-    expect(rest.calls).toHaveLength(1);
+    expect(rest.calls.map((call) => call.path)).toEqual(["/channels/c1/messages/m1"]);
     expect(hydrated.referencedMessage?.content).toBe("the replied-to message");
   });
 
   it("fetches the referenced message when the hydrated reply still omits it", async () => {
     const client = createInternalTestClient();
     const rest = createFakeRestClient([
-      createDefaultReplyPayload(),
       createReferencedMessagePayload("the directly fetched message"),
     ]);
     const message = new Message(client, createDefaultReplyPayload());
@@ -144,10 +158,7 @@ describe("hydrateDiscordMessageIfNeeded", () => {
       messageChannelId: "c1",
     });
 
-    expect(rest.calls.map((call) => call.path)).toEqual([
-      "/channels/c1/messages/m1",
-      "/channels/c1/messages/m0",
-    ]);
+    expect(rest.calls.map((call) => call.path)).toEqual(["/channels/c1/messages/m0"]);
     expect(hydrated.referencedMessage?.content).toBe("the directly fetched message");
 
     const ctx = await createBaseDiscordMessageContext({
@@ -179,7 +190,6 @@ describe("hydrateDiscordMessageIfNeeded", () => {
       },
     });
     const rest = createFakeRestClient([
-      reply,
       createReferencedMessagePayload("the cross-channel message"),
     ]);
     const message = new Message(client, reply);
@@ -190,7 +200,7 @@ describe("hydrateDiscordMessageIfNeeded", () => {
       messageChannelId: "c1",
     });
 
-    expect(rest.calls[1]?.path).toBe("/channels/c2/messages/m0");
+    expect(rest.calls[0]?.path).toBe("/channels/c2/messages/m0");
     expect(hydrated.referencedMessage?.content).toBe("the cross-channel message");
   });
 

--- a/extensions/discord/src/monitor/message-handler.hydration.ts
+++ b/extensions/discord/src/monitor/message-handler.hydration.ts
@@ -189,6 +189,43 @@ function hasMissingReferencedMessagePayload(message: Message): boolean {
   return !Object.hasOwn(readMessageRawData(message), "referenced_message");
 }
 
+async function hydrateDiscordReplyReference(params: {
+  client: { rest: Parameters<typeof getChannelMessage>[0] };
+  message: Message;
+  messageChannelId: string;
+}): Promise<Message> {
+  if (!hasMissingReferencedMessagePayload(params.message)) {
+    return params.message;
+  }
+  const reference = params.message.messageReference;
+  const referencedMessageId = reference?.message_id;
+  if (!referencedMessageId) {
+    return params.message;
+  }
+  const referencedChannelId = reference.channel_id ?? params.messageChannelId;
+  try {
+    const referenced = (await getChannelMessage(
+      params.client.rest,
+      referencedChannelId,
+      referencedMessageId,
+    )) as APIMessage | null | undefined;
+    if (!referenced) {
+      return params.message;
+    }
+    // Discord may omit referenced_message from both Gateway and REST reply payloads.
+    // Attach the canonical referenced fetch so downstream reply context stays bounded.
+    return mergeFetchedDiscordMessage(params.message, {
+      ...readMessageRawData(params.message),
+      referenced_message: referenced,
+    } as APIMessage);
+  } catch (err) {
+    logVerbose(
+      `discord: failed to hydrate referenced message ${referencedMessageId}: ${String(err)}`,
+    );
+    return params.message;
+  }
+}
+
 export async function hydrateDiscordMessageIfNeeded(params: {
   client: { rest: Parameters<typeof getChannelMessage>[0] };
   message: Message;
@@ -199,19 +236,24 @@ export async function hydrateDiscordMessageIfNeeded(params: {
   if (!shouldHydrateDiscordMessage({ message: params.message })) {
     return params.message;
   }
+  let hydrated = params.message;
   try {
     const fetched = (await getChannelMessage(
       params.client.rest,
       params.messageChannelId,
       params.message.id,
     )) as APIMessage | null | undefined;
-    if (!fetched) {
-      return params.message;
+    if (fetched) {
+      logVerbose(`discord: hydrated inbound payload via REST for ${params.message.id}`);
+      hydrated = mergeFetchedDiscordMessage(params.message, fetched);
     }
-    logVerbose(`discord: hydrated inbound payload via REST for ${params.message.id}`);
-    return mergeFetchedDiscordMessage(params.message, fetched);
   } catch (err) {
     logVerbose(`discord: failed to hydrate message ${params.message.id}: ${String(err)}`);
     return params.message;
   }
+  return hydrateDiscordReplyReference({
+    client: params.client,
+    message: hydrated,
+    messageChannelId: params.messageChannelId,
+  });
 }

--- a/extensions/discord/src/monitor/message-handler.hydration.ts
+++ b/extensions/discord/src/monitor/message-handler.hydration.ts
@@ -150,10 +150,7 @@ function copyRuntimeMessageFields(source: Message, target: Message): void {
   }
 }
 
-function shouldHydrateDiscordMessage(params: { message: Message }) {
-  if (hasMissingReferencedMessagePayload(params.message)) {
-    return true;
-  }
+function shouldHydrateDiscordMessagePayload(params: { message: Message }) {
   let currentText;
   try {
     currentText = resolveDiscordMessageText(params.message, {
@@ -233,23 +230,22 @@ export async function hydrateDiscordMessageIfNeeded(params: {
   channelInfo?: DiscordChannelInfo | null;
 }): Promise<Message> {
   void params.channelInfo;
-  if (!shouldHydrateDiscordMessage({ message: params.message })) {
-    return params.message;
-  }
   let hydrated = params.message;
-  try {
-    const fetched = (await getChannelMessage(
-      params.client.rest,
-      params.messageChannelId,
-      params.message.id,
-    )) as APIMessage | null | undefined;
-    if (fetched) {
-      logVerbose(`discord: hydrated inbound payload via REST for ${params.message.id}`);
-      hydrated = mergeFetchedDiscordMessage(params.message, fetched);
+  if (shouldHydrateDiscordMessagePayload({ message: params.message })) {
+    try {
+      const fetched = (await getChannelMessage(
+        params.client.rest,
+        params.messageChannelId,
+        params.message.id,
+      )) as APIMessage | null | undefined;
+      if (fetched) {
+        logVerbose(`discord: hydrated inbound payload via REST for ${params.message.id}`);
+        hydrated = mergeFetchedDiscordMessage(params.message, fetched);
+      }
+    } catch (err) {
+      logVerbose(`discord: failed to hydrate message ${params.message.id}: ${String(err)}`);
+      return params.message;
     }
-  } catch (err) {
-    logVerbose(`discord: failed to hydrate message ${params.message.id}: ${String(err)}`);
-    return params.message;
   }
   return hydrateDiscordReplyReference({
     client: params.client,


### PR DESCRIPTION
## What Problem This Solves

Fixes Discord inbound replies where Discord includes `message_reference.message_id` but omits the nested `referenced_message`, causing OpenClaw reply context to lose the replied-to message body.

Supersedes #105901 because the contributor fork rejected maintainer pushes even though maintainer edits were enabled.

## Why This Change Was Made

The Discord monitor now hydrates missing reply references explicitly after normal message hydration. Complete gateway reply payloads fetch only the referenced message, while partial payloads can still hydrate the current message first and reuse any `referenced_message` returned by Discord.

## User Impact

Discord replies keep `ReplyToId` and `ReplyToBody` in the inbound context when Discord omits the nested referenced payload. Deleted references, forwarded messages, and failed reference fetches remain non-blocking.

## Evidence

- `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.hydration.test.ts extensions/discord/src/monitor/message-handler.context.test.ts extensions/discord/src/monitor/message-utils.test.ts extensions/discord/src/monitor/message-handler.preflight.test.ts` — 4 files, 110 tests passed
- `node_modules/.bin/oxfmt --check extensions/discord/src/monitor/message-handler.hydration.ts extensions/discord/src/monitor/message-handler.hydration.test.ts` — passed
- `git diff --check` — passed
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings
