### PR TITLE
fix(ui): keep worktree mutation errors visible after refresh

### DIFF
--- a/ui/src/pages/worktrees/worktrees-page.test.ts
+++ b/ui/src/pages/worktrees/worktrees-page.test.ts
@@ -283,6 +283,64 @@ describe("WorktreesPage lifecycle", () => {
     expect(page.error).toBeNull();
   });
 
+  it("keeps a mutation error when the follow-up list refresh succeeds", async () => {
+    let listRequests = 0;
+    const request = vi.fn((method: string) => {
+      if (method === "worktrees.list") {
+        listRequests += 1;
+        return Promise.resolve({ worktrees: [] });
+      }
+      if (method === "worktrees.restore") {
+        return Promise.reject(new Error("restore denied"));
+      }
+      return Promise.resolve({});
+    });
+    const page = document.createElement("openclaw-worktrees-page") as WorktreesPageTestElement;
+    page.context = contextWithGateway(
+      gatewayWithClient({ request } as unknown as GatewayBrowserClient),
+    );
+    document.body.append(page);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
+    await vi.waitFor(() => expect(page.loading).toBe(false));
+
+    await page.restore(worktree());
+    await page.updateComplete;
+
+    expect(listRequests).toBe(2);
+    expect(page.error).toBe("Error: restore denied");
+    expect(page.querySelector(".callout.danger")?.textContent).toContain("restore denied");
+  });
+
+  it("replaces a mutation error when the follow-up list refresh fails", async () => {
+    let listRequests = 0;
+    const request = vi.fn((method: string) => {
+      if (method === "worktrees.list") {
+        listRequests += 1;
+        return listRequests === 1
+          ? Promise.resolve({ worktrees: [] })
+          : Promise.reject(new Error("refresh unavailable"));
+      }
+      if (method === "worktrees.restore") {
+        return Promise.reject(new Error("restore denied"));
+      }
+      return Promise.resolve({});
+    });
+    const page = document.createElement("openclaw-worktrees-page") as WorktreesPageTestElement;
+    page.context = contextWithGateway(
+      gatewayWithClient({ request } as unknown as GatewayBrowserClient),
+    );
+    document.body.append(page);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
+    await vi.waitFor(() => expect(page.loading).toBe(false));
+
+    await page.restore(worktree());
+    await page.updateComplete;
+
+    expect(listRequests).toBe(2);
+    expect(page.error).toBe("Error: refresh unavailable");
+    expect(page.querySelector(".callout.danger")?.textContent).toContain("refresh unavailable");
+  });
+
   it("discards a restore error across a same-client reconnect", async () => {
     const pendingRestore = deferred<unknown>();
     const request = vi.fn((method: string) => {

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -144,14 +144,16 @@ class WorktreesPage extends OpenClawLightDomElement {
     return this.loading || this.busyId !== null || this.creating;
   }
 
-  private async load() {
+  private async load(options: { preserveError?: boolean } = {}) {
     const client = this.client;
     if (!client || !this.gatewayConnected || this.operationPending) {
       return;
     }
     const generation = ++this.loadGeneration;
     this.loading = true;
-    this.error = null;
+    if (!options.preserveError) {
+      this.error = null;
+    }
     try {
       const result = await client.request<WorktreesListResult>("worktrees.list", {});
       if (generation === this.loadGeneration && client === this.client) {
@@ -212,7 +214,7 @@ class WorktreesPage extends OpenClawLightDomElement {
     } finally {
       if (this.isOperationScopeCurrent(scope)) {
         this.busyId = null;
-        await this.load();
+        await this.load({ preserveError: true });
       }
     }
   }
@@ -233,7 +235,7 @@ class WorktreesPage extends OpenClawLightDomElement {
     } finally {
       if (this.isOperationScopeCurrent(scope)) {
         this.busyId = null;
-        await this.load();
+        await this.load({ preserveError: true });
       }
     }
   }
@@ -254,7 +256,7 @@ class WorktreesPage extends OpenClawLightDomElement {
     } finally {
       if (this.isOperationScopeCurrent(scope)) {
         this.loading = false;
-        await this.load();
+        await this.load({ preserveError: true });
       }
     }
   }
@@ -325,7 +327,7 @@ class WorktreesPage extends OpenClawLightDomElement {
     } finally {
       if (this.isOperationScopeCurrent(scope)) {
         this.creating = false;
-        await this.load();
+        await this.load({ preserveError: true });
       }
     }
   }


### PR DESCRIPTION
Closes #106158

AI-assisted: Yes. This pull request was prepared with OpenAI Codex.

## What Problem This Solves

Fixes an issue where Control UI users managing worktrees would lose the actionable error from a failed create, remove, restore, or cleanup operation as soon as the mandatory list refresh succeeded.

## Why This Change Was Made

Post-mutation list refreshes now preserve the current operation error when the refresh succeeds. A refresh failure still replaces it with the newer list error, while normal non-mutation loads continue to clear stale errors as before.

## User Impact

Failed Worktrees actions now leave their Gateway error visible in the existing error callout, so users can understand and act on the failure instead of seeing the operation appear to do nothing.

## Evidence

- Added component regression coverage that drives the real `openclaw-worktrees-page` element and verifies the rendered error callout remains after a successful follow-up list refresh.
- Added coverage that verifies a failed follow-up list refresh replaces the mutation error with the newer refresh error.
- `node scripts/run-vitest.mjs ui/src/pages/worktrees/worktrees-page.test.ts` - 1 file passed, 12 tests passed.
- `pnpm tsgo:ui` - passed.
- `pnpm tsgo:test:ui` - passed.
- `pnpm exec oxfmt --check ui/src/pages/worktrees/worktrees-page.ts ui/src/pages/worktrees/worktrees-page.test.ts` - passed.
- `pnpm exec oxlint --tsconfig ./tsconfig.json ui/src/pages/worktrees/worktrees-page.ts ui/src/pages/worktrees/worktrees-page.test.ts` - passed.
- Local changed-surface run passed using the repository's remote-child lane: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed`.

The default `pnpm check:changed` delegation did not reach project validation because the bundled Crabbox client failed its own `--version`/`--help` sanity check. No screenshot is included because this changes error persistence only; it does not change copy or layout, and the component test asserts the existing callout's rendered text.
