### PR TITLE
fix: preserve safe pristine gateway startup

### DIFF
--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -14,6 +14,8 @@ type EnsureConfigReadyOptions = {
   beforeStateMigrations?: () => Promise<boolean>;
   commandPath?: string[];
   requireConfig?: boolean;
+  skipPristineCoreStateMigrations?: boolean;
+  skipPristineStartupStateMigrations?: boolean;
 };
 const ensureConfigReadyMock = vi.fn<(_opts: EnsureConfigReadyOptions) => Promise<void>>(
   async () => {},
@@ -23,6 +25,8 @@ const routeLogsToStderrMock = vi.fn();
 const prepareGatewayRunBootstrapMock = vi.fn(async () => true);
 const recheckGatewayRunBootstrapMock = vi.fn(async () => true);
 const reloadTrustedGatewayRunEnvironmentMock = vi.fn(async () => true);
+const wasPreparedGatewayRunCoreStatePristineMock = vi.fn(() => true);
+const wasPreparedGatewayRunStatePristineMock = vi.fn(() => true);
 
 const runtimeMock = {
   log: vi.fn(),
@@ -64,6 +68,8 @@ vi.mock("../gateway-cli/pre-bootstrap.js", () => ({
   prepareGatewayRunBootstrap: prepareGatewayRunBootstrapMock,
   recheckGatewayRunBootstrap: recheckGatewayRunBootstrapMock,
   reloadTrustedGatewayRunEnvironment: reloadTrustedGatewayRunEnvironmentMock,
+  wasPreparedGatewayRunCoreStatePristine: wasPreparedGatewayRunCoreStatePristineMock,
+  wasPreparedGatewayRunStatePristine: wasPreparedGatewayRunStatePristineMock,
 }));
 
 let registerPreActionHooks: typeof import("./preaction.js").registerPreActionHooks;
@@ -319,6 +325,8 @@ describe("registerPreActionHooks", () => {
       expect.objectContaining({
         beforeStateMigrations: expect.any(Function),
         commandPath: ["gateway", "run"],
+        skipPristineCoreStateMigrations: true,
+        skipPristineStartupStateMigrations: true,
       }),
     );
     const beforeStateMigrations = ensureConfigReadyMock.mock.calls[0]?.[0]?.beforeStateMigrations;

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -151,9 +151,15 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       return;
     }
     let beforeStateMigrations: ((snapshot?: ConfigFileSnapshot) => Promise<boolean>) | undefined;
+    let skipPristineStartupStateMigrations = false;
+    let skipPristineCoreStateMigrations = false;
     if (isGatewayRunAction(actionCommand)) {
-      const { prepareGatewayRunBootstrap, recheckGatewayRunBootstrap } =
-        await import("../gateway-cli/pre-bootstrap.js");
+      const {
+        prepareGatewayRunBootstrap,
+        recheckGatewayRunBootstrap,
+        wasPreparedGatewayRunCoreStatePristine,
+        wasPreparedGatewayRunStatePristine,
+      } = await import("../gateway-cli/pre-bootstrap.js");
       const { resolveGatewayRunOptions } = await import("../gateway-cli/run-options.js");
       const resolvedOptions = resolveGatewayRunOptions(actionCommand.opts(), actionCommand);
       const opts = {
@@ -164,6 +170,8 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       if (!shouldBootstrap) {
         return;
       }
+      skipPristineStartupStateMigrations = wasPreparedGatewayRunStatePristine();
+      skipPristineCoreStateMigrations = wasPreparedGatewayRunCoreStatePristine();
       beforeStateMigrations = (snapshot) =>
         recheckGatewayRunBootstrap({
           opts,
@@ -177,6 +185,8 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       startupPolicy,
       allowInvalid: shouldAllowInvalidConfigForAction(actionCommand, commandPath),
       ...(beforeStateMigrations ? { beforeStateMigrations } : {}),
+      ...(skipPristineStartupStateMigrations ? { skipPristineStartupStateMigrations: true } : {}),
+      ...(skipPristineCoreStateMigrations ? { skipPristineCoreStateMigrations: true } : {}),
       skipConfigGuard: shouldBypassConfigGuardForCommandPath(commandPath),
     });
     if (beforeStateMigrations) {

--- a/src/commands/doctor/shared/pristine-startup-state.test.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.test.ts
@@ -144,6 +144,12 @@ describe("pristine startup state", () => {
       skipAllStateMigrations: false,
       skipCoreStateMigrations: false,
     });
+    expect(
+      planPristineStartupConfigMigrations({ agents: { $include: "agents.json" } }, env),
+    ).toEqual({
+      skipAllStateMigrations: false,
+      skipCoreStateMigrations: false,
+    });
   });
 
   it("rejects enabled plugin entries and includes", () => {

--- a/src/commands/doctor/shared/pristine-startup-state.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.ts
@@ -105,7 +105,7 @@ export function planPristineStartupConfigMigrations(
   config: unknown,
   env: NodeJS.ProcessEnv = process.env,
 ): PristineStartupMigrationPlan {
-  if (!isRecord(config) || Object.hasOwn(config, "$include")) {
+  if (!isRecord(config) || containsObjectKey(config, "$include")) {
     return { skipAllStateMigrations: false, skipCoreStateMigrations: false };
   }
   const skipCoreStateMigrations = configIsPristineCoreStateSafe(config);


### PR DESCRIPTION
Related: #106194
Follow-up to #106195 and its two late review threads:
- https://github.com/openclaw/openclaw/pull/106195#discussion_r3569374618
- https://github.com/openclaw/openclaw/pull/106195#discussion_r3569426705

AI-assisted: yes.

## What Problem This Solves

Fixes an issue where pristine Gateway startup could skip required core migration discovery when config used a nested include, while full-CLI Gateway invocations such as `openclaw --log-level debug gateway run` missed the intended pristine-startup speedup.

## Why This Change Was Made

Nested include directives now conservatively keep the full migration path. The full Commander pre-action path also forwards the same pre-bootstrap pristine-state facts already used by the dedicated Gateway fast path.

## User Impact

Gateway startup remains migration-safe for included config and avoids redundant migration discovery on pristine full-CLI launches.

## Evidence

- Blacksmith Testbox through Crabbox: `tbx_01kxdq278e3xx9j17h85t4cvbm` ([run](https://github.com/openclaw/openclaw/actions/runs/29249842650))
- `pnpm test src/commands/doctor/shared/pristine-startup-state.test.ts src/cli/program/preaction.test.ts src/cli/command-execution-startup.test.ts src/cli/command-bootstrap.test.ts` — 47 tests passed
- `pnpm check:changed` — passed on `ffee18c0445af63a6b848cf1a572801387797dc9`
- `pnpm deadcode:dependencies`, `pnpm deadcode:unused-files`, `pnpm deadcode:exports` — passed; 25 unused-file and 3,234 unused-export baseline entries matched
- `pnpm check:test-types`, `pnpm tsgo:scripts`, `pnpm tsgo:test:root` — passed
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --no-web-search` — clean, no actionable findings (0.98 confidence)

No changelog entry: internal startup optimization and regression coverage follow-up.
