### PR TITLE
fix(infra): bound JSON string measurement memory

### DIFF
--- a/src/infra/json-utf8-bytes.test.ts
+++ b/src/infra/json-utf8-bytes.test.ts
@@ -123,6 +123,17 @@ describe("boundedJsonUtf8Bytes", () => {
     expect(result).toEqual({ bytes: expectedBytes, complete: true });
   });
 
+  it("skips expensive scans for CJK strings well within the byte budget", () => {
+    // "中"×2_000 = 2,000 code units → 6,000 UTF-8 bytes.
+    // Tier 1: 2,002 ≯ 10,000 → pass.
+    // Tier 2: 2,000 × 3 + 2 = 6,002 ≤ 10,000 → skip scan, JSON.stringify only.
+    // This is the common fitting-string path; no O(n) scan overhead.
+    const cjkFit = { value: "中".repeat(2_000) };
+    const expectedBytes = Buffer.byteLength(JSON.stringify(cjkFit), "utf8");
+    const result = boundedJsonUtf8Bytes(cjkFit, 10_000);
+    expect(result).toEqual({ bytes: expectedBytes, complete: true });
+  });
+
   it.each([
     { name: "circular objects", value: createCircularValue() },
     { name: "BigInt", value: { value: 12n } },

--- a/src/infra/json-utf8-bytes.test.ts
+++ b/src/infra/json-utf8-bytes.test.ts
@@ -94,6 +94,25 @@ describe("boundedJsonUtf8Bytes", () => {
     });
   });
 
