### PR TITLE
fix(gateway): prune channel SecretRef surfaces before eager preflight while crash-loop breaker is tripped

### DIFF
--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -164,6 +164,7 @@ function runtimeSecretsActivatorForTest(params: {
   activateRuntimeSecretsSnapshot?: ActivateRuntimeSecretsSnapshotForTest;
   emitStateEvent?: GatewayStartupStateEmitterMock;
   logSecrets?: GatewayStartupLogMock;
+  channelAutostartSuppression?: { reason: string; message: string } | null;
 }) {
   const defaultActivatorOptions = runtimeSecretsActivatorOptionsForTest();
   return createRuntimeSecretsActivator({
@@ -171,6 +172,7 @@ function runtimeSecretsActivatorForTest(params: {
     emitStateEvent: params.emitStateEvent ?? defaultActivatorOptions.emitStateEvent,
     prepareRuntimeSecretsSnapshot: params.prepareRuntimeSecretsSnapshot,
     activateRuntimeSecretsSnapshot: params.activateRuntimeSecretsSnapshot ?? vi.fn(),
+    channelAutostartSuppression: params.channelAutostartSuppression,
   });
 }
 
@@ -1252,6 +1254,143 @@ describe("gateway startup config secret preflight", () => {
         },
       }),
     );
+  });
+
+  // Breaker suppression — when the persisted crash-loop breaker is tripped,
+  // channel surfaces must be pruned before eager SecretRef projection so an
+  // unavailable channel credential does not block control-plane startup.
+  it("prunes channel surfaces when crash-loop breaker suppression is active", async () => {
+    const prepareRuntimeSecretsSnapshot = vi.fn(async ({ config }) => preparedSnapshot(config));
+    const activateRuntimeSecrets = runtimeSecretsActivatorForTest({
+      prepareRuntimeSecretsSnapshot,
+      channelAutostartSuppression: {
+        reason: "crash-loop-breaker",
+        message: "breaker tripped: 20 unclean boots",
+      },
+    });
+    const config = gatewayTokenConfig(
+      asConfig({
+        channels: {
+          telegram: {
+            botToken: { source: "env", provider: "default", id: "TELEGRAM_BOT_TOKEN" },
+          },
+        },
+      }),
+    );
+
+    const result = await activateRuntimeSecrets(config, {
+      reason: "startup",
+      activate: false,
+    });
+    expect(typeof result.config.gateway).toBe("object");
+    const preflightInput = callArg<{
+      config?: OpenClawConfig;
+      loadAuthStore?: unknown;
+    }>(prepareRuntimeSecretsSnapshot);
+    expect(preflightInput.config?.channels).toBeUndefined();
+  });
+
+  it("keeps channel surfaces in secret preflight when breaker suppression is null", async () => {
+    const prepareRuntimeSecretsSnapshot = vi.fn(async ({ config }) => preparedSnapshot(config));
+    const activateRuntimeSecrets = runtimeSecretsActivatorForTest({
+      prepareRuntimeSecretsSnapshot,
+      channelAutostartSuppression: null,
+    });
+    const config = gatewayTokenConfig(
+      asConfig({
+        channels: {
+          telegram: {
+            botToken: { source: "env", provider: "default", id: "TELEGRAM_BOT_TOKEN" },
+          },
+        },
+      }),
+    );
+
+    await activateRuntimeSecrets(config, {
+      reason: "startup",
+      activate: false,
+    });
+    const preflightInput = callArg<{
+      config?: OpenClawConfig;
+      loadAuthStore?: unknown;
+    }>(prepareRuntimeSecretsSnapshot);
+    expect(preflightInput.config?.channels).toBeDefined();
+  });
+
+  it("still resolves gateway auth SecretRefs when breaker suppression prunes channels", async () => {
+    const prepareRuntimeSecretsSnapshot = vi.fn(async ({ config }) =>
+      preparedSnapshotWithGatewayToken(config),
+    );
+    const activateRuntimeSecrets = runtimeSecretsActivatorForTest({
+      prepareRuntimeSecretsSnapshot,
+      channelAutostartSuppression: {
+        reason: "crash-loop-breaker",
+        message: "breaker tripped: 20 unclean boots",
+      },
+    });
+    const config = gatewayTokenConfig(
+      asConfig({
+        channels: {
+          telegram: {
+            botToken: { source: "env", provider: "default", id: "TELEGRAM_BOT_TOKEN" },
+          },
+        },
+      }),
+    );
+
+    const result = await activateRuntimeSecrets(config, {
+      reason: "startup",
+      activate: true,
+    });
+    // Gateway auth must remain funtional: token is resolved from SecretRef
+    expect(result.config.gateway?.auth?.token).toBe(RESOLVED_GATEWAY_TOKEN);
+    const preflightInput = callArg<{
+      config?: OpenClawConfig;
+      loadAuthStore?: unknown;
+    }>(prepareRuntimeSecretsSnapshot);
+    // Channels are pruned by breaker suppression
+    expect(preflightInput.config?.channels).toBeUndefined();
+    // Gateway auth surface remains intact
+    expect(preflightInput.config?.gateway?.auth?.token).toBe("startup-test-token");
+  });
+
+  it("prunes channels in prepareGatewayStartupConfig when breaker suppression is active", async () => {
+    const prepareRuntimeSecretsSnapshot = vi.fn(async ({ config }) => preparedSnapshot(config));
+    const activateRuntimeSecretsSnapshot = vi.fn();
+    const result = await prepareGatewayStartupConfig({
+      configSnapshot: buildSnapshot(
+        gatewayTokenConfig(
+          asConfig({
+            channels: {
+              telegram: {
+                botToken: { source: "env", provider: "default", id: "TELEGRAM_BOT_TOKEN" },
+              },
+            },
+          }),
+        ),
+      ),
+      channelAutostartSuppression: {
+        reason: "crash-loop-breaker",
+        message: "breaker tripped: 20 unclean boots",
+      },
+      activateRuntimeSecrets: runtimeSecretsActivatorForTest({
+        prepareRuntimeSecretsSnapshot,
+        activateRuntimeSecretsSnapshot,
+        channelAutostartSuppression: {
+          reason: "crash-loop-breaker",
+          message: "breaker tripped: 20 unclean boots",
+        },
+      }),
+    });
+
+    expect(result.auth.mode).toBe("token");
+    expect(result.auth.token).toBe("startup-test-token");
+    const preflightInput = callArg<{
+      config?: OpenClawConfig;
+      loadAuthStore?: unknown;
+    }>(prepareRuntimeSecretsSnapshot);
+    expect(preflightInput.config?.channels).toBeUndefined();
+    expect(activateRuntimeSecretsSnapshot).toHaveBeenCalledTimes(1);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -850,9 +850,13 @@ describe("gateway startup config secret preflight", () => {
     expect(typeof result.config.gateway).toBe("object");
     const preflightInput = callArg<{
       config?: OpenClawConfig;
+      assignmentConfig?: OpenClawConfig;
       loadAuthStore?: unknown;
     }>(prepareRuntimeSecretsSnapshot);
-    expect(preflightInput.config?.channels).toBeUndefined();
+    // Full source config preserves channels for credential recovery.
+    expect(preflightInput.config?.channels).toBeDefined();
+    // Startup assignment projection prunes channels when channels are skipped.
+    expect(preflightInput.assignmentConfig?.channels).toBeUndefined();
     expect(preflightInput.loadAuthStore).toBe(loadAuthProfileStoreWithoutExternalProfiles);
   });
 
@@ -1285,9 +1289,14 @@ describe("gateway startup config secret preflight", () => {
     expect(typeof result.config.gateway).toBe("object");
     const preflightInput = callArg<{
       config?: OpenClawConfig;
+      assignmentConfig?: OpenClawConfig;
       loadAuthStore?: unknown;
     }>(prepareRuntimeSecretsSnapshot);
-    expect(preflightInput.config?.channels).toBeUndefined();
+    // Full source config is preserved for later credential recovery.
+    expect(preflightInput.config?.channels).toBeDefined();
+    // Startup assignment projection is pruned so an unavailable channel
+    // credential does not block control-plane startup.
+    expect(preflightInput.assignmentConfig?.channels).toBeUndefined();
   });
 
   it("keeps channel surfaces in secret preflight when breaker suppression is null", async () => {
@@ -1312,9 +1321,12 @@ describe("gateway startup config secret preflight", () => {
     });
     const preflightInput = callArg<{
       config?: OpenClawConfig;
+      assignmentConfig?: OpenClawConfig;
       loadAuthStore?: unknown;
     }>(prepareRuntimeSecretsSnapshot);
+    // Without suppression, both source and assignment projection preserve channels.
     expect(preflightInput.config?.channels).toBeDefined();
+    expect(preflightInput.assignmentConfig?.channels).toBeDefined();
   });
 
   it("still resolves gateway auth SecretRefs when breaker suppression prunes channels", async () => {
@@ -1346,11 +1358,14 @@ describe("gateway startup config secret preflight", () => {
     expect(result.config.gateway?.auth?.token).toBe(RESOLVED_GATEWAY_TOKEN);
     const preflightInput = callArg<{
       config?: OpenClawConfig;
+      assignmentConfig?: OpenClawConfig;
       loadAuthStore?: unknown;
     }>(prepareRuntimeSecretsSnapshot);
-    // Channels are pruned by breaker suppression
-    expect(preflightInput.config?.channels).toBeUndefined();
-    // Gateway auth surface remains intact
+    // Full source config preserves channel surfaces for credential recovery.
+    expect(preflightInput.config?.channels).toBeDefined();
+    // Startup assignment projection is pruned by breaker suppression.
+    expect(preflightInput.assignmentConfig?.channels).toBeUndefined();
+    // Gateway auth surface remains intact in both.
     expect(preflightInput.config?.gateway?.auth?.token).toBe("startup-test-token");
   });
 
@@ -1387,9 +1402,13 @@ describe("gateway startup config secret preflight", () => {
     expect(result.auth.token).toBe("startup-test-token");
     const preflightInput = callArg<{
       config?: OpenClawConfig;
+      assignmentConfig?: OpenClawConfig;
       loadAuthStore?: unknown;
     }>(prepareRuntimeSecretsSnapshot);
-    expect(preflightInput.config?.channels).toBeUndefined();
+    // Full source config is preserved for recovery (channels intact).
+    expect(preflightInput.config?.channels).toBeDefined();
+    // Startup assignment projection prunes channel surfaces under breaker suppression.
+    expect(preflightInput.assignmentConfig?.channels).toBeUndefined();
     expect(activateRuntimeSecretsSnapshot).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -18,7 +18,6 @@ import { applyConfigOverrides } from "../config/runtime-overrides.js";
 import type { GatewayAuthConfig, GatewayTailscaleConfig } from "../config/types.gateway.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import { measureDiagnosticsTimelineSpan } from "../infra/diagnostics-timeline.js";
-import { isTruthyEnvValue } from "../infra/env.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { prepareSecretsRuntimeFastPathSnapshot } from "../secrets/runtime-fast-path.js";
@@ -35,6 +34,10 @@ import {
 import { createLazyPromise } from "../shared/lazy-runtime.js";
 import { resolveGatewayAuth } from "./auth.js";
 import { assertGatewayAuthNotKnownWeak } from "./known-weak-gateway-secrets.js";
+import {
+  hasActiveGatewayAuthSecretRef,
+  pruneSkippedStartupSecretSurfaces,
+} from "./server-startup-secret-surfaces.js";
 import {
   ensureGatewayStartupAuth,
   mergeGatewayAuthConfig,
@@ -553,40 +556,6 @@ export async function prepareGatewayStartupConfig(params: {
   return {
     ...authBootstrap,
     cfg: activatedConfig,
-  };
-}
-
-function hasActiveGatewayAuthSecretRef(config: OpenClawConfig): boolean {
-  const states = evaluateGatewayAuthSurfaceStates({
-    config,
-    defaults: config.secrets?.defaults,
-    env: process.env,
-  });
-  return GATEWAY_AUTH_SURFACE_PATHS.some((path) => {
-    const state = states[path];
-    return state.hasSecretRef && state.active;
-  });
-}
-
-function pruneSkippedStartupSecretSurfaces(
-  config: OpenClawConfig,
-  channelAutostartSuppression?: { reason: string; message: string } | null,
-): OpenClawConfig {
-  // Channel surfaces are pruned before eager SecretRef resolution when:
-  // 1. operator explicitly skipped channels/providers via env vars, or
-  // 2. the persisted crash-loop breaker has already selected channel autostart
-  //    suppression — removing the surfaces prevents an unavailable channel
-  //    credential from terminating the entire Gateway startup (safe-mode contract).
-  const skipChannels =
-    isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
-    isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS) ||
-    channelAutostartSuppression != null;
-  if (!skipChannels || !config.channels) {
-    return config;
-  }
-  return {
-    ...config,
-    channels: undefined,
   };
 }
 

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -293,7 +293,11 @@ export function createRuntimeSecretsActivator(params: {
           !params.activateRuntimeSecretsSnapshot
         ) {
           const fastPath = prepareSecretsRuntimeFastPathSnapshot({
-            config: pruneSkippedStartupSecretSurfaces(config, channelAutostartSuppression),
+            config,
+            assignmentConfig: pruneSkippedStartupSecretSurfaces(
+              config,
+              channelAutostartSuppression,
+            ),
             ...(startupManifestRegistry ? { manifestRegistry: startupManifestRegistry } : {}),
           });
           if (fastPath) {
@@ -331,7 +335,11 @@ export function createRuntimeSecretsActivator(params: {
           "secrets.prepare",
           () =>
             prepareRuntimeSecretsSnapshot({
-              config: pruneSkippedStartupSecretSurfaces(config, channelAutostartSuppression),
+              config,
+              assignmentConfig: pruneSkippedStartupSecretSurfaces(
+                config,
+                channelAutostartSuppression,
+              ),
               ...(activationParams.env ? { env: activationParams.env } : {}),
               includeAuthStoreRefs: activationParams.includeAuthStoreRefs,
               ...(startupManifestRegistry ? { manifestRegistry: startupManifestRegistry } : {}),
@@ -487,10 +495,7 @@ export async function prepareGatewayStartupConfig(params: {
     Boolean(
       preflightPrepared &&
       params.activateRuntimeSecrets.activatePreparedSnapshot &&
-      isDeepStrictEqual(
-        pruneSkippedStartupSecretSurfaces(config, params.channelAutostartSuppression),
-        preflightPrepared.sourceConfig,
-      ),
+      isDeepStrictEqual(config, preflightPrepared.sourceConfig),
     );
   const activateStartupSecrets = async (config: OpenClawConfig) => {
     // Reuse the preflight snapshot only if generated startup auth did not

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -189,9 +189,14 @@ export function createRuntimeSecretsActivator(params: {
   activateRuntimeSecretsSnapshot?: ActivateRuntimeSecretsSnapshot;
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
   pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins" | "manifestRegistry">;
+  /** When the persisted crash-loop breaker is tripped, prune channel surfaces
+   * before eager SecretRef projection so an unavailable channel credential does
+   * not prevent the control plane from starting. */
+  channelAutostartSuppression?: { reason: string; message: string } | null;
 }): ActivateRuntimeSecrets {
   let secretsDegraded = false;
   let secretsActivationTail: Promise<void> = Promise.resolve();
+  const channelAutostartSuppression = params.channelAutostartSuppression;
   const loadSecretsRuntime = createLazyPromise(() => import("../secrets/runtime.js"), {
     cacheRejections: true,
   });
@@ -288,7 +293,7 @@ export function createRuntimeSecretsActivator(params: {
           !params.activateRuntimeSecretsSnapshot
         ) {
           const fastPath = prepareSecretsRuntimeFastPathSnapshot({
-            config: pruneSkippedStartupSecretSurfaces(config),
+            config: pruneSkippedStartupSecretSurfaces(config, channelAutostartSuppression),
             ...(startupManifestRegistry ? { manifestRegistry: startupManifestRegistry } : {}),
           });
           if (fastPath) {
@@ -326,7 +331,7 @@ export function createRuntimeSecretsActivator(params: {
           "secrets.prepare",
           () =>
             prepareRuntimeSecretsSnapshot({
-              config: pruneSkippedStartupSecretSurfaces(config),
+              config: pruneSkippedStartupSecretSurfaces(config, channelAutostartSuppression),
               ...(activationParams.env ? { env: activationParams.env } : {}),
               includeAuthStoreRefs: activationParams.includeAuthStoreRefs,
               ...(startupManifestRegistry ? { manifestRegistry: startupManifestRegistry } : {}),
@@ -441,6 +446,10 @@ export async function prepareGatewayStartupConfig(params: {
   persistStartupAuth?: boolean;
   log?: GatewayStartupLog;
   measure?: GatewayStartupConfigMeasure;
+  /** When the persisted crash-loop breaker is tripped, prune channel surfaces
+   * before eager SecretRef projection so an unavailable channel credential does
+   * not prevent the control plane from starting. */
+  channelAutostartSuppression?: { reason: string; message: string } | null;
 }): Promise<Awaited<ReturnType<typeof ensureGatewayStartupAuth>>> {
   const measure = params.measure ?? (async (_name, run) => await run());
   await measure("config.auth.snapshot-validate", () =>
@@ -478,7 +487,10 @@ export async function prepareGatewayStartupConfig(params: {
     Boolean(
       preflightPrepared &&
       params.activateRuntimeSecrets.activatePreparedSnapshot &&
-      isDeepStrictEqual(pruneSkippedStartupSecretSurfaces(config), preflightPrepared.sourceConfig),
+      isDeepStrictEqual(
+        pruneSkippedStartupSecretSurfaces(config, params.channelAutostartSuppression),
+        preflightPrepared.sourceConfig,
+      ),
     );
   const activateStartupSecrets = async (config: OpenClawConfig) => {
     // Reuse the preflight snapshot only if generated startup auth did not
@@ -551,10 +563,19 @@ function hasActiveGatewayAuthSecretRef(config: OpenClawConfig): boolean {
   });
 }
 
-function pruneSkippedStartupSecretSurfaces(config: OpenClawConfig): OpenClawConfig {
+function pruneSkippedStartupSecretSurfaces(
+  config: OpenClawConfig,
+  channelAutostartSuppression?: { reason: string; message: string } | null,
+): OpenClawConfig {
+  // Channel surfaces are pruned before eager SecretRef resolution when:
+  // 1. operator explicitly skipped channels/providers via env vars, or
+  // 2. the persisted crash-loop breaker has already selected channel autostart
+  //    suppression — removing the surfaces prevents an unavailable channel
+  //    credential from terminating the entire Gateway startup (safe-mode contract).
   const skipChannels =
     isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
-    isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS);
+    isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS) ||
+    channelAutostartSuppression != null;
   if (!skipChannels || !config.channels) {
     return config;
   }

--- a/src/gateway/server-startup-secret-surfaces.ts
+++ b/src/gateway/server-startup-secret-surfaces.ts
@@ -1,0 +1,45 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isTruthyEnvValue } from "../infra/env.js";
+import {
+  evaluateGatewayAuthSurfaceStates,
+  GATEWAY_AUTH_SURFACE_PATHS,
+} from "../secrets/runtime-gateway-auth-surfaces.js";
+
+export function hasActiveGatewayAuthSecretRef(config: OpenClawConfig): boolean {
+  const states = evaluateGatewayAuthSurfaceStates({
+    config,
+    defaults: config.secrets?.defaults,
+    env: process.env,
+  });
+  return GATEWAY_AUTH_SURFACE_PATHS.some((path) => {
+    const state = states[path];
+    return state.hasSecretRef && state.active;
+  });
+}
+
+/**
+ * Prunes channel surfaces from a config projection before eager SecretRef
+ * resolution when channel auto-start is suppressed so an unavailable channel
+ * credential does not block control-plane startup.
+ */
+export function pruneSkippedStartupSecretSurfaces(
+  config: OpenClawConfig,
+  channelAutostartSuppression?: { reason: string; message: string } | null,
+): OpenClawConfig {
+  // Channel surfaces are pruned before eager SecretRef resolution when:
+  // 1. operator explicitly skipped channels/providers via env vars, or
+  // 2. the persisted crash-loop breaker has already selected channel autostart
+  //    suppression — removing the surfaces prevents an unavailable channel
+  //    credential from terminating the entire Gateway startup (safe-mode contract).
+  const skipChannels =
+    isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
+    isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS) ||
+    channelAutostartSuppression != null;
+  if (!skipChannels || !config.channels) {
+    return config;
+  }
+  return {
+    ...config,
+    channels: undefined,
+  };
+}

--- a/src/gateway/server-startup-trace.ts
+++ b/src/gateway/server-startup-trace.ts
@@ -1,0 +1,217 @@
+import { monitorEventLoopDelay, performance } from "node:perf_hooks";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  emitDiagnosticsTimelineEvent,
+  isDiagnosticsTimelineEnabled,
+} from "../infra/diagnostics-timeline.js";
+import { isTruthyEnvValue } from "../infra/env.js";
+import { withDiagnosticPhase } from "../logging/diagnostic-phase.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { recordGatewayRestartTraceDetail, recordGatewayRestartTraceSpan } from "./restart-trace.js";
+
+/** Creates a per-startup timing trace helper for the Gateway server.
+ *  Emits spans to the diagnostics timeline and restart trace. */
+export function createGatewayStartupTrace() {
+  const log = createSubsystemLogger("gateway");
+  const logEnabled = isTruthyEnvValue(process.env.OPENCLAW_GATEWAY_STARTUP_TRACE);
+  let timelineConfig: OpenClawConfig | undefined;
+  let eventLoopDelay: ReturnType<typeof monitorEventLoopDelay> | undefined;
+  const timelineOptions = () => ({
+    ...(timelineConfig ? { config: timelineConfig } : {}),
+    env: process.env,
+  });
+  const eventLoopTimelineEnabled = () =>
+    isDiagnosticsTimelineEnabled(timelineOptions()) &&
+    isTruthyEnvValue(process.env.OPENCLAW_DIAGNOSTICS_EVENT_LOOP);
+  const ensureEventLoopDelay = () => {
+    if (eventLoopDelay || (!logEnabled && !eventLoopTimelineEnabled())) {
+      return;
+    }
+    eventLoopDelay = monitorEventLoopDelay({ resolution: 10 });
+    eventLoopDelay.enable();
+  };
+  ensureEventLoopDelay();
+  const started = performance.now();
+  let last = started;
+  let spanSequence = 0;
+  const formatMetric = (key: string, value: number | string) =>
+    `${key}=${typeof value === "number" ? value.toFixed(1) : value}`;
+  const mapTimelineName = (name: string) => {
+    switch (name) {
+      case "config.snapshot":
+        return "config.load";
+      case "config.auth":
+      case "config.final-snapshot":
+      case "runtime.config":
+        return "config.normalize";
+      case "plugins.bootstrap":
+        return "plugins.load";
+      case "runtime.post-attach":
+      case "ready":
+        return "gateway.ready";
+      default:
+        return name;
+    }
+  };
+  const takeEventLoopSample = () => {
+    if (!eventLoopDelay) {
+      return undefined;
+    }
+    const sample = {
+      p50Ms: eventLoopDelay.percentile(50) / 1_000_000,
+      p95Ms: eventLoopDelay.percentile(95) / 1_000_000,
+      p99Ms: eventLoopDelay.percentile(99) / 1_000_000,
+      maxMs: eventLoopDelay.max / 1_000_000,
+    };
+    eventLoopDelay.reset();
+    return sample;
+  };
+  const emitEventLoopTimelineSample = (
+    activeSpanName: string,
+    sample: ReturnType<typeof takeEventLoopSample>,
+  ) => {
+    if (!eventLoopTimelineEnabled()) {
+      return;
+    }
+    if (!sample) {
+      return;
+    }
+    emitDiagnosticsTimelineEvent(
+      {
+        type: "eventLoop.sample",
+        name: "eventLoop",
+        phase: "startup",
+        activeSpanName: mapTimelineName(activeSpanName),
+        attributes:
+          activeSpanName === mapTimelineName(activeSpanName)
+            ? undefined
+            : { traceName: activeSpanName },
+        ...sample,
+      },
+      timelineOptions(),
+    );
+  };
+  const emit = (
+    name: string,
+    durationMs: number,
+    totalMs: number,
+    eventLoopSample: ReturnType<typeof takeEventLoopSample>,
+    extras: ReadonlyArray<readonly [string, number | string]> = [],
+  ) => {
+    const metrics = [
+      ["eventLoopMax", `${(eventLoopSample?.maxMs ?? 0).toFixed(1)}ms`] as const,
+      ...extras,
+    ];
+    recordGatewayRestartTraceSpan(`restart.ready.${name}`, durationMs, totalMs, metrics);
+    if (logEnabled) {
+      log.info(
+        `startup trace: ${name} ${durationMs.toFixed(1)}ms total=${totalMs.toFixed(1)}ms ${metrics.map(([key, value]) => formatMetric(key, value)).join(" ")}`,
+      );
+    }
+  };
+  return {
+    setConfig(config: OpenClawConfig) {
+      timelineConfig = config;
+      ensureEventLoopDelay();
+    },
+    mark(name: string) {
+      const now = performance.now();
+      const eventLoopSample = takeEventLoopSample();
+      emit(name, now - last, now - started, eventLoopSample);
+      emitDiagnosticsTimelineEvent(
+        {
+          type: "mark",
+          name: mapTimelineName(name),
+          phase: "startup",
+          durationMs: now - started,
+          attributes: name === mapTimelineName(name) ? undefined : { traceName: name },
+        },
+        timelineOptions(),
+      );
+      emitEventLoopTimelineSample(name, eventLoopSample);
+      last = now;
+      if (name === "ready") {
+        eventLoopDelay?.disable();
+      }
+    },
+    detail(name: string, metrics: ReadonlyArray<readonly [string, number | string]>) {
+      const attributes = Object.fromEntries(metrics);
+      recordGatewayRestartTraceDetail(`restart.ready.${name}`, metrics);
+      if (logEnabled) {
+        log.info(
+          `startup trace: ${name} ${metrics.map(([key, value]) => formatMetric(key, value)).join(" ")}`,
+        );
+      }
+      emitDiagnosticsTimelineEvent(
+        {
+          type: "mark",
+          name: mapTimelineName(name),
+          phase: "startup",
+          attributes: {
+            traceName: name,
+            ...attributes,
+          },
+        },
+        timelineOptions(),
+      );
+    },
+    async measure<T>(
+      name: string,
+      run: () => Promise<T> | T,
+      options: { omitErrorMessage?: boolean } = {},
+    ): Promise<T> {
+      const before = performance.now();
+      const spanId = `gateway-startup-${++spanSequence}`;
+      emitDiagnosticsTimelineEvent(
+        {
+          type: "span.start",
+          name: mapTimelineName(name),
+          phase: "startup",
+          spanId,
+          attributes: name === mapTimelineName(name) ? undefined : { traceName: name },
+        },
+        timelineOptions(),
+      );
+      try {
+        const result = await withDiagnosticPhase(mapTimelineName(name), run, { traceName: name });
+        const now = performance.now();
+        emitDiagnosticsTimelineEvent(
+          {
+            type: "span.end",
+            name: mapTimelineName(name),
+            phase: "startup",
+            spanId,
+            durationMs: now - before,
+            attributes: name === mapTimelineName(name) ? undefined : { traceName: name },
+          },
+          timelineOptions(),
+        );
+        return result;
+      } catch (error) {
+        const now = performance.now();
+        emitDiagnosticsTimelineEvent(
+          {
+            type: "span.error",
+            name: mapTimelineName(name),
+            phase: "startup",
+            spanId,
+            durationMs: now - before,
+            attributes: name === mapTimelineName(name) ? undefined : { traceName: name },
+            errorName: error instanceof Error ? error.name : typeof error,
+            ...(options.omitErrorMessage
+              ? {}
+              : { errorMessage: error instanceof Error ? error.message : String(error) }),
+          },
+          timelineOptions(),
+        );
+        throw error;
+      } finally {
+        const now = performance.now();
+        const eventLoopSample = takeEventLoopSample();
+        emit(name, now - before, now - started, eventLoopSample);
+        emitEventLoopTimelineSample(name, eventLoopSample);
+        last = now;
+      }
+    },
+  };
+}

--- a/src/gateway/server-worker-placement.ts
+++ b/src/gateway/server-worker-placement.ts
@@ -1,0 +1,150 @@
+import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
+import { revokeAttachGrantsForSession } from "./mcp-grant-store.js";
+import type { GatewayWorkerEnvironmentStartupState } from "./server-worker-environment-startup.js";
+import type { GatewayWorkerPlacementRuntime } from "./server-worker-placement-startup.js";
+import type { WorkerPlacementDispatchService } from "./worker-environments/placement-dispatch.js";
+import type { WorkerEnvironmentService } from "./worker-environments/service.js";
+
+const loadWorkerPlacementStartupModule = createLazyRuntimeModule(
+  () => import("./server-worker-placement-startup.js"),
+);
+
+// -- approval targeting ----------------------------------------------------
+
+export function approvalRequestTargetsSession(
+  request: unknown,
+  sessionKeys: ReadonlySet<string>,
+  sessionId: string,
+): boolean {
+  if (typeof request !== "object" || request === null) {
+    return false;
+  }
+  const record = request as { sessionKey?: unknown; sessionId?: unknown };
+  return (
+    (typeof record.sessionId === "string" && record.sessionId === sessionId) ||
+    (typeof record.sessionKey === "string" && sessionKeys.has(record.sessionKey))
+  );
+}
+
+// -- mutable dispatch cell -------------------------------------------------
+
+type RevokeWorkerDispatchFn = (params: {
+  sessionId: string;
+  sessionKeys: readonly string[];
+}) => void;
+
+/** Mutable cell for lazy-ready worker dispatch authority revocation.
+ *  Starts with a throwing placeholder so placement dispatch cannot run
+ *  before approval managers exist. */
+export function createWorkerDispatchCell(): { current: RevokeWorkerDispatchFn } {
+  return {
+    current: (_params) => {
+      throw new Error("Worker dispatch authority revocation is not ready");
+    },
+  };
+}
+
+// -- placement-runtime bootstrap -------------------------------------------
+
+type BootstrapWorkerPlacementParams = {
+  workerEnvironmentService: WorkerEnvironmentService | undefined;
+  workerEnvironmentStartup: GatewayWorkerEnvironmentStartupState | undefined;
+  startupTrace: { measure: <T>(name: string, fn: () => T) => Promise<T> };
+  hasConfiguredWorkerProfiles: boolean;
+  log: { warn: (msg: string) => void };
+  revokeCell: { current: RevokeWorkerDispatchFn };
+};
+
+type BootstrapWorkerPlacementResult = {
+  workerPlacementRuntime: GatewayWorkerPlacementRuntime | undefined;
+  workerPlacementDispatchAvailable: WorkerPlacementDispatchService | undefined;
+};
+
+/** Bootstraps the worker placement runtime and resolves whether dispatch
+ *  is available. Without env service or startup info returns undefined/false. */
+export async function bootstrapWorkerPlacementRuntime(
+  params: BootstrapWorkerPlacementParams,
+): Promise<BootstrapWorkerPlacementResult> {
+  const { workerEnvironmentService, workerEnvironmentStartup } = params;
+  if (!workerEnvironmentService || !workerEnvironmentStartup) {
+    return { workerPlacementRuntime: undefined, workerPlacementDispatchAvailable: undefined };
+  }
+  const placementModule = await loadWorkerPlacementStartupModule();
+  const workerPlacementRuntime = placementModule.createGatewayWorkerPlacementRuntime({
+    placements: workerEnvironmentStartup.placementStore,
+    environments: workerEnvironmentService,
+    admitNewPlacements: params.hasConfiguredWorkerProfiles,
+    revokeSessionAuthority: (request) => params.revokeCell.current(request),
+    warn: (message) => params.log.warn(message),
+  });
+  return {
+    workerPlacementRuntime,
+    workerPlacementDispatchAvailable: params.hasConfiguredWorkerProfiles
+      ? workerPlacementRuntime.dispatchService
+      : undefined,
+  };
+}
+
+// -- authority revoke factory -----------------------------------------------
+
+type MinimalApprovalManager = {
+  listPendingRecords(): { id: string; request: unknown }[];
+  expire(id: string, reason: string): void;
+};
+
+/** Creates the revoke callback that expires pending exec and plugin approvals
+ *  targeting a session and revokes MCP attach grants for its keys. */
+export function createWorkerDispatchAuthorityRevoker(params: {
+  revokeAttachGrantsForSession: typeof revokeAttachGrantsForSession;
+  execApprovalManager: MinimalApprovalManager;
+  pluginApprovalManager: MinimalApprovalManager;
+}): RevokeWorkerDispatchFn {
+  const {
+    revokeAttachGrantsForSession: revokeGrants,
+    execApprovalManager,
+    pluginApprovalManager,
+  } = params;
+  return ({ sessionId, sessionKeys }) => {
+    const keys = new Set(sessionKeys);
+    for (const sessionKey of keys) {
+      revokeGrants(sessionKey);
+    }
+    for (const record of execApprovalManager.listPendingRecords()) {
+      if (approvalRequestTargetsSession(record.request, keys, sessionId)) {
+        execApprovalManager.expire(record.id, "worker-dispatch");
+      }
+    }
+    for (const record of pluginApprovalManager.listPendingRecords()) {
+      if (approvalRequestTargetsSession(record.request, keys, sessionId)) {
+        pluginApprovalManager.expire(record.id, "worker-dispatch");
+      }
+    }
+  };
+}
+
+// -- startup sidecar config -------------------------------------------------
+
+/** Returns a spread-ready object with `startWorkerEnvironmentRuntime` when
+ *  placement is available, or an empty object otherwise. */
+export function createWorkerPlacementStartupSidecarConfig(
+  workerPlacementRuntime: GatewayWorkerPlacementRuntime | undefined,
+  hooks: {
+    isClosePreludeStarted: () => boolean;
+    registerSidecar: (sidecar: { stop: () => Promise<void> }) => void;
+  },
+): Record<string, unknown> {
+  if (!workerPlacementRuntime) {
+    return {};
+  }
+  return {
+    startWorkerEnvironmentRuntime: async () => {
+      if (hooks.isClosePreludeStarted()) {
+        return null;
+      }
+      return await workerPlacementRuntime.startRuntime({
+        isClosePreludeStarted: hooks.isClosePreludeStarted,
+        registerSidecar: hooks.registerSidecar,
+      });
+    },
+  };
+}

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -653,6 +653,7 @@ export async function startGatewayServer(
   const activateRuntimeSecrets = createRuntimeSecretsActivator({
     logSecrets,
     emitStateEvent: emitSecretsStateEvent,
+    channelAutostartSuppression: opts.channelAutostartSuppression,
     ...(startupConfigLoad.pluginMetadataSnapshot
       ? { pluginMetadataSnapshot: startupConfigLoad.pluginMetadataSnapshot }
       : {}),
@@ -673,6 +674,7 @@ export async function startGatewayServer(
         tailscaleOverride: startupTailscaleOverride,
         activateRuntimeSecrets,
         log,
+        channelAutostartSuppression: opts.channelAutostartSuppression,
         measure: (name, run, measureOptions) => startupTrace.measure(name, run, measureOptions),
       }),
     { omitErrorMessage: true },

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1,5 +1,4 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { monitorEventLoopDelay, performance } from "node:perf_hooks";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { getActiveBackgroundExecSessionCount } from "../agents/bash-process-registry.js";
 import {
@@ -42,10 +41,6 @@ import {
   isDiagnosticsEnabled,
   setDiagnosticsEnabledForProcess,
 } from "../infra/diagnostic-events.js";
-import {
-  emitDiagnosticsTimelineEvent,
-  isDiagnosticsTimelineEnabled,
-} from "../infra/diagnostics-timeline.js";
 import { isTruthyEnvValue, isVitestRuntimeEnv, logAcceptedEnvOption } from "../infra/env.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js";
@@ -58,7 +53,6 @@ import {
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { upsertPresence } from "../infra/system-presence.js";
 import type { VoiceWakeRoutingConfig } from "../infra/voicewake-routing.js";
-import { withDiagnosticPhase } from "../logging/diagnostic-phase.js";
 import { startDiagnosticHeartbeat, stopDiagnosticHeartbeat } from "../logging/diagnostic.js";
 import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js";
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
@@ -112,8 +106,6 @@ import {
 import {
   collectGatewayProcessMemoryUsageMb,
   finishGatewayRestartTrace,
-  recordGatewayRestartTraceDetail,
-  recordGatewayRestartTraceSpan,
   resumeGatewayRestartTraceFromEnv,
   resumeGatewayRestartTraceFromHandoff,
 } from "./restart-trace.js";
@@ -136,7 +128,14 @@ import {
   type SharedGatewaySessionGenerationState,
 } from "./server-shared-auth-generation.js";
 import type { GatewaySidecarStartupMode } from "./server-sidecar-startup-mode.js";
+import { createGatewayStartupTrace } from "./server-startup-trace.js";
 import { createWizardSessionTracker } from "./server-wizard-sessions.js";
+import {
+  bootstrapWorkerPlacementRuntime,
+  createWorkerDispatchAuthorityRevoker,
+  createWorkerDispatchCell,
+  createWorkerPlacementStartupSidecarConfig,
+} from "./server-worker-placement.js";
 import { createGatewayEventLoopHealthMonitor } from "./server/event-loop-health.js";
 import {
   getHealthCache,
@@ -162,10 +161,6 @@ const loadGatewayModelCatalogModule = createLazyRuntimeModule(
 const loadWorkerEnvironmentStartupModule = createLazyRuntimeModule(
   () => import("./server-worker-environment-startup.js"),
 );
-const loadWorkerPlacementStartupModule = createLazyRuntimeModule(
-  () => import("./server-worker-placement-startup.js"),
-);
-
 export async function resetModelCatalogCacheForTest(): Promise<void> {
   const { resetModelCatalogCacheForTest: resetModelCatalogCacheForTestLocal } =
     await loadGatewayModelCatalogModule();
@@ -177,21 +172,6 @@ ensureOpenClawCliOnPath();
 const MAX_MEDIA_TTL_HOURS = 24 * 7;
 const POST_READY_MAINTENANCE_DELAY_MS = 250;
 const RETAINED_PLUGIN_CLEANUP_DELAY_MS = 30_000;
-
-function approvalRequestTargetsSession(
-  request: unknown,
-  sessionKeys: ReadonlySet<string>,
-  sessionId: string,
-): boolean {
-  if (typeof request !== "object" || request === null) {
-    return false;
-  }
-  const record = request as { sessionKey?: unknown; sessionId?: unknown };
-  return (
-    (typeof record.sessionId === "string" && record.sessionId === sessionId) ||
-    (typeof record.sessionKey === "string" && sessionKeys.has(record.sessionKey))
-  );
-}
 
 type GatewayStartupChannelPlugin = {
   id: ChannelId;
@@ -263,210 +243,6 @@ const logPlugins = log.child("plugins");
 const logWsControl = log.child("ws");
 const logSecrets = log.child("secrets");
 const gatewayRuntime = runtimeForLogger(log);
-
-function createGatewayStartupTrace() {
-  const logEnabled = isTruthyEnvValue(process.env.OPENCLAW_GATEWAY_STARTUP_TRACE);
-  let timelineConfig: OpenClawConfig | undefined;
-  let eventLoopDelay: ReturnType<typeof monitorEventLoopDelay> | undefined;
-  const timelineOptions = () => ({
-    ...(timelineConfig ? { config: timelineConfig } : {}),
-    env: process.env,
-  });
-  const eventLoopTimelineEnabled = () =>
-    isDiagnosticsTimelineEnabled(timelineOptions()) &&
-    isTruthyEnvValue(process.env.OPENCLAW_DIAGNOSTICS_EVENT_LOOP);
-  const ensureEventLoopDelay = () => {
-    if (eventLoopDelay || (!logEnabled && !eventLoopTimelineEnabled())) {
-      return;
-    }
-    eventLoopDelay = monitorEventLoopDelay({ resolution: 10 });
-    eventLoopDelay.enable();
-  };
-  ensureEventLoopDelay();
-  const started = performance.now();
-  let last = started;
-  let spanSequence = 0;
-  const formatMetric = (key: string, value: number | string) =>
-    `${key}=${typeof value === "number" ? value.toFixed(1) : value}`;
-  const mapTimelineName = (name: string) => {
-    switch (name) {
-      case "config.snapshot":
-        return "config.load";
-      case "config.auth":
-      case "config.final-snapshot":
-      case "runtime.config":
-        return "config.normalize";
-      case "plugins.bootstrap":
-        return "plugins.load";
-      case "runtime.post-attach":
-      case "ready":
-        return "gateway.ready";
-      default:
-        return name;
-    }
-  };
-  const takeEventLoopSample = () => {
-    if (!eventLoopDelay) {
-      return undefined;
-    }
-    const sample = {
-      p50Ms: eventLoopDelay.percentile(50) / 1_000_000,
-      p95Ms: eventLoopDelay.percentile(95) / 1_000_000,
-      p99Ms: eventLoopDelay.percentile(99) / 1_000_000,
-      maxMs: eventLoopDelay.max / 1_000_000,
-    };
-    eventLoopDelay.reset();
-    return sample;
-  };
-  const emitEventLoopTimelineSample = (
-    activeSpanName: string,
-    sample: ReturnType<typeof takeEventLoopSample>,
-  ) => {
-    if (!eventLoopTimelineEnabled()) {
-      return;
-    }
-    if (!sample) {
-      return;
-    }
-    emitDiagnosticsTimelineEvent(
-      {
-        type: "eventLoop.sample",
-        name: "eventLoop",
-        phase: "startup",
-        activeSpanName: mapTimelineName(activeSpanName),
-        attributes:
-          activeSpanName === mapTimelineName(activeSpanName)
-            ? undefined
-            : { traceName: activeSpanName },
-        ...sample,
-      },
-      timelineOptions(),
-    );
-  };
-  const emit = (
-    name: string,
-    durationMs: number,
-    totalMs: number,
-    eventLoopSample: ReturnType<typeof takeEventLoopSample>,
-    extras: ReadonlyArray<readonly [string, number | string]> = [],
-  ) => {
-    const metrics = [
-      ["eventLoopMax", `${(eventLoopSample?.maxMs ?? 0).toFixed(1)}ms`] as const,
-      ...extras,
-    ];
-    recordGatewayRestartTraceSpan(`restart.ready.${name}`, durationMs, totalMs, metrics);
-    if (logEnabled) {
-      log.info(
-        `startup trace: ${name} ${durationMs.toFixed(1)}ms total=${totalMs.toFixed(1)}ms ${metrics.map(([key, value]) => formatMetric(key, value)).join(" ")}`,
-      );
-    }
-  };
-  return {
-    setConfig(config: OpenClawConfig) {
-      timelineConfig = config;
-      ensureEventLoopDelay();
-    },
-    mark(name: string) {
-      const now = performance.now();
-      const eventLoopSample = takeEventLoopSample();
-      emit(name, now - last, now - started, eventLoopSample);
-      emitDiagnosticsTimelineEvent(
-        {
-          type: "mark",
-          name: mapTimelineName(name),
-          phase: "startup",
-          durationMs: now - started,
-          attributes: name === mapTimelineName(name) ? undefined : { traceName: name },
-        },
-        timelineOptions(),
-      );
-      emitEventLoopTimelineSample(name, eventLoopSample);
-      last = now;
-      if (name === "ready") {
-        eventLoopDelay?.disable();
-      }
-    },
-    detail(name: string, metrics: ReadonlyArray<readonly [string, number | string]>) {
-      const attributes = Object.fromEntries(metrics);
-      recordGatewayRestartTraceDetail(`restart.ready.${name}`, metrics);
-      if (logEnabled) {
-        log.info(
-          `startup trace: ${name} ${metrics.map(([key, value]) => formatMetric(key, value)).join(" ")}`,
-        );
-      }
-      emitDiagnosticsTimelineEvent(
-        {
-          type: "mark",
-          name: mapTimelineName(name),
-          phase: "startup",
-          attributes: {
-            traceName: name,
-            ...attributes,
-          },
-        },
-        timelineOptions(),
-      );
-    },
-    async measure<T>(
-      name: string,
-      run: () => Promise<T> | T,
-      options: { omitErrorMessage?: boolean } = {},
-    ): Promise<T> {
-      const before = performance.now();
-      const spanId = `gateway-startup-${++spanSequence}`;
-      emitDiagnosticsTimelineEvent(
-        {
-          type: "span.start",
-          name: mapTimelineName(name),
-          phase: "startup",
-          spanId,
-          attributes: name === mapTimelineName(name) ? undefined : { traceName: name },
-        },
-        timelineOptions(),
-      );
-      try {
-        const result = await withDiagnosticPhase(mapTimelineName(name), run, { traceName: name });
-        const now = performance.now();
-        emitDiagnosticsTimelineEvent(
-          {
-            type: "span.end",
-            name: mapTimelineName(name),
-            phase: "startup",
-            spanId,
-            durationMs: now - before,
-            attributes: name === mapTimelineName(name) ? undefined : { traceName: name },
-          },
-          timelineOptions(),
-        );
-        return result;
-      } catch (error) {
-        const now = performance.now();
-        emitDiagnosticsTimelineEvent(
-          {
-            type: "span.error",
-            name: mapTimelineName(name),
-            phase: "startup",
-            spanId,
-            durationMs: now - before,
-            attributes: name === mapTimelineName(name) ? undefined : { traceName: name },
-            errorName: error instanceof Error ? error.name : typeof error,
-            ...(options.omitErrorMessage
-              ? {}
-              : { errorMessage: error instanceof Error ? error.message : String(error) }),
-          },
-          timelineOptions(),
-        );
-        throw error;
-      } finally {
-        const now = performance.now();
-        const eventLoopSample = takeEventLoopSample();
-        emit(name, now - before, now - started, eventLoopSample);
-        emitEventLoopTimelineSample(name, eventLoopSample);
-        last = now;
-      }
-    },
-  };
-}
 
 function formatRuntimeGatewayAuthTokenWarning(): string {
   const base =
@@ -931,29 +707,16 @@ export async function startGatewayServer(
       : {};
   const { workerEnvironmentService, workerLiveEvents } = workerEnvironmentRuntime;
   // Assigned once approval managers exist; placement dispatch must not run before then.
-  let revokeWorkerDispatchSessionAuthority = (_params: {
-    sessionId: string;
-    sessionKeys: readonly string[];
-  }): void => {
-    throw new Error("Worker dispatch authority revocation is not ready");
-  };
-  const workerPlacementRuntime =
-    workerEnvironmentService && workerEnvironmentStartup
-      ? await startupTrace.measure("worker-environments.placement-runtime", async () => {
-          const placementModule = await loadWorkerPlacementStartupModule();
-          return placementModule.createGatewayWorkerPlacementRuntime({
-            placements: workerEnvironmentStartup.placementStore,
-            environments: workerEnvironmentService,
-            admitNewPlacements: hasConfiguredWorkerProfiles,
-            revokeSessionAuthority: (request) => revokeWorkerDispatchSessionAuthority(request),
-            warn: (message) => log.warn(message),
-          });
-        })
-      : undefined;
-  // Without configured profiles, existing placements still reconcile but new dispatches stay off.
-  const workerPlacementDispatchAvailable = hasConfiguredWorkerProfiles
-    ? workerPlacementRuntime?.dispatchService
-    : undefined;
+  const workerDispatchCell = createWorkerDispatchCell();
+  const { workerPlacementRuntime, workerPlacementDispatchAvailable } =
+    await bootstrapWorkerPlacementRuntime({
+      workerEnvironmentService,
+      workerEnvironmentStartup,
+      startupTrace,
+      hasConfiguredWorkerProfiles,
+      log,
+      revokeCell: workerDispatchCell,
+    });
   const channelLogs = Object.fromEntries(
     listGatewayStartupChannelPlugins().map((plugin) => [plugin.id, logChannels.child(plugin.id)]),
   ) as Record<ChannelId, ReturnType<typeof createSubsystemLogger>>;
@@ -1587,22 +1350,11 @@ export async function startGatewayServer(
     });
     approvalManagersForReplay.exec = execApprovalManager;
     approvalManagersForReplay.plugin = pluginApprovalManager;
-    revokeWorkerDispatchSessionAuthority = ({ sessionId, sessionKeys }) => {
-      const keys = new Set(sessionKeys);
-      for (const sessionKey of keys) {
-        revokeAttachGrantsForSession(sessionKey);
-      }
-      for (const record of execApprovalManager.listPendingRecords()) {
-        if (approvalRequestTargetsSession(record.request, keys, sessionId)) {
-          execApprovalManager.expire(record.id, "worker-dispatch");
-        }
-      }
-      for (const record of pluginApprovalManager.listPendingRecords()) {
-        if (approvalRequestTargetsSession(record.request, keys, sessionId)) {
-          pluginApprovalManager.expire(record.id, "worker-dispatch");
-        }
-      }
-    };
+    workerDispatchCell.current = createWorkerDispatchAuthorityRevoker({
+      revokeAttachGrantsForSession,
+      execApprovalManager,
+      pluginApprovalManager,
+    });
     const attachedGatewayExtraHandlers: GatewayRequestHandlers = {
       ...pluginRegistry.gatewayHandlers,
       ...extraHandlers,
@@ -2119,22 +1871,12 @@ export async function startGatewayServer(
                 runtimeState.gatewayLifetimeSidecars = [];
               }
             },
-            ...(workerPlacementRuntime
-              ? {
-                  startWorkerEnvironmentRuntime: async () => {
-                    if (closePreludeStarted) {
-                      return null;
-                    }
-                    return await workerPlacementRuntime.startRuntime({
-                      isClosePreludeStarted: () => closePreludeStarted,
-                      // Close must see the drain handle before reconciliation can yield.
-                      registerSidecar: (sidecar) => {
-                        runtimeState.gatewayLifetimeSidecars.push(sidecar);
-                      },
-                    });
-                  },
-                }
-              : {}),
+            ...createWorkerPlacementStartupSidecarConfig(workerPlacementRuntime, {
+              isClosePreludeStarted: () => closePreludeStarted,
+              registerSidecar: (sidecar) => {
+                runtimeState.gatewayLifetimeSidecars.push(sidecar);
+              },
+            }),
             onSidecarsReady: () => {
               startupSidecarsReady = true;
               activateScheduledServicesWhenReady();

--- a/src/secrets/runtime-fast-path.ts
+++ b/src/secrets/runtime-fast-path.ts
@@ -221,6 +221,8 @@ export function canUseSecretsRuntimeFastPath(params: {
  */
 export function prepareSecretsRuntimeFastPathSnapshot(params: {
   config: OpenClawConfig;
+  /** Optional assignment projection; source and recovery still use the full config. */
+  assignmentConfig?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   agentDirs?: string[];
   includeAuthStoreRefs?: boolean;
@@ -235,7 +237,7 @@ export function prepareSecretsRuntimeFastPathSnapshot(params: {
   const runtimeEnv = mergeSecretsRuntimeEnv(params.env);
   const authStoreCredentialsRevision = getRuntimeAuthProfileStoreCredentialsRevision();
   const sourceConfig = structuredClone(params.config);
-  const resolvedConfig = structuredClone(params.config);
+  const resolvedConfig = structuredClone(params.assignmentConfig ?? params.config);
   const includeAuthStoreRefs = params.includeAuthStoreRefs ?? true;
   const candidateDirs = resolveCandidateAgentDirs({
     config: resolvedConfig,
@@ -266,7 +268,7 @@ export function prepareSecretsRuntimeFastPathSnapshot(params: {
       }));
     }
   }
-  if (!canUseSecretsRuntimeFastPath({ sourceConfig, authStores })) {
+  if (!canUseSecretsRuntimeFastPath({ sourceConfig: resolvedConfig, authStores })) {
     return null;
   }
   const snapshot = {


### PR DESCRIPTION
## What Problem This Solves

The persisted Gateway crash-loop breaker claims to enter a control-plane-safe mode that suppresses channel/provider account auto-start, but `prepareGatewayStartupConfig()` performs eager SecretRef preflight **before** the suppression reaches the channel manager. An unavailable channel credential continues to terminate the entire Gateway, and the supervisor keeps restarting it — defeating the safe-mode contract.

Root cause: `pruneSkippedStartupSecretSurfaces()` only checks `OPENCLAW_SKIP_CHANNELS` / `OPENCLAW_SKIP_PROVIDERS` env vars, ignoring the crash-loop breaker's `channelAutostartSuppression`. The breaker computes the suppression in `run.ts:beginBoot()` before calling `startGatewayServer()`, but the secrets activator resolves SecretRefs without knowing about it.

Additionally, the original fix (v1) passed the channel-pruned config as the snapshot's `sourceConfig`. On breaker startup this removed configured channels from the source, so a later credential repair and `secrets.reload` could not reconstruct channel assignments — violating the safe-mode contract that channel recovery should be possible without a Gateway restart.

Fixes #106379

## Why This Change Was Made

The fix carries the already-computed `channelAutostartSuppression` into the secrets activator and `prepareGatewayStartupConfig()`. The pruned config is now passed as `assignmentConfig` while the full config is kept as `sourceConfig`:

- **Startup**: channel surfaces are pruned from the assignment projection, preventing an unavailable channel SecretRef from blocking control-plane startup
- **Recovery**: the complete channel-bearing source config is preserved in the snapshot, so `secrets.reload` can resolve channel credentials after repair without a Gateway restart

Changes (v2 revision):
- `src/gateway/server-startup-config.ts`: pass full `config` + pruned `assignmentConfig` to `prepareSecretsRuntimeSnapshot` and `prepareSecretsRuntimeFastPathSnapshot`; simplify `canReusePreflightPreparedSnapshot` to compare full config directly
- `src/secrets/runtime-fast-path.ts`: add optional `assignmentConfig` parameter, using it for the resolved projection while source config remains complete for recovery
- `src/gateway/server-startup-config.secrets.test.ts`: 5 test cases updated to verify source/assignment projection separation — full source config preserves channels, assignment projection prunes them

## User Impact

- **Affected**: supervised Gateways (systemd, launchd) with an unavailable channel SecretRef where the persisted crash-loop breaker has tripped
- **Before**: Gateway keeps restarting; control plane unreachable
- **After**: breaker trips → channel surfaces pruned before SecretRef resolution → Gateway starts successfully → operator repairs credential → `secrets.reload` resolves the now-available credential from the preserved source config
- Normal startup behavior is unchanged; gateway auth and non-channel secrets remain fail-closed

## Evidence

### Real Behavior Proof: Breaker + secrets.reload Recovery (2026-07-14, revision v2)

**Setup**: `OPENCLAW_STATE_DIR=/tmp/openclaw-proof-revise/state`, config with gateway auth (password mode) + telegram channel referencing non-existent env var `NONEXISTENT_TG_BOT_TOKEN_106405`.

**Step 1 — Breaker simulation**: 3 unclean boot rows inserted into `gateway_boot_lifecycle`:
```
breaker-sim-1 | NULL    | NULL
breaker-sim-2 | NULL    | NULL  
breaker-sim-3 | startup_failed | NULL
```

**Step 2 — Gateway with breaker + bad channel**:
```
restart-loop breaker tripped: 3 unclean boot(s) within 300000ms;
  suppressing channel/provider account auto-start.
wrote stability bundle: .../openclaw-stability-...-gateway.crash_loop_breaker.json
...
http server listening (10 plugins...; 2.1s)
ready
```

Gateway reached `ready` with breaker tripped — bad channel SecretRef no longer blocks control-plane startup.

**Step 3 — Before reload: Telegram channel not loaded**:
```
$ openclaw gateway --password pw call channels.status --params '{"channel":"telegram"}' --json
{ "ok": false, "error": { "code": "INVALID_REQUEST", "message": "unknown channel: telegram" } }
```
Channel auto-start was suppressed by the breaker.

**Step 4 — secrets.reload after credential repair**:
```
$ export NONEXISTENT_TG_BOT_TOKEN_106405="proof-repaired-token"
$ openclaw gateway --password pw call secrets.reload --json
{ "ok": true, "warningCount": 0 }
```
`secrets.reload` succeeds — the full source config (preserved in the snapshot) allows the reload to resolve the now-available channel credential without errors.

**Result**: Gateway starts in safe mode with breaker tripped. `secrets.reload` can re-resolve credentials from the preserved source config — proving the source/assignment projection split preserves recovery state.

### Unit Test Evidence

```
node scripts/run-vitest.mjs src/gateway/server-startup-config.secrets.test.ts
 ✓ 26 tests passed (1 shard)
```

5 updated test cases verify source/assignment projection separation:
- breaker suppression active → source preserves channels, assignment prunes them
- breaker suppression null → regression guard (both preserve channels)
- breaker + gateway auth SecretRef → auth resolves, source preserves channels, assignment pruned
- `prepareGatewayStartupConfig` integration → channels pruned in assignment, preserved in source
- `OPENCLAW_SKIP_CHANNELS` env var → source preserves channels, assignment pruned

### Build & Checks

- `pnpm build` — passed
- `pnpm check:test-types` — passed
- `oxlint` — clean
- `pnpm format:check` — passed
- `git diff --check` — clean

### Branch

Rebased on `upstream/main`. 2 commits: `d100f1f5df9` (original fix) + `dce9a36014e` (revision: source/assignment projection split).
