### PR TITLE
test(gateway): cover session attach grant revocation

### DIFF
--- a/src/gateway/mcp-grant-store.test.ts
+++ b/src/gateway/mcp-grant-store.test.ts
@@ -7,6 +7,7 @@ import {
   resolveAttachGrant,
   resolveMcpLoopbackClientGrant,
   revokeAttachGrant,
+  revokeAttachGrantsForSession,
   revokeMcpLoopbackClientGrant,
   revokeMcpLoopbackClientGrantsForRuntime,
 } from "./mcp-grant-store.js";
@@ -56,6 +57,17 @@ describe("mcp-grant-store", () => {
     expect(revokeAttachGrant(g.token)).toBe(true);
     expect(resolveAttachGrant(g.token, T0)).toBeUndefined();
     expect(revokeAttachGrant(g.token)).toBe(false);
+  });
+
+  it("revokes every attach grant for one session", () => {
+    const first = mintAttachGrant({ sessionKey: "agent:main:first", nowMs: T0 });
+    const second = mintAttachGrant({ sessionKey: "agent:main:first", nowMs: T0 });
+    const other = mintAttachGrant({ sessionKey: "agent:main:other", nowMs: T0 });
+
+    expect(revokeAttachGrantsForSession(" agent:main:first ")).toBe(2);
+    expect(resolveAttachGrant(first.token, T0)).toBeUndefined();
+    expect(resolveAttachGrant(second.token, T0)).toBeUndefined();
+    expect(resolveAttachGrant(other.token, T0)?.sessionKey).toBe("agent:main:other");
   });
 
   it("clamps TTL: default for non-positive, ceiling at 12h", () => {


### PR DESCRIPTION
## What Problem This Solves

The restored session-scoped attach-grant revocation helper lacked regression coverage.

## Why

Cover multiple grants, trimmed keys, and isolation from other sessions.

## User Impact

Future worker-dispatch refactors cannot silently break session-scoped revocation behavior.

## Evidence

- Original current-main failure: https://github.com/openclaw/openclaw/actions/runs/29261021546/job/86854112654
- Equivalent helper restoration now on `main`: 2854dcf61b51978666ca2f317662efb01e5ab804
- Testbox focused test: 12/12 passed
- Testbox full build: passed
- Autoreview: clean, 0.98 confidence
