### PR TITLE
fix(clawrouter): sanitize attribution headers to ByteString

### DIFF
--- a/extensions/clawrouter/index.test.ts
+++ b/extensions/clawrouter/index.test.ts
@@ -171,11 +171,53 @@ describe("ClawRouter plugin", () => {
       Authorization: "Bearer runtime-proxy-key",
     });
     expect(calls[0]?.headers?.["X-ClawRouter-Session-Id"]).toHaveLength(256);
+    expect(calls[0]?.headers?.["X-ClawRouter-Session-Id"]).toMatch(/~[a-f0-9]{16}$/u);
     expect(calls[0]?.headers?.["X-Request-ID"]).toHaveLength(128);
     expect(calls[0]?.headers?.["X-Request-ID"]).toMatch(/~[a-f0-9]{16}:model:1$/u);
     expect(calls[1]?.headers?.["X-Request-ID"]).toMatch(/~[a-f0-9]{16}:model:2$/u);
     expect(calls[1]?.headers?.["X-Request-ID"]).not.toBe(calls[0]?.headers?.["X-Request-ID"]);
     expect(calls[2]?.headers?.["X-Request-ID"]).toMatch(/^turn-_~[a-f0-9]{16}:model:3$/u);
+  });
+
+  it("sanitizes Unicode attribution to distinct printable ASCII ByteStrings", () => {
+    const captured: Array<Record<string, string>> = [];
+    const baseStreamFn: StreamFn = (model) => {
+      captured.push(model.headers ?? {});
+      return {} as ReturnType<StreamFn>;
+    };
+
+    for (const [agentId, sessionId] of [
+      ["agent-😀中文-id", "session-🚀测试-id"],
+      ["agent-🚀中文-id", "session-😀测试-id"],
+    ] as const) {
+      const wrapped = wrapClawRouterProviderStream({
+        provider: "clawrouter",
+        modelId: "openai/gpt-5.5",
+        agentId,
+        streamFn: baseStreamFn,
+      } as never);
+
+      void wrapped?.(
+        {
+          provider: "clawrouter",
+          api: "openai-responses",
+          id: "openai/gpt-5.5",
+        } as never,
+        {} as never,
+        { sessionId } as never,
+      );
+    }
+
+    expect(captured).toHaveLength(2);
+    for (const headers of captured) {
+      expect(headers["X-ClawRouter-Agent-Id"]).toMatch(/^agent-___-id~[a-f0-9]{16}$/u);
+      expect(headers["X-ClawRouter-Session-Id"]).toMatch(/^session-___-id~[a-f0-9]{16}$/u);
+      expect(() => new Headers(headers)).not.toThrow();
+    }
+    expect(captured[0]?.["X-ClawRouter-Agent-Id"]).not.toBe(captured[1]?.["X-ClawRouter-Agent-Id"]);
+    expect(captured[0]?.["X-ClawRouter-Session-Id"]).not.toBe(
+      captured[1]?.["X-ClawRouter-Session-Id"],
+    );
   });
 
   it("keeps an explicit per-request header ahead of the automatic model-call id", () => {

--- a/extensions/clawrouter/index.test.ts
+++ b/extensions/clawrouter/index.test.ts
@@ -220,6 +220,43 @@ describe("ClawRouter plugin", () => {
     );
   });
 
+  it("keeps encoded and lone-surrogate attribution ids distinct", () => {
+    const captured: string[] = [];
+    const captureAgentId = (agentId: string) => {
+      const wrapped = wrapClawRouterProviderStream({
+        provider: "clawrouter",
+        modelId: "openai/gpt-5.5",
+        agentId,
+        streamFn: ((model) => {
+          captured.push(model.headers?.["X-ClawRouter-Agent-Id"] ?? "");
+          return {} as ReturnType<StreamFn>;
+        }) satisfies StreamFn,
+      } as never);
+      void wrapped?.(
+        {
+          provider: "clawrouter",
+          api: "openai-responses",
+          id: "openai/gpt-5.5",
+        } as never,
+        {} as never,
+        {} as never,
+      );
+    };
+
+    captureAgentId("agent-😀");
+    captureAgentId(captured[0]!);
+    captureAgentId("agent-\uD800");
+    captureAgentId("agent-\uD801");
+
+    expect(captured).toHaveLength(4);
+    expect(captured[1]).not.toBe(captured[0]);
+    expect(captured[2]).not.toBe(captured[3]);
+    for (const value of captured) {
+      expect(value).toMatch(/^[\x20-\x7E]+$/u);
+      expect(() => new Headers({ "X-ClawRouter-Agent-Id": value })).not.toThrow();
+    }
+  });
+
   it("keeps an explicit per-request header ahead of the automatic model-call id", () => {
     const calls: Array<{
       model: Parameters<StreamFn>[0];

--- a/extensions/clawrouter/stream.ts
+++ b/extensions/clawrouter/stream.ts
@@ -10,9 +10,31 @@ const CLIENT_HEADER = "X-ClawRouter-Client";
 const AGENT_HEADER = "X-ClawRouter-Agent-Id";
 const SESSION_HEADER = "X-ClawRouter-Session-Id";
 const REQUEST_ID_HEADER = "X-Request-ID";
-const REQUEST_ID_HASH_LENGTH = 16;
+const ID_HASH_LENGTH = 16;
 const REQUEST_ID_PATTERN = /^[A-Za-z0-9._~:/+@=-]+$/u;
 const REQUEST_ID_UNSAFE_CHARACTER_PATTERN = /[^A-Za-z0-9._~:/+@=-]/gu;
+const ATTRIBUTION_PRINTABLE_ASCII_PATTERN = /^[\x20-\x7E]+$/u;
+const ATTRIBUTION_NON_PRINTABLE_ASCII_PATTERN = /[^\x20-\x7E]/gu;
+const REQUEST_ID_SUFFIX_PATTERN = /:model:\d+$/u;
+
+type BoundedIdPolicy = {
+  maxLength: number;
+  safePattern: RegExp;
+  unsafeCharacterPattern: RegExp;
+  preservedSuffixPattern?: RegExp;
+};
+
+const ATTRIBUTION_ID_POLICY: BoundedIdPolicy = {
+  maxLength: ATTRIBUTION_VALUE_MAX_LENGTH,
+  safePattern: ATTRIBUTION_PRINTABLE_ASCII_PATTERN,
+  unsafeCharacterPattern: ATTRIBUTION_NON_PRINTABLE_ASCII_PATTERN,
+};
+const REQUEST_ID_POLICY: BoundedIdPolicy = {
+  maxLength: REQUEST_ID_MAX_LENGTH,
+  safePattern: REQUEST_ID_PATTERN,
+  unsafeCharacterPattern: REQUEST_ID_UNSAFE_CHARACTER_PATTERN,
+  preservedSuffixPattern: REQUEST_ID_SUFFIX_PATTERN,
+};
 
 function hasControlCharacter(value: string): boolean {
   for (let index = 0; index < value.length; index += 1) {
@@ -24,7 +46,7 @@ function hasControlCharacter(value: string): boolean {
   return false;
 }
 
-function normalizeAttributionValue(value: string | undefined): string | undefined {
+function normalizeHeaderId(value: string | undefined): string | undefined {
   const normalized = value?.trim();
   if (!normalized || hasControlCharacter(normalized)) {
     return undefined;
@@ -32,36 +54,24 @@ function normalizeAttributionValue(value: string | undefined): string | undefine
   return normalized;
 }
 
-function sanitizeAttributionValue(value: string | undefined): string | undefined {
-  const normalized = normalizeAttributionValue(value);
+function sanitizeBoundedId(value: string | undefined, policy: BoundedIdPolicy): string | undefined {
+  const normalized = normalizeHeaderId(value);
   if (!normalized) {
     return undefined;
   }
-  return normalized.slice(0, ATTRIBUTION_VALUE_MAX_LENGTH);
-}
-
-function sanitizeRequestId(value: string | undefined): string | undefined {
-  const normalized = normalizeAttributionValue(value);
-  if (!normalized) {
+  if (normalized.length <= policy.maxLength && policy.safePattern.test(normalized)) {
     return normalized;
   }
-  if (normalized.length <= REQUEST_ID_MAX_LENGTH && REQUEST_ID_PATTERN.test(normalized)) {
-    return normalized;
-  }
-  // Retain the per-call suffix while bounding long run ids; the hash keeps
-  // distinct long prefixes from collapsing onto the same audit identifier.
-  const hash = createHash("sha256")
-    .update(normalized)
-    .digest("hex")
-    .slice(0, REQUEST_ID_HASH_LENGTH);
-  const modelSuffix = normalized.match(/:model:\d+$/u)?.[0] ?? "";
-  const rawPrefix = modelSuffix ? normalized.slice(0, -modelSuffix.length) : normalized;
-  const safePrefix = rawPrefix.replace(REQUEST_ID_UNSAFE_CHARACTER_PATTERN, "_");
-  const boundedSuffix = `~${hash}${modelSuffix}`;
-  if (boundedSuffix.length >= REQUEST_ID_MAX_LENGTH) {
-    return `${safePrefix.slice(0, REQUEST_ID_MAX_LENGTH - hash.length - 1)}~${hash}`;
-  }
-  return `${safePrefix.slice(0, REQUEST_ID_MAX_LENGTH - boundedSuffix.length)}${boundedSuffix}`;
+  // Fetch converts header values to ByteString. Keep automatic IDs ASCII,
+  // bounded, readable, and collision-resistant before transport construction.
+  const hash = createHash("sha256").update(normalized).digest("hex").slice(0, ID_HASH_LENGTH);
+  const preservedSuffix = policy.preservedSuffixPattern?.exec(normalized)?.[0] ?? "";
+  const rawPrefix = preservedSuffix ? normalized.slice(0, -preservedSuffix.length) : normalized;
+  const safePrefix = rawPrefix.replace(policy.unsafeCharacterPattern, "_");
+  const hashSuffix = `~${hash}`;
+  const boundedSuffix = `${hashSuffix}${preservedSuffix}`;
+  const suffix = boundedSuffix.length < policy.maxLength ? boundedSuffix : hashSuffix;
+  return `${safePrefix.slice(0, policy.maxLength - suffix.length)}${suffix}`;
 }
 
 function findHeader(headers: Record<string, string>, target: string): string | undefined {
@@ -95,9 +105,13 @@ function withClawRouterHeaders(
     }
   }
   setHeaderDefault(next, CLIENT_HEADER, "openclaw");
-  setHeaderDefault(next, AGENT_HEADER, sanitizeAttributionValue(params.agentId));
-  setHeaderDefault(next, SESSION_HEADER, sanitizeAttributionValue(params.sessionId));
-  setHeaderDefault(next, REQUEST_ID_HEADER, sanitizeRequestId(params.requestId));
+  setHeaderDefault(next, AGENT_HEADER, sanitizeBoundedId(params.agentId, ATTRIBUTION_ID_POLICY));
+  setHeaderDefault(
+    next,
+    SESSION_HEADER,
+    sanitizeBoundedId(params.sessionId, ATTRIBUTION_ID_POLICY),
+  );
+  setHeaderDefault(next, REQUEST_ID_HEADER, sanitizeBoundedId(params.requestId, REQUEST_ID_POLICY));
   if (params.apiKey) {
     next.Authorization = `Bearer ${params.apiKey}`;
   }

--- a/extensions/clawrouter/stream.ts
+++ b/extensions/clawrouter/stream.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
@@ -15,9 +16,12 @@ const REQUEST_ID_PATTERN = /^[A-Za-z0-9._~:/+@=-]+$/u;
 const REQUEST_ID_UNSAFE_CHARACTER_PATTERN = /[^A-Za-z0-9._~:/+@=-]/gu;
 const ATTRIBUTION_PRINTABLE_ASCII_PATTERN = /^[\x20-\x7E]+$/u;
 const ATTRIBUTION_NON_PRINTABLE_ASCII_PATTERN = /[^\x20-\x7E]/gu;
+const ATTRIBUTION_ENCODED_SUFFIX_PATTERN = /~[a-f0-9]{16}$/u;
 const REQUEST_ID_SUFFIX_PATTERN = /:model:\d+$/u;
+const REQUEST_ID_ENCODED_SUFFIX_PATTERN = /~[a-f0-9]{16}(?::model:\d+)?$/u;
 
 type BoundedIdPolicy = {
+  encodedSuffixPattern: RegExp;
   maxLength: number;
   safePattern: RegExp;
   unsafeCharacterPattern: RegExp;
@@ -25,11 +29,13 @@ type BoundedIdPolicy = {
 };
 
 const ATTRIBUTION_ID_POLICY: BoundedIdPolicy = {
+  encodedSuffixPattern: ATTRIBUTION_ENCODED_SUFFIX_PATTERN,
   maxLength: ATTRIBUTION_VALUE_MAX_LENGTH,
   safePattern: ATTRIBUTION_PRINTABLE_ASCII_PATTERN,
   unsafeCharacterPattern: ATTRIBUTION_NON_PRINTABLE_ASCII_PATTERN,
 };
 const REQUEST_ID_POLICY: BoundedIdPolicy = {
+  encodedSuffixPattern: REQUEST_ID_ENCODED_SUFFIX_PATTERN,
   maxLength: REQUEST_ID_MAX_LENGTH,
   safePattern: REQUEST_ID_PATTERN,
   unsafeCharacterPattern: REQUEST_ID_UNSAFE_CHARACTER_PATTERN,
@@ -59,12 +65,20 @@ function sanitizeBoundedId(value: string | undefined, policy: BoundedIdPolicy): 
   if (!normalized) {
     return undefined;
   }
-  if (normalized.length <= policy.maxLength && policy.safePattern.test(normalized)) {
+  if (
+    normalized.length <= policy.maxLength &&
+    policy.safePattern.test(normalized) &&
+    !policy.encodedSuffixPattern.test(normalized)
+  ) {
     return normalized;
   }
-  // Fetch converts header values to ByteString. Keep automatic IDs ASCII,
-  // bounded, readable, and collision-resistant before transport construction.
-  const hash = createHash("sha256").update(normalized).digest("hex").slice(0, ID_HASH_LENGTH);
+  // Hash UTF-16 code units losslessly: UTF-8 string hashing replaces lone
+  // surrogates with U+FFFD. The reserved encoded suffix keeps a rewritten ID
+  // from aliasing an otherwise safe input that already looks encoded.
+  const hash = createHash("sha256")
+    .update(Buffer.from(normalized, "utf16le"))
+    .digest("hex")
+    .slice(0, ID_HASH_LENGTH);
   const preservedSuffix = policy.preservedSuffixPattern?.exec(normalized)?.[0] ?? "";
   const rawPrefix = preservedSuffix ? normalized.slice(0, -preservedSuffix.length) : normalized;
   const safePrefix = rawPrefix.replace(policy.unsafeCharacterPattern, "_");


### PR DESCRIPTION
## What Problem This Solves

ClawRouter automatic agent/session attribution can contain emoji, CJK characters, or other non-ByteString values. Node/Undici converts `Headers` values to ByteString, so those IDs throw before the model request is sent.

## Why This Change Was Made

One local policy-driven sanitizer now serves automatic agent, session, and request IDs. Ordinary safe values pass unchanged. Unsafe, encoded-looking, or oversized values become readable printable-ASCII prefixes plus a bounded SHA-256 suffix; request IDs retain their model-call suffix. Hashing uses the original UTF-16 code units so lone surrogates remain distinct. Control-character rejection and explicit operator headers remain unchanged.

This replaces the PR's initial duplicate attribution sanitizer with the existing request-ID strategy generalized behind one path, then closes encoded-namespace and lone-surrogate collision cases found during maintainer review.

## User Impact

**Before:** Unicode automatic attribution could crash request construction with a ByteString `TypeError`.

**After:** Automatic IDs are bounded, printable ASCII, collision-resistant after rewriting, and accepted by `Headers`.

## Evidence

Head: `c67249675d9a64cd0d4551189c883ac978850fbb`

```text
$ node scripts/run-vitest.mjs extensions/clawrouter/index.test.ts
Test Files  1 passed (1)
Tests      13 passed (13)

$ node scripts/check-changed.mjs -- extensions/clawrouter/stream.ts extensions/clawrouter/index.test.ts
Blacksmith Testbox: passed
https://github.com/openclaw/openclaw/actions/runs/29624226948
```

Live production-wrapper proof on Node v26.5.0 with bundled Undici 8.7.0 constructed `Headers` for distinct Unicode agent/session pairs and a Unicode request ID. Rewritten agent/session values remained distinct; the request model suffix remained intact. Regression coverage also proves encoded-looking literal IDs and distinct lone surrogates do not alias generated values.

- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns

## Real behavior proof

**Behavior addressed:** ClawRouter automatic attribution and request identifiers are sanitized before Node constructs transport headers.

**Environment tested:** macOS, Node v26.5.0, bundled Undici 8.7.0, production `wrapClawRouterProviderStream` imported from source.

**Observed result:** Unicode agent/session pairs produced distinct printable-ASCII headers; Unicode request ID remained bounded with `:model:3`; `new Headers(...)` succeeded for every captured request.

**Not tested:** Live ClawRouter server-side display. Explicit operator-supplied headers remain untouched by design.
