### PR TITLE
fix(message): preserve stringified channelData payloads

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -2006,9 +2006,7 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
           provider: "telegram",
           to: "chat-rich",
           text: "  ",
-          presentation: JSON.stringify({
-            blocks: [{ type: "buttons", buttons: [{ label: "OK", value: "ok" }] }],
-          }),
+          channelData: JSON.stringify({ telegram: { buttons: [{ text: "OK" }] } }),
         },
       } as never,
     );

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -728,6 +728,7 @@ function hasMessagingRichContent(record: Record<string, unknown>): boolean {
   };
   try {
     parseJsonMessageParam(payload, "presentation");
+    parseJsonMessageParam(payload, "channelData");
     parseInteractiveParam(payload);
   } catch {
     return false;

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -33,10 +33,7 @@ import {
 } from "../infra/agent-events.js";
 import { consumeRootOptionToken } from "../infra/cli-root-options.js";
 import type { ExecApprovalDecision } from "../infra/exec-approvals.js";
-import {
-  parseInteractiveParam,
-  parseJsonMessageParam,
-} from "../infra/outbound/message-action-params.js";
+import { parseStructuredMessageContentParams } from "../infra/outbound/message-action-structured-content.js";
 import { hasReplyPayloadContent } from "../interactive/payload.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
@@ -727,9 +724,7 @@ function hasMessagingRichContent(record: Record<string, unknown>): boolean {
     channelData: record.channelData,
   };
   try {
-    parseJsonMessageParam(payload, "presentation");
-    parseJsonMessageParam(payload, "channelData");
-    parseInteractiveParam(payload);
+    parseStructuredMessageContentParams(payload);
   } catch {
     return false;
   }

--- a/src/agents/tools/message-tool-content.ts
+++ b/src/agents/tools/message-tool-content.ts
@@ -1,0 +1,54 @@
+import { hasReplyPayloadContent } from "../../interactive/payload.js";
+import { readStringArrayParam, readStringParam } from "./common.js";
+
+export function hasSanitizedSendPayloadContent(params: Record<string, unknown>): boolean {
+  const text = ["message", "text", "content", "caption", "SendMessage"]
+    .map((field) => (typeof params[field] === "string" ? params[field] : ""))
+    .filter((value) => value.trim())
+    .join("\n");
+  const mediaUrls = [
+    ...(readStringArrayParam(params, "mediaUrls") ?? []),
+    ...readStructuredAttachmentMediaParams(params.attachments),
+  ];
+  return hasReplyPayloadContent(
+    {
+      text,
+      mediaUrl: readFirstStringParam(params, ["media", "mediaUrl", "path", "filePath", "fileUrl"]),
+      mediaUrls,
+      presentation: params.presentation,
+      interactive: params.interactive,
+      channelData: params.channelData,
+    },
+    { trimText: true },
+  );
+}
+
+function readFirstStringParam(params: Record<string, unknown>, keys: readonly string[]): string {
+  for (const key of keys) {
+    const value = readStringParam(params, key);
+    if (value) {
+      return value;
+    }
+  }
+  return "";
+}
+
+function readStructuredAttachmentMediaParams(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const values: string[] = [];
+  for (const attachment of value) {
+    if (!attachment || typeof attachment !== "object" || Array.isArray(attachment)) {
+      continue;
+    }
+    const record = attachment as Record<string, unknown>;
+    for (const key of ["media", "mediaUrl", "path", "filePath", "fileUrl", "url"]) {
+      const candidate = readStringParam(record, key);
+      if (candidate) {
+        values.push(candidate);
+      }
+    }
+  }
+  return values;
+}

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -3789,6 +3789,30 @@ describe("message tool internal-runtime-context sanitization", () => {
     expect(JSON.stringify(call?.params)).not.toContain("BOOT.md");
   });
 
+  it("drops stringified channelData containing mixed internal-runtime-context strings before dispatch", async () => {
+    const internalContext =
+      "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\nBOOT.md:\nWake up and report.\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";
+
+    for (const channelData of [
+      { slack: { blocks: [{ type: "section", text: `prefix\n${internalContext}\nsuffix` }] } },
+      { slack: { [`prefix\n${internalContext}\nsuffix`]: { type: "section" } } },
+    ]) {
+      mockSendResult({ channel: "slack", to: "slack:C123" });
+
+      const call = await executeSend({
+        action: {
+          target: "slack:C123",
+          message: "Visible",
+          channelData: JSON.stringify(channelData),
+        },
+      });
+
+      expect(call?.params?.message).toBe("Visible");
+      expect(call?.params?.channelData).toBeUndefined();
+      expect(JSON.stringify(call?.params)).not.toContain("BOOT.md");
+    }
+  });
+
   it("suppresses sends when visible text and stringified channelData both contain internal context", async () => {
     const internalContext =
       "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\nBOOT.md:\nWake up and report.\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -3714,6 +3714,7 @@ describe("message tool internal-runtime-context sanitization", () => {
         interactive: JSON.stringify({
           blocks: [{ type: "text", text: `Legacy\n${internalContext}` }],
         }),
+        channelData: JSON.stringify({ slack: { blocks: [{ type: "divider" }] } }),
       },
     });
 
