### PR TITLE
refactor(logging): privatize timezone validation helper

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -2068,7 +2068,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/logging/diagnostic-session-context.ts: readLastAssistantFromSessionFile",
   "src/logging/redact-internal.ts: withFullContextToolPayloadRedaction",
   "src/logging/secret-redaction-registry.ts: resetSecretRedactionRegistryForTest",
-  "src/logging/timestamps.ts: isValidTimeZone",
   "src/mcp/channel-bridge.ts: shouldRetryInitialMcpGatewayConnect",
   "src/mcp/channel-server.ts: createOpenClawChannelMcpServer",
   "src/mcp/channel-server.ts: OpenClawChannelBridge",

--- a/src/logging/timestamps.test.ts
+++ b/src/logging/timestamps.test.ts
@@ -1,6 +1,6 @@
-// Timestamp tests cover timezone validation and timestamp formatting.
+// Timestamp tests cover timestamp formatting and timezone fallback behavior.
 import { describe, expect, it } from "vitest";
-import { formatTimestamp, isValidTimeZone } from "./timestamps.js";
+import { formatTimestamp } from "./timestamps.js";
 
 describe("formatTimestamp", () => {
   const testDate = new Date("2024-01-15T14:30:45.123Z");
@@ -27,19 +27,5 @@ describe("formatTimestamp", () => {
     expect(formatTimestamp(testDate, { style: "short", timeZone: "not-a-tz" })).toMatch(
       /^\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/,
     );
-  });
-});
-
-describe("isValidTimeZone", () => {
-  it("returns true for valid IANA timezones", () => {
-    expect(isValidTimeZone("UTC")).toBe(true);
-    expect(isValidTimeZone("America/New_York")).toBe(true);
-    expect(isValidTimeZone("Asia/Shanghai")).toBe(true);
-  });
-
-  it("returns false for invalid timezone strings", () => {
-    expect(isValidTimeZone("not-a-tz")).toBe(false);
-    expect(isValidTimeZone("yo agent's")).toBe(false);
-    expect(isValidTimeZone("")).toBe(false);
   });
 });

--- a/src/logging/timestamps.ts
+++ b/src/logging/timestamps.ts
@@ -3,7 +3,7 @@ const validTimeZoneCache = new Map<string, boolean>();
 const timestampFormatterCache = new Map<string, Intl.DateTimeFormat>();
 let hostTimeZone: string | undefined;
 
-export function isValidTimeZone(tz: string): boolean {
+function isValidTimeZone(tz: string): boolean {
   const cached = validTimeZoneCache.get(tz);
   if (cached !== undefined) {
     return cached;


### PR DESCRIPTION
## What Problem This Solves

The logging timestamp module publicly exported `isValidTimeZone` even though runtime code only uses it inside the module. That widened the internal API, required a dead-export baseline entry, and encouraged tests to target implementation detail instead of public formatting behavior.

This is part of the maintainer-requested dead-code sweep.

## Why This Change Was Made

Make the timezone validator module-private, remove its direct tests, and retain behavior-focused coverage through `formatTimestamp` for valid timezones and invalid-timezone fallback. Remove the obsolete dead-export baseline entry.

## User Impact

No user-visible behavior changes. Log and CLI timestamp formatting keep the same timezone validation and fallback behavior.

## Evidence

- Codebase-memory graph refreshed at exact `main` (`1b43d7144083079f737a893ede45c855dbb2fdbd`): 310,724 nodes, 1,145,715 edges, zero changed files. The symbol is indexed as exported with no indexed external `CALLS`, `USAGE`, or `IMPORTS` edge; repository-wide source search confirms its only runtime caller is local to `src/logging/timestamps.ts`.
- Blacksmith Testbox `tbx_01kxdyhrv4x8vppd0rj7x5sxg9`, Actions run `29258712785`: 4/4 files and 48/48 tests passed across timestamp, logging, and CLI suites.
- `pnpm deadcode:exports`: passed with 2591 entries.
- Targeted `pnpm check:changed`: passed for the three touched files, including core/core-test typechecks, focused lint, tooling lint, storage/runtime guards, and import-cycle checks.
- Fresh uncommitted and branch-mode `gpt-5.6-sol` medium autoreviews: clean at 0.98 confidence.
- `git diff --check`: passed.
- Landed PR #106455 touched only the shared dead-export baseline for unrelated command exports; there is no semantic overlap. Current `main` at `ee80377a22b36b1bff6faed20c9233134e2a186d` has no source/test overlap and the three-way merge is clean.

AI-assisted: yes. The diff and validation evidence were reviewed; no transcript is attached.
