### PR TITLE
fix(discord): bound event listener slots after timeout

### DIFF
--- a/extensions/discord/src/internal/client.test.ts
+++ b/extensions/discord/src/internal/client.test.ts
@@ -509,7 +509,7 @@ describe("Client gateway event queue", () => {
     });
   });
 
-  it("times out hung queued listeners", async () => {
+  it("resolves timed-out dispatches while retaining the hung listener slot", async () => {
     vi.useFakeTimers();
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const listener = {
@@ -530,12 +530,62 @@ describe("Client gateway event queue", () => {
     );
     expect(client.getRuntimeMetrics().eventQueue).toEqual({
       queueSize: 0,
-      processing: 0,
+      processing: 1,
       processed: 1,
       dropped: 0,
       timeouts: 1,
       maxQueueSize: 10_000,
       maxConcurrency: 1,
+    });
+  });
+
+  it("holds a timed-out listener slot until its underlying promise settles", async () => {
+    vi.useFakeTimers();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const firstSettlement = createDeferred();
+    const started: string[] = [];
+    const first = {
+      type: "READY",
+      handle: vi.fn(async () => {
+        started.push("first");
+        await firstSettlement.promise;
+      }),
+    } satisfies AnyListener;
+    const second = {
+      type: "READY",
+      handle: vi.fn(async () => {
+        started.push("second");
+      }),
+    } satisfies AnyListener;
+    const client = createQueuedClient({
+      listeners: [first, second],
+      eventQueue: { listenerTimeout: 10, maxConcurrency: 1 },
+    });
+
+    const dispatch = client.dispatchGatewayEvent("READY", {});
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(started).toEqual(["first"]);
+    expect(client.getRuntimeMetrics().eventQueue).toMatchObject({
+      queueSize: 1,
+      processing: 1,
+      processed: 1,
+      timeouts: 1,
+    });
+
+    firstSettlement.reject(new Error("late listener failure"));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(started).toEqual(["first", "second"]);
+    expect(first.handle).toHaveBeenCalledTimes(1);
+    expect(second.handle).toHaveBeenCalledTimes(1);
+    await expect(dispatch).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(client.getRuntimeMetrics().eventQueue).toMatchObject({
+      queueSize: 0,
+      processing: 0,
+      processed: 2,
+      timeouts: 1,
     });
   });
 

--- a/extensions/discord/src/internal/client.test.ts
+++ b/extensions/discord/src/internal/client.test.ts
@@ -539,7 +539,7 @@ describe("Client gateway event queue", () => {
     });
   });
 
-  it("holds a timed-out listener slot until its underlying promise settles", async () => {
+  it("holds a timed-out listener slot until its underlying promise resolves", async () => {
     vi.useFakeTimers();
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const firstSettlement = createDeferred();
@@ -573,7 +573,7 @@ describe("Client gateway event queue", () => {
       timeouts: 1,
     });
 
-    firstSettlement.reject(new Error("late listener failure"));
+    firstSettlement.resolve();
     await vi.advanceTimersByTimeAsync(0);
 
     expect(started).toEqual(["first", "second"]);
@@ -585,6 +585,43 @@ describe("Client gateway event queue", () => {
       queueSize: 0,
       processing: 0,
       processed: 2,
+      timeouts: 1,
+    });
+  });
+
+  it("logs a listener failure that arrives after its dispatch timeout", async () => {
+    vi.useFakeTimers();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const settlement = createDeferred();
+    const lateError = new Error("late listener failure");
+    const listener = {
+      type: "READY",
+      handle: vi.fn(async () => await settlement.promise),
+    } satisfies AnyListener;
+    const client = createQueuedClient({
+      listeners: [listener],
+      eventQueue: { listenerTimeout: 10, maxConcurrency: 1 },
+    });
+
+    const dispatch = client.dispatchGatewayEvent("READY", {});
+    await vi.advanceTimersByTimeAsync(10);
+    await expect(dispatch).resolves.toBeUndefined();
+
+    settlement.reject(lateError);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(errorSpy).toHaveBeenNthCalledWith(
+      1,
+      "[EventQueue] Listener Object timed out after 10ms for event READY",
+    );
+    expect(errorSpy).toHaveBeenNthCalledWith(
+      2,
+      "[EventQueue] Listener Object failed after timeout for event READY:",
+      lateError,
+    );
+    expect(client.getRuntimeMetrics().eventQueue).toMatchObject({
+      processing: 0,
+      processed: 1,
       timeouts: 1,
     });
   });

--- a/extensions/discord/src/internal/event-queue.ts
+++ b/extensions/discord/src/internal/event-queue.ts
@@ -14,6 +14,8 @@ type DiscordEventQueueJob = {
   reject: (error: unknown) => void;
 };
 
+type DiscordEventQueueDispatchOutcome = "completed" | "failed" | "timed-out";
+
 type DiscordEventQueueMetrics = {
   queueSize: number;
   processing: number;
@@ -110,37 +112,55 @@ export class DiscordEventQueue {
       }
       this.processing += 1;
       const listenerPromise = Promise.resolve().then(() => job.run());
-      const dispatchPromise = this.runJob(job, listenerPromise)
-        .then(job.resolve, job.reject)
-        .finally(() => {
-          this.processedCount += 1;
-        });
+      const runJobPromise = this.runJob(job, listenerPromise);
+      void runJobPromise.then(job.resolve, job.reject).finally(() => {
+        // Processed counts externally settled dispatches; a timed-out listener
+        // can still retain its concurrency slot until its own settlement.
+        this.processedCount += 1;
+      });
       // A timeout settles enqueue but cannot cancel the listener. Hold its slot
       // until actual settlement or late listeners can exceed maxConcurrency.
-      void Promise.allSettled([dispatchPromise, listenerPromise]).then(() => {
-        this.processing -= 1;
-        this.processNext();
-      });
+      void Promise.allSettled([runJobPromise, listenerPromise]).then(
+        ([dispatchResult, listenerResult]) => {
+          if (
+            dispatchResult.status === "fulfilled" &&
+            dispatchResult.value === "timed-out" &&
+            listenerResult.status === "rejected"
+          ) {
+            console.error(
+              `[EventQueue] Listener ${job.listenerName} failed after timeout for event ${job.eventType}:`,
+              listenerResult.reason,
+            );
+          }
+          this.processing -= 1;
+          this.processNext();
+        },
+      );
     }
   }
 
-  private async runJob(job: DiscordEventQueueJob, listenerPromise: Promise<void>): Promise<void> {
+  private async runJob(
+    job: DiscordEventQueueJob,
+    listenerPromise: Promise<void>,
+  ): Promise<DiscordEventQueueDispatchOutcome> {
     const startedAt = Date.now();
     try {
       await this.runWithTimeout(listenerPromise);
       this.logSlowListener(job, Date.now() - startedAt);
+      return "completed";
     } catch (error) {
       if (isListenerTimeoutError(error)) {
         this.timeoutCount += 1;
         console.error(
           `[EventQueue] Listener ${job.listenerName} timed out after ${this.options.listenerTimeout}ms for event ${job.eventType}`,
         );
-        return;
+        return "timed-out";
       }
       console.error(
         `[EventQueue] Listener ${job.listenerName} failed for event ${job.eventType}:`,
         error,
       );
+      return "failed";
     }
   }
 

--- a/extensions/discord/src/internal/event-queue.ts
+++ b/extensions/discord/src/internal/event-queue.ts
@@ -109,20 +109,25 @@ export class DiscordEventQueue {
         return;
       }
       this.processing += 1;
-      void this.runJob(job)
+      const listenerPromise = Promise.resolve().then(() => job.run());
+      const dispatchPromise = this.runJob(job, listenerPromise)
         .then(job.resolve, job.reject)
         .finally(() => {
-          this.processing -= 1;
           this.processedCount += 1;
-          this.processNext();
         });
+      // A timeout settles enqueue but cannot cancel the listener. Hold its slot
+      // until actual settlement or late listeners can exceed maxConcurrency.
+      void Promise.allSettled([dispatchPromise, listenerPromise]).then(() => {
+        this.processing -= 1;
+        this.processNext();
+      });
     }
   }
 
-  private async runJob(job: DiscordEventQueueJob): Promise<void> {
+  private async runJob(job: DiscordEventQueueJob, listenerPromise: Promise<void>): Promise<void> {
     const startedAt = Date.now();
     try {
-      await this.runWithTimeout(job);
+      await this.runWithTimeout(listenerPromise);
       this.logSlowListener(job, Date.now() - startedAt);
     } catch (error) {
       if (isListenerTimeoutError(error)) {
@@ -139,11 +144,11 @@ export class DiscordEventQueue {
     }
   }
 
-  private async runWithTimeout(job: DiscordEventQueueJob): Promise<void> {
+  private async runWithTimeout(listenerPromise: Promise<void>): Promise<void> {
     let timeout: NodeJS.Timeout | undefined;
     try {
       await Promise.race([
-        job.run(),
+        listenerPromise,
         new Promise<never>((_, reject) => {
           timeout = setTimeout(() => {
             reject(createListenerTimeoutError(this.options.listenerTimeout));


### PR DESCRIPTION
## What Problem This Solves

Fixes Discord gateway listener accounting that released a concurrency slot when the configured dispatch timeout fired even though the uncancellable listener promise was still running. Repeated timeouts could therefore exceed `maxConcurrency` in real active work.

## Why This Change Was Made

The event queue now settles the caller-facing dispatch at `listenerTimeout`, but retains the slot until the underlying listener promise resolves or rejects. A rejection that arrives after timeout is logged explicitly instead of being silently consumed by `Promise.allSettled`.

`processed` continues to count externally settled dispatches; `processing` counts listener work that still owns a slot. The source comment and tests make that distinction explicit.

## User Impact

Timed-out Discord listeners no longer allow later listeners to exceed configured concurrency. Queued work resumes after a slow listener settles, and late failures remain observable.

## Evidence

Exact head: `ed4747bd7071f9d3063ed165dd05360e4e4e8545`.

The original behavior patch was replayed byte-for-byte onto known-green main `7651ef5fca04f8263dd7f2d558d7c1425d60391e` (patch-id `d2f420b973901c71063bfd2d424e498a91166909`). A second commit fixes the fresh-review finding for silent late rejection.

```text
node scripts/run-vitest.mjs extensions/discord/src/internal/client.test.ts --run
-> 1 file passed, 21 tests passed

node_modules/.bin/oxfmt --check extensions/discord/src/internal/event-queue.ts extensions/discord/src/internal/client.test.ts
-> passed

node scripts/run-oxlint.mjs extensions/discord/src/internal/event-queue.ts extensions/discord/src/internal/client.test.ts
-> passed

git diff --check
-> clean

fresh whole-branch autoreview (Claude Sonnet 4.6, high)
-> no accepted/actionable findings; patch correct (0.91)
```

Controlled real-timer runtime proof used production `Client.dispatchGatewayEvent("READY", ...)`, production `DiscordEventQueue`, a 40ms listener timeout, and controlled listener promises. No fake timers were used:

```text
case=retained-after-timeout started=first metrics={"queueSize":1,"processing":1,"processed":1,"dropped":0,"timeouts":1,"maxQueueSize":10000,"maxConcurrency":1}
case=timeout-log count=1 text=[EventQueue] Listener Object timed out after 40ms for event READY
case=recovered-after-settlement started=first,second metrics={"queueSize":0,"processing":0,"processed":2,"dropped":0,"timeouts":1,"maxQueueSize":10000,"maxConcurrency":1}
case=late-rejection errors=3 latest=[EventQueue] Listener Object failed after timeout for event READY: controlled late failure metrics={"queueSize":0,"processing":0,"processed":1,"dropped":0,"timeouts":1,"maxQueueSize":10000,"maxConcurrency":1}
```

This proves timeout, retained capacity, late settlement, queued-listener recovery, and late-rejection logging through the production client/queue path. It is controlled runtime evidence, not a live Discord gateway session; no Discord credentials or Crabbox/Testbox provider were available.

## Remaining Owner Decision

An underlying listener promise cannot be forcibly cancelled. With this policy, `maxConcurrency` permanently hung listeners can saturate the queue until they settle or the process restarts. The patch intentionally chooses a true active-work bound over releasing capacity while old work still runs; a Discord owner must still accept that availability tradeoff or require an abortable listener design.
