### PR TITLE
fix(gmail): preserve bind errors across watcher output chunks

### DIFF
--- a/src/hooks/gmail-watcher.test.ts
+++ b/src/hooks/gmail-watcher.test.ts
@@ -454,4 +454,82 @@ describe("startGmailWatcher", () => {
 
     await expect(startGmailWatcher(createGmailConfig())).resolves.toEqual({ started: true });
   });
+
+  it("stops restarts when address-in-use marker is split across stderr chunks", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.runCommandWithTimeout.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+      const spawnedChildren: Array<
+        EventEmitter & { kill: ReturnType<typeof vi.fn>; stderr?: EventEmitter }
+      > = [];
+      mocks.spawn.mockImplementation(() => {
+        const child = new EventEmitter();
+        const stderr = new EventEmitter();
+        const mockedChild = Object.assign(child, {
+          stderr,
+          kill: vi.fn(() => {
+            queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
+            return true;
+          }),
+        });
+        spawnedChildren.push(mockedChild);
+        return mockedChild;
+      });
+
+      await startGmailWatcher(createGmailConfig());
+      expect(spawnedChildren).toHaveLength(1);
+
+      // Emit the "address already in use" marker split across two chunks
+      const stderr = spawnedChildren[0]?.stderr as EventEmitter | undefined;
+      stderr?.emit("data", Buffer.from("address alre"));
+      stderr?.emit("data", Buffer.from("ady in use\n"));
+
+      // Exit should detect addressInUse and stop restarts, not schedule a 5 s
+      // respawn on line ~126.
+      spawnedChildren[0]?.emit("exit", 1, null);
+
+      await vi.advanceTimersByTimeAsync(6000);
+      expect(spawnedChildren).toHaveLength(1); // No respawn
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still respawns on non-bind stderr split across chunks", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.runCommandWithTimeout.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+      const spawnedChildren: Array<
+        EventEmitter & { kill: ReturnType<typeof vi.fn>; stderr?: EventEmitter }
+      > = [];
+      mocks.spawn.mockImplementation(() => {
+        const child = new EventEmitter();
+        const stderr = new EventEmitter();
+        const mockedChild = Object.assign(child, {
+          stderr,
+          kill: vi.fn(() => {
+            queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
+            return true;
+          }),
+        });
+        spawnedChildren.push(mockedChild);
+        return mockedChild;
+      });
+
+      await startGmailWatcher(createGmailConfig());
+      expect(spawnedChildren).toHaveLength(1);
+
+      // Emit a non-bind error split across chunks
+      const stderr = spawnedChildren[0]?.stderr as EventEmitter | undefined;
+      stderr?.emit("data", Buffer.from("some erro"));
+      stderr?.emit("data", Buffer.from("r message\n"));
+
+      spawnedChildren[0]?.emit("exit", 1, null);
+
+      await vi.advanceTimersByTimeAsync(6000);
+      expect(spawnedChildren).toHaveLength(2); // Respawn happened
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/hooks/gmail-watcher.test.ts
+++ b/src/hooks/gmail-watcher.test.ts
@@ -116,7 +116,7 @@ describe("startGmailWatcher", () => {
         reason: "startup cancelled",
       });
 
-      spawnedChildren[0]?.emit("exit", 1, null);
+      spawnedChildren[0]?.emit("close", 1, null);
       await vi.advanceTimersByTimeAsync(5000);
 
       expect(mocks.spawn).toHaveBeenCalledTimes(2);
@@ -412,7 +412,7 @@ describe("startGmailWatcher", () => {
       expect(spawnedChildren).toHaveLength(1);
 
       // Process crashes (exit code 1). This queues a 5s respawn timeout.
-      expectDefined(spawnedChildren[0], "spawnedChildren[0] test invariant").emit("exit", 1, null);
+      expectDefined(spawnedChildren[0], "spawnedChildren[0] test invariant").emit("close", 1, null);
 
       // Before the 5s timer fires, a config reload triggers re-entry.
       // The re-entry guard should cancel the stale respawn timeout.
@@ -484,9 +484,47 @@ describe("startGmailWatcher", () => {
       stderr?.emit("data", Buffer.from("address alre"));
       stderr?.emit("data", Buffer.from("ady in use\n"));
 
-      // Exit should detect addressInUse and stop restarts, not schedule a 5 s
-      // respawn on line ~126.
+      // Close (stdio drained) should detect addressInUse and stop restarts.
+      spawnedChildren[0]?.emit("close", 1, null);
+
+      await vi.advanceTimersByTimeAsync(6000);
+      expect(spawnedChildren).toHaveLength(1); // No respawn
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops restarts when final bind marker arrives after exit but before close", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.runCommandWithTimeout.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+      const spawnedChildren: Array<
+        EventEmitter & { kill: ReturnType<typeof vi.fn>; stderr?: EventEmitter }
+      > = [];
+      mocks.spawn.mockImplementation(() => {
+        const child = new EventEmitter();
+        const stderr = new EventEmitter();
+        const mockedChild = Object.assign(child, {
+          stderr,
+          kill: vi.fn(() => {
+            queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
+            return true;
+          }),
+        });
+        spawnedChildren.push(mockedChild);
+        return mockedChild;
+      });
+
+      await startGmailWatcher(createGmailConfig());
+      expect(spawnedChildren).toHaveLength(1);
+
+      const stderr = spawnedChildren[0]?.stderr as EventEmitter | undefined;
+      // First fragment only — incomplete marker at exit time.
+      stderr?.emit("data", Buffer.from("address alre"));
       spawnedChildren[0]?.emit("exit", 1, null);
+      // Final fragment arrives after exit (Node allows this); close drains stdio.
+      stderr?.emit("data", Buffer.from("ady in use\n"));
+      spawnedChildren[0]?.emit("close", 1, null);
 
       await vi.advanceTimersByTimeAsync(6000);
       expect(spawnedChildren).toHaveLength(1); // No respawn
@@ -524,7 +562,7 @@ describe("startGmailWatcher", () => {
       stderr?.emit("data", Buffer.from("some erro"));
       stderr?.emit("data", Buffer.from("r message\n"));
 
-      spawnedChildren[0]?.emit("exit", 1, null);
+      spawnedChildren[0]?.emit("close", 1, null);
 
       await vi.advanceTimersByTimeAsync(6000);
       expect(spawnedChildren).toHaveLength(2); // Respawn happened

--- a/src/hooks/gmail-watcher.test.ts
+++ b/src/hooks/gmail-watcher.test.ts
@@ -55,6 +55,36 @@ function deferredCommandResult() {
   return { promise, resolve };
 }
 
+type MockWatcherChild = EventEmitter & {
+  kill: ReturnType<typeof vi.fn>;
+  pid?: number;
+  stderr: EventEmitter;
+};
+
+function createMockWatcherChild(spawned = true): MockWatcherChild {
+  const child = new EventEmitter();
+  return Object.assign(child, {
+    stderr: new EventEmitter(),
+    kill: vi.fn(() => {
+      queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
+      return true;
+    }),
+    ...(spawned ? { pid: 1234 } : {}),
+  });
+}
+
+async function startMockWatcher(spawned = true): Promise<MockWatcherChild[]> {
+  mocks.runCommandWithTimeout.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+  const children: MockWatcherChild[] = [];
+  mocks.spawn.mockImplementation(() => {
+    const child = createMockWatcherChild(spawned);
+    children.push(child);
+    return child;
+  });
+  await startGmailWatcher(createGmailConfig());
+  return children;
+}
+
 describe("startGmailWatcher", () => {
   beforeEach(async () => {
     await stopGmailWatcher();
@@ -455,163 +485,61 @@ describe("startGmailWatcher", () => {
     await expect(startGmailWatcher(createGmailConfig())).resolves.toEqual({ started: true });
   });
 
-  it("stops restarts when address-in-use marker is split across stderr chunks", async () => {
+  it.each([
+    { name: "failed spawn", spawned: false, expectedChildren: 1 },
+    { name: "error from a running child", spawned: true, expectedChildren: 2 },
+  ])("handles $name without losing restart policy", async ({ spawned, expectedChildren }) => {
     vi.useFakeTimers();
     try {
-      mocks.runCommandWithTimeout.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
-      const spawnedChildren: Array<
-        EventEmitter & { kill: ReturnType<typeof vi.fn>; stderr?: EventEmitter }
-      > = [];
-      mocks.spawn.mockImplementation(() => {
-        const child = new EventEmitter();
-        const stderr = new EventEmitter();
-        const mockedChild = Object.assign(child, {
-          stderr,
-          kill: vi.fn(() => {
-            queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
-            return true;
-          }),
-        });
-        spawnedChildren.push(mockedChild);
-        return mockedChild;
-      });
-
-      await startGmailWatcher(createGmailConfig());
-      expect(spawnedChildren).toHaveLength(1);
-
-      // Emit the "address already in use" marker split across two chunks
-      const stderr = spawnedChildren[0]?.stderr as EventEmitter | undefined;
-      stderr?.emit("data", Buffer.from("address alre"));
-      stderr?.emit("data", Buffer.from("ady in use\n"));
-
-      // Close (stdio drained) should detect addressInUse and stop restarts.
-      spawnedChildren[0]?.emit("close", 1, null);
+      const children = await startMockWatcher(spawned);
+      const child = expectDefined(children[0], "watcher child");
+      child.emit("error", new Error(spawned ? "gog stream error" : "spawn gog ENOENT"));
+      child.emit("close", spawned ? 1 : -2, null);
 
       await vi.advanceTimersByTimeAsync(6000);
-      expect(spawnedChildren).toHaveLength(1); // No respawn
+      expect(children).toHaveLength(expectedChildren);
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("stops restarts when final bind marker arrives after exit but before close", async () => {
+  it.each([
+    {
+      name: "split address-in-use marker",
+      chunks: ["address alre", "ady in use\n"],
+      expectedChildren: 1,
+    },
+    {
+      name: "final bind fragment after exit",
+      chunks: ["address alre", "ady in use\n"],
+      exitAfterChunk: 0,
+      expectedChildren: 1,
+    },
+    {
+      name: "marker completed before tail truncation",
+      chunks: ["address alre", `ady in use ${"x".repeat(800)}`],
+      expectedChildren: 1,
+    },
+    {
+      name: "non-bind stderr",
+      chunks: ["some erro", "r message\n"],
+      expectedChildren: 2,
+    },
+  ])("classifies $name", async ({ chunks, exitAfterChunk, expectedChildren }) => {
     vi.useFakeTimers();
     try {
-      mocks.runCommandWithTimeout.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
-      const spawnedChildren: Array<
-        EventEmitter & { kill: ReturnType<typeof vi.fn>; stderr?: EventEmitter }
-      > = [];
-      mocks.spawn.mockImplementation(() => {
-        const child = new EventEmitter();
-        const stderr = new EventEmitter();
-        const mockedChild = Object.assign(child, {
-          stderr,
-          kill: vi.fn(() => {
-            queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
-            return true;
-          }),
-        });
-        spawnedChildren.push(mockedChild);
-        return mockedChild;
-      });
-
-      await startGmailWatcher(createGmailConfig());
-      expect(spawnedChildren).toHaveLength(1);
-
-      const stderr = spawnedChildren[0]?.stderr as EventEmitter | undefined;
-      // First fragment only — incomplete marker at exit time.
-      stderr?.emit("data", Buffer.from("address alre"));
-      spawnedChildren[0]?.emit("exit", 1, null);
-      // Final fragment arrives after exit (Node allows this); close drains stdio.
-      stderr?.emit("data", Buffer.from("ady in use\n"));
-      spawnedChildren[0]?.emit("close", 1, null);
+      const children = await startMockWatcher();
+      const child = expectDefined(children[0], "watcher child");
+      for (const [index, chunk] of chunks.entries()) {
+        child.stderr.emit("data", Buffer.from(chunk));
+        if (exitAfterChunk === index) {
+          child.emit("exit", 1, null);
+        }
+      }
+      child.emit("close", 1, null);
 
       await vi.advanceTimersByTimeAsync(6000);
-      expect(spawnedChildren).toHaveLength(1); // No respawn
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("stops restarts when cross-boundary marker completes but combined exceeds retention window", async () => {
-    vi.useFakeTimers();
-    try {
-      mocks.runCommandWithTimeout.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
-      const spawnedChildren: Array<
-        EventEmitter & { kill: ReturnType<typeof vi.fn>; stderr?: EventEmitter }
-      > = [];
-      mocks.spawn.mockImplementation(() => {
-        const child = new EventEmitter();
-        const stderr = new EventEmitter();
-        const mockedChild = Object.assign(child, {
-          stderr,
-          kill: vi.fn(() => {
-            queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
-            return true;
-          }),
-        });
-        spawnedChildren.push(mockedChild);
-        return mockedChild;
-      });
-
-      await startGmailWatcher(createGmailConfig());
-      expect(spawnedChildren).toHaveLength(1);
-
-      const stderr = spawnedChildren[0]?.stderr as EventEmitter | undefined;
-      // First chunk — marker prefix only ("address alre", 12 bytes).
-      stderr?.emit("data", Buffer.from("address alre"));
-      // Second chunk completes the marker ("ady in use ") then adds noise so
-      // the combined length (~824 bytes) exceeds the 512-byte retention window.
-      // The trailing half ("ady in use" + padding) does NOT independently
-      // match the address-in-use regex, so a truncate-before-classify bug would
-      // miss the completed marker and still respawn.
-      const tail = "ady in use " + "x".repeat(800);
-      stderr?.emit("data", Buffer.from(tail));
-
-      // Close (stdio drained) must detect addressInUse from the untruncated
-      // combined text and stop restarts.
-      spawnedChildren[0]?.emit("close", 1, null);
-
-      await vi.advanceTimersByTimeAsync(6000);
-      expect(spawnedChildren).toHaveLength(1); // No respawn
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("still respawns on non-bind stderr split across chunks", async () => {
-    vi.useFakeTimers();
-    try {
-      mocks.runCommandWithTimeout.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
-      const spawnedChildren: Array<
-        EventEmitter & { kill: ReturnType<typeof vi.fn>; stderr?: EventEmitter }
-      > = [];
-      mocks.spawn.mockImplementation(() => {
-        const child = new EventEmitter();
-        const stderr = new EventEmitter();
-        const mockedChild = Object.assign(child, {
-          stderr,
-          kill: vi.fn(() => {
-            queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
-            return true;
-          }),
-        });
-        spawnedChildren.push(mockedChild);
-        return mockedChild;
-      });
-
-      await startGmailWatcher(createGmailConfig());
-      expect(spawnedChildren).toHaveLength(1);
-
-      // Emit a non-bind error split across chunks
-      const stderr = spawnedChildren[0]?.stderr as EventEmitter | undefined;
-      stderr?.emit("data", Buffer.from("some erro"));
-      stderr?.emit("data", Buffer.from("r message\n"));
-
-      spawnedChildren[0]?.emit("close", 1, null);
-
-      await vi.advanceTimersByTimeAsync(6000);
-      expect(spawnedChildren).toHaveLength(2); // Respawn happened
+      expect(children).toHaveLength(expectedChildren);
     } finally {
       vi.useRealTimers();
     }

--- a/src/hooks/gmail-watcher.test.ts
+++ b/src/hooks/gmail-watcher.test.ts
@@ -533,6 +533,52 @@ describe("startGmailWatcher", () => {
     }
   });
 
+  it("stops restarts when cross-boundary marker completes but combined exceeds retention window", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.runCommandWithTimeout.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+      const spawnedChildren: Array<
+        EventEmitter & { kill: ReturnType<typeof vi.fn>; stderr?: EventEmitter }
+      > = [];
+      mocks.spawn.mockImplementation(() => {
+        const child = new EventEmitter();
+        const stderr = new EventEmitter();
+        const mockedChild = Object.assign(child, {
+          stderr,
+          kill: vi.fn(() => {
+            queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
+            return true;
+          }),
+        });
+        spawnedChildren.push(mockedChild);
+        return mockedChild;
+      });
+
+      await startGmailWatcher(createGmailConfig());
+      expect(spawnedChildren).toHaveLength(1);
+
+      const stderr = spawnedChildren[0]?.stderr as EventEmitter | undefined;
+      // First chunk — marker prefix only ("address alre", 12 bytes).
+      stderr?.emit("data", Buffer.from("address alre"));
+      // Second chunk completes the marker ("ady in use ") then adds noise so
+      // the combined length (~824 bytes) exceeds the 512-byte retention window.
+      // The trailing half ("ady in use" + padding) does NOT independently
+      // match the address-in-use regex, so a truncate-before-classify bug would
+      // miss the completed marker and still respawn.
+      const tail = "ady in use " + "x".repeat(800);
+      stderr?.emit("data", Buffer.from(tail));
+
+      // Close (stdio drained) must detect addressInUse from the untruncated
+      // combined text and stop restarts.
+      spawnedChildren[0]?.emit("close", 1, null);
+
+      await vi.advanceTimersByTimeAsync(6000);
+      expect(spawnedChildren).toHaveLength(1); // No respawn
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("still respawns on non-bind stderr split across chunks", async () => {
     vi.useFakeTimers();
     try {

--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -73,8 +73,10 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
   log.info(`starting gog ${buildGogWatchServeLogArgs(cfg).join(" ")}`);
   let addressInUse = false;
   // Carry a bounded tail across stderr chunks so split patterns such as
-  // "address alre" + "ady in use" are classified before the exit handler
-  // decides whether to stop restarts or to schedule a 5 s respawn.
+  // "address alre" + "ady in use" are classified before the close handler
+  // decides whether to stop restarts or to schedule a 5 s respawn. Restart
+  // policy waits for `close` (stdio drained) rather than `exit`, because Node
+  // can deliver the final stderr fragment after `exit`.
   let stderrTail = "";
   const invocation = resolveGogServeInvocation(args);
 
@@ -115,7 +117,7 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
     log.error(`gog process error: ${String(err)}`);
   });
 
-  child.on("exit", (code, signal) => {
+  child.on("close", (code, signal) => {
     // If a newer watcher has replaced this child, do not respawn.
     if (watcherProcess !== null && watcherProcess !== child) {
       return;

--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -72,6 +72,10 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
   const args = buildGogWatchServeArgs(cfg);
   log.info(`starting gog ${buildGogWatchServeLogArgs(cfg).join(" ")}`);
   let addressInUse = false;
+  // Carry a bounded tail across stderr chunks so split patterns such as
+  // "address alre" + "ady in use" are classified before the exit handler
+  // decides whether to stop restarts or to schedule a 5 s respawn.
+  let stderrTail = "";
   const invocation = resolveGogServeInvocation(args);
 
   const child = spawn(invocation.command, invocation.args, {
@@ -95,12 +99,14 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
     log.error(`gog stderr error: ${String(err)}`);
   });
   child.stderr?.on("data", (data: Buffer) => {
-    const line = data.toString().trim();
+    const chunk = data.toString();
+    stderrTail = (stderrTail + chunk).slice(-512);
+    if (!addressInUse && isAddressInUseError(stderrTail)) {
+      addressInUse = true;
+    }
+    const line = chunk.trim();
     if (!line) {
       return;
-    }
-    if (isAddressInUseError(line)) {
-      addressInUse = true;
     }
     log.warn(`[gog] ${line}`);
   });

--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -102,10 +102,14 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
   });
   child.stderr?.on("data", (data: Buffer) => {
     const chunk = data.toString();
-    stderrTail = (stderrTail + chunk).slice(-512);
-    if (!addressInUse && isAddressInUseError(stderrTail)) {
+    // Classify the untruncated combined text so a cross-boundary marker is
+    // detected even when the combined length exceeds the 512-byte retention
+    // window.  Only then truncate the tail for bounded memory.
+    const combined = stderrTail + chunk;
+    if (!addressInUse && isAddressInUseError(combined)) {
       addressInUse = true;
     }
+    stderrTail = combined.slice(-512);
     const line = chunk.trim();
     if (!line) {
       return;

--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -23,6 +23,7 @@ import {
 } from "./gmail.js";
 
 const log = createSubsystemLogger("gmail-watcher");
+const GMAIL_WATCHER_STDERR_TAIL_CHARS = 512;
 
 let watcherProcess: ChildProcess | null = null;
 let renewInterval: ReturnType<typeof setInterval> | null = null;
@@ -72,11 +73,8 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
   const args = buildGogWatchServeArgs(cfg);
   log.info(`starting gog ${buildGogWatchServeLogArgs(cfg).join(" ")}`);
   let addressInUse = false;
-  // Carry a bounded tail across stderr chunks so split patterns such as
-  // "address alre" + "ady in use" are classified before the close handler
-  // decides whether to stop restarts or to schedule a 5 s respawn. Restart
-  // policy waits for `close` (stdio drained) rather than `exit`, because Node
-  // can deliver the final stderr fragment after `exit`.
+  let spawnFailed = false;
+  // Carry a bounded tail so bind markers split across stderr chunks survive until close.
   let stderrTail = "";
   const invocation = resolveGogServeInvocation(args);
 
@@ -102,14 +100,12 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
   });
   child.stderr?.on("data", (data: Buffer) => {
     const chunk = data.toString();
-    // Classify the untruncated combined text so a cross-boundary marker is
-    // detected even when the combined length exceeds the 512-byte retention
-    // window.  Only then truncate the tail for bounded memory.
+    // Classify before truncation so a marker completed across the retention boundary survives.
     const combined = stderrTail + chunk;
     if (!addressInUse && isAddressInUseError(combined)) {
       addressInUse = true;
     }
-    stderrTail = combined.slice(-512);
+    stderrTail = combined.slice(-GMAIL_WATCHER_STDERR_TAIL_CHARS);
     const line = chunk.trim();
     if (!line) {
       return;
@@ -118,15 +114,24 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
   });
 
   child.on("error", (err) => {
+    // Failed spawn emits close without a pid; later errors on a running child remain retryable.
+    if (child.pid === undefined) {
+      spawnFailed = true;
+    }
     log.error(`gog process error: ${String(err)}`);
   });
 
+  // `close` follows stdio drain, so late stderr participates in restart classification.
   child.on("close", (code, signal) => {
     // If a newer watcher has replaced this child, do not respawn.
     if (watcherProcess !== null && watcherProcess !== child) {
       return;
     }
     if (shuttingDown) {
+      return;
+    }
+    if (spawnFailed) {
+      watcherProcess = null;
       return;
     }
     if (addressInUse) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Gmail watcher enters an endless 5-second respawn loop when its gog serve process fails with an "address already in use" error under two independent conditions:

1. The error message is split across stderr pipe chunks (e.g. `"address alre"` + `"ady in use"`) and the per-chunk classifier misses the completed marker.
2. The final stderr fragment arrives after the child `exit` event but before `close`, so a restart decision made on `exit` never sees the completed marker.

A third edge case remains reachable even with chunk-carrying: when the combined stderr text exceeds the 512-byte retention window, `.slice(-512)` can discard a cross-boundary marker from the retained tail before classification runs.

## Why This Change Was Made

The stderr `data` handler now carries a bounded 512-byte tail across chunks and **classifies the untruncated combined text** before retaining only the last 512 bytes — so a marker completed across the old-tail/new-chunk boundary is detected even when the combined length exceeds the retention window. The restart decision moved from `exit` to `close`, so classification sees every fragment after stdio has drained before deciding whether to stop or to schedule a respawn. The close handler also detects spawn failures from Node’s undefined child PID and clears the failed watcher without scheduling a launch retry. Bounded to the optional Gmail watcher serve path; no config or public API change.

## User Impact

Operators with an already-running Gmail watcher (or a stale port binding) no longer experience an infinite 5-second respawn loop when starting a second watcher. The watcher correctly stops restarts and logs a clear diagnostic.

## Evidence

**Before (RED) — exit-before-final-stderr (real child_process):** With stderr delivery paused so Node's documented `exit`-before-remaining-stdio ordering appears, deciding restart policy on `exit` misses the bind marker and would respawn:

```
BEFORE (decide on exit): addressInUse=false, wouldRespawn=true
events: ["exit:1:addressInUse=false"]
```

**Premise:** Node emits `exit` before all stdio is necessarily drained; `close` fires after streams close. Node also guarantees `close` after a failed-spawn `error`, with `subprocess.pid` left `undefined`; the new guard distinguishes that launch failure from errors on an already-running child. `isAddressInUseError` matches `/address already in use|EADDRINUSE/i` against the untruncated combined stderr text so a cross-boundary marker is classified before the tail is truncated for bounded memory.

**After (GREEN) — same harness on `close`:**

```
AFTER (decide on close): addressInUse=true, wouldRespawn=false
events: [
  "exit:1:addressInUse=false",
  "data:\"listen EADDRINUSE: address alre\"",
  "data:\"ady in use 127.0.0.1:18788\\n\"",
  "close:1:addressInUse=true"
]
VERDICT: RED→GREEN
```

**After (GREEN) — real occupied-port production path:** Port `127.0.0.1:18788` held by a real `net.Server`; PATH fake `gog` that for `watch serve` calls `server.listen` and surfaces the OS error. Production `startGmailWatcher` → `spawnGogServe` ran once and stopped restarts (no second serve after 6.5 s):

```
[gmail-watcher] [gog] listen EADDRINUSE: address already in use 127.0.0.1:18788
[gmail-watcher] gog serve failed to bind (address already in use); stopping restarts. ...
SERVE_INVOCATIONS 1
```

**Negative controls:**
- A failed spawn emitting `error` then `close` does not schedule a respawn.
- Non-bind stderr split across chunks still schedules exactly one respawn.
- Complete bind marker still stops restarts.
- Exit-before-final-bind-fragment then `close` stops restarts (no respawn after 6 s).
- Cross-boundary marker with second chunk large enough to push combined beyond 512 bytes (824 bytes total):
  - Chunk 1: `"address alre"` → Chunk 2: `"ady in use "` + 800 bytes noise
  - truncate-before-classify would miss the marker; classify-before-truncate detects it → stops restarts.

**Focused tests:** After rebasing onto `upstream/main` at `6a5736ba`, Linux Node CI ran `src/hooks/gmail-watcher.test.ts` — 14 passed in 118 ms, including failed-spawn `error` → `close`, split-chunk, exit-before-final-stderr, exceeds-retention-window, and non-bind controls. Exact-head CI run 29301471326 passed all Gmail and relevant checks; its only failure was unrelated latest-main deadcode export `src/agents/embedded-agent-runner/run/attempt-session-boundary.ts:27` (`CurrentUserTimestampOverride`), outside this PR’s two-file diff.

**Diff stats:** source net +23 LOC, tests net +187 LOC; total +217/-7 across 2 files. `git diff --check` clean.

**Unverified:** Live upstream `gog` binary / Gmail API watch-start credentials on this host (fake `gog` on PATH exercised the real spawn + OS EADDRINUSE path instead).

*AI-assisted*


