### PR TITLE
fix(media): keep host-staged images available to native vision

### DIFF
--- a/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
@@ -197,20 +197,20 @@ describe("stageSandboxMedia", () => {
     });
   });
 
-  it("stages managed inbound media URIs into the host workspace when sandboxing is off", async () => {
+  it("keeps host-staged inbound images available to native vision", async () => {
     await withSandboxMediaTempHome("openclaw-triggers-", async (home) => {
       const cfg = createSandboxMediaStageConfig(home);
       const workspaceDir = join(home, "openclaw");
       sandboxMocks.ensureSandboxWorkspaceForSession.mockResolvedValue(null);
-      const fileName = "host-report.pdf";
-      await writeInboundMedia(home, fileName, "host-pdf-bytes");
+      const fileName = "host-photo.png";
+      await writeInboundMedia(home, fileName, "host-image-bytes");
       const existingProjectFile = join(workspaceDir, "media", "inbound", fileName);
       await fs.mkdir(dirname(existingProjectFile), { recursive: true });
       await fs.writeFile(existingProjectFile, "project-file");
       const mediaUri = `media://inbound/${fileName}`;
       const { ctx, sessionCtx } = createSandboxMediaContexts(mediaUri);
-      ctx.MediaType = "application/pdf";
-      sessionCtx.MediaType = "application/pdf";
+      ctx.MediaType = "image/png";
+      sessionCtx.MediaType = "image/png";
 
       const result = await stageSandboxMedia({
         ctx,
@@ -227,7 +227,9 @@ describe("stageSandboxMedia", () => {
       );
       expect(result.staged.get(mediaUri)).toBe(stagedPath);
       expect(sessionCtx.MediaPath).toBe(stagedPath);
-      await expect(fs.readFile(stagedPath, "utf8")).resolves.toBe("host-pdf-bytes");
+      expect(ctx.MediaWorkspaceDir).toBe(dirname(stagedPath));
+      expect(sessionCtx.MediaWorkspaceDir).toBeUndefined();
+      await expect(fs.readFile(stagedPath, "utf8")).resolves.toBe("host-image-bytes");
       await expect(fs.readFile(existingProjectFile, "utf8")).resolves.toBe("project-file");
     });
   });

--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -61,6 +61,61 @@ describe("resolveCurrentTurnImages", () => {
     });
   });
 
+  it("does not duplicate a prepared host-staged image during runner hydration", async () => {
+    await withTempDir({ prefix: "openclaw-current-turn-staged-image-" }, async (base) => {
+      const stagingRoot = path.join(base, "media", "inbound", "staged");
+      const imagePath = path.join(stagingRoot, "photo.png");
+      const imageBytes = Buffer.from("host-staged-image");
+      await fs.mkdir(path.dirname(imagePath), { recursive: true });
+      await fs.writeFile(imagePath, imageBytes);
+      const sharedContext = {
+        Body: "caption",
+        MediaPath: imagePath,
+        MediaPaths: [imagePath],
+        MediaType: "image/png",
+        MediaTypes: ["image/png"],
+      } satisfies MsgContext;
+
+      const prepared = await resolveCurrentTurnImages({
+        ctx: { ...sharedContext, MediaWorkspaceDir: stagingRoot },
+        cfg: {} as OpenClawConfig,
+      });
+      const runner = await resolveCurrentTurnImages({
+        ctx: sharedContext,
+        cfg: {} as OpenClawConfig,
+        images: prepared.images,
+        imageOrder: prepared.imageOrder,
+      });
+
+      expect(prepared.images).toHaveLength(1);
+      expect(Buffer.from(prepared.images?.[0]?.data ?? "", "base64")).toEqual(imageBytes);
+      expect(runner.images).toEqual(prepared.images);
+    });
+  });
+
+  it("does not let a staging root expose sibling workspace images", async () => {
+    await withTempDir({ prefix: "openclaw-current-turn-staged-image-" }, async (base) => {
+      const stagingRoot = path.join(base, "media", "inbound", "staged");
+      const rejectedPath = path.join(base, "private.png");
+      await fs.mkdir(stagingRoot, { recursive: true });
+      await fs.writeFile(rejectedPath, "private-workspace-image");
+
+      const result = await resolveCurrentTurnImages({
+        ctx: {
+          Body: "caption",
+          MediaPath: rejectedPath,
+          MediaPaths: [rejectedPath],
+          MediaType: "image/png",
+          MediaTypes: ["image/png"],
+          MediaWorkspaceDir: stagingRoot,
+        } satisfies MsgContext,
+        cfg: {} as OpenClawConfig,
+      });
+
+      expect(result.images).toBeUndefined();
+    });
+  });
+
   it("preserves the full order when only inline image payloads are present", async () => {
     const inlineImage = {
       type: "image" as const,

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -152,6 +152,10 @@ export async function stageSandboxMedia(params: {
     }
   }
 
+  if (staged.size > 0 && hostWorkspaceStagingDir) {
+    ctx.MediaWorkspaceDir = path.join(effectiveWorkspaceDir, hostWorkspaceStagingDir);
+  }
+
   rewriteStagedMediaPaths({
     ctx,
     sessionCtx,


### PR DESCRIPTION
Closes #106408

## What Problem This Solves

Fixes an issue where users sending an image through a host-mode channel could receive a text-only native-vision turn after OpenClaw staged the attachment into the agent workspace.

## Why This Change Was Made

Host-mode staging now exposes only the unique per-turn staging directory to the preparation context, allowing the existing scoped media loader to read the rewritten path. The runner context remains unchanged so the already-prepared image is not hydrated twice. No general workspace or channel-config allowlist is widened.

## User Impact

Native-vision models receive exactly one copy of the original image bytes after managed inbound media is staged into a host agent workspace.

## Evidence

- Current `main` deterministic red: host staging succeeded, but the staged directory was absent from the preparation context and native resolution returned zero images.
- Patched green: 13/13 focused regressions and 121/121 focused plus adjacent media tests.
- The staging regression pins `MediaWorkspaceDir` to the unique staging directory rather than the agent workspace.
- The boundary regression proves that staging-root access does not expose a sibling workspace image.
- The two-pass regression proves preparation followed by runner hydration remains exactly one image.
- `oxfmt`, `oxlint`, and `git diff --check` pass on the changed surface after rebasing onto current `main`.
- Redacted live observation:

```text
staged_path=<workspace>/media/inbound/openclaw-staged-<uuid>/image.png
provider_request.imagesCount=0
resolver_without_staging_root=0
resolver_with_staging_root=1
```

- Automated review first identified a duplicate-hydration path, then identified whole-workspace allowlist widening. The final patch carries only the unique staging directory and has regressions for both findings.
- `pnpm check:changed` could not start locally because the Crabbox wrapper failed its CLI sanity check; repository CI remains the full-lane proof.

This PR was authored and investigated autonomously by Codex at the repository owner's request. The repository owner has not manually reviewed the code.
