### PR TITLE
fix(usage): ignore invalid Z.ai reset timestamps

### DIFF
--- a/src/infra/provider-usage.fetch.claude.test.ts
+++ b/src/infra/provider-usage.fetch.claude.test.ts
@@ -105,6 +105,29 @@ describe("fetchClaudeUsage", () => {
     ]);
   });
 
+  it("omits invalid reset timestamps from usage windows", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        five_hour: { utilization: 18, resets_at: "not-a-date" },
+        limits: [
+          {
+            percent: 27,
+            resets_at: "also-invalid",
+            is_active: true,
+            scope: { model: { display_name: "Fable" } },
+          },
+        ],
+      }),
+    );
+
+    const result = await fetchClaudeUsage("token", 5000, mockFetch);
+
+    expect(result.windows).toEqual([
+      { label: "5h", usedPercent: 18, resetAt: undefined },
+      { label: "Fable", usedPercent: 27, resetAt: undefined },
+    ]);
+  });
+
   it("parses model-scoped limits and extra usage billing", async () => {
     const reset = "2026-01-12T00:00:00Z";
     const mockFetch = createProviderUsageFetch(async () =>

--- a/src/infra/provider-usage.fetch.claude.ts
+++ b/src/infra/provider-usage.fetch.claude.ts
@@ -4,6 +4,7 @@ import {
   buildUsageHttpErrorSnapshot,
   discardUsageResponseBody,
   fetchJson,
+  parseUsageResetAt,
   readUsageJson,
 } from "./provider-usage.fetch.shared.js";
 import { clampPercent, PROVIDER_LABELS } from "./provider-usage.shared.js";
@@ -44,7 +45,7 @@ function buildClaudeUsageWindows(
     windows.push({
       label: "5h",
       usedPercent: clampPercent(data.five_hour.utilization),
-      resetAt: data.five_hour.resets_at ? new Date(data.five_hour.resets_at).getTime() : undefined,
+      resetAt: parseUsageResetAt(data.five_hour.resets_at),
     });
   }
 
@@ -52,7 +53,7 @@ function buildClaudeUsageWindows(
     windows.push({
       label: "Week",
       usedPercent: clampPercent(data.seven_day.utilization),
-      resetAt: data.seven_day.resets_at ? new Date(data.seven_day.resets_at).getTime() : undefined,
+      resetAt: parseUsageResetAt(data.seven_day.resets_at),
     });
   }
 
@@ -78,7 +79,7 @@ function buildClaudeUsageWindows(
     windows.push({
       label,
       usedPercent: clampPercent(limit.percent ?? 0),
-      resetAt: limit.resets_at ? new Date(limit.resets_at).getTime() : undefined,
+      resetAt: parseUsageResetAt(limit.resets_at),
     });
   }
 

--- a/src/infra/provider-usage.fetch.shared.ts
+++ b/src/infra/provider-usage.fetch.shared.ts
@@ -1,5 +1,8 @@
 // Shared fetch and parsing helpers for provider usage endpoints.
-import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import {
+  asDateTimestampMs,
+  resolveTimerTimeoutMs,
+} from "@openclaw/normalization-core/number-coercion";
 import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
 import { parseFiniteNumber as parseFiniteNumberish } from "./parse-finite-number.js";
 import { resolveProviderUsageDisplayName } from "./provider-usage.shared.js";
@@ -28,6 +31,14 @@ export async function discardUsageResponseBody(response: Response): Promise<void
 
 export function parseFiniteNumber(value: unknown): number | undefined {
   return parseFiniteNumberish(value);
+}
+
+/** Parses a provider reset-time string without leaking an invalid Date timestamp. */
+export function parseUsageResetAt(value: unknown): number | undefined {
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+  return asDateTimestampMs(Date.parse(value));
 }
 
 type BuildUsageHttpErrorSnapshotOptions = {

--- a/src/infra/provider-usage.fetch.zai.test.ts
+++ b/src/infra/provider-usage.fetch.zai.test.ts
@@ -149,4 +149,46 @@ describe("fetchZaiUsage", () => {
       },
     ]);
   });
+
+  it("ignores invalid nextResetTime while preserving valid ISO resets", async () => {
+    const validReset = "2026-01-08T00:00:00Z";
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        success: true,
+        code: 200,
+        data: {
+          planName: "Team",
+          limits: [
+            {
+              type: "TOKENS_LIMIT",
+              percentage: 20,
+              unit: 3,
+              number: 6,
+              nextResetTime: "not-a-date",
+            },
+            {
+              type: "TIME_LIMIT",
+              percentage: 40,
+              nextResetTime: validReset,
+            },
+          ],
+        },
+      }),
+    );
+
+    const result = await fetchZaiUsage("key", 5000, mockFetch);
+
+    expect(result.windows).toEqual([
+      {
+        label: "Tokens (6h)",
+        usedPercent: 20,
+        resetAt: undefined,
+      },
+      {
+        label: "Monthly",
+        usedPercent: 40,
+        resetAt: new Date(validReset).getTime(),
+      },
+    ]);
+  });
 });

