### PR TITLE
fix(agents): recognize config-defined cliBackends in runtime alias and binding checks

### DIFF
--- a/src/agents/cli-backends.test.ts
+++ b/src/agents/cli-backends.test.ts
@@ -15,6 +15,9 @@ import {
   testing as cliBackendsTesting,
   resolveCliBackendConfig,
   resolveCliBackendLiveTest,
+  listCliRuntimeModelBackendBindings,
+  resolveCliRuntimeModelBackendBinding,
+  isCliRuntimeModelBackendForProvider,
 } from "./cli-backends.js";
 
 type RuntimeBackendEntry = ReturnType<
@@ -1191,5 +1194,127 @@ describe("resolveCliBackendConfig alias precedence", () => {
 
     expect(resolved?.config.command).toBe("kimi-canonical");
     expect(resolved?.config.args).toEqual(["--canonical"]);
+  });
+});
+
+describe("listCliRuntimeModelBackendBindings with config-defined backends", () => {
+  it("includes config-defined CLI backends with a command in the bindings list", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli-max": {
+              command: "~/.local/bin/claude",
+              args: ["-p", "--output-format", "stream-json"],
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const bindings = listCliRuntimeModelBackendBindings({ config: cfg });
+    const customBinding = bindings.find((b) => b.runtime === "claude-cli-max");
+
+    expect(customBinding).toBeDefined();
+    expect(customBinding?.provider).toBe("claude-cli-max");
+    expect(customBinding?.runtime).toBe("claude-cli-max");
+  });
+
+  it("skips config-defined backends without a command", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "incomplete-cli": {
+              args: ["-p"],
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const bindings = listCliRuntimeModelBackendBindings({ config: cfg });
+    const customBinding = bindings.find((b) => b.runtime === "incomplete-cli");
+
+    expect(customBinding).toBeUndefined();
+  });
+
+  it("does not add config backends when no config is provided", () => {
+    // Ensure that without config, only plugin-registered backends are returned.
+    const bindings = listCliRuntimeModelBackendBindings();
+    const customBinding = bindings.find((b) => b.runtime === "claude-cli-max");
+
+    expect(customBinding).toBeUndefined();
+  });
+});
+
+describe("resolveCliRuntimeModelBackendBinding with config-defined backends", () => {
+  it("resolves a binding for a config-defined backend when runtime matches", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli-max": {
+              command: "~/.local/bin/claude",
+              args: ["-p"],
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const binding = resolveCliRuntimeModelBackendBinding({
+      provider: "anthropic",
+      runtime: "claude-cli-max",
+      config: cfg,
+    });
+
+    expect(binding).toBeDefined();
+    expect(binding?.runtime).toBe("claude-cli-max");
+  });
+
+  it("returns undefined for config backends without a command", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "incomplete-cli": {
+              args: ["-p"],
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const binding = resolveCliRuntimeModelBackendBinding({
+      provider: "anthropic",
+      runtime: "incomplete-cli",
+      config: cfg,
+    });
+
+    expect(binding).toBeUndefined();
+  });
+
+  it("isCliRuntimeModelBackendForProvider recognises config-defined backends", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli-max": {
+              command: "~/.local/bin/claude",
+              args: ["-p"],
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const found = isCliRuntimeModelBackendForProvider({
+      provider: "anthropic",
+      runtime: "claude-cli-max",
+      config: cfg,
+    });
+
+    expect(found).toBe(true);
   });
 });

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -226,6 +226,24 @@ export function listCliRuntimeModelBackendBindings(
       });
     }
   }
