### PR TITLE
refactor(infra): privatize gateway lock options

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -2510,7 +2510,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/infra/gateway-boot-lifecycle.ts: GATEWAY_BOOT_LOOP_UNCLEAN_THRESHOLD",
   "src/infra/gateway-boot-lifecycle.ts: GATEWAY_BOOT_LOOP_WINDOW_MS",
   "src/infra/gateway-boot-lifecycle.ts: GatewayBootLifecycleOutcome",
-  "src/infra/gateway-lock.ts: GatewayLockOptions",
   "src/infra/gateway-suspend-coordinator.ts: GATEWAY_SUSPEND_RETRY_AFTER_MS",
   "src/infra/gateway-suspend-coordinator.ts: GATEWAY_SUSPEND_TTL_MS",
   "src/infra/gateway-suspend-coordinator.ts: GatewaySuspendPrepareResult",

--- a/src/commands/doctor-sqlite-maintenance-lock.ts
+++ b/src/commands/doctor-sqlite-maintenance-lock.ts
@@ -3,19 +3,17 @@ import fs from "node:fs";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import { resolvePathViaExistingAncestorSync, resolveRootPathSync } from "../infra/boundary-path.js";
-import {
-  acquireGatewayLock,
-  GatewayLockError,
-  type GatewayLockOptions,
-} from "../infra/gateway-lock.js";
+import { acquireGatewayLock, GatewayLockError } from "../infra/gateway-lock.js";
 import { isPathInside } from "../infra/path-guards.js";
 import type { DoctorSessionSqliteMode } from "./doctor-session-sqlite-types.js";
 
 const MAINTENANCE_LOCK_TIMEOUT_MS = 250;
 const MAINTENANCE_LOCK_POLL_INTERVAL_MS = 25;
 
+type AcquireGatewayLockOptions = NonNullable<Parameters<typeof acquireGatewayLock>[0]>;
+
 type MaintenanceLockOptions = Pick<
-  GatewayLockOptions,
+  AcquireGatewayLockOptions,
   | "lockDir"
   | "now"
   | "platform"

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -53,9 +53,9 @@ type GatewayLockHandle = {
   release: () => Promise<void>;
 };
 
-export type GatewayLockRole = "gateway" | "sqlite-maintenance";
+type GatewayLockRole = "gateway" | "sqlite-maintenance";
 
-export type GatewayLockOptions = {
+type GatewayLockOptions = {
   env?: NodeJS.ProcessEnv;
   timeoutMs?: number;
   pollIntervalMs?: number;


### PR DESCRIPTION
## What Problem This Solves

Current main's shrink-only production dead-export ratchet drifted after the SQLite maintenance lock work: `GatewayLockOptions` became a production import while `GatewayLockRole` remained exported without a production consumer. This blocks exact-head `check-dependencies` for #106220.

## Why This Change Was Made

- Made both gateway-lock option types module-private.
- Derived the doctor command's narrow override shape from `acquireGatewayLock`'s parameter contract instead of importing an internal type.
- Removed the stale `GatewayLockOptions` baseline entry without adding `GatewayLockRole` debt.

AI-assisted implementation and review.

## User Impact

No runtime or user-visible behavior change. Internal TypeScript visibility and the enforced dead-export baseline are corrected.

No changelog entry: internal ratchet repair only.

## Evidence

- Blacksmith Testbox `tbx_01kxdg0hy49khr0nwddn63w6x4`: gateway-lock and doctor-maintenance-lock tests, 50/50 passed (https://github.com/openclaw/openclaw/actions/runs/29242545845).
- Final Blacksmith Testbox `tbx_01kxdg7xt54qad875whpsmdx2m`: baseline regeneration byte-identical; `deadcode:exports` matched exactly 3,319 entries (https://github.com/openclaw/openclaw/actions/runs/29242782522).
- Changed gate passed conflict, attribution, wildcard, duplicate, dependency-pin, and formatting checks. It then hit unrelated current-main Plugin SDK API hash drift; this PR does not touch Plugin SDK files.
- Targeted `oxfmt --check` and `git diff --check`: passed.
- Fresh autoreview: clean, no actionable findings, 0.86 confidence.
