### PR TITLE
fix(ci): refresh plugin SDK API baseline

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-87baa2d3514f422ccb0d35a6503db1803b029ae26d83727fcf0d9a4450d99fea  plugin-sdk-api-baseline.json
-406c88b0d2a9c357b65f58b61083569f43eeba3bbe30ac0b986acb6130fd88c7  plugin-sdk-api-baseline.jsonl
+682886cad249cb42b80d77f8420947202be260c1b94f5cc11a780e64e781fa16  plugin-sdk-api-baseline.json
+59ac0750a4d514753ce0051bc769a0d642ca6a004e64dec7e28ae7c46b00609f  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
Related: #105939

## What Problem This Solves

Resolves a problem where the Plugin SDK API contract check fails on `main` after the process runtime entrypoint was narrowed from a wildcard export to an explicit public surface.

## Why This Change Was Made

Regenerate the tracked Plugin SDK API checksums from the current public entrypoints. The generated JSON and JSONL inventories remain local artifacts; only their canonical hashes are committed.

## User Impact

No runtime behavior changes. Maintainers regain a green Plugin SDK contract gate, and future SDK drift is compared against the public surface that is actually shipped.

## Evidence

- Blacksmith Testbox `tbx_01kxddznectax862rbstfym4xy`, Actions run `29240414624`:
  - `corepack pnpm deadcode:exports` passed with 3,367 baseline entries.
  - `corepack pnpm plugin-sdk:api:check` passed.
  - touched-path `pnpm check:changed` passed for `docs/.generated/plugin-sdk-api-baseline.sha256`.
- `gpt-5.6-sol` autoreview at medium reasoning: clean, confidence `0.94`.
- Direct generator check and `git diff --check` passed.
