### PR TITLE
fix: keep lobster pet above sidebar footer

### DIFF
--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -301,10 +301,9 @@ const PASSER_CROSS_MS = 11_000;
 
 type LobsterPetAnchor = "ledge" | "bar";
 
-// The bar anchor stands the pet inside the footer bar's free stretch between
-// the status dot (left) and the settings icons (right).
+// The historical bar visit keeps its compact left-to-center roaming and scale
+// cap, while CSS places it on the same ledge as regular visits.
 const BAR_ZONE = [18, 50] as const;
-// Inside the ~30px bar the sprite must stay small regardless of rolled size.
 const BAR_MAX_SCALE = 1.7;
 
 // Visit cadence: seeded per load, the pet is a guest, not a fixture. A share
@@ -1481,8 +1480,8 @@ export class LobsterPet extends LitElement {
     }, PASSER_CROSS_MS / 2);
   }
 
-  // Each arrival re-rolls where the pet shows up: the ledge above the footer
-  // divider or the free stretch inside the footer bar.
+  // Each arrival re-rolls either the standard side zone or compact bar zone.
+  // Both visit profiles render above the footer divider.
   private rollPerch() {
     this.anchor = this.visitRng() < 0.6 ? "ledge" : "bar";
     this.setAttribute("data-spot", this.anchor);
@@ -1638,7 +1637,6 @@ export class LobsterPet extends LitElement {
     ].join(";");
   }
 
-  // The bar anchor stands inside the ~30px footer bar, so cap the sprite.
   private anchoredScale(scale: number): number {
     return this.anchor === "bar" ? Math.min(scale, BAR_MAX_SCALE) : scale;
   }

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -34,6 +34,31 @@ async function roundedWidth(locator: Locator): Promise<number> {
   return Math.round((await locator.boundingBox())?.width ?? 0);
 }
 
