### PR TITLE
refactor(channels): privatize approval channel list

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -2228,7 +2228,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/tui/tui-plugin-approvals.ts: parseTuiPluginApproval",
   "src/tui/tui-task-suggestions.ts: parseTuiTaskSuggestion",
   "src/tui/tui-waiting.ts: pickWaitingPhrase",
-  "src/utils/message-channel-constants.ts: NATIVE_APPROVAL_CHANNELS",
   "src/video-generation/runtime-types.ts: ListRuntimeVideoGenerationProvidersParams",
   "src/video-generation/runtime-types.ts: RuntimeVideoGenerationProvider",
   "src/web-search/runtime-types.ts: ListWebSearchProvidersParams",

--- a/src/utils/message-channel-constants.ts
+++ b/src/utils/message-channel-constants.ts
@@ -29,11 +29,11 @@ export function isInternalNonDeliveryChannel(
 // in place and the agent can wait inline for the result instead of falling
 // back to a fire-and-forget followup that loses the agent's session.
 //
-// Keep this list aligned with bundled extensions that publish
-// `approval-handler.runtime` and a `resolveApproveCommandBehavior` capability;
-// adding an extension without the runtime, or listing one without the runtime,
-// re-introduces the "approval loop" the inline path was added to avoid.
-export const NATIVE_APPROVAL_CHANNELS = [
+// Keep this list aligned with bundled channels whose
+// `approvalCapability.nativeRuntime` handles exec approvals; webchat is
+// core-owned. Listing a channel without that runtime re-introduces the
+// "approval loop" the inline path was added to avoid.
+const NATIVE_APPROVAL_CHANNELS = [
   "webchat",
   "discord",
   "googlechat",

--- a/src/utils/message-channel.test.ts
+++ b/src/utils/message-channel.test.ts
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.public.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
-import { NATIVE_APPROVAL_CHANNELS } from "./message-channel-constants.js";
 import {
   isEphemeralGatewayClient,
   isInternalNonDeliveryChannel,
@@ -93,10 +92,21 @@ describe("message-channel", () => {
   });
 
   it("lists native chat exec approval channels", () => {
-    for (const channel of NATIVE_APPROVAL_CHANNELS) {
+    for (const channel of [
+      "webchat",
+      "discord",
+      "googlechat",
+      "imessage",
+      "matrix",
+      "qqbot",
+      "signal",
+      "slack",
+      "telegram",
+      "whatsapp",
+    ]) {
       expect(isNativeApprovalChannel(channel)).toBe(true);
     }
-    // Channels without a bundled approval-handler.runtime must not claim native approval.
+    // Channels without a bundled exec-capable native approval runtime must not claim it.
     expect(isNativeApprovalChannel("feishu")).toBe(false);
     expect(isNativeApprovalChannel("msteams")).toBe(false);
     expect(isNativeApprovalChannel("line")).toBe(false);


### PR DESCRIPTION
## What Problem This Solves

The native approval channel list was exported only so its unit test could iterate the implementation data. That kept an internal policy table in the unused-export baseline and made the test circular: a missing channel in production would also disappear from the expected set.

## Why This Change Was Made

Keep the runtime list module-private, update its ownership comment to the canonical `approvalCapability.nativeRuntime` contract, and make the public predicate test enumerate the expected channels independently.

## User Impact

No runtime behavior change. The internal channel policy surface is narrower, and its test now detects accidental omissions instead of mirroring them.

## Evidence

- Blacksmith Testbox `tbx_01kxdxbf4j94mnww9tnkg87xke`, Actions run `29257214505`
  - `pnpm test:serial src/utils/message-channel.test.ts src/agents/bash-tools.exec-host-gateway.test.ts`: 84/84 passed
  - `pnpm deadcode:exports`: passed with 2594 entries
  - targeted `pnpm check:changed`: passed
- Fresh branch-mode `gpt-5.6-sol` medium autoreview: clean, 0.98 confidence
- `git diff --check`: passed
- Current `main` overlap audit: no landed-file overlap and the three-way merge is clean
- Open PR #80985 adds an unrelated cron error class in the same constants module; it does not touch the approval list or predicate

AI-assisted: yes. No transcript attached.
