### PR TITLE
fix(config): restore env vars after any load failure

### DIFF
--- a/src/config/io.invalid-config-env-restore.test.ts
+++ b/src/config/io.invalid-config-env-restore.test.ts
@@ -1,0 +1,129 @@
+// Verifies env.vars mutations are restored when config load fails for any reason.
+// Regression for: valid env.vars combined with a failing config section leaked
+// environment changes because only the INVALID_CONFIG rethrow path had cleanup.
+import { describe, expect, it } from "vitest";
+import { createConfigIO, restoreEnvChangesIfUnchanged } from "./io.js";
+import { withTempHome, writeOpenClawConfig } from "./test-helpers.js";
+
+describe("restoreEnvChangesIfUnchanged", () => {
+  it("removes a newly injected key when unchanged from after snapshot", () => {
+    const env = { HOME: "/tmp/test" } as Record<string, string | undefined>;
+    const before = { HOME: "/tmp/test" };
+    env["NEW_KEY"] = "injected";
+    const after = { HOME: "/tmp/test", NEW_KEY: "injected" };
+
+    restoreEnvChangesIfUnchanged({
+      env: env as NodeJS.ProcessEnv,
+      before,
+      after,
+    });
+
+    expect(env.NEW_KEY).toBeUndefined();
+  });
+
+  it("restores an overwritten key back to its before value", () => {
+    const env = { HOME: "/tmp/test", EXISTING: "original" } as Record<string, string | undefined>;
+    const before = { HOME: "/tmp/test", EXISTING: "original" };
+    env["EXISTING"] = "new-value";
+    const after = { HOME: "/tmp/test", EXISTING: "new-value" };
+
+    restoreEnvChangesIfUnchanged({
+      env: env as NodeJS.ProcessEnv,
+      before,
+      after,
+    });
+
+    expect(env.EXISTING).toBe("original");
+  });
+
+  it("preserves an externally modified key even when different from before", () => {
+    const env = { HOME: "/tmp/test" } as Record<string, string | undefined>;
+    const before = { HOME: "/tmp/test" };
+    env["KEY"] = "config-set";
+    const after = { HOME: "/tmp/test", KEY: "config-set" };
+    // External mutation after the after snapshot
+    env["KEY"] = "external-change";
+
+    restoreEnvChangesIfUnchanged({
+      env: env as NodeJS.ProcessEnv,
+      before,
+      after,
+    });
+
+    expect(env.KEY).toBe("external-change");
+  });
+});
+
+describe("config io invalid config env restoration", () => {
+  it("restores newly set env var after INVALID_CONFIG is thrown", async () => {
+    await withTempHome(async (home) => {
+      await writeOpenClawConfig(home, {
+        env: { vars: { TEST_VAR: "injected-value" } },
+        // gateway.port must be a number; a string triggers INVALID_CONFIG
+        gateway: { port: "invalid" },
+      });
+
+      const env = { HOME: home } as NodeJS.ProcessEnv;
+      const io = createConfigIO({
+        env,
+        homedir: () => home,
+        logger: { warn: () => {}, error: () => {} },
+      });
+
+      expect(env.TEST_VAR).toBeUndefined();
+      expect(() => io.loadConfig()).toThrow();
+      expect(env.TEST_VAR).toBeUndefined();
+    });
+  });
+
+  it("restores overwritten env key when another config section is invalid", async () => {
+    await withTempHome(async (home) => {
+      await writeOpenClawConfig(home, {
+        env: { vars: { PRE_EXISTING: "new-value" } },
+        gateway: { port: "invalid" },
+      });
+
+      const env = {
+        HOME: home,
+        PRE_EXISTING: "original-value",
+      } as NodeJS.ProcessEnv;
+
+      const io = createConfigIO({
+        env,
+        homedir: () => home,
+        logger: { warn: () => {}, error: () => {} },
+      });
+
+      expect(env.PRE_EXISTING).toBe("original-value");
+      expect(() => io.loadConfig()).toThrow();
+      expect(env.PRE_EXISTING).toBe("original-value");
+    });
+  });
+
+  it("restores env changes after non-INVALID_CONFIG error (DuplicateAgentDirError)", async () => {
+    await withTempHome(async (home) => {
+      // Two agents with the same explicit agentDir triggers DuplicateAgentDirError
+      // during finalization, which happens after resolveConfigForRead applies env.vars.
+      await writeOpenClawConfig(home, {
+        env: { vars: { DUP_DIR_TEST_VAR: "injected-value" } },
+        agents: {
+          list: [
+            { id: "agent-a", agentDir: "/tmp/dup-agent-dir" },
+            { id: "agent-b", agentDir: "/tmp/dup-agent-dir" },
+          ],
+        },
+      });
+
+      const env = { HOME: home } as NodeJS.ProcessEnv;
+      const io = createConfigIO({
+        env,
+        homedir: () => home,
+        logger: { warn: () => {}, error: () => {} },
+      });
+
+      expect(env.DUP_DIR_TEST_VAR).toBeUndefined();
+      expect(() => io.loadConfig()).toThrow();
+      expect(env.DUP_DIR_TEST_VAR).toBeUndefined();
+    });
+  });
+});

