### PR TITLE
fix(ci): sort Control UI assets explicitly

### DIFF
--- a/scripts/check-control-ui-performance.mjs
+++ b/scripts/check-control-ui-performance.mjs
@@ -40,7 +40,7 @@ export function extractControlUiStartupAssetPaths(html) {
       assets.add(assetPath);
     }
   }
-  return [...assets].toSorted();
+  return [...assets].toSorted((left, right) => left.localeCompare(right));
 }
 
 function readAssetMetrics(assetsDir, entry) {


### PR DESCRIPTION
## What Problem This Solves

The Control UI performance-budget checker added by #106367 calls `toSorted()` without a comparator. The repository's scripts Oxlint configuration rejects that call, so current-main `check-lint` fails.

## Why This Change Was Made

Provide an explicit string comparator for startup asset paths. This preserves the existing deterministic alphabetical result and satisfies the required lint rule.

## User Impact

No runtime behavior change. CI can validate the new performance-budget checker.

## Evidence

- Blacksmith Testbox run 29249230820
- `pnpm lint:scripts`
- `pnpm test test/scripts/control-ui-performance.test.ts` — 4 passed
- Fresh autoreview: clean, 0.98
- `git diff --check`

Internal CI repair only; no changelog entry.
