### PR TITLE
refactor(pairing): privatize setup helpers

### DIFF
--- a/src/pairing/setup-code.ts
+++ b/src/pairing/setup-code.ts
@@ -43,7 +43,7 @@ type PairingSetupPayload = {
   bootstrapToken: string;
 };
 
-export type PairingSetupAccess = "full" | "limited" | "node";
+type PairingSetupAccess = "full" | "limited" | "node";
 
 const PAIRING_SETUP_MAX_URLS = 8;
 

--- a/src/shared/device-bootstrap-profile.test.ts
+++ b/src/shared/device-bootstrap-profile.test.ts
@@ -7,7 +7,6 @@ import {
   PAIRING_SETUP_BOOTSTRAP_PROFILE,
   isMobilePairingSetupBootstrapProfile,
   isNodePairingSetupBootstrapProfile,
-  isPairingSetupBootstrapProfile,
   normalizeDeviceBootstrapHandoffProfile,
   normalizeDeviceBootstrapProfile,
   resolveBootstrapProfileScopesForRole,
@@ -120,8 +119,6 @@ describe("device bootstrap profile", () => {
       roles: ["node", "operator"],
       scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
     });
-    expect(isPairingSetupBootstrapProfile(PAIRING_SETUP_BOOTSTRAP_PROFILE)).toBe(true);
-    expect(isPairingSetupBootstrapProfile(FULL_ACCESS_PAIRING_SETUP_BOOTSTRAP_PROFILE)).toBe(false);
   });
 
   test("node setup profile carries no operator access", () => {

--- a/src/shared/device-bootstrap-profile.ts
+++ b/src/shared/device-bootstrap-profile.ts
@@ -92,7 +92,7 @@ export function isMobilePairingSetupBootstrapProfile(
 }
 
 /** Return whether an input exactly matches the existing limited setup profile. */
-export function isPairingSetupBootstrapProfile(
+function isPairingSetupBootstrapProfile(
   input: DeviceBootstrapProfileInput | undefined,
 ): boolean {
   return matchesBootstrapProfile(input, PAIRING_SETUP_BOOTSTRAP_PROFILE);

--- a/src/shared/device-bootstrap-profile.ts
+++ b/src/shared/device-bootstrap-profile.ts
@@ -92,9 +92,7 @@ export function isMobilePairingSetupBootstrapProfile(
 }
 
 /** Return whether an input exactly matches the existing limited setup profile. */
-function isPairingSetupBootstrapProfile(
-  input: DeviceBootstrapProfileInput | undefined,
-): boolean {
+function isPairingSetupBootstrapProfile(input: DeviceBootstrapProfileInput | undefined): boolean {
   return matchesBootstrapProfile(input, PAIRING_SETUP_BOOTSTRAP_PROFILE);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where current-main and merge-ref CI report two new production-unused exports in pairing setup code.

## Why This Change Was Made

Keeps both implementation details module-private and removes two redundant assertions that existed only through the former test import. The public dead-export baseline remains unchanged.

## User Impact

No user-visible behavior change. Maintainer CI again enforces the shrink-only production export surface without grandfathering new debt.

## Evidence

- Blacksmith Testbox: pairing/setup and device-bootstrap-profile tests — 49/49 passed.
- Production dead-export update/check: exact 3,376 entries; baseline unchanged.
- Focused run: https://github.com/openclaw/openclaw/actions/runs/29239828800
- Final pre-push regeneration: https://github.com/openclaw/openclaw/actions/runs/29240044825
- Fresh autoreview: clean, 0.96 confidence.
- `git diff --check` passed.
