### PR TITLE
fix(ci): refresh plugin SDK API baseline hash

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-258b7a39727a8306374bfdca2300d489fcbec41ef5a2f499c6a4b7cc83603e5c  plugin-sdk-api-baseline.json
-f3f0affc5cffbd83ffb84cbbc9be86fcaffb574f7022dd804212d0ceac04bd4a  plugin-sdk-api-baseline.jsonl
+8b66b318a1c92ddca44cc95063acc233293e9d9b17342af5d5a366630e9266b7  plugin-sdk-api-baseline.json
+0a0f6c3e0c3b32ee04a70a62131eab6ea9ad03f4a6614903ba96a959e2e77f76  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
## What Problem This Solves

The helper-consolidation landing in #106016 changed the generated Plugin SDK API state after its last committed hash refresh. Current main therefore fails `plugin-sdk:api:check`, blocking unrelated exact-head CI.

## Why This Change Was Made

Regenerated the tracked Plugin SDK API hash file from current main. The generated JSON/JSONL state remains local and gitignored; this PR contains only the two expected hash-line updates.

## User Impact

No runtime or published API behavior change. This records the API surface already present on main and restores the CI ratchet.

No changelog entry: generated CI metadata only.

## Evidence

- Blacksmith Testbox `tbx_01kxdgep0wsjdd5063abetxb3w`: `plugin-sdk:api:gen` produced only the expected tracked hash diff (https://github.com/openclaw/openclaw/actions/runs/29242995355).
- Blacksmith Testbox `tbx_01kxdgnt3qptzxv5kjtyxqkv89`: `plugin-sdk:api:check` passed on the updated file (https://github.com/openclaw/openclaw/actions/runs/29243225119).
- Stable patch-id across latest-main rebase; signed one-file commit.
- `git diff --check`: passed.