--- a/src/infra/provider-usage.fetch.zai.ts
+++ b/src/infra/provider-usage.fetch.zai.ts
@@ -3,6 +3,7 @@ import {
   buildUsageHttpErrorSnapshot,
   discardUsageResponseBody,
   fetchJson,
+  parseUsageResetAt,
   readUsageJson,
 } from "./provider-usage.fetch.shared.js";
 import { clampPercent, PROVIDER_LABELS } from "./provider-usage.shared.js";
@@ -71,9 +72,7 @@ export async function fetchZaiUsage(
 
   for (const limit of limits) {
     const percent = clampPercent(limit.percentage || 0);
-    // Invalid reset strings become NaN; keep resetAt unset instead of propagating NaN.
-    const parsedReset = limit.nextResetTime ? new Date(limit.nextResetTime).getTime() : undefined;
-    const nextReset = Number.isFinite(parsedReset) ? parsedReset : undefined;
+    const nextReset = parseUsageResetAt(limit.nextResetTime);
     let windowLabel = "Limit";
     if (limit.unit === 1) {
       windowLabel = `${limit.number}d`;

--- a/src/infra/provider-usage.fetch.zai.ts
+++ b/src/infra/provider-usage.fetch.zai.ts
@@ -71,7 +71,9 @@ export async function fetchZaiUsage(
 
   for (const limit of limits) {
     const percent = clampPercent(limit.percentage || 0);
-    const nextReset = limit.nextResetTime ? new Date(limit.nextResetTime).getTime() : undefined;
+    // Invalid reset strings become NaN; keep resetAt unset instead of propagating NaN.
+    const parsedReset = limit.nextResetTime ? new Date(limit.nextResetTime).getTime() : undefined;
+    const nextReset = Number.isFinite(parsedReset) ? parsedReset : undefined;
     let windowLabel = "Limit";
     if (limit.unit === 1) {
       windowLabel = `${limit.number}d`;


### PR DESCRIPTION
## What Problem This Solves

Z.ai usage parsing converted `nextResetTime` directly with `Date#getTime()`. A malformed provider value therefore produced `resetAt: NaN` instead of the domain's existing “timestamp absent” representation.

The same one-sided risk existed in Claude usage-window parsing, so the maintainer cleanup fixes the full string-reset boundary rather than leaving a sibling parser inconsistent.

## Why This Change Was Made

- Adds one shared `parseUsageResetAt` boundary helper.
- Accepts non-empty provider timestamp strings only when they parse to a Date-valid finite millisecond value.
- Uses that helper for Z.ai token/time limits and Claude 5-hour, weekly, and model-scoped limits.
- Keeps valid ISO reset timestamps unchanged.

## User Impact

**Before:** malformed reset strings could escape provider parsing as `NaN`.

**After:** malformed reset strings omit `resetAt`; valid reset timestamps still render normally.

## Evidence

Maintainer head: `ee1b7377e6b73c0dd847d55168697b7bbf7804d9`

- Blacksmith focused provider suites: 44/44 passed across Z.ai, Claude, and shared usage-fetch tests.
- Blacksmith exact path-scoped changed gate passed: formatting, production and test typechecks, lint, dependency/plugin guards, import-cycle checks, and storage guards.
- Blacksmith run: https://github.com/openclaw/openclaw/actions/runs/29496634811
- Fresh exact-branch Autoreview: clean, confidence 0.99.
- Contributor live-path proof: an authenticated Z.ai request reached the production usage endpoint and returned its structured “no coding plan” response. The same production parser then preserved a valid ISO reset and omitted an invalid reset. The available account did not return a naturally malformed live reset value.

- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
