### PR TITLE
fix(compaction): reconcile count via named export (export * drops def…

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.compaction.runtime.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.runtime.ts
@@ -4,8 +4,18 @@
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { updateSessionEntry } from "../config/sessions/session-accessor.js";
 
-/** Persist the highest observed compaction count after a successful subscribed run. */
-export default async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
+/**
+ * Persist the highest observed compaction count after a successful subscribed run.
+ *
+ * NOTE: exported as a NAMED export (in addition to the default below). Consumers
+ * reach this module through a dynamically-imported chunk; the bundler re-exports
+ * that chunk with `export *`, which per the ES module spec does NOT forward a
+ * `default` export. Importing the default therefore yielded `undefined` at runtime
+ * ("TypeError: reconcile is not a function"), silently breaking compaction-count
+ * reconciliation. A named export is forwarded by `export *`, so callers must import
+ * the named symbol. The default is kept for backward compatibility (tests, etc.).
+ */
+export async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
   sessionKey?: string;
   agentId?: string;
   configStore?: string;
@@ -32,3 +42,5 @@ export default async function reconcileSessionStoreCompactionCountAfterSuccess(p
   });
   return nextEntry?.compactionCount;
 }
+
+export default reconcileSessionStoreCompactionCountAfterSuccess;

--- a/src/agents/embedded-agent-subscribe.handlers.compaction.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.ts
@@ -205,7 +205,13 @@ async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
   observedCompactionCount: number;
   now?: number;
 }): Promise<number | undefined> {
-  const { default: reconcile } =
+  // Import the NAMED export, not the default: this module is loaded via a
+  // dynamically-imported chunk that the bundler re-exports with `export *`,
+  // which does not forward `default` (ESM spec). Importing `default` here
+  // resolved to `undefined` → "TypeError: reconcile is not a function", which
+  // broke compaction-count reconciliation and cascaded into a duplicate
+  // "Already compacted" failure on the turn that triggered compaction.
+  const { reconcileSessionStoreCompactionCountAfterSuccess: reconcile } =
     await import("./embedded-agent-subscribe.handlers.compaction.runtime.js");
   return reconcile(params);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a long conversation that crosses the auto-compaction
threshold fails on the exact turn that triggers compaction: the user gets an
empty / errored reply instead of a normal answer. It affects any chat session
long enough to auto-compact, on any channel.

## Why This Change Was Made

`reconcileSessionStoreCompactionCountAfterSuccess` is loaded by the compaction
handler via a dynamically-imported chunk. The bundler re-exports that chunk with
`export *`, which per the ES module spec does **not** forward a `default` export.
The consumer imported the default:

    const { default: reconcile } = await import("./...compaction.runtime.js");

so `reconcile` resolved to `undefined` → `TypeError: reconcile is not a function`.
The failed reconcile left the persisted `compactionCount` unchanged, so a second
(budget-triggered) compaction re-fired and hit an "Already compacted" state,
failing the response.

Fix: export the helper as a **named** export (which `export *` *does* forward)
and import the named symbol in the consumer. The `default` export is kept for
backward compatibility.

## User Impact

Long conversations now compact transparently: the turn that triggers compaction
returns a normal reply instead of failing, and the compaction count is persisted
correctly so no spurious second compaction fires.

## Evidence

Reproduced and verified on a live gateway by driving real conversations past the
compaction threshold on 3 concurrent sessions.

- **Before:** every compaction-triggering turn logged
  `late compaction count reconcile failed: TypeError: reconcile is not a function`,
  followed by an "Already compacted" failure on the retried turn.
- **After:** all compactions complete cleanly
  (`embedded run auto-compaction complete ... completed:true compactionCount:1`),
  no `reconcile` error, and the triggering turn returns a normal reply.
