### PR TITLE
fix(ui): stroke new-session target icons instead of black fills

### DIFF
--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -106,6 +106,20 @@ openclaw-new-session-page {
   color: inherit;
 }
 
+/* Icon templates only carry paths; without an explicit stroke rule the SVGs
+   render as solid black fills (invisible-blob chips in dark mode). */
+.new-session-page__trigger-chevron svg,
+.new-session-page__target-icon svg,
+.new-session-page__browser-nav svg {
+  width: 14px;
+  height: 14px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.7px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .new-session-page__trigger-chevron svg {
   width: 12px;
   height: 12px;
@@ -179,11 +193,6 @@ openclaw-new-session-page {
   color: var(--muted);
 }
 
-.new-session-page__target-icon svg {
-  width: 14px;
-  height: 14px;
-}
-
 .new-session-page__browser-nav {
   display: inline-flex;
   align-items: center;
@@ -200,11 +209,6 @@ openclaw-new-session-page {
 .new-session-page__browser-nav:hover:not(:disabled) {
   background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
   color: var(--text);
-}
-
-.new-session-page__browser-nav svg {
-  width: 14px;
-  height: 14px;
 }
 
 .new-session-page__browser-nav:disabled {


### PR DESCRIPTION
## What Problem This Solves

The start-screen ("New session") target row chips — agent, workspace folder, and gateway/device — rendered their Lucide icons as solid black blobs. `ui/src/styles/new-session.css` sized the SVGs but never set `stroke: currentColor; fill: none`, so the path-only icon templates fell back to the SVG default (black fill, no stroke). In dark mode the icons were nearly invisible; in light mode they read as filled blobs instead of the outline icon style used everywhere else in the Control UI.

## Why This Change Was Made

The icon templates in `ui/src/components/icons.ts` carry bare paths and rely on each consumer to apply the shared stroke rules (see `.session-menu__icon svg` in `ui/src/styles/layout.css`). The new-session page missed that rule for its three icon containers.

## User Impact

Agent/workspace/gateway chips on the start screen, plus the folder-browser icons (back arrow, close, device and folder rows), now render as proper outline icons that follow `currentColor` — muted by default, text color on hover — in both light and dark themes.

Before (dark):

![before dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/new-session-target-icons/before-dark-row.png)

After (dark):

![after dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/new-session-target-icons/after-dark-row.png)

After (light):

![after light](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/new-session-target-icons/after-light-row.png)

## Evidence

- CSS-only change: consolidated `.new-session-page__trigger-chevron svg`, `.new-session-page__target-icon svg`, and `.new-session-page__browser-nav svg` into one rule with `stroke: currentColor; fill: none; stroke-width: 1.7px` (matching the shared `.session-menu__*` icon rules); the chevron keeps its 12px override.
- Verified in the mock Control UI harness (`pnpm dev:ui:mock`) on `/new` in dark and light color schemes: trigger chips, the "Where" menu, and the folder browser all render outline icons (screenshots above).
- `git diff --check` clean; autoreview (Codex `gpt-5.6-sol`) clean: "no accepted/actionable findings".
