### PR TITLE
fix(reef): prevent oversized guard responses from consuming memory

### DIFF
--- a/extensions/reef/protocol/guard-adapters.ts
+++ b/extensions/reef/protocol/guard-adapters.ts
@@ -1,3 +1,4 @@
+import { readProviderTextResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   admitGuardAdapter,
   assertPinnedModel,
@@ -151,10 +152,9 @@ function attachProviderModel(value: unknown, model: string): unknown {
 }
 
 async function parseJsonResponse(response: Response): Promise<unknown> {
-  const text = await response.text();
-  if (text.length > 256 * 1024) {
-    throw new Error("guard response too large");
-  }
+  const text = await readProviderTextResponse(response, "Reef guard response", {
+    maxBytes: 256 * 1024,
+  });
   return parseStrictJson(text);
 }
 

--- a/extensions/reef/protocol/guard.test.ts
+++ b/extensions/reef/protocol/guard.test.ts
@@ -177,6 +177,62 @@ describe("provider adapters", () => {
     });
   });
 
+  it("cancels oversized provider response streams before buffering them fully", async () => {
+    const chunk = new TextEncoder().encode("x".repeat(64 * 1024));
+    const totalChunks = 8;
+    let emittedChunks = 0;
+    let cancelled = false;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (emittedChunks >= totalChunks) {
+            controller.close();
+            return;
+          }
+          controller.enqueue(chunk);
+          emittedChunks += 1;
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+      { headers: { "content-type": "application/json" } },
+    );
+    const guard = createOpenAiGuard({
+      apiKey: "test",
+      pinnedModel: model,
+      fetch: async () => response,
+    });
+
+    await expect(guard.classify(request)).resolves.toMatchObject({
+      decision: "deny",
+      category: "guard_failure",
+    });
+    expect(cancelled).toBe(true);
+    expect(emittedChunks).toBeLessThan(totalChunks);
+  });
+
+  it("accepts valid provider responses close to the body limit", async () => {
+    const body = JSON.stringify({
+      model,
+      status: "completed",
+      output: [
+        { type: "message", content: [{ type: "output_text", text: JSON.stringify(modelAllow) }] },
+      ],
+      provider_metadata: "x".repeat(240 * 1024),
+    });
+    const bodyBytes = new TextEncoder().encode(body).byteLength;
+    expect(bodyBytes).toBeGreaterThan(240 * 1024);
+    expect(bodyBytes).toBeLessThan(256 * 1024);
+    const guard = createOpenAiGuard({
+      apiKey: "test",
+      pinnedModel: model,
+      fetch: async () => new Response(body, { headers: { "content-type": "application/json" } }),
+    });
+
+    await expect(guard.classify(request)).resolves.toEqual(allow);
+  });
+
   it("fails closed on malformed JSON and provider model mismatch", async () => {
     const malformed = createOpenAiGuard({
       apiKey: "test",

--- a/extensions/reef/protocol/guard.test.ts
+++ b/extensions/reef/protocol/guard.test.ts
@@ -178,8 +178,9 @@ describe("provider adapters", () => {
   });
 
   it("cancels oversized provider response streams before buffering them fully", async () => {
+    const maxBytes = 256 * 1024;
     const chunk = new TextEncoder().encode("x".repeat(64 * 1024));
-    const totalChunks = 8;
+    const totalChunks = 64;
     let emittedChunks = 0;
     let cancelled = false;
     const response = new Response(
@@ -209,7 +210,8 @@ describe("provider adapters", () => {
       category: "guard_failure",
     });
     expect(cancelled).toBe(true);
-    expect(emittedChunks).toBeLessThan(totalChunks);
+    // Allow the overflow chunk plus one chunk queued by the stream implementation.
+    expect(emittedChunks * chunk.byteLength).toBeLessThanOrEqual(maxBytes + chunk.byteLength * 2);
   });
 
   it("accepts valid provider responses close to the body limit", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Reef users could have a guard request buffer an unbounded response body when a provider endpoint returned oversized data.

## Why This Change Was Made

Reef now applies its existing 256 KiB guard-response ceiling while streaming through the shared provider HTTP reader. Valid responses retain the existing strict JSON validation, while oversized streams are cancelled before their remaining data is buffered.

## User Impact

Reef guard requests remain fail-closed without allowing an oversized provider response to consume unbounded memory.

## Evidence

- Real production-module proof through `createOpenAiGuard`: a 246029-byte valid response remained accepted; a 524288-byte offered stream was cancelled after 393216 bytes and failed closed.
- `pnpm test:extension reef`: 11 files passed, 104 tests passed, 2 live tests skipped.

```text
$ pnpm exec tsx proof-reef-guard-body-limit.ts
near-limit bytes=246029 decision=allow category=coordination
oversized offeredBytes=524288 emittedBytes=393216 cancelled=true decision=deny category=guard_failure
```

<details>
<summary>proof-reef-guard-body-limit.ts</summary>

```ts
import { createOpenAiGuard } from "./extensions/reef/protocol/guard-adapters.js";
import type { GuardRequest } from "./extensions/reef/protocol/guard.js";

const model = "guard-model-2026-07-12";
const request: GuardRequest = {
  direction: "outbound",
  source: "proof-source",
  destination: "proof-destination",
  text: "meeting at ten",
  policyVersion: "v1",
};
const verdict = {
  decision: "allow",
  category: "coordination",
  reason: "Routine coordination.",
  policyVersion: "v1",
};
const nearLimitBody = JSON.stringify({
  model,
  status: "completed",
  output: [
    { type: "message", content: [{ type: "output_text", text: JSON.stringify(verdict) }] },
  ],
  provider_metadata: "x".repeat(240 * 1024),
});
const nearLimitBytes = new TextEncoder().encode(nearLimitBody).byteLength;
const nearLimitGuard = createOpenAiGuard({
  apiKey: "redacted-proof-key",
  pinnedModel: model,
  fetch: async () =>
    new Response(nearLimitBody, { headers: { "content-type": "application/json" } }),
});
const nearLimitResult = await nearLimitGuard.classify(request);

const chunk = new TextEncoder().encode("x".repeat(64 * 1024));
const totalChunks = 8;
let emittedChunks = 0;
let cancelled = false;
const oversizedGuard = createOpenAiGuard({
  apiKey: "redacted-proof-key",
  pinnedModel: model,
  fetch: async () =>
    new Response(
      new ReadableStream<Uint8Array>({
        pull(controller) {
          if (emittedChunks >= totalChunks) {
            controller.close();
            return;
          }
          controller.enqueue(chunk);
          emittedChunks += 1;
        },
        cancel() {
          cancelled = true;
        },
      }),
      { headers: { "content-type": "application/json" } },
    ),
});
const oversizedResult = await oversizedGuard.classify(request);

console.log(
  `near-limit bytes=${nearLimitBytes} decision=${nearLimitResult.decision} category=${nearLimitResult.category}`,
);
console.log(
  `oversized offeredBytes=${totalChunks * chunk.byteLength} emittedBytes=${emittedChunks * chunk.byteLength} cancelled=${cancelled} decision=${oversizedResult.decision} category=${oversizedResult.category}`,
);

if (
  nearLimitBytes >= 256 * 1024 ||
  nearLimitResult.decision !== "allow" ||
  !cancelled ||
  emittedChunks >= totalChunks ||
  oversizedResult.category !== "guard_failure"
) {
  process.exitCode = 1;
}
```

</details>

AI-assisted: built with Codex
