### PR TITLE
fix(ui): simplify Settings titlebar controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Claude CLI context budgets:** honor Anthropic model and per-agent `contextTokens` limits by passing the effective limit to Claude Code's native auto-compactor and persisting the same prepared budget in OpenClaw session state. Fixes #80933. (#93198) Thanks @mushuiyu886.
+- **Control UI Settings titlebar:** keep only back and forward controls in the macOS Settings titlebar, removing the inapplicable sidebar, search, and new-session actions while the fixed Settings sidebar is shown.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.
 - **Gateway source watch:** hand the configured port off from the installed service before starting the tmux watcher, preserve failed panes for attach/capture, and keep explicit alternate-port watches side by side with the managed Gateway.
 - **Claude CLI max-turn diagnostics:** preserve terminal max-turn results with OpenClaw and Claude session context, warn when tool actions may already have run, and stop unsafe auth-profile or model replay for potentially side-effecting turns. (#94130) Thanks @zhangguiping-xydt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Claude CLI context budgets:** honor Anthropic model and per-agent `contextTokens` limits by passing the effective limit to Claude Code's native auto-compactor and persisting the same prepared budget in OpenClaw session state. Fixes #80933. (#93198) Thanks @mushuiyu886.
-- **Control UI Settings titlebar:** keep only back and forward controls in the macOS Settings titlebar, removing the inapplicable sidebar, search, and new-session actions while the fixed Settings sidebar is shown.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.
 - **Gateway source watch:** hand the configured port off from the installed service before starting the tmux watcher, preserve failed panes for attach/capture, and keep explicit alternate-port watches side by side with the managed Gateway.
 - **Claude CLI max-turn diagnostics:** preserve terminal max-turn results with OpenClaw and Claude session context, warn when tool actions may already have run, and stop unsafe auth-profile or model replay for potentially side-effecting turns. (#94130) Thanks @zhangguiping-xydt.

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -1046,6 +1046,7 @@ class OpenClawShell extends OpenClawLightDomElement {
           ? html`
               <openclaw-macos-titlebar-controls
                 .navCollapsed=${this.nativeNavCollapsed()}
+                .historyOnly=${settingsTakeover}
                 .canGoBack=${this.nativeHistoryState.canGoBack}
                 .canGoForward=${this.nativeHistoryState.canGoForward}
                 .onToggleSidebar=${() => this.toggleNavigationSurface()}

--- a/ui/src/components/macos-titlebar-controls.ts
+++ b/ui/src/components/macos-titlebar-controls.ts
@@ -8,6 +8,7 @@ import "./tooltip.ts";
 
 class MacosTitlebarControls extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) navCollapsed = false;
+  @property({ attribute: false }) historyOnly = false;
   @property({ attribute: false }) canGoBack = false;
   @property({ attribute: false }) canGoForward = false;
   @property({ attribute: false }) onToggleSidebar?: () => void;
@@ -18,13 +19,15 @@ class MacosTitlebarControls extends OpenClawLightDomContentsElement {
     const toggleLabel = this.navCollapsed ? t("nav.expand") : t("nav.collapse");
     return html`
       <nav class="macos-titlebar-controls" @mousedown=${beginNativeWindowDrag}>
-        ${this.renderButton({
-          label: toggleLabel,
-          icon: this.navCollapsed ? icons.panelLeftOpen : icons.panelLeftClose,
-          ariaExpanded: !this.navCollapsed,
-          onClick: this.onToggleSidebar,
-          className: "macos-titlebar-controls__sidebar-toggle",
-        })}
+        ${this.historyOnly
+          ? nothing
+          : this.renderButton({
+              label: toggleLabel,
+              icon: this.navCollapsed ? icons.panelLeftOpen : icons.panelLeftClose,
+              ariaExpanded: !this.navCollapsed,
+              onClick: this.onToggleSidebar,
+              className: "macos-titlebar-controls__sidebar-toggle",
+            })}
         ${this.renderButton({
           label: t("nav.back"),
           icon: icons.chevronLeft,
@@ -39,7 +42,7 @@ class MacosTitlebarControls extends OpenClawLightDomContentsElement {
           onClick: () => globalThis.history.forward(),
           className: "macos-titlebar-controls__forward",
         })}
-        ${this.navCollapsed
+        ${this.navCollapsed && !this.historyOnly
           ? html`
               ${this.renderButton({
                 label: t("chat.openCommandPalette"),

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -238,6 +238,27 @@ describeControlUiE2e("Control UI native-nav sidebar toggle E2E", () => {
       .not.toContain("shell--nav-collapsed");
   });
 
+  it("keeps only history controls in the Settings titlebar", async () => {
+    const page = await openPage({ webChrome: true });
+    const response = await page.goto(`${server.baseUrl}settings/general`);
+    expect(response?.status()).toBe(200);
+
+    const toolbar = page.locator(".macos-titlebar-controls");
+    await expect.poll(() => toolbar.isVisible()).toBe(true);
+    await expect.poll(() => toolbar.getByRole("button").count()).toBe(2);
+    await expect.poll(() => toolbar.getByRole("button", { name: "Back" }).isVisible()).toBe(true);
+    await expect
+      .poll(() => toolbar.getByRole("button", { name: "Forward" }).isVisible())
+      .toBe(true);
+    await expect
+      .poll(() => toolbar.getByRole("button", { name: "Expand sidebar" }).count())
+      .toBe(0);
+    await expect
+      .poll(() => toolbar.getByRole("button", { name: "Open command palette" }).count())
+      .toBe(0);
+    await expect.poll(() => toolbar.getByRole("button", { name: "New session" }).count()).toBe(0);
+  });
+
   it("keeps the drawer hamburger at narrow widths in plain browsers", async () => {
     const page = await openPage({ nativeNav: false, width: 900 });
     await expect.poll(() => page.locator(".topbar-nav-toggle").isVisible()).toBe(true);


### PR DESCRIPTION
## What Problem This Solves

The macOS-style titlebar treated Settings' intentionally fixed sidebar as a collapsed workspace sidebar. Settings therefore showed controls that do not apply there: sidebar expand, search/command palette, and new session.

Regression source: #105902.

## Why This Change Was Made

Pass an explicit history-only mode from the Settings takeover state into the titlebar controls. In that mode, render only Back and Forward. Normal expanded and collapsed workspace titlebars keep their existing behavior.

## User Impact

Settings now has a focused titlebar with only navigation history controls. Its fixed sidebar remains visible, while ordinary workspace sidebar, search, and new-session controls are unchanged.

## Evidence

- Focused E2E: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts` — 7/7 passed on Testbox `tbx_01kxdbg1vwf52n9ptjf9ycp7bj`.
- Changed gate before rebase: `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` — passed formatting, guards, typechecks, and lint on Testbox `tbx_01kxd9te5kzftepycmmty2p5s9`.
- Source-blind visual inventory: Settings showed `["Back", "Forward"]`; expanded workspace showed `["Collapse sidebar", "Back", "Forward"]`; collapsed workspace showed `["Expand sidebar", "Back", "Forward", "Open command palette", "New session"]`.
- Fresh branch autoreview: clean, 0.96 correctness confidence, no accepted/actionable findings.
