### PR TITLE
feat(ui): dismissible sidebar attention chips

### DIFF
--- a/ui/src/components/sidebar-attention-dismissals.ts
+++ b/ui/src/components/sidebar-attention-dismissals.ts
@@ -1,0 +1,89 @@
+// Per-gateway, per-browser snooze state for the sidebar attention chips.
+// Deliberately client-side chrome (like nav width / dock layout), not gateway
+// state: dismissing a nag on one device should not acknowledge it everywhere.
+import { normalizeGatewayTokenScope } from "../app/gateway-scope.ts";
+import { getSafeLocalStorage } from "../local-storage.ts";
+
+const SIDEBAR_ATTENTION_KINDS = [
+  "cronFailed",
+  "cronOverdue",
+  "modelAuthExpired",
+  "modelAuthExpiring",
+] as const;
+export type SidebarAttentionKind = (typeof SIDEBAR_ATTENTION_KINDS)[number];
+
+export type SidebarAttentionDismissals = Partial<Record<SidebarAttentionKind, string>>;
+
+// Minimal chip shape the snooze logic needs; keeps this module free of the
+// component's item type so the two files cannot form an import cycle.
+type DismissableChip = { kind: SidebarAttentionKind; signature: string };
+
+const DISMISSED_STORE_PREFIX = "openclaw.control.sidebarAttention.v1:";
+
+function dismissedStoreKey(gatewayUrl: string): string {
+  return `${DISMISSED_STORE_PREFIX}${normalizeGatewayTokenScope(gatewayUrl)}`;
+}
+
+export function loadDismissals(gatewayUrl: string): SidebarAttentionDismissals {
+  const storage = getSafeLocalStorage();
+  if (!storage) {
+    return {};
+  }
+  try {
+    const parsed: unknown = JSON.parse(storage.getItem(dismissedStoreKey(gatewayUrl)) ?? "null");
+    if (!parsed || typeof parsed !== "object") {
+      return {};
+    }
+    const result: SidebarAttentionDismissals = {};
+    for (const kind of SIDEBAR_ATTENTION_KINDS) {
+      const value = (parsed as Record<string, unknown>)[kind];
+      if (typeof value === "string") {
+        result[kind] = value;
+      }
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+export function saveDismissals(gatewayUrl: string, dismissals: SidebarAttentionDismissals) {
+  const storage = getSafeLocalStorage();
+  if (!storage) {
+    return;
+  }
+  try {
+    if (Object.keys(dismissals).length === 0) {
+      storage.removeItem(dismissedStoreKey(gatewayUrl));
+    } else {
+      storage.setItem(dismissedStoreKey(gatewayUrl), JSON.stringify(dismissals));
+    }
+  } catch {
+    // Quota/privacy-mode failures just lose the snooze; chips reappear.
+  }
+}
+
+/**
+ * Drop dismissals whose chip is gone or whose entity set changed, so a state
+ * that clears and later recurs surfaces again instead of staying hidden by a
+ * stale snooze. Returns the input object when nothing changed.
+ */
+export function pruneDismissals(
+  dismissals: SidebarAttentionDismissals,
+  items: readonly DismissableChip[],
+): SidebarAttentionDismissals {
+  const next: SidebarAttentionDismissals = {};
+  let changed = false;
+  for (const kind of SIDEBAR_ATTENTION_KINDS) {
+    const stored = dismissals[kind];
+    if (stored === undefined) {
+      continue;
+    }
+    if (items.some((item) => item.kind === kind && item.signature === stored)) {
+      next[kind] = stored;
+    } else {
+      changed = true;
+    }
+  }
+  return changed ? next : dismissals;
+}

--- a/ui/src/components/sidebar-attention-dismissals.ts
+++ b/ui/src/components/sidebar-attention-dismissals.ts
@@ -20,7 +20,7 @@ type DismissableChip = { kind: SidebarAttentionKind; signature: string };
 
 const DISMISSED_STORE_PREFIX = "openclaw.control.sidebarAttention.v1:";
 
-function dismissedStoreKey(gatewayUrl: string): string {
+export function dismissalStoreKey(gatewayUrl: string): string {
   return `${DISMISSED_STORE_PREFIX}${normalizeGatewayTokenScope(gatewayUrl)}`;
 }
 
@@ -30,7 +30,7 @@ export function loadDismissals(gatewayUrl: string): SidebarAttentionDismissals {
     return {};
   }
   try {
-    const parsed: unknown = JSON.parse(storage.getItem(dismissedStoreKey(gatewayUrl)) ?? "null");
+    const parsed: unknown = JSON.parse(storage.getItem(dismissalStoreKey(gatewayUrl)) ?? "null");
     if (!parsed || typeof parsed !== "object") {
       return {};
     }
@@ -54,13 +54,28 @@ export function saveDismissals(gatewayUrl: string, dismissals: SidebarAttentionD
   }
   try {
     if (Object.keys(dismissals).length === 0) {
-      storage.removeItem(dismissedStoreKey(gatewayUrl));
+      storage.removeItem(dismissalStoreKey(gatewayUrl));
     } else {
-      storage.setItem(dismissedStoreKey(gatewayUrl), JSON.stringify(dismissals));
+      storage.setItem(dismissalStoreKey(gatewayUrl), JSON.stringify(dismissals));
     }
   } catch {
     // Quota/privacy-mode failures just lose the snooze; chips reappear.
   }
+}
+
+/**
+ * Record one dismissal via read-merge-write against the persisted map, not a
+ * caller-held snapshot: another tab may have dismissed a different chip since
+ * this tab last loaded, and a blind write would drop that entry.
+ */
+export function addDismissal(
+  gatewayUrl: string,
+  kind: SidebarAttentionKind,
+  signature: string,
+): SidebarAttentionDismissals {
+  const next = { ...loadDismissals(gatewayUrl), [kind]: signature };
+  saveDismissals(gatewayUrl, next);
+  return next;
 }
 
 /**

--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -2,7 +2,11 @@
 
 import { describe, expect, it } from "vitest";
 import type { CronJob, ModelAuthStatusResult } from "../api/types.ts";
-import { buildSidebarAttentionItems } from "./sidebar-attention.ts";
+import {
+  buildSidebarAttentionItems,
+  pruneDismissals,
+  type SidebarAttentionItem,
+} from "./sidebar-attention.ts";
 
 const NOW = 1_750_000_000_000;
 
@@ -34,18 +38,25 @@ describe("buildSidebarAttentionItems", () => {
   it("flags enabled failing cron jobs but not disabled ones", () => {
     const items = buildSidebarAttentionItems({
       cronJobs: [
-        cronJob({ state: { lastRunStatus: "error" } as CronJob["state"] }),
-        cronJob({ enabled: false, state: { lastRunStatus: "error" } as CronJob["state"] }),
+        cronJob({ id: "beta", state: { lastRunStatus: "error" } as CronJob["state"] }),
+        cronJob({ id: "alpha", state: { lastRunStatus: "error" } as CronJob["state"] }),
+        cronJob({
+          id: "off",
+          enabled: false,
+          state: { lastRunStatus: "error" } as CronJob["state"],
+        }),
       ],
       modelAuthStatus: null,
       now: NOW,
     });
     expect(items).toEqual([
       {
+        kind: "cronFailed",
         severity: "error",
         icon: "clock",
-        label: "1 cron job(s) failed",
+        label: "2 cron job(s) failed",
         routeId: "cron",
+        signature: "alpha\nbeta",
       },
     ]);
   });
@@ -53,19 +64,25 @@ describe("buildSidebarAttentionItems", () => {
   it("flags overdue jobs only past the grace window", () => {
     const items = buildSidebarAttentionItems({
       cronJobs: [
-        cronJob({ state: { nextRunAtMs: NOW - 400_000 } as CronJob["state"] }),
-        cronJob({ state: { nextRunAtMs: NOW - 100_000 } as CronJob["state"] }),
-        cronJob({ enabled: false, state: { nextRunAtMs: NOW - 400_000 } as CronJob["state"] }),
+        cronJob({ id: "late", state: { nextRunAtMs: NOW - 400_000 } as CronJob["state"] }),
+        cronJob({ id: "soon", state: { nextRunAtMs: NOW - 100_000 } as CronJob["state"] }),
+        cronJob({
+          id: "off",
+          enabled: false,
+          state: { nextRunAtMs: NOW - 400_000 } as CronJob["state"],
+        }),
       ],
       modelAuthStatus: null,
       now: NOW,
     });
     expect(items).toEqual([
       {
+        kind: "cronOverdue",
         severity: "warning",
         icon: "clock",
         label: "1 cron job(s) overdue",
         routeId: "cron",
+        signature: "late",
       },
     ]);
   });
@@ -99,17 +116,53 @@ describe("buildSidebarAttentionItems", () => {
     });
     expect(items).toEqual([
       {
+        kind: "modelAuthExpired",
         severity: "error",
         icon: "plug",
         label: "Model auth expired: Codex",
         routeId: "model-providers",
+        signature: "openai",
       },
       {
+        kind: "modelAuthExpiring",
         severity: "warning",
         icon: "plug",
         label: "Model auth expiring: Claude (6d)",
         routeId: "model-providers",
+        signature: "anthropic",
       },
     ]);
+  });
+});
+
+describe("pruneDismissals", () => {
+  const chip = (
+    kind: SidebarAttentionItem["kind"],
+    signature: string,
+  ): SidebarAttentionItem => ({
+    kind,
+    severity: "error",
+    icon: "clock",
+    label: kind,
+    routeId: "cron",
+    signature,
+  });
+
+  it("keeps a dismissal while the same entity set is still affected", () => {
+    const dismissals = { cronFailed: "alpha\nbeta" };
+    expect(pruneDismissals(dismissals, [chip("cronFailed", "alpha\nbeta")])).toBe(dismissals);
+  });
+
+  it("drops a dismissal when the affected set changes so the chip resurfaces", () => {
+    expect(
+      pruneDismissals(
+        { cronFailed: "alpha", modelAuthExpired: "openai" },
+        [chip("cronFailed", "alpha\nbeta"), chip("modelAuthExpired", "openai")],
+      ),
+    ).toEqual({ modelAuthExpired: "openai" });
+  });
+
+  it("drops a dismissal once the underlying state clears", () => {
+    expect(pruneDismissals({ cronFailed: "alpha" }, [])).toEqual({});
   });
 });

--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -1,8 +1,13 @@
 /* @vitest-environment jsdom */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CronJob, ModelAuthStatusResult } from "../api/types.ts";
-import { pruneDismissals, type SidebarAttentionKind } from "./sidebar-attention-dismissals.ts";
+import {
+  addDismissal,
+  dismissalStoreKey,
+  pruneDismissals,
+  type SidebarAttentionKind,
+} from "./sidebar-attention-dismissals.ts";
 import { buildSidebarAttentionItems } from "./sidebar-attention.ts";
 
 const NOW = 1_750_000_000_000;
@@ -151,5 +156,38 @@ describe("pruneDismissals", () => {
 
   it("drops a dismissal once the underlying state clears", () => {
     expect(pruneDismissals({ cronFailed: "alpha" }, [])).toEqual({});
+  });
+});
+
+describe("addDismissal", () => {
+  function createStorageMock(): Storage {
+    const map = new Map<string, string>();
+    return {
+      get length() {
+        return map.size;
+      },
+      clear: () => map.clear(),
+      getItem: (key: string) => map.get(key) ?? null,
+      key: (index: number) => [...map.keys()][index] ?? null,
+      removeItem: (key: string) => void map.delete(key),
+      setItem: (key: string, value: string) => void map.set(key, String(value)),
+    };
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("merges with the persisted map so another tab's dismissal survives", () => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    const key = dismissalStoreKey("ws://gateway.test");
+    // Another tab dismissed a cron chip after this tab last loaded.
+    localStorage.setItem(key, JSON.stringify({ cronFailed: "alpha" }));
+
+    const next = addDismissal("ws://gateway.test", "modelAuthExpired", "openai");
+
+    const expected = { cronFailed: "alpha", modelAuthExpired: "openai" };
+    expect(next).toEqual(expected);
+    expect(JSON.parse(localStorage.getItem(key) ?? "null")).toEqual(expected);
   });
 });

--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -170,7 +170,7 @@ describe("addDismissal", () => {
       getItem: (key: string) => map.get(key) ?? null,
       key: (index: number) => [...map.keys()][index] ?? null,
       removeItem: (key: string) => void map.delete(key),
-      setItem: (key: string, value: string) => void map.set(key, String(value)),
+      setItem: (key: string, value: string) => void map.set(key, value),
     };
   }
 

--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -2,11 +2,8 @@
 
 import { describe, expect, it } from "vitest";
 import type { CronJob, ModelAuthStatusResult } from "../api/types.ts";
-import {
-  buildSidebarAttentionItems,
-  pruneDismissals,
-  type SidebarAttentionItem,
-} from "./sidebar-attention.ts";
+import { pruneDismissals, type SidebarAttentionKind } from "./sidebar-attention-dismissals.ts";
+import { buildSidebarAttentionItems } from "./sidebar-attention.ts";
 
 const NOW = 1_750_000_000_000;
 
@@ -136,17 +133,7 @@ describe("buildSidebarAttentionItems", () => {
 });
 
 describe("pruneDismissals", () => {
-  const chip = (
-    kind: SidebarAttentionItem["kind"],
-    signature: string,
-  ): SidebarAttentionItem => ({
-    kind,
-    severity: "error",
-    icon: "clock",
-    label: kind,
-    routeId: "cron",
-    signature,
-  });
+  const chip = (kind: SidebarAttentionKind, signature: string) => ({ kind, signature });
 
   it("keeps a dismissal while the same entity set is still affected", () => {
     const dismissals = { cronFailed: "alpha\nbeta" };
@@ -155,10 +142,10 @@ describe("pruneDismissals", () => {
 
   it("drops a dismissal when the affected set changes so the chip resurfaces", () => {
     expect(
-      pruneDismissals(
-        { cronFailed: "alpha", modelAuthExpired: "openai" },
-        [chip("cronFailed", "alpha\nbeta"), chip("modelAuthExpired", "openai")],
-      ),
+      pruneDismissals({ cronFailed: "alpha", modelAuthExpired: "openai" }, [
+        chip("cronFailed", "alpha\nbeta"),
+        chip("modelAuthExpired", "openai"),
+      ]),
     ).toEqual({ modelAuthExpired: "openai" });
   });
 

--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -84,7 +84,7 @@ describe("buildSidebarAttentionItems", () => {
         icon: "clock",
         label: "1 cron job(s) overdue",
         routeId: "cron",
-        signature: "late",
+        signature: `late@${NOW - 400_000}`,
       },
     ]);
   });

--- a/ui/src/components/sidebar-attention.ts
+++ b/ui/src/components/sidebar-attention.ts
@@ -42,9 +42,15 @@ export type SidebarAttentionItem = {
   icon: IconName;
   label: string;
   routeId: NavigationRouteId;
-  // Sorted ids of the entities behind the chip. A dismissal stores this
-  // signature so the chip stays hidden only while the same set is affected;
-  // any change (new job/provider) resurfaces it.
+  // Sorted identities of the entities behind the chip. A dismissal stores
+  // this signature so the chip stays hidden only while the same incident set
+  // is affected; any change (new job/provider, new overdue run) resurfaces
+  // it. Failed-cron and auth chips key on entity ids alone on purpose: a
+  // persistently failing job gets a new lastRunAtMs every schedule tick, and
+  // short-lived OAuth tokens (e.g. Copilot) roll expiry continuously — either
+  // in the signature would resurface a dismissed chip within minutes. The
+  // cost is that a recover-then-recur cycle nobody observed stays snoozed;
+  // pruneAfterRefresh re-arms as soon as any tab sees the cleared state.
   signature: string;
 };
 
@@ -80,7 +86,10 @@ export function buildSidebarAttentionItems(params: {
       icon: "clock",
       label: t("attention.cronOverdue", { count: String(overdueCron.length) }),
       routeId: "cron",
-      signature: signatureOf(overdueCron.map((job) => job.id)),
+      // nextRunAtMs is the incident identity: stable while a job stays stuck,
+      // new once it runs again and later goes overdue anew — so a fresh
+      // overdue episode resurfaces even if no tab observed the recovery.
+      signature: signatureOf(overdueCron.map((job) => `${job.id}@${job.state?.nextRunAtMs}`)),
     });
   }
 
@@ -225,19 +234,20 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
     ]);
     if (isCurrent()) {
       this.loadedAtMs = Date.now();
+      this.pruneAfterRefresh();
     }
   }
 
-  // Re-arm stale snoozes after each data refresh. Runs against loaded data
-  // only: the empty pre-load snapshot must not wipe dismissals for chips that
-  // are still true on the gateway. A failed auth-status fetch (null) prunes
-  // auth snoozes, which fails safe — the chip re-nags instead of staying
-  // hidden.
-  override updated() {
-    if (this.loadedAtMs === 0 || !this.dismissedScope) {
-      return;
-    }
-    if (!this.context?.gateway.snapshot.connected) {
+  // Re-arm stale snoozes only right after this tab's own data refresh: fresh
+  // data is the only safe basis for deciding a chip is gone. Pruning from
+  // render/update hooks would let a hidden tab with stale data clobber a
+  // dismissal another tab just wrote (its storage event triggers an update
+  // here). Against the persisted map, not the in-memory snapshot, for the
+  // same lost-update reason as addDismissal. A failed fetch (empty cron list,
+  // null auth status) prunes those kinds, which fails safe — re-nag, never
+  // stay hidden.
+  private pruneAfterRefresh() {
+    if (!this.dismissedScope) {
       return;
     }
     const items = buildSidebarAttentionItems({
@@ -245,16 +255,12 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
       modelAuthStatus: this.modelAuthStatus,
       now: Date.now(),
     });
-    // Prune against the persisted map, not the in-memory snapshot, so a
-    // concurrent dismissal from another tab is not dropped by this write.
     const stored = loadDismissals(this.dismissedScope);
     const pruned = pruneDismissals(stored, items);
     if (pruned !== stored) {
       saveDismissals(this.dismissedScope, pruned);
     }
-    if (JSON.stringify(pruned) !== JSON.stringify(this.dismissed)) {
-      this.dismissed = pruned;
-    }
+    this.dismissed = pruned;
   }
 
   private dismiss(item: SidebarAttentionItem) {

--- a/ui/src/components/sidebar-attention.ts
+++ b/ui/src/components/sidebar-attention.ts
@@ -130,7 +130,7 @@ export function buildSidebarAttentionItems(params: {
   now: number;
 }): SidebarAttentionItem[] {
   const items: SidebarAttentionItem[] = [];
-  const signatureOf = (ids: readonly string[]) => [...ids].sort().join("\n");
+  const signatureOf = (ids: readonly string[]) => ids.toSorted().join("\n");
 
   const failedCron = params.cronJobs.filter(isCronJobActiveFailure);
   if (failedCron.length > 0) {

--- a/ui/src/components/sidebar-attention.ts
+++ b/ui/src/components/sidebar-attention.ts
@@ -10,14 +10,19 @@ import type { CronJob, ModelAuthStatusResult } from "../api/types.ts";
 import type { NavigationRouteId } from "../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../app/context.ts";
 import { t } from "../i18n/index.ts";
-import { normalizeGatewayTokenScope } from "../app/gateway-scope.ts";
 import { isCronJobActiveFailure } from "../lib/cron-status.ts";
 import { createInitialCronState, loadCronJobsPage } from "../lib/cron/index.ts";
 import { isMonitoredAuthProvider, loadModelAuthStatus } from "../lib/model-auth.ts";
-import { getSafeLocalStorage } from "../local-storage.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { icons, type IconName } from "./icons.ts";
+import {
+  loadDismissals,
+  pruneDismissals,
+  saveDismissals,
+  type SidebarAttentionDismissals,
+  type SidebarAttentionKind,
+} from "./sidebar-attention-dismissals.ts";
 
 // A cron job counts as overdue when its next planned run is this far in the
 // past; mirrors the threshold the Overview attention list used.
@@ -28,14 +33,6 @@ const VISIBILITY_REFRESH_MIN_AGE_MS = 60_000;
 // Always-visible windows (the macOS app) never fire visibilitychange, so a
 // slow lifecycle-owned interval keeps the chips from going permanently stale.
 const IDLE_REFRESH_INTERVAL_MS = 10 * 60_000;
-
-const SIDEBAR_ATTENTION_KINDS = [
-  "cronFailed",
-  "cronOverdue",
-  "modelAuthExpired",
-  "modelAuthExpiring",
-] as const;
-export type SidebarAttentionKind = (typeof SIDEBAR_ATTENTION_KINDS)[number];
 
 export type SidebarAttentionItem = {
   kind: SidebarAttentionKind;
@@ -48,81 +45,6 @@ export type SidebarAttentionItem = {
   // any change (new job/provider) resurfaces it.
   signature: string;
 };
-
-// Per-gateway, per-browser snooze state for the chips. Deliberately client-side
-// chrome (like nav width / dock layout), not gateway state: dismissing a nag on
-// one device should not acknowledge it everywhere.
-const DISMISSED_STORE_PREFIX = "openclaw.control.sidebarAttention.v1:";
-
-export type SidebarAttentionDismissals = Partial<Record<SidebarAttentionKind, string>>;
-
-function dismissedStoreKey(gatewayUrl: string): string {
-  return `${DISMISSED_STORE_PREFIX}${normalizeGatewayTokenScope(gatewayUrl)}`;
-}
-
-function loadDismissals(gatewayUrl: string): SidebarAttentionDismissals {
-  const storage = getSafeLocalStorage();
-  if (!storage) {
-    return {};
-  }
-  try {
-    const parsed: unknown = JSON.parse(storage.getItem(dismissedStoreKey(gatewayUrl)) ?? "null");
-    if (!parsed || typeof parsed !== "object") {
-      return {};
-    }
-    const result: SidebarAttentionDismissals = {};
-    for (const kind of SIDEBAR_ATTENTION_KINDS) {
-      const value = (parsed as Record<string, unknown>)[kind];
-      if (typeof value === "string") {
-        result[kind] = value;
-      }
-    }
-    return result;
-  } catch {
-    return {};
-  }
-}
-
-function saveDismissals(gatewayUrl: string, dismissals: SidebarAttentionDismissals) {
-  const storage = getSafeLocalStorage();
-  if (!storage) {
-    return;
-  }
-  try {
-    if (Object.keys(dismissals).length === 0) {
-      storage.removeItem(dismissedStoreKey(gatewayUrl));
-    } else {
-      storage.setItem(dismissedStoreKey(gatewayUrl), JSON.stringify(dismissals));
-    }
-  } catch {
-    // Quota/privacy-mode failures just lose the snooze; chips reappear.
-  }
-}
-
-/**
- * Drop dismissals whose chip is gone or whose entity set changed, so a state
- * that clears and later recurs surfaces again instead of staying hidden by a
- * stale snooze. Returns the input object when nothing changed.
- */
-export function pruneDismissals(
-  dismissals: SidebarAttentionDismissals,
-  items: readonly SidebarAttentionItem[],
-): SidebarAttentionDismissals {
-  const next: SidebarAttentionDismissals = {};
-  let changed = false;
-  for (const kind of SIDEBAR_ATTENTION_KINDS) {
-    const stored = dismissals[kind];
-    if (stored === undefined) {
-      continue;
-    }
-    if (items.some((item) => item.kind === kind && item.signature === stored)) {
-      next[kind] = stored;
-    } else {
-      changed = true;
-    }
-  }
-  return changed ? next : dismissals;
-}
 
 export function buildSidebarAttentionItems(params: {
   cronJobs: readonly CronJob[];

--- a/ui/src/components/sidebar-attention.ts
+++ b/ui/src/components/sidebar-attention.ts
@@ -10,9 +10,11 @@ import type { CronJob, ModelAuthStatusResult } from "../api/types.ts";
 import type { NavigationRouteId } from "../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../app/context.ts";
 import { t } from "../i18n/index.ts";
+import { normalizeGatewayTokenScope } from "../app/gateway-scope.ts";
 import { isCronJobActiveFailure } from "../lib/cron-status.ts";
 import { createInitialCronState, loadCronJobsPage } from "../lib/cron/index.ts";
 import { isMonitoredAuthProvider, loadModelAuthStatus } from "../lib/model-auth.ts";
+import { getSafeLocalStorage } from "../local-storage.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { icons, type IconName } from "./icons.ts";
@@ -27,12 +29,100 @@ const VISIBILITY_REFRESH_MIN_AGE_MS = 60_000;
 // slow lifecycle-owned interval keeps the chips from going permanently stale.
 const IDLE_REFRESH_INTERVAL_MS = 10 * 60_000;
 
+const SIDEBAR_ATTENTION_KINDS = [
+  "cronFailed",
+  "cronOverdue",
+  "modelAuthExpired",
+  "modelAuthExpiring",
+] as const;
+export type SidebarAttentionKind = (typeof SIDEBAR_ATTENTION_KINDS)[number];
+
 export type SidebarAttentionItem = {
+  kind: SidebarAttentionKind;
   severity: "error" | "warning";
   icon: IconName;
   label: string;
   routeId: NavigationRouteId;
+  // Sorted ids of the entities behind the chip. A dismissal stores this
+  // signature so the chip stays hidden only while the same set is affected;
+  // any change (new job/provider) resurfaces it.
+  signature: string;
 };
+
+// Per-gateway, per-browser snooze state for the chips. Deliberately client-side
+// chrome (like nav width / dock layout), not gateway state: dismissing a nag on
+// one device should not acknowledge it everywhere.
+const DISMISSED_STORE_PREFIX = "openclaw.control.sidebarAttention.v1:";
+
+export type SidebarAttentionDismissals = Partial<Record<SidebarAttentionKind, string>>;
+
+function dismissedStoreKey(gatewayUrl: string): string {
+  return `${DISMISSED_STORE_PREFIX}${normalizeGatewayTokenScope(gatewayUrl)}`;
+}
+
+function loadDismissals(gatewayUrl: string): SidebarAttentionDismissals {
+  const storage = getSafeLocalStorage();
+  if (!storage) {
+    return {};
+  }
+  try {
+    const parsed: unknown = JSON.parse(storage.getItem(dismissedStoreKey(gatewayUrl)) ?? "null");
+    if (!parsed || typeof parsed !== "object") {
+      return {};
+    }
+    const result: SidebarAttentionDismissals = {};
+    for (const kind of SIDEBAR_ATTENTION_KINDS) {
+      const value = (parsed as Record<string, unknown>)[kind];
+      if (typeof value === "string") {
+        result[kind] = value;
+      }
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+function saveDismissals(gatewayUrl: string, dismissals: SidebarAttentionDismissals) {
+  const storage = getSafeLocalStorage();
+  if (!storage) {
+    return;
+  }
+  try {
+    if (Object.keys(dismissals).length === 0) {
+      storage.removeItem(dismissedStoreKey(gatewayUrl));
+    } else {
+      storage.setItem(dismissedStoreKey(gatewayUrl), JSON.stringify(dismissals));
+    }
+  } catch {
+    // Quota/privacy-mode failures just lose the snooze; chips reappear.
+  }
+}
+
+/**
+ * Drop dismissals whose chip is gone or whose entity set changed, so a state
+ * that clears and later recurs surfaces again instead of staying hidden by a
+ * stale snooze. Returns the input object when nothing changed.
+ */
+export function pruneDismissals(
+  dismissals: SidebarAttentionDismissals,
+  items: readonly SidebarAttentionItem[],
+): SidebarAttentionDismissals {
+  const next: SidebarAttentionDismissals = {};
+  let changed = false;
+  for (const kind of SIDEBAR_ATTENTION_KINDS) {
+    const stored = dismissals[kind];
+    if (stored === undefined) {
+      continue;
+    }
+    if (items.some((item) => item.kind === kind && item.signature === stored)) {
+      next[kind] = stored;
+    } else {
+      changed = true;
+    }
+  }
+  return changed ? next : dismissals;
+}
 
 export function buildSidebarAttentionItems(params: {
   cronJobs: readonly CronJob[];
@@ -40,14 +130,17 @@ export function buildSidebarAttentionItems(params: {
   now: number;
 }): SidebarAttentionItem[] {
   const items: SidebarAttentionItem[] = [];
+  const signatureOf = (ids: readonly string[]) => [...ids].sort().join("\n");
 
-  const failedCron = params.cronJobs.filter(isCronJobActiveFailure).length;
-  if (failedCron > 0) {
+  const failedCron = params.cronJobs.filter(isCronJobActiveFailure);
+  if (failedCron.length > 0) {
     items.push({
+      kind: "cronFailed",
       severity: "error",
       icon: "clock",
-      label: t("attention.cronFailed", { count: String(failedCron) }),
+      label: t("attention.cronFailed", { count: String(failedCron.length) }),
       routeId: "cron",
+      signature: signatureOf(failedCron.map((job) => job.id)),
     });
   }
   const overdueCron = params.cronJobs.filter(
@@ -55,13 +148,15 @@ export function buildSidebarAttentionItems(params: {
       job.enabled &&
       job.state?.nextRunAtMs != null &&
       params.now - job.state.nextRunAtMs > CRON_OVERDUE_GRACE_MS,
-  ).length;
-  if (overdueCron > 0) {
+  );
+  if (overdueCron.length > 0) {
     items.push({
+      kind: "cronOverdue",
       severity: "warning",
       icon: "clock",
-      label: t("attention.cronOverdue", { count: String(overdueCron) }),
+      label: t("attention.cronOverdue", { count: String(overdueCron.length) }),
       routeId: "cron",
+      signature: signatureOf(overdueCron.map((job) => job.id)),
     });
   }
 
@@ -71,17 +166,20 @@ export function buildSidebarAttentionItems(params: {
   );
   if (expired.length > 0) {
     items.push({
+      kind: "modelAuthExpired",
       severity: "error",
       icon: "plug",
       label: t("attention.modelAuthExpired", {
         providers: expired.map((provider) => provider.displayName).join(", "),
       }),
       routeId: "model-providers",
+      signature: signatureOf(expired.map((provider) => provider.provider)),
     });
   }
   const expiring = monitored.filter((provider) => provider.status === "expiring");
   if (expiring.length > 0) {
     items.push({
+      kind: "modelAuthExpiring",
       severity: "warning",
       icon: "plug",
       label: t("attention.modelAuthExpiring", {
@@ -90,6 +188,7 @@ export function buildSidebarAttentionItems(params: {
           .join(", "),
       }),
       routeId: "model-providers",
+      signature: signatureOf(expiring.map((provider) => provider.provider)),
     });
   }
   return items;
@@ -101,11 +200,13 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
 
   @state() private cronJobs: CronJob[] = [];
   @state() private modelAuthStatus: ModelAuthStatusResult | null = null;
+  @state() private dismissed: SidebarAttentionDismissals = {};
 
   @property({ attribute: false }) onNavigate?: (routeId: NavigationRouteId) => void;
 
   private loadedClient: GatewayBrowserClient | null = null;
   private loadedAtMs = 0;
+  private dismissedScope: string | null = null;
   private idleRefreshTimer: ReturnType<typeof globalThis.setInterval> | null = null;
 
   private readonly subscriptions = new SubscriptionsController(this).effect(
@@ -146,6 +247,11 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
 
   private synchronize(gateway: ApplicationContext["gateway"]) {
     const snapshot = gateway.snapshot;
+    const gatewayUrl = gateway.connection.gatewayUrl;
+    if (gatewayUrl && gatewayUrl !== this.dismissedScope) {
+      this.dismissedScope = gatewayUrl;
+      this.dismissed = loadDismissals(gatewayUrl);
+    }
     if (!snapshot.connected || !snapshot.client) {
       this.loadedClient = null;
       this.cronJobs = [];
@@ -185,6 +291,39 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
     }
   }
 
+  // Re-arm stale snoozes after each data refresh. Runs against loaded data
+  // only: the empty pre-load snapshot must not wipe dismissals for chips that
+  // are still true on the gateway. A failed auth-status fetch (null) prunes
+  // auth snoozes, which fails safe — the chip re-nags instead of staying
+  // hidden.
+  override updated() {
+    if (this.loadedAtMs === 0 || !this.dismissedScope) {
+      return;
+    }
+    if (!this.context?.gateway.snapshot.connected) {
+      return;
+    }
+    const items = buildSidebarAttentionItems({
+      cronJobs: this.cronJobs,
+      modelAuthStatus: this.modelAuthStatus,
+      now: Date.now(),
+    });
+    const pruned = pruneDismissals(this.dismissed, items);
+    if (pruned !== this.dismissed) {
+      this.dismissed = pruned;
+      saveDismissals(this.dismissedScope, pruned);
+    }
+  }
+
+  private dismiss(item: SidebarAttentionItem) {
+    if (!this.dismissedScope) {
+      return;
+    }
+    const next = { ...this.dismissed, [item.kind]: item.signature };
+    this.dismissed = next;
+    saveDismissals(this.dismissedScope, next);
+  }
+
   override render() {
     if (!this.context?.gateway.snapshot.connected) {
       return nothing;
@@ -193,7 +332,7 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
       cronJobs: this.cronJobs,
       modelAuthStatus: this.modelAuthStatus,
       now: Date.now(),
-    });
+    }).filter((item) => this.dismissed[item.kind] !== item.signature);
     if (items.length === 0) {
       return nothing;
     }
@@ -201,15 +340,26 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
       <div class="sidebar-attention" role="status">
         ${items.map(
           (item) => html`
-            <button
-              type="button"
-              class="sidebar-attention__item sidebar-attention__item--${item.severity}"
-              title=${item.label}
-              @click=${() => this.onNavigate?.(item.routeId)}
-            >
-              <span class="sidebar-attention__icon" aria-hidden="true">${icons[item.icon]}</span>
-              <span class="sidebar-attention__label">${item.label}</span>
-            </button>
+            <div class="sidebar-attention__item sidebar-attention__item--${item.severity}">
+              <button
+                type="button"
+                class="sidebar-attention__open"
+                title=${item.label}
+                @click=${() => this.onNavigate?.(item.routeId)}
+              >
+                <span class="sidebar-attention__icon" aria-hidden="true">${icons[item.icon]}</span>
+                <span class="sidebar-attention__label">${item.label}</span>
+              </button>
+              <button
+                type="button"
+                class="sidebar-attention__dismiss"
+                title=${t("common.dismiss")}
+                aria-label=${t("common.dismiss")}
+                @click=${() => this.dismiss(item)}
+              >
+                ${icons.x}
+              </button>
+            </div>
           `,
         )}
       </div>

--- a/ui/src/components/sidebar-attention.ts
+++ b/ui/src/components/sidebar-attention.ts
@@ -17,6 +17,8 @@ import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { icons, type IconName } from "./icons.ts";
 import {
+  addDismissal,
+  dismissalStoreKey,
   loadDismissals,
   pruneDismissals,
   saveDismissals,
@@ -139,6 +141,17 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
     },
   );
 
+  // Cross-tab sync: another tab's dismiss/prune fires "storage" here, so this
+  // tab re-reads instead of rendering (or later writing) a stale snapshot.
+  private readonly syncDismissalsFromStorage = (event: StorageEvent) => {
+    if (!this.dismissedScope) {
+      return;
+    }
+    if (event.key === null || event.key === dismissalStoreKey(this.dismissedScope)) {
+      this.dismissed = loadDismissals(this.dismissedScope);
+    }
+  };
+
   private readonly refreshIfStale = () => {
     if (document.visibilityState !== "visible") {
       return;
@@ -153,11 +166,13 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
   override connectedCallback() {
     super.connectedCallback();
     document.addEventListener("visibilitychange", this.refreshIfStale);
+    globalThis.addEventListener("storage", this.syncDismissalsFromStorage);
     this.idleRefreshTimer = globalThis.setInterval(this.refreshIfStale, IDLE_REFRESH_INTERVAL_MS);
   }
 
   override disconnectedCallback() {
     document.removeEventListener("visibilitychange", this.refreshIfStale);
+    globalThis.removeEventListener("storage", this.syncDismissalsFromStorage);
     if (this.idleRefreshTimer !== null) {
       globalThis.clearInterval(this.idleRefreshTimer);
       this.idleRefreshTimer = null;
@@ -230,10 +245,15 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
       modelAuthStatus: this.modelAuthStatus,
       now: Date.now(),
     });
-    const pruned = pruneDismissals(this.dismissed, items);
-    if (pruned !== this.dismissed) {
-      this.dismissed = pruned;
+    // Prune against the persisted map, not the in-memory snapshot, so a
+    // concurrent dismissal from another tab is not dropped by this write.
+    const stored = loadDismissals(this.dismissedScope);
+    const pruned = pruneDismissals(stored, items);
+    if (pruned !== stored) {
       saveDismissals(this.dismissedScope, pruned);
+    }
+    if (JSON.stringify(pruned) !== JSON.stringify(this.dismissed)) {
+      this.dismissed = pruned;
     }
   }
 
@@ -241,9 +261,7 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
     if (!this.dismissedScope) {
       return;
     }
-    const next = { ...this.dismissed, [item.kind]: item.signature };
-    this.dismissed = next;
-    saveDismissals(this.dismissedScope, next);
+    this.dismissed = addDismissal(this.dismissedScope, item.kind, item.signature);
   }
 
   override render() {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -958,16 +958,57 @@ html.openclaw-native-web-chrome .sidebar-brand__collapse {
 .sidebar-attention__item {
   display: flex;
   align-items: center;
-  gap: 8px;
   width: 100%;
-  padding: 6px 8px;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-hover);
   color: var(--text);
   font-size: 12px;
+}
+
+/* Navigate + dismiss are sibling buttons inside the pill (buttons can't nest);
+   the open button carries the click padding so the whole pill stays a target. */
+.sidebar-attention__open {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0 6px 8px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
   text-align: left;
   cursor: pointer;
+}
+
+.sidebar-attention__dismiss {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 8px 6px 6px;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  opacity: 0.6;
+}
+
+.sidebar-attention__dismiss:hover {
+  color: var(--text);
+  opacity: 1;
+}
+
+.sidebar-attention__dismiss svg {
+  width: 12px;
+  height: 12px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .sidebar-attention__item--warning {


### PR DESCRIPTION
## What Problem This Solves

The sidebar attention chips (failing/overdue cron jobs, expired/expiring model auth) cannot be dismissed. A known-and-accepted problem — e.g. a cron job the user will fix later — nags on every page of every session with no way to snooze it.

## Why This Change Was Made

Adds a small ✕ button to each chip. Dismissals are deliberately client-side chrome (like nav width or dock layout), stored per gateway in localStorage under `openclaw.control.sidebarAttention.v1:<gateway-scope>` — dismissing a nag on one device should not acknowledge it everywhere, and no new gateway state/RPC surface is warranted for a snooze.

A dismissal is signature-keyed, not forever: each chip carries a signature of the sorted entity ids behind it (cron job ids, provider ids). The chip stays hidden only while the exact same set is affected:

- a new job fails / a new provider expires → signature changes → chip resurfaces
- the state clears (jobs recover, auth refreshed) → the stale dismissal is pruned, so a later recurrence surfaces again
- expiring → expired is a different chip kind, so an escalation always resurfaces as an error

Pruning runs only against loaded data, so an empty pre-load snapshot can't wipe valid snoozes.

Dismissals are multi-tab safe: writes merge with the persisted map (read-modify-write) instead of a tab-held snapshot, and tabs listen for `storage` events, so a dismissal in one tab hides the chip in every tab of that browser without losing the other tab's entries.

## User Impact

Each attention chip now has a subtle ✕ (visible on the right, `common.dismiss` tooltip). Clicking it hides that chip on this browser/device for as long as the underlying state is unchanged. The navigate-on-click behavior of the chip body is unchanged.

![attention chips with dismiss](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-attention-dismiss/attention-dismiss-dark.png)

## Evidence

- `ui/src/components/sidebar-attention.ts`: chips gain `kind` + `signature`; chip markup restructured to sibling navigate/dismiss buttons (buttons can't nest).
- `ui/src/components/sidebar-attention-dismissals.ts`: the per-gateway load/save/prune dismissal store lives in its own module (keeps the exports prod-imported for the deadcode ratchet and the snooze logic pure/unit-testable).
- `ui/src/styles/layout.css`: pill container split into `__open` + `__dismiss` buttons; dismiss is muted, brightens on hover.
- Tests: `pnpm test ui/src/components/sidebar-attention.test.ts` — 7 passed (signature construction incl. sorted ids and disabled-job exclusion; `pruneDismissals` keep/resurface/clear cases).
- Live-verified in the mock Control UI harness (dark mode): dismissing the "Model auth expired: Gemini" chip hides it and writes `{"modelAuthExpired":"google"}` to the gateway-scoped key; reload keeps it hidden while the state is unchanged; planting stale signatures (`google\nopenai`, `stale-provider`) resurfaces both chips and prunes the stored map back to empty.
- Multi-tab live-verified with two browser tabs on the mock harness: tab B saw tab A's dismissal without reload (storage event), tab B's own dismissal merged with A's (both entries persisted), and tab A synced back to zero chips.
- Reuses the existing `common.dismiss` i18n key — no locale changes needed.


