### PR TITLE
fix(device-pair): bound notifier polling overlap

### DIFF
--- a/extensions/device-pair/notify.test.ts
+++ b/extensions/device-pair/notify.test.ts
@@ -18,16 +18,27 @@ import {
 
 const listDevicePairingMock = vi.hoisted(() => vi.fn(async () => ({ pending: [] })));
 
-vi.mock("./api.js", () => ({
+vi.mock("openclaw/plugin-sdk/device-bootstrap", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/device-bootstrap")>()),
   listDevicePairing: listDevicePairingMock,
 }));
 
-import { handleNotifyCommand } from "./notify.js";
+import { createPairingNotifierService, handleNotifyCommand } from "./notify.js";
 
 afterAll(() => {
-  vi.doUnmock("./api.js");
+  vi.doUnmock("openclaw/plugin-sdk/device-bootstrap");
   vi.resetModules();
 });
+
+function createDeferred<T>() {
+  let resolve: (value: T) => void;
+  let reject: (reason?: unknown) => void;
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+  return { promise, resolve: resolve!, reject: reject! };
+}
 
 describe("device-pair notify persistence", () => {
   let stateDir: string;
@@ -42,6 +53,7 @@ describe("device-pair notify persistence", () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     await fs.rm(stateDir, { recursive: true, force: true });
   });
 
@@ -69,6 +81,45 @@ describe("device-pair notify persistence", () => {
       maxEntries: DEVICE_PAIR_NOTIFY_SUBSCRIBER_MAX_ENTRIES,
     });
   }
+
+  it("skips interval ticks while a notify poll is pending and resumes after it settles", async () => {
+    vi.useFakeTimers();
+    const firstPoll = createDeferred<Awaited<ReturnType<typeof listDevicePairingMock>>>();
+    const failedPoll = createDeferred<Awaited<ReturnType<typeof listDevicePairingMock>>>();
+    listDevicePairingMock
+      .mockResolvedValueOnce({ pending: [] })
+      .mockImplementationOnce(() => firstPoll.promise)
+      .mockImplementationOnce(() => failedPoll.promise)
+      .mockResolvedValue({ pending: [] });
+    const api = createApi();
+    const service = createPairingNotifierService(api);
+
+    await service.start({} as never);
+    expect(listDevicePairingMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(listDevicePairingMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(listDevicePairingMock).toHaveBeenCalledTimes(2);
+
+    await service.stop?.({} as never);
+    await service.start({} as never);
+    expect(listDevicePairingMock).toHaveBeenCalledTimes(2);
+
+    firstPoll.resolve({ pending: [] });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(listDevicePairingMock).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(listDevicePairingMock).toHaveBeenCalledTimes(3);
+
+    failedPoll.reject(new Error("poll failed"));
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(listDevicePairingMock).toHaveBeenCalledTimes(4);
+
+    await service.stop?.({} as never);
+  });
 
   it("matches persisted telegram thread ids across number and string roundtrips", async () => {
     const subscriber: NotifySubscription = {

--- a/extensions/device-pair/notify.test.ts
+++ b/extensions/device-pair/notify.test.ts
@@ -64,12 +64,17 @@ describe("device-pair notify persistence", () => {
     });
   }
 
-  function createApi() {
+  function createApi(sendText?: ReturnType<typeof vi.fn>) {
     return createTestPluginApi({
       runtime: {
         state: {
           resolveStateDir: () => stateDir,
           openKeyedStore: openStore,
+        },
+        channel: {
+          outbound: {
+            loadAdapter: vi.fn(async () => (sendText ? { sendText } : undefined)),
+          },
         },
       } as never,
     });
@@ -118,6 +123,63 @@ describe("device-pair notify persistence", () => {
     await vi.advanceTimersByTimeAsync(0);
     await vi.advanceTimersByTimeAsync(10_000);
     expect(listDevicePairingMock).toHaveBeenCalledTimes(4);
+
+    await service.stop?.({} as never);
+  });
+
+  it("delivers each request once when a service reload interrupts a slow send", async () => {
+    vi.useFakeTimers();
+    const firstSend = createDeferred<unknown>();
+    const sendText = vi
+      .fn()
+      .mockImplementationOnce(() => firstSend.promise)
+      .mockResolvedValue({ channel: "telegram", to: "chat-123" });
+    const firstRequest = {
+      requestId: "request-1",
+      deviceId: "device-1",
+      displayName: "First device",
+    };
+    const secondRequest = {
+      requestId: "request-2",
+      deviceId: "device-2",
+      displayName: "Second device",
+    };
+    const api = createApi(sendText);
+    await handleNotifyCommand({
+      api,
+      ctx: {
+        channel: "telegram",
+        senderId: "chat-123",
+      },
+      action: "on",
+    });
+    listDevicePairingMock.mockResolvedValueOnce({ pending: [] }).mockResolvedValue({
+      pending: [firstRequest],
+    });
+    let service = createPairingNotifierService(api);
+
+    await service.start({} as never);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(sendText).toHaveBeenCalledTimes(1);
+
+    await service.stop?.({} as never);
+    service = createPairingNotifierService(createApi(sendText));
+    await service.start({} as never);
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(sendText).toHaveBeenCalledTimes(1);
+
+    firstSend.resolve({ channel: "telegram", to: "chat-123" });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(sendText).toHaveBeenCalledTimes(1);
+
+    listDevicePairingMock.mockResolvedValue({ pending: [firstRequest, secondRequest] });
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(sendText).toHaveBeenCalledTimes(2);
+    expect(sendText.mock.calls[1]?.[0]).toMatchObject({
+      to: "chat-123",
+      text: expect.stringContaining("ID: request-2"),
+    });
 
     await service.stop?.({} as never);
   });

--- a/extensions/device-pair/notify.test.ts
+++ b/extensions/device-pair/notify.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { listDevicePairing as listDevicePairingFn } from "openclaw/plugin-sdk/device-bootstrap";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
   createPluginStateKeyedStoreForTests,
@@ -16,7 +17,9 @@ import {
   type NotifySubscription,
 } from "./notify-state.js";
 
-const listDevicePairingMock = vi.hoisted(() => vi.fn(async () => ({ pending: [] })));
+const listDevicePairingMock = vi.hoisted(() =>
+  vi.fn<typeof listDevicePairingFn>(async () => ({ pending: [], paired: [] })),
+);
 
 vi.mock("openclaw/plugin-sdk/device-bootstrap", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/device-bootstrap")>()),
@@ -47,7 +50,7 @@ describe("device-pair notify persistence", () => {
   beforeEach(async () => {
     resetPluginStateStoreForTests();
     vi.clearAllMocks();
-    listDevicePairingMock.mockResolvedValue({ pending: [] });
+    listDevicePairingMock.mockResolvedValue({ pending: [], paired: [] });
     stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "device-pair-notify-"));
     env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
   });
@@ -92,10 +95,10 @@ describe("device-pair notify persistence", () => {
     const firstPoll = createDeferred<Awaited<ReturnType<typeof listDevicePairingMock>>>();
     const failedPoll = createDeferred<Awaited<ReturnType<typeof listDevicePairingMock>>>();
     listDevicePairingMock
-      .mockResolvedValueOnce({ pending: [] })
+      .mockResolvedValueOnce({ pending: [], paired: [] })
       .mockImplementationOnce(() => firstPoll.promise)
       .mockImplementationOnce(() => failedPoll.promise)
-      .mockResolvedValue({ pending: [] });
+      .mockResolvedValue({ pending: [], paired: [] });
     const api = createApi();
     let service = createPairingNotifierService(api);
 
@@ -112,7 +115,7 @@ describe("device-pair notify persistence", () => {
     await service.start({} as never);
     expect(listDevicePairingMock).toHaveBeenCalledTimes(2);
 
-    firstPoll.resolve({ pending: [] });
+    firstPoll.resolve({ pending: [], paired: [] });
     await vi.advanceTimersByTimeAsync(0);
     await vi.advanceTimersByTimeAsync(10_000);
     expect(listDevicePairingMock).toHaveBeenCalledTimes(3);
@@ -137,12 +140,16 @@ describe("device-pair notify persistence", () => {
     const firstRequest = {
       requestId: "request-1",
       deviceId: "device-1",
+      publicKey: "public-key-1",
       displayName: "First device",
+      ts: 1,
     };
     const secondRequest = {
       requestId: "request-2",
       deviceId: "device-2",
+      publicKey: "public-key-2",
       displayName: "Second device",
+      ts: 2,
     };
     const api = createApi(sendText);
     await handleNotifyCommand({
@@ -153,9 +160,9 @@ describe("device-pair notify persistence", () => {
       },
       action: "on",
     });
-    listDevicePairingMock.mockResolvedValueOnce({ pending: [] }).mockResolvedValue({
-      pending: [firstRequest],
-    });
+    listDevicePairingMock
+      .mockResolvedValueOnce({ pending: [], paired: [] })
+      .mockResolvedValue({ pending: [firstRequest], paired: [] });
     let service = createPairingNotifierService(api);
 
     await service.start({} as never);
@@ -173,7 +180,10 @@ describe("device-pair notify persistence", () => {
     await vi.advanceTimersByTimeAsync(10_000);
     expect(sendText).toHaveBeenCalledTimes(1);
 
-    listDevicePairingMock.mockResolvedValue({ pending: [firstRequest, secondRequest] });
+    listDevicePairingMock.mockResolvedValue({
+      pending: [firstRequest, secondRequest],
+      paired: [],
+    });
     await vi.advanceTimersByTimeAsync(10_000);
     expect(sendText).toHaveBeenCalledTimes(2);
     expect(sendText.mock.calls[1]?.[0]).toMatchObject({

--- a/extensions/device-pair/notify.test.ts
+++ b/extensions/device-pair/notify.test.ts
@@ -82,7 +82,7 @@ describe("device-pair notify persistence", () => {
     });
   }
 
-  it("skips interval ticks while a notify poll is pending and resumes after it settles", async () => {
+  it("keeps one notify poll in flight across service recreation", async () => {
     vi.useFakeTimers();
     const firstPoll = createDeferred<Awaited<ReturnType<typeof listDevicePairingMock>>>();
     const failedPoll = createDeferred<Awaited<ReturnType<typeof listDevicePairingMock>>>();
@@ -92,7 +92,7 @@ describe("device-pair notify persistence", () => {
       .mockImplementationOnce(() => failedPoll.promise)
       .mockResolvedValue({ pending: [] });
     const api = createApi();
-    const service = createPairingNotifierService(api);
+    let service = createPairingNotifierService(api);
 
     await service.start({} as never);
     expect(listDevicePairingMock).toHaveBeenCalledTimes(1);
@@ -103,6 +103,7 @@ describe("device-pair notify persistence", () => {
     expect(listDevicePairingMock).toHaveBeenCalledTimes(2);
 
     await service.stop?.({} as never);
+    service = createPairingNotifierService(createApi());
     await service.start({} as never);
     expect(listDevicePairingMock).toHaveBeenCalledTimes(2);
 

--- a/extensions/device-pair/notify.ts
+++ b/extensions/device-pair/notify.ts
@@ -456,12 +456,24 @@ export async function handleNotifyCommand(params: {
 
 export function createPairingNotifierService(api: OpenClawPluginApi): OpenClawPluginService {
   let notifyInterval: ReturnType<typeof setInterval> | null = null;
+  // stop() cannot cancel an active delivery, so keep this guard across restarts
+  // until that poll settles rather than overlapping it with a new initial poll.
+  let notifyPollInFlight = false;
 
   return {
     id: "device-pair-notifier",
     start: async () => {
       const tick = async () => {
-        await notifyPendingPairingRequests({ api });
+        // Keep slow polls from racing notification state reads and delivery.
+        if (notifyPollInFlight) {
+          return;
+        }
+        notifyPollInFlight = true;
+        try {
+          await notifyPendingPairingRequests({ api });
+        } finally {
+          notifyPollInFlight = false;
+        }
       };
 
       await tick().catch((err: unknown) => {

--- a/extensions/device-pair/notify.ts
+++ b/extensions/device-pair/notify.ts
@@ -20,6 +20,10 @@ import {
 
 const NOTIFY_POLL_INTERVAL_MS = 10_000;
 
+// Config reload recreates plugin services before an uncancellable delivery may settle.
+// Keep one module-owned poll so the replacement service cannot race state or delivery.
+let notifyPollInFlight: Promise<void> | null = null;
+
 type NotifyStateFile = {
   subscribers: NotifySubscription[];
   notifiedRequestIds: Record<string, number>;
@@ -344,6 +348,18 @@ async function notifyPendingPairingRequests(params: { api: OpenClawPluginApi }):
   }
 }
 
+async function runNotifyPoll(api: OpenClawPluginApi): Promise<void> {
+  if (notifyPollInFlight) {
+    return;
+  }
+  notifyPollInFlight = notifyPendingPairingRequests({ api });
+  try {
+    await notifyPollInFlight;
+  } finally {
+    notifyPollInFlight = null;
+  }
+}
+
 export async function armPairNotifyOnce(params: {
   api: OpenClawPluginApi;
   ctx: {
@@ -456,24 +472,12 @@ export async function handleNotifyCommand(params: {
 
 export function createPairingNotifierService(api: OpenClawPluginApi): OpenClawPluginService {
   let notifyInterval: ReturnType<typeof setInterval> | null = null;
-  // stop() cannot cancel an active delivery, so keep this guard across restarts
-  // until that poll settles rather than overlapping it with a new initial poll.
-  let notifyPollInFlight = false;
 
   return {
     id: "device-pair-notifier",
     start: async () => {
       const tick = async () => {
-        // Keep slow polls from racing notification state reads and delivery.
-        if (notifyPollInFlight) {
-          return;
-        }
-        notifyPollInFlight = true;
-        try {
-          await notifyPendingPairingRequests({ api });
-        } finally {
-          notifyPollInFlight = false;
-        }
+        await runNotifyPoll(api);
       };
 
       await tick().catch((err: unknown) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes overlapping device-pair notification polls that can race notification state or send duplicate Telegram pairing reminders when one delivery crosses the 10-second polling interval.

## Why This Change Was Made

The notifier now keeps one module-owned poll in flight. Module ownership matters because Gateway configuration reload recreates plugin service objects before an already-running Telegram delivery can be cancelled or settled. The replacement service skips while that poll remains active; the guard clears after success or failure so later polling resumes.

## User Impact

Users should receive each pairing reminder once even when Telegram delivery is slow or plugin services reload during delivery. Later pairing requests continue to notify normally.

## Evidence

Exact head: `cf381ffb47b0e37e0d8ff19a28197b845b93007c`.

Maintainer fixups:

- moved the in-flight owner across recreated service instances;
- added controlled delayed-delivery proof through the production notifier and outbound-adapter boundary.

Sanitized AWS Crabbox proof used public networking, no Tailscale, no credential hydration, and exact-head verification. Run `run_99075fa1c1a4` passed:

```text
extensions/device-pair/notify.test.ts
Test Files  1 passed (1)
Tests       4 passed (4)

oxfmt --check extensions/device-pair/notify.ts extensions/device-pair/notify.test.ts
All matched files use the correct format.

oxlint extensions/device-pair/notify.ts extensions/device-pair/notify.test.ts
Found 0 warnings and 0 errors.

pnpm check:test-types
passed
```

The regression scenario persists a Telegram subscriber, blocks the first reminder send, recreates the plugin service, advances multiple poll intervals, and observes one first-request send. After the send settles, it proves the seen request is not duplicated and a distinct second request is delivered once.

Dependency contract review also confirmed the poll is bounded in production: pairing-list reads are synchronous SQLite; adapter lookup is an immediate registry read; OpenClaw applies finite Telegram fetch abort timers and finite retries; grammY 1.44.0 uses the supplied fetch and races requests against its own timeout. Fresh whole-branch autoreview with those contracts reported no findings (`patch is correct`, confidence 0.98).

Proof limit: no real Telegram credential was used. Delivery behavior is controlled at the production outbound-adapter boundary; network completion guarantees were verified from OpenClaw and grammY source.
