### PR TITLE
fix(logbook): reject malformed snapshot base64

### DIFF
--- a/extensions/logbook/src/service.test.ts
+++ b/extensions/logbook/src/service.test.ts
@@ -99,6 +99,24 @@ describe("LogbookService capture node selection", () => {
     expect(invoked.map((call) => call.nodeId)).toEqual(["a-broken", "b-working"]);
     expect(service.status().lastCaptureError).toBeUndefined();
   });
+
+  it("rejects malformed snapshot base64 before storing a frame", async () => {
+    const { service, tick, dataDir } = makeService({
+      nodes: [{ nodeId: "capture-node", commands: ["logbook.snapshot"] }],
+      invoke: async () => ({ payload: { format: "jpeg", base64: "not-base64!" } }),
+    });
+    cleanups.push(() => {
+      service.stop();
+      rmSync(dataDir, { recursive: true, force: true });
+    });
+
+    await tick();
+
+    expect(service.status()).toMatchObject({
+      pendingFrames: 0,
+      lastCaptureError: "logbook.snapshot returned invalid image payload",
+    });
+  });
 });
 
 describe("LogbookService vision model selection", () => {

--- a/extensions/logbook/src/service.test.ts
+++ b/extensions/logbook/src/service.test.ts
@@ -74,6 +74,7 @@ describe("LogbookService capture node selection", () => {
 
     await tick();
     expect(invoked).toEqual([{ nodeId: "b-mac-app", command: "screen.snapshot" }]);
+    expect(service.status()).toMatchObject({ pendingFrames: 1, lastCaptureError: undefined });
   });
 
   it("rotates to the next capture node after a failure instead of re-picking the broken one", async () => {
@@ -100,10 +101,14 @@ describe("LogbookService capture node selection", () => {
     expect(service.status().lastCaptureError).toBeUndefined();
   });
 
-  it("rejects malformed snapshot base64 before storing a frame", async () => {
+  it.each([
+    ["malformed string", "not-base64!"],
+    ["object", { encoded: "ZmFrZQ==" }],
+    ["array", ["ZmFrZQ=="]],
+  ])("rejects a %s snapshot payload before storing a frame", async (_label, base64) => {
     const { service, tick, dataDir } = makeService({
       nodes: [{ nodeId: "capture-node", commands: ["logbook.snapshot"] }],
-      invoke: async () => ({ payload: { format: "jpeg", base64: "not-base64!" } }),
+      invoke: async () => ({ payload: { format: "jpeg", base64 } }),
     });
     cleanups.push(() => {
       service.stop();

--- a/extensions/logbook/src/service.ts
+++ b/extensions/logbook/src/service.ts
@@ -2,6 +2,7 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import type {
   OpenClawConfig,
   OpenClawPluginApi,
@@ -41,7 +42,6 @@ const JPEG_QUALITY = 0.6;
 // Only Codex currently implements the structured image-extraction contract.
 // Borrowed defaults must not select a provider that will fail every batch.
 const STRUCTURED_MEDIA_PROVIDER = "codex";
-
 type SnapshotPayload = {
   format?: string;
   base64?: string;
@@ -255,9 +255,9 @@ export class LogbookService {
       if (raw?.error) {
         throw new Error(raw.error);
       }
-      const base64 = raw?.base64;
+      const base64 = raw?.base64 && canonicalizeBase64(raw.base64);
       if (!base64) {
-        throw new Error(`${node.command} returned no image payload`);
+        throw new Error(`${node.command} returned ${raw?.base64 ? "invalid" : "no"} image payload`);
       }
       const buffer = Buffer.from(base64, "base64");
       const capturedAtMs = Date.now();

--- a/extensions/logbook/src/service.ts
+++ b/extensions/logbook/src/service.ts
@@ -2,7 +2,7 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { canonicalizeBase64 } from "@openclaw/media-core/base64";
+import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import type {
   OpenClawConfig,
   OpenClawPluginApi,
@@ -44,7 +44,7 @@ const JPEG_QUALITY = 0.6;
 const STRUCTURED_MEDIA_PROVIDER = "codex";
 type SnapshotPayload = {
   format?: string;
-  base64?: string;
+  base64?: unknown;
   width?: number;
   height?: number;
   error?: string;
@@ -255,9 +255,16 @@ export class LogbookService {
       if (raw?.error) {
         throw new Error(raw.error);
       }
-      const base64 = raw?.base64 && canonicalizeBase64(raw.base64);
+      const rawBase64 = raw?.base64;
+      if (rawBase64 === undefined || rawBase64 === "") {
+        throw new Error(`${node.command} returned no image payload`);
+      }
+      if (typeof rawBase64 !== "string") {
+        throw new Error(`${node.command} returned invalid image payload`);
+      }
+      const base64 = canonicalizeBase64(rawBase64);
       if (!base64) {
-        throw new Error(`${node.command} returned ${raw?.base64 ? "invalid" : "no"} image payload`);
+        throw new Error(`${node.command} returned invalid image payload`);
       }
       const buffer = Buffer.from(base64, "base64");
       const capturedAtMs = Date.now();

--- a/extensions/logbook/src/service.ts
+++ b/extensions/logbook/src/service.ts
@@ -2,7 +2,7 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
+import { canonicalizeBase64 } from "@openclaw/media-core/base64";
 import type {
   OpenClawConfig,
   OpenClawPluginApi,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Logbook users could store a corrupt snapshot frame when a paired node returned malformed base64 for `logbook.snapshot` or `screen.snapshot`.

## Why This Change Was Made

The capture path now validates the node-returned image payload with the existing media base64 contract (`canonicalizeBase64` from the focused `@openclaw/media-core/base64` subpath) before decoding and writing the frame. Valid snapshot payloads still store normally.

Review follow-up: the canonicalizer import was moved off the deprecated `openclaw/plugin-sdk/media-runtime` barrel onto the focused `@openclaw/media-core/base64` subpath (the same source the barrel re-exports; extension-boundary typecheck and the plugin native resolver both support it).

## User Impact

Logbook keeps malformed node snapshot payloads out of the frame store instead of recording unusable screenshot artifacts.

## Evidence

- `node scripts/run-vitest.mjs extensions/logbook/src/service.test.ts`: 6 tests passed.
- `node --import tsx --input-type=module -`: imported the real `LogbookService` and drove `captureTick` through a node runtime returning malformed base64, then a valid control payload.

status: malformed snapshot rejected before storage; valid control snapshot stored.

```text
$ node --import tsx --input-type=module -
{
  "productionPath": [
    "LogbookService",
    "captureTick",
    "runtime.nodes.invoke(logbook.snapshot)",
    "canonicalizeBase64",
    "LogbookStore"
  ],
  "invalid": {
    "pendingFrames": 0,
    "lastCaptureError": "logbook.snapshot returned invalid image payload"
  },
  "valid": {
    "pendingFrames": 1,
    "lastCaptureError": null,
    "lastCaptureStored": true
  }
}
```

<details>
<summary>proof-live.ts</summary>

```ts
import { mkdtempSync, rmSync } from "node:fs";
import { realpathSync } from "node:fs";
import { tmpdir } from "node:os";
import path from "node:path";
import { LogbookService } from "./extensions/logbook/src/service.ts";
import { resolveLogbookConfig } from "./extensions/logbook/src/config.ts";

const dataDir = realpathSync(mkdtempSync(path.join(tmpdir(), "logbook-proof-")));
const quietLogger = { info() {}, warn() {}, error() {}, debug() {} };
let payload = { payload: { format: "jpeg", base64: "not-base64!" } };
const runtime = {
  nodes: {
    list: async () => ({ nodes: [{ nodeId: "capture-node", commands: ["logbook.snapshot"] }] }),
    invoke: async () => payload,
  },
};
const service = new LogbookService(resolveLogbookConfig({ captureEnabled: true }), {
  runtime: runtime as never,
  fullConfig: {} as never,
  logger: quietLogger as never,
  dataDir,
});
service.start();
try {
  await (service as unknown as { captureTick(): Promise<void> }).captureTick();
  const afterInvalid = service.status();
  payload = {
    payload: { format: "jpeg", base64: Buffer.from("fake-jpeg").toString("base64") },
  };
  await (service as unknown as { captureTick(): Promise<void> }).captureTick();
  const afterValid = service.status();
  console.log(JSON.stringify({
    productionPath: [
      "LogbookService",
      "captureTick",
      "runtime.nodes.invoke(logbook.snapshot)",
      "canonicalizeBase64",
      "LogbookStore",
    ],
    invalid: {
      pendingFrames: afterInvalid.pendingFrames,
      lastCaptureError: afterInvalid.lastCaptureError,
    },
    valid: {
      pendingFrames: afterValid.pendingFrames,
      lastCaptureError: afterValid.lastCaptureError ?? null,
      lastCaptureStored: afterValid.pendingFrames === 1,
    },
  }, null, 2));
} finally {
  service.stop();
  rmSync(dataDir, { recursive: true, force: true });
}
```

</details>

AI-assisted: built with Codex
