### PR TITLE
fix: let Control UI admins enable installed plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI plugin enablement:** treat an administrator's Enable action as explicit trust by adding the selected installed plugin to an existing restrictive `plugins.allow` list while preserving explicit deny rules. Fixes #106261.
 - **Claude CLI context budgets:** honor Anthropic model and per-agent `contextTokens` limits by passing the effective limit to Claude Code's native auto-compactor and persisting the same prepared budget in OpenClaw session state. Fixes #80933. (#93198) Thanks @mushuiyu886.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.
 - **Gateway source watch:** hand the configured port off from the installed service before starting the tmux watcher, preserve failed panes for attach/capture, and keep explicit alternate-port watches side by side with the managed Gateway.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI plugin enablement:** treat an administrator's Enable action as explicit trust by adding the selected installed plugin to an existing restrictive `plugins.allow` list while preserving explicit deny rules. Fixes #106261.
 - **Claude CLI context budgets:** honor Anthropic model and per-agent `contextTokens` limits by passing the effective limit to Claude Code's native auto-compactor and persisting the same prepared budget in OpenClaw session state. Fixes #80933. (#93198) Thanks @mushuiyu886.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.
 - **Gateway source watch:** hand the configured port off from the installed service before starting the tmux watcher, preserve failed panes for attach/capture, and keep explicit alternate-port watches side by side with the managed Gateway.

--- a/docs/plugins/manage-plugins.md
+++ b/docs/plugins/manage-plugins.md
@@ -46,7 +46,10 @@ removed, only disabled.
 Catalog and search access require `operator.read`. Install, enable, disable,
 remove, and MCP server changes require `operator.admin`. A ClawHub install is
 performed by the Gateway and preserves its trust, integrity, and plugin-install
-policy checks.
+policy checks. Enabling an installed plugin as an administrator also records
+that explicit trust by adding the selected plugin to an existing restrictive
+`plugins.allow` list. An explicit `plugins.deny` entry remains authoritative and
+must be removed before enabling the plugin.
 
 Installing or removing plugin code requires a Gateway restart. Enablement
 changes can be applied without a restart when the installed plugin and current

--- a/scripts/check-control-ui-performance.mjs
+++ b/scripts/check-control-ui-performance.mjs
@@ -40,7 +40,7 @@ export function extractControlUiStartupAssetPaths(html) {
       assets.add(assetPath);
     }
   }
-  return [...assets].toSorted();
+  return [...assets].toSorted((left, right) => left.localeCompare(right));
 }
 
 function readAssetMetrics(assetsDir, entry) {

--- a/src/plugins/management-service.test.ts
+++ b/src/plugins/management-service.test.ts
@@ -404,6 +404,84 @@ describe("plugin management service", () => {
     });
   });
 
