### PR TITLE
fix(ci): restore UI dead-export and Swift protocol gates

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -9496,6 +9496,7 @@ public struct CronDeclarativeAddResult: Codable, Sendable {
 }
 
 public struct CronRunsParams: Codable, Sendable {
+    public let agentid: String?
     public let scope: AnyCodable?
     public let id: String?
     public let jobid: String?
@@ -9510,6 +9511,7 @@ public struct CronRunsParams: Codable, Sendable {
     public let sortdir: AnyCodable?
 
     public init(
+        agentid: String? = nil,
         scope: AnyCodable? = nil,
         id: String? = nil,
         jobid: String? = nil,
@@ -9523,6 +9525,7 @@ public struct CronRunsParams: Codable, Sendable {
         query: String? = nil,
         sortdir: AnyCodable? = nil)
     {
+        self.agentid = agentid
         self.scope = scope
         self.id = id
         self.jobid = jobid
@@ -9538,6 +9541,7 @@ public struct CronRunsParams: Codable, Sendable {
     }
 
     private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
         case scope
         case id
         case jobid = "jobId"

--- a/ui/src/app/agent-selection.ts
+++ b/ui/src/app/agent-selection.ts
@@ -9,7 +9,7 @@ type AgentSelectionGateway = {
   subscribe: (listener: (snapshot: AgentSelectionGateway["snapshot"]) => void) => () => void;
 };
 
-export type AgentSelectionState = {
+type AgentSelectionState = {
   selectedId: string | null;
   /** Agent filter shared by agent-owned pages; null exposes all agents. */
   scopeId: string | null;

--- a/ui/src/pages/agents/route.test.ts
+++ b/ui/src/pages/agents/route.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AgentsListResult } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
-import { loadAgentsRouteData } from "./route.ts";
+import type { AgentsRouteData } from "./agents-page.ts";
+import { page } from "./route.ts";
 
 describe("agents route", () => {
   it("keeps a requested agent when the roster loads on a cold deep link", async () => {
@@ -24,9 +25,21 @@ describe("agents route", () => {
       },
     } as unknown as ApplicationContext;
 
-    const result = await loadAgentsRouteData(context, {
-      search: "?agent=research",
-    } as Parameters<typeof loadAgentsRouteData>[1]);
+    if (!page.loader) {
+      throw new Error("agents route has no loader");
+    }
+    const result = (await page.loader(context, {
+      signal: new AbortController().signal,
+      shouldRun: () => true,
+      revalidating: false,
+      location: {
+        pathname: "/settings/agents",
+        search: "?agent=research",
+        hash: "",
+      },
+      deps: "?agent=research",
+      cause: "navigation",
+    })) as AgentsRouteData;
 
     expect(ensureList).toHaveBeenCalledOnce();
     expect(result.agentsList).toBe(agentsList);

--- a/ui/src/pages/agents/route.ts
+++ b/ui/src/pages/agents/route.ts
@@ -4,7 +4,7 @@ import { html } from "lit";
 import type { ApplicationContext } from "../../app/context.ts";
 import type { AgentsRouteData } from "./agents-page.ts";
 
-export async function loadAgentsRouteData(
+async function loadAgentsRouteData(
   context: ApplicationContext,
   location: RouteLocation,
 ): Promise<AgentsRouteData> {

--- a/ui/src/pages/workboard/agent-filter.ts
+++ b/ui/src/pages/workboard/agent-filter.ts
@@ -4,7 +4,7 @@ import type { WorkboardCard, WorkboardUiState } from "../../lib/workboard/index.
 
 type WorkboardAgentRow = AgentsListResult["agents"][number];
 type WorkboardConfiguredAgentOption = { id: string; label: string; isDefault: boolean };
-export type WorkboardAgentFilterOption = {
+type WorkboardAgentFilterOption = {
   id: WorkboardUiState["agentFilter"];
   label: string;
   description?: string;


### PR DESCRIPTION
## What Problem This Solves

Current `main` has two generated/visibility mismatches that block unrelated maintainer landings:

- three Control UI implementation-only types/helpers are exported, tripping the production dead-export gate; and
- the generated Swift protocol model omits the optional cron-runs `agentId` filter already present in the canonical gateway schema.

This supersedes the partial generated-model repair in #106327.

## Why This Change Was Made

Repair the ownership boundaries instead of suppressing checks or growing baseline debt:

- make implementation-only UI types private and test the agents loader through its public route definition; and
- regenerate the Swift protocol model from the canonical gateway schema.

## User Impact

No intended runtime behavior change. Agent routing and workboard filtering keep the same behavior, while native cron-run decoding gains the optional field already supported by the protocol.

## Evidence

- Blacksmith Testbox `tbx_01kxdkad7k3r3312t1smb6s8zy` at exact head: three focused UI tests passed.
- Targeted type-aware oxlint: zero errors.
- `node scripts/check-deadcode-exports.mjs`: all 3,289 baseline entries matched.
- Swift and Kotlin protocol generators left the tree clean.
- GitHub Actions run `29245918530`.
- `git diff --check`: passed.
- Fresh autoreview: no findings, confidence 0.96.
