### PR TITLE
fix(http-error-body): log response body snippet read errors instead of silently returning empty string

### DIFF
--- a/src/infra/http-error-body.test.ts
+++ b/src/infra/http-error-body.test.ts
@@ -139,7 +139,7 @@ describe("readResponseBodySnippet", () => {
       maxChars: 10,
     });
 
-    expect(result).toBe("a" + "\u{1F99E}".repeat(4));
+    expect(result).toBe("a" + "🦞".repeat(4));
   });
 });
 
@@ -148,45 +148,43 @@ describe("readResponseBodySnippet error visibility", () => {
     mockWarn.mockClear();
   });
 
-  it("logs a warning and returns empty string when response.text() rejects", async () => {
-    const error = new Error("body already consumed");
-    const badResponse = {
-      body: null,
-      text: async () => {
-        throw error;
-      },
-    } as unknown as Response;
+  it.each([
+    {
+      name: "response.text() rejection",
+      response: () =>
+        ({
+          body: null,
+          text: async () => {
+            throw new Error("body already consumed");
+          },
+        }) as unknown as Response,
+      expectedError: "body already consumed",
+    },
+    {
+      name: "body stream failure",
+      response: () =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("partial"));
+              controller.error(new Error("stream aborted"));
+            },
+          }),
+        ),
+      expectedError: "stream aborted",
+    },
+  ])(
+    "logs the read error and preserves the empty fallback for $name",
+    async ({ response, expectedError }) => {
+      const result = await readResponseBodySnippet(response(), {
+        maxBytes: 1024,
+        maxChars: 50,
+      });
 
-    const result = await readResponseBodySnippet(badResponse, {
-      maxBytes: 1024,
-      maxChars: 50,
-    });
-
-    expect(result).toBe("");
-    expect(mockWarn).toHaveBeenCalledTimes(1);
-    expect(mockWarn).toHaveBeenCalledWith(
-      expect.stringContaining("Failed to read response body snippet"),
-    );
-  });
-
-  it("logs a warning and returns empty string when body stream throws", async () => {
-    const badStream = new ReadableStream({
-      start(controller) {
-        controller.enqueue(new TextEncoder().encode("partial"));
-        controller.error(new Error("stream aborted"));
-      },
-    });
-    const badResponse = new Response(badStream);
-
-    const result = await readResponseBodySnippet(badResponse, {
-      maxBytes: 1024,
-      maxChars: 50,
-    });
-
-    expect(result).toBe("");
-    expect(mockWarn).toHaveBeenCalledTimes(1);
-    expect(mockWarn).toHaveBeenCalledWith(
-      expect.stringContaining("Failed to read response body snippet"),
-    );
-  });
+      expect(result).toBe("");
+      expect(mockWarn).toHaveBeenCalledExactlyOnceWith(
+        `Failed to read response body snippet: ${expectedError}`,
+      );
+    },
+  );
 });

--- a/src/infra/http-error-body.test.ts
+++ b/src/infra/http-error-body.test.ts
@@ -130,6 +130,42 @@ describe("readResponseBodySnippet", () => {
       maxChars: 10,
     });
 
-    expect(result).toBe("a" + "🦞".repeat(4));
+    expect(result).toBe("a" + "\u{1F99E}".repeat(4));
+  });
+});
+
+describe("readResponseBodySnippet error visibility", () => {
+  it("logs a warning and returns empty string when response.text() rejects", async () => {
+    const error = new Error("body already consumed");
+    const badResponse = {
+      body: null,
+      text: async () => {
+        throw error;
+      },
+    } as unknown as Response;
+
+    const result = await readResponseBodySnippet(badResponse, {
+      maxBytes: 1024,
+      maxChars: 50,
+    });
+
+    expect(result).toBe("");
+  });
+
+  it("logs a warning and returns empty string when body stream throws", async () => {
+    const badStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("partial"));
+        controller.error(new Error("stream aborted"));
+      },
+    });
+    const badResponse = new Response(badStream);
+
+    const result = await readResponseBodySnippet(badResponse, {
+      maxBytes: 1024,
+      maxChars: 50,
+    });
+
+    expect(result).toBe("");
   });
 });

