### PR TITLE
fix(cli): stop stale session retry loops after failover

### DIFF
--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
 import { FailoverError } from "../../agents/failover-error.js";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
+import type { SessionEntry } from "../../config/sessions.js";
 import {
   emitAgentEvent,
   getAgentEventLifecycleGeneration,
@@ -14,6 +15,7 @@ import type {
   ReasoningTextPayload,
 } from "./agent-runner-cli-dispatch.js";
 import {
+  clearDroppedCliSessionBinding,
   createCliToolSummaryTracker,
   keepCliSessionBindingOnlyWhenReused,
   runCliAgentWithLifecycle,
@@ -21,16 +23,22 @@ import {
 
 const cliDispatchState = vi.hoisted(() => ({
   runCliAgentMock: vi.fn(),
+  updateSessionEntryMock: vi.fn(),
 }));
 
 vi.mock("../../agents/cli-runner.js", () => ({
   runCliAgent: (...args: unknown[]) => cliDispatchState.runCliAgentMock(...args),
 }));
 
+vi.mock("../../config/sessions/session-accessor.js", () => ({
+  updateSessionEntry: (...args: unknown[]) => cliDispatchState.updateSessionEntryMock(...args),
+}));
+
 afterEach(() => {
   vi.useRealTimers();
   resetAgentEventsForTest();
   cliDispatchState.runCliAgentMock.mockReset();
+  cliDispatchState.updateSessionEntryMock.mockReset();
 });
 
 describe("runCliAgentWithLifecycle", () => {
@@ -559,6 +567,100 @@ describe("keepCliSessionBindingOnlyWhenReused", () => {
     expect(onDroppedReplacement).toHaveBeenCalledOnce();
     expect(result.meta.agentMeta?.sessionId).toBe("");
     expect(result.meta.agentMeta?.cliSessionBinding).toBeUndefined();
+  });
+});
+
+describe("clearDroppedCliSessionBinding", () => {
+  it("clears a matching stale binding from memory and persistence", async () => {
+    const createEntry = (): SessionEntry =>
+      ({
+        cliSessionBindings: { "claude-cli": { sessionId: "stale-session" } },
+        cliSessionIds: { "claude-cli": "stale-session" },
+        claudeCliSessionId: "stale-session",
+        updatedAt: 1,
+      }) as SessionEntry;
+    const activeEntry = createEntry();
+    const storedEntry = createEntry();
+    const persistedEntry = createEntry();
+    cliDispatchState.updateSessionEntryMock.mockImplementationOnce(
+      async (_scope: unknown, update: (entry: SessionEntry) => Partial<SessionEntry> | null) => {
+        const patch = update(persistedEntry);
+        return patch ?? persistedEntry;
+      },
+    );
+
+    await expect(
+      clearDroppedCliSessionBinding({
+        provider: "claude-cli",
+        sessionKey: "main",
+        sessionStore: { main: storedEntry },
+        storePath: "/tmp/sessions.json",
+        activeSessionEntry: activeEntry,
+        expectedSessionId: "stale-session",
+      }),
+    ).resolves.toBe(true);
+
+    for (const entry of [activeEntry, storedEntry, persistedEntry]) {
+      expect(entry).toMatchObject({
+        cliSessionBindings: undefined,
+        cliSessionIds: undefined,
+        claudeCliSessionId: undefined,
+        updatedAt: expect.any(Number),
+      });
+    }
+  });
+
+  it("preserves a newer persisted binding", async () => {
+    const activeEntry = {
+      cliSessionIds: { "claude-cli": "stale-session" },
+      claudeCliSessionId: "stale-session",
+    } as SessionEntry;
+    const persistedEntry = {
+      cliSessionIds: { "claude-cli": "newer-session" },
+      claudeCliSessionId: "newer-session",
+    } as SessionEntry;
+    cliDispatchState.updateSessionEntryMock.mockImplementationOnce(
+      async (_scope: unknown, update: (entry: SessionEntry) => Partial<SessionEntry> | null) => {
+        const patch = update(persistedEntry);
+        return patch ?? persistedEntry;
+      },
+    );
+
+    await expect(
+      clearDroppedCliSessionBinding({
+        provider: "claude-cli",
+        sessionKey: "main",
+        sessionStore: { main: activeEntry },
+        storePath: "/tmp/sessions.json",
+        activeSessionEntry: activeEntry,
+        expectedSessionId: "stale-session",
+      }),
+    ).resolves.toBe(false);
+    expect(activeEntry.cliSessionIds?.["claude-cli"]).toBe("stale-session");
+    expect(persistedEntry.cliSessionIds?.["claude-cli"]).toBe("newer-session");
+  });
+
+  it("clears memory without retrying when the persisted row is missing", async () => {
+    const activeEntry = {
+      cliSessionIds: { "claude-cli": "stale-session" },
+      claudeCliSessionId: "stale-session",
+    } as SessionEntry;
+    cliDispatchState.updateSessionEntryMock.mockImplementationOnce(async () => null);
+
+    await expect(
+      clearDroppedCliSessionBinding({
+        provider: "claude-cli",
+        sessionKey: "main",
+        sessionStore: { main: activeEntry },
+        storePath: "/tmp/sessions.json",
+        activeSessionEntry: activeEntry,
+        expectedSessionId: "stale-session",
+      }),
+    ).resolves.toBe(false);
+    expect(activeEntry).toMatchObject({
+      cliSessionIds: undefined,
+      claudeCliSessionId: undefined,
+    });
   });
 });
 

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -3,7 +3,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
-import { clearCliSession } from "../../agents/cli-session.js";
+import { clearCliSession, getCliSessionId } from "../../agents/cli-session.js";
 import { extractToolResultText } from "../../agents/embedded-agent-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "../../agents/embedded-agent-utils.js";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent.js";
@@ -298,8 +298,22 @@ export async function clearDroppedCliSessionBinding(params: {
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
   activeSessionEntry?: SessionEntry;
-}): Promise<void> {
+  expectedSessionId?: string;
+}): Promise<boolean> {
   const updatedAt = Date.now();
+  const expectedSessionId = normalizeOptionalString(params.expectedSessionId);
+  const sessionStoreEntry = params.sessionKey
+    ? params.sessionStore?.[params.sessionKey]
+    : undefined;
+  const memoryEntries = Array.from(
+    new Set([params.activeSessionEntry, sessionStoreEntry].filter((entry) => entry !== undefined)),
+  );
+  const stillHasExpectedBinding = (entry: SessionEntry | undefined) => {
+    const sessionId = getCliSessionId(entry, params.provider);
+    return (
+      sessionId === undefined || expectedSessionId === undefined || sessionId === expectedSessionId
+    );
+  };
   const clearEntry = (entry: SessionEntry | undefined) => {
     if (!entry) {
       return;
@@ -307,18 +321,36 @@ export async function clearDroppedCliSessionBinding(params: {
     clearCliSession(entry, params.provider);
     entry.updatedAt = updatedAt;
   };
-  clearEntry(params.activeSessionEntry);
-  clearEntry(params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined);
-  if (!params.storePath || !params.sessionKey) {
-    return;
+  if (!memoryEntries.every(stillHasExpectedBinding)) {
+    return false;
   }
+  if (!params.storePath || !params.sessionKey) {
+    memoryEntries.forEach(clearEntry);
+    return true;
+  }
+  let persistedEntryObserved = false;
+  let persistedClearApplied = false;
   await updateSessionEntry(
     { storePath: params.storePath, sessionKey: params.sessionKey },
     (entry) => {
+      persistedEntryObserved = true;
+      if (!stillHasExpectedBinding(entry)) {
+        return null;
+      }
+      persistedClearApplied = true;
       clearEntry(entry);
       return entry;
     },
   );
+  if (!persistedEntryObserved) {
+    memoryEntries.forEach(clearEntry);
+    return false;
+  }
+  if (!persistedClearApplied || !memoryEntries.every(stillHasExpectedBinding)) {
+    return false;
+  }
+  memoryEntries.forEach(clearEntry);
+  return true;
 }
 
 function createToolEventBridge(params: {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -2875,6 +2875,60 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 
+  it("clears a stale CLI session before a fresh-session recovery retry", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "sonnet-4.6"),
+      provider: "claude-cli",
+      model: "sonnet-4.6",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockImplementationOnce(
+      async (runParams: {
+        cliSessionId?: string;
+        onBeforeFreshCliSessionRetry?: (params: {
+          provider: string;
+          reason: "session_expired";
+          sessionId: string;
+        }) => Promise<boolean>;
+      }) => {
+        expect(runParams.cliSessionId).toBe("stale-cli-session");
+        await expect(
+          runParams.onBeforeFreshCliSessionRetry?.({
+            provider: "claude-cli",
+            reason: "session_expired",
+            sessionId: "stale-cli-session",
+          }),
+        ).resolves.toBe(true);
+        return { payloads: [{ text: "recovered" }], meta: {} };
+      },
+    );
+
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "sonnet-4.6";
+    const sessionEntry = {
+      cliSessionBindings: { "claude-cli": { sessionId: "stale-cli-session" } },
+      cliSessionIds: { "claude-cli": "stale-cli-session" },
+      claudeCliSessionId: "stale-cli-session",
+    } as SessionEntry;
+    const activeSessionStore = { main: sessionEntry };
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({ followupRun }),
+      activeSessionStore,
+      getActiveSessionEntry: () => sessionEntry,
+    });
+
+    expect(result.kind).toBe("success");
+    expect(sessionEntry).toMatchObject({
+      cliSessionBindings: undefined,
+      cliSessionIds: undefined,
+      claudeCliSessionId: undefined,
+    });
+  });
+
   it("keeps the first CLI session created by a room-event turn", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2228,6 +2228,15 @@ async function runAgentTurnWithFallbackInternal(
                     ownerNumbers: params.followupRun.run.ownerNumbers,
                     cliSessionId: cliSessionBinding?.sessionId,
                     cliSessionBinding,
+                    onBeforeFreshCliSessionRetry: ({ provider: retryProvider, sessionId }) =>
+                      clearDroppedCliSessionBinding({
+                        provider: retryProvider,
+                        sessionKey: params.sessionKey,
+                        sessionStore: params.activeSessionStore,
+                        storePath: params.storePath,
+                        activeSessionEntry: params.getActiveSessionEntry(),
+                        expectedSessionId: sessionId,
+                      }),
                     authProfileId: authProfile.authProfileId,
                     bootstrapContextMode: params.opts?.bootstrapContextMode,
                     bootstrapContextRunKind,

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1754,6 +1754,74 @@ describe("createFollowupRunner runtime config", () => {
     expect(call.cliSessionBinding).toEqual({ sessionId: "cli-session-1" });
   });
 
+  it("clears a stale CLI session before retrying a queued followup", async () => {
+    const runtimeConfig: OpenClawConfig = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": { command: "claude" },
+          },
+          models: {
+            "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      },
+    };
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-cli-followup",
+      updatedAt: Date.now(),
+      cliSessionBindings: { "claude-cli": { sessionId: "stale-cli-session" } },
+      cliSessionIds: { "claude-cli": "stale-cli-session" },
+      claudeCliSessionId: "stale-cli-session",
+    };
+    runCliAgentMock.mockImplementationOnce(
+      async (runParams: {
+        cliSessionId?: string;
+        onBeforeFreshCliSessionRetry?: (params: {
+          provider: string;
+          reason: "session_expired";
+          sessionId: string;
+        }) => Promise<boolean>;
+      }) => {
+        expect(runParams.cliSessionId).toBe("stale-cli-session");
+        await expect(
+          runParams.onBeforeFreshCliSessionRetry?.({
+            provider: "claude-cli",
+            reason: "session_expired",
+            sessionId: "stale-cli-session",
+          }),
+        ).resolves.toBe(true);
+        return { payloads: [{ text: "recovered" }], meta: {} };
+      },
+    );
+
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      defaultModel: "anthropic/claude-opus-4-7",
+    });
+
+    await runner(
+      createQueuedRun({
+        run: {
+          config: runtimeConfig,
+          sessionId: "session-cli-followup",
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+        },
+      }),
+    );
+
+    expect(sessionEntry).toMatchObject({
+      cliSessionBindings: undefined,
+      cliSessionIds: undefined,
+      claudeCliSessionId: undefined,
+    });
+  });
+
   it("stores queued room-event CLI sessions created from the first ambient run", async () => {
     const runtimeConfig: OpenClawConfig = {
       agents: {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1312,6 +1312,15 @@ export function createFollowupRunner(params: {
                     ownerNumbers: run.ownerNumbers,
                     cliSessionId: cliSessionBinding?.sessionId,
                     cliSessionBinding,
+                    onBeforeFreshCliSessionRetry: ({ provider: retryProvider, sessionId }) =>
+                      clearDroppedCliSessionBinding({
+                        provider: retryProvider,
+                        sessionKey: replySessionKey,
+                        sessionStore,
+                        storePath,
+                        activeSessionEntry,
+                        expectedSessionId: sessionId,
+                      }),
                     bootstrapPromptWarningSignaturesSeen,
                     bootstrapPromptWarningSignature:
                       bootstrapPromptWarningSignaturesSeen[


### PR DESCRIPTION
Closes #97887

AI-assisted: implemented and reviewed with Codex.

## What Problem This Solves

Fixes an issue where CLI-backed turns could keep reusing an invalid session ID after a recoverable failover. Because the stale binding remained in session state, later turns could repeatedly resume the same broken CLI session instead of recovering with a fresh one.

## Why This Change Was Made

The existing CLI runner already supports a guarded fresh-session retry, but the direct reply and queued follow-up dispatch paths did not clear their stored binding before that retry. This change wires both paths to an atomic compare-and-clear helper. It clears only the expected stale CLI session across current memory and persistence, refuses to overwrite a newer concurrent binding, and does not recreate a session deleted during the failed attempt.

## User Impact

Users with Claude CLI or another CLI backend can recover from an expired or otherwise retryable stale session without entering a repeated failover loop. Concurrent session resets or replacements remain protected.

## Evidence

- Focused CLI dispatch suite: 23 passed.
- New queued follow-up recovery test: 1 passed with 149 unrelated tests skipped.
- Direct and queued-path combined suite: 276 passed; one existing thinking-level assertion also fails unchanged on origin/main.
- Follow-up full suite: 131 passed; 18 tests are blocked by the local Node 24.14 runtime because its embedded SQLite 3.51.2 is below the repository WAL-safety floor. The repository requires Node 24.15+ for this lane.
- oxfmt check passed for all changed files.
- oxlint passed for all changed files.
- git diff --check passed.
- Final Codex review: no actionable regression identified.

The added regression coverage verifies matching stale-state cleanup, protection of a newer persisted binding, missing-row lifecycle isolation, direct reply recovery, and queued follow-up recovery.

I understand the compare-and-clear behavior and verified that it only authorizes a fresh retry after the expected persisted stale binding was removed.