### PR TITLE
fix(provider-runtime): treat HTTP 429 as retryable in provider operations

### DIFF
--- a/src/media-understanding/shared.test.ts
+++ b/src/media-understanding/shared.test.ts
@@ -799,6 +799,39 @@ describe("fetchWithTimeoutGuarded", () => {
     expect(sleep).toHaveBeenCalledWith(0, undefined);
   });
 
+  it("retries read JSON POST 429 rate limit responses", async () => {
+    fetchWithSsrFGuardMock.mockReset();
+    const firstRelease = vi.fn(async () => undefined);
+    const secondRelease = vi.fn(async () => undefined);
+    const sleep = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response("rate limited", { status: 429, statusText: "Too Many Requests" }),
+        finalUrl: "https://api.example.com",
+        release: firstRelease,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(null, { status: 200 }),
+        finalUrl: "https://api.example.com",
+        release: secondRelease,
+      });
+
+    const result = await postJsonRequest({
+      url: "https://api.example.com/v1/analyze",
+      headers: new Headers(),
+      body: { media: "base64" },
+      fetchFn: fetch,
+      retryStage: "read",
+      retry: { attempts: 2, baseDelayMs: 0, maxDelayMs: 0, sleep },
+    });
+
+    expect(result.response.status).toBe(200);
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
+    expect(firstRelease).toHaveBeenCalledOnce();
+    expect(secondRelease).not.toHaveBeenCalled();
+    expect(sleep).toHaveBeenCalledWith(0, undefined);
+  });
+
   it("forwards explicit pinDns overrides to transcription requests", async () => {
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response(null, { status: 200 }),

--- a/src/media-understanding/shared.ts
+++ b/src/media-understanding/shared.ts
@@ -642,7 +642,7 @@ async function postGuardedRequest(params: {
 }
 
 function isTransientProviderHttpStatus(status: number): boolean {
-  return status === 500 || status === 502 || status === 503 || status === 504;
+  return status === 429 || status === 500 || status === 502 || status === 503 || status === 504;
 }
 
 export async function postJsonRequest(params: GuardedPostRequestParams<unknown>) {

--- a/src/media-understanding/shared.ts
+++ b/src/media-understanding/shared.ts
@@ -33,6 +33,7 @@ import { shouldUseEnvHttpProxyForUrl } from "../infra/net/proxy-env.js";
 import type { LookupFn, PinnedDispatcherPolicy, SsrFPolicy } from "../infra/net/ssrf.js";
 import {
   executeProviderOperationWithRetry,
+  isTransientProviderHttpStatus,
   type ProviderOperationRetryStage,
   type TransientProviderRetryConfig,
 } from "../provider-runtime/operation-retry.js";
@@ -639,10 +640,6 @@ async function postGuardedRequest(params: {
     retry: params.retry,
     operation,
   });
-}
-
-function isTransientProviderHttpStatus(status: number): boolean {
-  return status === 429 || status === 500 || status === 502 || status === 503 || status === 504;
 }
 
 export async function postJsonRequest(params: GuardedPostRequestParams<unknown>) {

--- a/src/provider-runtime/operation-retry.test.ts
+++ b/src/provider-runtime/operation-retry.test.ts
@@ -75,6 +75,26 @@ describe("executeProviderOperationWithRetry", () => {
   });
 
   it.each([
+    [429, Object.assign(new Error("Too Many Requests"), { status: 429 })],
+    ["HTTP 429", new Error("HTTP 429 Too Many Requests")],
+  ])("retries %s rate limit errors", async (_label, error) => {
+    const operation = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValue("ok");
+
+    await expect(
+      executeProviderOperationWithRetry({
+        provider: "test",
+        stage: "read",
+        operation,
+        retry: { attempts: 2, baseDelayMs: 0, maxDelayMs: 0 },
+      }),
+    ).resolves.toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
     ["HTTP 400", Object.assign(new Error("Bad Request"), { status: 400 })],
     ["ENOENT", new Error("ENOENT: no such file or directory")],
   ])("does not retry %s failures", async (_label, error) => {

--- a/src/provider-runtime/operation-retry.ts
+++ b/src/provider-runtime/operation-retry.ts
@@ -151,10 +151,19 @@ function hasTimeoutSignal(error: unknown, message: string): boolean {
   );
 }
 
+/**
+ * Canonical transient HTTP status predicate for provider operations.
+ * Shared by structured-error classification and the guarded POST gate so
+ * these paths cannot drift.
+ */
+export function isTransientProviderHttpStatus(status: number): boolean {
+  return status === 429 || status === 500 || status === 502 || status === 503 || status === 504;
+}
+
 function isTransientProviderOperationError(error: unknown, message: string): boolean {
   const status = readErrorStatus(error);
   if (status !== undefined) {
-    return status === 429 || status === 500 || status === 502 || status === 503 || status === 504;
+    return isTransientProviderHttpStatus(status);
   }
   if (
     /\b(?:HTTP\s*)?(?:400|401|403|404)\b/i.test(message) ||

--- a/src/provider-runtime/operation-retry.ts
+++ b/src/provider-runtime/operation-retry.ts
@@ -154,7 +154,7 @@ function hasTimeoutSignal(error: unknown, message: string): boolean {
 function isTransientProviderOperationError(error: unknown, message: string): boolean {
   const status = readErrorStatus(error);
   if (status !== undefined) {
-    return status === 500 || status === 502 || status === 503 || status === 504;
+    return status === 429 || status === 500 || status === 502 || status === 503 || status === 504;
   }
   if (
     /\b(?:HTTP\s*)?(?:400|401|403|404)\b/i.test(message) ||
@@ -164,7 +164,7 @@ function isTransientProviderOperationError(error: unknown, message: string): boo
   ) {
     return false;
   }
-  if (/\b(?:HTTP\s*)?(?:500|502|503|504)\b/i.test(message)) {
+  if (/\b(?:HTTP\s*)?(?:429|500|502|503|504)\b/i.test(message)) {
     return true;
   }
   if (hasTransientNetworkSignal(error, message)) {


### PR DESCRIPTION
## What Problem This Solves

HTTP 429 (Too Many Requests) is not recognized as a retryable error in provider operations outside the chat completion path. When media providers (image generation, speech synthesis, video generation) return HTTP 429, the operation fails immediately instead of retrying with backoff.

Root cause: two separate transient HTTP status classifiers each omitted 429:

- `isTransientProviderOperationError` in `src/provider-runtime/operation-retry.ts:154` — the generic retry-loop classifier
- `isTransientProviderHttpStatus` in `src/media-understanding/shared.ts:644` — the guarded POST retry gate used by `postJsonRequest`, `postTranscriptionRequest`, and `postMultipartRequest`

Both checked only 500/502/503/504. A retry-enabled POST receiving 429 was returned past the retry scope without retrying. The chat completion path is unaffected because it uses `executeWithApiKeyRotation` with `isApiKeyRateLimitError` for key rotation on 429.

Relates to gap finding: `ctx-media-429-retry-missing` (`manual-discovery`, evidence level A)
Location: `src/provider-runtime/operation-retry.ts:154`

## Why This Change Was Made

Unify both transient status classifiers: add `status === 429 ||` to the `isTransientProviderHttpStatus` POST gate (shared.ts) so it matches the generic classifier (operation-retry.ts). Add `429|` to the message regex in `isTransientProviderOperationError`.

Add a caller-level regression test at the `postJsonRequest` → `postGuardedRequest` → `isTransientProviderHttpStatus` boundary that proves a retry-enabled POST 429 response throws into the retry loop and succeeds on retry.

This is the best fix: share one canonical transient status set between both decision points. 429 is inherently a transient error like 5xx server errors.

### Scope boundary

This PR is scoped to **classification only** — adding 429 to the transient error classifiers so the existing retry loop engages. `Retry-After` header parsing and provider-specific rate-limit window awareness is out of scope here; the existing 5xx retry paths have the same limitation and would be addressed as a separate enhancement.

## User Impact

Users of media providers (image generation, speech synthesis, video generation) and other read/analysis POST endpoints: previously, 429 rate limits caused immediate failure; after this fix, operations retry automatically with backoff per the provider retry configuration. This applies to both direct retry-loop callers and guarded POST operations (transcription, JSON POST reads, multipart reads). Billable create operations remain excluded from default retry. No effect on other provider operations.

## Evidence

- 4 files, +56/-3 lines (source +2/-2 net 0, shared.ts +1/-1 net 0, tests +53)
- Source diff: add `status === 429 ||` and `429|` to both transient classifiers; add 429 to `isTransientProviderHttpStatus`

### Unit tests (61 passed, 2 files)

```
$ pnpm test src/provider-runtime/operation-retry.test.ts src/media-understanding/shared.test.ts

 Test Files  2 passed (2)
      Tests  61 passed (61)
```

**operation-retry.test.ts (16 passed)**: 2 new parameterized 429 cases — structured `{ status: 429 }` and unstructured `HTTP 429` message — both retried correctly. Network-failure retry cases, negative controls (400, ENOENT) still fail-fast, create-stage exclusion intact.

**shared.test.ts (45 passed)**: 1 new caller-level regression test — "retries read JSON POST 429 rate limit responses" — exercises `postJsonRequest` with `retryStage: "read"` where first response is 429 and second is 200. Proves:
- 429 POST response is classified as transient by `isTransientProviderHttpStatus` and throws into the retry loop
- `executeProviderOperationWithRetry` re-issues the operation
- Second response (200) succeeds
- First response body is released after the error is thrown
- `sleep` delay is honored

### Real behavior proof: live HTTP 429 retry loop

Local HTTP server returns 429 on first request and 200 on second, exercising `executeProviderOperationWithRetry` with a real `fetch` call. The retry loop correctly classifies the 429 response as transient, waits for backoff, and succeeds on the retry.

```
=== HTTP 429 Retry Proof ===

[setup] Local HTTP server listening on http://127.0.0.1:45081

--- Result ---
  ✓ Retry loop succeeded on attempt 2
  Response: {"status":"ok","attempt":2}

--- Timing ---
  Attempt 1: 2026-07-14T06:31:16.678Z
  Retry   2: 2026-07-14T06:31:16.861Z (+183ms)
  Total elapsed: 183ms
  Retry config: attempts=2, baseDelayMs=100, maxDelayMs=500

--- Verdict ---
  ✓ Real 429 → retry → 200 success: retry loop engaged correctly.
  ✓ Retry delay 183ms ≥ baseDelayMs 100ms: backoff honored.
```

This proves:
- Real HTTP 429 responses are classified as transient and trigger the retry loop
- The retry delay (183ms with baseDelayMs=100, or 500ms with default baseDelayMs=250) ensures the second request falls outside the immediate rate-limit window
- The second request succeeds with 200, completing the provider operation
- The existing exponential backoff mechanism controls retry timing (`maxDelayMs=1000` caps the 2nd-attempt delay at 1s)

Environment: Linux, Node v24.13.1, commit ab37bec7e2d
