### PR TITLE
refactor(agents): trim bootstrap test exports

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -872,8 +872,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/agents/auth-profiles/usage.ts: testing",
   "src/agents/bash-process-registry.ts: resetProcessRegistryForTests",
   "src/agents/bash-tools.exec.ts: testing",
-  "src/agents/bootstrap-cache.ts: clearAllBootstrapSnapshots",
-  "src/agents/bootstrap-files.ts: resetBootstrapWarningCacheForTest",
   "src/agents/cache-trace.ts: summarizeMessages",
   "src/agents/channel-tools.ts: testing",
   "src/agents/chutes-oauth.ts: CHUTES_TOKEN_ENDPOINT",

--- a/src/agents/bootstrap-cache.test.ts
+++ b/src/agents/bootstrap-cache.test.ts
@@ -2,6 +2,7 @@
  * Regression coverage for per-session workspace bootstrap caching.
  * Verifies reuse, refresh, pruning, and explicit cache clears.
  */
+import { randomUUID } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
 
@@ -11,6 +12,12 @@ vi.mock("./workspace.js", () => ({
 
 import { clearBootstrapSnapshot, getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
 import { loadWorkspaceBootstrapFiles } from "./workspace.js";
+
+let workspaceDir = "";
+
+beforeEach(() => {
+  workspaceDir = `/ws/${randomUUID()}`;
+});
 
 function makeFile(name: string, content: string): WorkspaceBootstrapFile {
   return {
@@ -35,7 +42,7 @@ describe("getOrLoadBootstrapFiles", () => {
 
   it("loads from disk on first call and caches", async () => {
     const result = await getOrLoadBootstrapFiles({
-      workspaceDir: "/ws",
+      workspaceDir,
       sessionKey: "session-1",
     });
 
@@ -47,8 +54,8 @@ describe("getOrLoadBootstrapFiles", () => {
     const refreshedFiles = [makeFile("AGENTS.md", "# Agent"), makeFile("SOUL.md", "# Soul")];
     mockLoad().mockResolvedValueOnce(files).mockResolvedValueOnce(refreshedFiles);
 
-    const first = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
-    const result = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
+    const first = await getOrLoadBootstrapFiles({ workspaceDir, sessionKey: "session-1" });
+    const result = await getOrLoadBootstrapFiles({ workspaceDir, sessionKey: "session-1" });
 
     expect(first).toBe(files);
     expect(result).toBe(first);
@@ -60,8 +67,8 @@ describe("getOrLoadBootstrapFiles", () => {
     const updatedFiles = [makeFile("AGENTS.md", "# Agent v2"), makeFile("SOUL.md", "# Soul")];
     mockLoad().mockResolvedValueOnce(files).mockResolvedValueOnce(updatedFiles);
 
-    const first = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
-    const result = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
+    const first = await getOrLoadBootstrapFiles({ workspaceDir, sessionKey: "session-1" });
+    const result = await getOrLoadBootstrapFiles({ workspaceDir, sessionKey: "session-1" });
 
     expect(first).toBe(files);
     expect(result).toBe(updatedFiles);
@@ -72,8 +79,8 @@ describe("getOrLoadBootstrapFiles", () => {
     const files2 = [makeFile("AGENTS.md", "# Agent v2")];
     mockLoad().mockResolvedValueOnce(files).mockResolvedValueOnce(files2);
 
-    const r1 = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
-    const r2 = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-2" });
+    const r1 = await getOrLoadBootstrapFiles({ workspaceDir, sessionKey: "session-1" });
+    const r2 = await getOrLoadBootstrapFiles({ workspaceDir, sessionKey: "session-2" });
 
     expect(r1).toBe(files);
     expect(r2).toBe(files2);
@@ -83,7 +90,7 @@ describe("getOrLoadBootstrapFiles", () => {
   it("evicts the oldest snapshot once the cache exceeds its cap", async () => {
     for (let index = 0; index <= 64; index += 1) {
       await getOrLoadBootstrapFiles({
-        workspaceDir: "/ws",
+        workspaceDir,
         sessionKey: `session-${index}`,
       });
     }
@@ -91,7 +98,7 @@ describe("getOrLoadBootstrapFiles", () => {
     expect(mockLoad()).toHaveBeenCalledTimes(65);
 
     await getOrLoadBootstrapFiles({
-      workspaceDir: "/ws",
+      workspaceDir,
       sessionKey: "session-0",
     });
 
@@ -111,22 +118,22 @@ describe("clearBootstrapSnapshot", () => {
   });
 
   it("clears a single session entry", async () => {
-    await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "sk" });
+    await getOrLoadBootstrapFiles({ workspaceDir, sessionKey: "sk" });
     clearBootstrapSnapshot("sk");
 
     // Next call should hit disk again.
-    await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "sk" });
+    await getOrLoadBootstrapFiles({ workspaceDir, sessionKey: "sk" });
     expect(mockLoad()).toHaveBeenCalledTimes(2);
   });
 
   it("does not affect other sessions", async () => {
-    await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "sk1" });
-    const first = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "sk2" });
+    await getOrLoadBootstrapFiles({ workspaceDir, sessionKey: "sk1" });
+    const first = await getOrLoadBootstrapFiles({ workspaceDir, sessionKey: "sk2" });
 
     clearBootstrapSnapshot("sk1");
 
     // sk2 should still preserve its cached snapshot identity after refresh.
-    const second = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "sk2" });
+    const second = await getOrLoadBootstrapFiles({ workspaceDir, sessionKey: "sk2" });
     expect(second).toBe(first);
     expect(mockLoad()).toHaveBeenCalledTimes(3); // sk1 x1, sk2 x2
   });

--- a/src/agents/bootstrap-cache.test.ts
+++ b/src/agents/bootstrap-cache.test.ts
@@ -9,11 +9,7 @@ vi.mock("./workspace.js", () => ({
   loadWorkspaceBootstrapFiles: vi.fn(),
 }));
 
-import {
-  clearAllBootstrapSnapshots,
-  clearBootstrapSnapshot,
-  getOrLoadBootstrapFiles,
-} from "./bootstrap-cache.js";
+import { clearBootstrapSnapshot, getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
 import { loadWorkspaceBootstrapFiles } from "./workspace.js";
 
 function makeFile(name: string, content: string): WorkspaceBootstrapFile {
@@ -30,12 +26,10 @@ describe("getOrLoadBootstrapFiles", () => {
   const mockLoad = () => vi.mocked(loadWorkspaceBootstrapFiles);
 
   beforeEach(() => {
-    clearAllBootstrapSnapshots();
     mockLoad().mockResolvedValue(files);
   });
 
   afterEach(() => {
-    clearAllBootstrapSnapshots();
     vi.clearAllMocks();
   });
 
@@ -109,12 +103,10 @@ describe("clearBootstrapSnapshot", () => {
   const mockLoad = () => vi.mocked(loadWorkspaceBootstrapFiles);
 
   beforeEach(() => {
-    clearAllBootstrapSnapshots();
     mockLoad().mockResolvedValue([makeFile("AGENTS.md", "content")]);
   });
 
   afterEach(() => {
-    clearAllBootstrapSnapshots();
     vi.clearAllMocks();
   });
 

--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -84,8 +84,3 @@ export function clearBootstrapSnapshotOnSessionRollover(params: {
 
   clearBootstrapSnapshot(params.sessionKey);
 }
-
-/** Clear all cached bootstrap snapshots. */
-export function clearAllBootstrapSnapshots(): void {
-  cache.clear();
-}

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -11,7 +11,6 @@ import {
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
-  resetBootstrapWarningCacheForTest,
   FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
   hasCompletedBootstrapTurn,
   makeBootstrapWarn,
@@ -654,10 +653,6 @@ describe("hasCompletedBootstrapTurn", () => {
 });
 
 describe("makeBootstrapWarn", () => {
-  afterEach(() => {
-    resetBootstrapWarningCacheForTest();
-  });
-
   it("deduplicates repeated warnings for the same session and message", () => {
     const warnings: string[] = [];
     const warn = makeBootstrapWarn({

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -1,4 +1,5 @@
 /** Tests agent bootstrap file discovery, filtering, and injected context modes. */
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
@@ -657,6 +658,7 @@ describe("makeBootstrapWarn", () => {
     const warnings: string[] = [];
     const warn = makeBootstrapWarn({
       sessionLabel: "agent:main:test-session",
+      workspaceDir: `/tmp/${randomUUID()}`,
       warn: (message) => warnings.push(message),
     });
 
@@ -670,12 +672,15 @@ describe("makeBootstrapWarn", () => {
 
   it("keeps warnings distinct across sessions", () => {
     const warnings: string[] = [];
+    const workspaceDir = `/tmp/${randomUUID()}`;
     const first = makeBootstrapWarn({
       sessionLabel: "agent:main:first-session",
+      workspaceDir,
       warn: (message) => warnings.push(message),
     });
     const second = makeBootstrapWarn({
       sessionLabel: "agent:main:second-session",
+      workspaceDir,
       warn: (message) => warnings.push(message),
     });
 
@@ -690,14 +695,15 @@ describe("makeBootstrapWarn", () => {
 
   it("keeps warnings distinct across workspaces with the same session", () => {
     const warnings: string[] = [];
+    const workspaceRoot = `/tmp/${randomUUID()}`;
     const first = makeBootstrapWarn({
       sessionLabel: "agent:main:shared-session",
-      workspaceDir: "/tmp/workspace-a",
+      workspaceDir: `${workspaceRoot}/workspace-a`,
       warn: (message) => warnings.push(message),
     });
     const second = makeBootstrapWarn({
       sessionLabel: "agent:main:shared-session",
-      workspaceDir: "/tmp/workspace-b",
+      workspaceDir: `${workspaceRoot}/workspace-b`,
       warn: (message) => warnings.push(message),
     });
 

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -55,12 +55,6 @@ function rememberBootstrapWarning(key: string): boolean {
   return true;
 }
 
-/** Clears the per-process bootstrap warning dedupe cache for isolated tests. */
-export function resetBootstrapWarningCacheForTest(): void {
-  seenBootstrapWarnings.clear();
-  bootstrapWarningOrder.length = 0;
-}
-
 /** Resolves the effective bootstrap injection mode for a session agent. */
 export function resolveContextInjectionMode(
   config?: OpenClawConfig,

--- a/src/agents/workspace.bootstrap-cache.test.ts
+++ b/src/agents/workspace.bootstrap-cache.test.ts
@@ -4,21 +4,16 @@
  */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js";
-import { clearAllBootstrapSnapshots, getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
+import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
 import { loadWorkspaceBootstrapFiles, DEFAULT_AGENTS_FILENAME } from "./workspace.js";
 
 describe("workspace bootstrap file caching", () => {
   let workspaceDir: string;
 
   beforeEach(async () => {
-    clearAllBootstrapSnapshots();
     workspaceDir = await makeTempWorkspace("openclaw-bootstrap-cache-test-");
-  });
-
-  afterEach(() => {
-    clearAllBootstrapSnapshots();
   });
 
   const loadAgentsFile = async (dir: string) => {

--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -4,7 +4,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { clearAllBootstrapSnapshots } from "../agents/bootstrap-cache.js";
 import {
   clearConfigCache,
   clearRuntimeConfigSnapshot,
@@ -175,7 +174,6 @@ function resetGatewayTestState(): void {
   clearConfigCache();
   clearSessionStoreCacheForTest();
   resetAgentRunContextForTest();
-  clearAllBootstrapSnapshots();
   clearGatewaySubagentRuntime();
 }
 

--- a/src/gateway/server-network-runtime.e2e.test.ts
+++ b/src/gateway/server-network-runtime.e2e.test.ts
@@ -4,7 +4,6 @@ import os from "node:os";
 import path from "node:path";
 import { Agent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { clearAllBootstrapSnapshots } from "../agents/bootstrap-cache.js";
 import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
 import { clearSessionStoreCacheForTest } from "../config/sessions/store.js";
 import { resetAgentRunContextForTest } from "../infra/agent-events.js";
@@ -53,7 +52,6 @@ describe("gateway network runtime", () => {
     clearConfigCache();
     clearSessionStoreCacheForTest();
     resetAgentRunContextForTest();
-    clearAllBootstrapSnapshots();
     clearGatewaySubagentRuntime();
   });
 
@@ -62,7 +60,6 @@ describe("gateway network runtime", () => {
     clearConfigCache();
     clearSessionStoreCacheForTest();
     resetAgentRunContextForTest();
-    clearAllBootstrapSnapshots();
     clearGatewaySubagentRuntime();
   });
 

--- a/test/helpers/cron/service-regression-fixtures.ts
+++ b/test/helpers/cron/service-regression-fixtures.ts
@@ -4,7 +4,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
-import { clearAllBootstrapSnapshots } from "../../../src/agents/bootstrap-cache.js";
 import { clearSessionStoreCacheForTest } from "../../../src/config/sessions/store.js";
 import {
   createDeferred,
@@ -50,7 +49,6 @@ export function setupCronRegressionFixtures(options?: { prefix?: string; baseTim
     resetCommandQueueStateForTest();
     clearSessionStoreCacheForTest();
     resetAgentRunContextForTest();
-    clearAllBootstrapSnapshots();
   });
 
   afterAll(async () => {


### PR DESCRIPTION
Related: #105595

## What Problem This Solves

The production dead-export baseline still carried two `src/agents` bootstrap reset helpers that existed only for tests.

## Why This Change Was Made

Delete the process-wide test reset helpers and their redundant hooks. Bootstrap snapshots remain bounded and refresh on every load; affected tests use unique workspaces so module state cannot leak between retries or shared workers.

## User Impact

No user-visible behavior change. Against current main, this shrinks the enforced dead-export baseline from 2,595 to 2,593 entries and the `src/agents` cluster from 409 to 407.

## Evidence

- Exact-head Blacksmith Testbox `tbx_01kxdxd735ndccvm0pynzwm8jb` / run `29257282398`
- Broader patch-identical Testbox `tbx_01kxdwtyq47ptcfwj43qwvdtjm` / run `29256571785`
- `pnpm deadcode:exports:update` byte-stable at 2,593 entries
- `pnpm deadcode:exports`
- Targeted `oxfmt --check` and type-aware oxlint
- Exact-head focused agent tests: 54 passed
- Broader focused agent, gateway, and cron tests: 158 passed
- `pnpm check:test-types`
- `pnpm tsgo:core`
- Fresh autoreview after test-isolation fix: clean, 0.98 confidence
