### PR TITLE
fix(pr): fail closed on paginated file errors

### DIFF
--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -68,7 +68,8 @@ pr_meta_json() {
 
   # Raw `gh pr view --json files` stops at 100 entries. Paginate REST so
   # review guards see every path, then fail closed on head or API drift.
-  files=$(
+  if ! files=$(
+    set -o pipefail
     gh api --paginate "repos/{owner}/{repo}/pulls/$pr/files?per_page=100" |
       jq -cs '
         add
@@ -83,7 +84,10 @@ pr_meta_json() {
             )
           })
       '
-  )
+  ); then
+    echo "Failed to collect paginated PR file metadata for #$pr." >&2
+    return 1
+  fi
 
   head_after=$(gh pr view "$pr" --json headRefOid | jq -r .headRefOid)
   if [ "$head_after" != "$head_before" ]; then
@@ -92,7 +96,13 @@ pr_meta_json() {
   fi
 
   expected_file_count=$(printf '%s\n' "$metadata" | jq -r .changedFiles)
-  actual_file_count=$(printf '%s\n' "$files" | jq 'length')
+  if ! actual_file_count=$(
+    printf '%s\n' "$files" |
+      jq -er 'if type == "array" then length else error("expected an array") end'
+  ); then
+    echo "Invalid paginated PR file metadata for #$pr: expected a JSON array." >&2
+    return 1
+  fi
   if [ "$actual_file_count" -ne "$expected_file_count" ]; then
     echo "Incomplete PR file metadata for #$pr: expected $expected_file_count changed files, received $actual_file_count from paginated REST." >&2
     return 1

--- a/test/scripts/pr-metadata.test.ts
+++ b/test/scripts/pr-metadata.test.ts
@@ -27,6 +27,10 @@ fi
 if [ "$1" = "api" ] && [ "$2" = "--paginate" ]; then
   [ "$3" = 'repos/{owner}/{repo}/pulls/42/files?per_page=100' ] || { echo "unexpected endpoint: $3" >&2; exit 4; }
   jq -nc '[range(0; 100) | {filename: ("src/file-" + (tostring) + ".ts"), status: "modified", additions: 1, deletions: 0}]'
+  if [ "\${FAKE_FILES_API_FAILURE:-0}" = "1" ]; then
+    echo "files API failed" >&2
+    exit 5
+  fi
   jq -nc '[{filename: "src/file-100.ts", status: "removed", additions: 0, deletions: 1}]'
   exit 0
 fi
@@ -41,7 +45,7 @@ exit 2
 
 function readPrMetadata(
   fakeGhDir: string,
-  options: { changedFiles?: string; headAfter?: string } = {},
+  options: { changedFiles?: string; filesApiFailure?: boolean; headAfter?: string } = {},
 ) {
   return spawnSync(
     "bash",
@@ -51,6 +55,7 @@ function readPrMetadata(
       env: {
         ...process.env,
         FAKE_CHANGED_FILES: options.changedFiles ?? "101",
+        FAKE_FILES_API_FAILURE: options.filesApiFailure ? "1" : "0",
         FAKE_HEAD_AFTER: options.headAfter ?? "head-a",
         PATH: `${fakeGhDir}:${process.env.PATH}`,
       },
@@ -103,6 +108,15 @@ describe("PR metadata", () => {
     expect(result.stderr).toContain(
       "Incomplete PR file metadata for #42: expected 102 changed files, received 101 from paginated REST.",
     );
+  });
+
+  it("fails closed when the paginated files API fails after emitting a page", () => {
+    const result = readPrMetadata(createFakeGh(), { filesApiFailure: true });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("files API failed");
+    expect(result.stderr).toContain("Failed to collect paginated PR file metadata for #42.");
+    expect(result.stdout).toBe("");
   });
 
   it("rejects files collected while the PR head changes", () => {


### PR DESCRIPTION
## What Problem This Solves

The maintainer PR guard could accept an incomplete changed-file list when a later page of the GitHub API request failed. The first page still reached jq, so command substitution could hide the upstream failure.

Related: #106217

## Why This Change Was Made

The paginated pipeline now enables pipefail inside the command substitution, checks the command status explicitly, and validates that the collected payload is an array before comparing counts. A regression test emits one successful page and then fails the next request.

## User Impact

Maintainer review and merge guards now fail closed instead of reasoning over partial file metadata. No end-user runtime behavior changes.

## Evidence

- Exact commit autoreview on 9342bdc5ae598d306283426a8b98e75ac37342d2: clean, no accepted or actionable findings.
- Testbox tbx_01kxddyws4nmckwbwef8ecwhbv, Actions run 29240389631: focused PR metadata tests passed, 4 of 4.
- Same Testbox: check:changed passed for tooling and test-root lanes.
- Exact-head CI run 29241327412 passed on attempt 2; the lone attempt-1 failure was an unrelated provider-auth cancellation timing flake.
- Latest main has no overlapping changes in the two touched files.

## AI Assistance

AI-assisted implementation and review. Exact-head autoreview completed before push.
