### PR TITLE
refactor(ui): privatize chat render scheduler

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -3128,7 +3128,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "ui/src/pages/chat/chat-session.ts: buildChatSessionListOptions",
   "ui/src/pages/chat/chat-session.ts: trackPendingChatPickerPatch",
   "ui/src/pages/chat/chat-state.ts: refreshChat",
-  "ui/src/pages/chat/chat-state.ts: requestChatPageUpdate",
   "ui/src/pages/chat/chat-thread.ts: buildChatItems",
   "ui/src/pages/chat/chat-thread.ts: BuildChatItemsProps",
   "ui/src/pages/chat/chat-thread.ts: WorkGroupRenderItem",

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -16,7 +16,6 @@ import {
   ChatStateController,
   handlePageGatewayEvent,
   refreshChatMetadata,
-  requestChatPageUpdate,
   resetChatStateForRouteSession,
   retryChatComposerMemoryFallback,
   resolveChatAvatarUrl,
@@ -59,11 +58,28 @@ describe("ChatStateController render lifecycle", () => {
       frames.delete(id);
     });
     const requestUpdate = vi.fn();
-    const state = { chatStreamRenderFrame: null, requestUpdate };
+    const state = {
+      chatMessages: [],
+      chatMessagesBySession: new Map(),
+      chatRunId: "run-1",
+      chatStream: null,
+      chatStreamRenderFrame: null,
+      chatStreamStartedAt: 1,
+      lastError: null,
+      pendingSessionMessageReloadSessionKey: null,
+      requestUpdate,
+      sessionKey: "main",
+    } as unknown as ChatPageHost;
+    const emitDelta = (deltaText: string) =>
+      handlePageGatewayEvent(state, {
+        type: "event",
+        event: "chat",
+        payload: { state: "delta", runId: "run-1", sessionKey: "main", deltaText },
+      });
 
-    requestChatPageUpdate(state, "animation-frame");
-    requestChatPageUpdate(state, "animation-frame");
-    requestChatPageUpdate(state, "animation-frame");
+    emitDelta("A");
+    emitDelta("B");
+    emitDelta("C");
 
     expect(frames.size).toBe(1);
     expect(requestUpdate).not.toHaveBeenCalled();
@@ -73,9 +89,10 @@ describe("ChatStateController render lifecycle", () => {
     expect(requestUpdate).toHaveBeenCalledOnce();
     expect(state.chatStreamRenderFrame).toBeNull();
 
-    requestChatPageUpdate(state, "animation-frame");
+    emitDelta("D");
     const staleFrame = frames.get(2);
-    requestChatPageUpdate(state);
+    vi.stubGlobal("requestAnimationFrame", undefined);
+    emitDelta("E");
     staleFrame?.(0);
 
     expect(cancelFrame).toHaveBeenCalledWith(2);

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -1534,7 +1534,7 @@ function cancelChatStreamRenderFrame(state: Pick<ChatPageHost, "chatStreamRender
   }
 }
 
-export function requestChatPageUpdate(
+function requestChatPageUpdate(
   state: Pick<ChatPageHost, "chatStreamRenderFrame" | "requestUpdate">,
   mode: ChatPageUpdateMode = "immediate",
 ): void {


### PR DESCRIPTION
Related: #106353

## What Problem This Solves

Restores the dead-export gate after the batched chat-render change exposed its scheduler only for direct testing.

## Why This Change Was Made

The scheduler test now exercises coalescing and immediate cancellation through the public `handlePageGatewayEvent` owner path. That allows `requestChatPageUpdate` to become module-private and removes its temporary dead-export baseline entry.

Main already owns the related event-discriminator fixture repair through `a03df5fd58`.

## User Impact

No runtime behavior changes. This removes an unnecessary Control UI export while preserving scheduler coverage through the production entry point.

## Evidence

- Blacksmith Testbox `tbx_01kxdn7thg46cdhwd0sc58w63c`
- Focused Control UI test: 1 file passed, 33 tests passed
- `pnpm deadcode:exports`
- `pnpm check:changed -- scripts/deadcode-exports.baseline.mjs ui/src/pages/chat/chat-state.ts ui/src/pages/chat/chat-state.test.ts`
- `git diff --check`
- Fresh `gpt-5.6-sol` medium autoreview: clean at 0.95 confidence

AI-assisted: yes. The patch, test, and current event contract were manually verified. No agent transcript is included.
