### PR TITLE
fix: core test typecheck fails for worker placement

### DIFF
--- a/src/gateway/worker-environments/placement-dispatch.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch.test.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkerAdmissionHandshake } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
+import type { WorkerProfile, WorkerSshEndpoint } from "../../plugins/types.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -18,11 +20,6 @@ import {
   type WorkerSessionPlacementRecord,
 } from "./placement-store.js";
 import { workerEnvironmentIdForIdempotencyKey } from "./service.js";
-import type {
-  WorkerEnvironmentBootstrapReceipt,
-  WorkerEnvironmentProfileSnapshot,
-  WorkerEnvironmentSshEndpoint,
-} from "./store.js";
 import type { WorkerTunnelHandle } from "./tunnel.js";
 
 type WorkerDispatchRequest = Parameters<
@@ -153,15 +150,15 @@ function createHarness(
   const environmentId = workerEnvironmentIdForIdempotencyKey(
     `session-dispatch:${REQUEST.sessionId}:1`,
   );
-  const profileSnapshot: WorkerEnvironmentProfileSnapshot = {
+  const profileSnapshot: WorkerProfile = {
     settings: { region: "test" },
   };
-  const bootstrapReceipt: WorkerEnvironmentBootstrapReceipt = {
+  const bootstrapReceipt: WorkerAdmissionHandshake = {
     bundleHash: BUNDLE_HASH,
     openclawVersion: "2026.7.2",
     protocolFeatures: [],
   };
-  const sshEndpoint: WorkerEnvironmentSshEndpoint = {
+  const sshEndpoint: WorkerSshEndpoint = {
     host: "worker.example.test",
     port: 22,
     user: "worker",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the core test typecheck failed after worker-placement tests imported three internal store aliases that are no longer exported.

## Why This Change Was Made

The test now imports the canonical protocol and plugin types directly. Production store aliases remain private, preserving the intended dead-export cleanup.

## User Impact

No runtime behavior changes. Core test typechecking and worker-placement validation can run again.

## Evidence

- Blacksmith Testbox run: https://github.com/openclaw/openclaw/actions/runs/29261760524
- `pnpm test src/gateway/worker-environments/placement-dispatch.test.ts` — 22 tests passed.
- `pnpm check:changed -- src/gateway/worker-environments/placement-dispatch.test.ts` — passed, including core-test typecheck, formatting, and lint.
- Fresh autoreview: no actionable findings.

