### PR TITLE
fix(browser): snapshots fail when managed proxy is enabled

### DIFF
--- a/extensions/browser/src/browser/chrome.diagnostics.ts
+++ b/extensions/browser/src/browser/chrome.diagnostics.ts
@@ -20,7 +20,6 @@ import {
   openCdpWebSocket,
   redactCdpUrl,
   scopeCdpPolicyToConfiguredEndpoint,
-  stripCdpUrlCredentials,
 } from "./cdp.helpers.js";
 import { normalizeCdpWsUrl } from "./cdp.js";
 import { BrowserCdpEndpointBlockedError } from "./errors.js";
@@ -127,18 +126,15 @@ async function readChromeVersion(
   }
 }
 
-/** Preserve authenticated providers that expose only Playwright's trailing-slash route. */
-export async function readChromeVersionWithCredentialFallback(
+/** Preserve providers that expose only Playwright's trailing-slash discovery route. */
+export async function readChromeVersionWithPathFallback(
   cdpUrl: string,
   timeoutMs = CHROME_REACHABILITY_TIMEOUT_MS,
   ssrfPolicy?: SsrFPolicy,
 ): Promise<ChromeVersion> {
   try {
     const primaryVersion = await readChromeVersion(cdpUrl, timeoutMs, ssrfPolicy);
-    if (
-      normalizeOptionalString(primaryVersion.webSocketDebuggerUrl) ||
-      stripCdpUrlCredentials(cdpUrl) === cdpUrl
-    ) {
+    if (normalizeOptionalString(primaryVersion.webSocketDebuggerUrl)) {
       return primaryVersion;
     }
     try {
@@ -147,9 +143,6 @@ export async function readChromeVersionWithCredentialFallback(
       return primaryVersion;
     }
   } catch (primaryError) {
-    if (stripCdpUrlCredentials(cdpUrl) === cdpUrl) {
-      throw primaryError;
-    }
     try {
       return await readChromeVersion(cdpUrl, timeoutMs, ssrfPolicy, "/json/version/");
     } catch {
@@ -399,11 +392,7 @@ export async function diagnoseChromeCdp(
     : cdpUrl;
   let version: ChromeVersion;
   try {
-    version = await readChromeVersionWithCredentialFallback(
-      discoveryUrl,
-      timeoutMs,
-      cdpControlPolicy,
-    );
+    version = await readChromeVersionWithPathFallback(discoveryUrl, timeoutMs, cdpControlPolicy);
   } catch (err) {
     if (isWebSocketUrl(cdpUrl)) {
       return await diagnoseCdpWebSocketEndpoint({

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -55,7 +55,7 @@ import {
   diagnoseChromeCdp,
   formatChromeCdpDiagnostic,
   type ChromeVersion,
-  readChromeVersionWithCredentialFallback,
+  readChromeVersionWithPathFallback,
   safeChromeCdpErrorMessage,
 } from "./chrome.diagnostics.js";
 import {
@@ -902,7 +902,7 @@ async function fetchChromeVersion(
   ssrfPolicy?: SsrFPolicy,
 ): Promise<ChromeVersion | null> {
   try {
-    return await readChromeVersionWithCredentialFallback(cdpUrl, timeoutMs, ssrfPolicy);
+    return await readChromeVersionWithPathFallback(cdpUrl, timeoutMs, ssrfPolicy);
   } catch {
     return null;
   }
@@ -1006,8 +1006,8 @@ export async function launchOpenClawChrome(
   }
 
   // Surface `loopbackMode=block` before spawning Chrome. The CDP fetch and
-  // WebSocket helpers install exact-URL bypasses for `/json/version` and
-  // `ws://.../devtools/...`.
+  // WebSocket helpers install exact-URL bypasses for each discovery route and
+  // WebSocket endpoint.
   try {
     assertManagedProxyAllowsCdpUrl(profile.cdpUrl);
   } catch (err) {

--- a/extensions/browser/src/browser/pw-ai.e2e.test.ts
+++ b/extensions/browser/src/browser/pw-ai.e2e.test.ts
@@ -1,6 +1,7 @@
 // Browser tests cover pw ai plugin behavior.
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { connectOverCdpMock, getChromeWebSocketUrlMock } from "./pw-session.mock-setup.js";
+import { toTestCdpWebSocketUrl } from "./pw-session.test-support.js";
 
 type FakeSession = {
   send: ReturnType<typeof vi.fn>;
@@ -57,7 +58,9 @@ let clickViaPlaywright: typeof import("./pw-tools-core.interactions.js").clickVi
 let closePlaywrightBrowserConnection: typeof import("./pw-session.js").closePlaywrightBrowserConnection;
 
 beforeAll(async () => {
-  getChromeWebSocketUrlMock.mockResolvedValue(null);
+  getChromeWebSocketUrlMock.mockImplementation(async (cdpUrl: unknown) =>
+    toTestCdpWebSocketUrl(String(cdpUrl)),
+  );
   ({ snapshotAiViaPlaywright } = await import("./pw-tools-core.snapshot.js"));
   ({ clickViaPlaywright } = await import("./pw-tools-core.interactions.js"));
   ({ closePlaywrightBrowserConnection } = await import("./pw-session.js"));

--- a/extensions/browser/src/browser/pw-session.connections.test.ts
+++ b/extensions/browser/src/browser/pw-session.connections.test.ts
@@ -1,8 +1,9 @@
 // Browser tests cover pw session.connections plugin behavior.
 import { chromium } from "playwright-core";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as chromeModule from "./chrome.js";
 import { pwAi } from "./pw-ai.js";
+import { toTestCdpWebSocketUrl } from "./pw-session.test-support.js";
 
 const {
   closePlaywrightBrowserConnection,
@@ -161,6 +162,10 @@ function makeMutatingDisconnectBrowser(): BrowserMockBundle & {
   return { browser, browserClose, newPage };
 }
 
+beforeEach(() => {
+  getChromeWebSocketUrlSpy.mockImplementation(async (cdpUrl) => toTestCdpWebSocketUrl(cdpUrl));
+});
+
 afterEach(async () => {
   connectOverCdpSpy.mockReset();
   getChromeWebSocketUrlSpy.mockReset();
@@ -175,7 +180,6 @@ describe("pw-session connection scoping", () => {
     const token = "browser-token";
     const cdpUrl = `wss://${username}:${password}@browserless.example/devtools/browser/id?token=${token}`;
     connectOverCdpSpy.mockRejectedValue(new Error(`connect failed for ${cdpUrl}`));
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     let message = "";
     try {
@@ -214,7 +218,6 @@ describe("pw-session connection scoping", () => {
   it("allows loopback CDP control without widening the navigation allowlist", async () => {
     const browser = makeBrowser("A", "https://example.com");
     connectOverCdpSpy.mockResolvedValue(browser.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
     const ssrfPolicy = {
       dangerouslyAllowPrivateNetwork: true,
       allowedHostnames: ["example.com"],
@@ -240,17 +243,16 @@ describe("pw-session connection scoping", () => {
 
     connectOverCdpSpy.mockImplementation((async (...args: unknown[]) => {
       const endpointText = String(args[0]);
-      if (endpointText === "http://127.0.0.1:9222") {
+      if (endpointText === toTestCdpWebSocketUrl("http://127.0.0.1:9222")) {
         return await new Promise<import("playwright-core").Browser>((resolve) => {
           resolveA = resolve;
         });
       }
-      if (endpointText === "http://127.0.0.1:9333") {
+      if (endpointText === toTestCdpWebSocketUrl("http://127.0.0.1:9333")) {
         return browserB.browser;
       }
       throw new Error(`unexpected endpoint: ${endpointText}`);
     }) as never);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     const pendingA = listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
     await Promise.resolve();
@@ -259,14 +261,22 @@ describe("pw-session connection scoping", () => {
     await vi.waitFor(() => {
       expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
     });
-    expect(connectOverCdpSpy).toHaveBeenNthCalledWith(1, "http://127.0.0.1:9222", {
-      timeout: 5000,
-      headers: {},
-    });
-    expect(connectOverCdpSpy).toHaveBeenNthCalledWith(2, "http://127.0.0.1:9333", {
-      timeout: 5000,
-      headers: {},
-    });
+    expect(connectOverCdpSpy).toHaveBeenNthCalledWith(
+      1,
+      toTestCdpWebSocketUrl("http://127.0.0.1:9222"),
+      {
+        timeout: 5000,
+        headers: {},
+      },
+    );
+    expect(connectOverCdpSpy).toHaveBeenNthCalledWith(
+      2,
+      toTestCdpWebSocketUrl("http://127.0.0.1:9333"),
+      {
+        timeout: 5000,
+        headers: {},
+      },
+    );
 
     resolveA?.(browserA.browser);
     const [pagesA, pagesB] = await Promise.all([pendingA, pendingB]);
@@ -280,15 +290,14 @@ describe("pw-session connection scoping", () => {
 
     connectOverCdpSpy.mockImplementation((async (...args: unknown[]) => {
       const endpointText = String(args[0]);
-      if (endpointText === "http://127.0.0.1:9222") {
+      if (endpointText === toTestCdpWebSocketUrl("http://127.0.0.1:9222")) {
         return browserA.browser;
       }
-      if (endpointText === "http://127.0.0.1:9333") {
+      if (endpointText === toTestCdpWebSocketUrl("http://127.0.0.1:9333")) {
         return browserB.browser;
       }
       throw new Error(`unexpected endpoint: ${endpointText}`);
     }) as never);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9333" });
@@ -308,7 +317,6 @@ describe("pw-session connection scoping", () => {
           resolveConnect = resolve;
         }),
     );
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     const listing = listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
     await vi.waitFor(() => expect(connectOverCdpSpy).toHaveBeenCalledOnce());
@@ -333,7 +341,6 @@ describe("pw-session connection scoping", () => {
       .mockRejectedValueOnce(new Error("disconnect failed"))
       .mockResolvedValue(undefined);
     connectOverCdpSpy.mockResolvedValue(browser.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
     await expect(
@@ -355,7 +362,6 @@ describe("pw-session connection scoping", () => {
     first.browserClose.mockReturnValue(closeGate);
     const second = makeBrowser("B", "https://b.example");
     connectOverCdpSpy.mockResolvedValueOnce(first.browser).mockResolvedValueOnce(second.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
     expect(retirePlaywrightBrowserConnection({ cdpUrl: "http://127.0.0.1:9222" })).toBe(true);
@@ -376,7 +382,6 @@ describe("pw-session connection scoping", () => {
     first.browserClose.mockReturnValue(closeGate);
     const successor = makeBrowser("B", "https://b.example");
     connectOverCdpSpy.mockResolvedValueOnce(first.browser).mockResolvedValueOnce(successor.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
     const retirement = retirePlaywrightBrowserConnectionExact({
@@ -398,7 +403,6 @@ describe("pw-session connection scoping", () => {
     const first = makeBrowser("A", "https://a.example");
     const late = makeBrowser("B", "https://b.example");
     connectOverCdpSpy.mockResolvedValueOnce(first.browser).mockResolvedValueOnce(late.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
     const retirement = retirePlaywrightBrowserConnectionExact({
@@ -424,7 +428,6 @@ describe("pw-session connection scoping", () => {
     });
     browser.browserClose.mockReturnValue(closeGate);
     connectOverCdpSpy.mockResolvedValue(browser.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
     const closing = closePlaywrightBrowserConnection({ cdpUrl: "http://127.0.0.1:9222" });
@@ -446,16 +449,15 @@ describe("pw-session connection scoping", () => {
 
     connectOverCdpSpy.mockImplementation((async (...args: unknown[]) => {
       const endpointText = String(args[0]);
-      if (endpointText === "http://127.0.0.1:9222") {
+      if (endpointText === toTestCdpWebSocketUrl("http://127.0.0.1:9222")) {
         callsForA += 1;
         return callsForA === 1 ? staleA.browser : refreshedA.browser;
       }
-      if (endpointText === "http://127.0.0.1:9333") {
+      if (endpointText === toTestCdpWebSocketUrl("http://127.0.0.1:9333")) {
         return browserB.browser;
       }
       throw new Error(`unexpected endpoint: ${endpointText}`);
     }) as never);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9333" });
@@ -478,13 +480,12 @@ describe("pw-session connection scoping", () => {
 
     connectOverCdpSpy.mockImplementation((async (...args: unknown[]) => {
       const endpointText = String(args[0]);
-      if (endpointText !== "http://127.0.0.1:9222") {
+      if (endpointText !== toTestCdpWebSocketUrl("http://127.0.0.1:9222")) {
         throw new Error(`unexpected endpoint: ${endpointText}`);
       }
       connectCalls += 1;
       return connectCalls === 1 ? stale.browser : refreshed.browser;
     }) as never);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     const pages = await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
@@ -501,13 +502,12 @@ describe("pw-session connection scoping", () => {
 
     connectOverCdpSpy.mockImplementation((async (...args: unknown[]) => {
       const endpointText = String(args[0]);
-      if (endpointText !== "http://127.0.0.1:9222") {
+      if (endpointText !== toTestCdpWebSocketUrl("http://127.0.0.1:9222")) {
         throw new Error(`unexpected endpoint: ${endpointText}`);
       }
       connectCalls += 1;
       return connectCalls === 1 ? stuck.browser : refreshed.browser;
     }) as never);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     await expect(
       listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222", timeoutMs: 20 }),
@@ -542,7 +542,6 @@ describe("pw-session connection scoping", () => {
         }
       });
     }) as never);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     await expect(
       listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222", timeoutMs: 20 }),
@@ -580,7 +579,6 @@ describe("pw-session connection scoping", () => {
       connectCalls += 1;
       return connectCalls === 1 ? stuck.browser : refreshed.browser;
     }) as never);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     await expect(
       listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222", timeoutMs: 20 }),
@@ -613,13 +611,12 @@ describe("pw-session connection scoping", () => {
 
     connectOverCdpSpy.mockImplementation((async (...args: unknown[]) => {
       const endpointText = String(args[0]);
-      if (endpointText !== "http://127.0.0.1:9222") {
+      if (endpointText !== toTestCdpWebSocketUrl("http://127.0.0.1:9222")) {
         throw new Error(`unexpected endpoint: ${endpointText}`);
       }
       connectCalls += 1;
       return connectCalls === 1 ? stale.browser : refreshed.browser;
     }) as never);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     await expect(
       createPageViaPlaywright({

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -13,6 +13,7 @@ import {
   wasBrowserNavigationSourcePreservedAfterPolicyDenial,
   withPageNavigationRequestGuard,
 } from "./pw-session.js";
+import { toTestCdpWebSocketUrl } from "./pw-session.test-support.js";
 
 const {
   closePlaywrightBrowserConnection,
@@ -115,7 +116,7 @@ function installBrowserMocks() {
   } as unknown as import("playwright-core").Browser;
 
   connectOverCdpSpy.mockResolvedValue(browser);
-  getChromeWebSocketUrlSpy.mockResolvedValue(null);
+  getChromeWebSocketUrlSpy.mockImplementation(async (cdpUrl) => toTestCdpWebSocketUrl(cdpUrl));
 
   const getBrowserDisconnectedHandler = () =>
     browserOn.mock.calls.find((call) => call[0] === "disconnected")?.[1] as

--- a/extensions/browser/src/browser/pw-session.get-page-for-targetid.test.ts
+++ b/extensions/browser/src/browser/pw-session.get-page-for-targetid.test.ts
@@ -1,9 +1,10 @@
 // Browser tests cover exact Playwright page selection by CDP target id.
 import { chromium } from "playwright-core";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as chromeModule from "./chrome.js";
 import { BrowserTabNotFoundError } from "./errors.js";
 import { pwAi } from "./pw-ai.js";
+import { toTestCdpWebSocketUrl } from "./pw-session.test-support.js";
 
 const {
   closePageByTargetIdViaPlaywright,
@@ -107,9 +108,12 @@ function makeBrowser(pages: MockPageSpec[]): BrowserMockBundle {
 function installBrowser(pages: MockPageSpec[]): BrowserMockBundle {
   const bundle = makeBrowser(pages);
   connectOverCdpSpy.mockResolvedValue(bundle.browser);
-  getChromeWebSocketUrlSpy.mockResolvedValue(null);
   return bundle;
 }
+
+beforeEach(() => {
+  getChromeWebSocketUrlSpy.mockImplementation(async (cdpUrl) => toTestCdpWebSocketUrl(cdpUrl));
+});
 
 afterEach(async () => {
   connectOverCdpSpy.mockReset();
@@ -227,7 +231,6 @@ describe("pw-session getPageForTargetId", () => {
     const fresh = makeBrowser([{ targetId: "TARGET_OK", url: "https://fresh.example" }]);
 
     connectOverCdpSpy.mockResolvedValueOnce(stale.browser).mockResolvedValueOnce(fresh.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
@@ -249,7 +252,6 @@ describe("pw-session getPageForTargetId", () => {
     ]);
 
     connectOverCdpSpy.mockResolvedValueOnce(stale.browser).mockResolvedValueOnce(fresh.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     await getPageForTargetId({ cdpUrl: "http://127.0.0.1:9333" });
 
@@ -270,7 +272,6 @@ describe("pw-session getPageForTargetId", () => {
     connectOverCdpSpy
       .mockResolvedValueOnce(stale.browser)
       .mockResolvedValueOnce(stillBroken.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9444" });
 
@@ -283,7 +284,6 @@ describe("pw-session getPageForTargetId", () => {
 
   it("does not add an extra top-level retry for non-recoverable connect failures", async () => {
     connectOverCdpSpy.mockRejectedValue(new Error("connectOverCDP exploded"));
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     await expect(getPageForTargetId({ cdpUrl: "http://127.0.0.1:9555" })).rejects.toThrow(
       "connectOverCDP exploded",

--- a/extensions/browser/src/browser/pw-session.managed-proxy.test.ts
+++ b/extensions/browser/src/browser/pw-session.managed-proxy.test.ts
@@ -1,0 +1,280 @@
+// Browser tests cover Playwright managed-proxy bypass lifecycle behavior.
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { chromium } from "playwright-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { registerManagedProxyBrowserCdpBypassMock } = vi.hoisted(() => ({
+  registerManagedProxyBrowserCdpBypassMock: vi.fn<(url: string) => (() => void) | undefined>(
+    () => undefined,
+  ),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime-internal", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime-internal")>();
+  return {
+    ...actual,
+    registerManagedProxyBrowserCdpBypass: registerManagedProxyBrowserCdpBypassMock,
+  };
+});
+
+import { pwAi } from "./pw-ai.js";
+
+const { closePlaywrightBrowserConnection, listPagesViaPlaywright } = pwAi;
+
+type ManagedLease = {
+  url: string;
+  release: ReturnType<typeof vi.fn>;
+};
+
+type DiscoveryServer = {
+  baseUrl: string;
+  bareWsUrl: string;
+  requests: string[];
+  versionUrl: string;
+  wsUrl: string;
+};
+
+const connectOverCdpSpy = vi.spyOn(chromium, "connectOverCDP");
+const runningServers: Server[] = [];
+
+async function startDiscoveryServer(
+  options: {
+    servedPaths?: readonly string[];
+    includeWebSocketUrl?: boolean;
+  } = {},
+): Promise<DiscoveryServer> {
+  const servedPaths = options.servedPaths ?? ["/json/version"];
+  const requests: string[] = [];
+  const server = createServer((req, res) => {
+    const requestPath = req.url ?? "";
+    requests.push(requestPath);
+    if (!servedPaths.includes(requestPath)) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    const address = server.address() as AddressInfo;
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({
+        Browser: "Chrome/Mock",
+        ...(options.includeWebSocketUrl === false
+          ? {}
+          : {
+              webSocketDebuggerUrl: `ws://127.0.0.1:${address.port}/devtools/browser/discovered`,
+            }),
+      }),
+    );
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  runningServers.push(server);
+  const port = (server.address() as AddressInfo).port;
+  const baseUrl = `http://127.0.0.1:${port}`;
+  return {
+    baseUrl,
+    bareWsUrl: `ws://127.0.0.1:${port}`,
+    requests,
+    versionUrl: `${baseUrl}/json/version`,
+    wsUrl: `ws://127.0.0.1:${port}/devtools/browser/discovered`,
+  };
+}
+
+function captureManagedLeases(): ManagedLease[] {
+  const leases: ManagedLease[] = [];
+  registerManagedProxyBrowserCdpBypassMock.mockImplementation((url) => {
+    const release = vi.fn();
+    leases.push({ url, release });
+    return release;
+  });
+  return leases;
+}
+
+function createDeferredBrowser(): {
+  promise: Promise<import("playwright-core").Browser>;
+  resolve: (browser: import("playwright-core").Browser) => void;
+} {
+  let resolve: ((browser: import("playwright-core").Browser) => void) | undefined;
+  const promise = new Promise<import("playwright-core").Browser>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  if (!resolve) {
+    throw new Error("Expected deferred callback to be initialized");
+  }
+  return { promise, resolve };
+}
+
+function makeBrowser(): import("playwright-core").Browser {
+  const context = {
+    pages: () => [],
+    on: vi.fn(),
+  } as unknown as import("playwright-core").BrowserContext;
+  return {
+    contexts: () => [context],
+    on: vi.fn(),
+    off: vi.fn(),
+    close: vi.fn(async () => {}),
+  } as unknown as import("playwright-core").Browser;
+}
+
+function releaseCounts(leases: ManagedLease[]): number[] {
+  return leases.map((lease) => lease.release.mock.calls.length);
+}
+
+afterEach(async () => {
+  await closePlaywrightBrowserConnection().catch(() => {});
+  connectOverCdpSpy.mockReset();
+  registerManagedProxyBrowserCdpBypassMock.mockReset();
+  registerManagedProxyBrowserCdpBypassMock.mockImplementation(() => undefined);
+  await Promise.all(
+    runningServers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        }),
+    ),
+  );
+});
+
+describe("Playwright managed-proxy bypass", () => {
+  it.each([
+    {
+      name: "canonical",
+      servedPaths: ["/json/version"],
+      expectedRequests: ["/json/version"],
+    },
+    {
+      name: "Playwright-compatible trailing-slash",
+      servedPaths: ["/json/version/"],
+      expectedRequests: ["/json/version", "/json/version/"],
+    },
+  ])("owns every actual URL for $name discovery", async ({ servedPaths, expectedRequests }) => {
+    const server = await startDiscoveryServer({ servedPaths });
+    const leases = captureManagedLeases();
+    const handshake = createDeferredBrowser();
+    connectOverCdpSpy.mockImplementationOnce(async () => await handshake.promise);
+
+    const listing = listPagesViaPlaywright({ cdpUrl: server.baseUrl });
+    await vi.waitFor(() => expect(connectOverCdpSpy).toHaveBeenCalledOnce());
+
+    const expectedHttpUrls = expectedRequests.map((path) => `${server.baseUrl}${path}`);
+    expect(server.requests).toEqual(expectedRequests);
+    expect(connectOverCdpSpy).toHaveBeenCalledWith(server.wsUrl, {
+      timeout: 5000,
+      headers: {},
+    });
+    expect(leases.map((lease) => lease.url)).toEqual([...expectedHttpUrls, server.wsUrl]);
+    expect(releaseCounts(leases)).toEqual([...expectedHttpUrls.map(() => 1), 0]);
+
+    handshake.resolve(makeBrowser());
+    await expect(listing).resolves.toEqual([]);
+    expect(releaseCounts(leases)).toEqual(leases.map(() => 1));
+  });
+
+  it("never hands an unresolved HTTP endpoint to Playwright", async () => {
+    const server = await startDiscoveryServer({
+      servedPaths: ["/json/version", "/json/version/"],
+      includeWebSocketUrl: false,
+    });
+    const leases = captureManagedLeases();
+
+    await expect(listPagesViaPlaywright({ cdpUrl: server.baseUrl })).rejects.toThrow(
+      "CDP HTTP endpoint did not expose a usable WebSocket URL.",
+    );
+
+    expect(connectOverCdpSpy).not.toHaveBeenCalled();
+    expect(server.requests).toEqual([
+      "/json/version",
+      "/json/version/",
+      "/json/version",
+      "/json/version/",
+      "/json/version",
+      "/json/version/",
+    ]);
+    expect(leases.map((lease) => lease.url)).toEqual(
+      server.requests.map((path) => `${server.baseUrl}${path}`),
+    );
+    expect(releaseCounts(leases)).toEqual(leases.map(() => 1));
+  });
+
+  it("releases discovery and WebSocket leases after a failed handshake", async () => {
+    const server = await startDiscoveryServer();
+    const leases = captureManagedLeases();
+    connectOverCdpSpy.mockRejectedValueOnce(new Error("rate limit"));
+
+    await expect(listPagesViaPlaywright({ cdpUrl: server.baseUrl })).rejects.toThrow("rate limit");
+
+    expect(leases.map((lease) => lease.url)).toEqual([server.versionUrl, server.wsUrl]);
+    expect(releaseCounts(leases)).toEqual([1, 1]);
+  });
+
+  it("uses and releases exact discovery and WebSocket leases for each retry", async () => {
+    const server = await startDiscoveryServer();
+    const leases = captureManagedLeases();
+    const handshake = createDeferredBrowser();
+    connectOverCdpSpy
+      .mockRejectedValueOnce(new Error("socket hang up"))
+      .mockImplementationOnce(async () => await handshake.promise);
+
+    const listing = listPagesViaPlaywright({ cdpUrl: server.baseUrl });
+    await vi.waitFor(() => expect(connectOverCdpSpy).toHaveBeenCalledTimes(2));
+
+    expect(server.requests).toEqual(["/json/version", "/json/version"]);
+    expect(leases.map((lease) => lease.url)).toEqual([
+      server.versionUrl,
+      server.wsUrl,
+      server.versionUrl,
+      server.wsUrl,
+    ]);
+    expect(releaseCounts(leases)).toEqual([1, 1, 1, 0]);
+
+    handshake.resolve(makeBrowser());
+    await expect(listing).resolves.toEqual([]);
+    expect(releaseCounts(leases)).toEqual([1, 1, 1, 1]);
+  });
+
+  it("releases discovery before activating the bare WebSocket fallback", async () => {
+    const server = await startDiscoveryServer();
+    const leases = captureManagedLeases();
+    const handshake = createDeferredBrowser();
+    connectOverCdpSpy
+      .mockRejectedValueOnce(new Error("socket hang up"))
+      .mockImplementationOnce(async () => await handshake.promise);
+
+    const listing = listPagesViaPlaywright({ cdpUrl: server.bareWsUrl });
+    await vi.waitFor(() => expect(connectOverCdpSpy).toHaveBeenCalledTimes(2));
+
+    expect(connectOverCdpSpy).toHaveBeenNthCalledWith(1, server.wsUrl, expect.any(Object));
+    expect(connectOverCdpSpy).toHaveBeenNthCalledWith(2, server.bareWsUrl, expect.any(Object));
+    expect(leases.map((lease) => lease.url)).toEqual([
+      server.versionUrl,
+      server.wsUrl,
+      server.bareWsUrl,
+    ]);
+    expect(releaseCounts(leases)).toEqual([1, 1, 0]);
+
+    handshake.resolve(makeBrowser());
+    await expect(listing).resolves.toEqual([]);
+    expect(releaseCounts(leases)).toEqual([1, 1, 1]);
+  });
+
+  it("releases the exact WebSocket lease after a superseded handshake settles", async () => {
+    const server = await startDiscoveryServer();
+    const leases = captureManagedLeases();
+    const handshake = createDeferredBrowser();
+    connectOverCdpSpy.mockImplementationOnce(async () => await handshake.promise);
+
+    const listing = listPagesViaPlaywright({ cdpUrl: server.baseUrl });
+    await vi.waitFor(() => expect(connectOverCdpSpy).toHaveBeenCalledOnce());
+    const closing = closePlaywrightBrowserConnection({ cdpUrl: server.baseUrl });
+    expect(releaseCounts(leases)).toEqual([1, 0]);
+
+    handshake.resolve(makeBrowser());
+    await expect(listing).rejects.toThrow("superseded");
+    await expect(closing).resolves.toBeUndefined();
+    expect(releaseCounts(leases)).toEqual([1, 1]);
+  });
+});

--- a/extensions/browser/src/browser/pw-session.termination-cdp-ssrf.test.ts
+++ b/extensions/browser/src/browser/pw-session.termination-cdp-ssrf.test.ts
@@ -3,6 +3,7 @@ import { chromium } from "playwright-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as chromeModule from "./chrome.js";
 import { pwAi } from "./pw-ai.js";
+import { toTestCdpWebSocketUrl } from "./pw-session.test-support.js";
 
 const {
   closePlaywrightBrowserConnection,
@@ -78,7 +79,7 @@ function installBrowserMock() {
   } as unknown as import("playwright-core").Browser;
 
   connectOverCdpSpy.mockResolvedValue(browser);
-  getChromeWebSocketUrlSpy.mockResolvedValue(null);
+  getChromeWebSocketUrlSpy.mockImplementation(async (cdpUrl) => toTestCdpWebSocketUrl(cdpUrl));
   return { browserClose };
 }
 

--- a/extensions/browser/src/browser/pw-session.test-support.ts
+++ b/extensions/browser/src/browser/pw-session.test-support.ts
@@ -1,0 +1,10 @@
+// Test helpers provide deterministic CDP WebSocket endpoints for session unit tests.
+export function toTestCdpWebSocketUrl(cdpUrl: string): string {
+  if (cdpUrl.startsWith("http://")) {
+    return `ws://${cdpUrl.slice("http://".length)}`;
+  }
+  if (cdpUrl.startsWith("https://")) {
+    return `wss://${cdpUrl.slice("https://".length)}`;
+  }
+  return cdpUrl;
+}

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -24,7 +24,7 @@ import type {
 } from "playwright-core";
 import { formatErrorMessage } from "../infra/errors.js";
 import { SsrFBlockedError, type SsrFPolicy } from "../infra/net/ssrf.js";
-import { withNoProxyForCdpUrl } from "./cdp-proxy-bypass.js";
+import { withManagedProxyForCdpUrl, withNoProxyForCdpUrl } from "./cdp-proxy-bypass.js";
 import {
   appendCdpPath,
   assertCdpEndpointAllowed,
@@ -1315,22 +1315,22 @@ async function connectBrowser(cdpUrl: string, ssrfPolicy?: SsrFPolicy): Promise<
       }
       try {
         const timeout = 5000 + attempt * 2000;
-        const wsUrl = await getChromeWebSocketUrl(normalized, timeout, ssrfPolicy).catch(
-          () => null,
-        );
+        const endpoint = await getChromeWebSocketUrl(normalized, timeout, ssrfPolicy);
         const hasUrlCredentials = stripCdpUrlCredentials(normalized) !== normalized;
-        if (!wsUrl && hasUrlCredentials && !isWebSocketUrl(normalized)) {
-          // Playwright preserves explicit headers across HTTP discovery redirects.
-          // Keep credentialed discovery in OpenClaw's guarded fetch path instead.
-          throw new Error("Authenticated CDP HTTP endpoint did not expose a usable WebSocket URL.");
+        if (!endpoint || !isWebSocketUrl(endpoint)) {
+          const prefix = hasUrlCredentials ? "Authenticated " : "";
+          // Never let Playwright derive an endpoint outside the exact managed-proxy leases.
+          throw new Error(`${prefix}CDP HTTP endpoint did not expose a usable WebSocket URL.`);
         }
-        const endpoint = wsUrl ?? normalized;
         const connectEndpoint = async (target: string) => {
           const headers = getHeadersWithAuth(target);
           const connectionUrl = stripCdpUrlCredentials(target);
-          // Bypass proxy for loopback CDP connections (#31219)
-          return await withNoProxyForCdpUrl(connectionUrl, () =>
-            chromium.connectOverCDP(connectionUrl, { timeout, headers }),
+          // Discovery owns exact HTTP leases; retain the exact WebSocket lease
+          // through Playwright's asynchronous handshake.
+          return await withManagedProxyForCdpUrl(connectionUrl, () =>
+            withNoProxyForCdpUrl(connectionUrl, () =>
+              chromium.connectOverCDP(connectionUrl, { timeout, headers }),
+            ),
           );
         };
         let browser: Browser;


### PR DESCRIPTION
Fixes #105306

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users taking browser snapshots with `proxy.enabled: true` could hit Playwright `connectOverCDP` socket failures when managed Chrome exposed CDP on loopback.

## Why This Change Was Made

OpenClaw now resolves HTTP CDP discovery itself, including the trailing-slash compatibility route, and gives Playwright only a validated WebSocket endpoint while retaining exact managed-proxy bypass leases through the handshake. Remote CDP endpoints remain subject to the configured proxy policy.

## User Impact

Browser snapshots and other Playwright-backed actions can attach to local managed Chrome while managed proxy routing is enabled, without widening proxy or SSRF bypasses.

## Evidence

- 258 focused browser/CDP tests passed in the implementation validation set.
- After updating to upstream `main`, a 266-test focused superset passed: 259 browser extension tests and 7 browser e2e tests.
- Path-scoped `oxfmt`, `oxlint`, browser production `tsgo`, and `git diff --cached --check` passed for all 10 changed files.
- Real WSL2 control experiment with Chrome for Testing 149.0.7827.55 and a deliberately rejecting managed proxy: raw Playwright hit `/json/version/` through the proxy and failed with HTTP 502; the patched snapshot returned the expected ARIA text with zero added proxy hits.

**AI assistance disclosure:** OpenCode using GPT-5.6 Sol assisted with change review, upstream updates, validation, and PR preparation. The final discovery, exact-bypass lifecycle, tests, and live control experiment were reviewed end-to-end.
