### PR TITLE
fix(msteams): bound probe token acquisition to request deadline

### DIFF
--- a/extensions/msteams/src/graph.timeout.test.ts
+++ b/extensions/msteams/src/graph.timeout.test.ts
@@ -1,0 +1,64 @@
+// Msteams tests cover Graph token request deadlines.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const sdkMock = vi.hoisted(() => ({
+  acquire: vi.fn<(scope: string) => Promise<string>>(),
+}));
+
+vi.mock("./sdk.js", () => ({
+  createMSTeamsTokenProvider() {
+    return {
+      async getAccessToken(scope: string) {
+        return await sdkMock.acquire(scope);
+      },
+    };
+  },
+  async loadMSTeamsSdkWithAuth() {
+    return { app: {} };
+  },
+}));
+
+vi.mock("./token-response.js", () => ({
+  readAccessToken(value: unknown) {
+    return typeof value === "string" ? value : null;
+  },
+}));
+
+vi.mock("./token.js", () => ({
+  async resolveDelegatedAccessToken() {
+    return undefined;
+  },
+  resolveMSTeamsCredentials() {
+    return {
+      type: "secret",
+      appId: "app-id",
+      appPassword: "test-app-password",
+      tenantId: "tenant-id",
+    };
+  },
+}));
+
+import { resolveGraphToken } from "./graph.js";
+import { MSTEAMS_REQUEST_TIMEOUT_MS } from "./request-timeout.js";
+
+describe("resolveGraphToken request deadline", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("bounds stalled SDK token acquisition", async () => {
+    sdkMock.acquire.mockImplementation(() => new Promise<string>(() => {}));
+    vi.useFakeTimers();
+
+    const result = resolveGraphToken({ channels: { msteams: {} } });
+    const rejection = expect(result).rejects.toThrow(
+      `MS Teams Graph token timed out after ${MSTEAMS_REQUEST_TIMEOUT_MS}ms`,
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(MSTEAMS_REQUEST_TIMEOUT_MS);
+
+    await rejection;
+    expect(sdkMock.acquire).toHaveBeenCalledWith("https://graph.microsoft.com");
+  });
+});

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -231,11 +231,10 @@ export async function resolveGraphToken(
 
   // Try delegated token if requested and configured
   if (options?.preferDelegated && msteamsCfg?.delegatedAuth?.enabled && creds.type === "secret") {
-    const { appPassword, appId: clientId, tenantId } = creds;
     const delegated = await resolveDelegatedAccessToken({
-      tenantId,
-      clientId,
-      clientSecret: appPassword,
+      tenantId: creds.tenantId,
+      clientId: creds.appId,
+      clientSecret: creds.appPassword,
     });
     if (delegated) {
       return delegated;

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -8,6 +8,7 @@ import {
   MSTEAMS_REQUEST_TIMEOUT_MS,
   resolveMSTeamsRequestTimeoutMs,
   type MSTeamsRequestDeadline,
+  withMSTeamsRequestDeadline,
 } from "./request-timeout.js";
 import { responseWithRelease } from "./response-with-release.js";
 import { createMSTeamsTokenProvider, loadMSTeamsSdkWithAuth } from "./sdk.js";
@@ -230,10 +231,11 @@ export async function resolveGraphToken(
 
   // Try delegated token if requested and configured
   if (options?.preferDelegated && msteamsCfg?.delegatedAuth?.enabled && creds.type === "secret") {
+    const { appPassword, appId: clientId, tenantId } = creds;
     const delegated = await resolveDelegatedAccessToken({
-      tenantId: creds.tenantId,
-      clientId: creds.appId,
-      clientSecret: creds.appPassword,
+      tenantId,
+      clientId,
+      clientSecret: appPassword,
     });
     if (delegated) {
       return delegated;
@@ -243,7 +245,10 @@ export async function resolveGraphToken(
 
   const { app } = await loadMSTeamsSdkWithAuth(creds, resolveMSTeamsSdkCloudOptions(msteamsCfg));
   const tokenProvider = createMSTeamsTokenProvider(app);
-  const graphTokenValue = await tokenProvider.getAccessToken("https://graph.microsoft.com");
+  const graphTokenValue = await withMSTeamsRequestDeadline({
+    label: "MS Teams Graph token",
+    work: () => tokenProvider.getAccessToken("https://graph.microsoft.com"),
+  });
   const accessToken = readAccessToken(graphTokenValue);
   if (!accessToken) {
     throw new Error("MS Teams graph token unavailable");

--- a/extensions/msteams/src/probe.timeout.test.ts
+++ b/extensions/msteams/src/probe.timeout.test.ts
@@ -7,12 +7,21 @@
 // the real `probeMSTeams()` code path with a stalled-token injection and
 // asserts that the call returns within the bounded deadline instead of
 // hanging on the naked await.
+//
+// Test design: drive `withTimeout`'s internal `setTimeout` via
+// `vi.useFakeTimers()` so each stalled case resolves in milliseconds instead
+// of waiting 30 production seconds. `withTimeout` (from
+// `@openclaw/fs-safe/dist/timing.js`) uses `setTimeout` + `clearTimeout`,
+// which `vi.useFakeTimers()` mocks globally. A separate case asserts the
+// production default deadline is exactly `MSTEAMS_REQUEST_TIMEOUT_MS = 30_000`
+// so the production contract is not silently weakened.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MSTeamsConfig } from "../runtime-api.js";
 
 const hostMockState = vi.hoisted(() => ({
   stallTokens: false as boolean,
   stallMode: "bot" as "bot" | "graph" | "both",
+  observedTimeouts: [] as number[],
 }));
 
 vi.mock("@microsoft/teams.apps", () => ({
@@ -50,6 +59,23 @@ vi.mock("@microsoft/teams.api", () => ({
   }),
 }));
 
+// Capture the timeoutMs value used by the production `withTimeout` helper so we
+// can assert the production default is the documented 30 seconds. We mock the
+// public helper rather than `withTimeout` itself so the real deadline-then-race
+// logic still runs under fake timers.
+vi.mock("openclaw/plugin-sdk/text-utility-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/text-utility-runtime")>(
+    "openclaw/plugin-sdk/text-utility-runtime",
+  );
+  return {
+    ...actual,
+    withTimeout: async <T>(promise: Promise<T>, timeoutMs: number, label?: string): Promise<T> => {
+      hostMockState.observedTimeouts.push(timeoutMs);
+      return actual.withTimeout(promise, timeoutMs, label);
+    },
+  };
+});
+
 import { probeMSTeams } from "./probe.js";
 
 const VALID_CFG = {
@@ -59,10 +85,13 @@ const VALID_CFG = {
   tenantId: "tenant",
 } as unknown as MSTeamsConfig;
 
+const PRODUCTION_DEADLINE_MS = 30_000;
+
 describe("msteams probe request-deadline", () => {
   beforeEach(() => {
     hostMockState.stallTokens = false;
     hostMockState.stallMode = "both";
+    hostMockState.observedTimeouts.length = 0;
     vi.stubEnv("MSTEAMS_APP_ID", "");
     vi.stubEnv("MSTEAMS_APP_PASSWORD", "");
     vi.stubEnv("MSTEAMS_TENANT_ID", "");
@@ -70,55 +99,70 @@ describe("msteams probe request-deadline", () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.useRealTimers();
   });
 
-  // Mirrors the pattern in error-body-boundary.test.ts: race the real probe
-  // against a proof budget. If the probe wraps the SDK call with
-  // withMSTeamsRequestDeadline (default MSTEAMS_REQUEST_TIMEOUT_MS = 30_000)
-  // the race resolves inside the budget. If the await is naked the race hits
-  // the budget and the test reports the elapsed wall-clock.
-  async function probeWithBudget(
-    mode: "bot" | "graph" | "both",
-    proofBudgetMs: number,
-  ): Promise<{ status: "resolved" | "budget-exceeded"; result: unknown; elapsedMs: number }> {
+  // Drives the real `withMSTeamsRequestDeadline` under fake timers so the
+  // stalled SDK promise rejects via the 30s deadline instead of waiting 30
+  // wall-clock seconds per case. `vi.advanceTimersByTimeAsync(PRODUCTION_DEADLINE_MS + 1_000)`
+  // trips the inner `setTimeout` from `withTimeout`, which causes the
+  // `Promise.race` to settle with the deadline-rejection error.
+  async function probeStalled(mode: "bot" | "graph" | "both"): Promise<unknown> {
     hostMockState.stallTokens = true;
     hostMockState.stallMode = mode;
-    const start = Date.now();
-    const winner = await Promise.race<{ kind: "ok"; result: unknown } | { kind: "budget" }>([
-      probeMSTeams(VALID_CFG).then((r) => ({ kind: "ok" as const, result: r })),
-      new Promise<void>((resolve) => {
-        setTimeout(() => resolve(), proofBudgetMs);
-      }).then(() => ({ kind: "budget" as const })),
-    ]);
-    const elapsed = Date.now() - start;
-    if (winner.kind === "ok") {
-      return { status: "resolved", result: winner.result, elapsedMs: elapsed };
-    }
-    return { status: "budget-exceeded", result: null, elapsedMs: elapsed };
+    vi.useFakeTimers();
+    const probePromise = probeMSTeams(VALID_CFG);
+    // Let the synchronous portion of probeMSTeams (App construction +
+    // tokenProvider wiring + withMSTeamsRequestDeadline race registration)
+    // complete on the microtask queue before advancing fake time.
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(PRODUCTION_DEADLINE_MS + 1_000);
+    return await probePromise;
   }
 
-  it("returns within the operation deadline when the bot token stalls", async () => {
-    const out = await probeWithBudget("bot", 45_000);
-    // The probe should be bounded by MSTEAMS_REQUEST_TIMEOUT_MS (30_000) plus
-    // some setup overhead. After the fix, this is well under 45s.
-    expect(out.status).toBe("resolved");
-    expect(out.elapsedMs).toBeLessThan(45_000);
+  it("returns a bounded probe result when the bot token stalls", async () => {
+    const result = (await probeStalled("bot")) as { ok: boolean; error?: string };
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/MS Teams Bot Framework probe token/);
+    expect(result.error).toMatch(/timed out after 30000ms/);
   });
 
-  it("returns within the operation deadline when the graph token stalls", async () => {
-    const out = await probeWithBudget("graph", 45_000);
-    expect(out.status).toBe("resolved");
-    expect(out.elapsedMs).toBeLessThan(45_000);
+  it("returns a bounded probe result when the graph token stalls", async () => {
+    const result = (await probeStalled("graph")) as {
+      ok: boolean;
+      error?: string;
+      graph?: { ok: boolean; error?: string };
+    };
+    // Outer probe is `ok: true` (bot succeeded); graph field carries the bounded failure.
+    expect(result.ok).toBe(true);
+    expect(result.graph?.ok).toBe(false);
+    expect(result.graph?.error).toMatch(/MS Teams Graph probe token/);
+    expect(result.graph?.error).toMatch(/timed out after 30000ms/);
   });
 
-  it("returns within the operation deadline when both tokens stall", async () => {
-    const out = await probeWithBudget("both", 60_000);
-    expect(out.status).toBe("resolved");
-    expect(out.elapsedMs).toBeLessThan(60_000);
+  it("returns a bounded probe result when both tokens stall", async () => {
+    const result = (await probeStalled("both")) as { ok: boolean; error?: string };
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/MS Teams Bot Framework probe token/);
+    expect(result.error).toMatch(/timed out after 30000ms/);
   });
 
   it("returns ok=true for a normal (non-stalled) probe", async () => {
+    hostMockState.stallTokens = false;
     const result = await probeMSTeams(VALID_CFG);
     expect(result.ok).toBe(true);
+  });
+
+  it("uses the documented 30s production default deadline for both token acquisitions", async () => {
+    // Run a normal probe and observe the two `withTimeout` calls. Both must use
+    // the production default — not a weakened test value. The probe calls
+    // `withMSTeamsRequestDeadline` twice in series (bot then graph); we expect
+    // exactly two observed timeouts, both 30_000.
+    hostMockState.stallTokens = false;
+    await probeMSTeams(VALID_CFG);
+    expect(hostMockState.observedTimeouts).toEqual([
+      PRODUCTION_DEADLINE_MS,
+      PRODUCTION_DEADLINE_MS,
+    ]);
   });
 });

--- a/extensions/msteams/src/probe.timeout.test.ts
+++ b/extensions/msteams/src/probe.timeout.test.ts
@@ -1,50 +1,25 @@
-// Msteams tests cover probe request-deadline behavior. Regression guard for
-// the unbounded `await tokenProvider.getAccessToken(...)` calls at probe.ts:75
-// and probe.ts:89. Other MS Teams paths (attachments/bot-framework.ts:252,
-// attachments/graph.ts:258, monitor-handler/message-handler.ts:594/654/685)
-// wrap the same SDK call with `withMSTeamsRequestDeadline` so stalled Azure AD
-// cannot pin the call; the probe was the one missing site. This test exercises
-// the real `probeMSTeams()` code path with a stalled-token injection and
-// asserts that the call returns within the bounded deadline instead of
-// hanging on the naked await.
-//
-// Test design: drive `withTimeout`'s internal `setTimeout` via
-// `vi.useFakeTimers()` so each stalled case resolves in milliseconds instead
-// of waiting 30 production seconds. `withTimeout` (from
-// `@openclaw/fs-safe/dist/timing.js`) uses `setTimeout` + `clearTimeout`,
-// which `vi.useFakeTimers()` mocks globally. A separate case asserts the
-// production default deadline is exactly `MSTEAMS_REQUEST_TIMEOUT_MS = 30_000`
-// so the production contract is not silently weakened.
+// Msteams tests cover probe token request deadlines.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MSTeamsConfig } from "../runtime-api.js";
 
-const hostMockState = vi.hoisted(() => ({
-  stallTokens: false as boolean,
-  stallMode: "bot" as "bot" | "graph" | "both",
-  observedTimeouts: [] as number[],
+const sdkState = vi.hoisted(() => ({
+  stall: null as "bot" | "graph" | null,
 }));
 
 vi.mock("@microsoft/teams.apps", () => ({
   App: class {
     tokenManager = {
-      getBotToken: async () => {
-        if (
-          hostMockState.stallTokens &&
-          (hostMockState.stallMode === "bot" || hostMockState.stallMode === "both")
-        ) {
-          // Never-resolving Promise simulates a stalled Azure AD token endpoint.
-          return await new Promise<{ toString(): string }>(() => {});
+      async getBotToken() {
+        if (sdkState.stall === "bot") {
+          return await new Promise<never>(() => {});
         }
-        return { toString: () => "bot-token" };
+        return { toString: () => "test-token" };
       },
-      getGraphToken: async () => {
-        if (
-          hostMockState.stallTokens &&
-          (hostMockState.stallMode === "graph" || hostMockState.stallMode === "both")
-        ) {
-          return await new Promise<{ toString(): string }>(() => {});
+      async getGraphToken() {
+        if (sdkState.stall === "graph") {
+          return await new Promise<never>(() => {});
         }
-        return { toString: () => "graph-token" };
+        return { toString: () => "test-token" };
       },
     };
   },
@@ -59,39 +34,19 @@ vi.mock("@microsoft/teams.api", () => ({
   }),
 }));
 
-// Capture the timeoutMs value used by the production `withTimeout` helper so we
-// can assert the production default is the documented 30 seconds. We mock the
-// public helper rather than `withTimeout` itself so the real deadline-then-race
-// logic still runs under fake timers.
-vi.mock("openclaw/plugin-sdk/text-utility-runtime", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/text-utility-runtime")>(
-    "openclaw/plugin-sdk/text-utility-runtime",
-  );
-  return {
-    ...actual,
-    withTimeout: async <T>(promise: Promise<T>, timeoutMs: number, label?: string): Promise<T> => {
-      hostMockState.observedTimeouts.push(timeoutMs);
-      return actual.withTimeout(promise, timeoutMs, label);
-    },
-  };
-});
-
 import { probeMSTeams } from "./probe.js";
+import { MSTEAMS_REQUEST_TIMEOUT_MS } from "./request-timeout.js";
 
-const VALID_CFG = {
+const cfg = {
   enabled: true,
-  appId: "app",
-  appPassword: "pw",
-  tenantId: "tenant",
+  appId: "app-id",
+  appPassword: "test-app-password",
+  tenantId: "tenant-id",
 } as unknown as MSTeamsConfig;
 
-const PRODUCTION_DEADLINE_MS = 30_000;
-
-describe("msteams probe request-deadline", () => {
+describe("probeMSTeams request deadline", () => {
   beforeEach(() => {
-    hostMockState.stallTokens = false;
-    hostMockState.stallMode = "both";
-    hostMockState.observedTimeouts.length = 0;
+    sdkState.stall = null;
     vi.stubEnv("MSTEAMS_APP_ID", "");
     vi.stubEnv("MSTEAMS_APP_PASSWORD", "");
     vi.stubEnv("MSTEAMS_TENANT_ID", "");
@@ -102,67 +57,34 @@ describe("msteams probe request-deadline", () => {
     vi.useRealTimers();
   });
 
-  // Drives the real `withMSTeamsRequestDeadline` under fake timers so the
-  // stalled SDK promise rejects via the 30s deadline instead of waiting 30
-  // wall-clock seconds per case. `vi.advanceTimersByTimeAsync(PRODUCTION_DEADLINE_MS + 1_000)`
-  // trips the inner `setTimeout` from `withTimeout`, which causes the
-  // `Promise.race` to settle with the deadline-rejection error.
-  async function probeStalled(mode: "bot" | "graph" | "both"): Promise<unknown> {
-    hostMockState.stallTokens = true;
-    hostMockState.stallMode = mode;
+  it.each([
+    {
+      stalled: "bot" as const,
+      expected: {
+        ok: false,
+        appId: "app-id",
+        error: `MS Teams Bot Framework probe token timed out after ${MSTEAMS_REQUEST_TIMEOUT_MS}ms`,
+      },
+    },
+    {
+      stalled: "graph" as const,
+      expected: {
+        ok: true,
+        appId: "app-id",
+        graph: {
+          ok: false,
+          error: `MS Teams Graph probe token timed out after ${MSTEAMS_REQUEST_TIMEOUT_MS}ms`,
+        },
+      },
+    },
+  ])("bounds stalled $stalled token acquisition", async ({ stalled, expected }) => {
+    sdkState.stall = stalled;
     vi.useFakeTimers();
-    const probePromise = probeMSTeams(VALID_CFG);
-    // Let the synchronous portion of probeMSTeams (App construction +
-    // tokenProvider wiring + withMSTeamsRequestDeadline race registration)
-    // complete on the microtask queue before advancing fake time.
+
+    const result = expect(probeMSTeams(cfg)).resolves.toEqual(expected);
     await vi.advanceTimersByTimeAsync(0);
-    await vi.advanceTimersByTimeAsync(PRODUCTION_DEADLINE_MS + 1_000);
-    return await probePromise;
-  }
+    await vi.advanceTimersByTimeAsync(MSTEAMS_REQUEST_TIMEOUT_MS);
 
-  it("returns a bounded probe result when the bot token stalls", async () => {
-    const result = (await probeStalled("bot")) as { ok: boolean; error?: string };
-    expect(result.ok).toBe(false);
-    expect(result.error).toMatch(/MS Teams Bot Framework probe token/);
-    expect(result.error).toMatch(/timed out after 30000ms/);
-  });
-
-  it("returns a bounded probe result when the graph token stalls", async () => {
-    const result = (await probeStalled("graph")) as {
-      ok: boolean;
-      error?: string;
-      graph?: { ok: boolean; error?: string };
-    };
-    // Outer probe is `ok: true` (bot succeeded); graph field carries the bounded failure.
-    expect(result.ok).toBe(true);
-    expect(result.graph?.ok).toBe(false);
-    expect(result.graph?.error).toMatch(/MS Teams Graph probe token/);
-    expect(result.graph?.error).toMatch(/timed out after 30000ms/);
-  });
-
-  it("returns a bounded probe result when both tokens stall", async () => {
-    const result = (await probeStalled("both")) as { ok: boolean; error?: string };
-    expect(result.ok).toBe(false);
-    expect(result.error).toMatch(/MS Teams Bot Framework probe token/);
-    expect(result.error).toMatch(/timed out after 30000ms/);
-  });
-
-  it("returns ok=true for a normal (non-stalled) probe", async () => {
-    hostMockState.stallTokens = false;
-    const result = await probeMSTeams(VALID_CFG);
-    expect(result.ok).toBe(true);
-  });
-
-  it("uses the documented 30s production default deadline for both token acquisitions", async () => {
-    // Run a normal probe and observe the two `withTimeout` calls. Both must use
-    // the production default — not a weakened test value. The probe calls
-    // `withMSTeamsRequestDeadline` twice in series (bot then graph); we expect
-    // exactly two observed timeouts, both 30_000.
-    hostMockState.stallTokens = false;
-    await probeMSTeams(VALID_CFG);
-    expect(hostMockState.observedTimeouts).toEqual([
-      PRODUCTION_DEADLINE_MS,
-      PRODUCTION_DEADLINE_MS,
-    ]);
+    await result;
   });
 });

--- a/extensions/msteams/src/probe.timeout.test.ts
+++ b/extensions/msteams/src/probe.timeout.test.ts
@@ -1,0 +1,124 @@
+// Msteams tests cover probe request-deadline behavior. Regression guard for
+// the unbounded `await tokenProvider.getAccessToken(...)` calls at probe.ts:75
+// and probe.ts:89. Other MS Teams paths (attachments/bot-framework.ts:252,
+// attachments/graph.ts:258, monitor-handler/message-handler.ts:594/654/685)
+// wrap the same SDK call with `withMSTeamsRequestDeadline` so stalled Azure AD
+// cannot pin the call; the probe was the one missing site. This test exercises
+// the real `probeMSTeams()` code path with a stalled-token injection and
+// asserts that the call returns within the bounded deadline instead of
+// hanging on the naked await.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MSTeamsConfig } from "../runtime-api.js";
+
+const hostMockState = vi.hoisted(() => ({
+  stallTokens: false as boolean,
+  stallMode: "bot" as "bot" | "graph" | "both",
+}));
+
+vi.mock("@microsoft/teams.apps", () => ({
+  App: class {
+    tokenManager = {
+      getBotToken: async () => {
+        if (
+          hostMockState.stallTokens &&
+          (hostMockState.stallMode === "bot" || hostMockState.stallMode === "both")
+        ) {
+          // Never-resolving Promise simulates a stalled Azure AD token endpoint.
+          return await new Promise<{ toString(): string }>(() => {});
+        }
+        return { toString: () => "bot-token" };
+      },
+      getGraphToken: async () => {
+        if (
+          hostMockState.stallTokens &&
+          (hostMockState.stallMode === "graph" || hostMockState.stallMode === "both")
+        ) {
+          return await new Promise<{ toString(): string }>(() => {});
+        }
+        return { toString: () => "graph-token" };
+      },
+    };
+  },
+  ExpressAdapter: vi.fn(),
+}));
+
+vi.mock("@microsoft/teams.api", () => ({
+  Client: function Client() {},
+  cloudFromName: () => ({
+    botScope: "https://api.botframework.com/.default",
+    graphScope: "https://graph.microsoft.com/.default",
+  }),
+}));
+
+import { probeMSTeams } from "./probe.js";
+
+const VALID_CFG = {
+  enabled: true,
+  appId: "app",
+  appPassword: "pw",
+  tenantId: "tenant",
+} as unknown as MSTeamsConfig;
+
+describe("msteams probe request-deadline", () => {
+  beforeEach(() => {
+    hostMockState.stallTokens = false;
+    hostMockState.stallMode = "both";
+    vi.stubEnv("MSTEAMS_APP_ID", "");
+    vi.stubEnv("MSTEAMS_APP_PASSWORD", "");
+    vi.stubEnv("MSTEAMS_TENANT_ID", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  // Mirrors the pattern in error-body-boundary.test.ts: race the real probe
+  // against a proof budget. If the probe wraps the SDK call with
+  // withMSTeamsRequestDeadline (default MSTEAMS_REQUEST_TIMEOUT_MS = 30_000)
+  // the race resolves inside the budget. If the await is naked the race hits
+  // the budget and the test reports the elapsed wall-clock.
+  async function probeWithBudget(
+    mode: "bot" | "graph" | "both",
+    proofBudgetMs: number,
+  ): Promise<{ status: "resolved" | "budget-exceeded"; result: unknown; elapsedMs: number }> {
+    hostMockState.stallTokens = true;
+    hostMockState.stallMode = mode;
+    const start = Date.now();
+    const winner = await Promise.race<{ kind: "ok"; result: unknown } | { kind: "budget" }>([
+      probeMSTeams(VALID_CFG).then((r) => ({ kind: "ok" as const, result: r })),
+      new Promise<void>((resolve) => {
+        setTimeout(() => resolve(), proofBudgetMs);
+      }).then(() => ({ kind: "budget" as const })),
+    ]);
+    const elapsed = Date.now() - start;
+    if (winner.kind === "ok") {
+      return { status: "resolved", result: winner.result, elapsedMs: elapsed };
+    }
+    return { status: "budget-exceeded", result: null, elapsedMs: elapsed };
+  }
+
+  it("returns within the operation deadline when the bot token stalls", async () => {
+    const out = await probeWithBudget("bot", 45_000);
+    // The probe should be bounded by MSTEAMS_REQUEST_TIMEOUT_MS (30_000) plus
+    // some setup overhead. After the fix, this is well under 45s.
+    expect(out.status).toBe("resolved");
+    expect(out.elapsedMs).toBeLessThan(45_000);
+  });
+
+  it("returns within the operation deadline when the graph token stalls", async () => {
+    const out = await probeWithBudget("graph", 45_000);
+    expect(out.status).toBe("resolved");
+    expect(out.elapsedMs).toBeLessThan(45_000);
+  });
+
+  it("returns within the operation deadline when both tokens stall", async () => {
+    const out = await probeWithBudget("both", 60_000);
+    expect(out.status).toBe("resolved");
+    expect(out.elapsedMs).toBeLessThan(60_000);
+  });
+
+  it("returns ok=true for a normal (non-stalled) probe", async () => {
+    const result = await probeMSTeams(VALID_CFG);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/extensions/msteams/src/probe.ts
+++ b/extensions/msteams/src/probe.ts
@@ -73,12 +73,8 @@ export async function probeMSTeams(cfg?: MSTeamsConfig): Promise<ProbeMSTeamsRes
   try {
     const { app } = await loadMSTeamsSdkWithAuth(creds, resolveMSTeamsSdkCloudOptions(cfg));
     const tokenProvider = createMSTeamsTokenProvider(app);
-    // Bound the SDK token acquisition: the Bot Framework and Graph SDK calls
-    // do not carry an inherent deadline, so a stalled Azure AD token endpoint
-    // would otherwise pin the probe indefinitely. Sibling MS Teams paths
-    // (attachments/bot-framework.ts, attachments/graph.ts,
-    // monitor-handler/message-handler.ts) already use withMSTeamsRequestDeadline
-    // for the same SDK calls; the probe was the one missing site.
+    // Token-manager calls can outlive the SDK HTTP timeout, so keep both probe
+    // phases bounded by the shared Teams request deadline.
     const botTokenValue = await withMSTeamsRequestDeadline({
       label: "MS Teams Bot Framework probe token",
       work: () => tokenProvider.getAccessToken("https://api.botframework.com"),

--- a/extensions/msteams/src/probe.ts
+++ b/extensions/msteams/src/probe.ts
@@ -7,6 +7,7 @@ import {
 } from "../runtime-api.js";
 import { resolveMSTeamsSdkCloudOptions } from "./cloud.js";
 import { formatUnknownError } from "./errors.js";
+import { withMSTeamsRequestDeadline } from "./request-timeout.js";
 import { createMSTeamsTokenProvider, loadMSTeamsSdkWithAuth } from "./sdk.js";
 import { readAccessToken } from "./token-response.js";
 import { loadDelegatedTokens, resolveMSTeamsCredentials } from "./token.js";
@@ -72,7 +73,16 @@ export async function probeMSTeams(cfg?: MSTeamsConfig): Promise<ProbeMSTeamsRes
   try {
     const { app } = await loadMSTeamsSdkWithAuth(creds, resolveMSTeamsSdkCloudOptions(cfg));
     const tokenProvider = createMSTeamsTokenProvider(app);
-    const botTokenValue = await tokenProvider.getAccessToken("https://api.botframework.com");
+    // Bound the SDK token acquisition: the Bot Framework and Graph SDK calls
+    // do not carry an inherent deadline, so a stalled Azure AD token endpoint
+    // would otherwise pin the probe indefinitely. Sibling MS Teams paths
+    // (attachments/bot-framework.ts, attachments/graph.ts,
+    // monitor-handler/message-handler.ts) already use withMSTeamsRequestDeadline
+    // for the same SDK calls; the probe was the one missing site.
+    const botTokenValue = await withMSTeamsRequestDeadline({
+      label: "MS Teams Bot Framework probe token",
+      work: () => tokenProvider.getAccessToken("https://api.botframework.com"),
+    });
     if (!botTokenValue) {
       throw new Error("Failed to acquire bot token");
     }
@@ -86,7 +96,10 @@ export async function probeMSTeams(cfg?: MSTeamsConfig): Promise<ProbeMSTeamsRes
         }
       | undefined;
     try {
-      const graphTokenValue = await tokenProvider.getAccessToken("https://graph.microsoft.com");
+      const graphTokenValue = await withMSTeamsRequestDeadline({
+        label: "MS Teams Graph probe token",
+        work: () => tokenProvider.getAccessToken("https://graph.microsoft.com"),
+      });
       const accessToken = readAccessToken(graphTokenValue);
       const payload = accessToken ? decodeJwtPayload(accessToken) : null;
       graph = {


### PR DESCRIPTION
## What Problem This Solves

MS Teams token acquisition could wait forever when the Teams SDK or its authentication transport stalled. The unbounded calls affected both `probeMSTeams()` phases and the shared `resolveGraphToken()` path used by Teams Graph actions.

## Why This Change Was Made

All three missing calls now reuse the plugin's existing `withMSTeamsRequestDeadline` helper and its established 30-second default:

- Bot Framework probe token
- Graph probe token
- shared Graph action token

This is the existing owner-local deadline contract already used by Teams attachment, media, identity, and message paths. No new helper, config, environment variable, SDK surface, fallback, or capability is introduced.

The regression coverage drives the real provider functions with never-settling SDK promises under fake timers. The original standalone 168-line test was rewritten into two focused suites covering the probe and shared Graph resolver, reducing the final PR by 13 lines while adding the missed Graph production path.

## User Impact

Teams health probes and Graph-backed actions now return a labeled timeout error instead of remaining pending indefinitely when token acquisition stalls. Existing successful, credential-error, delegated-token, and China-cloud behavior is unchanged.

## Evidence

Dependency contract:

- `@microsoft/teams.apps` 2.0.13 `TokenManager.getBotToken()` and `getGraphToken()` call MSAL or managed-identity token acquisition without accepting an abort signal or per-call timeout.
- The existing OpenClaw Teams request deadline is therefore the correct owner boundary for bounding these non-abortable SDK promises.

Focused tests after the final rewrite:

```bash
node scripts/run-vitest.mjs extensions/msteams/src/probe.test.ts extensions/msteams/src/probe.timeout.test.ts extensions/msteams/src/graph.test.ts extensions/msteams/src/graph.timeout.test.ts extensions/msteams/src/request-timeout.test.ts
```

Result: 5 files passed, 33 tests passed.

Hosted changed gate:

```bash
node scripts/check-changed.mjs -- extensions/msteams/src/graph.ts extensions/msteams/src/graph.timeout.test.ts extensions/msteams/src/probe.ts extensions/msteams/src/probe.timeout.test.ts
```

Result: passed on Blacksmith Testbox `tbx_01kxs8nxvngn01fktwyjdmgdjj`, including formatting, extension production/test typechecks, lint, Plugin SDK manifest, plugin boundaries, repository guards, and import-cycle checks: https://github.com/openclaw/openclaw/actions/runs/29622311925

Fresh autoreview: no findings; patch correct at 0.93 confidence.

The contributor's controlled transport proof also exercised the production Teams SDK and real `@azure/msal-node` path against a loopback response-body stall. The probe returned at 30,002 ms with the expected timeout and the following Graph acquisition remained usable. No credentials or live Azure traffic were used.

## Changelog

No `CHANGELOG.md` edit in this contributor PR. Release-note context is preserved here and in the squash message.
