### PR TITLE
fix(agents): terminate agent run on critical loop detection instead of continuing indefinitely

### DIFF
--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1872,6 +1872,210 @@ describe("agentLoop tool termination", () => {
     ]);
     expect(events.at(-1)).toMatchObject({ type: "agent_end" });
   });
+
+  it("stops after a mixed batch with one critical veto when shouldStopAfterTurn checks for tool-loop", async () => {
+    const executed: string[] = [];
+    let turn = 0;
+    const streamFn: StreamFn = () => {
+      turn += 1;
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message =
+          turn === 1
+            ? makeAssistantMessage([
+                { type: "toolCall", id: "call-veto", name: "veto_tool", arguments: {} },
+                { type: "toolCall", id: "call-normal", name: "normal_tool", arguments: {} },
+              ])
+            : makeAssistantMessage([{ type: "text", text: "should not reach" }]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+
+    const vetoTool: AgentTool = {
+      name: "veto_tool",
+      label: "veto_tool",
+      description: "critical loop veto tool",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => ({
+        content: [{ type: "text", text: "blocked" }],
+        details: { status: "blocked", deniedReason: "tool-loop", reason: "critical loop detected" },
+        terminate: true,
+      }),
+    };
+    const normalTool: AgentTool = {
+      name: "normal_tool",
+      label: "normal_tool",
+      description: "normal tool",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => {
+        executed.push("normal_tool");
+        return { content: [{ type: "text", text: "ok" }], details: {} };
+      },
+    };
+
+    const stream = agentLoop(
+      [{ role: "user", content: "run", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools: [vetoTool, normalTool] },
+      {
+        ...config,
+        shouldStopAfterTurn: async (context) => {
+          for (const msg of context.toolResults) {
+            const details = msg.details as { deniedReason?: string } | undefined;
+            if (details?.deniedReason === "tool-loop") {
+              return true;
+            }
+          }
+          return false;
+        },
+      },
+      undefined,
+      streamFn,
+    );
+
+    const events = await collectEvents(stream);
+    expect(turn).toBe(1);
+    expect(executed).toEqual(["normal_tool"]);
+    expect(events.filter((e) => e.type === "agent_end")).toHaveLength(1);
+  });
+
+  it("Agent.prompt stops after a single critical tool-loop terminate result", async () => {
+    let providerTurns = 0;
+    const transcript: string[] = [];
+    const streamFn: StreamFn = () => {
+      providerTurns += 1;
+      transcript.push(`provider-turn-${providerTurns}`);
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message =
+          providerTurns === 1
+            ? makeAssistantMessage([
+                { type: "toolCall", id: "call-loop", name: "loop_tool", arguments: {} },
+              ])
+            : makeAssistantMessage([{ type: "text", text: "should not reach" }]);
+        stream.push({
+          type: "done",
+          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
+          message,
+        });
+        stream.end();
+      });
+      return stream;
+    };
+    const loopTool: AgentTool = {
+      name: "loop_tool",
+      label: "loop_tool",
+      description: "critical loop",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => {
+        transcript.push("tool-loop-block");
+        return {
+          content: [{ type: "text", text: "CRITICAL: tool loop" }],
+          details: {
+            status: "blocked",
+            deniedReason: "tool-loop",
+            reason: "CRITICAL: tool loop",
+          },
+          terminate: true,
+        };
+      },
+    };
+    const agent = new Agent({
+      initialState: { model, tools: [loopTool] },
+      streamFn,
+      shouldStopAfterTurn: (context) => {
+        for (const msg of context.toolResults) {
+          const details = msg.details as { deniedReason?: string } | undefined;
+          if (details?.deniedReason === "tool-loop") {
+            transcript.push("should-stop-after-turn");
+            return true;
+          }
+        }
+        return false;
+      },
+    });
+    agent.subscribe(async (event) => {
+      if (event.type === "agent_end") {
+        transcript.push("agent_end");
+      }
+    });
+
+    await agent.prompt("trigger");
+    await agent.waitForIdle();
+
+    expect(providerTurns).toBe(1);
+    expect(transcript).toEqual([
+      "provider-turn-1",
+      "tool-loop-block",
+      "should-stop-after-turn",
+      "agent_end",
+    ]);
+  });
+
+  it("does not stop after a mixed batch when a tool-loop reason lacks blocked status", async () => {
+    // Regression: a finalized result carrying deniedReason: "tool-loop" but not
+    // the canonical status: "blocked" must not terminate the session. details
+    // is hook-overridable structured data, so the post-turn classifier requires
+    // both fields (issue #106231 / ClawSweeper P2 finding).
+    let turn = 0;
+    const streamFn: StreamFn = () => {
+      turn += 1;
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message =
+          turn === 1
+            ? makeAssistantMessage([
+                { type: "toolCall", id: "call-spoof", name: "spoof_tool", arguments: {} },
+              ])
+            : makeAssistantMessage([{ type: "text", text: "continued past spoof" }]);
+        stream.push({
+          type: "done",
+          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
+          message,
+        });
+        stream.end();
+      });
+      return stream;
+    };
+    const spoofTool: AgentTool = {
+      name: "spoof_tool",
+      label: "spoof_tool",
+      description: "non-blocked result with tool-loop reason",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => ({
+        content: [{ type: "text", text: "spoof" }],
+        // deniedReason is "tool-loop" but status is not "blocked": a hook could
+        // attach this to an unrelated result, so it must not be terminal.
+        details: { status: "error", deniedReason: "tool-loop" },
+      }),
+    };
+
+    const stream = agentLoop(
+      [{ role: "user", content: "run", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools: [spoofTool] },
+      {
+        ...config,
+        shouldStopAfterTurn: async (context) => {
+          for (const msg of context.toolResults) {
+            const details = msg.details as { status?: unknown; deniedReason?: unknown } | undefined;
+            if (details?.status === "blocked" && details?.deniedReason === "tool-loop") {
+              return true;
+            }
+          }
+          return false;
+        },
+      },
+      undefined,
+      streamFn,
+    );
+
+    const events = await collectEvents(stream);
+    // The non-blocked tool-loop result must not stop the run: the model issues
+    // a second provider turn.
+    expect(turn).toBe(2);
+    expect(events.filter((e) => e.type === "agent_end")).toHaveLength(1);
+  });
 });
 
 describe("Agent next-turn preparation", () => {

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -32,6 +32,7 @@ import type {
   BeforeToolCallResult,
   PrepareNextTurnContext,
   QueueMode,
+  ShouldStopAfterTurnContext,
   StreamFn,
   ToolExecutionMode,
 } from "./types.js";
@@ -131,6 +132,8 @@ export interface AgentOptions {
     context: AfterToolCallContext,
     signal?: AbortSignal,
   ) => Promise<AfterToolCallResult | undefined>;
+  /** Hook that may stop the agent loop after a turn completes. */
+  shouldStopAfterTurn?: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
   /** Hook that may alter any finalized tool outcome, including pre-execution failures. */
   afterToolOutcome?: (
     context: AfterToolOutcomeContext,
@@ -237,6 +240,7 @@ export class Agent {
     context: AfterToolCallContext,
     signal?: AbortSignal,
   ) => Promise<AfterToolCallResult | undefined>;
+  public shouldStopAfterTurn?: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
   public afterToolOutcome?: (
     context: AfterToolOutcomeContext,
     signal?: AbortSignal,
@@ -272,6 +276,7 @@ export class Agent {
     this.beforeToolCall = options.beforeToolCall;
     this.resolveDeferredTool = options.resolveDeferredTool;
     this.afterToolCall = options.afterToolCall;
+    this.shouldStopAfterTurn = options.shouldStopAfterTurn;
     this.afterToolOutcome = options.afterToolOutcome;
     this.prepareNextTurn = options.prepareNextTurn;
     this.prepareNextTurnWithContext = options.prepareNextTurnWithContext;
@@ -511,6 +516,7 @@ export class Agent {
       beforeToolCall: this.beforeToolCall,
       resolveDeferredTool: this.resolveDeferredTool,
       afterToolCall: this.afterToolCall,
+      shouldStopAfterTurn: this.shouldStopAfterTurn,
       afterToolOutcome: this.afterToolOutcome,
       prepareNextTurn:
         this.prepareNextTurnWithContext || this.prepareNextTurn

--- a/src/agents/agent-tools.before-tool-call.blocked-result.test.ts
+++ b/src/agents/agent-tools.before-tool-call.blocked-result.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { buildBlockedToolResult } from "./agent-tools.before-tool-call.js";
+import { resetAdjustedParamsByToolCallIdForTests } from "./agent-tools.before-tool-call.state.js";
+import { isCriticalToolLoopVeto } from "./agent-tools.before-tool-call.types.js";
+
+describe("buildBlockedToolResult", () => {
+  it("includes terminate: true for critical tool-loop vetoes", () => {
+    resetAdjustedParamsByToolCallIdForTests();
+    const result = buildBlockedToolResult({
+      reason:
+        "CRITICAL: Called exec with identical arguments and outcomes 10 times. Session blocked.",
+      deniedReason: "tool-loop",
+      toolCallId: "call-tl-1",
+      runId: "run-1",
+    });
+    expect(result.details).toMatchObject({
+      status: "blocked",
+      deniedReason: "tool-loop",
+    });
+    // agent-core requires terminate: true on all finalized results to stop
+    // the tool batch; without it the model retries the blocked tool.
+    expect(result.terminate).toBe(true);
+  });
+
+  it("does not include terminate for plugin-before-tool-call vetoes", () => {
+    resetAdjustedParamsByToolCallIdForTests();
+    const result = buildBlockedToolResult({
+      reason: "Plugin before-tool-call denied",
+      deniedReason: "plugin-before-tool-call",
+      toolCallId: "call-pb-1",
+      runId: "run-1",
+    });
+    expect(result.details.deniedReason).toBe("plugin-before-tool-call");
+    expect(result.terminate).toBeUndefined();
+  });
+
+  it("does not include terminate for plugin-approval vetoes", () => {
+    resetAdjustedParamsByToolCallIdForTests();
+    const result = buildBlockedToolResult({
+      reason: "Plugin approval denied",
+      deniedReason: "plugin-approval",
+      toolCallId: "call-pa-1",
+      runId: "run-1",
+    });
+    expect(result.details.deniedReason).toBe("plugin-approval");
+    expect(result.terminate).toBeUndefined();
+  });
+
+  it("defaults deniedReason to plugin-before-tool-call when omitted", () => {
+    resetAdjustedParamsByToolCallIdForTests();
+    const result = buildBlockedToolResult({
+      reason: "Default deny",
+      toolCallId: "call-def-1",
+      runId: "run-1",
+    });
+    expect(result.details.deniedReason).toBe("plugin-before-tool-call");
+    expect(result.terminate).toBeUndefined();
+  });
+});
+
+describe("isCriticalToolLoopVeto", () => {
+  // The helper guards `unknown` tool-result details at two call sites
+  // (buildBlockedToolResult per-result terminate, and the session
+  // shouldStopAfterTurn mixed-batch scan). Non-tool-loop vetoes and
+  // malformed details must not be treated as critical.
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["string", "tool-loop"],
+    ["number", 0],
+    ["object without deniedReason", { status: "blocked" }],
+    ["tool-loop reason without blocked status", { deniedReason: "tool-loop" }],
+    ["tool-loop reason with non-blocked status", { status: "error", deniedReason: "tool-loop" }],
+    ["plugin-approval veto", { deniedReason: "plugin-approval" }],
+    ["plugin-before-tool-call veto", { deniedReason: "plugin-before-tool-call" }],
+  ])("returns false for %s", (_label, details) => {
+    expect(isCriticalToolLoopVeto(details)).toBe(false);
+  });
+
+  it("returns true and narrows to a tool-loop veto", () => {
+    const details: unknown = { status: "blocked", deniedReason: "tool-loop" };
+    expect(isCriticalToolLoopVeto(details)).toBe(true);
+    // Type guard narrows `details` so callers can read deniedReason safely.
+    if (isCriticalToolLoopVeto(details)) {
+      expect(details.deniedReason).toBe("tool-loop");
+    }
+  });
+});

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -327,6 +327,10 @@ describe("before_tool_call loop detection behavior", () => {
     expect(details.status).toBe("blocked");
     expect(details.deniedReason).toBe("tool-loop");
     expect(String(details.reason)).toContain(expectedReason);
+    // Critical tool-loop veto must terminate the agent run so the model
+    // cannot keep retrying the same blocked tool after the safety breaker
+    // fires (issue #106231).
+    expect(record.terminate).toBe(true);
   }
 
   async function expectUnblockedToolExecution(

--- a/src/agents/agent-tools.before-tool-call.types.ts
+++ b/src/agents/agent-tools.before-tool-call.types.ts
@@ -100,6 +100,31 @@ export type HookBlockedReason =
   | "plugin-approval-unavailable"
   | "tool-loop";
 
+/**
+ * Critical tool-loop vetoes must terminate the agent run so the model cannot
+ * keep retrying the blocked tool indefinitely (issue #106231). Other veto
+ * reasons (plugin/approval) stay non-terminating. Shared by
+ * {@link buildBlockedToolResult} (per-result `terminate: true`) and the
+ * session-level `shouldStopAfterTurn` hook (mixed-batch coverage).
+ *
+ * Both canonical fields are required: `details` is hook-overridable structured
+ * data (`AgentToolResult.details`), so `deniedReason: "tool-loop"` alone is not
+ * enough — a non-blocked result carrying that string must not end the session.
+ * This matches the loop detector's own `isLoopVetoResult` classifier
+ * (`tool-loop-detection.ts`), which recognizes a loop veto only when both
+ * `status: "blocked"` and `deniedReason: "tool-loop"` are present.
+ */
+export function isCriticalToolLoopVeto(details: unknown): details is {
+  status: "blocked";
+  deniedReason: "tool-loop";
+} {
+  if (typeof details !== "object" || details === null) {
+    return false;
+  }
+  const { status, deniedReason } = details as { status?: unknown; deniedReason?: unknown };
+  return status === "blocked" && deniedReason === "tool-loop";
+}
+
 type HookBlockedOutcome = {
   blocked: true;
   deniedReason?: HookBlockedReason;

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -47,6 +47,7 @@ import type {
   HookContext,
   HookOutcome,
 } from "./agent-tools.before-tool-call.types.js";
+import { isCriticalToolLoopVeto } from "./agent-tools.before-tool-call.types.js";
 import { validateToolExecutionParams } from "./agent-tools.execution-validation.js";
 import {
   BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS,
@@ -248,13 +249,25 @@ export function buildBlockedToolResult(params: {
   runId?: string;
 }) {
   recordPreExecutionBlockedToolCall(params.toolCallId, params.runId);
+  const deniedReason = params.deniedReason ?? "plugin-before-tool-call";
+  // tool-loop vetoes must terminate the agent run so the model cannot keep
+  // retrying the blocked tool indefinitely (issue #106231). The per-result
+  // terminate: true flag handles single-tool batches via agent-core's
+  // shouldTerminateToolBatch; a post-turn shouldStopAfterTurn hook in
+  // createAgentSession covers mixed batches where the veto appears alongside
+  // normal tool results. The classifier requires both canonical fields
+  // (status: "blocked" + deniedReason: "tool-loop") so a non-blocked result
+  // carrying the tool-loop reason string cannot become terminal.
+  const details = {
+    status: "blocked" as const,
+    deniedReason,
+    reason: params.reason,
+  };
+  const terminateRun = isCriticalToolLoopVeto(details);
   const result = {
     content: [{ type: "text" as const, text: params.reason }],
-    details: {
-      status: "blocked",
-      deniedReason: params.deniedReason ?? "plugin-before-tool-call",
-      reason: params.reason,
-    },
+    details,
+    ...(terminateRun ? { terminate: true } : {}),
   };
   preExecutionBlockedToolResults.add(result);
   return result;

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -13,6 +13,7 @@ import {
 import { createSessionEntryWithTranscript } from "../../config/sessions/session-accessor.js";
 import { bindStreamLlmRuntime } from "../../llm/model-runtime-binding.js";
 import type { Message, Model } from "../../llm/types.js";
+import { isCriticalToolLoopVeto } from "../agent-tools.before-tool-call.types.js";
 import { getAgentDir } from "../config.js";
 import {
   Agent,
@@ -513,6 +514,14 @@ async function createAgentSessionImpl(
       );
     },
     sessionId: sessionManager.getSessionId(),
+    shouldStopAfterTurn: (context) => {
+      // Stop the agent loop when any tool result in the completed turn carries a
+      // critical tool-loop veto. Agent-core's shouldTerminateToolBatch requires
+      // every result in the batch to have terminate: true, which fails for mixed
+      // batches where the model emits the blocked loop tool alongside a normal
+      // tool call. The post-turn check ensures the run stops regardless.
+      return context.toolResults.some((msg) => isCriticalToolLoopVeto(msg.details));
+    },
     transformContext: async (messages) => {
       const runner = extensionRunnerRef.current;
       if (!runner) {


### PR DESCRIPTION
## What Problem This Solves

Critical loop detection correctly blocks a stuck tool (`deniedReason: "tool-loop"`, `action=block`), but the blocked result was returned as an ordinary tool result. The agent kept issuing provider turns and re-calling the same tool for hours (#106231).

## Why This Change Was Made

ClawSweeper Rank-up on the previous abort-helper tip required the **canonical agent-core termination contracts** instead of `abortRun` at the embedded-run boundary (which records synthetic `stopReason: "aborted"` and can cancel sibling tools in mixed batches).

Dual-layer stop:

1. **Per-result** `terminate: true` on critical tool-loop blocked results → `shouldTerminateToolBatch` stops single/all-veto batches.
2. **Post-turn** `shouldStopAfterTurn` in `createAgentSession` → stops **mixed** batches when any finalized result has `deniedReason: "tool-loop"`.

Plugin / approval vetoes stay non-terminating.

**ClawSweeper P2 rank-up (head `4370d55`):** the shared classifier `isCriticalToolLoopVeto` now requires both `status: "blocked"` **and** `deniedReason: "tool-loop"`, matching the loop detector's own `isLoopVetoResult` classifier (`tool-loop-detection.ts`). `details` is hook-overridable structured data, so `deniedReason: "tool-loop"` alone is not enough — a non-blocked result carrying that string must not end the session. The `buildBlockedToolResult` call site now passes the full `details` object (with `status: "blocked"`) so the narrowed predicate still fires `terminate: true`.

## User Impact

- Critical tool loops terminate the agent run instead of burning tokens indefinitely.
- Mixed parallel batches complete non-loop tools, then stop before the next provider turn.
- Non-loop blocks unchanged.
- A non-blocked result that happens to carry `deniedReason: "tool-loop"` (e.g. an after-tool hook attaching arbitrary details) does **not** terminate the session.
- Terminal outcome follows normal loop completion (not a synthetic aborted assistant message from embedded `abortRun`).

## Evidence

**Head SHA:** `4370d55fd32` (rebased onto `main` `714a46d7`; conflict-free, `MERGEABLE`, 0 commits behind)

**Patch quality:** 7 files, +354/−5 net, single owner boundary, no speculative exports, clean compare vs main. `buildBlockedToolResult` lives in `before-tool-call.wrapper.ts`, `shouldStopAfterTurn` is wired through `AgentOptions → Agent → agentLoop config`, and `createAgentSession` installs the post-turn hook. The critical tool-loop veto check is extracted into a shared `isCriticalToolLoopVeto` type guard (`before-tool-call.types.ts`), replacing the duplicated `deniedReason === "tool-loop"` literal and the inline `as` cast in `sdk.ts`.

| Rank-up | Status |
|---|---|
| Replace embedded abort with terminate + post-turn contracts | done |
| Cover single-tool + mixed-batch | done (`agent-loop.test.ts`, `blocked-result.test.ts`) |
| e2e asserts `terminate: true` on tool-loop blocks | done |
| Real-runtime transcript (no next provider turn; no unintended aborted entry) | **done** — see below |
| **P2: require `status: "blocked"` in `isCriticalToolLoopVeto` + negative regression** | **done (head `4370d55`)** |

### Commands (green locally)

```text
$ node_modules/.bin/oxlint <touched 4 files>
exit=0

$ node_modules/.bin/oxfmt --check <touched 4 files>
All matched files use the correct format.

$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test-amend.tsbuildinfo
# zero errors on the 4 touched files (remaining errors are pre-existing untracked files in the worktree)

$ node scripts/run-vitest.mjs packages/agent-core/src/agent-loop.test.ts -t "critical|shouldStopAfterTurn|mixed batch|terminate"
✓ stops after a mixed batch with one critical veto when shouldStopAfterTurn checks for tool-loop
✓ Agent.prompt stops after a single critical tool-loop terminate result
✓ does not stop after a mixed batch when a tool-loop reason lacks blocked status
Tests  4 passed | 33 skipped

$ node scripts/run-vitest.mjs src/agents/agent-tools.before-tool-call.blocked-result.test.ts
Test Files  1 passed (1)
Tests  14 passed (14)

$ node scripts/run-vitest.mjs --config test/vitest/vitest.e2e.config.ts src/agents/agent-tools.before-tool-call.e2e.test.ts -t "loop detection"
Test Files  1 passed (1)
Tests  49 passed | 49 skipped
```

### P2 negative regression (head `4370d55`)

`isCriticalToolLoopVeto` now rejects a result whose `details` carry `deniedReason: "tool-loop"` without the canonical `status: "blocked"` field, so a hook-overridable non-blocked result cannot become session-terminal:

- `blocked-result.test.ts` — `isCriticalToolLoopVeto` returns `false` for `{ deniedReason: "tool-loop" }` (no status) and `{ status: "error", deniedReason: "tool-loop" }` (non-blocked status).
- `agent-loop.test.ts` — mixed-batch negative case: a finalized result with `{ status: "error", deniedReason: "tool-loop" }` does **not** stop the run; the model issues a second provider turn.

### Real-runtime proof (live agent run)

**Provider:** `zte/Qwen3-235B-A22B` (real LLM, OpenAI-compatible API)
**Path:** `openclaw agent exec` (full embedded agent CLI path)
**Scenario:** model repeatedly calls `read` on a fixed file (`/tmp/loop-proof/status.txt`, content `waiting`) with `tools.loopDetection.enabled: true`; critical threshold is the default `CRITICAL_THRESHOLD = 20`.

A controlled before/after comparison was run on the same provider, same prompt, same config — the only variable is whether the `terminate: true` + `shouldStopAfterTurn` patch is applied.

#### After-patch (with terminate + shouldStopAfterTurn + isCriticalToolLoopVeto)

```text
[agents/loop-detection] Critical generic loop detected: read repeated 20 times
[agents/tools] Blocking read due to critical loop: CRITICAL: Called read with identical arguments and identical outcomes 20 times. Session execution blocked to prevent runaway loops.
[diagnostic] tool loop: tool=read level=critical action=block detector=generic_repeat count=20
[agents/agent-command] [agent] run fde1e863-3c24-4da3-a89e-dee447b15f80 ended with stopReason=toolUse
```

Persisted transcript (SQLite `transcript_events`):
- `seq=45` — assistant toolCall: `read /tmp/loop-proof/status.txt`
- `seq=46` — toolResult: `CRITICAL: Called read with identical arguments and identical outcomes 20 times.` (`details.deniedReason: "tool-loop"`, `details.status: "blocked"`)
- **no `seq=47`** — the agent ended immediately after the blocked result; no subsequent provider turn.

Result envelope: `assistantTurns: 21`, `stopReason: toolUse`, `toolSummary.calls: 21, failures: 1`.

**Terminal outcome:** the run ends with `stopReason: toolUse` — the normal loop-completion path after the tool batch terminates, not a synthetic `aborted` assistant message. The critical block is the terminal event; `shouldStopAfterTurn` fires after the batch completes, so a normal sibling tool in a mixed batch finishes before the run stops. Queued steering or follow-up input is not polled after the post-turn stop (the run reaches its terminal boundary before the next provider turn would begin), which is the intended behavior for a runaway-loop safety stop — a new user message starts a fresh run.

#### Before-patch (without terminate + shouldStopAfterTurn)

```text
[agents/loop-detection] Critical generic loop detected: read repeated 20 times
[agents/tools] Blocking read due to critical loop: CRITICAL: Called read with identical arguments and identical outcomes 20 times. Session execution blocked to prevent runaway loops.
[diagnostic] tool loop: tool=read level=critical action=block detector=generic_repeat count=20
[agents/agent-command] [agent] run 2c08dd4f-c77e-44fa-b29f-fe31e928d03b ended with stopReason=stop
```

Persisted transcript (SQLite `transcript_events`):
- `seq=45` — assistant toolCall: `read /tmp/loop-proof/status.txt`
- `seq=46` — toolResult: `CRITICAL: Called read with identical arguments and identical outcomes 20 times.`
- `seq=47` — **assistant turn after the block**: `"The polling loop has been blocked by the system after 20 identical read calls…"` (`stopReason: stop`)

Result envelope: `assistantTurns: 22`, `stopReason: stop`, `toolSummary.calls: 21, failures: 1`.

#### Before / after (contract)

| Case | BEFORE | AFTER |
|---|---|---|
| Critical tool-loop block (single tool) | result returned; model issues one more provider turn | `terminate: true` → batch terminates; no next provider turn |
| Critical tool-loop in mixed batch | continue if not every result terminates | `shouldStopAfterTurn` stops after turn |
| Non-blocked result with `deniedReason: "tool-loop"` | n/a | **does not stop** — predicate requires `status: "blocked"` |
| Other blocked reasons | unchanged | unchanged (no `terminate`) |

The live run confirms: with the patch, a critical tool-loop veto is the terminal event (no `seq=47`); without the patch, the model produces one more assistant turn after the block (`seq=47`), exactly the token-burn behavior reported in #106231.

Fixes #106231

## Agent Transcript

- Cursor session: rebuild #106297 onto main using ClawSweeper-recommended terminate + shouldStopAfterTurn path.
- Live proof session: `openclaw agent exec` with `zte/Qwen3-235B-A22B`, `tools.loopDetection.enabled: true`, before/after comparison on the same prompt.
- ClawSweeper P2 rank-up: narrowed `isCriticalToolLoopVeto` to require `status: "blocked"` + `deniedReason: "tool-loop"` and added negative regression coverage.

Made with [Cursor](https://cursor.com)
