### PR TITLE
fix(agents): terminate run on critical tool-loop veto

### DIFF
--- a/docs/tools/loop-detection.md
+++ b/docs/tools/loop-detection.md
@@ -172,7 +172,9 @@ spend and lockups while preserving normal tool access.
 - Blocking follows once a pattern persists past the warning threshold.
 - Critical thresholds block the next tool-cycle, surface a clear loop-detection
   reason in the run record, and terminate the agent run so the model cannot keep
-  retrying the blocked tool.
+  retrying the blocked tool. A critical veto ends the run after the current tool
+  batch even when the same assistant turn also has successful or otherwise
+  non-terminating tool results.
 - The post-compaction guard emits `compaction_loop_persisted` errors naming
   the offending tool and identical-call count.
 

--- a/docs/tools/loop-detection.md
+++ b/docs/tools/loop-detection.md
@@ -170,8 +170,9 @@ spend and lockups while preserving normal tool access.
 
 - Warnings come first.
 - Blocking follows once a pattern persists past the warning threshold.
-- Critical thresholds block the next tool-cycle and surface a clear
-  loop-detection reason in the run record.
+- Critical thresholds block the next tool-cycle, surface a clear loop-detection
+  reason in the run record, and terminate the agent run so the model cannot keep
+  retrying the blocked tool.
 - The post-compaction guard emits `compaction_loop_persisted` errors naming
   the offending tool and identical-call count.
 

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1194,6 +1194,62 @@ describe("agentLoop tool termination", () => {
     expect(events.at(-1)).toMatchObject({ type: "agent_end" });
   });
 
