### PR TITLE
fix(ui): restore chat render CI gates

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -3128,7 +3128,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "ui/src/pages/chat/chat-session.ts: buildChatSessionListOptions",
   "ui/src/pages/chat/chat-session.ts: trackPendingChatPickerPatch",
   "ui/src/pages/chat/chat-state.ts: refreshChat",
-  "ui/src/pages/chat/chat-state.ts: requestChatPageUpdate",
   "ui/src/pages/chat/chat-thread.ts: buildChatItems",
   "ui/src/pages/chat/chat-thread.ts: BuildChatItemsProps",
   "ui/src/pages/chat/chat-thread.ts: WorkGroupRenderItem",

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -16,7 +16,6 @@ import {
   ChatStateController,
   handlePageGatewayEvent,
   refreshChatMetadata,
-  requestChatPageUpdate,
   resetChatStateForRouteSession,
   retryChatComposerMemoryFallback,
   resolveChatAvatarUrl,
@@ -47,48 +46,14 @@ afterEach(() => {
 });
 
 describe("ChatStateController render lifecycle", () => {
-  it("coalesces stream invalidations into one animation frame", () => {
+  it("keeps every chat delta while batching and canceling renders", () => {
     let nextFrame = 1;
-    const frames = new Map<number, FrameRequestCallback>();
-    vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((callback) => {
-      const id = nextFrame++;
-      frames.set(id, callback);
-      return id;
-    });
-    const cancelFrame = vi.spyOn(globalThis, "cancelAnimationFrame").mockImplementation((id) => {
-      frames.delete(id);
-    });
-    const requestUpdate = vi.fn();
-    const state = { chatStreamRenderFrame: null, requestUpdate };
-
-    requestChatPageUpdate(state, "animation-frame");
-    requestChatPageUpdate(state, "animation-frame");
-    requestChatPageUpdate(state, "animation-frame");
-
-    expect(frames.size).toBe(1);
-    expect(requestUpdate).not.toHaveBeenCalled();
-    const firstFrame = frames.get(1);
-    frames.delete(1);
-    firstFrame?.(0);
-    expect(requestUpdate).toHaveBeenCalledOnce();
-    expect(state.chatStreamRenderFrame).toBeNull();
-
-    requestChatPageUpdate(state, "animation-frame");
-    const staleFrame = frames.get(2);
-    requestChatPageUpdate(state);
-    staleFrame?.(0);
-
-    expect(cancelFrame).toHaveBeenCalledWith(2);
-    expect(requestUpdate).toHaveBeenCalledTimes(2);
-    expect(state.chatStreamRenderFrame).toBeNull();
-  });
-
-  it("keeps every chat delta while batching their render", () => {
     let scheduledFrame: FrameRequestCallback | undefined;
     vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((callback) => {
       scheduledFrame = callback;
-      return 1;
+      return nextFrame++;
     });
+    const cancelFrame = vi.spyOn(globalThis, "cancelAnimationFrame");
     const requestUpdate = vi.fn();
     const state = {
       chatMessages: [],
@@ -105,6 +70,7 @@ describe("ChatStateController render lifecycle", () => {
 
     for (const deltaText of ["A", "B", "C"]) {
       handlePageGatewayEvent(state, {
+        type: "event",
         event: "chat",
         payload: { state: "delta", runId: "run-1", sessionKey: "main", deltaText },
       });
@@ -112,8 +78,21 @@ describe("ChatStateController render lifecycle", () => {
 
     expect(state.chatStream).toBe("ABC");
     expect(requestUpdate).not.toHaveBeenCalled();
-    scheduledFrame?.(0);
+    const staleFrame = scheduledFrame;
+    handlePageGatewayEvent(state, { type: "event", event: "agent", payload: {} });
+    expect(cancelFrame).toHaveBeenCalledWith(1);
     expect(requestUpdate).toHaveBeenCalledOnce();
+    staleFrame?.(0);
+    expect(requestUpdate).toHaveBeenCalledOnce();
+
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "chat",
+      payload: { state: "delta", runId: "run-1", sessionKey: "main", deltaText: "D" },
+    });
+    scheduledFrame?.(0);
+    expect(state.chatStream).toBe("ABCD");
+    expect(requestUpdate).toHaveBeenCalledTimes(2);
   });
 
   it("requests a render before selecting the commit promise", async () => {

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -1534,7 +1534,7 @@ function cancelChatStreamRenderFrame(state: Pick<ChatPageHost, "chatStreamRender
   }
 }
 
-export function requestChatPageUpdate(
+function requestChatPageUpdate(
   state: Pick<ChatPageHost, "chatStreamRenderFrame" | "requestUpdate">,
   mode: ChatPageUpdateMode = "immediate",
 ): void {


### PR DESCRIPTION
Related: #106341
Blocks: #106316

## What Problem This Solves

Restores the Control UI CI gates after chat render batching introduced a test-only production export, a stale dead-export baseline entry, and an event fixture missing the required frame discriminator.

## Why This Change Was Made

The render scheduler stays private. Its batching, immediate-cancel, stale-callback, and reschedule behavior is exercised through the public Gateway event path instead of exporting an internal helper only for tests. The stale dead-export allowlist entry is removed.

## User Impact

No user-visible behavior change. CI once again validates the real chat event path without expanding the production API surface.

## Evidence

- Blacksmith Testbox `tbx_01kxdn9ta6a9bqvnzhkwx1vvsq`: full Control UI suite passed, 243 files / 3,809 tests.
- Blacksmith Testbox `tbx_01kxdnwxdb1hkcdjh7ahabcj49`: final-head chat-state suite passed, 32 tests; dead-export gate passed.
- Test type gate passed.
- Fresh autoreview: clean at 0.94 for the runtime/test change and 0.98 for baseline cleanup.
- `git diff --check` passed.

Co-authored fixture correction preserved from @vincentkoc's unpushable #106341 branch.

AI-assisted: yes. Current source, affected tests, and hosted failures were inspected directly.
