### PR TITLE
test(gateway): isolate live-event sweep assertion

### DIFF
--- a/src/gateway/worker-environments/live-events.test.ts
+++ b/src/gateway/worker-environments/live-events.test.ts
@@ -493,7 +493,9 @@ describe("worker live events", () => {
 
   it.each([RUN, "run-sibling"])("resyncs after a swept context before %s", (runId) => {
     ack(msg(1, "before"));
-    expect(sweepStaleRunContexts(-1)).toBe(1);
+    expect(getAgentRunContext(RUN)).toBeDefined();
+    sweepStaleRunContexts(-1);
+    expect(getAgentRunContext(RUN)).toBeUndefined();
     fail(msg(2, "stale", 1, runId), "resync-required");
     ack(msg(1, "fresh", 0, runId));
     expect(deltas()).toEqual(["before", "fresh"]);

--- a/test/non-isolated-runner.test.ts
+++ b/test/non-isolated-runner.test.ts
@@ -281,6 +281,87 @@ it("clears session suspension state between files", async () => {
   }
 });
 
+it("clears agent run registry state between files", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-run-registry-runner-"));
+  try {
+    const write = (name: string, content: string) =>
+      fs.writeFile(path.join(root, name), content, "utf-8");
+    const agentRunRegistryPath = JSON.stringify(
+      path.join(repoRoot, "src", "infra", "agent-run-registry.ts"),
+    );
+    const sharedVitestConfigPath = JSON.stringify(
+      path.join(repoRoot, "test", "vitest", "vitest.shared.config.ts"),
+    );
+    await fs.symlink(
+      path.join(repoRoot, "node_modules"),
+      path.join(root, "node_modules"),
+      "junction",
+    );
+    await write(
+      "a-seed.test.ts",
+      [
+        `import { getAgentRunContext, registerAgentRunContext } from ${agentRunRegistryPath};`,
+        'import { expect, it } from "vitest";',
+        'it("seeds process-global run contexts", () => {',
+        '  registerAgentRunContext("unrelated-run-a", { sessionKey: "session-a" });',
+        '  registerAgentRunContext("unrelated-run-b", { sessionKey: "session-b" });',
+        '  expect(getAgentRunContext("unrelated-run-a")).toBeDefined();',
+        '  expect(getAgentRunContext("unrelated-run-b")).toBeDefined();',
+        "});",
+        "",
+      ].join("\n"),
+    );
+    await write(
+      "b-observe.test.ts",
+      [
+        `import { getAgentRunContext, registerAgentRunContext, sweepStaleRunContexts } from ${agentRunRegistryPath};`,
+        'import { expect, it } from "vitest";',
+        'it("sweeps only its own target context", () => {',
+        '  registerAgentRunContext("target-run", { sessionKey: "target-session" });',
+        "  expect(sweepStaleRunContexts(-1)).toBe(1);",
+        '  expect(getAgentRunContext("target-run")).toBeUndefined();',
+        "});",
+        "",
+      ].join("\n"),
+    );
+    await write(
+      "vitest.config.ts",
+      [
+        `import { sharedVitestConfig } from ${sharedVitestConfigPath};`,
+        'import { defineConfig } from "vitest/config";',
+        'import { BaseSequencer } from "vitest/node";',
+        "class AlphabeticalSequencer extends BaseSequencer {",
+        '  override async sort(files: Parameters<BaseSequencer["sort"]>[0]) {',
+        "    return [...files].sort((a, b) => a.moduleId.localeCompare(b.moduleId));",
+        "  }",
+        "}",
+        "export default defineConfig({",
+        `  cacheDir: ${JSON.stringify(path.join(root, ".vite"))},`,
+        "  resolve: sharedVitestConfig.resolve,",
+        "  test: {",
+        "    isolate: false,",
+        "    fileParallelism: false,",
+        "    maxWorkers: 1,",
+        "    sequence: { sequencer: AlphabeticalSequencer },",
+        `    runner: ${JSON.stringify(path.join(repoRoot, "test", "non-isolated-runner.ts"))},`,
+        "  },",
+        "});",
+        "",
+      ].join("\n"),
+    );
+
+    const vitestEntry = path.join(repoRoot, "node_modules", "vitest", "vitest.mjs");
+    const result = await execFileAsync(
+      process.execPath,
+      [vitestEntry, "run", "--root", root, "--config", path.join(root, "vitest.config.ts")],
+      { cwd: repoRoot, env: childEnv(), maxBuffer: 16 * 1024 * 1024 },
+    );
+    expect(`${result.stdout}\n${result.stderr}`).toContain("2 passed");
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
 it("disposes embedded-agent SQLite state before running the next file", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sqlite-lifecycle-runner-"));
   const orderLogPath = path.join(root, "order.log");

--- a/test/non-isolated-runner.test.ts
+++ b/test/non-isolated-runner.test.ts
@@ -289,6 +289,7 @@ it("clears agent run registry state between files", async () => {
     const agentRunRegistryPath = JSON.stringify(
       path.join(repoRoot, "src", "infra", "agent-run-registry.ts"),
     );
+    const agentEventsPath = JSON.stringify(path.join(repoRoot, "src", "infra", "agent-events.ts"));
     const sharedVitestConfigPath = JSON.stringify(
       path.join(repoRoot, "test", "vitest", "vitest.shared.config.ts"),
     );
@@ -301,12 +302,19 @@ it("clears agent run registry state between files", async () => {
       "a-seed.test.ts",
       [
         `import { getAgentRunContext, registerAgentRunContext } from ${agentRunRegistryPath};`,
+        `import { emitAgentEvent, onAgentEvent } from ${agentEventsPath};`,
         'import { expect, it } from "vitest";',
         'it("seeds process-global run contexts", () => {',
         '  registerAgentRunContext("unrelated-run-a", { sessionKey: "session-a" });',
         '  registerAgentRunContext("unrelated-run-b", { sessionKey: "session-b" });',
+        '  registerAgentRunContext("reused-run", { sessionKey: "reused-session" });',
+        "  let sequence;",
+        "  const unsubscribe = onAgentEvent((event) => { sequence = event.seq; });",
+        '  emitAgentEvent({ runId: "reused-run", stream: "assistant", data: {} });',
+        "  unsubscribe();",
         '  expect(getAgentRunContext("unrelated-run-a")).toBeDefined();',
         '  expect(getAgentRunContext("unrelated-run-b")).toBeDefined();',
+        "  expect(sequence).toBe(1);",
         "});",
         "",
       ].join("\n"),
@@ -314,9 +322,17 @@ it("clears agent run registry state between files", async () => {
     await write(
       "b-observe.test.ts",
       [
-        `import { getAgentRunContext, registerAgentRunContext, sweepStaleRunContexts } from ${agentRunRegistryPath};`,
+        `import { clearAgentRunContext, getAgentRunContext, registerAgentRunContext, sweepStaleRunContexts } from ${agentRunRegistryPath};`,
+        `import { emitAgentEvent, onAgentEvent } from ${agentEventsPath};`,
         'import { expect, it } from "vitest";',
-        'it("sweeps only its own target context", () => {',
+        'it("restarts sequence state and sweeps only its own target context", () => {',
+        '  registerAgentRunContext("reused-run", { sessionKey: "reused-session" });',
+        "  let sequence;",
+        "  const unsubscribe = onAgentEvent((event) => { sequence = event.seq; });",
+        '  emitAgentEvent({ runId: "reused-run", stream: "assistant", data: {} });',
+        "  unsubscribe();",
+        "  expect(sequence).toBe(1);",
+        '  clearAgentRunContext("reused-run");',
         '  registerAgentRunContext("target-run", { sessionKey: "target-session" });',
         "  expect(sweepStaleRunContexts(-1)).toBe(1);",
         '  expect(getAgentRunContext("target-run")).toBeUndefined();',

--- a/test/non-isolated-runner.ts
+++ b/test/non-isolated-runner.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { TestRunner, type RunnerTask, type RunnerTestFile, vi } from "vitest";
+import { resetAgentRunRegistryForTest } from "../src/infra/agent-run-registry.js";
 import { clearNamedPluginRuntimeStoresForTest } from "../src/plugin-sdk/runtime-store-registry.js";
 
 type EvaluatedModuleNode = {
@@ -374,6 +375,7 @@ export default class OpenClawNonIsolatedRunner extends TestRunner {
     restoreSharedTestHomeAfterEnvUnstub(testHome);
     vi.clearAllMocks();
     resetOpenClawGlobalRunState();
+    resetAgentRunRegistryForTest();
     resetOpenClawGlobalDiagnosticState();
     resetOpenClawSessionSuspensionState();
     // Named plugin runtimes intentionally survive duplicate module evaluation in production.

--- a/test/non-isolated-runner.ts
+++ b/test/non-isolated-runner.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { TestRunner, type RunnerTask, type RunnerTestFile, vi } from "vitest";
-import { resetAgentRunRegistryForTest } from "../src/infra/agent-run-registry.js";
+import { resetAgentEventsForTest } from "../src/infra/agent-events.js";
 import { clearNamedPluginRuntimeStoresForTest } from "../src/plugin-sdk/runtime-store-registry.js";
 
 type EvaluatedModuleNode = {
@@ -375,7 +375,7 @@ export default class OpenClawNonIsolatedRunner extends TestRunner {
     restoreSharedTestHomeAfterEnvUnstub(testHome);
     vi.clearAllMocks();
     resetOpenClawGlobalRunState();
-    resetAgentRunRegistryForTest();
+    resetAgentEventsForTest();
     resetOpenClawGlobalDiagnosticState();
     resetOpenClawSessionSuspensionState();
     // Named plugin runtimes intentionally survive duplicate module evaluation in production.


### PR DESCRIPTION
## What Problem This Solves

The non-isolated Vitest runner cleared active embedded/reply runs between files but left the process-global agent event state intact. A later worker live-event test could therefore inherit both unrelated run contexts and sequence counters from earlier files: its global sweep assertion observed three contexts instead of one, and a reused run ID resumed at sequence two instead of one.

## Why This Change Was Made

The agent-event owner already exposes `resetAgentEventsForTest()`, which clears per-run sequence state and delegates registry cleanup to `resetAgentRunRegistryForTest()`. The runner now invokes that canonical owner reset at its existing per-file lifecycle boundary.

The live-event regression checks that its specific run context exists before the sweep and is gone afterward instead of treating the global removal count as its contract. The ordered runner regression seeds unrelated contexts and emits sequence one in file A; file B reuses the same run ID, requires sequence one again, and proves that only its own target remains to sweep.

## User Impact

No runtime behavior changes. Non-isolated test files no longer inherit stale agent-event sequencing or run contexts, and the worker live-event regression now asserts only the run it owns.

## Evidence

- Bug on current main before the repair: `src/gateway/worker-environments/live-events.test.ts:496` asserted the global result of `sweepStaleRunContexts(-1)` was exactly one.
- Before registry cleanup, `node scripts/run-vitest.mjs test/non-isolated-runner.test.ts -t 'clears agent run registry state between files'` failed in the ordered child run: file B expected one swept target and received three.
- Before the final event-owner cleanup, the same ordered regression reused one run ID and failed with expected sequence one / received sequence two.
- After the final fix, the identical ordered regression passed 1/1.
- Full focused proof passed: `node scripts/run-vitest.mjs src/gateway/worker-environments/live-events.test.ts test/non-isolated-runner.test.ts src/infra/agent-events.test.ts` — 5/5 runner tests, 34/34 live-event tests, and 46/46 agent-event tests.
- `node scripts/check-changed.mjs` passed on the final checkout in 20m47s, including core-test/test-root typechecks, formatting, all selected lint shards, dead-code, dependency, boundary, and ratchet guards.
- `git diff --check` passed.
- Codex-backed autoreview was clean after the initial repair and again after the sequence-state follow-up, with no accepted/actionable findings.
- Production LOC: +0/-0. Tests/test infrastructure: +102/-1.
- The latest completed ClawSweeper rank-up requests are covered: the branch was rebased before proof, and the exact cross-file contaminated execution order is a checked-in regression with both failure modes and passing output above.
- Exact-head hosted CI passed: https://github.com/openclaw/openclaw/actions/runs/31311677106
