### PR TITLE
fix(pr): review all changed files in large PRs

### DIFF
--- a/scripts/pr-lib/review.sh
+++ b/scripts/pr-lib/review.sh
@@ -496,9 +496,10 @@ review_init() {
   local pr="$1"
   enter_worktree "$pr" true
 
-  local json
+  local json pr_url
   json=$(pr_meta_json "$pr")
   write_pr_meta_files "$json"
+  pr_url=$(printf '%s\n' "$json" | jq -r .url)
 
   git fetch origin "pull/$pr/head:pr-$pr" --force
   local mb
@@ -512,9 +513,9 @@ review_init() {
     > .local/review-context.env
   set_review_mode main
 
-  printf '%s\n' "$json" | jq '{number,title,url,state,isDraft,author:.author.login,base:.baseRefName,head:.headRefName,headSha:.headRefOid,headRepo:.headRepository.nameWithOwner,additions,deletions,files:(.files|length)}'
+  printf '%s\n' "$json" | jq '{number,title,url,state,isDraft,author:.author.login,base:.baseRefName,head:.headRefName,headSha:.headRefOid,headRepo:.headRepository.nameWithOwner,additions,deletions,files:.changedFiles}'
   echo "worktree=$PWD"
-  echo "pr_url=${PR_URL:-}"
+  echo "pr_url=$pr_url"
   echo "merge_base=$mb"
   echo "branch=$(git branch --show-current)"
   echo "wrote=.local/pr-meta.json .local/pr-meta.env .local/review-context.env .local/review-mode.env"

--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -62,7 +62,43 @@ enter_worktree() {
 
 pr_meta_json() {
   local pr="$1"
-  gh pr view "$pr" --json number,title,state,isDraft,author,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,url,body,labels,assignees,reviewRequests,files,additions,deletions,statusCheckRollup
+  local metadata files expected_file_count actual_file_count head_before head_after
+  metadata=$(gh pr view "$pr" --json number,title,state,isDraft,author,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,url,body,labels,assignees,reviewRequests,changedFiles,additions,deletions,statusCheckRollup)
+  head_before=$(printf '%s\n' "$metadata" | jq -r .headRefOid)
+
+  # Raw `gh pr view --json files` stops at 100 entries. Paginate REST so
+  # review guards see every path, then fail closed on head or API drift.
+  files=$(
+    gh api --paginate "repos/{owner}/{repo}/pulls/$pr/files?per_page=100" |
+      jq -cs '
+        add
+        | map({
+            path: .filename,
+            additions: .additions,
+            deletions: .deletions,
+            changeType: (
+              if .status == "removed" then "DELETED"
+              else (.status | ascii_upcase)
+              end
+            )
+          })
+      '
+  )
+
+  head_after=$(gh pr view "$pr" --json headRefOid | jq -r .headRefOid)
+  if [ "$head_after" != "$head_before" ]; then
+    echo "PR head changed while collecting file metadata for #$pr (started at $head_before, ended at $head_after). Retry review initialization." >&2
+    return 1
+  fi
+
+  expected_file_count=$(printf '%s\n' "$metadata" | jq -r .changedFiles)
+  actual_file_count=$(printf '%s\n' "$files" | jq 'length')
+  if [ "$actual_file_count" -ne "$expected_file_count" ]; then
+    echo "Incomplete PR file metadata for #$pr: expected $expected_file_count changed files, received $actual_file_count from paginated REST." >&2
+    return 1
+  fi
+
+  printf '%s\n%s\n' "$metadata" "$files" | jq -cs '.[0] + {files: .[1]}'
 }
 
 write_pr_meta_files() {

--- a/test/scripts/pr-metadata.test.ts
+++ b/test/scripts/pr-metadata.test.ts
@@ -1,0 +1,116 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const tempDirs: string[] = [];
+
+function createFakeGh(): string {
+  const dir = mkdtempSync(join(tmpdir(), "openclaw-pr-metadata-"));
+  const gh = join(dir, "gh");
+  tempDirs.push(dir);
+  writeFileSync(
+    gh,
+    `#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  if [[ "$*" == *changedFiles* ]]; then
+    printf '{"number":42,"url":"https://example.test/pr/42","headRefOid":"head-a","changedFiles":%s}\n' "\${FAKE_CHANGED_FILES:-101}"
+  else
+    printf '{"headRefOid":"%s"}\n' "\${FAKE_HEAD_AFTER:-head-a}"
+  fi
+  exit 0
+fi
+
+if [ "$1" = "api" ] && [ "$2" = "--paginate" ]; then
+  [ "$3" = 'repos/{owner}/{repo}/pulls/42/files?per_page=100' ] || { echo "unexpected endpoint: $3" >&2; exit 4; }
+  jq -nc '[range(0; 100) | {filename: ("src/file-" + (tostring) + ".ts"), status: "modified", additions: 1, deletions: 0}]'
+  jq -nc '[{filename: "src/file-100.ts", status: "removed", additions: 0, deletions: 1}]'
+  exit 0
+fi
+
+echo "unexpected gh command: $*" >&2
+exit 2
+`,
+  );
+  chmodSync(gh, 0o755);
+  return dir;
+}
+
+function readPrMetadata(
+  fakeGhDir: string,
+  options: { changedFiles?: string; headAfter?: string } = {},
+) {
+  return spawnSync(
+    "bash",
+    ["-c", "set -euo pipefail; source scripts/pr-lib/worktree.sh; pr_meta_json 42"],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        FAKE_CHANGED_FILES: options.changedFiles ?? "101",
+        FAKE_HEAD_AFTER: options.headAfter ?? "head-a",
+        PATH: `${fakeGhDir}:${process.env.PATH}`,
+      },
+      encoding: "utf8",
+    },
+  );
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("PR metadata", () => {
+  it("paginates all changed files and preserves the GraphQL file shape", () => {
+    const result = readPrMetadata(createFakeGh());
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    const metadata = JSON.parse(result.stdout) as {
+      changedFiles: number;
+      files: Array<{
+        path: string;
+        additions: number;
+        deletions: number;
+        changeType: string;
+      }>;
+    };
+    expect(metadata.changedFiles).toBe(101);
+    expect(metadata.files).toHaveLength(101);
+    expect(metadata.files[0]).toEqual({
+      path: "src/file-0.ts",
+      additions: 1,
+      deletions: 0,
+      changeType: "MODIFIED",
+    });
+    expect(metadata.files[100]).toEqual({
+      path: "src/file-100.ts",
+      additions: 0,
+      deletions: 1,
+      changeType: "DELETED",
+    });
+  });
+
+  it("rejects incomplete paginated file metadata", () => {
+    const result = readPrMetadata(createFakeGh(), { changedFiles: "102" });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Incomplete PR file metadata for #42: expected 102 changed files, received 101 from paginated REST.",
+    );
+  });
+
+  it("rejects files collected while the PR head changes", () => {
+    const result = readPrMetadata(createFakeGh(), { headAfter: "head-b" });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "PR head changed while collecting file metadata for #42 (started at head-a, ended at head-b). Retry review initialization.",
+    );
+  });
+});


### PR DESCRIPTION
Related: #105937

## What Problem This Solves

Fixes an issue where maintainers reviewing PRs with more than 100 changed files could receive incomplete path metadata. During #105937, `scripts/pr review-init` reported 100 files for a 342-file PR, so path-based behavioral-review guards could miss runtime files beyond the first page. The command also printed an empty PR URL.

## Why This Change Was Made

The PR helper now paginates the changed-files REST endpoint, preserves the existing file metadata shape, and verifies both the PR head SHA and expected file count before accepting the result. Any force-push, API cap, or incomplete page set fails closed. Review initialization prints the URL captured in the same metadata snapshot.

## User Impact

No product runtime impact. Maintainers can review large PRs with complete changed-file coverage, accurate counts, and a usable PR link.

AI-assisted: yes (Codex). I reviewed the complete patch and understand the changes.

## Evidence

- Before: raw GitHub CLI metadata for #105937 reported `changedFiles: 342` but returned only 100 entries in `files`; `review-init` printed an empty `pr_url`.
- After: a live `pr_meta_json 105937` probe returned 342/342 paths, from `scripts/deadcode-exports.baseline.mjs` through `test/scripts/test-live-shard.test.ts`.
- Blacksmith Testbox run [29237199694](https://github.com/openclaw/openclaw/actions/runs/29237199694): `pnpm test test/scripts/pr-metadata.test.ts` — 3/3 passed on exact head `05f75b8bdecc2d44c4a401193756a471b3c12eaa`.
- Regression coverage: multi-page collection, incomplete-page rejection, and PR-head-change rejection.
- `bash -n scripts/pr-lib/worktree.sh scripts/pr-lib/review.sh`
- `git diff --check`
- Fresh structured autoreview: clean, no accepted/actionable findings.
