### PR TITLE
fix(voice-call): bound stale-call reaper concurrency

### DIFF
--- a/extensions/voice-call/src/webhook/stale-call-reaper.test.ts
+++ b/extensions/voice-call/src/webhook/stale-call-reaper.test.ts
@@ -30,12 +30,12 @@ describe("startStaleCallReaper", () => {
         {
           callId: "call-stale",
           startedAt: Date.now() - 61_000,
-          state: "active",
+          state: "active" as const,
         },
         {
           callId: "call-fresh",
           startedAt: Date.now() - 10_000,
-          state: "active",
+          state: "active" as const,
         },
       ]),
       endCall,
@@ -68,7 +68,7 @@ describe("startStaleCallReaper", () => {
         {
           callId: "call-stale",
           startedAt: Date.now() - 61_000,
-          state: "active",
+          state: "active" as const,
         },
       ]),
       endCall,
@@ -134,7 +134,7 @@ describe("startStaleCallReaper", () => {
         {
           callId: "call-stale",
           startedAt: Date.now() - 61_000,
-          state: "active",
+          state: "active" as const,
         },
       ]),
       endCall,

--- a/extensions/voice-call/src/webhook/stale-call-reaper.test.ts
+++ b/extensions/voice-call/src/webhook/stale-call-reaper.test.ts
@@ -19,14 +19,12 @@ describe("startStaleCallReaper", () => {
       endCall: vi.fn(),
     };
 
-    expect(startStaleCallReaper({ manager: manager as never })).toBeNull();
-    expect(
-      startStaleCallReaper({ manager: manager as never, staleCallReaperSeconds: 0 }),
-    ).toBeNull();
+    expect(startStaleCallReaper({ manager })).toBeNull();
+    expect(startStaleCallReaper({ manager, staleCallReaperSeconds: 0 })).toBeNull();
   });
 
   it("reaps stale calls and ignores fresh ones", async () => {
-    const endCall = vi.fn(async () => {});
+    const endCall = vi.fn(async () => ({ success: true }));
     const manager = {
       getActiveCalls: vi.fn(() => [
         {
@@ -44,7 +42,7 @@ describe("startStaleCallReaper", () => {
     };
 
     const stop = startStaleCallReaper({
-      manager: manager as never,
+      manager,
       staleCallReaperSeconds: 60,
     });
 
@@ -56,17 +54,15 @@ describe("startStaleCallReaper", () => {
     stop?.();
   });
 
-  it("does not overlap stale-call reaps and retries after the pending attempt fails", async () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const endCallError = new Error("network");
-    let rejectFirstEndCall!: (error: Error) => void;
-    const firstEndCall = new Promise<void>((_resolve, reject) => {
-      rejectFirstEndCall = reject;
+  it("does not overlap stale-call reaps and retries after an unsuccessful attempt settles", async () => {
+    let resolveFirstEndCall!: (result: { success: false; error: string }) => void;
+    const firstEndCall = new Promise<{ success: false; error: string }>((resolve) => {
+      resolveFirstEndCall = resolve;
     });
     const endCall = vi
       .fn()
       .mockImplementationOnce(() => firstEndCall)
-      .mockResolvedValue(undefined);
+      .mockResolvedValue({ success: true });
     const manager = {
       getActiveCalls: vi.fn(() => [
         {
@@ -79,7 +75,7 @@ describe("startStaleCallReaper", () => {
     };
 
     const stop = startStaleCallReaper({
-      manager: manager as never,
+      manager,
       staleCallReaperSeconds: 60,
     });
 
@@ -88,15 +84,11 @@ describe("startStaleCallReaper", () => {
 
     expect(endCall).toHaveBeenCalledTimes(1);
 
-    rejectFirstEndCall(endCallError);
-    await firstEndCall.catch(() => {});
+    resolveFirstEndCall({ success: false, error: "network" });
+    await firstEndCall;
     await Promise.resolve();
     await vi.advanceTimersByTimeAsync(30_000);
 
-    expect(warn).toHaveBeenCalledWith(
-      "[voice-call] Reaper failed to end call call-stale:",
-      endCallError,
-    );
     expect(endCall).toHaveBeenCalledTimes(2);
     expect(endCall).toHaveBeenNthCalledWith(2, "call-stale");
 
@@ -106,7 +98,7 @@ describe("startStaleCallReaper", () => {
   it.each(["speaking", "listening"] as const)(
     "does not reap live %s calls without answeredAt",
     async (state) => {
-      const endCall = vi.fn(async () => {});
+      const endCall = vi.fn(async () => ({ success: true }));
       const manager = {
         getActiveCalls: vi.fn(() => [
           {
@@ -119,7 +111,7 @@ describe("startStaleCallReaper", () => {
       };
 
       const stop = startStaleCallReaper({
-        manager: manager as never,
+        manager,
         staleCallReaperSeconds: 60,
       });
 
@@ -134,6 +126,9 @@ describe("startStaleCallReaper", () => {
   it("logs and swallows endCall failures", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const endCallError = new Error("network");
+    const endCall = vi.fn(async () => {
+      throw endCallError;
+    });
     const manager = {
       getActiveCalls: vi.fn(() => [
         {
@@ -142,13 +137,11 @@ describe("startStaleCallReaper", () => {
           state: "active",
         },
       ]),
-      endCall: vi.fn(async () => {
-        throw endCallError;
-      }),
+      endCall,
     };
 
     const stop = startStaleCallReaper({
-      manager: manager as never,
+      manager,
       staleCallReaperSeconds: 60,
     });
 
@@ -159,6 +152,12 @@ describe("startStaleCallReaper", () => {
       "[voice-call] Reaper failed to end call call-stale:",
       endCallError,
     );
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await Promise.resolve();
+
+    expect(endCall).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledTimes(2);
 
     stop?.();
   });

--- a/extensions/voice-call/src/webhook/stale-call-reaper.test.ts
+++ b/extensions/voice-call/src/webhook/stale-call-reaper.test.ts
@@ -56,6 +56,53 @@ describe("startStaleCallReaper", () => {
     stop?.();
   });
 
+  it("does not overlap stale-call reaps and retries after the pending attempt fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const endCallError = new Error("network");
+    let rejectFirstEndCall!: (error: Error) => void;
+    const firstEndCall = new Promise<void>((_resolve, reject) => {
+      rejectFirstEndCall = reject;
+    });
+    const endCall = vi
+      .fn()
+      .mockImplementationOnce(() => firstEndCall)
+      .mockResolvedValue(undefined);
+    const manager = {
+      getActiveCalls: vi.fn(() => [
+        {
+          callId: "call-stale",
+          startedAt: Date.now() - 61_000,
+          state: "active",
+        },
+      ]),
+      endCall,
+    };
+
+    const stop = startStaleCallReaper({
+      manager: manager as never,
+      staleCallReaperSeconds: 60,
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(endCall).toHaveBeenCalledTimes(1);
+
+    rejectFirstEndCall(endCallError);
+    await firstEndCall.catch(() => {});
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(warn).toHaveBeenCalledWith(
+      "[voice-call] Reaper failed to end call call-stale:",
+      endCallError,
+    );
+    expect(endCall).toHaveBeenCalledTimes(2);
+    expect(endCall).toHaveBeenNthCalledWith(2, "call-stale");
+
+    stop?.();
+  });
+
   it.each(["speaking", "listening"] as const)(
     "does not reap live %s calls without answeredAt",
     async (state) => {

--- a/extensions/voice-call/src/webhook/stale-call-reaper.transport.test.ts
+++ b/extensions/voice-call/src/webhook/stale-call-reaper.transport.test.ts
@@ -1,0 +1,165 @@
+// Voice Call tests cover stale-call reaping through a real provider HTTP boundary.
+import type { ServerResponse } from "node:http";
+import { withFetchPreconnect, withServer } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { endCall } from "../manager/outbound.js";
+import { TelnyxProvider } from "../providers/telnyx.js";
+import type { CallRecord } from "../types.js";
+import { startStaleCallReaper } from "./stale-call-reaper.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((settle, fail) => {
+    resolve = settle;
+    reject = fail;
+  });
+  return { promise, reject, resolve };
+}
+
+async function waitForProofEvent<T>(promise: Promise<T>, label: string): Promise<T> {
+  // AbortSignal.timeout stays real while this suite fakes the global timer functions.
+  const timeoutSignal = AbortSignal.timeout(1_000);
+  return await new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new Error(`timed out waiting for ${label}`));
+    timeoutSignal.addEventListener("abort", onAbort, { once: true });
+    void promise.then(
+      (value) => {
+        timeoutSignal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        timeoutSignal.removeEventListener("abort", onAbort);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
+}
+
+describe("stale-call reaper provider transport", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps one Telnyx hangup in flight, then retries after the provider timeout", async () => {
+    vi.useFakeTimers({
+      // Voice provider requests use buildTimeoutAbortSignal's setTimeout timer.
+      toFake: ["Date", "setInterval", "clearInterval", "setTimeout", "clearTimeout"],
+    });
+    vi.setSystemTime(new Date("2026-07-15T12:00:00.000Z"));
+
+    const firstRequestStarted = deferred<void>();
+    const firstResponseClosed = deferred<void>();
+    const secondRequestStarted = deferred<void>();
+    const firstEndCallSettled = deferred<{ success: boolean; error?: string }>();
+    const secondEndCallSettled = deferred<{ success: boolean; error?: string }>();
+    let requestCount = 0;
+    let firstResponse: ServerResponse | undefined;
+
+    await withServer(
+      (_req, res) => {
+        requestCount += 1;
+        if (requestCount === 1) {
+          firstResponse = res;
+          res.once("close", () => firstResponseClosed.resolve());
+          firstRequestStarted.resolve();
+          return;
+        }
+        res.writeHead(503, { "content-type": "text/plain" });
+        res.end("controlled provider failure");
+        secondRequestStarted.resolve();
+      },
+      async (baseUrl) => {
+        const realFetch = globalThis.fetch.bind(globalThis);
+        const transport = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const providerUrl = new URL(input instanceof Request ? input.url : String(input));
+          const loopbackUrl = new URL(`${providerUrl.pathname}${providerUrl.search}`, baseUrl);
+          return await realFetch(loopbackUrl, init);
+        });
+        vi.stubGlobal("fetch", withFetchPreconnect(transport));
+
+        const provider = new TelnyxProvider({
+          apiKey: "KEY123",
+          connectionId: "connection-test",
+        });
+        const call = {
+          callId: "call-stale",
+          providerCallId: "provider-stale",
+          provider: "telnyx",
+          direction: "outbound",
+          from: "+10000000001",
+          to: "+10000000002",
+          startedAt: Date.now() - 61_000,
+          state: "active" as const,
+          transcript: [],
+          processedEventIds: [],
+        } satisfies CallRecord;
+        const context: Parameters<typeof endCall>[0] = {
+          activeCalls: new Map([[call.callId, call]]),
+          providerCallIdMap: new Map([[call.providerCallId, call.callId]]),
+          provider,
+          storePath: "/tmp/openclaw-voice-call-proof.json",
+          transcriptWaiters: new Map(),
+          maxDurationTimers: new Map(),
+        };
+        let settlementCount = 0;
+        const manager = {
+          getActiveCalls: () => [...context.activeCalls.values()],
+          endCall: vi.fn(async (callId: string) => {
+            const settlement = settlementCount++ === 0 ? firstEndCallSettled : secondEndCallSettled;
+            try {
+              const result = await endCall(context, callId);
+              settlement.resolve(result);
+              return result;
+            } catch (error) {
+              settlement.reject(error);
+              throw error;
+            }
+          }),
+        };
+
+        const stop = startStaleCallReaper({
+          manager,
+          staleCallReaperSeconds: 60,
+        });
+
+        await vi.advanceTimersByTimeAsync(30_000);
+        await waitForProofEvent(firstRequestStarted.promise, "the first provider request");
+        expect(requestCount).toBe(1);
+
+        // The next sweep coincides with the provider's 30s request timeout. It must
+        // not start another hangup before the first attempt has settled.
+        await vi.advanceTimersByTimeAsync(30_000);
+        expect(requestCount).toBe(1);
+        expect(manager.endCall).toHaveBeenCalledTimes(1);
+        expect(firstResponse).toBeDefined();
+
+        const firstResult = await waitForProofEvent(
+          firstEndCallSettled.promise,
+          "the first endCall settlement",
+        );
+        await waitForProofEvent(firstResponseClosed.promise, "the timed-out socket close");
+        expect(firstResult).toEqual({ success: false, error: "request timed out" });
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(30_000);
+        await waitForProofEvent(secondRequestStarted.promise, "the retried provider request");
+        const secondResult = await waitForProofEvent(
+          secondEndCallSettled.promise,
+          "the retried endCall settlement",
+        );
+
+        expect(requestCount).toBe(2);
+        expect(manager.endCall).toHaveBeenCalledTimes(2);
+        expect(secondResult).toEqual({
+          success: false,
+          error: "Telnyx API error: 503 controlled provider failure",
+        });
+        expect(transport).toHaveBeenCalledTimes(2);
+
+        stop?.();
+      },
+    );
+  });
+});

--- a/extensions/voice-call/src/webhook/stale-call-reaper.ts
+++ b/extensions/voice-call/src/webhook/stale-call-reaper.ts
@@ -24,6 +24,7 @@ export function startStaleCallReaper(params: {
   }
 
   const maxAgeMs = maxAgeSeconds * 1000;
+  const callsBeingReaped = new Set<string>();
   const interval = setInterval(() => {
     const now = Date.now();
     for (const call of params.manager.getActiveCalls()) {
@@ -42,13 +43,20 @@ export function startStaleCallReaper(params: {
 
       // Unanswered provider calls can be stranded when callbacks are missed; end them explicitly.
       const age = now - call.startedAt;
-      if (age > maxAgeMs) {
+      if (age > maxAgeMs && !callsBeingReaped.has(call.callId)) {
+        // Keep one hangup attempt per call in flight; settlement releases the call for later retries.
+        callsBeingReaped.add(call.callId);
         console.log(
           `[voice-call] Reaping stale call ${call.callId} (age: ${Math.round(age / 1000)}s, state: ${call.state})`,
         );
-        void params.manager.endCall(call.callId).catch((err: unknown) => {
-          console.warn(`[voice-call] Reaper failed to end call ${call.callId}:`, err);
-        });
+        void params.manager
+          .endCall(call.callId)
+          .catch((err: unknown) => {
+            console.warn(`[voice-call] Reaper failed to end call ${call.callId}:`, err);
+          })
+          .finally(() => {
+            callsBeingReaped.delete(call.callId);
+          });
       }
     }
   }, CHECK_INTERVAL_MS);

--- a/extensions/voice-call/src/webhook/stale-call-reaper.ts
+++ b/extensions/voice-call/src/webhook/stale-call-reaper.ts
@@ -1,6 +1,5 @@
 // Voice Call plugin module implements stale call reaper behavior.
-import type { CallManager } from "../manager.js";
-import type { CallState } from "../types.js";
+import type { CallId, CallRecord, CallState } from "../types.js";
 import { TerminalStates } from "../types.js";
 
 // Background cleanup loop for calls that never reached answered/terminal state.
@@ -13,9 +12,14 @@ const CHECK_INTERVAL_MS = 30_000;
  * prove the call is live and should not be reaped. */
 const LiveConversationStates: ReadonlySet<CallState> = new Set(["speaking", "listening"]);
 
+type StaleCallReaperManager = {
+  getActiveCalls(): Array<Pick<CallRecord, "answeredAt" | "callId" | "startedAt" | "state">>;
+  endCall(callId: CallId): Promise<{ success: boolean; error?: string }>;
+};
+
 /** Start a stale-call reaper and return its cleanup callback. */
 export function startStaleCallReaper(params: {
-  manager: CallManager;
+  manager: StaleCallReaperManager;
   staleCallReaperSeconds?: number;
 }): (() => void) | null {
   const maxAgeSeconds = params.staleCallReaperSeconds;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stale unanswered calls could trigger repeated provider hangup attempts every 30 seconds when an earlier hangup was still pending.

## Why This Change Was Made

The stale-call reaper now keeps one hangup attempt per call ID in flight and releases that guard only after the attempt settles. Existing stale-call predicates, interval cadence, failure logging, and later retries remain unchanged.

## User Impact

Slow provider hangups no longer cause duplicate termination requests, rate-limit pressure, or repeated cleanup logs. Timed-out and failed attempts can still retry on a later reaper tick.

## Evidence

- Exact head: `491ec87096f068b05d30c108189fb0900ccb8970`.
- Rebased onto current `main` `855659a1dd0542f6fc76dcc8343335e983f9189c` after its UI CI repairs landed.
- The old three-commit series at `2f43dbe91f98b9be6beb617a8e6ee0808e4a101b` and the rebased series are patch-identical: `git range-diff` marked all three commits `=`.
- `main` made no changes to the three stale-call reaper paths between the old merge base and the new base; `git diff --check upstream/main...HEAD` passed after the rebase.
- Patch-identical focused proof on the pre-rebase head: `node scripts/run-vitest.mjs extensions/voice-call/src/webhook/stale-call-reaper.test.ts extensions/voice-call/src/webhook/stale-call-reaper.transport.test.ts --reporter=dot`: 2 files, 7/7 tests passed.
- Targeted `oxlint` and `oxfmt --check` passed on the patch-identical series.
- Fresh whole-branch autoreview: clean, patch correct (0.92).
- Follow-up CI type fix autoreview: clean, patch correct (0.98); all four `active` state fixtures retain their literal type without runtime changes.
- The production provider clients bound Telnyx/Plivo shared JSON requests and Twilio API requests to 30 seconds.
- [Exact-head CI run 29414929531](https://github.com/openclaw/openclaw/actions/runs/29414929531) completed successfully at `491ec87096f068b05d30c108189fb0900ccb8970`; `check-dependencies`, runtime topology architecture, test types, and `openclaw/ci-gate` all passed. The prior untouched UI failures are no longer present.

## Proof

### Patch-identical provider transport proof

The transport test crosses the production stale reaper, `CallManager.endCall()`, `TelnyxProvider.hangupCall()`, shared guarded JSON transport, the actual global fetch shim, and a real loopback HTTP server. Only provider credentials and the destination URL are test values.

Observed sequence:

1. The first stale sweep opened exactly one Telnyx `POST /calls/provider-call-1/actions/hangup` request and left the server response pending.
2. A second 30-second reaper tick did not overlap that in-flight hangup.
3. At the provider transport's 30-second deadline, the request aborted and the server observed the socket close.
4. The guard was released after settlement, so the next reaper tick issued exactly one retry.
5. A real HTTP 503 response settled that retry through the structured `endCall` failure path without an unhandled rejection.

The focused unit coverage also proves that a deferred structured failure suppresses overlapping calls and permits a later retry, and that a thrown provider failure is logged and swallowed before retry.

Not tested: live Twilio/Telnyx/Plivo credentials, a real phone call, or provider rate limits. Crabbox/Testbox was unavailable for the original controlled transport run, so this is patch-identical production-path transport proof plus successful exact-head CI rather than live-provider proof.
