### PR TITLE
fix(msteams): remove orphaned attachment helper

### DIFF
--- a/extensions/msteams/src/attachments/html.ts
+++ b/extensions/msteams/src/attachments/html.ts
@@ -106,13 +106,6 @@ export function summarizeMSTeamsHtmlAttachments(
   };
 }
 
-function buildMSTeamsAttachmentPlaceholder(
-  attachments: MSTeamsAttachmentLike[] | undefined,
-  limits?: { maxInlineBytes?: number; maxInlineTotalBytes?: number },
-): string {
-  return resolveMSTeamsInboundAttachmentPresentation(attachments, limits).placeholder;
-}
-
 function isAdvertisedFileAttachment(attachment: MSTeamsAttachmentLike): boolean {
   const contentType = normalizeContentType(attachment.contentType) ?? "";
   if (


### PR DESCRIPTION
Related: #106279

## What Problem This Solves

Fixes an issue where current `main` fails extension production and test typechecks after #106279 made `buildMSTeamsAttachmentPlaceholder` private but left the now-unreferenced helper in place.

## Why This Change Was Made

Deletes the orphan wrapper. `resolveMSTeamsInboundAttachmentPresentation` remains the canonical implementation used by the Microsoft Teams attachment path.

## User Impact

No runtime behavior changes. This restores clean extension compilation after the dead-code cleanup.

No changelog entry: internal compile repair only.

## Evidence

- Exact reviewed head: `f99813618bab98b185019f5a55553f2242d3c4fd`.
- Blacksmith Testbox `tbx_01kxdh4xyy0bwejzm02710jsrd`, Actions run `29243705846`:
  - `pnpm deadcode:exports` passed with 3,306 baseline entries.
  - `pnpm test:extension msteams` passed 74/74 files and 1,090/1,090 tests.
  - Extension production and test typechecks passed.
  - Targeted extension lint, package patch guard, database-first storage guard, media helper guard, runtime sidecar guard, and import-cycle check passed.
- Fresh `gpt-5.6-sol` medium autoreview reported no accepted or actionable findings (`0.99` confidence).
- The independent generated Plugin SDK hash drift is already owned by #106289 and is intentionally not duplicated here.
- `git diff --check` passed.

AI-assisted: yes. The one-file deletion and all proof above were verified against the exact branch head.
