### PR TITLE
refactor: replace remaining worker pools with p-map

### DIFF
--- a/scripts/check-extension-package-tsc-boundary.mjs
+++ b/scripts/check-extension-package-tsc-boundary.mjs
@@ -14,6 +14,7 @@ import {
 import { createRequire } from "node:module";
 import os from "node:os";
 import path, { dirname, join, resolve } from "node:path";
+import pMap from "p-map";
 import { parsePositiveInt } from "./lib/numeric-options.mjs";
 import {
   forwardSignalToVitestProcessGroup,
@@ -631,29 +632,29 @@ export function runNodeStepAsync(label, args, timeoutMs, params = {}) {
 export async function runNodeStepsWithConcurrency(steps, concurrency) {
   const abortController = new AbortController();
   let firstFailure = null;
-  let nextIndex = 0;
-  const workers = Array.from({ length: Math.min(concurrency, steps.length) }, async () => {
-    while (true) {
+  await pMap(
+    steps,
+    async (step) => {
       if (abortController.signal.aborted) {
         return;
       }
-      const index = nextIndex;
-      nextIndex += 1;
-      if (index >= steps.length) {
-        return;
+      try {
+        step.onStart?.();
+        const result = await runNodeStepAsync(step.label, step.args, step.timeoutMs, {
+          abortController,
+          onFailure(error) {
+            firstFailure ??= error;
+          },
+        });
+        step.onSuccess?.(result);
+      } catch (error) {
+        // Keep the mapper fulfilled so pMap waits for active process-group cleanup.
+        firstFailure ??= error;
+        abortSiblingSteps(abortController);
       }
-      const step = steps[index];
-      step.onStart?.();
-      const result = await runNodeStepAsync(step.label, step.args, step.timeoutMs, {
-        abortController,
-        onFailure(error) {
-          firstFailure ??= error;
-        },
-      });
-      step.onSuccess?.(result);
-    }
-  });
-  await Promise.allSettled(workers);
+    },
+    { concurrency, stopOnError: false },
+  );
   if (firstFailure) {
     throw toLintErrorObject(firstFailure, "Non-Error thrown");
   }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1,5 +1,6 @@
 /** Cron timer loop, execution, catch-up, and run-result state transitions. */
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
+import pMap, { pMapSkip } from "p-map";
 import { resolveFailoverReasonFromError } from "../../agents/failover-error.js";
 import { resolveCronTriggerMinIntervalMs } from "../../config/cron-limits.js";
 import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
@@ -1501,7 +1502,6 @@ async function onAdmittedTimer(state: CronServiceState) {
     };
 
     const concurrency = Math.min(resolveRunConcurrency(state), Math.max(1, dueJobs.length));
-    const results: (TimedCronRunOutcome | undefined)[] = Array.from({ length: dueJobs.length });
     const claimedIndexes = new Set<number>();
     let reservationReleaseError: unknown;
     let setupTimeoutNotified = false;
@@ -1530,20 +1530,14 @@ async function onAdmittedTimer(state: CronServiceState) {
       await releaseUnclaimedDueJobReservations();
       return;
     }
-    let cursor = 0;
-    const workers = Array.from({ length: concurrency }, async () => {
-      for (;;) {
+    // Skipped mappers must not claim reservations: recovery releases those rows,
+    // while already-started jobs drain under the same concurrency cap.
+    const completedResults = await pMap(
+      dueJobs,
+      async (due, index): Promise<TimedCronRunOutcome | typeof pMapSkip> => {
         if (stopAdmittingDueJobs || state.stopped || state.restartRecoveryPending) {
           stopAdmittingDueJobs = true;
-          return;
-        }
-        const index = cursor++;
-        if (index >= dueJobs.length) {
-          return;
-        }
-        const due = dueJobs[index];
-        if (!due) {
-          return;
+          return pMapSkip;
         }
         claimedIndexes.add(index);
         const result = await runDueJob(due);
@@ -1552,11 +1546,10 @@ async function onAdmittedTimer(state: CronServiceState) {
           try {
             finalizedResults = await finalizeCompletedResults([result], { clearOnFailure: false });
           } catch {
-            results[index] = result;
-            continue;
+            return result;
           }
           if (!hasSetupTimeoutRecoveryHandler || finalizedResults.length === 0) {
-            continue;
+            return pMapSkip;
           }
           if (!setupTimeoutNotified) {
             setupTimeoutNotified = true;
@@ -1568,12 +1561,12 @@ async function onAdmittedTimer(state: CronServiceState) {
             }
             maybeNotifyIsolatedAgentSetupTimeout(state, result);
           }
-          continue;
+          return pMapSkip;
         }
-        results[index] = result;
-      }
-    });
-    await Promise.all(workers);
+        return result;
+      },
+      { concurrency, stopOnError: true },
+    );
     if (reservationReleaseError) {
       throw reservationReleaseError instanceof Error
         ? reservationReleaseError
@@ -1582,10 +1575,6 @@ async function onAdmittedTimer(state: CronServiceState) {
     if (stopAdmittingDueJobs) {
       await releaseUnclaimedDueJobReservations();
     }
-
-    const completedResults: TimedCronRunOutcome[] = results.filter(
-      (entry): entry is TimedCronRunOutcome => entry !== undefined,
-    );
 
     if (completedResults.length > 0) {
       const finalizedResults = await finalizeCompletedResults(completedResults);

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -100,7 +100,6 @@ const LOCAL_OUTPUT_TIMEOUT_MS = 120_000;
 const LOCAL_EXIT_TIMEOUT_MS = 4_000;
 const LOCAL_TEST_TIMEOUT_MS = 150_000;
 const SUBMISSION_SETTLE_MS = 150;
-const SESSION_ROLLOVER_RETRY_TIMEOUT_MS = 5_000;
 const SESSION_ROLLOVER_BUSY_MESSAGE = "abort the current run before /new";
 
 function createIdempotentCleanup(cleanup: () => Promise<void>) {
@@ -122,45 +121,37 @@ async function waitForOutputAfter(run: PtyRun, needle: string, offset: number) {
 }
 
 async function createFreshSession(run: PtyRun, newSessionPrefix: string) {
-  const outputOffset = run.output().length;
-  await run.write("/new\r", { delay: false });
-  const outcome = await waitFor({
-    timeoutMs: LOCAL_STARTUP_TIMEOUT_MS,
-    read: () => {
-      const output = run.output();
-      if (output.includes(newSessionPrefix, outputOffset)) {
-        return { kind: "created" } as const;
-      }
-      const busyIndex = output.indexOf(SESSION_ROLLOVER_BUSY_MESSAGE, outputOffset);
-      if (busyIndex >= 0) {
-        return {
-          kind: "busy",
-          outputEnd: busyIndex + SESSION_ROLLOVER_BUSY_MESSAGE.length,
-        } as const;
-      }
-      return null;
-    },
-    onTimeout: () => new Error(`timed out creating a fresh session\n${run.output()}`),
-  });
-  if (outcome.kind === "created") {
-    return;
+  const deadline = Date.now() + LOCAL_STARTUP_TIMEOUT_MS;
+  let attempts = 0;
+  let outputOffset = run.output().length;
+  while (Date.now() < deadline) {
+    attempts += 1;
+    await run.write("/new\r", { delay: false });
+    const outcome = await waitFor({
+      timeoutMs: Math.max(1, deadline - Date.now()),
+      read: () => {
+        const output = run.output();
+        if (output.includes(newSessionPrefix, outputOffset)) {
+          return "created";
+        }
+        return output.includes(SESSION_ROLLOVER_BUSY_MESSAGE, outputOffset) ? "busy" : null;
+      },
+      onTimeout: () =>
+        new Error(`timed out creating a fresh session after ${attempts} attempts\n${run.output()}`),
+    });
+    if (outcome === "created") {
+      return;
+    }
+
+    // Redraws can repeat an old rejection after this attempt's offset. Keep
+    // watching that attempt through settle so an accepted /new is not retried.
+    await sleep(SUBMISSION_SETTLE_MS);
+    if (run.output().includes(newSessionPrefix, outputOffset)) {
+      return;
+    }
+    outputOffset = run.output().length;
   }
-
-  // PTY redraws repeat old chat lines. Wait for post-rejection idle before one
-  // retry, or stale busy output can trigger multiple concurrent session changes.
-  await waitFor({
-    timeoutMs: SESSION_ROLLOVER_RETRY_TIMEOUT_MS,
-    read: () => (run.output().slice(outcome.outputEnd).includes("| idle") ? true : null),
-    onTimeout: () => new Error(`session rollover stayed busy\n${run.output()}`),
-  });
-
-  const retryOffset = run.output().length;
-  await run.write("/new\r", { delay: false });
-  await waitFor({
-    timeoutMs: LOCAL_STARTUP_TIMEOUT_MS,
-    read: () => (run.output().slice(retryOffset).includes(newSessionPrefix) ? true : null),
-    onTimeout: () => new Error(`timed out retrying fresh session creation\n${run.output()}`),
-  });
+  throw new Error(`timed out creating a fresh session after ${attempts} attempts\n${run.output()}`);
 }
 
 async function readRequestBody(req: IncomingMessage): Promise<string> {


### PR DESCRIPTION
Closes #106466

## What Problem This Solves

Resolves a maintenance and reliability risk in multi-job cron ticks and multi-plugin boundary compiles: both paths still carried bespoke cursor/worker pools after the repository standardized bounded concurrency on `p-limit`/`p-map`. It also fixes the real-Gateway TUI rollover test's one-shot retry race, exposed while proving the refactor on CI.

## Why This Change Was Made

The cron timer now uses ordered `pMap` results at the existing `cron.maxConcurrentRuns` limit. `pMapSkip` preserves unclaimed reservation cleanup when shutdown or setup-timeout recovery stops admission, while already-started jobs drain.

The extension boundary runner now maps steps at its existing compile limit with `stopOnError: false`, records the first failure, aborts active sibling process groups, waits for their cleanup, and skips queued work after abort. Root already pins `p-map@7.0.5`; no dependency ownership or lockfile change is needed.

The TUI PTY helper now retries `/new` within one deadline while preserving each attempt's output window through settle. It rechecks for an accepted session before advancing the offset, so repeated busy responses are tolerated without letting stale redraws trigger a second rollover.

## User Impact

No UI, configuration, or public API change. Cron batches retain their configured concurrency, ordering, recovery, and reservation semantics. Boundary compiles retain first-failure reporting and active child-process cleanup with less custom scheduler code. The real-Gateway TUI test no longer stalls for 60 seconds when run cleanup needs more than one retry.

## Evidence

- Blacksmith Testbox `tbx_01kxe4ppcxt6bqy5rk7qq7bk5x` ([run 29266283950](https://github.com/openclaw/openclaw/actions/runs/29266283950)): `pnpm test src/cron/service/timer.regression.test.ts src/cron/service/timer.test.ts test/scripts/check-extension-package-tsc-boundary.test.ts` — 96 tests passed.
- Same Testbox: the focused real-Gateway fresh-session PTY test passed three consecutive runs.
- Same Testbox: `pnpm check:changed -- scripts/check-extension-package-tsc-boundary.mjs src/cron/service/timer.ts src/tui/tui-pty-local.e2e.test.ts` — format, dependency pins, core/core-test typechecks, core/script lint, and runtime import-cycle checks passed.
- Direct dependency contract checked against `sindresorhus/p-map` v7.0.5 source, types, and README: ordered outputs, bounded mapper concurrency, `pMapSkip`, and explicit `stopOnError` behavior match these two paths.
- `git diff --numstat`: 64 additions, 83 deletions (net -19 LOC).
- Fresh branch-mode autoreview at pushed head `f67aed6bf924297234ef63e7cc0e5303ac0317b6`: clean, no accepted/actionable findings; patch correct at 0.91 confidence.

AI-assisted: yes. The change and failure semantics were reviewed against callers, cleanup paths, existing behavior tests, and the pinned dependency implementation.
