### PR TITLE
fix(plugins): allow user-installed and generated plugins to use api.runtime.state

### DIFF
--- a/src/plugins/registry-runtime-state-gate.test.ts
+++ b/src/plugins/registry-runtime-state-gate.test.ts
@@ -1,0 +1,68 @@
+// Regression test: plugins the user installed themselves (global/workspace
+// origins) — including plugins generated locally by OpenClaw's plugin-generation
+// flow — must be able to use api.runtime.state (openKeyedStore /
+// openSyncKeyedStore / openChannelIngressQueue). Previously the trust gate only
+// permitted `origin === "bundled"` or `trustedOfficialInstall === true`, which
+// blocked every user-installed/generated plugin and crashed their register().
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginRecord } from "./loader-records.js";
+import type { PluginOrigin } from "./plugin-origin.types.js";
+import { createPluginRegistry } from "./registry.js";
+import { createPluginRuntime } from "./runtime/index.js";
+
+vi.mock("../plugin-state/plugin-state-store.js", () => ({
+  createPluginStateKeyedStore: vi.fn(() => ({ kind: "keyed" })),
+  createPluginStateSyncKeyedStore: vi.fn(() => ({ kind: "sync-keyed" })),
+}));
+
+function buildApiForOrigin(origin: PluginOrigin, trustedOfficialInstall = false) {
+  const pluginRoot = path.join(os.tmpdir(), "openclaw-plugins", `state-gate-${origin}`);
+  const registry = createPluginRegistry({
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+    runtime: createPluginRuntime(),
+    activateGlobalSideEffects: false,
+  });
+  const record = createPluginRecord({
+    id: "state-plugin",
+    name: "State Plugin",
+    source: path.join(pluginRoot, "index.js"),
+    rootDir: pluginRoot,
+    origin,
+    trustedOfficialInstall,
+    enabled: true,
+    configSchema: false,
+  });
+  return registry.createApi(record, { config: {} as OpenClawConfig });
+}
+
+const openStore = (api: ReturnType<typeof buildApiForOrigin>) =>
+  api.runtime.state.openSyncKeyedStore({
+    namespace: "demo",
+    maxEntries: 10,
+    overflowPolicy: "reject-new",
+  });
+
+describe("plugin runtime state trust gate", () => {
+  it("allows user-installed (global) plugins to use api.runtime.state", () => {
+    const api = buildApiForOrigin("global");
+    expect(() => openStore(api)).not.toThrow();
+  });
+
+  it("allows user-installed (workspace) plugins to use api.runtime.state", () => {
+    const api = buildApiForOrigin("workspace");
+    expect(() => openStore(api)).not.toThrow();
+  });
+
+  it("still allows bundled plugins", () => {
+    const api = buildApiForOrigin("bundled");
+    expect(() => openStore(api)).not.toThrow();
+  });
+
+  it("still allows trusted official installs", () => {
+    const api = buildApiForOrigin("global", true);
+    expect(() => openStore(api)).not.toThrow();
+  });
+});

--- a/src/plugins/registry-runtime.ts
+++ b/src/plugins/registry-runtime.ts
@@ -466,7 +466,17 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
             const record =
               pluginRuntimeRecordById.get(pluginId) ??
               registry.plugins.find((entry) => entry.id === pluginId);
-            if (record?.origin !== "bundled" && record?.trustedOfficialInstall !== true) {
+            // `state` (openKeyedStore/openSyncKeyedStore/openChannelIngressQueue) is
+            // namespaced per-plugin persistent storage. It is safe for bundled plugins,
+            // official @openclaw installs, and plugins the user installed themselves
+            // (global/workspace origins) — including plugins generated locally by
+            // OpenClaw's own plugin-generation flow, which run the user's own code.
+            const trusted =
+              record?.origin === "bundled" ||
+              record?.trustedOfficialInstall === true ||
+              record?.origin === "global" ||
+              record?.origin === "workspace";
+            if (!trusted) {
               throw new Error(
                 "openKeyedStore is only available for trusted plugins in this release.",
               );


### PR DESCRIPTION
## Summary
- The \`state\` proxy in \`src/plugins/registry-runtime.ts\` only trusted plugins with \`origin === "bundled"\` or \`trustedOfficialInstall === true\`.
- Plugins installed by the user (global/workspace origins) — including plugins generated locally via OpenClaw's plugin-generation flow — were blocked from \`api.runtime.state\` (openKeyedStore / openSyncKeyedStore / openChannelIngressQueue).
- This caused \`register()\` to crash for such plugins (observed as \`api.runtime.state is undefined\` on \`2026.7.1-beta.5\`, and a thrown "only available for trusted plugins in this release." on newer builds).
- Extend the trust gate to also allow \`global\` and \`workspace\` origins. \`state\` is namespaced per-plugin persistent storage, so this is safe for the user's own explicitly-installed code.

## Root cause
\`assertPluginStateAllowed()\` in the \`state\` getter rejected any plugin whose record was neither \`bundled\` nor a trusted official install. A locally-generated \`@openclaw/codex\` plugin (origin \`global\`, installed under \`~/.openclaw/npm/projects/...\`) hit this and crashed on register.

## Test plan
- Added \`src/plugins/registry-runtime-state-gate.test.ts\` asserting that \`api.runtime.state.openSyncKeyedStore(...)\` does not throw for \`global\`, \`workspace\`, \`bundled\`, and trusted-official origins.
- All 4 new tests pass; neighboring \`registry.runtime-config.test.ts\` still passes.

## Notes for review
- This broadens the trust boundary to all user-installed plugins. \`openKeyedStore\`/\`openSyncKeyedStore\` are per-plugin-namespaced, so the blast radius is the plugin's own state. If maintainers prefer a narrower gate (e.g. only plugins generated by OpenClaw, or a separate \`userTrusted\` flag), I can adjust.
- Affects \`2026.7.1-beta.5\` and later; a backport to the \`2026.7.1\` release line may be warranted.