### PR TITLE
refactor(slack): use Web API response contracts

### DIFF
--- a/extensions/slack/src/directory-live.ts
+++ b/extensions/slack/src/directory-live.ts
@@ -1,4 +1,5 @@
 // Slack plugin module implements directory live behavior.
+import type { ConversationsListResponse, UsersListResponse } from "@slack/web-api";
 import type {
   ChannelDirectoryEntry,
   DirectoryConfigParams,
@@ -11,44 +12,8 @@ import {
 import { resolveSlackAccount } from "./accounts.js";
 import { createSlackWebClient } from "./client.js";
 
-type SlackUser = {
-  id?: string;
-  name?: string;
-  real_name?: string;
-  is_bot?: boolean;
-  is_app_user?: boolean;
-  deleted?: boolean;
-  profile?: {
-    display_name?: string;
-    real_name?: string;
-    email?: string;
-  };
-};
-
-type SlackChannel = {
-  id?: string;
-  name?: string;
-  is_archived?: boolean;
-  is_private?: boolean;
-};
-
-type SlackListUsersResponse = {
-  members?: SlackUser[];
-  response_metadata?: { next_cursor?: string };
-};
-
-type SlackListChannelsResponse = {
-  channels?: SlackChannel[];
-  response_metadata?: { next_cursor?: string };
-};
-
-type SlackAuthTestResponse = {
-  ok?: boolean;
-  user_id?: string;
-  user?: string;
-  team_id?: string;
-  team?: string;
-};
+type SlackUser = NonNullable<UsersListResponse["members"]>[number];
+type SlackChannel = NonNullable<ConversationsListResponse["channels"]>[number];
 
 function createSlackDirectoryClient(params: DirectoryConfigParams) {
   const account = resolveSlackAccount({ cfg: params.cfg, accountId: params.accountId });
@@ -106,13 +71,13 @@ export async function getSlackDirectorySelfLive(
   if (!client) {
     return null;
   }
-  const auth = (await client.auth.test()) as SlackAuthTestResponse;
+  const auth = await client.auth.test();
   const userId = normalizeOptionalString(auth.user_id);
   if (!userId) {
     return null;
   }
   try {
-    const info = (await client.users.info({ user: userId })) as { user?: SlackUser };
+    const info = await client.users.info({ user: userId });
     return slackUserToDirectoryEntry(info.user ?? {}, { id: userId, name: auth.user });
   } catch {
     return slackUserToDirectoryEntry(
@@ -134,10 +99,10 @@ export async function listSlackDirectoryPeersLive(
   let cursor: string | undefined;
 
   do {
-    const res = (await client.users.list({
+    const res = await client.users.list({
       limit: 200,
       cursor,
-    })) as SlackListUsersResponse;
+    });
     if (Array.isArray(res.members)) {
       members.push(...res.members);
     }
@@ -180,12 +145,12 @@ export async function listSlackDirectoryGroupsLive(
   let cursor: string | undefined;
 
   do {
-    const res = (await client.conversations.list({
+    const res = await client.conversations.list({
       types: "public_channel,private_channel",
       exclude_archived: false,
       limit: 1000,
       cursor,
-    })) as SlackListChannelsResponse;
+    });
     if (Array.isArray(res.channels)) {
       channels.push(...res.channels);
     }

--- a/extensions/slack/src/resolve-channels.ts
+++ b/extensions/slack/src/resolve-channels.ts
@@ -20,16 +20,6 @@ export type SlackChannelResolution = {
   archived?: boolean;
 };
 
-type SlackListResponse = {
-  channels?: Array<{
-    id?: string;
-    name?: string;
-    is_archived?: boolean;
-    is_private?: boolean;
-  }>;
-  response_metadata?: { next_cursor?: string };
-};
-
 function parseSlackChannelMention(raw: string): { id?: string; name?: string } {
   const trimmed = raw.trim();
   if (!trimmed) {
@@ -51,13 +41,13 @@ function parseSlackChannelMention(raw: string): { id?: string; name?: string } {
 
 async function listSlackChannels(client: WebClient): Promise<SlackChannelLookup[]> {
   return collectSlackCursorPages({
-    fetchPage: async (cursor) =>
-      (await client.conversations.list({
+    fetchPage: (cursor) =>
+      client.conversations.list({
         types: "public_channel,private_channel",
         exclude_archived: false,
         limit: 1000,
         cursor,
-      })) as SlackListResponse,
+      }),
     collectPageItems: (res) =>
       (res.channels ?? [])
         .map((channel) => {

--- a/extensions/slack/src/resolve-users.ts
+++ b/extensions/slack/src/resolve-users.ts
@@ -30,23 +30,6 @@ export type SlackUserResolution = {
   note?: string;
 };
 
-type SlackListUsersResponse = {
-  members?: Array<{
-    id?: string;
-    name?: string;
-    deleted?: boolean;
-    is_bot?: boolean;
-    is_app_user?: boolean;
-    real_name?: string;
-    profile?: {
-      display_name?: string;
-      real_name?: string;
-      email?: string;
-    };
-  }>;
-  response_metadata?: { next_cursor?: string };
-};
-
 function parseSlackUserInput(raw: string): { id?: string; name?: string; email?: string } {
   const trimmed = raw.trim();
   if (!trimmed) {
@@ -69,11 +52,11 @@ function parseSlackUserInput(raw: string): { id?: string; name?: string; email?:
 
 async function listSlackUsers(client: WebClient): Promise<SlackUserLookup[]> {
   return collectSlackCursorPages({
-    fetchPage: async (cursor) =>
-      (await client.users.list({
+    fetchPage: (cursor) =>
+      client.users.list({
         limit: 200,
         cursor,
-      })) as SlackListUsersResponse,
+      }),
     collectPageItems: (res) =>
       (res.members ?? [])
         .map((member) => {


### PR DESCRIPTION
Closes #106219

## What Problem This Solves

Slack directory and allowlist code locally duplicated response contracts already exported by the pinned Web API SDK. Those copies added 62 net lines of drift-prone type declarations and result casts.

## Why This Change Was Made

Derive the two accumulated element types from `UsersListResponse` and `ConversationsListResponse`, then rely on the typed `WebClient` method results everywhere else. Cursor pagination, filtering, fallbacks, and runtime behavior stay unchanged.

## User Impact

No intended user-visible behavior change. Slack API response ownership now stays with the exact SDK dependency.

## Evidence

- Net change: 15 insertions, 77 deletions (62 fewer lines).
- Direct dependency proof: `@slack/web-api` 7.18.0 publicly exports the list/info/auth response types, and its `WebClient` methods return those exact contracts.
- Delegated Blacksmith Testbox lease associated with [run 29237503233](https://github.com/openclaw/openclaw/actions/runs/29237503233): 11 focused tests passed across `directory-contract.test.ts`, `resolve-users.test.ts`, and `resolve-channels.test.ts`.
- Same Testbox lease: `pnpm check:changed` passed extension production/test typechecks, lint, formatting, dependency pins, API baseline, and runtime guards.
- The delegated Testbox command receipts exited 0; the linked portal run is marked cancelled after external lease cleanup, as expected for this provider path.
- `git diff --check` passed.
- Fresh pre-commit and post-rebase autoreviews: no actionable findings.

AI assistance: Codex audited the dependency contracts, implemented the refactor, and ran validation. Maintainer reviewed the resulting diff and evidence.
