### PR TITLE
fix(ci): refresh native i18n inventory

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -25347,7 +25347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 739,
+      "line": 749,
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host)",
       "surface": "apple",
@@ -25355,7 +25355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 739,
+      "line": 749,
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host):\\(port)",
       "surface": "apple",


### PR DESCRIPTION
## What Problem This Solves

`pnpm native:i18n:check` reports inventory drift on current `main`. Two conditional-branch entries for `AppState.swift` still point at line 739 after the source moved to line 749. This latent drift blocks PRs such as #106387 when their workflow changes schedule the native i18n gate.

## Why This Change Was Made

Regenerated `apps/.i18n/native-source.json` with the repository-owned sync command. The resulting patch updates only the two stale source coordinates; source text, ids, translations, and runtime code stay unchanged.

## User Impact

No product behavior change. Native i18n validation becomes green again, unblocking unrelated workflow PRs that correctly exercise the gate.

## Evidence

- Blacksmith Testbox [run 29255421946](https://github.com/openclaw/openclaw/actions/runs/29255421946): `pnpm native:i18n:check` completed with 4,320 entries and `changed=false`.
- Fresh autoreview: no accepted/actionable findings, confidence 0.99.
- `git diff --check` passed.