--- a/src/config/io.load-env-restore.test.ts
+++ b/src/config/io.load-env-restore.test.ts
@@ -1,7 +1,5 @@
-// Verifies env.vars mutations are restored when config load fails for any reason.
-// Regression for: valid env.vars combined with a failing config section leaked
-// environment changes because only the INVALID_CONFIG rethrow path had cleanup.
 import { describe, expect, it } from "vitest";
+import { DuplicateAgentDirError } from "./agent-dirs.js";
 import { createConfigIO, restoreEnvChangesIfUnchanged } from "./io.js";
 import { withTempHome, writeOpenClawConfig } from "./test-helpers.js";
 
@@ -54,7 +52,7 @@ describe("restoreEnvChangesIfUnchanged", () => {
   });
 });
 
-describe("config io invalid config env restoration", () => {
+describe("loadConfig env restoration", () => {
   it("restores newly set env var after INVALID_CONFIG is thrown", async () => {
     await withTempHome(async (home) => {
       await writeOpenClawConfig(home, {
@@ -71,7 +69,7 @@ describe("config io invalid config env restoration", () => {
       });
 
       expect(env.TEST_VAR).toBeUndefined();
-      expect(() => io.loadConfig()).toThrow();
+      expect(() => io.loadConfig()).toThrow(expect.objectContaining({ code: "INVALID_CONFIG" }));
       expect(env.TEST_VAR).toBeUndefined();
     });
   });
@@ -95,15 +93,13 @@ describe("config io invalid config env restoration", () => {
       });
 
       expect(env.PRE_EXISTING).toBe("original-value");
-      expect(() => io.loadConfig()).toThrow();
+      expect(() => io.loadConfig()).toThrow(expect.objectContaining({ code: "INVALID_CONFIG" }));
       expect(env.PRE_EXISTING).toBe("original-value");
     });
   });
 
   it("restores env changes after non-INVALID_CONFIG error (DuplicateAgentDirError)", async () => {
     await withTempHome(async (home) => {
-      // Two agents with the same explicit agentDir triggers DuplicateAgentDirError
-      // during finalization, which happens after resolveConfigForRead applies env.vars.
       await writeOpenClawConfig(home, {
         env: { vars: { DUP_DIR_TEST_VAR: "injected-value" } },
         agents: {
@@ -122,7 +118,7 @@ describe("config io invalid config env restoration", () => {
       });
 
       expect(env.DUP_DIR_TEST_VAR).toBeUndefined();
-      expect(() => io.loadConfig()).toThrow();
+      expect(() => io.loadConfig()).toThrow(DuplicateAgentDirError);
       expect(env.DUP_DIR_TEST_VAR).toBeUndefined();
     });
   });

--- a/src/config/io.load.ts
+++ b/src/config/io.load.ts
@@ -189,11 +189,8 @@ export function loadConfigFromContext(
     );
     return context.finalizeLoadedRuntimeConfig(cfg);
   } catch (error) {
-    // Restore env mutations from this config read before any rethrow.
-    // resolveConfigForRead() applies env.vars to process.env; any subsequent
-    // failure (INVALID_CONFIG, DuplicateAgentDirError, or other) leaks those
-    // mutations. envBeforeRead is undefined only when maybeLoadDotEnvForConfig()
-    // throws, which happens before any config env mutations are applied.
+    // Failed reads must not publish env.vars. The snapshot stays undefined only
+    // when dotenv loading fails before config-owned environment mutation begins.
     if (envBeforeRead) {
       restoreEnvChangesIfUnchanged({
         env: deps.env,

--- a/src/config/io.load.ts
+++ b/src/config/io.load.ts
@@ -35,9 +35,10 @@ export function loadConfigFromContext(
   options: { skipSuspiciousRecovery?: boolean } = {},
 ): OpenClawConfig {
   const { deps, configPath } = context;
+  let envBeforeRead: Record<string, string | undefined> | undefined;
   try {
     maybeLoadDotEnvForConfig(deps.env);
-    const envBeforeRead = snapshotEnv(deps.env);
+    envBeforeRead = snapshotEnv(deps.env);
     if (!deps.fs.existsSync(configPath)) {
       loggedConfigWarningFingerprints.delete(configPath);
       if (
@@ -188,6 +189,18 @@ export function loadConfigFromContext(
     );
     return context.finalizeLoadedRuntimeConfig(cfg);
   } catch (error) {
+    // Restore env mutations from this config read before any rethrow.
+    // resolveConfigForRead() applies env.vars to process.env; any subsequent
+    // failure (INVALID_CONFIG, DuplicateAgentDirError, or other) leaks those
+    // mutations. envBeforeRead is undefined only when maybeLoadDotEnvForConfig()
+    // throws, which happens before any config env mutations are applied.
+    if (envBeforeRead) {
+      restoreEnvChangesIfUnchanged({
+        env: deps.env,
+        before: envBeforeRead,
+        after: snapshotEnv(deps.env),
+      });
+    }
     if (error instanceof DuplicateAgentDirError) {
       deps.logger.error(error.message);
       throw error;


### PR DESCRIPTION
## What Problem This Solves

`loadConfigFromContext()` applies `env.vars` during config resolution. Its catch path rethrew failures such as `INVALID_CONFIG` and `DuplicateAgentDirError` without restoring those process-environment mutations.

**Trigger:** a config with valid `env.vars` plus a later load failure, such as an invalid `gateway.port` or duplicate agent directories.

## Why This Change Was Made

The shared catch path now restores config-owned environment changes before every rethrow. The snapshot remains unset only if dotenv loading itself fails, before config environment mutation begins. This uses the same snapshot-and-conditional-restore contract already used by suspicious-read recovery and write rollback.

The maintainer pass rebased the review against current `main`, renamed the regression file for the full failure scope, and made the integration tests assert the exact `INVALID_CONFIG` and `DuplicateAgentDirError` paths.

## User Impact

- Before: a failed config load could leave newly added or overwritten `env.vars` values in the running process.
- After: failed reads restore prior environment values; successful loads and dotenv behavior remain unchanged.

## Evidence

- Blacksmith Testbox: `pnpm test src/config/io.load-env-restore.test.ts` — 6/6 passed.
- Regression coverage: new keys, overwritten keys, externally changed keys, `INVALID_CONFIG`, and `DuplicateAgentDirError`.
- Fresh branch autoreview: no actionable findings.
- `git diff --check`: passed.

## Files Changed

| File | Purpose |
|---|---|
| `src/config/io.load.ts` | Restore config-owned environment changes in the shared failure boundary. |
| `src/config/io.load-env-restore.test.ts` | Unit and integration regression coverage for all failed-load paths. |
