### PR TITLE
fix: consolidate duplicate imports from the same module

### DIFF
--- a/src/infra/event-session-routing.ts
+++ b/src/infra/event-session-routing.ts
@@ -9,8 +9,9 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
   parseThreadSessionSuffix,
+  resolveEventSessionKey,
+  scopedHeartbeatWakeOptions,
 } from "../routing/session-key.js";
-import { resolveEventSessionKey, scopedHeartbeatWakeOptions } from "../routing/session-key.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../security/dm-policy-shared.js";
 import { deriveSessionChatTypeFromKey } from "../sessions/session-chat-type-shared.js";
 

--- a/src/infra/kysely-sync.ts
+++ b/src/infra/kysely-sync.ts
@@ -1,7 +1,12 @@
 // Adapts node:sqlite sync database calls for Kysely-style query execution.
 import type { DatabaseSync, SQLInputValue } from "node:sqlite";
-import type { CompiledQuery, Kysely, QueryResult } from "kysely";
-import { InsertQueryNode, Kysely as KyselyInstance } from "kysely";
+import {
+  type CompiledQuery,
+  InsertQueryNode,
+  type Kysely,
+  Kysely as KyselyInstance,
+  type QueryResult,
+} from "kysely";
 import { NodeSqliteKyselyDialect } from "./kysely-node-sqlite.js";
 
 // Sync query helpers execute compiled Kysely SQL against node:sqlite without

--- a/src/infra/restart-handoff.test.ts
+++ b/src/infra/restart-handoff.test.ts
@@ -16,10 +16,10 @@ import {
 import {
   formatGatewayRestartHandoffDiagnostic,
   GATEWAY_SUPERVISOR_RESTART_HANDOFF_KIND,
+  type GatewayRestartHandoff,
   readGatewayRestartHandoffSync,
   writeGatewayRestartHandoffSync,
 } from "./restart-handoff.js";
-import type { GatewayRestartHandoff } from "./restart-handoff.js";
 
 const tempDirs: string[] = [];
 type GatewayRestartHandoffDatabase = Pick<OpenClawStateKyselyDatabase, "gateway_restart_handoff">;

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -6,8 +6,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import type { NormalizedUsage, UsageLike } from "../agents/usage.js";
-import { normalizeUsage } from "../agents/usage.js";
+import { type NormalizedUsage, normalizeUsage, type UsageLike } from "../agents/usage.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import {
   materializeSessionArchiveForRead,

--- a/src/infra/state-migrations.session-roundtrip.test.ts
+++ b/src/infra/state-migrations.session-roundtrip.test.ts
@@ -11,8 +11,10 @@
  */
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { canonicalizeMainSessionAlias } from "../config/sessions/main-session.js";
-import { resolveMainSessionKey } from "../config/sessions/main-session.js";
+import {
+  canonicalizeMainSessionAlias,
+  resolveMainSessionKey,
+} from "../config/sessions/main-session.js";
 import { resolveSessionKey } from "../config/sessions/session-key.js";
 import { resolveCronAgentSessionKey } from "../cron/isolated-agent/session-key.js";
 import { resolveSessionStoreKey } from "../gateway/session-store-key.js";

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -22,8 +22,7 @@ import {
   resolveOAuthDir,
   resolveStateDir,
 } from "../config/paths.js";
-import type { SessionEntry } from "../config/sessions.js";
-import { saveSessionStore } from "../config/sessions.js";
+import { type SessionEntry, saveSessionStore } from "../config/sessions.js";
 import { canonicalizeMainSessionAlias } from "../config/sessions/main-session.js";
 import { resolveAgentsDirFromSessionStorePath } from "../config/sessions/paths.js";
 import { normalizePersistedSessionEntryShape } from "../config/sessions/store-entry-shape.js";

--- a/src/plugin-state/plugin-state-store.ts
+++ b/src/plugin-state/plugin-state-store.ts
@@ -13,15 +13,15 @@ import {
   pluginStateRegisterIfAbsent,
   pluginStateUpdate,
 } from "./plugin-state-store.sqlite.js";
-import type {
-  OpenKeyedStoreOptions,
-  PluginStateEntry,
-  PluginStateKeyedStore,
-  PluginStateSyncKeyedStore,
-  PluginStateOverflowPolicy,
-  PluginStateStoreOperation,
+import {
+  type OpenKeyedStoreOptions,
+  type PluginStateEntry,
+  type PluginStateKeyedStore,
+  type PluginStateSyncKeyedStore,
+  type PluginStateOverflowPolicy,
+  type PluginStateStoreOperation,
+  PluginStateStoreError,
 } from "./plugin-state-store.types.js";
-import { PluginStateStoreError } from "./plugin-state-store.types.js";
 
 // Public plugin-state facade over the sqlite-backed store. It validates plugin
 // ids, namespaces, JSON values, TTLs, and per-plugin limits before persistence.


### PR DESCRIPTION
## What Problem This Solves

Seven files had separate `import` / `import type` statements for the same module, which duplicates the module specifier and adds unnecessary lines. Consolidating them into a single combined import statement reduces noise and follows existing codebase conventions (10+ files already use combined `import { type X, Y }` style).

## Evidence

TypeScript's `import { type A, b }` syntax is functionally equivalent to separate `import type { A }` + `import { b }` statements. The change is purely cosmetic — no runtime or type-checking behavior changes.

- `npx tsc --noEmit` — no new errors (existing codebase errors unchanged)
- `npx vitest run` on affected test files — 3 passed, 3 failed due to unrelated Node/SQLite version incompatibility

## Merge Risk

None. This is a purely mechanical refactor with zero semantic impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)