### PR TITLE
fix(docs): refresh gateway lock map

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -3437,8 +3437,8 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Route: /gateway/gateway-lock
 - Headings:
   - H2: Why
-  - H2: Two layers
-  - H3: File lock
+  - H2: Three layers
+  - H3: State and config locks
   - H3: Socket bind
   - H2: Operational notes
   - H2: Related


### PR DESCRIPTION
## What Problem This Solves

The generated documentation map still listed the former gateway-lock headings, so `docs:map:check` failed on current `main` and every PR based on it.

## Why This Change Was Made

Regenerate the canonical map from `docs/gateway/gateway-lock.md`. This keeps the generated baseline aligned without changing source documentation.

## User Impact

None. Documentation navigation metadata now matches the published headings.

## Evidence

- `node scripts/generate-docs-map.mjs --check`
- `git diff --check`
