### PR TITLE
fix(ui): keep worktrees mutation error visible after a successful list refresh [AI-assisted]

### DIFF
--- a/ui/src/pages/worktrees/worktrees-page.test.ts
+++ b/ui/src/pages/worktrees/worktrees-page.test.ts
@@ -311,6 +311,43 @@ describe("WorktreesPage lifecycle", () => {
     expect(page.busyId).toBeNull();
   });
 
+  it("keeps a mutation error visible after a successful post-operation list refresh", async () => {
+    // Regression for #106158: a failed mutation assigns an actionable error,
+    // then the mandatory finally->load() refresh used to clear it (load() set
+    // this.error = null before requesting worktrees.list). The error must stay
+    // visible after a successful refresh so the user knows the operation failed.
+    const pendingRestore = deferred<unknown>();
+    let listCalls = 0;
+    const request = vi.fn((method: string) => {
+      if (method === "worktrees.restore") {
+        return pendingRestore.promise;
+      }
+      if (method === "worktrees.list") {
+        listCalls += 1;
+        return Promise.resolve({ worktrees: [] });
+      }
+      return Promise.resolve({ worktrees: [] });
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const source = mutableGateway(client);
+    const page = document.createElement("openclaw-worktrees-page") as WorktreesPageTestElement;
+    page.context = contextWithGateway(source.gateway);
+    document.body.append(page);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
+
+    const restoring = page.restore(worktree());
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith("worktrees.restore", { id: "worktree-1" }),
+    );
+    pendingRestore.reject(new Error("restore failed: worktree busy"));
+    await restoring;
+    // The post-operation list refresh runs and succeeds; the mutation error
+    // must survive it.
+    await vi.waitFor(() => expect(listCalls).toBeGreaterThanOrEqual(2));
+    expect(page.error).toContain("restore failed: worktree busy");
+    expect(page.busyId).toBeNull();
+  });
+
   it("clears pending create state across a same-client reconnect", async () => {
     const pendingCreate = deferred<unknown>();
     const request = vi.fn((method: string) => {

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -151,7 +151,6 @@ class WorktreesPage extends OpenClawLightDomElement {
     }
     const generation = ++this.loadGeneration;
     this.loading = true;
-    this.error = null;
     try {
       const result = await client.request<WorktreesListResult>("worktrees.list", {});
       if (generation === this.loadGeneration && client === this.client) {
@@ -159,6 +158,8 @@ class WorktreesPage extends OpenClawLightDomElement {
       }
     } catch (error) {
       if (generation === this.loadGeneration && client === this.client) {
+        // A list-refresh failure may replace a prior mutation error so the
+        // user sees the newest actionable failure.
         this.error = String(error);
       }
     } finally {


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

Closes #106158

## What Problem This Solves

Fixes an issue where a failed Worktrees mutation (restore/remove/force-remove/create/gc) briefly shows an actionable error, then immediately erases it during the mandatory post-operation `worktrees.list` refresh. The user sees the operation finish with no explanation even though the page had just rendered an error callout.

## Why This Change Was Made

Each mutation's `catch` assigns `this.error`, then its `finally` block calls `load()` to refresh the list. `load()` unconditionally ran `this.error = null` before requesting `worktrees.list`, so a successful refresh cleared the mutation error before the user could act on it.

The fix removes the `this.error = null` reset from `load()`. A successful list refresh no longer touches `this.error`, so the mutation error survives it. A failed list refresh still sets `this.error` (replacing the prior mutation error, so the user sees the newest actionable failure). The "clear stale error on reconnect/client-change" responsibility stays where it already lived - `applyGatewaySnapshot` sets `this.error = null` when the client identity changes - so reconnects still clear stale errors. Each mutation also still clears `this.error` at its start, so a successful mutation followed by a successful refresh ends with no error.

The change is a single line removed from `load()` in `ui/src/pages/worktrees/worktrees-page.ts` (plus a comment); the mutation paths, the list-failure path, and the reconnect path are unchanged.

## User Impact

A failed worktree restore/remove/create/gc now keeps its error callout visible after the automatic list refresh, so the user knows the operation failed and can retry or investigate. Successful operations and reconnects behave as before.

## Evidence

Regression test in `ui/src/pages/worktrees/worktrees-page.test.ts` (`keeps a mutation error visible after a successful post-operation list refresh`): it drives the real `WorktreesPage` element with a mock `client.request` whose `worktrees.restore` rejects with `"restore failed: worktree busy"` and whose `worktrees.list` resolves successfully, calls `page.restore(worktree())`, waits for the post-operation list refresh to run, then asserts `page.error` still contains the mutation error. The test fails on `main` and passes with the fix (failing-first).

**Before fix (current `main`)** - `load()` clears `this.error` before the list request, so the mutation error is gone by the time the successful refresh completes:

```
pendingRestore.reject(new Error("restore failed: worktree busy"));
await restoring;
await vi.waitFor(() => expect(listCalls).toBeGreaterThanOrEqual(2));
expect(page.error).toContain("restore failed: worktree busy");
// AssertionError: expected "" (null/empty) to contain "restore failed: worktree busy"
// load() set this.error = null before the successful worktrees.list call
```

**After fix** - `load()` no longer resets `this.error`; the mutation error survives the successful refresh:

```
pendingRestore.reject(new Error("restore failed: worktree busy"));
await restoring;
await vi.waitFor(() => expect(listCalls).toBeGreaterThanOrEqual(2));
expect(page.error).toContain("restore failed: worktree busy");   // passes
expect(page.busyId).toBeNull();                                   // passes
```

The existing `discards a restore error across a same-client reconnect` and `clears pending create state across a same-client reconnect` tests still pass - reconnects keep clearing stale errors via `applyGatewaySnapshot`.

Local verification:

- `node scripts/run-vitest.mjs ui/src/pages/worktrees/worktrees-page.test.ts` - 11/11 pass (1 new regression test fails on `main`, passes after the fix; 10 existing tests unchanged).
- `oxlint` + `oxfmt --check` on changed files - pass.
- `pnpm tsgo:ui` (UI prod types) + `pnpm tsgo:test:ui` (UI test types) - pass.

Not tested: the live Control UI in a browser against a real gateway (the proof drives the real `WorktreesPage` element directly with a mock gateway client, exercising the exact `restore` -> `catch` -> `finally` -> `load()` -> `worktrees.list` path the issue describes; no browser or live gateway is involved in this state transition).
