### PR TITLE
fix(skills): globally-installed ClawHub skills falsely show as not tracked [AI-assisted]

### DIFF
--- a/src/skills/discovery/status.test.ts
+++ b/src/skills/discovery/status.test.ts
@@ -2,13 +2,15 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { readLocalSkillCardContentSync } from "../lifecycle/clawhub.js";
 import { createCanonicalFixtureSkill } from "../test-support/test-helpers.js";
 import type { SkillEntry } from "../types.js";
 import { buildWorkspaceSkillStatus } from "./status.js";
 
 type SkillStatus = ReturnType<typeof buildWorkspaceSkillStatus>["skills"][number];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("buildWorkspaceSkillStatus", () => {
   it("surfaces valid ClawHub linkage and local Skill Card metadata", async () => {
@@ -238,68 +240,106 @@ describe("buildWorkspaceSkillStatus", () => {
     }
   });
 
-  it("links globally installed ClawHub skills via the managed lockfile, not the workspace lockfile", async () => {
-    const managedParentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-managed-"));
-    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-status-"));
-    try {
-      const managedSkillsDir = path.join(managedParentDir, "skills");
-      const skillDir = path.join(managedSkillsDir, "agentreceipt");
-      // Origin + lockfile live under the managed parent (global install), not the workspace.
-      await writeClawHubStatusFixture({
-        workspaceDir: managedParentDir,
-        skillDir,
-        slug: "agentreceipt",
-      });
+  it("links a discovered global ClawHub skill only through the managed lockfile", async () => {
+    const managedParentDir = tempDirs.make("openclaw-managed-");
+    const workspaceDir = tempDirs.make("openclaw-skill-status-");
+    const managedSkillsDir = path.join(managedParentDir, "skills");
+    const skillDir = path.join(managedSkillsDir, "agentreceipt");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      "---\nname: agentreceipt\ndescription: Global skill\n---\n",
+      "utf8",
+    );
+    await writeClawHubStatusFixture({
+      workspaceDir: managedParentDir,
+      skillDir,
+      slug: "agentreceipt",
+    });
+    // Same slug in the workspace must not cross-link the managed install.
+    await writeClawHubStatusFixture({
+      workspaceDir,
+      skillDir: path.join(workspaceDir, "unused"),
+      slug: "agentreceipt",
+      installedVersion: "9.9.9",
+    });
 
-      const report = buildWorkspaceSkillStatus(workspaceDir, {
-        managedSkillsDir,
-        entries: [createEntry("agentreceipt", { baseDir: skillDir, source: "openclaw-managed" })],
-      });
+    const report = buildWorkspaceSkillStatus(workspaceDir, { managedSkillsDir });
+    const skill = report.skills.find((entry) => entry.skillKey === "agentreceipt");
 
-      // Global skill must be linked via the managed lockfile, not flagged as
-      // "not tracked by the workspace ClawHub lockfile".
-      expect(report.skills[0]?.clawhub).toMatchObject({
-        status: "linked",
-        valid: true,
-        slug: "agentreceipt",
-      });
-    } finally {
-      await fs.rm(managedParentDir, { recursive: true, force: true });
-      await fs.rm(workspaceDir, { recursive: true, force: true });
-    }
+    expect(skill).toMatchObject({ source: "openclaw-managed" });
+    expect(skill?.clawhub).toMatchObject({
+      status: "linked",
+      valid: true,
+      slug: "agentreceipt",
+      installedVersion: "1.2.3",
+      lockPath: path.join(managedParentDir, ".clawhub", "lock.json"),
+    });
   });
 
   it("reports a globally installed skill as invalid when it is absent from the managed lockfile", async () => {
-    const managedParentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-managed-"));
-    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-status-"));
-    try {
+    const managedParentDir = tempDirs.make("openclaw-managed-");
+    const workspaceDir = tempDirs.make("openclaw-skill-status-");
+    const managedSkillsDir = path.join(managedParentDir, "skills");
+    const skillDir = path.join(managedSkillsDir, "agentreceipt");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      "---\nname: agentreceipt\ndescription: Global skill\n---\n",
+      "utf8",
+    );
+    await writeClawHubStatusFixture({
+      workspaceDir: managedParentDir,
+      skillDir,
+      slug: "agentreceipt",
+      writeLock: false,
+    });
+
+    const report = buildWorkspaceSkillStatus(workspaceDir, { managedSkillsDir });
+    const skill = report.skills.find((entry) => entry.skillKey === "agentreceipt");
+
+    expect(skill?.clawhub).toMatchObject({
+      status: "invalid",
+      valid: false,
+      reason: expect.stringContaining("not tracked by the managed ClawHub lockfile"),
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "links a discovered managed skill whose install directory is a symlink",
+    async () => {
+      const managedParentDir = tempDirs.make("openclaw-managed-");
+      const externalSkillDir = tempDirs.make("openclaw-skill-target-");
+      const workspaceDir = tempDirs.make("openclaw-skill-status-");
       const managedSkillsDir = path.join(managedParentDir, "skills");
-      const skillDir = path.join(managedSkillsDir, "agentreceipt");
-      // Origin metadata present, but no lockfile at the managed parent.
+      await fs.mkdir(managedSkillsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(externalSkillDir, "SKILL.md"),
+        "---\nname: linked-skill\ndescription: Symlinked global skill\n---\n",
+        "utf8",
+      );
+      await fs.symlink(externalSkillDir, path.join(managedSkillsDir, "linked-skill"));
       await writeClawHubStatusFixture({
         workspaceDir: managedParentDir,
-        skillDir,
-        slug: "agentreceipt",
-        writeLock: false,
+        skillDir: externalSkillDir,
+        slug: "linked-skill",
       });
 
-      const report = buildWorkspaceSkillStatus(workspaceDir, {
-        managedSkillsDir,
-        entries: [createEntry("agentreceipt", { baseDir: skillDir, source: "openclaw-managed" })],
-      });
+      const report = buildWorkspaceSkillStatus(workspaceDir, { managedSkillsDir });
+      const skill = report.skills.find((entry) => entry.skillKey === "linked-skill");
+      const externalSkillRealDir = await fs.realpath(externalSkillDir);
 
-      // No managed lockfile -> the global skill is genuinely untracked. The
-      // diagnostic must name the managed scope (not the workspace lockfile).
-      expect(report.skills[0]?.clawhub).toMatchObject({
-        status: "invalid",
-        valid: false,
-        reason: expect.stringContaining("not tracked by the managed ClawHub lockfile"),
+      expect(skill).toMatchObject({
+        source: "openclaw-managed",
+        baseDir: externalSkillRealDir,
       });
-    } finally {
-      await fs.rm(managedParentDir, { recursive: true, force: true });
-      await fs.rm(workspaceDir, { recursive: true, force: true });
-    }
-  });
+      expect(skill?.clawhub).toMatchObject({
+        status: "linked",
+        valid: true,
+        lockPath: path.join(managedParentDir, ".clawhub", "lock.json"),
+      });
+    },
+  );
 
   it("does not surface install options for OS-scoped skills on unsupported platforms", () => {
     if (process.platform === "win32") {

--- a/src/skills/discovery/status.test.ts
+++ b/src/skills/discovery/status.test.ts
@@ -238,6 +238,68 @@ describe("buildWorkspaceSkillStatus", () => {
     }
   });
 
+  it("links globally installed ClawHub skills via the managed lockfile, not the workspace lockfile", async () => {
+    const managedParentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-managed-"));
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-status-"));
+    try {
+      const managedSkillsDir = path.join(managedParentDir, "skills");
+      const skillDir = path.join(managedSkillsDir, "agentreceipt");
+      // Origin + lockfile live under the managed parent (global install), not the workspace.
+      await writeClawHubStatusFixture({
+        workspaceDir: managedParentDir,
+        skillDir,
+        slug: "agentreceipt",
+      });
+
+      const report = buildWorkspaceSkillStatus(workspaceDir, {
+        managedSkillsDir,
+        entries: [createEntry("agentreceipt", { baseDir: skillDir, source: "openclaw-managed" })],
+      });
+
+      // Global skill must be linked via the managed lockfile, not flagged as
+      // "not tracked by the workspace ClawHub lockfile".
+      expect(report.skills[0]?.clawhub).toMatchObject({
+        status: "linked",
+        valid: true,
+        slug: "agentreceipt",
+      });
+    } finally {
+      await fs.rm(managedParentDir, { recursive: true, force: true });
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports a globally installed skill as invalid when it is absent from the managed lockfile", async () => {
+    const managedParentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-managed-"));
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-status-"));
+    try {
+      const managedSkillsDir = path.join(managedParentDir, "skills");
+      const skillDir = path.join(managedSkillsDir, "agentreceipt");
+      // Origin metadata present, but no lockfile at the managed parent.
+      await writeClawHubStatusFixture({
+        workspaceDir: managedParentDir,
+        skillDir,
+        slug: "agentreceipt",
+        writeLock: false,
+      });
+
+      const report = buildWorkspaceSkillStatus(workspaceDir, {
+        managedSkillsDir,
+        entries: [createEntry("agentreceipt", { baseDir: skillDir, source: "openclaw-managed" })],
+      });
+
+      // No managed lockfile -> the global skill is genuinely untracked, not linked.
+      expect(report.skills[0]?.clawhub).toMatchObject({
+        status: "invalid",
+        valid: false,
+        reason: expect.stringContaining("not tracked"),
+      });
+    } finally {
+      await fs.rm(managedParentDir, { recursive: true, force: true });
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not surface install options for OS-scoped skills on unsupported platforms", () => {
     if (process.platform === "win32") {
       // Keep this simple; win32 platform naming is already explicitly handled elsewhere.

--- a/src/skills/discovery/status.test.ts
+++ b/src/skills/discovery/status.test.ts
@@ -288,11 +288,12 @@ describe("buildWorkspaceSkillStatus", () => {
         entries: [createEntry("agentreceipt", { baseDir: skillDir, source: "openclaw-managed" })],
       });
 
-      // No managed lockfile -> the global skill is genuinely untracked, not linked.
+      // No managed lockfile -> the global skill is genuinely untracked. The
+      // diagnostic must name the managed scope (not the workspace lockfile).
       expect(report.skills[0]?.clawhub).toMatchObject({
         status: "invalid",
         valid: false,
-        reason: expect.stringContaining("not tracked"),
+        reason: expect.stringContaining("not tracked by the managed ClawHub lockfile"),
       });
     } finally {
       await fs.rm(managedParentDir, { recursive: true, force: true });

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -306,7 +306,7 @@ function buildSkillStatus(
   // baseDir sits outside the managedSkillsDir tree. Resolve the link against
   // the managed parent dir so the expected install dir matches the skill dir.
   const isGlobalManagedSkill = !bundled && skillSource === "openclaw-managed";
-  const clawhub =
+  const resolvedLink =
     workspaceDir && !bundled
       ? resolveClawHubSkillStatusLinkSync({
           workspaceDir: isGlobalManagedSkill
@@ -315,11 +315,23 @@ function buildSkillStatus(
           skillDir: entry.skill.baseDir,
           skillKey,
           lockRead: isGlobalManagedSkill ? context.managedLockRead : context.clawhubLockRead,
-          // Keep invalid diagnostics truthful: a globally-managed skill is
-          // checked against the managed lockfile, not the workspace one.
-          lockfileScope: isGlobalManagedSkill ? "managed" : "workspace",
         })
       : undefined;
+  // resolveClawHubSkillStatusLinkSync names the workspace lockfile in its
+  // diagnostics. A globally-managed skill is tracked by the managed lockfile,
+  // so relabel the scope word in its invalid reason here rather than threading
+  // a scope parameter through the oversized clawhub.ts module (see check:loc
+  // ratchet). Only the five lockfile-scoped reasons contain this substring.
+  const clawhub =
+    resolvedLink && isGlobalManagedSkill && resolvedLink.status === "invalid"
+      ? {
+          ...resolvedLink,
+          reason: resolvedLink.reason.replaceAll(
+            "workspace ClawHub lockfile",
+            "managed ClawHub lockfile",
+          ),
+        }
+      : resolvedLink;
   const skillCard = resolveLocalSkillCardStatusSync(entry.skill.baseDir);
 
   return {

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -315,6 +315,9 @@ function buildSkillStatus(
           skillDir: entry.skill.baseDir,
           skillKey,
           lockRead: isGlobalManagedSkill ? context.managedLockRead : context.clawhubLockRead,
+          // Keep invalid diagnostics truthful: a globally-managed skill is
+          // checked against the managed lockfile, not the workspace one.
+          lockfileScope: isGlobalManagedSkill ? "managed" : "workspace",
         })
       : undefined;
   const skillCard = resolveLocalSkillCardStatusSync(entry.skill.baseDir);

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -252,6 +252,12 @@ type BuildSkillStatusContext = {
   agentSkillFilter?: string[];
   workspaceDir: string;
   clawhubLockRead: ClawHubSkillsLockfileStatusRead;
+  // Directory holding globally-installed (managed) skills, and the lockfile
+  // status for its parent. Globally installed skills are tracked in the
+  // managed lockfile (`<dirname(managedSkillsDir)>/.clawhub/lock.json`), not
+  // the workspace one, so both are needed to resolve their link status.
+  managedSkillsDir: string;
+  managedLockRead: ClawHubSkillsLockfileStatusRead;
 };
 
 function buildSkillStatus(
@@ -294,13 +300,21 @@ function buildSkillStatus(
   const availableToAgent = eligible && !blockedByAgentFilter;
   const userInvocable = indexed.userInvocable;
 
+  // Globally managed skills are tracked in the managed lockfile, not the
+  // workspace lockfile. Use the loader-assigned source rather than a lexical
+  // path check: managed skill roots may contain symlinks whose resolved
+  // baseDir sits outside the managedSkillsDir tree. Resolve the link against
+  // the managed parent dir so the expected install dir matches the skill dir.
+  const isGlobalManagedSkill = !bundled && skillSource === "openclaw-managed";
   const clawhub =
     workspaceDir && !bundled
       ? resolveClawHubSkillStatusLinkSync({
-          workspaceDir,
+          workspaceDir: isGlobalManagedSkill
+            ? path.dirname(path.resolve(context.managedSkillsDir))
+            : workspaceDir,
           skillDir: entry.skill.baseDir,
           skillKey,
-          lockRead: context.clawhubLockRead,
+          lockRead: isGlobalManagedSkill ? context.managedLockRead : context.clawhubLockRead,
         })
       : undefined;
   const skillCard = resolveLocalSkillCardStatusSync(entry.skill.baseDir);
@@ -367,6 +381,15 @@ export function buildWorkspaceSkillStatus(
   const prefs = resolveSkillsInstallPreferences(opts?.config);
   const allowBundled = resolveBundledAllowlist(opts?.config);
   const clawhubLockRead = readClawHubSkillsLockfileStatusSync(workspaceDir);
+  // Globally installed skills live under managedSkillsDir and are tracked in
+  // the managed lockfile at `<dirname(managedSkillsDir)>/.clawhub/lock.json`.
+  // Reuse the workspace read when the two directories coincide to avoid
+  // reading the same file twice.
+  const managedParentDir = path.dirname(path.resolve(managedSkillsDir));
+  const managedLockRead =
+    managedParentDir === path.resolve(workspaceDir)
+      ? clawhubLockRead
+      : readClawHubSkillsLockfileStatusSync(managedParentDir);
   const skillIndexEntries = buildSkillIndexEntries(skillEntries, {
     bundledNames: bundledContext.names,
     agentSkillFilter,
@@ -385,6 +408,8 @@ export function buildWorkspaceSkillStatus(
         agentSkillFilter,
         workspaceDir,
         clawhubLockRead,
+        managedSkillsDir,
+        managedLockRead,
       }),
     ),
   };

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -252,10 +252,6 @@ type BuildSkillStatusContext = {
   agentSkillFilter?: string[];
   workspaceDir: string;
   clawhubLockRead: ClawHubSkillsLockfileStatusRead;
-  // Directory holding globally-installed (managed) skills, and the lockfile
-  // status for its parent. Globally installed skills are tracked in the
-  // managed lockfile (`<dirname(managedSkillsDir)>/.clawhub/lock.json`), not
-  // the workspace one, so both are needed to resolve their link status.
   managedSkillsDir: string;
   managedLockRead: ClawHubSkillsLockfileStatusRead;
 };
@@ -300,13 +296,9 @@ function buildSkillStatus(
   const availableToAgent = eligible && !blockedByAgentFilter;
   const userInvocable = indexed.userInvocable;
 
-  // Globally managed skills are tracked in the managed lockfile, not the
-  // workspace lockfile. Use the loader-assigned source rather than a lexical
-  // path check: managed skill roots may contain symlinks whose resolved
-  // baseDir sits outside the managedSkillsDir tree. Resolve the link against
-  // the managed parent dir so the expected install dir matches the skill dir.
+  // Source ownership survives canonicalization of symlinked managed installs.
   const isGlobalManagedSkill = !bundled && skillSource === "openclaw-managed";
-  const resolvedLink =
+  const clawhub =
     workspaceDir && !bundled
       ? resolveClawHubSkillStatusLinkSync({
           workspaceDir: isGlobalManagedSkill
@@ -315,23 +307,9 @@ function buildSkillStatus(
           skillDir: entry.skill.baseDir,
           skillKey,
           lockRead: isGlobalManagedSkill ? context.managedLockRead : context.clawhubLockRead,
+          lockfileScope: isGlobalManagedSkill ? "managed" : "workspace",
         })
       : undefined;
-  // resolveClawHubSkillStatusLinkSync names the workspace lockfile in its
-  // diagnostics. A globally-managed skill is tracked by the managed lockfile,
-  // so relabel the scope word in its invalid reason here rather than threading
-  // a scope parameter through the oversized clawhub.ts module (see check:loc
-  // ratchet). Only the five lockfile-scoped reasons contain this substring.
-  const clawhub =
-    resolvedLink && isGlobalManagedSkill && resolvedLink.status === "invalid"
-      ? {
-          ...resolvedLink,
-          reason: resolvedLink.reason.replaceAll(
-            "workspace ClawHub lockfile",
-            "managed ClawHub lockfile",
-          ),
-        }
-      : resolvedLink;
   const skillCard = resolveLocalSkillCardStatusSync(entry.skill.baseDir);
 
   return {
@@ -396,10 +374,7 @@ export function buildWorkspaceSkillStatus(
   const prefs = resolveSkillsInstallPreferences(opts?.config);
   const allowBundled = resolveBundledAllowlist(opts?.config);
   const clawhubLockRead = readClawHubSkillsLockfileStatusSync(workspaceDir);
-  // Globally installed skills live under managedSkillsDir and are tracked in
-  // the managed lockfile at `<dirname(managedSkillsDir)>/.clawhub/lock.json`.
-  // Reuse the workspace read when the two directories coincide to avoid
-  // reading the same file twice.
+  // Global installs are tracked beside managedSkillsDir, never by fallback.
   const managedParentDir = path.dirname(path.resolve(managedSkillsDir));
   const managedLockRead =
     managedParentDir === path.resolve(workspaceDir)

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -737,9 +737,17 @@ export function resolveClawHubSkillStatusLinkSync(params: {
   skillDir: string;
   skillKey: string;
   lockRead?: ClawHubSkillsLockfileStatusRead;
+  /**
+   * Which lockfile scope `lockRead` belongs to. Diagnostics name this scope so a
+   * globally-managed skill (tracked in the managed lockfile) does not get a
+   * misleading "workspace ClawHub lockfile" troubleshooting message. Defaults to
+   * "workspace" for backward compatibility with workspace-scoped callers.
+   */
+  lockfileScope?: "workspace" | "managed";
 }): ClawHubSkillStatusLink | undefined {
   const originRead = readClawHubSkillOriginStatusSync(params.skillDir);
   const lockRead = params.lockRead ?? readClawHubSkillsLockfileStatusSync(params.workspaceDir);
+  const lockfileScopeLabel = params.lockfileScope === "managed" ? "managed" : "workspace";
 
   if (originRead.kind === "missing") {
     let trackedSlug: string;
@@ -755,7 +763,7 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     return {
       status: "invalid",
       valid: false,
-      reason: `Skill "${trackedSlug}" is tracked by the workspace ClawHub lockfile but is missing local ClawHub origin metadata.`,
+      reason: `Skill "${trackedSlug}" is tracked by the ${lockfileScopeLabel} ClawHub lockfile but is missing local ClawHub origin metadata.`,
       slug: trackedSlug,
       installedVersion: locked.version,
       installedAt: locked.installedAt,
@@ -795,7 +803,7 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     return {
       status: "invalid",
       valid: false,
-      reason: `Skill "${trackedSlug}" has ClawHub origin metadata but is not tracked by the workspace ClawHub lockfile.`,
+      reason: `Skill "${trackedSlug}" has ClawHub origin metadata but is not tracked by the ${lockfileScopeLabel} ClawHub lockfile.`,
       registry: originRead.origin.registry,
       slug: trackedSlug,
       installedVersion: originRead.origin.installedVersion,
@@ -807,7 +815,7 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     return {
       status: "invalid",
       valid: false,
-      reason: `Malformed workspace ClawHub lockfile at ${lockRead.path}: ${lockRead.error}`,
+      reason: `Malformed ${lockfileScopeLabel} ClawHub lockfile at ${lockRead.path}: ${lockRead.error}`,
       registry: originRead.origin.registry,
       slug: trackedSlug,
       installedVersion: originRead.origin.installedVersion,
@@ -821,7 +829,7 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     return {
       status: "invalid",
       valid: false,
-      reason: `Skill "${trackedSlug}" has ClawHub origin metadata but is not tracked by the workspace ClawHub lockfile.`,
+      reason: `Skill "${trackedSlug}" has ClawHub origin metadata but is not tracked by the ${lockfileScopeLabel} ClawHub lockfile.`,
       registry: originRead.origin.registry,
       slug: trackedSlug,
       installedVersion: originRead.origin.installedVersion,
@@ -872,7 +880,7 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     return {
       status: "invalid",
       valid: false,
-      reason: `Skill "${trackedSlug}" ClawHub origin metadata does not match the workspace ClawHub lockfile.`,
+      reason: `Skill "${trackedSlug}" ClawHub origin metadata does not match the ${lockfileScopeLabel} ClawHub lockfile.`,
       registry: lockedRegistry,
       slug: trackedSlug,
       installedVersion: originRead.origin.installedVersion,

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -737,10 +737,11 @@ export function resolveClawHubSkillStatusLinkSync(params: {
   skillDir: string;
   skillKey: string;
   lockRead?: ClawHubSkillsLockfileStatusRead;
+  lockfileScope?: "workspace" | "managed";
 }): ClawHubSkillStatusLink | undefined {
   const originRead = readClawHubSkillOriginStatusSync(params.skillDir);
   const lockRead = params.lockRead ?? readClawHubSkillsLockfileStatusSync(params.workspaceDir);
-
+  const lockfileLabel = `${params.lockfileScope ?? "workspace"} ClawHub lockfile`;
   if (originRead.kind === "missing") {
     let trackedSlug: string;
     try {
@@ -755,7 +756,7 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     return {
       status: "invalid",
       valid: false,
-      reason: `Skill "${trackedSlug}" is tracked by the workspace ClawHub lockfile but is missing local ClawHub origin metadata.`,
+      reason: `Skill "${trackedSlug}" is tracked by the ${lockfileLabel} but is missing local ClawHub origin metadata.`,
       slug: trackedSlug,
       installedVersion: locked.version,
       installedAt: locked.installedAt,
@@ -763,7 +764,6 @@ export function resolveClawHubSkillStatusLinkSync(params: {
       lockPath: lockRead.kind === "found" ? lockRead.path : undefined,
     };
   }
-
   if (originRead.kind === "malformed") {
     return {
       status: "invalid",
@@ -795,7 +795,7 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     return {
       status: "invalid",
       valid: false,
-      reason: `Skill "${trackedSlug}" has ClawHub origin metadata but is not tracked by the workspace ClawHub lockfile.`,
+      reason: `Skill "${trackedSlug}" has ClawHub origin metadata but is not tracked by the ${lockfileLabel}.`,
       registry: originRead.origin.registry,
       slug: trackedSlug,
       installedVersion: originRead.origin.installedVersion,
@@ -807,7 +807,7 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     return {
       status: "invalid",
       valid: false,
-      reason: `Malformed workspace ClawHub lockfile at ${lockRead.path}: ${lockRead.error}`,
+      reason: `Malformed ${lockfileLabel} at ${lockRead.path}: ${lockRead.error}`,
       registry: originRead.origin.registry,
       slug: trackedSlug,
       installedVersion: originRead.origin.installedVersion,
@@ -821,7 +821,7 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     return {
       status: "invalid",
       valid: false,
-      reason: `Skill "${trackedSlug}" has ClawHub origin metadata but is not tracked by the workspace ClawHub lockfile.`,
+      reason: `Skill "${trackedSlug}" has ClawHub origin metadata but is not tracked by the ${lockfileLabel}.`,
       registry: originRead.origin.registry,
       slug: trackedSlug,
       installedVersion: originRead.origin.installedVersion,
@@ -872,7 +872,7 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     return {
       status: "invalid",
       valid: false,
-      reason: `Skill "${trackedSlug}" ClawHub origin metadata does not match the workspace ClawHub lockfile.`,
+      reason: `Skill "${trackedSlug}" ClawHub origin metadata does not match the ${lockfileLabel}.`,
       registry: lockedRegistry,
       slug: trackedSlug,
       installedVersion: originRead.origin.installedVersion,

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -737,17 +737,9 @@ export function resolveClawHubSkillStatusLinkSync(params: {
   skillDir: string;
   skillKey: string;
   lockRead?: ClawHubSkillsLockfileStatusRead;
-  /**
-   * Which lockfile scope `lockRead` belongs to. Diagnostics name this scope so a
-   * globally-managed skill (tracked in the managed lockfile) does not get a
-   * misleading "workspace ClawHub lockfile" troubleshooting message. Defaults to
-   * "workspace" for backward compatibility with workspace-scoped callers.
-   */
-  lockfileScope?: "workspace" | "managed";
 }): ClawHubSkillStatusLink | undefined {
   const originRead = readClawHubSkillOriginStatusSync(params.skillDir);
   const lockRead = params.lockRead ?? readClawHubSkillsLockfileStatusSync(params.workspaceDir);
-  const lockfileScopeLabel = params.lockfileScope === "managed" ? "managed" : "workspace";
 
   if (originRead.kind === "missing") {
     let trackedSlug: string;
@@ -763,7 +755,7 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     return {
       status: "invalid",
       valid: false,
-      reason: `Skill "${trackedSlug}" is tracked by the ${lockfileScopeLabel} ClawHub lockfile but is missing local ClawHub origin metadata.`,
+      reason: `Skill "${trackedSlug}" is tracked by the workspace ClawHub lockfile but is missing local ClawHub origin metadata.`,
       slug: trackedSlug,
       installedVersion: locked.version,
       installedAt: locked.installedAt,
@@ -803,7 +795,7 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     return {
       status: "invalid",
       valid: false,
-      reason: `Skill "${trackedSlug}" has ClawHub origin metadata but is not tracked by the ${lockfileScopeLabel} ClawHub lockfile.`,
+      reason: `Skill "${trackedSlug}" has ClawHub origin metadata but is not tracked by the workspace ClawHub lockfile.`,
       registry: originRead.origin.registry,
       slug: trackedSlug,
       installedVersion: originRead.origin.installedVersion,
@@ -815,7 +807,7 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     return {
       status: "invalid",
       valid: false,
-      reason: `Malformed ${lockfileScopeLabel} ClawHub lockfile at ${lockRead.path}: ${lockRead.error}`,
+      reason: `Malformed workspace ClawHub lockfile at ${lockRead.path}: ${lockRead.error}`,
       registry: originRead.origin.registry,
       slug: trackedSlug,
       installedVersion: originRead.origin.installedVersion,
@@ -829,7 +821,7 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     return {
       status: "invalid",
       valid: false,
-      reason: `Skill "${trackedSlug}" has ClawHub origin metadata but is not tracked by the ${lockfileScopeLabel} ClawHub lockfile.`,
+      reason: `Skill "${trackedSlug}" has ClawHub origin metadata but is not tracked by the workspace ClawHub lockfile.`,
       registry: originRead.origin.registry,
       slug: trackedSlug,
       installedVersion: originRead.origin.installedVersion,
@@ -880,7 +872,7 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     return {
       status: "invalid",
       valid: false,
-      reason: `Skill "${trackedSlug}" ClawHub origin metadata does not match the ${lockfileScopeLabel} ClawHub lockfile.`,
+      reason: `Skill "${trackedSlug}" ClawHub origin metadata does not match the workspace ClawHub lockfile.`,
       registry: lockedRegistry,
       slug: trackedSlug,
       installedVersion: originRead.origin.installedVersion,


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

Closes #105530

## What Problem This Solves

Fixes an issue where users who install a ClawHub skill **globally** (`openclaw skills install <slug> --global`, living under the managed dir `~/.openclaw/skills/<slug>` and tracked in the **global** lockfile `~/.openclaw/.clawhub/lock.json`) would see the skill falsely reported as `ClawHub link invalid` in `openclaw skills status` and the Control UI, with the message:

> Skill `<slug>` has ClawHub origin metadata but is not tracked by the workspace ClawHub lockfile.

The skill is in fact correctly installed and tracked - just in the global lockfile, not the workspace one.

## Why This Change Was Made

`buildWorkspaceSkillStatus` read the ClawHub lockfile exclusively from the workspace directory (`readClawHubSkillsLockfileStatusSync(workspaceDir)`) and passed that single read to `resolveClawHubSkillStatusLinkSync` for every non-bundled skill. For a globally-installed skill (`source: "openclaw-managed"`), the tracking entry lives in the **managed** lockfile at `<dirname(managedSkillsDir)>/.clawhub/lock.json`, so the workspace lookup misses it and returns `invalid`.

The fix resolves the link status for `openclaw-managed` skills against the managed lockfile (and the managed parent dir, so the expected-install-dir check matches the skill dir) instead of the workspace lockfile. Workspace-local skills are unchanged. Detection uses the loader-assigned `source` rather than a lexical path check, because managed skill roots may contain symlinks whose resolved `baseDir` sits outside the `managedSkillsDir` tree.

## User Impact

Globally installed ClawHub skills now show as correctly `linked` in `openclaw skills status` and the Control UI skills view, instead of a false `ClawHub link invalid` / "not tracked" warning. Workspace-local skill status is unaffected.

## Evidence

Real behavior proof captured on Windows 10 by running the production `buildWorkspaceSkillStatus` against real on-disk lockfiles (standalone `tsx` repro script run locally; before/after output below). The script creates a managed (global) install - skill dir under `managedSkillsDir` with `.clawhub/origin.json`, plus a global lockfile at `<managedParent>/.clawhub/lock.json` tracking it - and a separate workspace whose own lockfile does **not** track the skill.

BEFORE (unpatched main) - the globally-installed skill is falsely `invalid`, read against the **workspace** lockfile:

```
"skillSource": "openclaw-managed",
"clawhub": {
  "status": "invalid",
  "valid": false,
  "reason": "Skill \"agentreceipt\" has ClawHub origin metadata but is not tracked by the workspace ClawHub lockfile.",
  "slug": "agentreceipt",
  "lockPath": "...\\openclaw-workspace-fYctHw\\.clawhub\\lock.json"
}
```

AFTER (this patch) - the same skill is correctly `linked`, read against the **managed (global)** lockfile:

```
"skillSource": "openclaw-managed",
"clawhub": {
  "status": "linked",
  "valid": true,
  "registry": "https://clawhub.ai",
  "slug": "agentreceipt",
  "installedVersion": "1.2.3",
  "lockPath": "...\\openclaw-managed-83CHpB\\.clawhub\\lock.json"
}
```

Regression tests added in `src/skills/discovery/status.test.ts`:
- links a globally-installed skill via the managed lockfile (asserts `status: "linked"`)
- reports a globally-installed skill as `invalid` when it is absent from the managed lockfile (guards against falsely linking)

Full skill-status suite passes (`pnpm test -- src/skills/discovery/status.test.ts` -> 13 passed, 1 skipped on win32).

## Real Behavior Proof

- Behavior addressed: Globally installed ClawHub skills (`source: "openclaw-managed"`) are falsely reported as `invalid` / "not tracked by the workspace ClawHub lockfile" because `buildWorkspaceSkillStatus` only consults the workspace lockfile.
- Real environment tested: Windows 10, Node v22.22.3, OpenClaw main @ 50e5ffcd25, running the production `buildWorkspaceSkillStatus` function from `src/skills/discovery/status.ts` via `pnpm exec tsx`.
- Exact steps or command run after this patch: a standalone `tsx` script builds a managed/global install (skill dir + `.clawhub/origin.json` + global lockfile tracking the slug) and a separate workspace whose lockfile omits the slug, then calls `buildWorkspaceSkillStatus(workspaceDir, { managedSkillsDir, entries })` and prints the resolved `clawhub` status.
- Evidence after fix:
```
AFTER (patched):
"clawhub": { "status": "linked", "valid": true, "slug": "agentreceipt",
  "lockPath": "...\\openclaw-managed-83CHpB\\.clawhub\\lock.json" }

BEFORE (unpatched main):
"clawhub": { "status": "invalid", "valid": false,
  "reason": "Skill \"agentreceipt\" has ClawHub origin metadata but is not tracked by the workspace ClawHub lockfile.",
  "lockPath": "...\\openclaw-workspace-fYctHw\\.clawhub\\lock.json" }
```
- Observed result after fix: The globally-installed skill resolves to `status: "linked"` against the managed (global) lockfile instead of `invalid` against the workspace lockfile. The `lockPath` in the resolved status now points at the global lockfile.
- What was not tested: End-to-end through a running gateway / live Control UI render; the real `openclaw skills status` CLI against a real `~/.openclaw` home. The proof exercises the real production status function with real on-disk lockfiles, which is the exact code path the CLI and UI consume.

## Human Verification

Verified: the production `buildWorkspaceSkillStatus` code path with real on-disk managed + workspace lockfiles (before/after), scoped `pnpm test` for the skills status suite, `pnpm tsgo` (type check), `pnpm format:check`, scoped `oxlint --type-aware` on the changed files. Not verified: Swift (skipped on Windows), full `pnpm test` suite, live Control UI rendering. Note: local `pnpm build` (tsdown) hit a V8 out-of-memory crash on this Windows machine (a known low-memory local-env quirk, unrelated to this 3-line logic change); relying on CI's build check on a properly-sized runner.

## Security Impact

- Does this change authentication, authorization, or trust boundaries? No.
- Does this change credential, secret, or token handling? No.
- Does this change sandboxing or process isolation? No.
- Does this change network boundaries or external API calls? No.
- Does this introduce a new trust boundary or change an existing one? No.

No CODEOWNERS secops paths are touched (`src/skills/` is not secops-owned). The change only affects which local lockfile is consulted for a status display.

## Compatibility / Migration

No config, API, CLI, or lockfile-format changes. The set of inputs/outputs of `buildWorkspaceSkillStatus` is unchanged; only the accuracy of the `clawhub` status for globally-installed skills improves. No migration required.

## Failure Recovery

If the managed lockfile read regresses, globally-installed skills would revert to the prior `invalid` / "not tracked" display behavior - a cosmetic status misreport, not a crash or data loss. The change is read-only with respect to lockfiles (no writes), so there is no risk of lockfile corruption. Reverting the commit fully restores prior behavior.

## Risks and Mitigations

- **Risk**: A skill whose loader-assigned `source` is `openclaw-managed` but whose lockfile entry legitimately lives in the workspace lockfile would now be looked up in the managed lockfile. **Mitigation**: managed skills are, by definition, installed under `managedSkillsDir` and tracked in the managed lockfile; workspace-local skills use other `source` values and are unaffected. Added a regression test for the "absent from managed lockfile" case to ensure such a skill still reports `invalid` rather than falsely `linked`.
- **Risk**: Competing/sibling PR on the same issue. **Mitigation**: this PR supplies the real-behavior-proof (real production-function output with real on-disk lockfiles, before/after) that the issue's proof gate requires, rather than a screenshot.

## Review Conversations

- [x] I will respond to review comments in the review conversation where they were left.
- [x] I understand review conversations belong to the reviewer and I should not resolve them myself unless requested.
