### PR TITLE
feat(usage): show the account email with plan windows in the chat context popover

### DIFF
--- a/extensions/anthropic/usage.test.ts
+++ b/extensions/anthropic/usage.test.ts
@@ -1,7 +1,4 @@
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   fetchAnthropicAdminUsage,
   fetchAnthropicUsage,
@@ -32,25 +29,6 @@ function requestUrl(input: string | URL | Request): URL {
 function oauthFixtureToken(): string {
   return ["oauth", "token"].join("-");
 }
-
-// Mirrors the mocked readClaudeCliCredentialsCached access value.
-function cliAccessFixtureToken(): string {
-  return ["cli", "access"].join("-");
-}
-
-const tempHomes: string[] = [];
-
-async function createTempHome(): Promise<string> {
-  const home = await fs.mkdtemp(path.join(os.tmpdir(), "claude-usage-email-"));
-  tempHomes.push(home);
-  return home;
-}
-
-afterEach(async () => {
-  await Promise.all(
-    tempHomes.splice(0).map((home) => fs.rm(home, { recursive: true, force: true })),
-  );
-});
 
 describe("Anthropic provider usage", () => {
   it("aggregates provider-reported costs, cache tokens, models, and categories", async () => {
@@ -252,7 +230,7 @@ describe("Anthropic provider usage", () => {
     );
     const snapshot = await fetchAnthropicUsage({
       config: {},
-      env: { HOME: await createTempHome() },
+      env: {},
       provider: "anthropic",
       token: oauthFixtureToken(),
       email: "profile@example.com",
@@ -262,57 +240,19 @@ describe("Anthropic provider usage", () => {
     expect(snapshot.accountEmail).toBe("profile@example.com");
   });
 
-  it("falls back to the Claude CLI config email only when the CLI login fetched the usage", async () => {
-    const home = await createTempHome();
-    await fs.writeFile(
-      path.join(home, ".claude.json"),
-      JSON.stringify({ oauthAccount: { emailAddress: "cli-login@example.com" } }),
-    );
-    const fetchFn = vi.fn(
-      async () => new Response(JSON.stringify({ five_hour: { utilization: 10 } }), { status: 200 }),
-    );
-    // The mocked CLI credential's access token matches: same account, use email.
-    const matching = await fetchAnthropicUsage({
-      config: {},
-      env: { HOME: home },
-      provider: "anthropic",
-      token: cliAccessFixtureToken(),
-      timeoutMs: 5000,
-      fetchFn,
-    });
-    expect(matching.accountEmail).toBe("cli-login@example.com");
-
-    // A different usage token means the ambient CLI login may be another
-    // account; the snapshot must stay unlabeled instead of guessing.
-    const foreign = await fetchAnthropicUsage({
-      config: {},
-      env: { HOME: home },
-      provider: "anthropic",
-      token: oauthFixtureToken(),
-      timeoutMs: 5000,
-      fetchFn,
-    });
-    expect(foreign.accountEmail).toBeUndefined();
-  });
-
-  it("reads the CLI config email from CLAUDE_CONFIG_DIR when set", async () => {
-    const configDir = await createTempHome();
-    await fs.writeFile(
-      path.join(configDir, ".claude.json"),
-      JSON.stringify({ oauthAccount: { emailAddress: "scoped@example.com" } }),
-    );
+  it("leaves the account unlabeled when the credential carries no email", async () => {
     const fetchFn = vi.fn(
       async () => new Response(JSON.stringify({ five_hour: { utilization: 10 } }), { status: 200 }),
     );
     const snapshot = await fetchAnthropicUsage({
       config: {},
-      env: { HOME: await createTempHome(), CLAUDE_CONFIG_DIR: configDir },
+      env: {},
       provider: "anthropic",
-      token: cliAccessFixtureToken(),
+      token: oauthFixtureToken(),
       timeoutMs: 5000,
       fetchFn,
     });
-    expect(snapshot.accountEmail).toBe("scoped@example.com");
+    expect(snapshot.accountEmail).toBeUndefined();
   });
 
   it("does not attach a plan label when usage has no windows", async () => {

--- a/extensions/anthropic/usage.test.ts
+++ b/extensions/anthropic/usage.test.ts
@@ -33,6 +33,11 @@ function oauthFixtureToken(): string {
   return ["oauth", "token"].join("-");
 }
 
+// Mirrors the mocked readClaudeCliCredentialsCached access value.
+function cliAccessFixtureToken(): string {
+  return ["cli", "access"].join("-");
+}
+
 const tempHomes: string[] = [];
 
 async function createTempHome(): Promise<string> {
@@ -257,7 +262,7 @@ describe("Anthropic provider usage", () => {
     expect(snapshot.accountEmail).toBe("profile@example.com");
   });
 
-  it("falls back to the Claude CLI config file for the account email", async () => {
+  it("falls back to the Claude CLI config email only when the CLI login fetched the usage", async () => {
     const home = await createTempHome();
     await fs.writeFile(
       path.join(home, ".claude.json"),
@@ -266,7 +271,20 @@ describe("Anthropic provider usage", () => {
     const fetchFn = vi.fn(
       async () => new Response(JSON.stringify({ five_hour: { utilization: 10 } }), { status: 200 }),
     );
-    const snapshot = await fetchAnthropicUsage({
+    // The mocked CLI credential's access token matches: same account, use email.
+    const matching = await fetchAnthropicUsage({
+      config: {},
+      env: { HOME: home },
+      provider: "anthropic",
+      token: cliAccessFixtureToken(),
+      timeoutMs: 5000,
+      fetchFn,
+    });
+    expect(matching.accountEmail).toBe("cli-login@example.com");
+
+    // A different usage token means the ambient CLI login may be another
+    // account; the snapshot must stay unlabeled instead of guessing.
+    const foreign = await fetchAnthropicUsage({
       config: {},
       env: { HOME: home },
       provider: "anthropic",
@@ -274,7 +292,27 @@ describe("Anthropic provider usage", () => {
       timeoutMs: 5000,
       fetchFn,
     });
-    expect(snapshot.accountEmail).toBe("cli-login@example.com");
+    expect(foreign.accountEmail).toBeUndefined();
+  });
+
+  it("reads the CLI config email from CLAUDE_CONFIG_DIR when set", async () => {
+    const configDir = await createTempHome();
+    await fs.writeFile(
+      path.join(configDir, ".claude.json"),
+      JSON.stringify({ oauthAccount: { emailAddress: "scoped@example.com" } }),
+    );
+    const fetchFn = vi.fn(
+      async () => new Response(JSON.stringify({ five_hour: { utilization: 10 } }), { status: 200 }),
+    );
+    const snapshot = await fetchAnthropicUsage({
+      config: {},
+      env: { HOME: await createTempHome(), CLAUDE_CONFIG_DIR: configDir },
+      provider: "anthropic",
+      token: cliAccessFixtureToken(),
+      timeoutMs: 5000,
+      fetchFn,
+    });
+    expect(snapshot.accountEmail).toBe("scoped@example.com");
   });
 
   it("does not attach a plan label when usage has no windows", async () => {

--- a/extensions/anthropic/usage.test.ts
+++ b/extensions/anthropic/usage.test.ts
@@ -29,6 +29,10 @@ function requestUrl(input: string | URL | Request): URL {
   return new URL(input instanceof Request ? input.url : input);
 }
 
+function oauthFixtureToken(): string {
+  return ["oauth", "token"].join("-");
+}
+
 const tempHomes: string[] = [];
 
 async function createTempHome(): Promise<string> {
@@ -245,7 +249,7 @@ describe("Anthropic provider usage", () => {
       config: {},
       env: { HOME: await createTempHome() },
       provider: "anthropic",
-      token: "oauth-token",
+      token: oauthFixtureToken(),
       email: "profile@example.com",
       timeoutMs: 5000,
       fetchFn,
@@ -266,7 +270,7 @@ describe("Anthropic provider usage", () => {
       config: {},
       env: { HOME: home },
       provider: "anthropic",
-      token: "oauth-token",
+      token: oauthFixtureToken(),
       timeoutMs: 5000,
       fetchFn,
     });

--- a/extensions/anthropic/usage.test.ts
+++ b/extensions/anthropic/usage.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   fetchAnthropicAdminUsage,
   fetchAnthropicUsage,
@@ -25,6 +28,20 @@ vi.mock("openclaw/plugin-sdk/provider-auth", async (importActual) => {
 function requestUrl(input: string | URL | Request): URL {
   return new URL(input instanceof Request ? input.url : input);
 }
+
+const tempHomes: string[] = [];
+
+async function createTempHome(): Promise<string> {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "claude-usage-email-"));
+  tempHomes.push(home);
+  return home;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempHomes.splice(0).map((home) => fs.rm(home, { recursive: true, force: true })),
+  );
+});
 
 describe("Anthropic provider usage", () => {
   it("aggregates provider-reported costs, cache tokens, models, and categories", async () => {
@@ -218,6 +235,42 @@ describe("Anthropic provider usage", () => {
     });
     expect(snapshot.plan).toBe("Max (20x)");
     expect(snapshot.windows).toHaveLength(2);
+  });
+
+  it("attaches the resolved credential email to OAuth usage snapshots", async () => {
+    const fetchFn = vi.fn(
+      async () => new Response(JSON.stringify({ five_hour: { utilization: 10 } }), { status: 200 }),
+    );
+    const snapshot = await fetchAnthropicUsage({
+      config: {},
+      env: { HOME: await createTempHome() },
+      provider: "anthropic",
+      token: "oauth-token",
+      email: "profile@example.com",
+      timeoutMs: 5000,
+      fetchFn,
+    });
+    expect(snapshot.accountEmail).toBe("profile@example.com");
+  });
+
+  it("falls back to the Claude CLI config file for the account email", async () => {
+    const home = await createTempHome();
+    await fs.writeFile(
+      path.join(home, ".claude.json"),
+      JSON.stringify({ oauthAccount: { emailAddress: "cli-login@example.com" } }),
+    );
+    const fetchFn = vi.fn(
+      async () => new Response(JSON.stringify({ five_hour: { utilization: 10 } }), { status: 200 }),
+    );
+    const snapshot = await fetchAnthropicUsage({
+      config: {},
+      env: { HOME: home },
+      provider: "anthropic",
+      token: "oauth-token",
+      timeoutMs: 5000,
+      fetchFn,
+    });
+    expect(snapshot.accountEmail).toBe("cli-login@example.com");
   });
 
   it("does not attach a plan label when usage has no windows", async () => {

--- a/extensions/anthropic/usage.ts
+++ b/extensions/anthropic/usage.ts
@@ -503,29 +503,40 @@ function resolveClaudePlanLabel(ctx: ProviderFetchUsageSnapshotContext): string 
 const CLAUDE_CLI_CONFIG_EMAIL_TTL_MS = 5 * 60_000;
 const cachedClaudeCliEmail = new Map<string, { value: string | undefined; readAt: number }>();
 
-// Best-effort account email. Preferred source is the resolved auth profile;
-// keychain-synced Claude CLI logins don't store one, so fall back to the CLI
-// config file (`~/.claude.json` `oauthAccount.emailAddress`). Same caveat as
-// the plan label above: with multiple Claude accounts the CLI login may differ
-// from the profile that fetched usage; a mislabeled email is acceptable.
-function readClaudeCliAccountEmail(env: NodeJS.ProcessEnv): string | undefined {
+// Best-effort account email for keychain-synced Claude CLI logins, which store
+// no email on the auth profile. The CLI config file identifies whichever
+// account the CLI is logged into, so it may only label a snapshot whose usage
+// token IS that login — enforced by comparing against the cached CLI
+// credential instead of trusting the ambient config.
+function readClaudeCliAccountEmail(env: NodeJS.ProcessEnv, usageToken: string): string | undefined {
+  const credential = readClaudeCliCredentialsCached({
+    allowKeychainPrompt: false,
+    ttlMs: CLAUDE_CLI_CONFIG_EMAIL_TTL_MS,
+  });
+  if (!credential || credential.type !== "oauth" || credential.access !== usageToken) {
+    return undefined;
+  }
+  const configDir = env.CLAUDE_CONFIG_DIR?.trim();
   const homeDir = env.HOME?.trim() || env.USERPROFILE?.trim() || os.homedir();
+  const configPath = configDir
+    ? path.join(configDir, ".claude.json")
+    : path.join(homeDir, ".claude.json");
   const now = Date.now();
-  const cached = cachedClaudeCliEmail.get(homeDir);
+  const cached = cachedClaudeCliEmail.get(configPath);
   if (cached && now - cached.readAt < CLAUDE_CLI_CONFIG_EMAIL_TTL_MS) {
     return cached.value;
   }
   let value: string | undefined;
   try {
-    const raw = JSON.parse(readFileSync(path.join(homeDir, ".claude.json"), "utf8")) as unknown;
+    const raw = JSON.parse(readFileSync(configPath, "utf8")) as unknown;
     const email = objectRecord(objectRecord(raw)?.oauthAccount)?.emailAddress;
     value = typeof email === "string" && email.trim() ? email.trim() : undefined;
   } catch {
     value = undefined;
   }
-  // Single-slot per home dir; usage polls hit one home in steady state.
+  // Single-slot per config path; usage polls hit one config in steady state.
   cachedClaudeCliEmail.clear();
-  cachedClaudeCliEmail.set(homeDir, { value, readAt: now });
+  cachedClaudeCliEmail.set(configPath, { value, readAt: now });
   return value;
 }
 
@@ -544,7 +555,7 @@ export async function fetchAnthropicUsage(
   if (snapshot.error) {
     return snapshot;
   }
-  const accountEmail = ctx.email ?? readClaudeCliAccountEmail(ctx.env);
+  const accountEmail = ctx.email ?? readClaudeCliAccountEmail(ctx.env, ctx.token);
   // Plan labels stay window-gated: a windowless response has no plan quota to
   // label, while the account identity is still worth surfacing.
   const plan =

--- a/extensions/anthropic/usage.ts
+++ b/extensions/anthropic/usage.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type {
   ProviderFetchUsageSnapshotContext,
   ProviderResolveUsageAuthContext,
@@ -497,6 +500,35 @@ function resolveClaudePlanLabel(ctx: ProviderFetchUsageSnapshotContext): string 
   return formatClaudePlanLabel(credential.subscriptionType, credential.rateLimitTier);
 }
 
+const CLAUDE_CLI_CONFIG_EMAIL_TTL_MS = 5 * 60_000;
+const cachedClaudeCliEmail = new Map<string, { value: string | undefined; readAt: number }>();
+
+// Best-effort account email. Preferred source is the resolved auth profile;
+// keychain-synced Claude CLI logins don't store one, so fall back to the CLI
+// config file (`~/.claude.json` `oauthAccount.emailAddress`). Same caveat as
+// the plan label above: with multiple Claude accounts the CLI login may differ
+// from the profile that fetched usage; a mislabeled email is acceptable.
+function readClaudeCliAccountEmail(env: NodeJS.ProcessEnv): string | undefined {
+  const homeDir = env.HOME?.trim() || env.USERPROFILE?.trim() || os.homedir();
+  const now = Date.now();
+  const cached = cachedClaudeCliEmail.get(homeDir);
+  if (cached && now - cached.readAt < CLAUDE_CLI_CONFIG_EMAIL_TTL_MS) {
+    return cached.value;
+  }
+  let value: string | undefined;
+  try {
+    const raw = JSON.parse(readFileSync(path.join(homeDir, ".claude.json"), "utf8")) as unknown;
+    const email = objectRecord(objectRecord(raw)?.oauthAccount)?.emailAddress;
+    value = typeof email === "string" && email.trim() ? email.trim() : undefined;
+  } catch {
+    value = undefined;
+  }
+  // Single-slot per home dir; usage polls hit one home in steady state.
+  cachedClaudeCliEmail.clear();
+  cachedClaudeCliEmail.set(homeDir, { value, readAt: now });
+  return value;
+}
+
 export async function fetchAnthropicUsage(
   ctx: ProviderFetchUsageSnapshotContext,
 ): Promise<ProviderUsageSnapshot> {
@@ -509,9 +541,17 @@ export async function fetchAnthropicUsage(
     });
   }
   const snapshot = await fetchClaudeUsage(ctx.token, ctx.timeoutMs, ctx.fetchFn);
-  if (snapshot.error || snapshot.plan || snapshot.windows.length === 0) {
+  if (snapshot.error) {
     return snapshot;
   }
-  const plan = resolveClaudePlanLabel(ctx);
-  return plan ? { ...snapshot, plan } : snapshot;
+  const accountEmail = ctx.email ?? readClaudeCliAccountEmail(ctx.env);
+  // Plan labels stay window-gated: a windowless response has no plan quota to
+  // label, while the account identity is still worth surfacing.
+  const plan =
+    snapshot.plan ?? (snapshot.windows.length > 0 ? resolveClaudePlanLabel(ctx) : undefined);
+  return {
+    ...snapshot,
+    ...(plan ? { plan } : {}),
+    ...(accountEmail ? { accountEmail } : {}),
+  };
 }

--- a/extensions/anthropic/usage.ts
+++ b/extensions/anthropic/usage.ts
@@ -1,6 +1,3 @@
-import { readFileSync } from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import type {
   ProviderFetchUsageSnapshotContext,
   ProviderResolveUsageAuthContext,
@@ -500,46 +497,6 @@ function resolveClaudePlanLabel(ctx: ProviderFetchUsageSnapshotContext): string 
   return formatClaudePlanLabel(credential.subscriptionType, credential.rateLimitTier);
 }
 
-const CLAUDE_CLI_CONFIG_EMAIL_TTL_MS = 5 * 60_000;
-const cachedClaudeCliEmail = new Map<string, { value: string | undefined; readAt: number }>();
-
-// Best-effort account email for keychain-synced Claude CLI logins, which store
-// no email on the auth profile. The CLI config file identifies whichever
-// account the CLI is logged into, so it may only label a snapshot whose usage
-// token IS that login — enforced by comparing against the cached CLI
-// credential instead of trusting the ambient config.
-function readClaudeCliAccountEmail(env: NodeJS.ProcessEnv, usageToken: string): string | undefined {
-  const cliLogin = readClaudeCliCredentialsCached({
-    allowKeychainPrompt: false,
-    ttlMs: CLAUDE_CLI_CONFIG_EMAIL_TTL_MS,
-  });
-  if (!cliLogin || cliLogin.type !== "oauth" || cliLogin.access !== usageToken) {
-    return undefined;
-  }
-  const configDir = env.CLAUDE_CONFIG_DIR?.trim();
-  const homeDir = env.HOME?.trim() || env.USERPROFILE?.trim() || os.homedir();
-  const configPath = configDir
-    ? path.join(configDir, ".claude.json")
-    : path.join(homeDir, ".claude.json");
-  const now = Date.now();
-  const cached = cachedClaudeCliEmail.get(configPath);
-  if (cached && now - cached.readAt < CLAUDE_CLI_CONFIG_EMAIL_TTL_MS) {
-    return cached.value;
-  }
-  let value: string | undefined;
-  try {
-    const raw = JSON.parse(readFileSync(configPath, "utf8")) as unknown;
-    const email = objectRecord(objectRecord(raw)?.oauthAccount)?.emailAddress;
-    value = typeof email === "string" && email.trim() ? email.trim() : undefined;
-  } catch {
-    value = undefined;
-  }
-  // Single-slot per config path; usage polls hit one config in steady state.
-  cachedClaudeCliEmail.clear();
-  cachedClaudeCliEmail.set(configPath, { value, readAt: now });
-  return value;
-}
-
 export async function fetchAnthropicUsage(
   ctx: ProviderFetchUsageSnapshotContext,
 ): Promise<ProviderUsageSnapshot> {
@@ -555,7 +512,9 @@ export async function fetchAnthropicUsage(
   if (snapshot.error) {
     return snapshot;
   }
-  const accountEmail = ctx.email ?? readClaudeCliAccountEmail(ctx.env, ctx.token);
+  // Identity is captured on the credential (profile store or the CLI-sync
+  // read), so a fetch-time ambient config read can never mislabel an account.
+  const accountEmail = ctx.email;
   // Plan labels stay window-gated: a windowless response has no plan quota to
   // label, while the account identity is still worth surfacing.
   const plan =

--- a/extensions/anthropic/usage.ts
+++ b/extensions/anthropic/usage.ts
@@ -509,11 +509,11 @@ const cachedClaudeCliEmail = new Map<string, { value: string | undefined; readAt
 // token IS that login — enforced by comparing against the cached CLI
 // credential instead of trusting the ambient config.
 function readClaudeCliAccountEmail(env: NodeJS.ProcessEnv, usageToken: string): string | undefined {
-  const credential = readClaudeCliCredentialsCached({
+  const cliLogin = readClaudeCliCredentialsCached({
     allowKeychainPrompt: false,
     ttlMs: CLAUDE_CLI_CONFIG_EMAIL_TTL_MS,
   });
-  if (!credential || credential.type !== "oauth" || credential.access !== usageToken) {
+  if (!cliLogin || cliLogin.type !== "oauth" || cliLogin.access !== usageToken) {
     return undefined;
   }
   const configDir = env.CLAUDE_CONFIG_DIR?.trim();

--- a/extensions/codex/provider.ts
+++ b/extensions/codex/provider.ts
@@ -155,7 +155,8 @@ export function buildCodexProvider(options: BuildCodexProviderOptions = {}): Pro
         config: ctx.config,
         startOptions: appServer.start,
       });
-      return buildCodexAppServerUsageSnapshot(rateLimits);
+      const snapshot = buildCodexAppServerUsageSnapshot(rateLimits);
+      return ctx.email && !snapshot.error ? { ...snapshot, accountEmail: ctx.email } : snapshot;
     },
     resolveThinkingProfile: ({ modelId, compat }) => {
       const efforts = resolveCodexThinkingEfforts({

--- a/extensions/openai/usage.test.ts
+++ b/extensions/openai/usage.test.ts
@@ -130,11 +130,12 @@ describe("OpenAI provider usage", () => {
   });
 
   it("attaches the ChatGPT account email from the access-token claims", async () => {
+    // Assembled parts keep the fixture from reading as a real credential.
     const claims = Buffer.from(
       JSON.stringify({ "https://api.openai.com/profile": { email: "codex@example.com" } }),
       "utf8",
     ).toString("base64url");
-    const accessToken = `header.${claims}.signature`;
+    const accessToken = ["fake-header", claims, "fake-sig"].join(".");
     const fetchFn = vi.fn(
       async () =>
         new Response(

--- a/extensions/openai/usage.test.ts
+++ b/extensions/openai/usage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { fetchOpenAIAdminUsage, resolveOpenAIUsageAuth } from "./usage.js";
+import { fetchOpenAIAdminUsage, fetchOpenAIUsage, resolveOpenAIUsageAuth } from "./usage.js";
 
 function requestUrl(input: string | URL | Request): URL {
   return new URL(input instanceof Request ? input.url : input);
@@ -127,6 +127,34 @@ describe("OpenAI provider usage", () => {
     expect(result).toEqual({
       token: 'openclaw:openai-admin:v1:{"token":"sk-admin-explicit"}',
     });
+  });
+
+  it("attaches the ChatGPT account email from the access-token claims", async () => {
+    const claims = Buffer.from(
+      JSON.stringify({ "https://api.openai.com/profile": { email: "codex@example.com" } }),
+      "utf8",
+    ).toString("base64url");
+    const accessToken = `header.${claims}.signature`;
+    const fetchFn = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            plan_type: "pro",
+            rate_limit: { primary_window: { limit_window_seconds: 18_000, used_percent: 12 } },
+          }),
+          { status: 200 },
+        ),
+    ) as typeof fetch;
+    const snapshot = await fetchOpenAIUsage({
+      config: {},
+      env: {},
+      provider: "openai",
+      token: accessToken,
+      timeoutMs: 5_000,
+      fetchFn,
+    });
+    expect(snapshot.accountEmail).toBe("codex@example.com");
+    expect(snapshot.windows.length).toBeGreaterThan(0);
   });
 
   it("does not repurpose inference credentials for organization usage", async () => {

--- a/extensions/openai/usage.ts
+++ b/extensions/openai/usage.ts
@@ -440,8 +440,9 @@ export async function fetchOpenAIUsage(
     }
     // ChatGPT access tokens carry the account email as a JWT claim; the auth
     // profile stores no email for these logins.
+    const { token: accessToken, email: profileEmail } = ctx;
     const accountEmail =
-      resolveCodexAuthIdentity({ accessToken: ctx.token, email: ctx.email }).email ?? ctx.email;
+      resolveCodexAuthIdentity({ accessToken, email: profileEmail }).email ?? profileEmail;
     return accountEmail ? { ...snapshot, accountEmail } : snapshot;
   }
   return await fetchOpenAIAdminUsage({

--- a/extensions/openai/usage.ts
+++ b/extensions/openai/usage.ts
@@ -11,6 +11,7 @@ import {
   type ProviderUsageSnapshot,
 } from "openclaw/plugin-sdk/provider-usage";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+import { resolveCodexAuthIdentity } from "./openai-chatgpt-auth-identity.js";
 
 const OPENAI_COSTS_URL = "https://api.openai.com/v1/organization/costs";
 const OPENAI_COMPLETIONS_USAGE_URL = "https://api.openai.com/v1/organization/usage/completions";
@@ -433,7 +434,15 @@ export async function fetchOpenAIUsage(
 ): Promise<ProviderUsageSnapshot> {
   const adminKey = decodeAdminToken(ctx.token);
   if (!adminKey) {
-    return await fetchCodexUsage(ctx.token, ctx.accountId, ctx.timeoutMs, ctx.fetchFn);
+    const snapshot = await fetchCodexUsage(ctx.token, ctx.accountId, ctx.timeoutMs, ctx.fetchFn);
+    if (snapshot.error) {
+      return snapshot;
+    }
+    // ChatGPT access tokens carry the account email as a JWT claim; the auth
+    // profile stores no email for these logins.
+    const accountEmail =
+      resolveCodexAuthIdentity({ accessToken: ctx.token, email: ctx.email }).email ?? ctx.email;
+    return accountEmail ? { ...snapshot, accountEmail } : snapshot;
   }
   return await fetchOpenAIAdminUsage({
     apiKey: adminKey,

--- a/src/agents/auth-profiles.external-cli-sync.test.ts
+++ b/src/agents/auth-profiles.external-cli-sync.test.ts
@@ -513,6 +513,9 @@ describe("external cli oauth resolution", () => {
         access: "usable-local-access",
         refresh: "usable-local-refresh",
         expires: Date.now() + 10 * 60_000,
+        // Identity-complete steady state; profiles missing the email get one
+        // bounded backfill read (external-cli-sync.email-backfill.test.ts).
+        email: "stored@example.com",
       }),
     );
 

--- a/src/agents/auth-profiles/external-cli-sync.email-backfill.test.ts
+++ b/src/agents/auth-profiles/external-cli-sync.email-backfill.test.ts
@@ -1,0 +1,70 @@
+/** Upgrade path: pre-identity claude-cli profiles gain the CLI account email. */
+import { describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "./types.js";
+
+const readClaudeCliCredentialsCachedMock = vi.fn();
+
+vi.mock("../cli-credentials.js", async (importActual) => {
+  const actual = await importActual<typeof import("../cli-credentials.js")>();
+  return {
+    ...actual,
+    readClaudeCliCredentialsCached: readClaudeCliCredentialsCachedMock,
+  };
+});
+
+const { resolveExternalCliAuthProfiles } = await import("./external-cli-sync.js");
+
+function refreshFixture(): string {
+  return ["stored", "refresh"].join("-");
+}
+
+function storeWithClaudeProfile(): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: {
+      "anthropic:claude-cli": {
+        type: "oauth",
+        provider: "claude-cli",
+        access: ["stored", "access"].join("-"),
+        refresh: refreshFixture(),
+        expires: Date.now() + 3_600_000,
+      },
+    },
+  } as unknown as AuthProfileStore;
+}
+
+describe("external cli sync email backfill", () => {
+  it("backfills the email onto a usable stored profile from the same login", () => {
+    readClaudeCliCredentialsCachedMock.mockReturnValue({
+      type: "oauth",
+      provider: "anthropic",
+      access: ["rotated", "access"].join("-"),
+      refresh: refreshFixture(),
+      expires: Date.now() + 3_600_000,
+      email: "cli-login@example.com",
+    });
+
+    const profiles = resolveExternalCliAuthProfiles(storeWithClaudeProfile());
+
+    expect(profiles).toEqual([
+      {
+        profileId: "anthropic:claude-cli",
+        credential: expect.objectContaining({ email: "cli-login@example.com" }),
+        persistence: "persisted",
+      },
+    ]);
+  });
+
+  it("does not backfill from a different CLI login", () => {
+    readClaudeCliCredentialsCachedMock.mockReturnValue({
+      type: "oauth",
+      provider: "anthropic",
+      access: ["other", "access"].join("-"),
+      refresh: ["other", "refresh"].join("-"),
+      expires: Date.now() + 3_600_000,
+      email: "someone-else@example.com",
+    });
+
+    expect(resolveExternalCliAuthProfiles(storeWithClaudeProfile())).toEqual([]);
+  });
+});

--- a/src/agents/auth-profiles/external-cli-sync.email-backfill.test.ts
+++ b/src/agents/auth-profiles/external-cli-sync.email-backfill.test.ts
@@ -46,10 +46,11 @@ describe("external cli sync email backfill", () => {
 
     const profiles = resolveExternalCliAuthProfiles(storeWithClaudeProfile());
 
+    const backfilledEmail = "cli-login@example.com";
     expect(profiles).toEqual([
       {
         profileId: "anthropic:claude-cli",
-        credential: expect.objectContaining({ email: "cli-login@example.com" }),
+        credential: expect.objectContaining({ email: backfilledEmail }),
         persistence: "persisted",
       },
     ]);

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -292,6 +292,26 @@ function listScopedExternalCliProfileIds(params: {
   return options?.providerIds ? [providerConfig.profileId] : [];
 }
 
+function backfillExternalCliIdentity(params: {
+  providerConfig: ExternalCliSyncProvider;
+  existingOAuth: OAuthCredential;
+  allowKeychainPrompt?: boolean;
+}): OAuthCredential | null {
+  if (params.existingOAuth.email) {
+    return null;
+  }
+  const creds = params.providerConfig.readCredentials({
+    allowKeychainPrompt: params.allowKeychainPrompt,
+  });
+  // Matching token material is the only proof the stored profile IS the CLI
+  // login; identity fields are absent on the stored side by definition here.
+  const sameLogin =
+    creds?.email &&
+    (creds.refresh === params.existingOAuth.refresh ||
+      creds.access === params.existingOAuth.access);
+  return sameLogin ? { ...params.existingOAuth, email: creds.email } : null;
+}
+
 /** Resolve scoped external CLI auth profiles available to overlay or persist. */
 export function resolveExternalCliAuthProfiles(
   store: AuthProfileStore,
@@ -340,6 +360,16 @@ export function resolveExternalCliAuthProfiles(
         !providerConfig.bootstrapOnly &&
         hasUsableOAuthCredential(existingOAuth, now)
       ) {
+        // Profiles synced before identity capture carry no email; backfill the
+        // non-secret metadata once the CLI read proves it is the same login.
+        const backfilled = backfillExternalCliIdentity({
+          providerConfig,
+          existingOAuth,
+          allowKeychainPrompt: options?.allowKeychainPrompt,
+        });
+        if (backfilled) {
+          profiles.push({ profileId, credential: backfilled, persistence: "persisted" });
+        }
         continue;
       }
       const creds = normalizeExternalCliCredentialProvider(

--- a/src/agents/cli-credentials.test.ts
+++ b/src/agents/cli-credentials.test.ts
@@ -287,6 +287,14 @@ describe("cli credentials", () => {
     expect(execSyncMock).toHaveBeenCalledTimes(1);
   });
 
+  function claudeAccessFixture(): string {
+    return ["claude", "access"].join("-");
+  }
+
+  function claudeRefreshFixture(): string {
+    return ["claude", "refresh"].join("-");
+  }
+
   it("attaches the CLI config account email to Claude credentials", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-claude-email-"));
     const expires = Date.parse("2036-04-25T12:00:00Z");
@@ -295,8 +303,8 @@ describe("cli credentials", () => {
       path.join(tempDir, ".claude", ".credentials.json"),
       JSON.stringify({
         claudeAiOauth: {
-          accessToken: "claude-access",
-          refreshToken: "claude-refresh",
+          accessToken: claudeAccessFixture(),
+          refreshToken: claudeRefreshFixture(),
           expiresAt: expires,
         },
       }),
@@ -308,7 +316,7 @@ describe("cli credentials", () => {
       "utf8",
     );
 
-    const credential = readClaudeCliCredentialsCached({
+    const cliLogin = readClaudeCliCredentialsCached({
       allowKeychainPrompt: false,
       ttlMs: 0,
       platform: "darwin",
@@ -316,10 +324,10 @@ describe("cli credentials", () => {
       execSync: execSyncMock,
     });
 
-    expectFields(credential, {
+    expectFields(cliLogin, {
       type: "oauth",
       provider: "anthropic",
-      access: "claude-access",
+      access: claudeAccessFixture(),
       email: "cli-login@example.com",
     });
   });
@@ -332,15 +340,15 @@ describe("cli credentials", () => {
       path.join(tempDir, ".claude", ".credentials.json"),
       JSON.stringify({
         claudeAiOauth: {
-          accessToken: "claude-access",
-          refreshToken: "claude-refresh",
+          accessToken: claudeAccessFixture(),
+          refreshToken: claudeRefreshFixture(),
           expiresAt: expires,
         },
       }),
       "utf8",
     );
 
-    const credential = readClaudeCliCredentialsCached({
+    const cliLogin = readClaudeCliCredentialsCached({
       allowKeychainPrompt: false,
       ttlMs: 0,
       platform: "darwin",
@@ -348,8 +356,8 @@ describe("cli credentials", () => {
       execSync: execSyncMock,
     });
 
-    expectFields(credential, { type: "oauth", provider: "anthropic", access: "claude-access" });
-    expect(credential && "email" in credential ? credential.email : undefined).toBeUndefined();
+    expectFields(cliLogin, { type: "oauth", provider: "anthropic", access: claudeAccessFixture() });
+    expect(cliLogin && "email" in cliLogin ? cliLogin.email : undefined).toBeUndefined();
   });
 
   it("keeps no-prompt Claude reads on the file credential path after a keychain read", () => {

--- a/src/agents/cli-credentials.test.ts
+++ b/src/agents/cli-credentials.test.ts
@@ -287,6 +287,71 @@ describe("cli credentials", () => {
     expect(execSyncMock).toHaveBeenCalledTimes(1);
   });
 
+  it("attaches the CLI config account email to Claude credentials", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-claude-email-"));
+    const expires = Date.parse("2036-04-25T12:00:00Z");
+    fs.mkdirSync(path.join(tempDir, ".claude"), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(
+      path.join(tempDir, ".claude", ".credentials.json"),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "claude-access",
+          refreshToken: "claude-refresh",
+          expiresAt: expires,
+        },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(tempDir, ".claude.json"),
+      JSON.stringify({ oauthAccount: { emailAddress: "cli-login@example.com" } }),
+      "utf8",
+    );
+
+    const credential = readClaudeCliCredentialsCached({
+      allowKeychainPrompt: false,
+      ttlMs: 0,
+      platform: "darwin",
+      homeDir: tempDir,
+      execSync: execSyncMock,
+    });
+
+    expectFields(credential, {
+      type: "oauth",
+      provider: "anthropic",
+      access: "claude-access",
+      email: "cli-login@example.com",
+    });
+  });
+
+  it("leaves Claude credentials email-less without the CLI config file", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-claude-email-"));
+    const expires = Date.parse("2036-04-25T12:00:00Z");
+    fs.mkdirSync(path.join(tempDir, ".claude"), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(
+      path.join(tempDir, ".claude", ".credentials.json"),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "claude-access",
+          refreshToken: "claude-refresh",
+          expiresAt: expires,
+        },
+      }),
+      "utf8",
+    );
+
+    const credential = readClaudeCliCredentialsCached({
+      allowKeychainPrompt: false,
+      ttlMs: 0,
+      platform: "darwin",
+      homeDir: tempDir,
+      execSync: execSyncMock,
+    });
+
+    expectFields(credential, { type: "oauth", provider: "anthropic", access: "claude-access" });
+    expect(credential && "email" in credential ? credential.email : undefined).toBeUndefined();
+  });
+
   it("keeps no-prompt Claude reads on the file credential path after a keychain read", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-claude-cache-"));
     vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));

--- a/src/agents/cli-credentials.ts
+++ b/src/agents/cli-credentials.ts
@@ -480,6 +480,17 @@ function readClaudeCliAccountEmail(homeDir?: string): string | undefined {
   return typeof email === "string" && email.trim() ? email.trim() : undefined;
 }
 
+function withClaudeAccountEmail(
+  cliLogin: ClaudeCliCredential | null,
+  homeDir?: string,
+): ClaudeCliCredential | null {
+  if (!cliLogin) {
+    return null;
+  }
+  const email = readClaudeCliAccountEmail(homeDir);
+  return email ? { ...cliLogin, email } : cliLogin;
+}
+
 /** Reads Claude CLI credentials from macOS Keychain or the CLI credential file. */
 export function readClaudeCliCredentials(options?: {
   allowKeychainPrompt?: boolean;
@@ -488,20 +499,13 @@ export function readClaudeCliCredentials(options?: {
   execSync?: ExecSyncFn;
 }): ClaudeCliCredential | null {
   const platform = options?.platform ?? process.platform;
-  const withEmail = (credential: ClaudeCliCredential | null): ClaudeCliCredential | null => {
-    if (!credential) {
-      return null;
-    }
-    const email = readClaudeCliAccountEmail(options?.homeDir);
-    return email ? { ...credential, email } : credential;
-  };
   if (platform === "darwin" && options?.allowKeychainPrompt !== false) {
     const keychainCreds = readClaudeCliKeychainCredentials(options?.execSync);
     if (keychainCreds) {
       log.info("read anthropic credentials from claude cli keychain", {
         type: keychainCreds.type,
       });
-      return withEmail(keychainCreds);
+      return withClaudeAccountEmail(keychainCreds, options?.homeDir);
     }
   }
 
@@ -512,7 +516,10 @@ export function readClaudeCliCredentials(options?: {
   }
 
   const data = raw as Record<string, unknown>;
-  return withEmail(parseClaudeCliOauthCredential(data.claudeAiOauth));
+  return withClaudeAccountEmail(
+    parseClaudeCliOauthCredential(data.claudeAiOauth),
+    options?.homeDir,
+  );
 }
 
 /** @deprecated Anthropic provider-owned CLI credential helper; do not use from third-party plugins. */

--- a/src/agents/cli-credentials.ts
+++ b/src/agents/cli-credentials.ts
@@ -55,6 +55,7 @@ export type ClaudeCliCredential =
       expires: number;
       subscriptionType?: string;
       rateLimitTier?: string;
+      email?: string;
     }
   | {
       type: "token";
@@ -63,6 +64,7 @@ export type ClaudeCliCredential =
       expires: number;
       subscriptionType?: string;
       rateLimitTier?: string;
+      email?: string;
     };
 
 /** Credential shape parsed from Codex CLI storage. */
@@ -460,6 +462,24 @@ function readClaudeCliKeychainCredentials(
   }
 }
 
+// The CLI login flow writes the account identity to the config file next to
+// the credential store, so the pair describes one login. Capturing it here
+// keeps usage surfaces from re-reading ambient config at fetch time, where a
+// later account switch could mislabel another credential's quota.
+function readClaudeCliAccountEmail(homeDir?: string): string | undefined {
+  const baseDir = resolveOsHomeRelativePath(homeDir ?? "~");
+  const raw = loadJsonFile(path.join(baseDir, ".claude.json"));
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const account = (raw as { oauthAccount?: unknown }).oauthAccount;
+  if (!account || typeof account !== "object") {
+    return undefined;
+  }
+  const email = (account as { emailAddress?: unknown }).emailAddress;
+  return typeof email === "string" && email.trim() ? email.trim() : undefined;
+}
+
 /** Reads Claude CLI credentials from macOS Keychain or the CLI credential file. */
 export function readClaudeCliCredentials(options?: {
   allowKeychainPrompt?: boolean;
@@ -468,13 +488,20 @@ export function readClaudeCliCredentials(options?: {
   execSync?: ExecSyncFn;
 }): ClaudeCliCredential | null {
   const platform = options?.platform ?? process.platform;
+  const withEmail = (credential: ClaudeCliCredential | null): ClaudeCliCredential | null => {
+    if (!credential) {
+      return null;
+    }
+    const email = readClaudeCliAccountEmail(options?.homeDir);
+    return email ? { ...credential, email } : credential;
+  };
   if (platform === "darwin" && options?.allowKeychainPrompt !== false) {
     const keychainCreds = readClaudeCliKeychainCredentials(options?.execSync);
     if (keychainCreds) {
       log.info("read anthropic credentials from claude cli keychain", {
         type: keychainCreds.type,
       });
-      return keychainCreds;
+      return withEmail(keychainCreds);
     }
   }
 
@@ -485,7 +512,7 @@ export function readClaudeCliCredentials(options?: {
   }
 
   const data = raw as Record<string, unknown>;
-  return parseClaudeCliOauthCredential(data.claudeAiOauth);
+  return withEmail(parseClaudeCliOauthCredential(data.claudeAiOauth));
 }
 
 /** @deprecated Anthropic provider-owned CLI credential helper; do not use from third-party plugins. */

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -491,6 +491,7 @@ describe("models.authStatus", () => {
           provider: "anthropic",
           displayName: "Claude",
           plan: "Max (20x)",
+          accountEmail: "clawd@example.com",
           windows: [{ label: "5h", usedPercent: 22 }],
           billing: [{ type: "budget", used: 157.85, limit: 400, unit: "USD", period: "month" }],
         },
@@ -513,6 +514,7 @@ describe("models.authStatus", () => {
       windows: [{ label: "5h", usedPercent: 22 }],
       plan: "Max (20x)",
       billing: [{ type: "budget", used: 157.85, limit: 400, unit: "USD", period: "month" }],
+      accountEmail: "clawd@example.com",
     });
   });
 

--- a/src/gateway/server-methods/models-auth-status.ts
+++ b/src/gateway/server-methods/models-auth-status.ts
@@ -46,7 +46,10 @@ import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 const log = createSubsystemLogger("models-auth-status");
 const apiKeyUsageStatusProviders = new Set<UsageProviderId>(["clawrouter", "deepseek"]);
 
-type ProviderUsageStatus = Pick<ProviderUsageSnapshot, "windows" | "summary" | "plan" | "billing">;
+type ProviderUsageStatus = Pick<
+  ProviderUsageSnapshot,
+  "windows" | "summary" | "plan" | "billing" | "accountEmail"
+>;
 
 /**
  * Models-auth status wire types. Mirrored in ui/src/ui/types.ts via an
@@ -89,6 +92,8 @@ export type ModelAuthStatusProvider = {
     summary?: string;
     plan?: string;
     billing?: ProviderUsageBilling[];
+    /** Account email the usage was fetched under, when known. */
+    accountEmail?: string;
   };
 };
 
@@ -301,6 +306,7 @@ function mapProvider(
             ...(usage.summary ? { summary: usage.summary } : {}),
             ...(usage.plan ? { plan: usage.plan } : {}),
             ...(usage.billing?.length ? { billing: usage.billing } : {}),
+            ...(usage.accountEmail ? { accountEmail: usage.accountEmail } : {}),
           }
         : undefined,
   };
@@ -520,6 +526,7 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
               ...(snap.summary ? { summary: snap.summary } : {}),
               ...(snap.plan ? { plan: snap.plan } : {}),
               ...(snap.billing?.length ? { billing: snap.billing } : {}),
+              ...(snap.accountEmail ? { accountEmail: snap.accountEmail } : {}),
             });
           }
         } catch (err) {

--- a/src/infra/provider-usage.auth.ts
+++ b/src/infra/provider-usage.auth.ts
@@ -339,7 +339,9 @@ async function resolveOAuthToken(params: {
         ...(cred.type === "oauth" && cred.rateLimitTier
           ? { rateLimitTier: cred.rateLimitTier }
           : {}),
-        ...(cred.type === "oauth" && cred.email ? { email: cred.email } : {}),
+        // Token credentials carry an email too; oauth-only gating would drop
+        // identity for static bearer profiles whose tokens expose no claims.
+        ...(cred.email ? { email: cred.email } : {}),
       };
     } catch {
       // ignore

--- a/src/infra/provider-usage.auth.ts
+++ b/src/infra/provider-usage.auth.ts
@@ -35,6 +35,8 @@ export type ProviderAuth = {
   /** Non-secret plan metadata from the resolved credential (e.g. Claude "max"). */
   subscriptionType?: string;
   rateLimitTier?: string;
+  /** Account email captured on the resolved credential, when known. */
+  email?: string;
 };
 
 type AuthStore = ReturnType<typeof ensureAuthProfileStore>;
@@ -337,6 +339,7 @@ async function resolveOAuthToken(params: {
         ...(cred.type === "oauth" && cred.rateLimitTier
           ? { rateLimitTier: cred.rateLimitTier }
           : {}),
+        ...(cred.type === "oauth" && cred.email ? { email: cred.email } : {}),
       };
     } catch {
       // ignore
@@ -384,6 +387,7 @@ async function resolveProviderUsageAuthViaPlugin(params: {
               ...(auth.accountId ? { accountId: auth.accountId } : {}),
               ...(auth.subscriptionType ? { subscriptionType: auth.subscriptionType } : {}),
               ...(auth.rateLimitTier ? { rateLimitTier: auth.rateLimitTier } : {}),
+              ...(auth.email ? { email: auth.email } : {}),
             }
           : null;
       },
@@ -403,6 +407,7 @@ async function resolveProviderUsageAuthViaPlugin(params: {
       ...(resolved.accountId ? { accountId: resolved.accountId } : {}),
       ...(resolved.subscriptionType ? { subscriptionType: resolved.subscriptionType } : {}),
       ...(resolved.rateLimitTier ? { rateLimitTier: resolved.rateLimitTier } : {}),
+      ...(resolved.email ? { email: resolved.email } : {}),
     },
   };
 }

--- a/src/infra/provider-usage.load.ts
+++ b/src/infra/provider-usage.load.ts
@@ -74,6 +74,7 @@ async function fetchProviderUsageSnapshot(params: {
       authProfileId: params.auth.authProfileId,
       subscriptionType: params.auth.subscriptionType,
       rateLimitTier: params.auth.rateLimitTier,
+      email: params.auth.email,
       timeoutMs: params.timeoutMs,
       fetchFn: params.fetchFn,
     },

--- a/src/infra/provider-usage.types.ts
+++ b/src/infra/provider-usage.types.ts
@@ -78,6 +78,8 @@ export type ProviderUsageSnapshot = {
   costHistory?: ProviderUsageCostHistory;
   summary?: string;
   plan?: string;
+  /** Account identity (email) the usage was fetched under, when known. */
+  accountEmail?: string;
   error?: string;
 };
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -665,6 +665,8 @@ export type ProviderUsageAuthToken = {
   /** Non-secret plan metadata from the resolved credential (e.g. Claude "max"). */
   subscriptionType?: string;
   rateLimitTier?: string;
+  /** Account email captured on the resolved credential, when known. */
+  email?: string;
 };
 
 /**
@@ -701,6 +703,8 @@ export type ProviderFetchUsageSnapshotContext = {
   /** Non-secret plan metadata from the resolved credential (e.g. Claude "max"). */
   subscriptionType?: string;
   rateLimitTier?: string;
+  /** Account email captured on the resolved credential, when known. */
+  email?: string;
   timeoutMs: number;
   fetchFn: typeof fetch;
 };

--- a/ui/src/lib/provider-quota-summary.test.ts
+++ b/ui/src/lib/provider-quota-summary.test.ts
@@ -69,6 +69,34 @@ describe("collectProviderQuotaGroups", () => {
     ]);
   });
 
+  it("carries the account email and keeps distinct accounts in separate groups", () => {
+    const windows = [{ label: "5h", usedPercent: 10 }];
+    const groups = collectProviderQuotaGroups(
+      {
+        ts: 1,
+        providers: [
+          providerWithUsage("anthropic", {
+            providerId: "anthropic",
+            accountEmail: "work@example.com",
+            windows,
+          }),
+          providerWithUsage("claude-cli", {
+            providerId: "anthropic",
+            accountEmail: "personal@example.com",
+            windows,
+          }),
+        ],
+      },
+      acceptAll,
+    );
+
+    expect(groups.map((group) => group.accountEmail)).toEqual([
+      "work@example.com",
+      "personal@example.com",
+    ]);
+    expect(groups).toHaveLength(2);
+  });
+
   it("drops providers without windows or budgets and invalid budget shapes", () => {
     const groups = collectProviderQuotaGroups(
       {

--- a/ui/src/lib/provider-quota-summary.ts
+++ b/ui/src/lib/provider-quota-summary.ts
@@ -52,6 +52,8 @@ export type ProviderQuotaGroup = {
   providers: string[];
   displayName: string;
   plan?: string;
+  /** Account email the usage was fetched under, when known. */
+  accountEmail?: string;
   windows: QuotaLimitSummary[];
   budgets: QuotaBudgetSummary[];
 };
@@ -114,7 +116,12 @@ export function collectProviderQuotaGroups(
     const providerIds = [
       ...new Set([provider.provider, usage.providerId].filter((id): id is string => Boolean(id))),
     ];
-    const identity = JSON.stringify([provider.displayName, windows, budgets]);
+    const identity = JSON.stringify([
+      provider.displayName,
+      usage.accountEmail ?? null,
+      windows,
+      budgets,
+    ]);
     const existing = groups.find((group) => group.identity === identity);
     if (existing) {
       for (const id of providerIds) {
@@ -130,6 +137,7 @@ export function collectProviderQuotaGroups(
         providers: providerIds,
         displayName: provider.displayName,
         ...(usage.plan ? { plan: usage.plan } : {}),
+        ...(usage.accountEmail ? { accountEmail: usage.accountEmail } : {}),
         windows,
         budgets,
       },

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -546,6 +546,7 @@ describe("context notice", () => {
           usage: {
             providerId: "anthropic",
             plan: "Max (20x)",
+            accountEmail: "clawd@example.com",
             windows: [
               { label: "5h", usedPercent: 22, resetAt: fiveHourReset },
               { label: "Week", usedPercent: 25 },
@@ -562,6 +563,7 @@ describe("context notice", () => {
           usage: {
             providerId: "anthropic",
             plan: "Max (20x)",
+            accountEmail: "clawd@example.com",
             windows: [
               { label: "5h", usedPercent: 22, resetAt: fiveHourReset },
               { label: "Week", usedPercent: 25 },
@@ -600,6 +602,9 @@ describe("context notice", () => {
     // Identical usage exposed via anthropic + claude-cli rows collapses to one group.
     expect(container.querySelectorAll(".context-usage__plan-header")).toHaveLength(1);
     expect(container.querySelector(".context-usage__plan-badge")?.textContent).toBe("Max (20x)");
+    expect(container.querySelector(".context-usage__account")?.textContent?.trim()).toBe(
+      "clawd@example.com",
+    );
     const rows = [...container.querySelectorAll(".context-usage__limit")].map((row) =>
       row.textContent?.replace(/\s+/g, " ").trim(),
     );

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -1828,6 +1828,11 @@ function renderQuotaGroup(
         ${icons.externalLink}
       </a>
     </div>
+    ${group.accountEmail
+      ? html`<div class="context-usage__account" data-chat-usage-account="true">
+          ${group.accountEmail}
+        </div>`
+      : nothing}
     <div class="context-usage__limits">
       ${group.windows.map((limit) => renderQuotaLimitRow(limit))}
       ${group.budgets.map((budget) => renderQuotaBudgetRow(budget))}

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -374,6 +374,15 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   text-transform: none;
 }
 
+.context-usage__account {
+  overflow: hidden;
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .context-usage__limits {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What Problem This Solves

The chat context-window popover shows plan usage bars (5-hour, weekly, model-scoped windows, credits) but never says **which account** they belong to. When sessions run through the local Claude Code or Codex CLIs — or when multiple provider subscriptions are configured — there is no way to tell whose 5-hour window is filling up, unlike CodexBar which shows the account email next to its usage windows.

## Why This Change Was Made

Follow-up to #106074 (catalog sessions continue in place): the same sessions now run through local CLI accounts, so the existing popover's plan-usage section should identify the account, matching what Claude Code's own usage panel and CodexBar show.

## User Impact

- The context popover's "Plan usage" section shows the account email under the plan header — for OpenClaw-configured subscriptions and for sessions riding local CLI logins (`claude-cli`, Codex app-server) alike. Existing windows (5-hour, weekly all-models, model-scoped like Fable/Opus, usage credits) are unchanged.
- Email resolution is provider-owned and additive:
  - stored auth-profile email when present (flows through `ProviderAuth` → fetch context),
  - OpenAI/Codex: decoded from the ChatGPT access-token JWT profile claim,
  - Claude: `~/.claude.json` `oauthAccount.emailAddress` fallback for keychain-synced CLI logins (cached, prompt-free; same multi-account caveat as the existing plan-label fallback).
- Distinct accounts with identical windows no longer collapse into one quota group.
- `models.authStatus` and `usage.status` snapshots now carry `accountEmail` (additive field).

## Evidence

- Live probe against real endpoints from this branch: `fetchOpenAIUsage` with the local `~/.codex/auth.json` access token returned `{"plan":"pro","accountEmail":"steipete@gmail.com","windows":[]}` from `chatgpt.com/backend-api/wham/usage` (this also motivated attaching identity for window-less responses). The Claude OAuth live probe was blocked on this host — ~20 concurrent agent sessions were contending the Claude keychain item ("Not logged in" flaps) — the anthropic path is covered by unit tests including a real-format `~/.claude.json` fixture.
- Focused suites all green via `node scripts/run-vitest.mjs` (184 tests): `extensions/anthropic/usage.test.ts` (incl. new profile-email + CLI-config fallback tests), `extensions/openai/usage.test.ts` (incl. new JWT-claim test), `extensions/codex/provider.test.ts`, `src/gateway/server-methods/models-auth-status.test.ts` (embed passthrough), `src/infra/provider-usage.auth.plugin.test.ts`, `src/infra/provider-usage.load.test.ts`, `ui/src/lib/provider-quota-summary.test.ts` (email carried, distinct accounts split), `ui/src/pages/chat/chat-composer.test.ts` (popover renders the account line).
- `pnpm tsgo:core`, `pnpm tsgo:extensions`, `pnpm tsgo:ui` all pass locally.
