### PR TITLE
test(gateway): fix cloud-worker type imports

### DIFF
--- a/src/gateway/worker-environments/placement-dispatch.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch.test.ts
@@ -2,6 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkerAdmissionHandshake as WorkerEnvironmentBootstrapReceipt } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
+import type {
+  WorkerProfile as WorkerEnvironmentProfileSnapshot,
+  WorkerSshEndpoint as WorkerEnvironmentSshEndpoint,
+} from "../../plugins/types.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -18,11 +23,6 @@ import {
   type WorkerSessionPlacementRecord,
 } from "./placement-store.js";
 import { workerEnvironmentIdForIdempotencyKey } from "./service.js";
-import type {
-  WorkerEnvironmentBootstrapReceipt,
-  WorkerEnvironmentProfileSnapshot,
-  WorkerEnvironmentSshEndpoint,
-} from "./store.js";
 import type { WorkerTunnelHandle } from "./tunnel.js";
 
 type WorkerDispatchRequest = Parameters<


### PR DESCRIPTION
## What Problem This Solves

`check-test-types` on current `main` fails because the cloud-worker dispatch test imports three aliases that were privatized by #106038 before #106332 merged.

## Why This Change Was Made

Import the canonical gateway-protocol and plugin-owned types directly. This preserves the production owner boundary instead of re-exporting test-only aliases from the worker environment store.

## User Impact

No runtime behavior change. Restores the core test typecheck after the merge-order regression.

## Evidence

- `pnpm tsgo:core:test`
- `pnpm test src/gateway/worker-environments/placement-dispatch.test.ts`
- `git diff --check`
- Fresh structured autoreview
