### PR TITLE
fix(ci): repair session suspension lint

### DIFF
--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -25,6 +25,13 @@ const log = createSubsystemLogger("session-suspension");
 
 const DEFAULT_CUSTOM_LANE_RESUME_CONCURRENCY = 1;
 const DEFAULT_QUOTA_SUSPENSION_RESUME_MS = 30 * 60 * 1000; // 30 min
+const GATEWAY_MANAGED_LANE_IDS: ReadonlySet<string> = new Set([
+  CommandLane.Main,
+  CommandLane.Subagent,
+  CommandLane.Cron,
+  CommandLane.CronNested,
+  CommandLane.Nested,
+]);
 
 type LaneResumeTimer = {
   timer: ReturnType<typeof setTimeout>;
@@ -94,7 +101,7 @@ function getSessionSuspensionState(): SessionSuspensionRuntimeState {
       }
     >();
   }
-  if (!state.suspensionWriteChain) {
+  if (state.suspensionWriteChain === undefined) {
     state.suspensionWriteChain = Promise.resolve();
   }
   return state;
@@ -136,13 +143,7 @@ function resolveLaneResumeConcurrency(cfg: OpenClawConfig | undefined, laneId: s
 }
 
 function isGatewayManagedLane(laneId: string): boolean {
-  return (
-    laneId === CommandLane.Main ||
-    laneId === CommandLane.Subagent ||
-    laneId === CommandLane.Cron ||
-    laneId === CommandLane.CronNested ||
-    laneId === CommandLane.Nested
-  );
+  return GATEWAY_MANAGED_LANE_IDS.has(laneId);
 }
 
 export function resolveSessionSuspensionReason(reason: FailoverReason): SessionSuspensionReason {
@@ -324,36 +325,36 @@ async function suspendSessionQueued(params: SessionSuspensionParams, queuedGener
       resolveLaneResumeConcurrency(params.cfg, params.laneId),
     );
   };
-  let persistedSuspension = false;
+  let persistedSuspension: boolean;
 
   try {
-    const patchedEntry = await patchSessionEntry(
-      { storePath, sessionKey },
-      (entry) => {
-        if (getSessionSuspensionState().cleanupGeneration !== suspensionGeneration) {
-          return null;
-        }
-        if (!pendingWrite.previousSnapshotCaptured) {
-          pendingWrite.previousQuotaSuspension = entry.quotaSuspension;
-          pendingWrite.previousSnapshotCaptured = true;
-        }
-        return {
-          quotaSuspension: {
-            schemaVersion: 1,
-            suspendedAt: now,
-            reason: params.reason,
-            failedProvider: params.failedProvider,
-            failedModel: params.failedModel,
-            summary: params.summary,
-            laneId: params.laneId,
-            expectedResumeBy,
-            state: "suspended",
-          },
-        };
-      },
-      { skipMaintenance: true, takeCacheOwnership: true },
-    );
-    persistedSuspension = patchedEntry !== null;
+    persistedSuspension =
+      (await patchSessionEntry(
+        { storePath, sessionKey },
+        (entry) => {
+          if (getSessionSuspensionState().cleanupGeneration !== suspensionGeneration) {
+            return null;
+          }
+          if (!pendingWrite.previousSnapshotCaptured) {
+            pendingWrite.previousQuotaSuspension = entry.quotaSuspension;
+            pendingWrite.previousSnapshotCaptured = true;
+          }
+          return {
+            quotaSuspension: {
+              schemaVersion: 1,
+              suspendedAt: now,
+              reason: params.reason,
+              failedProvider: params.failedProvider,
+              failedModel: params.failedModel,
+              summary: params.summary,
+              laneId: params.laneId,
+              expectedResumeBy,
+              state: "suspended",
+            },
+          };
+        },
+        { skipMaintenance: true, takeCacheOwnership: true },
+      )) !== null;
   } catch (err) {
     log.warn("failed to persist quota suspension; applying transient lane throttle", {
       sessionId: params.sessionId,

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -24,32 +24,29 @@ export function resolveGatewayLaneConcurrency(cfg: OpenClawConfig): GatewayLaneC
   };
 }
 
+function enableGatewayStartSuspensionTimers(
+  concurrency: GatewayLaneConcurrency,
+): ReadonlySet<string> {
+  const resumeConcurrencyByLane = new Map<string, number>([
+    [CommandLane.Cron, concurrency.cron],
+    [CommandLane.CronNested, concurrency.cron],
+    [CommandLane.Main, concurrency.main],
+    [CommandLane.Nested, 1],
+    [CommandLane.Subagent, concurrency.subagent],
+  ]);
+  return enableSessionSuspensionTimersForGatewayStart(
+    (laneId, savedResumeConcurrency) =>
+      resumeConcurrencyByLane.get(laneId) ?? savedResumeConcurrency,
+  );
+}
+
 export function applyGatewayLaneConcurrency(
   concurrency: GatewayLaneConcurrency,
   opts: { gatewayStart?: boolean } = {},
 ): void {
-  let suspendedLaneIds: ReadonlySet<string> = new Set<string>();
-  if (opts.gatewayStart) {
-    suspendedLaneIds = enableSessionSuspensionTimersForGatewayStart(
-      (laneId, savedResumeConcurrency) => {
-        switch (laneId) {
-          case CommandLane.Cron:
-          case CommandLane.CronNested:
-            return concurrency.cron;
-          case CommandLane.Main:
-            return concurrency.main;
-          case CommandLane.Nested:
-            return 1;
-          case CommandLane.Subagent:
-            return concurrency.subagent;
-          default:
-            return savedResumeConcurrency;
-        }
-      },
-    );
-  } else {
-    suspendedLaneIds = getCleanupSuspendedLaneIdsForGatewayPublication();
-  }
+  const suspendedLaneIds: ReadonlySet<string> = opts.gatewayStart
+    ? enableGatewayStartSuspensionTimers(concurrency)
+    : getCleanupSuspendedLaneIdsForGatewayPublication();
   // Resolution is deliberately separate: this commit-edge applier only updates
   // live queue state and cannot reject a config midway through publication.
   if (!suspendedLaneIds.has(CommandLane.Cron)) {


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails `check-lint` after #103211 added session-suspension lifecycle handling. Oxlint reports 13 errors: two useless initial assignments, five string/enum comparisons in gateway lane restoration, five more in the managed-lane predicate, and a Promise used as a boolean condition.

## Why This Change Was Made

- Replace string/enum comparisons with string-keyed membership lookups.
- Compute gateway startup suspension state directly instead of assigning a throwaway empty set.
- Test the global Promise slot explicitly for `undefined`.
- Assign the suspension persistence result directly after the awaited store patch.

Runtime behavior and lane mappings remain unchanged.

AI-assisted implementation and review.

## User Impact

None. CI and internal implementation cleanup only.

No changelog entry: no user-visible behavior change.

## Evidence

- Exact head: `bb60d3a57857edd562b48818512e64e488cd0fb2`; base: `4b6575636fd4493c9f12cc0d3367a9e55e71994b`.
- Failure reproduced in CI run 29245448361, job `check-lint`: exactly the 13 repaired diagnostics.
- `git diff --check` — passed.
- Whole-owner manual review covered startup/live publication callers and both focused test files; no finding.
- Fresh autoreview helper attempted on the exact patch; sandbox DNS could not reach `chatgpt.com`.
- Exact-head hosted CI is the lint and focused-test gate.
