### PR TITLE
chore: remove redundant Commander dependencies

### DIFF
--- a/extensions/browser/package.json
+++ b/extensions/browser/package.json
@@ -6,7 +6,6 @@
   "type": "module",
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",
-    "commander": "15.0.0",
     "express": "5.2.1",
     "playwright-core": "1.61.1",
     "typebox": "1.3.3",

--- a/extensions/google-meet/npm-shrinkwrap.json
+++ b/extensions/google-meet/npm-shrinkwrap.json
@@ -8,7 +8,6 @@
       "name": "@openclaw/google-meet",
       "version": "2026.7.2",
       "dependencies": {
-        "commander": "15.0.0",
         "pretty-ms": "9.3.0",
         "typebox": "1.3.3"
       },
@@ -19,15 +18,6 @@
         "openclaw": {
           "optional": true
         }
-      }
-    },
-    "node_modules/commander": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.12.0"
       }
     },
     "node_modules/parse-ms": {

--- a/extensions/google-meet/package.json
+++ b/extensions/google-meet/package.json
@@ -8,7 +8,6 @@
   },
   "type": "module",
   "dependencies": {
-    "commander": "15.0.0",
     "pretty-ms": "9.3.0",
     "typebox": "1.3.3"
   },

--- a/extensions/oc-path/package.json
+++ b/extensions/oc-path/package.json
@@ -5,7 +5,6 @@
   "description": "OpenClaw oc:// workspace path plugin",
   "type": "module",
   "dependencies": {
-    "commander": "15.0.0",
     "jsonc-parser": "3.3.1",
     "markdown-it": "14.3.0",
     "yaml": "2.9.0"

--- a/extensions/voice-call/npm-shrinkwrap.json
+++ b/extensions/voice-call/npm-shrinkwrap.json
@@ -8,7 +8,6 @@
       "name": "@openclaw/voice-call",
       "version": "2026.7.2",
       "dependencies": {
-        "commander": "15.0.0",
         "defu": "6.1.5",
         "typebox": "1.3.3",
         "ws": "8.21.0",
@@ -21,15 +20,6 @@
         "openclaw": {
           "optional": true
         }
-      }
-    },
-    "node_modules/commander": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.12.0"
       }
     },
     "node_modules/defu": {

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -8,7 +8,6 @@
   },
   "type": "module",
   "dependencies": {
-    "commander": "15.0.0",
     "defu": "6.1.5",
     "typebox": "1.3.3",
     "ws": "8.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,9 +461,6 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(zod@4.4.3)
-      commander:
-        specifier: 15.0.0
-        version: 15.0.0
       express:
         specifier: 5.2.1
         version: 5.2.1
@@ -859,9 +856,6 @@ importers:
 
   extensions/google-meet:
     dependencies:
-      commander:
-        specifier: 15.0.0
-        version: 15.0.0
       pretty-ms:
         specifier: 9.3.0
         version: 9.3.0
@@ -1297,9 +1291,6 @@ importers:
 
   extensions/oc-path:
     dependencies:
-      commander:
-        specifier: 15.0.0
-        version: 15.0.0
       jsonc-parser:
         specifier: 3.3.1
         version: 3.3.1
@@ -1793,9 +1784,6 @@ importers:
 
   extensions/voice-call:
     dependencies:
-      commander:
-        specifier: 15.0.0
-        version: 15.0.0
       defu:
         specifier: 6.1.5
         version: 6.1.5


### PR DESCRIPTION
Closes #106299

## What Problem This Solves

Four plugins declared Commander as a runtime dependency even though their production code only imports its `Command` type from the host CLI context. This duplicated dependency ownership and added avoidable package and lock metadata.

## Why This Change Was Made

Remove the redundant declarations from Browser, Google Meet, OC Path, and Voice Call. The OpenClaw host remains the runtime owner of the pinned Commander version; plugin tests continue to resolve the same workspace dependency.

## User Impact

No behavior change. Plugin package metadata is leaner, with 36 dependency and lockfile lines removed.

## Evidence

- Blacksmith Testbox `tbx_01kxdka10p6hcz6g2zs47wnpxe`: 230 focused CLI tests passed across Browser, Google Meet, OC Path, and Voice Call.
- `node scripts/generate-npm-shrinkwrap.mjs --changed --check`: all generated shrinkwraps current.
- `node scripts/root-dependency-ownership-audit.mjs --check`: passed.
- `pnpm check:changed`: passed remotely, including dependency guards, all-project typecheck, core/extensions/scripts lint, and runtime import-cycle checks.
- Fresh autoreview: no actionable findings, confidence 0.97.
- `git diff --check`: passed.

## AI Assistance

Codex agents audited the Commander contract, callers, sibling plugins, generated package artifacts, and upstream Commander 15.0.0 source. Codex implemented and validated the change.