@@ -3724,6 +3725,90 @@ describe("message tool internal-runtime-context sanitization", () => {
     expect(call?.params?.interactive).toEqual({
       blocks: [{ type: "text", text: "Legacy" }],
     });
+    expect(call?.params?.channelData).toEqual({
+      slack: { blocks: [{ type: "divider" }] },
+    });
+  });
+
+  it("keeps safe stringified channelData when visible text is stripped before dispatch", async () => {
+    mockSendResult({ channel: "slack", to: "slack:C123" });
+
+    const internalContext =
+      "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\nBOOT.md:\nWake up and report.\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";
+    const call = await executeSend({
+      action: {
+        target: "slack:C123",
+        message: internalContext,
+        channelData: JSON.stringify({ slack: { blocks: [{ type: "divider" }] } }),
+      },
+    });
+
+    expect(call?.params?.message).toBe("");
+    expect(call?.params?.channelData).toEqual({
+      slack: { blocks: [{ type: "divider" }] },
+    });
+  });
+
+  it("drops stringified channelData containing internal-runtime-context text before dispatch", async () => {
+    mockSendResult({ channel: "slack", to: "slack:C123" });
+
+    const internalContext =
+      "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\nBOOT.md:\nWake up and report.\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";
+    const call = await executeSend({
+      action: {
+        target: "slack:C123",
+        message: "Visible",
+        channelData: JSON.stringify({
+          slack: { blocks: [{ type: "section", text: internalContext }] },
+        }),
+      },
+    });
+
+    expect(call?.params?.message).toBe("Visible");
+    expect(call?.params?.channelData).toBeUndefined();
+    expect(JSON.stringify(call?.params)).not.toContain("BOOT.md");
+  });
+
+  it("drops stringified channelData containing internal-runtime-context keys before dispatch", async () => {
+    mockSendResult({ channel: "slack", to: "slack:C123" });
+
+    const internalContext =
+      "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\nBOOT.md:\nWake up and report.\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";
+    const call = await executeSend({
+      action: {
+        target: "slack:C123",
+        message: "Visible",
+        channelData: JSON.stringify({
+          slack: { [internalContext]: { type: "section" } },
+        }),
+      },
+    });
+
+    expect(call?.params?.message).toBe("Visible");
+    expect(call?.params?.channelData).toBeUndefined();
+    expect(JSON.stringify(call?.params)).not.toContain("BOOT.md");
+  });
+
+  it("suppresses sends when visible text and stringified channelData both contain internal context", async () => {
+    const internalContext =
+      "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\nBOOT.md:\nWake up and report.\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";
+    const { call, result } = await executeSendWithResult({
+      action: {
+        target: "slack:C123",
+        message: internalContext,
+        channelData: JSON.stringify({
+          slack: { blocks: [{ type: "section", text: internalContext }] },
+        }),
+      },
+    });
+
+    expect(call).toBeUndefined();
+    expect(mocks.runMessageAction).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      status: "suppressed",
+      reason: "internal_runtime_context_echo",
+    });
+    expect(JSON.stringify(result)).not.toContain("BOOT.md");
   });
 
   it("suppresses pure internal-runtime-context sends before generic raw-params logging can see original args", async () => {

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -3769,6 +3769,22 @@ describe("message tool internal-runtime-context sanitization", () => {
     expect(JSON.stringify(call?.params)).not.toContain("BOOT.md");
   });
 
+  it("keeps ordinary visible text around stripped internal-runtime-context before dispatch", async () => {
+    mockSendResult({ channel: "slack", to: "slack:C123" });
+
+    const internalContext =
+      "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\nBOOT.md:\nWake up and report.\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";
+    const call = await executeSend({
+      action: {
+        target: "slack:C123",
+        message: `Please summarize:\n${internalContext}`,
+      },
+    });
+
+    expect(call?.params?.message).toBe("Please summarize:");
+    expect(JSON.stringify(call?.params)).not.toContain("BOOT.md");
+  });
+
   it("drops stringified channelData containing internal-runtime-context keys before dispatch", async () => {
     mockSendResult({ channel: "slack", to: "slack:C123" });
 

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -310,6 +310,52 @@ function sanitizeStringArrayParam(
   return suppressionReason;
 }
 
+function detectOpaqueChannelDataSuppressionReason(
+  value: unknown,
+  bootPrompt: string | undefined,
+): VisibleTextSuppressionReason | undefined {
+  if (typeof value === "string") {
+    return sanitizeUserVisibleToolTextResult(value, bootPrompt).suppressionReason;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const reason = detectOpaqueChannelDataSuppressionReason(entry, bootPrompt);
+      if (reason) {
+        return reason;
+      }
+    }
+    return undefined;
+  }
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    const keyReason = sanitizeUserVisibleToolTextResult(key, bootPrompt).suppressionReason;
+    if (keyReason) {
+      return keyReason;
+    }
+    const reason = detectOpaqueChannelDataSuppressionReason(entry, bootPrompt);
+    if (reason) {
+      return reason;
+    }
+  }
+  return undefined;
+}
+
+function sanitizeOpaqueChannelDataParam(
+  params: Record<string, unknown>,
+  bootPrompt: string | undefined,
+): VisibleTextSuppressionReason | undefined {
+  const suppressionReason = detectOpaqueChannelDataSuppressionReason(
+    params.channelData,
+    bootPrompt,
+  );
+  if (suppressionReason) {
+    delete params.channelData;
+  }
+  return suppressionReason;
+}
+
 function sanitizePresentationTextFieldsResult(
   value: unknown,
   bootPrompt: string | undefined,
@@ -544,6 +590,7 @@ function hasSanitizedSendPayloadContent(params: Record<string, unknown>): boolea
       mediaUrls,
       presentation: params.presentation,
       interactive: params.interactive,
+      channelData: params.channelData,
     },
     { trimText: true },
   );
@@ -1452,6 +1499,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
       const bootPromptForSession = getBootEchoContextForSession(options?.agentSessionKey);
       let suppressedVisiblePayloadReason: VisibleTextSuppressionReason | undefined;
       parseJsonMessageParam(params, "presentation");
+      parseJsonMessageParam(params, "channelData");
       parseInteractiveParam(params);
       for (const field of [
         "text",
@@ -1485,6 +1533,11 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
       );
       params.interactive = sanitizedInteractive.value;
       suppressedVisiblePayloadReason ??= sanitizedInteractive.suppressionReason;
+      const channelDataSuppressionReason = sanitizeOpaqueChannelDataParam(
+        params,
+        bootPromptForSession,
+      );
+      suppressedVisiblePayloadReason ??= channelDataSuppressionReason;
 
       const action = readStringParam(params, "action", {
         required: true,

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -244,6 +244,7 @@ function resolvePollVoteEchoRoute(params: {
 function sanitizeUserVisibleToolTextResult(
   text: string,
   bootPrompt: string | undefined,
+  options?: { strictInternalRuntimeContext?: boolean },
 ): {
   text: string;
   suppressionReason?: VisibleTextSuppressionReason;
@@ -255,8 +256,12 @@ function sanitizeUserVisibleToolTextResult(
   const strippedInbound = hasInboundMetadataSentinel(strippedBoot)
     ? stripInboundMetadata(strippedBoot)
     : strippedBoot;
+  const internalRuntimeContextRemoved = strippedInternal !== strippedReasoning;
   const suppressionReason =
-    strippedInternal !== strippedReasoning ||
+    (options?.strictInternalRuntimeContext === true && internalRuntimeContextRemoved) ||
+    (strippedInternal.trim().length === 0 &&
+      strippedReasoning.trim().length > 0 &&
+      internalRuntimeContextRemoved) ||
     (strippedBoot.trim().length === 0 &&
       strippedReasoning.trim().length > 0 &&
       strippedBoot !== strippedInternal)

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -50,10 +50,6 @@ import { resolveMessageActionTurnCapability } from "../../gateway/message-action
 import { createAbortError } from "../../infra/abort-signal.js";
 import { sha256Base64UrlPrefix } from "../../infra/crypto-digest.js";
 import {
-  parseInteractiveParam,
-  parseJsonMessageParam,
-} from "../../infra/outbound/message-action-params.js";
-import {
   getToolResult,
   runMessageAction,
   type MessageActionRunResult,
@@ -61,10 +57,13 @@ import {
 } from "../../infra/outbound/message-action-runner.js";
 import { resolveActionDeliveryTargetAlias } from "../../infra/outbound/message-action-spec.js";
 import {
+  parseStructuredMessageContentParams,
+  sanitizeOpaqueChannelDataParam,
+} from "../../infra/outbound/message-action-structured-content.js";
+import {
   resolveAllowedMessageActions,
   shouldApplyCrossContextMarker,
 } from "../../infra/outbound/outbound-policy.js";
-import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
 import { POLL_CREATION_PARAM_DEFS, SHARED_POLL_CREATION_PARAM_NAMES } from "../../poll-params.js";
 import { normalizeAccountId, parseSessionDeliveryRoute } from "../../routing/session-key.js";
@@ -81,7 +80,7 @@ import {
   stringEnum,
 } from "../schema/typebox.js";
 import type { AnyAgentTool } from "./common.js";
-import { jsonResult, readStringArrayParam, readStringParam } from "./common.js";
+import { jsonResult, readStringParam } from "./common.js";
 import { gatewayCallOptionSchemaProperties } from "./gateway-schema.js";
 import {
   readGatewayCallOptions,
@@ -89,6 +88,7 @@ import {
   resolveMessageActionAgentRuntimeIdentityToken,
   type GatewayCallOptions,
 } from "./gateway.js";
+import { hasSanitizedSendPayloadContent } from "./message-tool-content.js";
 import {
   appendMessageToolReadHint,
   appendMessageToolVisibleReplyHint,
@@ -256,9 +256,10 @@ function sanitizeUserVisibleToolTextResult(
     ? stripInboundMetadata(strippedBoot)
     : strippedBoot;
   const suppressionReason =
-    strippedBoot.trim().length === 0 &&
-    strippedReasoning.trim().length > 0 &&
-    (strippedInternal !== strippedReasoning || strippedBoot !== strippedInternal)
+    strippedInternal !== strippedReasoning ||
+    (strippedBoot.trim().length === 0 &&
+      strippedReasoning.trim().length > 0 &&
+      strippedBoot !== strippedInternal)
       ? "internal_runtime_context_echo"
       : strippedInbound.trim().length === 0 &&
           strippedBoot.trim().length > 0 &&
@@ -307,52 +308,6 @@ function sanitizeStringArrayParam(
     suppressionReason ??= sanitized.suppressionReason;
     return sanitized.text;
   });
-  return suppressionReason;
-}
-
-function detectOpaqueChannelDataSuppressionReason(
-  value: unknown,
-  bootPrompt: string | undefined,
-): VisibleTextSuppressionReason | undefined {
-  if (typeof value === "string") {
-    return sanitizeUserVisibleToolTextResult(value, bootPrompt).suppressionReason;
-  }
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      const reason = detectOpaqueChannelDataSuppressionReason(entry, bootPrompt);
-      if (reason) {
-        return reason;
-      }
-    }
-    return undefined;
-  }
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
-    const keyReason = sanitizeUserVisibleToolTextResult(key, bootPrompt).suppressionReason;
-    if (keyReason) {
-      return keyReason;
-    }
-    const reason = detectOpaqueChannelDataSuppressionReason(entry, bootPrompt);
-    if (reason) {
-      return reason;
-    }
-  }
-  return undefined;
-}
-
-function sanitizeOpaqueChannelDataParam(
-  params: Record<string, unknown>,
-  bootPrompt: string | undefined,
-): VisibleTextSuppressionReason | undefined {
-  const suppressionReason = detectOpaqueChannelDataSuppressionReason(
-    params.channelData,
-    bootPrompt,
-  );
-  if (suppressionReason) {
-    delete params.channelData;
-  }
   return suppressionReason;
 }
 
@@ -542,58 +497,6 @@ function sanitizePresentationTextFieldsResult(
     });
   }
   return { value: presentation, ...(suppressionReason ? { suppressionReason } : {}) };
-}
-
-function readFirstStringParam(params: Record<string, unknown>, keys: readonly string[]): string {
-  for (const key of keys) {
-    const value = readStringParam(params, key);
-    if (value) {
-      return value;
-    }
-  }
-  return "";
-}
-
-function readStructuredAttachmentMediaParams(value: unknown): string[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  const values: string[] = [];
-  for (const attachment of value) {
-    if (!attachment || typeof attachment !== "object" || Array.isArray(attachment)) {
-      continue;
-    }
-    const record = attachment as Record<string, unknown>;
-    for (const key of ["media", "mediaUrl", "path", "filePath", "fileUrl", "url"]) {
-      const candidate = readStringParam(record, key);
-      if (candidate) {
-        values.push(candidate);
-      }
-    }
-  }
-  return values;
-}
-
-function hasSanitizedSendPayloadContent(params: Record<string, unknown>): boolean {
-  const text = ["message", "text", "content", "caption", "SendMessage"]
-    .map((field) => (typeof params[field] === "string" ? params[field] : ""))
-    .filter((value) => value.trim())
-    .join("\n");
-  const mediaUrls = [
-    ...(readStringArrayParam(params, "mediaUrls") ?? []),
-    ...readStructuredAttachmentMediaParams(params.attachments),
-  ];
-  return hasReplyPayloadContent(
-    {
-      text,
-      mediaUrl: readFirstStringParam(params, ["media", "mediaUrl", "path", "filePath", "fileUrl"]),
-      mediaUrls,
-      presentation: params.presentation,
-      interactive: params.interactive,
-      channelData: params.channelData,
-    },
-    { trimText: true },
-  );
 }
 
 function buildRoutingSchema() {
@@ -1498,9 +1401,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
       //    substantial chunk of the boot prompt content. Refs #53732.
       const bootPromptForSession = getBootEchoContextForSession(options?.agentSessionKey);
       let suppressedVisiblePayloadReason: VisibleTextSuppressionReason | undefined;
-      parseJsonMessageParam(params, "presentation");
-      parseJsonMessageParam(params, "channelData");
-      parseInteractiveParam(params);
+      parseStructuredMessageContentParams(params);
       for (const field of [
         "text",
         "content",
@@ -1536,6 +1437,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
       const channelDataSuppressionReason = sanitizeOpaqueChannelDataParam(
         params,
         bootPromptForSession,
+        sanitizeUserVisibleToolTextResult,
       );
       suppressedVisiblePayloadReason ??= channelDataSuppressionReason;
 

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -133,6 +133,7 @@ describe("runMessageAction send validation", () => {
       action: "send",
       params: {
         message: "hello from codex",
+        channelData: JSON.stringify({ webchat: { cardId: "card-1" } }),
       },
       toolContext: {
         currentChannelProvider: "webchat",
@@ -153,6 +154,9 @@ describe("runMessageAction send validation", () => {
         sourceReplySink: "internal-ui",
         sourceReply: {
           text: "hello from codex",
+          channelData: {
+            webchat: { cardId: "card-1" },
+          },
         },
       },
     });
@@ -174,6 +178,9 @@ describe("runMessageAction send validation", () => {
       sourceReplySink: "internal-ui",
       sourceReply: {
         text: "hello from codex",
+        channelData: {
+          webchat: { cardId: "card-1" },
+        },
       },
       message: "hello from codex",
       dryRun: false,
@@ -201,6 +208,35 @@ describe("runMessageAction send validation", () => {
       });
     },
   );
+
+  it("uses stringified channelData as internal source reply content", async () => {
+    const result = await runMessageAction({
+      cfg: emptyConfig,
+      action: "send",
+      params: {
+        channelData: JSON.stringify({ webchat: { cardId: "card-only" } }),
+      },
+      toolContext: {
+        currentChannelProvider: "webchat",
+      },
+      sessionKey: "agent:main",
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    expect(result).toMatchObject({
+      kind: "send",
+      channel: "webchat",
+      to: "current-run",
+      handledBy: "internal-source",
+      payload: {
+        sourceReply: {
+          channelData: {
+            webchat: { cardId: "card-only" },
+          },
+        },
+      },
+    });
+  });
 
   it("uses non-webchat current source context as the message-tool-only send sink", async () => {
     const result = await runMessageAction({

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -79,13 +79,16 @@ import {
   hydrateAttachmentParamsForAction,
   normalizeSandboxMediaList,
   normalizeSandboxMediaParams,
-  parseInteractiveParam,
-  parseJsonMessageParam,
   readBooleanParam,
   resolveAttachmentMediaPolicy,
   resolveExtraActionMediaSourceParamKeys,
 } from "./message-action-params.js";
 import { actionRequiresTarget } from "./message-action-spec.js";
+import {
+  hasChannelDataPayloadContent,
+  parseStructuredMessageContentParams,
+  readChannelDataObjectParam,
+} from "./message-action-structured-content.js";
 import {
   prepareOutboundMirrorRoute,
   resolveAndApplyOutboundReplyToId,
@@ -1188,7 +1191,7 @@ async function buildSendPayloadParts(params: {
     Boolean(mediaHint) || mediaUrlHints.length > 0 || attachmentMediaHints.length > 0;
   const hasPresentation = hasMessagePresentationBlocks(actionParams.presentation);
   const hasInteractive = hasLegacyInteractiveReplyBlocks(actionParams.interactive);
-  const hasChannelData = hasReplyPayloadContent({ channelData: actionParams.channelData });
+  const hasChannelData = hasChannelDataPayloadContent(actionParams);
   const location = normalizeOutboundLocation(actionParams.location);
   const caption = readStringParam(actionParams, "caption", { allowEmpty: true }) ?? "";
   let message =
@@ -1270,11 +1273,7 @@ async function buildSendPayloadParts(params: {
   }
 
   const mediaUrl = readStringParam(actionParams, "media", { trim: false });
-  const rawChannelData = actionParams.channelData;
-  const channelData =
-    rawChannelData && typeof rawChannelData === "object" && !Array.isArray(rawChannelData)
-      ? (rawChannelData as Record<string, unknown>)
-      : undefined;
+  const channelData = readChannelDataObjectParam(actionParams);
   if (
     !hasReplyPayloadContent({
       text: message,
@@ -1838,10 +1837,7 @@ export async function runMessageAction(
     (input.sessionKey
       ? resolveSessionAgentId({ sessionKey: input.sessionKey, config: cfg })
       : undefined);
-  parseJsonMessageParam(params, "presentation");
-  parseJsonMessageParam(params, "delivery");
-  parseJsonMessageParam(params, "channelData");
-  parseInteractiveParam(params);
+  parseStructuredMessageContentParams(params, { delivery: true });
 
   const action = input.action;
   enforceMessageActionAllowlist({

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -1188,11 +1188,13 @@ async function buildSendPayloadParts(params: {
     Boolean(mediaHint) || mediaUrlHints.length > 0 || attachmentMediaHints.length > 0;
   const hasPresentation = hasMessagePresentationBlocks(actionParams.presentation);
   const hasInteractive = hasLegacyInteractiveReplyBlocks(actionParams.interactive);
+  const hasChannelData = hasReplyPayloadContent({ channelData: actionParams.channelData });
   const location = normalizeOutboundLocation(actionParams.location);
   const caption = readStringParam(actionParams, "caption", { allowEmpty: true }) ?? "";
   let message =
     readStringParam(actionParams, "message", {
-      required: !hasMediaHint && !hasPresentation && !hasInteractive && !location,
+      required:
+        !hasMediaHint && !hasPresentation && !hasInteractive && !hasChannelData && !location,
       allowEmpty: true,
     }) ?? "";
   if (message.includes("\\n")) {
@@ -1268,6 +1270,11 @@ async function buildSendPayloadParts(params: {
   }
 
   const mediaUrl = readStringParam(actionParams, "media", { trim: false });
+  const rawChannelData = actionParams.channelData;
+  const channelData =
+    rawChannelData && typeof rawChannelData === "object" && !Array.isArray(rawChannelData)
+      ? (rawChannelData as Record<string, unknown>)
+      : undefined;
   if (
     !hasReplyPayloadContent({
       text: message,
@@ -1275,6 +1282,7 @@ async function buildSendPayloadParts(params: {
       mediaUrls: mergedMediaUrls,
       presentation: actionParams.presentation,
       interactive: actionParams.interactive,
+      channelData,
       location,
     })
   ) {
@@ -1303,11 +1311,6 @@ async function buildSendPayloadParts(params: {
   const delivery =
     rawDelivery && typeof rawDelivery === "object" && !Array.isArray(rawDelivery)
       ? (rawDelivery as ReplyPayloadDelivery)
-      : undefined;
-  const rawChannelData = actionParams.channelData;
-  const channelData =
-    rawChannelData && typeof rawChannelData === "object" && !Array.isArray(rawChannelData)
-      ? (rawChannelData as Record<string, unknown>)
       : undefined;
   const presentation = normalizeMessagePresentation(actionParams.presentation);
   const interactive = normalizeLegacyInteractiveReply(actionParams.interactive);
@@ -1837,6 +1840,7 @@ export async function runMessageAction(
       : undefined);
   parseJsonMessageParam(params, "presentation");
   parseJsonMessageParam(params, "delivery");
+  parseJsonMessageParam(params, "channelData");
   parseInteractiveParam(params);
 
   const action = input.action;

--- a/src/infra/outbound/message-action-structured-content.ts
+++ b/src/infra/outbound/message-action-structured-content.ts
@@ -1,0 +1,86 @@
+import { hasReplyPayloadContent } from "../../interactive/payload.js";
+import { parseInteractiveParam, parseJsonMessageParam } from "./message-action-params.js";
+
+type VisibleTextSuppressionResult<TReason extends string> = {
+  suppressionReason?: TReason;
+};
+
+export function parseStructuredMessageContentParams(
+  params: Record<string, unknown>,
+  options?: { delivery?: boolean },
+): void {
+  parseJsonMessageParam(params, "presentation");
+  parseJsonMessageParam(params, "channelData");
+  if (options?.delivery) {
+    parseJsonMessageParam(params, "delivery");
+  }
+  parseInteractiveParam(params);
+}
+
+export function readChannelDataObjectParam(
+  params: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const rawChannelData = params.channelData;
+  return rawChannelData && typeof rawChannelData === "object" && !Array.isArray(rawChannelData)
+    ? (rawChannelData as Record<string, unknown>)
+    : undefined;
+}
+
+export function hasChannelDataPayloadContent(params: Record<string, unknown>): boolean {
+  return hasReplyPayloadContent({ channelData: readChannelDataObjectParam(params) });
+}
+
+export function sanitizeOpaqueChannelDataParam<TReason extends string>(
+  params: Record<string, unknown>,
+  bootPrompt: string | undefined,
+  sanitizeText: (
+    value: string,
+    bootPrompt: string | undefined,
+  ) => VisibleTextSuppressionResult<TReason>,
+): TReason | undefined {
+  const suppressionReason = detectOpaqueChannelDataSuppressionReason(
+    params.channelData,
+    bootPrompt,
+    sanitizeText,
+  );
+  if (suppressionReason) {
+    delete params.channelData;
+  }
+  return suppressionReason;
+}
+
+function detectOpaqueChannelDataSuppressionReason<TReason extends string>(
+  value: unknown,
+  bootPrompt: string | undefined,
+  sanitizeText: (
+    value: string,
+    bootPrompt: string | undefined,
+  ) => VisibleTextSuppressionResult<TReason>,
+): TReason | undefined {
+  if (typeof value === "string") {
+    return sanitizeText(value, bootPrompt).suppressionReason;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const reason = detectOpaqueChannelDataSuppressionReason(entry, bootPrompt, sanitizeText);
+      if (reason) {
+        return reason;
+      }
+    }
+    return undefined;
+  }
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    const keyReason = sanitizeText(key, bootPrompt).suppressionReason;
+    if (keyReason) {
+      return keyReason;
+    }
+    const reason = detectOpaqueChannelDataSuppressionReason(entry, bootPrompt, sanitizeText);
+    if (reason) {
+      return reason;
+    }
+  }
+  return undefined;
+}

--- a/src/infra/outbound/message-action-structured-content.ts
+++ b/src/infra/outbound/message-action-structured-content.ts
@@ -36,6 +36,7 @@ export function sanitizeOpaqueChannelDataParam<TReason extends string>(
   sanitizeText: (
     value: string,
     bootPrompt: string | undefined,
+    options?: { strictInternalRuntimeContext?: boolean },
   ) => VisibleTextSuppressionResult<TReason>,
 ): TReason | undefined {
   const suppressionReason = detectOpaqueChannelDataSuppressionReason(
@@ -55,10 +56,13 @@ function detectOpaqueChannelDataSuppressionReason<TReason extends string>(
   sanitizeText: (
     value: string,
     bootPrompt: string | undefined,
+    options?: { strictInternalRuntimeContext?: boolean },
   ) => VisibleTextSuppressionResult<TReason>,
 ): TReason | undefined {
   if (typeof value === "string") {
-    return sanitizeText(value, bootPrompt).suppressionReason;
+    return sanitizeText(value, bootPrompt, {
+      strictInternalRuntimeContext: true,
+    }).suppressionReason;
   }
   if (Array.isArray(value)) {
     for (const entry of value) {
@@ -73,7 +77,9 @@ function detectOpaqueChannelDataSuppressionReason<TReason extends string>(
     return undefined;
   }
   for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
-    const keyReason = sanitizeText(key, bootPrompt).suppressionReason;
+    const keyReason = sanitizeText(key, bootPrompt, {
+      strictInternalRuntimeContext: true,
+    }).suppressionReason;
     if (keyReason) {
       return keyReason;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where message actions that pass channel-specific `channelData` as a JSON string could lose that payload or fail to treat it as send content when the visible text is blank or removed.

## Why This Change Was Made

The message tool, outbound runner, and embedded subscribe rich-content tracker now parse `channelData` with the same structured JSON boundary used for sibling message payload fields. Opaque `channelData` remains fail-closed when it contains protected internal runtime context, while ordinary visible text keeps the safe text that remains after protected context is stripped. The runner now counts valid object-shaped `channelData` as real send content without adding config, schema, provider, or compatibility behavior.

Duplicate search found no open or closed overlapping PRs or open issues for `channelData JSON message action`, `stringified channelData`, `message-tool channelData idempotency`, or `parseJsonMessageParam channelData`; open self PRs had no same-root outbound/message parameter normalization overlap.

## User Impact

Channel-native cards, buttons, and other provider payload metadata can be preserved when passed as JSON strings, including internal source replies that intentionally carry channel-specific structured data without visible text. Protected runtime context remains filtered before opaque payloads can be sent, and normal visible text around a stripped protected block is still delivered.

## Evidence

### Exact-head secretless internal-source proof (`7e1d80cc7594c5434b91190bc21a2cb64f106832`)

Workflow: [fork CI run 29741975727](https://github.com/qingminglong/openclaw/actions/runs/29741975727) completed successfully on Ubuntu 24.04 with Node 24, `contents: read`, lifecycle scripts disabled during install, and the exact public PR head fetched and detached before execution.

Command shape:

```text
node --import tsx --input-type=module
```

The inline script called `createMessageTool({ currentChannelProvider: "webchat", sourceReplyDeliveryMode: "message_tool_only" }).execute(...)` without injecting `runMessageAction` and without `dryRun`.

Observed output:

```json
{
  "head": "7e1d80cc7594c5434b91190bc21a2cb64f106832",
  "expectedHead": "7e1d80cc7594c5434b91190bc21a2cb64f106832",
  "invoked": "createMessageTool.execute",
  "injectedRunMessageAction": false,
  "dryRun": false,
  "safe": {
    "status": "ok",
    "deliveryStatus": "sent",
    "sourceReplyDeliveryMode": "message_tool_only",
    "sourceReplySink": "internal-ui",
    "deliveredChannelData": {
      "webchat": {
        "cardId": "proof-card-only"
      }
    },
    "visibleText": "proof-safe"
  },
  "protectedContextRejected": {
    "status": true,
    "reason": "internal_runtime_context_echo",
    "leakedMarker": false,
    "dispatchedToInternalUi": false
  }
}
```

Claim proved: the real message-tool entry point parses and delivers stringified `channelData` through the live `internal-ui` source sink with `dryRun: false`; a protected-only internal-runtime-context payload is suppressed before internal-ui dispatch, without leaking the marker.