### PR TITLE
fix(mac): remote nodes stay stuck in lifecycle transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS remote node readiness:** take the main-session key from the node hello snapshot instead of opening an operator connection during node admission, preventing remote tunnel recovery from leaving Computer Use and node exec stuck in lifecycle transition.
 - **Claude CLI context budgets:** honor Anthropic model and per-agent `contextTokens` limits by passing the effective limit to Claude Code's native auto-compactor and persisting the same prepared budget in OpenClaw session state. Fixes #80933. (#93198) Thanks @mushuiyu886.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.
 - **Gateway source watch:** hand the configured port off from the installed service before starting the tmux watcher, preserve failed panes for attach/capture, and keep explicit alternate-port watches side by side with the managed Gateway.

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -1300,6 +1300,10 @@ extension GatewayConnection {
         if let cached = cachedMainSessionKey() {
             return cached
         }
+        return await self.refreshMainSessionKey(timeoutMs: timeoutMs)
+    }
+
+    func refreshMainSessionKey(timeoutMs: Double = 15000) async -> String {
         do {
             let data = try await requestRaw(method: "config.get", params: nil, timeoutMs: timeoutMs)
             return try Self.mainSessionKey(fromConfigGetData: data)

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -58,6 +58,7 @@ final class MacNodeModeCoordinator: NSObject {
         let config: GatewayConnection.Config
         let options: GatewayConnectOptions
         let sessionBox: WebSocketSessionBox?
+        let fallbackMainSessionKey: String
     }
 
     static let shared = MacNodeModeCoordinator()
@@ -564,6 +565,9 @@ final class MacNodeModeCoordinator: NSObject {
             url: config.url,
             connectionMode: AppStateStore.shared.connectionMode)
 
+        // Resolve compatibility fallback before node admission. Operator recovery
+        // here cannot block the node lifecycle callback or its successor cleanup.
+        let fallbackMainSessionKey = await GatewayConnection.shared.refreshMainSessionKey()
         let currentConfig = try await GatewayEndpointStore.shared.requireConfig()
         guard Self.endpointAttemptCanConnect(
             capturedGeneration: endpointGeneration,
@@ -588,7 +592,8 @@ final class MacNodeModeCoordinator: NSObject {
                 MacNodeClaudeSessionCatalogContract.listCommand),
             config: config,
             options: options,
-            sessionBox: sessionBox)
+            sessionBox: sessionBox,
+            fallbackMainSessionKey: fallbackMainSessionKey)
     }
 
     private func connect(_ attempt: ConnectionAttempt) async throws {
@@ -613,11 +618,15 @@ final class MacNodeModeCoordinator: NSObject {
                 await self.nodeHostWorker?.publishInventory(ifCurrentRoute: installedRoute)
                 await self.cancelReconnectProbe()
                 self.logger.info("mac node connected to gateway")
-                let mainSessionKey = await GatewayConnection.shared.mainSessionKey()
-                await self.runtime.updateMainSessionKey(mainSessionKey)
+                // The node hello owns this route's session defaults. Reusing the operator
+                // connection here can trigger remote-tunnel recovery while the node connects.
+                let snapshotMainSessionKey = await self.session.waitForCurrentMainSessionKey(
+                    ifCurrentRoute: installedRoute)
+                let mainSessionKey = snapshotMainSessionKey ?? attempt.fallbackMainSessionKey
                 let routeStillAuthoritative = await self.routeAuthorityAllowsInvoke(attempt.routeAuthorityGeneration)
                 let currentRoute = await self.session.currentRoute()
                 guard routeStillAuthoritative, currentRoute == installedRoute else { return }
+                await self.runtime.updateMainSessionKey(mainSessionKey)
                 await self.presenceReporter.start { [weak self] event, payload in
                     guard let self else { return false }
                     return await self.session.sendEvent(

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -170,7 +170,9 @@ public actor GatewayNodeSession {
     private var snapshotReceived = false
     private var serverMethods: Set<String>?
     private var serverCapabilities: Set<GatewayServerCapability>?
+    private var mainSessionKey: String?
     private var snapshotWaiters: [CheckedContinuation<Bool, Never>] = []
+    private var snapshotReadyWaiters: [CheckedContinuation<Bool, Never>] = []
     // `computer.act` is not safe to repeat after a response is lost. Keep recent
     // in-flight/results on the long-lived node session so a channel reconnect can
     // replay the receipt without posting input twice. App restart intentionally
@@ -656,6 +658,24 @@ public actor GatewayNodeSession {
         return serverMethods.contains(method)
     }
 
+    public func currentMainSessionKey(
+        ifCurrentRoute expectedRoute: GatewayNodeSessionRoute) -> String?
+    {
+        guard self.isCurrentRoute(expectedRoute), self.channel != nil else { return nil }
+        return self.mainSessionKey
+    }
+
+    public func waitForCurrentMainSessionKey(
+        ifCurrentRoute expectedRoute: GatewayNodeSessionRoute) async -> String?
+    {
+        guard self.isCurrentRoute(expectedRoute), self.channel != nil else { return nil }
+        if !self.snapshotReceived {
+            guard await self.waitForSnapshot() else { return nil }
+        }
+        guard self.isCurrentRoute(expectedRoute), self.channel != nil else { return nil }
+        return self.mainSessionKey
+    }
+
     @discardableResult
     public func sendEvent(
         event: String,
@@ -764,6 +784,10 @@ extension GatewayNodeSession {
             self.serverMethods = ok.advertisedServerMethods()
             self.serverCapabilities = Set(
                 GatewayServerCapability.allCases.filter { ok.supportsServerCapability($0) })
+            let snapshotMainSessionKey = ok.snapshot.sessiondefaults?["mainSessionKey"]?.value as? String
+            let trimmedMainSessionKey = snapshotMainSessionKey?
+                .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) ?? ""
+            self.mainSessionKey = trimmedMainSessionKey.isEmpty ? nil : trimmedMainSessionKey
             if self.hasEverConnected {
                 self.broadcastServerEvent(
                     EventFrame(type: "event", event: "seqGap", payload: nil, seq: nil, stateversion: nil))
@@ -790,7 +814,9 @@ extension GatewayNodeSession {
         self.snapshotReceived = false
         self.serverMethods = nil
         self.serverCapabilities = nil
+        self.mainSessionKey = nil
         self.drainSnapshotWaiters(returning: false)
+        self.drainSnapshotReadyWaiters(returning: false)
     }
 
     private func handleChannelDisconnected(
@@ -832,6 +858,7 @@ extension GatewayNodeSession {
     private func markSnapshotReceived() {
         self.snapshotReceived = true
         self.drainSnapshotWaiters(returning: true)
+        self.drainSnapshotReadyWaiters(returning: true)
     }
 
     private func waitForSnapshot(timeoutMs: Int) async -> Bool {
@@ -849,6 +876,15 @@ extension GatewayNodeSession {
         }
     }
 
+    private func waitForSnapshot() async -> Bool {
+        if self.snapshotReceived {
+            return true
+        }
+        return await withCheckedContinuation { cont in
+            self.snapshotReadyWaiters.append(cont)
+        }
+    }
+
     private func timeoutSnapshotWaiters() {
         guard !self.snapshotReceived else { return }
         self.drainSnapshotWaiters(returning: false)
@@ -858,6 +894,16 @@ extension GatewayNodeSession {
         if !self.snapshotWaiters.isEmpty {
             let waiters = self.snapshotWaiters
             self.snapshotWaiters.removeAll()
+            for waiter in waiters {
+                waiter.resume(returning: value)
+            }
+        }
+    }
+
+    private func drainSnapshotReadyWaiters(returning value: Bool) {
+        if !self.snapshotReadyWaiters.isEmpty {
+            let waiters = self.snapshotReadyWaiters
+            self.snapshotReadyWaiters.removeAll()
             for waiter in waiters {
                 waiter.resume(returning: value)
             }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -24,6 +24,18 @@ private final class InvokeCancellationFlag: @unchecked Sendable {
     }
 }
 
+private actor StringCapture {
+    private var value: String?
+
+    func set(_ value: String?) {
+        self.value = value
+    }
+
+    func get() -> String? {
+        self.value
+    }
+}
+
 private final class DoubleCallbackPingWebSocketTask: WebSocketTasking, @unchecked Sendable {
     private let callbacks: [Error?]
 
@@ -101,6 +113,8 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
     private let lock = NSLock()
     private let helloAuth: [String: Any]?
     private let helloMethods: [String]
+    private let helloSessionDefaults: [String: Any]?
+    private let helloDelayNanoseconds: UInt64
     private let connectError: [String: Any]?
     private let cancelGate: FirstCancelGate?
     private var _state: URLSessionTask.State = .suspended
@@ -116,11 +130,15 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
     init(
         helloAuth: [String: Any]? = nil,
         helloMethods: [String] = [],
+        helloSessionDefaults: [String: Any]? = nil,
+        helloDelayNanoseconds: UInt64 = 0,
         connectError: [String: Any]? = nil,
         cancelGate: FirstCancelGate? = nil)
     {
         self.helloAuth = helloAuth
         self.helloMethods = helloMethods
+        self.helloSessionDefaults = helloSessionDefaults
+        self.helloDelayNanoseconds = helloDelayNanoseconds
         self.connectError = connectError
         self.cancelGate = cancelGate
     }
@@ -210,6 +228,9 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
         if phase == 0 {
             return .data(Self.connectChallengeData(nonce: "nonce-1"))
         }
+        if self.helloDelayNanoseconds > 0 {
+            try await Task.sleep(nanoseconds: self.helloDelayNanoseconds)
+        }
         for _ in 0..<50 {
             let id = self.lock.withLock { self.connectRequestId }
             if let id {
@@ -219,7 +240,8 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
                 return .data(Self.connectOkData(
                     id: id,
                     auth: self.helloAuth,
-                    methods: self.helloMethods))
+                    methods: self.helloMethods,
+                    sessionDefaults: self.helloSessionDefaults))
             }
             try await Task.sleep(nanoseconds: 1_000_000)
         }
@@ -229,7 +251,8 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
         return .data(Self.connectOkData(
             id: "connect",
             auth: self.helloAuth,
-            methods: self.helloMethods))
+            methods: self.helloMethods,
+            sessionDefaults: self.helloSessionDefaults))
     }
 
     func receive(
@@ -290,7 +313,8 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
     private static func connectOkData(
         id: String,
         auth: [String: Any]? = nil,
-        methods: [String] = []) -> Data
+        methods: [String] = [],
+        sessionDefaults: [String: Any]? = nil) -> Data
     {
         var payload: [String: Any] = [
             "type": "hello-ok",
@@ -321,6 +345,18 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
         ]
         if let auth {
             payload["auth"] = auth
+        }
+        if let sessionDefaults {
+            payload["snapshot"] = [
+                "presence": [["ts": 1]],
+                "health": [:],
+                "stateVersion": [
+                    "presence": 0,
+                    "health": 0,
+                ],
+                "uptimeMs": 0,
+                "sessionDefaults": sessionDefaults,
+            ]
         }
         let frame: [String: Any] = [
             "type": "res",
@@ -369,6 +405,8 @@ private final class FakeGatewayWebSocketSession: WebSocketSessioning, @unchecked
     private let lock = NSLock()
     private let helloAuth: [String: Any]?
     private let helloMethods: [String]
+    private let helloSessionDefaults: [String: Any]?
+    private let helloDelayNanoseconds: UInt64
     private let connectError: [String: Any]?
     private let cancelGate: FirstCancelGate?
     private var tasks: [FakeGatewayWebSocketTask] = []
@@ -378,11 +416,15 @@ private final class FakeGatewayWebSocketSession: WebSocketSessioning, @unchecked
     init(
         helloAuth: [String: Any]? = nil,
         helloMethods: [String] = [],
+        helloSessionDefaults: [String: Any]? = nil,
+        helloDelayNanoseconds: UInt64 = 0,
         connectError: [String: Any]? = nil,
         cancelGate: FirstCancelGate? = nil)
     {
         self.helloAuth = helloAuth
         self.helloMethods = helloMethods
+        self.helloSessionDefaults = helloSessionDefaults
+        self.helloDelayNanoseconds = helloDelayNanoseconds
         self.connectError = connectError
         self.cancelGate = cancelGate
     }
@@ -410,6 +452,8 @@ private final class FakeGatewayWebSocketSession: WebSocketSessioning, @unchecked
             let task = FakeGatewayWebSocketTask(
                 helloAuth: self.helloAuth,
                 helloMethods: self.helloMethods,
+                helloSessionDefaults: self.helloSessionDefaults,
+                helloDelayNanoseconds: self.helloDelayNanoseconds,
                 connectError: self.connectError,
                 cancelGate: self.cancelGate)
             self.tasks.append(task)
@@ -3012,6 +3056,51 @@ struct GatewayNodeSessionTests {
         var iterator = stream.makeAsyncIterator()
         let event = await iterator.next()
         #expect(event?.event == "target")
+    }
+
+    @Test
+    func `main session key follows the current node snapshot route`() async throws {
+        let session = FakeGatewayWebSocketSession(
+            helloSessionDefaults: ["mainSessionKey": " agent:main:main "],
+            helloDelayNanoseconds: 750_000_000)
+        let gateway = GatewayNodeSession()
+        let capturedMainSessionKey = StringCapture()
+        let options = GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: [],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-macos",
+            clientMode: "node",
+            clientDisplayName: "macOS Test",
+            includeDeviceIdentity: false)
+
+        try await gateway.connect(
+            url: #require(URL(string: "ws://example.invalid")),
+            credentials: .init(),
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: session),
+            onConnected: {
+                let route = await gateway.currentRoute()
+                let key: String? = if let route {
+                    await gateway.waitForCurrentMainSessionKey(ifCurrentRoute: route)
+                } else {
+                    nil
+                }
+                await capturedMainSessionKey.set(key)
+            },
+            onDisconnected: { _ in },
+            onInvoke: { req in
+                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
+            })
+
+        let route = try #require(await gateway.currentRoute())
+        #expect(await capturedMainSessionKey.get() == "agent:main:main")
+        #expect(await gateway.currentMainSessionKey(ifCurrentRoute: route) == "agent:main:main")
+
+        await gateway.disconnect()
+        #expect(await gateway.currentMainSessionKey(ifCurrentRoute: route) == nil)
     }
 
     @Test


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running the macOS app as a remote node could see the node connected while Computer Use and node exec stayed unavailable with `node lifecycle transition in progress`.

## Why This Change Was Made

Node admission now takes the main-session key from the route-bound hello snapshot. A forced current-endpoint compatibility fallback is prepared before node admission, so operator tunnel recovery cannot suspend the connected lifecycle callback. Snapshot waits are isolated from stale bounded-timeout tasks and remain bound to the installed route.

## User Impact

Remote Mac nodes become ready for Computer Use and exec after connecting, including after delayed hello delivery and automatic reconnects. Older gateways that omit session defaults retain global-session behavior.

## Evidence

- `swift test --package-path apps/shared/OpenClawKit --filter GatewayNodeSessionTests` — 57 passed, including a delayed-hello route-bound session-key regression test.
- `swift test --package-path apps/macos --filter MacNodeModeCoordinatorTests` — 26 passed.
- `swift test --package-path apps/macos --filter WebChatMainSessionKeyTests` — 5 passed, including global scope.
- `./scripts/format-swift.sh` — clean.
- `git diff --check` — clean.
- Structured autoreview — no actionable findings.

Before: exact-node exec on MegaClaw remained connected but returned `UNAVAILABLE: node lifecycle transition in progress` after an app restart and reconnect.

Agent transcript omitted: this task contains mixed private fleet and account operations unrelated to the public patch.
