### PR TITLE
refactor(ui): remove dead export seams

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -2954,7 +2954,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "ui/src/app/overlays.ts: ApplicationOverlaySnapshot",
   "ui/src/app/settings.ts: isViteDevPage",
   "ui/src/app/settings.ts: NAV_WIDTH_DEFAULT",
-  "ui/src/app/settings.ts: resetUnpersistedSettingsForTest",
   "ui/src/app/stale-chunk-reload.ts: resetStaleChunkReloadStateForTest",
   "ui/src/build-info.ts: deriveControlUiBuildId",
   "ui/src/build-info.ts: normalizeControlUiBranch",

--- a/ui/src/app/settings.node.test.ts
+++ b/ui/src/app/settings.node.test.ts
@@ -6,7 +6,6 @@ import {
   loadLocalUserIdentity,
   loadSettings,
   persistSessionToken,
-  resetUnpersistedSettingsForTest,
   resolvePageGatewaySettings,
   resolveApplicationStartupSettings,
   saveSettings,
@@ -106,7 +105,6 @@ describe("resolveApplicationStartupSettings", () => {
 
 describe("loadSettings default gateway URL derivation", () => {
   beforeEach(() => {
-    resetUnpersistedSettingsForTest();
     vi.stubGlobal("localStorage", createStorageMock());
     vi.stubGlobal("sessionStorage", createStorageMock());
     vi.stubGlobal("navigator", { language: "en-US" } as Navigator);
@@ -116,8 +114,12 @@ describe("loadSettings default gateway URL derivation", () => {
   });
 
   afterEach(() => {
-    resetUnpersistedSettingsForTest();
     vi.restoreAllMocks();
+    vi.stubGlobal("localStorage", createStorageMock());
+    vi.stubGlobal("sessionStorage", createStorageMock());
+    vi.stubGlobal("navigator", { language: "en-US" } as Navigator);
+    setTestLocation({ protocol: "https:", host: "gateway.example", pathname: "/" });
+    saveSettings(loadSettings());
     setControlUiBasePath(undefined);
     vi.unstubAllGlobals();
   });

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -494,10 +494,6 @@ export function persistSessionToken(gatewayUrl: string, token: string) {
 // another page re-reads storage in the same tab.
 let unpersistedSettings: UiSettings | null = null;
 
-export function resetUnpersistedSettingsForTest() {
-  unpersistedSettings = null;
-}
-
 export function loadSettings(): UiSettings {
   const cached = unpersistedSettings;
   if (cached) {

--- a/ui/src/pages/chat/chat-realtime.test.ts
+++ b/ui/src/pages/chat/chat-realtime.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
-import { loadSettings, resetUnpersistedSettingsForTest, saveSettings } from "../../app/settings.ts";
+import { loadSettings, saveSettings } from "../../app/settings.ts";
 import {
   attachChatRealtimeActions,
   createInitialChatRealtimeState,
@@ -42,7 +42,6 @@ describe("chat realtime actions", () => {
   let startSpy: MockInstance<RealtimeTalkSession["start"]>;
 
   beforeEach(() => {
-    resetUnpersistedSettingsForTest();
     vi.stubGlobal("localStorage", window.localStorage);
     localStorage.clear();
     startSpy = vi.spyOn(RealtimeTalkSession.prototype, "start").mockResolvedValue(undefined);
@@ -50,8 +49,9 @@ describe("chat realtime actions", () => {
   });
 
   afterEach(() => {
-    resetUnpersistedSettingsForTest();
     vi.restoreAllMocks();
+    saveSettings(loadSettings());
+    localStorage.clear();
     vi.unstubAllGlobals();
   });
 


### PR DESCRIPTION
## What Problem This Solves

Production-mode Knip still sees the Control UI's test-only settings reset helper as a dead export. Two types originally included in this cleanup were independently privatized on `main`, so this corrected branch keeps only the remaining settings seam.

Follow-up to #105595. Related: #106221 and #106242.

## Why This Change Was Made

- Removed the test-only settings reset export.
- Kept test isolation through the real successful `saveSettings` path, with browser globals restored before teardown cleanup.
- Regenerated the production dead-export baseline immediately before push.
- Re-cut the branch from current `main` to remove the previous synthetic ancestry and unrelated files.

AI-assisted implementation and review.

## User Impact

No intended user-visible behavior change. Production behavior stays unchanged; the internal UI export surface and shrink-only ratchet baseline are smaller.

No changelog entry: internal cleanup only.

## Evidence

- Exact pushed-head Blacksmith Testbox `tbx_01kxdhm0vv502evf058n3kg8kz`: final baseline regeneration was byte-identical, `deadcode:exports` matched exactly 3,293 entries, and 33/33 focused UI tests passed; Actions run https://github.com/openclaw/openclaw/actions/runs/29244173475.
- Baseline shrank by one entry.
- `git diff --check` and targeted `oxfmt --check`: passed.
- Final post-rebase autoreview: clean, no accepted/actionable findings.
