### PR TITLE
fix(memory-core): dreaming narrative subagent receives full generic prompt instead of minimal

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -460,6 +460,7 @@ snapshots; OpenClaw owns all persistence and lifecycle coordination.
       sessionKey: "agent:main:subagent:search-helper",
       message: "Expand this query into focused follow-up searches.",
       toolsAlsoAllow: ["my_plugin_progress"],
+      promptMode: "minimal", // optional bounded subagent prompt
       provider: "openai", // optional override
       model: "gpt-5.6-sol", // optional override
       deliver: false,
@@ -490,6 +491,8 @@ snapshots; OpenClaw owns all persistence and lifecycle coordination.
     </Warning>
 
     `toolsAlsoAllow` adds exact, uniquely owned tools registered by the calling plugin to the worker's normal tool surface. The runtime rejects core tools and names shared with another plugin. Profiles and operator tool policies still apply, including explicit allowlists and denies.
+
+    `promptMode: "minimal"` selects the bounded subagent prompt instead of the full conversation prompt. The plugin runtime exposes only this mode; omission keeps the full prompt. Use `disableTools: true` as well when the run must have an exact empty tool surface.
 
     `completionDelivery: "current-requester"` is default-off and is only available while a `before_dispatch` hook is handling an authenticated inbound request. OpenClaw captures the canonical requester session and delivery route before invoking the plugin, then delivers the subagent completion through the normal announce path. Plugins cannot provide or override requester lineage or destination fields. Calls outside that requester-bound hook context are rejected.
 

