### PR TITLE
fix(onepassword): preserve Unicode in audit reason truncation

### DIFF
--- a/extensions/onepassword/src/cli.test.ts
+++ b/extensions/onepassword/src/cli.test.ts
@@ -127,4 +127,23 @@ describe("1Password CLI output", () => {
     expect(rows[0]?.reason).toHaveLength(80);
     expect(JSON.stringify(rows)).not.toContain(["fixture", "value"].join("-"));
   });
+
+  it("does not split a surrogate pair when truncating an audit reason", async () => {
+    const store = new MemoryKeyedStore<AuditRow>();
+    await store.register("unicode", {
+      timestampMs: 1000,
+      agentId: "agent-a",
+      sessionKey: "session-a",
+      toolCallId: "call-a",
+      slug: "alpha",
+      reason: `${"x".repeat(76)}\u{1f600}tail`,
+      outcome: "auto",
+    });
+    const { onepassword, write } = setupCommands(store);
+
+    await onepassword.child("audit").run({ limit: "1" });
+    const rows = JSON.parse(String(write.mock.calls[0]?.[0])) as Array<Record<string, unknown>>;
+
+    expect(rows[0]?.reason).toBe(`${"x".repeat(76)}...`);
+  });
 });

--- a/extensions/onepassword/src/cli.test.ts
+++ b/extensions/onepassword/src/cli.test.ts
@@ -128,9 +128,9 @@ describe("1Password CLI output", () => {
     expect(JSON.stringify(rows)).not.toContain(["fixture", "value"].join("-"));
   });
 
-  it("does not split a surrogate pair when truncating an audit reason", async () => {
+  it("preserves complete surrogate pairs at the audit reason boundary", async () => {
     const store = new MemoryKeyedStore<AuditRow>();
-    await store.register("unicode", {
+    await store.register("split", {
       timestampMs: 1000,
       agentId: "agent-a",
       sessionKey: "session-a",
@@ -139,11 +139,25 @@ describe("1Password CLI output", () => {
       reason: `${"x".repeat(76)}\u{1f600}tail`,
       outcome: "auto",
     });
+    await store.register("fits", {
+      timestampMs: 2000,
+      agentId: "agent-a",
+      sessionKey: "session-a",
+      toolCallId: "call-b",
+      slug: "alpha",
+      reason: `${"x".repeat(75)}\u{1f600}tail`,
+      outcome: "auto",
+    });
     const { onepassword, write } = setupCommands(store);
 
-    await onepassword.child("audit").run({ limit: "1" });
-    const rows = JSON.parse(String(write.mock.calls[0]?.[0])) as Array<Record<string, unknown>>;
+    await onepassword.child("audit").run({ limit: "2" });
+    const output = String(write.mock.calls[0]?.[0]);
+    expect(output).not.toContain("\\ud83d");
+    const rows = JSON.parse(output) as Array<Record<string, unknown>>;
 
-    expect(rows[0]?.reason).toBe(`${"x".repeat(76)}...`);
+    expect(rows.map((row) => row.reason)).toEqual([
+      `${"x".repeat(75)}\u{1f600}...`,
+      `${"x".repeat(76)}...`,
+    ]);
   });
 });

--- a/extensions/onepassword/src/cli.ts
+++ b/extensions/onepassword/src/cli.ts
@@ -1,4 +1,5 @@
 import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { AuditRow } from "./broker.js";
 import type { OnePasswordConfig } from "./config.js";
 import type { OpClient } from "./op-client.js";
@@ -30,7 +31,7 @@ function parseLimit(value: unknown): number {
 }
 
 function truncateReason(reason: string): string {
-  return reason.length <= 80 ? reason : `${reason.slice(0, 77)}...`;
+  return reason.length <= 80 ? reason : `${truncateUtf16Safe(reason, 77)}...`;
 }
 
 async function buildStatus(


### PR DESCRIPTION
## What Problem This Solves

The 1Password audit CLI truncated long reasons with a raw UTF-16 slice. When the cutoff landed between an emoji's surrogate pair, the JSON output contained a split Unicode character.

## Why This Change Was Made

Audit reason truncation now uses the existing public `truncateUtf16Safe` plugin SDK helper. The 80-code-unit limit and existing ASCII output stay unchanged.

## User Impact

Long 1Password audit reasons no longer end with a broken Unicode character when the truncation boundary crosses an emoji or another supplementary-plane character.

## Evidence

- Exact-head focused test on Node 24.15.0: `node scripts/run-vitest.mjs extensions/onepassword/src/cli.test.ts` (3 tests passed).
- Regression coverage places an emoji across the old 77-code-unit cutoff and verifies the output contains no half surrogate.
- `oxfmt` on both touched files: passed.
- `git diff upstream/main...HEAD --check`: passed.

AI-assisted: yes (implementation and tests).