+  // Include config-defined CLI backends so callers like isCliRuntimeAlias
+  // and isCliRuntimeProvider recognize custom cliBackends entries.
+  if (params.config) {
+    const configured = params.config.agents?.defaults?.cliBackends ?? {};
+    for (const [id, backendConfig] of Object.entries(configured)) {
+      if (!backendConfig.command?.trim()) {
+        continue;
+      }
+      const normalizedId = normalizeBackendKey(id);
+      if (!normalizedId) {
+        continue;
+      }
+      const key = `config:${normalizedId}`;
+      if (!bindings.has(key)) {
+        bindings.set(key, { provider: normalizedId, runtime: normalizedId });
+      }
+    }
+  }
   return [...bindings.values()].toSorted((left, right) =>
     left.provider === right.provider
       ? left.runtime.localeCompare(right.runtime)
@@ -308,17 +326,27 @@ export function resolveCliRuntimeModelBackendBinding(params: {
     config: params.config,
     env: params.env,
   });
-  if (!setupBackend) {
-    return undefined;
-  }
-  const setupProvider = resolveCliBackendModelProvider(setupBackend.backend);
-  return setupProvider === provider
-    ? {
+  if (setupBackend) {
+    const setupProvider = resolveCliBackendModelProvider(setupBackend.backend);
+    if (setupProvider === provider) {
+      return {
         provider,
         runtime,
         ...(setupBackend.pluginId ? { pluginId: setupBackend.pluginId } : {}),
-      }
-    : undefined;
+      };
+    }
+  }
+  // Fallback: check config-defined CLI backends so custom cliBackends
+  // entries are recognized by isCliRuntimeAliasForProvider and the
+  // harness selection path.
+  if (params.config) {
+    const configured = params.config.agents?.defaults?.cliBackends ?? {};
+    const configBackend = pickBackendConfig(configured, runtime);
+    if (configBackend?.command?.trim()) {
+      return { provider, runtime };
+    }
+  }
+  return undefined;
 }
 
 /** Checks whether a runtime is registered to serve a model provider. */

--- a/src/agents/model-runtime-aliases.ts
+++ b/src/agents/model-runtime-aliases.ts
@@ -29,10 +29,13 @@ export function isCliRuntimeProvider(
   }).includes(normalized);
 }
 
-export function isCliRuntimeAlias(runtime: string | undefined): boolean {
+export function isCliRuntimeAlias(
+  runtime: string | undefined,
+  params: { config?: OpenClawConfig; env?: NodeJS.ProcessEnv; includeSetupRegistry?: boolean } = {},
+): boolean {
   const normalized = normalizeProviderId(runtime ?? "");
   return normalized
-    ? listCliRuntimeModelBackendBindings().some((binding) => binding.runtime === normalized)
+    ? listCliRuntimeModelBackendBindings(params).some((binding) => binding.runtime === normalized)
     : false;
 }
 


### PR DESCRIPTION
## Summary

Fixes #106373: `sessions.compact` throws `MissingAgentHarnessError` for sessions running on config-defined custom CLI backends.

## Root Cause

`listCliRuntimeModelBackendBindings()` only included plugin-registered and setup-registry backends, causing `isCliRuntimeAlias` and `isCliRuntimeProvider` to return false for custom backends defined solely under `agents.defaults.cliBackends`.

This caused `sessions.compact` to throw `MissingAgentHarnessError` for sessions running on config-defined CLI backends, because:
1. The harness selection path uses `isCliRuntimeAliasForProvider` which depends on `resolveCliRuntimeModelBackendBinding`
2. The compaction auth precheck path uses `isCliRuntimeAlias` which depends on `listCliRuntimeModelBackendBindings`

Neither function recognized config-only backends.

## Fix

- Include config-defined `cliBackends` entries (that have a `command`) in `listCliRuntimeModelBackendBindings` when config is provided.
- Fall back to config-defined backends in `resolveCliRuntimeModelBackendBinding` when neither runtime-plugin nor setup-registry entries match.
- Thread optional config params through `isCliRuntimeAlias` so it can also match config-defined backends.

## Testing

- Added 6 unit tests covering config-defined backend recognition in bindings, resolution, and provider checks.
- All 66 `cli-backends.test.ts` tests pass.
- Lint and boundary import checks pass.