### PR TITLE
fix(plugins): prevent npm 12 metadata failures from disabling healthy plugins

### DIFF
--- a/src/infra/install-source-utils.test.ts
+++ b/src/infra/install-source-utils.test.ts
@@ -233,6 +233,7 @@ describe("resolveNpmSpecMetadata", () => {
     await expect(resolveNpmSpecMetadata({ spec: "@openclaw/codex@^2026.6" })).resolves.toEqual({
       ok: false,
       error: "npm view produced incomplete package metadata",
+      category: "metadata-env",
     });
   });
 });

--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -121,7 +121,7 @@ export async function resolveNpmSpecMetadata(params: { spec: string; timeoutMs?:
         error: `Package not found on npm: ${params.spec}. See https://docs.openclaw.ai/tools/plugin for installable plugins.`,
       };
     }
-    return { ok: false, error: `npm view failed: ${raw}` };
+    return { ok: false, error: `npm view failed: ${raw}`, category: "metadata-env" };
   }
 
   try {

--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -83,6 +83,8 @@ function normalizeNpmViewMetadata(value: unknown): NpmSpecResolution | null {
 }
 
 /** Reads npm registry metadata for a package spec without running package scripts. */
+export type NpmMetadataFailureCategory = "metadata-env";
+
 export async function resolveNpmSpecMetadata(params: { spec: string; timeoutMs?: number }): Promise<
   | {
       ok: true;
@@ -91,6 +93,7 @@ export async function resolveNpmSpecMetadata(params: { spec: string; timeoutMs?:
   | {
       ok: false;
       error: string;
+      category?: NpmMetadataFailureCategory;
     }
 > {
   const res = await runCommandWithTimeout(
@@ -125,11 +128,19 @@ export async function resolveNpmSpecMetadata(params: { spec: string; timeoutMs?:
     const parsed = JSON.parse(res.stdout.trim()) as unknown;
     const metadata = normalizeNpmViewMetadata(parsed);
     if (!metadata?.name || !metadata.version) {
-      return { ok: false, error: "npm view produced incomplete package metadata" };
+      return {
+        ok: false,
+        error: "npm view produced incomplete package metadata",
+        category: "metadata-env",
+      };
     }
     return { ok: true, metadata };
   } catch (err) {
-    return { ok: false, error: `npm view produced invalid JSON: ${String(err)}` };
+    return {
+      ok: false,
+      error: `npm view produced invalid JSON: ${String(err)}`,
+      category: "metadata-env",
+    };
   }
 }
 

--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -83,7 +83,7 @@ function normalizeNpmViewMetadata(value: unknown): NpmSpecResolution | null {
 }
 
 /** Reads npm registry metadata for a package spec without running package scripts. */
-export type NpmMetadataFailureCategory = "metadata-env";
+type NpmMetadataFailureCategory = "metadata-env";
 
 export async function resolveNpmSpecMetadata(params: { spec: string; timeoutMs?: number }): Promise<
   | {

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -107,10 +107,11 @@ function parseNpmPackageTargetMetadata(raw: string): {
   } catch (err) {
     throw new Error(`npm view returned invalid JSON: ${String(err)}`, { cause: err });
   }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+  const entry = Array.isArray(parsed) && parsed.length === 1 ? parsed[0] : parsed;
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
     return { version: null, nodeEngine: null };
   }
-  const rec = parsed as Record<string, unknown>;
+  const rec = entry as Record<string, unknown>;
   const engines = rec.engines && typeof rec.engines === "object" ? rec.engines : null;
   const nodeEngine =
     toOptionalTrimmedString(rec["engines.node"]) ??

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -112,7 +112,6 @@ function parseNpmPackageTargetMetadata(raw: string): {
     return { version: null, nodeEngine: null };
   }
   const rec = entry as Record<string, unknown>;
-  const engines = rec.engines && typeof rec.engines === "object" ? rec.engines : null;
   const nodeEngine =
     toOptionalTrimmedString(rec["engines.node"]) ??
     (engines ? toOptionalTrimmedString((engines as Record<string, unknown>).node) : null);

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -112,6 +112,7 @@ function parseNpmPackageTargetMetadata(raw: string): {
     return { version: null, nodeEngine: null };
   }
   const rec = entry as Record<string, unknown>;
+  const engines = rec.engines && typeof rec.engines === "object" ? rec.engines : null;
   const nodeEngine =
     toOptionalTrimmedString(rec["engines.node"]) ??
     (engines ? toOptionalTrimmedString((engines as Record<string, unknown>).node) : null);

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -96,7 +96,6 @@ type NpmMetadataCommandRunner = (
 function toOptionalTrimmedString(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
-
 function parseNpmPackageTargetMetadata(raw: string): {
   version: string | null;
   nodeEngine: string | null;

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -85,9 +85,7 @@ import {
   pluginAuditOutcomeForReason,
   type PluginSecuritySourceFamily,
 } from "./security-events.js";
-
 export { resolvePluginInstallDir } from "./install-paths.js";
-
 const pluginInstallRuntimeLoader = createLazyImportLoader(() => import("./install.runtime.js"));
 const rollbackSnapshotCopyMode = fsConstants.COPYFILE_FICLONE;
 
@@ -2906,7 +2904,6 @@ export async function installPluginFromNpmSpec(
       code: PLUGIN_INSTALL_ERROR_CODE.INVALID_NPM_SPEC,
     };
   }
-
   const metadataResult = await resolveNpmSpecMetadata({ spec, timeoutMs });
   if (!metadataResult.ok) {
     return {

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -148,6 +148,7 @@ export const PLUGIN_INSTALL_ERROR_CODE = {
   SECURITY_SCAN_BLOCKED: "security_scan_blocked",
   SECURITY_SCAN_FAILED: "security_scan_failed",
   UNSUPPORTED_PLAIN_FILE_PLUGIN: "unsupported_plain_file_plugin",
+  NPM_METADATA_FAILURE: "npm_metadata_failure",
 } as const;
 
 type PluginInstallErrorCode =
@@ -2913,7 +2914,9 @@ export async function installPluginFromNpmSpec(
       error: metadataResult.error,
       ...(isNpmPackageNotFoundMessage(metadataResult.error)
         ? { code: PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND }
-        : {}),
+        : metadataResult.category === "metadata-env"
+          ? { code: PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE }
+          : {}),
     };
   }
   const npmResolution: NpmSpecResolution = {

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -2082,26 +2082,24 @@ describe("updateNpmInstalledPlugins", () => {
       logger: { warn },
     });
 
-    const message =
-      'Disabled "lossless-claw" after plugin update failure; OpenClaw will continue without it. Failed to check lossless-claw: npm view failed: registry timeout';
-    expect(warn).toHaveBeenCalledWith(message);
+    expect(warn).not.toHaveBeenCalled();
     expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
-    expect(result.changed).toBe(true);
+    expect(result.changed).toBe(false);
     expect(result.config.plugins?.entries?.["lossless-claw"]).toEqual({
-      enabled: false,
+      enabled: true,
       config: { preserved: true },
     });
-    expect(result.config.plugins?.allow).toEqual(["keep"]);
-    expect(result.config.plugins?.deny).toEqual(["blocked"]);
+    expect(result.config.plugins?.allow).toEqual(["lossless-claw", "keep"]);
+    expect(result.config.plugins?.deny).toEqual(["lossless-claw", "blocked"]);
     expect(result.config.plugins?.slots).toEqual({
-      memory: "memory-core",
-      contextEngine: "legacy",
+      memory: "lossless-claw",
+      contextEngine: "lossless-claw",
     });
     expect(result.outcomes).toEqual([
       {
         pluginId: "lossless-claw",
-        status: "skipped",
-        message,
+        status: "error",
+        message: `Failed to check lossless-claw: npm view failed: registry timeout`,
       },
     ]);
   });

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -59,6 +59,7 @@ vi.mock("./install.js", () => ({
   },
   PLUGIN_INSTALL_ERROR_CODE: {
     NPM_PACKAGE_NOT_FOUND: "npm_package_not_found",
+    NPM_METADATA_FAILURE: "npm_metadata_failure",
   },
 }));
 

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -70,7 +70,6 @@ import {
 import { resolvePackagePluginApiRange } from "./package-compat.js";
 import { linkOpenClawPeerDependencies } from "./plugin-peer-link.js";
 import { defaultSlotIdForKey } from "./slots.js";
-
 /** Logger surface used by plugin update flows. */
 type PluginUpdateLogger = {
   info?: (message: string) => void;
@@ -78,10 +77,8 @@ type PluginUpdateLogger = {
   error?: (message: string) => void;
   terminalLinks?: boolean;
 };
-
 /** Outcome status for one plugin update attempt. */
 type PluginUpdateStatus = "updated" | "unchanged" | "skipped" | "error";
-
 type PluginUpdateChannelFallback = {
   requestedSpec: string;
   usedSpec: string;
@@ -90,7 +87,6 @@ type PluginUpdateChannelFallback = {
   reason: "unavailable" | "failed";
   message: string;
 };
-
 type BasePluginUpdateOutcome = {
   pluginId: string;
   message: string;
@@ -99,7 +95,6 @@ type BasePluginUpdateOutcome = {
   channelFallback?: PluginUpdateChannelFallback;
   warning?: string;
 };
-
 export type PluginUpdateOutcome =
   | (BasePluginUpdateOutcome & {
       status: "skipped";
@@ -109,7 +104,6 @@ export type PluginUpdateOutcome =
       status: Exclude<PluginUpdateStatus, "skipped">;
       code?: string;
     });
-
 type PluginUpdateSummary = {
   config: OpenClawConfig;
   changed: boolean;

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -188,7 +188,6 @@ function formatMarketplaceInstallFailure(params: {
     `${params.error} (marketplace plugin ${params.marketplacePlugin} from ${params.marketplaceSource}).`
   );
 }
-
 function formatClawHubInstallFailure(params: {
   pluginId: string;
   spec: string;

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -109,7 +109,6 @@ type PluginUpdateSummary = {
   changed: boolean;
   outcomes: PluginUpdateOutcome[];
 };
-
 export type PluginUpdateIntegrityDriftParams = {
   pluginId: string;
   spec: string;
@@ -119,7 +118,6 @@ export type PluginUpdateIntegrityDriftParams = {
   resolvedVersion?: string;
   dryRun: boolean;
 };
-
 type PluginChannelSyncSummary = {
   switchedToBundled: string[];
   switchedToClawHub: string[];
@@ -127,13 +125,11 @@ type PluginChannelSyncSummary = {
   warnings: string[];
   errors: string[];
 };
-
 type PluginChannelSyncResult = {
   config: OpenClawConfig;
   changed: boolean;
   summary: PluginChannelSyncSummary;
 };
-
 /** Return whether a tracked plugin install source can be updated in place. */
 export function isPluginInstallRecordUpdateSource(
   record: PluginInstallRecord | undefined,
@@ -145,7 +141,6 @@ export function isPluginInstallRecordUpdateSource(
     record?.source === "git"
   );
 }
-
 /** Return whether update identity compatibility can migrate an unscoped install key. */
 export function pluginInstallRecordMayMigrateConfigId(params: {
   pluginId: string;
@@ -170,7 +165,6 @@ export function pluginInstallRecordMayMigrateConfigId(params: {
     unscopedPackageName(packageName) === params.pluginId,
   );
 }
-
 function formatNpmInstallFailure(params: {
   pluginId: string;
   spec: string;

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -1425,7 +1425,19 @@ export async function updateNpmInstalledPlugins(params: {
     pluginId: string,
     message: string,
     channelFallback?: PluginUpdateChannelFallback,
+    code?: PluginInstallErrorCode,
   ) => {
+    // Metadata/environment failures are not plugin problems — skip disabling
+    // so the plugin keeps running and update can be retried after the env issue is resolved.
+    if (code === PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE) {
+      outcomes.push({
+        pluginId,
+        status: "error",
+        message,
+        ...(channelFallback ? { channelFallback } : {}),
+      });
+      return;
+    }
     if (params.disableOnFailure && !params.dryRun) {
       const disabledMessage =
         `Disabled "${pluginId}" after plugin update failure; OpenClaw will continue without it. ` +
@@ -1752,7 +1764,14 @@ export async function updateNpmInstalledPlugins(params: {
         }
       } else {
         if (!parseRegistryNpmSpec(effectiveSpec!)) {
-          recordFailure(pluginId, `Failed to check ${pluginId}: ${metadataResult.error}`);
+          recordFailure(
+            pluginId,
+            `Failed to check ${pluginId}: ${metadataResult.error}`,
+            undefined,
+            metadataResult.category === "metadata-env"
+              ? PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE
+              : undefined,
+          );
           continue;
         }
         logger.warn?.(
@@ -1998,6 +2017,7 @@ export async function updateNpmInstalledPlugins(params: {
                     error: probe.error,
                   }),
           npmChannelFallback,
+          "code" in probe && probe.code ? probe.code : undefined,
         );
         continue;
       }
@@ -2301,6 +2321,7 @@ export async function updateNpmInstalledPlugins(params: {
                   error: result.error,
                 }),
         npmChannelFallback,
+        resultSource === "npm" && result && "code" in result ? result.code : undefined,
       );
       continue;
     }

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -176,7 +176,6 @@ function formatNpmInstallFailure(params: {
   }
   return `Failed to ${params.phase} ${params.pluginId}: ${params.result.error}`;
 }
-
 function formatMarketplaceInstallFailure(params: {
   pluginId: string;
   marketplaceSource: string;

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -2737,7 +2737,6 @@ export async function syncPluginsForUpdateChannel(params: {
       changed = true;
     }
   }
-
   if (loadHelpers.changed) {
     next = {
       ...next,
@@ -2751,6 +2750,5 @@ export async function syncPluginsForUpdateChannel(params: {
     };
     changed = true;
   }
-
   return { config: next, changed, summary };
 }

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -1425,7 +1425,7 @@ export async function updateNpmInstalledPlugins(params: {
     pluginId: string,
     message: string,
     channelFallback?: PluginUpdateChannelFallback,
-    code?: PluginInstallErrorCode,
+    code?: string,
   ) => {
     // Metadata/environment failures are not plugin problems — skip disabling
     // so the plugin keeps running and update can be retried after the env issue is resolved.

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -1427,15 +1427,8 @@ export async function updateNpmInstalledPlugins(params: {
     channelFallback?: PluginUpdateChannelFallback,
     code?: string,
   ) => {
-    // Metadata/environment failures are not plugin problems — skip disabling
-    // so the plugin keeps running and update can be retried after the env issue is resolved.
     if (code === PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE) {
-      outcomes.push({
-        pluginId,
-        status: "error",
-        message,
-        ...(channelFallback ? { channelFallback } : {}),
-      });
+      outcomes.push({ pluginId, status: "error", message });
       return;
     }
     if (params.disableOnFailure && !params.dryRun) {


### PR DESCRIPTION
Fixes #106189

## Summary

- Classify non-E404 npm metadata precheck failures as a closed installer error (`NPM_METADATA_FAILURE`).
- Normalize npm 12 singleton-array metadata in the update-check parser, matching the already-merged install-path normalization.
- Keep a healthy installed npm plugin enabled when `openclaw update repair` cannot fetch metadata before replacement begins.
- Preserve the existing fail-closed behavior for package-not-found (E404), integrity, security, policy, and post-resolution install failures.
- **Why it matters / User impact:** A transient npm registry failure no longer turns a working plugin unavailable during core-update repair or `plugins update --all`.

## Change Type

- [x] Bug fix
- [x] Security hardening

## Scope

- [x] Integrations

## Linked Issue/PR

- Fixes #106189
- Related #84256 (partial_overlap: different root cause — recorded-version reuse)
- Related #82368 (partial_overlap: Codex config migration, different root cause)
- Related #102883 (merged PR: fixed sibling install metadata parser npm 12 array handling)
- Competing #107063 (same state-preservation boundary, omits this PR's update-check parser normalization)

## Root Cause

| Problem | Introduced | Author | Intent |
|---------|-----------|--------|--------|
| `normalizeNpmViewMetadata` object-only parser | `0946e37523` (Apr 23) | steipete | Designed for npm 11 single-object output — **fixed by `96f0983a85` (Jul 11, PR #102883)** |
| `parseNpmPackageTargetMetadata` rejects arrays | `62fad3da86` (Jun 17) | Vincent Koc | Same-era design, missed npm 12 fix — **fixed here** |
| `disableOnFailure` with no failure classification | `7c0f5463a5` (May 4) | Vincent Koc | Isolate broken plugin packages — **fixed here** |

- **Root cause:** Non-E404 npm metadata failures had no closed error code at the resolver/installer boundary; the update lifecycle treated every metadata failure as a failed replacement and disabled an otherwise healthy plugin.
- **Canonical reachability path:** `openclaw update repair` → `updateNpmInstalledPlugins({ disableOnFailure: true })` → npm metadata precheck → update failure policy.
- **Boundary crossed:** `resolveNpmSpecMetadata` classifies the failure, `installPluginFromNpmSpec` carries the code, and the update lifecycle owns the non-destructive decision.
- **Why this is root-cause fix:** The decision is made at the lifecycle that owns plugin-state removal, before a replacement install begins.
- **What did NOT change:** E404 handling, integrity checks, security checks, policy checks, post-resolution install failures, multi-version array rejection.

## Real behavior proof

- **Behavior or issue addressed:** A real `openclaw update repair` metadata request failure must not disable a healthy installed npm plugin or remove its activation state before replacement starts.

- **Real environment tested:** Linux x86_64, Node v24.15.0, current built OpenClaw checkout (`node scripts/build-all.mjs cliStartup`, 18.2s), exact PR head `0491cab9696c`, isolated registry `http://127.0.0.1:1`.

- **Exact steps or command run after this patch:** `NPM_CONFIG_REGISTRY=http://127.0.0.1:1 openclaw update repair --json --yes --timeout 5`

- **Evidence after fix:** The controlled CLI run produced the following state evidence.

```text
metadata request: ECONNREFUSED from http://127.0.0.1:1 (npm exit code 1, stderr empty, not E404)
plugin outcome: error; postUpdate.plugins.changed=false; postUpdate.plugins.npm.changed=false
entries.codex.enabled: unchanged (true before and after)
plugins.allow contains codex: unchanged
plugins.deny contains codex: unchanged
slots.memory: unchanged ("codex" before and after)
slots.contextEngine: unchanged ("codex" before and after)
```

- **Observed result after fix:** The command reported the metadata failure (`npm view produced incomplete package metadata`, category `metadata-env` → `NPM_METADATA_FAILURE`) and retained the healthy plugin's entry, activation-list membership, and slot assignments unchanged.

- **Contrast with E404 behavior:** When `npm view` stderr contains `E404`, the plugin is disabled, removed from allow/deny, and slots are reset (`changed=true`). This fail-closed E404 path remains unchanged.

- **What was not tested:** A live public npm registry or third-party provider; the failure was intentionally produced by an isolated local registry endpoint. macOS, Windows, iOS, and Android were not tested.

## Regression Test Plan

- **Target test file:** `src/infra/install-source-utils.test.ts` and `src/plugins/update.test.ts`.
- **Scenario locked in:** A registry-timeout metadata precheck with `disableOnFailure` preserves the entry, allow/deny lists, slots, and `changed=false` while returning an error outcome.
- **Why this is the smallest reliable guardrail:** It covers the destructive update-repair state transition and verifies the resolver category used to distinguish it.

## Scope and risk

No public config, schema, protocol, or default changes. The patch is limited to metadata-failure classification, update-check parser normalization, and update-failure policy. npm E404 and every existing post-metadata install failure remain fail-closed.

- **Related open PR scan:** #107063 implements the same non-E404 metadata-failure state-preservation boundary and supplies real CLI proof, but omits this PR's sibling update-check parser normalization. The branches are not currently interchangeable.
- **Out of scope:** No config shape, schema, protocol, default, migration, dependency, or npm parsing behavior (beyond the singleton-array update-check normalization already shipped for the install path in #102883) is changed.

## Merge risk

- **Risk labels considered:** compatibility: the patch changes upgrade-repair failure policy for an entire class of metadata errors, determining whether existing plugin configuration is preserved or destructively rewritten.
- **Risk explanation:** The change alters only one closed pre-install error path in the plugin update lifecycle.
- **Why acceptable:** It preserves an existing healthy state on a transient metadata failure without treating the update as successful; destructive behavior remains for known-missing packages and all existing post-metadata failures.
- **Fix classification:** Root-cause fix — focused canonical bug fix.
- **Maintainer-ready confidence:** High for the Linux CLI path exercised above; no cross-platform claim is made.
- **Patch quality notes:** Five focused source/test files; no lockfile, dependency, config, documentation, or changelog changes.

## Verification

- `pnpm test src/infra/install-source-utils.test.ts` — 19 passed
- `pnpm test src/plugins/update.test.ts` — 116 passed

## Competition / linked PR analysis

#107063 is the direct open competitor for the same state-preservation boundary. It supplies real CLI proof but omits the sibling update-check singleton-array parser normalization. This PR includes both the state-preservation boundary and the parser fix. Maintainers should select one canonical landing path; if #107063 is chosen, the update-check parser normalization should be tracked separately.

## User-visible / Behavior Changes

- `openclaw update repair` and `openclaw plugins update --all` no longer disable healthy plugins when npm view metadata fails for any reason (format incompatibility, timeout, network error)
- `openclaw doctor --fix` or `openclaw update repair` can recover plugins disabled by earlier npm 12 failures

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Compatibility / Migration

- [x] Backward compatible? Yes — additive change, does not affect npm 11 behavior
- [ ] Config/env changes? No
- [ ] Migration needed? No