### PR TITLE
fix(mac): keep remote nodes connected during config metadata writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS remote node stability:** ignore config writer bookkeeping timestamps when watching gateway settings so metadata-only rewrites no longer restart node routing or interrupt remote Mac sessions.
 - **Claude CLI context budgets:** honor Anthropic model and per-agent `contextTokens` limits by passing the effective limit to Claude Code's native auto-compactor and persisting the same prepared budget in OpenClaw session state. Fixes #80933. (#93198) Thanks @mushuiyu886.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.
 - **Gateway source watch:** hand the configured port off from the installed service before starting the tmux watcher, preserve failed panes for attach/capture, and keep explicit alternate-port watches side by side with the managed Gateway.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS remote node stability:** ignore config writer bookkeeping timestamps when watching gateway settings so metadata-only rewrites no longer restart node routing or interrupt remote Mac sessions.
 - **Claude CLI context budgets:** honor Anthropic model and per-agent `contextTokens` limits by passing the effective limit to Claude Code's native auto-compactor and persisting the same prepared budget in OpenClaw session state. Fixes #80933. (#93198) Thanks @mushuiyu886.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.
 - **Gateway source watch:** hand the configured port off from the installed service before starting the tmux watcher, preserve failed panes for attach/capture, and keep explicit alternate-port watches side by side with the managed Gateway.

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -625,17 +625,27 @@ final class AppState {
     private func applyConfigFromDisk() {
         let root = OpenClawConfigFile.loadDict()
         let fingerprint = Self.configFingerprint(root)
-        let changed = fingerprint != self.lastConfigFingerprint
+        guard fingerprint != self.lastConfigFingerprint else { return }
         self.lastConfigFingerprint = fingerprint
         self.applyConfigOverrides(root)
         MacNodeModeCoordinator.shared.refresh()
-        if changed {
-            NotificationCenter.default.post(name: .openclawConfigDidChange, object: nil)
-        }
+        NotificationCenter.default.post(name: .openclawConfigDidChange, object: nil)
     }
 
     private static func configFingerprint(_ root: [String: Any]) -> Data? {
-        try? JSONSerialization.data(withJSONObject: root, options: [.sortedKeys])
+        var comparableRoot = root
+        if var meta = comparableRoot["meta"] as? [String: Any] {
+            // Writers refresh these bookkeeping fields without changing runtime configuration.
+            // Ignoring them prevents metadata churn from restarting gateway and node routing.
+            meta.removeValue(forKey: "lastTouchedAt")
+            meta.removeValue(forKey: "lastTouchedVersion")
+            if meta.isEmpty {
+                comparableRoot.removeValue(forKey: "meta")
+            } else {
+                comparableRoot["meta"] = meta
+            }
+        }
+        return try? JSONSerialization.data(withJSONObject: comparableRoot, options: [.sortedKeys])
     }
 
     private func applyConfigOverrides(_ root: [String: Any]) {
@@ -1187,6 +1197,10 @@ extension AppState {
 #if DEBUG
 @MainActor
 extension AppState {
+    static func _testConfigFingerprint(_ root: [String: Any]) -> Data? {
+        self.configFingerprint(root)
+    }
+
     static func _testUpdatedRemoteGatewayConfig(
         current: [String: Any],
         draft: RemoteGatewayConfigDraft) -> [String: Any]

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -52,6 +52,30 @@ private actor GatewayConfigReadGate {
 @MainActor
 struct AppStateRemoteConfigTests {
     @Test
+    func `config fingerprint ignores writer bookkeeping metadata`() {
+        let base: [String: Any] = [
+            "gateway": ["mode": "local"],
+        ]
+        let touched: [String: Any] = [
+            "gateway": ["mode": "local"],
+            "meta": [
+                "lastTouchedAt": "2026-07-13T09:12:53Z",
+                "lastTouchedVersion": "2026.7.2",
+            ],
+        ]
+        let changed: [String: Any] = [
+            "gateway": ["mode": "remote"],
+            "meta": [
+                "lastTouchedAt": "2026-07-13T09:13:25Z",
+                "lastTouchedVersion": "2026.7.2",
+            ],
+        ]
+
+        #expect(AppState._testConfigFingerprint(base) == AppState._testConfigFingerprint(touched))
+        #expect(AppState._testConfigFingerprint(base) != AppState._testConfigFingerprint(changed))
+    }
+
+    @Test
     func `route edit during config read fails the source snapshot closed`() async {
         let configPath = TestIsolation.tempConfigPath()
         await TestIsolation.withIsolatedState(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS nodes connected to a remote Gateway would repeatedly restart routing and briefly disconnect when the Gateway rewrote only config bookkeeping timestamps.

## Why This Change Was Made

The macOS config watcher now excludes only `meta.lastTouchedAt` and `meta.lastTouchedVersion` from its runtime fingerprint and returns before refreshing node routing when no meaningful config changed. All other metadata and runtime configuration remain change-sensitive.

## User Impact

Remote Mac nodes stay connected through metadata-only Gateway config writes, keeping Codex session catalogs and Computer Use commands available without periodic reconnect windows.

## Evidence

- Before: ClawMac rewrote bookkeeping metadata about every 31 seconds; each write advanced Mac routing generation and caused a brief node reconnect.
- `swift test --package-path apps/macos --filter AppStateRemoteConfigTests` — 27 tests passed.
- Regression coverage proves bookkeeping-only updates compare equal while a real Gateway mode change still compares different.
- `./scripts/format-swift.sh` — clean.
- Autoreview — clean, no accepted/actionable findings.
