### PR TITLE
fix(copilot): clean up polling abort listeners

### DIFF
--- a/src/llm/utils/oauth/github-copilot.test.ts
+++ b/src/llm/utils/oauth/github-copilot.test.ts
@@ -1,4 +1,5 @@
 // GitHub Copilot OAuth tests cover device flow polling and timeout behavior.
+import { getEventListeners } from "node:events";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Model } from "../../types.js";
 import { githubCopilotOAuthProvider } from "./github-copilot.js";
@@ -13,10 +14,11 @@ async function refreshThroughGitHubCopilotProvider(refreshToken: string, enterpr
   } as OAuthCredentials);
 }
 
-function startGitHubCopilotLogin(enterpriseUrl = "") {
+function startGitHubCopilotLogin(enterpriseUrl = "", signal?: AbortSignal) {
   return githubCopilotOAuthProvider.login({
     onAuth: vi.fn(),
     onPrompt: vi.fn(async () => enterpriseUrl),
+    signal,
   });
 }
 
@@ -54,6 +56,10 @@ function copilotTokenResponse(): Response {
 async function finishGitHubCopilotLogin(login: Promise<OAuthCredentials>) {
   await vi.advanceTimersByTimeAsync(1_200);
   return await login;
+}
+
+function abortListenerCount(signal: AbortSignal): number {
+  return getEventListeners(signal, "abort").length;
 }
 
 function stubHangingFetch(timeoutMs: number): void {
@@ -540,5 +546,85 @@ describe("GitHub Copilot OAuth error responses", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(cancel).toHaveBeenCalledOnce();
+  });
+});
+
+describe("GitHub Copilot OAuth abortable polling sleep", () => {
+  it("does not accumulate abort listeners across authorization_pending rounds", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const pendingResponse = () =>
+      new Response(JSON.stringify({ error: "authorization_pending" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(deviceCodeResponse())
+        .mockResolvedValueOnce(pendingResponse())
+        .mockResolvedValueOnce(pendingResponse())
+        .mockResolvedValueOnce(pendingResponse())
+        .mockResolvedValueOnce(deviceTokenResponse())
+        .mockResolvedValueOnce(copilotTokenResponse())
+        .mockResolvedValueOnce(new Response("nope", { status: 503 })),
+    );
+
+    const addSpy = vi.spyOn(controller.signal, "addEventListener");
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+    const pending = startGitHubCopilotLogin("", controller.signal);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const listenerCounts: number[] = [];
+    for (let round = 0; round < 4; round += 1) {
+      listenerCounts.push(abortListenerCount(controller.signal));
+      await vi.advanceTimersByTimeAsync(1_200);
+    }
+
+    await expect(pending).resolves.toMatchObject({ access: "copilot-token" });
+    expect(abortListenerCount(controller.signal)).toBe(0);
+    expect(Math.max(...listenerCounts)).toBe(1);
+    const abortAdds = addSpy.mock.calls.filter((call) => call[0] === "abort").length;
+    const abortRemoves = removeSpy.mock.calls.filter((call) => call[0] === "abort").length;
+    expect(abortAdds).toBeGreaterThanOrEqual(4);
+    expect(abortRemoves).toBe(abortAdds);
+  });
+
+  it("removes the abort listener when cancelled during sleep", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(deviceCodeResponse())
+      .mockRejectedValue(new Error("poll fetch should not run after abort"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = startGitHubCopilotLogin("", controller.signal);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(abortListenerCount(controller.signal)).toBe(1);
+    controller.abort();
+    await expect(pending).rejects.toThrow("Login cancelled");
+    expect(abortListenerCount(controller.signal)).toBe(0);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an already-aborted signal without registering a listener", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    controller.abort();
+    const addSpy = vi.spyOn(controller.signal, "addEventListener");
+    const fetchMock = vi.fn(async () => {
+      throw new Error("poll fetch should not run for aborted signal");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = startGitHubCopilotLogin("", controller.signal);
+
+    await expect(pending).rejects.toThrow("Login cancelled");
+    expect(addSpy.mock.calls.filter((call) => call[0] === "abort")).toHaveLength(0);
+    expect(abortListenerCount(controller.signal)).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/llm/utils/oauth/github-copilot.ts
+++ b/src/llm/utils/oauth/github-copilot.ts
@@ -223,7 +223,9 @@ async function startDeviceFlow(
 }
 
 /**
- * Sleep that can be interrupted by an AbortSignal
+ * Sleep that can be interrupted by an AbortSignal.
+ * Resolve and abort both settle once and remove the abort listener so
+ * multi-round device polling cannot accumulate listeners on a shared signal.
  */
 function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -232,16 +234,28 @@ function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
       return;
     }
 
-    const timeout = setTimeout(resolve, ms);
+    let settled = false;
+    const timeout = setTimeout(() => {
+      settle(resolve);
+    }, ms);
 
-    signal?.addEventListener(
-      "abort",
-      () => {
-        clearTimeout(timeout);
+    const onAbort = () => {
+      settle(() => {
         reject(new Error("Login cancelled"));
-      },
-      { once: true },
-    );
+      });
+    };
+
+    function settle(action: () => void) {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", onAbort);
+      action();
+    }
+
+    signal?.addEventListener("abort", onAbort);
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

GitHub Copilot device-code polling left abort listeners on its shared cancellation signal after every successful sleep. `{ once: true }` removes a listener only when abort fires, so repeated `authorization_pending` rounds accumulated retained promise closures and could trigger EventTarget listener-leak warnings.

## Why This Change Was Made

The polling sleep now settles once through one cleanup path on either timer completion or abort. Cleanup clears the timer, removes the named listener, then resolves or rejects. An already-aborted signal still rejects immediately without registering anything.

Maintainer rebase cleanup moved the regressions onto the current public `githubCopilotOAuthProvider.login` seam after main intentionally removed the private `testing.*` exports.

## User Impact

Long-running GitHub Copilot device login keeps at most one polling abort listener instead of accumulating one per pending round. Cancellation still reports `Login cancelled`; polling intervals and requests are unchanged.

## Evidence

- Public-provider regression: repeated pending rounds peak at one listener and finish at zero with matching add/remove counts.
- Cancellation and pre-aborted regressions finish with zero listeners and unchanged error behavior.
- Blacksmith focused OAuth suite: 24/24 passed.
- Exact-head Blacksmith changed gate passed on `3b265464597db`; the patch-identical final rebase is `cb899060d2ec3`.
- Blacksmith proof: https://github.com/openclaw/openclaw/actions/runs/29495189568
- Fresh exact-branch Autoreview: clean, confidence 0.99.

AI-assisted: built with Codex
