### PR TITLE
fix(ci): repair current dead-export ratchet

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -1914,7 +1914,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/config/sessions/transcript.ts: TailAssistantTranscriptText",
   "src/config/sessions/types.ts: LaneExecutionState",
   "src/config/sessions/types.ts: mergeSessionEntryWithPolicy",
-  "src/config/sessions/types.ts: QuotaSuspension",
   "src/config/sessions/types.ts: SessionAcpIdentitySource",
   "src/config/sessions/types.ts: SessionAcpIdentityState",
   "src/config/sessions/types.ts: SessionChannelId",

--- a/ui/src/app/agent-selection.ts
+++ b/ui/src/app/agent-selection.ts
@@ -9,7 +9,7 @@ type AgentSelectionGateway = {
   subscribe: (listener: (snapshot: AgentSelectionGateway["snapshot"]) => void) => () => void;
 };
 
-export type AgentSelectionState = {
+type AgentSelectionState = {
   selectedId: string | null;
   /** Agent filter shared by agent-owned pages; null exposes all agents. */
   scopeId: string | null;

--- a/ui/src/pages/agents/route.test.ts
+++ b/ui/src/pages/agents/route.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AgentsListResult } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
-import { loadAgentsRouteData } from "./route.ts";
+import type { AgentsRouteData } from "./agents-page.ts";
+import { page } from "./route.ts";
 
 describe("agents route", () => {
   it("keeps a requested agent when the roster loads on a cold deep link", async () => {
@@ -24,9 +25,14 @@ describe("agents route", () => {
       },
     } as unknown as ApplicationContext;
 
-    const result = await loadAgentsRouteData(context, {
-      search: "?agent=research",
-    } as Parameters<typeof loadAgentsRouteData>[1]);
+    const result = (await page.loader?.(context, {
+      cause: "navigation",
+      deps: "?agent=research",
+      location: { pathname: "/settings/agents", search: "?agent=research", hash: "" },
+      revalidating: false,
+      shouldRun: () => true,
+      signal: new AbortController().signal,
+    })) as AgentsRouteData;
 
     expect(ensureList).toHaveBeenCalledOnce();
     expect(result.agentsList).toBe(agentsList);

--- a/ui/src/pages/agents/route.ts
+++ b/ui/src/pages/agents/route.ts
@@ -4,7 +4,7 @@ import { html } from "lit";
 import type { ApplicationContext } from "../../app/context.ts";
 import type { AgentsRouteData } from "./agents-page.ts";
 
-export async function loadAgentsRouteData(
+async function loadAgentsRouteData(
   context: ApplicationContext,
   location: RouteLocation,
 ): Promise<AgentsRouteData> {

--- a/ui/src/pages/workboard/agent-filter.ts
+++ b/ui/src/pages/workboard/agent-filter.ts
@@ -4,7 +4,7 @@ import type { WorkboardCard, WorkboardUiState } from "../../lib/workboard/index.
 
 type WorkboardAgentRow = AgentsListResult["agents"][number];
 type WorkboardConfiguredAgentOption = { id: string; label: string; isDefault: boolean };
-export type WorkboardAgentFilterOption = {
+type WorkboardAgentFilterOption = {
   id: WorkboardUiState["agentFilter"];
   label: string;
   description?: string;


### PR DESCRIPTION
## What Problem This Solves

Current `main` breaks the enforced production dead-export check in two ways:

- `QuotaSuspension` became a real production import in #103211 while its old unused-export baseline entry remained.
- #106058 added three new UI exports that production never imports: `AgentSelectionState`, `loadAgentsRouteData`, and `WorkboardAgentFilterOption`.

## Why This Change Was Made

- Remove the single stale baseline entry while retaining the now-production-used `QuotaSuspension` export.
- Make the two UI types module-private.
- Make the agents route loader private and keep its regression coverage at the exported page-loader boundary.

AI-assisted implementation and review.

## User Impact

None. Internal surface and CI-ratchet repair only; runtime behavior unchanged.

No changelog entry: internal cleanup only.

## Evidence

- Exact published head: `316260dde9938eece47f3218540bc96ef1d56a93`.
- `node scripts/check-deadcode-exports.mjs` — matched exactly 3,289 entries.
- `git diff --check` — passed.
- The focused route-test fallback could not start because the linked local dependency tree lacks `p-map`; exact-head hosted CI is the test gate.
- Fresh autoreview helper attempted on the exact patch but sandbox DNS could not resolve `chatgpt.com`; equivalent manual review covered all three production owners, callers, and the route boundary test with no finding.
- Failures reproduced on CI run 29244910472: `check-dependencies` reported the three UI exports; the earlier run 29244568219 reported the stale `QuotaSuspension` baseline entry.
