### PR TITLE
refactor(macos): use swift-log contracts

### DIFF
--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/orchetect/MenuBarExtraAccess", exact: "1.3.0"),
         .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "0.4.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.10.1"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.12.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
         .package(url: "https://github.com/steipete/Peekaboo.git", exact: "3.9.0"),
         .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.3.1"),

--- a/apps/macos/Sources/OpenClaw/DebugSettings.swift
+++ b/apps/macos/Sources/OpenClaw/DebugSettings.swift
@@ -24,7 +24,7 @@ struct DebugSettings: View {
     @State private var tunnelResetStatus: String?
     @State private var pendingKill: DebugActions.PortListener?
     @AppStorage(debugFileLogEnabledKey) private var diagnosticsFileLogEnabled: Bool = false
-    @AppStorage(appLogLevelKey) private var appLogLevelRaw: String = AppLogLevel.default.rawValue
+    @AppStorage(appLogLevelKey) private var appLogLevelRaw: String = Logger.Level.info.rawValue
 
     @State private var canvasSessionKey: String = "main"
     @State private var canvasStatus: String?
@@ -275,7 +275,7 @@ struct DebugSettings: View {
                     self.gridLabel("App logging")
                     VStack(alignment: .leading, spacing: 8) {
                         Picker("Verbosity", selection: self.$appLogLevelRaw) {
-                            ForEach(AppLogLevel.allCases) { level in
+                            ForEach(Logger.Level.allCases, id: \.rawValue) { level in
                                 Text(level.title).tag(level.rawValue)
                             }
                         }

--- a/apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift
+++ b/apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift
@@ -26,21 +26,7 @@ enum AppLogSettings {
     }
 }
 
-enum AppLogLevel: String, CaseIterable, Identifiable {
-    case trace
-    case debug
-    case info
-    case notice
-    case warning
-    case error
-    case critical
-
-    static let `default`: AppLogLevel = .info
-
-    var id: String {
-        self.rawValue
-    }
-
+extension Logger.Level {
     var title: String {
         switch self {
         case .trace: "Trace"
@@ -140,29 +126,9 @@ struct OpenClawOSLogHandler: AppLogLevelBackedHandler {
     }
 
     func log(event: LogEvent) {
-        self.writeLog(level: event.level, message: event.message, metadata: event.metadata)
-    }
-
-    func log(
-        level: Logger.Level,
-        message: Logger.Message,
-        metadata: Logger.Metadata?,
-        source: String,
-        file: String,
-        function: String,
-        line: UInt)
-    {
-        self.writeLog(level: level, message: message, metadata: metadata)
-    }
-
-    private func writeLog(
-        level: Logger.Level,
-        message: Logger.Message,
-        metadata: Logger.Metadata?)
-    {
-        let merged = Self.mergeMetadata(self.metadata, metadata)
-        let rendered = Self.renderMessage(message, metadata: merged)
-        self.osLogger.log(level: Self.osLogType(for: level), "\(rendered, privacy: .public)")
+        let merged = self.metadata.merging(event.metadata ?? [:], uniquingKeysWith: { _, new in new })
+        let rendered = Self.renderMessage(event.message, metadata: merged)
+        self.osLogger.log(level: Self.osLogType(for: event.level), "\(rendered, privacy: .public)")
     }
 
     private static func osLogType(for level: Logger.Level) -> OSLogType {
@@ -180,14 +146,6 @@ struct OpenClawOSLogHandler: AppLogLevelBackedHandler {
         }
     }
 
-    private static func mergeMetadata(
-        _ base: Logger.Metadata,
-        _ extra: Logger.Metadata?) -> Logger.Metadata
-    {
-        guard let extra else { return base }
-        return base.merging(extra, uniquingKeysWith: { _, new in new })
-    }
-
     private static func renderMessage(_ message: Logger.Message, metadata: Logger.Metadata) -> String {
         guard !metadata.isEmpty else { return message.description }
         let meta = metadata
@@ -203,59 +161,21 @@ struct OpenClawFileLogHandler: AppLogLevelBackedHandler {
     var metadata: Logger.Metadata = [:]
 
     func log(event: LogEvent) {
-        self.writeLog(
-            level: event.level,
-            message: event.message,
-            metadata: event.metadata,
-            source: event.source,
-            file: event.file,
-            function: event.function,
-            line: event.line)
-    }
-
-    func log(
-        level: Logger.Level,
-        message: Logger.Message,
-        metadata: Logger.Metadata?,
-        source: String,
-        file: String,
-        function: String,
-        line: UInt)
-    {
-        self.writeLog(
-            level: level,
-            message: message,
-            metadata: metadata,
-            source: source,
-            file: file,
-            function: function,
-            line: line)
-    }
-
-    private func writeLog(
-        level: Logger.Level,
-        message: Logger.Message,
-        metadata: Logger.Metadata?,
-        source: String,
-        file: String,
-        function: String,
-        line: UInt)
-    {
         guard AppLogSettings.fileLoggingEnabled() else { return }
         let (subsystem, category) = OpenClawLogging.parseLabel(self.label)
         var fields: [String: String] = [
             "subsystem": subsystem,
             "category": category,
-            "level": level.rawValue,
-            "source": source,
-            "file": file,
-            "function": function,
-            "line": "\(line)",
+            "level": event.level.rawValue,
+            "source": event.source,
+            "file": event.file,
+            "function": event.function,
+            "line": "\(event.line)",
         ]
-        let merged = self.metadata.merging(metadata ?? [:], uniquingKeysWith: { _, new in new })
+        let merged = self.metadata.merging(event.metadata ?? [:], uniquingKeysWith: { _, new in new })
         for (key, value) in merged {
             fields["meta.\(key)"] = stringifyLogMetadataValue(value)
         }
-        DiagnosticsFileLog.shared.log(category: category, event: message.description, fields: fields)
+        DiagnosticsFileLog.shared.log(category: category, event: event.message.description, fields: fields)
     }
 }

--- a/apps/macos/Sources/OpenClaw/MenuContentView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuContentView.swift
@@ -23,7 +23,7 @@ struct MenuContent: View {
     @State private var micRefreshTask: Task<Void, Never>?
     @State private var browserControlEnabled = true
     @AppStorage(cameraEnabledKey) private var cameraEnabled: Bool = false
-    @AppStorage(appLogLevelKey) private var appLogLevelRaw: String = AppLogLevel.default.rawValue
+    @AppStorage(appLogLevelKey) private var appLogLevelRaw: String = Logger.Level.info.rawValue
     @AppStorage(debugFileLogEnabledKey) private var appFileLoggingEnabled: Bool = false
 
     init(state: AppState, updater: UpdaterProviding?) {
@@ -278,7 +278,7 @@ struct MenuContent: View {
                 }
                 Menu {
                     Picker("Verbosity", selection: self.$appLogLevelRaw) {
-                        ForEach(AppLogLevel.allCases) { level in
+                        ForEach(Logger.Level.allCases, id: \.rawValue) { level in
                             Text(level.title).tag(level.rawValue)
                         }
                     }


### PR DESCRIPTION
Fixes #106251

## What Problem This Solves

The macOS app carries duplicate logging-level and dispatch code already owned by swift-log, increasing maintenance cost and leaving production handlers on a deprecated callback surface.

## Why This Change Was Made

Use swift-log's native level cases and event callback directly, while preserving the existing localized titles, metadata merge order, log formatting, persisted raw values, and existing treatment of optional error payloads. Raise the declared swift-log floor to the first release that provides the event API.

## User Impact

No intended user-visible behavior change. The macOS logging path is smaller and follows the dependency's current contract.

## Evidence

- Net 80 lines removed: 16 insertions, 96 deletions.
- Direct source inspection of pinned swift-log 1.13.2 confirmed `LogHandler.log(event:)`, `Logger.Level: CaseIterable`, and event-based logger/multiplex dispatch.
- Remote macOS 26.5.2 / Xcode 26.6 release build passed.
- Focused MenuContent and Settings smoke tests passed: 35/35.
- Full macOS suite passed 1,162/1,163 tests; the sole failure was the unrelated pre-existing ExecApprovals migration concurrency test.
- Swift formatting passed for all macOS sources.
- Post-rebase patch ID exactly matches the remotely built/tested patch; latest main changed none of the four touched files.
- `swift package resolve` retained the existing swift-log 1.13.2 pin and left `Package.resolved` byte-identical.
- Fresh post-rebase autoreview: no actionable findings, correctness confidence 0.98.

AI assistance: Codex audited the dependency contract, implemented the refactor, and ran validation. Maintainer reviewed the resulting diff and evidence.
