### PR TITLE
fix: restore GitHub Copilot turns and account context limits

### DIFF
--- a/extensions/github-copilot/auth.test.ts
+++ b/extensions/github-copilot/auth.test.ts
@@ -4,6 +4,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vites
 const ensureAuthProfileStoreMock = vi.hoisted(() => vi.fn());
 const listProfilesForProviderMock = vi.hoisted(() => vi.fn());
 const coerceSecretRefMock = vi.hoisted(() => vi.fn());
+const resolveConfiguredSecretInputWithFallbackMock = vi.hoisted(() => vi.fn());
 const resolveRequiredConfiguredSecretRefInputStringMock = vi.hoisted(() => vi.fn());
 
 vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
@@ -13,6 +14,7 @@ vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
 }));
 
 vi.mock("openclaw/plugin-sdk/secret-input-runtime", () => ({
+  resolveConfiguredSecretInputWithFallback: resolveConfiguredSecretInputWithFallbackMock,
   resolveRequiredConfiguredSecretRefInputString: resolveRequiredConfiguredSecretRefInputStringMock,
 }));
 
@@ -41,6 +43,11 @@ describe("resolveFirstGithubToken", () => {
       id: "/providers/github-copilot/token",
     });
     resolveRequiredConfiguredSecretRefInputStringMock.mockResolvedValue("resolved-profile-token");
