### PR TITLE
refactor(macos): remove write-only voice wake state

### DIFF
--- a/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
@@ -12,8 +12,6 @@ import AppKit
 actor VoiceWakeRuntime {
     static let shared = VoiceWakeRuntime()
 
-    enum ListeningState { case idle, voiceWake, pushToTalk }
-
     private let logger = Logger(subsystem: "ai.openclaw", category: "voicewake.runtime")
 
     private var recognizer: SFSpeechRecognizer?
@@ -35,7 +33,6 @@ actor VoiceWakeRuntime {
     private var volatileTranscript: String = ""
     private var cooldownUntil: Date?
     private var currentConfig: RuntimeConfig?
-    private var listeningState: ListeningState = .idle
     private var overlayToken: UUID?
     private var activeTriggerEndTime: TimeInterval?
     private var activeTriggerWord: String?
@@ -252,7 +249,6 @@ actor VoiceWakeRuntime {
         self.haltRecognitionPipeline()
         self.recognizer = nil
         self.currentConfig = nil
-        self.listeningState = .idle
         self.activeTriggerEndTime = nil
         self.activeTriggerWord = nil
         self.logger.debug("voicewake runtime stopped")
@@ -572,7 +568,6 @@ actor VoiceWakeRuntime {
             await AppStateStore.shared.setTalkEnabled(true)
             return
         }
-        self.listeningState = .voiceWake
         self.isCapturing = true
         DiagnosticsFileLog.shared.log(category: "voicewake.runtime", event: "beginCapture")
         self.capturedTranscript = command
@@ -757,7 +752,6 @@ actor VoiceWakeRuntime {
     }
 
     func pauseForPushToTalk() {
-        self.listeningState = .pushToTalk
         self.stop(dismissOverlay: false)
     }
 


### PR DESCRIPTION
## What Problem This Solves

The macOS Voice Wake runtime retained a private listening-state model that was only written and never read. That stale state implied lifecycle authority it did not have and could drift from the runtime's actual capture and configuration state.

## Why This Change Was Made

Remove the unused enum, property, and three assignments while preserving the real lifecycle owners (`isCapturing`, `currentConfig`, recognition tasks, and push-to-talk coordination). `pauseForPushToTalk()` still calls `stop(dismissOverlay: false)` unchanged.

## User Impact

No user-visible behavior changes. The runtime now has one less misleading state path to maintain.

## Evidence

- Exhaustive symbol search found exactly five references: the declaration, property, and three writes; there were no reads or test dependencies.
- `swiftc -frontend -parse apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift`
- `swiftformat --lint apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift --config config/swiftformat`
- `swiftlint lint --strict --config config/swiftlint.yml apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift`
- `OPENCLAW_TESTBOX=1` changed gate: Blacksmith Testbox run 29260131827; all five macOS-related Vitest shards passed.
- Fresh `gpt-5.6-sol` medium autoreview: clean, confidence 0.99. The repository reviewer rejected the full file because existing unrelated content triggered its secret-like-content guard, so the review used a sanitized behavior-complete slice containing the exact six-line deletion plus source, history, ownership, and validation evidence.
- Open-PR overlap audit found no semantic overlap. Draft PR #101755 touches the same file in a large stacked branch but retains this state unchanged.

AI-assisted: yes. I reviewed the complete change and validation evidence. No transcript is attached.
