### PR TITLE
refactor(pairing): trim private exports

### DIFF
--- a/src/pairing/setup-code.ts
+++ b/src/pairing/setup-code.ts
@@ -43,7 +43,7 @@ type PairingSetupPayload = {
   bootstrapToken: string;
 };
 
-export type PairingSetupAccess = "full" | "limited" | "node";
+type PairingSetupAccess = "full" | "limited" | "node";
 
 const PAIRING_SETUP_MAX_URLS = 8;
 

--- a/src/shared/device-bootstrap-profile.test.ts
+++ b/src/shared/device-bootstrap-profile.test.ts
@@ -7,7 +7,6 @@ import {
   PAIRING_SETUP_BOOTSTRAP_PROFILE,
   isMobilePairingSetupBootstrapProfile,
   isNodePairingSetupBootstrapProfile,
-  isPairingSetupBootstrapProfile,
   normalizeDeviceBootstrapHandoffProfile,
   normalizeDeviceBootstrapProfile,
   resolveBootstrapProfileScopesForRole,
@@ -120,8 +119,6 @@ describe("device bootstrap profile", () => {
       roles: ["node", "operator"],
       scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
     });
-    expect(isPairingSetupBootstrapProfile(PAIRING_SETUP_BOOTSTRAP_PROFILE)).toBe(true);
-    expect(isPairingSetupBootstrapProfile(FULL_ACCESS_PAIRING_SETUP_BOOTSTRAP_PROFILE)).toBe(false);
   });
 
   test("node setup profile carries no operator access", () => {

--- a/src/shared/device-bootstrap-profile.ts
+++ b/src/shared/device-bootstrap-profile.ts
@@ -92,7 +92,7 @@ export function isMobilePairingSetupBootstrapProfile(
 }
 
 /** Return whether an input exactly matches the existing limited setup profile. */
-export function isPairingSetupBootstrapProfile(
+function isPairingSetupBootstrapProfile(
   input: DeviceBootstrapProfileInput | undefined,
 ): boolean {
   return matchesBootstrapProfile(input, PAIRING_SETUP_BOOTSTRAP_PROFILE);


### PR DESCRIPTION
Related: #106242

## What Problem This Solves

Resolves a problem where newly private pairing helpers were still exported, causing the unused-export gate to fail on current `main` and blocking unrelated exact-head validation.

## Why This Change Was Made

Keep the pairing access type and limited-profile predicate private to their owning modules. Remove redundant white-box test assertions; the supported mobile profile behavior remains covered through the public predicate.

AI-assisted.

## User Impact

No user-visible behavior change. Maintainer CI can validate current pairing and gateway changes against a clean unused-export baseline.

## Evidence

- Blacksmith Testbox `tbx_01kxddhhkm15mnvaq40q2e6edr`: `node scripts/check-deadcode-exports.mjs` passed with 3,376 baseline entries.
- Blacksmith Testbox `tbx_01kxddhhkm15mnvaq40q2e6edr`: `pnpm test src/shared/device-bootstrap-profile.test.ts` passed, 10/10 tests.
- Fresh structured autoreview: clean, correctness 0.98, no actionable findings.
