### PR TITLE
fix(ci): refresh plugin SDK API baseline hash

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-83cfad05d155e019b7bf2f3278eaa2dca6e59d391f124d8bf5bfc838e870d8dd  plugin-sdk-api-baseline.json
-275ad4b635e76fa209cb8d2d99d7de4225f154306cfb2cb0b0c36c17730e756e  plugin-sdk-api-baseline.jsonl
+8bb175b965c6fab4512f110cd584ba601074885fb49375f2dd18e832882d61a5  plugin-sdk-api-baseline.json
+5a1548ecb0cf8dffb67591b41b9e1a3c04ee7fe0cb22ac2f3bcfa24e319f4f47  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
Related: #106049

## What Problem This Solves

Exact `main` fails the Plugin SDK API baseline check because the committed SHA-256 state does not match the final merged SDK surface.

## Why This Change Was Made

Refreshes only the tracked Plugin SDK API digest file from the existing generator. No SDK declarations or runtime behavior change.

## User Impact

Restores the Plugin SDK baseline gate for subsequent changes. No user-visible behavior changes.

## Evidence

- Pristine `0ab7e2569b`: `generate-plugin-sdk-api-baseline.ts --check` failed with a digest mismatch.
- Rebased branch on `ffff72c43a`: the same generator check passes.
- Earlier patch-identical Testbox proof passed the generator check and docs-only `check:changed`.
- Exact-base Testbox run `29234752759` was cancelled by infrastructure during `Prepare Testbox shell`, before repository code ran.
- Fresh `gpt-5.6-sol` medium autoreview: clean, confidence 0.87.