+  it("stops after a mixed tool batch when any finalized result terminates", async () => {
+    const executed: string[] = [];
+    let turn = 0;
+    const streamFn: StreamFn = () => {
+      turn += 1;
+      if (turn > 1) {
+        throw new Error("model was called after mixed-batch terminate");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "call-success", name: "read", arguments: {} },
+          { type: "toolCall", id: "call-loop", name: "exec", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+
+    const stream = agentLoop(
+      [{ role: "user", content: "mixed batch", timestamp: 1 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [makeTool("read", executed), makeTool("exec", executed)],
+      },
+      {
+        ...config,
+        // Critical tool-loop shape: only the blocked result sets terminate; the
+        // sibling success result must not keep the agent loop running.
+        afterToolCall: async ({ toolCall }) =>
+          toolCall.name === "exec"
+            ? {
+                terminate: true,
+                details: {
+                  status: "blocked",
+                  deniedReason: "tool-loop",
+                  reason: "CRITICAL: Called exec with identical arguments 10 times.",
+                },
+              }
+            : undefined,
+      },
+      undefined,
+      streamFn,
+    );
+
+    const events = await collectEvents(stream);
+
+    expect(turn).toBe(1);
+    expect(executed).toEqual(["read", "exec"]);
+    expect(events.filter((event) => event.type === "tool_execution_start")).toHaveLength(2);
+    expect(events.filter((event) => event.type === "tool_execution_end")).toHaveLength(2);
+    expect(events.at(-1)).toMatchObject({ type: "agent_end" });
+  });
+
   it("does not request another model turn after a tool aborts the run", async () => {
     const controller = new AbortController();
     let streamCalls = 0;

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -805,10 +805,10 @@ type FinalizedToolCallOutcome = {
 type FinalizedToolCallEntry = FinalizedToolCallOutcome | (() => Promise<FinalizedToolCallOutcome>);
 
 function shouldTerminateToolBatch(finalizedCalls: FinalizedToolCallOutcome[]): boolean {
-  return (
-    finalizedCalls.length > 0 &&
-    finalizedCalls.every((finalized) => finalized.result.terminate === true)
-  );
+  // One terminating result ends the run after the current batch. Critical
+  // tool-loop vetoes rely on this so a mixed batch (loop block + success) cannot
+  // request another model turn and resume the runaway loop.
+  return finalizedCalls.some((finalized) => finalized.result.terminate === true);
 }
 
 function prepareToolCallArguments(tool: AgentTool, toolCall: AgentToolCall): AgentToolCall {

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -83,7 +83,7 @@ export interface AfterToolCallResult {
   isError?: boolean;
   /**
    * Hint that the agent should stop after the current tool batch.
-   * Early termination only happens when every finalized tool result in the batch sets this to true.
+   * Early termination happens when any finalized tool result in the batch sets this to true.
    */
   terminate?: boolean;
 }
@@ -447,7 +447,7 @@ export interface AgentToolResult<T> {
   progress?: AgentToolProgress;
   /**
    * Hint that the agent should stop after the current tool batch.
-   * Early termination only happens when every finalized tool result in the batch sets this to true.
+   * Early termination happens when any finalized tool result in the batch sets this to true.
    */
   terminate?: boolean;
 }

--- a/src/agents/agent-tools.before-tool-call.blocked-result.test.ts
+++ b/src/agents/agent-tools.before-tool-call.blocked-result.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { buildBlockedToolResult } from "./agent-tools.before-tool-call.js";
+import { resetAdjustedParamsByToolCallIdForTests } from "./agent-tools.before-tool-call.state.js";
+
+describe("buildBlockedToolResult", () => {
+  it("terminates the agent run for critical tool-loop vetoes", () => {
+    resetAdjustedParamsByToolCallIdForTests();
+    const result = buildBlockedToolResult({
+      reason: "CRITICAL: Called exec with identical arguments 10 times.",
+      deniedReason: "tool-loop",
+      toolCallId: "call-1",
+      runId: "run-1",
+    });
+    expect(result.details).toMatchObject({
+      status: "blocked",
+      deniedReason: "tool-loop",
+    });
+    expect(result.terminate).toBe(true);
+  });
+
+  it("does not terminate plugin or approval vetoes", () => {
+    resetAdjustedParamsByToolCallIdForTests();
+    const plugin = buildBlockedToolResult({
+      reason: "plugin denied",
+      deniedReason: "plugin-before-tool-call",
+    });
+    const approval = buildBlockedToolResult({
+      reason: "approval denied",
+      deniedReason: "plugin-approval",
+    });
+    expect(plugin.terminate).toBeUndefined();
+    expect(approval.terminate).toBeUndefined();
+  });
+});

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -304,6 +304,9 @@ describe("before_tool_call loop detection behavior", () => {
     expect(details.status).toBe("blocked");
     expect(details.deniedReason).toBe("tool-loop");
     expect(String(details.reason)).toContain(expectedReason);
+    // Critical loop blocks must terminate the agent-core turn batch so the model
+    // cannot keep issuing the same blocked tool after action=block.
+    expect(record.terminate).toBe(true);
   }
 
   async function expectUnblockedToolExecution(

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -1283,13 +1283,19 @@ export function buildBlockedToolResult(params: {
   runId?: string;
 }) {
   recordPreExecutionBlockedToolCall(params.toolCallId, params.runId);
+  const deniedReason = params.deniedReason ?? "plugin-before-tool-call";
+  // Critical tool-loop vetoes must stop the agent run, not only the next tool
+  // execution. agent-core ends the loop when every finalized result sets
+  // terminate; without it the model keeps calling the blocked tool for hours.
+  const terminateRun = deniedReason === "tool-loop";
   return {
     content: [{ type: "text" as const, text: params.reason }],
     details: {
       status: "blocked",
-      deniedReason: params.deniedReason ?? "plugin-before-tool-call",
+      deniedReason,
       reason: params.reason,
     },
+    ...(terminateRun ? { terminate: true as const } : {}),
   };
 }
 

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -1285,8 +1285,8 @@ export function buildBlockedToolResult(params: {
   recordPreExecutionBlockedToolCall(params.toolCallId, params.runId);
   const deniedReason = params.deniedReason ?? "plugin-before-tool-call";
   // Critical tool-loop vetoes must stop the agent run, not only the next tool
-  // execution. agent-core ends the loop when every finalized result sets
-  // terminate; without it the model keeps calling the blocked tool for hours.
+  // execution. agent-core ends the loop when any finalized result sets
+  // terminate (including mixed batches with a non-terminating sibling result).
   const terminateRun = deniedReason === "tool-loop";
   return {
     content: [{ type: "text" as const, text: params.reason }],


### PR DESCRIPTION
Closes #106231

## What Problem This Solves

Fixes an issue where users with loop detection enabled would keep burning model tokens for hours after a critical tool-loop block when the agent repeatedly called the same tool (for example `exec`) with identical arguments and outcomes. Loop detection correctly logged `action=block`, but the agent run continued until a manual `/stop`.

## Why This Change Was Made

Critical tool-loop vetoes now return a blocked tool result with agent-core’s existing `terminate: true` early-stop hint, so the current tool batch ends the run instead of only denying the next tool execution. Plugin and approval vetoes stay non-terminating. Docs describe the terminate-on-critical behavior. No new config, no independent abort path inside the detector.

**Fix quality:** compatibility — reuses agent-core terminate semantics; performance — stops unbounded post-block model calls; usability — critical loop ends the run with the existing CRITICAL reason text; security — no trust-boundary change, only enforces the safety breaker as labeled.

## User Impact

When loop detection reaches a critical threshold, OpenClaw blocks the looping tool **and** ends the agent run so the model cannot keep retrying the blocked call. Warning thresholds and post-compaction guard behavior are unchanged.

## Evidence

Verification host: local macOS

```text
node scripts/run-vitest.mjs src/agents/agent-tools.before-tool-call.blocked-result.test.ts
# 2 passed

node scripts/run-vitest.mjs src/agents/agent-tools.before-tool-call.e2e.test.ts
# 83 passed (critical tool-loop blocks assert terminate: true)

node scripts/run-vitest.mjs packages/agent-core/src/agent-loop.test.ts \
  -t "stops after a tool result only when the finalized result explicitly terminates|stops after a mixed tool batch when any finalized result terminates"
# 2 passed
# Mixed-batch proof: turn stays 1; both tools execute (read + exec); agent_end with no second model turn

node scripts/run-vitest.mjs packages/agent-core/src/agent-loop.test.ts -t "tool termination|abort"
# 12 passed | 14 skipped

./node_modules/.bin/oxfmt --check \
  packages/agent-core/src/agent-loop.ts \
  packages/agent-core/src/types.ts \
  packages/agent-core/src/agent-loop.test.ts \
  src/agents/agent-tools.before-tool-call.ts \
  docs/tools/loop-detection.md
# All matched files use the correct format

git diff --check
# clean
```

## Real behavior proof

- Behavior addressed: Critical tool-loop `action=block` must terminate the agent run so the model cannot keep issuing the same blocked tool after the safety breaker fires (issue #106231), including when the same assistant turn mixes a critical veto with a successful non-terminating tool result.
- Environment: local macOS openclaw checkout at branch `fix/106231-critical-tool-loop-terminate-run`, Node via `node scripts/run-vitest.mjs`.
- Current-main contrast: On main, critical tool-loop blocks did not set `terminate`, and agent-core only stopped a tool batch when every finalized result terminated. A mixed batch (critical veto + success) therefore requested another model turn, matching production logs where `action=block` repeated for hours until `/stop`.
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs src/agents/agent-tools.before-tool-call.blocked-result.test.ts`
  2. `node scripts/run-vitest.mjs src/agents/agent-tools.before-tool-call.e2e.test.ts` (critical poll/generic/ping-pong paths assert `terminate: true`)
  3. `node scripts/run-vitest.mjs packages/agent-core/src/agent-loop.test.ts -t "stops after a mixed tool batch when any finalized result terminates"`
- Evidence after fix (redacted agent-loop transcript from the mixed-batch regression):
  - Assistant turn emits two tool calls: `read` (success, no terminate) + `exec` (critical tool-loop shape with `terminate: true` / `deniedReason: "tool-loop"`).
  - Both tools finalize (`tool_execution_start` x2, `tool_execution_end` x2; executed order `["read", "exec"]`).
  - Model turn count stays `1` (second model invocation would throw `model was called after mixed-batch terminate`).
  - Stream ends with `agent_end` — run is terminal after the mixed batch.
  - Single-tool critical path still sets `terminate: true` on the blocked result only for `deniedReason === "tool-loop"`; plugin/approval vetoes remain non-terminating.
- Control check: Plugin-before-tool-call and plugin-approval blocked results omit `terminate`. Non-critical warning thresholds are unchanged. Docs state that a critical veto ends the run after the current batch even when sibling results are non-terminating.
- Observed result after fix: Focused unit, e2e (83), and agent-core terminate suites green; mixed-batch critical veto no longer leaves the run open for another model turn.
- What was not tested: Multi-hour live Discord/subagent burn against a real hosted model; full gateway session-lane release under load. The mixed-batch agent-loop proof is the acceptance path for terminal behavior without a paid live-model tenant.

## AI disclosure

This fix was authored with AI assistance (Grok). Reviewers should treat the Real behavior proof and focused tests as the primary validation, not the AI origin of the patch.

