### PR TITLE
refactor(ui): reuse shared record normalization

### DIFF
--- a/ui/src/components/browser/browser-client.ts
+++ b/ui/src/components/browser/browser-client.ts
@@ -4,6 +4,7 @@
 // that is dispatched against the browser plugin's control routes, either
 // locally or via a browser-capable node. This module narrows the handful of
 // routes the browser panel needs and keeps route-path knowledge in one place.
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 
 const BROWSER_REQUEST_METHOD = "browser.request";
@@ -61,12 +62,6 @@ type BrowserRequestEnvelope = {
 
 function browserRequest<T>(client: GatewayBrowserClient, envelope: BrowserRequestEnvelope) {
   return client.request<T>(BROWSER_REQUEST_METHOD, envelope);
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
 }
 
 function asString(value: unknown): string {

--- a/ui/src/components/github-link-hovercard.ts
+++ b/ui/src/components/github-link-hovercard.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { ControlUiGitHubPreview } from "../../../src/gateway/control-ui-contract.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { i18n, t } from "../i18n/index.ts";
@@ -34,10 +35,6 @@ type CacheEntry = {
 };
 
 let nextHovercardId = 0;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
 
 function requiredString(record: Record<string, unknown>, key: string): string {
   const value = record[key];

--- a/ui/src/lib/chat/commands.browser-import.test.ts
+++ b/ui/src/lib/chat/commands.browser-import.test.ts
@@ -47,6 +47,7 @@ describe("slash command browser import", () => {
     );
 
     expect(importDeclarations(commands)).toEqual([
+      'import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";',
       'import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";',
       'import type { CommandEntry } from "../../../../packages/gateway-protocol/src/index.js";',
       'import { buildBuiltinChatCommands } from "../../../../src/auto-reply/commands-registry.shared.js";',

--- a/ui/src/lib/chat/commands.test.ts
+++ b/ui/src/lib/chat/commands.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { expectDefined } from "@openclaw/normalization-core";
+import { expectDefined, isRecord } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   buildSlashCommandsFromEntries,
@@ -13,10 +13,6 @@ import {
 afterEach(() => {
   resetSlashCommandsForTest();
 });
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
   if (!isRecord(value)) {

--- a/ui/src/lib/chat/commands.ts
+++ b/ui/src/lib/chat/commands.ts
@@ -1,5 +1,6 @@
 // Control UI chat domain owns pure slash command rules.
 
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { CommandEntry } from "../../../../packages/gateway-protocol/src/index.js";
 import { buildBuiltinChatCommands } from "../../../../src/auto-reply/commands-registry.shared.js";
@@ -265,12 +266,6 @@ function normalizeSlashIdentifier(raw: string): string | null {
 function clampText(value: unknown, maxLength: number): string {
   const text = typeof value === "string" ? value : "";
   return text.length > maxLength ? truncateUtf16Safe(text, maxLength) : text;
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
 }
 
 function getEntryArgs(

--- a/ui/src/lib/chat/tool-call-patch.ts
+++ b/ui/src/lib/chat/tool-call-patch.ts
@@ -1,3 +1,4 @@
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   MAX_DIFF_RENDER_LINES,
   type DiffLine,
@@ -34,12 +35,6 @@ export type PatchViewData = {
   stat: DiffStat;
   move?: { from: string; to: string };
 };
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;

--- a/ui/src/lib/chat/tool-call-view.ts
+++ b/ui/src/lib/chat/tool-call-view.ts
@@ -6,6 +6,7 @@
  * the OpenClaw session tools and foreign harnesses (Claude/Codex style).
  */
 
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   buildWriteDiffLines,
   computeLineDiff,
@@ -55,12 +56,6 @@ const WRITE_TOOL_NAMES = new Set(["write", "write_file", "create_file"]);
 const SEARCH_TOOL_NAMES = new Set(["grep", "find", "glob", "ls", "list", "codebase_search"]);
 const FETCH_TOOL_NAMES = new Set(["web_fetch", "webfetch", "fetch"]);
 const PATCH_TOOL_NAMES = new Set(["apply_patch", "applypatch", "patch"]);
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;

--- a/ui/src/lib/config-form-utils.ts
+++ b/ui/src/lib/config-form-utils.ts
@@ -1,4 +1,5 @@
 // Control UI controller manages form utils gateway state.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import JSON5 from "json5";
 
 export function cloneConfigObject<T>(value: T): T {
@@ -16,10 +17,6 @@ const OMIT_VALUE: SanitizeResult = { omitted: true };
 
 function keepValue(value: unknown): SanitizeResult {
   return { omitted: false, value };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function hasOwnRecordValue(record: Record<string, unknown> | null, key: string): boolean {

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -1,3 +1,4 @@
+import { asNullableRecord as recordOrNull } from "@openclaw/normalization-core/record-coerce";
 import type { GatewaySessionRow, SessionRunStatus, SessionsListResult } from "../../api/types.ts";
 import { isSessionRunActive } from "../session-run-state.ts";
 import { compareSessionRowsByUpdatedAt } from "./navigation.ts";
@@ -175,12 +176,6 @@ function recordValue(record: Record<string, unknown>, key: string): unknown {
 
 function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function recordOrNull(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
 }
 
 function sessionRunStatus(value: unknown): SessionRunStatus | null {

--- a/ui/src/lib/tasks/data.ts
+++ b/ui/src/lib/tasks/data.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { t } from "../../i18n/index.ts";
 
 export type TaskStatus = "queued" | "running" | "completed" | "failed" | "cancelled" | "timed_out";
@@ -31,10 +32,6 @@ export type TaskEventPayload =
   | { action: "upserted"; task: TaskSummary }
   | { action: "deleted"; taskId: string }
   | { action: "restored" };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function optionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;

--- a/ui/src/lib/workspace/bridge.ts
+++ b/ui/src/lib/workspace/bridge.ts
@@ -17,6 +17,7 @@
 // - Parent→child posts always use targetOrigin "*" (opaque origin), carrying only
 //   binding data / theme tokens the widget is entitled to — never secrets.
 
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { WidgetManifestView } from "./types.ts";
 
 export const BRIDGE_ENVELOPE_VERSION = 1;
@@ -114,10 +115,6 @@ const INBOUND_TYPES = new Set<WidgetInboundType>([
   "workspace:getTheme",
   "workspace:sendPrompt",
 ]);
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 /**
  * Well-formedness filter: a valid inbound message is an object with `v === 1` and

--- a/ui/src/lib/workspace/index.ts
+++ b/ui/src/lib/workspace/index.ts
@@ -5,6 +5,7 @@
 // Follows the workboard three-way split — this module owns all logic; the view is
 // pure render fns and the page/controller is thin lifecycle glue.
 
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
 import { buildSessionUsageDateParams } from "../sessions/usage.ts";
 import {
@@ -103,10 +104,6 @@ export function getWorkspaceState(host: WorkspaceHost): WorkspaceUiState {
 
 function notify(state: WorkspaceUiState): void {
   state.requestUpdate?.();
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function readString(value: unknown, fallback = ""): string {

--- a/ui/src/pages/agents/memory/dreaming.ts
+++ b/ui/src/pages/agents/memory/dreaming.ts
@@ -1,3 +1,4 @@
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import type { GatewayBrowserClient, GatewayHelloOk } from "../../../api/gateway.ts";
 import type { ConfigSnapshot } from "../../../api/types.ts";
 import { copyToClipboard } from "../../../lib/clipboard.ts";
@@ -363,13 +364,6 @@ function buildDreamDiaryActionSuccessMessage(
       return `Cleared ${typeof payload?.removedShortTermEntries === "number" ? payload.removedShortTermEntries : 0} replayed short-term entries.`;
   }
   return "Dream diary action complete.";
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  return value as Record<string, unknown>;
 }
 
 function normalizeTrimmedString(value: unknown): string | undefined {

--- a/ui/src/pages/approval/approval-page.ts
+++ b/ui/src/pages/approval/approval-page.ts
@@ -1,4 +1,5 @@
 import { consume } from "@lit/context";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import {
@@ -26,10 +27,6 @@ const APPROVAL_MIN_POLL_DELAY_MS = 250;
 
 type ApprovalRequestError = "connection" | "unavailable" | null;
 type ResolutionOrigin = "here" | "elsewhere" | "observed";
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function isUnavailableApprovalError(error: unknown): boolean {
   if (!(error instanceof GatewayRequestError)) {

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -1,4 +1,5 @@
 import { consume } from "@lit/context";
+import { asNullableRecord as catalogRawRecord } from "@openclaw/normalization-core/record-coerce";
 import { html, nothing } from "lit";
 import { property, state as litState } from "lit/decorators.js";
 import type {
@@ -150,12 +151,6 @@ type ChatHistoryAnchor = {
 };
 
 const CATALOG_TOOL_RESULT_PREVIEW_MAX_CHARS = 500;
-
-function catalogRawRecord(raw: unknown): Record<string, unknown> | null {
-  return raw && typeof raw === "object" && !Array.isArray(raw)
-    ? (raw as Record<string, unknown>)
-    : null;
-}
 
 function catalogRawString(raw: unknown, keys: readonly string[]): string | null {
   const record = catalogRawRecord(raw);

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -1,4 +1,5 @@
 // Control UI chat module owns Chat thread item derivation and thread-local caches.
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   isToolCallContentType,
   isToolResultContentType,
@@ -129,12 +130,6 @@ function appendCanvasBlockToAssistantMessage(
       },
     ],
   };
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
 }
 
 function safeNormalizeMessage(message: unknown): NormalizedMessage | null {

--- a/ui/src/pages/chat/split-layout.ts
+++ b/ui/src/pages/chat/split-layout.ts
@@ -1,4 +1,4 @@
-import { expectDefined } from "@openclaw/normalization-core";
+import { expectDefined, isRecord } from "@openclaw/normalization-core";
 
 export type ChatSplitPane = { id: string; sessionKey: string };
 type ChatSplitColumn = { id: string; panes: ChatSplitPane[]; paneWeights: number[] };
@@ -231,10 +231,6 @@ export function resizePanes(
     column.paneWeights = resizePair(column.paneWeights, boundaryIndex, pairRatio);
   }
   return next;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function readWeights(value: unknown, length: number): number[] {

--- a/ui/src/pages/chat/stream-reconciliation.ts
+++ b/ui/src/pages/chat/stream-reconciliation.ts
@@ -1,4 +1,5 @@
 // Control UI chat module implements stream reconciliation behavior.
+import { asNullableRecord as asToolRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   isToolCallContentType,
   isToolResultContentType,
@@ -48,12 +49,6 @@ type ToolMessageRef = {
 };
 
 const TOOL_NAME_FIELDS = ["toolName", "tool_name"] as const;
-
-function asToolRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
 
 function addToolRef(refs: ToolMessageRef[], seen: Set<string>, id: string | undefined) {
   if (!id || seen.has(id)) {

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -1,4 +1,5 @@
 import { consume } from "@lit/context";
+import { asNullableRecord as asConfigRecord } from "@openclaw/normalization-core/record-coerce";
 import { html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
@@ -112,12 +113,6 @@ function defaultConfigSelection(pageId: ConfigPageId): ConfigSelection {
       return { activeSection: null, activeSubsection: null };
   }
   throw new Error("Unknown config page");
-}
-
-function asConfigRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
 }
 
 function normalizeConfigSelection(

--- a/ui/src/pages/config/mcp.ts
+++ b/ui/src/pages/config/mcp.ts
@@ -1,5 +1,6 @@
 // Control UI MCP Settings page presentation.
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { html, type TemplateResult } from "lit";
 import {
   renderSettingsEmpty,
@@ -31,12 +32,6 @@ export type McpViewProps = {
   onApplyConfig: () => void;
   editor: TemplateResult;
 };
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
 
 function getMcpServers(configObject: Record<string, unknown>): Record<string, unknown> {
   return asRecord(asRecord(configObject.mcp)?.servers) ?? {};

--- a/ui/src/pages/plugins/plugins-page.ts
+++ b/ui/src/pages/plugins/plugins-page.ts
@@ -1,5 +1,6 @@
 import { consume } from "@lit/context";
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { html, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
@@ -83,12 +84,6 @@ function mutationSuccessMessage(
   const warnings = "warnings" in result ? (result.warnings ?? []) : [];
   const lines = [t(key, { name: result.plugin.name }), ...warnings];
   return lines.filter(Boolean).join("\n");
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
 }
 
 /** Cold MCP server summary mirroring the config page's row projection. */

--- a/ui/src/pages/skill-workshop/self-learning.ts
+++ b/ui/src/pages/skill-workshop/self-learning.ts
@@ -1,5 +1,6 @@
 // Self-learning (skills.workshop.autonomous.enabled) surface for the Workshop
 // tab: config read/patch plumbing plus the toggle, pitch, and error renderers.
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { html, nothing } from "lit";
 import { t } from "../../i18n/index.ts";
 import {
@@ -12,12 +13,6 @@ export type SkillWorkshopSelfLearning = {
   busy: boolean;
   error: string | null;
 };
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
 
 // Mirrors the gateway default for skills.workshop.autonomous.enabled: absent
 // config means self-learning is off. Snapshot sourceConfig/resolved are both


### PR DESCRIPTION
Closes #106465

## What Problem This Solves

Control UI carried 21 private copies of the same non-array record checks already exported by its normalization-core dependency. The copies added maintenance surface and could drift from the shared array/null contract.

## Why This Change Was Made

This change replaces only behavior-identical private helpers with `isRecord` or `asNullableRecord` imports, using aliases so callers remain untouched. Exported facades, typed schema adapters, array-accepting guards, and serialized browser closures remain unchanged.

## User Impact

No user-visible behavior change. Control UI now uses one tested record-normalization contract and removes 91 physical lines across the affected surface.

## Evidence

- Blacksmith Testbox-through-Crabbox `tbx_01kxdztp50fa4ddqrgce1p3kyh`
- `pnpm test packages/normalization-core/src/record-coerce.test.ts` — 2 tests passed
- `pnpm test:ui` — 3,853 tests passed; one unrelated lazy-element mock flaked after passing in the prior run
- Focused rerun of `commands.browser-import.test.ts` and `chat-tool-cards.test.ts` — 37 tests passed
- `pnpm ui:build` — production build, precompressed assets, and performance budgets passed
- `git diff --check`
- No screenshot: no rendered output changes

AI-assisted: yes. I understand the change and verified the dependency contract and every replaced helper.
