### PR TITLE
refactor(ui): internalize chat update scheduling

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -3128,7 +3128,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "ui/src/pages/chat/chat-session.ts: buildChatSessionListOptions",
   "ui/src/pages/chat/chat-session.ts: trackPendingChatPickerPatch",
   "ui/src/pages/chat/chat-state.ts: refreshChat",
-  "ui/src/pages/chat/chat-state.ts: requestChatPageUpdate",
   "ui/src/pages/chat/chat-thread.ts: buildChatItems",
   "ui/src/pages/chat/chat-thread.ts: BuildChatItemsProps",
   "ui/src/pages/chat/chat-thread.ts: WorkGroupRenderItem",

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -16,7 +16,6 @@ import {
   ChatStateController,
   handlePageGatewayEvent,
   refreshChatMetadata,
-  requestChatPageUpdate,
   resetChatStateForRouteSession,
   retryChatComposerMemoryFallback,
   resolveChatAvatarUrl,
@@ -34,6 +33,7 @@ import {
   storedChatOutboxScopeKey,
 } from "./composer-persistence.ts";
 import { scheduleControlUiAfterPaint } from "./performance.ts";
+import { requestChatPageUpdate } from "./render-lifecycle.ts";
 
 vi.mock("../../app/assistant-identity.ts", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../app/assistant-identity.ts")>()),

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -119,7 +119,12 @@ import {
   type ChatInputHistoryKeyResult,
 } from "./input-history.ts";
 import { applyModelCatalogResult, loadModels } from "./models.ts";
-import type { AfterCommitEffect, RenderLifecycle } from "./render-lifecycle.ts";
+import {
+  cancelChatStreamRenderFrame,
+  requestChatPageUpdate,
+  type AfterCommitEffect,
+  type RenderLifecycle,
+} from "./render-lifecycle.ts";
 import {
   handleAbortChat,
   reconcileChatRunFromCurrentSessionRow,
@@ -1519,44 +1524,6 @@ function preserveDeliveredQueuedUserTurn(state: ChatPageHost, item: ChatQueueIte
   if (!containsUserTurn(cached)) {
     cacheChatMessages(state.chatMessagesBySession, state, target, [...cached, userMessage]);
   }
-}
-
-type ChatPageUpdateMode = "immediate" | "animation-frame";
-
-function cancelChatStreamRenderFrame(state: Pick<ChatPageHost, "chatStreamRenderFrame">): void {
-  const frame = state.chatStreamRenderFrame;
-  if (frame == null) {
-    return;
-  }
-  state.chatStreamRenderFrame = null;
-  if (typeof globalThis.cancelAnimationFrame === "function") {
-    globalThis.cancelAnimationFrame(frame);
-  }
-}
-
-export function requestChatPageUpdate(
-  state: Pick<ChatPageHost, "chatStreamRenderFrame" | "requestUpdate">,
-  mode: ChatPageUpdateMode = "immediate",
-): void {
-  if (mode === "immediate" || typeof globalThis.requestAnimationFrame !== "function") {
-    cancelChatStreamRenderFrame(state);
-    state.requestUpdate?.();
-    return;
-  }
-  if (state.chatStreamRenderFrame != null) {
-    return;
-  }
-  // Deltas still mutate the canonical stream immediately. One frame owns the
-  // paint; terminal/non-stream events cancel it so stale partial UI cannot win.
-  let frame = 0;
-  frame = globalThis.requestAnimationFrame(() => {
-    if (state.chatStreamRenderFrame !== frame) {
-      return;
-    }
-    state.chatStreamRenderFrame = null;
-    state.requestUpdate?.();
-  });
-  state.chatStreamRenderFrame = frame;
 }
 
 type ChatRenderLifecycleScope = {

--- a/ui/src/pages/chat/render-lifecycle.ts
+++ b/ui/src/pages/chat/render-lifecycle.ts
@@ -2,6 +2,51 @@ export type CancelAfterCommit = () => void;
 export type CompleteAfterCommit = () => void;
 export type AfterCommitEffect = (complete: CompleteAfterCommit) => CancelAfterCommit | void;
 
+type ChatPageUpdateHost = {
+  chatStreamRenderFrame: number | null;
+  requestUpdate?: () => void;
+};
+
+type ChatPageUpdateMode = "immediate" | "animation-frame";
+
+export function cancelChatStreamRenderFrame(
+  state: Pick<ChatPageUpdateHost, "chatStreamRenderFrame">,
+): void {
+  const frame = state.chatStreamRenderFrame;
+  if (frame == null) {
+    return;
+  }
+  state.chatStreamRenderFrame = null;
+  if (typeof globalThis.cancelAnimationFrame === "function") {
+    globalThis.cancelAnimationFrame(frame);
+  }
+}
+
+export function requestChatPageUpdate(
+  state: ChatPageUpdateHost,
+  mode: ChatPageUpdateMode = "immediate",
+): void {
+  if (mode === "immediate" || typeof globalThis.requestAnimationFrame !== "function") {
+    cancelChatStreamRenderFrame(state);
+    state.requestUpdate?.();
+    return;
+  }
+  if (state.chatStreamRenderFrame != null) {
+    return;
+  }
+  // Deltas still mutate the canonical stream immediately. One frame owns the
+  // paint; terminal/non-stream events cancel it so stale partial UI cannot win.
+  let frame = 0;
+  frame = globalThis.requestAnimationFrame(() => {
+    if (state.chatStreamRenderFrame !== frame) {
+      return;
+    }
+    state.chatStreamRenderFrame = null;
+    state.requestUpdate?.();
+  });
+  state.chatStreamRenderFrame = frame;
+}
+
 /**
  * Renderer-neutral boundary for state invalidation and DOM-dependent effects.
  * `afterCommit` must request a render before waiting for its commit.


### PR DESCRIPTION
## What Problem This Solves

PR #106353 exported `requestChatPageUpdate` only for a unit test. Production-mode Knip therefore rejected current `main`, and a temporary ratchet entry grew the shrink-only dead-export baseline.

## Why This Change Was Made

Move chat render scheduling and cancellation into the existing render-lifecycle owner. `chat-state.ts` now consumes both helpers in production, while the focused test imports the same canonical helper. Remove the temporary baseline entry.

The separate missing Gateway event discriminator is already fixed on `main` by a03df5fd589.

## User Impact

No behavior change. Streaming chat renders remain frame-coalesced, immediate updates still cancel stale frames, and route resets still cancel pending work.

## Evidence

- Blacksmith Testbox run 29248320617
- `pnpm deadcode:exports:update` regenerated 3,225 entries with byte-identical output
- `pnpm deadcode:exports`
- `pnpm check:test-types`
- `pnpm --dir ui test src/pages/chat/chat-state.test.ts` — 33 passed
- `pnpm ui:build`
- Fresh whole-branch autoreview: clean, 0.99

Internal refactor only; no changelog entry.
