### PR TITLE
fix(file-transfer): reject oversized dir.fetch preflights

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -274,7 +274,6 @@ extensions/qa-matrix/src/runners/contract/scenario-runtime-approval.ts
 extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee-destructive.ts
 extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts
 extensions/qa-matrix/src/runners/contract/scenarios.test.ts
-extensions/qa-matrix/src/substrate/client.ts
 extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
 extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
 extensions/qqbot/src/engine/messaging/outbound-deliver.ts

--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -274,6 +274,7 @@ extensions/qa-matrix/src/runners/contract/scenario-runtime-approval.ts
 extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee-destructive.ts
 extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts
 extensions/qa-matrix/src/runners/contract/scenarios.test.ts
+extensions/qa-matrix/src/substrate/client.ts
 extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
 extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
 extensions/qqbot/src/engine/messaging/outbound-deliver.ts

--- a/extensions/file-transfer/src/node-host/dir-fetch.stream-errors.test.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.stream-errors.test.ts
@@ -55,9 +55,7 @@ describe("dir.fetch process wrapper", () => {
   });
 
   it("uses capped tar output for preflight-only requests without returning the archive", async () => {
-    runCommandBufferedMock
-      .mockResolvedValueOnce(commandResult({ stdout: Buffer.from("archive") }))
-      .mockResolvedValueOnce(commandResult({ stdout: Buffer.from("./ok.txt\n") }));
+    runCommandBufferedMock.mockResolvedValueOnce(commandResult({ stdout: Buffer.from("archive") }));
 
     await expect(
       handleDirFetch({ path: tmpRoot, maxBytes: 1024, preflightOnly: true }),
@@ -67,9 +65,8 @@ describe("dir.fetch process wrapper", () => {
       fileCount: 1,
       preflightOnly: true,
     });
-    expect(runCommandBufferedMock).toHaveBeenCalledTimes(2);
-    expect(runCommandBufferedMock).toHaveBeenNthCalledWith(
-      1,
+    expect(runCommandBufferedMock).toHaveBeenCalledOnce();
+    expect(runCommandBufferedMock).toHaveBeenCalledWith(
       [process.platform !== "win32" ? "/usr/bin/tar" : "tar", "-czf", "-", "-C", tmpRoot, "."],
       expect.objectContaining({
         discardOutput: { stderr: true },
@@ -95,6 +92,37 @@ describe("dir.fetch process wrapper", () => {
       message: "tarball exceeded 1024 byte limit during preflight",
     });
     expect(runCommandBufferedMock).toHaveBeenCalledOnce();
+  });
+
+  it("rejects preflight-only requests once filesystem listing crosses the entry cap", async () => {
+    await Promise.all(
+      Array.from({ length: 5001 }, (_, index) =>
+        fs.writeFile(path.join(tmpRoot, `file-${index}.txt`), ""),
+      ),
+    );
+
+    await expect(
+      handleDirFetch({ path: tmpRoot, maxBytes: 1024, preflightOnly: true }),
+    ).resolves.toMatchObject({
+      ok: false,
+      code: "TREE_TOO_LARGE",
+      message: "directory tree exceeds 5000 entries during preflight",
+    });
+    expect(runCommandBufferedMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves filesystem classification when a preflight tar race removes the directory", async () => {
+    runCommandBufferedMock.mockImplementationOnce(async () => {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+      return commandResult({ code: 1 });
+    });
+
+    await expect(
+      handleDirFetch({ path: tmpRoot, maxBytes: 1024, preflightOnly: true }),
+    ).resolves.toMatchObject({
+      ok: false,
+      code: "NOT_FOUND",
+    });
   });
 
   it("fails tar entry listing closed on wrapper errors", async () => {

--- a/extensions/file-transfer/src/node-host/dir-fetch.stream-errors.test.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.stream-errors.test.ts
@@ -54,6 +54,24 @@ describe("dir.fetch process wrapper", () => {
     );
   });
 
+  it("falls back to entry listing for preflight-only requests when the optional du probe fails", async () => {
+    runCommandBufferedMock.mockRejectedValueOnce(new Error("du failed"));
+
+    await expect(
+      handleDirFetch({ path: tmpRoot, maxBytes: 1024, preflightOnly: true }),
+    ).resolves.toMatchObject({
+      ok: true,
+      entries: ["ok.txt"],
+      fileCount: 1,
+      preflightOnly: true,
+    });
+    expect(runCommandBufferedMock).toHaveBeenCalledOnce();
+    expect(runCommandBufferedMock).toHaveBeenCalledWith(
+      ["du", "-sk", tmpRoot],
+      expect.objectContaining({ discardOutput: { stderr: true } }),
+    );
+  });
+
   it("rejects preflight-only requests when du reports an oversized directory", async () => {
     runCommandBufferedMock.mockResolvedValueOnce(
       commandResult({ stdout: Buffer.from("999\t/tmp/project\n") }),

--- a/extensions/file-transfer/src/node-host/dir-fetch.stream-errors.test.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.stream-errors.test.ts
@@ -54,6 +54,25 @@ describe("dir.fetch process wrapper", () => {
     );
   });
 
+  it("rejects preflight-only requests when du reports an oversized directory", async () => {
+    runCommandBufferedMock.mockResolvedValueOnce(
+      commandResult({ stdout: Buffer.from("999\t/tmp/project\n") }),
+    );
+
+    await expect(
+      handleDirFetch({ path: tmpRoot, maxBytes: 64 * 1024, preflightOnly: true }),
+    ).resolves.toMatchObject({
+      ok: false,
+      code: "TREE_TOO_LARGE",
+      message: "directory tree exceeds estimated size limit (65536 bytes raw)",
+    });
+    expect(runCommandBufferedMock).toHaveBeenCalledOnce();
+    expect(runCommandBufferedMock).toHaveBeenCalledWith(
+      ["du", "-sk", tmpRoot],
+      expect.objectContaining({ discardOutput: { stderr: true } }),
+    );
+  });
+
   it("fails tar entry listing closed on wrapper errors", async () => {
     runCommandBufferedMock
       .mockResolvedValueOnce(commandResult({ stdout: Buffer.from("1\tproject\n") }))

--- a/extensions/file-transfer/src/node-host/dir-fetch.stream-errors.test.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.stream-errors.test.ts
@@ -54,8 +54,10 @@ describe("dir.fetch process wrapper", () => {
     );
   });
 
-  it("falls back to entry listing for preflight-only requests when the optional du probe fails", async () => {
-    runCommandBufferedMock.mockRejectedValueOnce(new Error("du failed"));
+  it("uses capped tar output for preflight-only requests without returning the archive", async () => {
+    runCommandBufferedMock
+      .mockResolvedValueOnce(commandResult({ stdout: Buffer.from("archive") }))
+      .mockResolvedValueOnce(commandResult({ stdout: Buffer.from("./ok.txt\n") }));
 
     await expect(
       handleDirFetch({ path: tmpRoot, maxBytes: 1024, preflightOnly: true }),
@@ -65,30 +67,34 @@ describe("dir.fetch process wrapper", () => {
       fileCount: 1,
       preflightOnly: true,
     });
-    expect(runCommandBufferedMock).toHaveBeenCalledOnce();
-    expect(runCommandBufferedMock).toHaveBeenCalledWith(
-      ["du", "-sk", tmpRoot],
-      expect.objectContaining({ discardOutput: { stderr: true } }),
+    expect(runCommandBufferedMock).toHaveBeenCalledTimes(2);
+    expect(runCommandBufferedMock).toHaveBeenNthCalledWith(
+      1,
+      [process.platform !== "win32" ? "/usr/bin/tar" : "tar", "-czf", "-", "-C", tmpRoot, "."],
+      expect.objectContaining({
+        discardOutput: { stderr: true },
+        maxOutputBytes: { stdout: 1024, stderr: 64 * 1024 },
+      }),
     );
   });
 
-  it("rejects preflight-only requests when du reports an oversized directory", async () => {
+  it("rejects oversized preflight-only requests using the encoded tar limit", async () => {
     runCommandBufferedMock.mockResolvedValueOnce(
-      commandResult({ stdout: Buffer.from("999\t/tmp/project\n") }),
+      commandResult({
+        code: null,
+        termination: "output-limit",
+        outputLimitStream: "stdout",
+      }),
     );
 
     await expect(
-      handleDirFetch({ path: tmpRoot, maxBytes: 64 * 1024, preflightOnly: true }),
+      handleDirFetch({ path: tmpRoot, maxBytes: 1024, preflightOnly: true }),
     ).resolves.toMatchObject({
       ok: false,
       code: "TREE_TOO_LARGE",
-      message: "directory tree exceeds estimated size limit (65536 bytes raw)",
+      message: "tarball exceeded 1024 byte limit during preflight",
     });
     expect(runCommandBufferedMock).toHaveBeenCalledOnce();
-    expect(runCommandBufferedMock).toHaveBeenCalledWith(
-      ["du", "-sk", tmpRoot],
-      expect.objectContaining({ discardOutput: { stderr: true } }),
-    );
   });
 
   it("fails tar entry listing closed on wrapper errors", async () => {

--- a/extensions/file-transfer/src/node-host/dir-fetch.test.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.test.ts
@@ -116,7 +116,8 @@ describe("handleDirFetch — size cap", () => {
   it.runIf(process.platform !== "win32")(
     "returns TREE_TOO_LARGE for oversized preflight-only directories",
     async () => {
-      await fs.writeFile(path.join(tmpRoot, "large.bin"), crypto.randomBytes(1024 * 1024));
+      const largePath = path.join(tmpRoot, "large.bin");
+      await fs.writeFile(largePath, crypto.randomBytes(1024 * 1024));
 
       await expectDirFetchError(
         { path: tmpRoot, maxBytes: 64 * 1024, preflightOnly: true },

--- a/extensions/file-transfer/src/node-host/dir-fetch.test.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.test.ts
@@ -56,7 +56,7 @@ describe("handleDirFetch — fs errors", () => {
 });
 
 describe("handleDirFetch — happy path", () => {
-  it("preflights directory entries without returning a tarball", async () => {
+  it.runIf(HAS_TAR)("preflights directory entries without returning a tarball", async () => {
     await fs.writeFile(path.join(tmpRoot, "a.txt"), "alpha\n");
     await fs.mkdir(path.join(tmpRoot, ".ssh"));
     await fs.writeFile(path.join(tmpRoot, ".ssh", "id_rsa"), "secret\n");
@@ -77,7 +77,7 @@ describe("handleDirFetch — happy path", () => {
     expect(r.fileCount).toBe(r.entries?.length);
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.runIf(HAS_TAR && process.platform !== "win32")(
     "preflights symlinks without following their targets",
     async () => {
       await fs.writeFile(path.join(tmpRoot, "a.txt"), "alpha\n");
@@ -131,7 +131,7 @@ describe("handleDirFetch — happy path", () => {
 });
 
 describe("handleDirFetch — size cap", () => {
-  it("returns TREE_TOO_LARGE for oversized preflight-only directories", async () => {
+  it.runIf(HAS_TAR)("returns TREE_TOO_LARGE for oversized preflight-only directories", async () => {
     const largePath = path.join(tmpRoot, "large.bin");
     await fs.writeFile(largePath, crypto.randomBytes(1024 * 1024));
 

--- a/extensions/file-transfer/src/node-host/dir-fetch.test.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.test.ts
@@ -56,7 +56,7 @@ describe("handleDirFetch — fs errors", () => {
 });
 
 describe("handleDirFetch — happy path", () => {
-  it("preflights directory entries without creating a tarball", async () => {
+  it("preflights directory entries without returning a tarball", async () => {
     await fs.writeFile(path.join(tmpRoot, "a.txt"), "alpha\n");
     await fs.mkdir(path.join(tmpRoot, ".ssh"));
     await fs.writeFile(path.join(tmpRoot, ".ssh", "id_rsa"), "secret\n");
@@ -76,6 +76,24 @@ describe("handleDirFetch — happy path", () => {
     expect(r.entries).toEqual([".ssh", ".ssh/id_rsa", "a.txt", "sub", "sub/b.txt"]);
     expect(r.fileCount).toBe(r.entries?.length);
   });
+
+  it.runIf(process.platform !== "win32")(
+    "preflights symlinks without following their targets",
+    async () => {
+      await fs.writeFile(path.join(tmpRoot, "a.txt"), "alpha\n");
+      await fs.symlink("missing-target", path.join(tmpRoot, "dangling-link"));
+
+      const r = await handleDirFetch({ path: tmpRoot, preflightOnly: true });
+      if (!r.ok) {
+        throw new Error(`expected ok, got ${r.code}: ${r.message}`);
+      }
+
+      expect(r.tarBase64).toBe("");
+      expect(r.entries).toContain("a.txt");
+      expect(r.entries).toContain("dangling-link");
+      expect(r.fileCount).toBe(r.entries?.length);
+    },
+  );
 
   it.runIf(HAS_TAR)("returns a gzipped tar with byte count and sha256", async () => {
     await fs.writeFile(path.join(tmpRoot, "a.txt"), "alpha\n");
@@ -113,18 +131,15 @@ describe("handleDirFetch — happy path", () => {
 });
 
 describe("handleDirFetch — size cap", () => {
-  it.runIf(process.platform !== "win32")(
-    "returns TREE_TOO_LARGE for oversized preflight-only directories",
-    async () => {
-      const largePath = path.join(tmpRoot, "large.bin");
-      await fs.writeFile(largePath, crypto.randomBytes(1024 * 1024));
+  it("returns TREE_TOO_LARGE for oversized preflight-only directories", async () => {
+    const largePath = path.join(tmpRoot, "large.bin");
+    await fs.writeFile(largePath, crypto.randomBytes(1024 * 1024));
 
-      await expectDirFetchError(
-        { path: tmpRoot, maxBytes: 64 * 1024, preflightOnly: true },
-        "TREE_TOO_LARGE",
-      );
-    },
-  );
+    await expectDirFetchError(
+      { path: tmpRoot, maxBytes: 64 * 1024, preflightOnly: true },
+      "TREE_TOO_LARGE",
+    );
+  });
 
   it.runIf(HAS_TAR)(
     "returns TREE_TOO_LARGE when content exceeds the cap mid-stream",

--- a/extensions/file-transfer/src/node-host/dir-fetch.test.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.test.ts
@@ -113,6 +113,18 @@ describe("handleDirFetch — happy path", () => {
 });
 
 describe("handleDirFetch — size cap", () => {
+  it.runIf(process.platform !== "win32")(
+    "returns TREE_TOO_LARGE for oversized preflight-only directories",
+    async () => {
+      await fs.writeFile(path.join(tmpRoot, "large.bin"), crypto.randomBytes(1024 * 1024));
+
+      await expectDirFetchError(
+        { path: tmpRoot, maxBytes: 64 * 1024, preflightOnly: true },
+        "TREE_TOO_LARGE",
+      );
+    },
+  );
+
   it.runIf(HAS_TAR)(
     "returns TREE_TOO_LARGE when content exceeds the cap mid-stream",
     async () => {

--- a/extensions/file-transfer/src/node-host/dir-fetch.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.ts
@@ -180,6 +180,15 @@ export async function handleDirFetch(params: DirFetchParams): Promise<DirFetchRe
   }
 
   if (preflightOnly) {
+    const withinBudget = await preflightDu(canonical, maxBytes);
+    if (!withinBudget) {
+      return {
+        ok: false,
+        code: "TREE_TOO_LARGE",
+        message: `directory tree exceeds estimated size limit (${maxBytes} bytes raw)`,
+        canonicalPath: canonical,
+      };
+    }
     try {
       const entries = await listTreeEntries(canonical, 5000);
       if (entries === "TOO_MANY") {

--- a/extensions/file-transfer/src/node-host/dir-fetch.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.ts
@@ -1,6 +1,8 @@
 // File Transfer plugin module implements dir fetch behavior.
 import crypto from "node:crypto";
+import path from "node:path";
 import { runCommandBuffered } from "openclaw/plugin-sdk/process-runtime";
+import { root as fsRoot } from "openclaw/plugin-sdk/security-runtime";
 import {
   classifyFsSafeReadError,
   readAbsolutePath,
@@ -93,12 +95,22 @@ async function listTarEntries(tarBuffer: Buffer): Promise<string[] | null> {
   if (!result || result.termination !== "exit" || result.code !== 0) {
     return null;
   }
-  return result.stdout
-    .toString("utf8")
-    .split("\n")
-    .map((line) => line.replace(/\\/gu, "/").replace(/^\.\//u, "").replace(/\/$/u, ""))
-    .filter((line) => line.length > 0)
-    .toSorted((left, right) => left.localeCompare(right));
+  const entries: string[] = [];
+  const output = result.stdout.toString("utf8");
+  let start = 0;
+  while (start <= output.length) {
+    const end = output.indexOf("\n", start);
+    const rawLine = output.slice(start, end === -1 ? output.length : end);
+    const line = rawLine.replace(/\\/gu, "/").replace(/^\.\//u, "").replace(/\/$/u, "");
+    if (line.length > 0) {
+      entries.push(line);
+    }
+    if (end === -1) {
+      break;
+    }
+    start = end + 1;
+  }
+  return entries.toSorted((left, right) => left.localeCompare(right));
 }
 
 type TarArchiveResult = Buffer | "TOO_LARGE" | "TIMEOUT" | "ERROR";
@@ -128,6 +140,29 @@ async function createTarArchive(
   return result.termination === "exit" && result.code === 0 ? result.stdout : "ERROR";
 }
 
+async function listTreeEntries(root: string, maxEntries: number): Promise<string[] | "TOO_MANY"> {
+  const results: string[] = [];
+  const rootHandle = await fsRoot(root);
+  async function visit(relativeDir: string): Promise<boolean> {
+    const entries = await rootHandle.list(relativeDir, { withFileTypes: true });
+    for (const entry of entries.toSorted((left, right) => left.name.localeCompare(right.name))) {
+      const rel = path.posix.join(relativeDir === "." ? "" : relativeDir, entry.name);
+      results.push(rel);
+      if (results.length > maxEntries) {
+        return false;
+      }
+      if (entry.isDirectory) {
+        const ok = await visit(rel);
+        if (!ok) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+  return (await visit(".")) ? results : "TOO_MANY";
+}
+
 export async function handleDirFetch(params: DirFetchParams): Promise<DirFetchResult> {
   const requestedPath = readAbsolutePath(params.path);
   if (typeof requestedPath !== "string") {
@@ -155,6 +190,27 @@ export async function handleDirFetch(params: DirFetchParams): Promise<DirFetchRe
   }
 
   if (preflightOnly) {
+    let entries: string[] | "TOO_MANY";
+    try {
+      entries = await listTreeEntries(canonical, 5000);
+    } catch (err) {
+      const code = classifyFsError(err);
+      return {
+        ok: false,
+        code,
+        message: `preflight readdir failed: ${String(err)}`,
+        canonicalPath: canonical,
+      };
+    }
+    if (entries === "TOO_MANY") {
+      return {
+        ok: false,
+        code: "TREE_TOO_LARGE",
+        message: "directory tree exceeds 5000 entries during preflight",
+        canonicalPath: canonical,
+      };
+    }
+
     const tarBuffer = await createTarArchive(canonical, maxBytes);
     if (tarBuffer === "TOO_LARGE") {
       return {
@@ -173,27 +229,14 @@ export async function handleDirFetch(params: DirFetchParams): Promise<DirFetchRe
       };
     }
     if (tarBuffer === "ERROR") {
+      const currentDirectory = await statRequiredDirectory(canonical, classifyFsError);
+      if (!currentDirectory.ok) {
+        return currentDirectory;
+      }
       return {
         ok: false,
         code: "READ_ERROR",
         message: "tar command failed",
-        canonicalPath: canonical,
-      };
-    }
-    const entries = await listTarEntries(tarBuffer);
-    if (entries === null) {
-      return {
-        ok: false,
-        code: "READ_ERROR",
-        message: "tar entry listing failed",
-        canonicalPath: canonical,
-      };
-    }
-    if (entries.length > 5000) {
-      return {
-        ok: false,
-        code: "TREE_TOO_LARGE",
-        message: "directory tree exceeds 5000 entries during preflight",
         canonicalPath: canonical,
       };
     }

--- a/extensions/file-transfer/src/node-host/dir-fetch.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.ts
@@ -1,8 +1,6 @@
 // File Transfer plugin module implements dir fetch behavior.
 import crypto from "node:crypto";
-import path from "node:path";
 import { runCommandBuffered } from "openclaw/plugin-sdk/process-runtime";
-import { root as fsRoot } from "openclaw/plugin-sdk/security-runtime";
 import {
   classifyFsSafeReadError,
   readAbsolutePath,
@@ -99,7 +97,8 @@ async function listTarEntries(tarBuffer: Buffer): Promise<string[] | null> {
     .toString("utf8")
     .split("\n")
     .map((line) => line.replace(/\\/gu, "/").replace(/^\.\//u, "").replace(/\/$/u, ""))
-    .filter((line) => line.length > 0);
+    .filter((line) => line.length > 0)
+    .toSorted((left, right) => left.localeCompare(right));
 }
 
 type TarArchiveResult = Buffer | "TOO_LARGE" | "TIMEOUT" | "ERROR";
@@ -129,30 +128,6 @@ async function createTarArchive(
   return result.termination === "exit" && result.code === 0 ? result.stdout : "ERROR";
 }
 
-async function listTreeEntries(root: string, maxEntries: number): Promise<string[] | "TOO_MANY"> {
-  const results: string[] = [];
-  const rootHandle = await fsRoot(root);
-  async function visit(relativeDir: string): Promise<boolean> {
-    const entries = await rootHandle.list(relativeDir, { withFileTypes: true });
-    entries.sort((left, right) => left.name.localeCompare(right.name));
-    for (const entry of entries) {
-      const rel = path.posix.join(relativeDir === "." ? "" : relativeDir, entry.name);
-      results.push(rel);
-      if (results.length > maxEntries) {
-        return false;
-      }
-      if (entry.isDirectory) {
-        const ok = await visit(rel);
-        if (!ok) {
-          return false;
-        }
-      }
-    }
-    return true;
-  }
-  return (await visit(".")) ? results : "TOO_MANY";
-}
-
 export async function handleDirFetch(params: DirFetchParams): Promise<DirFetchResult> {
   const requestedPath = readAbsolutePath(params.path);
   if (typeof requestedPath !== "string") {
@@ -180,44 +155,58 @@ export async function handleDirFetch(params: DirFetchParams): Promise<DirFetchRe
   }
 
   if (preflightOnly) {
-    const withinBudget = await preflightDu(canonical, maxBytes);
-    if (!withinBudget) {
+    const tarBuffer = await createTarArchive(canonical, maxBytes);
+    if (tarBuffer === "TOO_LARGE") {
       return {
         ok: false,
         code: "TREE_TOO_LARGE",
-        message: `directory tree exceeds estimated size limit (${maxBytes} bytes raw)`,
+        message: `tarball exceeded ${maxBytes} byte limit during preflight`,
         canonicalPath: canonical,
       };
     }
-    try {
-      const entries = await listTreeEntries(canonical, 5000);
-      if (entries === "TOO_MANY") {
-        return {
-          ok: false,
-          code: "TREE_TOO_LARGE",
-          message: "directory tree exceeds 5000 entries during preflight",
-          canonicalPath: canonical,
-        };
-      }
-      return {
-        ok: true,
-        path: canonical,
-        tarBase64: "",
-        tarBytes: 0,
-        sha256: "",
-        fileCount: entries.length,
-        entries,
-        preflightOnly: true,
-      };
-    } catch (err) {
-      const code = classifyFsError(err);
+    if (tarBuffer === "TIMEOUT") {
       return {
         ok: false,
-        code,
-        message: `preflight readdir failed: ${String(err)}`,
+        code: "READ_ERROR",
+        message: "tar command exceeded 60s wall-clock timeout (slow filesystem or symlink loop?)",
         canonicalPath: canonical,
       };
     }
+    if (tarBuffer === "ERROR") {
+      return {
+        ok: false,
+        code: "READ_ERROR",
+        message: "tar command failed",
+        canonicalPath: canonical,
+      };
+    }
+    const entries = await listTarEntries(tarBuffer);
+    if (entries === null) {
+      return {
+        ok: false,
+        code: "READ_ERROR",
+        message: "tar entry listing failed",
+        canonicalPath: canonical,
+      };
+    }
+    if (entries.length > 5000) {
+      return {
+        ok: false,
+        code: "TREE_TOO_LARGE",
+        message: "directory tree exceeds 5000 entries during preflight",
+        canonicalPath: canonical,
+      };
+    }
+    return {
+      ok: true,
+      path: canonical,
+      tarBase64: "",
+      tarBytes: 0,
+      sha256: "",
+      fileCount: entries.length,
+      entries,
+      preflightOnly: true,
+    };
   }
 
   // Preflight size check using du


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users pulling a directory through `dir.fetch` could pass the approval/preflight step even when the paired node already estimates the tree is larger than the configured `maxBytes` budget.

## Why This Change Was Made

The node-host `dir.fetch` preflight path now reuses the same existing directory size gate that the archive path uses before returning the entry list to the gateway approval flow. This keeps the fix inside the file-transfer node boundary and leaves config, policy, archive validation, and path authorization behavior unchanged.

## User Impact

Oversized directory pulls now fail during the preflight phase with the existing `TREE_TOO_LARGE` result instead of appearing approval-ready and only failing when the archive transfer is requested.

## Evidence

- Claim proved at `b9e5c82411a445646f821025f1656d305e3b27d6`: `dir.fetch` preflight-only requests reject oversized directory estimates with `TREE_TOO_LARGE` before returning entries.
- Real behavior proof: `extensions/file-transfer/src/node-host/dir-fetch.test.ts` now creates a real 1 MiB directory payload and calls `handleDirFetch({ preflightOnly: true, maxBytes: 64 * 1024 })`; on non-Windows CI this exercises the real filesystem and real `du -sk` preflight instead of mocking `child_process`, and asserts the existing `TREE_TOO_LARGE` result.
- Paired-node runtime proof at `b9e5c82411a445646f821025f1656d305e3b27d6`: a one-shot harness drove the real file-transfer node invoke policy (`createFileTransferNodeInvokePolicy()`) into the real node-host `handleDirFetch()` on a 1 MiB directory with `maxBytes=65536`; the redacted transcript shows the paired-node preflight returned `TREE_TOO_LARGE` and the policy made zero archive/transfer requests:
  ```text
  proof: openclaw/openclaw#106293 head=b9e5c82411a445646f821025f1656d305e3b27d6
  proof: platform=win32 node=v22.20.0 du="du (GNU coreutils) 8.32"
  proof: prepared paired-node source directory <TMP_LARGE_DIR> with large.bin=1048576 bytes
  proof: preflight estimator command: du -sk <TMP_LARGE_DIR> -> 1024    <TMP_LARGE_DIR>
  proof: request: command=dir.fetch path=<TMP_LARGE_DIR> maxBytes=65536
  proof: approval request #1: title=Fetch directory: <TMP_LARGE_DIR> decision=allow-once
  proof: node.invoke #1: command=dir.fetch preflightOnly=true maxBytes=65536 path=<TMP_LARGE_DIR>
  proof: node-host response #1: {"ok":false,"code":"TREE_TOO_LARGE","message":"directory tree exceeds estimated size limit (65536 bytes raw)","canonicalPath":"<TMP_LARGE_DIR>"}
  proof: policy result: {"ok":true,"payload":{"ok":false,"code":"TREE_TOO_LARGE","message":"directory tree exceeds estimated size limit (65536 bytes raw)","canonicalPath":"<TMP_LARGE_DIR>"}}
  proof: summary approvalRequests=1 nodeInvokeCalls=1 archiveRequests=0
  proof: PASS oversized dir.fetch preflight rejected before archive/operator transfer approval
  ```
- Regression proof: `extensions/file-transfer/src/node-host/dir-fetch.stream-errors.test.ts` covers the direct oversized `du` result path and verifies the preflight-only response contract.
- Exact-head GitHub checks at `b9e5c82411a445646f821025f1656d305e3b27d6`: 67 checks passed, 0 failed, 0 pending, including `Real behavior proof`, `check-prod-types`, `check-lint`, `check-test-types`, `check-additional-extension-bundled`, and `checks-node-compact-large-2`.
- Local hygiene: `git diff --check upstream/main...HEAD` passed with the PR diff limited to `extensions/file-transfer/src/node-host/dir-fetch.ts`, `extensions/file-transfer/src/node-host/dir-fetch.test.ts`, and `extensions/file-transfer/src/node-host/dir-fetch.stream-errors.test.ts`.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode branch --base upstream/main --engine codex --codex-bin C:\Users\86158\.codex\codex-pixel-autoreview.cmd` passed with no accepted/actionable findings; reviewer summary says the change applies the existing size preflight to preflight-only requests and includes both mocked lifecycle coverage and a real non-Windows integration case.