### PR TITLE
fix(claude-cli): hold live turn open while native background subagents and workflows run

### DIFF
--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -1294,12 +1294,28 @@ export function createCliJsonlStreamingParser(params: {
       usage,
     });
     if (result) {
-      // The terminal result can be empty after Claude already streamed text.
-      // Keep that delivered text; a genuinely empty turn still remains empty.
-      output =
-        result.text || result.errorText
-          ? result
-          : { ...result, text: assistantText.trim() || texts.join("\n").trim() };
+      if (result.errorText) {
+        output = result;
+        return;
+      }
+      // Empty terminal result can follow already-streamed text; keep that text.
+      const nextText = (result.text || assistantText.trim() || texts.join("\n").trim()).trim();
+      const previousText = output?.text?.trim() ?? "";
+      // Claude Code may emit an interim result while background agents run, then
+      // a second result after task-notification. Preserve earlier result text
+      // when the later envelope does not already include it.
+      let text = nextText;
+      if (
+        previousText &&
+        nextText &&
+        previousText !== nextText &&
+        !nextText.startsWith(previousText)
+      ) {
+        text = `${previousText}\n${nextText}`;
+      } else if (!nextText) {
+        text = previousText;
+      }
+      output = { ...result, text };
       return;
     }
 

--- a/src/agents/cli-runner/claude-live-session.background-tasks.test.ts
+++ b/src/agents/cli-runner/claude-live-session.background-tasks.test.ts
@@ -1,0 +1,504 @@
+/** Claude live session: interim result while native background subagents run. */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  setDiagnosticsEnabledForProcess,
+  waitForDiagnosticEventsDrained,
+} from "../../infra/diagnostic-events.js";
+import {
+  BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
+  getDiagnosticSessionActivitySnapshot,
+  resetDiagnosticRunActivityForTest,
+} from "../../logging/diagnostic-run-activity.js";
+import type { getProcessSupervisor } from "../../process/supervisor/index.js";
+import {
+  restoreCliRunnerPrepareTestDeps,
+  supervisorSpawnMock,
+} from "../cli-runner.test-support.js";
+import { resetClaudeLiveSessionsForTest, runClaudeLiveSessionTurn } from "./claude-live-session.js";
+import { setCliRunnerExecuteTestDeps } from "./execute.js";
+import { writeCliSystemPromptFile } from "./helpers.js";
+import type { PreparedCliRunContext } from "./types.js";
+
+vi.mock("../../plugin-sdk/anthropic-cli.js", () => ({
+  CLAUDE_CLI_BACKEND_ID: "claude-cli",
+  isClaudeCliProvider: (providerId: string) => providerId === "claude-cli",
+}));
+
+type ProcessSupervisor = ReturnType<typeof getProcessSupervisor>;
+type SupervisorSpawnFn = ProcessSupervisor["spawn"];
+
+beforeEach(() => {
+  setDiagnosticsEnabledForProcess(true);
+  resetDiagnosticRunActivityForTest();
+  resetClaudeLiveSessionsForTest();
+  restoreCliRunnerPrepareTestDeps();
+  setCliRunnerExecuteTestDeps({ writeCliSystemPromptFile });
+  supervisorSpawnMock.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  resetDiagnosticRunActivityForTest();
+  resetClaudeLiveSessionsForTest();
+});
+
+function buildPreparedCliRunContext(params: {
+  runId: string;
+  timeoutMs?: number;
+  sessionId?: string;
+  sessionKey?: string;
+}): PreparedCliRunContext {
+  const backend = {
+    command: "claude",
+    args: ["-p", "--output-format", "stream-json"],
+    output: "jsonl" as const,
+    input: "stdin" as const,
+    modelArg: "--model",
+    sessionArg: "--session-id",
+    sessionMode: "always" as const,
+    systemPromptFileArg: "--append-system-prompt-file",
+    systemPromptWhen: "first" as const,
+    serialize: true,
+    liveSession: "claude-stdio" as const,
+  };
+  return {
+    params: {
+      sessionId: params.sessionId ?? "s-bg",
+      sessionKey: params.sessionKey ?? "agent:main:bg",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hi",
+      provider: "claude-cli",
+      model: "sonnet",
+      timeoutMs: params.timeoutMs ?? 60_000,
+      runId: params.runId,
+    },
+    started: Date.now(),
+    workspaceDir: "/tmp",
+    backendResolved: {
+      id: "claude-cli",
+      config: backend,
+      bundleMcp: true,
+      pluginId: "anthropic",
+    },
+    preparedBackend: {
+      backend,
+      env: {},
+    },
+    reusableCliSession: { mode: "none" },
+    hadSessionFile: false,
+    contextEngineConfig: {},
+    modelId: "sonnet",
+    normalizedModel: "sonnet",
+    systemPrompt: "You are a helpful assistant.",
+    systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
+    bootstrapPromptWarningLines: [],
+    authEpochVersion: 2,
+  };
+}
+
+function getProcessSupervisorForTest() {
+  return {
+    spawn: (params: Parameters<SupervisorSpawnFn>[0]) =>
+      supervisorSpawnMock(params) as ReturnType<SupervisorSpawnFn>,
+    cancel: vi.fn(),
+    cancelScope: vi.fn(),
+    getRecord: vi.fn(),
+  };
+}
+
+function installLiveStdoutDriver(params?: {
+  onWrite?: (stdout: (chunk: string) => void) => void;
+}): {
+  cancel: ReturnType<typeof vi.fn>;
+  stdout: { emit: (chunk: string) => void; waitReady: () => Promise<void> };
+} {
+  let stdoutListener: ((chunk: string) => void) | undefined;
+  const cancel = vi.fn();
+  let markReady: (() => void) | undefined;
+  const ready = new Promise<void>((resolve) => {
+    markReady = resolve;
+  });
+  const stdin = {
+    write: vi.fn((_data: string, cb?: (err?: Error | null) => void) => {
+      if (stdoutListener && params?.onWrite) {
+        params.onWrite(stdoutListener);
+      }
+      cb?.();
+      markReady?.();
+    }),
+    end: vi.fn(),
+  };
+  supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+    const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+    stdoutListener = input.onStdout;
+    return {
+      runId: "live-bg-run",
+      pid: 4242,
+      startedAtMs: Date.now(),
+      stdin,
+      wait: vi.fn(() => new Promise(() => {})),
+      cancel,
+    };
+  });
+  return {
+    cancel,
+    stdout: {
+      emit: (chunk: string) => {
+        stdoutListener?.(chunk);
+      },
+      waitReady: () => ready,
+    },
+  };
+}
+
+function jsonl(lines: unknown[]): string {
+  return lines.map((line) => JSON.stringify(line)).join("\n") + "\n";
+}
+
+function startLiveTurn(params: { runId: string; timeoutMs?: number; noOutputTimeoutMs?: number }) {
+  const context = buildPreparedCliRunContext({
+    runId: params.runId,
+    timeoutMs: params.timeoutMs,
+  });
+  return runClaudeLiveSessionTurn({
+    context,
+    args: context.preparedBackend.backend.args ?? [],
+    env: {},
+    prompt: "hi",
+    useResume: false,
+    noOutputTimeoutMs: params.noOutputTimeoutMs ?? 5_000,
+    getProcessSupervisor: getProcessSupervisorForTest,
+    onAssistantDelta: () => {},
+    cleanup: async () => {},
+  });
+}
+
+describe("claude live session background tasks", () => {
+  it.each([
+    { taskType: "local_agent", label: "subagent" },
+    { taskType: "local_workflow", label: "workflow" },
+  ] as const)(
+    "defers the interim success result until $taskType ($label) tasks drain",
+    async ({ taskType }) => {
+      const driver = installLiveStdoutDriver();
+      const resultPromise = startLiveTurn({ runId: `run-bg-interim-${taskType}` });
+      await driver.stdout.waitReady();
+
+      // Tool spawn + authoritative outstanding-task list + immediate tool_result.
+      driver.stdout.emit(
+        jsonl([
+          { type: "system", subtype: "init", session_id: "live-bg" },
+          {
+            type: "assistant",
+            session_id: "live-bg",
+            message: {
+              role: "assistant",
+              content: [
+                {
+                  type: "tool_use",
+                  id: "tool-agent-1",
+                  name: "Agent",
+                  input: { description: "research topic", prompt: "do work" },
+                },
+              ],
+            },
+          },
+          {
+            type: "system",
+            subtype: "background_tasks_changed",
+            tasks: [{ task_id: "task-1", task_type: taskType, description: "research topic" }],
+          },
+          {
+            type: "system",
+            subtype: "task_started",
+            task_id: "task-1",
+            tool_use_id: "tool-agent-1",
+            subagent_type: "general-purpose",
+          },
+          {
+            type: "user",
+            session_id: "live-bg",
+            message: {
+              role: "user",
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "tool-agent-1",
+                  content: "Background agent started",
+                },
+              ],
+            },
+          },
+          {
+            type: "assistant",
+            session_id: "live-bg",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "Working on it in the background." }],
+            },
+          },
+          {
+            type: "result",
+            subtype: "success",
+            session_id: "live-bg",
+            result: "Working on it in the background.",
+            stop_reason: "end_turn",
+          },
+        ]),
+      );
+
+      // Interim result must not resolve while a result-holding task is outstanding.
+      let settled = false;
+      void resultPromise.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      expect(driver.cancel).not.toHaveBeenCalled();
+      await waitForDiagnosticEventsDrained();
+      expect(
+        getDiagnosticSessionActivitySnapshot({ sessionKey: "agent:main:bg" }).lastProgressReason,
+      ).toBe("cli_live:result_deferred_background_tasks");
+
+      driver.stdout.emit(
+        jsonl([
+          {
+            type: "system",
+            subtype: "task_notification",
+            task_id: "task-1",
+            status: "completed",
+            summary: "subagent final output",
+          },
+          { type: "system", subtype: "background_tasks_changed", tasks: [] },
+          {
+            type: "system",
+            subtype: "task_updated",
+            patch: { status: "completed" },
+          },
+          { type: "system", subtype: "init", session_id: "live-bg" },
+          {
+            type: "assistant",
+            session_id: "live-bg",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "Subagent finished: subagent final output" }],
+            },
+          },
+          {
+            type: "result",
+            subtype: "success",
+            session_id: "live-bg",
+            result: "Subagent finished: subagent final output",
+            origin: { kind: "task-notification" },
+          },
+        ]),
+      );
+
+      const result = await resultPromise;
+      expect(result.output.text).toContain("Working on it in the background.");
+      expect(result.output.text).toContain("Subagent finished: subagent final output");
+      expect(driver.cancel).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not defer a success result for local_bash background tasks", async () => {
+    const driver = installLiveStdoutDriver({
+      onWrite: (stdout) => {
+        stdout(
+          jsonl([
+            { type: "system", subtype: "init", session_id: "live-bg-bash" },
+            {
+              type: "system",
+              subtype: "background_tasks_changed",
+              tasks: [
+                {
+                  task_id: "bash-1",
+                  task_type: "local_bash",
+                  description: "background shell",
+                },
+              ],
+            },
+            {
+              type: "result",
+              subtype: "success",
+              session_id: "live-bg-bash",
+              result: "started bash in background",
+              stop_reason: "end_turn",
+            },
+          ]),
+        );
+      },
+    });
+    const result = await startLiveTurn({ runId: "run-bg-bash" });
+    expect(result.output.text).toBe("started bash in background");
+    expect(driver.cancel).not.toHaveBeenCalled();
+  });
+
+  it("resolves a single success result immediately when no background tasks are outstanding", async () => {
+    const driver = installLiveStdoutDriver({
+      onWrite: (stdout) => {
+        stdout(
+          jsonl([
+            { type: "system", subtype: "init", session_id: "live-bg-none" },
+            {
+              type: "assistant",
+              session_id: "live-bg-none",
+              message: {
+                role: "assistant",
+                content: [{ type: "text", text: "plain answer" }],
+              },
+            },
+            {
+              type: "result",
+              subtype: "success",
+              session_id: "live-bg-none",
+              result: "plain answer",
+            },
+          ]),
+        );
+      },
+    });
+    const result = await startLiveTurn({ runId: "run-bg-none" });
+    expect(result.output.text).toBe("plain answer");
+    expect(driver.cancel).not.toHaveBeenCalled();
+  });
+
+  it("fails the turn on an error result even when background tasks are outstanding", async () => {
+    const driver = installLiveStdoutDriver();
+    const resultPromise = startLiveTurn({ runId: "run-bg-error" });
+    await driver.stdout.waitReady();
+
+    driver.stdout.emit(
+      jsonl([
+        { type: "system", subtype: "init", session_id: "live-bg-err" },
+        {
+          type: "system",
+          subtype: "background_tasks_changed",
+          tasks: [{ task_id: "task-err", task_type: "local_agent", description: "stuck" }],
+        },
+        {
+          type: "result",
+          subtype: "error_during_execution",
+          is_error: true,
+          session_id: "live-bg-err",
+          result: "agent crashed",
+        },
+      ]),
+    );
+
+    await expect(resultPromise).rejects.toMatchObject({
+      name: "FailoverError",
+      rawError: expect.stringMatching(/agent crashed/i),
+    });
+  });
+
+  it("does not no-output-abort while a background task is outstanding within the blocked-tool floor", async () => {
+    const driver = installLiveStdoutDriver();
+    // Spawn with real timers so async supervisor setup settles, then fake the
+    // watchdog clock the same way as the blocked-tool live-session tests.
+    const resultPromise = startLiveTurn({
+      runId: "run-bg-quiet",
+      timeoutMs: 3_600_000,
+      noOutputTimeoutMs: 1_000,
+    });
+    await driver.stdout.waitReady();
+
+    driver.stdout.emit(
+      jsonl([
+        { type: "system", subtype: "init", session_id: "live-bg-quiet" },
+        {
+          type: "system",
+          subtype: "background_tasks_changed",
+          tasks: [{ task_id: "task-quiet", task_type: "local_agent", description: "long work" }],
+        },
+        {
+          type: "result",
+          subtype: "success",
+          session_id: "live-bg-quiet",
+          result: "started",
+          stop_reason: "end_turn",
+        },
+      ]),
+    );
+
+    await Promise.resolve();
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+    // Re-arm the no-output watchdog against the faked clock after the interim result.
+    driver.stdout.emit(
+      `${JSON.stringify({
+        type: "system",
+        subtype: "task_progress",
+        task_id: "task-quiet",
+        description: "still working",
+      })}\n`,
+    );
+
+    // Past the base no-output window (1s) but inside the blocked-tool floor (15m).
+    await vi.advanceTimersByTimeAsync(BLOCKED_TOOL_CALL_ABORT_FLOOR_MS - 1_000);
+    expect(driver.cancel).not.toHaveBeenCalled();
+
+    // Drain tasks and finish while still inside the floor window.
+    driver.stdout.emit(
+      jsonl([
+        { type: "system", subtype: "background_tasks_changed", tasks: [] },
+        {
+          type: "result",
+          subtype: "success",
+          session_id: "live-bg-quiet",
+          result: "done after wait",
+          origin: { kind: "task-notification" },
+        },
+      ]),
+    );
+
+    const result = await resultPromise;
+    expect(result.output.text).toContain("done after wait");
+    expect(driver.cancel).not.toHaveBeenCalled();
+  });
+
+  it("still aborts on overall turn timeout while waiting for a never-finishing background task", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+    const driver = installLiveStdoutDriver();
+    const resultPromise = startLiveTurn({
+      runId: "run-bg-turn-timeout",
+      timeoutMs: 5_000,
+      noOutputTimeoutMs: 60_000,
+    });
+    // Flush microtasks so the mocked supervisor spawn resolves under fake timers.
+    await vi.advanceTimersByTimeAsync(0);
+    await driver.stdout.waitReady();
+
+    driver.stdout.emit(
+      jsonl([
+        { type: "system", subtype: "init", session_id: "live-bg-timeout" },
+        {
+          type: "system",
+          subtype: "background_tasks_changed",
+          tasks: [{ task_id: "task-hang", task_type: "local_agent", description: "never ends" }],
+        },
+        {
+          type: "result",
+          subtype: "success",
+          session_id: "live-bg-timeout",
+          result: "started hang",
+          stop_reason: "end_turn",
+        },
+      ]),
+    );
+
+    const rejection = expect(resultPromise).rejects.toMatchObject({
+      name: "FailoverError",
+      message: expect.stringMatching(/exceeded timeout/i),
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await rejection;
+    expect(driver.cancel).toHaveBeenCalledWith("manual-cancel");
+  });
+});

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -91,6 +91,12 @@ type ClaudeLiveSession = {
   cleanupPromise: Promise<void> | null;
   closing: boolean;
   mcpCaptureKey?: string;
+  /**
+   * Subagent/workflow task ids from the latest background_tasks_changed event.
+   * That event lists all CLI background work, but only local_agent and
+   * local_workflow hold the final result (local_bash is killed at exit).
+   */
+  outstandingBackgroundTaskIds: Set<string>;
 };
 type ClaudeLiveSessionCreate = {
   generation: string;
@@ -426,6 +432,10 @@ function clearTurnTimers(turn: ClaudeLiveTurn): void {
   }
 }
 
