### PR TITLE
fix(transcript-stream): propagate non-missing filesystem errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Claude CLI context budgets:** honor Anthropic model and per-agent `contextTokens` limits by passing the effective limit to Claude Code's native auto-compactor and persisting the same prepared budget in OpenClaw session state. Fixes #80933. (#93198) Thanks @mushuiyu886.
+- **Transcript read failures:** propagate permission and I/O failures from streaming JSONL session reads instead of treating unreadable transcripts as empty. (#106412) Thanks @zenglingbiao.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.
 - **Gateway source watch:** hand the configured port off from the installed service before starting the tmux watcher, preserve failed panes for attach/capture, and keep explicit alternate-port watches side by side with the managed Gateway.
 - **Claude CLI max-turn diagnostics:** preserve terminal max-turn results with OpenClaw and Claude session context, warn when tool actions may already have run, and stop unsafe auth-profile or model replay for potentially side-effecting turns. (#94130) Thanks @zhangguiping-xydt.

--- a/src/config/sessions/transcript-stream.test.ts
+++ b/src/config/sessions/transcript-stream.test.ts
@@ -58,6 +58,14 @@ describe("streamSessionTranscriptLines", () => {
     expect(lines).toEqual([]);
   });
 
+  it("returns an empty iterator and logs a warning when stat fails with a permission error", async () => {
+    // Use a path under /root which should fail with EACCES for non-root users.
+    // If running as root, this test still passes — just exercises the ENOENT path.
+    const lines = await collect(streamSessionTranscriptLines("/root/nonexistent-transcript.jsonl"));
+
+    expect(lines).toEqual([]);
+  });
+
   it("forwards malformed JSON lines as raw text so callers can choose to skip them", async () => {
     fs.writeFileSync(
       transcriptPath,

--- a/src/config/sessions/transcript-stream.test.ts
+++ b/src/config/sessions/transcript-stream.test.ts
@@ -2,7 +2,16 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { warn: warnMock } = vi.hoisted(() => ({
+  warn: vi.fn(),
+}));
+
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({ warn: warnMock }),
+}));
+
 import {
   streamSessionTranscriptLines,
   streamSessionTranscriptLinesReverse,
@@ -20,6 +29,7 @@ let transcriptPath = "";
 beforeEach(() => {
   tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "transcript-stream-"));
   transcriptPath = path.join(tempDir, "session.jsonl");
+  warnMock.mockReset();
 });
 
 afterEach(() => {
@@ -58,12 +68,32 @@ describe("streamSessionTranscriptLines", () => {
     expect(lines).toEqual([]);
   });
 
-  it("returns an empty iterator and logs a warning when stat fails with a permission error", async () => {
-    // Use a path under /root which should fail with EACCES for non-root users.
-    // If running as root, this test still passes — just exercises the ENOENT path.
-    const lines = await collect(streamSessionTranscriptLines("/root/nonexistent-transcript.jsonl"));
+  it("logs a warning when stat fails with EACCES", async () => {
+    const statSpy = vi
+      .spyOn(fs.promises, "stat")
+      .mockRejectedValueOnce(
+        Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" }),
+      );
+
+    const lines = await collect(streamSessionTranscriptLines("/some/protected/transcript.jsonl"));
 
     expect(lines).toEqual([]);
+    expect(warnMock).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to stat transcript /some/protected/transcript.jsonl"),
+    );
+    statSpy.mockRestore();
+  });
+
+  it("does not log a warning when stat fails with ENOENT (missing file)", async () => {
+    const statSpy = vi
+      .spyOn(fs.promises, "stat")
+      .mockRejectedValueOnce(Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" }));
+
+    const lines = await collect(streamSessionTranscriptLines("/tmp/missing-transcript.jsonl"));
+
+    expect(lines).toEqual([]);
+    expect(warnMock).not.toHaveBeenCalled();
+    statSpy.mockRestore();
   });
 
   it("forwards malformed JSON lines as raw text so callers can choose to skip them", async () => {
@@ -120,6 +150,40 @@ describe("streamSessionTranscriptLinesReverse", () => {
     );
 
     expect(lines).toEqual([]);
+  });
+
+  it("logs a warning when open fails with EACCES (permission denied)", async () => {
+    const openSpy = vi
+      .spyOn(fs.promises, "open")
+      .mockRejectedValueOnce(
+        Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" }),
+      );
+
+    const lines = await collect(
+      streamSessionTranscriptLinesReverse("/some/protected/transcript.jsonl"),
+    );
+
+    expect(lines).toEqual([]);
+    expect(warnMock).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Failed to open transcript /some/protected/transcript.jsonl for reverse streaming",
+      ),
+    );
+    openSpy.mockRestore();
+  });
+
+  it("does not log a warning when open fails with ENOENT (missing file)", async () => {
+    const openSpy = vi
+      .spyOn(fs.promises, "open")
+      .mockRejectedValueOnce(Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" }));
+
+    const lines = await collect(
+      streamSessionTranscriptLinesReverse("/tmp/missing-transcript.jsonl"),
+    );
+
+    expect(lines).toEqual([]);
+    expect(warnMock).not.toHaveBeenCalled();
+    openSpy.mockRestore();
   });
 
   it("preserves complete lines across chunk boundaries", async () => {

--- a/src/config/sessions/transcript-stream.test.ts
+++ b/src/config/sessions/transcript-stream.test.ts
@@ -3,15 +3,6 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-const { warn: warnMock } = vi.hoisted(() => ({
-  warn: vi.fn(),
-}));
-
-vi.mock("../../logging/subsystem.js", () => ({
-  createSubsystemLogger: () => ({ warn: warnMock }),
-}));
-
 import {
   streamSessionTranscriptLines,
   streamSessionTranscriptLinesReverse,
@@ -29,10 +20,10 @@ let transcriptPath = "";
 beforeEach(() => {
   tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "transcript-stream-"));
   transcriptPath = path.join(tempDir, "session.jsonl");
-  warnMock.mockReset();
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   fs.rmSync(tempDir, { recursive: true, force: true });
 });
 
@@ -68,32 +59,13 @@ describe("streamSessionTranscriptLines", () => {
     expect(lines).toEqual([]);
   });
 
-  it("logs a warning when stat fails with EACCES", async () => {
-    const statSpy = vi
-      .spyOn(fs.promises, "stat")
-      .mockRejectedValueOnce(
-        Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" }),
-      );
+  it("propagates stat failures other than ENOENT", async () => {
+    const error = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+    vi.spyOn(fs.promises, "stat").mockRejectedValueOnce(error);
 
-    const lines = await collect(streamSessionTranscriptLines("/some/protected/transcript.jsonl"));
-
-    expect(lines).toEqual([]);
-    expect(warnMock).toHaveBeenCalledWith(
-      expect.stringContaining("Failed to stat transcript /some/protected/transcript.jsonl"),
-    );
-    statSpy.mockRestore();
-  });
-
-  it("does not log a warning when stat fails with ENOENT (missing file)", async () => {
-    const statSpy = vi
-      .spyOn(fs.promises, "stat")
-      .mockRejectedValueOnce(Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" }));
-
-    const lines = await collect(streamSessionTranscriptLines("/tmp/missing-transcript.jsonl"));
-
-    expect(lines).toEqual([]);
-    expect(warnMock).not.toHaveBeenCalled();
-    statSpy.mockRestore();
+    await expect(
+      collect(streamSessionTranscriptLines("/some/protected/transcript.jsonl")),
+    ).rejects.toBe(error);
   });
 
   it("forwards malformed JSON lines as raw text so callers can choose to skip them", async () => {
@@ -144,7 +116,7 @@ describe("streamSessionTranscriptLinesReverse", () => {
     expect(lines).toEqual(["third", "second", "first"]);
   });
 
-  it("returns an empty iterator when the file cannot be opened", async () => {
+  it("returns an empty iterator when the file does not exist", async () => {
     const lines = await collect(
       streamSessionTranscriptLinesReverse(path.join(tempDir, "missing.jsonl")),
     );
@@ -152,38 +124,13 @@ describe("streamSessionTranscriptLinesReverse", () => {
     expect(lines).toEqual([]);
   });
 
-  it("logs a warning when open fails with EACCES (permission denied)", async () => {
-    const openSpy = vi
-      .spyOn(fs.promises, "open")
-      .mockRejectedValueOnce(
-        Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" }),
-      );
+  it("propagates open failures other than ENOENT", async () => {
+    const error = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+    vi.spyOn(fs.promises, "open").mockRejectedValueOnce(error);
 
-    const lines = await collect(
-      streamSessionTranscriptLinesReverse("/some/protected/transcript.jsonl"),
-    );
-
-    expect(lines).toEqual([]);
-    expect(warnMock).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "Failed to open transcript /some/protected/transcript.jsonl for reverse streaming",
-      ),
-    );
-    openSpy.mockRestore();
-  });
-
-  it("does not log a warning when open fails with ENOENT (missing file)", async () => {
-    const openSpy = vi
-      .spyOn(fs.promises, "open")
-      .mockRejectedValueOnce(Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" }));
-
-    const lines = await collect(
-      streamSessionTranscriptLinesReverse("/tmp/missing-transcript.jsonl"),
-    );
-
-    expect(lines).toEqual([]);
-    expect(warnMock).not.toHaveBeenCalled();
-    openSpy.mockRestore();
+    await expect(
+      collect(streamSessionTranscriptLinesReverse("/some/protected/transcript.jsonl")),
+    ).rejects.toBe(error);
   });
 
   it("preserves complete lines across chunk boundaries", async () => {

--- a/src/config/sessions/transcript-stream.ts
+++ b/src/config/sessions/transcript-stream.ts
@@ -1,7 +1,11 @@
 // Transcript streaming reads large JSONL files forward or backward without whole-file buffering.
 import fs from "node:fs";
 import readline from "node:readline";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { readFileRangeAsync } from "./file-range.js";
+
+const transcriptLog = createSubsystemLogger("transcript-stream");
 
 // Shared streaming helpers for JSONL session transcripts.
 //
@@ -40,7 +44,8 @@ export async function* streamSessionTranscriptLines(
   let stat: fs.Stats;
   try {
     stat = await fs.promises.stat(filePath);
-  } catch {
+  } catch (err) {
+    transcriptLog.warn(`Failed to stat transcript ${filePath}: ${formatErrorMessage(err)}`);
     return;
   }
   if (!stat.isFile() || stat.size <= 0) {
@@ -88,7 +93,10 @@ export async function* streamSessionTranscriptLinesReverse(
   let fileHandle: Awaited<ReturnType<typeof fs.promises.open>>;
   try {
     fileHandle = await fs.promises.open(filePath, "r");
-  } catch {
+  } catch (err) {
+    transcriptLog.warn(
+      `Failed to open transcript ${filePath} for reverse streaming: ${formatErrorMessage(err)}`,
+    );
     return;
   }
   try {

--- a/src/config/sessions/transcript-stream.ts
+++ b/src/config/sessions/transcript-stream.ts
@@ -45,7 +45,9 @@ export async function* streamSessionTranscriptLines(
   try {
     stat = await fs.promises.stat(filePath);
   } catch (err) {
-    transcriptLog.warn(`Failed to stat transcript ${filePath}: ${formatErrorMessage(err)}`);
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      transcriptLog.warn(`Failed to stat transcript ${filePath}: ${formatErrorMessage(err)}`);
+    }
     return;
   }
   if (!stat.isFile() || stat.size <= 0) {
@@ -94,9 +96,11 @@ export async function* streamSessionTranscriptLinesReverse(
   try {
     fileHandle = await fs.promises.open(filePath, "r");
   } catch (err) {
-    transcriptLog.warn(
-      `Failed to open transcript ${filePath} for reverse streaming: ${formatErrorMessage(err)}`,
-    );
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      transcriptLog.warn(
+        `Failed to open transcript ${filePath} for reverse streaming: ${formatErrorMessage(err)}`,
+      );
+    }
     return;
   }
   try {

--- a/src/config/sessions/transcript-stream.ts
+++ b/src/config/sessions/transcript-stream.ts
@@ -1,11 +1,8 @@
 // Transcript streaming reads large JSONL files forward or backward without whole-file buffering.
 import fs from "node:fs";
 import readline from "node:readline";
-import { formatErrorMessage } from "../../infra/errors.js";
-import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { hasErrnoCode } from "../../infra/errors.js";
 import { readFileRangeAsync } from "./file-range.js";
-
-const transcriptLog = createSubsystemLogger("transcript-stream");
 
 // Shared streaming helpers for JSONL session transcripts.
 //
@@ -21,11 +18,11 @@ const DEFAULT_REVERSE_CHUNK_BYTES = 64 * 1024;
 const MAX_REVERSE_CHUNK_BYTES = 1024 * 1024;
 const MIN_REVERSE_CHUNK_BYTES = 1024;
 
-export type TranscriptStreamOptions = {
+type TranscriptStreamOptions = {
   signal?: AbortSignal;
 };
 
-export type TranscriptReverseStreamOptions = TranscriptStreamOptions & {
+type TranscriptReverseStreamOptions = TranscriptStreamOptions & {
   /** Bytes read per reverse scan chunk. Clamped to [1KiB, 1MiB]. */
   chunkBytes?: number;
 };
@@ -44,11 +41,11 @@ export async function* streamSessionTranscriptLines(
   let stat: fs.Stats;
   try {
     stat = await fs.promises.stat(filePath);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-      transcriptLog.warn(`Failed to stat transcript ${filePath}: ${formatErrorMessage(err)}`);
+  } catch (error) {
+    if (hasErrnoCode(error, "ENOENT")) {
+      return;
     }
-    return;
+    throw error;
   }
   if (!stat.isFile() || stat.size <= 0) {
     return;
@@ -79,7 +76,7 @@ export async function* streamSessionTranscriptLines(
  * Stream the non-empty, trimmed JSONL lines of a transcript file in reverse
  * (newest-first) order.
  *
- * Returns an empty async iterator if the file cannot be opened, is empty, or is
+ * Returns an empty async iterator if the file does not exist, is empty, or is
  * not a regular file. The implementation splits on newline bytes before UTF-8
  * decoding so multibyte characters survive arbitrary chunk boundaries.
  */
@@ -95,13 +92,11 @@ export async function* streamSessionTranscriptLinesReverse(
   let fileHandle: Awaited<ReturnType<typeof fs.promises.open>>;
   try {
     fileHandle = await fs.promises.open(filePath, "r");
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-      transcriptLog.warn(
-        `Failed to open transcript ${filePath} for reverse streaming: ${formatErrorMessage(err)}`,
-      );
+  } catch (error) {
+    if (hasErrnoCode(error, "ENOENT")) {
+      return;
     }
-    return;
+    throw error;
   }
   try {
     const stat = await fileHandle.stat();


### PR DESCRIPTION
## What Problem This Solves

The forward and reverse JSONL transcript readers treated every initial filesystem failure as an empty transcript. A missing file is expected before a transcript exists, but permission, path-component, and I/O failures must not be converted into successful absence.

## Why This Change Was Made

Both readers now follow the repository's existing transcript-store contract:

- `ENOENT` returns an empty iterator.
- Every other filesystem error is rethrown unchanged so the owning operation can decide how to report or recover.

This keeps policy out of the low-level iterator, preserves the original error object and stack, and avoids logging potentially sensitive transcript paths.

## User Impact

Unreadable or otherwise broken transcript files now fail visibly instead of causing callers to make decisions from a falsely empty history. Expected missing and empty transcripts behave as before.

## Evidence

- 186 focused transcript, compaction, TTS, attempt-execution, and Telegram context tests passed on Blacksmith Testbox.
- Real Linux proof forced an actual `ENOTDIR`; both forward stat and reverse open propagated it.
- `pnpm check:changed` passed in Blacksmith workflow 29471845238.
- Fresh current-main synthetic-merge autoreview: clean, 0.98.
- Exact-head GitHub CI is running for the maintainer fixup.
