### PR TITLE
fix(mac): allow five-minute node worker cold starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS node startup:** allow up to five minutes for cold node-host plugin discovery before timing out, preventing slow Codex-supervision startup from leaving the Mac disconnected.
 - **Claude CLI context budgets:** honor Anthropic model and per-agent `contextTokens` limits by passing the effective limit to Claude Code's native auto-compactor and persisting the same prepared budget in OpenClaw session state. Fixes #80933. (#93198) Thanks @mushuiyu886.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.
 - **Gateway source watch:** hand the configured port off from the installed service before starting the tmux watcher, preserve failed panes for attach/capture, and keep explicit alternate-port watches side by side with the managed Gateway.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS node startup:** allow up to five minutes for cold node-host plugin discovery before timing out, preventing slow Codex-supervision startup from leaving the Mac disconnected.
 - **Claude CLI context budgets:** honor Anthropic model and per-agent `contextTokens` limits by passing the effective limit to Claude Code's native auto-compactor and persisting the same prepared budget in OpenClaw session state. Fixes #80933. (#93198) Thanks @mushuiyu886.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.
 - **Gateway source watch:** hand the configured port off from the installed service before starting the tmux watcher, preserve failed panes for attach/capture, and keep explicit alternate-port watches side by side with the managed Gateway.

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
@@ -27,7 +27,7 @@ protocol MacNodeHostWorking: Sendable {
 /// The worker never connects to Gateway; this app remains the sole node identity
 /// and keeps TCC-sensitive execution behind the native exec-host socket.
 final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
-    nonisolated static let defaultStartupTimeout: TimeInterval = 120
+    nonisolated static let defaultStartupTimeout: TimeInterval = 300
 
     enum WorkerError: LocalizedError {
         case unavailable(String)

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
@@ -30,7 +30,7 @@ private actor StubMacNodeHostWorker: MacNodeHostWorking {
 @Suite(.serialized)
 struct MacNodeHostWorkerTests {
     @Test func `worker allows a generous cold-start window`() async throws {
-        #expect(MacNodeHostWorker.defaultStartupTimeout == 120)
+        #expect(MacNodeHostWorker.defaultStartupTimeout == 300)
 
         let worker = MacNodeHostWorker(session: GatewayNodeSession(), startupTimeout: 1)
         let script = """


### PR DESCRIPTION
## What Problem This Solves

Cold macOS node-host startup can spend more than two minutes loading configured plugins and Codex supervision. The existing hard deadline can therefore leave an otherwise healthy Mac node disconnected.

## Why This Change Was Made

Raise the existing bounded startup deadline from two minutes to five minutes. This keeps a hard failure bound while giving cold plugin discovery practical headroom.

## User Impact

Mac nodes remain able to connect during slow cold starts instead of timing out while the worker is still healthy.

## Evidence

- `swift test --package-path apps/macos --filter MacNodeHostWorkerTests` — 8 tests passed
- Signed local Mac app cold-started and connected to the remote Gateway with Codex app-server and CLI session catalogs advertised
- Autoreview clean; no accepted/actionable findings

Follow-up to #106281.