+async function expectLobsterOnFooterLedge(sidebar: Locator) {
+  const footer = sidebar.locator(".sidebar-shell__footer");
+  const sprite = footer.locator(".lobster-pet:not(.lobster-pet--passer)").first();
+  await sprite.waitFor();
+
+  await expect
+    .poll(async () => {
+      const [footerBox, spriteBox, borderTopWidth] = await Promise.all([
+        footer.boundingBox(),
+        sprite.boundingBox(),
+        footer.evaluate((element) =>
+          Number.parseFloat(window.getComputedStyle(element).borderTopWidth),
+        ),
+      ]);
+      if (!footerBox || !spriteBox) {
+        return null;
+      }
+      return {
+        bottomOverlap: Math.round(spriteBox.y + spriteBox.height - footerBox.y - borderTopWidth),
+        isAboveFooter: spriteBox.y < footerBox.y,
+      };
+    })
+    .toEqual({ bottomOverlap: 3, isAboveFooter: true });
+}
+
 async function captureUiProof(page: Page, fileName: string) {
   if (!captureUiProofEnabled) {
     return;
@@ -599,6 +624,56 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await expect.poll(() => sidebar.isVisible()).toBe(true);
       await expect.poll(() => pet.count()).toBe(1);
       await expect.poll(() => outcome(pet)).toBe("error");
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("keeps the lobster on the footer ledge across desktop and drawer layouts", async () => {
+    const { context, page } = await openSidebarTestPage();
+
+    try {
+      const sidebar = page.locator("openclaw-app-sidebar");
+      const pet = sidebar.locator("openclaw-lobster-pet");
+      const movement = await pet.evaluate(async (element) => {
+        const lobster = element as HTMLElement & {
+          anchor: "bar";
+          mode: "offline";
+          performAct(act: "scuttle"): void;
+          requestUpdate(): void;
+          updateComplete: Promise<unknown>;
+        };
+        lobster.mode = "offline";
+        await lobster.updateComplete;
+        lobster.anchor = "bar";
+        lobster.setAttribute("data-spot", "bar");
+        lobster.requestUpdate();
+        await lobster.updateComplete;
+
+        const sprite = lobster.querySelector<HTMLElement>(".lobster-pet:not(.lobster-pet--passer)");
+        const before = sprite?.style.getPropertyValue("--lob-x") ?? "";
+        lobster.performAct("scuttle");
+        await lobster.updateComplete;
+        const after = sprite?.style.getPropertyValue("--lob-x") ?? "";
+        return { after, before, spot: lobster.getAttribute("data-spot") };
+      });
+
+      expect(movement.spot).toBe("bar");
+      expect(movement.after).not.toBe(movement.before);
+      expect(Number.parseFloat(movement.after)).toBeGreaterThanOrEqual(18);
+      expect(Number.parseFloat(movement.after)).toBeLessThanOrEqual(50);
+      await expectLobsterOnFooterLedge(sidebar);
+      const sprite = pet.locator(".lobster-pet:not(.lobster-pet--passer)").first();
+      await sprite.dispatchEvent("pointerdown");
+      await sprite.dispatchEvent("pointerup");
+      await expect.poll(() => sprite.getAttribute("class")).toContain("lobster-pet--act-startle");
+      await captureUiProof(page, "08-lobster-footer-ledge-desktop.png");
+
+      await page.setViewportSize({ height: 900, width: 900 });
+      await page.locator(".topbar-nav-toggle").click();
+      await expect.poll(() => sidebar.isVisible()).toBe(true);
+      await expectLobsterOnFooterLedge(sidebar);
+      await captureUiProof(page, "09-lobster-footer-ledge-drawer.png");
     } finally {
       await context.close();
     }

--- a/ui/src/styles/lobster-pet.css
+++ b/ui/src/styles/lobster-pet.css
@@ -8,8 +8,8 @@
   position: relative;
 }
 
-/* Host is a zero-layout overlay strip above the footer bar. Its bottom edge
-   sits 3px inside the footer so feet dangle over the divider, and
+/* Every visit variant shares this zero-layout overlay strip above the footer.
+   Its bottom edge sits 3px inside the bar so feet dangle over the divider, and
    overflow: hidden makes duck/peek/enter moves read as "behind the ledge". */
 openclaw-lobster-pet {
   position: absolute;
@@ -20,17 +20,6 @@ openclaw-lobster-pet {
   height: 52px;
   overflow: hidden;
   pointer-events: none;
-}
-
-/* Bar anchor: the pet stands inside the footer bar's free stretch, between
-   the status dot and the settings icons. */
-openclaw-lobster-pet[data-spot="bar"] {
-  bottom: 0;
-  height: 34px;
-}
-
-openclaw-lobster-pet[data-spot="bar"] .lobster-pet {
-  bottom: 2px;
 }
 
 /* Departure/dismissal: duck down behind the ledge and fade. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where some lobster visits could appear inside the new agent footer chip instead of perching on top of the footer divider. This occurred when the pet selected its historical compact `bar` visit profile.

## Why This Change Was Made

The agent footer redesign replaced the old icon bar, but the compact visit profile still carried CSS that positioned it inside that retired layout. This removes only those stale vertical overrides while preserving the original random profile selection, left-to-center movement zone, scale cap, entrance and departure behavior, and click reactions.

The regression test forces the affected profile and verifies both its retained movement behavior and its corrected position in desktop and drawer layouts.

## User Impact

Every lobster visit now appears on the footer ledge and continues moving and reacting as before, without overlapping the agent identity chip or its controls.

## Evidence

- Testbox-through-Crabbox `tbx_01kxdxsghq1942mt6wyrb84fm6`, Actions run `29257754237`:
  - `corepack pnpm test ui/src/components/lobster-pet.test.ts` — 60 tests passed.
  - Focused Chromium E2E — compact-profile movement, desktop/drawer ledge position, and click/startle behavior passed.
  - Path-scoped `check:changed` — formatting, guards, core-test/UI typechecks, and lint passed.
- Current-main TypeScript LOC ratchet passed for the changed production file.
- Final desktop and drawer screenshots were captured from the mocked Control UI run and visually inspected.
- Auto-review: clean, no accepted/actionable findings; overall correctness confidence 0.94.
- Regression provenance: #103111 introduced the compact inside-bar visit for the old footer; #105777 replaced that footer bar with the agent identity chip without updating the lobster placement rule.
- AI-assisted: yes. I reviewed the implementation, behavior history, diff, and verification results and understand the change.
