### PR TITLE
fix(android): localize chat bubble role labels

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -11130,14 +11130,6 @@
       "id": "native.android.a50e44d8f380f9ad"
     },
     {
-      "kind": "ui-named-argument",
-      "line": 392,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
-      "source": "Tools",
-      "surface": "android",
-      "id": "native.android.ff4a092a02bd5d17"
-    },
-    {
       "kind": "ui-call",
       "line": 395,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
@@ -11242,14 +11234,6 @@
       "id": "native.android.5d4f893886312f82"
     },
     {
-      "kind": "ui-named-argument",
-      "line": 508,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
-      "source": "OpenClaw · Live",
-      "surface": "android",
-      "id": "native.android.dfbd755eb43b4d26"
-    },
-    {
       "kind": "ui-call",
       "line": 544,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
@@ -11269,13 +11253,29 @@
       "kind": "ui-call",
       "line": 546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
+      "source": "Tools",
+      "surface": "android",
+      "id": "native.android.ff4a092a02bd5d17"
+    },
+    {
+      "kind": "ui-call",
+      "line": 547,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
+      "source": "OpenClaw · Live",
+      "surface": "android",
+      "id": "native.android.dfbd755eb43b4d26"
+    },
+    {
+      "kind": "ui-call",
+      "line": 548,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "OpenClaw",
       "surface": "android",
       "id": "native.android.82e9fe45e93909b6"
     },
     {
       "kind": "ui-call",
-      "line": 569,
+      "line": 571,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Attachment",
       "surface": "android",
@@ -11283,7 +11283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 582,
+      "line": 584,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Open image preview",
       "surface": "android",
@@ -11291,7 +11291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 600,
+      "line": 602,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Image preview",
       "surface": "android",
@@ -11299,7 +11299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 614,
+      "line": 616,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Close image preview",
       "surface": "android",
@@ -11307,7 +11307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 623,
+      "line": 625,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Unsupported attachment",
       "surface": "android",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -6959,11 +6959,6 @@
       "translated": "جارٍ التفكير..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "الأدوات"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "جارٍ تشغيل الأدوات..."
@@ -7029,11 +7024,6 @@
       "translated": "المساعد"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · مباشر"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "أنت"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "النظام"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "الأدوات"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · مباشر"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -6959,11 +6959,6 @@
       "translated": "Denkt nach..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "Werkzeuge"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "Tools werden ausgeführt..."
@@ -7029,11 +7024,6 @@
       "translated": "Assistent"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · Live"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Du"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "System"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "Werkzeuge"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · Live"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -6959,11 +6959,6 @@
       "translated": "Pensando..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "Herramientas"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "Ejecutando herramientas..."
@@ -7029,11 +7024,6 @@
       "translated": "asistente"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · En vivo"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Tú"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "Sistema"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "Herramientas"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · En vivo"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -6959,11 +6959,6 @@
       "translated": "در حال فکر کردن..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "ابزارها"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "در حال اجرای ابزارها..."
@@ -7029,11 +7024,6 @@
       "translated": "دستیار"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · زنده"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "شما"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "سیستم"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "ابزارها"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · زنده"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -6959,11 +6959,6 @@
       "translated": "Réflexion..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "Outils"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "Exécution des outils..."
@@ -7029,11 +7024,6 @@
       "translated": "assistant"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · En direct"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Vous"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "Système"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "Outils"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · En direct"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -6959,11 +6959,6 @@
       "translated": "सोच रहा है..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "टूल्स"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "टूल चला रहा है..."
@@ -7029,11 +7024,6 @@
       "translated": "सहायक"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · लाइव"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "आप"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "सिस्टम"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "टूल्स"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · लाइव"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -6959,11 +6959,6 @@
       "translated": "Berpikir..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "Alat"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "Menjalankan alat..."
@@ -7029,11 +7024,6 @@
       "translated": "asisten"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · Langsung"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Anda"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "Sistem"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "Alat"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · Langsung"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -6959,11 +6959,6 @@
       "translated": "Sto pensando..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "Strumenti"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "Esecuzione degli strumenti..."
@@ -7029,11 +7024,6 @@
       "translated": "assistente"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · Live"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Tu"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "Sistema"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "Strumenti"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · Live"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -6959,11 +6959,6 @@
       "translated": "考えています..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "ツール"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "ツールを実行中..."
@@ -7029,11 +7024,6 @@
       "translated": "アシスタント"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · ライブ"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "あなた"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "システム"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "ツール"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · ライブ"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -6959,11 +6959,6 @@
       "translated": "생각 중..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "도구"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "도구 실행 중..."
@@ -7029,11 +7024,6 @@
       "translated": "어시스턴트"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · 라이브"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "나"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "시스템"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "도구"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · 라이브"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -6959,11 +6959,6 @@
       "translated": "Aan het nadenken..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "Tools"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "Tools worden uitgevoerd..."
@@ -7029,11 +7024,6 @@
       "translated": "assistent"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · Live"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Jij"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "Systeem"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "Tools"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · Live"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -6959,11 +6959,6 @@
       "translated": "Myślenie..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "Narzędzia"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "Uruchamianie narzędzi..."
@@ -7029,11 +7024,6 @@
       "translated": "asystent"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · Na żywo"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Ty"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "System"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "Narzędzia"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · Na żywo"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -6959,11 +6959,6 @@
       "translated": "Pensando..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "Ferramentas"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "Executando ferramentas..."
@@ -7029,11 +7024,6 @@
       "translated": "assistente"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · Ao vivo"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Você"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "Sistema"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "Ferramentas"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · Ao vivo"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -6959,11 +6959,6 @@
       "translated": "Думаем..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "Инструменты"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "Выполняются инструменты..."
@@ -7029,11 +7024,6 @@
       "translated": "ассистент"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · В эфире"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Вы"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "Система"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "Инструменты"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · В эфире"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -6959,11 +6959,6 @@
       "translated": "Tänker..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "Verktyg"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "Kör verktyg..."
@@ -7029,11 +7024,6 @@
       "translated": "assistent"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · Live"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Du"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "System"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "Verktyg"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · Live"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -6959,11 +6959,6 @@
       "translated": "กำลังคิด..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "เครื่องมือ"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "กำลังเรียกใช้เครื่องมือ..."
@@ -7029,11 +7024,6 @@
       "translated": "ผู้ช่วย"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · ไลฟ์"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "คุณ"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "ระบบ"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "เครื่องมือ"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · ไลฟ์"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -6959,11 +6959,6 @@
       "translated": "Düşünüyor..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "Araçlar"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "Araçlar çalıştırılıyor..."
@@ -7029,11 +7024,6 @@
       "translated": "asistan"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · Canlı"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Siz"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "Sistem"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "Araçlar"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · Canlı"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -6959,11 +6959,6 @@
       "translated": "Думаю..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "Інструменти"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "Виконуються інструменти..."
@@ -7029,11 +7024,6 @@
       "translated": "асистент"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · Наживо"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Ви"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "Система"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "Інструменти"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · Наживо"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -6959,11 +6959,6 @@
       "translated": "Đang suy nghĩ..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "Công cụ"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "Đang chạy công cụ..."
@@ -7029,11 +7024,6 @@
       "translated": "trợ lý"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · Trực tiếp"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Bạn"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "Hệ thống"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "Công cụ"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · Trực tiếp"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -6959,11 +6959,6 @@
       "translated": "正在思考..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "工具"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "正在运行工具..."
@@ -7029,11 +7024,6 @@
       "translated": "助手"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · 实时"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "你"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "系统"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "工具"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · 实时"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -6959,11 +6959,6 @@
       "translated": "思考中..."
     },
     {
-      "id": "native.android.ff4a092a02bd5d17",
-      "source": "Tools",
-      "translated": "工具"
-    },
-    {
       "id": "native.android.3788802f6c138c8b",
       "source": "Running tools...",
       "translated": "正在執行工具..."
@@ -7029,11 +7024,6 @@
       "translated": "助理"
     },
     {
-      "id": "native.android.dfbd755eb43b4d26",
-      "source": "OpenClaw · Live",
-      "translated": "OpenClaw · 即時"
-    },
-    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "你"
@@ -7042,6 +7032,16 @@
       "id": "native.android.d29098025118ce4b",
       "source": "System",
       "translated": "系統"