+function clearOutstandingBackgroundTasks(session: ClaudeLiveSession): void {
+  session.outstandingBackgroundTaskIds.clear();
+}
+
 function finishTurn(session: ClaudeLiveSession, output: CliOutput): void {
   const turn = session.currentTurn;
   if (!turn) {
@@ -437,6 +447,7 @@ function finishTurn(session: ClaudeLiveSession, output: CliOutput): void {
   turn.streamingParser.finish();
   failActiveClaudeLiveTools(turn, new Error("Tool result missing before turn completed"));
   clearTurnTimers(turn);
+  clearOutstandingBackgroundTasks(session);
   session.currentTurn = null;
   turn.resolve(output);
   scheduleIdleClose(session);
@@ -454,6 +465,7 @@ function failTurn(session: ClaudeLiveSession, error: unknown): void {
   turn.streamingParser.finish();
   failActiveClaudeLiveTools(turn, error);
   clearTurnTimers(turn);
+  clearOutstandingBackgroundTasks(session);
   session.currentTurn = null;
   turn.reject(error);
 }
@@ -496,6 +508,8 @@ function closeLiveSession(
   }
   if (error) {
     failTurn(session, error);
+  } else {
+    clearOutstandingBackgroundTasks(session);
   }
   session.managedRun.cancel("manual-cancel");
   void cleanupLiveSession(session);
@@ -731,15 +745,18 @@ function noteClaudeLiveProgress(
 
 // The CLI emits a tool_use line, then nothing until the tool result, so a
 // quiet long-running tool is indistinguishable from a wedged process at the
-// stdout level. While observed tool calls are outstanding, extend the quiet
-// window to the blocked-tool floor instead of killing mid-tool.
+// stdout level. While observed tool calls or CLI-reported background tasks
+// (background_tasks_changed) are outstanding, extend the quiet window to the
+// blocked-tool floor instead of killing mid-work.
 function armNoOutputTimer(session: ClaudeLiveSession, turn: ClaudeLiveTurn, delayMs: number): void {
   if (turn.noOutputTimer) {
     clearTimeout(turn.noOutputTimer);
   }
   turn.noOutputTimer = setTimeout(() => {
     const quietSinceMs = turn.lastOutputAtMs ?? turn.startedAtMs;
-    if (turn.activeTools.size > 0) {
+    const hasOutstandingBackgroundWork =
+      turn.activeTools.size > 0 || session.outstandingBackgroundTaskIds.size > 0;
+    if (hasOutstandingBackgroundWork) {
       const quietBudgetMs = Math.max(session.noOutputTimeoutMs, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS);
       const remainingMs = quietSinceMs + quietBudgetMs - Date.now();
       if (remainingMs > 0) {
@@ -758,6 +775,39 @@ function armNoOutputTimer(session: ClaudeLiveSession, turn: ClaudeLiveTurn, dela
       ),
     );
   }, delayMs);
+}
+
+// Claude Code holds its final output for background subagents AND workflows
+// (headless "Background tasks at exit" contract); both continue the parent and
+// emit a post-drain result. Dropping either type here would finalize the turn
+// early and strand that work; the turn timeout stays the explicit hard bound.
+const CLAUDE_LIVE_RESULT_HOLDING_BACKGROUND_TASK_TYPES = new Set(["local_agent", "local_workflow"]);
+
+/** Replace outstanding subagent/workflow task ids from background_tasks_changed. */
+function applyBackgroundTasksChanged(
+  session: ClaudeLiveSession,
+  parsed: Record<string, unknown>,
+): void {
+  if (parsed.type !== "system" || parsed.subtype !== "background_tasks_changed") {
+    return;
+  }
+  // tasks is the full authoritative list (not a delta). Only subagent/workflow
+  // types hold the final result; e.g. local_bash is listed but killed at exit.
+  const tasks = Array.isArray(parsed.tasks) ? parsed.tasks : [];
+  session.outstandingBackgroundTaskIds.clear();
+  for (const task of tasks) {
+    if (!isRecord(task)) {
+      continue;
+    }
+    const taskType = typeof task.task_type === "string" ? task.task_type.trim() : "";
+    if (!CLAUDE_LIVE_RESULT_HOLDING_BACKGROUND_TASK_TYPES.has(taskType)) {
+      continue;
+    }
+    const taskId = typeof task.task_id === "string" ? task.task_id.trim() : "";
+    if (taskId) {
+      session.outstandingBackgroundTaskIds.add(taskId);
+    }
+  }
 }
 
 function resetNoOutputTimer(session: ClaudeLiveSession): void {
@@ -930,6 +980,7 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
     return;
   }
   turn.rawLines.push(trimmed);
+  applyBackgroundTasksChanged(session, parsed);
   const toolEventCountBefore = turn.toolEventCount;
   turn.streamingParser.push(`${trimmed}\n`);
   turn.sessionId = parsedSessionId ?? turn.sessionId;
@@ -962,6 +1013,13 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
       failTurn(session, error);
     }
     scheduleIdleClose(session);
+    return;
+  }
+  // Interim success result while background_tasks_changed still reports
+  // outstanding subagent/workflow tasks: keep the turn open for the final
+  // post-drain result. Other listed types (e.g. local_bash) do not hold it.
+  if (session.outstandingBackgroundTaskIds.size > 0) {
+    emitClaudeLiveProgress(turn, "cli_live:result_deferred_background_tasks");
     return;
   }
   finishTurn(session, output);
@@ -1157,6 +1215,7 @@ async function createClaudeLiveSession(params: {
     cleanupPromise: null,
     closing: false,
     mcpCaptureKey: params.mcpCaptureKey,
+    outstandingBackgroundTaskIds: new Set(),
   };
   void managedRun.wait().then(
     (exit) => handleClaudeExit(session, exit.exitCode),


### PR DESCRIPTION
## What Problem This Solves

Fixes #106310. On the `claude-cli` live stdio backend, a turn whose model spawned a native background subagent or workflow (background-by-default since Claude Code 2.1.198) was finalized at the FIRST `result` event. Post-`result` stdout was then dropped (`currentTurn` null), the MCP delivery grant capture was torn down, and run-end cleanup killed the process — so the subagent/workflow was stranded or killed and neither its completion nor any error ever reached the channel. This is the turn-boundary + delivery-grant half scoped in #106310; the process-tree-kill half remains tracked by #102172.

## Why This Change Was Made

Claude Code's own contract holds the final output for background subagents and workflows: "Background subagents and workflows are exempt from the five-second grace because their result is part of the final output, so `claude -p` waits for them to complete" (https://code.claude.com/docs/en/headless#background-tasks-at-exit). Live probes on CLI 2.1.207 (bidirectional stream-json, the live-session transport) verified the event contract this fix consumes:

- `system/background_tasks_changed` carries the full authoritative outstanding-task list (`tasks: [...]` → `tasks: []` when drained).
- Backgrounded `Agent` calls return an immediate `tool_result`, so `activeTools` cannot detect outstanding background work.
- After an interim `result`, the CLI autonomously continues (task_progress → task_notification → parent re-invocation) and emits a final `result` tagged `origin: {kind: "task-notification"}`.
- Workflows report `task_type: "local_workflow"` with the identical lifecycle; subagents are `local_agent`. Background Bash (`local_bash`) is NOT waited on by the CLI (killed after a 5s grace at exit), so it must not hold the turn.

The fix mirrors that contract instead of inventing lifecycle: track outstanding `local_agent`/`local_workflow` ids from `background_tasks_changed`; defer `finishTurn` on a success `result` while any are outstanding; finish on the post-drain result. Error results still fail the turn immediately. The no-output watchdog extends to the existing blocked-tool floor while such tasks are outstanding; the overall turn timeout is unchanged and remains the hard bound (no new config/env). Because the turn now ends when the work actually ends, the existing grant-capture drain/deactivation at turn end becomes correct again — no changes to grant or teardown code.

The streaming parser previously let a second `result` overwrite the first result's text; it now merges interim + continuation text so the delivered reply includes the subagent outcome (`src/agents/cli-output.ts`).

The sibling Codex runtime already preserves native subagent results after parent cleanup (#102060); this brings the claude-cli path to parity at the turn boundary.

## User Impact

Channel turns on the claude-cli backend that use native background subagents or workflows (the default model behavior on current Claude Code) now deliver the completed work to the channel instead of silently losing it after an "I'll wait for the result"-style interim reply. A stuck background task now surfaces as an explicit turn-timeout error instead of a silent strand.

## Evidence

- Live probes (Claude Code 2.1.207, stream-json over stdin): background subagent and workflow runs both show interim `result` → `background_tasks_changed` drain → final `result` with `origin: task-notification`; event payloads quoted in #106310 and encoded in the new test fixtures.
- New colocated tests `src/agents/cli-runner/claude-live-session.background-tasks.test.ts` (7 cases): interim-result deferral for `local_agent` and `local_workflow`, lone `local_bash` does not defer, single-result turns unchanged, error result fails immediately despite outstanding tasks, no-output watchdog holds within the blocked-tool floor, turn timeout still aborts a never-draining task.
- Focused suites green: `pnpm test src/agents/cli-runner/claude-live-session.background-tasks.test.ts src/agents/cli-output.test.ts src/agents/cli-runner.spawn.test.ts src/agents/cli-runner.reliability.test.ts src/agents/cli-runner/execute.supervisor-capture.test.ts` → 285 passed.
- `pnpm check:changed` green on Blacksmith Testbox (run: https://github.com/openclaw/openclaw/actions/runs/29245645866).
- Structured second-model review (Codex gpt-5.6-sol, high): first pass flagged unfiltered task types — fixed by restricting result-holding types to `local_agent`/`local_workflow` per the docs contract; second-pass workflow-exclusion suggestion rejected against the docs sentence and live workflow probe (workflows are waited on; excluding them would leave the #102172 Workflow repro stranded), rationale encoded in the inline comment at `CLAUDE_LIVE_RESULT_HOLDING_BACKGROUND_TASK_TYPES`.
