### PR TITLE
fix(installer): avoid false Node rejection on Windows

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -173,7 +173,8 @@ function Test-NodeVersionSupported {
 
 function Test-NodeSqliteSupported {
     try {
-        & node -e 'const { DatabaseSync } = require("node:sqlite"); const db = new DatabaseSync(":memory:"); try { const value = db.prepare("SELECT sqlite_version() AS version").get()?.version; const match = typeof value === "string" ? /^(\d+)\.(\d+)\.(\d+)$/.exec(value) : null; const major = Number(match?.[1]); const minor = Number(match?.[2]); const patch = Number(match?.[3]); const safe = major > 3 || (major === 3 && (minor > 51 || (minor === 51 && patch >= 3) || (minor === 50 && patch >= 7) || (minor === 44 && patch >= 6))); if (!safe) process.exitCode = 1; } finally { db.close(); }' 2>$null
+        $probe = 'const { DatabaseSync } = require("node:sqlite"); const db = new DatabaseSync(":memory:"); try { const value = db.prepare("SELECT sqlite_version() AS version").get()?.version; const match = typeof value === "string" ? /^(\d+)\.(\d+)\.(\d+)$/.exec(value) : null; const major = Number(match?.[1]); const minor = Number(match?.[2]); const patch = Number(match?.[3]); const safe = major > 3 || (major === 3 && (minor > 51 || (minor === 51 && patch >= 3) || (minor === 50 && patch >= 7) || (minor === 44 && patch >= 6))); if (!safe) process.exitCode = 1; } finally { db.close(); }'
+        $probe | & node - 2>$null
         return ($LASTEXITCODE -eq 0)
     } catch {
         return $false

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -127,6 +127,15 @@ describe("install.ps1 failure handling", () => {
         ].join("\n"),
       },
       {
+        name: "node-sqlite-runtime",
+        source: [
+          scriptWithoutEntryPoint,
+          "",
+          "if (-not (Test-NodeSqliteSupported)) { throw 'Bundled SQLite runtime was rejected' }",
+          "",
+        ].join("\n"),
+      },
+      {
         name: "native-arm64-git",
         source: [
           scriptWithoutEntryPoint,
@@ -436,6 +445,8 @@ describe("install.ps1 failure handling", () => {
     expect(versionBody).toContain("$minor -ge 9");
     expect(versionBody).toContain("$major -gt 25");
     expect(sqliteBody).toContain("SELECT sqlite_version() AS version");
+    expect(sqliteBody).toContain("$probe | & node -");
+    expect(sqliteBody).not.toContain("& node -e");
     expect(sqliteBody).toContain("patch >= 3");
     expect(checkNodeBody).toContain("Test-NodeVersionSupported -Version $nodeVersion");
     expect(checkNodeBody).toContain("Test-NodeSqliteSupported");
@@ -444,6 +455,7 @@ describe("install.ps1 failure handling", () => {
 
   runIfPowerShell("accepts only supported Node versions", () => {
     expectBatchedPowerShellCase("node-versions");
+    expectBatchedPowerShellCase("node-sqlite-runtime");
   });
 
   runIfPowerShell("upgrades and validates Node installed by Windows package managers", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows installer users with a safe bundled SQLite runtime were told that Node.js remained unavailable after installation or upgrade.

## Why This Change Was Made

Windows PowerShell 5.1 can rewrite the embedded JavaScript passed through `node -e`, causing the SQLite safety probe to fail silently. The installer now sends the unchanged probe over standard input to `node -`, preserving the existing safety gate and exit-code behavior.

## User Impact

Supported Node.js installations now pass the SQLite runtime check on Windows instead of entering a false upgrade/failure loop.

## Evidence

- `pnpm exec oxfmt --check --threads=1 --no-error-on-unmatched-pattern -- scripts/install.ps1 test/scripts/install-ps1.test.ts`
- `pnpm test test/scripts/install-ps1.test.ts` — 15 passed, 11 platform-skipped
- Fresh exact-head autoreview: no actionable findings, confidence 0.96
- Reproduced failure: [Full Release Validation child run](https://github.com/openclaw/openclaw/actions/runs/29235617325), [Windows installer fresh job](https://github.com/openclaw/openclaw/actions/runs/29235617325/job/86771099129)