+  it("uses actual UTF-8 byte length for fast-path bailout on CJK strings", () => {
+    // "中".repeat(3_000) = 3,000 UTF-16 code units but 9,000 UTF-8 bytes.
+    // The old estimate (value.length + 2 = 3,002) would incorrectly pass the
+    // guard and fall through to the expensive JSON.stringify path.
+    // The fixed estimate (Buffer.byteLength + 2 = 9,002) correctly bails early.
+    const cjkPayload = { value: "中".repeat(3_000) };
+    const result = boundedJsonUtf8Bytes(cjkPayload, 8_192);
+    expect(result.complete).toBe(false);
+    expect(result.bytes).toBeGreaterThan(8_192);
+  });
+
+  it("completes accurately for unicode strings under the byte limit", () => {
+    // A short emoji string: "😀" is 2 UTF-16 code units but 4 UTF-8 bytes.
+    const emojiPayload = { value: "😀".repeat(10) };
+    const expectedBytes = Buffer.byteLength(JSON.stringify(emojiPayload), "utf8");
+    const result = boundedJsonUtf8Bytes(emojiPayload, 1_000);
+    expect(result).toEqual({ bytes: expectedBytes, complete: true });
+  });
+
   it.each([
     { name: "circular objects", value: createCircularValue() },
     { name: "BigInt", value: { value: 12n } },

--- a/src/infra/json-utf8-bytes.test.ts
+++ b/src/infra/json-utf8-bytes.test.ts
@@ -96,11 +96,21 @@ describe("boundedJsonUtf8Bytes", () => {
 
   it("uses actual UTF-8 byte length for fast-path bailout on CJK strings", () => {
     // "中".repeat(3_000) = 3,000 UTF-16 code units but 9,000 UTF-8 bytes.
-    // The old estimate (value.length + 2 = 3,002) would incorrectly pass the
-    // guard and fall through to the expensive JSON.stringify path.
-    // The fixed estimate (Buffer.byteLength + 2 = 9,002) correctly bails early.
+    // The O(1) lower bound (value.length + 2 = 3,002) does not exceed the
+    // remaining byte budget (~8,183), so it falls through to the UTF-8
+    // byte-length guard which correctly bails at 9,002 bytes.
     const cjkPayload = { value: "中".repeat(3_000) };
     const result = boundedJsonUtf8Bytes(cjkPayload, 8_192);
+    expect(result.complete).toBe(false);
+    expect(result.bytes).toBeGreaterThan(8_192);
+  });
+
+  it("preserves O(1) bailout for oversized ASCII strings", () => {
+    // "x".repeat(50_000) = 50,000 UTF-16 code units = 50,000 UTF-8 bytes.
+    // The O(1) lower bound (value.length + 2 = 50,002) immediately exceeds
+    // the budget, avoiding the O(n) Buffer.byteLength scan.
+    const asciiPayload = { value: "x".repeat(50_000) };
+    const result = boundedJsonUtf8Bytes(asciiPayload, 8_192);
     expect(result.complete).toBe(false);
     expect(result.bytes).toBeGreaterThan(8_192);
   });

--- a/src/infra/json-utf8-bytes.test.ts
+++ b/src/infra/json-utf8-bytes.test.ts
@@ -1,5 +1,5 @@
 // Tests JSON UTF-8 byte counting helpers.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   boundedJsonUtf8Bytes,
   firstEnumerableOwnKeys,
@@ -94,44 +94,17 @@ describe("boundedJsonUtf8Bytes", () => {
     });
   });
 
-  it("uses actual UTF-8 byte length for fast-path bailout on CJK strings", () => {
-    // "中".repeat(3_000) = 3,000 UTF-16 code units but 9,000 UTF-8 bytes.
-    // The O(1) lower bound (value.length + 2 = 3,002) does not exceed the
-    // remaining byte budget (~8,183), so it falls through to the UTF-8
-    // byte-length guard which correctly bails at 9,002 bytes.
-    const cjkPayload = { value: "中".repeat(3_000) };
-    const result = boundedJsonUtf8Bytes(cjkPayload, 8_192);
-    expect(result.complete).toBe(false);
-    expect(result.bytes).toBeGreaterThan(8_192);
-  });
-
-  it("preserves O(1) bailout for oversized ASCII strings", () => {
-    // "x".repeat(50_000) = 50,000 UTF-16 code units = 50,000 UTF-8 bytes.
-    // The O(1) lower bound (value.length + 2 = 50,002) immediately exceeds
-    // the budget, avoiding the O(n) Buffer.byteLength scan.
-    const asciiPayload = { value: "x".repeat(50_000) };
-    const result = boundedJsonUtf8Bytes(asciiPayload, 8_192);
-    expect(result.complete).toBe(false);
-    expect(result.bytes).toBeGreaterThan(8_192);
-  });
-
-  it("completes accurately for unicode strings under the byte limit", () => {
-    // A short emoji string: "😀" is 2 UTF-16 code units but 4 UTF-8 bytes.
-    const emojiPayload = { value: "😀".repeat(10) };
-    const expectedBytes = Buffer.byteLength(JSON.stringify(emojiPayload), "utf8");
-    const result = boundedJsonUtf8Bytes(emojiPayload, 1_000);
-    expect(result).toEqual({ bytes: expectedBytes, complete: true });
-  });
-
-  it("skips expensive scans for CJK strings well within the byte budget", () => {
-    // "中"×2_000 = 2,000 code units → 6,000 UTF-8 bytes.
-    // Tier 1: 2,002 ≯ 10,000 → pass.
-    // Tier 2: 2,000 × 3 + 2 = 6,002 ≤ 10,000 → skip scan, JSON.stringify only.
-    // This is the common fitting-string path; no O(n) scan overhead.
-    const cjkFit = { value: "中".repeat(2_000) };
-    const expectedBytes = Buffer.byteLength(JSON.stringify(cjkFit), "utf8");
-    const result = boundedJsonUtf8Bytes(cjkFit, 10_000);
-    expect(result).toEqual({ bytes: expectedBytes, complete: true });
+  it("rejects over-limit CJK strings before JSON serialization", () => {
+    const stringifySpy = vi.spyOn(JSON, "stringify");
+    try {
+      expect(boundedJsonUtf8Bytes("中".repeat(3_000), 8_192)).toEqual({
+        bytes: 8_193,
+        complete: false,
+      });
+      expect(stringifySpy).not.toHaveBeenCalled();
+    } finally {
+      stringifySpy.mockRestore();
+    }
   });
 
   it.each([

--- a/src/infra/json-utf8-bytes.ts
+++ b/src/infra/json-utf8-bytes.ts
@@ -28,7 +28,7 @@ export function jsonUtf8BytesOrInfinity(value: unknown): number {
 }
 
 function jsonStringByteLengthUpToLimit(value: string, remainingBytes: number): number {
-  if (value.length + 2 > remainingBytes) {
+  if (Buffer.byteLength(value, "utf8") + 2 > remainingBytes) {
     return remainingBytes + 1;
   }
   return jsonUtf8BytesOrInfinity(value);

--- a/src/infra/json-utf8-bytes.ts
+++ b/src/infra/json-utf8-bytes.ts
@@ -28,6 +28,15 @@ export function jsonUtf8BytesOrInfinity(value: unknown): number {
 }
 
 function jsonStringByteLengthUpToLimit(value: string, remainingBytes: number): number {
+  // O(1) lower-bound guard: value.length (UTF-16 code units) is never larger
+  // than the actual UTF-8 byte count.  If even this minimum already exceeds
+  // the budget, bail immediately without the O(n) UTF-8 scan.
+  if (value.length + 2 > remainingBytes) {
+    return remainingBytes + 1;
+  }
+  // CJK and emoji content can still exceed the budget when the code-unit lower
+  // bound is inconclusive; a UTF-8 byte-length pass catches those without the
+  // full JSON.stringify allocation.
   if (Buffer.byteLength(value, "utf8") + 2 > remainingBytes) {
     return remainingBytes + 1;
   }

--- a/src/infra/json-utf8-bytes.ts
+++ b/src/infra/json-utf8-bytes.ts
@@ -28,15 +28,21 @@ export function jsonUtf8BytesOrInfinity(value: unknown): number {
 }
 
 function jsonStringByteLengthUpToLimit(value: string, remainingBytes: number): number {
-  // O(1) lower-bound guard: value.length (UTF-16 code units) is never larger
-  // than the actual UTF-8 byte count.  If even this minimum already exceeds
-  // the budget, bail immediately without the O(n) UTF-8 scan.
+  // Tier 1 — O(1) lower bound.  Even the shortest possible encoding (ASCII,
+  // 1 byte per code unit) would exceed the budget, so bail immediately.
   if (value.length + 2 > remainingBytes) {
     return remainingBytes + 1;
   }
-  // CJK and emoji content can still exceed the budget when the code-unit lower
-  // bound is inconclusive; a UTF-8 byte-length pass catches those without the
-  // full JSON.stringify allocation.
+  // Tier 2 — O(1) upper bound.  Even the longest possible encoding (CJK,
+  // 3 bytes per code unit) + JSON quotes fits within the budget.  Skip both
+  // the O(n) UTF-8 scan and the JSON.stringify allocation; go straight to
+  // the accurate measurement.  This is the common case for fitting strings.
+  if (value.length * 3 + 2 <= remainingBytes) {
+    return jsonUtf8BytesOrInfinity(value);
+  }
+  // Tier 3 — O(n).  Only reached by strings in the narrow band where the
+  // code-unit bounds are inconclusive (CJK / emoji near the byte limit).
+  // A single UTF-8 scan decides bailout vs. JSON.stringify.
   if (Buffer.byteLength(value, "utf8") + 2 > remainingBytes) {
     return remainingBytes + 1;
   }

--- a/src/infra/json-utf8-bytes.ts
+++ b/src/infra/json-utf8-bytes.ts
@@ -28,22 +28,11 @@ export function jsonUtf8BytesOrInfinity(value: unknown): number {
 }
 
 function jsonStringByteLengthUpToLimit(value: string, remainingBytes: number): number {
-  // Tier 1 — O(1) lower bound.  Even the shortest possible encoding (ASCII,
-  // 1 byte per code unit) would exceed the budget, so bail immediately.
-  if (value.length + 2 > remainingBytes) {
-    return remainingBytes + 1;
-  }
-  // Tier 2 — O(1) upper bound.  Even the longest possible encoding (CJK,
-  // 3 bytes per code unit) + JSON quotes fits within the budget.  Skip both
-  // the O(n) UTF-8 scan and the JSON.stringify allocation; go straight to
-  // the accurate measurement.  This is the common case for fitting strings.
-  if (value.length * 3 + 2 <= remainingBytes) {
-    return jsonUtf8BytesOrInfinity(value);
-  }
-  // Tier 3 — O(n).  Only reached by strings in the narrow band where the
-  // code-unit bounds are inconclusive (CJK / emoji near the byte limit).
-  // A single UTF-8 scan decides bailout vs. JSON.stringify.
-  if (Buffer.byteLength(value, "utf8") + 2 > remainingBytes) {
+  // Pre-scan raw UTF-8 only when the code-unit bounds are inconclusive.
+  if (
+    value.length + 2 > remainingBytes ||
+    (value.length * 3 + 2 > remainingBytes && Buffer.byteLength(value, "utf8") + 2 > remainingBytes)
+  ) {
     return remainingBytes + 1;
   }
   return jsonUtf8BytesOrInfinity(value);


### PR DESCRIPTION
## What Problem This Solves

Bounded JSON measurement used UTF-16 code units as its only early rejection
check. Large CJK strings could therefore exceed the byte budget while still
falling through to `JSON.stringify`, creating an avoidable full serialized
copy near the 25 MiB worker payload cap.

## Why This Change Was Made

The shared string helper now keeps the constant-time code-unit lower and upper
bounds, then pre-scans raw UTF-8 only when those bounds are inconclusive.

- Strings already known to be too large return `remainingBytes + 1`.
- Strings that may fit still use the existing exact JSON measurement, including
  escape and control-character expansion.
- The result for an incomplete traversal is a lower bound, not an exact JSON
  length, matching the existing `BoundedJsonUtf8Bytes` contract.

This keeps the policy in the common helper used by MCP pagination, session
result guards/tools, gateway inference, and tool-result middleware.

## User Impact

Oversized Unicode payloads are rejected with materially lower time and peak
memory. Fitting and escape-heavy strings retain exact JSON byte semantics.

## Evidence

At a 25 MiB cap, five fresh-process samples with ten iterations each:

| Root string | Measurement | Before | After |
| --- | --- | ---: | ---: |
| 9,000,000 CJK chars | median time | 5.4100 ms/op | 0.5999 ms/op |
| 9,000,000 CJK chars | median max RSS | 155,992,064 B | 119,799,808 B |
| 5,000,000 NUL chars | median time | 23.1891 ms/op | 23.9931 ms/op |
| 5,000,000 NUL chars | median max RSS | 199,393,280 B | 199,753,728 B |

The CJK result changes from the exact `27,000,002` bytes to the valid
over-limit lower-bound sentinel `26,214,401`. The escaped control result remains
exactly `30,000,002` bytes. Its +3.5% time and +0.18% RSS movement are within
fresh-process noise and are not a material regression.

- Regression test spies on `JSON.stringify` and proves an over-limit CJK root
  string rejects without serialization.
- Focused helper and sibling caller proof: 6 files, 130 tests passed.
- `git diff --check` and targeted oxfmt passed.
- Changed TypeScript, oxlint, schema, database-first, media, sidecar,
  import-cycle, webhook, and pairing guards passed. Remote transport failures
  were completed with the documented trusted-source local fallback.
- Branch autoreview and secret scan: clean.
- Final diff: production +5/-1; tests +14/-1.

Punchcard-Session: coral-cedar-brook-8x

AI-assisted.
