### PR TITLE
fix(macos): defer cookie import banner until inline browser opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS browser login import:** wait until the inline browser first opens before offering cookie import, keeping the Gateway connection screen clear before authentication.
 - **Claude CLI context budgets:** honor Anthropic model and per-agent `contextTokens` limits by passing the effective limit to Claude Code's native auto-compactor and persisting the same prepared budget in OpenClaw session state. Fixes #80933. (#93198) Thanks @mushuiyu886.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.
 - **Gateway source watch:** hand the configured port off from the installed service before starting the tmux watcher, preserve failed panes for attach/capture, and keep explicit alternate-port watches side by side with the managed Gateway.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS browser login import:** wait until the inline browser first opens before offering cookie import, keeping the Gateway connection screen clear before authentication.
 - **Claude CLI context budgets:** honor Anthropic model and per-agent `contextTokens` limits by passing the effective limit to Claude Code's native auto-compactor and persisting the same prepared budget in OpenClaw session state. Fixes #80933. (#93198) Thanks @mushuiyu886.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.
 - **Gateway source watch:** hand the configured port off from the installed service before starting the tmux watcher, preserve failed panes for attach/capture, and keep explicit alternate-port watches side by side with the managed Gateway.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -25523,7 +25523,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 149,
+      "line": 154,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "Browser import requires Local mode",
       "surface": "apple",
@@ -25531,7 +25531,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 151,
+      "line": 156,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
       "surface": "apple",
@@ -25539,7 +25539,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 171,
+      "line": 177,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
       "surface": "apple",
@@ -25547,7 +25547,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 173,
+      "line": 179,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "System browser profile import is disabled in the local Gateway configuration.",
       "surface": "apple",
@@ -25555,7 +25555,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 174,
+      "line": 181,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "No browser login available",
       "surface": "apple",
@@ -25563,7 +25563,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 184,
+      "line": 193,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "Browser import unavailable",
       "surface": "apple",
@@ -27083,7 +27083,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 685,
+      "line": 705,
       "path": "apps/macos/Sources/OpenClaw/DashboardWindowController.swift",
       "source": "[\\(host)]",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -25523,7 +25523,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 154,
+      "line": 162,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "Browser import requires Local mode",
       "surface": "apple",
@@ -25531,7 +25531,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 156,
+      "line": 164,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
       "surface": "apple",
@@ -25539,7 +25539,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 177,
+      "line": 190,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
       "surface": "apple",
@@ -25547,7 +25547,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 179,
+      "line": 192,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "System browser profile import is disabled in the local Gateway configuration.",
       "surface": "apple",
@@ -25555,7 +25555,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 181,
+      "line": 194,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "No browser login available",
       "surface": "apple",
@@ -25563,7 +25563,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 193,
+      "line": 206,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "Browser import unavailable",
       "surface": "apple",
@@ -27083,7 +27083,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 711,
+      "line": 718,
       "path": "apps/macos/Sources/OpenClaw/DashboardWindowController.swift",
       "source": "[\\(host)]",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -27083,7 +27083,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 705,
+      "line": 711,
       "path": "apps/macos/Sources/OpenClaw/DashboardWindowController.swift",
       "source": "[\\(host)]",
       "surface": "apple",
@@ -29587,7 +29587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 687,
+      "line": 688,
       "path": "apps/macos/Sources/OpenClaw/Onboarding.swift",
       "source": "Finish",
       "surface": "apple",
@@ -29595,7 +29595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 687,
+      "line": 688,
       "path": "apps/macos/Sources/OpenClaw/Onboarding.swift",
       "source": "Next",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -25523,7 +25523,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 139,
+      "line": 149,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "Browser import requires Local mode",
       "surface": "apple",
@@ -25531,7 +25531,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 141,
+      "line": 151,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
       "surface": "apple",
@@ -25539,7 +25539,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 161,
+      "line": 171,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
       "surface": "apple",
@@ -25547,7 +25547,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 163,
+      "line": 173,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "System browser profile import is disabled in the local Gateway configuration.",
       "surface": "apple",
@@ -25555,7 +25555,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 164,
+      "line": 174,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "No browser login available",
       "surface": "apple",
@@ -25563,7 +25563,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 174,
+      "line": 184,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "Browser import unavailable",
       "surface": "apple",
@@ -27083,7 +27083,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 676,
+      "line": 674,
       "path": "apps/macos/Sources/OpenClaw/DashboardWindowController.swift",
       "source": "[\\(host)]",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -27083,7 +27083,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 674,
+      "line": 685,
       "path": "apps/macos/Sources/OpenClaw/DashboardWindowController.swift",
       "source": "[\\(host)]",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -27083,7 +27083,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 665,
+      "line": 676,
       "path": "apps/macos/Sources/OpenClaw/DashboardWindowController.swift",
       "source": "[\\(host)]",
       "surface": "apple",
@@ -28963,7 +28963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 108,
+      "line": 103,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Settings...",
       "surface": "apple",
@@ -28971,7 +28971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 115,
+      "line": 110,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Back",
       "surface": "apple",
@@ -28979,7 +28979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 120,
+      "line": 115,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Forward",
       "surface": "apple",
@@ -28987,7 +28987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 138,
+      "line": 133,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "OpenClaw - Voice Wake live meter active",
       "surface": "apple",
@@ -28995,7 +28995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 139,
+      "line": 134,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -29003,7 +29003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 339,
+      "line": 334,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Close Canvas",
       "surface": "apple",