+    resolveConfiguredSecretInputWithFallbackMock.mockResolvedValue({
+      value: "test-token-placeholder",
+      source: "config",
+      secretRefConfigured: false,
+    });
   });
 
   afterEach(() => {
@@ -48,6 +55,7 @@ describe("resolveFirstGithubToken", () => {
     ensureAuthProfileStoreMock.mockReset();
     listProfilesForProviderMock.mockReset();
     coerceSecretRefMock.mockReset();
+    resolveConfiguredSecretInputWithFallbackMock.mockReset();
     resolveRequiredConfiguredSecretRefInputStringMock.mockReset();
   });
 
@@ -82,6 +90,54 @@ describe("resolveFirstGithubToken", () => {
       githubToken: "profile-token",
       hasProfile: true,
     });
+  });
+
+  it("uses configured direct auth without falling back to the first profile", async () => {
+    const config = {
+      models: {
+        providers: {
+          "github-copilot": { apiKey: "test-token-placeholder" },
+        },
+      },
+    } as never;
+    const env = { GH_TOKEN: "test-auth-token" } as NodeJS.ProcessEnv;
+
+    const result = await resolveFirstGithubToken({
+      config,
+      env,
+      authProfileMode: "api_key",
+    });
+
+    expect(result).toEqual({
+      githubToken: "test-token-placeholder",
+      hasProfile: false,
+    });
+    expect(resolveConfiguredSecretInputWithFallbackMock).toHaveBeenCalledWith({
+      config,
+      env,
+      value: "test-token-placeholder",
+      path: "models.providers.github-copilot.apiKey",
+      readFallback: expect.any(Function),
+    });
+    expect(resolveRequiredConfiguredSecretRefInputStringMock).not.toHaveBeenCalled();
+  });
+
+  it("does not report stored profiles for a missing direct credential", async () => {
+    resolveConfiguredSecretInputWithFallbackMock.mockResolvedValue({
+      secretRefConfigured: false,
+    });
+
+    const result = await resolveFirstGithubToken({
+      config: {},
+      env: {} as NodeJS.ProcessEnv,
+      authProfileMode: "api_key",
+    });
+
+    expect(result).toEqual({
+      githubToken: "",
+      hasProfile: false,
+    });
+    expect(resolveRequiredConfiguredSecretRefInputStringMock).not.toHaveBeenCalled();
   });
 
   it("resolves non-env SecretRefs when config is available", async () => {

--- a/extensions/github-copilot/auth.test.ts
+++ b/extensions/github-copilot/auth.test.ts
@@ -11,6 +11,8 @@ vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
   coerceSecretRef: coerceSecretRefMock,
   ensureAuthProfileStore: ensureAuthProfileStoreMock,
   listProfilesForProvider: listProfilesForProviderMock,
+  normalizeOptionalSecretInput: (value: unknown) =>
+    typeof value === "string" && value.trim() ? value.trim() : undefined,
 }));
 
 vi.mock("openclaw/plugin-sdk/secret-input-runtime", () => ({
@@ -92,11 +94,38 @@ describe("resolveFirstGithubToken", () => {
     });
   });
 
-  it("uses configured direct auth without falling back to the first profile", async () => {
+  it("uses environment direct auth without falling back to config or the first profile", async () => {
     const config = {
       models: {
         providers: {
           "github-copilot": { apiKey: "test-token-placeholder" },
+        },
+      },
+    } as never;
+    const env = { GH_TOKEN: "test-auth-token" } as NodeJS.ProcessEnv;
+
+    const result = await resolveFirstGithubToken({
+      config,
+      env,
+      authProfileMode: "api_key",
+    });
+
+    expect(result).toEqual({
+      githubToken: "test-auth-token",
+      hasProfile: false,
+    });
+    expect(resolveConfiguredSecretInputWithFallbackMock).not.toHaveBeenCalled();
+    expect(resolveRequiredConfiguredSecretRefInputStringMock).not.toHaveBeenCalled();
+  });
+
+  it("lets explicit api-key config outrank environment direct auth", async () => {
+    const config = {
+      models: {
+        providers: {
+          "github-copilot": {
+            auth: "api-key",
+            apiKey: "test-token-placeholder",
+          },
         },
       },
     } as never;
@@ -120,6 +149,44 @@ describe("resolveFirstGithubToken", () => {
       readFallback: expect.any(Function),
     });
     expect(resolveRequiredConfiguredSecretRefInputStringMock).not.toHaveBeenCalled();
+  });
+
+  it("skips empty higher-priority environment variables", async () => {
+    const result = await resolveFirstGithubToken({
+      env: {
+        COPILOT_GITHUB_TOKEN: "",
+        GH_TOKEN: "test-auth-token",
+      } as NodeJS.ProcessEnv,
+      authProfileMode: "api_key",
+    });
+
+    expect(result).toEqual({
+      githubToken: "test-auth-token",
+      hasProfile: false,
+    });
+  });
+
+  it("resolves config-only direct auth for unscoped model discovery", async () => {
+    ensureAuthProfileStoreMock.mockReturnValue({ profiles: {} });
+    listProfilesForProviderMock.mockReturnValue([]);
+    const config = {
+      models: {
+        providers: {
+          "github-copilot": { apiKey: "test-token-placeholder" },
+        },
+      },
+    } as never;
+
+    const result = await resolveFirstGithubToken({
+      config,
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(result).toEqual({
+      githubToken: "test-token-placeholder",
+      hasProfile: false,
+    });
+    expect(resolveConfiguredSecretInputWithFallbackMock).toHaveBeenCalledOnce();
   });
 
   it("does not report stored profiles for a missing direct credential", async () => {

--- a/extensions/github-copilot/auth.ts
+++ b/extensions/github-copilot/auth.ts
@@ -5,6 +5,7 @@ import {
   coerceSecretRef,
   ensureAuthProfileStore,
   listProfilesForProvider,
+  normalizeOptionalSecretInput,
 } from "openclaw/plugin-sdk/provider-auth";
 import {
   resolveConfiguredSecretInputWithFallback,
@@ -28,28 +29,50 @@ export async function resolveFirstGithubToken(params: {
   const profileIds = listProfilesForProvider(authStore, PROVIDER_ID);
   const hasProfile = profileIds.length > 0;
   const requestedProfileId = params.profileId?.trim();
-  const envToken =
-    params.env.COPILOT_GITHUB_TOKEN ?? params.env.GH_TOKEN ?? params.env.GITHUB_TOKEN ?? "";
-  const githubToken = envToken.trim();
-  if (!requestedProfileId && params.authProfileMode) {
+  const githubToken =
+    [params.env.COPILOT_GITHUB_TOKEN, params.env.GH_TOKEN, params.env.GITHUB_TOKEN]
+      .map((value) => normalizeOptionalSecretInput(value))
+      .find((value) => value !== undefined) ?? "";
+  const providerConfig = params.config?.models?.providers?.[PROVIDER_ID];
+  const preferConfiguredToken =
+    providerConfig?.auth === "api-key" &&
+    Boolean(
+      normalizeOptionalSecretInput(providerConfig.apiKey) || coerceSecretRef(providerConfig.apiKey),
+    );
+  const resolveConfiguredGithubToken = async () => {
     if (!params.config) {
-      return { githubToken, hasProfile: false };
+      return "";
     }
+    const resolved = await resolveConfiguredSecretInputWithFallback({
+      config: params.config,
+      env: params.env,
+      value: providerConfig?.apiKey,
+      path: `models.providers.${PROVIDER_ID}.apiKey`,
+      readFallback: () => "",
+    });
+    return resolved.value?.trim() ?? "";
+  };
+  const resolveDirectGithubToken = async () => {
+    if (preferConfiguredToken) {
+      const configuredToken = await resolveConfiguredGithubToken();
+      if (configuredToken) {
+        return configuredToken;
+      }
+    }
+    if (githubToken) {
+      return githubToken;
+    }
+    return preferConfiguredToken ? "" : await resolveConfiguredGithubToken();
+  };
+  if (!requestedProfileId && params.authProfileMode) {
     // A missing profile id plus an explicit mode is a prepared direct-auth
     // attempt. Do not let it fall back into the first stored profile: model
     // limits and the later runtime exchange must use the same source token.
     // Stored profiles are therefore ineligible even when the store has one.
-    const resolved = await resolveConfiguredSecretInputWithFallback({
-      config: params.config,
-      env: params.env,
-      value: params.config.models?.providers?.[PROVIDER_ID]?.apiKey,
-      path: `models.providers.${PROVIDER_ID}.apiKey`,
-      readFallback: () => githubToken,
-    });
-    return { githubToken: resolved.value?.trim() ?? "", hasProfile: false };
+    return { githubToken: await resolveDirectGithubToken(), hasProfile: false };
   }
   if (!requestedProfileId && (githubToken || !hasProfile)) {
-    return { githubToken, hasProfile };
+    return { githubToken: await resolveDirectGithubToken(), hasProfile };
   }
 
   const profileId = requestedProfileId

--- a/extensions/github-copilot/auth.ts
+++ b/extensions/github-copilot/auth.ts
@@ -1,17 +1,23 @@
 // Github Copilot plugin module implements auth behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { ProviderPrepareDynamicModelContext } from "openclaw/plugin-sdk/plugin-entry";
 import {
   coerceSecretRef,
   ensureAuthProfileStore,
   listProfilesForProvider,
 } from "openclaw/plugin-sdk/provider-auth";
-import { resolveRequiredConfiguredSecretRefInputString } from "openclaw/plugin-sdk/secret-input-runtime";
+import {
+  resolveConfiguredSecretInputWithFallback,
+  resolveRequiredConfiguredSecretRefInputString,
+} from "openclaw/plugin-sdk/secret-input-runtime";
 import { PROVIDER_ID } from "./models.js";
 
 export async function resolveFirstGithubToken(params: {
   agentDir?: string;
   config?: OpenClawConfig;
   env: NodeJS.ProcessEnv;
+  profileId?: string;
+  authProfileMode?: ProviderPrepareDynamicModelContext["authProfileMode"];
 }): Promise<{
   githubToken: string;
   hasProfile: boolean;
@@ -21,14 +27,34 @@ export async function resolveFirstGithubToken(params: {
   });
   const profileIds = listProfilesForProvider(authStore, PROVIDER_ID);
   const hasProfile = profileIds.length > 0;
+  const requestedProfileId = params.profileId?.trim();
   const envToken =
     params.env.COPILOT_GITHUB_TOKEN ?? params.env.GH_TOKEN ?? params.env.GITHUB_TOKEN ?? "";
   const githubToken = envToken.trim();
-  if (githubToken || !hasProfile) {
+  if (!requestedProfileId && params.authProfileMode) {
+    if (!params.config) {
+      return { githubToken, hasProfile: false };
+    }
+    // A missing profile id plus an explicit mode is a prepared direct-auth
+    // attempt. Do not let it fall back into the first stored profile: model
+    // limits and the later runtime exchange must use the same source token.
+    // Stored profiles are therefore ineligible even when the store has one.
+    const resolved = await resolveConfiguredSecretInputWithFallback({
+      config: params.config,
+      env: params.env,
+      value: params.config.models?.providers?.[PROVIDER_ID]?.apiKey,
+      path: `models.providers.${PROVIDER_ID}.apiKey`,
+      readFallback: () => githubToken,
+    });
+    return { githubToken: resolved.value?.trim() ?? "", hasProfile: false };
+  }
+  if (!requestedProfileId && (githubToken || !hasProfile)) {
     return { githubToken, hasProfile };
   }
 
-  const profileId = profileIds[0];
+  const profileId = requestedProfileId
+    ? profileIds.find((candidate) => candidate === requestedProfileId)
+    : profileIds[0];
   const profile = profileId ? authStore.profiles[profileId] : undefined;
   if (profile?.type !== "token") {
     return { githubToken: "", hasProfile };

--- a/extensions/github-copilot/dynamic-models.ts
+++ b/extensions/github-copilot/dynamic-models.ts
@@ -1,10 +1,10 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import {
-  type ProviderCatalogContext,
-  type ProviderCatalogResult,
-  type ProviderPrepareDynamicModelContext,
-  type ProviderResolveDynamicModelContext,
-  type ProviderRuntimeModel,
+import type {
+  ProviderCatalogContext,
+  ProviderCatalogResult,
+  ProviderPrepareDynamicModelContext,
+  ProviderResolveDynamicModelContext,
+  ProviderRuntimeModel,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { getCachedLiveCatalogValue } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { resolveFirstGithubToken } from "./auth.js";

--- a/extensions/github-copilot/dynamic-models.ts
+++ b/extensions/github-copilot/dynamic-models.ts
@@ -1,0 +1,144 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  type ProviderCatalogContext,
+  type ProviderCatalogResult,
+  type ProviderPrepareDynamicModelContext,
+  type ProviderResolveDynamicModelContext,
+  type ProviderRuntimeModel,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { getCachedLiveCatalogValue } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { resolveFirstGithubToken } from "./auth.js";
+import { resolveGithubCopilotDomain } from "./domain.js";
+import {
+  PROVIDER_ID,
+  fetchCopilotModelCatalog,
+  resolveCopilotForwardCompatModel,
+} from "./models.js";
+
+type GithubCopilotCatalogContext = {
+  agentDir?: string;
+  config?: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  profileId?: string;
+  authProfileMode?: ProviderPrepareDynamicModelContext["authProfileMode"];
+};
+
+function dynamicModelScope(
+  profileId?: string,
+  authProfileMode?: ProviderPrepareDynamicModelContext["authProfileMode"],
+): string {
+  const normalizedProfileId = profileId?.trim();
+  return normalizedProfileId
+    ? `profile:${normalizedProfileId}`
+    : authProfileMode
+      ? `direct:${authProfileMode}`
+      : "unscoped";
+}
+
+async function loadGithubCopilotRuntime() {
+  return await import("./register.runtime.js");
+}
+
+export function createGithubCopilotDynamicModelHooks(params: {
+  discoveryEnabled(config?: OpenClawConfig): boolean;
+}) {
+  const preparedDynamicModels = new WeakMap<
+    object,
+    Map<string, ReadonlyMap<string, ProviderRuntimeModel>>
+  >();
+
+  async function resolveCatalog(ctx: GithubCopilotCatalogContext) {
+    if (!params.discoveryEnabled(ctx.config)) {
+      return null;
+    }
+    const { DEFAULT_COPILOT_API_BASE_URL, resolveCopilotApiToken } =
+      await loadGithubCopilotRuntime();
+    const { githubToken, hasProfile } = await resolveFirstGithubToken({
+      agentDir: ctx.agentDir,
+      env: ctx.env,
+      ...(ctx.config ? { config: ctx.config } : {}),
+      ...(ctx.profileId ? { profileId: ctx.profileId } : {}),
+      ...(ctx.authProfileMode ? { authProfileMode: ctx.authProfileMode } : {}),
+    });
+    if (!hasProfile && !githubToken) {
+      return null;
+    }
+    let baseUrl = DEFAULT_COPILOT_API_BASE_URL;
+    let copilotApiToken: string | undefined;
+    if (githubToken) {
+      try {
+        const token = await resolveCopilotApiToken({
+          githubToken,
+          env: ctx.env,
+          githubDomain: resolveGithubCopilotDomain({ env: ctx.env, config: ctx.config }),
+        });
+        baseUrl = token.baseUrl;
+        copilotApiToken = token.token;
+      } catch {
+        baseUrl = DEFAULT_COPILOT_API_BASE_URL;
+      }
+    }
+    // Live metadata follows account entitlements and context limits. Static
+    // manifest models remain the visible fallback when exchange or discovery fails.
+    let discoveredModels: Awaited<ReturnType<typeof fetchCopilotModelCatalog>> = [];
+    if (copilotApiToken) {
+      try {
+        discoveredModels = await getCachedLiveCatalogValue({
+          keyParts: [PROVIDER_ID, "models", baseUrl, copilotApiToken],
+          load: async () => await fetchCopilotModelCatalog({ copilotApiToken, baseUrl }),
+        });
+      } catch {
+        discoveredModels = [];
+      }
+    }
+    return { baseUrl, models: discoveredModels };
+  }
+
+  async function runCatalog(ctx: ProviderCatalogContext): Promise<ProviderCatalogResult> {
+    const catalog = await resolveCatalog(ctx);
+    return catalog ? { provider: catalog } : null;
+  }
+
+  async function prepareDynamicModel(ctx: ProviderPrepareDynamicModelContext): Promise<void> {
+    const catalog = await resolveCatalog({
+      agentDir: ctx.agentDir,
+      env: process.env,
+      ...(ctx.config ? { config: ctx.config } : {}),
+      ...(ctx.authProfileId ? { profileId: ctx.authProfileId } : {}),
+      ...(ctx.authProfileMode ? { authProfileMode: ctx.authProfileMode } : {}),
+    });
+    const models = new Map<string, ProviderRuntimeModel>();
+    if (catalog) {
+      for (const model of catalog.models) {
+        models.set(model.id, {
+          ...model,
+          provider: PROVIDER_ID,
+          baseUrl: catalog.baseUrl,
+        });
+      }
+    }
+    let scopedModels = preparedDynamicModels.get(ctx.modelRegistry);
+    if (!scopedModels) {
+      scopedModels = new Map();
+      preparedDynamicModels.set(ctx.modelRegistry, scopedModels);
+    }
+    scopedModels.set(dynamicModelScope(ctx.authProfileId, ctx.authProfileMode), models);
+  }
+
+  function resolveDynamicModel(ctx: ProviderResolveDynamicModelContext) {
+    return (
+      preparedDynamicModels
+        .get(ctx.modelRegistry)
+        ?.get(dynamicModelScope(ctx.authProfileId, ctx.authProfileMode))
+        ?.get(ctx.modelId) ?? resolveCopilotForwardCompatModel(ctx)
+    );
+  }
+
+  return {
+    prepareDynamicModel,
+    resolveDynamicModel,
+    runCatalog,
+    preferRuntimeResolvedModel: ({ config }: { config?: OpenClawConfig }) =>
+      params.discoveryEnabled(config),
+  };
+}

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -68,6 +68,9 @@ type GithubCopilotTestProvider = RegisteredProvider & {
   catalog: {
     run: (ctx: unknown) => Promise<ProviderCatalogResult>;
   };
+  prepareDynamicModel: NonNullable<RegisteredProvider["prepareDynamicModel"]>;
+  resolveDynamicModel: NonNullable<RegisteredProvider["resolveDynamicModel"]>;
+  preferRuntimeResolvedModel: NonNullable<RegisteredProvider["preferRuntimeResolvedModel"]>;
   resolveThinkingProfile: NonNullable<RegisteredProvider["resolveThinkingProfile"]>;
 };
 type GithubCopilotTestModelCatalogProvider = {
@@ -427,6 +430,222 @@ describe("github-copilot plugin", () => {
         },
       ],
       defaultModel: "github-copilot/claude-opus-4.7",
+    });
+  });
+
+  describe("github-copilot dynamic model resolution", () => {
+    it("uses live catalog metadata for request-time model resolution", async () => {
+      const agentDir = await createAgentDir();
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            "github-copilot:first": {
+              type: "token",
+              provider: "github-copilot",
+              token: "first",
+            },
+            "github-copilot:selected": {
+              type: "token",
+              provider: "github-copilot",
+              token: "chosen",
+            },
+          },
+        },
+        agentDir,
+        { filterExternalAuthProfiles: false, syncExternalCli: false },
+      );
+      mocks.resolveCopilotApiToken
+        .mockResolvedValueOnce({
+          token: "alpha",
+          baseUrl: "https://api.githubcopilot.live",
+        })
+        .mockResolvedValueOnce({
+          token: "beta",
+          baseUrl: "https://api.githubcopilot.first",
+        });
+      const catalogResponse = (contextWindow: number, promptTokens: number) =>
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: "gpt-5.6-sol",
+                name: "GPT-5.6 Sol",
+                object: "model",
+                vendor: "OpenAI",
+                capabilities: {
+                  type: "chat",
+                  limits: {
+                    max_context_window_tokens: contextWindow,
+                    max_prompt_tokens: promptTokens,
+                    max_output_tokens: 128_000,
+                  },
+                  supports: {
+                    vision: true,
+                    reasoning_effort: ["none", "low", "medium", "high", "xhigh"],
+                  },
+                },
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn()
+          .mockResolvedValueOnce(catalogResponse(1_050_000, 922_000))
+          .mockResolvedValueOnce(catalogResponse(400_000, 272_000)),
+      );
+      const provider = registerProviderWithPluginConfig({});
+      const modelRegistry = { find: vi.fn(() => null) };
+      const selectedContext = {
+        config: {},
+        agentDir,
+        provider: "github-copilot",
+        modelId: "gpt-5.6-sol",
+        modelRegistry,
+        authProfileId: "github-copilot:selected",
+      } as Parameters<typeof provider.prepareDynamicModel>[0];
+      const firstContext = {
+        ...selectedContext,
+        authProfileId: "github-copilot:first",
+      };
+
+      await provider.prepareDynamicModel(selectedContext);
+      await provider.prepareDynamicModel(firstContext);
+
+      expect(mocks.resolveCopilotApiToken).toHaveBeenNthCalledWith(1, {
+        githubToken: "chosen",
+        env: process.env,
+        githubDomain: "github.com",
+      });
+      expect(mocks.resolveCopilotApiToken).toHaveBeenNthCalledWith(2, {
+        githubToken: "first",
+        env: process.env,
+        githubDomain: "github.com",
+      });
+      expect(provider.preferRuntimeResolvedModel(selectedContext)).toBe(true);
+      expect(provider.resolveDynamicModel(selectedContext)).toMatchObject({
+        id: "gpt-5.6-sol",
+        provider: "github-copilot",
+        baseUrl: "https://api.githubcopilot.live",
+        contextWindow: 1_050_000,
+        contextTokens: 922_000,
+        maxTokens: 128_000,
+      });
+      expect(provider.resolveDynamicModel(firstContext)).toMatchObject({
+        id: "gpt-5.6-sol",
+        provider: "github-copilot",
+        baseUrl: "https://api.githubcopilot.first",
+        contextWindow: 400_000,
+        contextTokens: 272_000,
+        maxTokens: 128_000,
+      });
+    });
+
+    it("rematerializes direct-config metadata after a profile fallback", async () => {
+      const agentDir = await createAgentDir();
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            "github-copilot:first": {
+              type: "token",
+              provider: "github-copilot",
+              token: "test-auth-token",
+            },
+          },
+        },
+        agentDir,
+        { filterExternalAuthProfiles: false, syncExternalCli: false },
+      );
+      mocks.resolveCopilotApiToken
+        .mockResolvedValueOnce({
+          token: "test-auth-token",
+          baseUrl: "https://api.githubcopilot.profile",
+        })
+        .mockResolvedValueOnce({
+          token: "test-token-placeholder",
+          baseUrl: "https://api.githubcopilot.direct",
+        });
+      const catalogResponse = (contextWindow: number, promptTokens: number) =>
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: "gpt-5.6-sol",
+                name: "GPT-5.6 Sol",
+                object: "model",
+                vendor: "OpenAI",
+                capabilities: {
+                  type: "chat",
+                  limits: {
+                    max_context_window_tokens: contextWindow,
+                    max_prompt_tokens: promptTokens,
+                    max_output_tokens: 128_000,
+                  },
+                },
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn()
+          .mockResolvedValueOnce(catalogResponse(200_000, 150_000))
+          .mockResolvedValueOnce(catalogResponse(1_050_000, 922_000)),
+      );
+      const provider = registerProviderWithPluginConfig({});
+      const modelRegistry = { find: vi.fn(() => null) };
+      const config = {
+        models: {
+          providers: {
+            "github-copilot": { apiKey: "test-token-placeholder" },
+          },
+        },
+      } as OpenClawConfig;
+      const profileContext = {
+        config,
+        agentDir,
+        provider: "github-copilot",
+        modelId: "gpt-5.6-sol",
+        modelRegistry,
+        authProfileId: "github-copilot:first",
+      } as Parameters<typeof provider.prepareDynamicModel>[0];
+      const directContext = {
+        ...profileContext,
+        authProfileId: undefined,
+        authProfileMode: "api_key" as const,
+      };
+
+      // The first profile's credential can fail later during runtime auth. The
+      // prepared direct fallback must then replace its account-scoped limits.
+      await provider.prepareDynamicModel(profileContext);
+      await provider.prepareDynamicModel(directContext);
+
+      expect(mocks.resolveCopilotApiToken).toHaveBeenNthCalledWith(1, {
+        githubToken: "test-auth-token",
+        env: process.env,
+        githubDomain: "github.com",
+      });
+      expect(mocks.resolveCopilotApiToken).toHaveBeenNthCalledWith(2, {
+        githubToken: "test-token-placeholder",
+        env: process.env,
+        githubDomain: "github.com",
+      });
+      expect(provider.resolveDynamicModel(profileContext)).toMatchObject({
+        baseUrl: "https://api.githubcopilot.profile",
+        contextWindow: 200_000,
+        contextTokens: 150_000,
+      });
+      expect(provider.resolveDynamicModel(directContext)).toMatchObject({
+        baseUrl: "https://api.githubcopilot.direct",
+        contextWindow: 1_050_000,
+        contextTokens: 922_000,
+      });
     });
   });
 

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -96,6 +96,15 @@ async function createAgentDir() {
   return dir;
 }
 
+function createModelRegistry() {
+  return {
+    getAll: vi.fn(() => []),
+    getAvailable: vi.fn(() => []),
+    find: vi.fn(() => undefined),
+    hasConfiguredAuth: vi.fn(() => false),
+  };
+}
+
 function writeExistingCopilotTokenProfile(agentDir: string) {
   saveAuthProfileStore(
     {
@@ -498,7 +507,7 @@ describe("github-copilot plugin", () => {
           .mockResolvedValueOnce(catalogResponse(400_000, 272_000)),
       );
       const provider = registerProviderWithPluginConfig({});
-      const modelRegistry = { find: vi.fn(() => null) };
+      const modelRegistry = createModelRegistry();
       const selectedContext = {
         config: {},
         agentDir,
@@ -599,11 +608,15 @@ describe("github-copilot plugin", () => {
           .mockResolvedValueOnce(catalogResponse(1_050_000, 922_000)),
       );
       const provider = registerProviderWithPluginConfig({});
-      const modelRegistry = { find: vi.fn(() => null) };
+      const modelRegistry = createModelRegistry();
       const config = {
         models: {
           providers: {
-            "github-copilot": { apiKey: "test-token-placeholder" },
+            "github-copilot": {
+              apiKey: "test-token-placeholder",
+              baseUrl: "https://api.githubcopilot.test",
+              models: [],
+            },
           },
         },
       } as OpenClawConfig;

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -8,6 +8,8 @@ import {
   type ProviderAuthContext,
   type ProviderAuthResult,
   type ProviderAuthMethodNonInteractiveContext,
+  type ProviderPrepareDynamicModelContext,
+  type ProviderRuntimeModel,
   type UnifiedModelCatalogEntry,
   type UnifiedModelCatalogProviderContext,
 } from "openclaw/plugin-sdk/plugin-entry";
@@ -49,6 +51,14 @@ type GithubCopilotPluginConfig = {
   discovery?: {
     enabled?: boolean;
   };
+};
+
+type GithubCopilotCatalogContext = {
+  agentDir?: string;
+  config?: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  profileId?: string;
+  authProfileMode?: ProviderPrepareDynamicModelContext["authProfileMode"];
 };
 
 async function loadGithubCopilotRuntime() {
@@ -341,6 +351,21 @@ export default definePluginEntry({
   description: "Bundled GitHub Copilot provider plugin",
   register(api) {
     const startupPluginConfig = (api.pluginConfig ?? {}) as GithubCopilotPluginConfig;
+    const preparedDynamicModels = new WeakMap<
+      object,
+      Map<string, ReadonlyMap<string, ProviderRuntimeModel>>
+    >();
+    const dynamicModelScope = (
+      profileId?: string,
+      authProfileMode?: ProviderPrepareDynamicModelContext["authProfileMode"],
+    ) => {
+      const normalizedProfileId = profileId?.trim();
+      return normalizedProfileId
+        ? `profile:${normalizedProfileId}`
+        : authProfileMode
+          ? `direct:${authProfileMode}`
+          : "unscoped";
+    };
 
     function resolveCurrentPluginConfig(config?: OpenClawConfig): GithubCopilotPluginConfig {
       const runtimePluginConfig = resolvePluginConfigObject(config, "github-copilot");
@@ -350,9 +375,7 @@ export default definePluginEntry({
       return config ? {} : startupPluginConfig;
     }
 
-    async function runGithubCopilotCatalog(
-      ctx: ProviderCatalogContext,
-    ): Promise<ProviderCatalogResult> {
+    async function resolveGithubCopilotCatalog(ctx: GithubCopilotCatalogContext) {
       const pluginConfig = resolveCurrentPluginConfig(ctx.config);
       const discoveryEnabled = pluginConfig.discovery?.enabled;
       if (discoveryEnabled === false) {
@@ -362,8 +385,10 @@ export default definePluginEntry({
         await loadGithubCopilotRuntime();
       const { githubToken, hasProfile } = await resolveFirstGithubToken({
         agentDir: ctx.agentDir,
-        config: ctx.config,
         env: ctx.env,
+        ...(ctx.config ? { config: ctx.config } : {}),
+        ...(ctx.profileId ? { profileId: ctx.profileId } : {}),
+        ...(ctx.authProfileMode ? { authProfileMode: ctx.authProfileMode } : {}),
       });
       if (!hasProfile && !githubToken) {
         return null;
@@ -403,12 +428,42 @@ export default definePluginEntry({
           discoveredModels = [];
         }
       }
-      return {
-        provider: {
-          baseUrl,
-          models: discoveredModels,
-        },
-      };
+      return { baseUrl, models: discoveredModels };
+    }
+
+    async function runGithubCopilotCatalog(
+      ctx: ProviderCatalogContext,
+    ): Promise<ProviderCatalogResult> {
+      const catalog = await resolveGithubCopilotCatalog(ctx);
+      return catalog ? { provider: catalog } : null;
+    }
+
+    async function prepareGithubCopilotDynamicModel(
+      ctx: ProviderPrepareDynamicModelContext,
+    ): Promise<void> {
+      const catalog = await resolveGithubCopilotCatalog({
+        agentDir: ctx.agentDir,
+        env: process.env,
+        ...(ctx.config ? { config: ctx.config } : {}),
+        ...(ctx.authProfileId ? { profileId: ctx.authProfileId } : {}),
+        ...(ctx.authProfileMode ? { authProfileMode: ctx.authProfileMode } : {}),
+      });
+      const models = new Map<string, ProviderRuntimeModel>();
+      if (catalog) {
+        for (const model of catalog.models) {
+          models.set(model.id, {
+            ...model,
+            provider: PROVIDER_ID,
+            baseUrl: catalog.baseUrl,
+          });
+        }
+      }
+      let scopedModels = preparedDynamicModels.get(ctx.modelRegistry);
+      if (!scopedModels) {
+        scopedModels = new Map();
+        preparedDynamicModels.set(ctx.modelRegistry, scopedModels);
+      }
+      scopedModels.set(dynamicModelScope(ctx.authProfileId, ctx.authProfileMode), models);
     }
 
     async function runGithubCopilotUnifiedLiveCatalog(
@@ -664,7 +719,14 @@ export default definePluginEntry({
         order: "late",
         run: runGithubCopilotCatalog,
       },
-      resolveDynamicModel: (ctx) => resolveCopilotForwardCompatModel(ctx),
+      prepareDynamicModel: prepareGithubCopilotDynamicModel,
+      resolveDynamicModel: (ctx) =>
+        preparedDynamicModels
+          .get(ctx.modelRegistry)
+          ?.get(dynamicModelScope(ctx.authProfileId, ctx.authProfileMode))
+          ?.get(ctx.modelId) ?? resolveCopilotForwardCompatModel(ctx),
+      preferRuntimeResolvedModel: ({ config }) =>
+        resolveCurrentPluginConfig(config).discovery?.enabled !== false,
       wrapStreamFn: wrapCopilotProviderStream,
       buildReplayPolicy: ({ modelId }) => buildGithubCopilotReplayPolicy(modelId),
       sanitizeReplayHistory: sanitizeGithubCopilotReplayHistory,

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -3,13 +3,9 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolvePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
 import {
   definePluginEntry,
-  type ProviderCatalogContext,
-  type ProviderCatalogResult,
   type ProviderAuthContext,
   type ProviderAuthResult,
   type ProviderAuthMethodNonInteractiveContext,
-  type ProviderPrepareDynamicModelContext,
-  type ProviderRuntimeModel,
   type UnifiedModelCatalogEntry,
   type UnifiedModelCatalogProviderContext,
 } from "openclaw/plugin-sdk/plugin-entry";
@@ -23,16 +19,11 @@ import {
   resolveDefaultSecretProviderAlias,
   upsertAuthProfileWithLock,
 } from "openclaw/plugin-sdk/provider-auth";
-import { getCachedLiveCatalogValue } from "openclaw/plugin-sdk/provider-catalog-shared";
-import { resolveFirstGithubToken } from "./auth.js";
 import { PUBLIC_GITHUB_COPILOT_DOMAIN, resolveGithubCopilotDomain } from "./domain.js";
+import { createGithubCopilotDynamicModelHooks } from "./dynamic-models.js";
 import { githubCopilotMemoryEmbeddingProviderAdapter } from "./embeddings.js";
 import { resolveCopilotExtendedThinkingLevels } from "./model-metadata.js";
-import {
-  PROVIDER_ID,
-  fetchCopilotModelCatalog,
-  resolveCopilotForwardCompatModel,
-} from "./models.js";
+import { PROVIDER_ID } from "./models.js";
 import {
   buildGithubCopilotReplayPolicy,
   sanitizeGithubCopilotReplayHistory,
@@ -51,14 +42,6 @@ type GithubCopilotPluginConfig = {
   discovery?: {
     enabled?: boolean;
   };
-};
-
-type GithubCopilotCatalogContext = {
-  agentDir?: string;
-  config?: OpenClawConfig;
-  env: NodeJS.ProcessEnv;
-  profileId?: string;
-  authProfileMode?: ProviderPrepareDynamicModelContext["authProfileMode"];
 };
 
 async function loadGithubCopilotRuntime() {
@@ -351,21 +334,6 @@ export default definePluginEntry({
   description: "Bundled GitHub Copilot provider plugin",
   register(api) {
     const startupPluginConfig = (api.pluginConfig ?? {}) as GithubCopilotPluginConfig;
-    const preparedDynamicModels = new WeakMap<
-      object,
-      Map<string, ReadonlyMap<string, ProviderRuntimeModel>>
-    >();
-    const dynamicModelScope = (
-      profileId?: string,
-      authProfileMode?: ProviderPrepareDynamicModelContext["authProfileMode"],
-    ) => {
-      const normalizedProfileId = profileId?.trim();
-      return normalizedProfileId
-        ? `profile:${normalizedProfileId}`
-        : authProfileMode
-          ? `direct:${authProfileMode}`
-          : "unscoped";
-    };
 
     function resolveCurrentPluginConfig(config?: OpenClawConfig): GithubCopilotPluginConfig {
       const runtimePluginConfig = resolvePluginConfigObject(config, "github-copilot");
@@ -374,102 +342,14 @@ export default definePluginEntry({
       }
       return config ? {} : startupPluginConfig;
     }
-
-    async function resolveGithubCopilotCatalog(ctx: GithubCopilotCatalogContext) {
-      const pluginConfig = resolveCurrentPluginConfig(ctx.config);
-      const discoveryEnabled = pluginConfig.discovery?.enabled;
-      if (discoveryEnabled === false) {
-        return null;
-      }
-      const { DEFAULT_COPILOT_API_BASE_URL, resolveCopilotApiToken } =
-        await loadGithubCopilotRuntime();
-      const { githubToken, hasProfile } = await resolveFirstGithubToken({
-        agentDir: ctx.agentDir,
-        env: ctx.env,
-        ...(ctx.config ? { config: ctx.config } : {}),
-        ...(ctx.profileId ? { profileId: ctx.profileId } : {}),
-        ...(ctx.authProfileMode ? { authProfileMode: ctx.authProfileMode } : {}),
-      });
-      if (!hasProfile && !githubToken) {
-        return null;
-      }
-      let baseUrl = DEFAULT_COPILOT_API_BASE_URL;
-      let copilotApiToken: string | undefined;
-      if (githubToken) {
-        try {
-          const token = await resolveCopilotApiToken({
-            githubToken,
-            env: ctx.env,
-            githubDomain: resolveGithubCopilotDomain({ env: ctx.env, config: ctx.config }),
-          });
-          baseUrl = token.baseUrl;
-          copilotApiToken = token.token;
-        } catch {
-          baseUrl = DEFAULT_COPILOT_API_BASE_URL;
-        }
-      }
-      // Try to fetch the live model catalog from Copilot's /models endpoint so
-      // the runtime tracks per-account entitlements and accurate token limits
-      // without manifest churn. On any
-      // failure we return an empty model list, which lets the static manifest
-      // catalog continue to be the visible fallback for users.
-      let discoveredModels: Awaited<ReturnType<typeof fetchCopilotModelCatalog>> = [];
-      if (copilotApiToken) {
-        try {
-          discoveredModels = await getCachedLiveCatalogValue({
-            keyParts: [PROVIDER_ID, "models", baseUrl, copilotApiToken],
-            load: async () =>
-              await fetchCopilotModelCatalog({
-                copilotApiToken,
-                baseUrl,
-              }),
-          });
-        } catch {
-          discoveredModels = [];
-        }
-      }
-      return { baseUrl, models: discoveredModels };
-    }
-
-    async function runGithubCopilotCatalog(
-      ctx: ProviderCatalogContext,
-    ): Promise<ProviderCatalogResult> {
-      const catalog = await resolveGithubCopilotCatalog(ctx);
-      return catalog ? { provider: catalog } : null;
-    }
-
-    async function prepareGithubCopilotDynamicModel(
-      ctx: ProviderPrepareDynamicModelContext,
-    ): Promise<void> {
-      const catalog = await resolveGithubCopilotCatalog({
-        agentDir: ctx.agentDir,
-        env: process.env,
-        ...(ctx.config ? { config: ctx.config } : {}),
-        ...(ctx.authProfileId ? { profileId: ctx.authProfileId } : {}),
-        ...(ctx.authProfileMode ? { authProfileMode: ctx.authProfileMode } : {}),
-      });
-      const models = new Map<string, ProviderRuntimeModel>();
-      if (catalog) {
-        for (const model of catalog.models) {
-          models.set(model.id, {
-            ...model,
-            provider: PROVIDER_ID,
-            baseUrl: catalog.baseUrl,
-          });
-        }
-      }
-      let scopedModels = preparedDynamicModels.get(ctx.modelRegistry);
-      if (!scopedModels) {
-        scopedModels = new Map();
-        preparedDynamicModels.set(ctx.modelRegistry, scopedModels);
-      }
-      scopedModels.set(dynamicModelScope(ctx.authProfileId, ctx.authProfileMode), models);
-    }
+    const dynamicModels = createGithubCopilotDynamicModelHooks({
+      discoveryEnabled: (config) => resolveCurrentPluginConfig(config).discovery?.enabled !== false,
+    });
 
     async function runGithubCopilotUnifiedLiveCatalog(
       ctx: UnifiedModelCatalogProviderContext,
     ): Promise<UnifiedModelCatalogEntry[] | null> {
-      const result = await runGithubCopilotCatalog(ctx);
+      const result = await dynamicModels.runCatalog(ctx);
       if (!result || !("provider" in result)) {
         return null;
       }
@@ -717,16 +597,11 @@ export default definePluginEntry({
       },
       catalog: {
         order: "late",
-        run: runGithubCopilotCatalog,
+        run: dynamicModels.runCatalog,
       },
-      prepareDynamicModel: prepareGithubCopilotDynamicModel,
-      resolveDynamicModel: (ctx) =>
-        preparedDynamicModels
-          .get(ctx.modelRegistry)
-          ?.get(dynamicModelScope(ctx.authProfileId, ctx.authProfileMode))
-          ?.get(ctx.modelId) ?? resolveCopilotForwardCompatModel(ctx),
-      preferRuntimeResolvedModel: ({ config }) =>
-        resolveCurrentPluginConfig(config).discovery?.enabled !== false,
+      prepareDynamicModel: dynamicModels.prepareDynamicModel,
+      resolveDynamicModel: dynamicModels.resolveDynamicModel,
+      preferRuntimeResolvedModel: dynamicModels.preferRuntimeResolvedModel,
       wrapStreamFn: wrapCopilotProviderStream,
       buildReplayPolicy: ({ modelId }) => buildGithubCopilotReplayPolicy(modelId),
       sanitizeReplayHistory: sanitizeGithubCopilotReplayHistory,

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -1,4 +1,5 @@
 // Github Copilot tests cover models plugin behavior.
+import { createHash } from "node:crypto";
 import { expectDefined } from "@openclaw/normalization-core";
 import { createProviderUsageFetch, makeResponse } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -360,6 +361,7 @@ describe("github-copilot token", () => {
       expiresAt: now + 60 * 60 * 1000,
       updatedAt: now,
       integrationId: "vscode-chat",
+      sourceCredentialFingerprint: createHash("sha256").update("gh").digest("hex"),
       domain: "github.com",
     });
 

--- a/extensions/github-copilot/models.ts
+++ b/extensions/github-copilot/models.ts
@@ -144,8 +144,9 @@ type CopilotApiModelEntry = {
 
 const COPILOT_MODELS_LIST_DEFAULT_TIMEOUT_MS = 10_000;
 const COPILOT_ROUTER_ID_PREFIX = "accounts/";
-type CopilotCatalogModel = ModelDefinitionConfig & {
+type CopilotCatalogModel = Omit<ModelDefinitionConfig, "input"> & {
   api: NonNullable<ModelDefinitionConfig["api"]>;
+  input: ProviderRuntimeModel["input"];
 };
 
 function resolveCopilotApiForVendor(
@@ -220,7 +221,7 @@ function mapCopilotApiModelToDefinition(
     ? supports.reasoning_effort.length > 0
     : false;
   const supportsVision = supports?.vision === true;
-  const input: ModelDefinitionConfig["input"] = supportsVision ? ["text", "image"] : ["text"];
+  const input: CopilotCatalogModel["input"] = supportsVision ? ["text", "image"] : ["text"];
 
   const contextWindow =
     asPositiveSafeInteger(limits?.max_context_window_tokens) ?? DEFAULT_CONTEXT_WINDOW;

--- a/extensions/github-copilot/models.ts
+++ b/extensions/github-copilot/models.ts
@@ -144,6 +144,9 @@ type CopilotApiModelEntry = {
 
 const COPILOT_MODELS_LIST_DEFAULT_TIMEOUT_MS = 10_000;
 const COPILOT_ROUTER_ID_PREFIX = "accounts/";
+type CopilotCatalogModel = ModelDefinitionConfig & {
+  api: NonNullable<ModelDefinitionConfig["api"]>;
+};
 
 function resolveCopilotApiForVendor(
   vendor: string | undefined,
@@ -195,7 +198,7 @@ function resolveCopilotThinkingLevelMap(
 
 function mapCopilotApiModelToDefinition(
   entry: CopilotApiModelEntry,
-): ModelDefinitionConfig | undefined {
+): CopilotCatalogModel | undefined {
   const id = entry.id?.trim();
   if (!id) {
     return undefined;
@@ -227,7 +230,7 @@ function mapCopilotApiModelToDefinition(
   const api = resolveCopilotApiForVendor(entry.vendor, id);
   const thinkingLevelMap = resolveCopilotThinkingLevelMap(api, id, compat);
 
-  const definition: ModelDefinitionConfig = {
+  const definition: CopilotCatalogModel = {
     id,
     name: entry.name?.trim() || id,
     api,
@@ -273,7 +276,7 @@ type FetchCopilotModelCatalogParams = {
  */
 export async function fetchCopilotModelCatalog(
   params: FetchCopilotModelCatalogParams,
-): Promise<ModelDefinitionConfig[]> {
+): Promise<CopilotCatalogModel[]> {
   const fetchImpl = params.fetchImpl ?? fetch;
   const trimmedBase = params.baseUrl.replace(/\/+$/, "");
   if (!trimmedBase) {
@@ -303,7 +306,7 @@ export async function fetchCopilotModelCatalog(
     }
     const data = await readProviderJsonArrayFieldResponse(res, "Copilot /models", "data");
     const seen = new Set<string>();
-    const out: ModelDefinitionConfig[] = [];
+    const out: CopilotCatalogModel[] = [];
     for (const rawEntry of data) {
       const entry = asCopilotApiModelEntry(rawEntry);
       const def = mapCopilotApiModelToDefinition(entry);

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -643,7 +643,6 @@ export async function loadCompactHooksHarness(): Promise<{
   vi.doMock("../harness/policy.js", () => ({
     resolveAgentHarnessPolicy: resolveAgentHarnessPolicyMock,
   }));
-
   vi.doMock("../harness/runtime-plugin.js", () => ({
     ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
   }));

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -663,6 +663,7 @@ export async function loadCompactHooksHarness(): Promise<{
     resolveProviderReasoningOutputModeWithPlugin: vi.fn(() => undefined),
     resolveProviderSystemPromptContribution: vi.fn(() => undefined),
     resolveProviderTextTransforms: vi.fn(() => undefined),
+    shouldPreferProviderRuntimeResolvedModel: vi.fn(() => false),
     transformProviderSystemPrompt: vi.fn(
       (params: { systemPrompt?: string; context?: { systemPrompt?: string } }) =>
         params.context?.systemPrompt ?? params.systemPrompt,

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -462,6 +462,14 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
         return options?.authProfileId === "openai:backup";
       }),
     ).toBe(true);
+    expect(
+      resolveModelAsyncMock.mock.calls.some((call) => {
+        const options = (call as unknown as readonly unknown[])[4] as
+          | { authProfileId?: string }
+          | undefined;
+        return options?.authProfileId === "openai:missing";
+      }),
+    ).toBe(true);
     expect(resolveEmbeddedAgentStreamFnMock).toHaveBeenCalledWith(
       expect.objectContaining({ authProfileId: "openai:backup" }),
     );
@@ -800,7 +808,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     );
   });
 
-  it("routes compaction through shared stream resolution and extra params", () => {
+  it("routes compaction through shared stream resolution and extra params", async () => {
     const resolvedStreamFn = vi.fn();
     resolveEmbeddedAgentStreamFnMock.mockReturnValue(resolvedStreamFn);
     applyExtraParamsToAgentMock.mockReturnValue({
@@ -813,7 +821,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       messages: [{ role: "user", content: "hello" }],
     };
 
-    compactTesting.prepareCompactionSessionAgent({
+    await compactTesting.prepareCompactionSessionAgent({
       session: session as never,
       providerStreamFn: vi.fn(),
       sessionId: "session-1",
@@ -873,9 +881,9 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     );
   });
 
-  it("maps logical Ultra to max before compaction provider hooks", () => {
+  it("maps logical Ultra to max before compaction provider hooks", async () => {
     const resolveExtraParams = vi.fn(() => undefined);
-    compactTesting.prepareCompactionSessionAgent({
+    await compactTesting.prepareCompactionSessionAgent({
       session: {
         agent: { streamFn: vi.fn() },
         messages: [{ role: "user", content: "hello" }],
@@ -1453,6 +1461,12 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       workspaceDir: "/tmp/workspace",
       provider: "openai",
       model: "gpt-5.5",
+      runtimeAuthPlan: {
+        providerForAuth: "openai",
+        modelId: "gpt-5.5",
+        authProfileProviderForAuth: "openai",
+        selectedAuthMode: "api-key",
+      },
       config: {
         models: {
           providers: {
@@ -1466,6 +1480,9 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     expect(result.ok).toBe(true);
     expect(mockCallArg(resolveModelMock)).toBe("openai");
     expect(mockCallArg(resolveModelMock, 0, 1)).toBe("gpt-5.5");
+    expect(mockCallArg(resolveModelAsyncMock, 0, 4)).toEqual({
+      authProfileMode: "api_key",
+    });
   });
 
   it("uses the compaction model override with a pinned Codex harness", async () => {
@@ -1503,6 +1520,35 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       provider: "openai",
       modelId: "gpt-5.4-mini",
     });
+  });
+
+  it("does not reuse a source-provider profile for cross-provider compaction", async () => {
+    const result = await compactEmbeddedAgentSessionDirect({
+      ...wrappedCompactionArgs(),
+      provider: "openai",
+      model: "gpt-5.5",
+      authProfileId: "openai:work",
+      runtimeAuthPlan: {
+        providerForAuth: "openai",
+        modelId: "gpt-5.5",
+        authProfileProviderForAuth: "openai",
+        forwardedAuthProfileId: "openai:work",
+      },
+      config: {
+        agents: {
+          defaults: {
+            compaction: { model: "github-copilot/gpt-5.6-sol" },
+          },
+        },
+      } as never,
+    });
+
+    expect(result.ok).toBe(true);
+    const initialResolveCall = resolveModelAsyncMock.mock.calls[0] as
+      | [string, string, string, unknown, { authProfileId?: string }?]
+      | undefined;
+    expect(initialResolveCall?.[0]).toBe("github-copilot");
+    expect(initialResolveCall?.[4]?.authProfileId).toBeUndefined();
   });
 
   it("materializes subscription-auth OpenAI compaction while preserving logical context", async () => {
@@ -3112,6 +3158,9 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       }),
     );
 
+    expect(mockCallArg(resolveModelAsyncMock, 0, 4)).toEqual(
+      expect.objectContaining({ authProfileId: "openai:token" }),
+    );
     expect(resolveModelAsyncMock).toHaveBeenLastCalledWith(
       "openai",
       "gpt-5.5",
@@ -3156,6 +3205,8 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
   });
 
   it("prepares queued native harness auth without a host profile", async () => {
+    vi.stubEnv("CODEX_API_KEY", "");
+    vi.stubEnv("OPENAI_API_KEY", "");
     resolveAgentHarnessPolicyMock.mockReturnValue({
       runtime: "codex",
       runtimeSource: "model",
@@ -3330,6 +3381,38 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     expect(selectAgentHarnessMock.mock.results[0]?.value).toEqual(
       expect.objectContaining({ id: "openclaw" }),
     );
+  });
+
+  it("resolves reusable queued direct auth without a stored profile", async () => {
+    resolveAgentHarnessPolicyMock.mockReturnValue({
+      runtime: "openclaw",
+      runtimeSource: "implicit",
+    } as never);
+
+    const result = await compactEmbeddedAgentSession(
+      wrappedCompactionArgs({
+        provider: "openai",
+        model: "gpt-5.5",
+        runtimeAuthPlan: {
+          providerForAuth: "openai",
+          modelId: "gpt-5.5",
+          authProfileProviderForAuth: "openai",
+          selectedAuthMode: "api-key",
+        },
+        config: {
+          models: {
+            providers: {
+              openai: { models: [{ id: "gpt-5.5", contextWindow: 350_000 }] },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(mockCallArg(resolveModelAsyncMock, 0, 4)).toEqual({
+      authProfileMode: "api_key",
+    });
   });
 
   it("uses a prepared harness binding for queued custom OpenAI Responses compaction", async () => {

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -56,7 +56,6 @@ import {
   prepareAgentRuntimeAuth,
   type PreparedAgentRuntimeAuthAttempt,
 } from "../runtime-plan/prepare-auth.js";
-import type { AgentRuntimeAuthPlan } from "../runtime-plan/types.js";
 import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
 import { SessionManager } from "../sessions/index.js";
 import { DEFERRED_CONTEXT_ENGINE_COMPACTION_REASON } from "./compact-reasons.js";

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -26,7 +26,6 @@ import {
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
-import { shouldPreferProviderRuntimeResolvedModel } from "../../plugins/provider-runtime.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveUserPath } from "../../utils.js";
@@ -41,22 +40,19 @@ import { ensureSelectedAgentHarnessPlugin } from "../harness/runtime-plugin.js";
 import {
   selectAgentHarness,
   selectAgentHarnessForPreparedModelProviders,
-  type AgentHarnessPreparedModelProvider,
 } from "../harness/selection.js";
-import {
-  resolveAgentHarnessPreparedAuthSupport,
-  resolveAgentHarnessPreparedRouteSupport,
-} from "../harness/support.js";
 import {
   ensureAuthProfileStore,
   ensureAuthProfileStoreWithoutExternalProfiles,
 } from "../model-auth.js";
 import { isOpenAIProvider } from "../openai-routing.js";
-import { resolveProviderModelMaterializationAuthMode } from "../provider-model-route-auth.js";
 import { resolveAgentRunSessionTarget } from "../run-session-target.js";
+import {
+  providerUsesCredentialScopedModelMetadata,
+  resolveReusableRuntimeModelAuth,
+} from "../runtime-plan/credential-scoped-model.js";
 import { materializePreparedRuntimeModel } from "../runtime-plan/materialize-model.js";
 import {
-  agentRuntimeAuthPlanMatchesTarget,
   prepareAgentRuntimeAuth,
   type PreparedAgentRuntimeAuthAttempt,
 } from "../runtime-plan/prepare-auth.js";
@@ -65,6 +61,7 @@ import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
 import { SessionManager } from "../sessions/index.js";
 import { DEFERRED_CONTEXT_ENGINE_COMPACTION_REASON } from "./compact-reasons.js";
 import type { CompactEmbeddedAgentSessionParams } from "./compact.types.js";
+import { buildCompactionHarnessModelProvider } from "./compaction-harness-model-provider.js";
 import { asCompactionHookRunner, runPostCompactionSideEffects } from "./compaction-hooks.js";
 import {
   buildEmbeddedCompactionRuntimeContext,
@@ -120,27 +117,6 @@ const DEFERRED_CONTEXT_ENGINE_COMPACTION_SCHEDULE_FAILURE_REASON =
 const MANUAL_COMPACTION_ACTIVE_RUN_REASON =
   "manual compaction unavailable while another embedded run is active";
 const COMPACTION_ABORTED_REASON = "compaction aborted";
-
-function buildQueuedCompactionHarnessModelProvider(params: {
-  model?: ProviderRuntimeModel;
-  plan?: AgentRuntimeAuthPlan;
-  attempt?: PreparedAgentRuntimeAuthAttempt;
-}): AgentHarnessPreparedModelProvider {
-  const route = params.plan?.modelRoute;
-  return {
-    api: route?.api ?? params.model?.api,
-    baseUrl: route?.baseUrl ?? params.model?.baseUrl,
-    ...resolveAgentHarnessPreparedRouteSupport(params.plan),
-    ...(params.plan
-      ? {
-          preparedAuth: resolveAgentHarnessPreparedAuthSupport({
-            plan: params.plan,
-            source: params.attempt?.kind === "implicit" ? undefined : params.attempt?.kind,
-          }),
-        }
-      : {}),
-  };
-}
 
 function createCompactionAbortedResult(): EmbeddedAgentCompactResult {
   return {
@@ -452,25 +428,13 @@ async function compactResolvedContextEngine(
   const ceContextConfigProvider = resolvedCompactionTarget.contextProvider ?? ceProvider;
   const ceModelId = resolvedCompactionTarget.model ?? DEFAULT_MODEL;
   const providedRuntimeAuthPlan = params.runtimeAuthPlan ?? params.runtimePlan?.auth;
-  const reusableRuntimeAuthPlan =
-    providedRuntimeAuthPlan &&
-    agentRuntimeAuthPlanMatchesTarget(providedRuntimeAuthPlan, {
+  const { plan: reusableRuntimeAuthPlan, modelAuth: initialModelAuth } =
+    resolveReusableRuntimeModelAuth({
+      plan: providedRuntimeAuthPlan,
       provider: ceProvider,
       modelId: ceModelId,
-    })
-      ? providedRuntimeAuthPlan
-      : undefined;
-  const ceAuthProfileId =
-    resolvedCompactionTarget.authProfileId ?? reusableRuntimeAuthPlan?.forwardedAuthProfileId;
-  const ceAuthProfileMode = resolveProviderModelMaterializationAuthMode(
-    reusableRuntimeAuthPlan?.selectedAuthMode,
-  );
-  const initialModelAuth =
-    ceAuthProfileId !== undefined
-      ? { authProfileId: ceAuthProfileId }
-      : ceAuthProfileMode !== undefined
-        ? { authProfileMode: ceAuthProfileMode }
-        : undefined;
+      authProfileId: resolvedCompactionTarget.authProfileId,
+    });
   const attemptNativeHarnessCompaction = shouldAttemptNativeHarnessCompaction({
     provider: ceProvider,
     nativeHarnessCompaction: resolvedCompactionTarget.nativeHarnessCompaction,
@@ -520,7 +484,7 @@ async function compactResolvedContextEngine(
         provider: ceProvider,
         modelId: ceModelId,
         modelProviders: attempts.map((attempt) =>
-          buildQueuedCompactionHarnessModelProvider({
+          buildCompactionHarnessModelProvider({
             model: ceRuntimeModel,
             plan: attempt.plan,
             attempt,
@@ -537,7 +501,7 @@ async function compactResolvedContextEngine(
       : selectAgentHarness({
           provider: ceProvider,
           modelId: ceModelId,
-          modelProvider: buildQueuedCompactionHarnessModelProvider({ model: ceRuntimeModel }),
+          modelProvider: buildCompactionHarnessModelProvider({ model: ceRuntimeModel }),
           config: params.config,
           agentId: runtimePolicyAgentId,
           sessionKey: runtimePolicySessionKey,
@@ -580,18 +544,12 @@ async function compactResolvedContextEngine(
     }
     preparedHarnessRuntime = selectedPreparedHarness.id;
     const runtimeAuthPlan = runtimeAuthPreparation.plan;
-    const providerUsesProfileScopedModelMetadata = shouldPreferProviderRuntimeResolvedModel({
+    const providerUsesProfileScopedModelMetadata = providerUsesCredentialScopedModelMetadata({
       provider: ceRuntimeProvider,
+      modelId: ceModelId,
       config: params.config,
+      agentDir,
       workspaceDir: resolvedWorkspaceDir,
-      env: process.env,
-      context: {
-        config: params.config,
-        agentDir,
-        workspaceDir: resolvedWorkspaceDir,
-        provider: ceRuntimeProvider,
-        modelId: ceModelId,
-      },
     });
     effectiveRuntimeModel = await materializePreparedRuntimeModel<ProviderRuntimeModel>({
       plan: runtimeAuthPlan,

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -26,6 +26,7 @@ import {
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+import { shouldPreferProviderRuntimeResolvedModel } from "../../plugins/provider-runtime.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveUserPath } from "../../utils.js";
@@ -579,12 +580,27 @@ async function compactResolvedContextEngine(
     }
     preparedHarnessRuntime = selectedPreparedHarness.id;
     const runtimeAuthPlan = runtimeAuthPreparation.plan;
+    const providerUsesProfileScopedModelMetadata = shouldPreferProviderRuntimeResolvedModel({
+      provider: ceRuntimeProvider,
+      config: params.config,
+      workspaceDir: resolvedWorkspaceDir,
+      env: process.env,
+      context: {
+        config: params.config,
+        agentDir,
+        workspaceDir: resolvedWorkspaceDir,
+        provider: ceRuntimeProvider,
+        modelId: ceModelId,
+      },
+    });
     effectiveRuntimeModel = await materializePreparedRuntimeModel<ProviderRuntimeModel>({
       plan: runtimeAuthPlan,
       provider: ceProvider,
       modelId: ceModelId,
       config: params.config,
       model: ceRuntimeModel,
+      forceResolve:
+        providerUsesProfileScopedModelMetadata && Boolean(runtimeAuthPlan.selectedAuthMode),
       resolveModel: async ({ config, authProfileId, authProfileMode }) => {
         const resolved = await resolveModelAsync(ceRuntimeProvider, ceModelId, agentDir, config, {
           authStorage,

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -51,6 +51,7 @@ import {
   ensureAuthProfileStoreWithoutExternalProfiles,
 } from "../model-auth.js";
 import { isOpenAIProvider } from "../openai-routing.js";
+import { resolveProviderModelMaterializationAuthMode } from "../provider-model-route-auth.js";
 import { resolveAgentRunSessionTarget } from "../run-session-target.js";
 import { materializePreparedRuntimeModel } from "../runtime-plan/materialize-model.js";
 import {
@@ -449,6 +450,26 @@ async function compactResolvedContextEngine(
   const ceRuntimeProvider = resolvedCompactionTarget.runtimeProvider ?? ceProvider;
   const ceContextConfigProvider = resolvedCompactionTarget.contextProvider ?? ceProvider;
   const ceModelId = resolvedCompactionTarget.model ?? DEFAULT_MODEL;
+  const providedRuntimeAuthPlan = params.runtimeAuthPlan ?? params.runtimePlan?.auth;
+  const reusableRuntimeAuthPlan =
+    providedRuntimeAuthPlan &&
+    agentRuntimeAuthPlanMatchesTarget(providedRuntimeAuthPlan, {
+      provider: ceProvider,
+      modelId: ceModelId,
+    })
+      ? providedRuntimeAuthPlan
+      : undefined;
+  const ceAuthProfileId =
+    resolvedCompactionTarget.authProfileId ?? reusableRuntimeAuthPlan?.forwardedAuthProfileId;
+  const ceAuthProfileMode = resolveProviderModelMaterializationAuthMode(
+    reusableRuntimeAuthPlan?.selectedAuthMode,
+  );
+  const initialModelAuth =
+    ceAuthProfileId !== undefined
+      ? { authProfileId: ceAuthProfileId }
+      : ceAuthProfileMode !== undefined
+        ? { authProfileMode: ceAuthProfileMode }
+        : undefined;
   const attemptNativeHarnessCompaction = shouldAttemptNativeHarnessCompaction({
     provider: ceProvider,
     nativeHarnessCompaction: resolvedCompactionTarget.nativeHarnessCompaction,
@@ -473,9 +494,14 @@ async function compactResolvedContextEngine(
       model: ceModel,
       authStorage,
       modelRegistry,
-    } = await resolveModelAsync(ceRuntimeProvider, ceModelId, agentDir, params.config);
+    } = await resolveModelAsync(
+      ceRuntimeProvider,
+      ceModelId,
+      agentDir,
+      params.config,
+      initialModelAuth,
+    );
     const ceRuntimeModel = ceModel as ProviderRuntimeModel | undefined;
-    const providedRuntimeAuthPlan = params.runtimeAuthPlan ?? params.runtimePlan?.auth;
     const runtimeAuthProfileStore = isOpenAIProvider(ceProvider)
       ? ensureAuthProfileStore(agentDir, {
           externalCliProviderIds: ["openai"],
@@ -484,14 +510,6 @@ async function compactResolvedContextEngine(
       : ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
           allowKeychainPrompt: false,
         });
-    const reusableRuntimeAuthPlan =
-      providedRuntimeAuthPlan &&
-      agentRuntimeAuthPlanMatchesTarget(providedRuntimeAuthPlan, {
-        provider: ceProvider,
-        modelId: ceModelId,
-      })
-        ? providedRuntimeAuthPlan
-        : undefined;
     // Overrides stay unset when no bound/planned/explicit harness resolved so auth-aware
     // selection can pick the credential-owning harness (codex for ChatGPT OAuth).
     const selectHarnessForPreparedAttempts = (

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -125,6 +125,7 @@ import { ensureOpenClawModelsJson } from "../models-config.js";
 import { isOpenAIProvider } from "../openai-routing.js";
 import { wrapStreamFnTextTransforms } from "../plugin-text-transforms.js";
 import { resolveAgentPromptSurfaceForSessionKey } from "../prompt-surface.js";
+import { resolveProviderModelMaterializationAuthMode } from "../provider-model-route-auth.js";
 import { applyPreparedRuntimeAuthToModel } from "../provider-request-config.js";
 import {
   protectPreparedProviderRuntimeAuth,
@@ -220,6 +221,7 @@ import {
 } from "./sandbox-skills.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "./session-manager-cache.js";
 import {
+  resolveEmbeddedAgentApiKey,
   resolveEmbeddedAgentBaseStreamFn,
   resolveEmbeddedAgentStreamFn,
 } from "./stream-resolution.js";
@@ -257,7 +259,7 @@ function createCompactionDiagId(): string {
   return `cmp-${Date.now().toString(36)}-${generateSecureToken(4)}`;
 }
 
-function prepareCompactionSessionAgent(params: {
+async function prepareCompactionSessionAgent(params: {
   session: { agent: { streamFn?: unknown } };
   providerStreamFn: unknown;
   sessionId: string;
@@ -286,6 +288,22 @@ function prepareCompactionSessionAgent(params: {
   senderUsername?: string | null;
   senderE164?: string | null;
 }) {
+  const authStorage =
+    params.authStorage &&
+    typeof params.authStorage === "object" &&
+    "getApiKey" in params.authStorage &&
+    typeof params.authStorage.getApiKey === "function"
+      ? (params.authStorage as {
+          getApiKey(provider: string): Promise<string | undefined>;
+        })
+      : undefined;
+  const transportApiKey = authStorage
+    ? await resolveEmbeddedAgentApiKey({
+        provider: params.effectiveModel.provider,
+        resolvedApiKey: params.resolvedApiKey,
+        authStorage,
+      })
+    : params.resolvedApiKey;
   params.session.agent.streamFn = resolveEmbeddedAgentStreamFn({
     currentStreamFn: resolveEmbeddedAgentBaseStreamFn({ session: params.session as never }),
     providerStreamFn: params.providerStreamFn as never,
@@ -293,6 +311,7 @@ function prepareCompactionSessionAgent(params: {
     signal: params.signal,
     model: params.effectiveModel,
     resolvedApiKey: params.resolvedApiKey,
+    transportAuthAvailable: Boolean(transportApiKey?.trim()),
     authProfileId: params.runtimePlan?.auth.forwardedAuthProfileId,
     authStorage: params.authStorage as never,
   });
@@ -742,8 +761,23 @@ async function compactEmbeddedAgentSessionDirectOnce(
   const runtimeProvider = resolvedCompactionTarget.runtimeProvider ?? provider;
   const contextConfigProvider = resolvedCompactionTarget.contextProvider ?? provider;
   const modelId = resolvedCompactionTarget.model ?? DEFAULT_MODEL;
-  const authProfileId = resolvedCompactionTarget.authProfileId;
   const providedRuntimeAuthPlan = params.runtimeAuthPlan ?? params.runtimePlan?.auth;
+  const reusableRuntimeAuthPlan =
+    providedRuntimeAuthPlan &&
+    agentRuntimeAuthPlanMatchesTarget(providedRuntimeAuthPlan, { provider, modelId })
+      ? providedRuntimeAuthPlan
+      : undefined;
+  const authProfileId =
+    resolvedCompactionTarget.authProfileId ?? reusableRuntimeAuthPlan?.forwardedAuthProfileId;
+  const authProfileMode = resolveProviderModelMaterializationAuthMode(
+    reusableRuntimeAuthPlan?.selectedAuthMode,
+  );
+  const initialModelAuth =
+    authProfileId !== undefined
+      ? { authProfileId }
+      : authProfileMode !== undefined
+        ? { authProfileMode }
+        : undefined;
   // Ensure the policy-selected harness plugin so selection can pick implicit codex.
   await ensureSelectedAgentHarnessPlugin({
     config: params.config,
@@ -791,6 +825,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
     modelId,
     agentDir,
     params.config,
+    initialModelAuth,
   );
   if (!model) {
     const reason = error ?? `Unknown model: ${runtimeProvider}/${modelId}`;
@@ -804,11 +839,6 @@ async function compactEmbeddedAgentSessionDirectOnce(
     : ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
         allowKeychainPrompt: false,
       });
-  const reusableRuntimeAuthPlan =
-    providedRuntimeAuthPlan &&
-    agentRuntimeAuthPlanMatchesTarget(providedRuntimeAuthPlan, { provider, modelId })
-      ? providedRuntimeAuthPlan
-      : undefined;
   // Overrides stay unset when no bound/planned/explicit harness resolved so auth-aware
   // selection can pick the credential-owning harness (codex for ChatGPT OAuth); native
   // transcript compaction stays gated on selectedHarnessRuntime.
@@ -879,7 +909,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
   const resolvePreparedModel = ({
     config,
     authProfileId: profileId,
-    authProfileMode,
+    authProfileMode: resolvedAuthProfileMode,
   }: Parameters<
     Parameters<typeof materializePreparedRuntimeModel<ProviderRuntimeModel>>[0]["resolveModel"]
   >[0]) =>
@@ -891,7 +921,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
       preferBundledStaticCatalogTransport: true,
       workspaceDir: resolvedWorkspace,
       authProfileId: profileId,
-      authProfileMode,
+      authProfileMode: resolvedAuthProfileMode,
     });
   const materializeAuthAttemptModel = async (materializeParams: {
     plan: AgentRuntimeAuthPlan;
@@ -1619,7 +1649,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
           applySystemPromptToSession(session, systemPromptText);
           // Compaction builds the same embedded system prompt, so it must flow
           // through the same transport/payload shaping stack as normal turns.
-          prepareCompactionSessionAgent({
+          await prepareCompactionSessionAgent({
             session,
             providerStreamFn,
             sessionId: params.sessionId,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -37,6 +37,7 @@ import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.
 import {
   prepareProviderRuntimeAuth,
   resolveProviderTextTransforms,
+  shouldPreferProviderRuntimeResolvedModel,
   transformProviderSystemPrompt,
 } from "../../plugins/provider-runtime.js";
 import {
@@ -839,6 +840,19 @@ async function compactEmbeddedAgentSessionDirectOnce(
     : ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
         allowKeychainPrompt: false,
       });
+  const providerUsesProfileScopedModelMetadata = shouldPreferProviderRuntimeResolvedModel({
+    provider: runtimeProvider,
+    config: params.config,
+    workspaceDir: resolvedWorkspace,
+    env: process.env,
+    context: {
+      config: params.config,
+      agentDir,
+      workspaceDir: resolvedWorkspace,
+      provider: runtimeProvider,
+      modelId,
+    },
+  });
   // Overrides stay unset when no bound/planned/explicit harness resolved so auth-aware
   // selection can pick the credential-owning harness (codex for ChatGPT OAuth); native
   // transcript compaction stays gated on selectedHarnessRuntime.
@@ -944,6 +958,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
       modelId,
       model,
       materializeModel: materializeAuthAttemptModel,
+      forceCredentialScopedDirectModelResolve: providerUsesProfileScopedModelMetadata,
       resolveAuth: async ({ attempt: preparedAttempt, model: attemptModel }) =>
         await resolvePreparedRuntimeModelAuth({
           plan: preparedAttempt.plan,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -36,8 +36,6 @@ import { extractModelCompat } from "../../plugins/provider-model-compat.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import {
   prepareProviderRuntimeAuth,
-  resolveProviderTextTransforms,
-  shouldPreferProviderRuntimeResolvedModel,
   transformProviderSystemPrompt,
 } from "../../plugins/provider-runtime.js";
 import {
@@ -101,12 +99,7 @@ import { ensureSelectedAgentHarnessPlugin } from "../harness/runtime-plugin.js";
 import {
   selectAgentHarness,
   selectAgentHarnessForPreparedModelProviders,
-  type AgentHarnessPreparedModelProvider,
 } from "../harness/selection.js";
-import {
-  resolveAgentHarnessPreparedAuthSupport,
-  resolveAgentHarnessPreparedRouteSupport,
-} from "../harness/support.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../heartbeat-system-prompt.js";
 import {
   applyAuthHeaderOverride,
@@ -124,9 +117,7 @@ import {
 import { supportsModelTools } from "../model-tool-support.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import { isOpenAIProvider } from "../openai-routing.js";
-import { wrapStreamFnTextTransforms } from "../plugin-text-transforms.js";
 import { resolveAgentPromptSurfaceForSessionKey } from "../prompt-surface.js";
-import { resolveProviderModelMaterializationAuthMode } from "../provider-model-route-auth.js";
 import { applyPreparedRuntimeAuthToModel } from "../provider-request-config.js";
 import {
   protectPreparedProviderRuntimeAuth,
@@ -139,9 +130,12 @@ import {
 } from "../run-session-target.js";
 import { collectRuntimeChannelCapabilities } from "../runtime-capabilities.js";
 import { buildAgentRuntimePlan } from "../runtime-plan/build.js";
+import {
+  providerUsesCredentialScopedModelMetadata,
+  resolveReusableRuntimeModelAuth,
+} from "../runtime-plan/credential-scoped-model.js";
 import { materializePreparedRuntimeModel } from "../runtime-plan/materialize-model.js";
 import {
-  agentRuntimeAuthPlanMatchesTarget,
   prepareAgentRuntimeAuth,
   type PreparedAgentRuntimeAuthAttempt,
 } from "../runtime-plan/prepare-auth.js";
@@ -180,6 +174,7 @@ import type {
   CompactionMessageMetrics,
 } from "./compact.types.js";
 import { dedupeDuplicateUserMessagesForCompaction } from "./compaction-duplicate-user-messages.js";
+import { buildCompactionHarnessModelProvider } from "./compaction-harness-model-provider.js";
 import {
   asCompactionHookRunner,
   buildBeforeCompactionHookMetrics,
@@ -196,6 +191,7 @@ import {
   compactWithSafetyTimeout,
   resolveCompactionTimeoutMs,
 } from "./compaction-safety-timeout.js";
+import { prepareCompactionSessionAgent } from "./compaction-session-agent.js";
 import {
   type CompactionTranscriptRotation,
   rotateTranscriptAfterCompaction,
@@ -203,7 +199,6 @@ import {
 } from "./compaction-successor-transcript.js";
 import { applyFinalEffectiveToolPolicy } from "./effective-tool-policy.js";
 import { buildEmbeddedExtensionFactories } from "./extensions.js";
-import { applyExtraParamsToAgent } from "./extra-params.js";
 import { getHistoryLimitFromSessionKey, limitHistoryTurns } from "./history.js";
 import { log } from "./logger.js";
 import { hardenManualCompactionBoundary } from "./manual-compaction-boundary.js";
@@ -221,11 +216,6 @@ import {
   resolveSandboxSkillRuntimeInputs,
 } from "./sandbox-skills.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "./session-manager-cache.js";
-import {
-  resolveEmbeddedAgentApiKey,
-  resolveEmbeddedAgentBaseStreamFn,
-  resolveEmbeddedAgentStreamFn,
-} from "./stream-resolution.js";
 import { applySystemPromptToSession, buildEmbeddedSystemPrompt } from "./system-prompt.js";
 import {
   collectAllowedToolNames,
@@ -260,116 +250,6 @@ function createCompactionDiagId(): string {
   return `cmp-${Date.now().toString(36)}-${generateSecureToken(4)}`;
 }
 
-async function prepareCompactionSessionAgent(params: {
-  session: { agent: { streamFn?: unknown } };
-  providerStreamFn: unknown;
-  sessionId: string;
-  signal: AbortSignal;
-  effectiveModel: ProviderRuntimeModel;
-  resolvedApiKey?: string;
-  authStorage: unknown;
-  config?: OpenClawConfig;
-  provider: string;
-  modelId: string;
-  thinkLevel: ThinkLevel;
-  sessionAgentId: string;
-  effectiveWorkspace: string;
-  agentDir: string;
-  runtimePlan?: AgentRuntimePlan;
-  sessionKey?: string;
-  sandboxToolPolicy?: { allow?: string[]; deny?: string[] };
-  messageProvider?: string;
-  agentAccountId?: string | null;
-  groupId?: string | null;
-  groupChannel?: string | null;
-  groupSpace?: string | null;
-  spawnedBy?: string | null;
-  senderId?: string | null;
-  senderName?: string | null;
-  senderUsername?: string | null;
-  senderE164?: string | null;
-}) {
-  const authStorage =
-    params.authStorage &&
-    typeof params.authStorage === "object" &&
-    "getApiKey" in params.authStorage &&
-    typeof params.authStorage.getApiKey === "function"
-      ? (params.authStorage as {
-          getApiKey(provider: string): Promise<string | undefined>;
-        })
-      : undefined;
-  const transportApiKey = authStorage
-    ? await resolveEmbeddedAgentApiKey({
-        provider: params.effectiveModel.provider,
-        resolvedApiKey: params.resolvedApiKey,
-        authStorage,
-      })
-    : params.resolvedApiKey;
-  params.session.agent.streamFn = resolveEmbeddedAgentStreamFn({
-    currentStreamFn: resolveEmbeddedAgentBaseStreamFn({ session: params.session as never }),
-    providerStreamFn: params.providerStreamFn as never,
-    sessionId: params.sessionId,
-    signal: params.signal,
-    model: params.effectiveModel,
-    resolvedApiKey: params.resolvedApiKey,
-    transportAuthAvailable: Boolean(transportApiKey?.trim()),
-    authProfileId: params.runtimePlan?.auth.forwardedAuthProfileId,
-    authStorage: params.authStorage as never,
-  });
-  const providerTextTransforms = resolveProviderTextTransforms({
-    provider: params.provider,
-    config: params.config,
-    workspaceDir: params.effectiveWorkspace,
-  });
-  if (providerTextTransforms) {
-    params.session.agent.streamFn = wrapStreamFnTextTransforms({
-      streamFn: params.session.agent.streamFn as never,
-      input: providerTextTransforms.input,
-      output: providerTextTransforms.output,
-      transformSystemPrompt: false,
-    }) as never;
-  }
-  const providerThinkingLevel = mapThinkingLevelForProvider(params.thinkLevel);
-  const preparedRuntimeExtraParams = params.runtimePlan?.transport.resolveExtraParams({
-    thinkingLevel: providerThinkingLevel,
-    agentId: params.sessionAgentId,
-    workspaceDir: params.effectiveWorkspace,
-    model: params.effectiveModel,
-  });
-  return applyExtraParamsToAgent(
-    params.session.agent as never,
-    params.config,
-    params.provider,
-    params.modelId,
-    undefined,
-    providerThinkingLevel,
-    params.sessionAgentId,
-    params.effectiveWorkspace,
-    params.effectiveModel,
-    params.agentDir,
-    undefined,
-    {
-      ...(preparedRuntimeExtraParams ? { preparedExtraParams: preparedRuntimeExtraParams } : {}),
-      nativeWebSearchPolicyContext: {
-        // Compaction rebuilds the provider stream wrapper, so preserve the
-        // session-scoped policy inputs that can suppress provider-native search.
-        sessionKey: params.sessionKey,
-        sandboxToolPolicy: params.sandboxToolPolicy,
-        messageProvider: params.messageProvider,
-        agentAccountId: params.agentAccountId,
-        groupId: params.groupId,
-        groupChannel: params.groupChannel,
-        groupSpace: params.groupSpace,
-        spawnedBy: params.spawnedBy,
-        senderId: params.senderId,
-        senderName: params.senderName,
-        senderUsername: params.senderUsername,
-        senderE164: params.senderE164,
-      },
-    },
-  );
-}
-
 function resolveCompactionProviderStream(params: {
   effectiveModel: ProviderRuntimeModel;
   config?: OpenClawConfig;
@@ -382,27 +262,6 @@ function resolveCompactionProviderStream(params: {
     agentDir: params.agentDir,
     workspaceDir: params.effectiveWorkspace,
   });
-}
-
-function buildCompactionHarnessModelProvider(params: {
-  model: ProviderRuntimeModel;
-  plan?: AgentRuntimeAuthPlan;
-  attempt?: PreparedAgentRuntimeAuthAttempt;
-}): AgentHarnessPreparedModelProvider {
-  const route = params.plan?.modelRoute;
-  return {
-    api: route?.api ?? params.model.api,
-    baseUrl: route?.baseUrl ?? params.model.baseUrl,
-    ...resolveAgentHarnessPreparedRouteSupport(params.plan),
-    ...(params.plan
-      ? {
-          preparedAuth: resolveAgentHarnessPreparedAuthSupport({
-            plan: params.plan,
-            source: params.attempt?.kind === "implicit" ? undefined : params.attempt?.kind,
-          }),
-        }
-      : {}),
-  };
 }
 
 function normalizeObservedTokenCount(value: unknown): number | undefined {
@@ -763,22 +622,16 @@ async function compactEmbeddedAgentSessionDirectOnce(
   const contextConfigProvider = resolvedCompactionTarget.contextProvider ?? provider;
   const modelId = resolvedCompactionTarget.model ?? DEFAULT_MODEL;
   const providedRuntimeAuthPlan = params.runtimeAuthPlan ?? params.runtimePlan?.auth;
-  const reusableRuntimeAuthPlan =
-    providedRuntimeAuthPlan &&
-    agentRuntimeAuthPlanMatchesTarget(providedRuntimeAuthPlan, { provider, modelId })
-      ? providedRuntimeAuthPlan
-      : undefined;
-  const authProfileId =
-    resolvedCompactionTarget.authProfileId ?? reusableRuntimeAuthPlan?.forwardedAuthProfileId;
-  const authProfileMode = resolveProviderModelMaterializationAuthMode(
-    reusableRuntimeAuthPlan?.selectedAuthMode,
-  );
-  const initialModelAuth =
-    authProfileId !== undefined
-      ? { authProfileId }
-      : authProfileMode !== undefined
-        ? { authProfileMode }
-        : undefined;
+  const {
+    plan: reusableRuntimeAuthPlan,
+    authProfileId,
+    modelAuth: initialModelAuth,
+  } = resolveReusableRuntimeModelAuth({
+    plan: providedRuntimeAuthPlan,
+    provider,
+    modelId,
+    authProfileId: resolvedCompactionTarget.authProfileId,
+  });
   // Ensure the policy-selected harness plugin so selection can pick implicit codex.
   await ensureSelectedAgentHarnessPlugin({
     config: params.config,
@@ -840,18 +693,12 @@ async function compactEmbeddedAgentSessionDirectOnce(
     : ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
         allowKeychainPrompt: false,
       });
-  const providerUsesProfileScopedModelMetadata = shouldPreferProviderRuntimeResolvedModel({
+  const providerUsesProfileScopedModelMetadata = providerUsesCredentialScopedModelMetadata({
     provider: runtimeProvider,
+    modelId,
     config: params.config,
+    agentDir,
     workspaceDir: resolvedWorkspace,
-    env: process.env,
-    context: {
-      config: params.config,
-      agentDir,
-      workspaceDir: resolvedWorkspace,
-      provider: runtimeProvider,
-      modelId,
-    },
   });
   // Overrides stay unset when no bound/planned/explicit harness resolved so auth-aware
   // selection can pick the credential-owning harness (codex for ChatGPT OAuth); native

--- a/src/agents/embedded-agent-runner/compaction-harness-model-provider.ts
+++ b/src/agents/embedded-agent-runner/compaction-harness-model-provider.ts
@@ -1,0 +1,29 @@
+import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+import type { AgentHarnessPreparedModelProvider } from "../harness/selection.js";
+import {
+  resolveAgentHarnessPreparedAuthSupport,
+  resolveAgentHarnessPreparedRouteSupport,
+} from "../harness/support.js";
+import type { PreparedAgentRuntimeAuthAttempt } from "../runtime-plan/prepare-auth.js";
+import type { AgentRuntimeAuthPlan } from "../runtime-plan/types.js";
+
+export function buildCompactionHarnessModelProvider(params: {
+  model?: ProviderRuntimeModel;
+  plan?: AgentRuntimeAuthPlan;
+  attempt?: PreparedAgentRuntimeAuthAttempt;
+}): AgentHarnessPreparedModelProvider {
+  const route = params.plan?.modelRoute;
+  return {
+    api: route?.api ?? params.model?.api,
+    baseUrl: route?.baseUrl ?? params.model?.baseUrl,
+    ...resolveAgentHarnessPreparedRouteSupport(params.plan),
+    ...(params.plan
+      ? {
+          preparedAuth: resolveAgentHarnessPreparedAuthSupport({
+            plan: params.plan,
+            source: params.attempt?.kind === "implicit" ? undefined : params.attempt?.kind,
+          }),
+        }
+      : {}),
+  };
+}

--- a/src/agents/embedded-agent-runner/compaction-session-agent.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-agent.ts
@@ -1,0 +1,123 @@
+import type { ThinkLevel } from "../../auto-reply/thinking.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+import { resolveProviderTextTransforms } from "../../plugins/provider-runtime.js";
+import { wrapStreamFnTextTransforms } from "../plugin-text-transforms.js";
+import type { AgentRuntimePlan } from "../runtime-plan/types.js";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+import {
+  resolveEmbeddedAgentApiKey,
+  resolveEmbeddedAgentBaseStreamFn,
+  resolveEmbeddedAgentStreamFn,
+} from "./stream-resolution.js";
+import { mapThinkingLevelForProvider } from "./utils.js";
+
+export async function prepareCompactionSessionAgent(params: {
+  session: { agent: { streamFn?: unknown } };
+  providerStreamFn: unknown;
+  sessionId: string;
+  signal: AbortSignal;
+  effectiveModel: ProviderRuntimeModel;
+  resolvedApiKey?: string;
+  authStorage: unknown;
+  config?: OpenClawConfig;
+  provider: string;
+  modelId: string;
+  thinkLevel: ThinkLevel;
+  sessionAgentId: string;
+  effectiveWorkspace: string;
+  agentDir: string;
+  runtimePlan?: AgentRuntimePlan;
+  sessionKey?: string;
+  sandboxToolPolicy?: { allow?: string[]; deny?: string[] };
+  messageProvider?: string;
+  agentAccountId?: string | null;
+  groupId?: string | null;
+  groupChannel?: string | null;
+  groupSpace?: string | null;
+  spawnedBy?: string | null;
+  senderId?: string | null;
+  senderName?: string | null;
+  senderUsername?: string | null;
+  senderE164?: string | null;
+}) {
+  const authStorage =
+    params.authStorage &&
+    typeof params.authStorage === "object" &&
+    "getApiKey" in params.authStorage &&
+    typeof params.authStorage.getApiKey === "function"
+      ? (params.authStorage as {
+          getApiKey(provider: string): Promise<string | undefined>;
+        })
+      : undefined;
+  const transportApiKey = authStorage
+    ? await resolveEmbeddedAgentApiKey({
+        provider: params.effectiveModel.provider,
+        resolvedApiKey: params.resolvedApiKey,
+        authStorage,
+      })
+    : params.resolvedApiKey;
+  params.session.agent.streamFn = resolveEmbeddedAgentStreamFn({
+    currentStreamFn: resolveEmbeddedAgentBaseStreamFn({ session: params.session as never }),
+    providerStreamFn: params.providerStreamFn as never,
+    sessionId: params.sessionId,
+    signal: params.signal,
+    model: params.effectiveModel,
+    resolvedApiKey: params.resolvedApiKey,
+    transportAuthAvailable: Boolean(transportApiKey?.trim()),
+    authProfileId: params.runtimePlan?.auth.forwardedAuthProfileId,
+    authStorage: params.authStorage as never,
+  });
+  const providerTextTransforms = resolveProviderTextTransforms({
+    provider: params.provider,
+    config: params.config,
+    workspaceDir: params.effectiveWorkspace,
+  });
+  if (providerTextTransforms) {
+    params.session.agent.streamFn = wrapStreamFnTextTransforms({
+      streamFn: params.session.agent.streamFn as never,
+      input: providerTextTransforms.input,
+      output: providerTextTransforms.output,
+      transformSystemPrompt: false,
+    }) as never;
+  }
+  const providerThinkingLevel = mapThinkingLevelForProvider(params.thinkLevel);
+  const preparedRuntimeExtraParams = params.runtimePlan?.transport.resolveExtraParams({
+    thinkingLevel: providerThinkingLevel,
+    agentId: params.sessionAgentId,
+    workspaceDir: params.effectiveWorkspace,
+    model: params.effectiveModel,
+  });
+  return applyExtraParamsToAgent(
+    params.session.agent as never,
+    params.config,
+    params.provider,
+    params.modelId,
+    undefined,
+    providerThinkingLevel,
+    params.sessionAgentId,
+    params.effectiveWorkspace,
+    params.effectiveModel,
+    params.agentDir,
+    undefined,
+    {
+      ...(preparedRuntimeExtraParams ? { preparedExtraParams: preparedRuntimeExtraParams } : {}),
+      nativeWebSearchPolicyContext: {
+        // Compaction rebuilds the stream wrapper, so preserve the session policy
+        // inputs that can suppress provider-native search.
+        sessionKey: params.sessionKey,
+        sandboxToolPolicy: params.sandboxToolPolicy,
+        messageProvider: params.messageProvider,
+        agentAccountId: params.agentAccountId,
+        groupId: params.groupId,
+        groupChannel: params.groupChannel,
+        groupSpace: params.groupSpace,
+        spawnedBy: params.spawnedBy,
+        senderId: params.senderId,
+        senderName: params.senderName,
+        senderUsername: params.senderUsername,
+        senderE164: params.senderE164,
+      },
+    },
+  );
+}

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -674,6 +674,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
     prepareProviderRuntimeAuth: mockedPrepareProviderRuntimeAuth,
     resolveProviderCapabilitiesWithPlugin: vi.fn(() => ({})),
     resolveProviderAuthProfileId: vi.fn(() => undefined),
+    shouldPreferProviderRuntimeResolvedModel: vi.fn(() => false),
     prepareProviderExtraParams: vi.fn(async () => ({})),
     wrapProviderStreamFn: vi.fn((_cfg: unknown, _model: unknown, fn: unknown) => fn),
   }));

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -678,7 +678,6 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
     prepareProviderExtraParams: vi.fn(async () => ({})),
     wrapProviderStreamFn: vi.fn((_cfg: unknown, _model: unknown, fn: unknown) => fn),
   }));
-
   vi.doMock("../auth-profiles.js", () => ({
     isProfileInCooldown: mockedIsProfileInCooldown,
     markAuthProfileFailure: mockedMarkAuthProfileFailure,

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -35,7 +35,10 @@ import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
 import { redactIdentifier } from "../../logging/redact-identifier.js";
 import { buildAgentHookContextChannelFields } from "../../plugins/hook-agent-context.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { resolveProviderAuthProfileId } from "../../plugins/provider-runtime.js";
+import {
+  resolveProviderAuthProfileId,
+  shouldPreferProviderRuntimeResolvedModel,
+} from "../../plugins/provider-runtime.js";
 import { looksLikeSecretSentinel, resolveSecretSentinel } from "../../secrets/sentinel.js";
 import { createAgentHarnessTaskRuntimeScope } from "../../tasks/agent-harness-task-runtime-scope.js";
 import { createTrajectoryRuntimeRecorder } from "../../trajectory/runtime.js";
@@ -119,6 +122,7 @@ import {
   resolveContextConfigProviderForRuntime,
   resolveSelectedOpenAIRuntimeProvider,
 } from "../openai-routing.js";
+import { resolveProviderModelRouteAuthRequirement } from "../provider-model-route-auth.js";
 import { hasOnlyAssistantReasoningContent } from "../replay-turn-classification.js";
 import { runAgentCleanupStep } from "../run-cleanup-timeout.js";
 import {
@@ -131,6 +135,7 @@ import { materializePreparedRuntimeModel } from "../runtime-plan/materialize-mod
 import {
   canRunPreparedAgentRuntimeAuthAttempt,
   prepareAgentRuntimeAuth,
+  shouldForceDirectAuthFallbackModelResolve,
   type PreparedAgentRuntimeAuthAttempt,
 } from "../runtime-plan/prepare-auth.js";
 import type { AgentRuntimeAuthPlan } from "../runtime-plan/types.js";
@@ -180,6 +185,10 @@ import {
   shouldWarnEmbeddedRunStageSummary,
 } from "./run/attempt-stage-timing.js";
 import { forgetPromptBuildDrainCacheForRun } from "./run/attempt.prompt-helpers.js";
+import {
+  shouldForceProfileScopedModelResolve,
+  shouldMaterializeAuthPlanModel,
+} from "./run/attempt.run-decisions.js";
 import {
   createEmbeddedRunAuthController,
   resolveEmbeddedAuthCooldownProbePolicy,
@@ -922,15 +931,17 @@ async function runEmbeddedAgentInternal(
         AgentRuntimeAuthPlan,
         Promise<typeof runtimeModel>
       >();
-      const materializeAuthPlanUncached = async (plan: AgentRuntimeAuthPlan) => {
+      const materializeAuthPlanUncached = async (
+        plan: AgentRuntimeAuthPlan,
+        forceResolve = false,
+      ) => {
         // Native harness sessions own their model tuple. Route preparation may
         // attest auth/transport, but must not rediscover or replace that model.
         if (nativeModelOwned) {
           return runtimeModel;
         }
-        const requiresCredentialScopedResolve = Boolean(
-          plan.modelRoute && (plan.forwardedAuthProfileId || params.authProfileId),
-        );
+        const requiresCredentialScopedResolve =
+          forceResolve || shouldForceProfileScopedModelResolve(plan, params.authProfileId);
         return (
           (await materializePreparedRuntimeModel({
             plan,
@@ -1092,6 +1103,19 @@ async function runEmbeddedAgentInternal(
             : preparedAuthAttempts[attemptIndex];
         return attempt?.profileId === profileId ? attempt : undefined;
       };
+      const providerUsesProfileScopedModelMetadata = shouldPreferProviderRuntimeResolvedModel({
+        provider,
+        config: params.config,
+        workspaceDir: resolvedWorkspace,
+        env: process.env,
+        context: {
+          config: params.config,
+          agentDir,
+          workspaceDir: resolvedWorkspace,
+          provider,
+          modelId,
+        },
+      });
       let preparedProfileAttempted = false;
       const prepareAuthAttempt = async (attempt: (typeof preparedAuthAttempts)[number]) => {
         if (
@@ -1105,7 +1129,23 @@ async function runEmbeddedAgentInternal(
           );
         }
         const route = attempt.plan.modelRoute;
-        const nextRuntimeModel = route ? await materializeAuthPlan(attempt.plan) : runtimeModel;
+        const forceDirectFallbackResolve = shouldForceDirectAuthFallbackModelResolve({
+          attempt,
+          priorProfileAttempted: preparedProfileAttempted,
+        });
+        const shouldMaterializeModel =
+          shouldMaterializeAuthPlanModel(attempt.plan, params.authProfileId) ||
+          forceDirectFallbackResolve;
+        const nextRuntimeModel = shouldMaterializeModel
+          ? forceDirectFallbackResolve
+            ? await materializeAuthPlanUncached(attempt.plan, true)
+            : await materializeAuthPlan(attempt.plan)
+          : runtimeModel;
+        const authRequirement =
+          route?.authRequirement ??
+          (shouldMaterializeModel && providerUsesProfileScopedModelMetadata
+            ? resolveProviderModelRouteAuthRequirement(attempt.plan.selectedAuthMode)
+            : undefined);
         const nextResolvedModel = resolveEffectiveModel(nextRuntimeModel);
         const nextHarness = selectHarnessForPreparedAttempts(
           nextResolvedModel.effectiveModel,
@@ -1119,7 +1159,7 @@ async function runEmbeddedAgentInternal(
         preparedProfileAttempted ||= attempt.kind === "profile";
         return {
           runtimeModel: nextRuntimeModel,
-          authRequirement: route?.authRequirement,
+          authRequirement,
           allowAuthProfileFallback: attempt.allowAuthProfileFallback,
           commit() {
             // Model metadata and its prepared route/profile become active in
@@ -1130,7 +1170,11 @@ async function runEmbeddedAgentInternal(
         };
       };
       const hasPreparedAuthAttemptMetadata = preparedAuthAttempts.some(
-        (attempt) => attempt.plan.modelRoute || attempt.allowAuthProfileFallback !== undefined,
+        (attempt) =>
+          (providerUsesProfileScopedModelMetadata &&
+            (attempt.kind === "profile" || Boolean(attempt.plan.forwardedAuthProfileId))) ||
+          attempt.plan.modelRoute ||
+          attempt.allowAuthProfileFallback !== undefined,
       );
       const prepareModelForAuthProfile =
         hasPreparedAuthAttemptMetadata &&

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -186,7 +186,7 @@ import {
 } from "./run/attempt-stage-timing.js";
 import { forgetPromptBuildDrainCacheForRun } from "./run/attempt.prompt-helpers.js";
 import {
-  shouldForceProfileScopedModelResolve,
+  shouldForceCredentialScopedModelResolve,
   shouldMaterializeAuthPlanModel,
 } from "./run/attempt.run-decisions.js";
 import {
@@ -926,6 +926,19 @@ async function runEmbeddedAgentInternal(
               context,
             }),
         });
+      const providerUsesProfileScopedModelMetadata = shouldPreferProviderRuntimeResolvedModel({
+        provider,
+        config: params.config,
+        workspaceDir: resolvedWorkspace,
+        env: process.env,
+        context: {
+          config: params.config,
+          agentDir,
+          workspaceDir: resolvedWorkspace,
+          provider,
+          modelId,
+        },
+      });
 
       const materializedRouteModels = new WeakMap<
         AgentRuntimeAuthPlan,
@@ -941,7 +954,12 @@ async function runEmbeddedAgentInternal(
           return runtimeModel;
         }
         const requiresCredentialScopedResolve =
-          forceResolve || shouldForceProfileScopedModelResolve(plan, params.authProfileId);
+          forceResolve ||
+          shouldForceCredentialScopedModelResolve(
+            plan,
+            params.authProfileId,
+            providerUsesProfileScopedModelMetadata,
+          );
         return (
           (await materializePreparedRuntimeModel({
             plan,
@@ -949,8 +967,8 @@ async function runEmbeddedAgentInternal(
             modelId,
             config: params.config,
             model: runtimeModel,
-            // Unscoped direct auth cannot change credential-scoped metadata.
-            // Reuse an already matching tuple; route mismatches still resolve.
+            // Credential-scoped providers must replace metadata whenever the
+            // prepared profile or direct auth source changes.
             forceResolve: requiresCredentialScopedResolve,
             resolveModel: ({ config, authProfileId, authProfileMode }) =>
               resolveModelAsync(provider, modelId, agentDir, config, {
@@ -1103,19 +1121,6 @@ async function runEmbeddedAgentInternal(
             : preparedAuthAttempts[attemptIndex];
         return attempt?.profileId === profileId ? attempt : undefined;
       };
-      const providerUsesProfileScopedModelMetadata = shouldPreferProviderRuntimeResolvedModel({
-        provider,
-        config: params.config,
-        workspaceDir: resolvedWorkspace,
-        env: process.env,
-        context: {
-          config: params.config,
-          agentDir,
-          workspaceDir: resolvedWorkspace,
-          provider,
-          modelId,
-        },
-      });
       let preparedProfileAttempted = false;
       const prepareAuthAttempt = async (attempt: (typeof preparedAuthAttempts)[number]) => {
         if (
@@ -1134,8 +1139,11 @@ async function runEmbeddedAgentInternal(
           priorProfileAttempted: preparedProfileAttempted,
         });
         const shouldMaterializeModel =
-          shouldMaterializeAuthPlanModel(attempt.plan, params.authProfileId) ||
-          forceDirectFallbackResolve;
+          shouldMaterializeAuthPlanModel(
+            attempt.plan,
+            params.authProfileId,
+            providerUsesProfileScopedModelMetadata,
+          ) || forceDirectFallbackResolve;
         const nextRuntimeModel = shouldMaterializeModel
           ? forceDirectFallbackResolve
             ? await materializeAuthPlanUncached(attempt.plan, true)

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -35,10 +35,7 @@ import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
 import { redactIdentifier } from "../../logging/redact-identifier.js";
 import { buildAgentHookContextChannelFields } from "../../plugins/hook-agent-context.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import {
-  resolveProviderAuthProfileId,
-  shouldPreferProviderRuntimeResolvedModel,
-} from "../../plugins/provider-runtime.js";
+import { resolveProviderAuthProfileId } from "../../plugins/provider-runtime.js";
 import { looksLikeSecretSentinel, resolveSecretSentinel } from "../../secrets/sentinel.js";
 import { createAgentHarnessTaskRuntimeScope } from "../../tasks/agent-harness-task-runtime-scope.js";
 import { createTrajectoryRuntimeRecorder } from "../../trajectory/runtime.js";
@@ -122,7 +119,6 @@ import {
   resolveContextConfigProviderForRuntime,
   resolveSelectedOpenAIRuntimeProvider,
 } from "../openai-routing.js";
-import { resolveProviderModelRouteAuthRequirement } from "../provider-model-route-auth.js";
 import { hasOnlyAssistantReasoningContent } from "../replay-turn-classification.js";
 import { runAgentCleanupStep } from "../run-cleanup-timeout.js";
 import {
@@ -131,11 +127,15 @@ import {
 } from "../run-session-target.js";
 import { createAgentRunDirectAbortError } from "../run-termination.js";
 import { buildAgentRuntimePlan } from "../runtime-plan/build.js";
-import { materializePreparedRuntimeModel } from "../runtime-plan/materialize-model.js";
+import {
+  createPreparedRuntimeModelMaterializer,
+  hasPreparedAuthAttemptModelMetadata,
+  providerUsesCredentialScopedModelMetadata,
+  resolveCredentialScopedAuthAttemptModelDecision,
+} from "../runtime-plan/credential-scoped-model.js";
 import {
   canRunPreparedAgentRuntimeAuthAttempt,
   prepareAgentRuntimeAuth,
-  shouldForceDirectAuthFallbackModelResolve,
   type PreparedAgentRuntimeAuthAttempt,
 } from "../runtime-plan/prepare-auth.js";
 import type { AgentRuntimeAuthPlan } from "../runtime-plan/types.js";
@@ -185,10 +185,6 @@ import {
   shouldWarnEmbeddedRunStageSummary,
 } from "./run/attempt-stage-timing.js";
 import { forgetPromptBuildDrainCacheForRun } from "./run/attempt.prompt-helpers.js";
-import {
-  shouldForceCredentialScopedModelResolve,
-  shouldMaterializeAuthPlanModel,
-} from "./run/attempt.run-decisions.js";
 import {
   createEmbeddedRunAuthController,
   resolveEmbeddedAuthCooldownProbePolicy,
@@ -926,78 +922,34 @@ async function runEmbeddedAgentInternal(
               context,
             }),
         });
-      const providerUsesProfileScopedModelMetadata = shouldPreferProviderRuntimeResolvedModel({
+      const providerUsesProfileScopedModelMetadata = providerUsesCredentialScopedModelMetadata({
         provider,
+        modelId,
         config: params.config,
+        agentDir,
         workspaceDir: resolvedWorkspace,
-        env: process.env,
-        context: {
-          config: params.config,
-          agentDir,
-          workspaceDir: resolvedWorkspace,
+      });
+      const { materialize: materializeAuthPlan, materializeUncached: materializeAuthPlanUncached } =
+        createPreparedRuntimeModelMaterializer({
           provider,
           modelId,
-        },
-      });
-
-      const materializedRouteModels = new WeakMap<
-        AgentRuntimeAuthPlan,
-        Promise<typeof runtimeModel>
-      >();
-      const materializeAuthPlanUncached = async (
-        plan: AgentRuntimeAuthPlan,
-        forceResolve = false,
-      ) => {
-        // Native harness sessions own their model tuple. Route preparation may
-        // attest auth/transport, but must not rediscover or replace that model.
-        if (nativeModelOwned) {
-          return runtimeModel;
-        }
-        const requiresCredentialScopedResolve =
-          forceResolve ||
-          shouldForceCredentialScopedModelResolve(
-            plan,
-            params.authProfileId,
-            providerUsesProfileScopedModelMetadata,
-          );
-        return (
-          (await materializePreparedRuntimeModel({
-            plan,
-            provider,
-            modelId,
-            config: params.config,
-            model: runtimeModel,
-            // Credential-scoped providers must replace metadata whenever the
-            // prepared profile or direct auth source changes.
-            forceResolve: requiresCredentialScopedResolve,
-            resolveModel: ({ config, authProfileId, authProfileMode }) =>
-              resolveModelAsync(provider, modelId, agentDir, config, {
-                authStorage,
-                modelRegistry,
-                skipAgentDiscovery: true,
-                allowBundledStaticCatalogFallback: true,
-                preferBundledStaticCatalogTransport: true,
-                workspaceDir: resolvedWorkspace,
-                authProfileId,
-                authProfileMode,
-              }),
-          })) ?? runtimeModel
-        );
-      };
-      const materializeAuthPlan = (plan: AgentRuntimeAuthPlan) => {
-        if (!plan.modelRoute) {
-          return materializeAuthPlanUncached(plan);
-        }
-        const cached = materializedRouteModels.get(plan);
-        if (cached) {
-          return cached;
-        }
-        // Prepared plans are immutable within one run. Carry their exact model
-        // tuple into auth initialization instead of repeating provider discovery.
-        const materialized = materializeAuthPlanUncached(plan);
-        materializedRouteModels.set(plan, materialized);
-        return materialized;
-      };
+          config: params.config,
+          getModel: () => runtimeModel,
+          nativeModelOwned,
+          requestedProfileId: params.authProfileId,
+          providerUsesProfileScopedModelMetadata,
+          resolveModel: ({ config, authProfileId, authProfileMode }) =>
+            resolveModelAsync(provider, modelId, agentDir, config, {
+              authStorage,
+              modelRegistry,
+              skipAgentDiscovery: true,
+              allowBundledStaticCatalogFallback: true,
+              preferBundledStaticCatalogTransport: true,
+              workspaceDir: resolvedWorkspace,
+              authProfileId,
+              authProfileMode,
+            }),
+        });
       let resolvedAuthPreparation = createAuthPreparation();
       let preparedAuthAttempts = resolvedAuthPreparation.attempts;
       let activePreparedAuthPlan = resolvedAuthPreparation.plan;
@@ -1133,27 +1085,17 @@ async function runEmbeddedAgentInternal(
             `Prepared direct auth fallback cannot bypass unavailable profiles for ${provider}/${modelId}.`,
           );
         }
-        const route = attempt.plan.modelRoute;
-        const forceDirectFallbackResolve = shouldForceDirectAuthFallbackModelResolve({
+        const modelDecision = resolveCredentialScopedAuthAttemptModelDecision({
           attempt,
           priorProfileAttempted: preparedProfileAttempted,
+          requestedProfileId: params.authProfileId,
+          providerUsesProfileScopedModelMetadata,
         });
-        const shouldMaterializeModel =
-          shouldMaterializeAuthPlanModel(
-            attempt.plan,
-            params.authProfileId,
-            providerUsesProfileScopedModelMetadata,
-          ) || forceDirectFallbackResolve;
-        const nextRuntimeModel = shouldMaterializeModel
-          ? forceDirectFallbackResolve
+        const nextRuntimeModel = modelDecision.shouldMaterialize
+          ? modelDecision.forceResolve
             ? await materializeAuthPlanUncached(attempt.plan, true)
             : await materializeAuthPlan(attempt.plan)
           : runtimeModel;
-        const authRequirement =
-          route?.authRequirement ??
-          (shouldMaterializeModel && providerUsesProfileScopedModelMetadata
-            ? resolveProviderModelRouteAuthRequirement(attempt.plan.selectedAuthMode)
-            : undefined);
         const nextResolvedModel = resolveEffectiveModel(nextRuntimeModel);
         const nextHarness = selectHarnessForPreparedAttempts(
           nextResolvedModel.effectiveModel,
@@ -1167,7 +1109,7 @@ async function runEmbeddedAgentInternal(
         preparedProfileAttempted ||= attempt.kind === "profile";
         return {
           runtimeModel: nextRuntimeModel,
-          authRequirement,
+          authRequirement: modelDecision.authRequirement,
           allowAuthProfileFallback: attempt.allowAuthProfileFallback,
           commit() {
             // Model metadata and its prepared route/profile become active in
@@ -1177,13 +1119,10 @@ async function runEmbeddedAgentInternal(
           },
         };
       };
-      const hasPreparedAuthAttemptMetadata = preparedAuthAttempts.some(
-        (attempt) =>
-          (providerUsesProfileScopedModelMetadata &&
-            (attempt.kind === "profile" || Boolean(attempt.plan.forwardedAuthProfileId))) ||
-          attempt.plan.modelRoute ||
-          attempt.allowAuthProfileFallback !== undefined,
-      );
+      const hasPreparedAuthAttemptMetadata = hasPreparedAuthAttemptModelMetadata({
+        attempts: preparedAuthAttempts,
+        providerUsesProfileScopedModelMetadata,
+      });
       const prepareModelForAuthProfile =
         hasPreparedAuthAttemptMetadata &&
         (!pluginHarnessOwnsAuthBootstrap || pluginHarnessHasPreparedApiKeyAttempt)

--- a/src/agents/embedded-agent-runner/run/attempt-stream-transport.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-transport.ts
@@ -19,6 +19,7 @@ import { log } from "../logger.js";
 import { resolveCacheRetention } from "../prompt-cache-retention.js";
 import {
   describeEmbeddedAgentStreamStrategy,
+  resolveEmbeddedAgentApiKey,
   resolveEmbeddedAgentBaseStreamFn,
   resolveEmbeddedAgentStreamFn,
 } from "../stream-resolution.js";
@@ -29,7 +30,7 @@ import {
 } from "./attempt.run-decisions.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
 
-export function prepareEmbeddedAttemptTransport(input: {
+export async function prepareEmbeddedAttemptTransport(input: {
   attempt: EmbeddedRunAttemptParams;
   session: AgentSession;
   settingsManager: SettingsManager;
@@ -93,11 +94,16 @@ export function prepareEmbeddedAttemptTransport(input: {
     agentDir: input.agentDir,
     workspaceDir: input.workspaceDir,
   });
+  const transportApiKey = await resolveEmbeddedAgentApiKey({
+    provider: attempt.model.provider,
+    resolvedApiKey: attempt.resolvedApiKey,
+    authStorage: attempt.authStorage,
+  });
   const streamStrategy = describeEmbeddedAgentStreamStrategy({
     currentStreamFn: defaultSessionStreamFn,
     providerStreamFn,
     model: attempt.model,
-    resolvedApiKey: attempt.resolvedApiKey,
+    resolvedApiKey: transportApiKey,
   });
   session.agent.streamFn = resolveEmbeddedAgentStreamFn({
     currentStreamFn: defaultSessionStreamFn,
@@ -107,6 +113,7 @@ export function prepareEmbeddedAttemptTransport(input: {
     signal: input.abortSignal,
     model: attempt.model,
     resolvedApiKey: attempt.resolvedApiKey,
+    transportAuthAvailable: Boolean(transportApiKey?.trim()),
     authProfileId: resolveAttemptStreamAuthProfileId(attempt),
     authStorage: attempt.authStorage,
   });

--- a/src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts
@@ -1,9 +1,6 @@
 // Coverage for small run-attempt decision helpers.
 import { describe, expect, it } from "vitest";
-import {
-  shouldForceCredentialScopedModelResolve,
-  shouldMaterializeAuthPlanModel,
-} from "../../runtime-plan/credential-scoped-model.js";
+import { resolveCredentialScopedAuthAttemptModelDecision } from "../../runtime-plan/credential-scoped-model.js";
 import {
   resolveAttemptStreamAuthProfileId,
   resolveAttemptToolPolicyMessageProvider,
@@ -51,37 +48,34 @@ describe("resolveAttemptStreamAuthProfileId", () => {
     ).toBeUndefined();
   });
 
-  describe("shouldMaterializeAuthPlanModel", () => {
-    it("materializes route-less plans when a provider profile scopes model metadata", () => {
-      expect(
-        shouldMaterializeAuthPlanModel({
-          forwardedAuthProfileId: "github-copilot:work",
-        }),
-      ).toBe(true);
-      expect(shouldMaterializeAuthPlanModel({}, "github-copilot:requested")).toBe(true);
-      expect(shouldMaterializeAuthPlanModel({ selectedAuthMode: "api-key" }, undefined, true)).toBe(
-        true,
-      );
-      expect(
-        shouldMaterializeAuthPlanModel({ selectedAuthMode: "api-key" }, undefined, false),
-      ).toBe(false);
-      expect(shouldMaterializeAuthPlanModel({})).toBe(false);
-    });
+  describe("resolveCredentialScopedAuthAttemptModelDecision", () => {
+    const resolveDecision = (
+      plan: Record<string, unknown>,
+      requestedProfileId?: string,
+      providerUsesProfileScopedModelMetadata = false,
+    ) =>
+      resolveCredentialScopedAuthAttemptModelDecision({
+        attempt: { kind: "implicit", plan } as never,
+        priorProfileAttempted: false,
+        requestedProfileId,
+        providerUsesProfileScopedModelMetadata,
+      });
 
-    it("forces re-resolution for profiles and provider-scoped direct credentials", () => {
+    it("materializes route-less plans when a provider profile scopes model metadata", () => {
+      expect(resolveDecision({ forwardedAuthProfileId: "github-copilot:work" })).toMatchObject({
+        forceResolve: false,
+        shouldMaterialize: true,
+      });
+      expect(resolveDecision({}, "github-copilot:requested").shouldMaterialize).toBe(true);
+      expect(resolveDecision({ selectedAuthMode: "api-key" }, undefined, true)).toMatchObject({
+        forceResolve: false,
+        shouldMaterialize: true,
+        authRequirement: "api-key",
+      });
       expect(
-        shouldForceCredentialScopedModelResolve({
-          forwardedAuthProfileId: "github-copilot:work",
-        }),
-      ).toBe(true);
-      expect(shouldForceCredentialScopedModelResolve({}, "github-copilot:requested")).toBe(true);
-      expect(
-        shouldForceCredentialScopedModelResolve({ selectedAuthMode: "api-key" }, undefined, true),
-      ).toBe(true);
-      expect(
-        shouldForceCredentialScopedModelResolve({ selectedAuthMode: "api-key" }, undefined, false),
+        resolveDecision({ selectedAuthMode: "api-key" }, undefined, false).shouldMaterialize,
       ).toBe(false);
-      expect(shouldForceCredentialScopedModelResolve({})).toBe(false);
+      expect(resolveDecision({}).shouldMaterialize).toBe(false);
     });
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts
@@ -1,12 +1,14 @@
 // Coverage for small run-attempt decision helpers.
 import { describe, expect, it } from "vitest";
 import {
+  shouldForceCredentialScopedModelResolve,
+  shouldMaterializeAuthPlanModel,
+} from "../../runtime-plan/credential-scoped-model.js";
+import {
   resolveAttemptStreamAuthProfileId,
   resolveAttemptToolPolicyMessageProvider,
   resolveEmbeddedAttemptSessionWriteLockOptions,
   resolveUnknownToolGuardThreshold,
-  shouldForceCredentialScopedModelResolve,
-  shouldMaterializeAuthPlanModel,
   shouldRunLlmOutputHooksForAttempt,
 } from "./attempt.run-decisions.js";
 

--- a/src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts
@@ -5,6 +5,8 @@ import {
   resolveAttemptToolPolicyMessageProvider,
   resolveEmbeddedAttemptSessionWriteLockOptions,
   resolveUnknownToolGuardThreshold,
+  shouldForceProfileScopedModelResolve,
+  shouldMaterializeAuthPlanModel,
   shouldRunLlmOutputHooksForAttempt,
 } from "./attempt.run-decisions.js";
 
@@ -45,6 +47,28 @@ describe("resolveAttemptStreamAuthProfileId", () => {
         } as never,
       }),
     ).toBeUndefined();
+  });
+
+  describe("shouldMaterializeAuthPlanModel", () => {
+    it("materializes route-less plans when a provider profile scopes model metadata", () => {
+      expect(
+        shouldMaterializeAuthPlanModel({
+          forwardedAuthProfileId: "github-copilot:work",
+        }),
+      ).toBe(true);
+      expect(shouldMaterializeAuthPlanModel({}, "github-copilot:requested")).toBe(true);
+      expect(shouldMaterializeAuthPlanModel({})).toBe(false);
+    });
+
+    it("forces re-resolution for profiles but not route-only plans", () => {
+      expect(
+        shouldForceProfileScopedModelResolve({
+          forwardedAuthProfileId: "github-copilot:work",
+        }),
+      ).toBe(true);
+      expect(shouldForceProfileScopedModelResolve({}, "github-copilot:requested")).toBe(true);
+      expect(shouldForceProfileScopedModelResolve({})).toBe(false);
+    });
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts
@@ -5,7 +5,7 @@ import {
   resolveAttemptToolPolicyMessageProvider,
   resolveEmbeddedAttemptSessionWriteLockOptions,
   resolveUnknownToolGuardThreshold,
-  shouldForceProfileScopedModelResolve,
+  shouldForceCredentialScopedModelResolve,
   shouldMaterializeAuthPlanModel,
   shouldRunLlmOutputHooksForAttempt,
 } from "./attempt.run-decisions.js";
@@ -57,17 +57,29 @@ describe("resolveAttemptStreamAuthProfileId", () => {
         }),
       ).toBe(true);
       expect(shouldMaterializeAuthPlanModel({}, "github-copilot:requested")).toBe(true);
+      expect(shouldMaterializeAuthPlanModel({ selectedAuthMode: "api-key" }, undefined, true)).toBe(
+        true,
+      );
+      expect(
+        shouldMaterializeAuthPlanModel({ selectedAuthMode: "api-key" }, undefined, false),
+      ).toBe(false);
       expect(shouldMaterializeAuthPlanModel({})).toBe(false);
     });
 
-    it("forces re-resolution for profiles but not route-only plans", () => {
+    it("forces re-resolution for profiles and provider-scoped direct credentials", () => {
       expect(
-        shouldForceProfileScopedModelResolve({
+        shouldForceCredentialScopedModelResolve({
           forwardedAuthProfileId: "github-copilot:work",
         }),
       ).toBe(true);
-      expect(shouldForceProfileScopedModelResolve({}, "github-copilot:requested")).toBe(true);
-      expect(shouldForceProfileScopedModelResolve({})).toBe(false);
+      expect(shouldForceCredentialScopedModelResolve({}, "github-copilot:requested")).toBe(true);
+      expect(
+        shouldForceCredentialScopedModelResolve({ selectedAuthMode: "api-key" }, undefined, true),
+      ).toBe(true);
+      expect(
+        shouldForceCredentialScopedModelResolve({ selectedAuthMode: "api-key" }, undefined, false),
+      ).toBe(false);
+      expect(shouldForceCredentialScopedModelResolve({})).toBe(false);
     });
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt.run-decisions.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.run-decisions.ts
@@ -2,6 +2,7 @@
  * Resolves per-attempt runtime decisions from config and channel context.
  */
 import type { OpenClawConfig } from "../../../config/config.js";
+import type { AgentRuntimeAuthPlan } from "../../runtime-plan/types.js";
 import {
   resolveSessionLockMaxHoldFromTimeout,
   resolveSessionWriteLockOptions,
@@ -39,6 +40,22 @@ export function resolveAttemptStreamAuthProfileId(
   params: Pick<EmbeddedRunAttemptParams, "authProfileId" | "runtimePlan">,
 ): string | undefined {
   return params.runtimePlan?.auth.forwardedAuthProfileId;
+}
+
+/** Re-resolves model metadata whenever a concrete auth profile can change provider limits. */
+export function shouldMaterializeAuthPlanModel(
+  plan: Pick<AgentRuntimeAuthPlan, "forwardedAuthProfileId" | "modelRoute">,
+  requestedProfileId?: string,
+): boolean {
+  return Boolean(plan.modelRoute || plan.forwardedAuthProfileId || requestedProfileId);
+}
+
+/** Forces re-resolution only when a concrete profile can change provider model metadata. */
+export function shouldForceProfileScopedModelResolve(
+  plan: Pick<AgentRuntimeAuthPlan, "forwardedAuthProfileId">,
+  requestedProfileId?: string,
+): boolean {
+  return Boolean(plan.forwardedAuthProfileId || requestedProfileId);
 }
 
 /**

--- a/src/agents/embedded-agent-runner/run/attempt.run-decisions.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.run-decisions.ts
@@ -42,20 +42,33 @@ export function resolveAttemptStreamAuthProfileId(
   return params.runtimePlan?.auth.forwardedAuthProfileId;
 }
 
-/** Re-resolves model metadata whenever a concrete auth profile can change provider limits. */
+/** Re-resolves metadata whenever the prepared credential can change provider limits. */
 export function shouldMaterializeAuthPlanModel(
-  plan: Pick<AgentRuntimeAuthPlan, "forwardedAuthProfileId" | "modelRoute">,
+  plan: Pick<AgentRuntimeAuthPlan, "forwardedAuthProfileId" | "modelRoute" | "selectedAuthMode">,
   requestedProfileId?: string,
+  providerUsesProfileScopedModelMetadata = false,
 ): boolean {
-  return Boolean(plan.modelRoute || plan.forwardedAuthProfileId || requestedProfileId);
+  return Boolean(
+    plan.modelRoute ||
+    shouldForceCredentialScopedModelResolve(
+      plan,
+      requestedProfileId,
+      providerUsesProfileScopedModelMetadata,
+    ),
+  );
 }
 
-/** Forces re-resolution only when a concrete profile can change provider model metadata. */
-export function shouldForceProfileScopedModelResolve(
-  plan: Pick<AgentRuntimeAuthPlan, "forwardedAuthProfileId">,
+/** Re-resolves when the selected profile or direct credential can change provider metadata. */
+export function shouldForceCredentialScopedModelResolve(
+  plan: Pick<AgentRuntimeAuthPlan, "forwardedAuthProfileId" | "selectedAuthMode">,
   requestedProfileId?: string,
+  providerUsesProfileScopedModelMetadata = false,
 ): boolean {
-  return Boolean(plan.forwardedAuthProfileId || requestedProfileId);
+  return Boolean(
+    plan.forwardedAuthProfileId ||
+    requestedProfileId ||
+    (providerUsesProfileScopedModelMetadata && plan.selectedAuthMode),
+  );
 }
 
 /**

--- a/src/agents/embedded-agent-runner/run/attempt.run-decisions.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.run-decisions.ts
@@ -2,7 +2,6 @@
  * Resolves per-attempt runtime decisions from config and channel context.
  */
 import type { OpenClawConfig } from "../../../config/config.js";
-import type { AgentRuntimeAuthPlan } from "../../runtime-plan/types.js";
 import {
   resolveSessionLockMaxHoldFromTimeout,
   resolveSessionWriteLockOptions,
@@ -40,35 +39,6 @@ export function resolveAttemptStreamAuthProfileId(
   params: Pick<EmbeddedRunAttemptParams, "authProfileId" | "runtimePlan">,
 ): string | undefined {
   return params.runtimePlan?.auth.forwardedAuthProfileId;
-}
-
-/** Re-resolves metadata whenever the prepared credential can change provider limits. */
-export function shouldMaterializeAuthPlanModel(
-  plan: Pick<AgentRuntimeAuthPlan, "forwardedAuthProfileId" | "modelRoute" | "selectedAuthMode">,
-  requestedProfileId?: string,
-  providerUsesProfileScopedModelMetadata = false,
-): boolean {
-  return Boolean(
-    plan.modelRoute ||
-    shouldForceCredentialScopedModelResolve(
-      plan,
-      requestedProfileId,
-      providerUsesProfileScopedModelMetadata,
-    ),
-  );
-}
-
-/** Re-resolves when the selected profile or direct credential can change provider metadata. */
-export function shouldForceCredentialScopedModelResolve(
-  plan: Pick<AgentRuntimeAuthPlan, "forwardedAuthProfileId" | "selectedAuthMode">,
-  requestedProfileId?: string,
-  providerUsesProfileScopedModelMetadata = false,
-): boolean {
-  return Boolean(
-    plan.forwardedAuthProfileId ||
-    requestedProfileId ||
-    (providerUsesProfileScopedModelMetadata && plan.selectedAuthMode),
-  );
 }
 
 /**

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1235,7 +1235,7 @@ export async function runEmbeddedAttempt(
         effectivePromptCacheRetention,
         providerTextTransforms,
         streamStrategy,
-      } = prepareEmbeddedAttemptTransport({
+      } = await prepareEmbeddedAttemptTransport({
         attempt: params,
         session: activeSession,
         settingsManager,

--- a/src/agents/embedded-agent-runner/stream-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.test.ts
@@ -231,6 +231,46 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     expect(streamFn).not.toBe(streamSimple);
   });
 
+  it("reads refreshed runtime auth for each boundary-aware model call", async () => {
+    const firstSentinel = mintSecretSentinel("copilot-runtime-value-1", {
+      label: "model-auth:github-copilot:first",
+    });
+    const secondSentinel = mintSecretSentinel("copilot-runtime-value-2", {
+      label: "model-auth:github-copilot:second",
+    });
+    const getApiKey = vi
+      .fn<(provider: string) => Promise<string | undefined>>()
+      .mockResolvedValueOnce(firstSentinel)
+      .mockResolvedValueOnce(secondSentinel);
+    const currentStreamFn = vi.fn(async (_model, _context, options) => options);
+    const innerStreamFn = vi.fn(async (_model, _context, options) => options);
+    overrideBoundaryAwareStreamFnOnce(innerStreamFn as never);
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: currentStreamFn as never,
+      sessionId: "session-1",
+      model: {
+        api: "openai-responses",
+        provider: "github-copilot",
+        id: "gpt-5.6-sol",
+      } as never,
+      transportAuthAvailable: true,
+      authStorage: { getApiKey },
+    });
+
+    const firstResult = await expectStreamResultRecord(
+      streamFn({ provider: "github-copilot", id: "gpt-5.6-sol" } as never, {} as never, {}),
+      "first github copilot boundary result",
+    );
+    const secondResult = await expectStreamResultRecord(
+      streamFn({ provider: "github-copilot", id: "gpt-5.6-sol" } as never, {} as never, {}),
+      "second github copilot boundary result",
+    );
+    expect(firstResult.apiKey).toBe(firstSentinel);
+    expect(secondResult.apiKey).toBe(secondSentinel);
+    expect(currentStreamFn).not.toHaveBeenCalled();
+    expect(innerStreamFn).toHaveBeenCalledTimes(2);
+  });
+
   it("routes OpenClaw native OpenAI-compatible provider streams through boundary-aware transports", async () => {
     const nativeStreamFn = getApiProvider("openai-completions")?.streamSimple;
     if (!nativeStreamFn) {

--- a/src/agents/embedded-agent-runner/stream-resolution.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.ts
@@ -119,6 +119,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
   signal?: AbortSignal;
   model: EmbeddedRunAttemptParams["model"];
   resolvedApiKey?: string;
+  transportAuthAvailable?: boolean;
   authProfileId?: string;
   authStorage?: { getApiKey(provider: string): Promise<string | undefined> };
 }): StreamFn {
@@ -171,6 +172,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
   if (
     isDefaultOpenClawStreamFnForModel(params.model, params.currentStreamFn) ||
     hasResolvedRuntimeApiKey(params.resolvedApiKey) ||
+    params.transportAuthAvailable ||
     // Proxied anthropic-messages providers (provider !== "anthropic", e.g. pioneer)
     // must use the boundary-aware managed transport even without a resolved runtime
     // key — it is the only place a tool-using turn's narration gets tagged

--- a/src/agents/runtime-plan/credential-scoped-model.ts
+++ b/src/agents/runtime-plan/credential-scoped-model.ts
@@ -192,7 +192,7 @@ export function createPreparedRuntimeModelMaterializer<Model extends RuntimeRout
             params.requestedProfileId,
             params.providerUsesProfileScopedModelMetadata,
           ),
-        resolveModel: params.resolveModel,
+        resolveModel: (request) => params.resolveModel(request),
       })) ?? model
     );
   };

--- a/src/agents/runtime-plan/credential-scoped-model.ts
+++ b/src/agents/runtime-plan/credential-scoped-model.ts
@@ -1,0 +1,214 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { shouldPreferProviderRuntimeResolvedModel } from "../../plugins/provider-runtime.js";
+import {
+  resolveProviderModelMaterializationAuthMode,
+  resolveProviderModelRouteAuthRequirement,
+  type ProviderModelRouteMaterializationAuthMode,
+} from "../provider-model-route-auth.js";
+import { materializePreparedRuntimeModel } from "./materialize-model.js";
+import {
+  agentRuntimeAuthPlanMatchesTarget,
+  type PreparedAgentRuntimeAuthAttempt,
+} from "./prepare-auth.js";
+import type { AgentRuntimeAuthPlan } from "./types.js";
+
+type RuntimeRouteModel = {
+  provider?: string;
+  id?: string;
+  api?: string | null;
+  baseUrl?: string;
+};
+
+type RuntimeModelAuthSelection =
+  | { authProfileId: string }
+  | { authProfileMode: ProviderModelRouteMaterializationAuthMode }
+  | undefined;
+
+export function providerUsesCredentialScopedModelMetadata(params: {
+  provider: string;
+  modelId: string;
+  config?: OpenClawConfig;
+  agentDir?: string;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): boolean {
+  return shouldPreferProviderRuntimeResolvedModel({
+    provider: params.provider,
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env ?? process.env,
+    context: {
+      config: params.config,
+      agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
+      provider: params.provider,
+      modelId: params.modelId,
+    },
+  });
+}
+
+/** Reuses forwarded model auth only when the prepared plan owns the exact target. */
+export function resolveReusableRuntimeModelAuth(params: {
+  plan?: AgentRuntimeAuthPlan;
+  provider: string;
+  modelId: string;
+  authProfileId?: string;
+}): {
+  plan?: AgentRuntimeAuthPlan;
+  authProfileId?: string;
+  modelAuth: RuntimeModelAuthSelection;
+} {
+  const plan =
+    params.plan &&
+    agentRuntimeAuthPlanMatchesTarget(params.plan, {
+      provider: params.provider,
+      modelId: params.modelId,
+    })
+      ? params.plan
+      : undefined;
+  const authProfileId = params.authProfileId ?? plan?.forwardedAuthProfileId;
+  const authProfileMode = resolveProviderModelMaterializationAuthMode(plan?.selectedAuthMode);
+  const modelAuth =
+    authProfileId !== undefined
+      ? { authProfileId }
+      : authProfileMode !== undefined
+        ? { authProfileMode }
+        : undefined;
+  return { plan, authProfileId, modelAuth };
+}
+
+/** Direct auth after a profile attempt must drop credential-scoped model metadata. */
+export function shouldForceDirectAuthFallbackModelResolve(params: {
+  attempt: PreparedAgentRuntimeAuthAttempt;
+  priorProfileAttempted: boolean;
+}): boolean {
+  return params.attempt.kind === "direct" && params.priorProfileAttempted;
+}
+
+/** Re-resolves when the selected profile or direct credential can change provider metadata. */
+export function shouldForceCredentialScopedModelResolve(
+  plan: Pick<AgentRuntimeAuthPlan, "forwardedAuthProfileId" | "selectedAuthMode">,
+  requestedProfileId?: string,
+  providerUsesProfileScopedModelMetadata = false,
+): boolean {
+  return Boolean(
+    plan.forwardedAuthProfileId ||
+    requestedProfileId ||
+    (providerUsesProfileScopedModelMetadata && plan.selectedAuthMode),
+  );
+}
+
+/** Re-resolves metadata whenever the prepared credential can change provider limits. */
+export function shouldMaterializeAuthPlanModel(
+  plan: Pick<AgentRuntimeAuthPlan, "forwardedAuthProfileId" | "modelRoute" | "selectedAuthMode">,
+  requestedProfileId?: string,
+  providerUsesProfileScopedModelMetadata = false,
+): boolean {
+  return Boolean(
+    plan.modelRoute ||
+    shouldForceCredentialScopedModelResolve(
+      plan,
+      requestedProfileId,
+      providerUsesProfileScopedModelMetadata,
+    ),
+  );
+}
+
+export function resolveCredentialScopedAuthAttemptModelDecision(params: {
+  attempt: PreparedAgentRuntimeAuthAttempt;
+  priorProfileAttempted: boolean;
+  requestedProfileId?: string;
+  providerUsesProfileScopedModelMetadata: boolean;
+}) {
+  const forceResolve = shouldForceDirectAuthFallbackModelResolve(params);
+  const shouldMaterialize =
+    shouldMaterializeAuthPlanModel(
+      params.attempt.plan,
+      params.requestedProfileId,
+      params.providerUsesProfileScopedModelMetadata,
+    ) || forceResolve;
+  return {
+    forceResolve,
+    shouldMaterialize,
+    authRequirement:
+      params.attempt.plan.modelRoute?.authRequirement ??
+      (shouldMaterialize && params.providerUsesProfileScopedModelMetadata
+        ? resolveProviderModelRouteAuthRequirement(params.attempt.plan.selectedAuthMode)
+        : undefined),
+  };
+}
+
+export function hasPreparedAuthAttemptModelMetadata(params: {
+  attempts: readonly PreparedAgentRuntimeAuthAttempt[];
+  providerUsesProfileScopedModelMetadata: boolean;
+}): boolean {
+  return params.attempts.some(
+    (attempt) =>
+      (params.providerUsesProfileScopedModelMetadata &&
+        (attempt.kind === "profile" || Boolean(attempt.plan.forwardedAuthProfileId))) ||
+      Boolean(attempt.plan.modelRoute) ||
+      attempt.allowAuthProfileFallback !== undefined,
+  );
+}
+
+export function createPreparedRuntimeModelMaterializer<Model extends RuntimeRouteModel>(params: {
+  provider: string;
+  modelId: string;
+  config?: OpenClawConfig;
+  getModel(): Model;
+  nativeModelOwned: boolean;
+  requestedProfileId?: string;
+  providerUsesProfileScopedModelMetadata: boolean;
+  resolveModel(request: {
+    config: OpenClawConfig;
+    authProfileId?: string;
+    authProfileMode?: ProviderModelRouteMaterializationAuthMode;
+  }): Promise<{ model?: Model | null; error?: string }>;
+}) {
+  const materializedRouteModels = new WeakMap<AgentRuntimeAuthPlan, Promise<Model>>();
+  const materializeUncached = async (
+    plan: AgentRuntimeAuthPlan,
+    forceResolve = false,
+  ): Promise<Model> => {
+    const model = params.getModel();
+    // Native harness sessions own their model tuple. Route preparation may
+    // attest auth/transport, but must not rediscover or replace that model.
+    if (params.nativeModelOwned) {
+      return model;
+    }
+    return (
+      (await materializePreparedRuntimeModel({
+        plan,
+        provider: params.provider,
+        modelId: params.modelId,
+        config: params.config,
+        model,
+        // Credential-scoped providers must replace metadata whenever the
+        // prepared profile or direct auth source changes.
+        forceResolve:
+          forceResolve ||
+          shouldForceCredentialScopedModelResolve(
+            plan,
+            params.requestedProfileId,
+            params.providerUsesProfileScopedModelMetadata,
+          ),
+        resolveModel: params.resolveModel,
+      })) ?? model
+    );
+  };
+  const materialize = (plan: AgentRuntimeAuthPlan): Promise<Model> => {
+    if (!plan.modelRoute) {
+      return materializeUncached(plan);
+    }
+    const cached = materializedRouteModels.get(plan);
+    if (cached) {
+      return cached;
+    }
+    // Prepared plans are immutable within one run. Carry their exact model
+    // tuple into auth initialization instead of repeating provider discovery.
+    const materialized = materializeUncached(plan);
+    materializedRouteModels.set(plan, materialized);
+    return materialized;
+  };
+  return { materialize, materializeUncached };
+}

--- a/src/agents/runtime-plan/credential-scoped-model.ts
+++ b/src/agents/runtime-plan/credential-scoped-model.ts
@@ -86,7 +86,7 @@ export function shouldForceDirectAuthFallbackModelResolve(params: {
 }
 
 /** Re-resolves when the selected profile or direct credential can change provider metadata. */
-export function shouldForceCredentialScopedModelResolve(
+function shouldForceCredentialScopedModelResolve(
   plan: Pick<AgentRuntimeAuthPlan, "forwardedAuthProfileId" | "selectedAuthMode">,
   requestedProfileId?: string,
   providerUsesProfileScopedModelMetadata = false,
@@ -99,7 +99,7 @@ export function shouldForceCredentialScopedModelResolve(
 }
 
 /** Re-resolves metadata whenever the prepared credential can change provider limits. */
-export function shouldMaterializeAuthPlanModel(
+function shouldMaterializeAuthPlanModel(
   plan: Pick<AgentRuntimeAuthPlan, "forwardedAuthProfileId" | "modelRoute" | "selectedAuthMode">,
   requestedProfileId?: string,
   providerUsesProfileScopedModelMetadata = false,

--- a/src/agents/runtime-plan/prepare-auth.ts
+++ b/src/agents/runtime-plan/prepare-auth.ts
@@ -105,14 +105,6 @@ export function canRunPreparedAgentRuntimeAuthAttempt(params: {
   );
 }
 
-/** Direct auth after a profile attempt must drop credential-scoped model metadata. */
-export function shouldForceDirectAuthFallbackModelResolve(params: {
-  attempt: PreparedAgentRuntimeAuthAttempt;
-  priorProfileAttempted: boolean;
-}): boolean {
-  return params.attempt.kind === "direct" && params.priorProfileAttempted;
-}
-
 /** Rechecks automatic cooldowns immediately before a prepared profile attempt. */
 export function preparedAgentRuntimeProfileAttemptHasCandidate(params: {
   attempt: PreparedAgentRuntimeAuthAttempt;

--- a/src/agents/runtime-plan/prepare-auth.ts
+++ b/src/agents/runtime-plan/prepare-auth.ts
@@ -105,6 +105,14 @@ export function canRunPreparedAgentRuntimeAuthAttempt(params: {
   );
 }
 
+/** Direct auth after a profile attempt must drop credential-scoped model metadata. */
+export function shouldForceDirectAuthFallbackModelResolve(params: {
+  attempt: PreparedAgentRuntimeAuthAttempt;
+  priorProfileAttempted: boolean;
+}): boolean {
+  return params.attempt.kind === "direct" && params.priorProfileAttempted;
+}
+
 /** Rechecks automatic cooldowns immediately before a prepared profile attempt. */
 export function preparedAgentRuntimeProfileAttemptHasCandidate(params: {
   attempt: PreparedAgentRuntimeAuthAttempt;

--- a/src/agents/runtime-plan/resolve-auth.test.ts
+++ b/src/agents/runtime-plan/resolve-auth.test.ts
@@ -569,6 +569,41 @@ describe("resolvePreparedRuntimeModelAuth", () => {
     expect(materializeModel.mock.calls.map(([input]) => input.forceResolve)).toEqual([false, true]);
   });
 
+  it("forces the first direct model when provider metadata is credential-scoped", async () => {
+    const directPlan = {
+      providerForAuth: "github-copilot",
+      authProfileProviderForAuth: "github-copilot",
+      selectedAuthMode: "api-key",
+    };
+    const directModel = { ...platformModel, contextWindow: 1_050_000 };
+    const materializeModel = vi.fn(async () => directModel);
+
+    const result = await resolvePreparedRuntimeAuthAttempts({
+      attempts: [
+        {
+          kind: "direct",
+          plan: directPlan,
+          allowAuthProfileFallback: false,
+          requiresPriorProfileAttempt: false,
+        },
+      ],
+      store: authStore({}),
+      modelId: "gpt-5.6-sol",
+      model: platformModel,
+      materializeModel,
+      resolveAuth: async () => ({ plan: directPlan, auth: "direct" }),
+      forceCredentialScopedDirectModelResolve: true,
+      errorMessage: "prepared auth failed",
+    });
+
+    expect(result.model).toBe(directModel);
+    expect(materializeModel).toHaveBeenCalledWith({
+      plan: directPlan,
+      model: platformModel,
+      forceResolve: true,
+    });
+  });
+
   it("keeps a single bound prepared profile terminal", async () => {
     const store = authStore({
       "openai:bound": {

--- a/src/agents/runtime-plan/resolve-auth.test.ts
+++ b/src/agents/runtime-plan/resolve-auth.test.ts
@@ -513,6 +513,62 @@ describe("resolvePreparedRuntimeModelAuth", () => {
     expect(resolveAuth).not.toHaveBeenCalled();
   });
 
+  it("forces unscoped model rematerialization for direct fallback after profile failure", async () => {
+    const store = authStore({
+      "github-copilot:first": {
+        type: "token",
+        provider: "github-copilot",
+        token: "profile-token",
+      },
+    });
+    const profilePlan = {
+      providerForAuth: "github-copilot",
+      authProfileProviderForAuth: "github-copilot",
+      forwardedAuthProfileId: "github-copilot:first",
+      forwardedAuthProfileSource: "auto" as const,
+      forwardedAuthProfileCandidateIds: ["github-copilot:first"],
+    };
+    const directPlan = {
+      providerForAuth: "github-copilot",
+      authProfileProviderForAuth: "github-copilot",
+      selectedAuthMode: "token",
+    };
+    const profileModel = { ...platformModel, contextWindow: 1_050_000 };
+    const directModel = { ...platformModel, contextWindow: 400_000 };
+    const materializeModel = vi.fn(async ({ forceResolve }: { forceResolve?: boolean }) =>
+      forceResolve ? directModel : profileModel,
+    );
+    const resolveAuth = vi.fn(
+      async ({ attempt }: { attempt: { kind: "direct" | "implicit" | "profile" } }) => {
+        if (attempt.kind === "profile") {
+          throw new Error("profile credential failed");
+        }
+        return { plan: directPlan, auth: "direct" };
+      },
+    );
+
+    const result = await resolvePreparedRuntimeAuthAttempts({
+      attempts: [
+        { kind: "profile", plan: profilePlan, profileId: "github-copilot:first" },
+        {
+          kind: "direct",
+          plan: directPlan,
+          allowAuthProfileFallback: false,
+          requiresPriorProfileAttempt: true,
+        },
+      ],
+      store,
+      modelId: "gpt-5.6-sol",
+      model: platformModel,
+      materializeModel,
+      resolveAuth,
+      errorMessage: "prepared auth failed",
+    });
+
+    expect(result).toMatchObject({ auth: "direct", model: { contextWindow: 400_000 } });
+    expect(materializeModel.mock.calls.map(([input]) => input.forceResolve)).toEqual([false, true]);
+  });
+
   it("keeps a single bound prepared profile terminal", async () => {
     const store = authStore({
       "openai:bound": {

--- a/src/agents/runtime-plan/resolve-auth.ts
+++ b/src/agents/runtime-plan/resolve-auth.ts
@@ -62,6 +62,7 @@ export async function resolvePreparedRuntimeAuthAttempts<Model, Auth>(params: {
     attempt: PreparedAgentRuntimeAuthAttempt;
     model: Model;
   }): Promise<{ plan: AgentRuntimeAuthPlan; auth: Auth }>;
+  forceCredentialScopedDirectModelResolve?: boolean;
   errorMessage: string;
 }): Promise<PreparedRuntimeAuthAttemptResolution<Model, Auth>> {
   let firstError: unknown;
@@ -91,10 +92,14 @@ export async function resolvePreparedRuntimeAuthAttempts<Model, Auth>(params: {
       let model = await params.materializeModel({
         plan: attempt.plan,
         model: params.model,
-        forceResolve: shouldForceDirectAuthFallbackModelResolve({
-          attempt,
-          priorProfileAttempted,
-        }),
+        forceResolve:
+          (params.forceCredentialScopedDirectModelResolve === true &&
+            attempt.kind === "direct" &&
+            Boolean(attempt.plan.selectedAuthMode)) ||
+          shouldForceDirectAuthFallbackModelResolve({
+            attempt,
+            priorProfileAttempted,
+          }),
       });
       if (
         attempt.kind === "profile" &&

--- a/src/agents/runtime-plan/resolve-auth.ts
+++ b/src/agents/runtime-plan/resolve-auth.ts
@@ -4,11 +4,11 @@ import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { isProfileInCooldown } from "../auth-profiles/usage-state.js";
 import { getApiKeyForModel } from "../model-auth.js";
 import { providerModelRouteAcceptsAuthMode } from "../provider-model-route-auth.js";
+import { shouldForceDirectAuthFallbackModelResolve } from "./credential-scoped-model.js";
 import { sameAgentRuntimeAuthModelRoute } from "./model-route.js";
 import {
   canRunPreparedAgentRuntimeAuthAttempt,
   preparedAgentRuntimeProfileAttemptHasCandidate,
-  shouldForceDirectAuthFallbackModelResolve,
   type PreparedAgentRuntimeAuthAttempt,
 } from "./prepare-auth.js";
 import type { AgentRuntimeAuthPlan } from "./types.js";

--- a/src/agents/runtime-plan/resolve-auth.ts
+++ b/src/agents/runtime-plan/resolve-auth.ts
@@ -8,6 +8,7 @@ import { sameAgentRuntimeAuthModelRoute } from "./model-route.js";
 import {
   canRunPreparedAgentRuntimeAuthAttempt,
   preparedAgentRuntimeProfileAttemptHasCandidate,
+  shouldForceDirectAuthFallbackModelResolve,
   type PreparedAgentRuntimeAuthAttempt,
 } from "./prepare-auth.js";
 import type { AgentRuntimeAuthPlan } from "./types.js";
@@ -90,6 +91,10 @@ export async function resolvePreparedRuntimeAuthAttempts<Model, Auth>(params: {
       let model = await params.materializeModel({
         plan: attempt.plan,
         model: params.model,
+        forceResolve: shouldForceDirectAuthFallbackModelResolve({
+          attempt,
+          priorProfileAttempted,
+        }),
       });
       if (
         attempt.kind === "profile" &&

--- a/src/media-understanding/image-model-runtime.ts
+++ b/src/media-understanding/image-model-runtime.ts
@@ -1,0 +1,219 @@
+// Resolves image-capable model metadata and credential-bound runtime auth.
+import { resolveModelAsync } from "../agents/embedded-agent-runner/model.js";
+import { isMinimaxVlmModel } from "../agents/minimax-vlm.js";
+import {
+  applySecretRefHeaderSentinels,
+  getApiKeyForModel,
+  requireApiKey,
+} from "../agents/model-auth.js";
+import { normalizeModelRef } from "../agents/model-selection.js";
+import { ensureOpenClawModelsJson } from "../agents/models-config.js";
+import { resolveProviderModelMaterializationAuthMode } from "../agents/provider-model-route-auth.js";
+import {
+  protectPreparedProviderRuntimeAuth,
+  unwrapSecretSentinelsForProviderEgress,
+} from "../agents/provider-secret-egress.js";
+import { providerUsesCredentialScopedModelMetadata } from "../agents/runtime-plan/credential-scoped-model.js";
+import type { Model } from "../llm/types.js";
+import { resolveCopilotApiToken } from "../plugin-sdk/provider-auth.js";
+import type { ImageDescriptionRequest } from "./types.js";
+
+type ImageRuntimeParams = {
+  cfg: ImageDescriptionRequest["cfg"];
+  agentDir: string;
+  provider: string;
+  model: string;
+  profile?: string;
+  preferredProfile?: string;
+  authStore?: ImageDescriptionRequest["authStore"];
+  workspaceDir?: string;
+};
+
+function formatModelInputCapabilities(input: Model["input"] | undefined): string {
+  return input && input.length > 0 ? input.join(", ") : "none";
+}
+
+function requireImageCapableModel(params: {
+  model: Model | undefined;
+  resolvedProvider: string;
+  resolvedModel: string;
+  requestedProvider: string;
+  requestedModel: string;
+}): Model {
+  if (!params.model) {
+    throw new Error(`Unknown model: ${params.resolvedProvider}/${params.resolvedModel}`);
+  }
+  if (params.model.input?.includes("image")) {
+    return params.model;
+  }
+  // Keep MiniMax's unknown-model signal so its dedicated VLM fallback remains reachable.
+  if (isMinimaxVlmModel(params.resolvedProvider, params.resolvedModel)) {
+    throw new Error(`Unknown model: ${params.resolvedProvider}/${params.resolvedModel}`);
+  }
+  throw new Error(
+    `Model does not support images: ${params.requestedProvider}/${params.requestedModel} ` +
+      `(resolved ${params.model.provider}/${params.model.id} input: ${formatModelInputCapabilities(params.model.input)})`,
+  );
+}
+
+async function prepareResolvedImageRuntime(
+  params: ImageRuntimeParams,
+  resolvedModel: Model,
+  authStorage: Awaited<ReturnType<typeof resolveModelAsync>>["authStorage"],
+  modelRegistry: Awaited<ReturnType<typeof resolveModelAsync>>["modelRegistry"],
+): Promise<{ apiKey: string; model: Model }> {
+  let model = resolvedModel;
+  const apiKeyInfo = await getApiKeyForModel({
+    model,
+    cfg: params.cfg,
+    agentDir: params.agentDir,
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    profileId: params.profile,
+    preferredProfile: params.preferredProfile,
+    store: params.authStore,
+    secretSentinels: true,
+  });
+  if (
+    providerUsesCredentialScopedModelMetadata({
+      provider: model.provider,
+      modelId: model.id,
+      config: params.cfg,
+      agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
+    })
+  ) {
+    const authProfileMode = resolveProviderModelMaterializationAuthMode(apiKeyInfo.mode);
+    const authoritative = await resolveModelAsync(
+      model.provider,
+      model.id,
+      params.agentDir,
+      params.cfg,
+      {
+        authStorage,
+        modelRegistry,
+        skipAgentDiscovery: true,
+        allowBundledStaticCatalogFallback: true,
+        ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+        ...(apiKeyInfo.profileId
+          ? { authProfileId: apiKeyInfo.profileId }
+          : authProfileMode
+            ? { authProfileMode }
+            : {}),
+      },
+    );
+    model = requireImageCapableModel({
+      model: authoritative.model,
+      resolvedProvider: model.provider,
+      resolvedModel: model.id,
+      requestedProvider: params.provider,
+      requestedModel: params.model,
+    });
+  }
+  // Bedrock's runtime client owns AWS credential-chain resolution. Keep the
+  // empty sentinel out of auth storage and pass it through to the stream.
+  if (
+    !apiKeyInfo.apiKey?.trim() &&
+    apiKeyInfo.mode === "aws-sdk" &&
+    model.api === "bedrock-converse-stream"
+  ) {
+    return { apiKey: "", model: applySecretRefHeaderSentinels(model, params.cfg) };
+  }
+  let apiKey = requireApiKey(apiKeyInfo, model.provider);
+  // Image tool bypasses prepareRuntimeAuth — exchange OAuth token for
+  // a short-lived Copilot API token so the integrator scope (vscode-chat)
+  // matches what runtime chat requests send.
+  if (model.provider === "github-copilot") {
+    const copilotToken = await resolveCopilotApiToken({
+      githubToken: unwrapSecretSentinelsForProviderEgress(
+        apiKey,
+        "GitHub Copilot image-auth exchange",
+      ),
+      config: params.cfg,
+    });
+    const protectedAuth = protectPreparedProviderRuntimeAuth({
+      provider: model.provider,
+      preparedAuth: { apiKey: copilotToken.token, baseUrl: copilotToken.baseUrl },
+    });
+    apiKey = protectedAuth?.apiKey ?? copilotToken.token;
+    const runtimeBaseUrl = protectedAuth?.baseUrl?.trim();
+    if (runtimeBaseUrl) {
+      model = { ...model, baseUrl: runtimeBaseUrl };
+    }
+  }
+  authStorage.setRuntimeApiKey(model.provider, apiKey);
+  return { apiKey, model: applySecretRefHeaderSentinels(model, params.cfg) };
+}
+
+export async function resolveImageRuntime(
+  params: ImageRuntimeParams,
+): Promise<{ apiKey: string; model: Model }> {
+  // Fast static resolution avoids provider runtime hooks during tool discovery;
+  // execution falls back to full model discovery when static metadata lacks images.
+  const resolvedRef = normalizeModelRef(params.provider, params.model);
+  const authProfileOptions = {
+    ...(params.profile ? { authProfileId: params.profile } : {}),
+    ...(params.preferredProfile ? { preferredProfile: params.preferredProfile } : {}),
+  };
+  const fastResolved = await resolveModelAsync(
+    resolvedRef.provider,
+    resolvedRef.model,
+    params.agentDir,
+    params.cfg,
+    {
+      allowBundledStaticCatalogFallback: true,
+      skipAgentDiscovery: true,
+      skipProviderRuntimeHooks: true,
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+      ...authProfileOptions,
+    },
+  );
+  if (fastResolved.model?.input?.includes("image")) {
+    const normalizedResolved = await resolveModelAsync(
+      resolvedRef.provider,
+      resolvedRef.model,
+      params.agentDir,
+      params.cfg,
+      {
+        allowBundledStaticCatalogFallback: true,
+        skipAgentDiscovery: true,
+        ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+        ...authProfileOptions,
+      },
+    );
+    if (normalizedResolved.model?.input?.includes("image")) {
+      return await prepareResolvedImageRuntime(
+        params,
+        normalizedResolved.model,
+        normalizedResolved.authStorage,
+        normalizedResolved.modelRegistry,
+      );
+    }
+  }
+
+  const modelsOptions = params.workspaceDir ? { workspaceDir: params.workspaceDir } : undefined;
+  await ensureOpenClawModelsJson(params.cfg, params.agentDir, modelsOptions);
+  const resolved = await resolveModelAsync(
+    resolvedRef.provider,
+    resolvedRef.model,
+    params.agentDir,
+    params.cfg,
+    {
+      allowBundledStaticCatalogFallback: true,
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+      ...authProfileOptions,
+    },
+  );
+  const model = requireImageCapableModel({
+    model: resolved.model,
+    resolvedProvider: resolvedRef.provider,
+    resolvedModel: resolvedRef.model,
+    requestedProvider: params.provider,
+    requestedModel: params.model,
+  });
+  return await prepareResolvedImageRuntime(
+    params,
+    model,
+    resolved.authStorage,
+    resolved.modelRegistry,
+  );
+}

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -12,11 +12,18 @@ import {
 const hoisted = vi.hoisted(() => ({
   completeMock: vi.fn(),
   ensureOpenClawModelsJsonMock: vi.fn(async () => {}),
-  getApiKeyForModelMock: vi.fn(async () => ({
-    apiKey: "oauth-test", // pragma: allowlist secret
-    source: "test",
-    mode: "oauth",
-  })),
+  getApiKeyForModelMock: vi.fn(
+    async (): Promise<{
+      apiKey: string;
+      source: string;
+      mode: string;
+      profileId?: string;
+    }> => ({
+      apiKey: "oauth-test", // pragma: allowlist secret
+      source: "test",
+      mode: "oauth",
+    }),
+  ),
   resolveApiKeyForProviderMock: vi.fn(async () => ({
     apiKey: "oauth-test", // pragma: allowlist secret
     source: "test",
@@ -31,6 +38,7 @@ const hoisted = vi.hoisted(() => ({
   resolveModelAsyncMock: vi.fn(),
   resolveModelWithRegistryMock: vi.fn(),
   resolveCopilotApiTokenMock: vi.fn(),
+  shouldPreferProviderRuntimeResolvedModelMock: vi.fn(() => false),
   unwrapSecretSentinelsForProviderEgressMock: vi.fn((value: string) => value),
 }));
 const {
@@ -47,6 +55,7 @@ const {
   resolveModelAsyncMock,
   resolveModelWithRegistryMock,
   resolveCopilotApiTokenMock,
+  shouldPreferProviderRuntimeResolvedModelMock,
   unwrapSecretSentinelsForProviderEgressMock,
 } = hoisted;
 
@@ -58,6 +67,7 @@ type ResolveModelWithRegistryTestParams = {
 
 type AuthRequestCall = {
   profileId?: string;
+  preferredProfile?: string;
   store?: unknown;
 };
 
@@ -134,6 +144,7 @@ vi.mock("../plugins/provider-runtime.js", async () => ({
     "../plugins/provider-runtime.js",
   )),
   prepareProviderDynamicModel: prepareProviderDynamicModelMock,
+  shouldPreferProviderRuntimeResolvedModel: shouldPreferProviderRuntimeResolvedModelMock,
 }));
 
 vi.mock("../agents/embedded-agent-runner/model.js", () => ({
@@ -1331,7 +1342,7 @@ describe("describeImageWithModel", () => {
     expect(completeMock).not.toHaveBeenCalled();
   });
 
-  it("normalizes deprecated google flash ids before lookup and keeps profile auth selection", async () => {
+  it("normalizes deprecated google flash ids and keeps profile model/auth selection", async () => {
     const findMock = vi.fn((provider: string, modelId: string) => {
       expect(provider).toBe("google");
       expect(modelId).toBe("gemini-3-flash-preview");
@@ -1359,6 +1370,7 @@ describe("describeImageWithModel", () => {
       provider: "google",
       model: "gemini-3.1-flash-preview",
       profile: "google:default",
+      preferredProfile: "google:preferred",
       buffer: Buffer.from("png-bytes"),
       fileName: "image.png",
       mime: "image/png",
@@ -1371,8 +1383,17 @@ describe("describeImageWithModel", () => {
       model: "gemini-3-flash-preview",
     });
     expect(findMock).toHaveBeenCalled();
+    for (const call of resolveModelAsyncMock.mock.calls) {
+      expect(call[4]).toEqual(
+        expect.objectContaining({
+          authProfileId: "google:default",
+          preferredProfile: "google:preferred",
+        }),
+      );
+    }
     const authRequest = getApiKeyForModelCall();
     expect(authRequest?.profileId).toBe("google:default");
+    expect(authRequest?.preferredProfile).toBe("google:preferred");
     expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("google", "oauth-test");
   });
 
@@ -1419,6 +1440,73 @@ describe("describeImageWithModel", () => {
     const authRequest = getApiKeyForModelCall();
     expect(authRequest?.profileId).toBe("google:default");
     expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("google", "oauth-test");
+  });
+
+  it("rematerializes profile-scoped image metadata after auth selects a backup profile", async () => {
+    const authStorage = { setRuntimeApiKey: setRuntimeApiKeyMock };
+    const modelRegistry = {};
+    const hintedModel = {
+      provider: "github-copilot",
+      id: "gpt-5.6-sol",
+      api: "openai-responses",
+      input: ["text", "image"],
+      contextWindow: 200_000,
+      maxTokens: 64_000,
+    };
+    const authoritativeModel = {
+      ...hintedModel,
+      contextWindow: 1_050_000,
+      maxTokens: 128_000,
+    };
+    resolveModelAsyncMock
+      .mockResolvedValueOnce({ model: hintedModel, authStorage, modelRegistry })
+      .mockResolvedValueOnce({ model: hintedModel, authStorage, modelRegistry })
+      .mockResolvedValueOnce({ model: authoritativeModel, authStorage, modelRegistry });
+    getApiKeyForModelMock.mockResolvedValueOnce({
+      apiKey: "backup-profile-token",
+      source: "profile:github-copilot:backup",
+      mode: "token",
+      profileId: "github-copilot:backup",
+    });
+    shouldPreferProviderRuntimeResolvedModelMock.mockReturnValueOnce(true);
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "openai-responses",
+      provider: "github-copilot",
+      model: "gpt-5.6-sol",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "profile-scoped image ok" }],
+    });
+
+    await describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      provider: "github-copilot",
+      model: "gpt-5.6-sol",
+      profile: "github-copilot:preferred",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    expect(resolveModelAsyncMock).toHaveBeenCalledTimes(3);
+    expect(resolveModelAsyncMock.mock.calls[2]?.[4]).toEqual(
+      expect.objectContaining({
+        authStorage,
+        modelRegistry,
+        authProfileId: "github-copilot:backup",
+      }),
+    );
+    const [completionModel] = requireFirstMockCall(completeMock, "complete");
+    expect(completionModel).toEqual(
+      expect.objectContaining({
+        contextWindow: 1_050_000,
+        maxTokens: 128_000,
+      }),
+    );
   });
 
   it("places image prompt in user content for github-copilot provider", async () => {

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -13,6 +13,7 @@ import {
 import { normalizeModelRef } from "../agents/model-selection.js";
 import { ensureOpenClawModelsJson } from "../agents/models-config.js";
 import { resolveProviderRequestCapabilities } from "../agents/provider-attribution.js";
+import { resolveProviderModelMaterializationAuthMode } from "../agents/provider-model-route-auth.js";
 import {
   protectPreparedProviderRuntimeAuth,
   unwrapSecretSentinelsForProviderEgress,
@@ -30,6 +31,7 @@ import {
   COPILOT_INTEGRATION_ID,
   resolveCopilotApiToken,
 } from "../plugin-sdk/provider-auth.js";
+import { shouldPreferProviderRuntimeResolvedModel } from "../plugins/provider-runtime.js";
 import { normalizeMediaProviderId } from "./provider-id.js";
 import type {
   ImageDescriptionRequest,
@@ -68,6 +70,29 @@ function isNativeResponsesReasoningPayload(model: Model): boolean {
 
 function formatModelInputCapabilities(input: Model["input"] | undefined): string {
   return input && input.length > 0 ? input.join(", ") : "none";
+}
+
+function requireImageCapableModel(params: {
+  model: Model | undefined;
+  resolvedProvider: string;
+  resolvedModel: string;
+  requestedProvider: string;
+  requestedModel: string;
+}): Model {
+  if (!params.model) {
+    throw new Error(`Unknown model: ${params.resolvedProvider}/${params.resolvedModel}`);
+  }
+  if (params.model.input?.includes("image")) {
+    return params.model;
+  }
+  // Keep MiniMax's unknown-model signal so its dedicated VLM fallback remains reachable.
+  if (isMinimaxVlmModel(params.resolvedProvider, params.resolvedModel)) {
+    throw new Error(`Unknown model: ${params.resolvedProvider}/${params.resolvedModel}`);
+  }
+  throw new Error(
+    `Model does not support images: ${params.requestedProvider}/${params.requestedModel} ` +
+      `(resolved ${params.model.provider}/${params.model.id} input: ${formatModelInputCapabilities(params.model.input)})`,
+  );
 }
 
 function removeReasoningInclude(value: unknown): unknown {
@@ -150,6 +175,10 @@ async function resolveImageRuntime(params: {
   // Fast static resolution avoids provider runtime hooks during tool discovery;
   // execution falls back to full model discovery when the static path lacks image metadata.
   const resolvedRef = normalizeModelRef(params.provider, params.model);
+  const authProfileOptions = {
+    ...(params.profile ? { authProfileId: params.profile } : {}),
+    ...(params.preferredProfile ? { preferredProfile: params.preferredProfile } : {}),
+  };
   const fastResolved = await resolveModelAsync(
     resolvedRef.provider,
     resolvedRef.model,
@@ -160,6 +189,7 @@ async function resolveImageRuntime(params: {
       skipAgentDiscovery: true,
       skipProviderRuntimeHooks: true,
       ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+      ...authProfileOptions,
     },
   );
   if (fastResolved.model?.input?.includes("image")) {
@@ -172,6 +202,7 @@ async function resolveImageRuntime(params: {
         allowBundledStaticCatalogFallback: true,
         skipAgentDiscovery: true,
         ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+        ...authProfileOptions,
       },
     );
     if (normalizedResolved.model?.input?.includes("image")) {
@@ -179,6 +210,7 @@ async function resolveImageRuntime(params: {
         params,
         normalizedResolved.model,
         normalizedResolved.authStorage,
+        normalizedResolved.modelRegistry,
       );
     }
   }
@@ -193,27 +225,22 @@ async function resolveImageRuntime(params: {
     {
       allowBundledStaticCatalogFallback: true,
       ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+      ...authProfileOptions,
     },
   );
-  const { authStorage } = resolved;
-  const { model } = resolved;
-  if (!model) {
-    throw new Error(`Unknown model: ${resolvedRef.provider}/${resolvedRef.model}`);
-  }
-  if (!model.input?.includes("image")) {
-    // resolveModelWithRegistry may synthesize a text-only fallback for configured
-    // providers, which would change "Unknown model" → "Model does not support images"
-    // and skip the MiniMax VLM recovery path. Throw Unknown model for MiniMax VLM
-    // models so the caller can attempt the fallback.
-    if (isMinimaxVlmModel(resolvedRef.provider, resolvedRef.model)) {
-      throw new Error(`Unknown model: ${resolvedRef.provider}/${resolvedRef.model}`);
-    }
-    throw new Error(
-      `Model does not support images: ${params.provider}/${params.model} ` +
-        `(resolved ${model.provider}/${model.id} input: ${formatModelInputCapabilities(model.input)})`,
-    );
-  }
-  return await prepareResolvedImageRuntime(params, model, authStorage);
+  const model = requireImageCapableModel({
+    model: resolved.model,
+    resolvedProvider: resolvedRef.provider,
+    resolvedModel: resolvedRef.model,
+    requestedProvider: params.provider,
+    requestedModel: params.model,
+  });
+  return await prepareResolvedImageRuntime(
+    params,
+    model,
+    resolved.authStorage,
+    resolved.modelRegistry,
+  );
 }
 
 async function prepareResolvedImageRuntime(
@@ -229,6 +256,7 @@ async function prepareResolvedImageRuntime(
   },
   resolvedModel: Model,
   authStorage: Awaited<ReturnType<typeof resolveModelAsync>>["authStorage"],
+  modelRegistry: Awaited<ReturnType<typeof resolveModelAsync>>["modelRegistry"],
 ): Promise<{ apiKey: string; model: Model }> {
   let model = resolvedModel;
   const apiKeyInfo = await getApiKeyForModel({
@@ -241,6 +269,47 @@ async function prepareResolvedImageRuntime(
     store: params.authStore,
     secretSentinels: true,
   });
+  const providerUsesProfileScopedModelMetadata = shouldPreferProviderRuntimeResolvedModel({
+    provider: model.provider,
+    config: params.cfg,
+    workspaceDir: params.workspaceDir,
+    env: process.env,
+    context: {
+      config: params.cfg,
+      agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
+      provider: model.provider,
+      modelId: model.id,
+    },
+  });
+  if (providerUsesProfileScopedModelMetadata) {
+    const authProfileMode = resolveProviderModelMaterializationAuthMode(apiKeyInfo.mode);
+    const authoritative = await resolveModelAsync(
+      model.provider,
+      model.id,
+      params.agentDir,
+      params.cfg,
+      {
+        authStorage,
+        modelRegistry,
+        skipAgentDiscovery: true,
+        allowBundledStaticCatalogFallback: true,
+        ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+        ...(apiKeyInfo.profileId
+          ? { authProfileId: apiKeyInfo.profileId }
+          : authProfileMode
+            ? { authProfileMode }
+            : {}),
+      },
+    );
+    model = requireImageCapableModel({
+      model: authoritative.model,
+      resolvedProvider: model.provider,
+      resolvedModel: model.id,
+      requestedProvider: params.provider,
+      requestedModel: params.model,
+    });
+  }
   // Bedrock's runtime client owns AWS credential-chain resolution. Keep the
   // empty sentinel out of auth storage and pass it through to the stream.
   if (

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -2,22 +2,10 @@
 // provider hook.
 import { clampPositiveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { resolveModelAsync } from "../agents/embedded-agent-runner/model.js";
 import { isMinimaxVlmModel, minimaxUnderstandImage } from "../agents/minimax-vlm.js";
-import {
-  applySecretRefHeaderSentinels,
-  getApiKeyForModel,
-  requireApiKey,
-  resolveApiKeyForProvider,
-} from "../agents/model-auth.js";
-import { normalizeModelRef } from "../agents/model-selection.js";
-import { ensureOpenClawModelsJson } from "../agents/models-config.js";
+import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
 import { resolveProviderRequestCapabilities } from "../agents/provider-attribution.js";
-import { resolveProviderModelMaterializationAuthMode } from "../agents/provider-model-route-auth.js";
-import {
-  protectPreparedProviderRuntimeAuth,
-  unwrapSecretSentinelsForProviderEgress,
-} from "../agents/provider-secret-egress.js";
+import { unwrapSecretSentinelsForProviderEgress } from "../agents/provider-secret-egress.js";
 import { registerProviderStreamForModel } from "../agents/provider-stream.js";
 import {
   coerceImageAssistantText,
@@ -26,12 +14,8 @@ import {
 import { isSecretRef } from "../config/types.secrets.js";
 import { complete } from "../llm/stream.js";
 import type { AssistantMessage, Context, Model, ProviderStreamOptions } from "../llm/types.js";
-import {
-  buildCopilotIdeHeaders,
-  COPILOT_INTEGRATION_ID,
-  resolveCopilotApiToken,
-} from "../plugin-sdk/provider-auth.js";
-import { shouldPreferProviderRuntimeResolvedModel } from "../plugins/provider-runtime.js";
+import { buildCopilotIdeHeaders, COPILOT_INTEGRATION_ID } from "../plugin-sdk/provider-auth.js";
+import { resolveImageRuntime } from "./image-model-runtime.js";
 import { normalizeMediaProviderId } from "./provider-id.js";
 import type {
   ImageDescriptionRequest,
@@ -66,33 +50,6 @@ function isNativeResponsesReasoningPayload(model: Model): boolean {
     capability: "image",
     transport: "media-understanding",
   }).usesKnownNativeOpenAIRoute;
-}
-
-function formatModelInputCapabilities(input: Model["input"] | undefined): string {
-  return input && input.length > 0 ? input.join(", ") : "none";
-}
-
-function requireImageCapableModel(params: {
-  model: Model | undefined;
-  resolvedProvider: string;
-  resolvedModel: string;
-  requestedProvider: string;
-  requestedModel: string;
-}): Model {
-  if (!params.model) {
-    throw new Error(`Unknown model: ${params.resolvedProvider}/${params.resolvedModel}`);
-  }
-  if (params.model.input?.includes("image")) {
-    return params.model;
-  }
-  // Keep MiniMax's unknown-model signal so its dedicated VLM fallback remains reachable.
-  if (isMinimaxVlmModel(params.resolvedProvider, params.resolvedModel)) {
-    throw new Error(`Unknown model: ${params.resolvedProvider}/${params.resolvedModel}`);
-  }
-  throw new Error(
-    `Model does not support images: ${params.requestedProvider}/${params.requestedModel} ` +
-      `(resolved ${params.model.provider}/${params.model.id} input: ${formatModelInputCapabilities(params.model.input)})`,
-  );
 }
 
 function removeReasoningInclude(value: unknown): unknown {
@@ -160,189 +117,6 @@ function composeImageDescriptionPayloadHandlers(
     }
     return runSecond(firstResult);
   };
-}
-
-async function resolveImageRuntime(params: {
-  cfg: ImageDescriptionRequest["cfg"];
-  agentDir: string;
-  provider: string;
-  model: string;
-  profile?: string;
-  preferredProfile?: string;
-  authStore?: ImageDescriptionRequest["authStore"];
-  workspaceDir?: string;
-}): Promise<{ apiKey: string; model: Model }> {
-  // Fast static resolution avoids provider runtime hooks during tool discovery;
-  // execution falls back to full model discovery when the static path lacks image metadata.
-  const resolvedRef = normalizeModelRef(params.provider, params.model);
-  const authProfileOptions = {
-    ...(params.profile ? { authProfileId: params.profile } : {}),
-    ...(params.preferredProfile ? { preferredProfile: params.preferredProfile } : {}),
-  };
-  const fastResolved = await resolveModelAsync(
-    resolvedRef.provider,
-    resolvedRef.model,
-    params.agentDir,
-    params.cfg,
-    {
-      allowBundledStaticCatalogFallback: true,
-      skipAgentDiscovery: true,
-      skipProviderRuntimeHooks: true,
-      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-      ...authProfileOptions,
-    },
-  );
-  if (fastResolved.model?.input?.includes("image")) {
-    const normalizedResolved = await resolveModelAsync(
-      resolvedRef.provider,
-      resolvedRef.model,
-      params.agentDir,
-      params.cfg,
-      {
-        allowBundledStaticCatalogFallback: true,
-        skipAgentDiscovery: true,
-        ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-        ...authProfileOptions,
-      },
-    );
-    if (normalizedResolved.model?.input?.includes("image")) {
-      return await prepareResolvedImageRuntime(
-        params,
-        normalizedResolved.model,
-        normalizedResolved.authStorage,
-        normalizedResolved.modelRegistry,
-      );
-    }
-  }
-
-  const modelsOptions = params.workspaceDir ? { workspaceDir: params.workspaceDir } : undefined;
-  await ensureOpenClawModelsJson(params.cfg, params.agentDir, modelsOptions);
-  const resolved = await resolveModelAsync(
-    resolvedRef.provider,
-    resolvedRef.model,
-    params.agentDir,
-    params.cfg,
-    {
-      allowBundledStaticCatalogFallback: true,
-      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-      ...authProfileOptions,
-    },
-  );
-  const model = requireImageCapableModel({
-    model: resolved.model,
-    resolvedProvider: resolvedRef.provider,
-    resolvedModel: resolvedRef.model,
-    requestedProvider: params.provider,
-    requestedModel: params.model,
-  });
-  return await prepareResolvedImageRuntime(
-    params,
-    model,
-    resolved.authStorage,
-    resolved.modelRegistry,
-  );
-}
-
-async function prepareResolvedImageRuntime(
-  params: {
-    cfg: ImageDescriptionRequest["cfg"];
-    agentDir: string;
-    provider: string;
-    model: string;
-    profile?: string;
-    preferredProfile?: string;
-    authStore?: ImageDescriptionRequest["authStore"];
-    workspaceDir?: string;
-  },
-  resolvedModel: Model,
-  authStorage: Awaited<ReturnType<typeof resolveModelAsync>>["authStorage"],
-  modelRegistry: Awaited<ReturnType<typeof resolveModelAsync>>["modelRegistry"],
-): Promise<{ apiKey: string; model: Model }> {
-  let model = resolvedModel;
-  const apiKeyInfo = await getApiKeyForModel({
-    model,
-    cfg: params.cfg,
-    agentDir: params.agentDir,
-    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-    profileId: params.profile,
-    preferredProfile: params.preferredProfile,
-    store: params.authStore,
-    secretSentinels: true,
-  });
-  const providerUsesProfileScopedModelMetadata = shouldPreferProviderRuntimeResolvedModel({
-    provider: model.provider,
-    config: params.cfg,
-    workspaceDir: params.workspaceDir,
-    env: process.env,
-    context: {
-      config: params.cfg,
-      agentDir: params.agentDir,
-      workspaceDir: params.workspaceDir,
-      provider: model.provider,
-      modelId: model.id,
-    },
-  });
-  if (providerUsesProfileScopedModelMetadata) {
-    const authProfileMode = resolveProviderModelMaterializationAuthMode(apiKeyInfo.mode);
-    const authoritative = await resolveModelAsync(
-      model.provider,
-      model.id,
-      params.agentDir,
-      params.cfg,
-      {
-        authStorage,
-        modelRegistry,
-        skipAgentDiscovery: true,
-        allowBundledStaticCatalogFallback: true,
-        ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-        ...(apiKeyInfo.profileId
-          ? { authProfileId: apiKeyInfo.profileId }
-          : authProfileMode
-            ? { authProfileMode }
-            : {}),
-      },
-    );
-    model = requireImageCapableModel({
-      model: authoritative.model,
-      resolvedProvider: model.provider,
-      resolvedModel: model.id,
-      requestedProvider: params.provider,
-      requestedModel: params.model,
-    });
-  }
-  // Bedrock's runtime client owns AWS credential-chain resolution. Keep the
-  // empty sentinel out of auth storage and pass it through to the stream.
-  if (
-    !apiKeyInfo.apiKey?.trim() &&
-    apiKeyInfo.mode === "aws-sdk" &&
-    model.api === "bedrock-converse-stream"
-  ) {
-    return { apiKey: "", model: applySecretRefHeaderSentinels(model, params.cfg) };
-  }
-  let apiKey = requireApiKey(apiKeyInfo, model.provider);
-  // Image tool bypasses prepareRuntimeAuth — exchange OAuth token for
-  // a short-lived Copilot API token so the integrator scope (vscode-chat)
-  // matches what runtime chat requests send.
-  if (model.provider === "github-copilot") {
-    const copilotToken = await resolveCopilotApiToken({
-      githubToken: unwrapSecretSentinelsForProviderEgress(
-        apiKey,
-        "GitHub Copilot image-auth exchange",
-      ),
-      config: params.cfg,
-    });
-    const protectedAuth = protectPreparedProviderRuntimeAuth({
-      provider: model.provider,
-      preparedAuth: { apiKey: copilotToken.token, baseUrl: copilotToken.baseUrl },
-    });
-    apiKey = protectedAuth?.apiKey ?? copilotToken.token;
-    const runtimeBaseUrl = protectedAuth?.baseUrl?.trim();
-    if (runtimeBaseUrl) {
-      model = { ...model, baseUrl: runtimeBaseUrl };
-    }
-  }
-  authStorage.setRuntimeApiKey(model.provider, apiKey);
-  return { apiKey, model: applySecretRefHeaderSentinels(model, params.cfg) };
 }
 
 function buildImageContext(

--- a/src/plugin-sdk/provider-auth-copilot-cache.ts
+++ b/src/plugin-sdk/provider-auth-copilot-cache.ts
@@ -1,0 +1,113 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { asDateTimestampMs } from "../../packages/normalization-core/src/number-coercion.js";
+import { COPILOT_INTEGRATION_ID } from "../agents/copilot-dynamic-headers.js";
+import { resolveStateDir } from "../config/paths.js";
+import { loadJsonFile, saveJsonFile } from "../infra/json-file.js";
+
+export const DEFAULT_GITHUB_COPILOT_DOMAIN = "github.com";
+const COPILOT_CACHE_NAMESPACE = "github-copilot-token";
+// Retain ordinary multi-account rotation without letting credential-derived
+// bearer tokens grow unbounded in shared state.
+const COPILOT_TOKEN_CACHE_MAX_ENTRIES = 8;
+
+/** @deprecated GitHub Copilot provider-owned helper; do not use from third-party plugins. */
+export type CachedCopilotToken = {
+  /** Copilot API token returned by GitHub's internal exchange endpoint. */
+  token: string;
+  /** Absolute epoch milliseconds when the Copilot API token expires. */
+  expiresAt: number;
+  /** Absolute epoch milliseconds when this cache entry was written. */
+  updatedAt: number;
+  /** Copilot integration id that produced this cached token. */
+  integrationId?: string;
+  /** SHA-256 fingerprint of the GitHub credential exchanged for this token. */
+  sourceCredentialFingerprint?: string;
+  /**
+   * GitHub host this token was minted for. Guards against reusing a public
+   * `github.com` Copilot token against a `*.ghe.com` tenant host (or vice
+   * versa) after a domain switch. Shipped caches predate this field and were
+   * only ever minted for public github.com, so a missing value means
+   * `github.com` (keeps valid public entries usable across upgrade).
+   */
+  domain?: string;
+};
+
+function resolveLegacyCopilotTokenCachePath(env: NodeJS.ProcessEnv): string {
+  return path.join(resolveStateDir(env), "credentials", "github-copilot.token.json");
+}
+
+export function fingerprintCopilotSourceCredential(githubToken: string): string {
+  return createHash("sha256").update(githubToken).digest("hex");
+}
+
+export function isCopilotTokenUsable(params: {
+  cache: CachedCopilotToken;
+  domain: string;
+  sourceCredentialFingerprint: string;
+  now?: number;
+}): boolean {
+  const expiresAt = asDateTimestampMs(params.cache.expiresAt);
+  // Legacy entries (pre domain-stamp) could only have been minted for public
+  // github.com; defaulting keeps them usable across upgrade while tenant
+  // requests still force a re-exchange.
+  const cacheDomain = params.cache.domain ?? DEFAULT_GITHUB_COPILOT_DOMAIN;
+  return (
+    params.cache.integrationId === COPILOT_INTEGRATION_ID &&
+    cacheDomain === params.domain &&
+    params.cache.sourceCredentialFingerprint === params.sourceCredentialFingerprint &&
+    expiresAt !== undefined &&
+    expiresAt - (params.now ?? Date.now()) > 5 * 60 * 1000
+  );
+}
+
+type CopilotTokenCache = {
+  path: string;
+  load(): CachedCopilotToken | undefined;
+  save(value: CachedCopilotToken): void;
+};
+
+export async function resolveCopilotTokenCache(params: {
+  env: NodeJS.ProcessEnv;
+  domain: string;
+  sourceCredentialFingerprint: string;
+  cachePath?: string;
+  loadJsonFileImpl?: (path: string) => unknown;
+  saveJsonFileImpl?: (path: string, value: CachedCopilotToken) => void;
+}): Promise<CopilotTokenCache> {
+  const usesLegacyCacheAdapter =
+    params.cachePath !== undefined ||
+    params.loadJsonFileImpl !== undefined ||
+    params.saveJsonFileImpl !== undefined;
+  if (usesLegacyCacheAdapter) {
+    // Kept only for the deprecated public helper's explicit cache adapters.
+    // Normal runtime state uses the bounded SQLite namespace below.
+    const cachePath = params.cachePath?.trim() || resolveLegacyCopilotTokenCachePath(params.env);
+    const loadJsonFileFn = params.loadJsonFileImpl ?? loadJsonFile;
+    const saveJsonFileFn = params.saveJsonFileImpl ?? saveJsonFile;
+    return {
+      path: cachePath,
+      load: () => loadJsonFileFn(cachePath) as CachedCopilotToken | undefined,
+      save: (value) => saveJsonFileFn(cachePath, value),
+    };
+  }
+
+  const { createCorePluginStateSyncKeyedStore } =
+    await import("../plugin-state/plugin-state-store.js");
+  const store = createCorePluginStateSyncKeyedStore<CachedCopilotToken>({
+    ownerId: "core:provider-auth",
+    namespace: COPILOT_CACHE_NAMESPACE,
+    maxEntries: COPILOT_TOKEN_CACHE_MAX_ENTRIES,
+    overflowPolicy: "evict-oldest",
+    env: params.env,
+  });
+  const key = `${params.domain}:${params.sourceCredentialFingerprint}`;
+  return {
+    path: "plugin-state",
+    load: () => store.lookup(key),
+    save: (value) =>
+      store.register(key, value, {
+        ttlMs: Math.max(1, value.expiresAt - Date.now()),
+      }),
+  };
+}

--- a/src/plugin-sdk/provider-auth.test.ts
+++ b/src/plugin-sdk/provider-auth.test.ts
@@ -1,4 +1,8 @@
 // Provider auth tests cover credential resolution, setup state, and auth method contracts.
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 
@@ -7,6 +11,7 @@ const TEST_CACHED_COPILOT_TOKEN = [
   "cached",
   ["proxy-ep", "proxy.individual.githubcopilot.com"].join("="),
 ].join(";");
+const TEST_GITHUB_TOKEN_FINGERPRINT = createHash("sha256").update(TEST_GITHUB_TOKEN).digest("hex");
 
 async function withPartialCopilotResponse(run: (port: number) => Promise<void>): Promise<void> {
   const { once } = await import("node:events");
@@ -316,6 +321,7 @@ describe("provider auth profile helpers", () => {
     expect(saved).toEqual([
       expect.objectContaining({
         expiresAt: 2_000_000_000_000,
+        sourceCredentialFingerprint: createHash("sha256").update("github-token").digest("hex"),
         token: "token;proxy-ep=proxy.individual.githubcopilot.com",
       }),
     ]);
@@ -544,8 +550,8 @@ describe("provider auth profile helpers", () => {
         fetchImpl: fetchImpl as typeof fetch,
         cachePath: "/tmp/copilot-token-http-happy.json",
         loadJsonFileImpl: () => undefined,
-        saveJsonFileImpl: (path, value) => {
-          saved.push({ path, value });
+        saveJsonFileImpl: (cachePath, value) => {
+          saved.push({ path: cachePath, value });
         },
       });
 
@@ -584,6 +590,7 @@ describe("provider auth profile helpers", () => {
         expiresAt: Number.MAX_SAFE_INTEGER,
         updatedAt: Date.now(),
         integrationId: COPILOT_INTEGRATION_ID,
+        sourceCredentialFingerprint: TEST_GITHUB_TOKEN_FINGERPRINT,
       }),
       saveJsonFileImpl: (_path, value) => saved.push(value),
     });
@@ -774,6 +781,7 @@ describe("provider auth profile helpers", () => {
         expiresAt: Date.now() + 60 * 60 * 1000,
         updatedAt: Date.now(),
         integrationId: COPILOT_INTEGRATION_ID,
+        sourceCredentialFingerprint: TEST_GITHUB_TOKEN_FINGERPRINT,
       }),
       saveJsonFileImpl: () => {},
     });
@@ -781,6 +789,100 @@ describe("provider auth profile helpers", () => {
     expect(result.source).toBe("cache:/tmp/copilot-token-cache-hit.json");
     expect(timeout).not.toHaveBeenCalled();
     expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("does not reuse a cached Copilot token from another GitHub credential", async () => {
+    vi.resetModules();
+
+    const saved: unknown[] = [];
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            token: "fresh;proxy-ep=proxy.individual.githubcopilot.com",
+            expires_at: "+2000000000",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    const { COPILOT_INTEGRATION_ID, resolveCopilotApiToken } = await import("./provider-auth.js");
+
+    const result = await resolveCopilotApiToken({
+      githubToken: TEST_GITHUB_TOKEN,
+      fetchImpl: fetchImpl as typeof fetch,
+      cachePath: "/tmp/copilot-token-cache-profile-mismatch.json",
+      loadJsonFileImpl: () => ({
+        token: TEST_CACHED_COPILOT_TOKEN,
+        expiresAt: Date.now() + 60 * 60 * 1000,
+        updatedAt: Date.now(),
+        integrationId: COPILOT_INTEGRATION_ID,
+        sourceCredentialFingerprint: createHash("sha256").update("different-token").digest("hex"),
+      }),
+      saveJsonFileImpl: (_path, value) => saved.push(value),
+    });
+
+    expect(result.source).toContain("fetched:");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(saved).toEqual([
+      expect.objectContaining({
+        sourceCredentialFingerprint: TEST_GITHUB_TOKEN_FINGERPRINT,
+        token: "fresh;proxy-ep=proxy.individual.githubcopilot.com",
+      }),
+    ]);
+  });
+
+  it("retains valid Copilot exchanges across A to B to A profile rotation", async () => {
+    vi.resetModules();
+
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-copilot-cache-"));
+    try {
+      const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+        const authorization = new Headers(init?.headers).get("authorization");
+        const sourceFixture = authorization?.replace(/^Bearer\s+/u, "") ?? "";
+        let exchangeFixture = "test-token-placeholder";
+        if (sourceFixture === "test-auth-token") {
+          exchangeFixture = "test-auth-token";
+        }
+        return new Response(
+          JSON.stringify(
+            Object.fromEntries([
+              ["token", exchangeFixture],
+              ["expires_at", Date.now() + 60 * 60 * 1000],
+            ]),
+          ),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      });
+      const { resolveCopilotApiToken } = await import("./provider-auth.js");
+      const env = { OPENCLAW_STATE_DIR: stateDir } as NodeJS.ProcessEnv;
+
+      const firstA = await resolveCopilotApiToken({
+        githubToken: "test-auth-token",
+        env,
+        fetchImpl: fetchImpl as typeof fetch,
+      });
+      const firstB = await resolveCopilotApiToken({
+        githubToken: "test-token-placeholder",
+        env,
+        fetchImpl: fetchImpl as typeof fetch,
+      });
+      const secondA = await resolveCopilotApiToken({
+        githubToken: "test-auth-token",
+        env,
+        fetchImpl: fetchImpl as typeof fetch,
+      });
+
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(firstA.token).toBe("test-auth-token");
+      expect(firstB.token).toBe("test-token-placeholder");
+      expect(secondA.token).toBe(firstA.token);
+      expect(secondA.source).toBe("cache:plugin-state");
+    } finally {
+      const { resetPluginStateStoreForTests } =
+        await import("../plugin-state/plugin-state-store.js");
+      resetPluginStateStoreForTests();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("times out while reading a stalled HTTP response body", async () => {
@@ -1002,15 +1104,22 @@ describe("Copilot data-residency domain resolution", () => {
     expect(saved).toEqual([expect.objectContaining({ domain: "acme.ghe.com" })]);
   });
 
-  it("keeps legacy pre-domain cache entries usable for github.com across upgrade", async () => {
+  it("re-exchanges legacy cache entries without a source credential fingerprint", async () => {
     vi.resetModules();
 
-    const fetchImpl = vi.fn();
+    const saved: unknown[] = [];
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            token: "fresh-public;proxy-ep=proxy.individual.githubcopilot.com",
+            expires_at: "+2000000000",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
     const { COPILOT_INTEGRATION_ID, resolveCopilotApiToken } = await import("./provider-auth.js");
 
-    // Shipped caches predate the domain stamp and were only ever minted for
-    // public github.com. A valid legacy entry must stay a cache hit for the
-    // default domain instead of forcing a re-exchange on upgrade.
     const result = await resolveCopilotApiToken({
       githubToken: "github-token",
       env: {},
@@ -1021,13 +1130,19 @@ describe("Copilot data-residency domain resolution", () => {
         expiresAt: Date.now() + 60 * 60 * 1000,
         updatedAt: Date.now(),
         integrationId: COPILOT_INTEGRATION_ID,
-        // no domain field
+        // no domain or source credential fingerprint
       }),
-      saveJsonFileImpl: () => {},
+      saveJsonFileImpl: (_path, value) => saved.push(value),
     });
 
-    expect(fetchImpl).not.toHaveBeenCalled();
-    expect(result.source).toBe("cache:/tmp/copilot-token-legacy.json");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result.source).toBe("fetched:https://api.github.com/copilot_internal/v2/token");
+    expect(saved).toEqual([
+      expect.objectContaining({
+        domain: "github.com",
+        sourceCredentialFingerprint: TEST_GITHUB_TOKEN_FINGERPRINT,
+      }),
+    ]);
   });
 
   it("does not reuse a legacy pre-domain cache entry for a tenant domain", async () => {
@@ -1082,6 +1197,7 @@ describe("Copilot data-residency domain resolution", () => {
         expiresAt: Date.now() + 60 * 60 * 1000,
         updatedAt: Date.now(),
         integrationId: COPILOT_INTEGRATION_ID,
+        sourceCredentialFingerprint: TEST_GITHUB_TOKEN_FINGERPRINT,
         domain: "acme.ghe.com",
       }),
       saveJsonFileImpl: () => {},

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -1,6 +1,4 @@
 // Provider auth helpers define auth methods, credential resolution, and setup status contracts.
-import { createHash } from "node:crypto";
-import path from "node:path";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromEpochSeconds,
@@ -26,12 +24,18 @@ import {
 import { resolveEnvApiKey } from "../agents/model-auth-env.js";
 import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveStateDir } from "../config/paths.js";
-import { loadJsonFile, saveJsonFile } from "../infra/json-file.js";
 import { logWarn } from "../logger.js";
+import {
+  DEFAULT_GITHUB_COPILOT_DOMAIN,
+  fingerprintCopilotSourceCredential,
+  isCopilotTokenUsable,
+  resolveCopilotTokenCache,
+  type CachedCopilotToken,
+} from "./provider-auth-copilot-cache.js";
 import { resolveProviderEndpoint } from "./provider-model-shared.js";
 
 export type { OpenClawConfig } from "../config/config.js";
+export type { CachedCopilotToken } from "./provider-auth-copilot-cache.js";
 export type { SecretInput } from "../config/types.secrets.js";
 export type { SecretInputMode } from "../plugins/provider-auth-types.js";
 export type { ProviderAuthResult } from "../plugins/types.js";
@@ -143,12 +147,7 @@ export const DEFAULT_COPILOT_API_BASE_URL = "https://api.individual.githubcopilo
  */
 const COPILOT_PROVIDER_ID = "github-copilot";
 
-const DEFAULT_GITHUB_COPILOT_DOMAIN = "github.com";
 const COPILOT_TOKEN_EXCHANGE_TIMEOUT_MS = 30_000;
-const COPILOT_CACHE_NAMESPACE = "github-copilot-token";
-// Retain ordinary multi-account rotation without letting credential-derived
-// bearer tokens grow unbounded in shared state.
-const COPILOT_TOKEN_CACHE_MAX_ENTRIES = 8;
 
 // Matches a data-residency GHE tenant root (`<tenant>.ghe.com`, single label).
 // GitHub defines a GHE.com enterprise as a dedicated `SUBDOMAIN.ghe.com` domain;
@@ -249,107 +248,6 @@ function copilotApiBaseFallback(domain: string): string {
   return domain === DEFAULT_GITHUB_COPILOT_DOMAIN
     ? DEFAULT_COPILOT_API_BASE_URL
     : `https://copilot-api.${domain}`;
-}
-
-/** @deprecated GitHub Copilot provider-owned helper; do not use from third-party plugins. */
-export type CachedCopilotToken = {
-  /** Copilot API token returned by GitHub's internal exchange endpoint. */
-  token: string;
-  /** Absolute epoch milliseconds when the Copilot API token expires. */
-  expiresAt: number;
-  /** Absolute epoch milliseconds when this cache entry was written. */
-  updatedAt: number;
-  /** Copilot integration id that produced this cached token. */
-  integrationId?: string;
-  /** SHA-256 fingerprint of the GitHub credential exchanged for this token. */
-  sourceCredentialFingerprint?: string;
-  /**
-   * GitHub host this token was minted for. Guards against reusing a public
-   * `github.com` Copilot token against a `*.ghe.com` tenant host (or vice
-   * versa) after a domain switch. Shipped caches predate this field and were
-   * only ever minted for public github.com, so a missing value means
-   * `github.com` (keeps valid public entries usable across upgrade).
-   */
-  domain?: string;
-};
-
-function resolveLegacyCopilotTokenCachePath(env: NodeJS.ProcessEnv = process.env) {
-  return path.join(resolveStateDir(env), "credentials", "github-copilot.token.json");
-}
-
-function isCopilotTokenUsable(
-  cache: CachedCopilotToken,
-  domain: string,
-  sourceCredentialFingerprint: string,
-  now = Date.now(),
-): boolean {
-  const expiresAt = asDateTimestampMs(cache.expiresAt);
-  // Legacy entries (pre domain-stamp) could only have been minted for public
-  // github.com; defaulting keeps them usable across upgrade while tenant
-  // requests still force a re-exchange.
-  const cacheDomain = cache.domain ?? DEFAULT_GITHUB_COPILOT_DOMAIN;
-  return (
-    cache.integrationId === COPILOT_INTEGRATION_ID &&
-    cacheDomain === domain &&
-    cache.sourceCredentialFingerprint === sourceCredentialFingerprint &&
-    expiresAt !== undefined &&
-    expiresAt - now > 5 * 60 * 1000
-  );
-}
-
-function fingerprintCopilotSourceCredential(githubToken: string): string {
-  return createHash("sha256").update(githubToken).digest("hex");
-}
-
-type CopilotTokenCache = {
-  path: string;
-  load(): CachedCopilotToken | undefined;
-  save(value: CachedCopilotToken): void;
-};
-
-async function resolveCopilotTokenCache(params: {
-  env: NodeJS.ProcessEnv;
-  domain: string;
-  sourceCredentialFingerprint: string;
-  cachePath?: string;
-  loadJsonFileImpl?: (path: string) => unknown;
-  saveJsonFileImpl?: (path: string, value: CachedCopilotToken) => void;
-}): Promise<CopilotTokenCache> {
-  const usesLegacyCacheAdapter =
-    params.cachePath !== undefined ||
-    params.loadJsonFileImpl !== undefined ||
-    params.saveJsonFileImpl !== undefined;
-  if (usesLegacyCacheAdapter) {
-    // Kept only for the deprecated public helper's explicit cache adapters.
-    // Normal runtime state uses the bounded SQLite namespace below.
-    const cachePath = params.cachePath?.trim() || resolveLegacyCopilotTokenCachePath(params.env);
-    const loadJsonFileFn = params.loadJsonFileImpl ?? loadJsonFile;
-    const saveJsonFileFn = params.saveJsonFileImpl ?? saveJsonFile;
-    return {
-      path: cachePath,
-      load: () => loadJsonFileFn(cachePath) as CachedCopilotToken | undefined,
-      save: (value) => saveJsonFileFn(cachePath, value),
-    };
-  }
-
-  const { createCorePluginStateSyncKeyedStore } =
-    await import("../plugin-state/plugin-state-store.js");
-  const store = createCorePluginStateSyncKeyedStore<CachedCopilotToken>({
-    ownerId: "core:provider-auth",
-    namespace: COPILOT_CACHE_NAMESPACE,
-    maxEntries: COPILOT_TOKEN_CACHE_MAX_ENTRIES,
-    overflowPolicy: "evict-oldest",
-    env: params.env,
-  });
-  const key = `${params.domain}:${params.sourceCredentialFingerprint}`;
-  return {
-    path: "plugin-state",
-    load: () => store.lookup(key),
-    save: (value) =>
-      store.register(key, value, {
-        ttlMs: Math.max(1, value.expiresAt - Date.now()),
-      }),
-  };
 }
 
 function resolveCopilotTokenExpiresAtMs(expiresAt: unknown): number | undefined {
@@ -507,7 +405,7 @@ export async function resolveCopilotApiToken(params: {
     // Token cache entries are scoped to the current Copilot integration id and
     // GitHub host so stale tokens from older editor identities or a different
     // domain are exchanged again.
-    if (isCopilotTokenUsable(cached, domain, sourceCredentialFingerprint)) {
+    if (isCopilotTokenUsable({ cache: cached, domain, sourceCredentialFingerprint })) {
       return {
         token: cached.token,
         expiresAt: cached.expiresAt,

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -1,4 +1,5 @@
 // Provider auth helpers define auth methods, credential resolution, and setup status contracts.
+import { createHash } from "node:crypto";
 import path from "node:path";
 import {
   asDateTimestampMs,
@@ -144,6 +145,10 @@ const COPILOT_PROVIDER_ID = "github-copilot";
 
 const DEFAULT_GITHUB_COPILOT_DOMAIN = "github.com";
 const COPILOT_TOKEN_EXCHANGE_TIMEOUT_MS = 30_000;
+const COPILOT_CACHE_NAMESPACE = "github-copilot-token";
+// Retain ordinary multi-account rotation without letting credential-derived
+// bearer tokens grow unbounded in shared state.
+const COPILOT_TOKEN_CACHE_MAX_ENTRIES = 8;
 
 // Matches a data-residency GHE tenant root (`<tenant>.ghe.com`, single label).
 // GitHub defines a GHE.com enterprise as a dedicated `SUBDOMAIN.ghe.com` domain;
@@ -256,6 +261,8 @@ export type CachedCopilotToken = {
   updatedAt: number;
   /** Copilot integration id that produced this cached token. */
   integrationId?: string;
+  /** SHA-256 fingerprint of the GitHub credential exchanged for this token. */
+  sourceCredentialFingerprint?: string;
   /**
    * GitHub host this token was minted for. Guards against reusing a public
    * `github.com` Copilot token against a `*.ghe.com` tenant host (or vice
@@ -266,13 +273,14 @@ export type CachedCopilotToken = {
   domain?: string;
 };
 
-function resolveCopilotTokenCachePath(env: NodeJS.ProcessEnv = process.env) {
+function resolveLegacyCopilotTokenCachePath(env: NodeJS.ProcessEnv = process.env) {
   return path.join(resolveStateDir(env), "credentials", "github-copilot.token.json");
 }
 
 function isCopilotTokenUsable(
   cache: CachedCopilotToken,
   domain: string,
+  sourceCredentialFingerprint: string,
   now = Date.now(),
 ): boolean {
   const expiresAt = asDateTimestampMs(cache.expiresAt);
@@ -283,9 +291,65 @@ function isCopilotTokenUsable(
   return (
     cache.integrationId === COPILOT_INTEGRATION_ID &&
     cacheDomain === domain &&
+    cache.sourceCredentialFingerprint === sourceCredentialFingerprint &&
     expiresAt !== undefined &&
     expiresAt - now > 5 * 60 * 1000
   );
+}
+
+function fingerprintCopilotSourceCredential(githubToken: string): string {
+  return createHash("sha256").update(githubToken).digest("hex");
+}
+
+type CopilotTokenCache = {
+  path: string;
+  load(): CachedCopilotToken | undefined;
+  save(value: CachedCopilotToken): void;
+};
+
+async function resolveCopilotTokenCache(params: {
+  env: NodeJS.ProcessEnv;
+  domain: string;
+  sourceCredentialFingerprint: string;
+  cachePath?: string;
+  loadJsonFileImpl?: (path: string) => unknown;
+  saveJsonFileImpl?: (path: string, value: CachedCopilotToken) => void;
+}): Promise<CopilotTokenCache> {
+  const usesLegacyCacheAdapter =
+    params.cachePath !== undefined ||
+    params.loadJsonFileImpl !== undefined ||
+    params.saveJsonFileImpl !== undefined;
+  if (usesLegacyCacheAdapter) {
+    // Kept only for the deprecated public helper's explicit cache adapters.
+    // Normal runtime state uses the bounded SQLite namespace below.
+    const cachePath = params.cachePath?.trim() || resolveLegacyCopilotTokenCachePath(params.env);
+    const loadJsonFileFn = params.loadJsonFileImpl ?? loadJsonFile;
+    const saveJsonFileFn = params.saveJsonFileImpl ?? saveJsonFile;
+    return {
+      path: cachePath,
+      load: () => loadJsonFileFn(cachePath) as CachedCopilotToken | undefined,
+      save: (value) => saveJsonFileFn(cachePath, value),
+    };
+  }
+
+  const { createCorePluginStateSyncKeyedStore } =
+    await import("../plugin-state/plugin-state-store.js");
+  const store = createCorePluginStateSyncKeyedStore<CachedCopilotToken>({
+    ownerId: "core:provider-auth",
+    namespace: COPILOT_CACHE_NAMESPACE,
+    maxEntries: COPILOT_TOKEN_CACHE_MAX_ENTRIES,
+    overflowPolicy: "evict-oldest",
+    env: params.env,
+  });
+  const key = `${params.domain}:${params.sourceCredentialFingerprint}`;
+  return {
+    path: "plugin-state",
+    load: () => store.lookup(key),
+    save: (value) =>
+      store.register(key, value, {
+        ttlMs: Math.max(1, value.expiresAt - Date.now()),
+      }),
+  };
 }
 
 function resolveCopilotTokenExpiresAtMs(expiresAt: unknown): number | undefined {
@@ -426,17 +490,24 @@ export async function resolveCopilotApiToken(params: {
     explicit: params.githubDomain,
     config: params.config,
   });
-  const cachePath = params.cachePath?.trim() || resolveCopilotTokenCachePath(env);
   const tokenUrl = copilotTokenUrl(domain);
   const apiBaseFallback = copilotApiBaseFallback(domain);
-  const loadJsonFileFn = params.loadJsonFileImpl ?? loadJsonFile;
-  const saveJsonFileFn = params.saveJsonFileImpl ?? saveJsonFile;
-  const cached = loadJsonFileFn(cachePath) as CachedCopilotToken | undefined;
+  const sourceCredentialFingerprint = fingerprintCopilotSourceCredential(params.githubToken);
+  const cache = await resolveCopilotTokenCache({
+    env,
+    domain,
+    sourceCredentialFingerprint,
+    ...(params.cachePath !== undefined ? { cachePath: params.cachePath } : {}),
+    ...(params.loadJsonFileImpl ? { loadJsonFileImpl: params.loadJsonFileImpl } : {}),
+    ...(params.saveJsonFileImpl ? { saveJsonFileImpl: params.saveJsonFileImpl } : {}),
+  });
+  const cachePath = cache.path;
+  const cached = cache.load();
   if (cached && typeof cached.token === "string" && typeof cached.expiresAt === "number") {
     // Token cache entries are scoped to the current Copilot integration id and
     // GitHub host so stale tokens from older editor identities or a different
     // domain are exchanged again.
-    if (isCopilotTokenUsable(cached, domain)) {
+    if (isCopilotTokenUsable(cached, domain, sourceCredentialFingerprint)) {
       return {
         token: cached.token,
         expiresAt: cached.expiresAt,
@@ -483,9 +554,10 @@ export async function resolveCopilotApiToken(params: {
     expiresAt: json.expiresAt,
     updatedAt: Date.now(),
     integrationId: COPILOT_INTEGRATION_ID,
+    sourceCredentialFingerprint,
     domain,
   };
-  saveJsonFileFn(cachePath, payload);
+  cache.save(payload);
 
   return {
     token: payload.token,


### PR DESCRIPTION
Closes #106170

## What Problem This Solves

Fixes an issue where users selecting GitHub Copilot models could receive a `network connection error` after runtime token exchange, before the model request reached GitHub.

The same path could use synthetic 128K model limits instead of the selected account's live catalog limits, and could retain another profile's limits during profile rotation, direct-auth fallback, or compaction.

## Why This Change Was Made

The complete fix keeps runtime credentials refreshable while ensuring OpenClaw selects its managed provider transport whenever exchanged auth is available. GitHub Copilot live catalogs and cached exchanged tokens are scoped to the source credential/profile, and normal plus compaction paths rematerialize model metadata whenever the active credential changes.

Cross-provider compaction only reuses a forwarded profile when its prepared auth plan matches the target provider/model. Route-less profile handling is gated by the provider's existing `preferRuntimeResolvedModel` ownership hook, so unrelated Claude CLI/PI auth overlays retain their current behavior.

## User Impact

GitHub Copilot turns now reach the provider after token exchange, token refreshes remain effective during long tool loops, and long-context budgeting reflects the active account. For the tested GPT-5.6 Sol account, OpenClaw uses the live 922K prompt budget from Copilot's 1.05M context window instead of falling back to 128K.

## Evidence

Focused regression coverage:

```text
src/plugin-sdk/provider-auth.test.ts: 28 passed
extensions/github-copilot/{auth,index,models}.test.ts: 63 passed
src/agents/embedded-agent-runner/{stream-resolution,compact.hooks}.test.ts: 132 passed
src/agents/embedded-agent-runner/run.overflow-compaction.test.ts: 67 passed
src/agents/embedded-agent-runner/run/auth-controller.test.ts: 16 passed
src/agents/runtime-plan/resolve-auth.test.ts: 13 passed
src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts: 11 passed
```

Build:

```text
corepack pnpm build
PASS
```

Live GitHub Copilot proof from this source checkout:

```bash
node scripts/run-node.mjs agent --local --agent main \
  --session-key agent:main:copilot-sol-pr-final-proof \
  --message 'Reply with exactly OK.' \
  --model github-copilot/gpt-5.6-sol --thinking low --json
```

```json
{
  "text": "OK",
  "provider": "github-copilot",
  "model": "gpt-5.6-sol",
  "contextTokens": 922000,
  "contextTokenBudget": 922000,
  "stopReason": "stop",
  "fallbackUsed": false
}
```

The provider transport log returned HTTP 200 with `content-type: text/event-stream`.

Known validation notes:

- `plugin-sdk:surface:check` reports the current baseline budget as one export over (`10641 > 10640`, callable `5357 > 5356`); none of the new internal helpers appear in `dist/plugin-sdk`.
- Structured autoreview fails closed before engine invocation because credential-shaped hunks trigger its secret scanner. Multiple read-only code-review passes were run instead; all reported runtime refresh, profile scoping, cache identity, compaction, and fallback findings were addressed with regression coverage.
- GitHub receive-pack and large Git Data writes returned server-side `commit_refs`/5xx errors. The fork branch was therefore published through the Contents API and is squash-ready; its final 20 file blob SHAs were verified against the local commits.
