### PR TITLE
fix(ci): add control UI asset sort comparator

### DIFF
--- a/scripts/check-control-ui-performance.mjs
+++ b/scripts/check-control-ui-performance.mjs
@@ -40,7 +40,7 @@ export function extractControlUiStartupAssetPaths(html) {
       assets.add(assetPath);
     }
   }
-  return [...assets].toSorted();
+  return [...assets].toSorted((left, right) => left.localeCompare(right));
 }
 
 function readAssetMetrics(assetsDir, entry) {


### PR DESCRIPTION
## Summary

- add the required comparator to the Control UI startup asset sort
- keep deterministic lexicographic ordering while satisfying the lint rule

## Proof

- `pnpm exec oxlint scripts/check-control-ui-performance.mjs`
- `pnpm exec oxfmt --check scripts/check-control-ui-performance.mjs`
- `pnpm exec vitest run test/scripts/control-ui-performance.test.ts`
- autoreview: clean

Fixes the `check-lint` failure in CI run 29249080135.
