### PR TITLE
fix(googlechat): bound auth transporter fetches

### DIFF
--- a/extensions/googlechat/src/google-auth.runtime.test.ts
+++ b/extensions/googlechat/src/google-auth.runtime.test.ts
@@ -84,6 +84,7 @@ function mockCallArg(mock: ReturnType<typeof vi.fn>, callIndex = 0, argIndex = 0
 describe("googlechat google auth runtime", () => {
   it("routes Google auth fetches through the SSRF guard and preserves explicit proxy mTLS", async () => {
     const release = vi.fn();
+    const controller = new AbortController();
     const injectedFetch = vi.fn(globalThis.fetch);
     mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
       response: new Response("ok", { status: 200 }),
@@ -98,6 +99,7 @@ describe("googlechat google auth runtime", () => {
       key: "CLIENT_KEY",
       method: "POST",
       proxy: "http://proxy.example:8080",
+      signal: controller.signal,
     } as RequestInit);
 
     expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledWith({
@@ -115,10 +117,12 @@ describe("googlechat google auth runtime", () => {
       init: {
         headers: { "content-type": "application/json" },
         method: "POST",
+        signal: controller.signal,
       },
       policy: {
         hostnameAllowlist: ["accounts.google.com", "googleapis.com"],
       },
+      signal: controller.signal,
       timeoutMs: 30_000,
       url: "https://oauth2.googleapis.com/token",
     });

--- a/extensions/googlechat/src/google-auth.runtime.test.ts
+++ b/extensions/googlechat/src/google-auth.runtime.test.ts
@@ -119,6 +119,7 @@ describe("googlechat google auth runtime", () => {
       policy: {
         hostnameAllowlist: ["accounts.google.com", "googleapis.com"],
       },
+      timeoutMs: 30_000,
       url: "https://oauth2.googleapis.com/token",
     });
     await expect(response.text()).resolves.toBe("ok");
@@ -195,6 +196,7 @@ describe("googlechat google auth runtime", () => {
       policy: {
         hostnameAllowlist: ["accounts.google.com", "googleapis.com"],
       },
+      timeoutMs: 30_000,
       url: "https://oauth2.googleapis.com/token",
     });
     await expect(response.text()).resolves.toBe("ok");
@@ -232,6 +234,7 @@ describe("googlechat google auth runtime", () => {
       policy: {
         hostnameAllowlist: ["accounts.google.com", "googleapis.com"],
       },
+      timeoutMs: 30_000,
       url: "https://oauth2.googleapis.com/token",
     });
     await expect(response.text()).resolves.toBe("ok");

--- a/extensions/googlechat/src/google-auth.runtime.ts
+++ b/extensions/googlechat/src/google-auth.runtime.ts
@@ -42,6 +42,7 @@ const GOOGLE_AUTH_POLICY = buildHostnameAllowlistPolicyFromSuffixAllowlist(
   GOOGLE_AUTH_ALLOWED_HOST_SUFFIXES,
 );
 const GOOGLE_AUTH_AUDIT_CONTEXT = "googlechat.auth.google-auth";
+const GOOGLE_AUTH_FETCH_TIMEOUT_MS = 30_000;
 const GOOGLE_AUTH_URI = "https://accounts.google.com/o/oauth2/auth";
 const GOOGLE_AUTH_PROVIDER_CERTS_URL = "https://www.googleapis.com/oauth2/v1/certs";
 const GOOGLE_AUTH_TOKEN_URI = "https://oauth2.googleapis.com/token";
@@ -423,6 +424,7 @@ export function createGoogleAuthFetch(baseFetch?: FetchLike): FetchLike {
       dispatcherPolicy: guardedOptions.dispatcherPolicy,
       init: guardedOptions.init,
       policy: GOOGLE_AUTH_POLICY,
+      timeoutMs: GOOGLE_AUTH_FETCH_TIMEOUT_MS,
       url,
       ...(baseFetch ? { fetchImpl: baseFetch } : {}),
     });

--- a/extensions/googlechat/src/google-auth.runtime.ts
+++ b/extensions/googlechat/src/google-auth.runtime.ts
@@ -1,4 +1,3 @@
-// Googlechat plugin module implements google auth behavior.
 import fs from "node:fs/promises";
 import type { ConnectionOptions } from "node:tls";
 import { parseMediaContentLength } from "openclaw/plugin-sdk/media-runtime";
@@ -10,8 +9,6 @@ import {
 import { resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 
-type TlsCert = ConnectionOptions["cert"];
-type TlsKey = ConnectionOptions["key"];
 type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 type GoogleAuthRuntime = typeof import("google-auth-library");
 type GoogleAuthTransport = InstanceType<GoogleAuthRuntime["gaxios"]["Gaxios"]>;
@@ -21,8 +18,8 @@ type GoogleAuthTransportOptions = NonNullable<
 type GoogleAuthTransportInit = GoogleAuthTransportOptions & { dispatcher?: unknown };
 type ProxyRule = NonNullable<GoogleAuthTransportOptions["noProxy"]>[number];
 type TlsOptions = {
-  cert?: TlsCert;
-  key?: TlsKey;
+  cert?: ConnectionOptions["cert"];
+  key?: ConnectionOptions["key"];
 };
 type ProxyAgentLike = {
   connectOpts?: TlsOptions;
@@ -41,7 +38,6 @@ const GOOGLE_AUTH_ALLOWED_HOST_SUFFIXES = ["accounts.google.com", "googleapis.co
 const GOOGLE_AUTH_POLICY = buildHostnameAllowlistPolicyFromSuffixAllowlist(
   GOOGLE_AUTH_ALLOWED_HOST_SUFFIXES,
 );
-const GOOGLE_AUTH_AUDIT_CONTEXT = "googlechat.auth.google-auth";
 const GOOGLE_AUTH_FETCH_TIMEOUT_MS = 30_000;
 const GOOGLE_AUTH_URI = "https://accounts.google.com/o/oauth2/auth";
 const GOOGLE_AUTH_PROVIDER_CERTS_URL = "https://www.googleapis.com/oauth2/v1/certs";
@@ -420,10 +416,11 @@ export function createGoogleAuthFetch(baseFetch?: FetchLike): FetchLike {
     const url = input instanceof Request ? input.url : String(input);
     const guardedOptions = resolveGoogleAuthDispatcherPolicy(input, init);
     const { response, release } = await fetchWithSsrFGuard({
-      auditContext: GOOGLE_AUTH_AUDIT_CONTEXT,
+      auditContext: "googlechat.auth.google-auth",
       dispatcherPolicy: guardedOptions.dispatcherPolicy,
       init: guardedOptions.init,
       policy: GOOGLE_AUTH_POLICY,
+      signal: guardedOptions.init?.signal ?? undefined,
       timeoutMs: GOOGLE_AUTH_FETCH_TIMEOUT_MS,
       url,
       ...(baseFetch ? { fetchImpl: baseFetch } : {}),


### PR DESCRIPTION
## What Problem This Solves

Google Chat's direct API calls already use a 30-second guarded-fetch deadline, but the google-auth transporter used for token and certificate requests did not pass a deadline into the same guard. A stalled proxy, DNS lookup, or auth endpoint could therefore block authentication indefinitely. Caller cancellation also needed to reach the guard's composed signal rather than being left only inside the request init.

## Why This Change Was Made

The plugin-owned google-auth fetch adapter is the common transport seam for `google-auth-library` 10.9.0 and its `gaxios` 7.1.5 requests. This change keeps the policy there:

- forwards a caller-provided signal to the SSRF guard so cancellation composes with the production deadline;
- applies a named 30-second auth-fetch deadline across proxy, DNS, fetch, token, and certificate paths;
- preserves the existing request init, explicit-proxy/mTLS policy, SSRF allowlist, response cap, and release lifecycle;
- keeps the production module below its LOC ratchet by removing a redundant banner and one-use type aliases.

No new config or fallback surface is introduced.

## User Impact

Google Chat auth network stalls now fail after 30 seconds. User-initiated cancellation still wins immediately. Healthy Google auth responses continue through the same guarded transport.

Release-note context: fix Google Chat authentication hanging indefinitely when its auth transport or proxy stalls.

## Evidence

Current pushed head: `682af50d3defb952e0eddfb0af55018cac888bee`.

Blacksmith Testbox `tbx_01kxfvrdpv1etc4b21zq6k564j` ([run 29318036744](https://github.com/openclaw/openclaw/actions/runs/29318036744)):

```text
pnpm test extensions/googlechat/src/google-auth.runtime.test.ts
1 file passed; 19 tests passed

pnpm check:changed
production LOC ratchet, formatting, and preflight guards passed; the frozen main snapshot then reported unrelated Plugin SDK generated-hash drift

pnpm tsgo:extensions
pnpm tsgo:extensions:test
targeted extension oxlint
database-first, media-helper, sidecar-loader, and import-cycle guards
all affected lanes passed on the exact two-file patch
```

The final rebase onto `main` commit `69e2282c46d25d7bfad348f104cc9b04962fa67b` preserved the complete diff byte-for-byte (`patch-id 2ec74117e554eb20c934ae3ee16b7e2312583499`), so the exact-content Testbox proof remains applicable.

Source-blind production behavior validation through the real `createGoogleAuthFetch` transport:

```text
hanging HTTP CONNECT proxy: TimeoutError after 30,124 ms
same proxy with caller cancellation: AbortError after 252 ms
real oauth2.googleapis.com invalid request: HTTP 400 invalid_request after 36 ms
```

Fresh structured review:

```text
autoreview --engine codex --model gpt-5.6-sol --thinking high
no accepted/actionable findings; patch is correct (0.89 confidence)
```

Related work: #103627 independently developed caller-signal composition and deeper guard proof; #104138 independently identified the same missing timeout. This refreshed branch preserves the original contribution from @QiuYuang and credits @Monkey-wusky and @maweibin for their overlapping work.
