### PR TITLE
fix(anthropic): run claude-cli sub-agents synchronously by default

### DIFF
--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -90,6 +90,10 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
       systemPromptFileArg: "--append-system-prompt-file",
       systemPromptMode: "append",
       systemPromptWhen: "always",
+      // claude-cli >= v2.1.198 backgrounds sub-agents by default; our live session
+      // ends the turn on the first `result` without waiting, dropping their output.
+      // Force synchronous sub-agents (operator-overridable via cliBackends env).
+      env: { CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1" },
       clearEnv: [...CLAUDE_CLI_CLEAR_ENV],
       reliability: {
         watchdog: {

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -529,7 +529,9 @@ describe("normalizeClaudeBackendConfig", () => {
   it("leaves claude cli subscription-managed, restricts setting sources, and clears inherited env overrides", () => {
     const backend = buildAnthropicCliBackend();
 
-    expect(backend.config.env).toBeUndefined();
+    // claude-cli >= v2.1.198 backgrounds sub-agents by default; forcing this off
+    // keeps the live turn's `result` from arriving before sub-agent output lands.
+    expect(backend.config.env).toEqual({ CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1" });
     expect(backend.config.liveSession).toBe("claude-stdio");
     expect(backend.config.output).toBe("jsonl");
     expect(backend.config.input).toBe("stdin");


### PR DESCRIPTION
## What Problem This Solves

Since Claude Code (`claude-cli`) **v2.1.198** (2026-07-01), sub-agents spawned via the Agent tool run in the **background by default**. OpenClaw's claude-cli live session finishes a turn the instant it sees the first stream-json `result` event (`src/agents/cli-runner/claude-live-session.ts` — `handleClaudeLiveLine` → `finishTurn`) and does **not** wait for background sub-agents. So a backgrounded sub-agent's output is produced *after* the turn has already resolved and is silently dropped — the user gets a truncated or empty answer even though the sub-agent was doing real work.

## Why This Change Was Made

OpenClaw's turn model is "one `result` = turn complete", and the backend already suppresses background **bash** work via `--disallowedTools ...Bash(run_in_background:true)...`. The v2.1.198 default extended backgrounding to native sub-agents, which that arg cannot reach. Setting `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` on the backend descriptor forces claude-cli to run sub-agents inline, so `result` only arrives after their output is folded in — restoring the invariant the turn model relies on.

This uses the existing `CliBackendSchema.env` mechanism, so it adds **no new config/env surface**; it only sets a default within a surface that already exists. Operators can still override it via `agents.defaults.cliBackends["claude-cli"].env` — `mergeBackendConfig` merges `env: { ...base.env, ...override.env }`, so the descriptor value is a default, not a lock.

## User Impact

- Fixes silently-dropped sub-agent output on every OpenClaw install running claude-cli ≥ v2.1.198 (the current default). No user action required.
- Additive default only; no new config key, no migration. An operator who wants the old background behavior can set `agents.defaults.cliBackends["claude-cli"].env` to override.
- No change to the gemini or codex backends.

## Evidence

**Root cause (source):**
- Turn ends on `type:"result"` with no background-sub-agent wait — `src/agents/cli-runner/claude-live-session.ts` (`handleClaudeLiveLine` → `finishTurn`).
- Spawn env is assembled in `src/agents/cli-runner/execute.ts`; the descriptor `env` merges in cleanly — `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` is not in `CLAUDE_CLI_CLEAR_ENV`, and the backend-env layer is applied *after* the `clearEnv` scrub, so the value reaches the process.

**Dependency contract:** `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` — "disable all background task functionality, including the `run_in_background` parameter on Bash and subagent tools, auto-backgrounding" (https://code.claude.com/docs/en/env-vars). The default flip is the v2.1.198 changelog entry "Subagents now run in the background by default".

**Tests / checks (local):**
- Updated the exhaustive backend-config assertion in `extensions/anthropic/cli-shared.test.ts` to pin `config.env` = `{ CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1" }` (guards against removal, a typo'd value, and stray env keys).
- `node scripts/run-vitest.mjs extensions/anthropic/cli-shared.test.ts` → **37/37 pass**.
- `oxfmt --check` and `oxlint` clean on both changed files; `git diff --check` clean.

**Scope boundary:** only the anthropic descriptor (`extensions/anthropic/cli-backend.ts`) and its test. The existing `Bash(run_in_background:true)` disallowedTools guard is intentionally left in place as defense-in-depth at the permission layer.

**Risk / mitigation:** ClawSweeper treats default changes as compatibility-sensitive. Mitigated by (a) using an existing config surface rather than adding one, (b) keeping the value operator-overridable, and (c) matching OpenClaw's already-expressed "no background work in this turn" intent (the disallowedTools guard).

_Authored with Claude Code._
