### PR TITLE
fix(msteams): remove unused attachment helper

### DIFF
--- a/extensions/msteams/src/attachments/html.ts
+++ b/extensions/msteams/src/attachments/html.ts
@@ -106,13 +106,6 @@ export function summarizeMSTeamsHtmlAttachments(
   };
 }
 
-function buildMSTeamsAttachmentPlaceholder(
-  attachments: MSTeamsAttachmentLike[] | undefined,
-  limits?: { maxInlineBytes?: number; maxInlineTotalBytes?: number },
-): string {
-  return resolveMSTeamsInboundAttachmentPresentation(attachments, limits).placeholder;
-}
-
 function isAdvertisedFileAttachment(attachment: MSTeamsAttachmentLike): boolean {
   const contentType = normalizeContentType(attachment.contentType) ?? "";
   if (


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails the production TypeScript gate after #106279 made `buildMSTeamsAttachmentPlaceholder` private without removing it. TypeScript reports TS6133 because the helper has no callers.

## Why This Change Was Made

Delete the unused wrapper. Its only behavior delegates directly to `resolveMSTeamsInboundAttachmentPresentation`, which remains the canonical production API.

## User Impact

No runtime behavior change. This restores the production typecheck on current `main`.

## Evidence

- Failure: [CI run 29242903349, check-prod-types](https://github.com/openclaw/openclaw/actions/runs/29242903349/job/86793082132) reports `extensions/msteams/src/attachments/html.ts(109,10): error TS6133`.
- Repository search found no production caller for the private helper.
- Hosted CI is the validation gate.
