### PR TITLE
fix(ci): refresh plugin SDK API baseline

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-978a859940a58f357cf23ea76afd3cc0cc9b026564acb507e57c65fb82f42035  plugin-sdk-api-baseline.json
-21b3f73ae293afbb6930552585bae7c33e2a6538c64fbec02e6b570e54c1ba32  plugin-sdk-api-baseline.jsonl
+52a3eb5ba5538fa684972c98970ff70e0a5af55b900b4ecd2a633f53943a0eab  plugin-sdk-api-baseline.json
+07c99e2211a3ce675609d42ff4e12955f456b9c6ec6031fbcdaf98ab0d2d2973  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails the Plugin SDK API baseline check after #106038 changed the
generated SDK/runtime type surface without refreshing the committed checksum
manifest.

## Why This Change Was Made

Regenerate `docs/.generated/plugin-sdk-api-baseline.sha256` from current `main`.
The JSON and JSONL baseline artifacts are intentionally gitignored local-only
outputs; repository convention commits only this checksum file.

## User Impact

No runtime or public API behavior changes. This restores the generated Plugin SDK
baseline gate so unrelated changes can pass `check:changed`.

## Evidence

- Clean `main` at `93b3f4c45b17ff40d9997e55de4d3a3b13f84bdb` reproduced:
  `Plugin SDK API baseline drift detected`.
- Fresh Blacksmith Testbox `tbx_01kxdskwevn877xcbwrxtr0bwc`, Actions run
  `29252743448`:
  - `scripts/generate-plugin-sdk-api-baseline.ts --check`: passed.
  - targeted `pnpm check:changed` for the checksum file: passed.
- Fresh branch-mode `gpt-5.6-sol` medium autoreview: clean, 0.97 confidence.
- Prior repository repairs #106253 and #106289 use the same checksum-only shape.
