### PR TITLE
fix(startup-context): use Number.isNaN instead of falsy check on parseInt results

### DIFF
--- a/src/auto-reply/reply/startup-context.ts
+++ b/src/auto-reply/reply/startup-context.ts
@@ -61,7 +61,7 @@ function resolveStartupContextLimits(cfg?: OpenClawConfig) {
 
 function shiftDateStampByCalendarDays(stamp: string, offsetDays: number): string {
   const [yearRaw, monthRaw, dayRaw] = stamp.split("-").map((part) => Number.parseInt(part, 10));
-  if (!yearRaw || !monthRaw || !dayRaw) {
+  if (Number.isNaN(yearRaw) || Number.isNaN(monthRaw) || Number.isNaN(dayRaw)) {
     return stamp;
   }
   const shifted = new Date(Date.UTC(yearRaw, monthRaw - 1, dayRaw - offsetDays));


### PR DESCRIPTION
## Summary

`shiftDateStampByCalendarDays` used `if (!yearRaw || !monthRaw || !dayRaw)` to detect invalid `parseInt` results. Replace with explicit `Number.isNaN()` checks.

## What Problem This Solves

The falsy check `!value` rejects `0` (`!0 === true`), which is a valid return from `Number.parseInt("0", 10)`. While date components are never `0` in practice, `NaN` (from invalid parse) is caught correctly by both patterns. The explicit `Number.isNaN()` check is semantically correct and avoids the edge case.

## Root Cause

`Number.parseInt` returns `NaN` for invalid input and a number otherwise. The falsy check `!NaN === true` works but also rejects `0`. Use `Number.isNaN()` for precise NaN detection.

## Why This Fix

Same pattern as [#106407](https://github.com/openclaw/openclaw/pull/106407) (falsy check → explicit check). One-line change with no behavioral difference for valid date stamps.

## Evidence

| Input | Old (`!value`) | New (`Number.isNaN()`) |
|-------|---------------|----------------------|
| `2026, 7, 13` | accept | accept |
| `NaN, 7, 13` | REJECT (correct) | REJECT (correct) |
| `0, 7, 13` | REJECT (buggy) | accept (correct) |

- `pnpm check` passed (no lint errors)
