### PR TITLE
fix(reef): bound relay HTTP JSON response body reads

### DIFF
--- a/extensions/reef/src/transport.test.ts
+++ b/extensions/reef/src/transport.test.ts
@@ -164,3 +164,129 @@ describe("ReefTransportClient device authentication", () => {
     expect(new Set(seenTs).size).toBe(3);
   });
 });
+
+function createTrackedOverflowResponse(params: {
+  status: number;
+  chunkBytes: number;
+  totalChunks: number;
+}): {
+  response: Response;
+  state: { emittedBytes: number; cancelled: boolean };
+} {
+  const chunk = new Uint8Array(params.chunkBytes).fill(0x78);
+  const state = { emittedBytes: 0, cancelled: false };
+  let remaining = params.totalChunks;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (remaining <= 0) {
+        controller.close();
+        return;
+      }
+      remaining -= 1;
+      state.emittedBytes += chunk.byteLength;
+      controller.enqueue(chunk);
+    },
+    cancel() {
+      state.cancelled = true;
+    },
+  });
+  return {
+    response: new Response(body, {
+      status: params.status,
+      headers: { "content-type": "application/json" },
+    }),
+    state,
+  };
+}
+
+describe("ReefTransportClient response body bounds", () => {
+  it("accepts near-limit success JSON without cancelling the stream", async () => {
+    const payload = { entries: [], cursor: 9, pad: "x".repeat(8 * 1024) };
+    const body = JSON.stringify(payload);
+    let cancelled = false;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(body));
+          controller.close();
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async () => response,
+      () => ts,
+    );
+
+    await expect(client.pull(0)).resolves.toEqual(payload);
+    expect(cancelled).toBe(false);
+  });
+
+  it("cancels oversized success bodies before buffering the rest", async () => {
+    const offered = createTrackedOverflowResponse({
+      status: 200,
+      chunkBytes: 64 * 1024,
+      totalChunks: 320, // 20 MiB offered
+    });
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async () => offered.response,
+      () => ts,
+    );
+
+    await expect(client.pull(0)).rejects.toThrow(
+      /reef\.relay: JSON response exceeds 16777216 bytes/,
+    );
+    expect(offered.state.cancelled).toBe(true);
+    expect(offered.state.emittedBytes).toBeGreaterThan(16 * 1024 * 1024);
+    expect(offered.state.emittedBytes).toBeLessThan(20 * 1024 * 1024);
+  });
+
+  it("keeps status fallback and cancels oversized error bodies", async () => {
+    const offered = createTrackedOverflowResponse({
+      status: 503,
+      chunkBytes: 8 * 1024,
+      totalChunks: 16, // 128 KiB offered against 64 KiB error cap
+    });
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async () => offered.response,
+      () => ts,
+    );
+
+    await expect(client.listFriends()).rejects.toMatchObject({
+      name: "ReefRelayError",
+      status: 503,
+      message: "relay HTTP 503",
+    });
+    expect(offered.state.cancelled).toBe(true);
+    expect(offered.state.emittedBytes).toBeGreaterThan(64 * 1024);
+    expect(offered.state.emittedBytes).toBeLessThan(128 * 1024);
+  });
+
+  it("still surfaces bounded relay error messages", async () => {
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async () => Response.json({ error: "friend code expired" }, { status: 400 }),
+      () => ts,
+    );
+
+    await expect(client.requestFriend("bob", "code")).rejects.toMatchObject({
+      name: "ReefRelayError",
+      status: 400,
+      message: "friend code expired",
+    });
+  });
+});

--- a/extensions/reef/src/transport.test.ts
+++ b/extensions/reef/src/transport.test.ts
@@ -1,7 +1,7 @@
 import { createPublicKey, verify as verifySignature } from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
 import { canonicalBytes, fromBase64url, sha256Hex } from "../protocol/index.js";
-import { ReefTransportClient } from "./transport.js";
+import { ReefRelayError, ReefTransportClient } from "./transport.js";
 import type { ReefKeys, RelayFriend } from "./types.js";
 
 const ts = 1_752_300_000;
@@ -165,24 +165,28 @@ describe("ReefTransportClient device authentication", () => {
   });
 });
 
