### PR TITLE
improve(ui): reduce streaming chat render work

### DIFF
--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -14,7 +14,9 @@ import {
 } from "./chat-queue.ts";
 import {
   ChatStateController,
+  handlePageGatewayEvent,
   refreshChatMetadata,
+  requestChatPageUpdate,
   resetChatStateForRouteSession,
   retryChatComposerMemoryFallback,
   resolveChatAvatarUrl,
@@ -45,6 +47,75 @@ afterEach(() => {
 });
 
 describe("ChatStateController render lifecycle", () => {
+  it("coalesces stream invalidations into one animation frame", () => {
+    let nextFrame = 1;
+    const frames = new Map<number, FrameRequestCallback>();
+    vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((callback) => {
+      const id = nextFrame++;
+      frames.set(id, callback);
+      return id;
+    });
+    const cancelFrame = vi.spyOn(globalThis, "cancelAnimationFrame").mockImplementation((id) => {
+      frames.delete(id);
+    });
+    const requestUpdate = vi.fn();
+    const state = { chatStreamRenderFrame: null, requestUpdate };
+
+    requestChatPageUpdate(state, "animation-frame");
+    requestChatPageUpdate(state, "animation-frame");
+    requestChatPageUpdate(state, "animation-frame");
+
+    expect(frames.size).toBe(1);
+    expect(requestUpdate).not.toHaveBeenCalled();
+    const firstFrame = frames.get(1);
+    frames.delete(1);
+    firstFrame?.(0);
+    expect(requestUpdate).toHaveBeenCalledOnce();
+    expect(state.chatStreamRenderFrame).toBeNull();
+
+    requestChatPageUpdate(state, "animation-frame");
+    const staleFrame = frames.get(2);
+    requestChatPageUpdate(state);
+    staleFrame?.(0);
+
+    expect(cancelFrame).toHaveBeenCalledWith(2);
+    expect(requestUpdate).toHaveBeenCalledTimes(2);
+    expect(state.chatStreamRenderFrame).toBeNull();
+  });
+
+  it("keeps every chat delta while batching their render", () => {
+    let scheduledFrame: FrameRequestCallback | undefined;
+    vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((callback) => {
+      scheduledFrame = callback;
+      return 1;
+    });
+    const requestUpdate = vi.fn();
+    const state = {
+      chatMessages: [],
+      chatMessagesBySession: new Map(),
+      chatRunId: "run-1",
+      chatStream: null,
+      chatStreamRenderFrame: null,
+      chatStreamStartedAt: 1,
+      lastError: null,
+      pendingSessionMessageReloadSessionKey: null,
+      requestUpdate,
+      sessionKey: "main",
+    } as unknown as ChatPageHost;
+
+    for (const deltaText of ["A", "B", "C"]) {
+      handlePageGatewayEvent(state, {
+        event: "chat",
+        payload: { state: "delta", runId: "run-1", sessionKey: "main", deltaText },
+      });
+    }
+
+    expect(state.chatStream).toBe("ABC");
+    expect(requestUpdate).not.toHaveBeenCalled();
+    scheduledFrame?.(0);
+    expect(requestUpdate).toHaveBeenCalledOnce();
+  });
+
   it("requests a render before selecting the commit promise", async () => {
     let resolveCommit: (value: boolean) => void = () => {};
     const nextCommit = new Promise<boolean>((resolve) => {

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -234,6 +234,7 @@ export type ChatPageHost = ChatHost &
     chatInputHistoryIndex: number;
     chatDraftBeforeHistory: string | null;
     chatScrollCommitCleanup: (() => void) | null;
+    chatStreamRenderFrame: number | null;
     chatScrollFrame: number | null;
     chatScrollGuardFrame: number | null;
     chatScrollTimeout: number | null;
@@ -454,6 +455,7 @@ export function resetChatStateForRouteSession(
     previousComposerScope?: StoredChatOutboxScope;
   } = {},
 ): ChatComposerRouteResetResult {
+  cancelChatStreamRenderFrame(state);
   const previousSessionKey = state.sessionKey;
   const previousComposerScopeKey = storedChatOutboxScopeKey(
     options.previousComposerScope ?? resolveStoredChatOutboxScope(state, previousSessionKey),
@@ -1263,6 +1265,7 @@ export function createPageState(
     chatInputHistoryIndex: -1,
     chatDraftBeforeHistory: null,
     chatScrollCommitCleanup: null,
+    chatStreamRenderFrame: null,
     chatScrollFrame: null,
     chatScrollGuardFrame: null,
     chatScrollTimeout: null,
@@ -1387,23 +1390,23 @@ export function handlePageGatewayEvent(state: ChatPageHost, event: GatewayEventF
       removeDeliveredQueuedChatSendForRun(state, payload?.runId);
       void resumeStoredChatOutboxes(state);
     }
-    requestPageUpdate(state);
+    requestChatPageUpdate(state, payload?.state === "delta" ? "animation-frame" : "immediate");
     return;
   }
   if (event.event === "chat.side_result") {
     if (handleChatSideResultGatewayEvent(state as unknown as ChatState, event.payload)) {
-      requestPageUpdate(state);
+      requestChatPageUpdate(state);
     }
     return;
   }
   if (event.event === "agent" || event.event === "session.tool") {
     handleAgentEvent(state as never, event.payload as never);
-    requestPageUpdate(state);
+    requestChatPageUpdate(state);
     return;
   }
   if (event.event === "session.operation") {
     handleSessionOperationEvent(state as never, event.payload as never);
-    requestPageUpdate(state);
+    requestChatPageUpdate(state);
     return;
   }
   if (event.event === "chat.send_timing") {
@@ -1413,13 +1416,13 @@ export function handlePageGatewayEvent(state: ChatPageHost, event: GatewayEventF
   if (event.event === "session.message") {
     handleSessionMessageEvent(state, event.payload);
     void resumeStoredChatOutboxes(state);
-    requestPageUpdate(state);
+    requestChatPageUpdate(state);
     return;
   }
   if (event.event === "sessions.changed") {
     handleSessionsChangedEvent(state, event.payload);
     void resumeStoredChatOutboxes(state);
-    requestPageUpdate(state);
+    requestChatPageUpdate(state);
     return;
   }
   if (event.event === "task") {
@@ -1518,8 +1521,42 @@ function preserveDeliveredQueuedUserTurn(state: ChatPageHost, item: ChatQueueIte
   }
 }
 
-function requestPageUpdate(state: ChatPageHost) {
-  state.requestUpdate?.();
+type ChatPageUpdateMode = "immediate" | "animation-frame";
+
+function cancelChatStreamRenderFrame(state: Pick<ChatPageHost, "chatStreamRenderFrame">): void {
+  const frame = state.chatStreamRenderFrame;
+  if (frame == null) {
+    return;
+  }
+  state.chatStreamRenderFrame = null;
+  if (typeof globalThis.cancelAnimationFrame === "function") {
+    globalThis.cancelAnimationFrame(frame);
+  }
+}
+
+export function requestChatPageUpdate(
+  state: Pick<ChatPageHost, "chatStreamRenderFrame" | "requestUpdate">,
+  mode: ChatPageUpdateMode = "immediate",
+): void {
+  if (mode === "immediate" || typeof globalThis.requestAnimationFrame !== "function") {
+    cancelChatStreamRenderFrame(state);
+    state.requestUpdate?.();
+    return;
+  }
+  if (state.chatStreamRenderFrame != null) {
+    return;
+  }
+  // Deltas still mutate the canonical stream immediately. One frame owns the
+  // paint; terminal/non-stream events cancel it so stale partial UI cannot win.
+  let frame = 0;
+  frame = globalThis.requestAnimationFrame(() => {
+    if (state.chatStreamRenderFrame !== frame) {
+      return;
+    }
+    state.chatStreamRenderFrame = null;
+    state.requestUpdate?.();
+  });
+  state.chatStreamRenderFrame = frame;
 }
 
 type ChatRenderLifecycleScope = {
@@ -1578,6 +1615,7 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
   attach(state: TState) {
     if (this.stateValue && this.stateValue !== state) {
       this.composerPersistence.stop();
+      cancelChatStreamRenderFrame(this.stateValue);
       cancelChatScroll(this.stateValue);
     }
     this.stateValue = state;
@@ -1859,6 +1897,7 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
     }
     const state = this.stateValue;
     if (state) {
+      cancelChatStreamRenderFrame(state);
       cancelChatScroll(state);
       clearSessionWorkspaceTimers(state);
     }

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -2258,7 +2258,7 @@ describe("tool expansion state", () => {
 });
 
 describe("thread item cache", () => {
-  it("reuses transcript items when thread inputs keep the same references", () => {
+  it("preserves stable transcript rows while the live stream changes", () => {
     resetChatThreadState();
     const messages = [{ role: "assistant", content: "ready" }];
     const toolMessages: unknown[] = [];
@@ -2268,7 +2268,22 @@ describe("thread item cache", () => {
 
     const first = buildCachedChatItems(input);
     expect(buildCachedChatItems({ ...input })).toBe(first);
-    expect(buildCachedChatItems({ ...input, messages: [...messages] })).not.toBe(first);
+    expect(buildCachedChatItems({ ...input, messages: [...messages] })).toBe(first);
+
+    const streaming = buildCachedChatItems({
+      ...input,
+      stream: "partial reply",
+      streamStartedAt: 10,
+    });
+    expect(streaming).not.toBe(first);
+    expect(streaming.find((item) => item.key === first[0]?.key)).toBe(first[0]);
+
+    expect(
+      buildCachedChatItems({
+        ...input,
+        messages: [{ role: "assistant", content: "changed" }],
+      }),
+    ).not.toBe(first);
   });
 });
 

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -1595,6 +1595,80 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   );
 }
 
+function sameMessageGroup(previous: MessageGroup, next: MessageGroup): boolean {
+  // Source message identity owns the row timestamp too: normalization supplies
+  // Date.now() for missing timestamps, which must not churn stable rows.
+  return (
+    previous.role === next.role &&
+    previous.senderLabel === next.senderLabel &&
+    previous.isStreaming === next.isStreaming &&
+    previous.turnSucceeded === next.turnSucceeded &&
+    previous.messages.length === next.messages.length &&
+    previous.messages.every((entry, index) => {
+      const candidate = next.messages[index];
+      return (
+        candidate !== undefined &&
+        entry.key === candidate.key &&
+        entry.message === candidate.message &&
+        entry.duplicateCount === candidate.duplicateCount
+      );
+    })
+  );
+}
+
+function sameChatItem(previous: RenderChatItem, next: RenderChatItem): boolean {
+  if (previous.kind !== next.kind || previous.key !== next.key) {
+    return false;
+  }
+  switch (next.kind) {
+    case "group":
+      return previous.kind === "group" && sameMessageGroup(previous, next);
+    case "message":
+      return (
+        previous.kind === "message" &&
+        previous.message === next.message &&
+        previous.duplicateCount === next.duplicateCount
+      );
+    case "divider":
+      return (
+        previous.kind === "divider" &&
+        previous.label === next.label &&
+        previous.description === next.description &&
+        previous.timestamp === next.timestamp &&
+        previous.action?.kind === next.action?.kind &&
+        previous.action?.label === next.action?.label
+      );
+    case "stream":
+      return (
+        previous.kind === "stream" &&
+        previous.text === next.text &&
+        previous.startedAt === next.startedAt &&
+        previous.isStreaming === next.isStreaming
+      );
+    case "reading-indicator":
+      return previous.kind === "reading-indicator";
+  }
+  return false;
+}
+
+function stabilizeChatItems(
+  previous: ReturnType<typeof buildChatItems>,
+  next: ReturnType<typeof buildChatItems>,
+): ReturnType<typeof buildChatItems> {
+  if (previous.length === 0 || next.length === 0) {
+    return next;
+  }
+  const previousByKey = new Map(previous.map((item) => [`${item.kind}\u0000${item.key}`, item]));
+  const stabilized = next.map((item) => {
+    const prior = previousByKey.get(`${item.kind}\u0000${item.key}`);
+    return prior && sameChatItem(prior, item) ? prior : item;
+  });
+  return stabilized.length === previous.length &&
+    stabilized.every((item, index) => item === previous[index])
+    ? previous
+    : stabilized;
+}
+
 function sameChatItemsInput(previous: BuildChatItemsProps, next: BuildChatItemsProps): boolean {
   return (
     previous.sessionKey === next.sessionKey &&
@@ -1625,7 +1699,7 @@ export function buildCachedChatItems(
   if (cached.input && sameChatItemsInput(cached.input, input)) {
     return cached.items;
   }
-  const items = buildChatItems(input);
+  const items = stabilizeChatItems(cached.items, buildChatItems(input));
   cached.input = input;
   cached.items = items;
   return items;

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -91,6 +91,8 @@ type ChatThreadState = {
     scrollTop: number;
   } | null;
   historyRenderAnchorFrame: number | null;
+  transcriptRenderDependencies: readonly unknown[];
+  transcriptRenderContext: object;
 };
 
 type ChatThreadProps = {
@@ -171,6 +173,8 @@ function createChatThreadState(): ChatThreadState {
     historyRenderExpansionFrame: null,
     historyRenderAnchorAdjustment: null,
     historyRenderAnchorFrame: null,
+    transcriptRenderDependencies: [],
+    transcriptRenderContext: {},
   };
 }
 
@@ -716,6 +720,47 @@ function renderLoadingSkeleton() {
   `;
 }
 
+function chatRenderItemGuardDependencies(
+  item: ReturnType<typeof collapseCompletedTurnWork>[number],
+): readonly unknown[] {
+  if (item.kind === "stream-run") {
+    return [item.key, ...item.parts];
+  }
+  if (item.kind === "work-group") {
+    return [item.key, item.durationMs, item.hasError, ...item.groups];
+  }
+  return [item];
+}
+
+function trackTranscriptRenderDependencies(
+  state: ChatThreadState,
+  dependencies: unknown[],
+): unknown[] {
+  const previous = state.transcriptRenderDependencies;
+  const nextLength = dependencies.length - 1;
+  let changed = previous.length !== nextLength;
+  for (let index = 0; !changed && index < nextLength; index += 1) {
+    changed = !Object.is(previous[index], dependencies[index + 1]);
+  }
+  if (changed) {
+    // The first dependency is chatItems. Keep the shared context stable when
+    // only the live row changes, but invalidate every row for presentation changes.
+    state.transcriptRenderDependencies = dependencies.slice(1);
+    state.transcriptRenderContext = {};
+  }
+  return dependencies;
+}
+
+function guardChatRenderItems(
+  state: ChatThreadState,
+  render: (item: ReturnType<typeof collapseCompletedTurnWork>[number]) => unknown,
+) {
+  return (item: ReturnType<typeof collapseCompletedTurnWork>[number]) =>
+    guard([...chatRenderItemGuardDependencies(item), state.transcriptRenderContext], () =>
+      render(item),
+    );
+}
+
 export function renderChatThread(props: ChatThreadProps) {
   const state = getChatThreadState(props.paneId);
   const requestUpdate = props.onRequestUpdate ?? (() => {});
@@ -852,7 +897,7 @@ export function renderChatThread(props: ChatThreadProps) {
           ? html` <div class="agent-chat__empty">${t("chat.thread.noMatches")}</div> `
           : nothing}
         ${guard(
-          [
+          trackTranscriptRenderDependencies(state, [
             chatItems,
             locale,
             deletedChatItemsSignature(deleted, chatItems),
@@ -879,7 +924,7 @@ export function renderChatThread(props: ChatThreadProps) {
             props.embedSandboxMode ?? "scripts",
             props.allowExternalEmbedUrls ?? false,
             threadContextWindow,
-          ],
+          ]),
           () => {
             const renderGroupItem = (item: MessageGroup) => {
               if (deleted.has(item.key)) {
@@ -929,7 +974,7 @@ export function renderChatThread(props: ChatThreadProps) {
                 searchActive: state.searchOpen && Boolean(state.searchQuery.trim()),
               }),
               (item) => item.key,
-              (item) => {
+              guardChatRenderItems(state, (item) => {
                 if (item.kind === "divider") {
                   return html`
                     <div class="chat-divider" data-ts=${String(item.timestamp)}>
@@ -989,7 +1034,7 @@ export function renderChatThread(props: ChatThreadProps) {
                   return renderGroupItem(item);
                 }
                 return nothing;
-              },
+              }),
             );
           },
         )}


### PR DESCRIPTION
Closes #106343

## What Problem This Solves

Resolves a problem where long Control UI chats repeatedly rebuilt and diffed stable transcript history for every streamed token delta, adding avoidable main-thread work while the assistant replied.

## Why This Change Was Made

Every delta still mutates canonical chat state immediately, while visual invalidation is coalesced to one animation frame. Terminal and non-stream events preempt queued frames, lifecycle teardown cancels them, and stable transcript item identities plus keyed row guards keep unchanged history out of live-tail rendering work.

AI-assisted: yes. The implementation and tests were reviewed with the repository autoreview helper.

## User Impact

Streaming replies do less repeated rendering work, especially in long transcripts. No stream text is dropped, completion and error states remain immediate, and there is no visual layout change.

## Evidence

- Blacksmith Testbox `tbx_01kxdmgyy3w7gpztq12bvjgvdv` / [run 29247136952](https://github.com/openclaw/openclaw/actions/runs/29247136952): 507 tests passed across `chat-state`, `chat-thread`, `chat-gateway`, `chat-pane`, and `chat-send`.
- `pnpm tsgo:ui`: passed.
- Targeted Oxlint on all five changed files: 0 warnings, 0 errors.
- Oxfmt check on all five changed files: passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local`: clean; no accepted/actionable findings.
- Regression coverage proves three deltas accumulate without loss into one scheduled render, immediate work preempts a queued frame, and unchanged historical rows retain identity while the live tail changes.
- Screenshots not applicable: rendering cadence and object reuse changed; visible layout did not.
