### PR TITLE
improve(gateway): speed up pristine plugin-heavy startup [AI]

### DIFF
--- a/src/cli/command-bootstrap.test.ts
+++ b/src/cli/command-bootstrap.test.ts
@@ -44,6 +44,25 @@ describe("ensureCliCommandBootstrap", () => {
     });
   });
 
+  it("forwards prepared pristine migration facts to the config guard", async () => {
+    const runtime = {} as never;
+
+    await ensureCliCommandBootstrap({
+      runtime,
+      commandPath: ["gateway"],
+      loadPlugins: false,
+      skipPristineCoreStateMigrations: true,
+      skipPristineStartupStateMigrations: true,
+    });
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime,
+      commandPath: ["gateway"],
+      skipPristineCoreStateMigrations: true,
+      skipPristineStartupStateMigrations: true,
+    });
+  });
+
   it("skips config guard without skipping plugin loading", async () => {
     await ensureCliCommandBootstrap({
       runtime: {} as never,

--- a/src/cli/command-bootstrap.ts
+++ b/src/cli/command-bootstrap.ts
@@ -22,6 +22,7 @@ export async function ensureCliCommandBootstrap(params: {
   beforeStateMigrations?: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
   loadPlugins?: boolean;
   pluginRegistry?: CliPluginRegistryPolicy;
+  skipPristineCoreStateMigrations?: boolean;
   skipPristineStartupStateMigrations?: boolean;
 }) {
   if (!params.skipConfigGuard) {
@@ -37,6 +38,7 @@ export async function ensureCliCommandBootstrap(params: {
       ...(params.skipPristineStartupStateMigrations
         ? { skipPristineStartupStateMigrations: true }
         : {}),
+      ...(params.skipPristineCoreStateMigrations ? { skipPristineCoreStateMigrations: true } : {}),
     });
   }
   if (!params.loadPlugins) {

--- a/src/cli/command-execution-startup.test.ts
+++ b/src/cli/command-execution-startup.test.ts
@@ -217,6 +217,8 @@ describe("command-execution-startup", () => {
       },
       allowInvalid: true,
       loadPlugins: true,
+      skipPristineCoreStateMigrations: true,
+      skipPristineStartupStateMigrations: true,
     });
 
     expect(ensureCliCommandBootstrapMock).toHaveBeenLastCalledWith({
@@ -227,6 +229,8 @@ describe("command-execution-startup", () => {
       loadPlugins: true,
       pluginRegistry: { scope: "all" },
       skipConfigGuard: false,
+      skipPristineCoreStateMigrations: true,
+      skipPristineStartupStateMigrations: true,
     });
   });
 });

--- a/src/cli/command-execution-startup.ts
+++ b/src/cli/command-execution-startup.ts
@@ -71,6 +71,7 @@ export async function ensureCliExecutionBootstrap(params: {
   beforeStateMigrations?: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
   loadPlugins?: boolean;
   skipConfigGuard?: boolean;
+  skipPristineCoreStateMigrations?: boolean;
   skipPristineStartupStateMigrations?: boolean;
 }) {
   await ensureCliCommandBootstrap({
@@ -87,5 +88,6 @@ export async function ensureCliExecutionBootstrap(params: {
     ...(params.skipPristineStartupStateMigrations
       ? { skipPristineStartupStateMigrations: true }
       : {}),
+    ...(params.skipPristineCoreStateMigrations ? { skipPristineCoreStateMigrations: true } : {}),
   });
 }

--- a/src/cli/gateway-cli/pre-bootstrap.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.ts
@@ -626,7 +626,7 @@ export async function prepareGatewayRunBootstrap(params: GatewayRunGuardParams):
   preparedGatewayRunStateWasPristine = false;
   preparedGatewayRunCoreStateWasPristine = false;
   const pristineSelectionSignature = resolveGatewayConfigSelectionSignature(process.env);
-  const { planPristineStartupStateMigrations } =
+  const { planPristineStartupConfigMigrations, planPristineStartupStateMigrations } =
     await import("../../commands/doctor/shared/pristine-startup-state.js");
   const pristineStatePlan = planPristineStartupStateMigrations(process.env);
   // Stop the early proxy before recovery can select another config/state target. Its lifecycle
@@ -645,15 +645,23 @@ export async function prepareGatewayRunBootstrap(params: GatewayRunGuardParams):
         recoverSuspicious: true,
         restoreSuspicious: true,
       });
+  // Recovery can replace config without changing its selected path. Revalidate the final authored
+  // file while retaining the pre-guard physical-state fact, or stateful backup config could skip.
+  const guardedConfigPlan = planPristineStartupConfigMigrations(
+    guarded ? lastGuardedGatewayRunSnapshot?.parsed : undefined,
+    process.env,
+  );
   preparedGatewayRunStateWasPristine =
     guarded &&
     !params.opts.reset &&
     pristineStatePlan.skipAllStateMigrations &&
+    guardedConfigPlan.skipAllStateMigrations &&
     resolveGatewayConfigSelectionSignature(process.env) === pristineSelectionSignature;
   preparedGatewayRunCoreStateWasPristine =
     guarded &&
     !params.opts.reset &&
     pristineStatePlan.skipCoreStateMigrations &&
+    guardedConfigPlan.skipCoreStateMigrations &&
     resolveGatewayConfigSelectionSignature(process.env) === pristineSelectionSignature;
   await pinGatewayRunRuntimePaths();
   // Dev reset deletes the state directory before recreating config. Migrating first would

--- a/src/cli/gateway-cli/pre-bootstrap.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.ts
@@ -29,6 +29,7 @@ let appliedGatewayRunConfigEnvironment: GatewayRunEnvironmentSelection | undefin
 let lastGuardedGatewayRunSnapshot: ConfigFileSnapshot | undefined;
 let preparedGatewayRunBootstrapSnapshot: ConfigFileSnapshot | undefined;
 let preparedGatewayRunStateWasPristine = false;
+let preparedGatewayRunCoreStateWasPristine = false;
 let preparedGatewayRunReset: PreparedGatewayRunReset | undefined;
 let gatewayRunTargetSelectedByConfig = false;
 
@@ -623,10 +624,11 @@ export async function selectGatewayRunEnvironment(params: GatewayRunGuardParams)
 export async function prepareGatewayRunBootstrap(params: GatewayRunGuardParams): Promise<boolean> {
   preparedGatewayRunReset = undefined;
   preparedGatewayRunStateWasPristine = false;
+  preparedGatewayRunCoreStateWasPristine = false;
   const pristineSelectionSignature = resolveGatewayConfigSelectionSignature(process.env);
-  const { canSkipPristineStartupStateMigrations } =
+  const { planPristineStartupStateMigrations } =
     await import("../../commands/doctor/shared/pristine-startup-state.js");
-  const selectedStateWasPristine = canSkipPristineStartupStateMigrations(process.env);
+  const pristineStatePlan = planPristineStartupStateMigrations(process.env);
   // Stop the early proxy before recovery can select another config/state target. Its lifecycle
   // restores the underlying env snapshot so the selected target's trusted dotenv can replace it.
   await getGatewayRunRuntimeHooks().releaseManagedProxy?.();
@@ -646,7 +648,12 @@ export async function prepareGatewayRunBootstrap(params: GatewayRunGuardParams):
   preparedGatewayRunStateWasPristine =
     guarded &&
     !params.opts.reset &&
-    selectedStateWasPristine &&
+    pristineStatePlan.skipAllStateMigrations &&
+    resolveGatewayConfigSelectionSignature(process.env) === pristineSelectionSignature;
+  preparedGatewayRunCoreStateWasPristine =
+    guarded &&
+    !params.opts.reset &&
+    pristineStatePlan.skipCoreStateMigrations &&
     resolveGatewayConfigSelectionSignature(process.env) === pristineSelectionSignature;
   await pinGatewayRunRuntimePaths();
   // Dev reset deletes the state directory before recreating config. Migrating first would
@@ -666,6 +673,11 @@ export async function prepareGatewayRunBootstrap(params: GatewayRunGuardParams):
 /** Prepared fact captured before Gateway bootstrap can create runtime state. */
 export function wasPreparedGatewayRunStatePristine(): boolean {
   return preparedGatewayRunStateWasPristine;
+}
+
+/** Prepared fact keeps plugin-only configs out of unrelated core migration discovery. */
+export function wasPreparedGatewayRunCoreStatePristine(): boolean {
+  return preparedGatewayRunCoreStateWasPristine;
 }
 
 export async function recheckGatewayRunBootstrap(

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -65,6 +65,10 @@ const configState = vi.hoisted(() => ({
   cfg: {} as Record<string, unknown>,
   snapshot: { config: {}, exists: false, sourceConfig: {}, valid: true } as Record<string, unknown>,
 }));
+const pristineStartupMigrationPlan = vi.hoisted(() => ({
+  config: vi.fn(),
+  state: vi.fn(),
+}));
 const readBestEffortConfig = vi.fn(async () => configState.cfg);
 type ConfigSnapshotReadOptionsStub = {
   isolateEnv?: boolean;
@@ -136,6 +140,13 @@ vi.mock("../../config/config.js", () => ({
   readConfigFileSnapshot: async () => configState.snapshot,
   readConfigFileSnapshotWithPluginMetadata: (options?: ConfigSnapshotReadOptionsStub) =>
     readConfigFileSnapshotWithPluginMetadata(options),
+}));
+
+vi.mock("../../commands/doctor/shared/pristine-startup-state.js", () => ({
+  planPristineStartupConfigMigrations: (config: unknown, env?: NodeJS.ProcessEnv) =>
+    pristineStartupMigrationPlan.config(config, env),
+  planPristineStartupStateMigrations: (env?: NodeJS.ProcessEnv) =>
+    pristineStartupMigrationPlan.state(env),
 }));
 
 vi.mock("../../config/paths.js", () => ({
@@ -342,6 +353,16 @@ describe("gateway run option collisions", () => {
     resetRuntimeCapture();
     configState.cfg = {};
     configState.snapshot = { config: {}, exists: false, sourceConfig: {}, valid: true };
+    pristineStartupMigrationPlan.config.mockReset();
+    pristineStartupMigrationPlan.config.mockReturnValue({
+      skipAllStateMigrations: false,
+      skipCoreStateMigrations: false,
+    });
+    pristineStartupMigrationPlan.state.mockReset();
+    pristineStartupMigrationPlan.state.mockReturnValue({
+      skipAllStateMigrations: false,
+      skipCoreStateMigrations: false,
+    });
     netState.autoBindHost = "127.0.0.1";
     netState.container = false;
     readBestEffortConfig.mockClear();
@@ -423,6 +444,50 @@ describe("gateway run option collisions", () => {
 
     expect(beforeRun).toHaveBeenCalledOnce();
     expect(callOrder).toEqual(["bootstrap", "normalize", "normalize", "start"]);
+  });
+
+  it("drops the pristine core fact when guarded config becomes stateful", async () => {
+    const initialConfig = {
+      gateway: { mode: "local" },
+      plugins: { load: { paths: ["/plugins/example"] } },
+    };
+    configState.snapshot = {
+      config: initialConfig,
+      exists: true,
+      hash: "initial",
+      parsed: initialConfig,
+      path: "/tmp/openclaw.json",
+      sourceConfig: initialConfig,
+      valid: true,
+    };
+    pristineStartupMigrationPlan.state.mockReturnValue({
+      skipAllStateMigrations: false,
+      skipCoreStateMigrations: true,
+    });
+    const {
+      prepareGatewayRunBootstrap,
+      selectGatewayRunEnvironment,
+      wasPreparedGatewayRunCoreStatePristine,
+    } = await import("./pre-bootstrap.js");
+
+    expect(await selectGatewayRunEnvironment({ opts: {}, runtime: defaultRuntime })).toBe(true);
+    const recoveredConfig = {
+      gateway: { mode: "local" },
+      session: { store: "/tmp/sessions.json" },
+    };
+    configState.snapshot = {
+      config: recoveredConfig,
+      exists: true,
+      hash: "recovered",
+      parsed: recoveredConfig,
+      path: "/tmp/openclaw.json",
+      sourceConfig: recoveredConfig,
+      valid: true,
+    };
+
+    expect(await prepareGatewayRunBootstrap({ opts: {}, runtime: defaultRuntime })).toBe(true);
+    expect(wasPreparedGatewayRunCoreStatePristine()).toBe(false);
+    expect(pristineStartupMigrationPlan.config).toHaveBeenCalledWith(recoveredConfig, process.env);
   });
 
   it("refreshes the managed proxy from the final accepted config before gateway startup", async () => {

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -215,6 +215,7 @@ export async function ensureConfigReady(params: {
   suppressDoctorStdout?: boolean;
   allowInvalid?: boolean;
   beforeStateMigrations?: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
+  skipPristineCoreStateMigrations?: boolean;
   skipPristineStartupStateMigrations?: boolean;
 }): Promise<void> {
   const commandPath = params.commandPath ?? [];
@@ -240,6 +241,9 @@ export async function ensureConfigReady(params: {
           : {}),
         ...(params.skipPristineStartupStateMigrations
           ? { skipPristineStartupStateMigrations: true }
+          : {}),
+        ...(params.skipPristineCoreStateMigrations
+          ? { skipPristineCoreStateMigrations: true }
           : {}),
       });
     try {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -183,15 +183,18 @@ async function tryRunGatewayRunFastPath(
   const beforeRun = async (opts: { force?: boolean; reset?: boolean }) => {
     let beforeStateMigrations: ((snapshot?: ConfigFileSnapshot) => Promise<boolean>) | undefined;
     let skipPristineStartupStateMigrations = false;
+    let skipPristineCoreStateMigrations = false;
     const shouldBootstrap = await startupTrace.measure("gateway-run-pre-bootstrap", async () => {
       const {
         prepareGatewayRunBootstrap,
         recheckGatewayRunBootstrap,
+        wasPreparedGatewayRunCoreStatePristine,
         wasPreparedGatewayRunStatePristine,
       } = await import("./gateway-cli/pre-bootstrap.js");
       const prepared = await prepareGatewayRunBootstrap({ opts, runtime: defaultRuntime });
       if (prepared) {
         skipPristineStartupStateMigrations = wasPreparedGatewayRunStatePristine();
+        skipPristineCoreStateMigrations = wasPreparedGatewayRunCoreStatePristine();
         beforeStateMigrations = (snapshot) =>
           recheckGatewayRunBootstrap({
             opts,
@@ -212,6 +215,7 @@ async function tryRunGatewayRunFastPath(
         loadPlugins: false,
         ...(beforeStateMigrations ? { beforeStateMigrations } : {}),
         ...(skipPristineStartupStateMigrations ? { skipPristineStartupStateMigrations: true } : {}),
+        ...(skipPristineCoreStateMigrations ? { skipPristineCoreStateMigrations: true } : {}),
       });
       const { reloadTrustedGatewayRunEnvironment } = await import("./gateway-cli/pre-bootstrap.js");
       await reloadTrustedGatewayRunEnvironment({ runtime: defaultRuntime });

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -94,6 +94,12 @@ const runPostCorePluginConvergence = vi.hoisted(() =>
 const planStartupPluginConvergence = vi.hoisted(() =>
   vi.fn(async () => ({ required: true, installRecords: {} })),
 );
+const planPristineStartupStateMigrations = vi.hoisted(() =>
+  vi.fn(() => ({
+    skipAllStateMigrations: false,
+    skipCoreStateMigrations: false,
+  })),
+);
 const makeStartupConvergenceResult = vi.hoisted(
   () =>
     (overrides: Partial<StartupConvergenceResult> = {}): StartupConvergenceResult => ({
@@ -145,6 +151,10 @@ vi.mock("./doctor/shared/startup-plugin-convergence-plan.js", () => ({
   planStartupPluginConvergence,
 }));
 
+vi.mock("./doctor/shared/pristine-startup-state.js", () => ({
+  planPristineStartupStateMigrations,
+}));
+
 vi.mock("../config/io.js", () => ({
   readConfigFileSnapshot,
   recoverConfigFromJsonRootSuffix: vi.fn(),
@@ -161,6 +171,10 @@ describe("runDoctorConfigPreflight state migration", () => {
     needsStartupMigrationCheckpoint.mockReturnValue(false);
     runPostCorePluginConvergence.mockResolvedValue(makeStartupConvergenceResult());
     planStartupPluginConvergence.mockResolvedValue({ required: true, installRecords: {} });
+    planPristineStartupStateMigrations.mockReturnValue({
+      skipAllStateMigrations: false,
+      skipCoreStateMigrations: false,
+    });
     autoMigrateLegacyStateDir.mockResolvedValue({
       migrated: false,
       skipped: false,
@@ -460,6 +474,43 @@ describe("runDoctorConfigPreflight state migration", () => {
       expect.objectContaining({ valid: true }),
     );
     expect(recordSuccessfulStartupMigrations).toHaveBeenCalledOnce();
+  });
+
+  it("runs only plugin-owned migrations for a pristine core state root", async () => {
+    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    planPristineStartupStateMigrations.mockReturnValueOnce({
+      skipAllStateMigrations: false,
+      skipCoreStateMigrations: true,
+    });
+
+    await runDoctorConfigPreflight({
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+      requireStartupMigrationCheckpoint: true,
+    });
+
+    expect(autoMigrateLegacyStateDir).toHaveBeenCalledOnce();
+    expect(repairLegacyCronStoreWithoutPrompt).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyState).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyTaskStateSidecars).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyPluginDoctorState).toHaveBeenCalledWith({
+      config: { gateway: { mode: "local", port: 19091 } },
+      env: process.env,
+    });
+  });
+
+  it("retains the prepared core-state fact after runtime files appear", async () => {
+    needsStartupMigrationCheckpoint.mockReturnValue(true);
+
+    await runDoctorConfigPreflight({
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+      requireStartupMigrationCheckpoint: true,
+      skipPristineCoreStateMigrations: true,
+    });
+
+    expect(autoMigrateLegacyState).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyPluginDoctorState).toHaveBeenCalledOnce();
   });
 
   it("blocks gateway readiness when startup migrations leave warnings", async () => {

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -217,6 +217,8 @@ export async function runDoctorConfigPreflight(
     /** Return false or reject on config drift; the preflight always unwinds owned resources. */
     beforeStateMigrations?: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
     requireStartupMigrationCheckpoint?: boolean;
+    /** Core state was proven absent before Gateway selection could create runtime files. */
+    skipPristineCoreStateMigrations?: boolean;
     /** Prepared before Gateway bootstrap can create files under an otherwise pristine state root. */
     skipPristineStartupStateMigrations?: boolean;
     /**
@@ -237,6 +239,8 @@ export async function runDoctorConfigPreflight(
   let startupMigrationEnv = process.env;
   let shouldRecordStartupCheckpoint = false;
   let skipPristineStartupStateMigrations = options.skipPristineStartupStateMigrations === true;
+  let skipPristineCoreStateMigrations =
+    skipPristineStartupStateMigrations || options.skipPristineCoreStateMigrations === true;
   let startupMigrationLease: StartupMigrationLease | undefined;
   let startupMigrationHeartbeat: ReturnType<typeof setInterval> | undefined;
   let startupMigrationHeartbeatError: unknown;
@@ -252,14 +256,15 @@ export async function runDoctorConfigPreflight(
   try {
     if (startupCheckpoint && !skipPristineStartupStateMigrations) {
       // Capture pristine state before the Gateway's fresh-config guard can prepare runtime state.
-      const { canSkipPristineStartupStateMigrations } = await measureStartupPreflightStep(
+      const { planPristineStartupStateMigrations } = await measureStartupPreflightStep(
         "pristine-state-plan-import",
         () => import("./doctor/shared/pristine-startup-state.js"),
       );
-      skipPristineStartupStateMigrations = await measureStartupPreflightStep(
-        "pristine-state-plan",
-        () => canSkipPristineStartupStateMigrations(process.env),
+      const pristineStatePlan = await measureStartupPreflightStep("pristine-state-plan", () =>
+        planPristineStartupStateMigrations(process.env),
       );
+      skipPristineStartupStateMigrations = pristineStatePlan.skipAllStateMigrations;
+      skipPristineCoreStateMigrations ||= pristineStatePlan.skipCoreStateMigrations;
     }
     // The gateway uses this last-moment guard to ensure its prepared config did not change before
     // any automatic migration mutates state. A rejected guard skips every state migration stage.
@@ -374,7 +379,18 @@ export async function runDoctorConfigPreflight(
         autoMigrateLegacyTaskStateSidecars,
       } = stateMigrations;
       if (stateMigrationInput) {
-        if (stateMigrationInput.cfg) {
+        const pluginDoctorOnlyConfig =
+          stateMigrationInput.pluginDoctorConfig ?? stateMigrationInput.cfg;
+        if (skipPristineCoreStateMigrations && pluginDoctorOnlyConfig) {
+          // Core state is absent, but plugin paths may own external migration state.
+          // Keep their doctor owner active without loading channel/session detectors.
+          noteStartupStateMigrationResult(
+            await autoMigrateLegacyPluginDoctorState({
+              config: pluginDoctorOnlyConfig,
+              env: process.env,
+            }),
+          );
+        } else if (stateMigrationInput.cfg) {
           const { repairLegacyCronStoreWithoutPrompt } = await loadDoctorCron();
           const cronResult = await repairLegacyCronStoreWithoutPrompt({
             cfg: stateMigrationInput.cfg,

--- a/src/commands/doctor/shared/pristine-startup-state.test.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.test.ts
@@ -2,7 +2,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { canSkipPristineStartupStateMigrations } from "./pristine-startup-state.js";
+import {
+  canSkipPristineStartupStateMigrations,
+  planPristineStartupStateMigrations,
+} from "./pristine-startup-state.js";
 
 const roots: string[] = [];
 
@@ -101,6 +104,27 @@ describe("pristine startup state", () => {
     );
 
     expect(canSkipPristineStartupStateMigrations(env)).toBe(false);
+  });
+
+  it("retains plugin migrations while skipping absent core state for load paths", () => {
+    const env = createFixture({
+      gateway: { mode: "local" },
+      plugins: { allow: ["example"], load: { paths: ["/plugins/example"] } },
+    });
+
+    expect(planPristineStartupStateMigrations(env)).toEqual({
+      skipAllStateMigrations: false,
+      skipCoreStateMigrations: true,
+    });
+  });
+
+  it("retains core migrations for config that can point outside the state root", () => {
+    const env = createFixture({ session: { store: "/tmp/sessions.json" } });
+
+    expect(planPristineStartupStateMigrations(env)).toEqual({
+      skipAllStateMigrations: false,
+      skipCoreStateMigrations: false,
+    });
   });
 
   it("rejects enabled plugin entries and includes", () => {

--- a/src/commands/doctor/shared/pristine-startup-state.test.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   canSkipPristineStartupStateMigrations,
+  planPristineStartupConfigMigrations,
   planPristineStartupStateMigrations,
 } from "./pristine-startup-state.js";
 
@@ -122,6 +123,24 @@ describe("pristine startup state", () => {
     const env = createFixture({ session: { store: "/tmp/sessions.json" } });
 
     expect(planPristineStartupStateMigrations(env)).toEqual({
+      skipAllStateMigrations: false,
+      skipCoreStateMigrations: false,
+    });
+  });
+
+  it("revalidates guarded config without depending on post-guard state files", () => {
+    const env = createFixture({});
+
+    expect(
+      planPristineStartupConfigMigrations(
+        { gateway: { mode: "local" }, plugins: { load: { paths: ["/plugins/example"] } } },
+        env,
+      ),
+    ).toEqual({ skipAllStateMigrations: false, skipCoreStateMigrations: true });
+    expect(
+      planPristineStartupConfigMigrations({ session: { store: "/tmp/sessions.json" } }, env),
+    ).toEqual({ skipAllStateMigrations: false, skipCoreStateMigrations: false });
+    expect(planPristineStartupConfigMigrations({ $include: "base.json" }, env)).toEqual({
       skipAllStateMigrations: false,
       skipCoreStateMigrations: false,
     });

--- a/src/commands/doctor/shared/pristine-startup-state.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.ts
@@ -85,14 +85,6 @@ function hasOnlyMigrationSafePluginEntries(
   });
 }
 
-function readPristineStartupConfig(configPath: string): Record<string, unknown> | null {
-  const config = tryReadJsonSync(configPath);
-  if (!isRecord(config) || Object.hasOwn(config, "$include")) {
-    return null;
-  }
-  return config;
-}
-
 function configIsPristineCoreStateSafe(config: Record<string, unknown>): boolean {
   if ([...STATEFUL_CONFIG_KEYS].some((key) => Object.hasOwn(config, key))) {
     return false;
@@ -101,6 +93,26 @@ function configIsPristineCoreStateSafe(config: Record<string, unknown>): boolean
     return false;
   }
   return true;
+}
+
+export type PristineStartupMigrationPlan = {
+  skipAllStateMigrations: boolean;
+  skipCoreStateMigrations: boolean;
+};
+
+/** Revalidates the authored config after startup recovery without rereading physical state. */
+export function planPristineStartupConfigMigrations(
+  config: unknown,
+  env: NodeJS.ProcessEnv = process.env,
+): PristineStartupMigrationPlan {
+  if (!isRecord(config) || Object.hasOwn(config, "$include")) {
+    return { skipAllStateMigrations: false, skipCoreStateMigrations: false };
+  }
+  const skipCoreStateMigrations = configIsPristineCoreStateSafe(config);
+  return {
+    skipAllStateMigrations: skipCoreStateMigrations && configIsPristineStateSafe(config, env),
+    skipCoreStateMigrations,
+  };
 }
 
 function configIsPristineStateSafe(
@@ -141,14 +153,12 @@ export function canSkipPristineStartupStateMigrations(
 }
 
 /** Separates provably absent core state from plugin-owned migration work. */
-export function planPristineStartupStateMigrations(env: NodeJS.ProcessEnv = process.env): {
-  skipAllStateMigrations: boolean;
-  skipCoreStateMigrations: boolean;
-} {
+export function planPristineStartupStateMigrations(
+  env: NodeJS.ProcessEnv = process.env,
+): PristineStartupMigrationPlan {
   const stateDir = resolveStateDir(env);
   const configPath = resolveConfigPath(env, stateDir);
-  const config = readPristineStartupConfig(configPath);
-  if (!config || !stateDirHasOnlyConfig(stateDir, configPath)) {
+  if (!stateDirHasOnlyConfig(stateDir, configPath)) {
     return { skipAllStateMigrations: false, skipCoreStateMigrations: false };
   }
   const homeDir = resolveEffectiveHomeDir(env);
@@ -161,9 +171,12 @@ export function planPristineStartupStateMigrations(env: NodeJS.ProcessEnv = proc
     }
     return !fs.existsSync(legacyDir);
   });
-  const skipCoreStateMigrations = legacyStateAbsent && configIsPristineCoreStateSafe(config);
+  if (!legacyStateAbsent) {
+    return { skipAllStateMigrations: false, skipCoreStateMigrations: false };
+  }
+  const configPlan = planPristineStartupConfigMigrations(tryReadJsonSync(configPath), env);
   return {
-    skipAllStateMigrations: skipCoreStateMigrations && configIsPristineStateSafe(config, env),
-    skipCoreStateMigrations,
+    skipAllStateMigrations: configPlan.skipAllStateMigrations,
+    skipCoreStateMigrations: configPlan.skipCoreStateMigrations,
   };
 }

--- a/src/commands/doctor/shared/pristine-startup-state.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.ts
@@ -85,15 +85,29 @@ function hasOnlyMigrationSafePluginEntries(
   });
 }
 
-function configIsPristineStateSafe(configPath: string, env: NodeJS.ProcessEnv): boolean {
+function readPristineStartupConfig(configPath: string): Record<string, unknown> | null {
   const config = tryReadJsonSync(configPath);
   if (!isRecord(config) || Object.hasOwn(config, "$include")) {
-    return false;
+    return null;
   }
+  return config;
+}
+
+function configIsPristineCoreStateSafe(config: Record<string, unknown>): boolean {
   if ([...STATEFUL_CONFIG_KEYS].some((key) => Object.hasOwn(config, key))) {
     return false;
   }
   if (containsObjectKey(config.agents, "memorySearch")) {
+    return false;
+  }
+  return true;
+}
+
+function configIsPristineStateSafe(
+  config: Record<string, unknown>,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  if (!configIsPristineCoreStateSafe(config)) {
     return false;
   }
   if (!hasOnlyMigrationSafePluginEntries(config, env)) {
@@ -123,19 +137,33 @@ function stateDirHasOnlyConfig(stateDir: string, configPath: string): boolean {
 export function canSkipPristineStartupStateMigrations(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
+  return planPristineStartupStateMigrations(env).skipAllStateMigrations;
+}
+
+/** Separates provably absent core state from plugin-owned migration work. */
+export function planPristineStartupStateMigrations(env: NodeJS.ProcessEnv = process.env): {
+  skipAllStateMigrations: boolean;
+  skipCoreStateMigrations: boolean;
+} {
   const stateDir = resolveStateDir(env);
   const configPath = resolveConfigPath(env, stateDir);
-  if (!configIsPristineStateSafe(configPath, env) || !stateDirHasOnlyConfig(stateDir, configPath)) {
-    return false;
+  const config = readPristineStartupConfig(configPath);
+  if (!config || !stateDirHasOnlyConfig(stateDir, configPath)) {
+    return { skipAllStateMigrations: false, skipCoreStateMigrations: false };
   }
   const homeDir = resolveEffectiveHomeDir(env);
   if (!homeDir) {
-    return false;
+    return { skipAllStateMigrations: false, skipCoreStateMigrations: false };
   }
-  return resolveLegacyStateDirs(() => homeDir).every((legacyDir) => {
+  const legacyStateAbsent = resolveLegacyStateDirs(() => homeDir).every((legacyDir) => {
     if (path.resolve(legacyDir) === path.resolve(stateDir)) {
       return false;
     }
     return !fs.existsSync(legacyDir);
   });
+  const skipCoreStateMigrations = legacyStateAbsent && configIsPristineCoreStateSafe(config);
+  return {
+    skipAllStateMigrations: skipCoreStateMigrations && configIsPristineStateSafe(config, env),
+    skipCoreStateMigrations,
+  };
 }


### PR DESCRIPTION
Closes #106194

## What Problem This Solves

Fixes an issue where users starting a Gateway against a pristine state root would wait for unrelated core legacy-migration detector imports when local plugins were configured. Plugin-heavy first starts paid this cost even though no core state existed to migrate.

## Why This Change Was Made

The Gateway now captures the physically pristine core-state fact before selection can create runtime files, then carries it through the existing bootstrap seam. Startup skips only core migration discovery when that fact remains safe; plugin-owned doctor migrations still run, and existing core state, external session stores, `$include`, or stateful core config retain the full migration path.

This keeps one canonical migration boundary and adds no cache, config, protocol, persistence, compatibility shim, or fallback.

## User Impact

Newly provisioned Gateways become ready sooner, especially with many local plugins. Existing installations and migration behavior are unchanged.

Release note: Faster first Gateway startup for plugin-heavy configurations.

## Evidence

Controlled Blacksmith Testbox A/B: 7 measured runs, 2 warmups, p50.

- 50 manifest plugins: `/readyz` 4911.3 ms -> 4242.9 ms (-13.6%); bootstrap 2711.2 ms -> 2289.9 ms (-15.5%).
- 50 startup-lazy plugins: `/readyz` 4603.2 ms -> 4287.0 ms (-6.9%); bootstrap 2741.9 ms -> 2426.6 ms (-11.5%).
- Default config: `/readyz` 3184.7 ms -> 3039.7 ms (-4.6%); bootstrap remained flat (143.7 ms -> 143.1 ms).

Exact rebased-head proof at `ed243b617059` on direct AWS Crabbox `cbx_8df19c39207d` ([run](https://crabbox.openclaw.ai/portal/runs/run_9cb4f2539051)):

- `pnpm build`
- 111 tests across command bootstrap, execution startup, guarded recovery, pristine-state planning, doctor migration routing, and the plugin SDK surface contract
- touched-file oxlint
- 3-run benchmark confirmation on the AWS host: default `/readyz` p50 4797.5 ms; 50 plugins 7509.1 ms; 50 startup-lazy plugins 7260.3 ms

Pre-commit autoreview: clean, no accepted/actionable findings. GitHub review's same-path recovery edge is fixed by revalidating the final guarded config without repeating physical-state discovery.

AI-assisted implementation; maintainer-reviewed behavior and proof.