-function createTrackedOverflowResponse(params: {
-  status: number;
-  chunkBytes: number;
-  totalChunks: number;
-}): {
+const SUCCESS_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
+const ERROR_RESPONSE_MAX_BYTES = 64 * 1024;
+
+function jsonObjectBodyAtSize(bytes: number, field: "pad" | "error"): string {
+  const prefix = `{"${field}":"`;
+  const suffix = `"}`;
+  return `${prefix}${"x".repeat(bytes - prefix.length - suffix.length)}${suffix}`;
+}
+
+function createTrackedResponse(params: { status: number; chunks: Uint8Array[] }): {
   response: Response;
   state: { emittedBytes: number; cancelled: boolean };
 } {
-  const chunk = new Uint8Array(params.chunkBytes).fill(0x78);
   const state = { emittedBytes: 0, cancelled: false };
-  let remaining = params.totalChunks;
+  let index = 0;
   const body = new ReadableStream<Uint8Array>({
     pull(controller) {
-      if (remaining <= 0) {
+      const chunk = params.chunks[index++];
+      if (!chunk) {
         controller.close();
         return;
       }
-      remaining -= 1;
       state.emittedBytes += chunk.byteLength;
       controller.enqueue(chunk);
     },
@@ -200,9 +204,8 @@ function createTrackedOverflowResponse(params: {
 }
 
 describe("ReefTransportClient response body bounds", () => {
-  it("accepts near-limit success JSON without cancelling the stream", async () => {
-    const payload = { entries: [], cursor: 9, pad: "x".repeat(8 * 1024) };
-    const body = JSON.stringify(payload);
+  it("accepts success JSON exactly at the byte limit", async () => {
+    const body = jsonObjectBodyAtSize(SUCCESS_RESPONSE_MAX_BYTES, "pad");
     let cancelled = false;
     const response = new Response(
       new ReadableStream<Uint8Array>({
@@ -224,15 +227,24 @@ describe("ReefTransportClient response body bounds", () => {
       () => ts,
     );
 
-    await expect(client.pull(0)).resolves.toEqual(payload);
+    const result = await client.pull(0);
+    const pad = (result as unknown as { pad: string }).pad;
+    expect(pad).toHaveLength(SUCCESS_RESPONSE_MAX_BYTES - 10);
+    expect(pad[0]).toBe("x");
+    expect(pad.at(-1)).toBe("x");
+    expect(Buffer.byteLength(body)).toBe(SUCCESS_RESPONSE_MAX_BYTES);
     expect(cancelled).toBe(false);
   });
 
-  it("cancels oversized success bodies before buffering the rest", async () => {
-    const offered = createTrackedOverflowResponse({
+  it("cancels success JSON when a chunk crosses the byte limit", async () => {
+    const offered = createTrackedResponse({
       status: 200,
-      chunkBytes: 64 * 1024,
-      totalChunks: 320, // 20 MiB offered
+      chunks: [
+        new Uint8Array(SUCCESS_RESPONSE_MAX_BYTES - 1).fill(0x78),
+        new Uint8Array(2).fill(0x78),
+        new Uint8Array(1024).fill(0x78),
+        new Uint8Array(1024).fill(0x78),
+      ],
     });
     const client = new ReefTransportClient(
       "https://relay.example",
@@ -246,15 +258,31 @@ describe("ReefTransportClient response body bounds", () => {
       /reef\.relay: JSON response exceeds 16777216 bytes/,
     );
     expect(offered.state.cancelled).toBe(true);
-    expect(offered.state.emittedBytes).toBeGreaterThan(16 * 1024 * 1024);
-    expect(offered.state.emittedBytes).toBeLessThan(20 * 1024 * 1024);
+    expect(offered.state.emittedBytes).toBeGreaterThan(SUCCESS_RESPONSE_MAX_BYTES);
+    expect(offered.state.emittedBytes).toBeLessThan(SUCCESS_RESPONSE_MAX_BYTES + 1 + 2048);
+  });
+
+  it("surfaces relay error JSON exactly at the error byte limit", async () => {
+    const body = jsonObjectBodyAtSize(ERROR_RESPONSE_MAX_BYTES, "error");
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async () => new Response(body, { status: 400 }),
+      () => ts,
+    );
+
+    const error = await client.requestFriend("bob", "code").catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(ReefRelayError);
+    expect(error).toMatchObject({ status: 400 });
+    expect((error as Error).message).toHaveLength(ERROR_RESPONSE_MAX_BYTES - 12);
+    expect(Buffer.byteLength(body)).toBe(ERROR_RESPONSE_MAX_BYTES);
   });
 
   it("keeps status fallback and cancels oversized error bodies", async () => {
-    const offered = createTrackedOverflowResponse({
+    const offered = createTrackedResponse({
       status: 503,
-      chunkBytes: 8 * 1024,
-      totalChunks: 16, // 128 KiB offered against 64 KiB error cap
+      chunks: Array.from({ length: 16 }, () => new Uint8Array(8 * 1024).fill(0x78)),
     });
     const client = new ReefTransportClient(
       "https://relay.example",
@@ -274,19 +302,19 @@ describe("ReefTransportClient response body bounds", () => {
     expect(offered.state.emittedBytes).toBeLessThan(128 * 1024);
   });
 
-  it("still surfaces bounded relay error messages", async () => {
+  it("keeps the typed status fallback for malformed error JSON", async () => {
     const client = new ReefTransportClient(
       "https://relay.example",
       "alice",
       keys,
-      async () => Response.json({ error: "friend code expired" }, { status: 400 }),
+      async () => new Response("{", { status: 502 }),
       () => ts,
     );
 
     await expect(client.requestFriend("bob", "code")).rejects.toMatchObject({
       name: "ReefRelayError",
-      status: 400,
-      message: "friend code expired",
+      status: 502,
+      message: "relay HTTP 502",
     });
   });
 });

--- a/extensions/reef/src/transport.ts
+++ b/extensions/reef/src/transport.ts
@@ -1,8 +1,15 @@
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { sha256Hex, signDeviceRequest, utf8 } from "../protocol/index.js";
 import type { Envelope, SignedReceipt } from "../protocol/index.js";
 import type { InboxEntry, ReefKeys, RelayFriend } from "./types.js";
 
 type FetchLike = typeof fetch;
+
+// Relay JSON is untrusted network input. Cap success bodies at the shared
+// provider default and keep error bodies smaller so a hostile relay cannot
+// force unbounded allocation through response.json().
+const REEF_RELAY_JSON_MAX_BYTES = 16 * 1024 * 1024;
+const REEF_RELAY_ERROR_JSON_MAX_BYTES = 64 * 1024;
 
 export class ReefRelayError extends Error {
   constructor(
@@ -150,17 +157,26 @@ export class ReefTransportClient {
     if (!response.ok) {
       let message = `relay HTTP ${response.status}`;
       try {
-        const parsed = (await response.json()) as { error?: string };
-        if (parsed.error) {
+        const parsed = await readProviderJsonResponse<{ error?: string }>(
+          response,
+          "reef.relay.error",
+          { maxBytes: REEF_RELAY_ERROR_JSON_MAX_BYTES },
+        );
+        if (typeof parsed.error === "string" && parsed.error) {
           message = parsed.error;
         }
-      } catch {}
+      } catch {
+        // Keep the status fallback when the error body is missing, malformed,
+        // or oversized; callers still get a typed ReefRelayError.
+      }
       throw new ReefRelayError(response.status, message);
     }
     if (response.status === 204) {
       return undefined as T;
     }
-    return (await response.json()) as T;
+    return await readProviderJsonResponse<T>(response, "reef.relay", {
+      maxBytes: REEF_RELAY_JSON_MAX_BYTES,
+    });
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Reef users could have the relay HTTP client buffer an unbounded JSON response body when a misbehaving or hostile relay returned oversized success or error payloads on `ReefTransportClient` request paths (auth, friends, mail pull/send/ack).

Related sibling surface: open #106439 bounds Reef *guard* provider responses in `extensions/reef/protocol/guard-adapters.ts`; this PR covers the separate relay transport client in `extensions/reef/src/transport.ts`, which still used unbounded `response.json()`.

## Why This Change Was Made

`ReefTransportClient.request` now reads JSON through the shared `readProviderJsonResponse` helper from `openclaw/plugin-sdk/provider-http`:

- success bodies capped at 16 MiB (`reef.relay`)
- error bodies capped at 64 KiB (`reef.relay.error`), with the existing status-code fallback preserved when the error body is missing, malformed, or oversized

Oversized streams are cancelled before the remainder is buffered. Non-goal: changing guard adapters (owned by #106439) or adding new config.

## User Impact

Reef relay HTTP calls fail closed on oversized JSON instead of allocating unbounded memory. Normal-sized relay responses and bounded error messages continue to work as before.

## Evidence

Head: `7d4ab0a3461a71021bd0d0ba53d5aade8573206f`

**Head:** `f8d35557ae69c3e457b601cbe2bc535049689032`

**Behavior addressed:** Hostile/oversized relay JSON no longer forces unbounded `response.json()` allocation; streams cancel after the byte budget.

**Real environment tested:** Linux WSL2, Node `v22.22.0`, local checkout of this branch.

### Path-level proof (production `ReefTransportClient` + negative control)

```text
$ ./node_modules/.bin/tsx proof-reef-relay-json-bound.ts
success overflow cancelled=true emittedBytes=16908288 error=reef.relay: JSON response exceeds 16777216 bytes
error overflow name=ReefRelayError status=503 message=relay HTTP 503 cancelled=true emittedBytes=81920
negative control response.json() cancelled=false emittedBytes=262144
ok
```

Interpretation:

- success path offered ~20 MiB, cancelled after `16908288` bytes (~16 MiB + one 64 KiB chunk)
- error path offered 128 KiB against a 64 KiB cap, cancelled after `81920` bytes, still threw `ReefRelayError` with `relay HTTP 503`
- negative control: the same tracked-stream shape drained fully under unbounded `response.json()` with `cancelled=false`

### Focused Vitest regression

```text
$ node scripts/run-vitest.mjs extensions/reef/src/transport.test.ts -t "response body bounds"

 Test Files  1 passed (1)
      Tests  4 passed | 3 skipped (7)
   Duration  2.19s
```

```text
$ node scripts/run-vitest.mjs extensions/reef/src/transport.test.ts

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Duration  2.19s
```

### Sibling / owner lane

```text
$ node scripts/run-vitest.mjs extensions/reef

 Test Files  11 passed (11)
      Tests  106 passed | 2 skipped (108)
   Duration  3.10s
```

```text
$ node scripts/check-src-extension-import-boundary.mjs --json
[]
```

AI-assisted.

Made with [Cursor](https://cursor.com)
