### PR TITLE
fix(ci): refresh generated locale metadata

### DIFF
--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:08.861Z",
+  "generatedAt": "2026-07-13T09:01:53.352Z",
   "locale": "ar",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:06.016Z",
+  "generatedAt": "2026-07-13T09:01:51.574Z",
   "locale": "de",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:06.393Z",
+  "generatedAt": "2026-07-13T09:01:51.855Z",
   "locale": "es",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:19.374Z",
+  "generatedAt": "2026-07-13T09:01:55.962Z",
   "locale": "fa",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:07.850Z",
+  "generatedAt": "2026-07-13T09:01:52.733Z",
   "locale": "fr",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/hi.meta.json
+++ b/ui/src/i18n/.i18n/hi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:08.469Z",
+  "generatedAt": "2026-07-13T09:01:53.053Z",
   "locale": "hi",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:11.608Z",
+  "generatedAt": "2026-07-13T09:01:54.510Z",
   "locale": "id",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:09.240Z",
+  "generatedAt": "2026-07-13T09:01:53.635Z",
   "locale": "it",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:06.895Z",
+  "generatedAt": "2026-07-13T09:01:52.149Z",
   "locale": "ja-JP",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:07.392Z",
+  "generatedAt": "2026-07-13T09:01:52.433Z",
   "locale": "ko",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:18.775Z",
+  "generatedAt": "2026-07-13T09:01:55.678Z",
   "locale": "nl",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:13.094Z",
+  "generatedAt": "2026-07-13T09:01:54.802Z",
   "locale": "pl",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:05.623Z",
+  "generatedAt": "2026-07-13T09:01:51.291Z",
   "locale": "pt-BR",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ru.meta.json
+++ b/ui/src/i18n/.i18n/ru.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:19.866Z",
+  "generatedAt": "2026-07-13T09:01:56.270Z",
   "locale": "ru",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:15.582Z",
+  "generatedAt": "2026-07-13T09:01:55.105Z",
   "locale": "th",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:09.659Z",
+  "generatedAt": "2026-07-13T09:01:53.913Z",
   "locale": "tr",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:10.335Z",
+  "generatedAt": "2026-07-13T09:01:54.206Z",
   "locale": "uk",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:17.598Z",
+  "generatedAt": "2026-07-13T09:01:55.393Z",
   "locale": "vi",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:04.516Z",
+  "generatedAt": "2026-07-13T09:01:50.687Z",
   "locale": "zh-CN",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T08:35:05.137Z",
+  "generatedAt": "2026-07-13T09:01:50.985Z",
   "locale": "zh-TW",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0fdccd7259e966cccecab2ed147ca3b9f11f3cab854faced3049cb819d119eef",
-  "totalKeys": 3112,
-  "translatedKeys": 3112,
+  "sourceHash": "04d248d028a9ce039ca74aaa5c618e81020e22b9128d61efa20e0f258b833632",
+  "totalKeys": 3091,
+  "translatedKeys": 3091,
   "workflow": 1
 }


### PR DESCRIPTION
## What Problem This Solves

PR #105904 changed the generated locale key set without refreshing the 20 locale metadata files. Main commit `a8ae27fd354` has already removed the duplicate `automations.runNotStarted` blocks, but `control-ui-i18n` still reports every non-English locale dirty because the recorded source hash and key counts are stale.

## Why This Change Was Made

Run the canonical locale sync after the duplicate-block repair and commit its only remaining output: refreshed metadata for all 20 locales. The sync produced zero fallbacks and did not rewrite any locale bundle.

## User Impact

Restores the Control UI i18n gate without changing runtime copy or translation coverage.

## Evidence

- AWS Crabbox `cbx_c9743861f2fd`: canonical `pnpm ui:i18n:sync` produced exactly 20 metadata files with zero fallbacks
- Blacksmith Testbox `tbx_01kxdbf4qryg8q436xvd80jnzr`: `pnpm ui:i18n:check && pnpm tsgo:prod` passed, exit 0; backing run https://github.com/openclaw/openclaw/actions/runs/29237627398
- `git diff --check` passed
- Fresh full-branch autoreview: clean, no accepted/actionable findings

No changelog: generated-output CI repair only.