--- a/extensions/memory-core/src/dreaming-consolidation-projects.test.ts
+++ b/extensions/memory-core/src/dreaming-consolidation-projects.test.ts
@@ -118,7 +118,9 @@ describe("memory consolidation project groups", () => {
     expect(promptedGroups).toEqual([[null], ["github.com/acme/alpha"], ["github.com/acme/beta"]]);
     expect(
       subagent.run.mock.calls.every(
-        ([options]) => (options as { disableTools?: boolean }).disableTools === true,
+        ([options]) =>
+          (options as { disableTools?: boolean; promptMode?: string }).disableTools === true &&
+          (options as { promptMode?: string }).promptMode === "minimal",
       ),
     ).toBe(true);
 

--- a/extensions/memory-core/src/dreaming-consolidation.ts
+++ b/extensions/memory-core/src/dreaming-consolidation.ts
@@ -608,6 +608,7 @@ async function runConsolidationGroup(params: {
       disableTools: true,
       ...(params.model ? { model: params.model } : {}),
       extraSystemPrompt: CONSOLIDATION_SYSTEM_PROMPT,
+      promptMode: "minimal",
       lane: `dreaming-consolidation:${params.sessionKey}`,
       lightContext: true,
       deliver: false,

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -833,6 +833,7 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(runOptions.lane).toBe(`dreaming-narrative:${expectedSessionKey}`);
     expect(runOptions.lightContext).toBe(true);
     expect(runOptions.deliver).toBe(false);
+    expect(runOptions.promptMode).toBe("minimal");
     expect(runOptions.model).toBe("anthropic/claude-sonnet-4-6");
     expect(subagent.waitForRun).toHaveBeenCalledOnce();
     expect(subagent.deleteSession).toHaveBeenCalledTimes(2);

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -491,6 +491,7 @@ describe("runDreamNarrative", () => {
     expect(runOptions.lightContext).toBe(true);
     expect(runOptions.deliver).toBe(false);
     expect(runOptions.disableTools).toBe(true);
+    expect(runOptions.promptMode).toBe("minimal");
     expect(runOptions.model).toBe("anthropic/claude-sonnet-4-6");
     expect(subagent.waitForRun).toHaveBeenCalledOnce();
     expect(subagent.deleteSession).toHaveBeenCalledTimes(2);

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -28,6 +28,7 @@ type SubagentSurface = {
     message: string;
     model?: string;
     extraSystemPrompt?: string;
+    promptMode?: "full" | "minimal" | "none";
     lane?: string;
     lightContext?: boolean;
     deliver?: boolean;
@@ -245,6 +246,7 @@ async function startNarrativeRunOrFallback(params: {
       message: params.message,
       ...(params.model ? { model: params.model } : {}),
       extraSystemPrompt: NARRATIVE_SYSTEM_PROMPT,
+      promptMode: "minimal",
       lane: `dreaming-narrative:${params.sessionKey}`,
       lightContext: true,
       deliver: false,

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/error-runtime";
 import { resolveGlobalMap } from "openclaw/plugin-sdk/global-singleton";
 import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
+import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import pLimit from "p-limit";
 import { readDreamsFile, resolveDreamsPath, updateDreamsFile } from "./dreaming-dreams-file.js";
@@ -22,18 +23,10 @@ import { readStore } from "./short-term-promotion-store.js";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
+type SubagentRunParams = Parameters<PluginRuntime["subagent"]["run"]>[0];
+
 export type SubagentSurface = {
-  run: (params: {
-    idempotencyKey: string;
-    sessionKey: string;
-    message: string;
-    disableTools?: boolean;
-    model?: string;
-    extraSystemPrompt?: string;
-    lane?: string;
-    lightContext?: boolean;
-    deliver?: boolean;
-  }) => Promise<{ runId: string }>;
+  run: (params: SubagentRunParams) => Promise<{ runId: string }>;
   waitForRun: (params: { runId: string; timeoutMs?: number }) => Promise<{
     status: string;
     error?: string;
@@ -261,6 +254,7 @@ async function startNarrativeRunOrFallback(params: {
       disableTools: true,
       ...(params.model ? { model: params.model } : {}),
       extraSystemPrompt: NARRATIVE_SYSTEM_PROMPT,
+      promptMode: "minimal",
       lane: `dreaming-narrative:${params.sessionKey}`,
       lightContext: true,
       deliver: false,

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -389,6 +389,18 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).not.toContain("## Skills");
   });
 
+  it("omits tool guidance from tool-free minimal prompts", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      promptMode: "minimal",
+      extraSystemPrompt: "Write only the requested prose.",
+    });
+
+    expect(prompt).not.toContain("## Tooling");
+    expect(prompt).not.toContain("## Tool Call Style");
+    expect(prompt).toContain("## Subagent Context\nWrite only the requested prose.");
+  });
+
   it("avoids the Claude subscription classifier wording in reply tag guidance", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1046,6 +1046,8 @@ export function buildAgentSystemPrompt(params: {
   ) as Partial<Record<ProviderSystemPromptSectionId, string>>;
   const promptMode = params.promptMode ?? "full";
   const isMinimal = promptMode === "minimal" || promptMode === "none";
+  const includeToolGuidance =
+    !isMinimal || availableTools.size > 0 || promptSurface === "cli_backend";
   const ownerDisplay = params.ownerDisplay === "hash" ? "hash" : "raw";
   const ownerLine = isMinimal
     ? undefined
@@ -1227,17 +1229,21 @@ export function buildAgentSystemPrompt(params: {
     const lines = [
       "You are a personal assistant running inside OpenClaw.",
       "",
-      "## Tooling",
-      "Tools policy-filtered. Names case-sensitive; call exact.",
-      toolLines.length > 0
-        ? toolLines.join("\n")
-        : buildOpenClawToolFallbackText({
-            surface: promptSurface,
-          }),
-      ...(toolSchemaDirectoryPrompt
-        ? ["", "### Deferred Tool Schemas", toolSchemaDirectoryPrompt]
+      ...(includeToolGuidance
+        ? [
+            "## Tooling",
+            "Tools policy-filtered. Names case-sensitive; call exact.",
+            toolLines.length > 0
+              ? toolLines.join("\n")
+              : buildOpenClawToolFallbackText({
+                  surface: promptSurface,
+                }),
+            ...(toolSchemaDirectoryPrompt
+              ? ["", "### Deferred Tool Schemas", toolSchemaDirectoryPrompt]
+              : []),
+            "The AGENTS.md Tools section guides usage; it never grants availability.",
+          ]
         : []),
-      "The AGENTS.md Tools section guides usage; it never grants availability.",
       ...(renderOpenClawToolWorkflowHints
         ? [
             ...(waitToolHints.length > 0
@@ -1305,19 +1311,21 @@ export function buildAgentSystemPrompt(params: {
         override: providerSectionOverrides.interaction_style,
         fallback: [],
       }),
-      ...buildOverridablePromptSection({
-        override: providerSectionOverrides.tool_call_style,
-        fallback: [
-          "## Tool Call Style",
-          "Routine low-risk: call silently.",
-          "Narrate only complex, sensitive/destructive, or requested steps.",
-          "First-class tool exists: use it; never ask user for equivalent CLI/slash.",
-          "/approve is user command; never execute via shell/tool.",
-          "allow-once = one command. Another elevated command needs fresh /approve.",
-          "Approval preview: exact full command/script, including chains/multiline. Keep preview separate from /approve; never use script as approval id/slug.",
-          "",
-        ],
-      }),
+      ...(includeToolGuidance
+        ? buildOverridablePromptSection({
+            override: providerSectionOverrides.tool_call_style,
+            fallback: [
+              "## Tool Call Style",
+              "Routine low-risk: call silently.",
+              "Narrate only complex, sensitive/destructive, or requested steps.",
+              "First-class tool exists: use it; never ask user for equivalent CLI/slash.",
+              "/approve is user command; never execute via shell/tool.",
+              "allow-once = one command. Another elevated command needs fresh /approve.",
+              "Approval preview: exact full command/script, including chains/multiline. Keep preview separate from /approve; never use script as approval id/slug.",
+              "",
+            ],
+          })
+        : []),
       ...buildOverridablePromptSection({
         override: providerSectionOverrides.execution_bias,
         fallback: buildExecutionBiasSection({

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -2181,7 +2181,7 @@ describe("loadGatewayPlugins", () => {
     expect(getLastDispatchedClientInternal().delegatedToolPolicyHandoffId).toBeUndefined();
   });
 
-  test("forwards lightContext as lightweight bootstrap context on subagent run", async () => {
+  test("forwards bounded context options on subagent run", async () => {
     const serverPlugins = serverPluginsModule;
     const runtime = await createSubagentRuntime(serverPlugins);
     serverPlugins.setFallbackGatewayContext(createTestContext("light-context-forward"));
@@ -2190,6 +2190,7 @@ describe("loadGatewayPlugins", () => {
       sessionKey: "s-light-context",
       message: "hello",
       lightContext: true,
+      promptMode: "minimal",
       lane: "dreaming-narrative:s-light-context",
       deliver: false,
     });
@@ -2199,6 +2200,7 @@ describe("loadGatewayPlugins", () => {
     expect(params.message).toBe("hello");
     expect(params.lane).toBe("dreaming-narrative:s-light-context");
     expect(params.bootstrapContextMode).toBe("lightweight");
+    expect(params.promptMode).toBe("minimal");
     expect(params.deliver).toBe(false);
   });
 

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -591,6 +591,7 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
           ...(allowOverride && params.provider && { provider: params.provider }),
           ...(allowOverride && params.model && { model: params.model }),
           ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
+          ...(params.promptMode && { promptMode: params.promptMode }),
           ...(params.lane && { lane: params.lane }),
           ...(params.cwd && { cwd: params.cwd }),
           ...(params.lightContext === true && { bootstrapContextMode: "lightweight" }),

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -316,6 +316,7 @@ export function createGatewaySubagentRuntime(
           ...(allowOverride && params.provider && { provider: params.provider }),
           ...(allowOverride && params.model && { model: params.model }),
           ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
+          ...(params.promptMode === "minimal" && { promptMode: params.promptMode }),
           ...(params.lane && { lane: params.lane }),
           ...(params.cwd && { cwd: params.cwd }),
           ...(params.lightContext === true && { bootstrapContextMode: "lightweight" }),

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -17,6 +17,7 @@ export type SubagentRunParams = {
   provider?: string;
   model?: string;
   extraSystemPrompt?: string;
+  promptMode?: "full" | "minimal" | "none";
   lane?: string;
   lightContext?: boolean;
   deliver?: boolean;

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -23,6 +23,8 @@ type SubagentRunParams = {
   provider?: string;
   model?: string;
   extraSystemPrompt?: string;
+  /** Use the bounded subagent prompt instead of the full conversation prompt. */
+  promptMode?: "minimal";
   lane?: string;
   lightContext?: boolean;
   deliver?: boolean;


### PR DESCRIPTION
Fixes #105513

Reported by @OskarSwierad. Original patch by @bladin.

## What Problem This Solves

Dream Diary narrative and memory-consolidation model calls received the full conversation prompt. The prompt added tool, execution, messaging, and Control UI instructions that do not apply to prose-only memory work.

## Why This Change Was Made

Memory-core owns stable session keys for cleanup and persistence. Those keys are not generic `subagent:` keys, so session-key inference selects the full prompt.

The repair makes prompt policy explicit at the owning boundary:

- The public plugin subagent runtime exposes only `promptMode: "minimal"`; it does not expose `full` or `none`.
- The Gateway preserves that value in the internal agent request.
- Dream Diary and memory consolidation both request the same minimal mode.
- Tool-free minimal prompts omit generic tool and tool-call instructions. Full prompts and minimal prompts with tools keep their existing behavior.
- Memory-core derives its run parameter type from the canonical PluginRuntime contract instead of maintaining a duplicate field list.

This avoids session-key naming rules, fallback classification, a Dream Diary-only prompt profile, and a broad plugin-controlled prompt selector.

## User Impact

Dreaming still uses the same memory fragments, narrative instructions, model, output handling, session ownership, and cleanup. The model request is smaller and no longer tells a tool-free narrative run how to call tools, execute work, message channels, or operate the Control UI.

## Evidence

### Live Gateway red/green

The same isolated Linux environment built and ran exact base `34a6b24a6245` and exact head `aee14db80e70`. A real Gateway loaded memory-core, and the production `runDreamNarrative` path called a local OpenAI-compatible recording provider. The provider boundary was controlled only to return deterministic prose and preserve the exact request bytes.

| Check | Base | Head |
| --- | --- | --- |
| Memory-core request mode | omitted | `minimal` |
| Session-key inferred mode | `full` | `full` |
| Rendered system prompt | 8,554 bytes | 4,812 bytes |
| `Tooling` | present | absent |
| `Tool Call Style` | present | absent |
| `Execution Bias` | present | absent |
| `Messaging` | present | absent |
| Control UI session guidance | present | absent |
| Narrative provider response | completed | completed |

The unchanged inferred mode proves the fix does not depend on renaming or reclassifying memory-core sessions. The exact Gateway request, provider request, rendered system-prompt bytes, session classification, revisions, and SHA-256 hashes are retained in the private task evidence.

### Validation

- Focused tests: 259 passed across `src/agents/system-prompt.test.ts`, `src/gateway/server-plugins.test.ts`, `extensions/memory-core/src/dreaming-narrative.test.ts`, and `extensions/memory-core/src/dreaming-consolidation-projects.test.ts`.
- `pnpm check:changed` passed, including core, core-test, plugin, and plugin-test type-check and lint lanes.
- `pnpm plugin-sdk:check-exports` passed.
- `pnpm plugin-sdk:surface:check` passed.
- `pnpm plugin-sdk:api:diff -- --base 34a6b24a6245 --head aee14db80e70` reported only the new `promptMode?: "minimal"` field.
- `pnpm docs:check-mdx` and `pnpm format:docs:check` passed.
- `pnpm build` passed for both exact base and exact head.
- `git diff --check` passed.

### Change size

- Production: +40/-34, net +6. The growth defines the minimal-only PluginRuntime boundary and omits irrelevant tool guidance from tool-free minimal prompts; memory-core's duplicate run-parameter fields were removed.
- Tests: +18/-2.
- Docs: +3/-0.
