### PR TITLE
fix(ci): restore Control UI agent selection tests

### DIFF
--- a/ui/src/pages/agents/agents-page.test.ts
+++ b/ui/src/pages/agents/agents-page.test.ts
@@ -155,13 +155,14 @@ describe("AgentsPage gateway lifecycle", () => {
     expect(page.client).toBe(client);
     expect(page.agentsList).toBe(preloadedAgents);
     expect(page.agentsSelectedId).toBe("main");
-    expect(page.requestGeneration).toBe(0);
+    const initialRequestGeneration = page.requestGeneration;
+    expect(initialRequestGeneration).toBeGreaterThan(0);
 
     page.context = { gateway: gateway(snapshot(client, false)) } as unknown as ApplicationContext;
     page.subscriptions.hostUpdate();
     expect(page.agentsList).toBeNull();
     expect(page.agentsSelectedId).toBeNull();
-    expect(page.requestGeneration).toBeGreaterThan(0);
+    expect(page.requestGeneration).toBeGreaterThan(initialRequestGeneration);
     page.subscriptions.hostDisconnected();
   });
 

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -105,6 +105,7 @@ describe("ChatStateController render lifecycle", () => {
 
     for (const deltaText of ["A", "B", "C"]) {
       handlePageGatewayEvent(state, {
+        type: "event",
         event: "chat",
         payload: { state: "delta", runId: "run-1", sessionKey: "main", deltaText },
       });

--- a/ui/src/pages/route-provenance.test.ts
+++ b/ui/src/pages/route-provenance.test.ts
@@ -28,6 +28,10 @@ const loaderOptions: RouteLoaderOptions = {
   cause: "preload",
 };
 
+const allAgentsSelection = {
+  state: { selectedId: null, scopeId: null },
+} as ApplicationContext["agentSelection"];
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((resolvePromise) => {
@@ -79,7 +83,10 @@ describe("route preload gateway provenance", () => {
     const agentsGateway = mutableGateway(snapshot(null, false));
     const agentsData = await loadRoute<AgentsRouteData>(agentsPage, {
       gateway: agentsGateway.gateway,
-      agents: { state: { agentsList: null, agentsError: null } },
+      agents: {
+        state: { agentsList: null, agentsError: null },
+        ensureList: vi.fn(async () => null),
+      },
     } as unknown as ApplicationContext);
     expect(agentsData.gateway).toBe(agentsGateway.gateway);
     expect(agentsData.gatewaySnapshot).toBe(agentsGateway.gateway.snapshot);
@@ -102,6 +109,7 @@ describe("route preload gateway provenance", () => {
       gateway,
       sessions: { list: vi.fn(() => list.promise) },
       runtimeConfig: { ensureLoaded: vi.fn(async () => undefined) },
+      agentSelection: allAgentsSelection,
     } as unknown as ApplicationContext);
 
     mutable.replaceSnapshot(snapshot(client, false));
@@ -121,6 +129,7 @@ describe("route preload gateway provenance", () => {
     const gateway = mutable.gateway;
     const request = loadRoute<UsageRouteData>(usagePage, {
       gateway,
+      agentSelection: allAgentsSelection,
     } as unknown as ApplicationContext);
 
     mutable.replaceSnapshot(snapshot(client, false));


### PR DESCRIPTION
Related: #106058

## What Problem This Solves

This PR originally repaired Control UI agent-selection test fixtures after the selection-scope contract changed.

## Why This Change Was Made

The original fixture repairs are now superseded by current `main`:

- `8f7df1b94bd` restores the gateway source-replacement fixture.
- `bd2be839ced` updates the agents lifecycle assertion and route-provenance fixtures.

The unrelated chat event-envelope fixture fix was split into #106361.

## User Impact

No runtime behavior changes.

## Evidence

See the maintainer close comment for current-main proof and the canonical landed commits.

AI-assisted: yes. No agent transcript is included.
