### PR TITLE
refactor(queue): remove dead summary reset

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -2229,7 +2229,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/tui/tui-task-suggestions.ts: parseTuiTaskSuggestion",
   "src/tui/tui-waiting.ts: pickWaitingPhrase",
   "src/utils/message-channel-constants.ts: NATIVE_APPROVAL_CHANNELS",
-  "src/utils/queue-helpers.ts: clearQueueSummaryState",
   "src/video-generation/runtime-types.ts: ListRuntimeVideoGenerationProvidersParams",
   "src/video-generation/runtime-types.ts: RuntimeVideoGenerationProvider",
   "src/web-search/runtime-types.ts: ListWebSearchProvidersParams",

--- a/src/utils/queue-helpers.test.ts
+++ b/src/utils/queue-helpers.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
   applyQueueDropPolicy,
   applyQueueRuntimeSettings,
-  clearQueueSummaryState,
   countPendingQueueItems,
   drainCollectQueueStep,
   drainNextQueueItem,
@@ -83,17 +82,6 @@ describe("queue summary helpers", () => {
       droppedCount: 2,
       summaryLines: ["first", "second"],
     });
-  });
-
-  it("clearQueueSummaryState resets summary counters", () => {
-    const state = {
-      dropPolicy: "summarize" as const,
-      droppedCount: 5,
-      summaryLines: ["a", "b"],
-    };
-    clearQueueSummaryState(state);
-    expect(state.droppedCount).toBe(0);
-    expect(state.summaryLines).toStrictEqual([]);
   });
 
   it("keeps dropped-item previews free of lone surrogates", () => {

--- a/src/utils/queue-helpers.ts
+++ b/src/utils/queue-helpers.ts
@@ -23,12 +23,6 @@ type QueueState<T> = QueueSummaryState & {
   cap: number;
 };
 
-/** Clear accumulated overflow summary state after it has been emitted. */
-export function clearQueueSummaryState(state: QueueSummaryState): void {
-  state.droppedCount = 0;
-  state.summaryLines = [];
-}
-
 /** Build a summary prompt preview without mutating the source queue state. */
 export function previewQueueSummaryPrompt(params: {
   state: QueueSummaryState;
@@ -36,11 +30,7 @@ export function previewQueueSummaryPrompt(params: {
   title?: string;
 }): string | undefined {
   return buildQueueSummaryPrompt({
-    state: {
-      dropPolicy: params.state.dropPolicy,
-      droppedCount: params.state.droppedCount,
-      summaryLines: [...params.state.summaryLines],
-    },
+    state: params.state,
     noun: params.noun,
     title: params.title,
   });
@@ -310,7 +300,7 @@ export async function drainCollectQueueStep<T>(params: {
   });
 }
 
-/** Build and consume the queue overflow summary prompt. */
+/** Build the queue overflow summary prompt. */
 function buildQueueSummaryPrompt(params: {
   state: QueueSummaryState;
   noun: string;
@@ -330,7 +320,6 @@ function buildQueueSummaryPrompt(params: {
       lines.push(`- ${line}`);
     }
   }
-  clearQueueSummaryState(params.state);
   return lines.join("\n");
 }
 


### PR DESCRIPTION
## What Problem This Solves

The shared queue helper surface retained a reset export that production only called while rendering a defensive copy. The write was therefore unobservable, while the export and its dedicated test kept dead API surface and a dead-code baseline allowance alive.

## Why This Change Was Made

Make summary prompt construction read-only, pass the source state directly, and remove the unused reset helper, redundant direct test, and matching unused-export allowance. Queue ownership and runtime clearing behavior remain unchanged.

## User Impact

No user-visible behavior change. This narrows an internal queue utility surface and removes 24 net lines of dead code.

## Evidence

- Blacksmith Testbox `tbx_01kxdw6xjbt57pn76p7c3et9cz`, Actions run `29255794672`
  - `pnpm test:serial src/utils/queue-helpers.test.ts`: 15/15 passed
  - `pnpm deadcode:exports`: passed with 2595 entries
  - targeted `pnpm check:changed`: passed
- Fresh branch-mode `gpt-5.6-sol` medium autoreview: clean, 0.98 confidence
- `git diff --check`: passed
- Current `main` overlap audit: no touched runtime/test files overlap; three-way merge is clean

AI-assisted: yes. No transcript attached.