+    },
+    {
+      "id": "native.android.ff4a092a02bd5d17",
+      "source": "Tools",
+      "translated": "工具"
+    },
+    {
+      "id": "native.android.dfbd755eb43b4d26",
+      "source": "OpenClaw · Live",
+      "translated": "OpenClaw · 即時"
     },
     {
       "id": "native.android.82e9fe45e93909b6",

--- a/apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotMode.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotMode.kt
@@ -11,6 +11,7 @@ enum class AndroidScreenshotScene(
 ) {
   Home("home", HomeDestination.Connect),
   Chat("chat", HomeDestination.Chat),
+  ChatProof("chat-proof", HomeDestination.Chat),
   Voice("voice", HomeDestination.Voice),
   Settings("settings", HomeDestination.Settings),
   ;

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -199,6 +199,9 @@ class MainViewModel(
         "Screenshot fixture mode must be selected before live runtime startup"
       }
       runtime.setForeground(foreground)
+      if (scene == AndroidScreenshotScene.ChatProof) {
+        runtime.applyScreenshotChatProof()
+      }
       _requestedHomeDestination.value = scene.homeDestination
       return
     }
@@ -208,6 +211,9 @@ class MainViewModel(
     prefs.setSpeakerEnabled(true)
     val runtime = nodeApp.ensureScreenshotFixtureRuntime()
     runtime.setForeground(foreground)
+    if (scene == AndroidScreenshotScene.ChatProof) {
+      runtime.applyScreenshotChatProof()
+    }
     runtimeRef.value = runtime
     _requestedHomeDestination.value = scene.homeDestination
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -2150,6 +2150,11 @@ class NodeRuntime private constructor(
 
   fun deleteChatOutboxCommand(id: String) = chat.deleteOutboxCommand(id)
 
+  internal fun applyScreenshotChatProof() {
+    check(mode == NodeRuntimeMode.ScreenshotFixture) { "Chat proof is only available in screenshot fixture mode" }
+    chat.applyScreenshotChatProof()
+  }
+
   private fun applyScreenshotFixture() {
     check(BuildConfig.DEBUG) { "Android screenshot fixtures require a debug build" }
     _serverName.value = "OpenClaw Gateway"

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -208,6 +208,8 @@ class ChatController internal constructor(
   // any run the gateway still reports in flight (chat.history `inFlightRun`).
   private var restoreRunStateOnReconnect = false
   private var reconnectRecoveryGeneration: Long? = null
+  // Screenshot proof state must survive the fixture's normal chat.history refresh.
+  private var screenshotChatProofEnabled = false
 
   private fun updateErrorText(
     message: String?,
@@ -1561,6 +1563,9 @@ class ChatController internal constructor(
         // replace) adopt the gateway's in-flight run snapshot so restored
         // runs keep their pending state and streaming text.
         adoptInFlightRun(history.inFlightRun)
+        if (screenshotChatProofEnabled) {
+          publishScreenshotChatProof()
+        }
         history.thinkingLevel
           ?.trim()
           ?.takeIf { it.isNotEmpty() }
@@ -2645,6 +2650,24 @@ class ChatController internal constructor(
   private fun publishPendingToolCalls() {
     _pendingToolCalls.value =
       pendingToolCallsById.values.sortedBy { it.startedAtMs }
+  }
+
+  internal fun applyScreenshotChatProof() {
+    screenshotChatProofEnabled = true
+    publishScreenshotChatProof()
+  }
+
+  private fun publishScreenshotChatProof() {
+    _pendingRunCount.value = 1
+    pendingToolCallsById.clear()
+    pendingToolCallsById["screenshot-tool"] =
+      ChatPendingToolCall(
+        toolCallId = "screenshot-tool",
+        name = "read_file",
+        startedAtMs = 1_783_555_210_000,
+      )
+    publishPendingToolCalls()
+    _streamingAssistantText.value = "Checking Android localization wiring..."
   }
 
   /**

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
@@ -127,7 +127,7 @@ internal fun ChatMessageBubble(
     onToggleListen = toggleListen,
     modifier = Modifier.fillMaxWidth(),
   ) {
-    ChatBubbleContainer(style = style, roleLabel = roleLabel(role)) {
+    ChatBubbleContainer(style = style, roleLabel = chatRoleLabel(role)) {
       ChatMessageBody(content = displayableContent, textColor = mobileText)
       ChatMessageLinkPreview(messageId = message.id, role = role, content = displayableContent)
       messageSpeech?.let { speech ->
@@ -366,7 +366,7 @@ private fun linkPreviewDomain(url: String): String =
 fun ChatTypingIndicatorBubble() {
   ChatBubbleContainer(
     style = bubbleStyle("assistant"),
-    roleLabel = roleLabel("assistant"),
+    roleLabel = chatRoleLabel("assistant"),
   ) {
     Row(
       verticalAlignment = Alignment.CenterVertically,
@@ -389,7 +389,7 @@ fun ChatPendingToolsBubble(toolCalls: List<ChatPendingToolCall>) {
 
   ChatBubbleContainer(
     style = bubbleStyle("assistant"),
-    roleLabel = "Tools",
+    roleLabel = chatRoleLabel("tools"),
   ) {
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
       Text(nativeString("Running tools..."), style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold), color = mobileTextSecondary)
@@ -445,7 +445,7 @@ fun ChatOutboxBubble(
 
   ChatBubbleContainer(
     style = bubbleStyle("user").copy(borderColor = statusColor.copy(alpha = 0.6f)),
-    roleLabel = nativeString("You"),
+    roleLabel = chatRoleLabel("user"),
   ) {
     if (item.text.isNotBlank()) {
       ChatMarkdown(text = item.text, textColor = mobileText)
@@ -505,7 +505,7 @@ private fun ChatOutboxAction(
 fun ChatStreamingAssistantBubble(text: String) {
   ChatBubbleContainer(
     style = bubbleStyle("assistant").copy(borderColor = mobileAccent),
-    roleLabel = "OpenClaw · Live",
+    roleLabel = chatRoleLabel("assistant_live"),
   ) {
     ChatMarkdown(text = text, textColor = mobileText, isStreaming = true)
   }
@@ -539,10 +539,12 @@ private fun bubbleStyle(role: String): ChatBubbleStyle =
       )
   }
 
-private fun roleLabel(role: String): String =
+internal fun chatRoleLabel(role: String): String =
   when (role) {
     "user" -> nativeString("You")
     "system" -> nativeString("System")
+    "tools" -> nativeString("Tools")
+    "assistant_live" -> nativeString("OpenClaw · Live")
     else -> nativeString("OpenClaw")
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMessageViewsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMessageViewsTest.kt
@@ -1,0 +1,15 @@
+package ai.openclaw.app.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChatMessageViewsTest {
+  @Test
+  fun roleLabelMapsKnownChatRoles() {
+    assertEquals("You", chatRoleLabel("user"))
+    assertEquals("System", chatRoleLabel("system"))
+    assertEquals("Tools", chatRoleLabel("tools"))
+    assertEquals("OpenClaw · Live", chatRoleLabel("assistant_live"))
+    assertEquals("OpenClaw", chatRoleLabel("assistant"))
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Android chat bubbles still had two visible role labels that bypassed the native localization path: the pending tools bubble (`Tools`) and the streaming assistant bubble (`OpenClaw · Live`). That made the chat UI inconsistent with the rest of the localized Android role labels.

## Why This Change Was Made

This updates the chat bubble role-label helper so all chat role labels, including tools and live assistant states, resolve through literal `nativeString(...)` calls. Keeping the literals in the helper preserves native i18n extraction while avoiding per-bubble hard-coded English labels.

The branch also adds a debug-only screenshot fixture scene (`chat-proof`) so Android proof can repeatedly render the exact pending-tools and live-assistant chat states from a real emulator/device setup without needing a live Gateway run.

## User Impact

Android users get consistent localized role-label handling across normal assistant, user, system, pending tools, and live assistant chat bubbles. Translators and generated Android native string resources now cover the modified labels through the same inventory path as the existing labels.

## Localization Label Coverage

| Bubble/state | Source label | Localization path |
| --- | --- | --- |
| User outbox | `You` | `chatRoleLabel("user")` -> `nativeString("You")` |
| System | `System` | `chatRoleLabel("system")` -> `nativeString("System")` |
| Pending tools | `Tools` | `chatRoleLabel("tools")` -> `nativeString("Tools")` |
| Streaming assistant | `OpenClaw · Live` | `chatRoleLabel("assistant_live")` -> `nativeString("OpenClaw · Live")` |
| Assistant fallback | `OpenClaw` | `chatRoleLabel("assistant")` -> `nativeString("OpenClaw")` |

## Evidence

- `node --import tsx scripts/native-app-i18n.ts check` passed. The command still prints existing advisory diagnostics, but exits 0.
- `git diff --check -- apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotMode.kt apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMessageViewsTest.kt apps/.i18n/native-source.json apps/.i18n/native` passed.
- `apps/android: .\gradlew.bat --console=plain --no-daemon :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.chat.ChatMessageViewsTest` passed with Android Studio JBR (`JAVA_HOME=F:\Program Files\Android\Android Studio\jbr`).
- `apps/android: .\gradlew.bat --console=plain --no-daemon :app:assemblePlayDebug` passed with Android Studio JBR.
- Real emulator proof on `Medium_Phone` / `emulator-5554` passed after installing the Play debug APK, setting app locale to `zh-CN`, and launching `openclaw.screenshotScene=chat-proof`; UIAutomator dump showed `OpenClaw · Live`, `Tools running`, `read_file`, and `Checking Android localization wiring...` from `ai.openclaw.app/ai.openclaw.app.MainActivity`.
- `python .agents\skills\autoreview\scripts\autoreview --mode commit --commit HEAD --model gpt-5.5 --thinking medium` passed: `autoreview clean: no accepted/actionable findings reported`.