### PR TITLE
fix: show Sessions custom-group failures

### DIFF
--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -674,6 +674,44 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
     }
   });
 
+  it("shows a rejected Sessions-page custom group instead of leaking a page error", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["sessions.groups.put"],
+      featureMethods: ["chat.metadata", "chat.startup", "sessions.groups.list"],
+      methodResponses: {
+        "sessions.list": sessionsListResponse([]),
+      },
+      sessionKey: "agent:main:main",
+    });
+    const pageErrors: string[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    try {
+      await page.goto(`${server.baseUrl}sessions`);
+      await page.locator(".session-groupby__select").selectOption("category");
+      page.once("dialog", (dialog) => void dialog.accept("X".repeat(513)));
+      await page.getByRole("button", { name: "New group…" }).click();
+      await gateway.waitForRequest("sessions.groups.put");
+      await gateway.rejectDeferred("sessions.groups.put", {
+        code: "INVALID_REQUEST",
+        message: "group name exceeds 512 characters",
+      });
+
+      const error = page.locator(".card .callout.danger");
+      await error.waitFor({ state: "visible" });
+      await expect.poll(() => error.textContent()).toContain("group name exceeds 512 characters");
+      expect(pageErrors).toEqual([]);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps sidebar sessions visible through a same-client Gateway reconnect", async () => {
     const context = await browser.newContext({
       locale: "en-US",

--- a/ui/src/lib/sessions/custom-groups.test.ts
+++ b/ui/src/lib/sessions/custom-groups.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { reorderSessionCustomGroups } from "./custom-groups.ts";
+import { readSessionCustomGroupNames, reorderSessionCustomGroups } from "./custom-groups.ts";
+
+describe("readSessionCustomGroupNames", () => {
+  it("normalizes valid names and ignores malformed entries", () => {
+    expect(
+      readSessionCustomGroupNames({
+        groups: [{ name: " Alpha " }, { name: "" }, { name: 42 }, null],
+      }),
+    ).toEqual(["Alpha"]);
+    expect(readSessionCustomGroupNames(null)).toEqual([]);
+  });
+});
 
 describe("reorderSessionCustomGroups", () => {
   it("moves a group before the drop target and keeps the rest stable", () => {

--- a/ui/src/lib/sessions/custom-groups.ts
+++ b/ui/src/lib/sessions/custom-groups.ts
@@ -2,6 +2,16 @@
 // Catalog storage and member updates live on the gateway (sessions.groups.*);
 // the SessionCapability mirrors the catalog into state.groups.
 
+export function readSessionCustomGroupNames(payload: unknown): string[] {
+  const groups = (payload as { groups?: Array<{ name?: unknown }> } | null)?.groups;
+  if (!Array.isArray(groups)) {
+    return [];
+  }
+  return groups.flatMap((group) =>
+    typeof group?.name === "string" && group.name.trim() ? [group.name.trim()] : [],
+  );
+}
+
 /** Move one custom group before another while preserving every other group. */
 export function reorderSessionCustomGroups(
   groups: readonly string[],

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -176,6 +176,22 @@ describe("createSessionCapability", () => {
     sessions.dispose();
   });
 
+  it("publishes state.error when replacing the group catalog is rejected", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.groups.put") {
+        throw new Error("group catalog rejected");
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { gateway } = createGatewayHarness(client, ["sessions.groups.put"]);
+    const sessions = createSessionCapability(gateway);
+
+    await expect(sessions.groupsPut(["Alpha"])).rejects.toThrow("group catalog rejected");
+    expect(sessions.state.error).toBe("Error: group catalog rejected");
+    sessions.dispose();
+  });
+
   it("publishes state.error when group delete is rejected", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.groups.delete") {
@@ -217,6 +233,35 @@ describe("createSessionCapability", () => {
 
     await expect(operation).resolves.toBe("stale");
     expect(sessions.state.groups).toEqual([]);
+    sessions.dispose();
+  });
+
+  it("reports a group catalog replacement as stale after a same-client reconnect", async () => {
+    const replaced = deferred<{ groups: Array<{ name: string }> }>();
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.groups.put") {
+        return await replaced.promise;
+      }
+      if (method === "sessions.subscribe") {
+        return {};
+      }
+      if (method === "sessions.list") {
+        return sessionsResult([], 2);
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { gateway, publish } = createGatewayHarness(client, ["sessions.groups.put"]);
+    const sessions = createSessionCapability(gateway);
+
+    const operation = sessions.groupsPut(["Alpha"]);
+    publish(false);
+    publish(true);
+    replaced.resolve({ groups: [{ name: "Alpha" }] });
+
+    await expect(operation).resolves.toBe("stale");
+    expect(sessions.state.groups).toEqual([]);
+    expect(sessions.state.error).toBeNull();
     sessions.dispose();
   });
 

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -240,8 +240,8 @@ export type SessionCapability = {
   ) => Promise<SessionsCompactionRestoreResult>;
   /** Loads the gateway-owned group catalog, coalescing successful connection attempts. */
   groupsLoad: () => Promise<void>;
-  /** Replaces the gateway-owned group catalog (order included). */
-  groupsPut: (names: readonly string[]) => Promise<void>;
+  /** Replaces the group catalog; stale means the initiating connection retired. */
+  groupsPut: (names: readonly string[]) => Promise<SessionGroupMutationResult>;
   /** Renames a group; stale means the initiating connection retired before reconciliation. */
   groupsRename: (from: string, to: string) => Promise<SessionGroupMutationResult>;
   /** Deletes a group; stale means the initiating connection retired before reconciliation. */
@@ -985,14 +985,24 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     await loadGroups(scope, generation, advertised);
   };
 
-  const groupsPut = async (names: readonly string[]) => {
+  const groupsPut = async (names: readonly string[]): Promise<SessionGroupMutationResult> => {
     const scope = captureConnection();
     if (!scope) {
-      return;
+      return "stale";
     }
-    const result = await scope.client.request("sessions.groups.put", { names: [...names] });
-    if (isCurrentConnection(scope)) {
+    try {
+      const result = await scope.client.request("sessions.groups.put", { names: [...names] });
+      if (!isCurrentConnection(scope)) {
+        return "stale";
+      }
       publishGroups(readGroupNames(result));
+      return "completed";
+    } catch (error) {
+      if (!isCurrentConnection(scope)) {
+        return "stale";
+      }
+      publish({ ...state, error: String(error) });
+      throw error;
     }
   };
 

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -27,6 +27,7 @@ import {
   type SessionCreateOutcome,
   type SessionCreateParams,
 } from "./create.ts";
+import { readSessionCustomGroupNames } from "./custom-groups.ts";
 import { scopedAgentListParamsForSession } from "./navigation.ts";
 import {
   readSessionChangedEvent,
@@ -879,21 +880,22 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     return Math.min(Math.max(requested, GROUPS_RETRY_MIN_MS), GROUPS_RETRY_MAX_MS);
   };
 
-  const readGroupNames = (payload: unknown): string[] => {
-    const groups = (payload as { groups?: Array<{ name?: unknown }> } | null)?.groups;
-    if (!Array.isArray(groups)) {
-      return [];
-    }
-    return groups.flatMap((group) =>
-      typeof group?.name === "string" && group.name.trim() ? [group.name.trim()] : [],
-    );
-  };
-
   const publishGroups = (groups: readonly string[]) => {
     if (groups.length === state.groups.length && groups.every((g, i) => g === state.groups[i])) {
       return;
     }
     publish({ ...state, groups: [...groups] });
+  };
+
+  const finishGroupMutationFailure = (
+    current: boolean,
+    error: unknown,
+  ): SessionGroupMutationResult => {
+    if (!current) {
+      return "stale";
+    }
+    publish({ ...state, error: String(error) });
+    throw error;
   };
 
   const readLegacyStoredGroups = (): string[] => {
@@ -925,7 +927,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       if (!isCurrentConnection(scope) || generation !== groupsLoadGeneration) {
         return;
       }
-      let names = readGroupNames(listed);
+      let names = readSessionCustomGroupNames(listed);
       // One-time migration: browser-local catalogs predate the gateway store.
       const legacy = readLegacyStoredGroups();
       if (names.length === 0 && legacy.length > 0) {
@@ -933,7 +935,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         if (!isCurrentConnection(scope) || generation !== groupsLoadGeneration) {
           return;
         }
-        names = readGroupNames(put);
+        names = readSessionCustomGroupNames(put);
       }
       if (legacy.length > 0) {
         try {
@@ -995,14 +997,10 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       if (!isCurrentConnection(scope)) {
         return "stale";
       }
-      publishGroups(readGroupNames(result));
+      publishGroups(readSessionCustomGroupNames(result));
       return "completed";
     } catch (error) {
-      if (!isCurrentConnection(scope)) {
-        return "stale";
-      }
-      publish({ ...state, error: String(error) });
-      throw error;
+      return finishGroupMutationFailure(isCurrentConnection(scope), error);
     }
   };
 
@@ -1016,17 +1014,13 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       if (!isCurrentConnection(scope)) {
         return "stale";
       }
-      publishGroups(readGroupNames(result));
+      publishGroups(readSessionCustomGroupNames(result));
       // The mutation response is the commit point. Reconcile member rows in
       // the background so a later disconnect cannot downgrade confirmed work.
       void refresh({ ...lastListOptions, force: true });
       return "completed";
     } catch (error) {
-      if (!isCurrentConnection(scope)) {
-        return "stale";
-      }
-      publish({ ...state, error: String(error) });
-      throw error;
+      return finishGroupMutationFailure(isCurrentConnection(scope), error);
     }
   };
 
@@ -1040,17 +1034,13 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       if (!isCurrentConnection(scope)) {
         return "stale";
       }
-      publishGroups(readGroupNames(result));
+      publishGroups(readSessionCustomGroupNames(result));
       // See groupsRename: collapsed-state consumers must observe confirmed
       // completion before an unrelated refresh can outlive the connection.
       void refresh({ ...lastListOptions, force: true });
       return "completed";
     } catch (error) {
-      if (!isCurrentConnection(scope)) {
-        return "stale";
-      }
-      publish({ ...state, error: String(error) });
-      throw error;
+      return finishGroupMutationFailure(isCurrentConnection(scope), error);
     }
   };
 

--- a/ui/src/pages/sessions/custom-groups.ts
+++ b/ui/src/pages/sessions/custom-groups.ts
@@ -1,0 +1,33 @@
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import type { SessionCapability } from "../../lib/sessions/index.ts";
+
+export function sessionCategoryNames(
+  result: SessionsListResult | null,
+  customGroups: readonly string[],
+): string[] {
+  const fromRows = (result?.sessions ?? [])
+    .map((row: GatewaySessionRow) => row.category?.trim())
+    .filter((name): name is string => Boolean(name));
+  return [...new Set([...customGroups, ...fromRows.toSorted((a, b) => a.localeCompare(b))])];
+}
+
+type GroupMutationSessions = Pick<SessionCapability, "groupsPut" | "state">;
+
+export async function rememberSessionCustomGroup(options: {
+  name: string;
+  knownCategories: readonly string[];
+  sessions: GroupMutationSessions | undefined;
+  isCurrent: () => boolean;
+  onError: (message: string) => void;
+}): Promise<void> {
+  if (!options.sessions || options.knownCategories.includes(options.name)) {
+    return;
+  }
+  try {
+    await options.sessions.groupsPut([...(options.sessions.state.groups ?? []), options.name]);
+  } catch (error) {
+    if (options.isCurrent()) {
+      options.onError(String(error));
+    }
+  }
+}

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -40,6 +40,7 @@ type TestSessionsPage = HTMLElement & {
   loadCheckpoint: (sessionKey: string) => Promise<void>;
   deleteSelected: () => Promise<void>;
   deleteSessionFromMenu: (row: GatewaySessionRow) => Promise<void>;
+  rememberCustomGroup: (name: string) => Promise<void>;
   openSessionMenu: (
     row: GatewaySessionRow,
     position: { x: number; y: number },
@@ -570,6 +571,21 @@ describe("sessions page lifecycle", () => {
     expect(page.result?.sessions).toEqual([]);
   });
 
+  it("surfaces a rejected custom-group creation on the Sessions page", async () => {
+    const groupsPut = vi.fn(async () => {
+      throw new Error("group name exceeds 512 characters");
+    });
+    const sessions = createSessions({ groupsPut });
+    const { gateway } = createGateway({} as GatewayBrowserClient);
+    const page = await createPage(createContext(gateway, sessions));
+    const name = "X".repeat(513);
+
+    await page.rememberCustomGroup(name);
+
+    expect(groupsPut).toHaveBeenCalledWith([name]);
+    expect(page.error).toBe("Error: group name exceeds 512 characters");
+  });
+
   it("drops stale mutation state, errors, and navigation after disconnect", async () => {
     const deleted = deferred<{
       deleted: string[];
@@ -581,12 +597,14 @@ describe("sessions page lifecycle", () => {
     const branched = deferred<{ key: string }>();
     const restored = deferred<unknown>();
     const captured = deferred<unknown>();
+    const groupsPut = deferred<Awaited<ReturnType<SessionCapability["groupsPut"]>>>();
     const sessions = createSessions({
       deleteMany: vi.fn(() => deleted.promise),
       patch: vi.fn(() => patched.promise as never),
       create: vi.fn(() => forked.promise),
       branchCheckpoint: vi.fn(() => branched.promise as never),
       restoreCheckpoint: vi.fn(() => restored.promise as never),
+      groupsPut: vi.fn(() => groupsPut.promise),
     });
     const request = vi.fn((method: string) => {
       if (method === "chat.history") {
@@ -613,6 +631,7 @@ describe("sessions page lifecycle", () => {
       page.branchCheckpoint("main", "branch-checkpoint"),
       page.restoreCheckpoint("main", "restore-checkpoint"),
       page.addToWorkboard({ key: "main" } as GatewaySessionRow),
+      page.rememberCustomGroup("Stale group"),
     ];
     await vi.waitFor(() =>
       expect(request).toHaveBeenCalledWith("workboard.cards.create", expect.any(Object)),
@@ -625,6 +644,7 @@ describe("sessions page lifecycle", () => {
     branched.resolve({ key: "branched" });
     restored.reject(new Error("stale restore error"));
     captured.reject(new Error("stale capture error"));
+    groupsPut.reject(new Error("stale group error"));
     await Promise.all(requests);
 
     expect(page.result?.sessions.map((row) => row.key)).toEqual(["main"]);

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -711,10 +711,21 @@ class SessionsPage extends OpenClawLightDomElement {
     saveStoredGroupBy(mode);
   }
 
-  private rememberCustomGroup(name: string) {
+  private async rememberCustomGroup(name: string) {
     const known = this.knownCategories();
-    if (!known.includes(name)) {
-      void this.context?.sessions.groupsPut([...this.customGroups(), name]);
+    if (known.includes(name)) {
+      return;
+    }
+    const scope = this.captureRequestScope();
+    if (!scope) {
+      return;
+    }
+    try {
+      await scope.sessions.groupsPut([...(scope.sessions.state.groups ?? []), name]);
+    } catch (error) {
+      if (this.isRequestScopeCurrent(scope)) {
+        this.error = String(error);
+      }
     }
   }
 
@@ -731,7 +742,7 @@ class SessionsPage extends OpenClawLightDomElement {
       return;
     }
     if (category) {
-      this.rememberCustomGroup(category);
+      void this.rememberCustomGroup(category);
     }
     void this.patchSession(key, { category });
   }
@@ -742,7 +753,7 @@ class SessionsPage extends OpenClawLightDomElement {
     if (!name) {
       return;
     }
-    this.rememberCustomGroup(name);
+    void this.rememberCustomGroup(name);
     if (sessionKey) {
       void this.patchSession(sessionKey, { category: name });
     }

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -40,6 +40,7 @@ import {
   sessionAgentIdentityById,
   sessionAgentIds,
 } from "./agent-scope.ts";
+import { rememberSessionCustomGroup, sessionCategoryNames } from "./custom-groups.ts";
 import { loadStoredGroupBy, parseFilterInteger, saveStoredGroupBy } from "./page-state.ts";
 import { renderSessions, type SessionsProps, type TranscriptSearchState } from "./view.ts";
 
@@ -693,17 +694,8 @@ class SessionsPage extends OpenClawLightDomElement {
     await this.deleteSessions([row.key]);
   }
 
-  private customGroups(): readonly string[] {
-    return this.context?.sessions.state.groups ?? [];
-  }
-
   private knownCategories(): string[] {
-    const fromRows = (this.result?.sessions ?? [])
-      .map((row) => row.category?.trim())
-      .filter((name): name is string => Boolean(name));
-    return [
-      ...new Set([...this.customGroups(), ...fromRows.toSorted((a, b) => a.localeCompare(b))]),
-    ];
+    return sessionCategoryNames(this.result, this.context?.sessions.state.groups ?? []);
   }
 
   private setGroupBy(mode: SessionsGroupBy) {
@@ -712,21 +704,16 @@ class SessionsPage extends OpenClawLightDomElement {
   }
 
   private async rememberCustomGroup(name: string) {
-    const known = this.knownCategories();
-    if (known.includes(name)) {
-      return;
-    }
     const scope = this.captureRequestScope();
-    if (!scope) {
-      return;
-    }
-    try {
-      await scope.sessions.groupsPut([...(scope.sessions.state.groups ?? []), name]);
-    } catch (error) {
-      if (this.isRequestScopeCurrent(scope)) {
-        this.error = String(error);
-      }
-    }
+    await rememberSessionCustomGroup({
+      name,
+      knownCategories: this.knownCategories(),
+      sessions: scope?.sessions,
+      isCurrent: () => Boolean(scope && this.isRequestScopeCurrent(scope)),
+      onError: (message) => {
+        this.error = message;
+      },
+    });
   }
 
   private assignCategory(key: string, category: string | null) {


### PR DESCRIPTION
Closes #106340

## What Problem This Solves

The dedicated Control UI Sessions page discarded rejected custom-group creation promises. A Gateway validation failure left the group unapplied, showed no explanation, and surfaced as an unhandled browser page error.

## Why This Change Was Made

Group-catalog replacement now follows the same connection-scoped contract as group rename and delete: current-connection failures publish shared Sessions error state, while completions from retired connections resolve as stale and cannot overwrite replacement state. The Sessions page awaits the mutation inside its existing page request scope and renders only current-context failures through its established danger callout.

This keeps error ownership at both required layers: the shared capability normalizes group-mutation state for every caller, and the initiating page turns that state into user-visible feedback.

## User Impact

Users creating a custom group from Settings → Sessions now see the Gateway's actionable rejection reason. The rejected name remains unapplied, no unhandled page error leaks, and a disconnect or reconnect cannot publish an obsolete failure into the replacement page context.

AI-assisted implementation; reviewed and understood by the PR author.

## Evidence

- Before: OpenClaw 2026.7.2 rejected a 513-character group name with `INVALID_REQUEST`; the Sessions page showed zero danger callouts and Playwright captured an unhandled page error, as documented in #106340.
- Blacksmith Testbox `tbx_01kxdyd1grq04eq3pt3f4yhbqk`: the focused custom-group/capability/page/browser command passed 49 unit tests and 16 Chromium E2E tests.
- The browser suite includes the exact Sessions-page rejection path and asserts a visible error plus zero page errors.
- The same Testbox exact changed-file gate passed the TypeScript LOC ratchet, formatting, core/UI TypeScript, lint, and guards.
- Blacksmith Testbox `tbx_01kxdxqwb2r8kwh1t9rbfvb7r7`, hydration run 29257689463: `pnpm build` passed the production Control UI build, 474 sidecars, and performance budgets.
- Hosted CI run `29259041652` passed the exact-head Control UI, LOC, build-artifacts, and completed broad shards.
- The packaged `dist-runtime-build` from exact head `6fd36b74b8e36b7120c9ed8a8110a737798ee4cf` passed real-Gateway Playwright proof: `INVALID_REQUEST` surfaced in a danger callout, the rejected group stayed absent across reload, a valid control persisted, UI deletion persisted, and page errors remained zero.
- Fresh structured autoreview completed with no accepted or actionable findings; overall correctness confidence 0.96.