@@ -29011,7 +29011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 339,
+      "line": 334,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Open Canvas",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift
+++ b/apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift
@@ -123,18 +123,22 @@ final class BrowserProfileImportModel {
     /// visible offer, in-flight import, or result is never clobbered by the
     /// status poll.
     @discardableResult
-    func refreshIfIdle() async -> Bool {
+    func refreshIfIdle(
+        while shouldApply: @escaping @MainActor () -> Bool = { true }) async -> Bool
+    {
         guard !self.dismissedThisSession, case .hidden = self.phase else { return false }
-        return await self.performRefresh(force: false).didApply
+        return await self.performRefresh(force: false, shouldApply: shouldApply).didApply
     }
 
     /// Defers the one-shot automatic offer until the app can actually query
     /// the host-local import endpoint. A remote or pre-onboarding sidebar open
     /// must not consume the first eligible local attempt.
     @discardableResult
-    func requestAutomaticOfferIfEligible() async -> Bool {
-        guard self.isOnboarded(), self.isLocalMode() else { return false }
-        return await self.refreshIfIdle()
+    func requestAutomaticOfferIfEligible(
+        while shouldApply: @escaping @MainActor () -> Bool = { true }) async -> Bool
+    {
+        guard self.isOnboarded(), self.isLocalMode(), shouldApply() else { return false }
+        return await self.refreshIfIdle(while: shouldApply)
     }
 
     /// Force (Settings → Import…) re-offers even after a persisted dismissal
@@ -146,7 +150,11 @@ final class BrowserProfileImportModel {
 
     /// Automatic offers are consumed only after a status response is applied.
     /// Failed or stale startup/reconnect requests stay retryable.
-    private func performRefresh(force: Bool) async -> (outcome: ForceRefreshOutcome, didApply: Bool) {
+    private func performRefresh(
+        force: Bool,
+        shouldApply: @escaping @MainActor () -> Bool = { true }) async
+        -> (outcome: ForceRefreshOutcome, didApply: Bool)
+    {
         guard self.isOnboarded(), self.isLocalMode() else {
             self.setPhase(.hidden)
             return (
@@ -168,7 +176,12 @@ final class BrowserProfileImportModel {
             if force {
                 if case .importing = self.phase { return (.offering, true) }
             } else {
-                guard self.phaseGeneration == generation else { return (.offering, false) }
+                // The sidebar may close while the host-local status request is
+                // in flight. Never surface its automatic offer after that UI
+                // owner has gone away.
+                guard self.phaseGeneration == generation, shouldApply() else {
+                    return (.offering, false)
+                }
             }
             guard Self.shouldOffer(status: status, force: force) else {
                 self.setPhase(.hidden)

--- a/apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift
+++ b/apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift
@@ -125,30 +125,36 @@ final class BrowserProfileImportModel {
     @discardableResult
     func refreshIfIdle() async -> Bool {
         guard !self.dismissedThisSession, case .hidden = self.phase else { return false }
-        await self.refresh(force: false)
-        return true
+        return await self.performRefresh(force: false).didQuery
     }
 
     /// Defers the one-shot automatic offer until the app can actually query
     /// the host-local import endpoint. A remote or pre-onboarding sidebar open
     /// must not consume the first eligible local attempt.
     @discardableResult
-    func requestAutomaticOfferIfEligible() -> Bool {
+    func requestAutomaticOfferIfEligible() async -> Bool {
         guard self.isOnboarded(), self.isLocalMode() else { return false }
-        Task { await self.refreshIfIdle() }
-        return true
+        return await self.refreshIfIdle()
     }
 
     /// Force (Settings → Import…) re-offers even after a persisted dismissal
     /// and reports why nothing can be offered so the caller can tell the user.
     @discardableResult
     func refresh(force: Bool) async -> ForceRefreshOutcome {
+        await self.performRefresh(force: force).outcome
+    }
+
+    /// Automatic offers are consumed only after a status response. A failed
+    /// startup/reconnect request stays retryable on the next sidebar event.
+    private func performRefresh(force: Bool) async -> (outcome: ForceRefreshOutcome, didQuery: Bool) {
         guard self.isOnboarded(), self.isLocalMode() else {
             self.setPhase(.hidden)
-            return .unavailable(
-                title: String(localized: "Browser import requires Local mode"),
-                message: String(
-                    localized: "Switch this Mac app to a local Gateway before importing browser cookies."))
+            return (
+                .unavailable(
+                    title: String(localized: "Browser import requires Local mode"),
+                    message: String(
+                        localized: "Switch this Mac app to a local Gateway before importing browser cookies.")),
+                false)
         }
         let generation = self.phaseGeneration
         do {
@@ -160,9 +166,9 @@ final class BrowserProfileImportModel {
             // must stay dismissed); a forced refresh wins over everything
             // except an import that is already running.
             if force {
-                if case .importing = self.phase { return .offering }
+                if case .importing = self.phase { return (.offering, true) }
             } else {
-                guard self.phaseGeneration == generation else { return .offering }
+                guard self.phaseGeneration == generation else { return (.offering, true) }
             }
             guard Self.shouldOffer(status: status, force: force) else {
                 self.setPhase(.hidden)
@@ -171,18 +177,22 @@ final class BrowserProfileImportModel {
                         localized: "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.")
                     : String(
                         localized: "System browser profile import is disabled in the local Gateway configuration.")
-                return .unavailable(title: String(localized: "No browser login available"), message: message)
+                return (
+                    .unavailable(title: String(localized: "No browser login available"), message: message),
+                    true)
             }
             self.setPhase(.offering(status))
-            return .offering
+            return (.offering, true)
         } catch {
             // Same interleaving rule: a failed poll only clears state it owns.
             if force, self.phaseGeneration == generation {
                 if case .importing = self.phase {} else { self.setPhase(.hidden) }
             }
-            return .unavailable(
-                title: String(localized: "Browser import unavailable"),
-                message: error.localizedDescription)
+            return (
+                .unavailable(
+                    title: String(localized: "Browser import unavailable"),
+                    message: error.localizedDescription),
+                false)
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift
+++ b/apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift
@@ -119,9 +119,9 @@ final class BrowserProfileImportModel {
         self.phaseGeneration += 1
     }
 
-    /// Launch/connect/window triggers. Only fills an empty banner slot so a
-    /// visible offer, in-flight import, or result is never clobbered by a
-    /// background status poll.
+    /// First inline-browser open trigger. Only fills an empty banner slot so a
+    /// visible offer, in-flight import, or result is never clobbered by the
+    /// status poll.
     @discardableResult
     func refreshIfIdle() async -> Bool {
         guard !self.dismissedThisSession, case .hidden = self.phase else { return false }

--- a/apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift
+++ b/apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift
@@ -129,6 +129,16 @@ final class BrowserProfileImportModel {
         return true
     }
 
+    /// Defers the one-shot automatic offer until the app can actually query
+    /// the host-local import endpoint. A remote or pre-onboarding sidebar open
+    /// must not consume the first eligible local attempt.
+    @discardableResult
+    func requestAutomaticOfferIfEligible() -> Bool {
+        guard self.isOnboarded(), self.isLocalMode() else { return false }
+        Task { await self.refreshIfIdle() }
+        return true
+    }
+
     /// Force (Settings → Import…) re-offers even after a persisted dismissal
     /// and reports why nothing can be offered so the caller can tell the user.
     @discardableResult

--- a/apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift
+++ b/apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift
@@ -125,7 +125,7 @@ final class BrowserProfileImportModel {
     @discardableResult
     func refreshIfIdle() async -> Bool {
         guard !self.dismissedThisSession, case .hidden = self.phase else { return false }
-        return await self.performRefresh(force: false).didQuery
+        return await self.performRefresh(force: false).didApply
     }
 
     /// Defers the one-shot automatic offer until the app can actually query
@@ -144,9 +144,9 @@ final class BrowserProfileImportModel {
         await self.performRefresh(force: force).outcome
     }
 
-    /// Automatic offers are consumed only after a status response. A failed
-    /// startup/reconnect request stays retryable on the next sidebar event.
-    private func performRefresh(force: Bool) async -> (outcome: ForceRefreshOutcome, didQuery: Bool) {
+    /// Automatic offers are consumed only after a status response is applied.
+    /// Failed or stale startup/reconnect requests stay retryable.
+    private func performRefresh(force: Bool) async -> (outcome: ForceRefreshOutcome, didApply: Bool) {
         guard self.isOnboarded(), self.isLocalMode() else {
             self.setPhase(.hidden)
             return (
@@ -168,7 +168,7 @@ final class BrowserProfileImportModel {
             if force {
                 if case .importing = self.phase { return (.offering, true) }
             } else {
-                guard self.phaseGeneration == generation else { return (.offering, true) }
+                guard self.phaseGeneration == generation else { return (.offering, false) }
             }
             guard Self.shouldOffer(status: status, force: force) else {
                 self.setPhase(.hidden)

--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -235,6 +235,10 @@ final class DashboardManager {
         self.controller?.closeDashboard()
     }
 
+    func handleOnboardingCompletion() {
+        self.controller?.handleOnboardingCompletion()
+    }
+
     func navigateBack() {
         guard self.controller?.window?.isKeyWindow == true else { return }
         self.controller?.navigateBack()

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -341,11 +341,11 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         self.browserProfileImportOfferRequestIsInFlight = true
         Task { [weak self] in
             guard let self else { return }
-            let didQuery = await self.requestBrowserProfileImportOffer()
+            let didApply = await self.requestBrowserProfileImportOffer()
             self.browserProfileImportOfferRequestIsInFlight = false
-            let shouldRetry = self.browserProfileImportOfferRetryPending && !didQuery
+            let shouldRetry = self.browserProfileImportOfferRetryPending && !didApply
             self.browserProfileImportOfferRetryPending = false
-            if didQuery {
+            if didApply {
                 self.didRequestBrowserProfileImportOffer = true
             } else if shouldRetry {
                 self.requestBrowserProfileImportOfferIfNeeded()

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -80,6 +80,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     private var didRequestBrowserProfileImportOffer = false
     private var browserProfileImportOfferIsArmed = false
     private var browserProfileImportOfferRequestIsInFlight = false
+    private var browserProfileImportOfferRetryPending = false
 
     init(
         url: URL,
@@ -329,16 +330,25 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     private func requestBrowserProfileImportOfferIfNeeded() {
         guard self.browserProfileImportOfferIsArmed,
               !self.linkBrowserItem.isCollapsed,
-              !self.didRequestBrowserProfileImportOffer,
-              !self.browserProfileImportOfferRequestIsInFlight
+              !self.didRequestBrowserProfileImportOffer
         else { return }
+        if self.browserProfileImportOfferRequestIsInFlight {
+            // Gateway readiness can arrive while the status poll awaits transport.
+            // Latch one retry so in-flight dedupe does not discard that reconnect signal.
+            self.browserProfileImportOfferRetryPending = true
+            return
+        }
         self.browserProfileImportOfferRequestIsInFlight = true
         Task { [weak self] in
             guard let self else { return }
             let didQuery = await self.requestBrowserProfileImportOffer()
             self.browserProfileImportOfferRequestIsInFlight = false
+            let shouldRetry = self.browserProfileImportOfferRetryPending && !didQuery
+            self.browserProfileImportOfferRetryPending = false
             if didQuery {
                 self.didRequestBrowserProfileImportOffer = true
+            } else if shouldRetry {
+                self.requestBrowserProfileImportOfferIfNeeded()
             }
         }
     }

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -74,20 +74,26 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     private var auth: DashboardWindowAuth
     private let updater: UpdaterProviding?
     private var updateBridgeEnabled: Bool
+    private let requestBrowserProfileImportOffer: @MainActor () -> Void
     private var canGoBackObservation: NSKeyValueObservation?
     private var canGoForwardObservation: NSKeyValueObservation?
+    private var didOpenLinkBrowser = false
 
     init(
         url: URL,
         auth: DashboardWindowAuth,
         updater: UpdaterProviding? = nil,
-        updateBridgeEnabled: Bool = true)
+        updateBridgeEnabled: Bool = true,
+        requestBrowserProfileImportOffer: @escaping @MainActor () -> Void = {
+            Task { await BrowserProfileImportModel.shared.refreshIfIdle() }
+        })
     {
         let shouldEnableUpdateBridge = updater?.isAvailable == true && updateBridgeEnabled
         self.currentURL = url
         self.auth = auth
         self.updater = updater
         self.updateBridgeEnabled = shouldEnableUpdateBridge
+        self.requestBrowserProfileImportOffer = requestBrowserProfileImportOffer
 
         let dataStore = WKWebsiteDataStore.default()
         let config = WKWebViewConfiguration()
@@ -307,10 +313,15 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         self.webView.load(URLRequest(url: url))
     }
 
-    private func openLinkBrowser(_ url: URL) {
+    private func openLinkBrowser(_ url: URL, requestBrowserProfileImportOffer: Bool = true) {
+        let isFirstOpen = !self.didOpenLinkBrowser
+        self.didOpenLinkBrowser = true
         self.linkBrowserItem.isCollapsed = false
         self.linkBrowser.open(url)
         window?.makeFirstResponder(self.linkBrowser.activeWebView)
+        if isFirstOpen, requestBrowserProfileImportOffer {
+            self.requestBrowserProfileImportOffer()
+        }
     }
 
     private func closeLinkBrowser(focusDashboard: Bool = true) {
@@ -984,8 +995,8 @@ extension DashboardWindowController {
         self.splitViewController.splitView.autosaveName
     }
 
-    func _testOpenLinkBrowser(_ url: URL) {
-        self.openLinkBrowser(url)
+    func _testOpenLinkBrowser(_ url: URL, requestBrowserProfileImportOffer: Bool = false) {
+        self.openLinkBrowser(url, requestBrowserProfileImportOffer: requestBrowserProfileImportOffer)
     }
 
     func _testCloseLinkBrowser() {

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -74,19 +74,20 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     private var auth: DashboardWindowAuth
     private let updater: UpdaterProviding?
     private var updateBridgeEnabled: Bool
-    private let requestBrowserProfileImportOffer: @MainActor () -> Bool
+    private let requestBrowserProfileImportOffer: @MainActor () async -> Bool
     private var canGoBackObservation: NSKeyValueObservation?
     private var canGoForwardObservation: NSKeyValueObservation?
     private var didRequestBrowserProfileImportOffer = false
     private var browserProfileImportOfferIsArmed = false
+    private var browserProfileImportOfferRequestIsInFlight = false
 
     init(
         url: URL,
         auth: DashboardWindowAuth,
         updater: UpdaterProviding? = nil,
         updateBridgeEnabled: Bool = true,
-        requestBrowserProfileImportOffer: @escaping @MainActor () -> Bool = {
-            BrowserProfileImportModel.shared.requestAutomaticOfferIfEligible()
+        requestBrowserProfileImportOffer: @escaping @MainActor () async -> Bool = {
+            await BrowserProfileImportModel.shared.requestAutomaticOfferIfEligible()
         })
     {
         let shouldEnableUpdateBridge = updater?.isAvailable == true && updateBridgeEnabled
@@ -328,9 +329,18 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     private func requestBrowserProfileImportOfferIfNeeded() {
         guard self.browserProfileImportOfferIsArmed,
               !self.linkBrowserItem.isCollapsed,
-              !self.didRequestBrowserProfileImportOffer
+              !self.didRequestBrowserProfileImportOffer,
+              !self.browserProfileImportOfferRequestIsInFlight
         else { return }
-        self.didRequestBrowserProfileImportOffer = self.requestBrowserProfileImportOffer()
+        self.browserProfileImportOfferRequestIsInFlight = true
+        Task { [weak self] in
+            guard let self else { return }
+            let didQuery = await self.requestBrowserProfileImportOffer()
+            self.browserProfileImportOfferRequestIsInFlight = false
+            if didQuery {
+                self.didRequestBrowserProfileImportOffer = true
+            }
+        }
     }
 
     private func closeLinkBrowser(focusDashboard: Bool = true) {

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -74,7 +74,8 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     private var auth: DashboardWindowAuth
     private let updater: UpdaterProviding?
     private var updateBridgeEnabled: Bool
-    private let requestBrowserProfileImportOffer: @MainActor () async -> Bool
+    private let requestBrowserProfileImportOffer:
+        @MainActor (@escaping @MainActor () -> Bool) async -> Bool
     private var canGoBackObservation: NSKeyValueObservation?
     private var canGoForwardObservation: NSKeyValueObservation?
     private var didRequestBrowserProfileImportOffer = false
@@ -87,8 +88,9 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         auth: DashboardWindowAuth,
         updater: UpdaterProviding? = nil,
         updateBridgeEnabled: Bool = true,
-        requestBrowserProfileImportOffer: @escaping @MainActor () async -> Bool = {
-            await BrowserProfileImportModel.shared.requestAutomaticOfferIfEligible()
+        requestBrowserProfileImportOffer:
+        @escaping @MainActor (@escaping @MainActor () -> Bool) async -> Bool = { shouldApply in
+            await BrowserProfileImportModel.shared.requestAutomaticOfferIfEligible(while: shouldApply)
         })
     {
         let shouldEnableUpdateBridge = updater?.isAvailable == true && updateBridgeEnabled
@@ -341,7 +343,12 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         self.browserProfileImportOfferRequestIsInFlight = true
         Task { [weak self] in
             guard let self else { return }
-            let didApply = await self.requestBrowserProfileImportOffer()
+            let didApply = await self.requestBrowserProfileImportOffer { [weak self] in
+                guard let self else { return false }
+                return self.browserProfileImportOfferIsArmed &&
+                    !self.linkBrowserItem.isCollapsed &&
+                    !self.didRequestBrowserProfileImportOffer
+            }
             self.browserProfileImportOfferRequestIsInFlight = false
             let shouldRetry = self.browserProfileImportOfferRetryPending && !didApply
             self.browserProfileImportOfferRetryPending = false

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -78,6 +78,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     private var canGoBackObservation: NSKeyValueObservation?
     private var canGoForwardObservation: NSKeyValueObservation?
     private var didRequestBrowserProfileImportOffer = false
+    private var browserProfileImportOfferIsArmed = false
 
     init(
         url: URL,
@@ -267,6 +268,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
             self.setUpdateBridgeEnabled(updateBridgeEnabled)
         }
         self.load(url)
+        self.requestBrowserProfileImportOfferIfNeeded()
     }
 
     /// Miniaturized windows report `isVisible == false` but must still follow
@@ -317,9 +319,18 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         self.linkBrowserItem.isCollapsed = false
         self.linkBrowser.open(url)
         window?.makeFirstResponder(self.linkBrowser.activeWebView)
-        if requestBrowserProfileImportOffer, !self.didRequestBrowserProfileImportOffer {
-            self.didRequestBrowserProfileImportOffer = self.requestBrowserProfileImportOffer()
+        if requestBrowserProfileImportOffer {
+            self.browserProfileImportOfferIsArmed = true
+            self.requestBrowserProfileImportOfferIfNeeded()
         }
+    }
+
+    private func requestBrowserProfileImportOfferIfNeeded() {
+        guard self.browserProfileImportOfferIsArmed,
+              !self.linkBrowserItem.isCollapsed,
+              !self.didRequestBrowserProfileImportOffer
+        else { return }
+        self.didRequestBrowserProfileImportOffer = self.requestBrowserProfileImportOffer()
     }
 
     private func closeLinkBrowser(focusDashboard: Bool = true) {

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -353,6 +353,12 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         }
     }
 
+    func handleOnboardingCompletion() {
+        // A pre-onboarding inline browser leaves the one-shot armed. Retry at
+        // the eligibility transition so it does not depend on later navigation.
+        self.requestBrowserProfileImportOfferIfNeeded()
+    }
+
     private func closeLinkBrowser(focusDashboard: Bool = true) {
         self.linkBrowser.closeBrowser()
         self.linkBrowserItem.isCollapsed = true

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -74,18 +74,18 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     private var auth: DashboardWindowAuth
     private let updater: UpdaterProviding?
     private var updateBridgeEnabled: Bool
-    private let requestBrowserProfileImportOffer: @MainActor () -> Void
+    private let requestBrowserProfileImportOffer: @MainActor () -> Bool
     private var canGoBackObservation: NSKeyValueObservation?
     private var canGoForwardObservation: NSKeyValueObservation?
-    private var didOpenLinkBrowser = false
+    private var didRequestBrowserProfileImportOffer = false
 
     init(
         url: URL,
         auth: DashboardWindowAuth,
         updater: UpdaterProviding? = nil,
         updateBridgeEnabled: Bool = true,
-        requestBrowserProfileImportOffer: @escaping @MainActor () -> Void = {
-            Task { await BrowserProfileImportModel.shared.refreshIfIdle() }
+        requestBrowserProfileImportOffer: @escaping @MainActor () -> Bool = {
+            BrowserProfileImportModel.shared.requestAutomaticOfferIfEligible()
         })
     {
         let shouldEnableUpdateBridge = updater?.isAvailable == true && updateBridgeEnabled
@@ -314,13 +314,11 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     }
 
     private func openLinkBrowser(_ url: URL, requestBrowserProfileImportOffer: Bool = true) {
-        let isFirstOpen = !self.didOpenLinkBrowser
-        self.didOpenLinkBrowser = true
         self.linkBrowserItem.isCollapsed = false
         self.linkBrowser.open(url)
         window?.makeFirstResponder(self.linkBrowser.activeWebView)
-        if isFirstOpen, requestBrowserProfileImportOffer {
-            self.requestBrowserProfileImportOffer()
+        if requestBrowserProfileImportOffer, !self.didRequestBrowserProfileImportOffer {
+            self.didRequestBrowserProfileImportOffer = self.requestBrowserProfileImportOffer()
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -78,11 +78,6 @@ struct OpenClawApp: App {
         }
         .onChange(of: self.controlChannel.state) { _, _ in
             self.applyStatusItemAppearance(paused: self.state.isPaused, sleeping: self.isGatewaySleeping)
-            if self.controlChannel.state == .connected {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                    Task { await BrowserProfileImportModel.shared.refreshIfIdle() }
-                }
-            }
         }
         .onChange(of: self.gatewayManager.status) { _, _ in
             self.applyStatusItemAppearance(paused: self.state.isPaused, sleeping: self.isGatewaySleeping)
@@ -453,9 +448,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task { await PeekabooBridgeHostCoordinator.shared.setEnabled(AppStateStore.shared.peekabooBridgeEnabled) }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             CLIInstallPrompter.shared.checkAndPromptIfNeeded(reason: "launch")
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) {
-            Task { await BrowserProfileImportModel.shared.refreshIfIdle() }
         }
 
         #if DEBUG

--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -496,6 +496,7 @@ final class OnboardingController: NSObject, NSWindowDelegate {
         UserDefaults.standard.set(true, forKey: onboardingSeenKey)
         UserDefaults.standard.set(currentOnboardingVersion, forKey: onboardingVersionKey)
         AppStateStore.shared.onboardingSeen = true
+        DashboardManager.shared.handleOnboardingCompletion()
     }
 
     func show() {

--- a/apps/macos/Tests/OpenClawIPCTests/BrowserProfileImportModelTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/BrowserProfileImportModelTests.swift
@@ -29,7 +29,10 @@ private final class BrowserImportTransportStub {
     }
     """
 
-    func makeModel(isLocalMode: @escaping @MainActor () -> Bool = { true }) -> BrowserProfileImportModel {
+    func makeModel(
+        isOnboarded: @escaping @MainActor () -> Bool = { true },
+        isLocalMode: @escaping @MainActor () -> Bool = { true }) -> BrowserProfileImportModel
+    {
         BrowserProfileImportModel(
             transport: { [weak self] request in
                 guard let self else { throw StubError() }
@@ -50,7 +53,7 @@ private final class BrowserImportTransportStub {
                     return Data(#"{"ok":true}"#.utf8)
                 }
             },
-            isOnboarded: { true },
+            isOnboarded: isOnboarded,
             isLocalMode: isLocalMode)
     }
 
@@ -123,6 +126,26 @@ struct BrowserProfileImportModelTests {
             message: "Switch this Mac app to a local Gateway before importing browser cookies."))
         #expect(model.phase == .hidden)
         #expect(stub.requests.isEmpty)
+    }
+
+    @Test func `automatic offer request waits for onboarding and local mode`() async {
+        let stub = BrowserImportTransportStub()
+        var isOnboarded = false
+        var isLocalMode = false
+        let model = stub.makeModel(
+            isOnboarded: { isOnboarded },
+            isLocalMode: { isLocalMode })
+
+        #expect(!model.requestAutomaticOfferIfEligible())
+        isOnboarded = true
+        #expect(!model.requestAutomaticOfferIfEligible())
+        isLocalMode = true
+        #expect(model.requestAutomaticOfferIfEligible())
+
+        for _ in 0..<200 where stub.requests(for: "/system-profile-import/status").isEmpty {
+            await Task.yield()
+        }
+        #expect(stub.requests(for: "/system-profile-import/status").count == 1)
     }
 
     @Test func `import success records counts and target`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/BrowserProfileImportModelTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/BrowserProfileImportModelTests.swift
@@ -155,6 +155,28 @@ struct BrowserProfileImportModelTests {
         #expect(stub.requests(for: "/system-profile-import/status").count == 2)
     }
 
+    @Test func `automatic offer does not apply after its inline browser closes`() async {
+        let stub = BrowserImportTransportStub()
+        let model = stub.makeModel()
+        let gate = ContinuationBox()
+        var shouldApply = true
+        stub.beforeStatusResponse = {
+            await withCheckedContinuation { gate.continuation = $0 }
+        }
+
+        let request = Task {
+            await model.requestAutomaticOfferIfEligible(while: { shouldApply })
+        }
+        while gate.continuation == nil {
+            await Task.yield()
+        }
+
+        shouldApply = false
+        gate.continuation?.resume()
+        #expect(await !request.value)
+        #expect(model.phase == .hidden)
+    }
+
     @Test func `import success records counts and target`() async throws {
         let stub = BrowserImportTransportStub()
         let model = stub.makeModel()

--- a/apps/macos/Tests/OpenClawIPCTests/BrowserProfileImportModelTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/BrowserProfileImportModelTests.swift
@@ -242,7 +242,7 @@ struct BrowserProfileImportModelTests {
         model._testSetPhase(.offering(forced))
 
         gate.continuation?.resume()
-        _ = await idle.value
+        #expect(await !idle.value)
         #expect(model.phase == .offering(forced))
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/BrowserProfileImportModelTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/BrowserProfileImportModelTests.swift
@@ -136,16 +136,23 @@ struct BrowserProfileImportModelTests {
             isOnboarded: { isOnboarded },
             isLocalMode: { isLocalMode })
 
-        #expect(!model.requestAutomaticOfferIfEligible())
+        #expect(await !model.requestAutomaticOfferIfEligible())
         isOnboarded = true
-        #expect(!model.requestAutomaticOfferIfEligible())
+        #expect(await !model.requestAutomaticOfferIfEligible())
         isLocalMode = true
-        #expect(model.requestAutomaticOfferIfEligible())
-
-        for _ in 0..<200 where stub.requests(for: "/system-profile-import/status").isEmpty {
-            await Task.yield()
-        }
+        #expect(await model.requestAutomaticOfferIfEligible())
         #expect(stub.requests(for: "/system-profile-import/status").count == 1)
+    }
+
+    @Test func `failed automatic status request stays retryable`() async {
+        let stub = BrowserImportTransportStub()
+        stub.failingPaths = ["/system-profile-import/status"]
+        let model = stub.makeModel()
+
+        #expect(await !model.requestAutomaticOfferIfEligible())
+        stub.failingPaths = []
+        #expect(await model.requestAutomaticOfferIfEligible())
+        #expect(stub.requests(for: "/system-profile-import/status").count == 2)
     }
 
     @Test func `import success records counts and target`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -109,7 +109,7 @@ struct DashboardWindowSmokeTests {
         let controller = DashboardWindowController(
             url: dashboard,
             auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
-            requestBrowserProfileImportOffer: {
+            requestBrowserProfileImportOffer: { _ in
                 requestCount += 1
                 if requestCount == 1 {
                     return await withCheckedContinuation { continuation in
@@ -160,7 +160,7 @@ struct DashboardWindowSmokeTests {
         let controller = DashboardWindowController(
             url: dashboard,
             auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
-            requestBrowserProfileImportOffer: { gate.request() })
+            requestBrowserProfileImportOffer: { _ in gate.request() })
         defer { controller.closeDashboard() }
         let manager = DashboardManager._testMake()
         manager._testSetController(controller)
@@ -184,6 +184,48 @@ struct DashboardWindowSmokeTests {
             await Task.yield()
         }
         #expect(gate.requestCount == 2)
+    }
+
+    @Test func `closing inline browser invalidates an in-flight import offer`() async throws {
+        let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        var requestCount = 0
+        var firstRequestContinuation: CheckedContinuation<Void, Never>?
+        var firstRequestApplied: Bool?
+        let controller = DashboardWindowController(
+            url: dashboard,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            requestBrowserProfileImportOffer: { shouldApply in
+                requestCount += 1
+                if requestCount == 1 {
+                    await withCheckedContinuation { continuation in
+                        firstRequestContinuation = continuation
+                    }
+                    firstRequestApplied = shouldApply()
+                    return firstRequestApplied == true
+                }
+                return shouldApply()
+            })
+        defer { controller.closeDashboard() }
+
+        let link = try #require(URL(string: "https://docs.openclaw.ai/"))
+        controller._testOpenLinkBrowser(link, requestBrowserProfileImportOffer: true)
+        for _ in 0..<200 where firstRequestContinuation == nil {
+            await Task.yield()
+        }
+        #expect(requestCount == 1)
+
+        controller._testCloseLinkBrowser()
+        firstRequestContinuation?.resume()
+        for _ in 0..<200 where firstRequestApplied == nil {
+            await Task.yield()
+        }
+        #expect(firstRequestApplied == false)
+
+        controller._testOpenLinkBrowser(link, requestBrowserProfileImportOffer: true)
+        for _ in 0..<200 where requestCount == 1 {
+            await Task.yield()
+        }
+        #expect(requestCount == 2)
     }
 
     @Test func `dashboard parses only bounded native link requests`() throws {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -107,12 +107,21 @@ struct DashboardWindowSmokeTests {
         #expect(requestCount == 0)
 
         let link = try #require(URL(string: "https://docs.openclaw.ai/"))
+        controller._testOpenLinkBrowser(link)
+        isEligible = true
+        controller.update(
+            url: dashboard,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+        #expect(requestCount == 0)
+
+        isEligible = false
         controller._testOpenLinkBrowser(link, requestBrowserProfileImportOffer: true)
         #expect(requestCount == 0)
 
-        controller._testCloseLinkBrowser()
         isEligible = true
-        controller._testOpenLinkBrowser(link, requestBrowserProfileImportOffer: true)
+        controller.update(
+            url: dashboard,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
         #expect(requestCount == 1)
 
         controller._testCloseLinkBrowser()

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -89,6 +89,27 @@ struct DashboardWindowSmokeTests {
         #expect(controller._testNavigationWebViewIdentity == linkWebView)
     }
 
+    @Test func `browser import offer waits for the first inline browser open`() throws {
+        let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        var requestCount = 0
+        let controller = DashboardWindowController(
+            url: dashboard,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            requestBrowserProfileImportOffer: { requestCount += 1 })
+        defer { controller.closeDashboard() }
+
+        controller.show()
+        #expect(requestCount == 0)
+
+        let link = try #require(URL(string: "https://docs.openclaw.ai/"))
+        controller._testOpenLinkBrowser(link, requestBrowserProfileImportOffer: true)
+        #expect(requestCount == 1)
+
+        controller._testCloseLinkBrowser()
+        controller._testOpenLinkBrowser(link, requestBrowserProfileImportOffer: true)
+        #expect(requestCount == 1)
+    }
+
     @Test func `dashboard parses only bounded native link requests`() throws {
         let request = DashboardWindowController.linkRequest(from: [
             "type": "open-link",

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -94,13 +94,18 @@ struct DashboardWindowSmokeTests {
     @Test func `browser import offer retries until the first completed inline browser request`() async throws {
         let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
         var requestCount = 0
-        var didQuery = false
+        var firstRequestContinuation: CheckedContinuation<Bool, Never>?
         let controller = DashboardWindowController(
             url: dashboard,
             auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
             requestBrowserProfileImportOffer: {
                 requestCount += 1
-                return didQuery
+                if requestCount == 1 {
+                    return await withCheckedContinuation { continuation in
+                        firstRequestContinuation = continuation
+                    }
+                }
+                return true
             })
         defer { controller.closeDashboard() }
 
@@ -115,18 +120,16 @@ struct DashboardWindowSmokeTests {
         #expect(requestCount == 0)
 
         controller._testOpenLinkBrowser(link, requestBrowserProfileImportOffer: true)
-        for _ in 0..<200 where requestCount == 0 {
+        for _ in 0..<200 where firstRequestContinuation == nil {
             await Task.yield()
         }
         #expect(requestCount == 1)
-        for _ in 0..<10 {
-            await Task.yield()
-        }
 
-        didQuery = true
         controller.update(
             url: dashboard,
             auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+        firstRequestContinuation?.resume(returning: false)
+        firstRequestContinuation = nil
         for _ in 0..<200 where requestCount == 1 {
             await Task.yield()
         }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -89,19 +89,29 @@ struct DashboardWindowSmokeTests {
         #expect(controller._testNavigationWebViewIdentity == linkWebView)
     }
 
-    @Test func `browser import offer waits for the first inline browser open`() throws {
+    @Test func `browser import offer waits for the first eligible inline browser open`() throws {
         let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
         var requestCount = 0
+        var isEligible = false
         let controller = DashboardWindowController(
             url: dashboard,
             auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
-            requestBrowserProfileImportOffer: { requestCount += 1 })
+            requestBrowserProfileImportOffer: {
+                guard isEligible else { return false }
+                requestCount += 1
+                return true
+            })
         defer { controller.closeDashboard() }
 
         controller.show()
         #expect(requestCount == 0)
 
         let link = try #require(URL(string: "https://docs.openclaw.ai/"))
+        controller._testOpenLinkBrowser(link, requestBrowserProfileImportOffer: true)
+        #expect(requestCount == 0)
+
+        controller._testCloseLinkBrowser()
+        isEligible = true
         controller._testOpenLinkBrowser(link, requestBrowserProfileImportOffer: true)
         #expect(requestCount == 1)
 

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -25,7 +25,9 @@ private actor DashboardRouteAuthGate {
         self.token = token
     }
 
-    func probes() -> Int { self.probeCount }
+    func probes() -> Int {
+        self.probeCount
+    }
 }
 
 @Suite(.serialized)
@@ -83,23 +85,22 @@ struct DashboardWindowSmokeTests {
             auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
         #expect(controller._testNavigationWebViewIdentity == controller._testDashboardWebViewIdentity)
 
-        controller._testOpenLinkBrowser(try #require(URL(string: "https://docs.openclaw.ai/")))
+        try controller._testOpenLinkBrowser(#require(URL(string: "https://docs.openclaw.ai/")))
         let linkWebView = try #require(controller._testLinkBrowserWebViewIdentity)
         #expect(controller._testFocusLinkBrowser())
         #expect(controller._testNavigationWebViewIdentity == linkWebView)
     }
 
-    @Test func `browser import offer waits for the first eligible inline browser open`() throws {
+    @Test func `browser import offer retries until the first completed inline browser request`() async throws {
         let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
         var requestCount = 0
-        var isEligible = false
+        var didQuery = false
         let controller = DashboardWindowController(
             url: dashboard,
             auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
             requestBrowserProfileImportOffer: {
-                guard isEligible else { return false }
                 requestCount += 1
-                return true
+                return didQuery
             })
         defer { controller.closeDashboard() }
 
@@ -108,25 +109,35 @@ struct DashboardWindowSmokeTests {
 
         let link = try #require(URL(string: "https://docs.openclaw.ai/"))
         controller._testOpenLinkBrowser(link)
-        isEligible = true
         controller.update(
             url: dashboard,
             auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
         #expect(requestCount == 0)
 
-        isEligible = false
         controller._testOpenLinkBrowser(link, requestBrowserProfileImportOffer: true)
-        #expect(requestCount == 0)
+        for _ in 0..<200 where requestCount == 0 {
+            await Task.yield()
+        }
+        #expect(requestCount == 1)
+        for _ in 0..<10 {
+            await Task.yield()
+        }
 
-        isEligible = true
+        didQuery = true
         controller.update(
             url: dashboard,
             auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
-        #expect(requestCount == 1)
+        for _ in 0..<200 where requestCount == 1 {
+            await Task.yield()
+        }
+        #expect(requestCount == 2)
 
         controller._testCloseLinkBrowser()
         controller._testOpenLinkBrowser(link, requestBrowserProfileImportOffer: true)
-        #expect(requestCount == 1)
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+        #expect(requestCount == 2)
     }
 
     @Test func `dashboard parses only bounded native link requests`() throws {
@@ -691,9 +702,9 @@ struct DashboardWindowSmokeTests {
         manager._testSetController(controller)
         defer { manager._testController()?.closeDashboard() }
 
-        await manager.handleEndpointState(.ready(
+        try await manager.handleEndpointState(.ready(
             mode: .remote,
-            url: try #require(URL(string: "ws://127.0.0.1:60001")),
+            url: #require(URL(string: "ws://127.0.0.1:60001")),
             token: nil,
             password: nil,
             routeRevision: 2))

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -30,6 +30,17 @@ private actor DashboardRouteAuthGate {
     }
 }
 
+@MainActor
+private final class DashboardBrowserImportGate {
+    var isOnboarded = false
+    private(set) var requestCount = 0
+
+    func request() -> Bool {
+        self.requestCount += 1
+        return self.isOnboarded
+    }
+}
+
 @Suite(.serialized)
 @MainActor
 struct DashboardWindowSmokeTests {
@@ -141,6 +152,38 @@ struct DashboardWindowSmokeTests {
             await Task.yield()
         }
         #expect(requestCount == 2)
+    }
+
+    @Test func `browser import offer retries when onboarding completes with browser open`() async throws {
+        let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        let gate = DashboardBrowserImportGate()
+        let controller = DashboardWindowController(
+            url: dashboard,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            requestBrowserProfileImportOffer: { gate.request() })
+        defer { controller.closeDashboard() }
+        let manager = DashboardManager._testMake()
+        manager._testSetController(controller)
+
+        let link = try #require(URL(string: "https://docs.openclaw.ai/"))
+        controller._testOpenLinkBrowser(link, requestBrowserProfileImportOffer: true)
+        for _ in 0..<200 where gate.requestCount == 0 {
+            await Task.yield()
+        }
+        #expect(gate.requestCount == 1)
+
+        gate.isOnboarded = true
+        manager.handleOnboardingCompletion()
+        for _ in 0..<200 where gate.requestCount == 1 {
+            await Task.yield()
+        }
+        #expect(gate.requestCount == 2)
+
+        manager.handleOnboardingCompletion()
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+        #expect(gate.requestCount == 2)
     }
 
     @Test func `dashboard parses only bounded native link requests`() throws {

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -67,7 +67,7 @@ Right-click an external link to choose **Open in Sidebar**, **Open in Default Br
 
 ## Import browser logins
 
-When the app runs against a local Gateway and a Chrome-family profile with cookies exists on the Mac, the dashboard window shows a dismissible banner offering to copy those cookies into an isolated managed profile that agents use for browsing. Choose a profile from the banner's **Import** control (Touch ID may be required); progress and the imported-cookie count appear inline, and only cookies are copied — passwords never leave the source browser. Dismissing the banner records the choice; **Settings → General → Browser login → Import…** re-offers it at any time. See [Browser](/cli/browser) for the underlying import flow and the `browser.allowSystemProfileImport` gate.
+The first time the browser sidebar opens while the app runs against a local Gateway, the dashboard shows a dismissible banner when a Chrome-family profile with cookies exists on the Mac. The banner offers to copy those cookies into an isolated managed profile that agents use for browsing. Choose a profile from its **Import** control (Touch ID may be required); progress and the imported-cookie count appear inline, and only cookies are copied — passwords never leave the source browser. Dismissing the banner records the choice; **Settings → General → Browser login → Import…** re-offers it at any time. See [Browser](/cli/browser) for the underlying import flow and the `browser.allowSystemProfileImport` gate.
 
 ## Choose a Gateway mode
 


### PR DESCRIPTION
## What Problem This Solves

Fixes the macOS cookie-import banner appearing while the embedded dashboard is still showing its Gateway connection or authentication screen. The automatic offer previously ran after app launch and every Gateway connection, before the inline browser was used.

## Why This Change Was Made

The automatic offer is now armed only when the inline browser first opens. Pre-onboarding, remote-Gateway, failed startup, stale in-flight responses, and overlapping reconnect attempts remain armed until one host-local status query is applied. If the first open happens before onboarding completes, completion retries only that existing open, armed dashboard offer. A live sidebar predicate prevents an in-flight response from surfacing the banner after the inline browser closes. The first applied query consumes the one-shot; later inline-browser opens stay silent. Settings -> General -> Browser login -> Import remains the explicit re-offer path.

This is the narrow timing follow-up to the inline banner introduced in #104591. AI-assisted; reviewed with the repository autoreview helper.

## User Impact

The Gateway connection/authentication screen stays clear. Eligible local-Gateway users see the cookie-import offer only when inline browsing becomes relevant.

## Evidence

- Added macOS regressions for silent dashboard launch, first inline-browser arming, failed status retry, stale-response retry, overlapping reconnect-event retry, pre-onboarding completion retry, close-during-poll invalidation, retry after reopening, first applied-query consumption, and later-open suppression.
- `swift test --package-path apps/macos --filter 'BrowserProfileImportModelTests|DashboardWindowSmokeTests'` - 48 tests passed.
- SwiftFormat lint - no files require formatting.
- SwiftLint strict - 0 violations.
- Native i18n sync/check - 4,320 entries; final check reports no drift.
- Repository autoreview fix cycle - clean, no accepted/actionable findings.
- Exact dirty-checkout Blacksmith Testbox changed gate (`tbx_01kxe32vjhsycsc535crjzg3aj`) - all five routed Vitest shards and repository gates passed.
- Exact-head release gate: https://github.com/openclaw/openclaw/actions/runs/29265358719
- Hosted macOS Swift lane - lint, release build, and full Swift tests passed: https://github.com/openclaw/openclaw/actions/runs/29265358719/job/86869157059

A signed Developer ID build completed and passed code-signature verification. Interactive visual capture was blocked by macOS secure Screen Recording and Keychain approval prompts; no security setting or credential was changed.
