### PR TITLE
refactor(acpx): privatize internal helpers

### DIFF
--- a/extensions/acpx/src/process-lease.test.ts
+++ b/extensions/acpx/src/process-lease.test.ts
@@ -13,10 +13,11 @@ import {
   OPENCLAW_ACPX_LEASE_ID_ARG,
   OPENCLAW_ACPX_LEASE_ID_ENV,
   OPENCLAW_GATEWAY_INSTANCE_ID_ARG,
-  OPENCLAW_GATEWAY_INSTANCE_ID_ENV,
   withAcpxLeaseEnvironment,
   type AcpxProcessLease,
 } from "./process-lease.js";
+
+const OPENCLAW_GATEWAY_INSTANCE_ID_ENV = "OPENCLAW_GATEWAY_INSTANCE_ID";
 
 function makeLease(index: number): AcpxProcessLease {
   return {

--- a/extensions/acpx/src/process-lease.ts
+++ b/extensions/acpx/src/process-lease.ts
@@ -12,7 +12,7 @@ import { ACPX_PROCESS_LEASE_MAX_ENTRIES, ACPX_PROCESS_LEASE_NAMESPACE } from "./
 /** Environment variable carrying the ACPX process lease id. */
 export const OPENCLAW_ACPX_LEASE_ID_ENV = "OPENCLAW_ACPX_LEASE_ID";
 /** Environment variable carrying the owning gateway instance id. */
-export const OPENCLAW_GATEWAY_INSTANCE_ID_ENV = "OPENCLAW_GATEWAY_INSTANCE_ID";
+const OPENCLAW_GATEWAY_INSTANCE_ID_ENV = "OPENCLAW_GATEWAY_INSTANCE_ID";
 /** CLI argument carrying the ACPX process lease id for platforms without env wrapping. */
 export const OPENCLAW_ACPX_LEASE_ID_ARG = "--openclaw-acpx-lease-id";
 /** CLI argument carrying the owning gateway instance id. */

--- a/extensions/acpx/src/runtime-turn.test.ts
+++ b/extensions/acpx/src/runtime-turn.test.ts
@@ -1,7 +1,7 @@
 // ACPX tests cover legacy runTurn adaptation into the terminal result contract.
 import { describe, expect, it, vi } from "vitest";
 import type { AcpRuntime, AcpRuntimeEvent, AcpRuntimeTurnInput } from "../runtime-api.js";
-import { startRuntimeTurn } from "./runtime-turn.js";
+import { lazyStartRuntimeTurn } from "./runtime-turn.js";
 
 function createLegacyRuntime(events: AcpRuntimeEvent[]): AcpRuntime {
   return {
@@ -25,11 +25,14 @@ const turnInput: AcpRuntimeTurnInput = {
   requestId: "request-1",
 };
 
-describe("startRuntimeTurn", () => {
+describe("lazyStartRuntimeTurn", () => {
   it.each(["cancel", "cancelled", "manual-cancel"])(
     "preserves %s cancellation from a legacy done event",
     async (stopReason) => {
-      const turn = startRuntimeTurn(createLegacyRuntime([{ type: "done", stopReason }]), turnInput);
+      const turn = lazyStartRuntimeTurn(
+        async () => createLegacyRuntime([{ type: "done", stopReason }]),
+        turnInput,
+      );
 
       expect(await turn.result).toEqual({ status: "cancelled", stopReason });
       const events: AcpRuntimeEvent[] = [];

--- a/extensions/acpx/src/runtime-turn.ts
+++ b/extensions/acpx/src/runtime-turn.ts
@@ -157,7 +157,7 @@ function legacyRunTurnAsStartTurn(runtime: AcpRuntime, input: AcpRuntimeTurnInpu
 }
 
 /** Start an ACP turn, adapting legacy runTurn-only runtimes when needed. */
-export function startRuntimeTurn(runtime: AcpRuntime, input: AcpRuntimeTurnInput): AcpRuntimeTurn {
+function startRuntimeTurn(runtime: AcpRuntime, input: AcpRuntimeTurnInput): AcpRuntimeTurn {
   return runtime.startTurn?.(input) ?? legacyRunTurnAsStartTurn(runtime, input);
 }
 

--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -2,10 +2,8 @@
 // New entries fail CI. After deleting dead code, run `pnpm deadcode:exports:update`.
 // Do not add entries to avoid fixing new findings.
 export const KNIP_UNUSED_EXPORT_BASELINE = [
-  "extensions/acpx/src/process-lease.ts: OPENCLAW_GATEWAY_INSTANCE_ID_ENV",
   "extensions/acpx/src/process-reaper.ts: AcpxProcessInfo",
   "extensions/acpx/src/process-reaper.ts: isOpenClawOwnedAcpxProcessCommand",
-  "extensions/acpx/src/runtime-turn.ts: startRuntimeTurn",
   "extensions/canvas/src/host/a2ui.ts: createA2uiHttpRequestHandler",
   "extensions/canvas/src/host/a2ui.ts: injectCanvasRuntime",
   "extensions/canvas/src/host/a2ui.ts: isA2uiPath",


### PR DESCRIPTION
## What Problem This Solves

Two ACPX implementation details are exported even though they have no production
consumers outside their defining modules. Keeping those unsupported exports also
requires permanent Knip baseline allowances and weakens the dead-code ratchet.

## Why This Change Was Made

Make the gateway instance env-name constant and legacy turn adapter helper
module-private, then test the same behavior through observable command output and
the used `lazyStartRuntimeTurn` facade. Process-reaper exports are deliberately
excluded because active PRs #104929 and #99010 touch that lifecycle surface.

## User Impact

No user-visible behavior changes. Maintainers get two fewer unsupported exports
and two fewer dead-code baseline exceptions without changing ACPX runtime or
process cleanup behavior.

## Evidence

- Exact-symbol search and the current code-memory graph found no production
  consumers outside the defining modules.
- Open ACPX PR audit found no changed-file overlap for this five-file slice.
- Fresh Blacksmith Testbox `tbx_01kxdr8ctdr5yxnkqv86r16adw`, Actions run
  `29251160401`, based on `5ca0e634bca64c64e6810d36d47efc9e11fac9e5`:
  - `pnpm test:extension acpx`: 14/14 files and 154/154 tests passed.
  - `pnpm deadcode:exports`: passed with 3208 baseline entries.
  - Targeted `pnpm check:changed`: formatting, production/test extension
    typechecks, extension/script lint, package/storage/media/sidecar guards, and
    runtime import-cycle checks passed.
- Fresh `gpt-5.6-sol` medium autoreview: clean, 0.98 confidence.