--- a/src/infra/http-error-body.test.ts
+++ b/src/infra/http-error-body.test.ts
@@ -1,4 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockWarn } = vi.hoisted(() => ({
+  mockWarn: vi.fn(),
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({ warn: mockWarn }),
+}));
+
 import { readResponseBodySnippet } from "./http-error-body.js";
 
 function bodyLessResponse(text: string): Response {
@@ -135,6 +144,10 @@ describe("readResponseBodySnippet", () => {
 });
 
 describe("readResponseBodySnippet error visibility", () => {
+  beforeEach(() => {
+    mockWarn.mockClear();
+  });
+
   it("logs a warning and returns empty string when response.text() rejects", async () => {
     const error = new Error("body already consumed");
     const badResponse = {
@@ -150,6 +163,10 @@ describe("readResponseBodySnippet error visibility", () => {
     });
 
     expect(result).toBe("");
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to read response body snippet"),
+    );
   });
 
   it("logs a warning and returns empty string when body stream throws", async () => {
@@ -167,5 +184,9 @@ describe("readResponseBodySnippet error visibility", () => {
     });
 
     expect(result).toBe("");
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to read response body snippet"),
+    );
   });
 });

--- a/src/infra/http-error-body.ts
+++ b/src/infra/http-error-body.ts
@@ -1,6 +1,10 @@
 import { decodeTextPrefix } from "@openclaw/normalization-core";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { formatErrorMessage } from "./errors.js";
 import { readResponseTextPrefix } from "./http-body.js";
+
+const errorBodyLog = createSubsystemLogger("http-error-body");
 
 export async function readResponseBodySnippet(
   response: Response,
@@ -22,7 +26,8 @@ export async function readResponseBodySnippet(
 
     const prefix = await readResponseTextPrefix(response, limits.maxBytes);
     return truncateUtf16Safe(prefix.text, limits.maxChars);
-  } catch {
+  } catch (err) {
+    errorBodyLog.warn(`Failed to read response body snippet: ${formatErrorMessage(err)}`);
     return "";
   }
 }


### PR DESCRIPTION
## Summary

`readResponseBodySnippet` used a bare `catch {}` that silently swallowed all errors and returned `""` with no diagnostic. This PR replaces it with `catch (err) { errorBodyLog.warn(...); return ""; }` so failures are visible in diagnostics.

## What Problem This Solves

In `src/infra/http-error-body.ts:25`, `readResponseBodySnippet` catches all errors and returns an empty string with no logging. When a response body cannot be read — network failure, body already consumed, stream abort, decode error — the failure is completely invisible. Callers receive `""` and cannot distinguish between a genuinely empty response body and a read failure.

**Code evidence**: In `http-error-body.ts:25`, the `catch { return ""; }` provides zero visibility into why the snippet read failed.

## Root Cause

The function was written with best-effort semantics (it provides a diagnostic snippet, not the primary response data), but the empty catch block went too far by discarding all diagnostic information. Similar to the pattern fixed in [#106385](https://github.com/openclaw/openclaw/pull/106385).

## Why This Fix

Follows the same pattern accepted in:
- [#84449](https://github.com/openclaw/openclaw/pull/84449) (`fix(delivery): log failDelivery errors instead of silently swallowing`) by @SebTardif
- [#106385](https://github.com/openclaw/openclaw/pull/106385) (`fix(restart-sentinel): log DB errors instead of silently swallowing them`)

Uses `createSubsystemLogger("http-error-body")` + `formatErrorMessage(err)` — consistent with other infra modules.

## User Impact

- **Before**: Operators had no diagnostic signal when an HTTP error body snippet could not be read — failures were completely invisible.
- **After**: A warning is emitted (`[http-error-body]` prefix) with the full error context; the function continues to return `""` (safe default for diagnostic snippets).

## Evidence

- **Before**: No warnings emitted when `response.text()` rejects — error is silently swallowed.
- **After**: Warning emitted with full error context; empty string returned as safe default.

## Real Behavior Proof

### Before (on main)
```bash
$ node --import tsx proof.mjs
=== readResponseBodySnippet (error case) ===
Returned: ""
readResponseBodySnippet completed without throwing

=== stderr (warnings captured) ===
FAIL: No warnings were emitted on stderr!
      The catch block is silently swallowing errors.
```

### After (with fix)
```bash
$ node --import tsx proof.mjs
=== readResponseBodySnippet (error case) ===
Returned: ""
readResponseBodySnippet completed without throwing

=== stderr (warnings captured) ===
PASS: Warning was emitted on stderr:
  [http-error-body] Failed to read response body snippet: body already consumed
```

## Tests and Validation

- `pnpm check` passed (no lint errors)
- Added 2 regression tests: `response.text()` rejection + stream abort
