### PR TITLE
fix: show sidebar session action failures

### DIFF
--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -168,7 +168,9 @@ function createSessionsHarness(agentId: string, keys: string[]) {
   const groupsRename = vi.fn(() => Promise.resolve<SessionGroupMutationResult>("completed"));
   const groupsDelete = vi.fn(() => Promise.resolve<SessionGroupMutationResult>("completed"));
   const create = vi.fn(() => Promise.resolve("agent:main:fork"));
-  const patch = vi.fn((key: string) => Promise.resolve(successfulSessionPatch(key)));
+  const patch = vi.fn((key: string, _patch: Parameters<SessionCapability["patch"]>[1]) =>
+    Promise.resolve(successfulSessionPatch(key)),
+  );
   const deleteSession = vi.fn(
     (): Promise<SessionDeleteOutcome> => Promise.resolve({ deleted: false }),
   );

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -17,7 +17,11 @@ import {
   type ApplicationGatewaySnapshot,
 } from "../app/context.ts";
 import { CATALOG_SESSION_CONTINUED_EVENT } from "../lib/sessions/catalog-key.ts";
-import type { SessionCapability, SessionState } from "../lib/sessions/index.ts";
+import type {
+  SessionCapability,
+  SessionDeleteOutcome,
+  SessionState,
+} from "../lib/sessions/index.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import "./app-sidebar.ts";
 import {
@@ -137,6 +141,25 @@ function createSessionState(agentId: string, keys: string[]): SessionState {
   };
 }
 
+function successfulSessionPatch(key: string) {
+  return {
+    ok: true as const,
+    path: "",
+    key,
+    entry: { sessionId: key },
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 function createSessionsHarness(agentId: string, keys: string[]) {
   let state = createSessionState(agentId, keys);
   let canonicalListRevision = 1;
@@ -144,9 +167,17 @@ function createSessionsHarness(agentId: string, keys: string[]) {
   const groupsPut = vi.fn(() => Promise.resolve());
   const groupsRename = vi.fn(() => Promise.resolve<SessionGroupMutationResult>("completed"));
   const groupsDelete = vi.fn(() => Promise.resolve<SessionGroupMutationResult>("completed"));
-  const patch = vi.fn(() => Promise.resolve(null));
+  const create = vi.fn(() => Promise.resolve("agent:main:fork"));
+  const patch = vi.fn((key: string) => Promise.resolve(successfulSessionPatch(key)));
+  const deleteSession = vi.fn(
+    (): Promise<SessionDeleteOutcome> => Promise.resolve({ deleted: false }),
+  );
   const deleteMany = vi.fn(() =>
-    Promise.resolve({ deleted: [] as string[], errors: [], preservedWorktrees: [] }),
+    Promise.resolve({
+      deleted: [] as string[],
+      errors: [] as string[],
+      preservedWorktrees: [] as Array<{ id: string; branch: string; path: string }>,
+    }),
   );
   const sessions = {
     get state() {
@@ -164,7 +195,9 @@ function createSessionsHarness(agentId: string, keys: string[]) {
     groupsPut,
     groupsRename,
     groupsDelete,
+    create,
     patch,
+    delete: deleteSession,
     deleteMany,
     refresh: () => Promise.resolve(),
   } as unknown as SessionCapability;
@@ -179,7 +212,9 @@ function createSessionsHarness(agentId: string, keys: string[]) {
     groupsPut,
     groupsRename,
     groupsDelete,
+    create,
     patch,
+    deleteSession,
     deleteMany,
     publish,
     publishList(statePatch: Partial<SessionState>) {
@@ -1568,6 +1603,210 @@ describe("AppSidebar session source lifecycle", () => {
   });
 });
 
+describe("AppSidebar session mutation feedback", () => {
+  async function mountMutationHarness(client: GatewayBrowserClient = {} as GatewayBrowserClient) {
+    const gateway = createGatewayHarness(client);
+    const harness = createSessionsHarness("main", [
+      "agent:main:main",
+      "agent:main:a",
+      "agent:main:b",
+    ]);
+    const { sidebar } = await mountSidebar(gateway.gateway, harness.sessions);
+    sidebar.connected = true;
+    await sidebar.updateComplete;
+    return { gateway, harness, sidebar };
+  }
+
+  async function openSessionMenu(sidebar: SidebarLifecycleState, key: string) {
+    const button = sidebar.querySelector<HTMLButtonElement>(
+      `[data-session-key="${key}"] [data-session-menu="true"]`,
+    );
+    if (!button) {
+      throw new Error(`expected menu button for ${key}`);
+    }
+    button.click();
+    await sidebar.updateComplete;
+    const menu = sidebar.querySelector<TestSessionMenu>("openclaw-session-menu");
+    if (!menu) {
+      throw new Error("expected session menu");
+    }
+    await menu.updateComplete;
+    return menu;
+  }
+
+  function selectSession(sidebar: SidebarLifecycleState, key: string) {
+    const link = sidebar.querySelector<HTMLAnchorElement>(
+      `[data-session-key="${key}"] .sidebar-recent-session__link`,
+    );
+    if (!link) {
+      throw new Error(`expected row link for ${key}`);
+    }
+    link.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, metaKey: true }));
+  }
+
+  it("shows and dismisses a fixed sidebar error when a session patch is rejected", async () => {
+    const { harness, sidebar } = await mountMutationHarness();
+    harness.patch.mockRejectedValueOnce(new Error("rename rejected by Gateway"));
+    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Rejected rename");
+    try {
+      const menu = await openSessionMenu(sidebar, "agent:main:a");
+      menu.querySelector<HTMLButtonElement>('[data-shortcut="r"]')?.click();
+
+      await vi.waitFor(() => {
+        expect(sidebar.querySelector("[data-sidebar-session-error]")?.textContent).toContain(
+          "rename rejected by Gateway",
+        );
+      });
+      const error = sidebar.querySelector("[data-sidebar-session-error]");
+      expect(error?.parentElement?.classList.contains("sidebar-sessions")).toBe(true);
+      expect(error?.closest(".sidebar-recent-sessions")).toBeNull();
+
+      error?.querySelector<HTMLButtonElement>('[aria-label="Dismiss error"]')?.click();
+      await sidebar.updateComplete;
+      expect(sidebar.querySelector("[data-sidebar-session-error]")).toBeNull();
+    } finally {
+      promptSpy.mockRestore();
+    }
+  });
+
+  it("surfaces partial batch-delete errors", async () => {
+    const { harness, sidebar } = await mountMutationHarness();
+    harness.deleteMany.mockResolvedValueOnce({
+      deleted: ["agent:main:a"],
+      errors: ["agent:main:b: permission denied"],
+      preservedWorktrees: [],
+    });
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    try {
+      selectSession(sidebar, "agent:main:a");
+      selectSession(sidebar, "agent:main:b");
+      await sidebar.updateComplete;
+      const row = sidebar.querySelector('[data-session-key="agent:main:b"]');
+      row?.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+      await sidebar.updateComplete;
+      const menu = sidebar.querySelector<TestSessionMenu>("openclaw-session-menu");
+      await menu?.updateComplete;
+      menu?.querySelector<HTMLButtonElement>('[data-shortcut="d"]')?.click();
+
+      await vi.waitFor(() => {
+        expect(sidebar.querySelector("[data-sidebar-session-error]")?.textContent).toContain(
+          "agent:main:b: permission denied",
+        );
+      });
+    } finally {
+      confirmSpy.mockRestore();
+    }
+  });
+
+  it("suppresses a late rejection after a same-client reconnect", async () => {
+    const { gateway, harness, sidebar } = await mountMutationHarness();
+    const pending = deferred<ReturnType<typeof successfulSessionPatch>>();
+    harness.patch.mockImplementationOnce(() => pending.promise);
+    const menu = await openSessionMenu(sidebar, "agent:main:a");
+    menu.querySelector<HTMLButtonElement>('[data-shortcut="p"]')?.click();
+    await vi.waitFor(() => expect(harness.patch).toHaveBeenCalledOnce());
+
+    gateway.publish({ connected: false, reconnecting: true });
+    gateway.publish({ connected: true, reconnecting: false });
+    pending.reject(new Error("late old-connection rejection"));
+    await pending.promise.catch(() => undefined);
+    await Promise.resolve();
+    await sidebar.updateComplete;
+
+    expect(sidebar.querySelector("[data-sidebar-session-error]")).toBeNull();
+  });
+
+  it("does not continue a batch patch on a reconnected Gateway", async () => {
+    const { gateway, harness, sidebar } = await mountMutationHarness();
+    const pending = deferred<ReturnType<typeof successfulSessionPatch>>();
+    harness.patch.mockImplementationOnce(() => pending.promise);
+    selectSession(sidebar, "agent:main:a");
+    selectSession(sidebar, "agent:main:b");
+    await sidebar.updateComplete;
+    const row = sidebar.querySelector('[data-session-key="agent:main:b"]');
+    row?.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    await sidebar.updateComplete;
+    const menu = sidebar.querySelector<TestSessionMenu>("openclaw-session-menu");
+    await menu?.updateComplete;
+    menu?.querySelector<HTMLButtonElement>('[data-shortcut="a"]')?.click();
+    await vi.waitFor(() => expect(harness.patch).toHaveBeenCalledOnce());
+
+    gateway.publish({ connected: false, reconnecting: true });
+    gateway.publish({ connected: true, reconnecting: false });
+    pending.resolve(successfulSessionPatch("agent:main:a"));
+    await pending.promise;
+    await new Promise<void>((resolve) => {
+      globalThis.setTimeout(resolve, 0);
+    });
+
+    expect(harness.patch).toHaveBeenCalledOnce();
+  });
+
+  it("does not truncate a pending batch when another mutation starts", async () => {
+    const { harness, sidebar } = await mountMutationHarness();
+    const firstPatch = deferred<ReturnType<typeof successfulSessionPatch>>();
+    harness.patch.mockImplementationOnce(() => firstPatch.promise);
+    selectSession(sidebar, "agent:main:a");
+    selectSession(sidebar, "agent:main:b");
+    await sidebar.updateComplete;
+    const row = sidebar.querySelector('[data-session-key="agent:main:b"]');
+
+    row?.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    await sidebar.updateComplete;
+    let menu = sidebar.querySelector<TestSessionMenu>("openclaw-session-menu");
+    await menu?.updateComplete;
+    menu?.querySelector<HTMLButtonElement>('[data-shortcut="a"]')?.click();
+    await vi.waitFor(() => expect(harness.patch).toHaveBeenCalledOnce());
+
+    row?.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    await sidebar.updateComplete;
+    menu = sidebar.querySelector<TestSessionMenu>("openclaw-session-menu");
+    await menu?.updateComplete;
+    menu?.querySelector<HTMLButtonElement>('[data-shortcut="u"]')?.click();
+    await vi.waitFor(() => expect(harness.patch).toHaveBeenCalledTimes(3));
+
+    firstPatch.resolve(successfulSessionPatch("agent:main:a"));
+    await vi.waitFor(() => expect(harness.patch).toHaveBeenCalledTimes(4));
+    expect(harness.patch.mock.calls.map(([, patch]) => patch)).toEqual(
+      expect.arrayContaining([
+        { archived: true },
+        { archived: true },
+        { unread: true },
+        { unread: true },
+      ]),
+    );
+  });
+
+  it("never force-removes a preserved worktree through a reconnected client", async () => {
+    const request = vi.fn(() => Promise.resolve({}));
+    const { gateway, harness, sidebar } = await mountMutationHarness({
+      request,
+    } as unknown as GatewayBrowserClient);
+    harness.deleteSession.mockResolvedValueOnce({
+      deleted: true,
+      worktreePreserved: { id: "wt-1", branch: "feature", path: "/tmp/worktree" },
+    });
+    let confirmations = 0;
+    const confirmSpy = vi.spyOn(window, "confirm").mockImplementation(() => {
+      confirmations += 1;
+      if (confirmations === 2) {
+        gateway.publish({ connected: false, reconnecting: true });
+        gateway.publish({ connected: true, reconnecting: false });
+      }
+      return true;
+    });
+    try {
+      const menu = await openSessionMenu(sidebar, "agent:main:a");
+      menu.querySelector<HTMLButtonElement>('[data-shortcut="d"]')?.click();
+      await vi.waitFor(() => expect(confirmations).toBe(2));
+
+      expect(request).not.toHaveBeenCalled();
+    } finally {
+      confirmSpy.mockRestore();
+    }
+  });
+});
+
 function createDataTransferStub() {
   const data = new Map<string, string>();
   return {
@@ -1766,6 +2005,7 @@ describe("AppSidebar custom group reordering", () => {
     const gateway = createGateway(client);
     const harness = createSessionsHarness("main", ["agent:main:main"]);
     const { sidebar } = await mountSidebar(gateway, harness.sessions);
+    sidebar.connected = true;
     harness.publish({ groups });
     await sidebar.updateComplete;
     return { sidebar, harness };

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -156,6 +156,17 @@ type SidebarSessionGroupDropTarget = {
   position: "before" | "after";
 };
 
+type SidebarSessionMutationScope = {
+  epoch: number;
+  context: ApplicationContext<RouteId>;
+  gateway: ApplicationContext<RouteId>["gateway"];
+  sessions: SessionCapability;
+  client: GatewayBrowserClient;
+  selectedAgentId: string;
+};
+
+type SidebarSessionMutationResult = "completed" | "failed" | "stale";
+
 const SIDEBAR_SESSION_GROUPING_STORAGE_KEY = "openclaw:sidebar:sessions:grouping";
 const SIDEBAR_SESSION_SHOW_CRON_STORAGE_KEY = "openclaw:sidebar:sessions:show-cron";
 const SIDEBAR_AGENT_SESSION_LIST_LIMIT = 60;
@@ -308,6 +319,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
   @state() private sessionsScrollState: SidebarSessionsScrollState = "none";
   @state() private sessionCatalogs: SessionCatalog[] = [];
   @state() private loadingMoreSessionCatalogIds: ReadonlySet<string> = new Set();
+  @state() private sessionMutationError: string | null = null;
   @state() private logoVisit: LobsterLogoVisitDetail | null = null;
 
   private readonly subscriptions = new SubscriptionsController(this);
@@ -326,6 +338,10 @@ class AppSidebar extends OpenClawLightDomContentsElement {
   private reconnectListRevision: number | null = null;
   private gatewaySource: ApplicationContext<RouteId>["gateway"] | null = null;
   private gatewayClient: GatewayBrowserClient | null = null;
+  private gatewayConnected = false;
+  // Mutation completions belong to one context/capability/connection epoch.
+  // Bumping this prevents old failures or batch tails crossing a reconnect.
+  private sessionMutationEpoch = 0;
   private sessionsScrollElement: HTMLElement | null = null;
   private sessionsScrollResizeObserver: ResizeObserver | null = null;
   private sessionCatalogTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
@@ -385,8 +401,10 @@ class AppSidebar extends OpenClawLightDomContentsElement {
       this.handleCatalogSessionContinued as EventListener,
     );
     this.dismissTransientMenus();
+    this.invalidateSessionMutations();
     this.gatewaySource = null;
     this.gatewayClient = null;
+    this.gatewayConnected = false;
     this.sessionCatalogGeneration += 1;
     for (const timer of this.routePreloadTimers.values()) {
       globalThis.clearTimeout(timer);
@@ -745,6 +763,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
 
   private synchronizeSessions(sessions: SessionCapability) {
     if (sessions !== this.sessionsSource) {
+      this.invalidateSessionMutations();
       this.clearSessionCache();
       this.sessionsSource = sessions;
     }
@@ -757,14 +776,22 @@ class AppSidebar extends OpenClawLightDomContentsElement {
 
   private synchronizeGateway(gateway: ApplicationContext<RouteId>["gateway"]) {
     const client = gateway.snapshot.client;
-    if (gateway === this.gatewaySource && client === this.gatewayClient) {
+    const connected = gateway.snapshot.connected;
+    const sourceOrClientChanged = gateway !== this.gatewaySource || client !== this.gatewayClient;
+    const connectionChanged = connected !== this.gatewayConnected;
+    if (!sourceOrClientChanged && !connectionChanged) {
+      return;
+    }
+    this.invalidateSessionMutations();
+    this.gatewaySource = gateway;
+    this.gatewayClient = client;
+    this.gatewayConnected = connected;
+    if (!sourceOrClientChanged) {
       return;
     }
     this.clearSessionCache();
     this.sessionCatalogGeneration += 1;
     this.sessionCatalogRevision += 1;
-    this.gatewaySource = gateway;
-    this.gatewayClient = client;
     if (this.sessionCatalogTimer) {
       globalThis.clearTimeout(this.sessionCatalogTimer);
       this.sessionCatalogTimer = null;
@@ -782,6 +809,52 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     this.sessionRowsByAgent = {};
     this.sessionCreatedOrder.clear();
     this.visibleSessionLimit = SIDEBAR_SESSION_PAGE_SIZE;
+  }
+
+  private invalidateSessionMutations() {
+    this.sessionMutationEpoch += 1;
+    this.sessionMutationError = null;
+  }
+
+  private beginSessionMutation(): SidebarSessionMutationScope | null {
+    const context = this.context;
+    if (!context || !this.connected) {
+      return null;
+    }
+    const gateway = context.gateway;
+    const client = gateway.snapshot.client;
+    if (!gateway.snapshot.connected || !client) {
+      return null;
+    }
+    this.sessionMutationError = null;
+    return {
+      epoch: this.sessionMutationEpoch,
+      context,
+      gateway,
+      sessions: context.sessions,
+      client,
+      selectedAgentId: this.getSessionNavigationState().selectedAgentId,
+    };
+  }
+
+  private isSessionMutationScopeCurrent(scope: SidebarSessionMutationScope): boolean {
+    const context = this.context;
+    const gateway = context?.gateway;
+    return (
+      this.connected &&
+      this.sessionMutationEpoch === scope.epoch &&
+      context === scope.context &&
+      gateway === scope.gateway &&
+      context.sessions === scope.sessions &&
+      gateway.snapshot.connected &&
+      gateway.snapshot.client === scope.client
+    );
+  }
+
+  private publishSessionMutationError(scope: SidebarSessionMutationScope, error: unknown) {
+    if (this.isSessionMutationScopeCurrent(scope)) {
+      this.sessionMutationError = String(error);
+    }
   }
 
   private readonly handleLogoVisit = (event: Event) => {
@@ -1112,84 +1185,122 @@ class AppSidebar extends OpenClawLightDomContentsElement {
       label?: string | null;
       category?: string | null;
     },
-  ) => {
-    const context = this.context;
-    if (!context || !this.connected) {
-      return;
+    scope: SidebarSessionMutationScope | null = this.beginSessionMutation(),
+  ): Promise<SidebarSessionMutationResult> => {
+    if (!scope) {
+      return "stale";
     }
-    const { selectedAgentId } = this.getSessionNavigationState();
-    const agentId = parseAgentSessionKey(session.key)?.agentId ?? selectedAgentId;
+    const agentId = parseAgentSessionKey(session.key)?.agentId ?? scope.selectedAgentId;
     try {
-      const patched = await context.sessions.patch(session.key, patch, { agentId });
-      if (!patched || patch.archived !== true || !session.active) {
-        return;
+      const patched = await scope.sessions.patch(session.key, patch, { agentId });
+      if (!this.isSessionMutationScopeCurrent(scope)) {
+        return "stale";
+      }
+      if (!patched) {
+        if (scope.sessions.state.error) {
+          this.publishSessionMutationError(scope, scope.sessions.state.error);
+        }
+        return "failed";
+      }
+      if (patch.archived !== true || !session.active) {
+        return "completed";
       }
       this.replaceCurrentSession(
         buildAgentMainSessionKey({
           agentId,
           mainKey: resolveUiConfiguredMainKey({
-            agentsList: context.agents.state.agentsList,
-            hello: context.gateway.snapshot.hello,
+            agentsList: scope.context.agents.state.agentsList,
+            hello: scope.gateway.snapshot.hello,
           }),
         }),
       );
-    } catch {
-      // Session capability publishes the actionable error for the owning page.
+      return "completed";
+    } catch (error) {
+      if (!this.isSessionMutationScopeCurrent(scope)) {
+        return "stale";
+      }
+      this.publishSessionMutationError(scope, error);
+      return "failed";
     }
   };
 
-  private patchSessions(
+  private async patchSessions(
     rows: readonly SidebarRecentSession[],
     patch: { archived?: boolean; unread?: boolean; category?: string | null },
-  ) {
-    void (async () => {
-      // Sequential like deleteMany: parallel patches would race the shared
-      // session-state publishes inside the capability.
-      for (const row of rows) {
-        await this.patchSession(row, patch);
+    scope: SidebarSessionMutationScope | null = this.beginSessionMutation(),
+  ): Promise<SidebarSessionMutationResult> {
+    if (!scope) {
+      return "stale";
+    }
+    let result: SidebarSessionMutationResult = "completed";
+    // Sequential like deleteMany: parallel patches would race the shared
+    // session-state publishes inside the capability.
+    for (const row of rows) {
+      const rowResult = await this.patchSession(row, patch, scope);
+      if (rowResult === "stale") {
+        return "stale";
       }
-    })();
+      if (rowResult === "failed") {
+        result = "failed";
+      }
+    }
+    return result;
   }
 
   /** Batch delete: one confirm and one preserved-worktrees alert for the whole
       selection instead of cascading per-session prompts. */
   private async deleteSessionsBatch(rows: readonly SidebarRecentSession[]) {
-    const context = this.context;
-    if (!context || rows.length === 0) {
+    if (rows.length === 0) {
       return;
     }
     if (!window.confirm(t("sessionsView.deleteSessionsConfirm", { count: String(rows.length) }))) {
       return;
     }
-    const { selectedAgentId } = this.getSessionNavigationState();
-    const result = await context.sessions.deleteMany(
-      rows.map((row) => ({
-        key: row.key,
-        agentId: parseAgentSessionKey(row.key)?.agentId ?? selectedAgentId,
-        deleteTranscript: true,
-      })),
-    );
-    // Dirty/unpushed checkouts survive deletion; point at the Worktrees page
-    // instead of cascading one force-delete confirm per session.
-    if (result.preservedWorktrees.length > 0) {
-      window.alert(
-        t("sessionsView.deletePreservedWorktrees", {
-          count: String(result.preservedWorktrees.length),
-          branches: result.preservedWorktrees.map((worktree) => worktree.branch).join(", "),
-        }),
-      );
+    const scope = this.beginSessionMutation();
+    if (!scope) {
+      return;
     }
-    const deletedActive = rows.find((row) => row.active && result.deleted.includes(row.key));
-    if (deletedActive) {
-      this.replaceCurrentSession(
-        buildAgentMainSessionKey({
-          agentId: parseAgentSessionKey(deletedActive.key)?.agentId ?? selectedAgentId,
-          mainKey: resolveUiConfiguredMainKey({
-            agentsList: context.agents.state.agentsList,
-            hello: context.gateway.snapshot.hello,
-          }),
-        }),
+    try {
+      const result = await scope.sessions.deleteMany(
+        rows.map((row) => ({
+          key: row.key,
+          agentId: parseAgentSessionKey(row.key)?.agentId ?? scope.selectedAgentId,
+          deleteTranscript: true,
+        })),
       );
+      if (!this.isSessionMutationScopeCurrent(scope)) {
+        return;
+      }
+      // Dirty/unpushed checkouts survive deletion; point at the Worktrees page
+      // instead of cascading one force-delete confirm per session.
+      if (result.preservedWorktrees.length > 0) {
+        window.alert(
+          t("sessionsView.deletePreservedWorktrees", {
+            count: String(result.preservedWorktrees.length),
+            branches: result.preservedWorktrees.map((worktree) => worktree.branch).join(", "),
+          }),
+        );
+        if (!this.isSessionMutationScopeCurrent(scope)) {
+          return;
+        }
+      }
+      const deletedActive = rows.find((row) => row.active && result.deleted.includes(row.key));
+      if (deletedActive) {
+        this.replaceCurrentSession(
+          buildAgentMainSessionKey({
+            agentId: parseAgentSessionKey(deletedActive.key)?.agentId ?? scope.selectedAgentId,
+            mainKey: resolveUiConfiguredMainKey({
+              agentsList: scope.context.agents.state.agentsList,
+              hello: scope.gateway.snapshot.hello,
+            }),
+          }),
+        );
+      }
+      if (result.errors.length > 0) {
+        this.publishSessionMutationError(scope, result.errors.join("; "));
+      }
+    } catch (error) {
+      this.publishSessionMutationError(scope, error);
     }
   }
 
@@ -1200,10 +1311,10 @@ class AppSidebar extends OpenClawLightDomContentsElement {
   ) {
     switch (action.kind) {
       case "toggle-unread":
-        this.patchSessions(rows, { unread: !allUnread });
+        void this.patchSessions(rows, { unread: !allUnread });
         break;
       case "move-to-group":
-        this.patchSessions(
+        void this.patchSessions(
           rows.filter((row) => (row.category ?? null) !== action.category),
           { category: action.category },
         );
@@ -1212,7 +1323,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
         this.createSessionGroup(rows);
         break;
       case "toggle-archived":
-        this.patchSessions(rows, { archived: true });
+        void this.patchSessions(rows, { archived: true });
         break;
       case "delete":
         void this.deleteSessionsBatch(rows);
@@ -1585,10 +1696,23 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     return [...catalog, ...new Set(discovered)];
   }
 
-  private rememberSessionGroup(name: string) {
+  private async rememberSessionGroup(
+    name: string,
+    scope: SidebarSessionMutationScope,
+  ): Promise<SidebarSessionMutationResult> {
     const groups = this.knownSessionGroups();
-    if (!groups.includes(name)) {
-      void this.context?.sessions.groupsPut([...groups, name]);
+    if (groups.includes(name)) {
+      return "completed";
+    }
+    try {
+      await scope.sessions.groupsPut([...groups, name]);
+      return this.isSessionMutationScopeCurrent(scope) ? "completed" : "stale";
+    } catch (error) {
+      if (!this.isSessionMutationScopeCurrent(scope)) {
+        return "stale";
+      }
+      this.publishSessionMutationError(scope, error);
+      return "failed";
     }
   }
 
@@ -1605,30 +1729,38 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     if (!name) {
       return;
     }
-    this.rememberSessionGroup(name);
-    if (sessions.length > 0) {
-      this.patchSessions(sessions, { category: name });
-    } else {
-      // Header-created groups start empty; re-render so the section shows up.
-      this.requestUpdate();
+    const scope = this.beginSessionMutation();
+    if (!scope) {
+      return;
     }
+    void (async () => {
+      if ((await this.rememberSessionGroup(name, scope)) !== "completed") {
+        return;
+      }
+      if (sessions.length > 0) {
+        await this.patchSessions(sessions, { category: name }, scope);
+      } else if (this.isSessionMutationScopeCurrent(scope)) {
+        // Header-created groups start empty; re-render so the section shows up.
+        this.requestUpdate();
+      }
+    })();
   }
 
   private renameSessionGroupFromMenu(group: string) {
-    const context = this.context;
-    const client = context?.gateway.snapshot.client;
-    if (!context || !client || !this.connected || !context.gateway.snapshot.connected) {
-      return;
-    }
     const next = window.prompt(t("sessionsView.renameGroupPrompt"), group)?.trim();
     if (!next || next === group) {
       return;
     }
-    // Collapse keys follow the confirmed Gateway rename only and stay scoped
-    // to the connection that issued it; stale completions must not rewrite storage.
-    void context.sessions.groupsRename(group, next).then(
-      (outcome) => {
-        if (outcome !== "completed" || !this.isCurrentSessionGroupMutation(context, client)) {
+    const scope = this.beginSessionMutation();
+    if (!scope) {
+      return;
+    }
+    // Collapse keys follow only a confirmed Gateway rename. A stale completion
+    // must not rewrite storage owned by the replacement connection.
+    void (async () => {
+      try {
+        const outcome = await scope.sessions.groupsRename(group, next);
+        if (outcome !== "completed" || !this.isSessionMutationScopeCurrent(scope)) {
           return;
         }
         const from = `category:${group}`;
@@ -1639,42 +1771,34 @@ class AppSidebar extends OpenClawLightDomContentsElement {
           this.saveCollapsedSessionSections(collapsed);
         }
         this.requestUpdate();
-      },
-      () => undefined,
-    );
+      } catch (error) {
+        this.publishSessionMutationError(scope, error);
+      }
+    })();
   }
 
   private deleteSessionGroupFromMenu(group: string) {
-    const context = this.context;
-    const client = context?.gateway.snapshot.client;
-    if (!context || !client || !this.connected || !context.gateway.snapshot.connected) {
-      return;
-    }
     if (!window.confirm(t("sessionsView.deleteGroupConfirm", { group }))) {
       return;
     }
-    void context.sessions.groupsDelete(group).then(
-      (outcome) => {
-        if (outcome !== "completed" || !this.isCurrentSessionGroupMutation(context, client)) {
+    const scope = this.beginSessionMutation();
+    if (!scope) {
+      return;
+    }
+    void (async () => {
+      try {
+        const outcome = await scope.sessions.groupsDelete(group);
+        if (outcome !== "completed" || !this.isSessionMutationScopeCurrent(scope)) {
           return;
         }
         const collapsed = new Set(this.collapsedSessionSections);
         collapsed.delete(`category:${group}`);
         this.saveCollapsedSessionSections(collapsed);
         this.requestUpdate();
-      },
-      () => undefined,
-    );
-  }
-
-  private isCurrentSessionGroupMutation(
-    context: ApplicationContext<RouteId>,
-    client: GatewayBrowserClient,
-  ) {
-    const snapshot = context.gateway.snapshot;
-    return (
-      this.context === context && this.connected && snapshot.connected && snapshot.client === client
-    );
+      } catch (error) {
+        this.publishSessionMutationError(scope, error);
+      }
+    })();
   }
 
   private saveCollapsedSessionSections(sections: ReadonlySet<string>) {
@@ -1701,8 +1825,37 @@ class AppSidebar extends OpenClawLightDomContentsElement {
 
   private reorderSessionGroup(source: string, target: string, position: "before" | "after") {
     const groups = reorderSessionCustomGroups(this.knownSessionGroups(), source, target, position);
-    void this.context?.sessions.groupsPut(groups);
-    this.requestUpdate();
+    const scope = this.beginSessionMutation();
+    if (!scope) {
+      return;
+    }
+    void (async () => {
+      try {
+        await scope.sessions.groupsPut(groups);
+        if (this.isSessionMutationScopeCurrent(scope)) {
+          this.requestUpdate();
+        }
+      } catch (error) {
+        this.publishSessionMutationError(scope, error);
+      }
+    })();
+  }
+
+  private assignSessionCategory(
+    session: SidebarRecentSession,
+    category: string | null,
+    patch: { pinned?: boolean } = {},
+  ) {
+    const scope = this.beginSessionMutation();
+    if (!scope) {
+      return;
+    }
+    void (async () => {
+      if (category && (await this.rememberSessionGroup(category, scope)) !== "completed") {
+        return;
+      }
+      await this.patchSession(session, { category, ...patch }, scope);
+    })();
   }
 
   private handleSessionSectionDragOver(event: DragEvent, sectionId: string, category?: string) {
@@ -1780,13 +1933,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
       const session = sessionKey ? this.findSidebarSessionByKey(sessionKey) : undefined;
       const nextCategory = category ?? null;
       if (session && (session.category !== nextCategory || session.pinned)) {
-        if (category) {
-          this.rememberSessionGroup(category);
-        }
-        void this.patchSession(session, {
-          category: nextCategory,
-          ...(session.pinned ? { pinned: false } : {}),
-        });
+        this.assignSessionCategory(session, nextCategory, session.pinned ? { pinned: false } : {});
       }
     }
     this.draggingSessionKey = null;
@@ -1814,19 +1961,30 @@ class AppSidebar extends OpenClawLightDomContentsElement {
   }
 
   private async forkSession(session: SidebarRecentSession) {
-    const context = this.context;
-    if (!context) {
+    const scope = this.beginSessionMutation();
+    if (!scope) {
       return;
     }
-    const { selectedAgentId } = this.getSessionNavigationState();
-    const agentId = parseAgentSessionKey(session.key)?.agentId ?? selectedAgentId;
-    const key = await context.sessions.create({
-      parentSessionKey: session.key,
-      fork: true,
-      agentId,
-    });
-    if (key) {
-      this.selectSession(key);
+    const agentId = parseAgentSessionKey(session.key)?.agentId ?? scope.selectedAgentId;
+    try {
+      const key = await scope.sessions.create({
+        parentSessionKey: session.key,
+        fork: true,
+        agentId,
+      });
+      if (!this.isSessionMutationScopeCurrent(scope)) {
+        return;
+      }
+      if (key) {
+        this.selectSession(key);
+      } else {
+        this.publishSessionMutationError(
+          scope,
+          scope.sessions.state.error ?? t("newSession.createFailed"),
+        );
+      }
+    } catch (error) {
+      this.publishSessionMutationError(scope, error);
     }
   }
 
@@ -1834,17 +1992,19 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     if (!window.confirm(t("sessionsView.deleteSessionConfirm", { session: session.label }))) {
       return;
     }
-    const context = this.context;
-    if (!context) {
+    const scope = this.beginSessionMutation();
+    if (!scope) {
       return;
     }
-    const { selectedAgentId } = this.getSessionNavigationState();
-    const agentId = parseAgentSessionKey(session.key)?.agentId ?? selectedAgentId;
+    const agentId = parseAgentSessionKey(session.key)?.agentId ?? scope.selectedAgentId;
     try {
-      const outcome = await context.sessions.delete(session.key, {
+      const outcome = await scope.sessions.delete(session.key, {
         agentId,
         deleteTranscript: true,
       });
+      if (!this.isSessionMutationScopeCurrent(scope)) {
+        return;
+      }
       // Dirty/unpushed checkouts survive the delete; offer an explicit force
       // removal instead of silently orphaning them under the state dir.
       if (outcome.worktreePreserved) {
@@ -1854,13 +2014,19 @@ class AppSidebar extends OpenClawLightDomContentsElement {
             t("sessionsView.deletePreservedWorktreeConfirm", { branch: preserved.branch }),
           )
         ) {
+          if (!this.isSessionMutationScopeCurrent(scope)) {
+            return;
+          }
           try {
-            await context.gateway.snapshot.client?.request("worktrees.remove", {
+            await scope.client.request("worktrees.remove", {
               id: preserved.id,
               force: true,
             });
           } catch (error) {
-            window.alert(String(error));
+            this.publishSessionMutationError(scope, error);
+          }
+          if (!this.isSessionMutationScopeCurrent(scope)) {
+            return;
           }
         }
       }
@@ -1871,13 +2037,13 @@ class AppSidebar extends OpenClawLightDomContentsElement {
         buildAgentMainSessionKey({
           agentId,
           mainKey: resolveUiConfiguredMainKey({
-            agentsList: context.agents.state.agentsList,
-            hello: context.gateway.snapshot.hello,
+            agentsList: scope.context.agents.state.agentsList,
+            hello: scope.gateway.snapshot.hello,
           }),
         }),
       );
-    } catch {
-      // Session capability publishes the actionable error for the owning page.
+    } catch (error) {
+      this.publishSessionMutationError(scope, error);
     }
   }
 
@@ -2098,7 +2264,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
               break;
             case "move-to-group":
               if (action.category === null || session.category !== action.category) {
-                void this.patchSession(session, { category: action.category });
+                this.assignSessionCategory(session, action.category);
               }
               break;
             case "new-group":
@@ -2673,6 +2839,29 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     const expandedAgentId = this.expandedAgentId();
     return html`
       <section class="sidebar-sessions">
+        ${this.sessionMutationError
+          ? html`
+              <div
+                class="sidebar-session-error callout danger callout--dismissible"
+                role="alert"
+                data-sidebar-session-error
+              >
+                <span class="callout__content">${this.sessionMutationError}</span>
+                <openclaw-tooltip .content=${t("chat.actions.dismissError")}>
+                  <button
+                    class="callout__dismiss"
+                    type="button"
+                    @click=${() => {
+                      this.sessionMutationError = null;
+                    }}
+                    aria-label=${t("chat.actions.dismissError")}
+                  >
+                    ${icons.x}
+                  </button>
+                </openclaw-tooltip>
+              </div>
+            `
+          : nothing}
         <div
           class="sidebar-recent-sessions sidebar-recent-sessions--scroll-${this
             .sessionsScrollState}"

--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -184,6 +184,53 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
     }
   });
 
+  it("keeps a rejected sidebar mutation visible until the user dismisses it", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["sessions.patch"],
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          sessionRow("agent:main:rename-me", "Rename me", Date.now()),
+        ]),
+      },
+      sessionKey: "agent:main:rename-me",
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const row = page.locator('[data-session-key="agent:main:rename-me"]');
+      await row.waitFor({ state: "visible", timeout: 10_000 });
+      await row.hover();
+      await row.getByRole("button", { name: "Open session menu" }).click();
+      page.once("dialog", (dialog) => void dialog.accept("Rejected rename"));
+      await page.getByRole("menuitem", { name: "Rename…" }).click();
+      await gateway.waitForRequest("sessions.patch");
+      await gateway.rejectDeferred("sessions.patch", {
+        code: "INVALID_REQUEST",
+        message: "sidebar rename rejected",
+      });
+
+      const error = page.locator("[data-sidebar-session-error]");
+      await error.waitFor({ state: "visible" });
+      await expect.poll(() => error.textContent()).toContain("sidebar rename rejected");
+      expect(
+        await error
+          .locator("xpath=ancestor::*[contains(@class, 'sidebar-recent-sessions')]")
+          .count(),
+      ).toBe(0);
+
+      await error.getByRole("button", { name: "Dismiss error" }).click();
+      await expect.poll(() => error.count()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("manages sessions through the sidebar groups and command palette", async () => {
     const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
     const context = await browser.newContext({

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1227,6 +1227,24 @@ html.openclaw-native-web-chrome .sidebar-brand__collapse {
   margin-top: 10px;
 }
 
+.sidebar-session-error {
+  flex: 0 0 auto;
+  padding: 8px 10px;
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.sidebar-session-error .callout__content {
+  max-height: 72px;
+  overflow: auto;
+  overflow-wrap: anywhere;
+}
+
+.sidebar-session-error .callout__dismiss {
+  width: 22px;
+  height: 22px;
+}
+
 /* min-height: 0 down this chain lets the recent list shrink and scroll instead
    of pushing the sidebar footer out of view. */
 .sidebar-recent-sessions {


### PR DESCRIPTION
Closes #105973

## What Problem This Solves

Fixes an issue where users managing sessions from the global Control UI sidebar received no visible feedback when rename, pin, unread, archive, group, fork, or delete actions failed. Partial batch-delete failures were also discarded, making unsuccessful actions appear successful.

## Why This Change Was Made

The sidebar now owns a dismissible mutation alert and routes every sidebar session mutation through a connection-scoped operation context. Rejections and partial failures remain visible on the initiating surface, while completions from an obsolete Gateway connection are discarded before they can show stale errors, continue a batch, navigate, or force-remove a preserved worktree.

## User Impact

Users now see the Gateway's actionable failure reason directly above the sidebar session list and can dismiss it after correcting the problem. Reconnects cannot let old mutation completions affect the replacement connection.

AI-assisted implementation; reviewed and understood by the PR author.

## Evidence

- Before: the real OpenClaw 2026.7.2 Gateway rejected an invalid sidebar rename, but the sidebar rendered no failure feedback, as documented in #105973.
- Final head `e2fc236070e1038ef1a3a27cc2117d3caf1805d0`, hosted CI run 29255631509: all required jobs passed, including Control UI, production build artifacts, QA smoke, type, lint, and Node shards.
- Final hosted `dist-runtime-build` artifact against a real authenticated Gateway: a 513-character sidebar group rename was rejected with `INVALID_REQUEST`; the alert appeared outside the scroll container, retained the original group, created no replacement, dismissed cleanly, and produced zero browser page errors.
- Blacksmith Testbox run 29254363773: 62/62 focused sidebar unit tests passed.
- Blacksmith Testbox run 29254363773: 15/15 Chromium session-management E2E tests passed, including visible rejected-mutation feedback and dismissal.
- `pnpm check:changed -- ui/src/components/app-sidebar.ts ui/src/components/app-sidebar.test.ts ui/src/e2e/session-management.e2e.test.ts ui/src/styles/layout.css` passed, including formatting, TypeScript, and lint lanes.
- `pnpm build` passed, including the production Control UI build, precompressed-asset validation, 474 sidecars, and performance budgets.
- Structured Codex autoreview completed with no accepted or actionable findings.
