### PR TITLE
fix(ci): refresh cron runs Swift protocol model

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -9496,6 +9496,7 @@ public struct CronDeclarativeAddResult: Codable, Sendable {
 }
 
 public struct CronRunsParams: Codable, Sendable {
+    public let agentid: String?
     public let scope: AnyCodable?
     public let id: String?
     public let jobid: String?
@@ -9510,6 +9511,7 @@ public struct CronRunsParams: Codable, Sendable {
     public let sortdir: AnyCodable?
 
     public init(
+        agentid: String? = nil,
         scope: AnyCodable? = nil,
         id: String? = nil,
         jobid: String? = nil,
@@ -9523,6 +9525,7 @@ public struct CronRunsParams: Codable, Sendable {
         query: String? = nil,
         sortdir: AnyCodable? = nil)
     {
+        self.agentid = agentid
         self.scope = scope
         self.id = id
         self.jobid = jobid
@@ -9538,6 +9541,7 @@ public struct CronRunsParams: Codable, Sendable {
     }
 
     private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
         case scope
         case id
         case jobid = "jobId"


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails the bundled protocol gate because #106058 added `agentId` to `CronRunsParams` without refreshing the generated Swift model.

## Why This Change Was Made

Regenerate `GatewayModels.swift` from the current gateway protocol schema. The generated model now carries `agentId` through its property, initializer, assignment, and coding key.

AI-assisted implementation and review.

## User Impact

None beyond restoring Swift protocol parity with the existing gateway schema.

No changelog entry: generated protocol synchronization only.

## Evidence

- `node --import tsx scripts/protocol-gen-swift.ts` — regenerated byte-identical output after the patch.
- `git diff --check` — passed.
- Failure reproduced on CI run 29244910472, job `checks-fast-bundled-protocol`.
