### PR TITLE
fix(envelope): accept timestamp 0 in formatEnvelopeTimestamp

### DIFF
--- a/src/auto-reply/envelope.test.ts
+++ b/src/auto-reply/envelope.test.ts
@@ -217,3 +217,17 @@ describe("formatInboundEnvelope", () => {
     });
   });
 });
+
+describe("formatEnvelopeTimestamp", () => {
+  it("formats timestamp 0 (Unix epoch) instead of rejecting it as falsy", () => {
+    withEnv({ TZ: "UTC" }, () => {
+      const result = formatEnvelopeTimestamp(0, { timezone: "utc" });
+      expect(result).toBeDefined();
+      expect(result).toContain("1970");
+    });
+  });
+
+  it("returns undefined for undefined timestamp", () => {
+    expect(formatEnvelopeTimestamp(undefined)).toBeUndefined();
+  });
+});

--- a/src/auto-reply/envelope.test.ts
+++ b/src/auto-reply/envelope.test.ts
@@ -79,6 +79,16 @@ describe("formatAgentEnvelope", () => {
     const body = formatAgentEnvelope({ channel: "Telegram", body: "hi" });
     expect(body).toBe("[Telegram] hi");
   });
+
+  it("formats the Unix epoch timestamp", () => {
+    const body = formatAgentEnvelope({
+      channel: "WebChat",
+      timestamp: 0,
+      envelope: { timezone: "utc" },
+      body: "hello",
+    });
+    expect(body).toBe("[WebChat Thu 1970-01-01T00:00:00Z] hello");
+  });
 });
 
 describe("formatInboundEnvelope", () => {
@@ -215,19 +225,5 @@ describe("formatInboundEnvelope", () => {
       includeElapsed: false,
       userTimezone: "Europe/Vienna",
     });
-  });
-});
-
-describe("formatEnvelopeTimestamp", () => {
-  it("formats timestamp 0 (Unix epoch) instead of rejecting it as falsy", () => {
-    withEnv({ TZ: "UTC" }, () => {
-      const result = formatEnvelopeTimestamp(0, { timezone: "utc" });
-      expect(result).toBeDefined();
-      expect(result).toContain("1970");
-    });
-  });
-
-  it("returns undefined for undefined timestamp", () => {
-    expect(formatEnvelopeTimestamp(undefined)).toBeUndefined();
   });
 });

--- a/src/auto-reply/envelope.ts
+++ b/src/auto-reply/envelope.ts
@@ -114,7 +114,7 @@ export function formatEnvelopeTimestamp(
   ts: number | Date | undefined,
   options?: EnvelopeFormatOptions,
 ): string | undefined {
-  if (!ts) {
+  if (ts === undefined || ts === null) {
     return undefined;
   }
   const resolved = normalizeEnvelopeOptions(options);

--- a/src/auto-reply/envelope.ts
+++ b/src/auto-reply/envelope.ts
@@ -114,7 +114,7 @@ export function formatEnvelopeTimestamp(
   ts: number | Date | undefined,
   options?: EnvelopeFormatOptions,
 ): string | undefined {
-  if (ts === undefined || ts === null) {
+  if (ts === undefined) {
     return undefined;
   }
   const resolved = normalizeEnvelopeOptions(options);


### PR DESCRIPTION
## What Problem This Solves

`formatEnvelopeTimestamp` accepted numeric millisecond timestamps but used a falsy guard for missing values. Numeric `0` is the valid Unix epoch and was silently omitted from agent-visible envelopes.

## Why This Change Was Made

The formatter now checks only its declared missing value, `undefined`, before the existing Date validity and display-option branches. The regression test exercises the public `formatAgentEnvelope` path and asserts the exact UTC epoch result.

Alternatives rejected:

- Fixing individual channel callers would duplicate timestamp policy.
- Special-casing zero after Date construction is less direct.
- Retaining a null branch preserves an undeclared hypothetical input rather than the current typed contract.

## User Impact

- Numeric epoch zero formats as `Thu 1970-01-01T00:00:00Z` in UTC envelopes.
- Missing timestamps, invalid dates, and disabled timestamp display keep their existing behavior.
- No configuration, persistence, network, or channel contract changes.

## Evidence

Head: `7687fbc839c3563e94067c951fb2ee43723a454b`.

- Blacksmith Testbox: `src/auto-reply/envelope.test.ts`, 18/18 passed.
- Full path-scoped `check:changed` passed, including core source/test typechecks, formatting, lint, plugin boundaries, database-first, sidecar, import-cycle, webhook, and pairing guards.
- Fresh maintainer autoreview clean.
- Historical CI red was unrelated gateway worker test-type drift; the prior bot "missing imports" finding was false because both imports already existed on main.
- Fresh exact-head hosted CI required before merge.

## AI disclosure

The contributor used AI assistance. Maintainer review rebased the patch, removed the undeclared null compatibility branch, replaced helper-substring assertions with exact public-envelope proof, and preserved contributor credit.
