### PR TITLE
fix(usage): guard malformed Gemini quota buckets

### DIFF
--- a/src/infra/provider-usage.fetch.gemini.test.ts
+++ b/src/infra/provider-usage.fetch.gemini.test.ts
@@ -64,6 +64,23 @@ describe("fetchGeminiUsage", () => {
     });
   });
 
+  it("treats a non-array buckets object as empty without erroring", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        buckets: {},
+      }),
+    );
+
+    const result = await fetchGeminiUsage("token", 5000, mockFetch, usageProvider);
+
+    expect(result.error).toBeUndefined();
+    expect(result).toEqual({
+      provider: usageProvider,
+      displayName: "OpenAI",
+      windows: [],
+    });
+  });
+
   it("defaults missing fractions to fully available and clamps invalid fractions", async () => {
     const mockFetch = createProviderUsageFetch(async () =>
       makeResponse(200, {

--- a/src/infra/provider-usage.fetch.gemini.test.ts
+++ b/src/infra/provider-usage.fetch.gemini.test.ts
@@ -64,21 +64,39 @@ describe("fetchGeminiUsage", () => {
     });
   });
 
-  it("treats a non-array buckets object as empty without erroring", async () => {
-    const mockFetch = createProviderUsageFetch(async () =>
-      makeResponse(200, {
-        buckets: {},
-      }),
-    );
+  it.each([
+    ["null response", null],
+    ["array response", []],
+    ["non-array buckets", { buckets: {} }],
+  ])("treats %s as empty usage", async (_name, payload) => {
+    const mockFetch = createProviderUsageFetch(async () => makeResponse(200, payload));
 
     const result = await fetchGeminiUsage("token", 5000, mockFetch, usageProvider);
 
-    expect(result.error).toBeUndefined();
     expect(result).toEqual({
       provider: usageProvider,
       displayName: "OpenAI",
       windows: [],
     });
+  });
+
+  it("ignores malformed buckets and preserves a zero remaining fraction", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        buckets: [
+          null,
+          [],
+          "invalid",
+          { modelId: 42, remainingFraction: "0.2" },
+          { modelId: "gemini-pro", remainingFraction: 0 },
+          { modelId: "gemini-pro", remainingFraction: 0.5 },
+        ],
+      }),
+    );
+
+    const result = await fetchGeminiUsage("token", 5000, mockFetch, usageProvider);
+
+    expect(result.windows).toEqual([{ label: "Pro", usedPercent: 100 }]);
   });
 
   it("defaults missing fractions to fully available and clamps invalid fractions", async () => {

--- a/src/infra/provider-usage.fetch.gemini.ts
+++ b/src/infra/provider-usage.fetch.gemini.ts
@@ -53,7 +53,12 @@ export async function fetchGeminiUsage(
   const data = parsed.data as GeminiUsageResponse;
   const quotas: Record<string, number> = {};
 
-  for (const bucket of data.buckets || []) {
+  // Malformed APIs may return a non-array `buckets` object; iterating it throws.
+  const buckets = Array.isArray(data.buckets) ? data.buckets : [];
+  for (const bucket of buckets) {
+    if (!bucket || typeof bucket !== "object") {
+      continue;
+    }
     const model = bucket.modelId || "unknown";
     const frac = bucket.remainingFraction ?? 1;
     if (!quotas[model] || frac < quotas[model]) {

--- a/src/infra/provider-usage.fetch.gemini.ts
+++ b/src/infra/provider-usage.fetch.gemini.ts
@@ -1,4 +1,5 @@
 import { expectDefined } from "@openclaw/normalization-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 // Fetches Gemini provider usage windows.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import {
@@ -13,10 +14,6 @@ import type {
   UsageProviderId,
   UsageWindow,
 } from "./provider-usage.types.js";
-
-type GeminiUsageResponse = {
-  buckets?: Array<{ modelId?: string; remainingFraction?: number }>;
-};
 
 export async function fetchGeminiUsage(
   token: string,
@@ -50,19 +47,18 @@ export async function fetchGeminiUsage(
   if (!parsed.ok) {
     return parsed.snapshot;
   }
-  const data = parsed.data as GeminiUsageResponse;
-  const quotas: Record<string, number> = {};
-
-  // Malformed APIs may return a non-array `buckets` object; iterating it throws.
-  const buckets = Array.isArray(data.buckets) ? data.buckets : [];
+  const buckets =
+    isRecord(parsed.data) && Array.isArray(parsed.data.buckets) ? parsed.data.buckets : [];
+  const quotas = new Map<string, number>();
   for (const bucket of buckets) {
-    if (!bucket || typeof bucket !== "object") {
+    if (!isRecord(bucket)) {
       continue;
     }
-    const model = bucket.modelId || "unknown";
-    const frac = bucket.remainingFraction ?? 1;
-    if (!quotas[model] || frac < quotas[model]) {
-      quotas[model] = frac;
+    const model = typeof bucket.modelId === "string" ? bucket.modelId : "unknown";
+    const frac = typeof bucket.remainingFraction === "number" ? bucket.remainingFraction : 1;
+    const current = quotas.get(model);
+    if (current === undefined || frac < current) {
+      quotas.set(model, frac);
     }
   }
 
@@ -72,7 +68,7 @@ export async function fetchGeminiUsage(
   let hasPro = false;
   let hasFlash = false;
 
-  for (const [model, frac] of Object.entries(quotas)) {
+  for (const [model, frac] of quotas) {
     const lower = normalizeLowercaseStringOrEmpty(model);
     if (lower.includes("pro")) {
       hasPro = true;


### PR DESCRIPTION
## What Problem This Solves

Gemini usage fetch iterates `data.buckets` with `data.buckets || []`. When the API returns a non-array truthy value such as `{}`, the loop throws because objects are not iterable, and the usage snapshot path fails instead of degrading to empty windows.

## Why This Change Was Made

In `src/infra/provider-usage.fetch.gemini.ts`, normalize `buckets` with `Array.isArray` before iteration, and skip non-object entries so malformed quota payloads cannot crash the fetch path.

## User Impact

**Before:** A malformed Gemini quota response with non-array `buckets` could throw during usage fetch.
**After:** Non-array `buckets` are treated as empty; usage returns no windows and no error for that shape.

## Evidence

Branch: `codex/gemini-usage-buckets-boundary` | Base: `upstream/main` | Head: `dfbb757d` | Node: v24.18.0 — Windows

### Diff summary

```text
src/infra/provider-usage.fetch.gemini.ts       | Array.isArray guard + non-object skip
src/infra/provider-usage.fetch.gemini.test.ts  | malformed buckets regression
```

What was not tested: live Gemini quota API responses against `retrieveUserQuota`.

## Real behavior proof

**Behavior addressed:** Malformed non-array `buckets` objects no longer crash production `fetchGeminiUsage`; the path degrades to an empty usage snapshot without error, while valid bucket arrays still normalize Pro/Flash windows.
**Environment tested:** Windows, Node v24.18.0, patched branch `dfbb757d`; production `fetchGeminiUsage` imported from `src/infra/provider-usage.fetch.gemini.ts` via `node --import tsx` (script: `gemini-usage-buckets-proof.mts`).
**Steps run after the patch:**

1. Run `node --import tsx --no-warnings gemini-usage-buckets-proof.mts`.
2. Show main-style control: iterating `(data.buckets || [])` when `buckets={}` throws.
3. Call production `fetchGeminiUsage` with a synthetic 200 response `{ buckets: {} }` and with a valid buckets array.

**Evidence after fix:**

```text
$ node --import tsx --no-warnings gemini-usage-buckets-proof.mts

gemini-usage-buckets-proof start
main-style control: buckets={} with (data.buckets || []) -> throws=true message=object is not iterable (cannot read property Symbol(Symbol.iterator))
production fetchGeminiUsage malformed buckets: {
  "provider": "openai",
  "displayName": "OpenAI",
  "windowCount": 0,
  "windows": []
}
production fetchGeminiUsage valid buckets: {
  "windowCount": 2,
  "windows": [
    {
      "label": "Pro",
      "usedPercent": 19.999999999999996
    },
    {
      "label": "Flash",
      "usedPercent": 30.000000000000004
    }
  ]
}
{
  "mainStyleThrows": true,
  "malformedNoError": true,
  "malformedEmptyWindows": true,
  "validStillParses": true
}
```

**Observed result:** Main-style iteration on `{ buckets: {} }` throws; production `fetchGeminiUsage` after the patch returns no error and zero windows for the malformed payload, and still parses valid Pro/Flash windows for a normal buckets array.
**Not tested:** Live authenticated call to `https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota`; proof uses production parser code with synthetic 200 JSON bodies.

- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
