### PR TITLE
fix(plugin-sdk): keep wildcard surface budget current

### DIFF
--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -219,7 +219,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicWildcardReexports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_WILDCARD_REEXPORTS",
-      210,
+      209,
       env,
     ),
   };


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where current-main and merge-ref CI fail the Plugin SDK surface-budget test after the public wildcard re-export count shrank from 210 to 209.

## Why This Change Was Made

Pins the shrink-only wildcard re-export budget to the source graph's current count. No runtime behavior or Plugin SDK export changes are included.

## User Impact

No user-visible behavior change. Maintainer CI again enforces the exact current Plugin SDK wildcard surface.

## Evidence

- Blacksmith Testbox: `test/scripts/plugin-sdk-surface-report.test.ts` — 10/10 passed.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29239358406
- Before: #106220 merge-ref CI reported expected 209, budget 210.
- `git diff --check` passed.
