### PR TITLE
fix(codex): avoid shutdown warnings after live updates

### DIFF
--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -1,5 +1,5 @@
 // Codex tests cover harness plugin behavior.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createCodexAppServerAgentHarness } from "./harness.js";
 import {
   createCodexTestBindingStore,
@@ -256,5 +256,30 @@ describe("Codex agent harness reset()", () => {
     });
 
     await expect(bindingStore.read(identity)).resolves.toBeUndefined();
+  });
+});
+
+describe("Codex agent harness dispose()", () => {
+  it("uses the preloaded shared-client lifecycle seam", async () => {
+    const sharedDisposer = Symbol.for("openclaw.codexAppServerClientDisposer");
+    const state = globalThis as typeof globalThis & {
+      [sharedDisposer]?: () => Promise<void>;
+    };
+    const previous = state[sharedDisposer];
+    const dispose = vi.fn(async () => {});
+    state[sharedDisposer] = dispose;
+    const harness = createCodexAppServerAgentHarness({
+      bindingStore: testCodexAppServerBindingStore,
+    });
+    try {
+      await harness.dispose?.();
+      expect(dispose).toHaveBeenCalledOnce();
+    } finally {
+      if (previous) {
+        state[sharedDisposer] = previous;
+      } else {
+        delete state[sharedDisposer];
+      }
+    }
   });
 });

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -16,6 +16,7 @@ import type {
 import type { CodexAppServerBindingStore } from "./src/app-server/session-binding.js";
 
 const DEFAULT_CODEX_HARNESS_PROVIDER_IDS = new Set(["codex", "openai"]);
+const SHARED_CODEX_APP_SERVER_CLIENT_DISPOSER = Symbol.for("openclaw.codexAppServerClientDisposer");
 const CODEX_APP_SERVER_CONTEXT_ENGINE_HOST_CAPABILITIES = [
   "bootstrap",
   "assemble-before-prompt",
@@ -34,6 +35,15 @@ type CodexAppServerAgentHarness = AgentHarness & {
     params: AgentHarnessCompactParams,
   ): Promise<AgentHarnessCompactResult | undefined>;
 };
+
+async function disposeSharedCodexAppServerClients(): Promise<void> {
+  const dispose = (
+    globalThis as typeof globalThis & {
+      [SHARED_CODEX_APP_SERVER_CLIENT_DISPOSER]?: () => Promise<void>;
+    }
+  )[SHARED_CODEX_APP_SERVER_CLIENT_DISPOSER];
+  await dispose?.();
+}
 
 /**
  * Creates the Codex app-server harness used for attempts, side questions,
@@ -194,11 +204,7 @@ export function createCodexAppServerAgentHarness(options: {
         }
       }
     },
-    dispose: async () => {
-      const { clearSharedCodexAppServerClientAndWait } =
-        await import("./src/app-server/shared-client.js");
-      await clearSharedCodexAppServerClientAndWait();
-    },
+    dispose: disposeSharedCodexAppServerClients,
   };
   return harness;
 }

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -90,6 +90,7 @@ const suspectClosedClients = new WeakSet<CodexAppServerClient>();
 // src bundles in one process). Plugin updates restart the gateway, so every
 // copy writing this state runs the same code and the shape never migrates.
 const SHARED_CODEX_APP_SERVER_CLIENT_STATE = Symbol.for("openclaw.codexAppServerClientState");
+const SHARED_CODEX_APP_SERVER_CLIENT_DISPOSER = Symbol.for("openclaw.codexAppServerClientDisposer");
 const CODEX_APP_SERVER_CLIENT_START_METADATA = Symbol.for(
   "openclaw.codexAppServerClientStartMetadata",
 );
@@ -1085,6 +1086,12 @@ export async function clearSharedCodexAppServerClientAndWait(options?: {
   state.clients.clear();
   await Promise.all(clients.map((client) => client.closeAndWait(options)));
 }
+
+(
+  globalThis as typeof globalThis & {
+    [SHARED_CODEX_APP_SERVER_CLIENT_DISPOSER]?: () => Promise<void>;
+  }
+)[SHARED_CODEX_APP_SERVER_CLIENT_DISPOSER] = clearSharedCodexAppServerClientAndWait;
 
 function getOrCreateSharedClientEntry(
   state: SharedCodexAppServerClientState,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators applying live builds could see Codex harness shutdown warnings because the running Gateway tried to load a content-hashed client chunk that the new build had replaced.

## Why This Change Was Made

The Codex harness now calls a preloaded, process-global disposer. The lazy shared-client runtime registers the real cleanup callback only when loaded, preserving cold-start behavior while keeping teardown callable after the on-disk `dist` tree changes.

## User Impact

Gateway restarts after live builds can close Codex app-server clients without a stale-chunk `ERR_MODULE_NOT_FOUND` warning. No user-facing API or configuration changes.

## Evidence

- Repeated live restart logs reproduced `Codex agent harness dispose hook failed` with missing `shared-client-*.js` chunks.
- Blacksmith Testbox: `pnpm test extensions/codex/harness.test.ts` — 25 tests passed.
- Regression test verifies harness disposal uses the preloaded process-global callback.
- Upstream Codex confirms stdio EOF is the graceful shutdown signal and bounded shutdown is the intended client lifecycle.
- Autoreview: clean, no accepted/actionable findings.
