### PR TITLE
refactor(gateway): share closed TypeBox objects

### DIFF
--- a/packages/gateway-protocol/src/schema/agent.ts
+++ b/packages/gateway-protocol/src/schema/agent.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { InputProvenanceSchema, NonEmptyString, SessionLabelString } from "./primitives.js";
 
 /**
@@ -21,267 +22,231 @@ const AGENT_INTERNAL_EVENT_SOURCES = [
 const AGENT_INTERNAL_EVENT_STATUSES = ["ok", "timeout", "error", "unknown"] as const;
 
 /** Generated media/file attachment metadata carried by internal agent events. */
-export const AgentGeneratedAttachmentSchema = Type.Object(
-  {
-    type: Type.Optional(Type.String({ enum: ["image", "audio", "video", "file"] })),
-    path: Type.Optional(Type.String()),
-    url: Type.Optional(Type.String()),
-    mediaUrl: Type.Optional(Type.String()),
-    filePath: Type.Optional(Type.String()),
-    mimeType: Type.Optional(Type.String()),
-    name: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const AgentGeneratedAttachmentSchema = closedObject({
+  type: Type.Optional(Type.String({ enum: ["image", "audio", "video", "file"] })),
+  path: Type.Optional(Type.String()),
+  url: Type.Optional(Type.String()),
+  mediaUrl: Type.Optional(Type.String()),
+  filePath: Type.Optional(Type.String()),
+  mimeType: Type.Optional(Type.String()),
+  name: Type.Optional(Type.String()),
+});
 
 /** Internal completion event surfaced when child automation reports back to a parent run. */
-export const AgentInternalEventSchema = Type.Object(
-  {
-    type: Type.Literal(AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION),
-    source: Type.String({ enum: [...AGENT_INTERNAL_EVENT_SOURCES] }),
-    childSessionKey: Type.String(),
-    childSessionId: Type.Optional(Type.String()),
-    announceType: Type.String(),
-    taskLabel: Type.String(),
-    status: Type.String({ enum: [...AGENT_INTERNAL_EVENT_STATUSES] }),
-    statusLabel: Type.String(),
-    result: Type.String(),
-    attachments: Type.Optional(Type.Array(AgentGeneratedAttachmentSchema)),
-    mediaUrls: Type.Optional(Type.Array(Type.String())),
-    statsLine: Type.Optional(Type.String()),
-    replyInstruction: Type.String(),
-  },
-  { additionalProperties: false },
-);
+export const AgentInternalEventSchema = closedObject({
+  type: Type.Literal(AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION),
+  source: Type.String({ enum: [...AGENT_INTERNAL_EVENT_SOURCES] }),
+  childSessionKey: Type.String(),
+  childSessionId: Type.Optional(Type.String()),
+  announceType: Type.String(),
+  taskLabel: Type.String(),
+  status: Type.String({ enum: [...AGENT_INTERNAL_EVENT_STATUSES] }),
+  statusLabel: Type.String(),
+  result: Type.String(),
+  attachments: Type.Optional(Type.Array(AgentGeneratedAttachmentSchema)),
+  mediaUrls: Type.Optional(Type.Array(Type.String())),
+  statsLine: Type.Optional(Type.String()),
+  replyInstruction: Type.String(),
+});
 
 /** Stream event emitted by the agent runtime over the gateway protocol. */
-export const AgentEventSchema = Type.Object(
-  {
-    runId: NonEmptyString,
-    seq: Type.Integer({ minimum: 0 }),
-    stream: NonEmptyString,
-    ts: Type.Integer({ minimum: 0 }),
-    spawnedBy: Type.Optional(NonEmptyString),
-    isHeartbeat: Type.Optional(Type.Boolean()),
-    data: Type.Record(Type.String(), Type.Unknown()),
-  },
-  { additionalProperties: false },
-);
+export const AgentEventSchema = closedObject({
+  runId: NonEmptyString,
+  seq: Type.Integer({ minimum: 0 }),
+  stream: NonEmptyString,
+  ts: Type.Integer({ minimum: 0 }),
+  spawnedBy: Type.Optional(NonEmptyString),
+  isHeartbeat: Type.Optional(Type.Boolean()),
+  data: Type.Record(Type.String(), Type.Unknown()),
+});
 
 /** Caller-supplied routing hints. Authorization must use trusted runtime context. */
-export const MessageActionToolContextSchema = Type.Object(
-  {
-    currentChannelId: Type.Optional(Type.String()),
-    currentMessagingTarget: Type.Optional(Type.String()),
-    currentGraphChannelId: Type.Optional(Type.String()),
-    currentChannelProvider: Type.Optional(Type.String()),
-    currentThreadTs: Type.Optional(Type.String()),
-    currentMessageId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
-    replyToMode: Type.Optional(
-      Type.Union([
-        Type.Literal("off"),
-        Type.Literal("first"),
-        Type.Literal("all"),
-        Type.Literal("batched"),
-      ]),
-    ),
-    hasRepliedRef: Type.Optional(
-      Type.Object(
-        {
-          value: Type.Boolean(),
-        },
-        { additionalProperties: false },
-      ),
-    ),
-    sameChannelThreadRequired: Type.Optional(Type.Boolean()),
-    skipCrossContextDecoration: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const MessageActionToolContextSchema = closedObject({
+  currentChannelId: Type.Optional(Type.String()),
+  currentMessagingTarget: Type.Optional(Type.String()),
+  currentGraphChannelId: Type.Optional(Type.String()),
+  currentChannelProvider: Type.Optional(Type.String()),
+  currentThreadTs: Type.Optional(Type.String()),
+  currentMessageId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+  replyToMode: Type.Optional(
+    Type.Union([
+      Type.Literal("off"),
+      Type.Literal("first"),
+      Type.Literal("all"),
+      Type.Literal("batched"),
+    ]),
+  ),
+  hasRepliedRef: Type.Optional(
+    closedObject({
+      value: Type.Boolean(),
+    }),
+  ),
+  sameChannelThreadRequired: Type.Optional(Type.Boolean()),
+  skipCrossContextDecoration: Type.Optional(Type.Boolean()),
+});
 
 /** Request to execute a channel message action through a configured adapter. */
-export const MessageActionParamsSchema = Type.Object(
-  {
-    channel: NonEmptyString,
-    action: NonEmptyString,
-    params: Type.Record(Type.String(), Type.Unknown()),
-    accountId: Type.Optional(Type.String()),
-    requesterAccountId: Type.Optional(Type.String()),
-    requesterSenderId: Type.Optional(Type.String()),
-    // Honored only when the RPC caller has the full operator scope set
-    // (shared-secret bearer or `operator.admin`). For narrowly-scoped
-    // callers (e.g. `operator.write`-only) the gateway forces this to
-    // `false` regardless of the value sent here.
-    senderIsOwner: Type.Optional(Type.Boolean()),
-    sessionKey: Type.Optional(Type.String()),
-    sessionId: Type.Optional(Type.String()),
-    inboundTurnKind: Type.Optional(Type.String({ enum: ["user_request", "room_event"] })),
-    agentId: Type.Optional(Type.String()),
-    toolContext: Type.Optional(MessageActionToolContextSchema),
-    /**
-     * Explicit operation-local marker for an authenticated direct operator.
-     * Missing values remain delegated, and agent runtime identity wins server-side.
-     */
-    conversationReadOrigin: Type.Optional(Type.Literal("direct-operator")),
-    idempotencyKey: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const MessageActionParamsSchema = closedObject({
+  channel: NonEmptyString,
+  action: NonEmptyString,
+  params: Type.Record(Type.String(), Type.Unknown()),
+  accountId: Type.Optional(Type.String()),
+  requesterAccountId: Type.Optional(Type.String()),
+  requesterSenderId: Type.Optional(Type.String()),
+  // Honored only when the RPC caller has the full operator scope set
+  // (shared-secret bearer or `operator.admin`). For narrowly-scoped
+  // callers (e.g. `operator.write`-only) the gateway forces this to
+  // `false` regardless of the value sent here.
+  senderIsOwner: Type.Optional(Type.Boolean()),
+  sessionKey: Type.Optional(Type.String()),
+  sessionId: Type.Optional(Type.String()),
+  inboundTurnKind: Type.Optional(Type.String({ enum: ["user_request", "room_event"] })),
+  agentId: Type.Optional(Type.String()),
+  toolContext: Type.Optional(MessageActionToolContextSchema),
+  /**
+   * Explicit operation-local marker for an authenticated direct operator.
+   * Missing values remain delegated, and agent runtime identity wins server-side.
+   */
+  conversationReadOrigin: Type.Optional(Type.Literal("direct-operator")),
+  idempotencyKey: NonEmptyString,
+});
 
 /** Outbound send request shared by channel adapters. */
-export const SendParamsSchema = Type.Object(
-  {
-    to: NonEmptyString,
-    message: Type.Optional(Type.String()),
-    mediaUrl: Type.Optional(Type.String()),
-    mediaUrls: Type.Optional(Type.Array(Type.String())),
-    /** Base64 attachment payload for gateway-local media materialization. */
-    buffer: Type.Optional(Type.String()),
-    /** Optional filename for a base64 attachment payload. */
-    filename: Type.Optional(Type.String()),
-    /** Optional MIME type for a base64 attachment payload. */
-    contentType: Type.Optional(Type.String()),
-    asVoice: Type.Optional(Type.Boolean()),
-    gifPlayback: Type.Optional(Type.Boolean()),
-    channel: Type.Optional(Type.String()),
-    accountId: Type.Optional(Type.String()),
-    /** Optional agent id for per-agent media root resolution on gateway sends. */
-    agentId: Type.Optional(Type.String()),
-    /** Reply target message id for native quoted/threaded sends where supported. */
-    replyToId: Type.Optional(Type.String()),
-    /** Thread id (channel-specific meaning, e.g. Telegram forum topic id). */
-    threadId: Type.Optional(Type.String()),
-    /** Force document-style media sends where supported. */
-    forceDocument: Type.Optional(Type.Boolean()),
-    /** Send silently (no notification) where supported. */
-    silent: Type.Optional(Type.Boolean()),
-    /** Channel-specific parse mode for formatted text. */
-    parseMode: Type.Optional(Type.Literal("HTML")),
-    /** Optional session key for mirroring delivered output back into the transcript. */
-    sessionKey: Type.Optional(Type.String()),
-    idempotencyKey: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const SendParamsSchema = closedObject({
+  to: NonEmptyString,
+  message: Type.Optional(Type.String()),
+  mediaUrl: Type.Optional(Type.String()),
+  mediaUrls: Type.Optional(Type.Array(Type.String())),
+  /** Base64 attachment payload for gateway-local media materialization. */
+  buffer: Type.Optional(Type.String()),
+  /** Optional filename for a base64 attachment payload. */
+  filename: Type.Optional(Type.String()),
+  /** Optional MIME type for a base64 attachment payload. */
+  contentType: Type.Optional(Type.String()),
+  asVoice: Type.Optional(Type.Boolean()),
+  gifPlayback: Type.Optional(Type.Boolean()),
+  channel: Type.Optional(Type.String()),
+  accountId: Type.Optional(Type.String()),
+  /** Optional agent id for per-agent media root resolution on gateway sends. */
+  agentId: Type.Optional(Type.String()),
+  /** Reply target message id for native quoted/threaded sends where supported. */
+  replyToId: Type.Optional(Type.String()),
+  /** Thread id (channel-specific meaning, e.g. Telegram forum topic id). */
+  threadId: Type.Optional(Type.String()),
+  /** Force document-style media sends where supported. */
+  forceDocument: Type.Optional(Type.Boolean()),
+  /** Send silently (no notification) where supported. */
+  silent: Type.Optional(Type.Boolean()),
+  /** Channel-specific parse mode for formatted text. */
+  parseMode: Type.Optional(Type.Literal("HTML")),
+  /** Optional session key for mirroring delivered output back into the transcript. */
+  sessionKey: Type.Optional(Type.String()),
+  idempotencyKey: NonEmptyString,
+});
 
 /** Poll creation request for adapters that support native polls. */
-export const PollParamsSchema = Type.Object(
-  {
-    to: NonEmptyString,
-    question: NonEmptyString,
-    options: Type.Array(NonEmptyString, { minItems: 2, maxItems: 12 }),
-    maxSelections: Type.Optional(Type.Integer({ minimum: 1, maximum: 12 })),
-    /** Poll duration in seconds (channel-specific limits may apply). */
-    durationSeconds: Type.Optional(Type.Integer({ minimum: 1, maximum: 604_800 })),
-    durationHours: Type.Optional(Type.Integer({ minimum: 1 })),
-    /** Send silently (no notification) where supported. */
-    silent: Type.Optional(Type.Boolean()),
-    /** Poll anonymity where supported (e.g. Telegram polls default to anonymous). */
-    isAnonymous: Type.Optional(Type.Boolean()),
-    /** Thread id (channel-specific meaning, e.g. Telegram forum topic id). */
-    threadId: Type.Optional(Type.String()),
-    channel: Type.Optional(Type.String()),
-    accountId: Type.Optional(Type.String()),
-    idempotencyKey: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const PollParamsSchema = closedObject({
+  to: NonEmptyString,
+  question: NonEmptyString,
+  options: Type.Array(NonEmptyString, { minItems: 2, maxItems: 12 }),
+  maxSelections: Type.Optional(Type.Integer({ minimum: 1, maximum: 12 })),
+  /** Poll duration in seconds (channel-specific limits may apply). */
+  durationSeconds: Type.Optional(Type.Integer({ minimum: 1, maximum: 604_800 })),
+  durationHours: Type.Optional(Type.Integer({ minimum: 1 })),
+  /** Send silently (no notification) where supported. */
+  silent: Type.Optional(Type.Boolean()),
+  /** Poll anonymity where supported (e.g. Telegram polls default to anonymous). */
+  isAnonymous: Type.Optional(Type.Boolean()),
+  /** Thread id (channel-specific meaning, e.g. Telegram forum topic id). */
+  threadId: Type.Optional(Type.String()),
+  channel: Type.Optional(Type.String()),
+  accountId: Type.Optional(Type.String()),
+  idempotencyKey: NonEmptyString,
+});
 
 /** Main agent-run request accepted by the gateway. */
-export const AgentParamsSchema = Type.Object(
-  {
-    message: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    provider: Type.Optional(Type.String()),
-    model: Type.Optional(Type.String()),
-    to: Type.Optional(Type.String()),
-    replyTo: Type.Optional(Type.String()),
-    sessionId: Type.Optional(Type.String()),
-    sessionKey: Type.Optional(Type.String()),
-    // Backend-owned continuations can bind work to an already-admitted transcript.
-    expectedExistingSessionId: Type.Optional(NonEmptyString),
-    thinking: Type.Optional(Type.String()),
-    deliver: Type.Optional(Type.Boolean()),
-    attachments: Type.Optional(Type.Array(Type.Unknown())),
-    channel: Type.Optional(Type.String()),
-    replyChannel: Type.Optional(Type.String()),
-    accountId: Type.Optional(Type.String()),
-    replyAccountId: Type.Optional(Type.String()),
-    threadId: Type.Optional(Type.String()),
-    groupId: Type.Optional(Type.String()),
-    groupChannel: Type.Optional(Type.String()),
-    groupSpace: Type.Optional(Type.String()),
-    timeout: Type.Optional(Type.Integer({ minimum: 0 })),
-    bestEffortDeliver: Type.Optional(Type.Boolean()),
-    lane: Type.Optional(Type.String()),
-    cwd: Type.Optional(NonEmptyString),
-    // One-shot CLI gateway requests can ask the gateway to close process-wide
-    // bundle MCP resources after the run instead of keeping them warm.
-    cleanupBundleMcpOnRunEnd: Type.Optional(Type.Boolean()),
-    modelRun: Type.Optional(Type.Boolean()),
-    promptMode: Type.Optional(
-      Type.Union([Type.Literal("full"), Type.Literal("minimal"), Type.Literal("none")]),
-    ),
-    extraSystemPrompt: Type.Optional(Type.String()),
-    bootstrapContextMode: Type.Optional(
-      Type.Union([Type.Literal("full"), Type.Literal("lightweight")]),
-    ),
-    // Commitment fan-out scope is scheduler-internal and cannot be selected over Gateway RPC.
-    bootstrapContextRunKind: Type.Optional(
-      Type.Union([Type.Literal("default"), Type.Literal("heartbeat"), Type.Literal("cron")]),
-    ),
-    acpTurnSource: Type.Optional(Type.Literal("manual_spawn")),
-    internalRuntimeHandoffId: Type.Optional(NonEmptyString),
-    execApprovalFollowupExpectedSessionId: Type.Optional(NonEmptyString),
-    internalEvents: Type.Optional(Type.Array(AgentInternalEventSchema)),
-    inputProvenance: Type.Optional(InputProvenanceSchema),
-    suppressPromptPersistence: Type.Optional(Type.Boolean()),
-    sessionEffects: Type.Optional(Type.Union([Type.Literal("visible"), Type.Literal("internal")])),
-    sourceReplyDeliveryMode: Type.Optional(
-      Type.Union([Type.Literal("automatic"), Type.Literal("message_tool_only")]),
-    ),
-    disableMessageTool: Type.Optional(Type.Boolean()),
-    // Host-owned recovery turns can force every Code Mode exec onto the
-    // restart-safe path even if the model omits or clears the tool argument.
-    forceRestartSafeTools: Type.Optional(Type.Boolean()),
-    voiceWakeTrigger: Type.Optional(Type.String()),
-    idempotencyKey: NonEmptyString,
-    label: Type.Optional(SessionLabelString),
-  },
-  { additionalProperties: false },
-);
+export const AgentParamsSchema = closedObject({
+  message: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  provider: Type.Optional(Type.String()),
+  model: Type.Optional(Type.String()),
+  to: Type.Optional(Type.String()),
+  replyTo: Type.Optional(Type.String()),
+  sessionId: Type.Optional(Type.String()),
+  sessionKey: Type.Optional(Type.String()),
+  // Backend-owned continuations can bind work to an already-admitted transcript.
+  expectedExistingSessionId: Type.Optional(NonEmptyString),
+  thinking: Type.Optional(Type.String()),
+  deliver: Type.Optional(Type.Boolean()),
+  attachments: Type.Optional(Type.Array(Type.Unknown())),
+  channel: Type.Optional(Type.String()),
+  replyChannel: Type.Optional(Type.String()),
+  accountId: Type.Optional(Type.String()),
+  replyAccountId: Type.Optional(Type.String()),
+  threadId: Type.Optional(Type.String()),
+  groupId: Type.Optional(Type.String()),
+  groupChannel: Type.Optional(Type.String()),
+  groupSpace: Type.Optional(Type.String()),
+  timeout: Type.Optional(Type.Integer({ minimum: 0 })),
+  bestEffortDeliver: Type.Optional(Type.Boolean()),
+  lane: Type.Optional(Type.String()),
+  cwd: Type.Optional(NonEmptyString),
+  // One-shot CLI gateway requests can ask the gateway to close process-wide
+  // bundle MCP resources after the run instead of keeping them warm.
+  cleanupBundleMcpOnRunEnd: Type.Optional(Type.Boolean()),
+  modelRun: Type.Optional(Type.Boolean()),
+  promptMode: Type.Optional(
+    Type.Union([Type.Literal("full"), Type.Literal("minimal"), Type.Literal("none")]),
+  ),
+  extraSystemPrompt: Type.Optional(Type.String()),
+  bootstrapContextMode: Type.Optional(
+    Type.Union([Type.Literal("full"), Type.Literal("lightweight")]),
+  ),
+  // Commitment fan-out scope is scheduler-internal and cannot be selected over Gateway RPC.
+  bootstrapContextRunKind: Type.Optional(
+    Type.Union([Type.Literal("default"), Type.Literal("heartbeat"), Type.Literal("cron")]),
+  ),
+  acpTurnSource: Type.Optional(Type.Literal("manual_spawn")),
+  internalRuntimeHandoffId: Type.Optional(NonEmptyString),
+  execApprovalFollowupExpectedSessionId: Type.Optional(NonEmptyString),
+  internalEvents: Type.Optional(Type.Array(AgentInternalEventSchema)),
+  inputProvenance: Type.Optional(InputProvenanceSchema),
+  suppressPromptPersistence: Type.Optional(Type.Boolean()),
+  sessionEffects: Type.Optional(Type.Union([Type.Literal("visible"), Type.Literal("internal")])),
+  sourceReplyDeliveryMode: Type.Optional(
+    Type.Union([Type.Literal("automatic"), Type.Literal("message_tool_only")]),
+  ),
+  disableMessageTool: Type.Optional(Type.Boolean()),
+  // Host-owned recovery turns can force every Code Mode exec onto the
+  // restart-safe path even if the model omits or clears the tool argument.
+  forceRestartSafeTools: Type.Optional(Type.Boolean()),
+  voiceWakeTrigger: Type.Optional(Type.String()),
+  idempotencyKey: NonEmptyString,
+  label: Type.Optional(SessionLabelString),
+});
 
 /** Identity lookup request for the current or selected agent/session. */
-export const AgentIdentityParamsSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-    sessionKey: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const AgentIdentityParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+  sessionKey: Type.Optional(Type.String()),
+});
 
 /** Public display identity returned for an agent. */
-export const AgentIdentityResultSchema = Type.Object(
-  {
-    agentId: NonEmptyString,
-    name: Type.Optional(NonEmptyString),
-    avatar: Type.Optional(NonEmptyString),
-    avatarSource: Type.Optional(NonEmptyString),
-    avatarStatus: Type.Optional(Type.String({ enum: ["none", "local", "remote", "data"] })),
-    avatarReason: Type.Optional(NonEmptyString),
-    emoji: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const AgentIdentityResultSchema = closedObject({
+  agentId: NonEmptyString,
+  name: Type.Optional(NonEmptyString),
+  avatar: Type.Optional(NonEmptyString),
+  avatarSource: Type.Optional(NonEmptyString),
+  avatarStatus: Type.Optional(Type.String({ enum: ["none", "local", "remote", "data"] })),
+  avatarReason: Type.Optional(NonEmptyString),
+  emoji: Type.Optional(NonEmptyString),
+});
 
 /** Waits for a submitted agent run to complete or time out. */
-export const AgentWaitParamsSchema = Type.Object(
-  {
-    runId: NonEmptyString,
-    timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
-  },
-  { additionalProperties: false },
-);
+export const AgentWaitParamsSchema = closedObject({
+  runId: NonEmptyString,
+  timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
+});
 
 /** Wake request from external schedulers or devices into an agent session. */
 export const WakeParamsSchema = Type.Object(

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 /**
@@ -13,283 +14,211 @@ import { NonEmptyString } from "./primitives.js";
  */
 
 /** Model option shown in selectors and model catalog results. */
-export const ModelChoiceSchema = Type.Object(
-  {
-    id: NonEmptyString,
-    name: NonEmptyString,
-    provider: NonEmptyString,
-    alias: Type.Optional(NonEmptyString),
-    available: Type.Optional(Type.Boolean()),
-    contextWindow: Type.Optional(Type.Integer({ minimum: 1 })),
-    reasoning: Type.Optional(Type.Boolean()),
-    input: Type.Optional(
-      Type.Array(
-        Type.Union([
-          Type.Literal("text"),
-          Type.Literal("image"),
-          Type.Literal("audio"),
-          Type.Literal("video"),
-          Type.Literal("document"),
-        ]),
-      ),
-    ),
-  },
-  { additionalProperties: false },
-);
-
-/** Condensed agent record returned by list APIs. */
-export const AgentSummarySchema = Type.Object(
-  {
-    id: NonEmptyString,
-    name: Type.Optional(NonEmptyString),
-    identity: Type.Optional(
-      Type.Object(
-        {
-          name: Type.Optional(NonEmptyString),
-          theme: Type.Optional(NonEmptyString),
-          emoji: Type.Optional(NonEmptyString),
-          avatar: Type.Optional(NonEmptyString),
-          avatarUrl: Type.Optional(NonEmptyString),
-        },
-        { additionalProperties: false },
-      ),
-    ),
-    workspace: Type.Optional(NonEmptyString),
-    workspaceGit: Type.Optional(Type.Boolean()),
-    model: Type.Optional(
-      Type.Object(
-        {
-          primary: Type.Optional(NonEmptyString),
-          fallbacks: Type.Optional(Type.Array(NonEmptyString)),
-        },
-        { additionalProperties: false },
-      ),
-    ),
-    agentRuntime: Type.Optional(
-      Type.Object(
-        {
-          id: NonEmptyString,
-          fallback: Type.Optional(Type.Union([Type.Literal("openclaw"), Type.Literal("none")])),
-          source: Type.Union([
-            Type.Literal("env"),
-            Type.Literal("agent"),
-            Type.Literal("defaults"),
-            Type.Literal("model"),
-            Type.Literal("provider"),
-            Type.Literal("implicit"),
-          ]),
-        },
-        { additionalProperties: false },
-      ),
-    ),
-    thinkingLevels: Type.Optional(
-      Type.Array(
-        Type.Object(
-          {
-            id: NonEmptyString,
-            label: NonEmptyString,
-          },
-          { additionalProperties: false },
-        ),
-      ),
-    ),
-    thinkingOptions: Type.Optional(Type.Array(NonEmptyString)),
-    thinkingDefault: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
-
-/** Empty request payload for listing configured agents. */
-export const AgentsListParamsSchema = Type.Object({}, { additionalProperties: false });
-
-/** Agent list result including the default agent and session scoping mode. */
-export const AgentsListResultSchema = Type.Object(
-  {
-    defaultId: NonEmptyString,
-    mainKey: NonEmptyString,
-    scope: Type.Union([Type.Literal("per-sender"), Type.Literal("global")]),
-    agents: Type.Array(AgentSummarySchema),
-  },
-  { additionalProperties: false },
-);
-
-/** Creates a configured agent with workspace, identity, and optional model. */
-export const AgentsCreateParamsSchema = Type.Object(
-  {
-    name: NonEmptyString,
-    workspace: NonEmptyString,
-    model: Type.Optional(NonEmptyString),
-    emoji: Type.Optional(Type.String()),
-    avatar: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
-
-/** Result returned after creating an agent. */
-export const AgentsCreateResultSchema = Type.Object(
-  {
-    ok: Type.Literal(true),
-    agentId: NonEmptyString,
-    name: NonEmptyString,
-    workspace: NonEmptyString,
-    model: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
-
-/** Updates mutable agent identity, workspace, and model fields. */
-export const AgentsUpdateParamsSchema = Type.Object(
-  {
-    agentId: NonEmptyString,
-    name: Type.Optional(NonEmptyString),
-    workspace: Type.Optional(NonEmptyString),
-    model: Type.Optional(NonEmptyString),
-    emoji: Type.Optional(Type.String()),
-    avatar: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
-
-/** Result returned after updating an agent. */
-export const AgentsUpdateResultSchema = Type.Object(
-  {
-    ok: Type.Literal(true),
-    agentId: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
-
-/** Deletes an agent and optionally its workspace/config files. */
-export const AgentsDeleteParamsSchema = Type.Object(
-  {
-    agentId: NonEmptyString,
-    deleteFiles: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
-
-/** Result returned after deleting an agent and unbinding sessions. */
-export const AgentsDeleteResultSchema = Type.Object(
-  {
-    ok: Type.Literal(true),
-    agentId: NonEmptyString,
-    removedBindings: Type.Integer({ minimum: 0 }),
-  },
-  { additionalProperties: false },
-);
-
-/** File metadata and optional content for agent-local editable files. */
-export const AgentsFileEntrySchema = Type.Object(
-  {
-    name: NonEmptyString,
-    path: NonEmptyString,
-    missing: Type.Boolean(),
-    size: Type.Optional(Type.Integer({ minimum: 0 })),
-    updatedAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    content: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
-
-/** Lists editable files for one agent. */
-export const AgentsFilesListParamsSchema = Type.Object(
-  {
-    agentId: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
-
-/** Editable file list for an agent workspace. */
-export const AgentsFilesListResultSchema = Type.Object(
-  {
-    agentId: NonEmptyString,
-    workspace: NonEmptyString,
-    files: Type.Array(AgentsFileEntrySchema),
-  },
-  { additionalProperties: false },
-);
-
-/** Reads one editable agent file by name. */
-export const AgentsFilesGetParamsSchema = Type.Object(
-  {
-    agentId: NonEmptyString,
-    name: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
-
-/** Result for reading one editable agent file. */
-export const AgentsFilesGetResultSchema = Type.Object(
-  {
-    agentId: NonEmptyString,
-    workspace: NonEmptyString,
-    file: AgentsFileEntrySchema,
-  },
-  { additionalProperties: false },
-);
-
-/** Writes one editable agent file. */
-export const AgentsFilesSetParamsSchema = Type.Object(
-  {
-    agentId: NonEmptyString,
-    name: NonEmptyString,
-    content: Type.String(),
-  },
-  { additionalProperties: false },
-);
-
-/** Result returned after writing an editable agent file. */
-export const AgentsFilesSetResultSchema = Type.Object(
-  {
-    ok: Type.Literal(true),
-    agentId: NonEmptyString,
-    workspace: NonEmptyString,
-    file: AgentsFileEntrySchema,
-  },
-  { additionalProperties: false },
-);
-
-/** Model catalog request with optional visibility scope. */
-export const ModelsListParamsSchema = Type.Object(
-  {
-    view: Type.Optional(
+export const ModelChoiceSchema = closedObject({
+  id: NonEmptyString,
+  name: NonEmptyString,
+  provider: NonEmptyString,
+  alias: Type.Optional(NonEmptyString),
+  available: Type.Optional(Type.Boolean()),
+  contextWindow: Type.Optional(Type.Integer({ minimum: 1 })),
+  reasoning: Type.Optional(Type.Boolean()),
+  input: Type.Optional(
+    Type.Array(
       Type.Union([
-        Type.Literal("default"),
-        Type.Literal("configured"),
-        Type.Literal("provider-config"),
-        Type.Literal("all"),
+        Type.Literal("text"),
+        Type.Literal("image"),
+        Type.Literal("audio"),
+        Type.Literal("video"),
+        Type.Literal("document"),
       ]),
     ),
-  },
-  { additionalProperties: false },
-);
+  ),
+});
+
+/** Condensed agent record returned by list APIs. */
+export const AgentSummarySchema = closedObject({
+  id: NonEmptyString,
+  name: Type.Optional(NonEmptyString),
+  identity: Type.Optional(
+    closedObject({
+      name: Type.Optional(NonEmptyString),
+      theme: Type.Optional(NonEmptyString),
+      emoji: Type.Optional(NonEmptyString),
+      avatar: Type.Optional(NonEmptyString),
+      avatarUrl: Type.Optional(NonEmptyString),
+    }),
+  ),
+  workspace: Type.Optional(NonEmptyString),
+  workspaceGit: Type.Optional(Type.Boolean()),
+  model: Type.Optional(
+    closedObject({
+      primary: Type.Optional(NonEmptyString),
+      fallbacks: Type.Optional(Type.Array(NonEmptyString)),
+    }),
+  ),
+  agentRuntime: Type.Optional(
+    closedObject({
+      id: NonEmptyString,
+      fallback: Type.Optional(Type.Union([Type.Literal("openclaw"), Type.Literal("none")])),
+      source: Type.Union([
+        Type.Literal("env"),
+        Type.Literal("agent"),
+        Type.Literal("defaults"),
+        Type.Literal("model"),
+        Type.Literal("provider"),
+        Type.Literal("implicit"),
+      ]),
+    }),
+  ),
+  thinkingLevels: Type.Optional(
+    Type.Array(
+      closedObject({
+        id: NonEmptyString,
+        label: NonEmptyString,
+      }),
+    ),
+  ),
+  thinkingOptions: Type.Optional(Type.Array(NonEmptyString)),
+  thinkingDefault: Type.Optional(NonEmptyString),
+});
+
+/** Empty request payload for listing configured agents. */
+export const AgentsListParamsSchema = closedObject({});
+
+/** Agent list result including the default agent and session scoping mode. */
+export const AgentsListResultSchema = closedObject({
+  defaultId: NonEmptyString,
+  mainKey: NonEmptyString,
+  scope: Type.Union([Type.Literal("per-sender"), Type.Literal("global")]),
+  agents: Type.Array(AgentSummarySchema),
+});
+
+/** Creates a configured agent with workspace, identity, and optional model. */
+export const AgentsCreateParamsSchema = closedObject({
+  name: NonEmptyString,
+  workspace: NonEmptyString,
+  model: Type.Optional(NonEmptyString),
+  emoji: Type.Optional(Type.String()),
+  avatar: Type.Optional(Type.String()),
+});
+
+/** Result returned after creating an agent. */
+export const AgentsCreateResultSchema = closedObject({
+  ok: Type.Literal(true),
+  agentId: NonEmptyString,
+  name: NonEmptyString,
+  workspace: NonEmptyString,
+  model: Type.Optional(NonEmptyString),
+});
+
+/** Updates mutable agent identity, workspace, and model fields. */
+export const AgentsUpdateParamsSchema = closedObject({
+  agentId: NonEmptyString,
+  name: Type.Optional(NonEmptyString),
+  workspace: Type.Optional(NonEmptyString),
+  model: Type.Optional(NonEmptyString),
+  emoji: Type.Optional(Type.String()),
+  avatar: Type.Optional(Type.String()),
+});
+
+/** Result returned after updating an agent. */
+export const AgentsUpdateResultSchema = closedObject({
+  ok: Type.Literal(true),
+  agentId: NonEmptyString,
+});
+
+/** Deletes an agent and optionally its workspace/config files. */
+export const AgentsDeleteParamsSchema = closedObject({
+  agentId: NonEmptyString,
+  deleteFiles: Type.Optional(Type.Boolean()),
+});
+
+/** Result returned after deleting an agent and unbinding sessions. */
+export const AgentsDeleteResultSchema = closedObject({
+  ok: Type.Literal(true),
+  agentId: NonEmptyString,
+  removedBindings: Type.Integer({ minimum: 0 }),
+});
+
+/** File metadata and optional content for agent-local editable files. */
+export const AgentsFileEntrySchema = closedObject({
+  name: NonEmptyString,
+  path: NonEmptyString,
+  missing: Type.Boolean(),
+  size: Type.Optional(Type.Integer({ minimum: 0 })),
+  updatedAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  content: Type.Optional(Type.String()),
+});
+
+/** Lists editable files for one agent. */
+export const AgentsFilesListParamsSchema = closedObject({
+  agentId: NonEmptyString,
+});
+
+/** Editable file list for an agent workspace. */
+export const AgentsFilesListResultSchema = closedObject({
+  agentId: NonEmptyString,
+  workspace: NonEmptyString,
+  files: Type.Array(AgentsFileEntrySchema),
+});
+
+/** Reads one editable agent file by name. */
+export const AgentsFilesGetParamsSchema = closedObject({
+  agentId: NonEmptyString,
+  name: NonEmptyString,
+});
+
+/** Result for reading one editable agent file. */
+export const AgentsFilesGetResultSchema = closedObject({
+  agentId: NonEmptyString,
+  workspace: NonEmptyString,
+  file: AgentsFileEntrySchema,
+});
+
+/** Writes one editable agent file. */
+export const AgentsFilesSetParamsSchema = closedObject({
+  agentId: NonEmptyString,
+  name: NonEmptyString,
+  content: Type.String(),
+});
+
+/** Result returned after writing an editable agent file. */
+export const AgentsFilesSetResultSchema = closedObject({
+  ok: Type.Literal(true),
+  agentId: NonEmptyString,
+  workspace: NonEmptyString,
+  file: AgentsFileEntrySchema,
+});
+
+/** Model catalog request with optional visibility scope. */
+export const ModelsListParamsSchema = closedObject({
+  view: Type.Optional(
+    Type.Union([
+      Type.Literal("default"),
+      Type.Literal("configured"),
+      Type.Literal("provider-config"),
+      Type.Literal("all"),
+    ]),
+  ),
+});
 
 /** Model catalog result. */
-export const ModelsListResultSchema = Type.Object(
-  {
-    models: Type.Array(ModelChoiceSchema),
-  },
-  { additionalProperties: false },
-);
+export const ModelsListResultSchema = closedObject({
+  models: Type.Array(ModelChoiceSchema),
+});
 
 /** Reads installed skill status, optionally for a selected agent. */
-export const SkillsStatusParamsSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const SkillsStatusParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+});
 
 /** Empty request payload for listing available skill bins. */
-export const SkillsBinsParamsSchema = Type.Object({}, { additionalProperties: false });
+export const SkillsBinsParamsSchema = closedObject({});
 
 /** Skill bin names available to the gateway. */
-export const SkillsBinsResultSchema = Type.Object(
-  {
-    bins: Type.Array(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const SkillsBinsResultSchema = closedObject({
+  bins: Type.Array(NonEmptyString),
+});
 
 const Sha256String = Type.String({
   minLength: 64,
@@ -306,274 +235,205 @@ const SkillUploadDataBase64String = Type.String({
 });
 
 /** Starts a chunked skill archive upload. */
-export const SkillsUploadBeginParamsSchema = Type.Object(
-  {
-    kind: Type.Literal("skill-archive"),
-    slug: NonEmptyString,
-    sizeBytes: Type.Integer({ minimum: 1 }),
-    sha256: Type.Optional(Sha256String),
-    force: Type.Optional(Type.Boolean()),
-    idempotencyKey: Type.Optional(SkillUploadIdempotencyKeyString),
-  },
-  { additionalProperties: false },
-);
+export const SkillsUploadBeginParamsSchema = closedObject({
+  kind: Type.Literal("skill-archive"),
+  slug: NonEmptyString,
+  sizeBytes: Type.Integer({ minimum: 1 }),
+  sha256: Type.Optional(Sha256String),
+  force: Type.Optional(Type.Boolean()),
+  idempotencyKey: Type.Optional(SkillUploadIdempotencyKeyString),
+});
 
 /** Uploads one base64-encoded chunk for a skill archive. */
-export const SkillsUploadChunkParamsSchema = Type.Object(
-  {
-    uploadId: NonEmptyString,
-    offset: Type.Integer({ minimum: 0 }),
-    dataBase64: SkillUploadDataBase64String,
-  },
-  { additionalProperties: false },
-);
+export const SkillsUploadChunkParamsSchema = closedObject({
+  uploadId: NonEmptyString,
+  offset: Type.Integer({ minimum: 0 }),
+  dataBase64: SkillUploadDataBase64String,
+});
 
 /** Commits a completed skill archive upload. */
-export const SkillsUploadCommitParamsSchema = Type.Object(
-  {
-    uploadId: NonEmptyString,
-    sha256: Type.Optional(Sha256String),
-  },
-  { additionalProperties: false },
-);
+export const SkillsUploadCommitParamsSchema = closedObject({
+  uploadId: NonEmptyString,
+  sha256: Type.Optional(Sha256String),
+});
 
 /** Installs a skill from legacy install id, ClawHub, or uploaded archive. */
 export const SkillsInstallParamsSchema = Type.Union([
-  Type.Object(
-    {
-      agentId: Type.Optional(NonEmptyString),
-      name: NonEmptyString,
-      installId: NonEmptyString,
-      dangerouslyForceUnsafeInstall: Type.Optional(
-        Type.Boolean({
-          deprecated: true,
-          description:
-            "Deprecated compatibility field. Current servers ignore it; install policy is controlled by security.installPolicy.",
-        }),
-      ),
-      timeoutMs: Type.Optional(Type.Integer({ minimum: 1000 })),
-    },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
-      agentId: Type.Optional(NonEmptyString),
-      source: Type.Literal("clawhub"),
-      slug: NonEmptyString,
-      version: Type.Optional(NonEmptyString),
-      force: Type.Optional(Type.Boolean()),
-      acknowledgeClawHubRisk: Type.Optional(Type.Boolean()),
-      timeoutMs: Type.Optional(Type.Integer({ minimum: 1000 })),
-    },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
-      agentId: Type.Optional(NonEmptyString),
-      source: Type.Literal("upload"),
-      uploadId: NonEmptyString,
-      slug: NonEmptyString,
-      force: Type.Optional(Type.Boolean()),
-      sha256: Type.Optional(Sha256String),
-      timeoutMs: Type.Optional(Type.Integer({ minimum: 1000 })),
-    },
-    { additionalProperties: false },
-  ),
+  closedObject({
+    agentId: Type.Optional(NonEmptyString),
+    name: NonEmptyString,
+    installId: NonEmptyString,
+    dangerouslyForceUnsafeInstall: Type.Optional(
+      Type.Boolean({
+        deprecated: true,
+        description:
+          "Deprecated compatibility field. Current servers ignore it; install policy is controlled by security.installPolicy.",
+      }),
+    ),
+    timeoutMs: Type.Optional(Type.Integer({ minimum: 1000 })),
+  }),
+  closedObject({
+    agentId: Type.Optional(NonEmptyString),
+    source: Type.Literal("clawhub"),
+    slug: NonEmptyString,
+    version: Type.Optional(NonEmptyString),
+    force: Type.Optional(Type.Boolean()),
+    acknowledgeClawHubRisk: Type.Optional(Type.Boolean()),
+    timeoutMs: Type.Optional(Type.Integer({ minimum: 1000 })),
+  }),
+  closedObject({
+    agentId: Type.Optional(NonEmptyString),
+    source: Type.Literal("upload"),
+    uploadId: NonEmptyString,
+    slug: NonEmptyString,
+    force: Type.Optional(Type.Boolean()),
+    sha256: Type.Optional(Sha256String),
+    timeoutMs: Type.Optional(Type.Integer({ minimum: 1000 })),
+  }),
 ]);
 
 /** Updates installed skill settings or refreshes ClawHub-installed skills. */
 export const SkillsUpdateParamsSchema = Type.Union([
-  Type.Object(
-    {
-      skillKey: NonEmptyString,
-      enabled: Type.Optional(Type.Boolean()),
-      apiKey: Type.Optional(Type.String()),
-      env: Type.Optional(Type.Record(NonEmptyString, Type.String())),
-    },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
-      agentId: Type.Optional(NonEmptyString),
-      source: Type.Literal("clawhub"),
-      slug: Type.Optional(NonEmptyString),
-      all: Type.Optional(Type.Boolean()),
-      acknowledgeClawHubRisk: Type.Optional(Type.Boolean()),
-    },
-    { additionalProperties: false },
-  ),
+  closedObject({
+    skillKey: NonEmptyString,
+    enabled: Type.Optional(Type.Boolean()),
+    apiKey: Type.Optional(Type.String()),
+    env: Type.Optional(Type.Record(NonEmptyString, Type.String())),
+  }),
+  closedObject({
+    agentId: Type.Optional(NonEmptyString),
+    source: Type.Literal("clawhub"),
+    slug: Type.Optional(NonEmptyString),
+    all: Type.Optional(Type.Boolean()),
+    acknowledgeClawHubRisk: Type.Optional(Type.Boolean()),
+  }),
 ]);
 
 /** Searches the skill registry. */
-export const SkillsSearchParamsSchema = Type.Object(
-  {
-    query: Type.Optional(NonEmptyString),
-    limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
-  },
-  { additionalProperties: false },
-);
+export const SkillsSearchParamsSchema = closedObject({
+  query: Type.Optional(NonEmptyString),
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
+});
 
 /** Ranked skill registry search results. */
-export const SkillsSearchResultSchema = Type.Object(
-  {
-    results: Type.Array(
-      Type.Object(
-        {
-          score: Type.Number(),
-          slug: NonEmptyString,
-          displayName: NonEmptyString,
-          summary: Type.Optional(Type.String()),
-          version: Type.Optional(NonEmptyString),
-          updatedAt: Type.Optional(Type.Integer()),
-        },
-        { additionalProperties: false },
-      ),
-    ),
-  },
-  { additionalProperties: false },
-);
+export const SkillsSearchResultSchema = closedObject({
+  results: Type.Array(
+    closedObject({
+      score: Type.Number(),
+      slug: NonEmptyString,
+      displayName: NonEmptyString,
+      summary: Type.Optional(Type.String()),
+      version: Type.Optional(NonEmptyString),
+      updatedAt: Type.Optional(Type.Integer()),
+    }),
+  ),
+});
 
 /** Reads registry detail for one skill slug. */
-export const SkillsDetailParamsSchema = Type.Object(
-  {
-    slug: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const SkillsDetailParamsSchema = closedObject({
+  slug: NonEmptyString,
+});
 
 /** Reads current security verdicts for configured skills. */
-export const SkillsSecurityVerdictsParamsSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const SkillsSecurityVerdictsParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+});
 
 /** Skill registry detail, latest version, metadata, and owner info. */
-export const SkillsDetailResultSchema = Type.Object(
-  {
-    skill: Type.Union([
-      Type.Object(
-        {
-          slug: NonEmptyString,
-          displayName: NonEmptyString,
-          summary: Type.Optional(Type.String()),
-          tags: Type.Optional(Type.Record(NonEmptyString, Type.String())),
-          channel: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-          isOfficial: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
-          createdAt: Type.Integer(),
-          updatedAt: Type.Integer(),
-        },
-        { additionalProperties: false },
-      ),
+export const SkillsDetailResultSchema = closedObject({
+  skill: Type.Union([
+    closedObject({
+      slug: NonEmptyString,
+      displayName: NonEmptyString,
+      summary: Type.Optional(Type.String()),
+      tags: Type.Optional(Type.Record(NonEmptyString, Type.String())),
+      channel: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+      isOfficial: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
+      createdAt: Type.Integer(),
+      updatedAt: Type.Integer(),
+    }),
+    Type.Null(),
+  ]),
+  latestVersion: Type.Optional(
+    Type.Union([
+      closedObject({
+        version: NonEmptyString,
+        createdAt: Type.Integer(),
+        changelog: Type.Optional(Type.String()),
+      }),
       Type.Null(),
     ]),
-    latestVersion: Type.Optional(
-      Type.Union([
-        Type.Object(
-          {
-            version: NonEmptyString,
-            createdAt: Type.Integer(),
-            changelog: Type.Optional(Type.String()),
-          },
-          { additionalProperties: false },
-        ),
-        Type.Null(),
-      ]),
-    ),
-    metadata: Type.Optional(
-      Type.Union([
-        Type.Object(
-          {
-            os: Type.Optional(Type.Union([Type.Array(Type.String()), Type.Null()])),
-            systems: Type.Optional(Type.Union([Type.Array(Type.String()), Type.Null()])),
-          },
-          { additionalProperties: false },
-        ),
-        Type.Null(),
-      ]),
-    ),
-    owner: Type.Optional(
-      Type.Union([
-        Type.Object(
-          {
-            handle: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-            displayName: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-            image: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-            official: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
-            channel: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-            isOfficial: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
-          },
-          { additionalProperties: false },
-        ),
-        Type.Null(),
-      ]),
-    ),
-  },
-  { additionalProperties: false },
-);
+  ),
+  metadata: Type.Optional(
+    Type.Union([
+      closedObject({
+        os: Type.Optional(Type.Union([Type.Array(Type.String()), Type.Null()])),
+        systems: Type.Optional(Type.Union([Type.Array(Type.String()), Type.Null()])),
+      }),
+      Type.Null(),
+    ]),
+  ),
+  owner: Type.Optional(
+    Type.Union([
+      closedObject({
+        handle: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+        displayName: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+        image: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        official: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
+        channel: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        isOfficial: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
+      }),
+      Type.Null(),
+    ]),
+  ),
+});
 
 /** Security verdict report for installed/requested skills. */
-export const SkillsSecurityVerdictsResultSchema = Type.Object(
-  {
-    schema: Type.Literal("openclaw.skills.security-verdicts.v1"),
-    items: Type.Array(
-      Type.Object(
-        {
-          registry: NonEmptyString,
-          ok: Type.Boolean(),
-          decision: NonEmptyString,
-          reasons: Type.Array(Type.String()),
-          requestedSlug: NonEmptyString,
-          requestedVersion: NonEmptyString,
-          slug: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-          version: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-          displayName: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-          publisherHandle: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-          publisherDisplayName: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-          createdAt: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
-          checkedAt: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
-          skillUrl: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-          securityAuditUrl: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-          securityStatus: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-          securityPassed: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
-          error: Type.Optional(
-            Type.Object(
-              {
-                code: Type.Optional(Type.String()),
-                message: Type.Optional(Type.String()),
-              },
-              { additionalProperties: false },
-            ),
-          ),
-        },
-        { additionalProperties: false },
+export const SkillsSecurityVerdictsResultSchema = closedObject({
+  schema: Type.Literal("openclaw.skills.security-verdicts.v1"),
+  items: Type.Array(
+    closedObject({
+      registry: NonEmptyString,
+      ok: Type.Boolean(),
+      decision: NonEmptyString,
+      reasons: Type.Array(Type.String()),
+      requestedSlug: NonEmptyString,
+      requestedVersion: NonEmptyString,
+      slug: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+      version: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+      displayName: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+      publisherHandle: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+      publisherDisplayName: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+      createdAt: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
+      checkedAt: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
+      skillUrl: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+      securityAuditUrl: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+      securityStatus: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+      securityPassed: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
+      error: Type.Optional(
+        closedObject({
+          code: Type.Optional(Type.String()),
+          message: Type.Optional(Type.String()),
+        }),
       ),
-    ),
-  },
-  { additionalProperties: false },
-);
+    }),
+  ),
+});
 
 /** Reads the rendered skill card for one installed skill. */
-export const SkillsSkillCardParamsSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-    skillKey: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const SkillsSkillCardParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+  skillKey: NonEmptyString,
+});
 
 /** Rendered skill card content and file metadata. */
-export const SkillsSkillCardResultSchema = Type.Object(
-  {
-    schema: Type.Literal("openclaw.skills.skill-card.v1"),
-    skillKey: NonEmptyString,
-    path: NonEmptyString,
-    sizeBytes: Type.Integer({ minimum: 0 }),
-    content: Type.String(),
-  },
-  { additionalProperties: false },
-);
+export const SkillsSkillCardResultSchema = closedObject({
+  schema: Type.Literal("openclaw.skills.skill-card.v1"),
+  skillKey: NonEmptyString,
+  path: NonEmptyString,
+  sizeBytes: Type.Integer({ minimum: 0 }),
+  content: Type.String(),
+});
 
 const SkillProposalStatusSchema = Type.Union([
   Type.Literal("pending"),
@@ -599,214 +459,166 @@ const SkillProposalSourceSchema = Type.Union([
 ]);
 const SkillProposalContentString = Type.String({ minLength: 1, maxLength: 1_048_576 });
 /** Support file payload accepted from proposal create/revise requests. */
-const SkillProposalSupportFileInputSchema = Type.Object(
-  {
-    path: NonEmptyString,
-    content: Type.String({ maxLength: 262_144 }),
-  },
-  { additionalProperties: false },
-);
+const SkillProposalSupportFileInputSchema = closedObject({
+  path: NonEmptyString,
+  content: Type.String({ maxLength: 262_144 }),
+});
 /** Stored support file metadata, including target conflict hashes for updates. */
-const SkillProposalSupportFileSchema = Type.Object(
-  {
-    path: NonEmptyString,
-    sizeBytes: Type.Integer({ minimum: 0, maximum: 262_144 }),
-    hash: Sha256String,
-    targetExisted: Type.Optional(Type.Boolean()),
-    targetContentHash: Type.Optional(Sha256String),
-  },
-  { additionalProperties: false },
-);
+const SkillProposalSupportFileSchema = closedObject({
+  path: NonEmptyString,
+  sizeBytes: Type.Integer({ minimum: 0, maximum: 262_144 }),
+  hash: Sha256String,
+  targetExisted: Type.Optional(Type.Boolean()),
+  targetContentHash: Type.Optional(Sha256String),
+});
 
 /** One static-scan finding against proposed skill content. */
-const SkillProposalFindingSchema = Type.Object(
-  {
-    ruleId: NonEmptyString,
-    severity: Type.Union([Type.Literal("info"), Type.Literal("warn"), Type.Literal("critical")]),
-    file: NonEmptyString,
-    line: Type.Integer({ minimum: 1 }),
-    message: NonEmptyString,
-    evidence: Type.String(),
-  },
-  { additionalProperties: false },
-);
+const SkillProposalFindingSchema = closedObject({
+  ruleId: NonEmptyString,
+  severity: Type.Union([Type.Literal("info"), Type.Literal("warn"), Type.Literal("critical")]),
+  file: NonEmptyString,
+  line: Type.Integer({ minimum: 1 }),
+  message: NonEmptyString,
+  evidence: Type.String(),
+});
 
 /** Aggregated scan report attached to a proposal record. */
-const SkillProposalScanSchema = Type.Object(
-  {
-    state: SkillProposalScanStateSchema,
-    scannedAt: NonEmptyString,
-    critical: Type.Integer({ minimum: 0 }),
-    warn: Type.Integer({ minimum: 0 }),
-    info: Type.Integer({ minimum: 0 }),
-    findings: Type.Array(SkillProposalFindingSchema),
-  },
-  { additionalProperties: false },
-);
+const SkillProposalScanSchema = closedObject({
+  state: SkillProposalScanStateSchema,
+  scannedAt: NonEmptyString,
+  critical: Type.Integer({ minimum: 0 }),
+  warn: Type.Integer({ minimum: 0 }),
+  info: Type.Integer({ minimum: 0 }),
+  findings: Type.Array(SkillProposalFindingSchema),
+});
 
 /** Skill file target that a proposal creates or updates. */
-const SkillProposalTargetSchema = Type.Object(
-  {
-    skillName: NonEmptyString,
-    skillKey: NonEmptyString,
-    skillDir: NonEmptyString,
-    skillFile: NonEmptyString,
-    source: Type.Optional(NonEmptyString),
-    currentContentHash: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+const SkillProposalTargetSchema = closedObject({
+  skillName: NonEmptyString,
+  skillKey: NonEmptyString,
+  skillDir: NonEmptyString,
+  skillFile: NonEmptyString,
+  source: Type.Optional(NonEmptyString),
+  currentContentHash: Type.Optional(NonEmptyString),
+});
 
 /** Optional runtime origin tying a proposal back to an agent turn. */
-const SkillProposalOriginSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-    sessionKey: Type.Optional(NonEmptyString),
-    runId: Type.Optional(NonEmptyString),
-    messageId: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+const SkillProposalOriginSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+  sessionKey: Type.Optional(NonEmptyString),
+  runId: Type.Optional(NonEmptyString),
+  messageId: Type.Optional(NonEmptyString),
+});
 
 /** Full persisted skill proposal record. */
-const SkillProposalRecordSchema = Type.Object(
-  {
-    schema: Type.Literal("openclaw.skill-workshop.proposal.v1"),
-    id: NonEmptyString,
-    kind: SkillProposalKindSchema,
-    status: SkillProposalStatusSchema,
-    title: NonEmptyString,
-    description: NonEmptyString,
-    createdAt: NonEmptyString,
-    updatedAt: NonEmptyString,
-    createdBy: SkillProposalSourceSchema,
-    origin: Type.Optional(SkillProposalOriginSchema),
-    proposedVersion: NonEmptyString,
-    draftFile: Type.Literal("PROPOSAL.md"),
-    draftHash: NonEmptyString,
-    supportFiles: Type.Optional(Type.Array(SkillProposalSupportFileSchema, { maxItems: 64 })),
-    target: SkillProposalTargetSchema,
-    scan: SkillProposalScanSchema,
-    goal: Type.Optional(Type.String()),
-    evidence: Type.Optional(Type.String()),
-    appliedAt: Type.Optional(NonEmptyString),
-    rejectedAt: Type.Optional(NonEmptyString),
-    quarantinedAt: Type.Optional(NonEmptyString),
-    staleAt: Type.Optional(NonEmptyString),
-    statusReason: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+const SkillProposalRecordSchema = closedObject({
+  schema: Type.Literal("openclaw.skill-workshop.proposal.v1"),
+  id: NonEmptyString,
+  kind: SkillProposalKindSchema,
+  status: SkillProposalStatusSchema,
+  title: NonEmptyString,
+  description: NonEmptyString,
+  createdAt: NonEmptyString,
+  updatedAt: NonEmptyString,
+  createdBy: SkillProposalSourceSchema,
+  origin: Type.Optional(SkillProposalOriginSchema),
+  proposedVersion: NonEmptyString,
+  draftFile: Type.Literal("PROPOSAL.md"),
+  draftHash: NonEmptyString,
+  supportFiles: Type.Optional(Type.Array(SkillProposalSupportFileSchema, { maxItems: 64 })),
+  target: SkillProposalTargetSchema,
+  scan: SkillProposalScanSchema,
+  goal: Type.Optional(Type.String()),
+  evidence: Type.Optional(Type.String()),
+  appliedAt: Type.Optional(NonEmptyString),
+  rejectedAt: Type.Optional(NonEmptyString),
+  quarantinedAt: Type.Optional(NonEmptyString),
+  staleAt: Type.Optional(NonEmptyString),
+  statusReason: Type.Optional(Type.String()),
+});
 
 /** Condensed proposal manifest entry for list views. */
-const SkillProposalManifestEntrySchema = Type.Object(
-  {
-    id: NonEmptyString,
-    kind: SkillProposalKindSchema,
-    status: SkillProposalStatusSchema,
-    title: NonEmptyString,
-    description: NonEmptyString,
-    skillName: NonEmptyString,
-    skillKey: NonEmptyString,
-    createdAt: NonEmptyString,
-    updatedAt: NonEmptyString,
-    scanState: SkillProposalScanStateSchema,
-  },
-  { additionalProperties: false },
-);
+const SkillProposalManifestEntrySchema = closedObject({
+  id: NonEmptyString,
+  kind: SkillProposalKindSchema,
+  status: SkillProposalStatusSchema,
+  title: NonEmptyString,
+  description: NonEmptyString,
+  skillName: NonEmptyString,
+  skillKey: NonEmptyString,
+  createdAt: NonEmptyString,
+  updatedAt: NonEmptyString,
+  scanState: SkillProposalScanStateSchema,
+});
 
 /** Lists skill-workshop proposals for the selected agent scope. */
-export const SkillsProposalsListParamsSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const SkillsProposalsListParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+});
 
 /** Proposal manifest response for dashboard/workshop list views. */
-export const SkillsProposalsListResultSchema = Type.Object(
-  {
-    schema: Type.Literal("openclaw.skill-workshop.proposals-manifest.v1"),
-    updatedAt: NonEmptyString,
-    proposals: Type.Array(SkillProposalManifestEntrySchema),
-  },
-  { additionalProperties: false },
-);
+export const SkillsProposalsListResultSchema = closedObject({
+  schema: Type.Literal("openclaw.skill-workshop.proposals-manifest.v1"),
+  updatedAt: NonEmptyString,
+  proposals: Type.Array(SkillProposalManifestEntrySchema),
+});
 
 /** Reads a proposal record plus editable draft/support content. */
-export const SkillsProposalInspectParamsSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-    proposalId: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const SkillsProposalInspectParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+  proposalId: NonEmptyString,
+});
 
 /** Full proposal inspection result used before apply/revise decisions. */
-export const SkillsProposalInspectResultSchema = Type.Object(
-  {
-    record: SkillProposalRecordSchema,
-    content: Type.String(),
-    supportFiles: Type.Optional(Type.Array(SkillProposalSupportFileInputSchema, { maxItems: 64 })),
-  },
-  { additionalProperties: false },
-);
+export const SkillsProposalInspectResultSchema = closedObject({
+  record: SkillProposalRecordSchema,
+  content: Type.String(),
+  supportFiles: Type.Optional(Type.Array(SkillProposalSupportFileInputSchema, { maxItems: 64 })),
+});
 
 /** Creates a proposal for a new skill. */
-export const SkillsProposalCreateParamsSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-    name: NonEmptyString,
-    description: NonEmptyString,
-    content: SkillProposalContentString,
-    supportFiles: Type.Optional(Type.Array(SkillProposalSupportFileInputSchema, { maxItems: 64 })),
-    goal: Type.Optional(Type.String()),
-    evidence: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const SkillsProposalCreateParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+  name: NonEmptyString,
+  description: NonEmptyString,
+  content: SkillProposalContentString,
+  supportFiles: Type.Optional(Type.Array(SkillProposalSupportFileInputSchema, { maxItems: 64 })),
+  goal: Type.Optional(Type.String()),
+  evidence: Type.Optional(Type.String()),
+});
 
 /** Creates a proposal to update an existing skill. */
-export const SkillsProposalUpdateParamsSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-    skillName: NonEmptyString,
-    description: Type.Optional(NonEmptyString),
-    content: SkillProposalContentString,
-    supportFiles: Type.Optional(Type.Array(SkillProposalSupportFileInputSchema, { maxItems: 64 })),
-    goal: Type.Optional(Type.String()),
-    evidence: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const SkillsProposalUpdateParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+  skillName: NonEmptyString,
+  description: Type.Optional(NonEmptyString),
+  content: SkillProposalContentString,
+  supportFiles: Type.Optional(Type.Array(SkillProposalSupportFileInputSchema, { maxItems: 64 })),
+  goal: Type.Optional(Type.String()),
+  evidence: Type.Optional(Type.String()),
+});
 
 /** Replaces draft content/support files for an existing proposal. */
-export const SkillsProposalReviseParamsSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-    proposalId: NonEmptyString,
-    content: SkillProposalContentString,
-    supportFiles: Type.Optional(Type.Array(SkillProposalSupportFileInputSchema, { maxItems: 64 })),
-    description: Type.Optional(NonEmptyString),
-    goal: Type.Optional(Type.String()),
-    evidence: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const SkillsProposalReviseParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+  proposalId: NonEmptyString,
+  content: SkillProposalContentString,
+  supportFiles: Type.Optional(Type.Array(SkillProposalSupportFileInputSchema, { maxItems: 64 })),
+  description: Type.Optional(NonEmptyString),
+  goal: Type.Optional(Type.String()),
+  evidence: Type.Optional(Type.String()),
+});
 
 /** Starts an agent turn that revises a pending proposal from natural-language instructions. */
-export const SkillsProposalRequestRevisionParamsSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-    targetAgentId: Type.Optional(NonEmptyString),
-    proposalId: NonEmptyString,
-    instructions: Type.String({ minLength: 1, maxLength: 32_768 }),
-    sessionKey: NonEmptyString,
-    sessionId: Type.Optional(NonEmptyString),
-    idempotencyKey: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const SkillsProposalRequestRevisionParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+  targetAgentId: Type.Optional(NonEmptyString),
+  proposalId: NonEmptyString,
+  instructions: Type.String({ minLength: 1, maxLength: 32_768 }),
+  sessionKey: NonEmptyString,
+  sessionId: Type.Optional(NonEmptyString),
+  idempotencyKey: NonEmptyString,
+});
 
 /** Chat-run acknowledgement returned after queueing a Skill Workshop revision request. */
 export const SkillsProposalRequestRevisionResultSchema = Type.Object(
@@ -824,23 +636,17 @@ export const SkillsProposalRequestRevisionResultSchema = Type.Object(
 );
 
 /** Shared approve/reject/quarantine action payload for one proposal. */
-export const SkillsProposalActionParamsSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-    proposalId: NonEmptyString,
-    reason: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const SkillsProposalActionParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+  proposalId: NonEmptyString,
+  reason: Type.Optional(Type.String()),
+});
 
 /** Result returned after applying a skill proposal to disk. */
-export const SkillsProposalApplyResultSchema = Type.Object(
-  {
-    record: SkillProposalRecordSchema,
-    targetSkillFile: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const SkillsProposalApplyResultSchema = closedObject({
+  record: SkillProposalRecordSchema,
+  targetSkillFile: NonEmptyString,
+});
 
 /** Proposal record result returned after non-apply proposal actions. */
 export const SkillsProposalRecordResultSchema = SkillProposalRecordSchema;
@@ -851,254 +657,200 @@ const SkillLifecycleStateSchema = Type.Union([
   Type.Literal("archived"),
 ]);
 
-const SkillCuratorEntrySchema = Type.Object(
-  {
-    skillFile: NonEmptyString,
-    skillKey: NonEmptyString,
-    skillName: NonEmptyString,
-    state: SkillLifecycleStateSchema,
-    pinned: Type.Boolean(),
-    createdAtMs: Type.Number(),
-    stateChangedAtMs: Type.Number(),
-    lastUsedAtMs: Type.Union([Type.Number(), Type.Null()]),
-    useCount: Type.Number(),
-    archivedReason: Type.Union([Type.String(), Type.Null()]),
-  },
-  { additionalProperties: false },
-);
+const SkillCuratorEntrySchema = closedObject({
+  skillFile: NonEmptyString,
+  skillKey: NonEmptyString,
+  skillName: NonEmptyString,
+  state: SkillLifecycleStateSchema,
+  pinned: Type.Boolean(),
+  createdAtMs: Type.Number(),
+  stateChangedAtMs: Type.Number(),
+  lastUsedAtMs: Type.Union([Type.Number(), Type.Null()]),
+  useCount: Type.Number(),
+  archivedReason: Type.Union([Type.String(), Type.Null()]),
+});
 
-const SkillOverlapCandidateSchema = Type.Object(
-  {
-    left: NonEmptyString,
-    right: NonEmptyString,
-    score: Type.Number(),
-  },
-  { additionalProperties: false },
-);
+const SkillOverlapCandidateSchema = closedObject({
+  left: NonEmptyString,
+  right: NonEmptyString,
+  score: Type.Number(),
+});
 
 /** Reads persisted skill lifecycle curation state. */
-export const SkillsCuratorStatusParamsSchema = Type.Object({}, { additionalProperties: false });
+export const SkillsCuratorStatusParamsSchema = closedObject({});
 
-export const SkillsCuratorStatusResultSchema = Type.Object(
-  {
-    lastAttemptAtMs: Type.Union([Type.Number(), Type.Null()]),
-    lastSuccessAtMs: Type.Union([Type.Number(), Type.Null()]),
-    lastError: Type.Union([Type.String(), Type.Null()]),
-    counts: Type.Object(
-      {
-        active: Type.Number(),
-        stale: Type.Number(),
-        archived: Type.Number(),
-      },
-      { additionalProperties: false },
-    ),
-    skills: Type.Array(SkillCuratorEntrySchema),
-    overlaps: Type.Array(SkillOverlapCandidateSchema),
-  },
-  { additionalProperties: false },
-);
+export const SkillsCuratorStatusResultSchema = closedObject({
+  lastAttemptAtMs: Type.Union([Type.Number(), Type.Null()]),
+  lastSuccessAtMs: Type.Union([Type.Number(), Type.Null()]),
+  lastError: Type.Union([Type.String(), Type.Null()]),
+  counts: closedObject({
+    active: Type.Number(),
+    stale: Type.Number(),
+    archived: Type.Number(),
+  }),
+  skills: Type.Array(SkillCuratorEntrySchema),
+  overlaps: Type.Array(SkillOverlapCandidateSchema),
+});
 
 /** Pins, unpins, or explicitly restores one curated skill. */
-export const SkillsCuratorActionParamsSchema = Type.Object(
-  { skill: NonEmptyString },
-  { additionalProperties: false },
-);
+export const SkillsCuratorActionParamsSchema = closedObject({ skill: NonEmptyString });
 
 export const SkillsCuratorActionResultSchema = SkillCuratorEntrySchema;
 
 /** Reads the configured tool catalog for an agent. */
-export const ToolsCatalogParamsSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-    includePlugins: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const ToolsCatalogParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+  includePlugins: Type.Optional(Type.Boolean()),
+});
 
 /** Reads the effective tool set for one session. */
-export const ToolsEffectiveParamsSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-    sessionKey: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const ToolsEffectiveParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+  sessionKey: NonEmptyString,
+});
 
 /** Invokes one tool through the gateway tool dispatcher. */
-export const ToolsInvokeParamsSchema = Type.Object(
-  {
-    name: NonEmptyString,
-    args: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
-    sessionKey: Type.Optional(NonEmptyString),
-    agentId: Type.Optional(NonEmptyString),
-    confirm: Type.Optional(Type.Boolean()),
-    idempotencyKey: Type.Optional(NonEmptyString),
-    /**
-     * Explicit operation-local marker for an authenticated direct operator.
-     * Missing values remain delegated, and agent runtime identity wins server-side.
-     */
-    conversationReadOrigin: Type.Optional(Type.Literal("direct-operator")),
-  },
-  { additionalProperties: false },
-);
+export const ToolsInvokeParamsSchema = closedObject({
+  name: NonEmptyString,
+  args: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  sessionKey: Type.Optional(NonEmptyString),
+  agentId: Type.Optional(NonEmptyString),
+  confirm: Type.Optional(Type.Boolean()),
+  idempotencyKey: Type.Optional(NonEmptyString),
+  /**
+   * Explicit operation-local marker for an authenticated direct operator.
+   * Missing values remain delegated, and agent runtime identity wins server-side.
+   */
+  conversationReadOrigin: Type.Optional(Type.Literal("direct-operator")),
+});
 
 /** Tool profile shown in catalog views. */
-export const ToolCatalogProfileSchema = Type.Object(
-  {
-    id: Type.Union([
+export const ToolCatalogProfileSchema = closedObject({
+  id: Type.Union([
+    Type.Literal("minimal"),
+    Type.Literal("coding"),
+    Type.Literal("messaging"),
+    Type.Literal("full"),
+  ]),
+  label: NonEmptyString,
+});
+
+/** Tool catalog entry before session-specific filtering is applied. */
+export const ToolCatalogEntrySchema = closedObject({
+  id: NonEmptyString,
+  label: NonEmptyString,
+  description: Type.String(),
+  source: Type.Union([Type.Literal("core"), Type.Literal("plugin")]),
+  pluginId: Type.Optional(NonEmptyString),
+  optional: Type.Optional(Type.Boolean()),
+  risk: Type.Optional(
+    Type.Union([Type.Literal("low"), Type.Literal("medium"), Type.Literal("high")]),
+  ),
+  tags: Type.Optional(Type.Array(NonEmptyString)),
+  defaultProfiles: Type.Array(
+    Type.Union([
       Type.Literal("minimal"),
       Type.Literal("coding"),
       Type.Literal("messaging"),
       Type.Literal("full"),
     ]),
-    label: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
-
-/** Tool catalog entry before session-specific filtering is applied. */
-export const ToolCatalogEntrySchema = Type.Object(
-  {
-    id: NonEmptyString,
-    label: NonEmptyString,
-    description: Type.String(),
-    source: Type.Union([Type.Literal("core"), Type.Literal("plugin")]),
-    pluginId: Type.Optional(NonEmptyString),
-    optional: Type.Optional(Type.Boolean()),
-    risk: Type.Optional(
-      Type.Union([Type.Literal("low"), Type.Literal("medium"), Type.Literal("high")]),
-    ),
-    tags: Type.Optional(Type.Array(NonEmptyString)),
-    defaultProfiles: Type.Array(
-      Type.Union([
-        Type.Literal("minimal"),
-        Type.Literal("coding"),
-        Type.Literal("messaging"),
-        Type.Literal("full"),
-      ]),
-    ),
-  },
-  { additionalProperties: false },
-);
+  ),
+});
 
 /** Group of related catalog tools from core or a plugin. */
-export const ToolCatalogGroupSchema = Type.Object(
-  {
-    id: NonEmptyString,
-    label: NonEmptyString,
-    source: Type.Union([Type.Literal("core"), Type.Literal("plugin")]),
-    pluginId: Type.Optional(NonEmptyString),
-    tools: Type.Array(ToolCatalogEntrySchema),
-  },
-  { additionalProperties: false },
-);
+export const ToolCatalogGroupSchema = closedObject({
+  id: NonEmptyString,
+  label: NonEmptyString,
+  source: Type.Union([Type.Literal("core"), Type.Literal("plugin")]),
+  pluginId: Type.Optional(NonEmptyString),
+  tools: Type.Array(ToolCatalogEntrySchema),
+});
 
 /** Tool catalog result for agent configuration UI. */
-export const ToolsCatalogResultSchema = Type.Object(
-  {
-    agentId: NonEmptyString,
-    profiles: Type.Array(ToolCatalogProfileSchema),
-    groups: Type.Array(ToolCatalogGroupSchema),
-  },
-  { additionalProperties: false },
-);
+export const ToolsCatalogResultSchema = closedObject({
+  agentId: NonEmptyString,
+  profiles: Type.Array(ToolCatalogProfileSchema),
+  groups: Type.Array(ToolCatalogGroupSchema),
+});
 
 /** Effective tool entry after session/profile/channel/plugin filtering. */
-export const ToolsEffectiveEntrySchema = Type.Object(
-  {
-    id: NonEmptyString,
-    label: NonEmptyString,
-    description: Type.String(),
-    rawDescription: Type.String(),
-    source: Type.Union([
-      Type.Literal("core"),
-      Type.Literal("plugin"),
-      Type.Literal("channel"),
-      Type.Literal("mcp"),
-    ]),
-    pluginId: Type.Optional(NonEmptyString),
-    channelId: Type.Optional(NonEmptyString),
-    risk: Type.Optional(
-      Type.Union([Type.Literal("low"), Type.Literal("medium"), Type.Literal("high")]),
-    ),
-    tags: Type.Optional(Type.Array(NonEmptyString)),
-  },
-  { additionalProperties: false },
-);
+export const ToolsEffectiveEntrySchema = closedObject({
+  id: NonEmptyString,
+  label: NonEmptyString,
+  description: Type.String(),
+  rawDescription: Type.String(),
+  source: Type.Union([
+    Type.Literal("core"),
+    Type.Literal("plugin"),
+    Type.Literal("channel"),
+    Type.Literal("mcp"),
+  ]),
+  pluginId: Type.Optional(NonEmptyString),
+  channelId: Type.Optional(NonEmptyString),
+  risk: Type.Optional(
+    Type.Union([Type.Literal("low"), Type.Literal("medium"), Type.Literal("high")]),
+  ),
+  tags: Type.Optional(Type.Array(NonEmptyString)),
+});
 
 /** Effective tool group shown to runtime/session callers. */
-export const ToolsEffectiveGroupSchema = Type.Object(
-  {
-    id: Type.Union([
-      Type.Literal("core"),
-      Type.Literal("plugin"),
-      Type.Literal("channel"),
-      Type.Literal("mcp"),
-    ]),
-    label: NonEmptyString,
-    source: Type.Union([
-      Type.Literal("core"),
-      Type.Literal("plugin"),
-      Type.Literal("channel"),
-      Type.Literal("mcp"),
-    ]),
-    tools: Type.Array(ToolsEffectiveEntrySchema),
-  },
-  { additionalProperties: false },
-);
+export const ToolsEffectiveGroupSchema = closedObject({
+  id: Type.Union([
+    Type.Literal("core"),
+    Type.Literal("plugin"),
+    Type.Literal("channel"),
+    Type.Literal("mcp"),
+  ]),
+  label: NonEmptyString,
+  source: Type.Union([
+    Type.Literal("core"),
+    Type.Literal("plugin"),
+    Type.Literal("channel"),
+    Type.Literal("mcp"),
+  ]),
+  tools: Type.Array(ToolsEffectiveEntrySchema),
+});
 
 /** Notice explaining runtime filtering such as quarantined tool schemas. */
-export const ToolsEffectiveNoticeSchema = Type.Object(
-  {
-    id: NonEmptyString,
-    severity: Type.Union([Type.Literal("info"), Type.Literal("warning")]),
-    message: Type.String(),
-  },
-  { additionalProperties: false },
-);
+export const ToolsEffectiveNoticeSchema = closedObject({
+  id: NonEmptyString,
+  severity: Type.Union([Type.Literal("info"), Type.Literal("warning")]),
+  message: Type.String(),
+});
 
 /** Effective tool set for a session, including profile and filtering notices. */
-export const ToolsEffectiveResultSchema = Type.Object(
-  {
-    agentId: NonEmptyString,
-    profile: NonEmptyString,
-    groups: Type.Array(ToolsEffectiveGroupSchema),
-    notices: Type.Optional(Type.Array(ToolsEffectiveNoticeSchema)),
-  },
-  { additionalProperties: false },
-);
+export const ToolsEffectiveResultSchema = closedObject({
+  agentId: NonEmptyString,
+  profile: NonEmptyString,
+  groups: Type.Array(ToolsEffectiveGroupSchema),
+  notices: Type.Optional(Type.Array(ToolsEffectiveNoticeSchema)),
+});
 
 /** Normalized error shape for tool invocation failures. */
-export const ToolsInvokeErrorSchema = Type.Object(
-  {
-    code: NonEmptyString,
-    message: NonEmptyString,
-    details: Type.Optional(Type.Unknown()),
-  },
-  { additionalProperties: false },
-);
+export const ToolsInvokeErrorSchema = closedObject({
+  code: NonEmptyString,
+  message: NonEmptyString,
+  details: Type.Optional(Type.Unknown()),
+});
 
 /** Tool invocation result, including approval handoff when required. */
-export const ToolsInvokeResultSchema = Type.Object(
-  {
-    ok: Type.Boolean(),
-    toolName: NonEmptyString,
-    output: Type.Optional(Type.Unknown()),
-    requiresApproval: Type.Optional(Type.Boolean()),
-    approvalId: Type.Optional(NonEmptyString),
-    source: Type.Optional(
-      Type.Union([
-        Type.Literal("core"),
-        Type.Literal("plugin"),
-        Type.Literal("mcp"),
-        Type.Literal("channel"),
-        Type.String(),
-      ]),
-    ),
-    error: Type.Optional(ToolsInvokeErrorSchema),
-  },
-  { additionalProperties: false },
-);
+export const ToolsInvokeResultSchema = closedObject({
+  ok: Type.Boolean(),
+  toolName: NonEmptyString,
+  output: Type.Optional(Type.Unknown()),
+  requiresApproval: Type.Optional(Type.Boolean()),
+  approvalId: Type.Optional(NonEmptyString),
+  source: Type.Optional(
+    Type.Union([
+      Type.Literal("core"),
+      Type.Literal("plugin"),
+      Type.Literal("mcp"),
+      Type.Literal("channel"),
+      Type.String(),
+    ]),
+  ),
+  error: Type.Optional(ToolsInvokeErrorSchema),
+});
 
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/agents-workspace.ts
+++ b/packages/gateway-protocol/src/schema/agents-workspace.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 /**
@@ -13,72 +14,54 @@ import { NonEmptyString } from "./primitives.js";
  */
 
 /** One file or folder in an agent workspace directory listing. */
-export const AgentsWorkspaceEntrySchema = Type.Object(
-  {
-    path: NonEmptyString,
-    name: NonEmptyString,
-    kind: Type.Union([Type.Literal("file"), Type.Literal("directory")]),
-    size: Type.Optional(Type.Integer({ minimum: 0 })),
-    updatedAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-  },
-  { additionalProperties: false },
-);
+export const AgentsWorkspaceEntrySchema = closedObject({
+  path: NonEmptyString,
+  name: NonEmptyString,
+  kind: Type.Union([Type.Literal("file"), Type.Literal("directory")]),
+  size: Type.Optional(Type.Integer({ minimum: 0 })),
+  updatedAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+});
 
 /** Lists one directory of an agent workspace. */
-export const AgentsWorkspaceListParamsSchema = Type.Object(
-  {
-    agentId: NonEmptyString,
-    path: Type.Optional(Type.String()),
-    offset: Type.Optional(Type.Integer({ minimum: 0 })),
-    limit: Type.Optional(Type.Integer({ minimum: 1 })),
-  },
-  { additionalProperties: false },
-);
+export const AgentsWorkspaceListParamsSchema = closedObject({
+  agentId: NonEmptyString,
+  path: Type.Optional(Type.String()),
+  offset: Type.Optional(Type.Integer({ minimum: 0 })),
+  limit: Type.Optional(Type.Integer({ minimum: 1 })),
+});
 
 /** Paginated directory listing rooted at the agent workspace. */
-export const AgentsWorkspaceListResultSchema = Type.Object(
-  {
-    agentId: NonEmptyString,
-    path: Type.String(),
-    parentPath: Type.Optional(Type.String()),
-    entries: Type.Array(AgentsWorkspaceEntrySchema),
-    totalEntries: Type.Integer({ minimum: 0 }),
-    offset: Type.Integer({ minimum: 0 }),
-  },
-  { additionalProperties: false },
-);
+export const AgentsWorkspaceListResultSchema = closedObject({
+  agentId: NonEmptyString,
+  path: Type.String(),
+  parentPath: Type.Optional(Type.String()),
+  entries: Type.Array(AgentsWorkspaceEntrySchema),
+  totalEntries: Type.Integer({ minimum: 0 }),
+  offset: Type.Integer({ minimum: 0 }),
+});
 
 /** One workspace file preview payload (UTF-8 text or base64 image). */
-export const AgentsWorkspaceFileSchema = Type.Object(
-  {
-    path: NonEmptyString,
-    name: NonEmptyString,
-    size: Type.Integer({ minimum: 0 }),
-    updatedAtMs: Type.Integer({ minimum: 0 }),
-    mimeType: NonEmptyString,
-    encoding: Type.Union([Type.Literal("utf8"), Type.Literal("base64")]),
-    content: Type.String(),
-  },
-  { additionalProperties: false },
-);
+export const AgentsWorkspaceFileSchema = closedObject({
+  path: NonEmptyString,
+  name: NonEmptyString,
+  size: Type.Integer({ minimum: 0 }),
+  updatedAtMs: Type.Integer({ minimum: 0 }),
+  mimeType: NonEmptyString,
+  encoding: Type.Union([Type.Literal("utf8"), Type.Literal("base64")]),
+  content: Type.String(),
+});
 
 /** Reads one workspace file by workspace-relative path. */
-export const AgentsWorkspaceGetParamsSchema = Type.Object(
-  {
-    agentId: NonEmptyString,
-    path: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const AgentsWorkspaceGetParamsSchema = closedObject({
+  agentId: NonEmptyString,
+  path: NonEmptyString,
+});
 
 /** Result for reading one workspace file. */
-export const AgentsWorkspaceGetResultSchema = Type.Object(
-  {
-    agentId: NonEmptyString,
-    file: AgentsWorkspaceFileSchema,
-  },
-  { additionalProperties: false },
-);
+export const AgentsWorkspaceGetResultSchema = closedObject({
+  agentId: NonEmptyString,
+  file: AgentsWorkspaceFileSchema,
+});
 
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/approvals.ts
+++ b/packages/gateway-protocol/src/schema/approvals.ts
@@ -2,6 +2,7 @@ import type { Static } from "typebox";
 // Gateway Protocol schema module defines durable cross-surface approval shapes.
 import { Type } from "typebox";
 import { APPROVAL_ID_WELL_FORMED_UNICODE_PATTERN } from "./approval-id.js";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 export { isWellFormedApprovalId } from "./approval-id.js";
@@ -95,19 +96,16 @@ export const ExecApprovalPresentationSchema = Type.Object(
 );
 
 /** Plugin-supplied reviewer text safe to persist and render across surfaces. */
-export const PluginApprovalPresentationSchema = Type.Object(
-  {
-    kind: Type.Literal("plugin"),
-    title: Type.String({ minLength: 1, maxLength: 80 }),
-    description: Type.String({ minLength: 1, maxLength: 512 }),
-    severity: PluginApprovalSeveritySchema,
-    pluginId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    toolName: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    agentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    allowedDecisions: ApprovalAllowedDecisionsSchema,
-  },
-  { additionalProperties: false },
-);
+export const PluginApprovalPresentationSchema = closedObject({
+  kind: Type.Literal("plugin"),
+  title: Type.String({ minLength: 1, maxLength: 80 }),
+  description: Type.String({ minLength: 1, maxLength: 512 }),
+  severity: PluginApprovalSeveritySchema,
+  pluginId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  toolName: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  agentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  allowedDecisions: ApprovalAllowedDecisionsSchema,
+});
 
 /** Reviewer-safe presentation discriminated by the approval owner. */
 export const ApprovalPresentationSchema = Type.Union([
@@ -128,56 +126,44 @@ const ApprovalResolutionFields = {
 };
 
 /** Approval that has not yet accepted a reviewer decision. */
-export const PendingApprovalSnapshotSchema = Type.Object(
-  { ...ApprovalRecordCommonFields, status: Type.Literal("pending") },
-  { additionalProperties: false },
-);
+export const PendingApprovalSnapshotSchema = closedObject({
+  ...ApprovalRecordCommonFields,
+  status: Type.Literal("pending"),
+});
 
 /** Approval whose first recorded reviewer decision allows the operation. */
-export const AllowedApprovalSnapshotSchema = Type.Object(
-  {
-    ...ApprovalRecordCommonFields,
-    ...ApprovalResolutionFields,
-    status: Type.Literal("allowed"),
-    decision: ApprovalAllowDecisionSchema,
-    reason: ApprovalAllowedReasonSchema,
-  },
-  { additionalProperties: false },
-);
+export const AllowedApprovalSnapshotSchema = closedObject({
+  ...ApprovalRecordCommonFields,
+  ...ApprovalResolutionFields,
+  status: Type.Literal("allowed"),
+  decision: ApprovalAllowDecisionSchema,
+  reason: ApprovalAllowedReasonSchema,
+});
 
 /** Approval whose first recorded reviewer decision denies the operation. */
-export const DeniedApprovalSnapshotSchema = Type.Object(
-  {
-    ...ApprovalRecordCommonFields,
-    ...ApprovalResolutionFields,
-    status: Type.Literal("denied"),
-    decision: Type.Literal("deny"),
-    reason: ApprovalDeniedReasonSchema,
-  },
-  { additionalProperties: false },
-);
+export const DeniedApprovalSnapshotSchema = closedObject({
+  ...ApprovalRecordCommonFields,
+  ...ApprovalResolutionFields,
+  status: Type.Literal("denied"),
+  decision: Type.Literal("deny"),
+  reason: ApprovalDeniedReasonSchema,
+});
 
 /** Approval that reached its deadline and therefore failed closed. */
-export const ExpiredApprovalSnapshotSchema = Type.Object(
-  {
-    ...ApprovalRecordCommonFields,
-    ...ApprovalResolutionFields,
-    status: Type.Literal("expired"),
-    reason: ApprovalExpiredReasonSchema,
-  },
-  { additionalProperties: false },
-);
+export const ExpiredApprovalSnapshotSchema = closedObject({
+  ...ApprovalRecordCommonFields,
+  ...ApprovalResolutionFields,
+  status: Type.Literal("expired"),
+  reason: ApprovalExpiredReasonSchema,
+});
 
 /** Approval cancelled by its runtime owner before a reviewer decision. */
-export const CancelledApprovalSnapshotSchema = Type.Object(
-  {
-    ...ApprovalRecordCommonFields,
-    ...ApprovalResolutionFields,
-    status: Type.Literal("cancelled"),
-    reason: ApprovalCancelledReasonSchema,
-  },
-  { additionalProperties: false },
-);
+export const CancelledApprovalSnapshotSchema = closedObject({
+  ...ApprovalRecordCommonFields,
+  ...ApprovalResolutionFields,
+  status: Type.Literal("cancelled"),
+  reason: ApprovalCancelledReasonSchema,
+});
 
 /** Durable approval projection returned identically to every authorized surface. */
 export const ApprovalSnapshotSchema = Type.Union([
@@ -197,35 +183,23 @@ export const TerminalApprovalSnapshotSchema = Type.Union([
 ]);
 
 /** Lookup payload for one approval by its exact full id. */
-export const ApprovalGetParamsSchema = Type.Object(
-  { id: ApprovalRecordCommonFields.id },
-  { additionalProperties: false },
-);
+export const ApprovalGetParamsSchema = closedObject({ id: ApprovalRecordCommonFields.id });
 
 /** Current durable state for one authorized approval lookup. */
-export const ApprovalGetResultSchema = Type.Object(
-  { approval: ApprovalSnapshotSchema },
-  { additionalProperties: false },
-);
+export const ApprovalGetResultSchema = closedObject({ approval: ApprovalSnapshotSchema });
 
 /** Reviewer decision for one approval identified by its exact full id. */
-export const ApprovalResolveParamsSchema = Type.Object(
-  {
-    id: ApprovalRecordCommonFields.id,
-    kind: ApprovalKindSchema,
-    decision: ApprovalDecisionSchema,
-  },
-  { additionalProperties: false },
-);
+export const ApprovalResolveParamsSchema = closedObject({
+  id: ApprovalRecordCommonFields.id,
+  kind: ApprovalKindSchema,
+  decision: ApprovalDecisionSchema,
+});
 
 /** First-answer outcome plus the canonical recorded state returned to all contenders. */
-export const ApprovalResolveResultSchema = Type.Object(
-  {
-    applied: Type.Boolean(),
-    approval: TerminalApprovalSnapshotSchema,
-  },
-  { additionalProperties: false },
-);
+export const ApprovalResolveResultSchema = closedObject({
+  applied: Type.Boolean(),
+  approval: TerminalApprovalSnapshotSchema,
+});
 
 const SessionApprovalEventCommonFields = {
   sessionKey: NonEmptyString,
@@ -234,24 +208,18 @@ const SessionApprovalEventCommonFields = {
 };
 
 /** Sanitized pending transition delivered only to an opted-in session audience. */
-export const PendingSessionApprovalEventSchema = Type.Object(
-  {
-    ...SessionApprovalEventCommonFields,
-    phase: Type.Literal("pending"),
-    approval: PendingApprovalSnapshotSchema,
-  },
-  { additionalProperties: false },
-);
+export const PendingSessionApprovalEventSchema = closedObject({
+  ...SessionApprovalEventCommonFields,
+  phase: Type.Literal("pending"),
+  approval: PendingApprovalSnapshotSchema,
+});
 
 /** Sanitized terminal transition delivered only to an opted-in session audience. */
-export const TerminalSessionApprovalEventSchema = Type.Object(
-  {
-    ...SessionApprovalEventCommonFields,
-    phase: Type.Literal("terminal"),
-    approval: TerminalApprovalSnapshotSchema,
-  },
-  { additionalProperties: false },
-);
+export const TerminalSessionApprovalEventSchema = closedObject({
+  ...SessionApprovalEventCommonFields,
+  phase: Type.Literal("terminal"),
+  approval: TerminalApprovalSnapshotSchema,
+});
 
 /** Sanitized approval transition delivered only to an opted-in session audience. */
 export const SessionApprovalEventSchema = Type.Union([
@@ -260,15 +228,12 @@ export const SessionApprovalEventSchema = Type.Union([
 ]);
 
 /** Authoritative pending approval set returned when a session stream subscribes. */
-export const SessionApprovalReplaySchema = Type.Object(
-  {
-    sessionKey: NonEmptyString,
-    updatedAtMs: Type.Integer({ minimum: 0 }),
-    approvals: Type.Array(PendingApprovalSnapshotSchema),
-    truncated: Type.Boolean(),
-  },
-  { additionalProperties: false },
-);
+export const SessionApprovalReplaySchema = closedObject({
+  sessionKey: NonEmptyString,
+  updatedAtMs: Type.Integer({ minimum: 0 }),
+  approvals: Type.Array(PendingApprovalSnapshotSchema),
+  truncated: Type.Boolean(),
+});
 
 // Owner-local wire types derived directly from local schema consts so the
 // public plugin-sdk declaration graph never pulls in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/artifacts.ts
+++ b/packages/gateway-protocol/src/schema/artifacts.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 /**
@@ -17,77 +18,57 @@ const ArtifactQueryParamsProperties = {
 };
 
 /** Shared artifact filter payload used by list-style requests. */
-export const ArtifactQueryParamsSchema = Type.Object(ArtifactQueryParamsProperties, {
-  additionalProperties: false,
-});
+export const ArtifactQueryParamsSchema = closedObject(ArtifactQueryParamsProperties);
 
 /** Artifact lookup payload with a required artifact id plus optional scope filters. */
-export const ArtifactGetParamsSchema = Type.Object(
-  {
-    ...ArtifactQueryParamsProperties,
-    artifactId: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const ArtifactGetParamsSchema = closedObject({
+  ...ArtifactQueryParamsProperties,
+  artifactId: NonEmptyString,
+});
 
 /** Public artifact metadata returned before or alongside download data. */
-export const ArtifactSummarySchema = Type.Object(
-  {
-    id: NonEmptyString,
-    type: NonEmptyString,
-    title: NonEmptyString,
-    mimeType: Type.Optional(NonEmptyString),
-    sizeBytes: Type.Optional(Type.Integer({ minimum: 0 })),
-    sessionKey: Type.Optional(NonEmptyString),
-    runId: Type.Optional(NonEmptyString),
-    taskId: Type.Optional(NonEmptyString),
-    messageSeq: Type.Optional(Type.Integer({ minimum: 1 })),
-    source: Type.Optional(NonEmptyString),
-    download: Type.Object(
-      {
-        mode: Type.Union([Type.Literal("bytes"), Type.Literal("url"), Type.Literal("unsupported")]),
-      },
-      { additionalProperties: false },
-    ),
-  },
-  { additionalProperties: false },
-);
+export const ArtifactSummarySchema = closedObject({
+  id: NonEmptyString,
+  type: NonEmptyString,
+  title: NonEmptyString,
+  mimeType: Type.Optional(NonEmptyString),
+  sizeBytes: Type.Optional(Type.Integer({ minimum: 0 })),
+  sessionKey: Type.Optional(NonEmptyString),
+  runId: Type.Optional(NonEmptyString),
+  taskId: Type.Optional(NonEmptyString),
+  messageSeq: Type.Optional(Type.Integer({ minimum: 1 })),
+  source: Type.Optional(NonEmptyString),
+  download: closedObject({
+    mode: Type.Union([Type.Literal("bytes"), Type.Literal("url"), Type.Literal("unsupported")]),
+  }),
+});
 
 /** List request payload for artifacts visible in the selected scope. */
 export const ArtifactsListParamsSchema = ArtifactQueryParamsSchema;
 
 /** List response containing artifact summaries only. */
-export const ArtifactsListResultSchema = Type.Object(
-  {
-    artifacts: Type.Array(ArtifactSummarySchema),
-  },
-  { additionalProperties: false },
-);
+export const ArtifactsListResultSchema = closedObject({
+  artifacts: Type.Array(ArtifactSummarySchema),
+});
 
 /** Get request payload for one artifact summary. */
 export const ArtifactsGetParamsSchema = ArtifactGetParamsSchema;
 
 /** Get response containing one artifact summary. */
-export const ArtifactsGetResultSchema = Type.Object(
-  {
-    artifact: ArtifactSummarySchema,
-  },
-  { additionalProperties: false },
-);
+export const ArtifactsGetResultSchema = closedObject({
+  artifact: ArtifactSummarySchema,
+});
 
 /** Download request payload for one artifact. */
 export const ArtifactsDownloadParamsSchema = ArtifactGetParamsSchema;
 
 /** Download response, either inline base64 bytes, URL, or metadata for unsupported modes. */
-export const ArtifactsDownloadResultSchema = Type.Object(
-  {
-    artifact: ArtifactSummarySchema,
-    encoding: Type.Optional(Type.Literal("base64")),
-    data: Type.Optional(Type.String()),
-    url: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const ArtifactsDownloadResultSchema = closedObject({
+  artifact: ArtifactSummarySchema,
+  encoding: Type.Optional(Type.Literal("base64")),
+  data: Type.Optional(Type.String()),
+  url: Type.Optional(NonEmptyString),
+});
 
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/audit-activity.ts
+++ b/packages/gateway-protocol/src/schema/audit-activity.ts
@@ -1,5 +1,6 @@
 // Versioned metadata-only activity audit query payloads.
 import { type TProperties, type TSchema, Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 const AuditActivitySchemaVersionV1Schema = Type.Integer({ minimum: 1, maximum: 1 });
@@ -36,38 +37,26 @@ const AuditActivityHmacRefV1Schema = Type.String({
   pattern: "^hmac-sha256:v1:[a-f0-9]{32}:[a-f0-9]{64}$",
 });
 
-const AuditActivityAgentActorV1Schema = Type.Object(
-  {
-    type: Type.Union([Type.Literal("agent"), Type.Literal("system")]),
-    id: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+const AuditActivityAgentActorV1Schema = closedObject({
+  type: Type.Union([Type.Literal("agent"), Type.Literal("system")]),
+  id: NonEmptyString,
+});
 
 const AuditActivityInboundActorV1Schema = Type.Union([
-  Type.Object(
-    {
-      type: Type.Literal("channel_sender"),
-      id: AuditActivityHmacRefV1Schema,
-    },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
-      type: Type.Literal("system"),
-      id: NonEmptyString,
-    },
-    { additionalProperties: false },
-  ),
+  closedObject({
+    type: Type.Literal("channel_sender"),
+    id: AuditActivityHmacRefV1Schema,
+  }),
+  closedObject({
+    type: Type.Literal("system"),
+    id: NonEmptyString,
+  }),
 ]);
 
-const AuditActivityOutboundActorV1Schema = Type.Object(
-  {
-    type: Type.Union([Type.Literal("agent"), Type.Literal("system")]),
-    id: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+const AuditActivityOutboundActorV1Schema = closedObject({
+  type: Type.Union([Type.Literal("agent"), Type.Literal("system")]),
+  id: NonEmptyString,
+});
 
 const commonProperties = {
   schemaVersion: AuditActivitySchemaVersionV1Schema,
@@ -433,31 +422,25 @@ export const AuditActivityEventV1Schema: TSchema = Type.Union([
 ]);
 
 /** Bounded newest-first V1 activity query filters. */
-export const AuditActivityListParamsSchema: TSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-    sessionKey: Type.Optional(NonEmptyString),
-    runId: Type.Optional(NonEmptyString),
-    kind: Type.Optional(AuditActivityKindV1Schema),
-    status: Type.Optional(AuditActivityStatusV1Schema),
-    direction: Type.Optional(AuditActivityDirectionV1Schema),
-    channel: Type.Optional(NonEmptyString),
-    after: Type.Optional(Type.Integer({ minimum: 0 })),
-    before: Type.Optional(Type.Integer({ minimum: 0 })),
-    limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 500 })),
-    cursor: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const AuditActivityListParamsSchema: TSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+  sessionKey: Type.Optional(NonEmptyString),
+  runId: Type.Optional(NonEmptyString),
+  kind: Type.Optional(AuditActivityKindV1Schema),
+  status: Type.Optional(AuditActivityStatusV1Schema),
+  direction: Type.Optional(AuditActivityDirectionV1Schema),
+  channel: Type.Optional(NonEmptyString),
+  after: Type.Optional(Type.Integer({ minimum: 0 })),
+  before: Type.Optional(Type.Integer({ minimum: 0 })),
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 500 })),
+  cursor: Type.Optional(NonEmptyString),
+});
 
 /** Stable sequence-cursor V1 activity page. */
-export const AuditActivityListResultSchema: TSchema = Type.Object(
-  {
-    events: Type.Array(AuditActivityEventV1Schema),
-    nextCursor: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const AuditActivityListResultSchema: TSchema = closedObject({
+  events: Type.Array(AuditActivityEventV1Schema),
+  nextCursor: Type.Optional(NonEmptyString),
+});
 
 /** Metadata-only audit query payloads. */
 // These wire types stay explicit because the runtime schemas use JSON Schema

--- a/packages/gateway-protocol/src/schema/audit.ts
+++ b/packages/gateway-protocol/src/schema/audit.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines metadata-only audit query payloads.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 export const AuditEventKindSchema = Type.Union([
@@ -38,58 +39,46 @@ export const AuditEventErrorCodeSchema = Type.Union([
 ]);
 
 /** One content-free run/tool audit record. */
-export const AuditEventSchema = Type.Object(
-  {
-    eventId: NonEmptyString,
-    sequence: Type.Integer({ minimum: 1 }),
-    sourceSequence: Type.Integer({ minimum: 1 }),
-    occurredAt: Type.Integer({ minimum: 0 }),
-    kind: AuditEventKindSchema,
-    action: AuditEventActionSchema,
-    status: AuditEventStatusSchema,
-    errorCode: Type.Optional(AuditEventErrorCodeSchema),
-    actor: Type.Object(
-      {
-        type: Type.Union([Type.Literal("agent"), Type.Literal("system")]),
-        id: NonEmptyString,
-      },
-      { additionalProperties: false },
-    ),
-    agentId: NonEmptyString,
-    sessionKey: Type.Optional(NonEmptyString),
-    sessionId: Type.Optional(NonEmptyString),
-    runId: NonEmptyString,
-    toolCallId: Type.Optional(NonEmptyString),
-    toolName: Type.Optional(NonEmptyString),
-    redaction: Type.Literal("metadata_only"),
-  },
-  { additionalProperties: false },
-);
+export const AuditEventSchema = closedObject({
+  eventId: NonEmptyString,
+  sequence: Type.Integer({ minimum: 1 }),
+  sourceSequence: Type.Integer({ minimum: 1 }),
+  occurredAt: Type.Integer({ minimum: 0 }),
+  kind: AuditEventKindSchema,
+  action: AuditEventActionSchema,
+  status: AuditEventStatusSchema,
+  errorCode: Type.Optional(AuditEventErrorCodeSchema),
+  actor: closedObject({
+    type: Type.Union([Type.Literal("agent"), Type.Literal("system")]),
+    id: NonEmptyString,
+  }),
+  agentId: NonEmptyString,
+  sessionKey: Type.Optional(NonEmptyString),
+  sessionId: Type.Optional(NonEmptyString),
+  runId: NonEmptyString,
+  toolCallId: Type.Optional(NonEmptyString),
+  toolName: Type.Optional(NonEmptyString),
+  redaction: Type.Literal("metadata_only"),
+});
 
 /** Bounded newest-first audit query filters. */
-export const AuditListParamsSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-    sessionKey: Type.Optional(NonEmptyString),
-    runId: Type.Optional(NonEmptyString),
-    kind: Type.Optional(AuditEventKindSchema),
-    status: Type.Optional(AuditEventStatusSchema),
-    after: Type.Optional(Type.Integer({ minimum: 0 })),
-    before: Type.Optional(Type.Integer({ minimum: 0 })),
-    limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 500 })),
-    cursor: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const AuditListParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+  sessionKey: Type.Optional(NonEmptyString),
+  runId: Type.Optional(NonEmptyString),
+  kind: Type.Optional(AuditEventKindSchema),
+  status: Type.Optional(AuditEventStatusSchema),
+  after: Type.Optional(Type.Integer({ minimum: 0 })),
+  before: Type.Optional(Type.Integer({ minimum: 0 })),
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 500 })),
+  cursor: Type.Optional(NonEmptyString),
+});
 
 /** Stable sequence-cursor page suitable for bounded JSON export. */
-export const AuditListResultSchema = Type.Object(
-  {
-    events: Type.Array(AuditEventSchema),
-    nextCursor: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const AuditListResultSchema = closedObject({
+  events: Type.Array(AuditEventSchema),
+  nextCursor: Type.Optional(NonEmptyString),
+});
 
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/channels.ts
+++ b/packages/gateway-protocol/src/schema/channels.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString, SecretInputSchema } from "./primitives.js";
 
 /**
@@ -12,53 +13,41 @@ import { NonEmptyString, SecretInputSchema } from "./primitives.js";
  */
 
 /** Toggles Talk mode for the gateway, with an optional rollout phase marker. */
-export const TalkModeParamsSchema = Type.Object(
-  {
-    enabled: Type.Boolean(),
-    phase: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const TalkModeParamsSchema = closedObject({
+  enabled: Type.Boolean(),
+  phase: Type.Optional(Type.String()),
+});
 
 /** Reads Talk configuration; secrets are included only for trusted callers. */
-export const TalkConfigParamsSchema = Type.Object(
-  {
-    includeSecrets: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const TalkConfigParamsSchema = closedObject({
+  includeSecrets: Type.Optional(Type.Boolean()),
+});
 
 /** One-shot text-to-speech request with provider-specific voice tuning knobs. */
-export const TalkSpeakParamsSchema = Type.Object(
-  {
-    text: NonEmptyString,
-    voiceId: Type.Optional(Type.String()),
-    modelId: Type.Optional(Type.String()),
-    outputFormat: Type.Optional(Type.String()),
-    speed: Type.Optional(Type.Number()),
-    rateWpm: Type.Optional(Type.Integer({ minimum: 1 })),
-    stability: Type.Optional(Type.Number()),
-    similarity: Type.Optional(Type.Number()),
-    style: Type.Optional(Type.Number()),
-    speakerBoost: Type.Optional(Type.Boolean()),
-    seed: Type.Optional(Type.Integer({ minimum: 0 })),
-    normalize: Type.Optional(Type.String()),
-    language: Type.Optional(Type.String()),
-    latencyTier: Type.Optional(Type.Integer({ minimum: 0 })),
-  },
-  { additionalProperties: false },
-);
+export const TalkSpeakParamsSchema = closedObject({
+  text: NonEmptyString,
+  voiceId: Type.Optional(Type.String()),
+  modelId: Type.Optional(Type.String()),
+  outputFormat: Type.Optional(Type.String()),
+  speed: Type.Optional(Type.Number()),
+  rateWpm: Type.Optional(Type.Integer({ minimum: 1 })),
+  stability: Type.Optional(Type.Number()),
+  similarity: Type.Optional(Type.Number()),
+  style: Type.Optional(Type.Number()),
+  speakerBoost: Type.Optional(Type.Boolean()),
+  seed: Type.Optional(Type.Integer({ minimum: 0 })),
+  normalize: Type.Optional(Type.String()),
+  language: Type.Optional(Type.String()),
+  latencyTier: Type.Optional(Type.Integer({ minimum: 0 })),
+});
 
 /**
  * One-shot text-to-speech request rendered with the configured TTS provider
  * chain (unlike `talk.speak`, which pins the Talk-mode provider).
  */
-export const TtsSpeakParamsSchema = Type.Object(
-  {
-    text: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const TtsSpeakParamsSchema = closedObject({
+  text: NonEmptyString,
+});
 
 /** Supported Talk session shapes exposed to clients and providers. */
 const TalkModeSchema = Type.Union([
@@ -198,409 +187,316 @@ export const TalkEventSchema = Type.Object(
 );
 
 /** Creates a browser-facing Talk client session. */
-export const TalkClientCreateParamsSchema = Type.Object(
-  {
-    sessionKey: Type.Optional(Type.String()),
-    provider: Type.Optional(Type.String()),
-    model: Type.Optional(Type.String()),
-    voice: Type.Optional(Type.String()),
-    vadThreshold: Type.Optional(Type.Number()),
-    silenceDurationMs: Type.Optional(Type.Integer({ minimum: 1 })),
-    prefixPaddingMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    reasoningEffort: Type.Optional(Type.String()),
-    mode: Type.Optional(TalkModeSchema),
-    transport: Type.Optional(TalkTransportSchema),
-    brain: Type.Optional(TalkBrainSchema),
-  },
-  { additionalProperties: false },
-);
+export const TalkClientCreateParamsSchema = closedObject({
+  sessionKey: Type.Optional(Type.String()),
+  provider: Type.Optional(Type.String()),
+  model: Type.Optional(Type.String()),
+  voice: Type.Optional(Type.String()),
+  vadThreshold: Type.Optional(Type.Number()),
+  silenceDurationMs: Type.Optional(Type.Integer({ minimum: 1 })),
+  prefixPaddingMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  reasoningEffort: Type.Optional(Type.String()),
+  mode: Type.Optional(TalkModeSchema),
+  transport: Type.Optional(TalkTransportSchema),
+  brain: Type.Optional(TalkBrainSchema),
+});
 
 /** Tool-call request from a browser/client session back into the agent runtime. */
-export const TalkClientToolCallParamsSchema = Type.Object(
-  {
-    sessionKey: NonEmptyString,
-    callId: NonEmptyString,
-    name: NonEmptyString,
-    args: Type.Optional(Type.Unknown()),
-    relaySessionId: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const TalkClientToolCallParamsSchema = closedObject({
+  sessionKey: NonEmptyString,
+  callId: NonEmptyString,
+  name: NonEmptyString,
+  args: Type.Optional(Type.Unknown()),
+  relaySessionId: Type.Optional(NonEmptyString),
+});
 
 /** Agent run identity returned after accepting a Talk client tool call. */
-export const TalkClientToolCallResultSchema = Type.Object(
-  {
-    runId: NonEmptyString,
-    idempotencyKey: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const TalkClientToolCallResultSchema = closedObject({
+  runId: NonEmptyString,
+  idempotencyKey: NonEmptyString,
+});
 
 /** Text steering request for a Talk session bound to an agent turn. */
-export const TalkClientSteerParamsSchema = Type.Object(
-  {
-    sessionKey: NonEmptyString,
-    text: NonEmptyString,
-    mode: Type.Optional(TalkAgentControlModeSchema),
-  },
-  { additionalProperties: false },
-);
+export const TalkClientSteerParamsSchema = closedObject({
+  sessionKey: NonEmptyString,
+  text: NonEmptyString,
+  mode: Type.Optional(TalkAgentControlModeSchema),
+});
 
 /** Result of applying agent control to an embedded or reply-backed Talk run. */
-export const TalkAgentControlResultSchema = Type.Object(
-  {
-    ok: Type.Boolean(),
-    mode: TalkAgentControlModeSchema,
-    sessionKey: NonEmptyString,
-    sessionId: Type.Optional(NonEmptyString),
-    active: Type.Boolean(),
-    queued: Type.Optional(Type.Boolean()),
-    aborted: Type.Optional(Type.Boolean()),
-    target: Type.Optional(Type.Union([Type.Literal("embedded_run"), Type.Literal("reply_run")])),
-    reason: Type.Optional(Type.String()),
-    message: Type.String(),
-    speak: Type.Boolean(),
-    show: Type.Boolean(),
-    suppress: Type.Boolean(),
-    providerResult: Type.Optional(
-      Type.Object(
-        {
-          status: Type.Literal("cancelled"),
-          message: Type.String(),
-        },
-        { additionalProperties: false },
-      ),
-    ),
-    enqueuedAtMs: Type.Optional(Type.Number()),
-    deliveredAtMs: Type.Optional(Type.Number()),
-  },
-  { additionalProperties: false },
-);
+export const TalkAgentControlResultSchema = closedObject({
+  ok: Type.Boolean(),
+  mode: TalkAgentControlModeSchema,
+  sessionKey: NonEmptyString,
+  sessionId: Type.Optional(NonEmptyString),
+  active: Type.Boolean(),
+  queued: Type.Optional(Type.Boolean()),
+  aborted: Type.Optional(Type.Boolean()),
+  target: Type.Optional(Type.Union([Type.Literal("embedded_run"), Type.Literal("reply_run")])),
+  reason: Type.Optional(Type.String()),
+  message: Type.String(),
+  speak: Type.Boolean(),
+  show: Type.Boolean(),
+  suppress: Type.Boolean(),
+  providerResult: Type.Optional(
+    closedObject({
+      status: Type.Literal("cancelled"),
+      message: Type.String(),
+    }),
+  ),
+  enqueuedAtMs: Type.Optional(Type.Number()),
+  deliveredAtMs: Type.Optional(Type.Number()),
+});
 
 /** Joins an existing managed-room Talk session. */
-export const TalkSessionJoinParamsSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    token: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const TalkSessionJoinParamsSchema = closedObject({
+  sessionId: NonEmptyString,
+  token: NonEmptyString,
+});
 
 /** Creates a gateway-managed Talk session for realtime, transcription, or relay use. */
-export const TalkSessionCreateParamsSchema = Type.Object(
-  {
-    sessionKey: Type.Optional(Type.String()),
-    spawnedBy: Type.Optional(NonEmptyString),
-    provider: Type.Optional(Type.String()),
-    model: Type.Optional(Type.String()),
-    voice: Type.Optional(Type.String()),
-    vadThreshold: Type.Optional(Type.Number()),
-    silenceDurationMs: Type.Optional(Type.Integer({ minimum: 1 })),
-    prefixPaddingMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    reasoningEffort: Type.Optional(Type.String()),
-    mode: Type.Optional(TalkModeSchema),
-    transport: Type.Optional(TalkTransportSchema),
-    brain: Type.Optional(TalkBrainSchema),
-    ttlMs: Type.Optional(Type.Integer({ minimum: 1000, maximum: 3600000 })),
-  },
-  { additionalProperties: false },
-);
+export const TalkSessionCreateParamsSchema = closedObject({
+  sessionKey: Type.Optional(Type.String()),
+  spawnedBy: Type.Optional(NonEmptyString),
+  provider: Type.Optional(Type.String()),
+  model: Type.Optional(Type.String()),
+  voice: Type.Optional(Type.String()),
+  vadThreshold: Type.Optional(Type.Number()),
+  silenceDurationMs: Type.Optional(Type.Integer({ minimum: 1 })),
+  prefixPaddingMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  reasoningEffort: Type.Optional(Type.String()),
+  mode: Type.Optional(TalkModeSchema),
+  transport: Type.Optional(TalkTransportSchema),
+  brain: Type.Optional(TalkBrainSchema),
+  ttlMs: Type.Optional(Type.Integer({ minimum: 1000, maximum: 3600000 })),
+});
 
 /** Appends base64 audio to an active Talk session. */
-export const TalkSessionAppendAudioParamsSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    audioBase64: NonEmptyString,
-    timestamp: Type.Optional(Type.Number()),
-  },
-  { additionalProperties: false },
-);
+export const TalkSessionAppendAudioParamsSchema = closedObject({
+  sessionId: NonEmptyString,
+  audioBase64: NonEmptyString,
+  timestamp: Type.Optional(Type.Number()),
+});
 
 /** Starts or advances a Talk turn within a session. */
-export const TalkSessionTurnParamsSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    turnId: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const TalkSessionTurnParamsSchema = closedObject({
+  sessionId: NonEmptyString,
+  turnId: Type.Optional(Type.String()),
+});
 
 /** Cancels the active or named Talk turn. */
-export const TalkSessionCancelTurnParamsSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    turnId: Type.Optional(Type.String()),
-    reason: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const TalkSessionCancelTurnParamsSchema = closedObject({
+  sessionId: NonEmptyString,
+  turnId: Type.Optional(Type.String()),
+  reason: Type.Optional(Type.String()),
+});
 
 /** Cancels currently streaming Talk output without necessarily ending the turn. */
-export const TalkSessionCancelOutputParamsSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    turnId: Type.Optional(Type.String()),
-    reason: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const TalkSessionCancelOutputParamsSchema = closedObject({
+  sessionId: NonEmptyString,
+  turnId: Type.Optional(Type.String()),
+  reason: Type.Optional(Type.String()),
+});
 
 /** Submits a tool result back to a Talk provider session. */
-export const TalkSessionSubmitToolResultParamsSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    callId: NonEmptyString,
-    result: Type.Unknown(),
-    options: Type.Optional(
-      Type.Object(
-        {
-          suppressResponse: Type.Optional(Type.Boolean()),
-          willContinue: Type.Optional(Type.Boolean()),
-        },
-        { additionalProperties: false },
-      ),
-    ),
-  },
-  { additionalProperties: false },
-);
+export const TalkSessionSubmitToolResultParamsSchema = closedObject({
+  sessionId: NonEmptyString,
+  callId: NonEmptyString,
+  result: Type.Unknown(),
+  options: Type.Optional(
+    closedObject({
+      suppressResponse: Type.Optional(Type.Boolean()),
+      willContinue: Type.Optional(Type.Boolean()),
+    }),
+  ),
+});
 
 /** Steers a managed Talk session by session id rather than transcript key. */
-export const TalkSessionSteerParamsSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    sessionKey: Type.Optional(NonEmptyString),
-    text: NonEmptyString,
-    mode: Type.Optional(TalkAgentControlModeSchema),
-  },
-  { additionalProperties: false },
-);
+export const TalkSessionSteerParamsSchema = closedObject({
+  sessionId: NonEmptyString,
+  sessionKey: Type.Optional(NonEmptyString),
+  text: NonEmptyString,
+  mode: Type.Optional(TalkAgentControlModeSchema),
+});
 
 /** Closes a gateway-managed Talk session. */
-export const TalkSessionCloseParamsSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const TalkSessionCloseParamsSchema = closedObject({
+  sessionId: NonEmptyString,
+});
 
 /** Mutable room state returned when a client joins a managed Talk room. */
-const TalkSessionManagedRoomStateSchema = Type.Object(
-  {
-    activeClientId: Type.Optional(Type.String()),
-    activeTurnId: Type.Optional(Type.String()),
-    recentTalkEvents: Type.Array(TalkEventSchema),
-  },
-  { additionalProperties: false },
-);
+const TalkSessionManagedRoomStateSchema = closedObject({
+  activeClientId: Type.Optional(Type.String()),
+  activeTurnId: Type.Optional(Type.String()),
+  recentTalkEvents: Type.Array(TalkEventSchema),
+});
 
 /** Managed-room session record shared with browser clients. */
-const TalkSessionManagedRoomRecordSchema = Type.Object(
-  {
-    id: NonEmptyString,
-    roomId: NonEmptyString,
-    roomUrl: NonEmptyString,
-    sessionKey: NonEmptyString,
-    sessionId: Type.Optional(Type.String()),
-    channel: Type.Optional(Type.String()),
-    target: Type.Optional(Type.String()),
-    provider: Type.Optional(Type.String()),
-    model: Type.Optional(Type.String()),
-    voice: Type.Optional(Type.String()),
-    mode: TalkModeSchema,
-    transport: TalkTransportSchema,
-    brain: TalkBrainSchema,
-    createdAt: Type.Number(),
-    expiresAt: Type.Number(),
-    room: TalkSessionManagedRoomStateSchema,
-  },
-  { additionalProperties: false },
-);
+const TalkSessionManagedRoomRecordSchema = closedObject({
+  id: NonEmptyString,
+  roomId: NonEmptyString,
+  roomUrl: NonEmptyString,
+  sessionKey: NonEmptyString,
+  sessionId: Type.Optional(Type.String()),
+  channel: Type.Optional(Type.String()),
+  target: Type.Optional(Type.String()),
+  provider: Type.Optional(Type.String()),
+  model: Type.Optional(Type.String()),
+  voice: Type.Optional(Type.String()),
+  mode: TalkModeSchema,
+  transport: TalkTransportSchema,
+  brain: TalkBrainSchema,
+  createdAt: Type.Number(),
+  expiresAt: Type.Number(),
+  room: TalkSessionManagedRoomStateSchema,
+});
 
 /** Empty request payload for reading configured Talk provider capabilities. */
-export const TalkCatalogParamsSchema = Type.Object({}, { additionalProperties: false });
+export const TalkCatalogParamsSchema = closedObject({});
 
 /** One provider entry in the Talk capability catalog. */
-const TalkCatalogProviderSchema = Type.Object(
-  {
-    id: NonEmptyString,
-    label: NonEmptyString,
-    configured: Type.Boolean(),
-    aliases: Type.Optional(Type.Array(NonEmptyString)),
-    models: Type.Optional(Type.Array(Type.String())),
-    voices: Type.Optional(Type.Array(Type.String())),
-    defaultModel: Type.Optional(Type.String()),
-    modes: Type.Optional(Type.Array(TalkModeSchema)),
-    transports: Type.Optional(Type.Array(TalkTransportSchema)),
-    brains: Type.Optional(Type.Array(TalkBrainSchema)),
-    inputAudioFormats: Type.Optional(
-      Type.Array(
-        Type.Object(
-          {
-            encoding: Type.Union([Type.Literal("pcm16"), Type.Literal("g711_ulaw")]),
-            sampleRateHz: Type.Integer({ minimum: 1 }),
-            channels: Type.Integer({ minimum: 1 }),
-          },
-          { additionalProperties: false },
-        ),
-      ),
+const TalkCatalogProviderSchema = closedObject({
+  id: NonEmptyString,
+  label: NonEmptyString,
+  configured: Type.Boolean(),
+  aliases: Type.Optional(Type.Array(NonEmptyString)),
+  models: Type.Optional(Type.Array(Type.String())),
+  voices: Type.Optional(Type.Array(Type.String())),
+  defaultModel: Type.Optional(Type.String()),
+  modes: Type.Optional(Type.Array(TalkModeSchema)),
+  transports: Type.Optional(Type.Array(TalkTransportSchema)),
+  brains: Type.Optional(Type.Array(TalkBrainSchema)),
+  inputAudioFormats: Type.Optional(
+    Type.Array(
+      closedObject({
+        encoding: Type.Union([Type.Literal("pcm16"), Type.Literal("g711_ulaw")]),
+        sampleRateHz: Type.Integer({ minimum: 1 }),
+        channels: Type.Integer({ minimum: 1 }),
+      }),
     ),
-    outputAudioFormats: Type.Optional(
-      Type.Array(
-        Type.Object(
-          {
-            encoding: Type.Union([Type.Literal("pcm16"), Type.Literal("g711_ulaw")]),
-            sampleRateHz: Type.Integer({ minimum: 1 }),
-            channels: Type.Integer({ minimum: 1 }),
-          },
-          { additionalProperties: false },
-        ),
-      ),
+  ),
+  outputAudioFormats: Type.Optional(
+    Type.Array(
+      closedObject({
+        encoding: Type.Union([Type.Literal("pcm16"), Type.Literal("g711_ulaw")]),
+        sampleRateHz: Type.Integer({ minimum: 1 }),
+        channels: Type.Integer({ minimum: 1 }),
+      }),
     ),
-    supportsBrowserSession: Type.Optional(Type.Boolean()),
-    supportsBargeIn: Type.Optional(Type.Boolean()),
-    supportsToolCalls: Type.Optional(Type.Boolean()),
-    supportsVideoFrames: Type.Optional(Type.Boolean()),
-    supportsSessionResumption: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+  ),
+  supportsBrowserSession: Type.Optional(Type.Boolean()),
+  supportsBargeIn: Type.Optional(Type.Boolean()),
+  supportsToolCalls: Type.Optional(Type.Boolean()),
+  supportsVideoFrames: Type.Optional(Type.Boolean()),
+  supportsSessionResumption: Type.Optional(Type.Boolean()),
+});
 
 /** Active provider plus all candidates for a Talk capability family. */
-const TalkCatalogProviderGroupSchema = Type.Object(
-  {
-    ready: Type.Optional(Type.Boolean()),
-    activeProvider: Type.Optional(Type.String()),
-    providers: Type.Array(TalkCatalogProviderSchema),
-  },
-  { additionalProperties: false },
-);
+const TalkCatalogProviderGroupSchema = closedObject({
+  ready: Type.Optional(Type.Boolean()),
+  activeProvider: Type.Optional(Type.String()),
+  providers: Type.Array(TalkCatalogProviderSchema),
+});
 
 /** Provider, mode, transport, and audio-format catalog returned to clients. */
-export const TalkCatalogResultSchema = Type.Object(
-  {
-    modes: Type.Array(TalkModeSchema),
-    transports: Type.Array(TalkTransportSchema),
-    brains: Type.Array(TalkBrainSchema),
-    speech: TalkCatalogProviderGroupSchema,
-    transcription: TalkCatalogProviderGroupSchema,
-    realtime: TalkCatalogProviderGroupSchema,
-  },
-  { additionalProperties: false },
-);
+export const TalkCatalogResultSchema = closedObject({
+  modes: Type.Array(TalkModeSchema),
+  transports: Type.Array(TalkTransportSchema),
+  brains: Type.Array(TalkBrainSchema),
+  speech: TalkCatalogProviderGroupSchema,
+  transcription: TalkCatalogProviderGroupSchema,
+  realtime: TalkCatalogProviderGroupSchema,
+});
 
 /** Audio format contract for realtime browser sessions. */
-const BrowserRealtimeAudioContractSchema = Type.Object(
-  {
-    inputEncoding: Type.Union([Type.Literal("pcm16"), Type.Literal("g711_ulaw")]),
-    inputSampleRateHz: Type.Integer({ minimum: 1 }),
-    outputEncoding: Type.Union([Type.Literal("pcm16"), Type.Literal("g711_ulaw")]),
-    outputSampleRateHz: Type.Integer({ minimum: 1 }),
-  },
-  { additionalProperties: false },
-);
+const BrowserRealtimeAudioContractSchema = closedObject({
+  inputEncoding: Type.Union([Type.Literal("pcm16"), Type.Literal("g711_ulaw")]),
+  inputSampleRateHz: Type.Integer({ minimum: 1 }),
+  outputEncoding: Type.Union([Type.Literal("pcm16"), Type.Literal("g711_ulaw")]),
+  outputSampleRateHz: Type.Integer({ minimum: 1 }),
+});
 
 /** Session creation result with transport-specific ids and credentials. */
-export const TalkSessionCreateResultSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    provider: Type.Optional(Type.String()),
-    mode: TalkModeSchema,
-    transport: TalkTransportSchema,
-    brain: TalkBrainSchema,
-    relaySessionId: Type.Optional(NonEmptyString),
-    transcriptionSessionId: Type.Optional(NonEmptyString),
-    handoffId: Type.Optional(NonEmptyString),
-    roomId: Type.Optional(NonEmptyString),
-    roomUrl: Type.Optional(NonEmptyString),
-    token: Type.Optional(NonEmptyString),
-    audio: Type.Optional(Type.Unknown()),
-    model: Type.Optional(Type.String()),
-    voice: Type.Optional(Type.String()),
-    expiresAt: Type.Optional(Type.Number()),
-  },
-  { additionalProperties: false },
-);
+export const TalkSessionCreateResultSchema = closedObject({
+  sessionId: NonEmptyString,
+  provider: Type.Optional(Type.String()),
+  mode: TalkModeSchema,
+  transport: TalkTransportSchema,
+  brain: TalkBrainSchema,
+  relaySessionId: Type.Optional(NonEmptyString),
+  transcriptionSessionId: Type.Optional(NonEmptyString),
+  handoffId: Type.Optional(NonEmptyString),
+  roomId: Type.Optional(NonEmptyString),
+  roomUrl: Type.Optional(NonEmptyString),
+  token: Type.Optional(NonEmptyString),
+  audio: Type.Optional(Type.Unknown()),
+  model: Type.Optional(Type.String()),
+  voice: Type.Optional(Type.String()),
+  expiresAt: Type.Optional(Type.Number()),
+});
 
 /** Result for a Talk turn request, optionally including emitted events. */
-export const TalkSessionTurnResultSchema = Type.Object(
-  {
-    ok: Type.Boolean(),
-    turnId: Type.Optional(Type.String()),
-    events: Type.Optional(Type.Array(TalkEventSchema)),
-  },
-  { additionalProperties: false },
-);
+export const TalkSessionTurnResultSchema = closedObject({
+  ok: Type.Boolean(),
+  turnId: Type.Optional(Type.String()),
+  events: Type.Optional(Type.Array(TalkEventSchema)),
+});
 
 /** Managed-room record returned to clients after joining an existing Talk session. */
 export const TalkSessionJoinResultSchema = TalkSessionManagedRoomRecordSchema;
 
 /** Generic success result for Talk session lifecycle calls. */
-export const TalkSessionOkResultSchema = Type.Object(
-  {
-    ok: Type.Boolean(),
-  },
-  { additionalProperties: false },
-);
+export const TalkSessionOkResultSchema = closedObject({
+  ok: Type.Boolean(),
+});
 
 /** Browser WebRTC setup payload using provider SDP exchange. */
-const BrowserRealtimeWebRtcSdpSessionSchema = Type.Object(
-  {
-    provider: NonEmptyString,
-    transport: Type.Literal("webrtc"),
-    clientSecret: NonEmptyString,
-    offerUrl: Type.Optional(Type.String()),
-    offerHeaders: Type.Optional(Type.Record(Type.String(), Type.String())),
-    model: Type.Optional(Type.String()),
-    voice: Type.Optional(Type.String()),
-    expiresAt: Type.Optional(Type.Number()),
-  },
-  { additionalProperties: false },
-);
+const BrowserRealtimeWebRtcSdpSessionSchema = closedObject({
+  provider: NonEmptyString,
+  transport: Type.Literal("webrtc"),
+  clientSecret: NonEmptyString,
+  offerUrl: Type.Optional(Type.String()),
+  offerHeaders: Type.Optional(Type.Record(Type.String(), Type.String())),
+  model: Type.Optional(Type.String()),
+  voice: Type.Optional(Type.String()),
+  expiresAt: Type.Optional(Type.Number()),
+});
 
 /** Browser websocket setup payload with JSON/PCM audio contract. */
-const BrowserRealtimeJsonPcmWebSocketSessionSchema = Type.Object(
-  {
-    provider: NonEmptyString,
-    transport: Type.Literal("provider-websocket"),
-    protocol: NonEmptyString,
-    clientSecret: NonEmptyString,
-    websocketUrl: NonEmptyString,
-    audio: BrowserRealtimeAudioContractSchema,
-    initialMessage: Type.Optional(Type.Unknown()),
-    model: Type.Optional(Type.String()),
-    voice: Type.Optional(Type.String()),
-    expiresAt: Type.Optional(Type.Number()),
-  },
-  { additionalProperties: false },
-);
+const BrowserRealtimeJsonPcmWebSocketSessionSchema = closedObject({
+  provider: NonEmptyString,
+  transport: Type.Literal("provider-websocket"),
+  protocol: NonEmptyString,
+  clientSecret: NonEmptyString,
+  websocketUrl: NonEmptyString,
+  audio: BrowserRealtimeAudioContractSchema,
+  initialMessage: Type.Optional(Type.Unknown()),
+  model: Type.Optional(Type.String()),
+  voice: Type.Optional(Type.String()),
+  expiresAt: Type.Optional(Type.Number()),
+});
 
 /** Browser setup payload for gateway-relayed realtime audio. */
-const BrowserRealtimeGatewayRelaySessionSchema = Type.Object(
-  {
-    provider: NonEmptyString,
-    transport: Type.Literal("gateway-relay"),
-    relaySessionId: NonEmptyString,
-    audio: BrowserRealtimeAudioContractSchema,
-    model: Type.Optional(Type.String()),
-    voice: Type.Optional(Type.String()),
-    expiresAt: Type.Optional(Type.Number()),
-  },
-  { additionalProperties: false },
-);
+const BrowserRealtimeGatewayRelaySessionSchema = closedObject({
+  provider: NonEmptyString,
+  transport: Type.Literal("gateway-relay"),
+  relaySessionId: NonEmptyString,
+  audio: BrowserRealtimeAudioContractSchema,
+  model: Type.Optional(Type.String()),
+  voice: Type.Optional(Type.String()),
+  expiresAt: Type.Optional(Type.Number()),
+});
 
 /** Browser setup payload for managed-room Talk sessions. */
-const BrowserRealtimeManagedRoomSessionSchema = Type.Object(
-  {
-    provider: NonEmptyString,
-    transport: Type.Literal("managed-room"),
-    roomUrl: NonEmptyString,
-    token: Type.Optional(Type.String()),
-    model: Type.Optional(Type.String()),
-    voice: Type.Optional(Type.String()),
-    expiresAt: Type.Optional(Type.Number()),
-  },
-  { additionalProperties: false },
-);
+const BrowserRealtimeManagedRoomSessionSchema = closedObject({
+  provider: NonEmptyString,
+  transport: Type.Literal("managed-room"),
+  roomUrl: NonEmptyString,
+  token: Type.Optional(Type.String()),
+  model: Type.Optional(Type.String()),
+  voice: Type.Optional(Type.String()),
+  expiresAt: Type.Optional(Type.Number()),
+});
 
 /** Union of all browser Talk session setup payloads. */
 export const TalkClientCreateResultSchema = Type.Union([
@@ -621,117 +517,87 @@ const TalkProviderConfigSchema = Type.Object(talkProviderFieldSchemas, {
 });
 
 /** Realtime Talk defaults and provider selection stored in config. */
-const TalkRealtimeConfigSchema = Type.Object(
-  {
-    provider: Type.Optional(Type.String()),
-    providers: Type.Optional(Type.Record(Type.String(), TalkProviderConfigSchema)),
-    model: Type.Optional(Type.String()),
-    speakerVoice: Type.Optional(Type.String()),
-    speakerVoiceId: Type.Optional(Type.String()),
-    voice: Type.Optional(Type.String()),
-    instructions: Type.Optional(Type.String()),
-    mode: Type.Optional(TalkModeSchema),
-    transport: Type.Optional(TalkTransportSchema),
-    vadThreshold: Type.Optional(Type.Number({ minimum: 0, maximum: 1 })),
-    silenceDurationMs: Type.Optional(Type.Integer({ minimum: 1 })),
-    prefixPaddingMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    reasoningEffort: Type.Optional(Type.String({ minLength: 1 })),
-    brain: Type.Optional(TalkBrainSchema),
-    consultRouting: Type.Optional(
-      Type.Union([Type.Literal("provider-direct"), Type.Literal("force-agent-consult")]),
-    ),
-  },
-  { additionalProperties: false },
-);
+const TalkRealtimeConfigSchema = closedObject({
+  provider: Type.Optional(Type.String()),
+  providers: Type.Optional(Type.Record(Type.String(), TalkProviderConfigSchema)),
+  model: Type.Optional(Type.String()),
+  speakerVoice: Type.Optional(Type.String()),
+  speakerVoiceId: Type.Optional(Type.String()),
+  voice: Type.Optional(Type.String()),
+  instructions: Type.Optional(Type.String()),
+  mode: Type.Optional(TalkModeSchema),
+  transport: Type.Optional(TalkTransportSchema),
+  vadThreshold: Type.Optional(Type.Number({ minimum: 0, maximum: 1 })),
+  silenceDurationMs: Type.Optional(Type.Integer({ minimum: 1 })),
+  prefixPaddingMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  reasoningEffort: Type.Optional(Type.String({ minLength: 1 })),
+  brain: Type.Optional(TalkBrainSchema),
+  consultRouting: Type.Optional(
+    Type.Union([Type.Literal("provider-direct"), Type.Literal("force-agent-consult")]),
+  ),
+});
 
 /** Resolved active Talk provider plus its normalized provider config. */
-const ResolvedTalkConfigSchema = Type.Object(
-  {
-    provider: Type.String(),
-    config: TalkProviderConfigSchema,
-  },
-  { additionalProperties: false },
-);
+const ResolvedTalkConfigSchema = closedObject({
+  provider: Type.String(),
+  config: TalkProviderConfigSchema,
+});
 
 /** Talk config subtree returned through gateway config APIs. */
-const TalkConfigSchema = Type.Object(
-  {
-    provider: Type.Optional(Type.String()),
-    providers: Type.Optional(Type.Record(Type.String(), TalkProviderConfigSchema)),
-    realtime: Type.Optional(TalkRealtimeConfigSchema),
-    resolved: Type.Optional(ResolvedTalkConfigSchema),
-    consultThinkingLevel: Type.Optional(Type.String()),
-    consultFastMode: Type.Optional(Type.Boolean()),
-    speechLocale: Type.Optional(Type.String()),
-    interruptOnSpeech: Type.Optional(Type.Boolean()),
-    silenceTimeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
-  },
-  { additionalProperties: false },
-);
+const TalkConfigSchema = closedObject({
+  provider: Type.Optional(Type.String()),
+  providers: Type.Optional(Type.Record(Type.String(), TalkProviderConfigSchema)),
+  realtime: Type.Optional(TalkRealtimeConfigSchema),
+  resolved: Type.Optional(ResolvedTalkConfigSchema),
+  consultThinkingLevel: Type.Optional(Type.String()),
+  consultFastMode: Type.Optional(Type.Boolean()),
+  speechLocale: Type.Optional(Type.String()),
+  interruptOnSpeech: Type.Optional(Type.Boolean()),
+  silenceTimeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
+});
 
 /** Full Talk config read result, including related session/UI context. */
-export const TalkConfigResultSchema = Type.Object(
-  {
-    config: Type.Object(
-      {
-        talk: Type.Optional(TalkConfigSchema),
-        session: Type.Optional(
-          Type.Object(
-            {
-              mainKey: Type.Optional(Type.String()),
-            },
-            { additionalProperties: false },
-          ),
-        ),
-        ui: Type.Optional(
-          Type.Object(
-            {
-              seamColor: Type.Optional(Type.String()),
-            },
-            { additionalProperties: false },
-          ),
-        ),
-      },
-      { additionalProperties: false },
+export const TalkConfigResultSchema = closedObject({
+  config: closedObject({
+    talk: Type.Optional(TalkConfigSchema),
+    session: Type.Optional(
+      closedObject({
+        mainKey: Type.Optional(Type.String()),
+      }),
     ),
-  },
-  { additionalProperties: false },
-);
+    ui: Type.Optional(
+      closedObject({
+        seamColor: Type.Optional(Type.String()),
+      }),
+    ),
+  }),
+});
 
 /** Text-to-speech result with encoded audio and provider output metadata. */
-export const TalkSpeakResultSchema = Type.Object(
-  {
-    audioBase64: NonEmptyString,
-    provider: NonEmptyString,
-    outputFormat: Type.Optional(Type.String()),
-    voiceCompatible: Type.Optional(Type.Boolean()),
-    mimeType: Type.Optional(Type.String()),
-    fileExtension: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const TalkSpeakResultSchema = closedObject({
+  audioBase64: NonEmptyString,
+  provider: NonEmptyString,
+  outputFormat: Type.Optional(Type.String()),
+  voiceCompatible: Type.Optional(Type.Boolean()),
+  mimeType: Type.Optional(Type.String()),
+  fileExtension: Type.Optional(Type.String()),
+});
 
 /** Text-to-speech result for `tts.speak` with encoded audio and provider metadata. */
-export const TtsSpeakResultSchema = Type.Object(
-  {
-    audioBase64: NonEmptyString,
-    provider: NonEmptyString,
-    outputFormat: Type.Optional(Type.String()),
-    mimeType: Type.Optional(Type.String()),
-    fileExtension: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const TtsSpeakResultSchema = closedObject({
+  audioBase64: NonEmptyString,
+  provider: NonEmptyString,
+  outputFormat: Type.Optional(Type.String()),
+  mimeType: Type.Optional(Type.String()),
+  fileExtension: Type.Optional(Type.String()),
+});
 
 /** Channel status request, optionally probing one channel before returning. */
-export const ChannelsStatusParamsSchema = Type.Object(
-  {
-    probe: Type.Optional(Type.Boolean()),
-    timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    channel: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const ChannelsStatusParamsSchema = closedObject({
+  probe: Type.Optional(Type.Boolean()),
+  timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  channel: Type.Optional(NonEmptyString),
+});
 
 /**
  * Per-account status snapshot for channel docking.
@@ -780,92 +646,71 @@ export const ChannelAccountSnapshotSchema = Type.Object(
 );
 
 /** UI label and icon metadata for one channel. */
-export const ChannelUiMetaSchema = Type.Object(
-  {
-    id: NonEmptyString,
-    label: NonEmptyString,
-    detailLabel: NonEmptyString,
-    systemImage: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const ChannelUiMetaSchema = closedObject({
+  id: NonEmptyString,
+  label: NonEmptyString,
+  detailLabel: NonEmptyString,
+  systemImage: Type.Optional(Type.String()),
+});
 
 /** Event-loop health snapshot included with channel status responses. */
-export const ChannelEventLoopHealthSchema = Type.Object(
-  {
-    degraded: Type.Boolean(),
-    reasons: Type.Array(
-      Type.Union([
-        Type.Literal("event_loop_delay"),
-        Type.Literal("event_loop_utilization"),
-        Type.Literal("cpu"),
-      ]),
-    ),
-    intervalMs: Type.Integer({ minimum: 0 }),
-    delayP99Ms: Type.Number({ minimum: 0 }),
-    delayMaxMs: Type.Number({ minimum: 0 }),
-    utilization: Type.Number({ minimum: 0 }),
-    cpuCoreRatio: Type.Number({ minimum: 0 }),
-  },
-  { additionalProperties: false },
-);
+export const ChannelEventLoopHealthSchema = closedObject({
+  degraded: Type.Boolean(),
+  reasons: Type.Array(
+    Type.Union([
+      Type.Literal("event_loop_delay"),
+      Type.Literal("event_loop_utilization"),
+      Type.Literal("cpu"),
+    ]),
+  ),
+  intervalMs: Type.Integer({ minimum: 0 }),
+  delayP99Ms: Type.Number({ minimum: 0 }),
+  delayMaxMs: Type.Number({ minimum: 0 }),
+  utilization: Type.Number({ minimum: 0 }),
+  cpuCoreRatio: Type.Number({ minimum: 0 }),
+});
 
 /** Full channel status result for dashboard and operator diagnostics. */
-export const ChannelsStatusResultSchema = Type.Object(
-  {
-    ts: Type.Integer({ minimum: 0 }),
-    channelOrder: Type.Array(NonEmptyString),
-    channelLabels: Type.Record(NonEmptyString, NonEmptyString),
-    channelDetailLabels: Type.Optional(Type.Record(NonEmptyString, NonEmptyString)),
-    channelSystemImages: Type.Optional(Type.Record(NonEmptyString, NonEmptyString)),
-    channelMeta: Type.Optional(Type.Array(ChannelUiMetaSchema)),
-    channels: Type.Record(NonEmptyString, Type.Unknown()),
-    channelAccounts: Type.Record(NonEmptyString, Type.Array(ChannelAccountSnapshotSchema)),
-    channelDefaultAccountId: Type.Record(NonEmptyString, NonEmptyString),
-    eventLoop: Type.Optional(ChannelEventLoopHealthSchema),
-    partial: Type.Optional(Type.Boolean()),
-    warnings: Type.Optional(Type.Array(Type.String())),
-  },
-  { additionalProperties: false },
-);
+export const ChannelsStatusResultSchema = closedObject({
+  ts: Type.Integer({ minimum: 0 }),
+  channelOrder: Type.Array(NonEmptyString),
+  channelLabels: Type.Record(NonEmptyString, NonEmptyString),
+  channelDetailLabels: Type.Optional(Type.Record(NonEmptyString, NonEmptyString)),
+  channelSystemImages: Type.Optional(Type.Record(NonEmptyString, NonEmptyString)),
+  channelMeta: Type.Optional(Type.Array(ChannelUiMetaSchema)),
+  channels: Type.Record(NonEmptyString, Type.Unknown()),
+  channelAccounts: Type.Record(NonEmptyString, Type.Array(ChannelAccountSnapshotSchema)),
+  channelDefaultAccountId: Type.Record(NonEmptyString, NonEmptyString),
+  eventLoop: Type.Optional(ChannelEventLoopHealthSchema),
+  partial: Type.Optional(Type.Boolean()),
+  warnings: Type.Optional(Type.Array(Type.String())),
+});
 
 /** Logs out one channel account. */
-export const ChannelsLogoutParamsSchema = Type.Object(
-  {
-    channel: NonEmptyString,
-    accountId: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const ChannelsLogoutParamsSchema = closedObject({
+  channel: NonEmptyString,
+  accountId: Type.Optional(Type.String()),
+});
 
 /** Stops one channel account runtime. */
-export const ChannelsStopParamsSchema = Type.Object(
-  {
-    channel: NonEmptyString,
-    accountId: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const ChannelsStopParamsSchema = closedObject({
+  channel: NonEmptyString,
+  accountId: Type.Optional(Type.String()),
+});
 
 /** Starts one channel account runtime. */
-export const ChannelsStartParamsSchema = Type.Object(
-  {
-    channel: NonEmptyString,
-    accountId: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const ChannelsStartParamsSchema = closedObject({
+  channel: NonEmptyString,
+  accountId: Type.Optional(Type.String()),
+});
 
 /** Starts browser/web login for a channel account. */
-export const WebLoginStartParamsSchema = Type.Object(
-  {
-    force: Type.Optional(Type.Boolean()),
-    timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    verbose: Type.Optional(Type.Boolean()),
-    accountId: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const WebLoginStartParamsSchema = closedObject({
+  force: Type.Optional(Type.Boolean()),
+  timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  verbose: Type.Optional(Type.Boolean()),
+  accountId: Type.Optional(Type.String()),
+});
 
 const QrDataUrlSchema = Type.String({
   maxLength: 16_384,
@@ -873,14 +718,11 @@ const QrDataUrlSchema = Type.String({
 });
 
 /** Waits for web login completion or the next QR code. */
-export const WebLoginWaitParamsSchema = Type.Object(
-  {
-    timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    accountId: Type.Optional(Type.String()),
-    currentQrDataUrl: Type.Optional(QrDataUrlSchema),
-  },
-  { additionalProperties: false },
-);
+export const WebLoginWaitParamsSchema = closedObject({
+  timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  accountId: Type.Optional(Type.String()),
+  currentQrDataUrl: Type.Optional(QrDataUrlSchema),
+});
 
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/closed-object.ts
+++ b/packages/gateway-protocol/src/schema/closed-object.ts
@@ -1,0 +1,5 @@
+import { Type, type TProperties } from "typebox";
+
+export function closedObject<Properties extends TProperties>(properties: Properties) {
+  return Type.Object(properties, { additionalProperties: false });
+}

--- a/packages/gateway-protocol/src/schema/commands.ts
+++ b/packages/gateway-protocol/src/schema/commands.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 /**
@@ -58,67 +59,52 @@ export const CommandCategorySchema = Type.Union([
 ]);
 
 /** Static argument choice shown to clients. */
-export const CommandArgChoiceSchema = Type.Object(
-  {
-    value: Type.String({ maxLength: COMMAND_CHOICE_VALUE_MAX_LENGTH }),
-    label: Type.String({ maxLength: COMMAND_CHOICE_LABEL_MAX_LENGTH }),
-  },
-  { additionalProperties: false },
-);
+export const CommandArgChoiceSchema = closedObject({
+  value: Type.String({ maxLength: COMMAND_CHOICE_VALUE_MAX_LENGTH }),
+  label: Type.String({ maxLength: COMMAND_CHOICE_LABEL_MAX_LENGTH }),
+});
 
 /** One typed argument advertised for a command. */
-export const CommandArgSchema = Type.Object(
-  {
-    name: BoundedNonEmptyString(COMMAND_ARG_NAME_MAX_LENGTH),
-    description: Type.String({ maxLength: COMMAND_ARG_DESCRIPTION_MAX_LENGTH }),
-    type: Type.Union([Type.Literal("string"), Type.Literal("number"), Type.Literal("boolean")]),
-    required: Type.Optional(Type.Boolean()),
-    choices: Type.Optional(
-      Type.Array(CommandArgChoiceSchema, { maxItems: COMMAND_ARG_CHOICES_MAX_ITEMS }),
-    ),
-    dynamic: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const CommandArgSchema = closedObject({
+  name: BoundedNonEmptyString(COMMAND_ARG_NAME_MAX_LENGTH),
+  description: Type.String({ maxLength: COMMAND_ARG_DESCRIPTION_MAX_LENGTH }),
+  type: Type.Union([Type.Literal("string"), Type.Literal("number"), Type.Literal("boolean")]),
+  required: Type.Optional(Type.Boolean()),
+  choices: Type.Optional(
+    Type.Array(CommandArgChoiceSchema, { maxItems: COMMAND_ARG_CHOICES_MAX_ITEMS }),
+  ),
+  dynamic: Type.Optional(Type.Boolean()),
+});
 
 /** One command catalog entry visible to clients. */
-export const CommandEntrySchema = Type.Object(
-  {
-    name: BoundedNonEmptyString(COMMAND_NAME_MAX_LENGTH),
-    nativeName: Type.Optional(BoundedNonEmptyString(COMMAND_NAME_MAX_LENGTH)),
-    textAliases: Type.Optional(
-      Type.Array(BoundedNonEmptyString(COMMAND_NAME_MAX_LENGTH), {
-        maxItems: COMMAND_ALIAS_MAX_ITEMS,
-      }),
-    ),
-    description: Type.String({ maxLength: COMMAND_DESCRIPTION_MAX_LENGTH }),
-    category: Type.Optional(CommandCategorySchema),
-    source: CommandSourceSchema,
-    scope: CommandScopeSchema,
-    acceptsArgs: Type.Boolean(),
-    args: Type.Optional(Type.Array(CommandArgSchema, { maxItems: COMMAND_ARGS_MAX_ITEMS })),
-  },
-  { additionalProperties: false },
-);
+export const CommandEntrySchema = closedObject({
+  name: BoundedNonEmptyString(COMMAND_NAME_MAX_LENGTH),
+  nativeName: Type.Optional(BoundedNonEmptyString(COMMAND_NAME_MAX_LENGTH)),
+  textAliases: Type.Optional(
+    Type.Array(BoundedNonEmptyString(COMMAND_NAME_MAX_LENGTH), {
+      maxItems: COMMAND_ALIAS_MAX_ITEMS,
+    }),
+  ),
+  description: Type.String({ maxLength: COMMAND_DESCRIPTION_MAX_LENGTH }),
+  category: Type.Optional(CommandCategorySchema),
+  source: CommandSourceSchema,
+  scope: CommandScopeSchema,
+  acceptsArgs: Type.Boolean(),
+  args: Type.Optional(Type.Array(CommandArgSchema, { maxItems: COMMAND_ARGS_MAX_ITEMS })),
+});
 
 /** Command catalog request filters. */
-export const CommandsListParamsSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-    provider: Type.Optional(NonEmptyString),
-    scope: Type.Optional(CommandScopeSchema),
-    includeArgs: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const CommandsListParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+  provider: Type.Optional(NonEmptyString),
+  scope: Type.Optional(CommandScopeSchema),
+  includeArgs: Type.Optional(Type.Boolean()),
+});
 
 /** Bounded command catalog response. */
-export const CommandsListResultSchema = Type.Object(
-  {
-    commands: Type.Array(CommandEntrySchema, { maxItems: COMMAND_LIST_MAX_ITEMS }),
-  },
-  { additionalProperties: false },
-);
+export const CommandsListResultSchema = closedObject({
+  commands: Type.Array(CommandEntrySchema, { maxItems: COMMAND_LIST_MAX_ITEMS }),
+});
 
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/config.ts
+++ b/packages/gateway-protocol/src/schema/config.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 /**
@@ -15,27 +16,21 @@ const ConfigSchemaLookupPathString = Type.String({
   pattern: "^[A-Za-z0-9_./\\[\\]\\-*]+$",
 });
 
-const ConfigDeliveryContextSchema = Type.Object(
-  {
-    channel: Type.Optional(Type.String()),
-    to: Type.Optional(Type.String()),
-    accountId: Type.Optional(Type.String()),
-    threadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
-  },
-  { additionalProperties: false },
-);
+const ConfigDeliveryContextSchema = closedObject({
+  channel: Type.Optional(Type.String()),
+  to: Type.Optional(Type.String()),
+  accountId: Type.Optional(Type.String()),
+  threadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+});
 
 /** Empty request payload for reading the current raw config. */
-export const ConfigGetParamsSchema = Type.Object({}, { additionalProperties: false });
+export const ConfigGetParamsSchema = closedObject({});
 
 /** Full raw config replacement request with optional base hash guard. */
-export const ConfigSetParamsSchema = Type.Object(
-  {
-    raw: NonEmptyString,
-    baseHash: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const ConfigSetParamsSchema = closedObject({
+  raw: NonEmptyString,
+  baseHash: Type.Optional(NonEmptyString),
+});
 
 /** Shared config apply/patch payload with optional restart notification context. */
 const ConfigApplyLikeParamProperties = {
@@ -47,106 +42,83 @@ const ConfigApplyLikeParamProperties = {
   restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
 } as const;
 
-const ConfigApplyLikeParamsSchema = Type.Object(ConfigApplyLikeParamProperties, {
-  additionalProperties: false,
-});
+const ConfigApplyLikeParamsSchema = closedObject(ConfigApplyLikeParamProperties);
 
 /** Raw config apply request that may schedule a restart. */
 export const ConfigApplyParamsSchema = ConfigApplyLikeParamsSchema;
 /** Raw config patch request that may schedule a restart. */
-export const ConfigPatchParamsSchema = Type.Object(
-  {
-    ...ConfigApplyLikeParamProperties,
-    replacePaths: Type.Optional(Type.Array(NonEmptyString, { maxItems: 256 })),
-  },
-  { additionalProperties: false },
-);
+export const ConfigPatchParamsSchema = closedObject({
+  ...ConfigApplyLikeParamProperties,
+  replacePaths: Type.Optional(Type.Array(NonEmptyString, { maxItems: 256 })),
+});
 
 /** Empty request payload for fetching the generated config schema. */
-export const ConfigSchemaParamsSchema = Type.Object({}, { additionalProperties: false });
+export const ConfigSchemaParamsSchema = closedObject({});
 
 /** Schema lookup request for one config path. */
-export const ConfigSchemaLookupParamsSchema = Type.Object(
-  {
-    path: ConfigSchemaLookupPathString,
-  },
-  { additionalProperties: false },
-);
+export const ConfigSchemaLookupParamsSchema = closedObject({
+  path: ConfigSchemaLookupPathString,
+});
 
 /** Empty request payload for checking update/restart status. */
-export const UpdateStatusParamsSchema = Type.Object({}, { additionalProperties: false });
+export const UpdateStatusParamsSchema = closedObject({});
 
 /** Request payload for running an update/restart flow with optional channel delivery context. */
-export const UpdateRunParamsSchema = Type.Object(
-  {
-    sessionKey: Type.Optional(Type.String()),
-    deliveryContext: Type.Optional(ConfigDeliveryContextSchema),
-    note: Type.Optional(Type.String()),
-    continuationMessage: Type.Optional(Type.String()),
-    restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    timeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
-  },
-  { additionalProperties: false },
-);
+export const UpdateRunParamsSchema = closedObject({
+  sessionKey: Type.Optional(Type.String()),
+  deliveryContext: Type.Optional(ConfigDeliveryContextSchema),
+  note: Type.Optional(Type.String()),
+  continuationMessage: Type.Optional(Type.String()),
+  restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  timeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
+});
 
 /** UI metadata attached to config schema paths. */
-export const ConfigUiHintSchema = Type.Object(
-  {
-    label: Type.Optional(Type.String()),
-    help: Type.Optional(Type.String()),
-    tags: Type.Optional(Type.Array(Type.String())),
-    group: Type.Optional(Type.String()),
-    order: Type.Optional(Type.Integer()),
-    advanced: Type.Optional(Type.Boolean()),
-    sensitive: Type.Optional(Type.Boolean()),
-    placeholder: Type.Optional(Type.String()),
-    itemTemplate: Type.Optional(Type.Unknown()),
-  },
-  { additionalProperties: false },
-);
+export const ConfigUiHintSchema = closedObject({
+  label: Type.Optional(Type.String()),
+  help: Type.Optional(Type.String()),
+  tags: Type.Optional(Type.Array(Type.String())),
+  group: Type.Optional(Type.String()),
+  order: Type.Optional(Type.Integer()),
+  advanced: Type.Optional(Type.Boolean()),
+  sensitive: Type.Optional(Type.Boolean()),
+  placeholder: Type.Optional(Type.String()),
+  itemTemplate: Type.Optional(Type.Unknown()),
+});
 
 /** Full generated config schema response. */
-export const ConfigSchemaResponseSchema = Type.Object(
-  {
-    schema: Type.Unknown(),
-    uiHints: Type.Record(Type.String(), ConfigUiHintSchema),
-    version: NonEmptyString,
-    generatedAt: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const ConfigSchemaResponseSchema = closedObject({
+  schema: Type.Unknown(),
+  uiHints: Type.Record(Type.String(), ConfigUiHintSchema),
+  version: NonEmptyString,
+  generatedAt: NonEmptyString,
+});
 
 /** Child entry returned when looking up a config schema path. */
-export const ConfigSchemaLookupChildSchema = Type.Object(
-  {
-    key: NonEmptyString,
-    path: NonEmptyString,
-    type: Type.Optional(Type.Union([Type.String(), Type.Array(Type.String())])),
-    required: Type.Boolean(),
-    hasChildren: Type.Boolean(),
-    reloadKind: Type.Optional(
-      Type.Union([Type.Literal("restart"), Type.Literal("hot"), Type.Literal("none")]),
-    ),
-    hint: Type.Optional(ConfigUiHintSchema),
-    hintPath: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const ConfigSchemaLookupChildSchema = closedObject({
+  key: NonEmptyString,
+  path: NonEmptyString,
+  type: Type.Optional(Type.Union([Type.String(), Type.Array(Type.String())])),
+  required: Type.Boolean(),
+  hasChildren: Type.Boolean(),
+  reloadKind: Type.Optional(
+    Type.Union([Type.Literal("restart"), Type.Literal("hot"), Type.Literal("none")]),
+  ),
+  hint: Type.Optional(ConfigUiHintSchema),
+  hintPath: Type.Optional(Type.String()),
+});
 
 /** Schema lookup response for one config path and its immediate children. */
-export const ConfigSchemaLookupResultSchema = Type.Object(
-  {
-    path: NonEmptyString,
-    schema: Type.Unknown(),
-    reloadKind: Type.Optional(
-      Type.Union([Type.Literal("restart"), Type.Literal("hot"), Type.Literal("none")]),
-    ),
-    hint: Type.Optional(ConfigUiHintSchema),
-    hintPath: Type.Optional(Type.String()),
-    children: Type.Array(ConfigSchemaLookupChildSchema),
-  },
-  { additionalProperties: false },
-);
+export const ConfigSchemaLookupResultSchema = closedObject({
+  path: NonEmptyString,
+  schema: Type.Unknown(),
+  reloadKind: Type.Optional(
+    Type.Union([Type.Literal("restart"), Type.Literal("hot"), Type.Literal("none")]),
+  ),
+  hint: Type.Optional(ConfigUiHintSchema),
+  hintPath: Type.Optional(Type.String()),
+  children: Type.Array(ConfigSchemaLookupChildSchema),
+});
 
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/crestodian.ts
+++ b/packages/gateway-protocol/src/schema/crestodian.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines Crestodian chat payloads.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 import { WizardStartResultSchema } from "./wizard.js";
 
@@ -10,35 +11,29 @@ import { WizardStartResultSchema } from "./wizard.js";
  * configured inference route before creating a session. Omitting `message`
  * returns the welcome/greeting for a verified fresh session without input.
  */
-export const CrestodianChatParamsSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    message: Type.Optional(Type.String()),
-    /** "onboarding" seeds the first-run setup proposal in the greeting. */
-    welcomeVariant: Type.Optional(Type.Union([Type.Literal("onboarding")])),
-    /** Drop any in-flight approval/wizard state and start the session over. */
-    reset: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const CrestodianChatParamsSchema = closedObject({
+  sessionId: NonEmptyString,
+  message: Type.Optional(Type.String()),
+  /** "onboarding" seeds the first-run setup proposal in the greeting. */
+  welcomeVariant: Type.Optional(Type.Union([Type.Literal("onboarding")])),
+  /** Drop any in-flight approval/wizard state and start the session over. */
+  reset: Type.Optional(Type.Boolean()),
+});
 
 /** One Crestodian reply; `action` tells clients about conversation handoffs. */
-export const CrestodianChatResultSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    reply: NonEmptyString,
-    /** The next reply is a hosted-wizard secret and clients must mask its input/echo. */
-    sensitive: Type.Optional(Type.Boolean()),
-    action: Type.Union([
-      Type.Literal("none"),
-      // The user asked to talk to their agent; clients should move to their
-      // normal agent chat surface.
-      Type.Literal("open-agent"),
-      Type.Literal("exit"),
-    ]),
-  },
-  { additionalProperties: false },
-);
+export const CrestodianChatResultSchema = closedObject({
+  sessionId: NonEmptyString,
+  reply: NonEmptyString,
+  /** The next reply is a hosted-wizard secret and clients must mask its input/echo. */
+  sensitive: Type.Optional(Type.Boolean()),
+  action: Type.Union([
+    Type.Literal("none"),
+    // The user asked to talk to their agent; clients should move to their
+    // normal agent chat surface.
+    Type.Literal("open-agent"),
+    Type.Literal("exit"),
+  ]),
+});
 
 /**
  * Structured first-run inference setup for GUI clients: detect reusable AI
@@ -47,7 +42,7 @@ export const CrestodianChatResultSchema = Type.Object(
  * client can walk the ladder candidate-by-candidate without ever leaving a
  * broken default model behind.
  */
-export const CrestodianSetupDetectParamsSchema = Type.Object({}, { additionalProperties: false });
+export const CrestodianSetupDetectParamsSchema = closedObject({});
 
 const SetupInferenceKind = Type.Union([
   Type.Literal("existing-model"),
@@ -79,127 +74,100 @@ const SetupInferenceFailureStatus = Type.Union([
   Type.Literal("unknown"),
 ]);
 
-export const CrestodianSetupDetectResultSchema = Type.Object(
-  {
-    candidates: Type.Array(
-      Type.Object(
-        {
-          kind: SetupInferenceKind,
-          label: NonEmptyString,
-          detail: Type.String(),
-          modelRef: NonEmptyString,
-          recommended: Type.Boolean(),
-          /** true: verified; false: definitively logged out; absent: unknown. */
-          credentials: Type.Optional(Type.Boolean()),
-        },
-        { additionalProperties: false },
-      ),
+export const CrestodianSetupDetectResultSchema = closedObject({
+  candidates: Type.Array(
+    closedObject({
+      kind: SetupInferenceKind,
+      label: NonEmptyString,
+      detail: Type.String(),
+      modelRef: NonEmptyString,
+      recommended: Type.Boolean(),
+      /** true: verified; false: definitively logged out; absent: unknown. */
+      credentials: Type.Optional(Type.Boolean()),
+    }),
+  ),
+  /** Text-inference key/token methods exposed by the Gateway provider registry. */
+  manualProviders: Type.Array(
+    closedObject({
+      /** Opaque provider-auth choice sent back during activation. */
+      id: NonEmptyString,
+      label: NonEmptyString,
+      hint: Type.Optional(Type.String()),
+    }),
+  ),
+  /** Provider-owned browser and device-code login methods. */
+  authOptions: Type.Optional(
+    Type.Array(
+      closedObject({
+        id: NonEmptyString,
+        label: NonEmptyString,
+        hint: Type.Optional(Type.String()),
+        groupLabel: Type.Optional(Type.String()),
+        kind: Type.Union([Type.Literal("oauth"), Type.Literal("device-code")]),
+        featured: Type.Boolean(),
+      }),
     ),
-    /** Text-inference key/token methods exposed by the Gateway provider registry. */
-    manualProviders: Type.Array(
-      Type.Object(
-        {
-          /** Opaque provider-auth choice sent back during activation. */
-          id: NonEmptyString,
-          label: NonEmptyString,
-          hint: Type.Optional(Type.String()),
-        },
-        { additionalProperties: false },
-      ),
-    ),
-    /** Provider-owned browser and device-code login methods. */
-    authOptions: Type.Optional(
-      Type.Array(
-        Type.Object(
-          {
-            id: NonEmptyString,
-            label: NonEmptyString,
-            hint: Type.Optional(Type.String()),
-            groupLabel: Type.Optional(Type.String()),
-            kind: Type.Union([Type.Literal("oauth"), Type.Literal("device-code")]),
-            featured: Type.Boolean(),
-          },
-          { additionalProperties: false },
-        ),
-      ),
-    ),
-    workspace: NonEmptyString,
-    codexAppServerDetected: Type.Optional(Type.Boolean()),
-    configuredModel: Type.Optional(Type.String()),
-    setupComplete: Type.Boolean(),
-  },
-  { additionalProperties: false },
-);
+  ),
+  workspace: NonEmptyString,
+  codexAppServerDetected: Type.Optional(Type.Boolean()),
+  configuredModel: Type.Optional(Type.String()),
+  setupComplete: Type.Boolean(),
+});
 
 /** Live verification of the Gateway's current default-agent inference route. */
-export const CrestodianSetupVerifyParamsSchema = Type.Object({}, { additionalProperties: false });
+export const CrestodianSetupVerifyParamsSchema = closedObject({});
 
 export const CrestodianSetupVerifyResultSchema = Type.Union([
-  Type.Object(
-    {
-      ok: Type.Literal(true),
-      modelRef: NonEmptyString,
-      latencyMs: Type.Number(),
-    },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
-      ok: Type.Literal(false),
-      status: SetupInferenceFailureStatus,
-      error: NonEmptyString,
-    },
-    { additionalProperties: false },
-  ),
+  closedObject({
+    ok: Type.Literal(true),
+    modelRef: NonEmptyString,
+    latencyMs: Type.Number(),
+  }),
+  closedObject({
+    ok: Type.Literal(false),
+    status: SetupInferenceFailureStatus,
+    error: NonEmptyString,
+  }),
 ]);
 
-export const CrestodianSetupActivateParamsSchema = Type.Object(
-  {
-    kind: Type.Union([
-      Type.Literal("existing-model"),
-      Type.Literal("openai-api-key"),
-      Type.Literal("anthropic-api-key"),
-      Type.Literal("claude-cli"),
-      Type.Literal("codex-cli"),
-      Type.Literal("gemini-cli"),
-      Type.Literal("api-key"),
-    ]),
-    /** Exact detected model for this route; prevents detect/activate drift. */
-    modelRef: Type.Optional(NonEmptyString),
-    /** Manual step only: opaque provider-auth choice returned by detection. */
-    authChoice: Type.Optional(Type.String()),
-    /** Manual step only: the pasted API key or token; masked by clients, never echoed. */
-    apiKey: Type.Optional(Type.String()),
-    workspace: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const CrestodianSetupActivateParamsSchema = closedObject({
+  kind: Type.Union([
+    Type.Literal("existing-model"),
+    Type.Literal("openai-api-key"),
+    Type.Literal("anthropic-api-key"),
+    Type.Literal("claude-cli"),
+    Type.Literal("codex-cli"),
+    Type.Literal("gemini-cli"),
+    Type.Literal("api-key"),
+  ]),
+  /** Exact detected model for this route; prevents detect/activate drift. */
+  modelRef: Type.Optional(NonEmptyString),
+  /** Manual step only: opaque provider-auth choice returned by detection. */
+  authChoice: Type.Optional(Type.String()),
+  /** Manual step only: the pasted API key or token; masked by clients, never echoed. */
+  apiKey: Type.Optional(Type.String()),
+  workspace: Type.Optional(Type.String()),
+});
 
-export const CrestodianSetupActivateResultSchema = Type.Object(
-  {
-    ok: Type.Boolean(),
-    /** Present on success: the model ref that answered the live test. */
-    modelRef: Type.Optional(Type.String()),
-    latencyMs: Type.Optional(Type.Number()),
-    /** Human-readable setup summary lines (workspace, model, gateway). */
-    lines: Type.Optional(Type.Array(Type.String())),
-    /** Present on failure: coarse bucket for client copy + docs links. */
-    status: Type.Optional(SetupInferenceStatus),
-    error: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const CrestodianSetupActivateResultSchema = closedObject({
+  ok: Type.Boolean(),
+  /** Present on success: the model ref that answered the live test. */
+  modelRef: Type.Optional(Type.String()),
+  latencyMs: Type.Optional(Type.Number()),
+  /** Human-readable setup summary lines (workspace, model, gateway). */
+  lines: Type.Optional(Type.Array(Type.String())),
+  /** Present on failure: coarse bucket for client copy + docs links. */
+  status: Type.Optional(SetupInferenceStatus),
+  error: Type.Optional(Type.String()),
+});
 
 /** Starts one provider-owned interactive login as a gateway wizard session. */
-export const CrestodianSetupAuthStartParamsSchema = Type.Object(
-  {
-    /** Client-generated so cancellation remains possible if the start reply is lost. */
-    sessionId: NonEmptyString,
-    authChoice: NonEmptyString,
-    workspace: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const CrestodianSetupAuthStartParamsSchema = closedObject({
+  /** Client-generated so cancellation remains possible if the start reply is lost. */
+  sessionId: NonEmptyString,
+  authChoice: NonEmptyString,
+  workspace: Type.Optional(Type.String()),
+});
 
 export const CrestodianSetupAuthStartResultSchema = WizardStartResultSchema;
 

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import type { Static } from "typebox";
 import { Type, type TSchema } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 /**
@@ -18,40 +19,34 @@ function cronAgentTurnPayloadSchema(params: {
   toolsAllow: TSchema;
   thinking: TSchema;
 }) {
-  return Type.Object(
-    {
-      kind: Type.Literal("agentTurn"),
-      message: params.message,
-      model: Type.Optional(params.model),
-      fallbacks: Type.Optional(params.fallbacks),
-      thinking: Type.Optional(params.thinking),
-      timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
-      allowUnsafeExternalContent: Type.Optional(Type.Boolean()),
-      lightContext: Type.Optional(Type.Boolean()),
-      toolsAllow: Type.Optional(params.toolsAllow),
-      // Server-managed marker for auto-stamped defaults; persisted so CLI cron
-      // runs can drop only the cap that was never user-explicit.
-      toolsAllowIsDefault: Type.Optional(Type.Boolean()),
-    },
-    { additionalProperties: false },
-  );
+  return closedObject({
+    kind: Type.Literal("agentTurn"),
+    message: params.message,
+    model: Type.Optional(params.model),
+    fallbacks: Type.Optional(params.fallbacks),
+    thinking: Type.Optional(params.thinking),
+    timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
+    allowUnsafeExternalContent: Type.Optional(Type.Boolean()),
+    lightContext: Type.Optional(Type.Boolean()),
+    toolsAllow: Type.Optional(params.toolsAllow),
+    // Server-managed marker for auto-stamped defaults; persisted so CLI cron
+    // runs can drop only the cap that was never user-explicit.
+    toolsAllowIsDefault: Type.Optional(Type.Boolean()),
+  });
 }
 
 /** Builds command payload variants while preserving create/patch argv optionality. */
 function cronCommandPayloadSchema(params: { argv: TSchema }) {
-  return Type.Object(
-    {
-      kind: Type.Literal("command"),
-      argv: params.argv,
-      cwd: Type.Optional(Type.String({ minLength: 1 })),
-      env: Type.Optional(Type.Record(Type.String({ minLength: 1 }), Type.String())),
-      input: Type.Optional(Type.String()),
-      timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
-      noOutputTimeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
-      outputMaxBytes: Type.Optional(Type.Integer({ minimum: 1 })),
-    },
-    { additionalProperties: false },
-  );
+  return closedObject({
+    kind: Type.Literal("command"),
+    argv: params.argv,
+    cwd: Type.Optional(Type.String({ minLength: 1 })),
+    env: Type.Optional(Type.Record(Type.String({ minLength: 1 }), Type.String())),
+    input: Type.Optional(Type.String()),
+    timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
+    noOutputTimeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
+    outputMaxBytes: Type.Optional(Type.Integer({ minimum: 1 })),
+  });
 }
 
 /** Session target accepted by cron jobs. */
@@ -119,13 +114,10 @@ const CronDeliveryStatusSchema = Type.Union([
 const NonBlankString = Type.String({ minLength: 1, pattern: "\\S" });
 const CronDeclarationKeySchema = Type.String({ minLength: 1, maxLength: 200, pattern: "\\S" });
 const CronDisplayNameSchema = Type.String({ minLength: 1, maxLength: 200, pattern: "\\S" });
-const CronOwnerSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-    sessionKey: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+const CronOwnerSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+  sessionKey: Type.Optional(NonEmptyString),
+});
 const CronAnnounceChannelSchema = Type.Union([Type.Literal("last"), NonBlankString]);
 const CronFailoverReasonSchema = Type.Union([
   Type.Literal("auth"),
@@ -158,25 +150,19 @@ const CronRunDiagnosticSourceSchema = Type.Union([
   Type.Literal("exec"),
   Type.Literal("delivery"),
 ]);
-const CronRunDiagnosticSchema = Type.Object(
-  {
-    ts: Type.Integer({ minimum: 0 }),
-    source: CronRunDiagnosticSourceSchema,
-    severity: CronRunDiagnosticSeveritySchema,
-    message: Type.String(),
-    toolName: Type.Optional(Type.String()),
-    exitCode: Type.Optional(Type.Union([Type.Number(), Type.Null()])),
-    truncated: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
-const CronRunDiagnosticsSchema = Type.Object(
-  {
-    summary: Type.Optional(Type.String()),
-    entries: Type.Array(CronRunDiagnosticSchema),
-  },
-  { additionalProperties: false },
-);
+const CronRunDiagnosticSchema = closedObject({
+  ts: Type.Integer({ minimum: 0 }),
+  source: CronRunDiagnosticSourceSchema,
+  severity: CronRunDiagnosticSeveritySchema,
+  message: Type.String(),
+  toolName: Type.Optional(Type.String()),
+  exitCode: Type.Optional(Type.Union([Type.Number(), Type.Null()])),
+  truncated: Type.Optional(Type.Boolean()),
+});
+const CronRunDiagnosticsSchema = closedObject({
+  summary: Type.Optional(Type.String()),
+  entries: Type.Array(CronRunDiagnosticSchema),
+});
 const CronCommonOptionalFields = {
   agentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
   sessionKey: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
@@ -187,20 +173,14 @@ const CronCommonOptionalFields = {
 
 function cronIdOrJobIdParams(extraFields: Record<string, TSchema>) {
   return Type.Union([
-    Type.Object(
-      {
-        id: NonEmptyString,
-        ...extraFields,
-      },
-      { additionalProperties: false },
-    ),
-    Type.Object(
-      {
-        jobId: NonEmptyString,
-        ...extraFields,
-      },
-      { additionalProperties: false },
-    ),
+    closedObject({
+      id: NonEmptyString,
+      ...extraFields,
+    }),
+    closedObject({
+      jobId: NonEmptyString,
+      ...extraFields,
+    }),
   ]);
 }
 
@@ -212,61 +192,43 @@ const CronRunLogJobIdSchema = Type.String({
 
 /** Schedule expression for one-time, interval, or cron-expression jobs. */
 export const CronScheduleSchema = Type.Union([
-  Type.Object(
-    {
-      kind: Type.Literal("at"),
-      at: NonEmptyString,
-    },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
-      kind: Type.Literal("every"),
-      everyMs: Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER }),
-      anchorMs: Type.Optional(Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER })),
-    },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
-      kind: Type.Literal("cron"),
-      expr: NonEmptyString,
-      tz: Type.Optional(Type.String()),
-      staggerMs: Type.Optional(Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER })),
-    },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
-      // Event-driven trigger: fires once when the gateway-owned watcher running
-      // `command` exits. Survives per-turn CLI teardown (runs under the gateway
-      // ProcessSupervisor, not the turn process tree).
-      kind: Type.Literal("on-exit"),
-      command: NonEmptyString,
-      cwd: Type.Optional(NonEmptyString),
-    },
-    { additionalProperties: false },
-  ),
+  closedObject({
+    kind: Type.Literal("at"),
+    at: NonEmptyString,
+  }),
+  closedObject({
+    kind: Type.Literal("every"),
+    everyMs: Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER }),
+    anchorMs: Type.Optional(Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER })),
+  }),
+  closedObject({
+    kind: Type.Literal("cron"),
+    expr: NonEmptyString,
+    tz: Type.Optional(Type.String()),
+    staggerMs: Type.Optional(Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER })),
+  }),
+  closedObject({
+    // Event-driven trigger: fires once when the gateway-owned watcher running
+    // `command` exits. Survives per-turn CLI teardown (runs under the gateway
+    // ProcessSupervisor, not the turn process tree).
+    kind: Type.Literal("on-exit"),
+    command: NonEmptyString,
+    cwd: Type.Optional(NonEmptyString),
+  }),
 ]);
 
 /** Headless condition script evaluated before a recurring cron payload runs. */
-export const CronTriggerSchema = Type.Object(
-  {
-    script: Type.String({ minLength: 1, maxLength: 65_536 }),
-    once: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const CronTriggerSchema = closedObject({
+  script: Type.String({ minLength: 1, maxLength: 65_536 }),
+  once: Type.Optional(Type.Boolean()),
+});
 
 /** Full cron payload for new jobs. */
 export const CronPayloadSchema = Type.Union([
-  Type.Object(
-    {
-      kind: Type.Literal("systemEvent"),
-      text: NonEmptyString,
-    },
-    { additionalProperties: false },
-  ),
+  closedObject({
+    kind: Type.Literal("systemEvent"),
+    text: NonEmptyString,
+  }),
   cronAgentTurnPayloadSchema({
     message: NonEmptyString,
     model: Type.String(),
@@ -281,13 +243,10 @@ export const CronPayloadSchema = Type.Union([
 
 /** Partial cron payload for job updates. */
 export const CronPayloadPatchSchema = Type.Union([
-  Type.Object(
-    {
-      kind: Type.Literal("systemEvent"),
-      text: Type.Optional(NonEmptyString),
-    },
-    { additionalProperties: false },
-  ),
+  closedObject({
+    kind: Type.Literal("systemEvent"),
+    text: Type.Optional(NonEmptyString),
+  }),
   cronAgentTurnPayloadSchema({
     message: Type.Optional(NonEmptyString),
     model: Type.Union([Type.String(), Type.Null()]),
@@ -301,49 +260,35 @@ export const CronPayloadPatchSchema = Type.Union([
 ]);
 
 /** Failure alert policy for repeated cron run failures. */
-export const CronFailureAlertSchema = Type.Object(
-  {
-    after: Type.Optional(Type.Integer({ minimum: 1 })),
-    channel: Type.Optional(CronAnnounceChannelSchema),
-    to: Type.Optional(NonBlankString),
-    cooldownMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    includeSkipped: Type.Optional(Type.Boolean()),
-    mode: Type.Optional(Type.Union([Type.Literal("announce"), Type.Literal("webhook")])),
-    accountId: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const CronFailureAlertSchema = closedObject({
+  after: Type.Optional(Type.Integer({ minimum: 1 })),
+  channel: Type.Optional(CronAnnounceChannelSchema),
+  to: Type.Optional(NonBlankString),
+  cooldownMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  includeSkipped: Type.Optional(Type.Boolean()),
+  mode: Type.Optional(Type.Union([Type.Literal("announce"), Type.Literal("webhook")])),
+  accountId: Type.Optional(NonEmptyString),
+});
 
 /** Delivery destination used when failure alerts need a separate target. */
-export const CronFailureDestinationSchema = Type.Object(
-  {
-    channel: Type.Optional(CronAnnounceChannelSchema),
-    to: Type.Optional(NonBlankString),
-    accountId: Type.Optional(NonEmptyString),
-    mode: Type.Optional(Type.Union([Type.Literal("announce"), Type.Literal("webhook")])),
-  },
-  { additionalProperties: false },
-);
+export const CronFailureDestinationSchema = closedObject({
+  channel: Type.Optional(CronAnnounceChannelSchema),
+  to: Type.Optional(NonBlankString),
+  accountId: Type.Optional(NonEmptyString),
+  mode: Type.Optional(Type.Union([Type.Literal("announce"), Type.Literal("webhook")])),
+});
 
-const CronFailureDestinationPatchSchema = Type.Object(
-  {
-    channel: Type.Optional(Type.Union([CronAnnounceChannelSchema, Type.Null()])),
-    to: Type.Optional(Type.Union([NonBlankString, Type.Null()])),
-    accountId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    mode: Type.Optional(
-      Type.Union([Type.Literal("announce"), Type.Literal("webhook"), Type.Null()]),
-    ),
-  },
-  { additionalProperties: false },
-);
+const CronFailureDestinationPatchSchema = closedObject({
+  channel: Type.Optional(Type.Union([CronAnnounceChannelSchema, Type.Null()])),
+  to: Type.Optional(Type.Union([NonBlankString, Type.Null()])),
+  accountId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  mode: Type.Optional(Type.Union([Type.Literal("announce"), Type.Literal("webhook"), Type.Null()])),
+});
 
-export const CronCompletionDestinationSchema = Type.Object(
-  {
-    mode: Type.Literal("webhook"),
-    to: NonBlankString,
-  },
-  { additionalProperties: false },
-);
+export const CronCompletionDestinationSchema = closedObject({
+  mode: Type.Literal("webhook"),
+  to: NonBlankString,
+});
 
 const CronDeliverySharedProperties = {
   channel: Type.Optional(CronAnnounceChannelSchema),
@@ -361,33 +306,24 @@ const CronDeliveryPatchSharedProperties = {
   failureDestination: Type.Optional(Type.Union([CronFailureDestinationPatchSchema, Type.Null()])),
 };
 
-const CronDeliveryNoopSchema = Type.Object(
-  {
-    mode: Type.Literal("none"),
-    ...CronDeliverySharedProperties,
-    to: Type.Optional(NonBlankString),
-  },
-  { additionalProperties: false },
-);
+const CronDeliveryNoopSchema = closedObject({
+  mode: Type.Literal("none"),
+  ...CronDeliverySharedProperties,
+  to: Type.Optional(NonBlankString),
+});
 
-const CronDeliveryAnnounceSchema = Type.Object(
-  {
-    mode: Type.Literal("announce"),
-    ...CronDeliverySharedProperties,
-    completionDestination: Type.Optional(CronCompletionDestinationSchema),
-    to: Type.Optional(NonBlankString),
-  },
-  { additionalProperties: false },
-);
+const CronDeliveryAnnounceSchema = closedObject({
+  mode: Type.Literal("announce"),
+  ...CronDeliverySharedProperties,
+  completionDestination: Type.Optional(CronCompletionDestinationSchema),
+  to: Type.Optional(NonBlankString),
+});
 
-const CronDeliveryWebhookSchema = Type.Object(
-  {
-    mode: Type.Literal("webhook"),
-    ...CronDeliverySharedProperties,
-    to: NonBlankString,
-  },
-  { additionalProperties: false },
-);
+const CronDeliveryWebhookSchema = closedObject({
+  mode: Type.Literal("webhook"),
+  ...CronDeliverySharedProperties,
+  to: NonBlankString,
+});
 
 /** Delivery policy for cron run output. */
 export const CronDeliverySchema = Type.Union([
@@ -397,198 +333,169 @@ export const CronDeliverySchema = Type.Union([
 ]);
 
 /** Patch shape for cron delivery policy updates. */
-export const CronDeliveryPatchSchema = Type.Object(
-  {
-    mode: Type.Optional(
-      Type.Union([Type.Literal("none"), Type.Literal("announce"), Type.Literal("webhook")]),
-    ),
-    ...CronDeliveryPatchSharedProperties,
-    completionDestination: Type.Optional(
-      Type.Union([CronCompletionDestinationSchema, Type.Null()]),
-    ),
-    to: Type.Optional(Type.Union([NonBlankString, Type.Null()])),
-  },
-  { additionalProperties: false },
-);
+export const CronDeliveryPatchSchema = closedObject({
+  mode: Type.Optional(
+    Type.Union([Type.Literal("none"), Type.Literal("announce"), Type.Literal("webhook")]),
+  ),
+  ...CronDeliveryPatchSharedProperties,
+  completionDestination: Type.Optional(Type.Union([CronCompletionDestinationSchema, Type.Null()])),
+  to: Type.Optional(Type.Union([NonBlankString, Type.Null()])),
+});
 
-const CronFailureNotificationDeliverySchema = Type.Object(
-  {
-    delivered: Type.Optional(Type.Boolean()),
-    status: CronDeliveryStatusSchema,
-    error: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+const CronFailureNotificationDeliverySchema = closedObject({
+  delivered: Type.Optional(Type.Boolean()),
+  status: CronDeliveryStatusSchema,
+  error: Type.Optional(Type.String()),
+});
 
 /** Scheduler-maintained state for the latest run/delivery outcome. */
-export const CronJobStateSchema = Type.Object(
-  {
-    nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    runningAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    lastRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    lastRunStatus: Type.Optional(CronRunStatusSchema),
-    lastStatus: Type.Optional(DeprecatedCronRunStatusSchema),
-    lastError: Type.Optional(Type.String()),
-    lastDiagnostics: Type.Optional(CronRunDiagnosticsSchema),
-    lastDiagnosticSummary: Type.Optional(Type.String()),
-    lastErrorReason: Type.Optional(CronFailoverReasonSchema),
-    lastDurationMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    consecutiveErrors: Type.Optional(Type.Integer({ minimum: 0 })),
-    consecutiveSkipped: Type.Optional(Type.Integer({ minimum: 0 })),
-    lastDelivered: Type.Optional(Type.Boolean()),
-    lastDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
-    lastDeliveryError: Type.Optional(Type.String()),
-    lastFailureNotificationDelivered: Type.Optional(Type.Boolean()),
-    lastFailureNotificationDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
-    lastFailureNotificationDeliveryError: Type.Optional(Type.String()),
-    lastFailureAlertAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    lastTriggerEvalAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    triggerEvalCount: Type.Optional(Type.Integer({ minimum: 0 })),
-    lastTriggerFireAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    triggerState: Type.Optional(Type.Unknown()),
-  },
-  { additionalProperties: false },
-);
+export const CronJobStateSchema = closedObject({
+  nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  runningAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  lastRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  lastRunStatus: Type.Optional(CronRunStatusSchema),
+  lastStatus: Type.Optional(DeprecatedCronRunStatusSchema),
+  lastError: Type.Optional(Type.String()),
+  lastDiagnostics: Type.Optional(CronRunDiagnosticsSchema),
+  lastDiagnosticSummary: Type.Optional(Type.String()),
+  lastErrorReason: Type.Optional(CronFailoverReasonSchema),
+  lastDurationMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  consecutiveErrors: Type.Optional(Type.Integer({ minimum: 0 })),
+  consecutiveSkipped: Type.Optional(Type.Integer({ minimum: 0 })),
+  lastDelivered: Type.Optional(Type.Boolean()),
+  lastDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
+  lastDeliveryError: Type.Optional(Type.String()),
+  lastFailureNotificationDelivered: Type.Optional(Type.Boolean()),
+  lastFailureNotificationDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
+  lastFailureNotificationDeliveryError: Type.Optional(Type.String()),
+  lastFailureAlertAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  lastTriggerEvalAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  triggerEvalCount: Type.Optional(Type.Integer({ minimum: 0 })),
+  lastTriggerFireAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  triggerState: Type.Optional(Type.Unknown()),
+});
 
-const CronJobStatePatchSchema = Type.Object(
-  {
-    nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    runningAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    lastRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    lastRunStatus: Type.Optional(CronRunStatusSchema),
-    lastStatus: Type.Optional(DeprecatedCronRunStatusSchema),
-    lastError: Type.Optional(Type.String()),
-    lastErrorReason: Type.Optional(CronFailoverReasonSchema),
-    lastDurationMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    consecutiveErrors: Type.Optional(Type.Integer({ minimum: 0 })),
-    consecutiveSkipped: Type.Optional(Type.Integer({ minimum: 0 })),
-    lastDelivered: Type.Optional(Type.Boolean()),
-    lastDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
-    lastDeliveryError: Type.Optional(Type.String()),
-    lastFailureNotificationDelivered: Type.Optional(Type.Boolean()),
-    lastFailureNotificationDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
-    lastFailureNotificationDeliveryError: Type.Optional(Type.String()),
-    lastFailureAlertAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    lastTriggerEvalAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    triggerEvalCount: Type.Optional(Type.Integer({ minimum: 0 })),
-    lastTriggerFireAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    triggerState: Type.Optional(Type.Unknown()),
-  },
-  { additionalProperties: false },
-);
+const CronJobStatePatchSchema = closedObject({
+  nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  runningAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  lastRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  lastRunStatus: Type.Optional(CronRunStatusSchema),
+  lastStatus: Type.Optional(DeprecatedCronRunStatusSchema),
+  lastError: Type.Optional(Type.String()),
+  lastErrorReason: Type.Optional(CronFailoverReasonSchema),
+  lastDurationMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  consecutiveErrors: Type.Optional(Type.Integer({ minimum: 0 })),
+  consecutiveSkipped: Type.Optional(Type.Integer({ minimum: 0 })),
+  lastDelivered: Type.Optional(Type.Boolean()),
+  lastDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
+  lastDeliveryError: Type.Optional(Type.String()),
+  lastFailureNotificationDelivered: Type.Optional(Type.Boolean()),
+  lastFailureNotificationDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
+  lastFailureNotificationDeliveryError: Type.Optional(Type.String()),
+  lastFailureAlertAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  lastTriggerEvalAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  triggerEvalCount: Type.Optional(Type.Integer({ minimum: 0 })),
+  lastTriggerFireAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  triggerState: Type.Optional(Type.Unknown()),
+});
 
 /** Persisted cron job definition returned by scheduler list/get APIs. */
-export const CronJobSchema = Type.Object(
-  {
-    id: NonEmptyString,
-    declarationKey: Type.Optional(CronDeclarationKeySchema),
-    displayName: Type.Optional(CronDisplayNameSchema),
-    owner: Type.Optional(CronOwnerSchema),
-    agentId: Type.Optional(NonEmptyString),
-    sessionKey: Type.Optional(NonEmptyString),
-    name: NonEmptyString,
-    description: Type.Optional(Type.String()),
-    enabled: Type.Boolean(),
-    deleteAfterRun: Type.Optional(Type.Boolean()),
-    createdAtMs: Type.Integer({ minimum: 0 }),
-    updatedAtMs: Type.Integer({ minimum: 0 }),
-    /** Opaque Gateway-computed token for the job definition, excluding scheduler state. */
-    configRevision: Type.Optional(CronConfigRevisionSchema),
-    schedule: CronScheduleSchema,
-    trigger: Type.Optional(CronTriggerSchema),
-    sessionTarget: CronSessionTargetSchema,
-    wakeMode: CronWakeModeSchema,
-    payload: CronPayloadSchema,
-    delivery: Type.Optional(CronDeliverySchema),
-    failureAlert: Type.Optional(Type.Union([Type.Literal(false), CronFailureAlertSchema])),
-    state: CronJobStateSchema,
-    nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    lastRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    lastRunStatus: Type.Optional(CronRunStatusSchema),
-    lastRunError: Type.Optional(Type.String()),
-    lastDelivered: Type.Optional(Type.Boolean()),
-    lastDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
-    lastDeliveryError: Type.Optional(Type.String()),
-    lastFailureNotificationDelivered: Type.Optional(Type.Boolean()),
-    lastFailureNotificationDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
-    lastFailureNotificationDeliveryError: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const CronJobSchema = closedObject({
+  id: NonEmptyString,
+  declarationKey: Type.Optional(CronDeclarationKeySchema),
+  displayName: Type.Optional(CronDisplayNameSchema),
+  owner: Type.Optional(CronOwnerSchema),
+  agentId: Type.Optional(NonEmptyString),
+  sessionKey: Type.Optional(NonEmptyString),
+  name: NonEmptyString,
+  description: Type.Optional(Type.String()),
+  enabled: Type.Boolean(),
+  deleteAfterRun: Type.Optional(Type.Boolean()),
+  createdAtMs: Type.Integer({ minimum: 0 }),
+  updatedAtMs: Type.Integer({ minimum: 0 }),
+  /** Opaque Gateway-computed token for the job definition, excluding scheduler state. */
+  configRevision: Type.Optional(CronConfigRevisionSchema),
+  schedule: CronScheduleSchema,
+  trigger: Type.Optional(CronTriggerSchema),
+  sessionTarget: CronSessionTargetSchema,
+  wakeMode: CronWakeModeSchema,
+  payload: CronPayloadSchema,
+  delivery: Type.Optional(CronDeliverySchema),
+  failureAlert: Type.Optional(Type.Union([Type.Literal(false), CronFailureAlertSchema])),
+  state: CronJobStateSchema,
+  nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  lastRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  lastRunStatus: Type.Optional(CronRunStatusSchema),
+  lastRunError: Type.Optional(Type.String()),
+  lastDelivered: Type.Optional(Type.Boolean()),
+  lastDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
+  lastDeliveryError: Type.Optional(Type.String()),
+  lastFailureNotificationDelivered: Type.Optional(Type.Boolean()),
+  lastFailureNotificationDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
+  lastFailureNotificationDeliveryError: Type.Optional(Type.String()),
+});
 
 /** Query params for listing cron jobs with filters and pagination. */
-export const CronListParamsSchema = Type.Object(
-  {
-    includeDisabled: Type.Optional(Type.Boolean()),
-    limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200 })),
-    offset: Type.Optional(Type.Integer({ minimum: 0 })),
-    query: Type.Optional(Type.String()),
-    enabled: Type.Optional(CronJobsEnabledFilterSchema),
-    scheduleKind: Type.Optional(CronJobsScheduleKindFilterSchema),
-    lastRunStatus: Type.Optional(CronJobsLastRunStatusFilterSchema),
-    sortBy: Type.Optional(CronJobsSortBySchema),
-    sortDir: Type.Optional(CronSortDirSchema),
-    agentId: Type.Optional(NonEmptyString),
-    compact: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const CronListParamsSchema = closedObject({
+  includeDisabled: Type.Optional(Type.Boolean()),
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200 })),
+  offset: Type.Optional(Type.Integer({ minimum: 0 })),
+  query: Type.Optional(Type.String()),
+  enabled: Type.Optional(CronJobsEnabledFilterSchema),
+  scheduleKind: Type.Optional(CronJobsScheduleKindFilterSchema),
+  lastRunStatus: Type.Optional(CronJobsLastRunStatusFilterSchema),
+  sortBy: Type.Optional(CronJobsSortBySchema),
+  sortDir: Type.Optional(CronSortDirSchema),
+  agentId: Type.Optional(NonEmptyString),
+  compact: Type.Optional(Type.Boolean()),
+});
 
 /** Empty request payload for scheduler status. */
-export const CronStatusParamsSchema = Type.Object({}, { additionalProperties: false });
+export const CronStatusParamsSchema = closedObject({});
 
 /** Looks up a job by stable id or legacy jobId alias. */
 export const CronGetParamsSchema = cronIdOrJobIdParams({});
 
 /** Creates a scheduled job with schedule, target, payload, and delivery policy. */
-export const CronAddParamsSchema = Type.Object(
-  {
-    name: NonEmptyString,
-    declarationKey: Type.Optional(CronDeclarationKeySchema),
-    displayName: Type.Optional(CronDisplayNameSchema),
-    owner: Type.Optional(CronOwnerSchema),
-    ...CronCommonOptionalFields,
-    schedule: CronScheduleSchema,
-    trigger: Type.Optional(CronTriggerSchema),
-    sessionTarget: CronSessionTargetSchema,
-    wakeMode: CronWakeModeSchema,
-    payload: CronPayloadSchema,
-    delivery: Type.Optional(CronDeliverySchema),
-    failureAlert: Type.Optional(Type.Union([Type.Literal(false), CronFailureAlertSchema])),
-  },
-  { additionalProperties: false },
-);
+export const CronAddParamsSchema = closedObject({
+  name: NonEmptyString,
+  declarationKey: Type.Optional(CronDeclarationKeySchema),
+  displayName: Type.Optional(CronDisplayNameSchema),
+  owner: Type.Optional(CronOwnerSchema),
+  ...CronCommonOptionalFields,
+  schedule: CronScheduleSchema,
+  trigger: Type.Optional(CronTriggerSchema),
+  sessionTarget: CronSessionTargetSchema,
+  wakeMode: CronWakeModeSchema,
+  payload: CronPayloadSchema,
+  delivery: Type.Optional(CronDeliverySchema),
+  failureAlert: Type.Optional(Type.Union([Type.Literal(false), CronFailureAlertSchema])),
+});
 
 /** Successful declaration-key convergence result. */
-export const CronDeclarativeAddResultSchema = Type.Object(
-  {
-    created: Type.Boolean(),
-    updated: Type.Optional(Type.Boolean()),
-    job: CronJobSchema,
-  },
-  { additionalProperties: false },
-);
+export const CronDeclarativeAddResultSchema = closedObject({
+  created: Type.Boolean(),
+  updated: Type.Optional(Type.Boolean()),
+  job: CronJobSchema,
+});
 
 /** Successful result from imperative create or declaration-key convergence. */
 export const CronAddResultSchema = Type.Union([CronJobSchema, CronDeclarativeAddResultSchema]);
 
 /** Mutable cron job fields accepted by update APIs. */
-export const CronJobPatchSchema = Type.Object(
-  {
-    name: Type.Optional(NonEmptyString),
-    displayName: Type.Optional(Type.Union([CronDisplayNameSchema, Type.Null()])),
-    ...CronCommonOptionalFields,
-    schedule: Type.Optional(CronScheduleSchema),
-    trigger: Type.Optional(Type.Union([CronTriggerSchema, Type.Null()])),
-    sessionTarget: Type.Optional(CronSessionTargetSchema),
-    wakeMode: Type.Optional(CronWakeModeSchema),
-    payload: Type.Optional(CronPayloadPatchSchema),
-    delivery: Type.Optional(CronDeliveryPatchSchema),
-    failureAlert: Type.Optional(Type.Union([Type.Literal(false), CronFailureAlertSchema])),
-    state: Type.Optional(CronJobStatePatchSchema),
-  },
-  { additionalProperties: false },
-);
+export const CronJobPatchSchema = closedObject({
+  name: Type.Optional(NonEmptyString),
+  displayName: Type.Optional(Type.Union([CronDisplayNameSchema, Type.Null()])),
+  ...CronCommonOptionalFields,
+  schedule: Type.Optional(CronScheduleSchema),
+  trigger: Type.Optional(Type.Union([CronTriggerSchema, Type.Null()])),
+  sessionTarget: Type.Optional(CronSessionTargetSchema),
+  wakeMode: Type.Optional(CronWakeModeSchema),
+  payload: Type.Optional(CronPayloadPatchSchema),
+  delivery: Type.Optional(CronDeliveryPatchSchema),
+  failureAlert: Type.Optional(Type.Union([Type.Literal(false), CronFailureAlertSchema])),
+  state: Type.Optional(CronJobStatePatchSchema),
+});
 
 /** Updates a cron job by id or legacy jobId alias. */
 export const CronUpdateParamsSchema = cronIdOrJobIdParams({
@@ -606,67 +513,58 @@ export const CronRunParamsSchema = cronIdOrJobIdParams({
 });
 
 /** Query params for cron run history. */
-export const CronRunsParamsSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-    scope: Type.Optional(Type.Union([Type.Literal("job"), Type.Literal("all")])),
-    id: Type.Optional(CronRunLogJobIdSchema),
-    jobId: Type.Optional(CronRunLogJobIdSchema),
-    runId: Type.Optional(NonEmptyString),
-    limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200 })),
-    offset: Type.Optional(Type.Integer({ minimum: 0 })),
-    statuses: Type.Optional(Type.Array(CronRunsStatusValueSchema, { minItems: 1, maxItems: 3 })),
-    status: Type.Optional(CronRunsStatusFilterSchema),
-    deliveryStatuses: Type.Optional(
-      Type.Array(CronDeliveryStatusSchema, { minItems: 1, maxItems: 4 }),
-    ),
-    deliveryStatus: Type.Optional(CronDeliveryStatusSchema),
-    query: Type.Optional(Type.String()),
-    sortDir: Type.Optional(CronSortDirSchema),
-  },
-  { additionalProperties: false },
-);
+export const CronRunsParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+  scope: Type.Optional(Type.Union([Type.Literal("job"), Type.Literal("all")])),
+  id: Type.Optional(CronRunLogJobIdSchema),
+  jobId: Type.Optional(CronRunLogJobIdSchema),
+  runId: Type.Optional(NonEmptyString),
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200 })),
+  offset: Type.Optional(Type.Integer({ minimum: 0 })),
+  statuses: Type.Optional(Type.Array(CronRunsStatusValueSchema, { minItems: 1, maxItems: 3 })),
+  status: Type.Optional(CronRunsStatusFilterSchema),
+  deliveryStatuses: Type.Optional(
+    Type.Array(CronDeliveryStatusSchema, { minItems: 1, maxItems: 4 }),
+  ),
+  deliveryStatus: Type.Optional(CronDeliveryStatusSchema),
+  query: Type.Optional(Type.String()),
+  sortDir: Type.Optional(CronSortDirSchema),
+});
 
 /** One persisted cron run history entry. */
-export const CronRunLogEntrySchema = Type.Object(
-  {
-    ts: Type.Integer({ minimum: 0 }),
-    jobId: NonEmptyString,
-    action: Type.Literal("finished"),
-    status: Type.Optional(CronRunStatusSchema),
-    error: Type.Optional(Type.String()),
-    errorReason: Type.Optional(CronFailoverReasonSchema),
-    summary: Type.Optional(Type.String()),
-    diagnostics: Type.Optional(CronRunDiagnosticsSchema),
-    delivered: Type.Optional(Type.Boolean()),
-    deliveryStatus: Type.Optional(CronDeliveryStatusSchema),
-    deliveryError: Type.Optional(Type.String()),
-    failureNotificationDelivery: Type.Optional(CronFailureNotificationDeliverySchema),
-    sessionId: Type.Optional(NonEmptyString),
-    sessionKey: Type.Optional(NonEmptyString),
-    runId: Type.Optional(NonEmptyString),
-    runAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    durationMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    triggerFired: Type.Optional(Type.Boolean()),
-    model: Type.Optional(Type.String()),
-    provider: Type.Optional(Type.String()),
-    usage: Type.Optional(
-      Type.Object(
-        {
-          input_tokens: Type.Optional(Type.Number()),
-          output_tokens: Type.Optional(Type.Number()),
-          total_tokens: Type.Optional(Type.Number()),
-          cache_read_tokens: Type.Optional(Type.Number()),
-          cache_write_tokens: Type.Optional(Type.Number()),
-        },
-        { additionalProperties: false },
-      ),
-    ),
-    jobName: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const CronRunLogEntrySchema = closedObject({
+  ts: Type.Integer({ minimum: 0 }),
+  jobId: NonEmptyString,
+  action: Type.Literal("finished"),
+  status: Type.Optional(CronRunStatusSchema),
+  error: Type.Optional(Type.String()),
+  errorReason: Type.Optional(CronFailoverReasonSchema),
+  summary: Type.Optional(Type.String()),
+  diagnostics: Type.Optional(CronRunDiagnosticsSchema),
+  delivered: Type.Optional(Type.Boolean()),
+  deliveryStatus: Type.Optional(CronDeliveryStatusSchema),
+  deliveryError: Type.Optional(Type.String()),
+  failureNotificationDelivery: Type.Optional(CronFailureNotificationDeliverySchema),
+  sessionId: Type.Optional(NonEmptyString),
+  sessionKey: Type.Optional(NonEmptyString),
+  runId: Type.Optional(NonEmptyString),
+  runAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  durationMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  triggerFired: Type.Optional(Type.Boolean()),
+  model: Type.Optional(Type.String()),
+  provider: Type.Optional(Type.String()),
+  usage: Type.Optional(
+    closedObject({
+      input_tokens: Type.Optional(Type.Number()),
+      output_tokens: Type.Optional(Type.Number()),
+      total_tokens: Type.Optional(Type.Number()),
+      cache_read_tokens: Type.Optional(Type.Number()),
+      cache_write_tokens: Type.Optional(Type.Number()),
+    }),
+  ),
+  jobName: Type.Optional(Type.String()),
+});
 
 // Wire types derive from local schemas without importing the ProtocolSchemas registry.
 export type CronJob = Static<typeof CronJobSchema>;

--- a/packages/gateway-protocol/src/schema/devices.ts
+++ b/packages/gateway-protocol/src/schema/devices.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 /**
@@ -10,86 +11,65 @@ import { NonEmptyString } from "./primitives.js";
  * ids stay explicit and feature handlers own the authorization checks.
  */
 /** Lists pending and approved device pairing records. */
-export const DevicePairListParamsSchema = Type.Object({}, { additionalProperties: false });
+export const DevicePairListParamsSchema = closedObject({});
 
 /** Approves a pending pairing request by request id. */
-export const DevicePairApproveParamsSchema = Type.Object(
-  { requestId: NonEmptyString },
-  { additionalProperties: false },
-);
+export const DevicePairApproveParamsSchema = closedObject({ requestId: NonEmptyString });
 
 /** Rejects a pending pairing request by request id. */
-export const DevicePairRejectParamsSchema = Type.Object(
-  { requestId: NonEmptyString },
-  { additionalProperties: false },
-);
+export const DevicePairRejectParamsSchema = closedObject({ requestId: NonEmptyString });
 
 /** Removes an approved or remembered device by device id. */
-export const DevicePairRemoveParamsSchema = Type.Object(
-  { deviceId: NonEmptyString },
-  { additionalProperties: false },
-);
+export const DevicePairRemoveParamsSchema = closedObject({ deviceId: NonEmptyString });
 
 /** Operator-assigned label for a paired device (max 64 chars after protocol bound). */
 const DevicePairLabelString = Type.String({ minLength: 1, maxLength: 64 });
 
 /** Renames a paired device while preserving its stable device id. */
-export const DevicePairRenameParamsSchema = Type.Object(
-  { deviceId: NonEmptyString, label: DevicePairLabelString },
-  { additionalProperties: false },
-);
+export const DevicePairRenameParamsSchema = closedObject({
+  deviceId: NonEmptyString,
+  label: DevicePairLabelString,
+});
 
 /** Rotates or issues a device token for a specific role/scope grant. */
-export const DeviceTokenRotateParamsSchema = Type.Object(
-  {
-    deviceId: NonEmptyString,
-    role: NonEmptyString,
-    scopes: Type.Optional(Type.Array(NonEmptyString)),
-  },
-  { additionalProperties: false },
-);
+export const DeviceTokenRotateParamsSchema = closedObject({
+  deviceId: NonEmptyString,
+  role: NonEmptyString,
+  scopes: Type.Optional(Type.Array(NonEmptyString)),
+});
 
 /** Revokes one role-bound device token grant. */
-export const DeviceTokenRevokeParamsSchema = Type.Object(
-  {
-    deviceId: NonEmptyString,
-    role: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const DeviceTokenRevokeParamsSchema = closedObject({
+  deviceId: NonEmptyString,
+  role: NonEmptyString,
+});
 
 /** Event emitted when a client opens or refreshes a pairing request. */
-export const DevicePairRequestedEventSchema = Type.Object(
-  {
-    requestId: NonEmptyString,
-    deviceId: NonEmptyString,
-    publicKey: NonEmptyString,
-    displayName: Type.Optional(NonEmptyString),
-    platform: Type.Optional(NonEmptyString),
-    deviceFamily: Type.Optional(NonEmptyString),
-    clientId: Type.Optional(NonEmptyString),
-    clientMode: Type.Optional(NonEmptyString),
-    role: Type.Optional(NonEmptyString),
-    roles: Type.Optional(Type.Array(NonEmptyString)),
-    scopes: Type.Optional(Type.Array(NonEmptyString)),
-    remoteIp: Type.Optional(NonEmptyString),
-    silent: Type.Optional(Type.Boolean()),
-    isRepair: Type.Optional(Type.Boolean()),
-    ts: Type.Integer({ minimum: 0 }),
-  },
-  { additionalProperties: false },
-);
+export const DevicePairRequestedEventSchema = closedObject({
+  requestId: NonEmptyString,
+  deviceId: NonEmptyString,
+  publicKey: NonEmptyString,
+  displayName: Type.Optional(NonEmptyString),
+  platform: Type.Optional(NonEmptyString),
+  deviceFamily: Type.Optional(NonEmptyString),
+  clientId: Type.Optional(NonEmptyString),
+  clientMode: Type.Optional(NonEmptyString),
+  role: Type.Optional(NonEmptyString),
+  roles: Type.Optional(Type.Array(NonEmptyString)),
+  scopes: Type.Optional(Type.Array(NonEmptyString)),
+  remoteIp: Type.Optional(NonEmptyString),
+  silent: Type.Optional(Type.Boolean()),
+  isRepair: Type.Optional(Type.Boolean()),
+  ts: Type.Integer({ minimum: 0 }),
+});
 
 /** Event emitted after a pairing request is approved, rejected, or otherwise resolved. */
-export const DevicePairResolvedEventSchema = Type.Object(
-  {
-    requestId: NonEmptyString,
-    deviceId: NonEmptyString,
-    decision: NonEmptyString,
-    ts: Type.Integer({ minimum: 0 }),
-  },
-  { additionalProperties: false },
-);
+export const DevicePairResolvedEventSchema = closedObject({
+  requestId: NonEmptyString,
+  deviceId: NonEmptyString,
+  decision: NonEmptyString,
+  ts: Type.Integer({ minimum: 0 }),
+});
 
 const SetupCodeQrDataUrlSchema = Type.String({
   maxLength: 16_384,
@@ -106,15 +86,12 @@ const SetupCodeQrDataUrlSchema = Type.String({
  * `bootstrapProfile: "node"` narrows the handoff to a node role with no operator
  * scopes for companion devices such as watchOS.
  */
-export const DevicePairSetupCodeParamsSchema = Type.Object(
-  {
-    publicUrl: Type.Optional(NonEmptyString),
-    preferRemoteUrl: Type.Optional(Type.Boolean()),
-    includeQr: Type.Optional(Type.Boolean()),
-    bootstrapProfile: Type.Optional(Type.String({ enum: ["limited", "node"] })),
-  },
-  { additionalProperties: false },
-);
+export const DevicePairSetupCodeParamsSchema = closedObject({
+  publicUrl: Type.Optional(NonEmptyString),
+  preferRemoteUrl: Type.Optional(Type.Boolean()),
+  includeQr: Type.Optional(Type.Boolean()),
+  bootstrapProfile: Type.Optional(Type.String({ enum: ["limited", "node"] })),
+});
 
 /**
  * Setup code plus non-secret connection metadata. `auth` is a label only
@@ -122,23 +99,20 @@ export const DevicePairSetupCodeParamsSchema = Type.Object(
  * `accessDowngraded` reports the plaintext-LAN safety fallback from full to
  * limited access so the presenting client can explain how to upgrade.
  */
-export const DevicePairSetupCodeResultSchema = Type.Object(
-  {
-    setupCode: NonEmptyString,
-    qrDataUrl: Type.Optional(SetupCodeQrDataUrlSchema),
-    gatewayUrl: NonEmptyString,
-    gatewayUrls: Type.Optional(
-      Type.Array(NonEmptyString, { minItems: 2, maxItems: 8, uniqueItems: true }),
-    ),
-    auth: Type.Union([Type.Literal("token"), Type.Literal("password")]),
-    urlSource: NonEmptyString,
-    access: Type.Optional(
-      Type.Union([Type.Literal("full"), Type.Literal("limited"), Type.Literal("node")]),
-    ),
-    accessDowngraded: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const DevicePairSetupCodeResultSchema = closedObject({
+  setupCode: NonEmptyString,
+  qrDataUrl: Type.Optional(SetupCodeQrDataUrlSchema),
+  gatewayUrl: NonEmptyString,
+  gatewayUrls: Type.Optional(
+    Type.Array(NonEmptyString, { minItems: 2, maxItems: 8, uniqueItems: true }),
+  ),
+  auth: Type.Union([Type.Literal("token"), Type.Literal("password")]),
+  urlSource: NonEmptyString,
+  access: Type.Optional(
+    Type.Union([Type.Literal("full"), Type.Literal("limited"), Type.Literal("node")]),
+  ),
+  accessDowngraded: Type.Optional(Type.Boolean()),
+});
 
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/environments.ts
+++ b/packages/gateway-protocol/src/schema/environments.ts
@@ -1,5 +1,6 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import { Type, type Static } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 /**
@@ -37,70 +38,55 @@ export const WorkerTunnelStatusSchema = Type.Union([
 ]);
 
 /** Worker-only lifecycle metadata layered onto the existing environment projection. */
-export const WorkerEnvironmentMetadataSchema = Type.Object(
-  {
-    providerId: NonEmptyString,
-    leaseId: Type.Optional(NonEmptyString),
-    state: WorkerEnvironmentStateSchema,
-    ageMs: Type.Integer({ minimum: 0 }),
-    idleMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    attachedSessionIds: Type.Array(NonEmptyString),
-    tunnelStatus: WorkerTunnelStatusSchema,
-  },
-  { additionalProperties: false },
-);
+export const WorkerEnvironmentMetadataSchema = closedObject({
+  providerId: NonEmptyString,
+  leaseId: Type.Optional(NonEmptyString),
+  state: WorkerEnvironmentStateSchema,
+  ageMs: Type.Integer({ minimum: 0 }),
+  idleMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  attachedSessionIds: Type.Array(NonEmptyString),
+  tunnelStatus: WorkerTunnelStatusSchema,
+});
 
 function createEnvironmentSummarySchema() {
-  return Type.Object(
-    {
-      id: NonEmptyString,
-      type: NonEmptyString,
-      label: Type.Optional(NonEmptyString),
-      status: EnvironmentStatusSchema,
-      capabilities: Type.Optional(Type.Array(NonEmptyString)),
-      worker: Type.Optional(WorkerEnvironmentMetadataSchema),
-    },
-    { additionalProperties: false },
-  );
+  return closedObject({
+    id: NonEmptyString,
+    type: NonEmptyString,
+    label: Type.Optional(NonEmptyString),
+    status: EnvironmentStatusSchema,
+    capabilities: Type.Optional(Type.Array(NonEmptyString)),
+    worker: Type.Optional(WorkerEnvironmentMetadataSchema),
+  });
 }
 
 /** Public environment summary shown in listings and status responses. */
 export const EnvironmentSummarySchema = createEnvironmentSummarySchema();
 
 /** Empty request payload for listing known environments. */
-export const EnvironmentsListParamsSchema = Type.Object({}, { additionalProperties: false });
+export const EnvironmentsListParamsSchema = closedObject({});
 
 /** List response containing all gateway-visible environment summaries. */
-export const EnvironmentsListResultSchema = Type.Object(
-  {
-    environments: Type.Array(EnvironmentSummarySchema),
-  },
-  { additionalProperties: false },
-);
+export const EnvironmentsListResultSchema = closedObject({
+  environments: Type.Array(EnvironmentSummarySchema),
+});
 
 /** Status lookup request for one environment id. */
-export const EnvironmentsStatusParamsSchema = Type.Object(
-  { environmentId: NonEmptyString },
-  { additionalProperties: false },
-);
+export const EnvironmentsStatusParamsSchema = closedObject({ environmentId: NonEmptyString });
 
 /** Status lookup result for one environment id. */
 export const EnvironmentsStatusResultSchema = createEnvironmentSummarySchema();
 
 /** Creates a worker environment from one configured provider profile. */
-export const EnvironmentsCreateParamsSchema = Type.Object(
-  { profileId: NonEmptyString, idempotencyKey: NonEmptyString },
-  { additionalProperties: false },
-);
+export const EnvironmentsCreateParamsSchema = closedObject({
+  profileId: NonEmptyString,
+  idempotencyKey: NonEmptyString,
+});
 
 /** Create result uses the same public summary shape as list and status. */
 export const EnvironmentsCreateResultSchema = createEnvironmentSummarySchema();
 
 /** Destroys one durable worker environment by its gateway-owned id. */
-export const EnvironmentsDestroyParamsSchema = Type.Object(
-  { environmentId: NonEmptyString },
-  { additionalProperties: false },
-);
+export const EnvironmentsDestroyParamsSchema = closedObject({ environmentId: NonEmptyString });
 
 /** Destroy result exposes the terminal worker lifecycle state. */
 export const EnvironmentsDestroyResultSchema = createEnvironmentSummarySchema();

--- a/packages/gateway-protocol/src/schema/exec-approvals.ts
+++ b/packages/gateway-protocol/src/schema/exec-approvals.ts
@@ -1,6 +1,7 @@
 import type { Static } from "typebox";
 // Gateway Protocol schema module defines protocol validation shapes.
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 /**
@@ -10,19 +11,16 @@ import { NonEmptyString } from "./primitives.js";
  * persisted policy, request snapshots, and resolve decisions stay explicit.
  */
 /** One persisted allowlist entry for a command pattern or resolved executable. */
-export const ExecApprovalsAllowlistEntrySchema = Type.Object(
-  {
-    id: Type.Optional(NonEmptyString),
-    pattern: Type.String(),
-    source: Type.Optional(Type.Literal("allow-always")),
-    commandText: Type.Optional(Type.String()),
-    argPattern: Type.Optional(Type.String()),
-    lastUsedAt: Type.Optional(Type.Number({ minimum: 0 })),
-    lastUsedCommand: Type.Optional(Type.String()),
-    lastResolvedPath: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const ExecApprovalsAllowlistEntrySchema = closedObject({
+  id: Type.Optional(NonEmptyString),
+  pattern: Type.String(),
+  source: Type.Optional(Type.Literal("allow-always")),
+  commandText: Type.Optional(Type.String()),
+  argPattern: Type.Optional(Type.String()),
+  lastUsedAt: Type.Optional(Type.Number({ minimum: 0 })),
+  lastUsedCommand: Type.Optional(Type.String()),
+  lastResolvedPath: Type.Optional(Type.String()),
+});
 
 const ExecApprovalsPolicyFields = {
   security: Type.Optional(Type.String()),
@@ -43,59 +41,42 @@ const ExecAskSchema = Type.Union([
 ]);
 
 /** Host-resolved default policy after applying persisted defaults and runtime fallbacks. */
-const ExecApprovalsResolvedDefaultsSchema = Type.Object(
-  {
-    security: ExecSecuritySchema,
-    ask: ExecAskSchema,
-    askFallback: ExecSecuritySchema,
-    autoAllowSkills: Type.Boolean(),
-  },
-  { additionalProperties: false },
-);
-
-/** Default exec approval policy shared by all agents unless overridden. */
-export const ExecApprovalsDefaultsSchema = Type.Object(ExecApprovalsPolicyFields, {
-  additionalProperties: false,
+const ExecApprovalsResolvedDefaultsSchema = closedObject({
+  security: ExecSecuritySchema,
+  ask: ExecAskSchema,
+  askFallback: ExecSecuritySchema,
+  autoAllowSkills: Type.Boolean(),
 });
 
+/** Default exec approval policy shared by all agents unless overridden. */
+export const ExecApprovalsDefaultsSchema = closedObject(ExecApprovalsPolicyFields);
+
 /** Agent-specific exec approval policy and allowlist. */
-export const ExecApprovalsAgentSchema = Type.Object(
-  {
-    ...ExecApprovalsPolicyFields,
-    allowlist: Type.Optional(Type.Array(ExecApprovalsAllowlistEntrySchema)),
-  },
-  { additionalProperties: false },
-);
+export const ExecApprovalsAgentSchema = closedObject({
+  ...ExecApprovalsPolicyFields,
+  allowlist: Type.Optional(Type.Array(ExecApprovalsAllowlistEntrySchema)),
+});
 
 /** Versioned exec approvals config file edited through gateway APIs. */
-export const ExecApprovalsFileSchema = Type.Object(
-  {
-    version: Type.Literal(1),
-    socket: Type.Optional(
-      Type.Object(
-        {
-          path: Type.Optional(Type.String()),
-          token: Type.Optional(Type.String()),
-        },
-        { additionalProperties: false },
-      ),
-    ),
-    defaults: Type.Optional(ExecApprovalsDefaultsSchema),
-    agents: Type.Optional(Type.Record(Type.String(), ExecApprovalsAgentSchema)),
-  },
-  { additionalProperties: false },
-);
+export const ExecApprovalsFileSchema = closedObject({
+  version: Type.Literal(1),
+  socket: Type.Optional(
+    closedObject({
+      path: Type.Optional(Type.String()),
+      token: Type.Optional(Type.String()),
+    }),
+  ),
+  defaults: Type.Optional(ExecApprovalsDefaultsSchema),
+  agents: Type.Optional(Type.Record(Type.String(), ExecApprovalsAgentSchema)),
+});
 
 /** File-backed read snapshot with path/hash metadata for optimistic writes. */
-export const ExecApprovalsSnapshotSchema = Type.Object(
-  {
-    path: NonEmptyString,
-    exists: Type.Boolean(),
-    hash: NonEmptyString,
-    file: ExecApprovalsFileSchema,
-  },
-  { additionalProperties: false },
-);
+export const ExecApprovalsSnapshotSchema = closedObject({
+  path: NonEmptyString,
+  exists: Type.Boolean(),
+  hash: NonEmptyString,
+  file: ExecApprovalsFileSchema,
+});
 
 const NativeExecApprovalActionSchema = Type.Union([
   Type.Literal("allow"),
@@ -104,26 +85,20 @@ const NativeExecApprovalActionSchema = Type.Union([
 ]);
 
 /** One rule owned and enforced by a host-native exec policy implementation. */
-const NativeExecApprovalRuleSchema = Type.Object(
-  {
-    pattern: NonEmptyString,
-    action: NativeExecApprovalActionSchema,
-    shells: Type.Optional(Type.Array(NonEmptyString)),
-    description: Type.Optional(Type.String()),
-    enabled: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+const NativeExecApprovalRuleSchema = closedObject({
+  pattern: NonEmptyString,
+  action: NativeExecApprovalActionSchema,
+  shells: Type.Optional(Type.Array(NonEmptyString)),
+  description: Type.Optional(Type.String()),
+  enabled: Type.Optional(Type.Boolean()),
+});
 
-const NativeExecApprovalConstraintsSchema = Type.Object(
-  {
-    baseHashRequired: Type.Optional(Type.Boolean()),
-    defaultAllowAllowed: Type.Optional(Type.Boolean()),
-    broadAllowRulesAllowed: Type.Optional(Type.Boolean()),
-    dangerousAllowRulesAllowed: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+const NativeExecApprovalConstraintsSchema = closedObject({
+  baseHashRequired: Type.Optional(Type.Boolean()),
+  defaultAllowAllowed: Type.Optional(Type.Boolean()),
+  broadAllowRulesAllowed: Type.Optional(Type.Boolean()),
+  dangerousAllowRulesAllowed: Type.Optional(Type.Boolean()),
+});
 
 /** Node read snapshot supporting file-backed and host-native approval owners. */
 export const ExecApprovalsNodeSnapshotSchema = Type.Object(
@@ -191,34 +166,25 @@ export const ExecApprovalsNodeSnapshotSchema = Type.Object(
 );
 
 /** Empty request payload for reading local exec approval policy. */
-export const ExecApprovalsGetParamsSchema = Type.Object({}, { additionalProperties: false });
+export const ExecApprovalsGetParamsSchema = closedObject({});
 
 /** Local exec approval policy write request with optional base hash guard. */
-export const ExecApprovalsSetParamsSchema = Type.Object(
-  {
-    file: ExecApprovalsFileSchema,
-    baseHash: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const ExecApprovalsSetParamsSchema = closedObject({
+  file: ExecApprovalsFileSchema,
+  baseHash: Type.Optional(NonEmptyString),
+});
 
 /** Node-scoped request payload for reading exec approval policy. */
-export const ExecApprovalsNodeGetParamsSchema = Type.Object(
-  {
-    nodeId: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const ExecApprovalsNodeGetParamsSchema = closedObject({
+  nodeId: NonEmptyString,
+});
 
 /** Writable host-native policy fields; the node remains the validation authority. */
-const NativeExecApprovalPolicySchema = Type.Object(
-  {
-    defaultAction: Type.Optional(NativeExecApprovalActionSchema),
-    // Windows treats set as full replacement; omission would silently clear the rule list.
-    rules: Type.Array(NativeExecApprovalRuleSchema),
-  },
-  { additionalProperties: false },
-);
+const NativeExecApprovalPolicySchema = closedObject({
+  defaultAction: Type.Optional(NativeExecApprovalActionSchema),
+  // Windows treats set as full replacement; omission would silently clear the rule list.
+  rules: Type.Array(NativeExecApprovalRuleSchema),
+});
 
 /** Node-scoped write for exactly one file-backed or host-native approval owner. */
 export const ExecApprovalsNodeSetParamsSchema = Type.Object(
@@ -241,12 +207,9 @@ export const ExecApprovalsNodeSetParamsSchema = Type.Object(
 );
 
 /** Lookup request for one pending exec approval by id. */
-export const ExecApprovalGetParamsSchema = Type.Object(
-  {
-    id: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const ExecApprovalGetParamsSchema = closedObject({
+  id: NonEmptyString,
+});
 
 const ExecApprovalPolicySecuritySchema = Type.Union([
   Type.Literal("deny"),
@@ -254,119 +217,98 @@ const ExecApprovalPolicySecuritySchema = Type.Union([
   Type.Literal("full"),
 ]);
 
-const ExecApprovalPolicySnapshotSchema = Type.Object(
-  {
-    security: ExecApprovalPolicySecuritySchema,
-    ask: Type.Union([Type.Literal("off"), Type.Literal("on-miss"), Type.Literal("always")]),
-    askFallback: ExecApprovalPolicySecuritySchema,
-    autoAllowSkills: Type.Boolean(),
-    allowlistRules: Type.Array(
-      Type.Object(
-        {
-          pattern: Type.String(),
-          argPattern: Type.Optional(Type.String()),
-          source: Type.Optional(Type.Literal("allow-always")),
-        },
-        { additionalProperties: false },
-      ),
-    ),
-  },
-  { additionalProperties: false },
-);
+const ExecApprovalPolicySnapshotSchema = closedObject({
+  security: ExecApprovalPolicySecuritySchema,
+  ask: Type.Union([Type.Literal("off"), Type.Literal("on-miss"), Type.Literal("always")]),
+  askFallback: ExecApprovalPolicySecuritySchema,
+  autoAllowSkills: Type.Boolean(),
+  allowlistRules: Type.Array(
+    closedObject({
+      pattern: Type.String(),
+      argPattern: Type.Optional(Type.String()),
+      source: Type.Optional(Type.Literal("allow-always")),
+    }),
+  ),
+});
 
 /** Pending command execution approval request shown to reviewers. */
-export const ExecApprovalRequestParamsSchema = Type.Object(
-  {
-    id: Type.Optional(NonEmptyString),
-    command: Type.Optional(NonEmptyString),
-    commandArgv: Type.Optional(Type.Array(Type.String())),
-    systemRunPlan: Type.Optional(
-      Type.Object(
-        {
-          argv: Type.Array(Type.String()),
-          cwd: Type.Union([Type.String(), Type.Null()]),
-          commandText: Type.String(),
-          commandPreview: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-          agentId: Type.Union([Type.String(), Type.Null()]),
-          sessionKey: Type.Union([Type.String(), Type.Null()]),
-          policySnapshot: Type.Optional(ExecApprovalPolicySnapshotSchema),
-          mutableFileOperand: Type.Optional(
-            Type.Union([
-              Type.Object(
-                {
-                  argvIndex: Type.Integer({ minimum: 0 }),
-                  path: Type.String(),
-                  sha256: Type.String(),
-                },
-                { additionalProperties: false },
-              ),
-              Type.Null(),
-            ]),
-          ),
-        },
-        { additionalProperties: false },
+export const ExecApprovalRequestParamsSchema = closedObject({
+  id: Type.Optional(NonEmptyString),
+  command: Type.Optional(NonEmptyString),
+  commandArgv: Type.Optional(Type.Array(Type.String())),
+  systemRunPlan: Type.Optional(
+    closedObject({
+      argv: Type.Array(Type.String()),
+      cwd: Type.Union([Type.String(), Type.Null()]),
+      commandText: Type.String(),
+      commandPreview: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+      agentId: Type.Union([Type.String(), Type.Null()]),
+      sessionKey: Type.Union([Type.String(), Type.Null()]),
+      policySnapshot: Type.Optional(ExecApprovalPolicySnapshotSchema),
+      mutableFileOperand: Type.Optional(
+        Type.Union([
+          closedObject({
+            argvIndex: Type.Integer({ minimum: 0 }),
+            path: Type.String(),
+            sha256: Type.String(),
+          }),
+          Type.Null(),
+        ]),
       ),
-    ),
-    env: Type.Optional(Type.Record(NonEmptyString, Type.String())),
-    cwd: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-    nodeId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    host: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-    security: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-    ask: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-    warningText: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-    unavailableDecisions: Type.Optional(
-      Type.Array(Type.String({ enum: ["allow-always"] }), {
-        minItems: 1,
-        maxItems: 1,
+    }),
+  ),
+  env: Type.Optional(Type.Record(NonEmptyString, Type.String())),
+  cwd: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  nodeId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  host: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  security: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  ask: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  warningText: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  unavailableDecisions: Type.Optional(
+    Type.Array(Type.String({ enum: ["allow-always"] }), {
+      minItems: 1,
+      maxItems: 1,
+    }),
+  ),
+  commandSpans: Type.Optional(
+    Type.Array(
+      closedObject({
+        startIndex: Type.Integer({
+          minimum: 0,
+          description: "Inclusive UTF-16 code unit offset into command.",
+        }),
+        endIndex: Type.Integer({
+          minimum: 1,
+          description:
+            "Exclusive UTF-16 code unit offset into command; must be greater than startIndex and no greater than command.length.",
+        }),
       }),
     ),
-    commandSpans: Type.Optional(
-      Type.Array(
-        Type.Object(
-          {
-            startIndex: Type.Integer({
-              minimum: 0,
-              description: "Inclusive UTF-16 code unit offset into command.",
-            }),
-            endIndex: Type.Integer({
-              minimum: 1,
-              description:
-                "Exclusive UTF-16 code unit offset into command; must be greater than startIndex and no greater than command.length.",
-            }),
-          },
-          { additionalProperties: false },
-        ),
-      ),
-    ),
-    agentId: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-    resolvedPath: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-    sessionKey: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-    turnSourceChannel: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-    turnSourceTo: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-    turnSourceAccountId: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-    turnSourceThreadId: Type.Optional(Type.Union([Type.String(), Type.Number(), Type.Null()])),
-    approvalReviewerDeviceIds: Type.Optional(
-      Type.Array(NonEmptyString, {
-        description:
-          "Trusted approval-runtime metadata naming operator devices that may review this approval; ordinary Gateway clients may send the field, but the Gateway only binds it for internal approval-runtime requests.",
-      }),
-    ),
-    requireDeliveryRoute: Type.Optional(Type.Boolean()),
-    suppressDelivery: Type.Optional(Type.Boolean()),
-    timeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
-    twoPhase: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+  ),
+  agentId: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  resolvedPath: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  sessionKey: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  turnSourceChannel: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  turnSourceTo: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  turnSourceAccountId: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  turnSourceThreadId: Type.Optional(Type.Union([Type.String(), Type.Number(), Type.Null()])),
+  approvalReviewerDeviceIds: Type.Optional(
+    Type.Array(NonEmptyString, {
+      description:
+        "Trusted approval-runtime metadata naming operator devices that may review this approval; ordinary Gateway clients may send the field, but the Gateway only binds it for internal approval-runtime requests.",
+    }),
+  ),
+  requireDeliveryRoute: Type.Optional(Type.Boolean()),
+  suppressDelivery: Type.Optional(Type.Boolean()),
+  timeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
+  twoPhase: Type.Optional(Type.Boolean()),
+});
 
 /** Reviewer decision payload for one pending exec approval. */
-export const ExecApprovalResolveParamsSchema = Type.Object(
-  {
-    id: NonEmptyString,
-    decision: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const ExecApprovalResolveParamsSchema = closedObject({
+  id: NonEmptyString,
+  decision: NonEmptyString,
+});
 
 // Owner-local wire types derived directly from local schema consts so the
 // public plugin-sdk declaration graph never pulls in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/frames.ts
+++ b/packages/gateway-protocol/src/schema/frames.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { GatewayClientIdSchema, GatewayClientModeSchema, NonEmptyString } from "./primitives.js";
 import { SnapshotSchema, StateVersionSchema } from "./snapshot.js";
 
@@ -16,197 +17,146 @@ export const GATEWAY_SERVER_CAPS = {
  * in feature-specific modules and are referenced by runtime validators.
  */
 /** Periodic server heartbeat event payload. */
-export const TickEventSchema = Type.Object(
-  {
-    ts: Type.Integer({ minimum: 0 }),
-  },
-  { additionalProperties: false },
-);
+export const TickEventSchema = closedObject({
+  ts: Type.Integer({ minimum: 0 }),
+});
 
 /** Server shutdown notice event payload. */
-export const ShutdownEventSchema = Type.Object(
-  {
-    reason: NonEmptyString,
-    restartExpectedMs: Type.Optional(Type.Integer({ minimum: 0 })),
-  },
-  { additionalProperties: false },
-);
+export const ShutdownEventSchema = closedObject({
+  reason: NonEmptyString,
+  restartExpectedMs: Type.Optional(Type.Integer({ minimum: 0 })),
+});
 
 /** Initial client hello/connect payload sent before the gateway accepts frames. */
-export const ConnectParamsSchema = Type.Object(
-  {
-    minProtocol: Type.Integer({ minimum: 1 }),
-    maxProtocol: Type.Integer({ minimum: 1 }),
-    client: Type.Object(
-      {
-        id: GatewayClientIdSchema,
-        displayName: Type.Optional(NonEmptyString),
-        version: NonEmptyString,
-        platform: NonEmptyString,
-        deviceFamily: Type.Optional(NonEmptyString),
-        modelIdentifier: Type.Optional(NonEmptyString),
-        mode: GatewayClientModeSchema,
-        instanceId: Type.Optional(NonEmptyString),
-      },
-      { additionalProperties: false },
-    ),
-    caps: Type.Optional(Type.Array(NonEmptyString, { default: [] })),
-    commands: Type.Optional(Type.Array(NonEmptyString)),
-    permissions: Type.Optional(Type.Record(NonEmptyString, Type.Boolean())),
-    pathEnv: Type.Optional(Type.String()),
-    role: Type.Optional(NonEmptyString),
-    scopes: Type.Optional(Type.Array(NonEmptyString)),
-    device: Type.Optional(
-      Type.Object(
-        {
-          id: NonEmptyString,
-          publicKey: NonEmptyString,
-          signature: NonEmptyString,
-          signedAt: Type.Integer({ minimum: 0 }),
-          nonce: NonEmptyString,
-        },
-        { additionalProperties: false },
-      ),
-    ),
-    auth: Type.Optional(
-      Type.Object(
-        {
-          token: Type.Optional(Type.String()),
-          bootstrapToken: Type.Optional(Type.String()),
-          deviceToken: Type.Optional(Type.String()),
-          password: Type.Optional(Type.String()),
-          approvalRuntimeToken: Type.Optional(Type.String()),
-          agentRuntimeIdentityToken: Type.Optional(Type.String()),
-        },
-        { additionalProperties: false },
-      ),
-    ),
-    locale: Type.Optional(Type.String()),
-    userAgent: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const ConnectParamsSchema = closedObject({
+  minProtocol: Type.Integer({ minimum: 1 }),
+  maxProtocol: Type.Integer({ minimum: 1 }),
+  client: closedObject({
+    id: GatewayClientIdSchema,
+    displayName: Type.Optional(NonEmptyString),
+    version: NonEmptyString,
+    platform: NonEmptyString,
+    deviceFamily: Type.Optional(NonEmptyString),
+    modelIdentifier: Type.Optional(NonEmptyString),
+    mode: GatewayClientModeSchema,
+    instanceId: Type.Optional(NonEmptyString),
+  }),
+  caps: Type.Optional(Type.Array(NonEmptyString, { default: [] })),
+  commands: Type.Optional(Type.Array(NonEmptyString)),
+  permissions: Type.Optional(Type.Record(NonEmptyString, Type.Boolean())),
+  pathEnv: Type.Optional(Type.String()),
+  role: Type.Optional(NonEmptyString),
+  scopes: Type.Optional(Type.Array(NonEmptyString)),
+  device: Type.Optional(
+    closedObject({
+      id: NonEmptyString,
+      publicKey: NonEmptyString,
+      signature: NonEmptyString,
+      signedAt: Type.Integer({ minimum: 0 }),
+      nonce: NonEmptyString,
+    }),
+  ),
+  auth: Type.Optional(
+    closedObject({
+      token: Type.Optional(Type.String()),
+      bootstrapToken: Type.Optional(Type.String()),
+      deviceToken: Type.Optional(Type.String()),
+      password: Type.Optional(Type.String()),
+      approvalRuntimeToken: Type.Optional(Type.String()),
+      agentRuntimeIdentityToken: Type.Optional(Type.String()),
+    }),
+  ),
+  locale: Type.Optional(Type.String()),
+  userAgent: Type.Optional(Type.String()),
+});
 
 /** Successful gateway hello response with negotiated protocol and initial state. */
-export const HelloOkSchema = Type.Object(
-  {
-    type: Type.Literal("hello-ok"),
-    protocol: Type.Integer({ minimum: 1 }),
-    server: Type.Object(
-      {
-        version: NonEmptyString,
-        connId: NonEmptyString,
-      },
-      { additionalProperties: false },
+export const HelloOkSchema = closedObject({
+  type: Type.Literal("hello-ok"),
+  protocol: Type.Integer({ minimum: 1 }),
+  server: closedObject({
+    version: NonEmptyString,
+    connId: NonEmptyString,
+  }),
+  features: closedObject({
+    methods: Type.Array(NonEmptyString),
+    events: Type.Array(NonEmptyString),
+    capabilities: Type.Optional(Type.Array(NonEmptyString)),
+  }),
+  snapshot: SnapshotSchema,
+  // Additive: plugin-declared Control UI tabs (surface "tab" descriptors).
+  controlUiTabs: Type.Optional(
+    Type.Array(
+      closedObject({
+        pluginId: NonEmptyString,
+        id: NonEmptyString,
+        label: NonEmptyString,
+        description: Type.Optional(Type.String()),
+        icon: Type.Optional(Type.String()),
+        path: Type.Optional(Type.String()),
+        group: Type.Optional(Type.Union([Type.Literal("control"), Type.Literal("agent")])),
+        order: Type.Optional(Type.Number()),
+      }),
     ),
-    features: Type.Object(
-      {
-        methods: Type.Array(NonEmptyString),
-        events: Type.Array(NonEmptyString),
-        capabilities: Type.Optional(Type.Array(NonEmptyString)),
-      },
-      { additionalProperties: false },
-    ),
-    snapshot: SnapshotSchema,
-    // Additive: plugin-declared Control UI tabs (surface "tab" descriptors).
-    controlUiTabs: Type.Optional(
+  ),
+  pluginSurfaceUrls: Type.Optional(Type.Record(NonEmptyString, NonEmptyString)),
+  auth: closedObject({
+    deviceToken: Type.Optional(NonEmptyString),
+    role: NonEmptyString,
+    scopes: Type.Array(NonEmptyString),
+    issuedAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    deviceTokens: Type.Optional(
       Type.Array(
-        Type.Object(
-          {
-            pluginId: NonEmptyString,
-            id: NonEmptyString,
-            label: NonEmptyString,
-            description: Type.Optional(Type.String()),
-            icon: Type.Optional(Type.String()),
-            path: Type.Optional(Type.String()),
-            group: Type.Optional(Type.Union([Type.Literal("control"), Type.Literal("agent")])),
-            order: Type.Optional(Type.Number()),
-          },
-          { additionalProperties: false },
-        ),
+        closedObject({
+          deviceToken: NonEmptyString,
+          role: NonEmptyString,
+          scopes: Type.Array(NonEmptyString),
+          issuedAtMs: Type.Integer({ minimum: 0 }),
+        }),
       ),
     ),
-    pluginSurfaceUrls: Type.Optional(Type.Record(NonEmptyString, NonEmptyString)),
-    auth: Type.Object(
-      {
-        deviceToken: Type.Optional(NonEmptyString),
-        role: NonEmptyString,
-        scopes: Type.Array(NonEmptyString),
-        issuedAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-        deviceTokens: Type.Optional(
-          Type.Array(
-            Type.Object(
-              {
-                deviceToken: NonEmptyString,
-                role: NonEmptyString,
-                scopes: Type.Array(NonEmptyString),
-                issuedAtMs: Type.Integer({ minimum: 0 }),
-              },
-              { additionalProperties: false },
-            ),
-          ),
-        ),
-      },
-      { additionalProperties: false },
-    ),
-    policy: Type.Object(
-      {
-        maxPayload: Type.Integer({ minimum: 1 }),
-        maxBufferedBytes: Type.Integer({ minimum: 1 }),
-        tickIntervalMs: Type.Integer({ minimum: 1 }),
-      },
-      { additionalProperties: false },
-    ),
-  },
-  { additionalProperties: false },
-);
+  }),
+  policy: closedObject({
+    maxPayload: Type.Integer({ minimum: 1 }),
+    maxBufferedBytes: Type.Integer({ minimum: 1 }),
+    tickIntervalMs: Type.Integer({ minimum: 1 }),
+  }),
+});
 
 /** Standard structured error shape used in response frames and connect failures. */
-export const ErrorShapeSchema = Type.Object(
-  {
-    code: NonEmptyString,
-    message: NonEmptyString,
-    details: Type.Optional(Type.Unknown()),
-    retryable: Type.Optional(Type.Boolean()),
-    retryAfterMs: Type.Optional(Type.Integer({ minimum: 0 })),
-  },
-  { additionalProperties: false },
-);
+export const ErrorShapeSchema = closedObject({
+  code: NonEmptyString,
+  message: NonEmptyString,
+  details: Type.Optional(Type.Unknown()),
+  retryable: Type.Optional(Type.Boolean()),
+  retryAfterMs: Type.Optional(Type.Integer({ minimum: 0 })),
+});
 
 /** Client request frame envelope; `method` selects the payload validator. */
-export const RequestFrameSchema = Type.Object(
-  {
-    type: Type.Literal("req"),
-    id: NonEmptyString,
-    method: NonEmptyString,
-    params: Type.Optional(Type.Unknown()),
-  },
-  { additionalProperties: false },
-);
+export const RequestFrameSchema = closedObject({
+  type: Type.Literal("req"),
+  id: NonEmptyString,
+  method: NonEmptyString,
+  params: Type.Optional(Type.Unknown()),
+});
 
 /** Server response frame envelope paired with a prior request id. */
-export const ResponseFrameSchema = Type.Object(
-  {
-    type: Type.Literal("res"),
-    id: NonEmptyString,
-    ok: Type.Boolean(),
-    payload: Type.Optional(Type.Unknown()),
-    error: Type.Optional(ErrorShapeSchema),
-  },
-  { additionalProperties: false },
-);
+export const ResponseFrameSchema = closedObject({
+  type: Type.Literal("res"),
+  id: NonEmptyString,
+  ok: Type.Boolean(),
+  payload: Type.Optional(Type.Unknown()),
+  error: Type.Optional(ErrorShapeSchema),
+});
 
 /** Server event frame envelope; `event` selects the payload validator. */
-export const EventFrameSchema = Type.Object(
-  {
-    type: Type.Literal("event"),
-    event: NonEmptyString,
-    payload: Type.Optional(Type.Unknown()),
-    seq: Type.Optional(Type.Integer({ minimum: 0 })),
-    stateVersion: Type.Optional(StateVersionSchema),
-  },
-  { additionalProperties: false },
-);
+export const EventFrameSchema = closedObject({
+  type: Type.Literal("event"),
+  event: NonEmptyString,
+  payload: Type.Optional(Type.Unknown()),
+  seq: Type.Optional(Type.Integer({ minimum: 0 })),
+  stateVersion: Type.Optional(StateVersionSchema),
+});
 
 // Discriminated union of all top-level frames. Using a discriminator makes
 // downstream codegen (quicktype) produce tighter types instead of all-optional

--- a/packages/gateway-protocol/src/schema/fs.ts
+++ b/packages/gateway-protocol/src/schema/fs.ts
@@ -1,41 +1,33 @@
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 // Host directory browsing for the new-session folder picker. Admin-only on the
 // gateway; listing stays directories-only so the picker never leaks file names.
-export const FsListDirParamsSchema = Type.Object(
-  {
-    /** Absolute directory to list; omitted means the selected host's home directory. */
-    path: Type.Optional(NonEmptyString),
-    /** Connected node host to browse; omitted means the Gateway host. */
-    nodeId: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const FsListDirParamsSchema = closedObject({
+  /** Absolute directory to list; omitted means the selected host's home directory. */
+  path: Type.Optional(NonEmptyString),
+  /** Connected node host to browse; omitted means the Gateway host. */
+  nodeId: Type.Optional(NonEmptyString),
+});
 
-export const FsDirEntrySchema = Type.Object(
-  {
-    name: NonEmptyString,
-    path: NonEmptyString,
-    /** Dot-prefixed directories; clients render them dimmed after visible ones. */
-    hidden: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const FsDirEntrySchema = closedObject({
+  name: NonEmptyString,
+  path: NonEmptyString,
+  /** Dot-prefixed directories; clients render them dimmed after visible ones. */
+  hidden: Type.Optional(Type.Boolean()),
+});
 
-export const FsListDirResultSchema = Type.Object(
-  {
-    /** Resolved absolute path that was listed. */
-    path: NonEmptyString,
-    /** Absent at the filesystem root. */
-    parent: Type.Optional(NonEmptyString),
-    /** Selected host's home directory, for the picker's "home" shortcut. */
-    home: NonEmptyString,
-    entries: Type.Array(FsDirEntrySchema),
-  },
-  { additionalProperties: false },
-);
+export const FsListDirResultSchema = closedObject({
+  /** Resolved absolute path that was listed. */
+  path: NonEmptyString,
+  /** Absent at the filesystem root. */
+  parent: Type.Optional(NonEmptyString),
+  /** Selected host's home directory, for the picker's "home" shortcut. */
+  home: NonEmptyString,
+  entries: Type.Array(FsDirEntrySchema),
+});
 
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/gateway-suspend.ts
+++ b/packages/gateway-protocol/src/schema/gateway-suspend.ts
@@ -1,97 +1,81 @@
 // Gateway Protocol schemas for cooperative host suspension.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 
 const SuspensionTokenSchema = Type.String({ minLength: 1, maxLength: 128, pattern: "\\S" });
 const CountSchema = Type.Integer({ minimum: 0 });
 
-export const GatewaySuspendTaskBlockerSchema = Type.Object(
-  {
-    taskId: Type.String(),
-    status: Type.Literal("running"),
-    runtime: Type.Union([
-      Type.Literal("subagent"),
-      Type.Literal("acp"),
-      Type.Literal("cli"),
-      Type.Literal("cron"),
-    ]),
-    runId: Type.Optional(Type.String()),
-    label: Type.Optional(Type.String()),
-    title: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const GatewaySuspendTaskBlockerSchema = closedObject({
+  taskId: Type.String(),
+  status: Type.Literal("running"),
+  runtime: Type.Union([
+    Type.Literal("subagent"),
+    Type.Literal("acp"),
+    Type.Literal("cli"),
+    Type.Literal("cron"),
+  ]),
+  runId: Type.Optional(Type.String()),
+  label: Type.Optional(Type.String()),
+  title: Type.Optional(Type.String()),
+});
 
-export const GatewaySuspendBlockerSchema = Type.Object(
-  {
-    kind: Type.Union([
-      Type.Literal("queue"),
-      Type.Literal("reply"),
-      Type.Literal("embedded-run"),
-      Type.Literal("background-exec"),
-      Type.Literal("cron-run"),
-      Type.Literal("task"),
-      Type.Literal("root-request"),
-      Type.Literal("session-admission"),
-      Type.Literal("session-mutation"),
-      Type.Literal("chat-run"),
-      Type.Literal("queued-turn"),
-      Type.Literal("terminal-persistence"),
-      Type.Literal("terminal-session"),
-    ]),
-    count: CountSchema,
-    message: Type.String(),
-    task: Type.Optional(GatewaySuspendTaskBlockerSchema),
-  },
-  { additionalProperties: false },
-);
+export const GatewaySuspendBlockerSchema = closedObject({
+  kind: Type.Union([
+    Type.Literal("queue"),
+    Type.Literal("reply"),
+    Type.Literal("embedded-run"),
+    Type.Literal("background-exec"),
+    Type.Literal("cron-run"),
+    Type.Literal("task"),
+    Type.Literal("root-request"),
+    Type.Literal("session-admission"),
+    Type.Literal("session-mutation"),
+    Type.Literal("chat-run"),
+    Type.Literal("queued-turn"),
+    Type.Literal("terminal-persistence"),
+    Type.Literal("terminal-session"),
+  ]),
+  count: CountSchema,
+  message: Type.String(),
+  task: Type.Optional(GatewaySuspendTaskBlockerSchema),
+});
 
-export const GatewaySuspendPrepareParamsSchema = Type.Object(
-  { requestId: SuspensionTokenSchema },
-  { additionalProperties: false },
-);
+export const GatewaySuspendPrepareParamsSchema = closedObject({ requestId: SuspensionTokenSchema });
 
-export const GatewaySuspendPrepareBusyResultSchema = Type.Object(
-  {
-    status: Type.Literal("busy"),
-    reason: Type.Union([Type.Literal("active-work"), Type.Literal("gateway-draining")]),
-    retryAfterMs: CountSchema,
-    activeCount: CountSchema,
-    blockers: Type.Array(GatewaySuspendBlockerSchema),
-  },
-  { additionalProperties: false },
-);
+export const GatewaySuspendPrepareBusyResultSchema = closedObject({
+  status: Type.Literal("busy"),
+  reason: Type.Union([Type.Literal("active-work"), Type.Literal("gateway-draining")]),
+  retryAfterMs: CountSchema,
+  activeCount: CountSchema,
+  blockers: Type.Array(GatewaySuspendBlockerSchema),
+});
 
-export const GatewaySuspendPrepareReadyResultSchema = Type.Object(
-  {
-    status: Type.Literal("ready"),
-    suspensionId: SuspensionTokenSchema,
-    expiresAtMs: CountSchema,
-    activeCount: CountSchema,
-    blockers: Type.Array(GatewaySuspendBlockerSchema),
-  },
-  { additionalProperties: false },
-);
+export const GatewaySuspendPrepareReadyResultSchema = closedObject({
+  status: Type.Literal("ready"),
+  suspensionId: SuspensionTokenSchema,
+  expiresAtMs: CountSchema,
+  activeCount: CountSchema,
+  blockers: Type.Array(GatewaySuspendBlockerSchema),
+});
 
 export const GatewaySuspendPrepareResultSchema = Type.Union([
   GatewaySuspendPrepareBusyResultSchema,
   GatewaySuspendPrepareReadyResultSchema,
 ]);
 
-export const GatewaySuspendStatusParamsSchema = Type.Object(
-  { suspensionId: SuspensionTokenSchema },
-  { additionalProperties: false },
-);
+export const GatewaySuspendStatusParamsSchema = closedObject({
+  suspensionId: SuspensionTokenSchema,
+});
 
-export const GatewaySuspendStatusRunningResultSchema = Type.Object(
-  { status: Type.Literal("running") },
-  { additionalProperties: false },
-);
+export const GatewaySuspendStatusRunningResultSchema = closedObject({
+  status: Type.Literal("running"),
+});
 
-export const GatewaySuspendStatusReadyResultSchema = Type.Object(
-  { status: Type.Literal("ready"), expiresAtMs: CountSchema },
-  { additionalProperties: false },
-);
+export const GatewaySuspendStatusReadyResultSchema = closedObject({
+  status: Type.Literal("ready"),
+  expiresAtMs: CountSchema,
+});
 
 export const GatewaySuspendStatusResultSchema = Type.Union([
   GatewaySuspendStatusRunningResultSchema,
@@ -100,14 +84,11 @@ export const GatewaySuspendStatusResultSchema = Type.Union([
 
 export const GatewaySuspendResumeParamsSchema = GatewaySuspendStatusParamsSchema;
 
-export const GatewaySuspendResumeResultSchema = Type.Object(
-  {
-    ok: Type.Literal(true),
-    status: Type.Literal("running"),
-    resumed: Type.Boolean(),
-  },
-  { additionalProperties: false },
-);
+export const GatewaySuspendResumeResultSchema = closedObject({
+  ok: Type.Literal(true),
+  status: Type.Literal("running"),
+  resumed: Type.Boolean(),
+});
 
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/logs-chat.ts
+++ b/packages/gateway-protocol/src/schema/logs-chat.ts
@@ -1,165 +1,126 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { ChatSendSessionKeyString, InputProvenanceSchema, NonEmptyString } from "./primitives.js";
 
 /** Cursor-based request for the gateway log tail endpoint. */
-export const LogsTailParamsSchema = Type.Object(
-  {
-    cursor: Type.Optional(Type.Integer({ minimum: 0 })),
-    limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 5000 })),
-    maxBytes: Type.Optional(Type.Integer({ minimum: 1, maximum: 1_000_000 })),
-  },
-  { additionalProperties: false },
-);
+export const LogsTailParamsSchema = closedObject({
+  cursor: Type.Optional(Type.Integer({ minimum: 0 })),
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 5000 })),
+  maxBytes: Type.Optional(Type.Integer({ minimum: 1, maximum: 1_000_000 })),
+});
 
 /** Gateway log tail payload returned to dashboard clients. */
-export const LogsTailResultSchema = Type.Object(
-  {
-    file: NonEmptyString,
-    cursor: Type.Integer({ minimum: 0 }),
-    size: Type.Integer({ minimum: 0 }),
-    lines: Type.Array(Type.String()),
-    truncated: Type.Optional(Type.Boolean()),
-    reset: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const LogsTailResultSchema = closedObject({
+  file: NonEmptyString,
+  cursor: Type.Integer({ minimum: 0 }),
+  size: Type.Integer({ minimum: 0 }),
+  lines: Type.Array(Type.String()),
+  truncated: Type.Optional(Type.Boolean()),
+  reset: Type.Optional(Type.Boolean()),
+});
 
 /** Session-scoped history request used by WebChat and native WebSocket clients. */
-export const ChatHistoryParamsSchema = Type.Object(
-  {
-    sessionKey: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
-    offset: Type.Optional(Type.Integer({ minimum: 0 })),
-    messageId: Type.Optional(NonEmptyString),
-    sessionId: Type.Optional(NonEmptyString),
-    maxChars: Type.Optional(Type.Integer({ minimum: 1, maximum: 500_000 })),
-  },
-  { additionalProperties: false },
-);
+export const ChatHistoryParamsSchema = closedObject({
+  sessionKey: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
+  offset: Type.Optional(Type.Integer({ minimum: 0 })),
+  messageId: Type.Optional(NonEmptyString),
+  sessionId: Type.Optional(NonEmptyString),
+  maxChars: Type.Optional(Type.Integer({ minimum: 1, maximum: 500_000 })),
+});
 
 /** Lightweight chat metadata request; optional agent scope keeps selector state explicit. */
-export const ChatMetadataParamsSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const ChatMetadataParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+});
 
 /** Batched purpose-title request for tool calls rendered in the Control UI. */
-export const ChatToolTitlesParamsSchema = Type.Object(
-  {
-    sessionKey: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    items: Type.Array(
-      Type.Object(
-        {
-          id: Type.String({ minLength: 1, maxLength: 64 }),
-          name: Type.String({ minLength: 1, maxLength: 200 }),
-          input: Type.String({ minLength: 1, maxLength: 4_000 }),
-        },
-        { additionalProperties: false },
-      ),
-      { minItems: 1, maxItems: 24 },
-    ),
-  },
-  { additionalProperties: false },
-);
+export const ChatToolTitlesParamsSchema = closedObject({
+  sessionKey: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  items: Type.Array(
+    closedObject({
+      id: Type.String({ minLength: 1, maxLength: 64 }),
+      name: Type.String({ minLength: 1, maxLength: 200 }),
+      input: Type.String({ minLength: 1, maxLength: 4_000 }),
+    }),
+    { minItems: 1, maxItems: 24 },
+  ),
+});
 
 /**
  * Titles keyed by the caller-provided item id; missing ids mean no title.
  * `disabled: true` tells clients the gateway has tool titles switched off so
  * they stop requesting for the rest of the session.
  */
-export const ChatToolTitlesResultSchema = Type.Object(
-  {
-    titles: Type.Record(Type.String(), Type.String()),
-    disabled: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const ChatToolTitlesResultSchema = closedObject({
+  titles: Type.Record(Type.String(), Type.String()),
+  disabled: Type.Optional(Type.Boolean()),
+});
 /** Typed result shape for tool-title consumers. */
 export type ChatToolTitlesResult = Static<typeof ChatToolTitlesResultSchema>;
 
 /** Fetches one stored chat message without forcing history callers to request huge payloads. */
-export const ChatMessageGetParamsSchema = Type.Object(
-  {
-    sessionKey: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    messageId: NonEmptyString,
-    maxChars: Type.Optional(Type.Integer({ minimum: 1, maximum: 2_000_000 })),
-  },
-  { additionalProperties: false },
-);
+export const ChatMessageGetParamsSchema = closedObject({
+  sessionKey: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  messageId: NonEmptyString,
+  maxChars: Type.Optional(Type.Integer({ minimum: 1, maximum: 2_000_000 })),
+});
 
 /** Result envelope for single-message lookup, including the stable miss/visibility reason. */
-export const ChatMessageGetResultSchema = Type.Object(
-  {
-    ok: Type.Boolean(),
-    message: Type.Optional(Type.Unknown()),
-    unavailableReason: Type.Optional(
-      Type.Union([
-        Type.Literal("not_found"),
-        Type.Literal("oversized"),
-        Type.Literal("not_visible"),
-      ]),
-    ),
-  },
-  { additionalProperties: false },
-);
+export const ChatMessageGetResultSchema = closedObject({
+  ok: Type.Boolean(),
+  message: Type.Optional(Type.Unknown()),
+  unavailableReason: Type.Optional(
+    Type.Union([Type.Literal("not_found"), Type.Literal("oversized"), Type.Literal("not_visible")]),
+  ),
+});
 /** Typed result shape for callers that branch on message availability. */
 export type ChatMessageGetResult = Static<typeof ChatMessageGetResultSchema>;
 
 /** User-to-agent send request; idempotency key lets clients safely retry transport failures. */
-export const ChatSendParamsSchema = Type.Object(
-  {
-    sessionKey: ChatSendSessionKeyString,
-    agentId: Type.Optional(NonEmptyString),
-    sessionId: Type.Optional(NonEmptyString),
-    message: Type.String(),
-    thinking: Type.Optional(Type.String()),
-    fastMode: Type.Optional(Type.Union([Type.Boolean(), Type.Literal("auto")])),
-    // One-turn override for auto fast-mode cutoff seconds.
-    fastAutoOnSeconds: Type.Optional(Type.Integer({ minimum: 1 })),
-    deliver: Type.Optional(Type.Boolean()),
-    originatingChannel: Type.Optional(Type.String()),
-    originatingTo: Type.Optional(Type.String()),
-    originatingAccountId: Type.Optional(Type.String()),
-    originatingThreadId: Type.Optional(Type.String()),
-    attachments: Type.Optional(Type.Array(Type.Unknown())),
-    timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    systemInputProvenance: Type.Optional(InputProvenanceSchema),
-    systemProvenanceReceipt: Type.Optional(Type.String()),
-    suppressCommandInterpretation: Type.Optional(Type.Boolean()),
-    expectedSessionRoutingContract: Type.Optional(NonEmptyString),
-    idempotencyKey: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const ChatSendParamsSchema = closedObject({
+  sessionKey: ChatSendSessionKeyString,
+  agentId: Type.Optional(NonEmptyString),
+  sessionId: Type.Optional(NonEmptyString),
+  message: Type.String(),
+  thinking: Type.Optional(Type.String()),
+  fastMode: Type.Optional(Type.Union([Type.Boolean(), Type.Literal("auto")])),
+  // One-turn override for auto fast-mode cutoff seconds.
+  fastAutoOnSeconds: Type.Optional(Type.Integer({ minimum: 1 })),
+  deliver: Type.Optional(Type.Boolean()),
+  originatingChannel: Type.Optional(Type.String()),
+  originatingTo: Type.Optional(Type.String()),
+  originatingAccountId: Type.Optional(Type.String()),
+  originatingThreadId: Type.Optional(Type.String()),
+  attachments: Type.Optional(Type.Array(Type.Unknown())),
+  timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  systemInputProvenance: Type.Optional(InputProvenanceSchema),
+  systemProvenanceReceipt: Type.Optional(Type.String()),
+  suppressCommandInterpretation: Type.Optional(Type.Boolean()),
+  expectedSessionRoutingContract: Type.Optional(NonEmptyString),
+  idempotencyKey: NonEmptyString,
+});
 
 /** Cancels the active or named run for a chat session. */
-export const ChatAbortParamsSchema = Type.Object(
-  {
-    sessionKey: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    runId: Type.Optional(NonEmptyString),
-    preserveSideRuns: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const ChatAbortParamsSchema = closedObject({
+  sessionKey: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  runId: Type.Optional(NonEmptyString),
+  preserveSideRuns: Type.Optional(Type.Boolean()),
+});
 
 /** Inserts an operator-visible synthetic message into an existing chat transcript. */
-export const ChatInjectParamsSchema = Type.Object(
-  {
-    sessionKey: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    message: NonEmptyString,
-    label: Type.Optional(Type.String({ maxLength: 100 })),
-  },
-  { additionalProperties: false },
-);
+export const ChatInjectParamsSchema = closedObject({
+  sessionKey: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  message: NonEmptyString,
+  label: Type.Optional(Type.String({ maxLength: 100 })),
+});
 
 /** Shared event fields preserve stream ordering and route events to the right session. */
 const ChatEventBaseSchema = {
@@ -180,55 +141,43 @@ const ChatEventErrorKindSchema = Type.Union([
 ]);
 
 /** Incremental assistant output event; `replace` marks full-content refresh deltas. */
-export const ChatDeltaEventSchema = Type.Object(
-  {
-    ...ChatEventBaseSchema,
-    state: Type.Literal("delta"),
-    message: Type.Optional(Type.Unknown()),
-    deltaText: Type.String(),
-    replace: Type.Optional(Type.Boolean()),
-    usage: Type.Optional(Type.Unknown()),
-  },
-  { additionalProperties: false },
-);
+export const ChatDeltaEventSchema = closedObject({
+  ...ChatEventBaseSchema,
+  state: Type.Literal("delta"),
+  message: Type.Optional(Type.Unknown()),
+  deltaText: Type.String(),
+  replace: Type.Optional(Type.Boolean()),
+  usage: Type.Optional(Type.Unknown()),
+});
 
 /** Successful terminal event for a completed chat run. */
-export const ChatFinalEventSchema = Type.Object(
-  {
-    ...ChatEventBaseSchema,
-    state: Type.Literal("final"),
-    message: Type.Optional(Type.Unknown()),
-    usage: Type.Optional(Type.Unknown()),
-    stopReason: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const ChatFinalEventSchema = closedObject({
+  ...ChatEventBaseSchema,
+  state: Type.Literal("final"),
+  message: Type.Optional(Type.Unknown()),
+  usage: Type.Optional(Type.Unknown()),
+  stopReason: Type.Optional(Type.String()),
+});
 
 /** Terminal event for user-initiated or coordinator-initiated cancellation. */
-export const ChatAbortedEventSchema = Type.Object(
-  {
-    ...ChatEventBaseSchema,
-    state: Type.Literal("aborted"),
-    message: Type.Optional(Type.Unknown()),
-    errorMessage: Type.Optional(Type.String()),
-    stopReason: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const ChatAbortedEventSchema = closedObject({
+  ...ChatEventBaseSchema,
+  state: Type.Literal("aborted"),
+  message: Type.Optional(Type.Unknown()),
+  errorMessage: Type.Optional(Type.String()),
+  stopReason: Type.Optional(Type.String()),
+});
 
 /** Terminal event for failed chat runs with an optional normalized failure kind. */
-export const ChatErrorEventSchema = Type.Object(
-  {
-    ...ChatEventBaseSchema,
-    state: Type.Literal("error"),
-    message: Type.Optional(Type.Unknown()),
-    errorMessage: Type.Optional(Type.String()),
-    errorKind: Type.Optional(ChatEventErrorKindSchema),
-    usage: Type.Optional(Type.Unknown()),
-    stopReason: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const ChatErrorEventSchema = closedObject({
+  ...ChatEventBaseSchema,
+  state: Type.Literal("error"),
+  message: Type.Optional(Type.Unknown()),
+  errorMessage: Type.Optional(Type.String()),
+  errorKind: Type.Optional(ChatEventErrorKindSchema),
+  usage: Type.Optional(Type.Unknown()),
+  stopReason: Type.Optional(Type.String()),
+});
 
 /** Public chat stream event union consumed by gateway protocol validators. */
 export const ChatEventSchema = Type.Union([

--- a/packages/gateway-protocol/src/schema/nodes.ts
+++ b/packages/gateway-protocol/src/schema/nodes.ts
@@ -1,5 +1,6 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import { type Static, Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 const NodePluginToolNameSchema = Type.String({
@@ -37,98 +38,71 @@ export const NodePresenceAliveReasonSchema = Type.String({
 });
 
 /** Presence heartbeat payload sent by remote nodes to refresh gateway state. */
-export const NodePresenceAlivePayloadSchema = Type.Object(
-  {
-    trigger: NodePresenceAliveReasonSchema,
-    sentAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    displayName: Type.Optional(NonEmptyString),
-    version: Type.Optional(NonEmptyString),
-    platform: Type.Optional(NonEmptyString),
-    deviceFamily: Type.Optional(NonEmptyString),
-    modelIdentifier: Type.Optional(NonEmptyString),
-    pushTransport: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const NodePresenceAlivePayloadSchema = closedObject({
+  trigger: NodePresenceAliveReasonSchema,
+  sentAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  displayName: Type.Optional(NonEmptyString),
+  version: Type.Optional(NonEmptyString),
+  platform: Type.Optional(NonEmptyString),
+  deviceFamily: Type.Optional(NonEmptyString),
+  modelIdentifier: Type.Optional(NonEmptyString),
+  pushTransport: Type.Optional(NonEmptyString),
+});
 
 /** Recent operator input activity reported by an interactive node. */
-export const NodePresenceActivityPayloadSchema = Type.Object(
-  {
-    idleSeconds: Type.Integer({ minimum: 0, maximum: 2_592_000 }),
-    saturated: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const NodePresenceActivityPayloadSchema = closedObject({
+  idleSeconds: Type.Integer({ minimum: 0, maximum: 2_592_000 }),
+  saturated: Type.Optional(Type.Boolean()),
+});
 
 /** Normalized result for node-originated events after gateway dispatch. */
-export const NodeEventResultSchema = Type.Object(
-  {
-    ok: Type.Boolean(),
-    event: NonEmptyString,
-    handled: Type.Boolean(),
-    reason: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const NodeEventResultSchema = closedObject({
+  ok: Type.Boolean(),
+  event: NonEmptyString,
+  handled: Type.Boolean(),
+  reason: Type.Optional(NonEmptyString),
+});
 
 /** Lists pending node-pairing requests. */
-export const NodePairListParamsSchema = Type.Object({}, { additionalProperties: false });
+export const NodePairListParamsSchema = closedObject({});
 
 /** Approves a pending node-pairing request by request id. */
-export const NodePairApproveParamsSchema = Type.Object(
-  { requestId: NonEmptyString },
-  { additionalProperties: false },
-);
+export const NodePairApproveParamsSchema = closedObject({ requestId: NonEmptyString });
 
 /** Rejects a pending node-pairing request by request id. */
-export const NodePairRejectParamsSchema = Type.Object(
-  { requestId: NonEmptyString },
-  { additionalProperties: false },
-);
+export const NodePairRejectParamsSchema = closedObject({ requestId: NonEmptyString });
 
 /** Removes an already paired node from the gateway trust set. */
-export const NodePairRemoveParamsSchema = Type.Object(
-  { nodeId: NonEmptyString },
-  { additionalProperties: false },
-);
+export const NodePairRemoveParamsSchema = closedObject({ nodeId: NonEmptyString });
 
 /** Renames a paired node while preserving its stable node id. */
-export const NodeRenameParamsSchema = Type.Object(
-  { nodeId: NonEmptyString, displayName: NonEmptyString },
-  { additionalProperties: false },
-);
+export const NodeRenameParamsSchema = closedObject({
+  nodeId: NonEmptyString,
+  displayName: NonEmptyString,
+});
 
 /** Lists paired nodes known to the gateway. */
-export const NodeListParamsSchema = Type.Object({}, { additionalProperties: false });
+export const NodeListParamsSchema = closedObject({});
 
 /** Agent-visible tool descriptor advertised by a connected node. */
-export const NodePluginToolDescriptorSchema = Type.Object(
-  {
-    pluginId: NonEmptyString,
-    name: NodePluginToolNameSchema,
-    description: NonEmptyString,
-    parameters: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
-    command: Type.Optional(NonEmptyString),
-    mcp: Type.Optional(
-      Type.Object(
-        {
-          server: NonEmptyString,
-          tool: NonEmptyString,
-        },
-        { additionalProperties: false },
-      ),
-    ),
-  },
-  { additionalProperties: false },
-);
+export const NodePluginToolDescriptorSchema = closedObject({
+  pluginId: NonEmptyString,
+  name: NodePluginToolNameSchema,
+  description: NonEmptyString,
+  parameters: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  command: Type.Optional(NonEmptyString),
+  mcp: Type.Optional(
+    closedObject({
+      server: NonEmptyString,
+      tool: NonEmptyString,
+    }),
+  ),
+});
 
 /** Replaces the connected node's dynamic agent-visible plugin/MCP tool catalog. */
-export const NodePluginToolsUpdateParamsSchema = Type.Object(
-  {
-    tools: Type.Array(NodePluginToolDescriptorSchema),
-  },
-  { additionalProperties: false },
-);
+export const NodePluginToolsUpdateParamsSchema = closedObject({
+  tools: Type.Array(NodePluginToolDescriptorSchema),
+});
 
 // Plugin-SDK-reachable types export directly from this owner module; routing them
 // through the ProtocolSchemas registry retains the whole registry in public dts.
@@ -136,155 +110,113 @@ export type NodePluginToolDescriptor = Static<typeof NodePluginToolDescriptorSch
 export type NodePluginToolsUpdateParams = Static<typeof NodePluginToolsUpdateParamsSchema>;
 
 /** Agent-visible skill descriptor advertised by a connected node. */
-export const NodeSkillDescriptorSchema = Type.Object(
-  {
-    name: NodeSkillNameSchema,
-    description: Type.String({ minLength: 1, maxLength: 1024 }),
-    content: Type.String({ minLength: 1, maxLength: 64 * 1024 }),
-  },
-  { additionalProperties: false },
-);
+export const NodeSkillDescriptorSchema = closedObject({
+  name: NodeSkillNameSchema,
+  description: Type.String({ minLength: 1, maxLength: 1024 }),
+  content: Type.String({ minLength: 1, maxLength: 64 * 1024 }),
+});
 
 /** Replaces the connected node's agent-visible skill catalog. */
-export const NodeSkillsUpdateParamsSchema = Type.Object(
-  {
-    skills: Type.Array(NodeSkillDescriptorSchema, { maxItems: 64 }),
-  },
-  { additionalProperties: false },
-);
+export const NodeSkillsUpdateParamsSchema = closedObject({
+  skills: Type.Array(NodeSkillDescriptorSchema, { maxItems: 64 }),
+});
 
 export type NodeSkillDescriptor = Static<typeof NodeSkillDescriptorSchema>;
 export type NodeSkillsUpdateParams = Static<typeof NodeSkillsUpdateParamsSchema>;
 
 /** Acknowledges queued node work that the node has consumed. */
-export const NodePendingAckParamsSchema = Type.Object(
-  {
-    ids: Type.Array(NonEmptyString, { minItems: 1 }),
-  },
-  { additionalProperties: false },
-);
+export const NodePendingAckParamsSchema = closedObject({
+  ids: Type.Array(NonEmptyString, { minItems: 1 }),
+});
 
 /** Requests detailed metadata for one paired node. */
-export const NodeDescribeParamsSchema = Type.Object(
-  { nodeId: NonEmptyString },
-  { additionalProperties: false },
-);
+export const NodeDescribeParamsSchema = closedObject({ nodeId: NonEmptyString });
 
 /** Invokes a command on a paired node; idempotency allows safe retries. */
-export const NodeInvokeParamsSchema = Type.Object(
-  {
-    nodeId: NonEmptyString,
-    command: NonEmptyString,
-    params: Type.Optional(Type.Unknown()),
-    timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    idempotencyKey: NonEmptyString,
-    // Gateway-only approval routing metadata. Node forwarding strips these fields.
-    turnSourceChannel: Type.Optional(Type.String()),
-    turnSourceTo: Type.Optional(Type.String()),
-    turnSourceAccountId: Type.Optional(Type.String()),
-    turnSourceThreadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
-  },
-  { additionalProperties: false },
-);
+export const NodeInvokeParamsSchema = closedObject({
+  nodeId: NonEmptyString,
+  command: NonEmptyString,
+  params: Type.Optional(Type.Unknown()),
+  timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  idempotencyKey: NonEmptyString,
+  // Gateway-only approval routing metadata. Node forwarding strips these fields.
+  turnSourceChannel: Type.Optional(Type.String()),
+  turnSourceTo: Type.Optional(Type.String()),
+  turnSourceAccountId: Type.Optional(Type.String()),
+  turnSourceThreadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+});
 
 /** Result callback payload for a node command invocation. */
-export const NodeInvokeResultParamsSchema = Type.Object(
-  {
-    id: NonEmptyString,
-    nodeId: NonEmptyString,
-    ok: Type.Boolean(),
-    payload: Type.Optional(Type.Unknown()),
-    payloadJSON: Type.Optional(Type.String()),
-    error: Type.Optional(
-      Type.Object(
-        {
-          code: Type.Optional(NonEmptyString),
-          message: Type.Optional(NonEmptyString),
-        },
-        { additionalProperties: false },
-      ),
-    ),
-  },
-  { additionalProperties: false },
-);
+export const NodeInvokeResultParamsSchema = closedObject({
+  id: NonEmptyString,
+  nodeId: NonEmptyString,
+  ok: Type.Boolean(),
+  payload: Type.Optional(Type.Unknown()),
+  payloadJSON: Type.Optional(Type.String()),
+  error: Type.Optional(
+    closedObject({
+      code: Type.Optional(NonEmptyString),
+      message: Type.Optional(NonEmptyString),
+    }),
+  ),
+});
 
 /** Generic node event envelope accepted by the gateway. */
-export const NodeEventParamsSchema = Type.Object(
-  {
-    event: NonEmptyString,
-    payload: Type.Optional(Type.Unknown()),
-    payloadJSON: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const NodeEventParamsSchema = closedObject({
+  event: NonEmptyString,
+  payload: Type.Optional(Type.Unknown()),
+  payloadJSON: Type.Optional(Type.String()),
+});
 
 /** Request for a bounded batch of queued work assigned to the calling node. */
-export const NodePendingDrainParamsSchema = Type.Object(
-  {
-    maxItems: Type.Optional(Type.Integer({ minimum: 1, maximum: 10 })),
-  },
-  { additionalProperties: false },
-);
+export const NodePendingDrainParamsSchema = closedObject({
+  maxItems: Type.Optional(Type.Integer({ minimum: 1, maximum: 10 })),
+});
 
 /** One queued node-work item returned by pending-work drain calls. */
-export const NodePendingDrainItemSchema = Type.Object(
-  {
-    id: NonEmptyString,
-    type: NodePendingWorkTypeSchema,
-    priority: Type.String({ enum: ["default", "normal", "high"] }),
-    createdAtMs: Type.Integer({ minimum: 0 }),
-    expiresAtMs: Type.Optional(Type.Union([Type.Integer({ minimum: 0 }), Type.Null()])),
-    payload: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
-  },
-  { additionalProperties: false },
-);
+export const NodePendingDrainItemSchema = closedObject({
+  id: NonEmptyString,
+  type: NodePendingWorkTypeSchema,
+  priority: Type.String({ enum: ["default", "normal", "high"] }),
+  createdAtMs: Type.Integer({ minimum: 0 }),
+  expiresAtMs: Type.Optional(Type.Union([Type.Integer({ minimum: 0 }), Type.Null()])),
+  payload: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+});
 
 /** Drain response with a revision marker for node queue state. */
-export const NodePendingDrainResultSchema = Type.Object(
-  {
-    nodeId: NonEmptyString,
-    revision: Type.Integer({ minimum: 0 }),
-    items: Type.Array(NodePendingDrainItemSchema),
-    hasMore: Type.Boolean(),
-  },
-  { additionalProperties: false },
-);
+export const NodePendingDrainResultSchema = closedObject({
+  nodeId: NonEmptyString,
+  revision: Type.Integer({ minimum: 0 }),
+  items: Type.Array(NodePendingDrainItemSchema),
+  hasMore: Type.Boolean(),
+});
 
 /** Enqueues gateway-initiated work for a paired node. */
-export const NodePendingEnqueueParamsSchema = Type.Object(
-  {
-    nodeId: NonEmptyString,
-    type: NodePendingWorkTypeSchema,
-    priority: Type.Optional(NodePendingWorkPrioritySchema),
-    expiresInMs: Type.Optional(Type.Integer({ minimum: 1_000, maximum: 86_400_000 })),
-    wake: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const NodePendingEnqueueParamsSchema = closedObject({
+  nodeId: NonEmptyString,
+  type: NodePendingWorkTypeSchema,
+  priority: Type.Optional(NodePendingWorkPrioritySchema),
+  expiresInMs: Type.Optional(Type.Integer({ minimum: 1_000, maximum: 86_400_000 })),
+  wake: Type.Optional(Type.Boolean()),
+});
 
 /** Enqueue result echoes queue revision and whether wake delivery was attempted. */
-export const NodePendingEnqueueResultSchema = Type.Object(
-  {
-    nodeId: NonEmptyString,
-    revision: Type.Integer({ minimum: 0 }),
-    queued: NodePendingDrainItemSchema,
-    wakeTriggered: Type.Boolean(),
-  },
-  { additionalProperties: false },
-);
+export const NodePendingEnqueueResultSchema = closedObject({
+  nodeId: NonEmptyString,
+  revision: Type.Integer({ minimum: 0 }),
+  queued: NodePendingDrainItemSchema,
+  wakeTriggered: Type.Boolean(),
+});
 
 /** Event payload used by the gateway to ask a node to run a command. */
-export const NodeInvokeRequestEventSchema = Type.Object(
-  {
-    id: NonEmptyString,
-    nodeId: NonEmptyString,
-    command: NonEmptyString,
-    paramsJSON: Type.Optional(Type.String()),
-    timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    idempotencyKey: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const NodeInvokeRequestEventSchema = closedObject({
+  id: NonEmptyString,
+  nodeId: NonEmptyString,
+  command: NonEmptyString,
+  paramsJSON: Type.Optional(Type.String()),
+  timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  idempotencyKey: Type.Optional(NonEmptyString),
+});
 
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/plugin-approvals.ts
+++ b/packages/gateway-protocol/src/schema/plugin-approvals.ts
@@ -1,6 +1,7 @@
 import type { Static } from "typebox";
 // Gateway Protocol schema module defines protocol validation shapes.
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 /**
@@ -15,46 +16,40 @@ const PLUGIN_APPROVAL_TITLE_MAX_LENGTH = 80;
 const PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH = 512;
 
 /** Approval request raised by a plugin before a sensitive tool action proceeds. */
-export const PluginApprovalRequestParamsSchema = Type.Object(
-  {
-    pluginId: Type.Optional(NonEmptyString),
-    title: Type.String({ minLength: 1, maxLength: PLUGIN_APPROVAL_TITLE_MAX_LENGTH }),
-    description: Type.String({ minLength: 1, maxLength: PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH }),
-    severity: Type.Optional(Type.String({ enum: ["info", "warning", "critical"] })),
-    toolName: Type.Optional(Type.String()),
-    toolCallId: Type.Optional(Type.String()),
-    allowedDecisions: Type.Optional(
-      Type.Array(Type.String({ enum: ["allow-once", "allow-always", "deny"] }), {
-        minItems: 1,
-        maxItems: 3,
-      }),
-    ),
-    agentId: Type.Optional(Type.String()),
-    sessionKey: Type.Optional(Type.String()),
-    approvalReviewerDeviceIds: Type.Optional(
-      Type.Array(NonEmptyString, {
-        description:
-          "Trusted approval-runtime metadata naming operator devices that may review this approval; ordinary Gateway clients may send the field, but the Gateway only binds it for internal approval-runtime requests.",
-      }),
-    ),
-    turnSourceChannel: Type.Optional(Type.String()),
-    turnSourceTo: Type.Optional(Type.String()),
-    turnSourceAccountId: Type.Optional(Type.String()),
-    turnSourceThreadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
-    timeoutMs: Type.Optional(Type.Integer({ minimum: 1, maximum: MAX_PLUGIN_APPROVAL_TIMEOUT_MS })),
-    twoPhase: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const PluginApprovalRequestParamsSchema = closedObject({
+  pluginId: Type.Optional(NonEmptyString),
+  title: Type.String({ minLength: 1, maxLength: PLUGIN_APPROVAL_TITLE_MAX_LENGTH }),
+  description: Type.String({ minLength: 1, maxLength: PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH }),
+  severity: Type.Optional(Type.String({ enum: ["info", "warning", "critical"] })),
+  toolName: Type.Optional(Type.String()),
+  toolCallId: Type.Optional(Type.String()),
+  allowedDecisions: Type.Optional(
+    Type.Array(Type.String({ enum: ["allow-once", "allow-always", "deny"] }), {
+      minItems: 1,
+      maxItems: 3,
+    }),
+  ),
+  agentId: Type.Optional(Type.String()),
+  sessionKey: Type.Optional(Type.String()),
+  approvalReviewerDeviceIds: Type.Optional(
+    Type.Array(NonEmptyString, {
+      description:
+        "Trusted approval-runtime metadata naming operator devices that may review this approval; ordinary Gateway clients may send the field, but the Gateway only binds it for internal approval-runtime requests.",
+    }),
+  ),
+  turnSourceChannel: Type.Optional(Type.String()),
+  turnSourceTo: Type.Optional(Type.String()),
+  turnSourceAccountId: Type.Optional(Type.String()),
+  turnSourceThreadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+  timeoutMs: Type.Optional(Type.Integer({ minimum: 1, maximum: MAX_PLUGIN_APPROVAL_TIMEOUT_MS })),
+  twoPhase: Type.Optional(Type.Boolean()),
+});
 
 /** Reviewer decision payload resolving one pending plugin approval request. */
-export const PluginApprovalResolveParamsSchema = Type.Object(
-  {
-    id: NonEmptyString,
-    decision: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const PluginApprovalResolveParamsSchema = closedObject({
+  id: NonEmptyString,
+  decision: NonEmptyString,
+});
 
 // Owner-local wire types derived directly from local schema consts so the
 // public plugin-sdk declaration graph never pulls in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/plugins.ts
+++ b/packages/gateway-protocol/src/schema/plugins.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 /**
@@ -13,70 +14,55 @@ import { NonEmptyString } from "./primitives.js";
 export const PluginJsonValueSchema = Type.Unknown();
 
 /** Descriptor for one plugin-provided control UI action or surface. */
-export const PluginControlUiDescriptorSchema = Type.Object(
-  {
-    id: NonEmptyString,
-    pluginId: NonEmptyString,
-    pluginName: Type.Optional(NonEmptyString),
-    surface: Type.Union([
-      Type.Literal("session"),
-      Type.Literal("tool"),
-      Type.Literal("run"),
-      Type.Literal("settings"),
-    ]),
-    label: NonEmptyString,
-    description: Type.Optional(Type.String()),
-    placement: Type.Optional(Type.String()),
-    schema: Type.Optional(PluginJsonValueSchema),
-    requiredScopes: Type.Optional(Type.Array(NonEmptyString)),
-  },
-  { additionalProperties: false },
-);
+export const PluginControlUiDescriptorSchema = closedObject({
+  id: NonEmptyString,
+  pluginId: NonEmptyString,
+  pluginName: Type.Optional(NonEmptyString),
+  surface: Type.Union([
+    Type.Literal("session"),
+    Type.Literal("tool"),
+    Type.Literal("run"),
+    Type.Literal("settings"),
+  ]),
+  label: NonEmptyString,
+  description: Type.Optional(Type.String()),
+  placement: Type.Optional(Type.String()),
+  schema: Type.Optional(PluginJsonValueSchema),
+  requiredScopes: Type.Optional(Type.Array(NonEmptyString)),
+});
 
 /** Empty request payload for listing plugin UI descriptors. */
-export const PluginsUiDescriptorsParamsSchema = Type.Object({}, { additionalProperties: false });
+export const PluginsUiDescriptorsParamsSchema = closedObject({});
 
 /** Response payload containing all plugin UI descriptors visible to the client. */
-export const PluginsUiDescriptorsResultSchema = Type.Object(
-  {
-    ok: Type.Literal(true),
-    descriptors: Type.Array(PluginControlUiDescriptorSchema),
-  },
-  { additionalProperties: false },
-);
+export const PluginsUiDescriptorsResultSchema = closedObject({
+  ok: Type.Literal(true),
+  descriptors: Type.Array(PluginControlUiDescriptorSchema),
+});
 
 /** Request payload for invoking one plugin-owned session action. */
-export const PluginsSessionActionParamsSchema = Type.Object(
-  {
-    pluginId: NonEmptyString,
-    actionId: NonEmptyString,
-    sessionKey: Type.Optional(NonEmptyString),
-    payload: Type.Optional(PluginJsonValueSchema),
-  },
-  { additionalProperties: false },
-);
+export const PluginsSessionActionParamsSchema = closedObject({
+  pluginId: NonEmptyString,
+  actionId: NonEmptyString,
+  sessionKey: Type.Optional(NonEmptyString),
+  payload: Type.Optional(PluginJsonValueSchema),
+});
 
 /** Successful plugin action result, optionally continuing the agent turn. */
-export const PluginsSessionActionSuccessResultSchema = Type.Object(
-  {
-    ok: Type.Literal(true),
-    result: Type.Optional(PluginJsonValueSchema),
-    continueAgent: Type.Optional(Type.Boolean()),
-    reply: Type.Optional(PluginJsonValueSchema),
-  },
-  { additionalProperties: false },
-);
+export const PluginsSessionActionSuccessResultSchema = closedObject({
+  ok: Type.Literal(true),
+  result: Type.Optional(PluginJsonValueSchema),
+  continueAgent: Type.Optional(Type.Boolean()),
+  reply: Type.Optional(PluginJsonValueSchema),
+});
 
 /** Failed plugin action result with plugin-owned detail payload. */
-export const PluginsSessionActionFailureResultSchema = Type.Object(
-  {
-    ok: Type.Literal(false),
-    error: Type.String(),
-    code: Type.Optional(Type.String()),
-    details: Type.Optional(PluginJsonValueSchema),
-  },
-  { additionalProperties: false },
-);
+export const PluginsSessionActionFailureResultSchema = closedObject({
+  ok: Type.Literal(false),
+  error: Type.String(),
+  code: Type.Optional(Type.String()),
+  details: Type.Optional(PluginJsonValueSchema),
+});
 
 /** Discriminated plugin action result returned to gateway clients. */
 export const PluginsSessionActionResultSchema = Type.Union([
@@ -85,22 +71,16 @@ export const PluginsSessionActionResultSchema = Type.Union([
 ]);
 
 /** ClawHub-backed install action for one catalog entry. */
-export const PluginCatalogClawHubInstallSchema = Type.Object(
-  {
-    source: Type.Literal("clawhub"),
-    packageName: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const PluginCatalogClawHubInstallSchema = closedObject({
+  source: Type.Literal("clawhub"),
+  packageName: NonEmptyString,
+});
 
 /** Official-catalog install action for one catalog entry. */
-export const PluginCatalogOfficialInstallSchema = Type.Object(
-  {
-    source: Type.Literal("official"),
-    pluginId: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const PluginCatalogOfficialInstallSchema = closedObject({
+  source: Type.Literal("official"),
+  pluginId: NonEmptyString,
+});
 
 // Branches stay named schemas: the Swift generator only emits discriminated
 // unions whose branches resolve to registered types (see PluginsSessionActionResult).
@@ -110,163 +90,126 @@ export const PluginCatalogInstallActionSchema = Type.Union([
 ]);
 
 /** Cold control-plane representation of an installed or available plugin. */
-export const PluginCatalogEntrySchema = Type.Object(
-  {
-    id: NonEmptyString,
-    name: NonEmptyString,
-    packageName: Type.Optional(NonEmptyString),
-    description: Type.Optional(Type.String()),
-    version: Type.Optional(NonEmptyString),
-    kind: Type.Optional(Type.Array(NonEmptyString)),
-    origin: Type.Optional(NonEmptyString),
-    installed: Type.Boolean(),
-    enabled: Type.Boolean(),
-    state: Type.Union([
-      Type.Literal("enabled"),
-      Type.Literal("disabled"),
-      Type.Literal("not-installed"),
-      Type.Literal("error"),
-    ]),
-    featured: Type.Optional(Type.Boolean()),
-    order: Type.Optional(Type.Number()),
-    install: Type.Optional(PluginCatalogInstallActionSchema),
-    error: Type.Optional(Type.String()),
-    /** Coarse manifest-derived grouping (channel, provider, memory, ...) for catalog UIs. */
-    category: Type.Optional(NonEmptyString),
-    /** True when the plugin has an install record and can be removed via plugins.uninstall. */
-    removable: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const PluginCatalogEntrySchema = closedObject({
+  id: NonEmptyString,
+  name: NonEmptyString,
+  packageName: Type.Optional(NonEmptyString),
+  description: Type.Optional(Type.String()),
+  version: Type.Optional(NonEmptyString),
+  kind: Type.Optional(Type.Array(NonEmptyString)),
+  origin: Type.Optional(NonEmptyString),
+  installed: Type.Boolean(),
+  enabled: Type.Boolean(),
+  state: Type.Union([
+    Type.Literal("enabled"),
+    Type.Literal("disabled"),
+    Type.Literal("not-installed"),
+    Type.Literal("error"),
+  ]),
+  featured: Type.Optional(Type.Boolean()),
+  order: Type.Optional(Type.Number()),
+  install: Type.Optional(PluginCatalogInstallActionSchema),
+  error: Type.Optional(Type.String()),
+  /** Coarse manifest-derived grouping (channel, provider, memory, ...) for catalog UIs. */
+  category: Type.Optional(NonEmptyString),
+  /** True when the plugin has an install record and can be removed via plugins.uninstall. */
+  removable: Type.Optional(Type.Boolean()),
+});
 
 /** Empty request payload for the cold plugin catalog. */
-export const PluginsListParamsSchema = Type.Object({}, { additionalProperties: false });
+export const PluginsListParamsSchema = closedObject({});
 
 /** Installed and curated plugin catalog visible to the current gateway client. */
-export const PluginsListResultSchema = Type.Object(
-  {
-    plugins: Type.Array(PluginCatalogEntrySchema),
-    diagnostics: Type.Array(Type.Unknown()),
-    mutationAllowed: Type.Boolean(),
-  },
-  { additionalProperties: false },
-);
+export const PluginsListResultSchema = closedObject({
+  plugins: Type.Array(PluginCatalogEntrySchema),
+  diagnostics: Type.Array(Type.Unknown()),
+  mutationAllowed: Type.Boolean(),
+});
 
 /** Request payload for searching installable ClawHub plugin families. */
-export const PluginsSearchParamsSchema = Type.Object(
-  {
-    query: NonEmptyString,
-    limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
-  },
-  { additionalProperties: false },
-);
+export const PluginsSearchParamsSchema = closedObject({
+  query: NonEmptyString,
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
+});
 
 /** ClawHub package fields exposed by plugin search. */
-export const PluginSearchPackageSchema = Type.Object(
-  {
-    name: NonEmptyString,
-    displayName: NonEmptyString,
-    family: Type.Union([Type.Literal("code-plugin"), Type.Literal("bundle-plugin")]),
-    channel: Type.Union([
-      Type.Literal("official"),
-      Type.Literal("community"),
-      Type.Literal("private"),
-    ]),
-    isOfficial: Type.Boolean(),
-    summary: Type.Optional(Type.String()),
-    latestVersion: Type.Optional(NonEmptyString),
-    runtimeId: Type.Optional(NonEmptyString),
-    downloads: Type.Optional(Type.Number({ minimum: 0 })),
-    verificationTier: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const PluginSearchPackageSchema = closedObject({
+  name: NonEmptyString,
+  displayName: NonEmptyString,
+  family: Type.Union([Type.Literal("code-plugin"), Type.Literal("bundle-plugin")]),
+  channel: Type.Union([
+    Type.Literal("official"),
+    Type.Literal("community"),
+    Type.Literal("private"),
+  ]),
+  isOfficial: Type.Boolean(),
+  summary: Type.Optional(Type.String()),
+  latestVersion: Type.Optional(NonEmptyString),
+  runtimeId: Type.Optional(NonEmptyString),
+  downloads: Type.Optional(Type.Number({ minimum: 0 })),
+  verificationTier: Type.Optional(NonEmptyString),
+});
 
 /** Ranked ClawHub plugin search hit. */
-export const PluginSearchResultEntrySchema = Type.Object(
-  {
-    score: Type.Number(),
-    package: PluginSearchPackageSchema,
-  },
-  { additionalProperties: false },
-);
+export const PluginSearchResultEntrySchema = closedObject({
+  score: Type.Number(),
+  package: PluginSearchPackageSchema,
+});
 
 /** Ranked installable plugin packages matching the query. */
-export const PluginsSearchResultSchema = Type.Object(
-  { results: Type.Array(PluginSearchResultEntrySchema) },
-  { additionalProperties: false },
-);
+export const PluginsSearchResultSchema = closedObject({
+  results: Type.Array(PluginSearchResultEntrySchema),
+});
 
 /** Trusted official-catalog or acknowledged ClawHub install request. */
 export const PluginsInstallParamsSchema = Type.Union([
-  Type.Object(
-    {
-      source: Type.Literal("clawhub"),
-      packageName: NonEmptyString,
-      version: Type.Optional(NonEmptyString),
-      acknowledgeClawHubRisk: Type.Optional(Type.Boolean()),
-    },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
-      source: Type.Literal("official"),
-      pluginId: NonEmptyString,
-    },
-    { additionalProperties: false },
-  ),
+  closedObject({
+    source: Type.Literal("clawhub"),
+    packageName: NonEmptyString,
+    version: Type.Optional(NonEmptyString),
+    acknowledgeClawHubRisk: Type.Optional(Type.Boolean()),
+  }),
+  closedObject({
+    source: Type.Literal("official"),
+    pluginId: NonEmptyString,
+  }),
 ]);
 
 /** Successful plugin installation result. */
-export const PluginsInstallResultSchema = Type.Object(
-  {
-    ok: Type.Literal(true),
-    plugin: PluginCatalogEntrySchema,
-    restartRequired: Type.Literal(true),
-    warnings: Type.Optional(Type.Array(Type.String())),
-  },
-  { additionalProperties: false },
-);
+export const PluginsInstallResultSchema = closedObject({
+  ok: Type.Literal(true),
+  plugin: PluginCatalogEntrySchema,
+  restartRequired: Type.Literal(true),
+  warnings: Type.Optional(Type.Array(Type.String())),
+});
 
 /** Request payload for removing one installed plugin and its managed files. */
-export const PluginsUninstallParamsSchema = Type.Object(
-  {
-    pluginId: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const PluginsUninstallParamsSchema = closedObject({
+  pluginId: NonEmptyString,
+});
 
 /** Successful plugin removal result listing the cleanup actions that ran. */
-export const PluginsUninstallResultSchema = Type.Object(
-  {
-    ok: Type.Literal(true),
-    pluginId: NonEmptyString,
-    restartRequired: Type.Literal(true),
-    removed: Type.Array(Type.String()),
-    warnings: Type.Optional(Type.Array(Type.String())),
-  },
-  { additionalProperties: false },
-);
+export const PluginsUninstallResultSchema = closedObject({
+  ok: Type.Literal(true),
+  pluginId: NonEmptyString,
+  restartRequired: Type.Literal(true),
+  removed: Type.Array(Type.String()),
+  warnings: Type.Optional(Type.Array(Type.String())),
+});
 
 /** Request payload for changing one installed plugin's policy state. */
-export const PluginsSetEnabledParamsSchema = Type.Object(
-  {
-    pluginId: NonEmptyString,
-    enabled: Type.Boolean(),
-  },
-  { additionalProperties: false },
-);
+export const PluginsSetEnabledParamsSchema = closedObject({
+  pluginId: NonEmptyString,
+  enabled: Type.Boolean(),
+});
 
 /** Successful plugin enablement policy update. */
-export const PluginsSetEnabledResultSchema = Type.Object(
-  {
-    ok: Type.Literal(true),
-    plugin: PluginCatalogEntrySchema,
-    restartRequired: Type.Boolean(),
-    warnings: Type.Optional(Type.Array(Type.String())),
-  },
-  { additionalProperties: false },
-);
+export const PluginsSetEnabledResultSchema = closedObject({
+  ok: Type.Literal(true),
+  plugin: PluginCatalogEntrySchema,
+  restartRequired: Type.Boolean(),
+  warnings: Type.Optional(Type.Array(Type.String())),
+});
 
 export type PluginCatalogEntry = Static<typeof PluginCatalogEntrySchema>;
 export type PluginsListParams = Static<typeof PluginsListParamsSchema>;

--- a/packages/gateway-protocol/src/schema/primitives.ts
+++ b/packages/gateway-protocol/src/schema/primitives.ts
@@ -8,6 +8,7 @@ import {
   SECRET_PROVIDER_ALIAS_PATTERN,
   SINGLE_VALUE_FILE_REF_ID,
 } from "../secret-ref-contract.js";
+import { closedObject } from "./closed-object.js";
 
 /**
  * Shared schema primitives reused by gateway protocol request/result schemas.
@@ -34,16 +35,13 @@ export const SessionLabelString = Type.String({
   maxLength: SESSION_LABEL_MAX_LENGTH,
 });
 /** Provenance marker for content copied from another user/session/system source. */
-export const InputProvenanceSchema = Type.Object(
-  {
-    kind: Type.String({ enum: [...INPUT_PROVENANCE_KIND_VALUES] }),
-    originSessionId: Type.Optional(Type.String()),
-    sourceSessionKey: Type.Optional(Type.String()),
-    sourceChannel: Type.Optional(Type.String()),
-    sourceTool: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const InputProvenanceSchema = closedObject({
+  kind: Type.String({ enum: [...INPUT_PROVENANCE_KIND_VALUES] }),
+  originSessionId: Type.Optional(Type.String()),
+  sourceSessionKey: Type.Optional(Type.String()),
+  sourceChannel: Type.Optional(Type.String()),
+  sourceTool: Type.Optional(Type.String()),
+});
 
 /** Closed gateway client id schema aligned with `GATEWAY_CLIENT_IDS`. */
 export const GatewayClientIdSchema = Type.Enum(GATEWAY_CLIENT_IDS);
@@ -62,14 +60,11 @@ const SecretProviderAliasString = Type.String({
   pattern: SECRET_PROVIDER_ALIAS_PATTERN.source,
 });
 
-const EnvSecretRefSchema = Type.Object(
-  {
-    source: Type.Literal("env"),
-    provider: SecretProviderAliasString,
-    id: Type.String({ pattern: ENV_SECRET_REF_ID_RE.source }),
-  },
-  { additionalProperties: false },
-);
+const EnvSecretRefSchema = closedObject({
+  source: Type.Literal("env"),
+  provider: SecretProviderAliasString,
+  id: Type.String({ pattern: ENV_SECRET_REF_ID_RE.source }),
+});
 
 const FileSecretRefIdSchema = Type.Unsafe<string>({
   type: "string",
@@ -84,23 +79,17 @@ const FileSecretRefIdSchema = Type.Unsafe<string>({
   ],
 });
 
-const FileSecretRefSchema = Type.Object(
-  {
-    source: Type.Literal("file"),
-    provider: SecretProviderAliasString,
-    id: FileSecretRefIdSchema,
-  },
-  { additionalProperties: false },
-);
+const FileSecretRefSchema = closedObject({
+  source: Type.Literal("file"),
+  provider: SecretProviderAliasString,
+  id: FileSecretRefIdSchema,
+});
 
-const ExecSecretRefSchema = Type.Object(
-  {
-    source: Type.Literal("exec"),
-    provider: SecretProviderAliasString,
-    id: Type.String({ pattern: EXEC_SECRET_REF_ID_JSON_SCHEMA_PATTERN }),
-  },
-  { additionalProperties: false },
-);
+const ExecSecretRefSchema = closedObject({
+  source: Type.Literal("exec"),
+  provider: SecretProviderAliasString,
+  id: Type.String({ pattern: EXEC_SECRET_REF_ID_JSON_SCHEMA_PATTERN }),
+});
 
 /** Structured secret reference accepted by config and channel protocol payloads. */
 export const SecretRefSchema = Type.Union([

--- a/packages/gateway-protocol/src/schema/push.ts
+++ b/packages/gateway-protocol/src/schema/push.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 /**
@@ -12,69 +13,51 @@ import { NonEmptyString } from "./primitives.js";
 const ApnsEnvironmentSchema = Type.String({ enum: ["sandbox", "production"] });
 
 /** Request payload for sending a test APNS notification to one node. */
-export const PushTestParamsSchema = Type.Object(
-  {
-    nodeId: NonEmptyString,
-    title: Type.Optional(Type.String()),
-    body: Type.Optional(Type.String()),
-    environment: Type.Optional(ApnsEnvironmentSchema),
-  },
-  { additionalProperties: false },
-);
+export const PushTestParamsSchema = closedObject({
+  nodeId: NonEmptyString,
+  title: Type.Optional(Type.String()),
+  body: Type.Optional(Type.String()),
+  environment: Type.Optional(ApnsEnvironmentSchema),
+});
 
 /** Result payload from an APNS push test, including provider status and transport. */
-export const PushTestResultSchema = Type.Object(
-  {
-    ok: Type.Boolean(),
-    status: Type.Integer(),
-    apnsId: Type.Optional(Type.String()),
-    reason: Type.Optional(Type.String()),
-    tokenSuffix: Type.String(),
-    topic: Type.String(),
-    environment: ApnsEnvironmentSchema,
-    transport: Type.String({ enum: ["direct", "relay"] }),
-  },
-  { additionalProperties: false },
-);
+export const PushTestResultSchema = closedObject({
+  ok: Type.Boolean(),
+  status: Type.Integer(),
+  apnsId: Type.Optional(Type.String()),
+  reason: Type.Optional(Type.String()),
+  tokenSuffix: Type.String(),
+  topic: Type.String(),
+  environment: ApnsEnvironmentSchema,
+  transport: Type.String({ enum: ["direct", "relay"] }),
+});
 
 // --- Web Push schemas ---
 
-const WebPushKeysSchema = Type.Object(
-  {
-    p256dh: Type.String({ minLength: 1, maxLength: 512 }),
-    auth: Type.String({ minLength: 1, maxLength: 512 }),
-  },
-  { additionalProperties: false },
-);
+const WebPushKeysSchema = closedObject({
+  p256dh: Type.String({ minLength: 1, maxLength: 512 }),
+  auth: Type.String({ minLength: 1, maxLength: 512 }),
+});
 
 /** Empty request payload for fetching the Web Push VAPID public key. */
-export const WebPushVapidPublicKeyParamsSchema = Type.Object({}, { additionalProperties: false });
+export const WebPushVapidPublicKeyParamsSchema = closedObject({});
 
 /** Browser Web Push subscription payload registered with the gateway. */
-export const WebPushSubscribeParamsSchema = Type.Object(
-  {
-    endpoint: Type.String({ minLength: 1, maxLength: 2048, pattern: "^https://" }),
-    keys: WebPushKeysSchema,
-  },
-  { additionalProperties: false },
-);
+export const WebPushSubscribeParamsSchema = closedObject({
+  endpoint: Type.String({ minLength: 1, maxLength: 2048, pattern: "^https://" }),
+  keys: WebPushKeysSchema,
+});
 
 /** Browser Web Push endpoint removal payload. */
-export const WebPushUnsubscribeParamsSchema = Type.Object(
-  {
-    endpoint: Type.String({ minLength: 1, maxLength: 2048, pattern: "^https://" }),
-  },
-  { additionalProperties: false },
-);
+export const WebPushUnsubscribeParamsSchema = closedObject({
+  endpoint: Type.String({ minLength: 1, maxLength: 2048, pattern: "^https://" }),
+});
 
 /** Request payload for sending a test Web Push notification to current subscriptions. */
-export const WebPushTestParamsSchema = Type.Object(
-  {
-    title: Type.Optional(Type.String()),
-    body: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const WebPushTestParamsSchema = closedObject({
+  title: Type.Optional(Type.String()),
+  body: Type.Optional(Type.String()),
+});
 
 /** Empty request type for fetching the Web Push VAPID public key. */
 export type WebPushVapidPublicKeyParams = Record<string, never>;

--- a/packages/gateway-protocol/src/schema/secrets.ts
+++ b/packages/gateway-protocol/src/schema/secrets.ts
@@ -1,5 +1,6 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import { Type, type Static } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 /**
@@ -9,52 +10,40 @@ import { NonEmptyString } from "./primitives.js";
  * caller scope, allowed paths, and provider overrides explicit.
  */
 /** Empty request payload for reloading configured secret providers. */
-export const SecretsReloadParamsSchema = Type.Object({}, { additionalProperties: false });
+export const SecretsReloadParamsSchema = closedObject({});
 
 /** Request payload for resolving the secrets needed by one command invocation. */
-export const SecretsResolveParamsSchema = Type.Object(
-  {
-    commandName: NonEmptyString,
-    targetIds: Type.Array(NonEmptyString),
-    allowedPaths: Type.Optional(Type.Array(NonEmptyString)),
-    forcedActivePaths: Type.Optional(Type.Array(NonEmptyString)),
-    optionalActivePaths: Type.Optional(Type.Array(NonEmptyString)),
-    providerOverrides: Type.Optional(
-      Type.Object(
-        {
-          webSearch: Type.Optional(NonEmptyString),
-          webFetch: Type.Optional(NonEmptyString),
-        },
-        { additionalProperties: false },
-      ),
-    ),
-  },
-  { additionalProperties: false },
-);
+export const SecretsResolveParamsSchema = closedObject({
+  commandName: NonEmptyString,
+  targetIds: Type.Array(NonEmptyString),
+  allowedPaths: Type.Optional(Type.Array(NonEmptyString)),
+  forcedActivePaths: Type.Optional(Type.Array(NonEmptyString)),
+  optionalActivePaths: Type.Optional(Type.Array(NonEmptyString)),
+  providerOverrides: Type.Optional(
+    closedObject({
+      webSearch: Type.Optional(NonEmptyString),
+      webFetch: Type.Optional(NonEmptyString),
+    }),
+  ),
+});
 
 /** Static type for secret resolution requests. */
 export type SecretsResolveParams = Static<typeof SecretsResolveParamsSchema>;
 
 /** One resolved secret assignment path plus its provider-owned value. */
-export const SecretsResolveAssignmentSchema = Type.Object(
-  {
-    path: Type.Optional(NonEmptyString),
-    pathSegments: Type.Array(NonEmptyString),
-    value: Type.Unknown(),
-  },
-  { additionalProperties: false },
-);
+export const SecretsResolveAssignmentSchema = closedObject({
+  path: Type.Optional(NonEmptyString),
+  pathSegments: Type.Array(NonEmptyString),
+  value: Type.Unknown(),
+});
 
 /** Secret resolution response with assignments and safe diagnostics. */
-export const SecretsResolveResultSchema = Type.Object(
-  {
-    ok: Type.Optional(Type.Boolean()),
-    assignments: Type.Optional(Type.Array(SecretsResolveAssignmentSchema)),
-    diagnostics: Type.Optional(Type.Array(NonEmptyString)),
-    inactiveRefPaths: Type.Optional(Type.Array(NonEmptyString)),
-  },
-  { additionalProperties: false },
-);
+export const SecretsResolveResultSchema = closedObject({
+  ok: Type.Optional(Type.Boolean()),
+  assignments: Type.Optional(Type.Array(SecretsResolveAssignmentSchema)),
+  diagnostics: Type.Optional(Type.Array(NonEmptyString)),
+  inactiveRefPaths: Type.Optional(Type.Array(NonEmptyString)),
+});
 
 /** Static type for secret resolution responses. */
 export type SecretsResolveResult = Static<typeof SecretsResolveResultSchema>;

--- a/packages/gateway-protocol/src/schema/sessions-catalog.ts
+++ b/packages/gateway-protocol/src/schema/sessions-catalog.ts
@@ -1,68 +1,58 @@
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { PluginJsonValueSchema } from "./plugins.js";
 import { NonEmptyString } from "./primitives.js";
 
-const SessionCatalogErrorSchema = Type.Object(
-  { code: NonEmptyString, message: NonEmptyString },
-  { additionalProperties: false },
-);
+const SessionCatalogErrorSchema = closedObject({ code: NonEmptyString, message: NonEmptyString });
 
-export const SessionCatalogCapabilitiesSchema = Type.Object(
-  { continueSession: Type.Boolean(), archive: Type.Boolean() },
-  { additionalProperties: false },
-);
+export const SessionCatalogCapabilitiesSchema = closedObject({
+  continueSession: Type.Boolean(),
+  archive: Type.Boolean(),
+});
 
-export const SessionCatalogDescriptorSchema = Type.Object(
-  { id: NonEmptyString, label: NonEmptyString, capabilities: SessionCatalogCapabilitiesSchema },
-  { additionalProperties: false },
-);
+export const SessionCatalogDescriptorSchema = closedObject({
+  id: NonEmptyString,
+  label: NonEmptyString,
+  capabilities: SessionCatalogCapabilitiesSchema,
+});
 
-export const SessionCatalogSessionSchema = Type.Object(
-  {
-    threadId: NonEmptyString,
-    name: Type.Optional(Type.String()),
-    cwd: Type.Optional(Type.String()),
-    status: NonEmptyString,
-    createdAt: Type.Optional(Type.Number()),
-    updatedAt: Type.Optional(Type.Number()),
-    recencyAt: Type.Optional(Type.Number()),
-    source: Type.Optional(Type.String()),
-    modelProvider: Type.Optional(Type.String()),
-    cliVersion: Type.Optional(Type.String()),
-    gitBranch: Type.Optional(Type.String()),
-    archived: Type.Boolean(),
-    openClawSessionKey: Type.Optional(NonEmptyString),
-    canContinue: Type.Boolean(),
-    canArchive: Type.Boolean(),
-  },
-  { additionalProperties: false },
-);
+export const SessionCatalogSessionSchema = closedObject({
+  threadId: NonEmptyString,
+  name: Type.Optional(Type.String()),
+  cwd: Type.Optional(Type.String()),
+  status: NonEmptyString,
+  createdAt: Type.Optional(Type.Number()),
+  updatedAt: Type.Optional(Type.Number()),
+  recencyAt: Type.Optional(Type.Number()),
+  source: Type.Optional(Type.String()),
+  modelProvider: Type.Optional(Type.String()),
+  cliVersion: Type.Optional(Type.String()),
+  gitBranch: Type.Optional(Type.String()),
+  archived: Type.Boolean(),
+  openClawSessionKey: Type.Optional(NonEmptyString),
+  canContinue: Type.Boolean(),
+  canArchive: Type.Boolean(),
+});
 
-export const SessionCatalogHostSchema = Type.Object(
-  {
-    hostId: NonEmptyString,
-    label: NonEmptyString,
-    kind: Type.Union([Type.Literal("gateway"), Type.Literal("node")]),
-    connected: Type.Boolean(),
-    nodeId: Type.Optional(NonEmptyString),
-    sessions: Type.Array(SessionCatalogSessionSchema),
-    nextCursor: Type.Optional(Type.String()),
-    error: Type.Optional(SessionCatalogErrorSchema),
-  },
-  { additionalProperties: false },
-);
+export const SessionCatalogHostSchema = closedObject({
+  hostId: NonEmptyString,
+  label: NonEmptyString,
+  kind: Type.Union([Type.Literal("gateway"), Type.Literal("node")]),
+  connected: Type.Boolean(),
+  nodeId: Type.Optional(NonEmptyString),
+  sessions: Type.Array(SessionCatalogSessionSchema),
+  nextCursor: Type.Optional(Type.String()),
+  error: Type.Optional(SessionCatalogErrorSchema),
+});
 
-export const SessionCatalogSchema = Type.Object(
-  {
-    id: NonEmptyString,
-    label: NonEmptyString,
-    capabilities: SessionCatalogCapabilitiesSchema,
-    hosts: Type.Array(SessionCatalogHostSchema),
-    error: Type.Optional(SessionCatalogErrorSchema),
-  },
-  { additionalProperties: false },
-);
+export const SessionCatalogSchema = closedObject({
+  id: NonEmptyString,
+  label: NonEmptyString,
+  capabilities: SessionCatalogCapabilitiesSchema,
+  hosts: Type.Array(SessionCatalogHostSchema),
+  error: Type.Optional(SessionCatalogErrorSchema),
+});
 
 const SessionsCatalogListCommonProperties = {
   search: Type.Optional(Type.String()),
@@ -71,91 +61,70 @@ const SessionsCatalogListCommonProperties = {
 };
 
 export const SessionsCatalogListParamsSchema = Type.Union([
-  Type.Object(
-    { catalogId: Type.Optional(NonEmptyString), ...SessionsCatalogListCommonProperties },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
-      catalogId: NonEmptyString,
-      cursors: Type.Record(NonEmptyString, Type.String()),
-      ...SessionsCatalogListCommonProperties,
-    },
-    { additionalProperties: false },
-  ),
+  closedObject({
+    catalogId: Type.Optional(NonEmptyString),
+    ...SessionsCatalogListCommonProperties,
+  }),
+  closedObject({
+    catalogId: NonEmptyString,
+    cursors: Type.Record(NonEmptyString, Type.String()),
+    ...SessionsCatalogListCommonProperties,
+  }),
 ]);
 
-export const SessionsCatalogListResultSchema = Type.Object(
-  { catalogs: Type.Array(SessionCatalogSchema) },
-  { additionalProperties: false },
-);
+export const SessionsCatalogListResultSchema = closedObject({
+  catalogs: Type.Array(SessionCatalogSchema),
+});
 
-export const SessionCatalogTranscriptItemSchema = Type.Object(
-  {
-    id: Type.Optional(Type.String()),
-    type: Type.Union([
-      Type.Literal("userMessage"),
-      Type.Literal("agentMessage"),
-      Type.Literal("reasoning"),
-      Type.Literal("toolCall"),
-      Type.Literal("toolResult"),
-      Type.Literal("other"),
-    ]),
-    text: Type.Optional(Type.String()),
-    timestamp: Type.Optional(Type.String()),
-    model: Type.Optional(Type.String()),
-    truncated: Type.Optional(Type.Boolean()),
-    raw: Type.Optional(PluginJsonValueSchema),
-  },
-  { additionalProperties: false },
-);
+export const SessionCatalogTranscriptItemSchema = closedObject({
+  id: Type.Optional(Type.String()),
+  type: Type.Union([
+    Type.Literal("userMessage"),
+    Type.Literal("agentMessage"),
+    Type.Literal("reasoning"),
+    Type.Literal("toolCall"),
+    Type.Literal("toolResult"),
+    Type.Literal("other"),
+  ]),
+  text: Type.Optional(Type.String()),
+  timestamp: Type.Optional(Type.String()),
+  model: Type.Optional(Type.String()),
+  truncated: Type.Optional(Type.Boolean()),
+  raw: Type.Optional(PluginJsonValueSchema),
+});
 
-export const SessionsCatalogReadParamsSchema = Type.Object(
-  {
-    catalogId: NonEmptyString,
-    hostId: NonEmptyString,
-    threadId: NonEmptyString,
-    limit: Type.Optional(Type.Integer({ minimum: 1 })),
-    cursor: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const SessionsCatalogReadParamsSchema = closedObject({
+  catalogId: NonEmptyString,
+  hostId: NonEmptyString,
+  threadId: NonEmptyString,
+  limit: Type.Optional(Type.Integer({ minimum: 1 })),
+  cursor: Type.Optional(Type.String()),
+});
 
-export const SessionsCatalogReadResultSchema = Type.Object(
-  {
-    hostId: NonEmptyString,
-    label: Type.Optional(Type.String()),
-    threadId: NonEmptyString,
-    items: Type.Array(SessionCatalogTranscriptItemSchema),
-    nextCursor: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const SessionsCatalogReadResultSchema = closedObject({
+  hostId: NonEmptyString,
+  label: Type.Optional(Type.String()),
+  threadId: NonEmptyString,
+  items: Type.Array(SessionCatalogTranscriptItemSchema),
+  nextCursor: Type.Optional(Type.String()),
+});
 
-export const SessionsCatalogContinueParamsSchema = Type.Object(
-  { catalogId: NonEmptyString, hostId: NonEmptyString, threadId: NonEmptyString },
-  { additionalProperties: false },
-);
+export const SessionsCatalogContinueParamsSchema = closedObject({
+  catalogId: NonEmptyString,
+  hostId: NonEmptyString,
+  threadId: NonEmptyString,
+});
 
-export const SessionsCatalogContinueResultSchema = Type.Object(
-  { sessionKey: NonEmptyString },
-  { additionalProperties: false },
-);
+export const SessionsCatalogContinueResultSchema = closedObject({ sessionKey: NonEmptyString });
 
-export const SessionsCatalogArchiveParamsSchema = Type.Object(
-  {
-    catalogId: NonEmptyString,
-    hostId: NonEmptyString,
-    threadId: NonEmptyString,
-    confirmNoOtherRunner: Type.Literal(true),
-  },
-  { additionalProperties: false },
-);
+export const SessionsCatalogArchiveParamsSchema = closedObject({
+  catalogId: NonEmptyString,
+  hostId: NonEmptyString,
+  threadId: NonEmptyString,
+  confirmNoOtherRunner: Type.Literal(true),
+});
 
-export const SessionsCatalogArchiveResultSchema = Type.Object(
-  { ok: Type.Literal(true) },
-  { additionalProperties: false },
-);
+export const SessionsCatalogArchiveResultSchema = closedObject({ ok: Type.Literal(true) });
 
 export type SessionCatalogCapabilities = Static<typeof SessionCatalogCapabilitiesSchema>;
 export type SessionCatalogDescriptor = Static<typeof SessionCatalogDescriptorSchema>;

--- a/packages/gateway-protocol/src/schema/sessions.ts
+++ b/packages/gateway-protocol/src/schema/sessions.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { ErrorShapeSchema } from "./frames.js";
 import { PluginJsonValueSchema } from "./plugins.js";
 import { NonEmptyString, SessionLabelString } from "./primitives.js";
@@ -22,48 +23,39 @@ export const SessionCompactionCheckpointReasonSchema = Type.Union([
 ]);
 
 /** Start/end event emitted while a session compaction operation runs. */
-export const SessionOperationEventSchema = Type.Object(
-  {
-    operationId: NonEmptyString,
-    operation: Type.Literal("compact"),
-    phase: Type.Union([Type.Literal("start"), Type.Literal("end")]),
-    sessionKey: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    ts: Type.Integer({ minimum: 0 }),
-    completed: Type.Optional(Type.Boolean()),
-    reason: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const SessionOperationEventSchema = closedObject({
+  operationId: NonEmptyString,
+  operation: Type.Literal("compact"),
+  phase: Type.Union([Type.Literal("start"), Type.Literal("end")]),
+  sessionKey: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  ts: Type.Integer({ minimum: 0 }),
+  completed: Type.Optional(Type.Boolean()),
+  reason: Type.Optional(Type.String()),
+});
 
 /** Reference to the transcript location before or after compaction. */
-export const SessionCompactionTranscriptReferenceSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    sessionFile: Type.Optional(NonEmptyString),
-    leafId: Type.Optional(NonEmptyString),
-    entryId: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const SessionCompactionTranscriptReferenceSchema = closedObject({
+  sessionId: NonEmptyString,
+  sessionFile: Type.Optional(NonEmptyString),
+  leafId: Type.Optional(NonEmptyString),
+  entryId: Type.Optional(NonEmptyString),
+});
 
 /** Stored compaction checkpoint metadata for branching or restoring a session. */
-export const SessionCompactionCheckpointSchema = Type.Object(
-  {
-    checkpointId: NonEmptyString,
-    sessionKey: NonEmptyString,
-    sessionId: NonEmptyString,
-    createdAt: Type.Integer({ minimum: 0 }),
-    reason: SessionCompactionCheckpointReasonSchema,
-    tokensBefore: Type.Optional(Type.Integer({ minimum: 0 })),
-    tokensAfter: Type.Optional(Type.Integer({ minimum: 0 })),
-    summary: Type.Optional(Type.String()),
-    firstKeptEntryId: Type.Optional(NonEmptyString),
-    preCompaction: SessionCompactionTranscriptReferenceSchema,
-    postCompaction: SessionCompactionTranscriptReferenceSchema,
-  },
-  { additionalProperties: false },
-);
+export const SessionCompactionCheckpointSchema = closedObject({
+  checkpointId: NonEmptyString,
+  sessionKey: NonEmptyString,
+  sessionId: NonEmptyString,
+  createdAt: Type.Integer({ minimum: 0 }),
+  reason: SessionCompactionCheckpointReasonSchema,
+  tokensBefore: Type.Optional(Type.Integer({ minimum: 0 })),
+  tokensAfter: Type.Optional(Type.Integer({ minimum: 0 })),
+  summary: Type.Optional(Type.String()),
+  firstKeptEntryId: Type.Optional(NonEmptyString),
+  preCompaction: SessionCompactionTranscriptReferenceSchema,
+  postCompaction: SessionCompactionTranscriptReferenceSchema,
+});
 
 /** Session file grouping used by the Control UI session workspace rail. */
 export const SessionFileKindSchema = Type.Union([Type.Literal("modified"), Type.Literal("read")]);
@@ -82,109 +74,82 @@ const SessionFileHashSchema = Type.String({
 });
 
 /** One file path referenced by a session transcript. */
-export const SessionFileEntrySchema = Type.Object(
-  {
-    path: NonEmptyString,
-    workspacePath: Type.Optional(NonEmptyString),
-    name: NonEmptyString,
-    kind: SessionFileKindSchema,
-    missing: Type.Boolean(),
-    size: Type.Optional(Type.Integer({ minimum: 0 })),
-    updatedAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    content: Type.Optional(Type.String()),
-    hash: Type.Optional(SessionFileHashSchema),
-  },
-  { additionalProperties: false },
-);
+export const SessionFileEntrySchema = closedObject({
+  path: NonEmptyString,
+  workspacePath: Type.Optional(NonEmptyString),
+  name: NonEmptyString,
+  kind: SessionFileKindSchema,
+  missing: Type.Boolean(),
+  size: Type.Optional(Type.Integer({ minimum: 0 })),
+  updatedAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  content: Type.Optional(Type.String()),
+  hash: Type.Optional(SessionFileHashSchema),
+});
 
 /** One file or folder in the session-rooted browser. */
-export const SessionFileBrowserEntrySchema = Type.Object(
-  {
-    path: Type.String(),
-    name: NonEmptyString,
-    kind: Type.Union([Type.Literal("file"), Type.Literal("directory")]),
-    sessionKind: Type.Optional(SessionFileRelevanceSchema),
-    size: Type.Optional(Type.Integer({ minimum: 0 })),
-    updatedAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-  },
-  { additionalProperties: false },
-);
+export const SessionFileBrowserEntrySchema = closedObject({
+  path: Type.String(),
+  name: NonEmptyString,
+  kind: Type.Union([Type.Literal("file"), Type.Literal("directory")]),
+  sessionKind: Type.Optional(SessionFileRelevanceSchema),
+  size: Type.Optional(Type.Integer({ minimum: 0 })),
+  updatedAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+});
 
 /** Folder listing or search result rooted at the session workspace. */
-export const SessionFileBrowserResultSchema = Type.Object(
-  {
-    path: Type.String(),
-    parentPath: Type.Optional(Type.String()),
-    search: Type.Optional(Type.String()),
-    entries: Type.Array(SessionFileBrowserEntrySchema),
-    truncated: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const SessionFileBrowserResultSchema = closedObject({
+  path: Type.String(),
+  parentPath: Type.Optional(Type.String()),
+  search: Type.Optional(Type.String()),
+  entries: Type.Array(SessionFileBrowserEntrySchema),
+  truncated: Type.Optional(Type.Boolean()),
+});
 
 /** Lists files touched by a session transcript. */
-export const SessionsFilesListParamsSchema = Type.Object(
-  {
-    sessionKey: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    path: Type.Optional(Type.String()),
-    search: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const SessionsFilesListParamsSchema = closedObject({
+  sessionKey: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  path: Type.Optional(Type.String()),
+  search: Type.Optional(Type.String()),
+});
 
 /** File references visible in one session workspace. */
-export const SessionsFilesListResultSchema = Type.Object(
-  {
-    sessionKey: NonEmptyString,
-    root: Type.Optional(NonEmptyString),
-    files: Type.Array(SessionFileEntrySchema),
-    browser: Type.Optional(SessionFileBrowserResultSchema),
-  },
-  { additionalProperties: false },
-);
+export const SessionsFilesListResultSchema = closedObject({
+  sessionKey: NonEmptyString,
+  root: Type.Optional(NonEmptyString),
+  files: Type.Array(SessionFileEntrySchema),
+  browser: Type.Optional(SessionFileBrowserResultSchema),
+});
 
 /** Reads one session-referenced file by path. */
-export const SessionsFilesGetParamsSchema = Type.Object(
-  {
-    sessionKey: NonEmptyString,
-    path: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const SessionsFilesGetParamsSchema = closedObject({
+  sessionKey: NonEmptyString,
+  path: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+});
 
 /** Result for reading one session-referenced file. */
-export const SessionsFilesGetResultSchema = Type.Object(
-  {
-    sessionKey: NonEmptyString,
-    root: Type.Optional(NonEmptyString),
-    file: SessionFileEntrySchema,
-  },
-  { additionalProperties: false },
-);
+export const SessionsFilesGetResultSchema = closedObject({
+  sessionKey: NonEmptyString,
+  root: Type.Optional(NonEmptyString),
+  file: SessionFileEntrySchema,
+});
 
 /** Overwrites one existing session workspace file with hash-based CAS. */
-export const SessionsFilesSetParamsSchema = Type.Object(
-  {
-    sessionKey: NonEmptyString,
-    path: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    content: Type.String(),
-    expectedHash: SessionFileHashSchema,
-  },
-  { additionalProperties: false },
-);
+export const SessionsFilesSetParamsSchema = closedObject({
+  sessionKey: NonEmptyString,
+  path: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  content: Type.String(),
+  expectedHash: SessionFileHashSchema,
+});
 
 /** Result for overwriting one session workspace file. */
-export const SessionsFilesSetResultSchema = Type.Object(
-  {
-    sessionKey: NonEmptyString,
-    root: Type.Optional(NonEmptyString),
-    file: SessionFileEntrySchema,
-  },
-  { additionalProperties: false },
-);
+export const SessionsFilesSetResultSchema = closedObject({
+  sessionKey: NonEmptyString,
+  root: Type.Optional(NonEmptyString),
+  file: SessionFileEntrySchema,
+});
 
 /** Change status for one file in a session checkout diff. */
 export const SessionDiffFileStatusSchema = Type.Union([
@@ -195,225 +160,185 @@ export const SessionDiffFileStatusSchema = Type.Union([
 ]);
 
 /** One changed file in a session checkout diff. */
-export const SessionDiffFileSchema = Type.Object(
-  {
-    path: NonEmptyString,
-    oldPath: Type.Optional(NonEmptyString),
-    status: SessionDiffFileStatusSchema,
-    additions: Type.Integer({ minimum: 0 }),
-    deletions: Type.Integer({ minimum: 0 }),
-    binary: Type.Optional(Type.Boolean()),
-    untracked: Type.Optional(Type.Boolean()),
-    /** Per-file unified patch text; absent for binary or oversized files. */
-    patch: Type.Optional(Type.String()),
-    truncated: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const SessionDiffFileSchema = closedObject({
+  path: NonEmptyString,
+  oldPath: Type.Optional(NonEmptyString),
+  status: SessionDiffFileStatusSchema,
+  additions: Type.Integer({ minimum: 0 }),
+  deletions: Type.Integer({ minimum: 0 }),
+  binary: Type.Optional(Type.Boolean()),
+  untracked: Type.Optional(Type.Boolean()),
+  /** Per-file unified patch text; absent for binary or oversized files. */
+  patch: Type.Optional(Type.String()),
+  truncated: Type.Optional(Type.Boolean()),
+});
 
 /** Reads the git diff of a session checkout against its base branch. */
-export const SessionsDiffParamsSchema = Type.Object(
-  {
-    sessionKey: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const SessionsDiffParamsSchema = closedObject({
+  sessionKey: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+});
 
 /** Branch + working-tree diff for one session checkout. */
-export const SessionsDiffResultSchema = Type.Object(
-  {
-    sessionKey: NonEmptyString,
-    root: Type.Optional(NonEmptyString),
-    branch: Type.Optional(NonEmptyString),
-    /** Display label of the diff base: the default branch name or "HEAD". */
-    baseRef: Type.Optional(NonEmptyString),
-    files: Type.Array(SessionDiffFileSchema),
-    additions: Type.Integer({ minimum: 0 }),
-    deletions: Type.Integer({ minimum: 0 }),
-    truncated: Type.Optional(Type.Boolean()),
-    unavailableReason: Type.Optional(
-      Type.Union([Type.Literal("unknown_session"), Type.Literal("not_git")]),
-    ),
-  },
-  { additionalProperties: false },
-);
+export const SessionsDiffResultSchema = closedObject({
+  sessionKey: NonEmptyString,
+  root: Type.Optional(NonEmptyString),
+  branch: Type.Optional(NonEmptyString),
+  /** Display label of the diff base: the default branch name or "HEAD". */
+  baseRef: Type.Optional(NonEmptyString),
+  files: Type.Array(SessionDiffFileSchema),
+  additions: Type.Integer({ minimum: 0 }),
+  deletions: Type.Integer({ minimum: 0 }),
+  truncated: Type.Optional(Type.Boolean()),
+  unavailableReason: Type.Optional(
+    Type.Union([Type.Literal("unknown_session"), Type.Literal("not_git")]),
+  ),
+});
 
 /** Lists sessions with optional scope, activity, label, and preview filters. */
-export const SessionsListParamsSchema = Type.Object(
-  {
-    /**
-     * Maximum rows to return. Omitted Gateway RPC calls use a bounded default
-     * to keep large session stores from monopolizing the event loop.
-     */
-    limit: Type.Optional(Type.Integer({ minimum: 1 })),
-    offset: Type.Optional(Type.Integer({ minimum: 0 })),
-    activeMinutes: Type.Optional(Type.Integer({ minimum: 1 })),
-    includeGlobal: Type.Optional(Type.Boolean()),
-    includeUnknown: Type.Optional(Type.Boolean()),
-    /**
-     * Limit returned agent-scoped rows to agents currently present in config.
-     * Broad disk discovery remains the default for recovery/ACP consumers.
-     */
-    configuredAgentsOnly: Type.Optional(Type.Boolean()),
-    /**
-     * Read first 8KB of each session transcript to derive title from first user message.
-     * Performs a file read per session - use `limit` to bound result set on large stores.
-     */
-    includeDerivedTitles: Type.Optional(Type.Boolean()),
-    /**
-     * Read last 16KB of each session transcript to extract most recent message preview.
-     * Performs a file read per session - use `limit` to bound result set on large stores.
-     */
-    includeLastMessage: Type.Optional(Type.Boolean()),
-    label: Type.Optional(SessionLabelString),
-    spawnedBy: Type.Optional(NonEmptyString),
-    agentId: Type.Optional(NonEmptyString),
-    search: Type.Optional(Type.String()),
-    /** True lists archived sessions; false or omitted lists active sessions. */
-    archived: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const SessionsListParamsSchema = closedObject({
+  /**
+   * Maximum rows to return. Omitted Gateway RPC calls use a bounded default
+   * to keep large session stores from monopolizing the event loop.
+   */
+  limit: Type.Optional(Type.Integer({ minimum: 1 })),
+  offset: Type.Optional(Type.Integer({ minimum: 0 })),
+  activeMinutes: Type.Optional(Type.Integer({ minimum: 1 })),
+  includeGlobal: Type.Optional(Type.Boolean()),
+  includeUnknown: Type.Optional(Type.Boolean()),
+  /**
+   * Limit returned agent-scoped rows to agents currently present in config.
+   * Broad disk discovery remains the default for recovery/ACP consumers.
+   */
+  configuredAgentsOnly: Type.Optional(Type.Boolean()),
+  /**
+   * Read first 8KB of each session transcript to derive title from first user message.
+   * Performs a file read per session - use `limit` to bound result set on large stores.
+   */
+  includeDerivedTitles: Type.Optional(Type.Boolean()),
+  /**
+   * Read last 16KB of each session transcript to extract most recent message preview.
+   * Performs a file read per session - use `limit` to bound result set on large stores.
+   */
+  includeLastMessage: Type.Optional(Type.Boolean()),
+  label: Type.Optional(SessionLabelString),
+  spawnedBy: Type.Optional(NonEmptyString),
+  agentId: Type.Optional(NonEmptyString),
+  search: Type.Optional(Type.String()),
+  /** True lists archived sessions; false or omitted lists active sessions. */
+  archived: Type.Optional(Type.Boolean()),
+});
 
 /** Searches one agent's indexed session transcripts, optionally within selected sessions. */
-export const SessionsSearchParamsSchema = Type.Object(
-  {
-    agentId: Type.Optional(NonEmptyString),
-    sessionKeys: Type.Optional(Type.Array(NonEmptyString, { minItems: 1, maxItems: 200 })),
-    query: Type.String({ minLength: 1, maxLength: 4096 }),
-    limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 25 })),
-  },
-  { additionalProperties: false },
-);
+export const SessionsSearchParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+  sessionKeys: Type.Optional(Type.Array(NonEmptyString, { minItems: 1, maxItems: 200 })),
+  query: Type.String({ minLength: 1, maxLength: 4096 }),
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 25 })),
+});
 
 /** One full-text session transcript match with follow-up provenance. */
-export const SessionsSearchHitSchema = Type.Object(
-  {
-    sessionKey: NonEmptyString,
-    sessionId: NonEmptyString,
-    messageId: NonEmptyString,
-    role: Type.Union([Type.Literal("user"), Type.Literal("assistant")]),
-    timestamp: Type.Integer({ minimum: 0 }),
-    snippet: Type.String(),
-    score: Type.Number(),
-  },
-  { additionalProperties: false },
-);
+export const SessionsSearchHitSchema = closedObject({
+  sessionKey: NonEmptyString,
+  sessionId: NonEmptyString,
+  messageId: NonEmptyString,
+  role: Type.Union([Type.Literal("user"), Type.Literal("assistant")]),
+  timestamp: Type.Integer({ minimum: 0 }),
+  snippet: Type.String(),
+  score: Type.Number(),
+});
 
 /** Full-text search response; indexing marks a still-running first-use reconcile. */
-export const SessionsSearchResultSchema = Type.Object(
-  {
-    results: Type.Array(SessionsSearchHitSchema),
-    indexing: Type.Optional(Type.Boolean()),
-    truncated: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const SessionsSearchResultSchema = closedObject({
+  results: Type.Array(SessionsSearchHitSchema),
+  indexing: Type.Optional(Type.Boolean()),
+  truncated: Type.Optional(Type.Boolean()),
+});
 
 /** Repairs or removes invalid session records from the selected agent scope. */
-export const SessionsCleanupParamsSchema = Type.Object(
-  {
-    agent: Type.Optional(NonEmptyString),
-    allAgents: Type.Optional(Type.Boolean()),
-    enforce: Type.Optional(Type.Boolean()),
-    activeKey: Type.Optional(NonEmptyString),
-    fixMissing: Type.Optional(Type.Boolean()),
-    fixDmScope: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const SessionsCleanupParamsSchema = closedObject({
+  agent: Type.Optional(NonEmptyString),
+  allAgents: Type.Optional(Type.Boolean()),
+  enforce: Type.Optional(Type.Boolean()),
+  activeKey: Type.Optional(NonEmptyString),
+  fixMissing: Type.Optional(Type.Boolean()),
+  fixDmScope: Type.Optional(Type.Boolean()),
+});
 
 /** Reads short previews for selected session keys. */
-export const SessionsPreviewParamsSchema = Type.Object(
-  {
-    keys: Type.Array(NonEmptyString, { minItems: 1 }),
-    limit: Type.Optional(Type.Integer({ minimum: 1 })),
-    maxChars: Type.Optional(Type.Integer({ minimum: 20 })),
-  },
-  { additionalProperties: false },
-);
+export const SessionsPreviewParamsSchema = closedObject({
+  keys: Type.Array(NonEmptyString, { minItems: 1 }),
+  limit: Type.Optional(Type.Integer({ minimum: 1 })),
+  maxChars: Type.Optional(Type.Integer({ minimum: 20 })),
+});
 
 /** Describes one session and optional derived title/last-message previews. */
-export const SessionsDescribeParamsSchema = Type.Object(
-  {
-    key: NonEmptyString,
-    includeDerivedTitles: Type.Optional(Type.Boolean()),
-    includeLastMessage: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const SessionsDescribeParamsSchema = closedObject({
+  key: NonEmptyString,
+  includeDerivedTitles: Type.Optional(Type.Boolean()),
+  includeLastMessage: Type.Optional(Type.Boolean()),
+});
 
 /** Resolves a session by key, raw session id, label, or parent/agent scope. */
-export const SessionsResolveParamsSchema = Type.Object(
-  {
-    key: Type.Optional(NonEmptyString),
-    sessionId: Type.Optional(NonEmptyString),
-    label: Type.Optional(SessionLabelString),
-    agentId: Type.Optional(NonEmptyString),
-    spawnedBy: Type.Optional(NonEmptyString),
-    includeGlobal: Type.Optional(Type.Boolean()),
-    includeUnknown: Type.Optional(Type.Boolean()),
-    /** Return a successful `{ ok: false }` response when the selector does not match a session. */
-    allowMissing: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const SessionsResolveParamsSchema = closedObject({
+  key: Type.Optional(NonEmptyString),
+  sessionId: Type.Optional(NonEmptyString),
+  label: Type.Optional(SessionLabelString),
+  agentId: Type.Optional(NonEmptyString),
+  spawnedBy: Type.Optional(NonEmptyString),
+  includeGlobal: Type.Optional(Type.Boolean()),
+  includeUnknown: Type.Optional(Type.Boolean()),
+  /** Return a successful `{ ok: false }` response when the selector does not match a session. */
+  allowMissing: Type.Optional(Type.Boolean()),
+});
 
 /** Creates or adopts a session with optional model, label, and parent linkage. */
-export const SessionsCreateParamsSchema = Type.Object(
-  {
-    key: Type.Optional(NonEmptyString),
-    agentId: Type.Optional(NonEmptyString),
-    label: Type.Optional(SessionLabelString),
-    model: Type.Optional(NonEmptyString),
-    parentSessionKey: Type.Optional(NonEmptyString),
-    fork: Type.Optional(
-      Type.Boolean({ description: "Fork the parent transcript; requires parentSessionKey." }),
-    ),
-    emitCommandHooks: Type.Optional(Type.Boolean()),
-    task: Type.Optional(Type.String()),
-    message: Type.Optional(Type.String()),
-    worktree: Type.Optional(Type.Boolean()),
-    worktreeBaseRef: Type.Optional(
-      Type.String({
-        minLength: 1,
-        description: "Base ref for the new managed worktree branch. Requires worktree=true.",
-      }),
-    ),
-    worktreeName: Type.Optional(
-      Type.String({
-        pattern: "^[a-z0-9][a-z0-9-]{0,63}$",
-        description:
-          "Managed worktree name; becomes branch openclaw/<name>. Requires worktree=true.",
-      }),
-    ),
-    execNode: Type.Optional(
-      Type.String({
-        minLength: 1,
-        description:
-          "Bind session exec to host=node with this node id/name. Requires operator.admin.",
-      }),
-    ),
-    cwd: Type.Optional(
-      Type.String({
-        minLength: 1,
-        description:
-          "Absolute source directory for a managed worktree, or the working directory on execNode. Requires operator.admin.",
-      }),
-    ),
-  },
-  { additionalProperties: false },
-);
+export const SessionsCreateParamsSchema = closedObject({
+  key: Type.Optional(NonEmptyString),
+  agentId: Type.Optional(NonEmptyString),
+  label: Type.Optional(SessionLabelString),
+  model: Type.Optional(NonEmptyString),
+  parentSessionKey: Type.Optional(NonEmptyString),
+  fork: Type.Optional(
+    Type.Boolean({ description: "Fork the parent transcript; requires parentSessionKey." }),
+  ),
+  emitCommandHooks: Type.Optional(Type.Boolean()),
+  task: Type.Optional(Type.String()),
+  message: Type.Optional(Type.String()),
+  worktree: Type.Optional(Type.Boolean()),
+  worktreeBaseRef: Type.Optional(
+    Type.String({
+      minLength: 1,
+      description: "Base ref for the new managed worktree branch. Requires worktree=true.",
+    }),
+  ),
+  worktreeName: Type.Optional(
+    Type.String({
+      pattern: "^[a-z0-9][a-z0-9-]{0,63}$",
+      description: "Managed worktree name; becomes branch openclaw/<name>. Requires worktree=true.",
+    }),
+  ),
+  execNode: Type.Optional(
+    Type.String({
+      minLength: 1,
+      description:
+        "Bind session exec to host=node with this node id/name. Requires operator.admin.",
+    }),
+  ),
+  cwd: Type.Optional(
+    Type.String({
+      minLength: 1,
+      description:
+        "Absolute source directory for a managed worktree, or the working directory on execNode. Requires operator.admin.",
+    }),
+  ),
+});
 
-export const SessionWorktreeInfoSchema = Type.Object(
-  {
-    id: NonEmptyString,
-    path: NonEmptyString,
-    branch: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const SessionWorktreeInfoSchema = closedObject({
+  id: NonEmptyString,
+  path: NonEmptyString,
+  branch: NonEmptyString,
+});
 
 /** Result returned after creating or adopting a session. */
 export const SessionsCreateResultSchema = Type.Object(
@@ -430,354 +355,284 @@ export const SessionsCreateResultSchema = Type.Object(
 );
 
 /** Sends one message into an existing session. */
-export const SessionsSendParamsSchema = Type.Object(
-  {
-    key: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    message: Type.String(),
-    thinking: Type.Optional(Type.String()),
-    attachments: Type.Optional(Type.Array(Type.Unknown())),
-    timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    idempotencyKey: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const SessionsSendParamsSchema = closedObject({
+  key: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  message: Type.String(),
+  thinking: Type.Optional(Type.String()),
+  attachments: Type.Optional(Type.Array(Type.Unknown())),
+  timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  idempotencyKey: Type.Optional(NonEmptyString),
+});
 
 /** Subscribes a client to live message updates for one session. */
-export const SessionsMessagesSubscribeParamsSchema = Type.Object(
-  {
-    key: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    /** Opt in to sanitized durable approval events for this session and its descendants. */
-    includeApprovals: Type.Optional(Type.Literal(true)),
-  },
-  { additionalProperties: false },
-);
+export const SessionsMessagesSubscribeParamsSchema = closedObject({
+  key: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  /** Opt in to sanitized durable approval events for this session and its descendants. */
+  includeApprovals: Type.Optional(Type.Literal(true)),
+});
 
 /** Removes a live message subscription for one session. */
-export const SessionsMessagesUnsubscribeParamsSchema = Type.Object(
-  {
-    key: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const SessionsMessagesUnsubscribeParamsSchema = closedObject({
+  key: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+});
 
 /** Aborts the active or named run for a session. */
-export const SessionsAbortParamsSchema = Type.Object(
-  {
-    key: Type.Optional(NonEmptyString),
-    runId: Type.Optional(NonEmptyString),
-    agentId: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const SessionsAbortParamsSchema = closedObject({
+  key: Type.Optional(NonEmptyString),
+  runId: Type.Optional(NonEmptyString),
+  agentId: Type.Optional(NonEmptyString),
+});
 
 /** Mutable per-session preferences and routing metadata. */
-export const SessionsPatchParamsSchema = Type.Object(
-  {
-    key: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    label: Type.Optional(Type.Union([SessionLabelString, Type.Null()])),
-    /** User-defined organization bucket ("category", not chat-group); null clears it. */
-    category: Type.Optional(Type.Union([SessionLabelString, Type.Null()])),
-    archived: Type.Optional(Type.Boolean()),
-    pinned: Type.Optional(Type.Boolean()),
-    unread: Type.Optional(
-      Type.Boolean({ description: "Set true to mark unread; false records the session as read." }),
-    ),
-    thinkingLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    fastMode: Type.Optional(Type.Union([Type.Boolean(), Type.Literal("auto"), Type.Null()])),
-    verboseLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    traceLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    reasoningLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    responseUsage: Type.Optional(
-      Type.Union([
-        Type.Literal("off"),
-        Type.Literal("tokens"),
-        Type.Literal("full"),
-        // Backward compat with older clients/stores.
-        Type.Literal("on"),
-        Type.Null(),
-      ]),
-    ),
-    elevatedLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    execHost: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    execSecurity: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    execAsk: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    execNode: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    model: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    spawnedBy: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    spawnedWorkspaceDir: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    spawnedCwd: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    spawnDepth: Type.Optional(Type.Union([Type.Integer({ minimum: 0 }), Type.Null()])),
-    subagentRole: Type.Optional(
-      Type.Union([Type.Literal("orchestrator"), Type.Literal("leaf"), Type.Null()]),
-    ),
-    subagentControlScope: Type.Optional(
-      Type.Union([Type.Literal("children"), Type.Literal("none"), Type.Null()]),
-    ),
-    inheritedToolAllow: Type.Optional(Type.Union([Type.Array(NonEmptyString), Type.Null()])),
-    inheritedToolDeny: Type.Optional(Type.Union([Type.Array(NonEmptyString), Type.Null()])),
-    sendPolicy: Type.Optional(
-      Type.Union([Type.Literal("allow"), Type.Literal("deny"), Type.Null()]),
-    ),
-    groupActivation: Type.Optional(
-      Type.Union([Type.Literal("mention"), Type.Literal("always"), Type.Null()]),
-    ),
-  },
-  { additionalProperties: false },
-);
+export const SessionsPatchParamsSchema = closedObject({
+  key: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  label: Type.Optional(Type.Union([SessionLabelString, Type.Null()])),
+  /** User-defined organization bucket ("category", not chat-group); null clears it. */
+  category: Type.Optional(Type.Union([SessionLabelString, Type.Null()])),
+  archived: Type.Optional(Type.Boolean()),
+  pinned: Type.Optional(Type.Boolean()),
+  unread: Type.Optional(
+    Type.Boolean({ description: "Set true to mark unread; false records the session as read." }),
+  ),
+  thinkingLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  fastMode: Type.Optional(Type.Union([Type.Boolean(), Type.Literal("auto"), Type.Null()])),
+  verboseLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  traceLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  reasoningLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  responseUsage: Type.Optional(
+    Type.Union([
+      Type.Literal("off"),
+      Type.Literal("tokens"),
+      Type.Literal("full"),
+      // Backward compat with older clients/stores.
+      Type.Literal("on"),
+      Type.Null(),
+    ]),
+  ),
+  elevatedLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  execHost: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  execSecurity: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  execAsk: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  execNode: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  model: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  spawnedBy: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  spawnedWorkspaceDir: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  spawnedCwd: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  spawnDepth: Type.Optional(Type.Union([Type.Integer({ minimum: 0 }), Type.Null()])),
+  subagentRole: Type.Optional(
+    Type.Union([Type.Literal("orchestrator"), Type.Literal("leaf"), Type.Null()]),
+  ),
+  subagentControlScope: Type.Optional(
+    Type.Union([Type.Literal("children"), Type.Literal("none"), Type.Null()]),
+  ),
+  inheritedToolAllow: Type.Optional(Type.Union([Type.Array(NonEmptyString), Type.Null()])),
+  inheritedToolDeny: Type.Optional(Type.Union([Type.Array(NonEmptyString), Type.Null()])),
+  sendPolicy: Type.Optional(Type.Union([Type.Literal("allow"), Type.Literal("deny"), Type.Null()])),
+  groupActivation: Type.Optional(
+    Type.Union([Type.Literal("mention"), Type.Literal("always"), Type.Null()]),
+  ),
+});
 export type SessionsPatchParams = Static<typeof SessionsPatchParamsSchema>;
 
 /** Updates or clears one plugin namespace value on a session record. */
-export const SessionsPluginPatchParamsSchema = Type.Object(
-  {
-    key: NonEmptyString,
-    pluginId: NonEmptyString,
-    namespace: NonEmptyString,
-    value: Type.Optional(PluginJsonValueSchema),
-    unset: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const SessionsPluginPatchParamsSchema = closedObject({
+  key: NonEmptyString,
+  pluginId: NonEmptyString,
+  namespace: NonEmptyString,
+  value: Type.Optional(PluginJsonValueSchema),
+  unset: Type.Optional(Type.Boolean()),
+});
 
 /** Result returned after patching session plugin state. */
-export const SessionsPluginPatchResultSchema = Type.Object(
-  {
-    ok: Type.Literal(true),
-    key: NonEmptyString,
-    value: Type.Optional(PluginJsonValueSchema),
-  },
-  { additionalProperties: false },
-);
+export const SessionsPluginPatchResultSchema = closedObject({
+  ok: Type.Literal(true),
+  key: NonEmptyString,
+  value: Type.Optional(PluginJsonValueSchema),
+});
 
 /** Resets a session to a new or reset transcript state. */
-export const SessionsResetParamsSchema = Type.Object(
-  {
-    key: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    reason: Type.Optional(Type.Union([Type.Literal("new"), Type.Literal("reset")])),
-  },
-  { additionalProperties: false },
-);
+export const SessionsResetParamsSchema = closedObject({
+  key: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  reason: Type.Optional(Type.Union([Type.Literal("new"), Type.Literal("reset")])),
+});
 
 /** Deletes a session record and optionally its transcript. */
-export const SessionsDeleteParamsSchema = Type.Object(
-  {
-    key: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    deleteTranscript: Type.Optional(Type.Boolean()),
-    // Internal compare-and-delete guard for lifecycle-owned cleanup.
-    expectedSessionId: Type.Optional(NonEmptyString),
-    expectedLifecycleRevision: Type.Optional(NonEmptyString),
-    expectedSessionUpdatedAt: Type.Optional(Type.Number({ minimum: 0 })),
-    // Internal control: when false, still unbind thread bindings but skip hook emission.
-    emitLifecycleHooks: Type.Optional(Type.Boolean()),
-    /**
-     * Restricts the delete to already-archived sessions (archive-then-delete).
-     * operator.write callers must set this; deletes without it require
-     * operator.admin.
-     */
-    archivedOnly: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const SessionsDeleteParamsSchema = closedObject({
+  key: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  deleteTranscript: Type.Optional(Type.Boolean()),
+  // Internal compare-and-delete guard for lifecycle-owned cleanup.
+  expectedSessionId: Type.Optional(NonEmptyString),
+  expectedLifecycleRevision: Type.Optional(NonEmptyString),
+  expectedSessionUpdatedAt: Type.Optional(Type.Number({ minimum: 0 })),
+  // Internal control: when false, still unbind thread bindings but skip hook emission.
+  emitLifecycleHooks: Type.Optional(Type.Boolean()),
+  /**
+   * Restricts the delete to already-archived sessions (archive-then-delete).
+   * operator.write callers must set this; deletes without it require
+   * operator.admin.
+   */
+  archivedOnly: Type.Optional(Type.Boolean()),
+});
 
 /** Lists the gateway-owned custom session group catalog (names + order). */
-export const SessionsGroupsListParamsSchema = Type.Object({}, { additionalProperties: false });
+export const SessionsGroupsListParamsSchema = closedObject({});
 
 /** One custom session group catalog entry. */
-export const SessionGroupSchema = Type.Object(
-  {
-    name: SessionLabelString,
-    position: Type.Integer({ minimum: 0 }),
-  },
-  { additionalProperties: false },
-);
+export const SessionGroupSchema = closedObject({
+  name: SessionLabelString,
+  position: Type.Integer({ minimum: 0 }),
+});
 
 /** Custom session group catalog in display order. */
-export const SessionsGroupsListResultSchema = Type.Object(
-  { groups: Type.Array(SessionGroupSchema) },
-  { additionalProperties: false },
-);
+export const SessionsGroupsListResultSchema = closedObject({
+  groups: Type.Array(SessionGroupSchema),
+});
 
 /** Replaces the ordered group catalog; creates listed names, keeps member categories untouched. */
-export const SessionsGroupsPutParamsSchema = Type.Object(
-  { names: Type.Array(SessionLabelString, { maxItems: 200 }) },
-  { additionalProperties: false },
-);
+export const SessionsGroupsPutParamsSchema = closedObject({
+  names: Type.Array(SessionLabelString, { maxItems: 200 }),
+});
 
 /** Renames a group and repoints every member session's category. */
-export const SessionsGroupsRenameParamsSchema = Type.Object(
-  { name: SessionLabelString, to: SessionLabelString },
-  { additionalProperties: false },
-);
+export const SessionsGroupsRenameParamsSchema = closedObject({
+  name: SessionLabelString,
+  to: SessionLabelString,
+});
 
 /** Deletes a group and clears every member session's category. */
-export const SessionsGroupsDeleteParamsSchema = Type.Object(
-  { name: SessionLabelString },
-  { additionalProperties: false },
-);
+export const SessionsGroupsDeleteParamsSchema = closedObject({ name: SessionLabelString });
 
 /** Result for group catalog mutations, with member sessions updated where applicable. */
-export const SessionsGroupsMutationResultSchema = Type.Object(
-  {
-    ok: Type.Literal(true),
-    groups: Type.Array(SessionGroupSchema),
-    updatedSessions: Type.Optional(Type.Integer({ minimum: 0 })),
-  },
-  { additionalProperties: false },
-);
+export const SessionsGroupsMutationResultSchema = closedObject({
+  ok: Type.Literal(true),
+  groups: Type.Array(SessionGroupSchema),
+  updatedSessions: Type.Optional(Type.Integer({ minimum: 0 })),
+});
 
 /** Requests manual compaction for a session transcript. */
-export const SessionsCompactParamsSchema = Type.Object(
-  {
-    key: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    maxLines: Type.Optional(Type.Integer({ minimum: 1 })),
-  },
-  { additionalProperties: false },
-);
+export const SessionsCompactParamsSchema = closedObject({
+  key: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  maxLines: Type.Optional(Type.Integer({ minimum: 1 })),
+});
 
 /** Lists compaction checkpoints for one session. */
-export const SessionsCompactionListParamsSchema = Type.Object(
-  {
-    key: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const SessionsCompactionListParamsSchema = closedObject({
+  key: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+});
 
 /** Reads one compaction checkpoint by id. */
-export const SessionsCompactionGetParamsSchema = Type.Object(
-  {
-    key: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    checkpointId: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const SessionsCompactionGetParamsSchema = closedObject({
+  key: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  checkpointId: NonEmptyString,
+});
 
 /** Creates a new branch from a compaction checkpoint. */
-export const SessionsCompactionBranchParamsSchema = Type.Object(
-  {
-    key: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    checkpointId: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const SessionsCompactionBranchParamsSchema = closedObject({
+  key: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  checkpointId: NonEmptyString,
+});
 
 /** Restores an existing session to a compaction checkpoint. */
-export const SessionsCompactionRestoreParamsSchema = Type.Object(
-  {
-    key: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    checkpointId: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const SessionsCompactionRestoreParamsSchema = closedObject({
+  key: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  checkpointId: NonEmptyString,
+});
 
 /** List response for session compaction checkpoints. */
-export const SessionsCompactionListResultSchema = Type.Object(
-  {
-    ok: Type.Literal(true),
-    key: NonEmptyString,
-    checkpoints: Type.Array(SessionCompactionCheckpointSchema),
-  },
-  { additionalProperties: false },
-);
+export const SessionsCompactionListResultSchema = closedObject({
+  ok: Type.Literal(true),
+  key: NonEmptyString,
+  checkpoints: Type.Array(SessionCompactionCheckpointSchema),
+});
 
 /** Get response for a single compaction checkpoint. */
-export const SessionsCompactionGetResultSchema = Type.Object(
-  {
-    ok: Type.Literal(true),
-    key: NonEmptyString,
-    checkpoint: SessionCompactionCheckpointSchema,
-  },
-  { additionalProperties: false },
-);
+export const SessionsCompactionGetResultSchema = closedObject({
+  ok: Type.Literal(true),
+  key: NonEmptyString,
+  checkpoint: SessionCompactionCheckpointSchema,
+});
 
 /** Branch response with the newly created session key and entry metadata. */
-export const SessionsCompactionBranchResultSchema = Type.Object(
-  {
-    ok: Type.Literal(true),
-    sourceKey: NonEmptyString,
-    key: NonEmptyString,
-    sessionId: NonEmptyString,
-    checkpoint: SessionCompactionCheckpointSchema,
-    entry: Type.Object(
-      {
-        sessionId: NonEmptyString,
-        updatedAt: Type.Integer({ minimum: 0 }),
-      },
-      { additionalProperties: true },
-    ),
-  },
-  { additionalProperties: false },
-);
+export const SessionsCompactionBranchResultSchema = closedObject({
+  ok: Type.Literal(true),
+  sourceKey: NonEmptyString,
+  key: NonEmptyString,
+  sessionId: NonEmptyString,
+  checkpoint: SessionCompactionCheckpointSchema,
+  entry: Type.Object(
+    {
+      sessionId: NonEmptyString,
+      updatedAt: Type.Integer({ minimum: 0 }),
+    },
+    { additionalProperties: true },
+  ),
+});
 
 /** Restore response with updated session entry metadata. */
-export const SessionsCompactionRestoreResultSchema = Type.Object(
-  {
-    ok: Type.Literal(true),
-    key: NonEmptyString,
-    sessionId: NonEmptyString,
-    checkpoint: SessionCompactionCheckpointSchema,
-    entry: Type.Object(
-      {
-        sessionId: NonEmptyString,
-        updatedAt: Type.Integer({ minimum: 0 }),
-      },
-      { additionalProperties: true },
-    ),
-  },
-  { additionalProperties: false },
-);
+export const SessionsCompactionRestoreResultSchema = closedObject({
+  ok: Type.Literal(true),
+  key: NonEmptyString,
+  sessionId: NonEmptyString,
+  checkpoint: SessionCompactionCheckpointSchema,
+  entry: Type.Object(
+    {
+      sessionId: NonEmptyString,
+      updatedAt: Type.Integer({ minimum: 0 }),
+    },
+    { additionalProperties: true },
+  ),
+});
 
 /** Usage report query across one session, one agent, or all agent sessions. */
-export const SessionsUsageParamsSchema = Type.Object(
-  {
-    /** Specific session key to analyze; if omitted returns sessions for the effective agent. */
-    key: Type.Optional(NonEmptyString),
-    /** Agent scope for list-style usage queries. */
-    agentId: Type.Optional(NonEmptyString),
-    /** Explicit all-agent scope for list-style usage queries. */
-    agentScope: Type.Optional(Type.Literal("all")),
-    /** Start date for range filter (YYYY-MM-DD). */
-    startDate: Type.Optional(Type.String({ pattern: "^\\d{4}-\\d{2}-\\d{2}$" })),
-    /** End date for range filter (YYYY-MM-DD). */
-    endDate: Type.Optional(Type.String({ pattern: "^\\d{4}-\\d{2}-\\d{2}$" })),
-    /** How start/end dates should be interpreted. Defaults to UTC when omitted. */
-    mode: Type.Optional(
-      Type.Union([Type.Literal("utc"), Type.Literal("gateway"), Type.Literal("specific")]),
-    ),
-    /** Preset range for usage queries when explicit start/end dates are omitted. */
-    range: Type.Optional(
-      Type.Union([
-        Type.Literal("7d"),
-        Type.Literal("30d"),
-        Type.Literal("90d"),
-        Type.Literal("1y"),
-        Type.Literal("all"),
-      ]),
-    ),
-    /** Usage row grouping. `family` rolls up known rotated session ids for a logical key. */
-    groupBy: Type.Optional(Type.Union([Type.Literal("instance"), Type.Literal("family")])),
-    /** Backward-compatible alias for requesting family grouping. */
-    includeHistorical: Type.Optional(Type.Boolean()),
-    /** UTC offset to use when mode is `specific` (for example, UTC-4 or UTC+5:30). */
-    utcOffset: Type.Optional(Type.String({ pattern: "^UTC[+-]\\d{1,2}(?::[0-5]\\d)?$" })),
-    /** IANA time zone for `specific`; preferred over `utcOffset`, which remains a compatibility fallback. */
-    timeZone: Type.Optional(NonEmptyString),
-    /** Maximum sessions to return (default 50). */
-    limit: Type.Optional(Type.Integer({ minimum: 1 })),
-    /** Include context weight breakdown (systemPromptReport). */
-    includeContextWeight: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+export const SessionsUsageParamsSchema = closedObject({
+  /** Specific session key to analyze; if omitted returns sessions for the effective agent. */
+  key: Type.Optional(NonEmptyString),
+  /** Agent scope for list-style usage queries. */
+  agentId: Type.Optional(NonEmptyString),
+  /** Explicit all-agent scope for list-style usage queries. */
+  agentScope: Type.Optional(Type.Literal("all")),
+  /** Start date for range filter (YYYY-MM-DD). */
+  startDate: Type.Optional(Type.String({ pattern: "^\\d{4}-\\d{2}-\\d{2}$" })),
+  /** End date for range filter (YYYY-MM-DD). */
+  endDate: Type.Optional(Type.String({ pattern: "^\\d{4}-\\d{2}-\\d{2}$" })),
+  /** How start/end dates should be interpreted. Defaults to UTC when omitted. */
+  mode: Type.Optional(
+    Type.Union([Type.Literal("utc"), Type.Literal("gateway"), Type.Literal("specific")]),
+  ),
+  /** Preset range for usage queries when explicit start/end dates are omitted. */
+  range: Type.Optional(
+    Type.Union([
+      Type.Literal("7d"),
+      Type.Literal("30d"),
+      Type.Literal("90d"),
+      Type.Literal("1y"),
+      Type.Literal("all"),
+    ]),
+  ),
+  /** Usage row grouping. `family` rolls up known rotated session ids for a logical key. */
+  groupBy: Type.Optional(Type.Union([Type.Literal("instance"), Type.Literal("family")])),
+  /** Backward-compatible alias for requesting family grouping. */
+  includeHistorical: Type.Optional(Type.Boolean()),
+  /** UTC offset to use when mode is `specific` (for example, UTC-4 or UTC+5:30). */
+  utcOffset: Type.Optional(Type.String({ pattern: "^UTC[+-]\\d{1,2}(?::[0-5]\\d)?$" })),
+  /** IANA time zone for `specific`; preferred over `utcOffset`, which remains a compatibility fallback. */
+  timeZone: Type.Optional(NonEmptyString),
+  /** Maximum sessions to return (default 50). */
+  limit: Type.Optional(Type.Integer({ minimum: 1 })),
+  /** Include context weight breakdown (systemPromptReport). */
+  includeContextWeight: Type.Optional(Type.Boolean()),
+});
 
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/snapshot.ts
+++ b/packages/gateway-protocol/src/schema/snapshot.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 /**
@@ -10,79 +11,67 @@ import { NonEmptyString } from "./primitives.js";
  * presence, health, session defaults, and version counters for clients.
  */
 /** One gateway-visible presence record for a node/client/runtime. */
-export const PresenceEntrySchema = Type.Object(
-  {
-    host: Type.Optional(NonEmptyString),
-    ip: Type.Optional(NonEmptyString),
-    version: Type.Optional(NonEmptyString),
-    platform: Type.Optional(NonEmptyString),
-    deviceFamily: Type.Optional(NonEmptyString),
-    modelIdentifier: Type.Optional(NonEmptyString),
-    mode: Type.Optional(NonEmptyString),
-    lastInputSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
-    reason: Type.Optional(NonEmptyString),
-    tags: Type.Optional(Type.Array(NonEmptyString)),
-    text: Type.Optional(Type.String()),
-    ts: Type.Integer({ minimum: 0 }),
-    deviceId: Type.Optional(NonEmptyString),
-    roles: Type.Optional(Type.Array(NonEmptyString)),
-    scopes: Type.Optional(Type.Array(NonEmptyString)),
-    instanceId: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const PresenceEntrySchema = closedObject({
+  host: Type.Optional(NonEmptyString),
+  ip: Type.Optional(NonEmptyString),
+  version: Type.Optional(NonEmptyString),
+  platform: Type.Optional(NonEmptyString),
+  deviceFamily: Type.Optional(NonEmptyString),
+  modelIdentifier: Type.Optional(NonEmptyString),
+  mode: Type.Optional(NonEmptyString),
+  lastInputSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
+  reason: Type.Optional(NonEmptyString),
+  tags: Type.Optional(Type.Array(NonEmptyString)),
+  text: Type.Optional(Type.String()),
+  ts: Type.Integer({ minimum: 0 }),
+  deviceId: Type.Optional(NonEmptyString),
+  roles: Type.Optional(Type.Array(NonEmptyString)),
+  scopes: Type.Optional(Type.Array(NonEmptyString)),
+  instanceId: Type.Optional(NonEmptyString),
+});
 
 /** Health snapshot is intentionally opaque because providers contribute nested shapes. */
 export const HealthSnapshotSchema = Type.Any();
 
 /** Default session routing keys included in initial gateway snapshots. */
-export const SessionDefaultsSchema = Type.Object(
-  {
-    defaultAgentId: NonEmptyString,
-    mainKey: NonEmptyString,
-    mainSessionKey: NonEmptyString,
-    scope: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const SessionDefaultsSchema = closedObject({
+  defaultAgentId: NonEmptyString,
+  mainKey: NonEmptyString,
+  mainSessionKey: NonEmptyString,
+  scope: Type.Optional(NonEmptyString),
+});
 
 /** Monotonic version counters for snapshot subtrees. */
-export const StateVersionSchema = Type.Object(
-  {
-    presence: Type.Integer({ minimum: 0 }),
-    health: Type.Integer({ minimum: 0 }),
-  },
-  { additionalProperties: false },
-);
+export const StateVersionSchema = closedObject({
+  presence: Type.Integer({ minimum: 0 }),
+  health: Type.Integer({ minimum: 0 }),
+});
 
 /** Initial and incremental gateway state snapshot payload. */
-export const SnapshotSchema = Type.Object(
-  {
-    presence: Type.Array(PresenceEntrySchema),
-    health: HealthSnapshotSchema,
-    stateVersion: StateVersionSchema,
-    uptimeMs: Type.Integer({ minimum: 0 }),
-    configPath: Type.Optional(NonEmptyString),
-    stateDir: Type.Optional(NonEmptyString),
-    sessionDefaults: Type.Optional(SessionDefaultsSchema),
-    authMode: Type.Optional(
-      Type.Union([
-        Type.Literal("none"),
-        Type.Literal("token"),
-        Type.Literal("password"),
-        Type.Literal("trusted-proxy"),
-      ]),
-    ),
-    updateAvailable: Type.Optional(
-      Type.Object({
-        currentVersion: NonEmptyString,
-        latestVersion: NonEmptyString,
-        channel: NonEmptyString,
-      }),
-    ),
-  },
-  { additionalProperties: false },
-);
+export const SnapshotSchema = closedObject({
+  presence: Type.Array(PresenceEntrySchema),
+  health: HealthSnapshotSchema,
+  stateVersion: StateVersionSchema,
+  uptimeMs: Type.Integer({ minimum: 0 }),
+  configPath: Type.Optional(NonEmptyString),
+  stateDir: Type.Optional(NonEmptyString),
+  sessionDefaults: Type.Optional(SessionDefaultsSchema),
+  authMode: Type.Optional(
+    Type.Union([
+      Type.Literal("none"),
+      Type.Literal("token"),
+      Type.Literal("password"),
+      Type.Literal("trusted-proxy"),
+    ]),
+  ),
+  updateAvailable: Type.Optional(
+    Type.Object({
+      currentVersion: NonEmptyString,
+      latestVersion: NonEmptyString,
+      channel: NonEmptyString,
+    }),
+  ),
+});
 
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/system-info.ts
+++ b/packages/gateway-protocol/src/schema/system-info.ts
@@ -1,35 +1,33 @@
 // Gateway Protocol schema module defines Gateway host system information.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 
 /** Empty request payload for Gateway host system information. */
-export const SystemInfoParamsSchema = Type.Object({}, { additionalProperties: false });
+export const SystemInfoParamsSchema = closedObject({});
 
 /** Gateway host identity and resource snapshot. */
-export const SystemInfoResultSchema = Type.Object(
-  {
-    machineName: Type.String(),
-    hostname: Type.String(),
-    platform: Type.String(),
-    release: Type.String(),
-    arch: Type.String(),
-    osLabel: Type.String(),
-    lanAddress: Type.Optional(Type.String()),
-    port: Type.Optional(Type.Integer()),
-    nodeVersion: Type.String(),
-    pid: Type.Integer(),
-    uptimeMs: Type.Integer(),
-    cpuCount: Type.Integer(),
-    cpuModel: Type.Optional(Type.String()),
-    loadAverage: Type.Optional(Type.Tuple([Type.Number(), Type.Number(), Type.Number()])),
-    memoryTotalBytes: Type.Integer(),
-    memoryFreeBytes: Type.Integer(),
-    diskTotalBytes: Type.Optional(Type.Integer()),
-    diskAvailableBytes: Type.Optional(Type.Integer()),
-    diskPath: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const SystemInfoResultSchema = closedObject({
+  machineName: Type.String(),
+  hostname: Type.String(),
+  platform: Type.String(),
+  release: Type.String(),
+  arch: Type.String(),
+  osLabel: Type.String(),
+  lanAddress: Type.Optional(Type.String()),
+  port: Type.Optional(Type.Integer()),
+  nodeVersion: Type.String(),
+  pid: Type.Integer(),
+  uptimeMs: Type.Integer(),
+  cpuCount: Type.Integer(),
+  cpuModel: Type.Optional(Type.String()),
+  loadAverage: Type.Optional(Type.Tuple([Type.Number(), Type.Number(), Type.Number()])),
+  memoryTotalBytes: Type.Integer(),
+  memoryFreeBytes: Type.Integer(),
+  diskTotalBytes: Type.Optional(Type.Integer()),
+  diskAvailableBytes: Type.Optional(Type.Integer()),
+  diskPath: Type.Optional(Type.String()),
+});
 
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/talk-marks.ts
+++ b/packages/gateway-protocol/src/schema/talk-marks.ts
@@ -1,5 +1,4 @@
 import type { Static } from "typebox";
-import { Type } from "typebox";
 import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 

--- a/packages/gateway-protocol/src/schema/talk-marks.ts
+++ b/packages/gateway-protocol/src/schema/talk-marks.ts
@@ -1,15 +1,13 @@
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 /** Acknowledges playback through a named realtime provider mark. */
-export const TalkSessionAcknowledgeMarkParamsSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    markName: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const TalkSessionAcknowledgeMarkParamsSchema = closedObject({
+  sessionId: NonEmptyString,
+  markName: NonEmptyString,
+});
 
 export type TalkSessionAcknowledgeMarkParams = Static<
   typeof TalkSessionAcknowledgeMarkParamsSchema

--- a/packages/gateway-protocol/src/schema/task-suggestions.ts
+++ b/packages/gateway-protocol/src/schema/task-suggestions.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines ephemeral follow-up task suggestions.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 
 const TaskIdSchema = Type.String({ minLength: 1, maxLength: 128 });
 const TaskTitleSchema = Type.String({ minLength: 1, maxLength: 60 });
@@ -11,51 +12,41 @@ const TaskSessionKeySchema = Type.String({ minLength: 1, maxLength: 512 });
 const TaskAgentIdSchema = Type.String({ minLength: 1, maxLength: 128 });
 
 /** One model-proposed follow-up task waiting for operator action. */
-export const TaskSuggestionSchema = Type.Object(
-  {
-    id: TaskIdSchema,
-    title: TaskTitleSchema,
-    prompt: TaskPromptSchema,
-    tldr: TaskTldrSchema,
-    cwd: TaskCwdSchema,
-    sessionKey: TaskSessionKeySchema,
-    agentId: Type.Optional(TaskAgentIdSchema),
-    createdAt: Type.Integer({ minimum: 0 }),
-  },
-  { additionalProperties: false },
-);
+export const TaskSuggestionSchema = closedObject({
+  id: TaskIdSchema,
+  title: TaskTitleSchema,
+  prompt: TaskPromptSchema,
+  tldr: TaskTldrSchema,
+  cwd: TaskCwdSchema,
+  sessionKey: TaskSessionKeySchema,
+  agentId: Type.Optional(TaskAgentIdSchema),
+  createdAt: Type.Integer({ minimum: 0 }),
+});
 
 /** Lists pending suggestions, optionally narrowed to one source session. */
-export const TaskSuggestionsListParamsSchema = Type.Object(
-  {
-    sessionKey: Type.Optional(TaskSessionKeySchema),
-    agentId: Type.Optional(TaskAgentIdSchema),
-  },
-  { additionalProperties: false },
-);
+export const TaskSuggestionsListParamsSchema = closedObject({
+  sessionKey: Type.Optional(TaskSessionKeySchema),
+  agentId: Type.Optional(TaskAgentIdSchema),
+});
 
-export const TaskSuggestionsListResultSchema = Type.Object(
-  { suggestions: Type.Array(TaskSuggestionSchema) },
-  { additionalProperties: false },
-);
+export const TaskSuggestionsListResultSchema = closedObject({
+  suggestions: Type.Array(TaskSuggestionSchema),
+});
 
 /** Creates a pending suggestion without starting any work. */
-export const TaskSuggestionsCreateParamsSchema = Type.Object(
-  {
-    title: TaskTitleSchema,
-    prompt: TaskPromptSchema,
-    tldr: TaskTldrSchema,
-    cwd: TaskCwdSchema,
-    sessionKey: TaskSessionKeySchema,
-    agentId: Type.Optional(TaskAgentIdSchema),
-  },
-  { additionalProperties: false },
-);
+export const TaskSuggestionsCreateParamsSchema = closedObject({
+  title: TaskTitleSchema,
+  prompt: TaskPromptSchema,
+  tldr: TaskTldrSchema,
+  cwd: TaskCwdSchema,
+  sessionKey: TaskSessionKeySchema,
+  agentId: Type.Optional(TaskAgentIdSchema),
+});
 
-export const TaskSuggestionsCreateResultSchema = Type.Object(
-  { taskId: TaskIdSchema, suggestion: TaskSuggestionSchema },
-  { additionalProperties: false },
-);
+export const TaskSuggestionsCreateResultSchema = closedObject({
+  taskId: TaskIdSchema,
+  suggestion: TaskSuggestionSchema,
+});
 
 export const TaskSuggestionResolutionSchema = Type.Union([
   Type.Literal("dismissed"),
@@ -64,44 +55,32 @@ export const TaskSuggestionResolutionSchema = Type.Union([
 ]);
 
 /** Atomically claims a pending suggestion and starts its server-owned worktree session. */
-export const TaskSuggestionsAcceptParamsSchema = Type.Object(
-  { taskId: TaskIdSchema },
-  { additionalProperties: false },
-);
+export const TaskSuggestionsAcceptParamsSchema = closedObject({ taskId: TaskIdSchema });
 
-export const TaskSuggestionsAcceptResultSchema = Type.Object(
-  { taskId: TaskIdSchema, key: TaskSessionKeySchema },
-  { additionalProperties: false },
-);
+export const TaskSuggestionsAcceptResultSchema = closedObject({
+  taskId: TaskIdSchema,
+  key: TaskSessionKeySchema,
+});
 
 /** Removes a pending suggestion without starting work. */
-export const TaskSuggestionsDismissParamsSchema = Type.Object(
-  {
-    taskId: TaskIdSchema,
-    reason: Type.Optional(Type.String({ maxLength: 1_024 })),
-  },
-  { additionalProperties: false },
-);
+export const TaskSuggestionsDismissParamsSchema = closedObject({
+  taskId: TaskIdSchema,
+  reason: Type.Optional(Type.String({ maxLength: 1_024 })),
+});
 
-export const TaskSuggestionsDismissResultSchema = Type.Object(
-  { taskId: TaskIdSchema, dismissed: Type.Boolean() },
-  { additionalProperties: false },
-);
+export const TaskSuggestionsDismissResultSchema = closedObject({
+  taskId: TaskIdSchema,
+  dismissed: Type.Boolean(),
+});
 
 /** Live update emitted when a pending suggestion is created or resolved. */
 export const TaskSuggestionEventSchema = Type.Union([
-  Type.Object(
-    { action: Type.Literal("created"), suggestion: TaskSuggestionSchema },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
-      action: Type.Literal("resolved"),
-      taskId: TaskIdSchema,
-      resolution: TaskSuggestionResolutionSchema,
-    },
-    { additionalProperties: false },
-  ),
+  closedObject({ action: Type.Literal("created"), suggestion: TaskSuggestionSchema }),
+  closedObject({
+    action: Type.Literal("resolved"),
+    taskId: TaskIdSchema,
+    resolution: TaskSuggestionResolutionSchema,
+  }),
 ]);
 
 // Wire types derive directly from local schema consts so public d.ts graphs never

--- a/packages/gateway-protocol/src/schema/tasks.ts
+++ b/packages/gateway-protocol/src/schema/tasks.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 /**
@@ -22,91 +23,70 @@ export const TaskLedgerStatusSchema = Type.Union([
 const TimestampSchema = Type.Union([Type.String(), Type.Integer({ minimum: 0 })]);
 
 /** Public task summary returned by task list/get/cancel responses. */
-export const TaskSummarySchema = Type.Object(
-  {
-    id: NonEmptyString,
-    kind: Type.Optional(Type.String()),
-    runtime: Type.Optional(Type.String()),
-    status: TaskLedgerStatusSchema,
-    title: Type.Optional(Type.String()),
-    agentId: Type.Optional(Type.String()),
-    sessionKey: Type.Optional(Type.String()),
-    childSessionKey: Type.Optional(Type.String()),
-    ownerKey: Type.Optional(Type.String()),
-    runId: Type.Optional(Type.String()),
-    taskId: Type.Optional(Type.String()),
-    flowId: Type.Optional(Type.String()),
-    parentTaskId: Type.Optional(Type.String()),
-    sourceId: Type.Optional(Type.String()),
-    createdAt: Type.Optional(TimestampSchema),
-    updatedAt: Type.Optional(TimestampSchema),
-    startedAt: Type.Optional(TimestampSchema),
-    endedAt: Type.Optional(TimestampSchema),
-    toolUseCount: Type.Optional(Type.Integer({ minimum: 0 })),
-    lastToolName: Type.Optional(Type.String()),
-    progressSummary: Type.Optional(Type.String()),
-    terminalSummary: Type.Optional(Type.String()),
-    error: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const TaskSummarySchema = closedObject({
+  id: NonEmptyString,
+  kind: Type.Optional(Type.String()),
+  runtime: Type.Optional(Type.String()),
+  status: TaskLedgerStatusSchema,
+  title: Type.Optional(Type.String()),
+  agentId: Type.Optional(Type.String()),
+  sessionKey: Type.Optional(Type.String()),
+  childSessionKey: Type.Optional(Type.String()),
+  ownerKey: Type.Optional(Type.String()),
+  runId: Type.Optional(Type.String()),
+  taskId: Type.Optional(Type.String()),
+  flowId: Type.Optional(Type.String()),
+  parentTaskId: Type.Optional(Type.String()),
+  sourceId: Type.Optional(Type.String()),
+  createdAt: Type.Optional(TimestampSchema),
+  updatedAt: Type.Optional(TimestampSchema),
+  startedAt: Type.Optional(TimestampSchema),
+  endedAt: Type.Optional(TimestampSchema),
+  toolUseCount: Type.Optional(Type.Integer({ minimum: 0 })),
+  lastToolName: Type.Optional(Type.String()),
+  progressSummary: Type.Optional(Type.String()),
+  terminalSummary: Type.Optional(Type.String()),
+  error: Type.Optional(Type.String()),
+});
 
 /** Task list filters with bounded pagination. */
-export const TasksListParamsSchema = Type.Object(
-  {
-    status: Type.Optional(Type.Union([TaskLedgerStatusSchema, Type.Array(TaskLedgerStatusSchema)])),
-    agentId: Type.Optional(NonEmptyString),
-    sessionKey: Type.Optional(NonEmptyString),
-    limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 500 })),
-    cursor: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const TasksListParamsSchema = closedObject({
+  status: Type.Optional(Type.Union([TaskLedgerStatusSchema, Type.Array(TaskLedgerStatusSchema)])),
+  agentId: Type.Optional(NonEmptyString),
+  sessionKey: Type.Optional(NonEmptyString),
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 500 })),
+  cursor: Type.Optional(Type.String()),
+});
 
 /** Task list page response. */
-export const TasksListResultSchema = Type.Object(
-  {
-    tasks: Type.Array(TaskSummarySchema),
-    nextCursor: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const TasksListResultSchema = closedObject({
+  tasks: Type.Array(TaskSummarySchema),
+  nextCursor: Type.Optional(Type.String()),
+});
 
 /** Lookup request for one task id. */
-export const TasksGetParamsSchema = Type.Object(
-  {
-    taskId: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const TasksGetParamsSchema = closedObject({
+  taskId: NonEmptyString,
+});
 
 /** Lookup result for one task summary. */
-export const TasksGetResultSchema = Type.Object(
-  {
-    task: TaskSummarySchema,
-  },
-  { additionalProperties: false },
-);
+export const TasksGetResultSchema = closedObject({
+  task: TaskSummarySchema,
+});
 
 /** Cancel request for one task id with optional operator reason. */
-export const TasksCancelParamsSchema = Type.Object(
-  {
-    taskId: NonEmptyString,
-    reason: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const TasksCancelParamsSchema = closedObject({
+  taskId: NonEmptyString,
+  reason: Type.Optional(Type.String()),
+});
 
 /** Cancel result, including the task snapshot when it was found. */
-export const TasksCancelResultSchema = Type.Object(
-  {
-    found: Type.Boolean(),
-    cancelled: Type.Boolean(),
-    reason: Type.Optional(Type.String()),
-    task: Type.Optional(TaskSummarySchema),
-  },
-  { additionalProperties: false },
-);
+export const TasksCancelResultSchema = closedObject({
+  found: Type.Boolean(),
+  cancelled: Type.Boolean(),
+  reason: Type.Optional(Type.String()),
+  task: Type.Optional(TaskSummarySchema),
+});
 
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/terminal.ts
+++ b/packages/gateway-protocol/src/schema/terminal.ts
@@ -3,6 +3,7 @@
 // operator connection and stream its bytes back over the existing WebSocket.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 // PTY grids are bounded so a hostile client cannot request an allocation that
@@ -10,60 +11,45 @@ import { NonEmptyString } from "./primitives.js";
 const TerminalDimension = Type.Integer({ minimum: 1, maximum: 2000 });
 
 /** Opens a shell session; the server picks the shell, cwd, and confinement. */
-export const TerminalOpenParamsSchema = Type.Object(
-  {
-    // Optional agent selector; defaults to the gateway's default agent. The
-    // session starts in that agent's workspace and inherits its isolation.
-    agentId: Type.Optional(NonEmptyString),
-    cols: TerminalDimension,
-    rows: TerminalDimension,
-  },
-  { additionalProperties: false },
-);
+export const TerminalOpenParamsSchema = closedObject({
+  // Optional agent selector; defaults to the gateway's default agent. The
+  // session starts in that agent's workspace and inherits its isolation.
+  agentId: Type.Optional(NonEmptyString),
+  cols: TerminalDimension,
+  rows: TerminalDimension,
+});
 export type TerminalOpenParams = Static<typeof TerminalOpenParamsSchema>;
 
 /** Result of a successful open; carries the facts the UI header renders. */
-export const TerminalOpenResultSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    agentId: NonEmptyString,
-    shell: NonEmptyString,
-    cwd: NonEmptyString,
-    // True when the shell runs inside the agent's sandbox and cannot escape the
-    // workspace; false for a host shell that can navigate the whole filesystem.
-    confined: Type.Boolean(),
-  },
-  { additionalProperties: false },
-);
+export const TerminalOpenResultSchema = closedObject({
+  sessionId: NonEmptyString,
+  agentId: NonEmptyString,
+  shell: NonEmptyString,
+  cwd: NonEmptyString,
+  // True when the shell runs inside the agent's sandbox and cannot escape the
+  // workspace; false for a host shell that can navigate the whole filesystem.
+  confined: Type.Boolean(),
+});
 export type TerminalOpenResult = Static<typeof TerminalOpenResultSchema>;
 
 /** Writes client keystrokes to the session stdin. */
-export const TerminalInputParamsSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    // Raw terminal input (already-encoded escape sequences from the emulator).
-    data: Type.String(),
-  },
-  { additionalProperties: false },
-);
+export const TerminalInputParamsSchema = closedObject({
+  sessionId: NonEmptyString,
+  // Raw terminal input (already-encoded escape sequences from the emulator).
+  data: Type.String(),
+});
 export type TerminalInputParams = Static<typeof TerminalInputParamsSchema>;
 
 /** Resizes the PTY grid after the client viewport changes. */
-export const TerminalResizeParamsSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    cols: TerminalDimension,
-    rows: TerminalDimension,
-  },
-  { additionalProperties: false },
-);
+export const TerminalResizeParamsSchema = closedObject({
+  sessionId: NonEmptyString,
+  cols: TerminalDimension,
+  rows: TerminalDimension,
+});
 export type TerminalResizeParams = Static<typeof TerminalResizeParamsSchema>;
 
 /** Closes a session and kills its process tree. */
-export const TerminalCloseParamsSchema = Type.Object(
-  { sessionId: NonEmptyString },
-  { additionalProperties: false },
-);
+export const TerminalCloseParamsSchema = closedObject({ sessionId: NonEmptyString });
 export type TerminalCloseParams = Static<typeof TerminalCloseParamsSchema>;
 
 /**
@@ -71,44 +57,35 @@ export type TerminalCloseParams = Static<typeof TerminalCloseParamsSchema>;
  * Attach is take-over (tmux-like): the previous owner, if still connected,
  * receives `terminal.exit` with reason "detached".
  */
-export const TerminalAttachParamsSchema = Type.Object(
-  { sessionId: NonEmptyString },
-  { additionalProperties: false },
-);
+export const TerminalAttachParamsSchema = closedObject({ sessionId: NonEmptyString });
 export type TerminalAttachParams = Static<typeof TerminalAttachParamsSchema>;
 
 /** Result of a successful attach; mirrors open plus the replay buffer. */
-export const TerminalAttachResultSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    agentId: NonEmptyString,
-    shell: NonEmptyString,
-    cwd: NonEmptyString,
-    confined: Type.Boolean(),
-    // Recent raw output from the server's bounded ring buffer, replayed into
-    // the client emulator before live terminal.data resumes. Not a true screen
-    // snapshot: after truncation it can start mid-escape-sequence; emulators
-    // recover on the next full repaint (prompt, clear, resize redraw).
-    buffer: Type.String(),
-  },
-  { additionalProperties: false },
-);
+export const TerminalAttachResultSchema = closedObject({
+  sessionId: NonEmptyString,
+  agentId: NonEmptyString,
+  shell: NonEmptyString,
+  cwd: NonEmptyString,
+  confined: Type.Boolean(),
+  // Recent raw output from the server's bounded ring buffer, replayed into
+  // the client emulator before live terminal.data resumes. Not a true screen
+  // snapshot: after truncation it can start mid-escape-sequence; emulators
+  // recover on the next full repaint (prompt, clear, resize redraw).
+  buffer: Type.String(),
+});
 export type TerminalAttachResult = Static<typeof TerminalAttachResultSchema>;
 
 /** One attachable session, as reported by terminal.list. */
-export const TerminalSessionInfoSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    agentId: NonEmptyString,
-    shell: NonEmptyString,
-    cwd: NonEmptyString,
-    confined: Type.Boolean(),
-    /** False while the session is detached (no connection owns its stream). */
-    attached: Type.Boolean(),
-    createdAtMs: Type.Integer({ minimum: 0 }),
-  },
-  { additionalProperties: false },
-);
+export const TerminalSessionInfoSchema = closedObject({
+  sessionId: NonEmptyString,
+  agentId: NonEmptyString,
+  shell: NonEmptyString,
+  cwd: NonEmptyString,
+  confined: Type.Boolean(),
+  /** False while the session is detached (no connection owns its stream). */
+  attached: Type.Boolean(),
+  createdAtMs: Type.Integer({ minimum: 0 }),
+});
 export type TerminalSessionInfo = Static<typeof TerminalSessionInfoSchema>;
 
 /**
@@ -116,67 +93,51 @@ export type TerminalSessionInfo = Static<typeof TerminalSessionInfoSchema>;
  * the same list: the terminal surface is already operator.admin (full host
  * access), so cross-connection visibility adds no privilege.
  */
-export const TerminalListResultSchema = Type.Object(
-  { sessions: Type.Array(TerminalSessionInfoSchema) },
-  { additionalProperties: false },
-);
+export const TerminalListResultSchema = closedObject({
+  sessions: Type.Array(TerminalSessionInfoSchema),
+});
 export type TerminalListResult = Static<typeof TerminalListResultSchema>;
 
 /** Reads the current output buffer as plain text without attaching. */
-export const TerminalTextParamsSchema = Type.Object(
-  { sessionId: NonEmptyString },
-  { additionalProperties: false },
-);
+export const TerminalTextParamsSchema = closedObject({ sessionId: NonEmptyString });
 export type TerminalTextParams = Static<typeof TerminalTextParamsSchema>;
 
 /** Plain-text buffer contents (ANSI stripped); an agent/LLM affordance. */
-export const TerminalTextResultSchema = Type.Object(
-  { text: Type.String() },
-  { additionalProperties: false },
-);
+export const TerminalTextResultSchema = closedObject({ text: Type.String() });
 export type TerminalTextResult = Static<typeof TerminalTextResultSchema>;
 
 /** Shared ok/void result for input, resize, and close. */
-export const TerminalAckResultSchema = Type.Object(
-  { ok: Type.Boolean() },
-  { additionalProperties: false },
-);
+export const TerminalAckResultSchema = closedObject({ ok: Type.Boolean() });
 export type TerminalAckResult = Static<typeof TerminalAckResultSchema>;
 
 /** Streamed output chunk; seq lets the client detect gaps and preserve order. */
-export const TerminalDataEventSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    seq: Type.Integer({ minimum: 0 }),
-    data: Type.String(),
-  },
-  { additionalProperties: false },
-);
+export const TerminalDataEventSchema = closedObject({
+  sessionId: NonEmptyString,
+  seq: Type.Integer({ minimum: 0 }),
+  data: Type.String(),
+});
 export type TerminalDataEvent = Static<typeof TerminalDataEventSchema>;
 
 /** Terminal end-of-life notice; the session id is invalid after this event. */
-export const TerminalExitEventSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    exitCode: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
-    signal: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
-    // Stable reason code so clients can distinguish process exit from a
-    // server-side teardown (disconnect, idle sweep, config disable).
-    reason: Type.Optional(
-      Type.Union([
-        Type.Literal("process_exit"),
-        Type.Literal("closed"),
-        Type.Literal("disconnected"),
-        // Another admin connection attached the session away; the session is
-        // still alive server-side, but no longer streams to this connection.
-        Type.Literal("detached"),
-        Type.Literal("error"),
-      ]),
-    ),
-    error: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const TerminalExitEventSchema = closedObject({
+  sessionId: NonEmptyString,
+  exitCode: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
+  signal: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
+  // Stable reason code so clients can distinguish process exit from a
+  // server-side teardown (disconnect, idle sweep, config disable).
+  reason: Type.Optional(
+    Type.Union([
+      Type.Literal("process_exit"),
+      Type.Literal("closed"),
+      Type.Literal("disconnected"),
+      // Another admin connection attached the session away; the session is
+      // still alive server-side, but no longer streams to this connection.
+      Type.Literal("detached"),
+      Type.Literal("error"),
+    ]),
+  ),
+  error: Type.Optional(Type.String()),
+});
 export type TerminalExitEvent = Static<typeof TerminalExitEventSchema>;
 
 /** Union of every event a terminal session can emit. */

--- a/packages/gateway-protocol/src/schema/wizard.ts
+++ b/packages/gateway-protocol/src/schema/wizard.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 /** Runtime state reported for gateway-driven setup wizard sessions. */
@@ -12,39 +13,27 @@ const WizardRunStatusSchema = Type.Union([
 ]);
 
 /** Starts a setup wizard, optionally scoped to a local or remote workspace. */
-export const WizardStartParamsSchema = Type.Object(
-  {
-    mode: Type.Optional(Type.Union([Type.Literal("local"), Type.Literal("remote")])),
-    workspace: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const WizardStartParamsSchema = closedObject({
+  mode: Type.Optional(Type.Union([Type.Literal("local"), Type.Literal("remote")])),
+  workspace: Type.Optional(Type.String()),
+});
 
 /** Client answer payload for the current wizard step. */
-export const WizardAnswerSchema = Type.Object(
-  {
-    stepId: NonEmptyString,
-    value: Type.Optional(Type.Unknown()),
-  },
-  { additionalProperties: false },
-);
+export const WizardAnswerSchema = closedObject({
+  stepId: NonEmptyString,
+  value: Type.Optional(Type.Unknown()),
+});
 
 /** Advances a wizard session, with an answer when the previous step requested input. */
-export const WizardNextParamsSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    answer: Type.Optional(WizardAnswerSchema),
-  },
-  { additionalProperties: false },
-);
+export const WizardNextParamsSchema = closedObject({
+  sessionId: NonEmptyString,
+  answer: Type.Optional(WizardAnswerSchema),
+});
 
 /** Shared session-id-only params for cancel and status requests. */
-const WizardSessionIdParamsSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+const WizardSessionIdParamsSchema = closedObject({
+  sessionId: NonEmptyString,
+});
 
 /** Cancels an active wizard session. */
 export const WizardCancelParamsSchema = WizardSessionIdParamsSchema;
@@ -53,50 +42,41 @@ export const WizardCancelParamsSchema = WizardSessionIdParamsSchema;
 export const WizardStatusParamsSchema = WizardSessionIdParamsSchema;
 
 /** Selectable value shown in a choice-based wizard step. */
-export const WizardStepOptionSchema = Type.Object(
-  {
-    value: Type.Unknown(),
-    label: NonEmptyString,
-    hint: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const WizardStepOptionSchema = closedObject({
+  value: Type.Unknown(),
+  label: NonEmptyString,
+  hint: Type.Optional(Type.String()),
+});
 
-const WizardDeviceCodeSchema = Type.Object(
-  {
-    code: NonEmptyString,
-    expiresInMinutes: Type.Optional(Type.Integer({ minimum: 1, maximum: 1440 })),
-    message: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+const WizardDeviceCodeSchema = closedObject({
+  code: NonEmptyString,
+  expiresInMinutes: Type.Optional(Type.Integer({ minimum: 1, maximum: 1440 })),
+  message: Type.Optional(Type.String()),
+});
 
 /** UI contract for one wizard step rendered by gateway clients. */
-export const WizardStepSchema = Type.Object(
-  {
-    id: NonEmptyString,
-    type: Type.Union([
-      Type.Literal("note"),
-      Type.Literal("select"),
-      Type.Literal("text"),
-      Type.Literal("confirm"),
-      Type.Literal("multiselect"),
-      Type.Literal("progress"),
-      Type.Literal("action"),
-    ]),
-    title: Type.Optional(Type.String()),
-    message: Type.Optional(Type.String()),
-    format: Type.Optional(Type.Union([Type.Literal("plain")])),
-    options: Type.Optional(Type.Array(WizardStepOptionSchema)),
-    initialValue: Type.Optional(Type.Unknown()),
-    placeholder: Type.Optional(Type.String()),
-    sensitive: Type.Optional(Type.Boolean()),
-    executor: Type.Optional(Type.Union([Type.Literal("gateway"), Type.Literal("client")])),
-    externalUrl: Type.Optional(Type.String()),
-    deviceCode: Type.Optional(WizardDeviceCodeSchema),
-  },
-  { additionalProperties: false },
-);
+export const WizardStepSchema = closedObject({
+  id: NonEmptyString,
+  type: Type.Union([
+    Type.Literal("note"),
+    Type.Literal("select"),
+    Type.Literal("text"),
+    Type.Literal("confirm"),
+    Type.Literal("multiselect"),
+    Type.Literal("progress"),
+    Type.Literal("action"),
+  ]),
+  title: Type.Optional(Type.String()),
+  message: Type.Optional(Type.String()),
+  format: Type.Optional(Type.Union([Type.Literal("plain")])),
+  options: Type.Optional(Type.Array(WizardStepOptionSchema)),
+  initialValue: Type.Optional(Type.Unknown()),
+  placeholder: Type.Optional(Type.String()),
+  sensitive: Type.Optional(Type.Boolean()),
+  executor: Type.Optional(Type.Union([Type.Literal("gateway"), Type.Literal("client")])),
+  externalUrl: Type.Optional(Type.String()),
+  deviceCode: Type.Optional(WizardDeviceCodeSchema),
+});
 
 /** Common response fields for start and next calls. */
 const WizardResultFields = {
@@ -107,27 +87,19 @@ const WizardResultFields = {
 };
 
 /** Result after advancing a wizard session. */
-export const WizardNextResultSchema = Type.Object(WizardResultFields, {
-  additionalProperties: false,
-});
+export const WizardNextResultSchema = closedObject(WizardResultFields);
 
 /** Result returned when a wizard session is created. */
-export const WizardStartResultSchema = Type.Object(
-  {
-    sessionId: NonEmptyString,
-    ...WizardResultFields,
-  },
-  { additionalProperties: false },
-);
+export const WizardStartResultSchema = closedObject({
+  sessionId: NonEmptyString,
+  ...WizardResultFields,
+});
 
 /** Minimal status poll result used when the client does not need the next step. */
-export const WizardStatusResultSchema = Type.Object(
-  {
-    status: WizardRunStatusSchema,
-    error: Type.Optional(Type.String()),
-  },
-  { additionalProperties: false },
-);
+export const WizardStatusResultSchema = closedObject({
+  status: WizardRunStatusSchema,
+  error: Type.Optional(Type.String()),
+});
 
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.

--- a/packages/gateway-protocol/src/schema/worker-admission.ts
+++ b/packages/gateway-protocol/src/schema/worker-admission.ts
@@ -1,5 +1,6 @@
 import { Type, type Static, type TProperties } from "typebox";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../client-info.js";
+import { closedObject } from "./closed-object.js";
 
 // Additive RPCs require exact build-bound features; bump only for an incompatible base set.
 export const WORKER_RPC_SET_VERSION = 1;
@@ -48,57 +49,42 @@ const WorkerBundleHashSchema = Type.String({
 });
 
 /** Build identity presented by a worker before the gateway admits it. */
-export const WorkerAdmissionHandshakeSchema = Type.Object(
-  {
-    bundleHash: WorkerBundleHashSchema,
-    openclawVersion: Type.String({ minLength: 1, maxLength: 128 }),
-    protocolFeatures: Type.Array(WorkerProtocolFeatureSchema, {
-      maxItems: WORKER_PROTOCOL_MAX_FEATURES,
-      uniqueItems: true,
-    }),
-  },
-  { additionalProperties: false },
-);
+export const WorkerAdmissionHandshakeSchema = closedObject({
+  bundleHash: WorkerBundleHashSchema,
+  openclawVersion: Type.String({ minLength: 1, maxLength: 128 }),
+  protocolFeatures: Type.Array(WorkerProtocolFeatureSchema, {
+    maxItems: WORKER_PROTOCOL_MAX_FEATURES,
+    uniqueItems: true,
+  }),
+});
 
 /** Dedicated first-frame payload accepted only on the worker ingress. */
-export const WorkerConnectParamsSchema = Type.Object(
-  {
-    minProtocol: Type.Integer({ minimum: 1 }),
-    maxProtocol: Type.Integer({ minimum: 1 }),
-    client: Type.Object(
-      {
-        id: Type.Literal(GATEWAY_CLIENT_IDS.WORKER),
-        version: Type.String({ minLength: 1, maxLength: 128 }),
-        platform: Type.String({ minLength: 1, maxLength: 128 }),
-        mode: Type.Literal(GATEWAY_CLIENT_MODES.WORKER),
-      },
-      { additionalProperties: false },
-    ),
-    role: Type.Literal("worker"),
-    admission: Type.Object(
-      {
-        environmentId: WorkerIdentifierSchema,
-        credential: WorkerCredentialSchema,
-        sessionId: Type.Union([WorkerIdentifierSchema, Type.Null()]),
-        ownerEpoch: Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
-        rpcSetVersion: Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER }),
-        handshake: WorkerAdmissionHandshakeSchema,
-      },
-      { additionalProperties: false },
-    ),
-  },
-  { additionalProperties: false },
-);
+export const WorkerConnectParamsSchema = closedObject({
+  minProtocol: Type.Integer({ minimum: 1 }),
+  maxProtocol: Type.Integer({ minimum: 1 }),
+  client: closedObject({
+    id: Type.Literal(GATEWAY_CLIENT_IDS.WORKER),
+    version: Type.String({ minLength: 1, maxLength: 128 }),
+    platform: Type.String({ minLength: 1, maxLength: 128 }),
+    mode: Type.Literal(GATEWAY_CLIENT_MODES.WORKER),
+  }),
+  role: Type.Literal("worker"),
+  admission: closedObject({
+    environmentId: WorkerIdentifierSchema,
+    credential: WorkerCredentialSchema,
+    sessionId: Type.Union([WorkerIdentifierSchema, Type.Null()]),
+    ownerEpoch: Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
+    rpcSetVersion: Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER }),
+    handshake: WorkerAdmissionHandshakeSchema,
+  }),
+});
 
-export const WorkerConnectRequestFrameSchema = Type.Object(
-  {
-    type: Type.Literal("req"),
-    id: WorkerFrameIdSchema,
-    method: Type.Literal("connect"),
-    params: WorkerConnectParamsSchema,
-  },
-  { additionalProperties: false },
-);
+export const WorkerConnectRequestFrameSchema = closedObject({
+  type: Type.Literal("req"),
+  id: WorkerFrameIdSchema,
+  method: Type.Literal("connect"),
+  params: WorkerConnectParamsSchema,
+});
 
 export const WorkerAdmissionFailureReasonSchema = Type.Union([
   Type.Literal("invalid-credential"),
@@ -131,65 +117,47 @@ const WorkerErrorCodeSchema = Type.Union([
   Type.Literal("UNAVAILABLE"),
 ]);
 
-const WorkerErrorDetailsSchema = Type.Object(
-  { reason: WorkerProtocolCloseReasonSchema },
-  { additionalProperties: false },
-);
+const WorkerErrorDetailsSchema = closedObject({ reason: WorkerProtocolCloseReasonSchema });
 
-export const WorkerErrorShapeSchema = Type.Object(
-  {
-    code: WorkerErrorCodeSchema,
-    message: Type.String({ minLength: 1, maxLength: 256 }),
-    details: WorkerErrorDetailsSchema,
-    retryable: Type.Optional(Type.Boolean()),
-    retryAfterMs: Type.Optional(Type.Integer({ minimum: 0 })),
-  },
-  { additionalProperties: false },
-);
+export const WorkerErrorShapeSchema = closedObject({
+  code: WorkerErrorCodeSchema,
+  message: Type.String({ minLength: 1, maxLength: 256 }),
+  details: WorkerErrorDetailsSchema,
+  retryable: Type.Optional(Type.Boolean()),
+  retryAfterMs: Type.Optional(Type.Integer({ minimum: 0 })),
+});
 
 /** Minimal admission response; workers never receive the general gateway snapshot. */
-export const WorkerHelloOkSchema = Type.Object(
-  {
-    type: Type.Literal("worker-hello-ok"),
-    environmentId: WorkerIdentifierSchema,
-    sessionId: Type.Union([WorkerIdentifierSchema, Type.Null()]),
-    ownerEpoch: Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
-    rpcSetVersion: Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER }),
-    protocolFeatures: Type.Array(WorkerProtocolFeatureSchema, {
-      maxItems: WORKER_PROTOCOL_MAX_FEATURES,
-      uniqueItems: true,
-    }),
-    credentialExpiresAtMs: Type.Integer({ minimum: 0 }),
-    policy: Type.Object(
-      {
-        heartbeatIntervalMs: Type.Integer({ minimum: 1 }),
-        maxPayload: Type.Integer({ minimum: 1 }),
-      },
-      { additionalProperties: false },
-    ),
-  },
-  { additionalProperties: false },
-);
+export const WorkerHelloOkSchema = closedObject({
+  type: Type.Literal("worker-hello-ok"),
+  environmentId: WorkerIdentifierSchema,
+  sessionId: Type.Union([WorkerIdentifierSchema, Type.Null()]),
+  ownerEpoch: Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
+  rpcSetVersion: Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER }),
+  protocolFeatures: Type.Array(WorkerProtocolFeatureSchema, {
+    maxItems: WORKER_PROTOCOL_MAX_FEATURES,
+    uniqueItems: true,
+  }),
+  credentialExpiresAtMs: Type.Integer({ minimum: 0 }),
+  policy: closedObject({
+    heartbeatIntervalMs: Type.Integer({ minimum: 1 }),
+    maxPayload: Type.Integer({ minimum: 1 }),
+  }),
+});
 
-const WorkerErrorResponseFrameSchema = Type.Object(
-  {
-    type: Type.Literal("res"),
-    id: WorkerFrameIdSchema,
-    ok: Type.Literal(false),
-    error: WorkerErrorShapeSchema,
-  },
-  { additionalProperties: false },
-);
+const WorkerErrorResponseFrameSchema = closedObject({
+  type: Type.Literal("res"),
+  id: WorkerFrameIdSchema,
+  ok: Type.Literal(false),
+  error: WorkerErrorShapeSchema,
+});
 
-const WorkerAdmissionSuccessResponseFrameSchema = Type.Object(
-  {
-    type: Type.Literal("res"),
-    id: WorkerFrameIdSchema,
-    ok: Type.Literal(true),
-    payload: WorkerHelloOkSchema,
-  },
-  { additionalProperties: false },
-);
+const WorkerAdmissionSuccessResponseFrameSchema = closedObject({
+  type: Type.Literal("res"),
+  id: WorkerFrameIdSchema,
+  ok: Type.Literal(true),
+  payload: WorkerHelloOkSchema,
+});
 
 export const WorkerAdmissionResponseFrameSchema = Type.Union([
   WorkerAdmissionSuccessResponseFrameSchema,
@@ -202,218 +170,168 @@ const WorkerStatusSchema = Type.Union([
   Type.Literal("draining"),
 ]);
 
-export const WorkerHeartbeatParamsSchema = Type.Object(
-  {
-    sentAtMs: Type.Integer({ minimum: 0 }),
-    status: WorkerStatusSchema,
-  },
-  { additionalProperties: false },
-);
+export const WorkerHeartbeatParamsSchema = closedObject({
+  sentAtMs: Type.Integer({ minimum: 0 }),
+  status: WorkerStatusSchema,
+});
 
-export const WorkerHeartbeatResultSchema = Type.Object(
-  {
-    receivedAtMs: Type.Integer({ minimum: 0 }),
-    status: Type.Literal("ok"),
-    ownerEpoch: Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
-  },
-  { additionalProperties: false },
-);
+export const WorkerHeartbeatResultSchema = closedObject({
+  receivedAtMs: Type.Integer({ minimum: 0 }),
+  status: Type.Literal("ok"),
+  ownerEpoch: Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
+});
 
-export const WorkerHeartbeatRequestFrameSchema = Type.Object(
-  {
-    type: Type.Literal("req"),
-    id: WorkerFrameIdSchema,
-    method: Type.Literal(WORKER_PROTOCOL_METHODS[0]),
-    params: WorkerHeartbeatParamsSchema,
-  },
-  { additionalProperties: false },
-);
+export const WorkerHeartbeatRequestFrameSchema = closedObject({
+  type: Type.Literal("req"),
+  id: WorkerFrameIdSchema,
+  method: Type.Literal(WORKER_PROTOCOL_METHODS[0]),
+  params: WorkerHeartbeatParamsSchema,
+});
 
-const WorkerHeartbeatSuccessResponseFrameSchema = Type.Object(
-  {
-    type: Type.Literal("res"),
-    id: WorkerFrameIdSchema,
-    ok: Type.Literal(true),
-    payload: WorkerHeartbeatResultSchema,
-  },
-  { additionalProperties: false },
-);
+const WorkerHeartbeatSuccessResponseFrameSchema = closedObject({
+  type: Type.Literal("res"),
+  id: WorkerFrameIdSchema,
+  ok: Type.Literal(true),
+  payload: WorkerHeartbeatResultSchema,
+});
 
 export const WorkerHeartbeatResponseFrameSchema = Type.Union([
   WorkerHeartbeatSuccessResponseFrameSchema,
   WorkerErrorResponseFrameSchema,
 ]);
 
-const WorkerTranscriptTextContentSchema = Type.Object(
-  {
-    type: Type.Literal("text"),
-    text: Type.String({ maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES }),
-    textSignature: Type.Optional(
-      Type.String({ minLength: 1, maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES }),
-    ),
-  },
-  { additionalProperties: false },
-);
+const WorkerTranscriptTextContentSchema = closedObject({
+  type: Type.Literal("text"),
+  text: Type.String({ maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES }),
+  textSignature: Type.Optional(
+    Type.String({ minLength: 1, maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES }),
+  ),
+});
 
-const WorkerTranscriptThinkingContentSchema = Type.Object(
-  {
-    type: Type.Literal("thinking"),
-    thinking: Type.String({ maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES }),
-    thinkingSignature: Type.Optional(
-      Type.String({ minLength: 1, maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES }),
-    ),
-    redacted: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
+const WorkerTranscriptThinkingContentSchema = closedObject({
+  type: Type.Literal("thinking"),
+  thinking: Type.String({ maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES }),
+  thinkingSignature: Type.Optional(
+    Type.String({ minLength: 1, maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES }),
+  ),
+  redacted: Type.Optional(Type.Boolean()),
+});
 
-const WorkerTranscriptImageContentSchema = Type.Object(
-  {
-    type: Type.Literal("image"),
-    data: Type.String({ minLength: 1, maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES }),
-    mimeType: Type.String({ minLength: 1, maxLength: 256 }),
-  },
-  { additionalProperties: false },
-);
+const WorkerTranscriptImageContentSchema = closedObject({
+  type: Type.Literal("image"),
+  data: Type.String({ minLength: 1, maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES }),
+  mimeType: Type.String({ minLength: 1, maxLength: 256 }),
+});
 
-const WorkerTranscriptToolCallSchema = Type.Object(
-  {
-    type: Type.Literal("toolCall"),
-    id: WorkerIdentifierSchema,
-    name: WorkerIdentifierSchema,
-    arguments: Type.Record(Type.String({ minLength: 1, maxLength: 256 }), Type.Unknown()),
-    thoughtSignature: Type.Optional(
-      Type.String({ minLength: 1, maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES }),
-    ),
-    executionMode: Type.Optional(
-      Type.Union([Type.Literal("sequential"), Type.Literal("parallel")]),
-    ),
-  },
-  { additionalProperties: false },
-);
+const WorkerTranscriptToolCallSchema = closedObject({
+  type: Type.Literal("toolCall"),
+  id: WorkerIdentifierSchema,
+  name: WorkerIdentifierSchema,
+  arguments: Type.Record(Type.String({ minLength: 1, maxLength: 256 }), Type.Unknown()),
+  thoughtSignature: Type.Optional(
+    Type.String({ minLength: 1, maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES }),
+  ),
+  executionMode: Type.Optional(Type.Union([Type.Literal("sequential"), Type.Literal("parallel")])),
+});
 
-const WorkerTranscriptUsageSchema = Type.Object(
-  {
+const WorkerTranscriptUsageSchema = closedObject({
+  input: Type.Number({ minimum: 0 }),
+  output: Type.Number({ minimum: 0 }),
+  cacheRead: Type.Number({ minimum: 0 }),
+  cacheWrite: Type.Number({ minimum: 0 }),
+  contextUsage: Type.Optional(
+    Type.Union([
+      closedObject({
+        state: Type.Literal("available"),
+        promptTokens: Type.Number({ minimum: 0 }),
+        totalTokens: Type.Number({ minimum: 0 }),
+      }),
+      closedObject({ state: Type.Literal("unavailable") }),
+    ]),
+  ),
+  totalTokens: Type.Number({ minimum: 0 }),
+  cost: closedObject({
     input: Type.Number({ minimum: 0 }),
     output: Type.Number({ minimum: 0 }),
     cacheRead: Type.Number({ minimum: 0 }),
     cacheWrite: Type.Number({ minimum: 0 }),
-    contextUsage: Type.Optional(
-      Type.Union([
-        Type.Object(
-          {
-            state: Type.Literal("available"),
-            promptTokens: Type.Number({ minimum: 0 }),
-            totalTokens: Type.Number({ minimum: 0 }),
-          },
-          { additionalProperties: false },
-        ),
-        Type.Object({ state: Type.Literal("unavailable") }, { additionalProperties: false }),
-      ]),
-    ),
-    totalTokens: Type.Number({ minimum: 0 }),
-    cost: Type.Object(
-      {
-        input: Type.Number({ minimum: 0 }),
-        output: Type.Number({ minimum: 0 }),
-        cacheRead: Type.Number({ minimum: 0 }),
-        cacheWrite: Type.Number({ minimum: 0 }),
-        total: Type.Number({ minimum: 0 }),
-        totalOrigin: Type.Optional(Type.Literal("provider-billed")),
-      },
-      { additionalProperties: false },
-    ),
-  },
-  { additionalProperties: false },
-);
+    total: Type.Number({ minimum: 0 }),
+    totalOrigin: Type.Optional(Type.Literal("provider-billed")),
+  }),
+});
 
-const WorkerTranscriptAssistantDiagnosticSchema = Type.Object(
-  {
-    type: WorkerIdentifierSchema,
-    timestamp: Type.Integer({ minimum: 0 }),
-    error: Type.Optional(
-      Type.Object(
-        {
-          name: Type.Optional(Type.String({ maxLength: 256 })),
-          message: Type.String({ maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES }),
-          stack: Type.Optional(Type.String({ maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES })),
-          code: Type.Optional(Type.Union([Type.String({ maxLength: 256 }), Type.Number()])),
-        },
-        { additionalProperties: false },
-      ),
-    ),
-    details: Type.Optional(
-      Type.Record(Type.String({ minLength: 1, maxLength: 256 }), Type.Unknown()),
-    ),
-  },
-  { additionalProperties: false },
-);
+const WorkerTranscriptAssistantDiagnosticSchema = closedObject({
+  type: WorkerIdentifierSchema,
+  timestamp: Type.Integer({ minimum: 0 }),
+  error: Type.Optional(
+    closedObject({
+      name: Type.Optional(Type.String({ maxLength: 256 })),
+      message: Type.String({ maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES }),
+      stack: Type.Optional(Type.String({ maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES })),
+      code: Type.Optional(Type.Union([Type.String({ maxLength: 256 }), Type.Number()])),
+    }),
+  ),
+  details: Type.Optional(
+    Type.Record(Type.String({ minLength: 1, maxLength: 256 }), Type.Unknown()),
+  ),
+});
 
-const WorkerTranscriptUserMessageSchema = Type.Object(
-  {
-    role: Type.Literal("user"),
-    content: Type.Array(
-      Type.Union([WorkerTranscriptTextContentSchema, WorkerTranscriptImageContentSchema]),
-      { minItems: 1, maxItems: WORKER_TRANSCRIPT_MAX_CONTENT_PARTS },
-    ),
-    timestamp: Type.Integer({ minimum: 0 }),
-  },
-  { additionalProperties: false },
-);
+const WorkerTranscriptUserMessageSchema = closedObject({
+  role: Type.Literal("user"),
+  content: Type.Array(
+    Type.Union([WorkerTranscriptTextContentSchema, WorkerTranscriptImageContentSchema]),
+    { minItems: 1, maxItems: WORKER_TRANSCRIPT_MAX_CONTENT_PARTS },
+  ),
+  timestamp: Type.Integer({ minimum: 0 }),
+});
 
-const WorkerTranscriptAssistantMessageSchema = Type.Object(
-  {
-    role: Type.Literal("assistant"),
-    content: Type.Array(
-      Type.Union([
-        WorkerTranscriptTextContentSchema,
-        WorkerTranscriptThinkingContentSchema,
-        WorkerTranscriptToolCallSchema,
-      ]),
-      { maxItems: WORKER_TRANSCRIPT_MAX_CONTENT_PARTS },
-    ),
-    api: WorkerIdentifierSchema,
-    provider: WorkerIdentifierSchema,
-    model: WorkerIdentifierSchema,
-    responseModel: Type.Optional(WorkerIdentifierSchema),
-    responseId: Type.Optional(WorkerIdentifierSchema),
-    diagnostics: Type.Optional(
-      Type.Array(WorkerTranscriptAssistantDiagnosticSchema, {
-        maxItems: WORKER_TRANSCRIPT_MAX_CONTENT_PARTS,
-      }),
-    ),
-    usage: WorkerTranscriptUsageSchema,
-    stopReason: Type.Union([
-      Type.Literal("stop"),
-      Type.Literal("length"),
-      Type.Literal("toolUse"),
-      Type.Literal("error"),
-      Type.Literal("aborted"),
+const WorkerTranscriptAssistantMessageSchema = closedObject({
+  role: Type.Literal("assistant"),
+  content: Type.Array(
+    Type.Union([
+      WorkerTranscriptTextContentSchema,
+      WorkerTranscriptThinkingContentSchema,
+      WorkerTranscriptToolCallSchema,
     ]),
-    errorMessage: Type.Optional(Type.String({ maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES })),
-    errorCode: Type.Optional(Type.String({ maxLength: 256 })),
-    errorType: Type.Optional(Type.String({ maxLength: 256 })),
-    errorBody: Type.Optional(Type.String({ maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES })),
-    timestamp: Type.Integer({ minimum: 0 }),
-  },
-  { additionalProperties: false },
-);
+    { maxItems: WORKER_TRANSCRIPT_MAX_CONTENT_PARTS },
+  ),
+  api: WorkerIdentifierSchema,
+  provider: WorkerIdentifierSchema,
+  model: WorkerIdentifierSchema,
+  responseModel: Type.Optional(WorkerIdentifierSchema),
+  responseId: Type.Optional(WorkerIdentifierSchema),
+  diagnostics: Type.Optional(
+    Type.Array(WorkerTranscriptAssistantDiagnosticSchema, {
+      maxItems: WORKER_TRANSCRIPT_MAX_CONTENT_PARTS,
+    }),
+  ),
+  usage: WorkerTranscriptUsageSchema,
+  stopReason: Type.Union([
+    Type.Literal("stop"),
+    Type.Literal("length"),
+    Type.Literal("toolUse"),
+    Type.Literal("error"),
+    Type.Literal("aborted"),
+  ]),
+  errorMessage: Type.Optional(Type.String({ maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES })),
+  errorCode: Type.Optional(Type.String({ maxLength: 256 })),
+  errorType: Type.Optional(Type.String({ maxLength: 256 })),
+  errorBody: Type.Optional(Type.String({ maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES })),
+  timestamp: Type.Integer({ minimum: 0 }),
+});
 
-const WorkerTranscriptToolResultMessageSchema = Type.Object(
-  {
-    role: Type.Literal("toolResult"),
-    toolCallId: WorkerIdentifierSchema,
-    toolName: WorkerIdentifierSchema,
-    content: Type.Array(
-      Type.Union([WorkerTranscriptTextContentSchema, WorkerTranscriptImageContentSchema]),
-      { maxItems: WORKER_TRANSCRIPT_MAX_CONTENT_PARTS },
-    ),
-    details: Type.Optional(Type.Unknown()),
-    isError: Type.Boolean(),
-    timestamp: Type.Integer({ minimum: 0 }),
-  },
-  { additionalProperties: false },
-);
+const WorkerTranscriptToolResultMessageSchema = closedObject({
+  role: Type.Literal("toolResult"),
+  toolCallId: WorkerIdentifierSchema,
+  toolName: WorkerIdentifierSchema,
+  content: Type.Array(
+    Type.Union([WorkerTranscriptTextContentSchema, WorkerTranscriptImageContentSchema]),
+    { maxItems: WORKER_TRANSCRIPT_MAX_CONTENT_PARTS },
+  ),
+  details: Type.Optional(Type.Unknown()),
+  isError: Type.Boolean(),
+  timestamp: Type.Integer({ minimum: 0 }),
+});
 
 export const WorkerTranscriptMessageSchema = Type.Union([
   WorkerTranscriptUserMessageSchema,
@@ -421,29 +339,23 @@ export const WorkerTranscriptMessageSchema = Type.Union([
   WorkerTranscriptToolResultMessageSchema,
 ]);
 
-export const WorkerTranscriptCommitParamsSchema = Type.Object(
-  {
-    runEpoch: Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
-    seq: Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER }),
-    baseLeafId: Type.Union([WorkerIdentifierSchema, Type.Null()]),
-    messages: Type.Array(WorkerTranscriptMessageSchema, {
-      minItems: 1,
-      maxItems: WORKER_TRANSCRIPT_MAX_BATCH_MESSAGES,
-    }),
-  },
-  { additionalProperties: false },
-);
+export const WorkerTranscriptCommitParamsSchema = closedObject({
+  runEpoch: Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
+  seq: Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER }),
+  baseLeafId: Type.Union([WorkerIdentifierSchema, Type.Null()]),
+  messages: Type.Array(WorkerTranscriptMessageSchema, {
+    minItems: 1,
+    maxItems: WORKER_TRANSCRIPT_MAX_BATCH_MESSAGES,
+  }),
+});
 
-export const WorkerTranscriptCommitResultSchema = Type.Object(
-  {
-    entryIds: Type.Array(WorkerIdentifierSchema, {
-      minItems: 1,
-      maxItems: WORKER_TRANSCRIPT_MAX_BATCH_MESSAGES,
-    }),
-    newLeafId: WorkerIdentifierSchema,
-  },
-  { additionalProperties: false },
-);
+export const WorkerTranscriptCommitResultSchema = closedObject({
+  entryIds: Type.Array(WorkerIdentifierSchema, {
+    minItems: 1,
+    maxItems: WORKER_TRANSCRIPT_MAX_BATCH_MESSAGES,
+  }),
+  newLeafId: WorkerIdentifierSchema,
+});
 
 export const WorkerTranscriptCommitErrorReasonSchema = Type.Union([
   Type.Literal("stale-base-leaf"),
@@ -452,47 +364,32 @@ export const WorkerTranscriptCommitErrorReasonSchema = Type.Union([
   Type.Literal("session-not-attached"),
 ]);
 
-export const WorkerTranscriptCommitErrorShapeSchema = Type.Object(
-  {
-    code: Type.Literal("INVALID_REQUEST"),
-    message: Type.String({ minLength: 1, maxLength: 256 }),
-    details: Type.Object(
-      { reason: WorkerTranscriptCommitErrorReasonSchema },
-      { additionalProperties: false },
-    ),
-  },
-  { additionalProperties: false },
-);
+export const WorkerTranscriptCommitErrorShapeSchema = closedObject({
+  code: Type.Literal("INVALID_REQUEST"),
+  message: Type.String({ minLength: 1, maxLength: 256 }),
+  details: closedObject({ reason: WorkerTranscriptCommitErrorReasonSchema }),
+});
 
-export const WorkerTranscriptCommitRequestFrameSchema = Type.Object(
-  {
-    type: Type.Literal("req"),
-    id: WorkerFrameIdSchema,
-    method: Type.Literal(WORKER_PROTOCOL_METHODS[1]),
-    params: WorkerTranscriptCommitParamsSchema,
-  },
-  { additionalProperties: false },
-);
+export const WorkerTranscriptCommitRequestFrameSchema = closedObject({
+  type: Type.Literal("req"),
+  id: WorkerFrameIdSchema,
+  method: Type.Literal(WORKER_PROTOCOL_METHODS[1]),
+  params: WorkerTranscriptCommitParamsSchema,
+});
 
-const WorkerTranscriptCommitSuccessResponseFrameSchema = Type.Object(
-  {
-    type: Type.Literal("res"),
-    id: WorkerFrameIdSchema,
-    ok: Type.Literal(true),
-    payload: WorkerTranscriptCommitResultSchema,
-  },
-  { additionalProperties: false },
-);
+const WorkerTranscriptCommitSuccessResponseFrameSchema = closedObject({
+  type: Type.Literal("res"),
+  id: WorkerFrameIdSchema,
+  ok: Type.Literal(true),
+  payload: WorkerTranscriptCommitResultSchema,
+});
 
-const WorkerTranscriptCommitErrorResponseFrameSchema = Type.Object(
-  {
-    type: Type.Literal("res"),
-    id: WorkerFrameIdSchema,
-    ok: Type.Literal(false),
-    error: WorkerTranscriptCommitErrorShapeSchema,
-  },
-  { additionalProperties: false },
-);
+const WorkerTranscriptCommitErrorResponseFrameSchema = closedObject({
+  type: Type.Literal("res"),
+  id: WorkerFrameIdSchema,
+  ok: Type.Literal(false),
+  error: WorkerTranscriptCommitErrorShapeSchema,
+});
 
 export const WorkerTranscriptCommitResponseFrameSchema = Type.Union([
   WorkerTranscriptCommitSuccessResponseFrameSchema,
@@ -501,7 +398,7 @@ export const WorkerTranscriptCommitResponseFrameSchema = Type.Union([
 ]);
 
 function workerLiveObject<const Properties extends TProperties>(properties: Properties) {
-  return Type.Object(properties, { additionalProperties: false });
+  return closedObject(properties);
 }
 
 const LiveTextSchema = Type.String({

--- a/packages/gateway-protocol/src/schema/worker-inference.ts
+++ b/packages/gateway-protocol/src/schema/worker-inference.ts
@@ -1,5 +1,6 @@
 import { Type, type TProperties, type TSchema } from "typebox";
 import { Value } from "typebox/value";
+import { closedObject } from "./closed-object.js";
 import {
   WORKER_PROTOCOL_MAX_FRAME_ID_LENGTH,
   WORKER_PROTOCOL_MAX_IDENTIFIER_LENGTH,
@@ -30,18 +31,15 @@ const WorkerFrameIdSchema = Type.String({
   minLength: 1,
   maxLength: WORKER_PROTOCOL_MAX_FRAME_ID_LENGTH,
 });
-const WorkerErrorResponseFrameSchema = Type.Object(
-  {
-    type: Type.Literal("res"),
-    id: WorkerFrameIdSchema,
-    ok: Type.Literal(false),
-    error: WorkerErrorShapeSchema,
-  },
-  { additionalProperties: false },
-);
+const WorkerErrorResponseFrameSchema = closedObject({
+  type: Type.Literal("res"),
+  id: WorkerFrameIdSchema,
+  ok: Type.Literal(false),
+  error: WorkerErrorShapeSchema,
+});
 
 function workerInferenceObject<const Properties extends TProperties>(properties: Properties) {
-  return Type.Object(properties, { additionalProperties: false });
+  return closedObject(properties);
 }
 
 const LiveTextSchema = Type.String({
@@ -60,62 +58,47 @@ const LiveSequenceSchema = Type.Integer({
   maximum: Number.MAX_SAFE_INTEGER,
 });
 
-const WorkerTranscriptUsageSchema = Type.Object(
-  {
+const WorkerTranscriptUsageSchema = closedObject({
+  input: Type.Number({ minimum: 0 }),
+  output: Type.Number({ minimum: 0 }),
+  cacheRead: Type.Number({ minimum: 0 }),
+  cacheWrite: Type.Number({ minimum: 0 }),
+  contextUsage: Type.Optional(
+    Type.Union([
+      closedObject({
+        state: Type.Literal("available"),
+        promptTokens: Type.Number({ minimum: 0 }),
+        totalTokens: Type.Number({ minimum: 0 }),
+      }),
+      closedObject({ state: Type.Literal("unavailable") }),
+    ]),
+  ),
+  totalTokens: Type.Number({ minimum: 0 }),
+  cost: closedObject({
     input: Type.Number({ minimum: 0 }),
     output: Type.Number({ minimum: 0 }),
     cacheRead: Type.Number({ minimum: 0 }),
     cacheWrite: Type.Number({ minimum: 0 }),
-    contextUsage: Type.Optional(
-      Type.Union([
-        Type.Object(
-          {
-            state: Type.Literal("available"),
-            promptTokens: Type.Number({ minimum: 0 }),
-            totalTokens: Type.Number({ minimum: 0 }),
-          },
-          { additionalProperties: false },
-        ),
-        Type.Object({ state: Type.Literal("unavailable") }, { additionalProperties: false }),
-      ]),
-    ),
-    totalTokens: Type.Number({ minimum: 0 }),
-    cost: Type.Object(
-      {
-        input: Type.Number({ minimum: 0 }),
-        output: Type.Number({ minimum: 0 }),
-        cacheRead: Type.Number({ minimum: 0 }),
-        cacheWrite: Type.Number({ minimum: 0 }),
-        total: Type.Number({ minimum: 0 }),
-        totalOrigin: Type.Optional(Type.Literal("provider-billed")),
-      },
-      { additionalProperties: false },
-    ),
-  },
-  { additionalProperties: false },
-);
+    total: Type.Number({ minimum: 0 }),
+    totalOrigin: Type.Optional(Type.Literal("provider-billed")),
+  }),
+});
 
-const WorkerTranscriptAssistantDiagnosticSchema = Type.Object(
-  {
-    type: WorkerIdentifierSchema,
-    timestamp: Type.Integer({ minimum: 0 }),
-    error: Type.Optional(
-      Type.Object(
-        {
-          name: Type.Optional(Type.String({ maxLength: 256 })),
-          message: Type.String({ maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES }),
-          stack: Type.Optional(Type.String({ maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES })),
-          code: Type.Optional(Type.Union([Type.String({ maxLength: 256 }), Type.Number()])),
-        },
-        { additionalProperties: false },
-      ),
-    ),
-    details: Type.Optional(
-      Type.Record(Type.String({ minLength: 1, maxLength: 256 }), Type.Unknown()),
-    ),
-  },
-  { additionalProperties: false },
-);
+const WorkerTranscriptAssistantDiagnosticSchema = closedObject({
+  type: WorkerIdentifierSchema,
+  timestamp: Type.Integer({ minimum: 0 }),
+  error: Type.Optional(
+    closedObject({
+      name: Type.Optional(Type.String({ maxLength: 256 })),
+      message: Type.String({ maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES }),
+      stack: Type.Optional(Type.String({ maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES })),
+      code: Type.Optional(Type.Union([Type.String({ maxLength: 256 }), Type.Number()])),
+    }),
+  ),
+  details: Type.Optional(
+    Type.Record(Type.String({ minLength: 1, maxLength: 256 }), Type.Unknown()),
+  ),
+});
 
 const WorkerInferenceTextContentSchema = workerInferenceObject({
   type: Type.Literal("text"),

--- a/packages/gateway-protocol/src/schema/worktrees.ts
+++ b/packages/gateway-protocol/src/schema/worktrees.ts
@@ -1,90 +1,66 @@
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 const WorktreeNameSchema = Type.String({ pattern: "^[a-z0-9][a-z0-9-]{0,63}$" });
 
-export const WorktreeRecordSchema = Type.Object(
-  {
-    id: NonEmptyString,
-    name: WorktreeNameSchema,
-    repoFingerprint: Type.String({ pattern: "^[a-f0-9]{16}$" }),
-    repoRoot: NonEmptyString,
-    path: NonEmptyString,
-    branch: NonEmptyString,
-    baseRef: NonEmptyString,
-    ownerKind: Type.String({ enum: ["manual", "workboard", "session"] }),
-    ownerId: Type.Optional(NonEmptyString),
-    snapshotRef: Type.Optional(NonEmptyString),
-    createdAt: Type.Integer({ minimum: 0 }),
-    lastActiveAt: Type.Integer({ minimum: 0 }),
-    removedAt: Type.Optional(Type.Integer({ minimum: 0 })),
-  },
-  { additionalProperties: false },
-);
+export const WorktreeRecordSchema = closedObject({
+  id: NonEmptyString,
+  name: WorktreeNameSchema,
+  repoFingerprint: Type.String({ pattern: "^[a-f0-9]{16}$" }),
+  repoRoot: NonEmptyString,
+  path: NonEmptyString,
+  branch: NonEmptyString,
+  baseRef: NonEmptyString,
+  ownerKind: Type.String({ enum: ["manual", "workboard", "session"] }),
+  ownerId: Type.Optional(NonEmptyString),
+  snapshotRef: Type.Optional(NonEmptyString),
+  createdAt: Type.Integer({ minimum: 0 }),
+  lastActiveAt: Type.Integer({ minimum: 0 }),
+  removedAt: Type.Optional(Type.Integer({ minimum: 0 })),
+});
 
-export const WorktreesListParamsSchema = Type.Object({}, { additionalProperties: false });
-export const WorktreesListResultSchema = Type.Object(
-  { worktrees: Type.Array(WorktreeRecordSchema) },
-  { additionalProperties: false },
-);
+export const WorktreesListParamsSchema = closedObject({});
+export const WorktreesListResultSchema = closedObject({
+  worktrees: Type.Array(WorktreeRecordSchema),
+});
 
-export const WorktreesCreateParamsSchema = Type.Object(
-  {
-    repoRoot: NonEmptyString,
-    name: Type.Optional(WorktreeNameSchema),
-    baseRef: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const WorktreesCreateParamsSchema = closedObject({
+  repoRoot: NonEmptyString,
+  name: Type.Optional(WorktreeNameSchema),
+  baseRef: Type.Optional(NonEmptyString),
+});
 
-export const WorktreesRemoveParamsSchema = Type.Object(
-  { id: NonEmptyString, force: Type.Optional(Type.Boolean()) },
-  { additionalProperties: false },
-);
-export const WorktreesRemoveResultSchema = Type.Object(
-  {
-    removed: Type.Boolean(),
-    snapshotRef: Type.Optional(NonEmptyString),
-    /** Why the pre-removal snapshot failed; present only on forced removals that continued without one. */
-    snapshotError: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const WorktreesRemoveParamsSchema = closedObject({
+  id: NonEmptyString,
+  force: Type.Optional(Type.Boolean()),
+});
+export const WorktreesRemoveResultSchema = closedObject({
+  removed: Type.Boolean(),
+  snapshotRef: Type.Optional(NonEmptyString),
+  /** Why the pre-removal snapshot failed; present only on forced removals that continued without one. */
+  snapshotError: Type.Optional(NonEmptyString),
+});
 
-export const WorktreesBranchesParamsSchema = Type.Object(
-  { repoRoot: NonEmptyString },
-  { additionalProperties: false },
-);
-export const WorktreeBranchSchema = Type.Object(
-  {
-    name: NonEmptyString,
-    kind: Type.Union([Type.Literal("local"), Type.Literal("remote")]),
-  },
-  { additionalProperties: false },
-);
-export const WorktreesBranchesResultSchema = Type.Object(
-  {
-    branches: Type.Array(WorktreeBranchSchema),
-    defaultBranch: Type.Optional(NonEmptyString),
-    headBranch: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const WorktreesBranchesParamsSchema = closedObject({ repoRoot: NonEmptyString });
+export const WorktreeBranchSchema = closedObject({
+  name: NonEmptyString,
+  kind: Type.Union([Type.Literal("local"), Type.Literal("remote")]),
+});
+export const WorktreesBranchesResultSchema = closedObject({
+  branches: Type.Array(WorktreeBranchSchema),
+  defaultBranch: Type.Optional(NonEmptyString),
+  headBranch: Type.Optional(NonEmptyString),
+});
 
-export const WorktreesRestoreParamsSchema = Type.Object(
-  { id: NonEmptyString },
-  { additionalProperties: false },
-);
-export const WorktreesGcParamsSchema = Type.Object({}, { additionalProperties: false });
-export const WorktreesGcResultSchema = Type.Object(
-  {
-    removed: Type.Array(NonEmptyString),
-    orphansDeleted: Type.Integer({ minimum: 0 }),
-    snapshotsPruned: Type.Integer({ minimum: 0 }),
-  },
-  { additionalProperties: false },
-);
+export const WorktreesRestoreParamsSchema = closedObject({ id: NonEmptyString });
+export const WorktreesGcParamsSchema = closedObject({});
+export const WorktreesGcResultSchema = closedObject({
+  removed: Type.Array(NonEmptyString),
+  orphansDeleted: Type.Integer({ minimum: 0 }),
+  snapshotsPruned: Type.Integer({ minimum: 0 }),
+});
 
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.


### PR DESCRIPTION
## What Problem This Solves

Closes #106433.

Gateway protocol schemas repeated the exact TypeBox call for a closed object 575 times across 37 modules, leaving 1,500+ lines of duplicate policy and formatting.

## Why This Change Was Made

- Add one internal `closedObject(properties)` helper that delegates to TypeBox's existing `Type.Object` API with `additionalProperties: false`.
- Mechanically migrate only exact closed-object calls.
- Keep specialized worker const-generic helpers so their public declaration inference remains unchanged.
- Leave open objects and objects with extra schema options on direct `Type.Object` calls.

## User Impact

No wire, validation, or public type behavior changes. The gateway protocol implementation loses 1,549 production lines and gains one canonical closed-object construction path.

## Evidence

- Built package declarations: byte-identical SHA-256 inventory before/after.
- 559 exported runtime schema values: byte-identical sorted JSON serialization before/after.
- `pnpm --filter @openclaw/gateway-protocol build`
- `pnpm test packages/gateway-protocol/src` (24 files, 206 tests)
- Fresh structured autoreview across four bounded bundles: clean, no accepted/actionable findings.
- `git diff --check`