+  it("adds an admin-selected plugin to an existing restrictive allowlist", async () => {
+    const config = {
+      plugins: {
+        allow: ["memory-core"],
+        entries: { workboard: { enabled: false } },
+      },
+    };
+    mocks.readConfig.mockResolvedValue(configSnapshot(config));
+    mocks.replaceConfig.mockResolvedValue({});
+    mocks.refreshRegistry.mockResolvedValue(undefined);
+    mocks.metadata
+      .mockReturnValueOnce(metadataSnapshot({ enabled: false }))
+      .mockReturnValueOnce(metadataSnapshot({ enabled: true }));
+
+    const result = await setManagedPluginEnabled({
+      pluginId: "workboard",
+      enabled: true,
+      env: {},
+    });
+
+    expect(mocks.replaceConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nextConfig: {
+          plugins: {
+            allow: ["memory-core", "workboard"],
+            entries: { workboard: { enabled: true } },
+          },
+        },
+      }),
+    );
+    expect(result.changedPaths).toEqual(["plugins.allow[1]", "plugins.entries.workboard.enabled"]);
+  });
+
+  it("keeps an explicit deny authoritative for admin enablement", async () => {
+    const config = {
+      plugins: {
+        allow: ["memory-core"],
+        deny: ["workboard"],
+        entries: { workboard: { enabled: false } },
+      },
+    };
+    mocks.readConfig.mockResolvedValue(configSnapshot(config));
+    mocks.metadata.mockReturnValue(metadataSnapshot({ enabled: false }));
+
+    await expect(
+      setManagedPluginEnabled({ pluginId: "workboard", enabled: true, env: {} }),
+    ).rejects.toThrow('plugin "workboard" could not be enabled (blocked by denylist)');
+    expect(mocks.replaceConfig).not.toHaveBeenCalled();
+  });
+
+  it("does not turn an empty allowlist into a restrictive one", async () => {
+    const config = {
+      plugins: {
+        allow: [],
+        entries: { workboard: { enabled: false } },
+      },
+    };
+    mocks.readConfig.mockResolvedValue(configSnapshot(config));
+    mocks.replaceConfig.mockResolvedValue({});
+    mocks.refreshRegistry.mockResolvedValue(undefined);
+    mocks.metadata
+      .mockReturnValueOnce(metadataSnapshot({ enabled: false }))
+      .mockReturnValueOnce(metadataSnapshot({ enabled: true }));
+
+    await setManagedPluginEnabled({ pluginId: "workboard", enabled: true, env: {} });
+
+    expect(mocks.replaceConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nextConfig: {
+          plugins: {
+            allow: [],
+            entries: { workboard: { enabled: true } },
+          },
+        },
+      }),
+    );
+  });
+
   it("reports exclusive-slot side effects in established plugin config", async () => {
     const config = {
       plugins: {

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -9,6 +9,7 @@ import {
 } from "../config/config.js";
 import { collectChangedPaths } from "../config/io.write-prepare.js";
 import { resolveIsNixMode } from "../config/paths.js";
+import { ensurePluginAllowlisted } from "../config/plugins-allowlist.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
@@ -862,6 +863,11 @@ export async function setManagedPluginEnabled(params: {
     const warnings: string[] = [];
     let policyPluginId = pluginId;
     if (params.enabled) {
+      // The admin-scoped enable RPC is an explicit trust action. Preserve the
+      // existing inventory while admitting only the selected installed plugin.
+      if ((next.plugins?.allow?.length ?? 0) > 0) {
+        next = ensurePluginAllowlisted(next, pluginId);
+      }
       const enableResult = enableExplicitlySelectedPluginInConfig(next, pluginId, {
         updateChannelConfig: false,
       });


### PR DESCRIPTION
Closes #106261

## What Problem This Solves

Fixes an issue where Control UI administrators could not enable an installed plugin when `plugins.allow` was already restrictive, even though the Enable action is an admin-only configuration mutation.

## Why This Change Was Made

The Gateway now treats an administrator's explicit Enable action as trust for the selected installed plugin and appends its ID to a nonempty restrictive allowlist. Missing and empty allowlists remain unrestricted, while explicit deny entries remain authoritative.

The branch also carries a one-line comparator fix for the Control UI performance checker. The frozen base introduced a new lint error while this PR was running; keeping the repair here avoids another moving-base rebase without changing plugin behavior.

## User Impact

Administrators can enable included or installed plugins such as Workboard directly from the Control UI without first editing `openclaw.json` by hand.

## Evidence

- Blacksmith Testbox `tbx_01kxdhy5zyh8crmsc596hqn3cv`: `corepack pnpm test src/plugins/management-service.test.ts ui/src/pages/plugins/plugins.e2e.test.ts` — 25 Gateway tests and 3 Chromium Control UI scenarios passed on the rebased head.
- Blacksmith Testbox `tbx_01kxdg398qx30kakkmywnwzdzc`: changed-file gate passed, including formatting, core and core-test typechecks, lint, API baseline, import-cycle, database-first, docs, and changelog checks.
- Source-blind live Gateway contract: admin `plugins.setEnabled` enabled Workboard, persisted `plugins.allow` as `["memory-core", "workboard"]`, survived a Gateway restart, and continued to reject an explicit deny.
- Fresh autoreview: no accepted or actionable findings; patch judged correct with 0.93 confidence.
- The first exact-head hosted run passed every completed job except the base-only `typescript(require-array-sort-compare)` lint error; the branch repair supplies the required deterministic comparator.

AI assistance: Codex implemented and validated the change under maintainer direction.
