### PR TITLE
fix(auto-reply): keep export tree truncation UTF-16 safe

### DIFF
--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -726,7 +726,19 @@
     if (s.length <= maxLen) {
       return s;
     }
-    return s.slice(0, maxLen) + "...";
+    let endOffset = maxLen;
+    const beforeBoundary = s.charCodeAt(endOffset - 1);
+    const afterBoundary = s.charCodeAt(endOffset);
+    // Keep the existing UTF-16 unit ceiling, but retreat if it splits a surrogate pair.
+    if (
+      beforeBoundary >= 0xd800 &&
+      beforeBoundary <= 0xdbff &&
+      afterBoundary >= 0xdc00 &&
+      afterBoundary <= 0xdfff
+    ) {
+      endOffset -= 1;
+    }
+    return s.slice(0, endOffset) + "...";
   }
 
   /**

--- a/src/auto-reply/reply/export-html/template.security.test.ts
+++ b/src/auto-reply/reply/export-html/template.security.test.ts
@@ -586,6 +586,38 @@ describe("export html security hardening", () => {
     expect(elementId.startsWith("entry-")).toBe(true);
   });
 
+  it("truncates tree node text without splitting surrogate pairs", async () => {
+    const emoji = "😀";
+    const prefix = "x".repeat(99);
+    const session: SessionData = {
+      header: { id: "session-surrogate-truncation", timestamp: now() },
+      entries: [
+        {
+          id: "surrogate-user",
+          parentId: null,
+          timestamp: now(),
+          type: "message",
+          message: { role: "user", content: `${prefix}${emoji}tail` },
+        },
+      ],
+      leafId: "surrogate-user",
+      systemPrompt: "",
+      tools: [],
+    };
+
+    const { document } = await renderTemplate(session);
+    const treeText =
+      Array.from(document.querySelectorAll(".tree-content")).find((node) =>
+        node.textContent?.includes("user:"),
+      )?.textContent ?? "";
+
+    expect(treeText).toContain(`user: ${prefix}...`);
+    expect(treeText).not.toContain(emoji);
+    expect(treeText).not.toMatch(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
+    );
+  });
+
   it("copy-link round-trip: dataset.entryId matches raw entry.id after browser decoding", async () => {
     // IDs with characters that need HTML escaping but should round-trip correctly
     const specialId = `msg-with"quotes&amp's`;


### PR DESCRIPTION
## What Problem This Solves

Exported session HTML truncates tree labels at 100 UTF-16 units. A raw slice at that boundary could separate an emoji or another supplementary-plane character into an unpaired surrogate, leaving malformed text in the exported tree.

## Why This Change Was Made

The maintained version keeps the existing 100-unit ceiling and short-string fast path. When the cutoff falls between a high and low surrogate, it retreats by one unit before slicing. This is constant-time, preserves existing preview sizing, and avoids changing the limit into 100 Unicode code points.

The regression renders the real export template at the exact split boundary and verifies the visible prefix, truncation suffix, omitted split emoji, and absence of either kind of unpaired surrogate.

## User Impact

Exported session tree previews no longer contain malformed UTF-16 when truncation lands inside an emoji. All other preview limits and rendering behavior remain unchanged.

## Evidence

- Exact reviewed head: `3debf64179cff20ee2e6c5d51139a0dcd11246c4`.
- `node scripts/run-vitest.mjs src/auto-reply/reply/export-html/template.security.test.ts`: pass (`16 passed`).
- Blacksmith path-scoped changed gate for the identical two-file diff before the final main rebase: pass (run 29500744421, exit code 0).
- `git diff --check`: pass.
- Pre-commit, committed branch, and post-rebase Autoreview: clean (`0.99`, `0.99`, and `0.98` confidence).

## Maintainer Cleanup

- Squashed four contributor commits and merge commits into one contributor-authored current-main commit.
- Replaced the full code-point scan with an O(1) boundary check aligned with the shared UTF-16 helper contract.
- Removed the redundant 500,000-character test whose end-to-end path still normalized the full string before truncation.
