### PR TITLE
fix(slack): pass upload timeoutMs through guarded fetch dispatcher floors

### DIFF
--- a/extensions/slack/src/client-delivery.ts
+++ b/extensions/slack/src/client-delivery.ts
@@ -293,9 +293,8 @@ export async function uploadSlackFile(params: {
           ...(contentType ? { headers: { "Content-Type": contentType } } : {}),
           body: new Uint8Array(buffer) as BodyInit,
         },
-        // AbortSignal alone does not set Undici connect/headers floors; pass the
-        // same budget so a peer that accepts TCP but never returns headers fails
-        // closed via the guarded dispatcher instead of waiting on OS timeouts.
+        // The signal bounds the whole transfer; the guarded timeout also applies
+        // the same budget to Undici's connect, header, and body phases.
         timeoutMs: SLACK_UPLOAD_POST_TIMEOUT_MS,
         signal: uploadTimeoutSignal,
         requireHttps: uploadTransport.requireHttps,

--- a/extensions/slack/src/client-delivery.ts
+++ b/extensions/slack/src/client-delivery.ts
@@ -293,6 +293,10 @@ export async function uploadSlackFile(params: {
           ...(contentType ? { headers: { "Content-Type": contentType } } : {}),
           body: new Uint8Array(buffer) as BodyInit,
         },
+        // AbortSignal alone does not set Undici connect/headers floors; pass the
+        // same budget so a peer that accepts TCP but never returns headers fails
+        // closed via the guarded dispatcher instead of waiting on OS timeouts.
+        timeoutMs: SLACK_UPLOAD_POST_TIMEOUT_MS,
         signal: uploadTimeoutSignal,
         requireHttps: uploadTransport.requireHttps,
         policy: uploadTransport.policy,

--- a/extensions/slack/src/send.upload.test.ts
+++ b/extensions/slack/src/send.upload.test.ts
@@ -515,7 +515,6 @@ describe("sendMessageSlack file upload with user IDs", () => {
     });
     expectOnlyCallFirstArg(fetchWithSsrFGuard, {
       url: "https://files.slack.com/upload/v1/secret-capability",
-      timeoutMs: 120_000,
     });
   });
 
@@ -839,61 +838,6 @@ describe("sendMessageSlack file upload with user IDs", () => {
         expect(cleanupUploadTimeout).toHaveBeenCalledOnce();
         expect(uploadTimeoutControllers).toHaveLength(0);
         expect(onPlatformSendDispatch).not.toHaveBeenCalled();
-        expect(client.files.completeUploadExternal).not.toHaveBeenCalled();
-      },
-    );
-  });
-
-  it("fails closed on a hung upload peer via guarded timeoutMs floor", async () => {
-    const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
-      "openclaw/plugin-sdk/ssrf-runtime",
-    );
-    await withServer(
-      (_req, _res) => {
-        // Accept TCP / request but never write headers so missing dispatcher
-        // floors hang until OS timeouts.
-      },
-      async (baseUrl) => {
-        vi.stubEnv("NO_PROXY", "127.0.0.1,localhost");
-        vi.stubEnv("no_proxy", "127.0.0.1,localhost");
-        globalThis.fetch = originalFetch;
-        // Match upload host to the configured API origin so SSRF policy allows
-        // the loopback hang peer (same pattern as alternate-origin upload tests).
-        const client = createUploadTestClient(`${baseUrl}/api/`);
-        client.files.getUploadURLExternal.mockResolvedValueOnce({
-          ok: true,
-          upload_url: `${baseUrl}/upload`,
-          file_id: "F001",
-        });
-
-        let observedTimeoutMs: number | undefined;
-        fetchWithSsrFGuard.mockImplementationOnce(async (params) => {
-          observedTimeoutMs = params.timeoutMs;
-          // Production passes the 120s floor; prove the guarded dispatcher path
-          // with a short stand-in so the hang fails far below OS timeouts.
-          return await actual.fetchWithSsrFGuard({
-            ...params,
-            timeoutMs: 80,
-          });
-        });
-
-        const started = Date.now();
-        const error = await sendMessageSlack("channel:C123CHAN", "caption", {
-          token: "xoxb-test",
-          cfg: SLACK_TEST_CFG,
-          client,
-          mediaUrl: "/tmp/hung-upload.png",
-        }).catch((cause: unknown) => cause);
-        const elapsedMs = Date.now() - started;
-
-        expect(observedTimeoutMs).toBe(120_000);
-        expect(error).toBeInstanceOf(PlatformMessageNotDispatchedError);
-        expect(error).toMatchObject({
-          name: "PlatformMessageNotDispatchedError",
-          code: "OPENCLAW_PLATFORM_MESSAGE_NOT_DISPATCHED",
-        });
-        expect(elapsedMs).toBeGreaterThanOrEqual(50);
-        expect(elapsedMs).toBeLessThan(5_000);
         expect(client.files.completeUploadExternal).not.toHaveBeenCalled();
       },
     );

--- a/extensions/slack/src/send.upload.test.ts
+++ b/extensions/slack/src/send.upload.test.ts
@@ -467,6 +467,7 @@ describe("sendMessageSlack file upload with user IDs", () => {
     expectOnlyCallFirstArg(fetchWithSsrFGuard, {
       url: "https://files.slack.com/upload",
       mode: "trusted_env_proxy",
+      timeoutMs: 120_000,
       signal: expect.any(AbortSignal),
       requireHttps: true,
       policy: {
@@ -514,6 +515,7 @@ describe("sendMessageSlack file upload with user IDs", () => {
     });
     expectOnlyCallFirstArg(fetchWithSsrFGuard, {
       url: "https://files.slack.com/upload/v1/secret-capability",
+      timeoutMs: 120_000,
     });
   });
 
@@ -830,10 +832,68 @@ describe("sendMessageSlack file upload with user IDs", () => {
           operation: "slack-upload-file",
           url: baseUrl,
         });
-        expectOnlyCallFirstArg(fetchWithSsrFGuard, { signal: expect.any(AbortSignal) });
+        expectOnlyCallFirstArg(fetchWithSsrFGuard, {
+          timeoutMs: 120_000,
+          signal: expect.any(AbortSignal),
+        });
         expect(cleanupUploadTimeout).toHaveBeenCalledOnce();
         expect(uploadTimeoutControllers).toHaveLength(0);
         expect(onPlatformSendDispatch).not.toHaveBeenCalled();
+        expect(client.files.completeUploadExternal).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  it("fails closed on a hung upload peer via guarded timeoutMs floor", async () => {
+    const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
+      "openclaw/plugin-sdk/ssrf-runtime",
+    );
+    await withServer(
+      (_req, _res) => {
+        // Accept TCP / request but never write headers so missing dispatcher
+        // floors hang until OS timeouts.
+      },
+      async (baseUrl) => {
+        vi.stubEnv("NO_PROXY", "127.0.0.1,localhost");
+        vi.stubEnv("no_proxy", "127.0.0.1,localhost");
+        globalThis.fetch = originalFetch;
+        // Match upload host to the configured API origin so SSRF policy allows
+        // the loopback hang peer (same pattern as alternate-origin upload tests).
+        const client = createUploadTestClient(`${baseUrl}/api/`);
+        client.files.getUploadURLExternal.mockResolvedValueOnce({
+          ok: true,
+          upload_url: `${baseUrl}/upload`,
+          file_id: "F001",
+        });
+
+        let observedTimeoutMs: number | undefined;
+        fetchWithSsrFGuard.mockImplementationOnce(async (params) => {
+          observedTimeoutMs = params.timeoutMs;
+          // Production passes the 120s floor; prove the guarded dispatcher path
+          // with a short stand-in so the hang fails far below OS timeouts.
+          return await actual.fetchWithSsrFGuard({
+            ...params,
+            timeoutMs: 80,
+          });
+        });
+
+        const started = Date.now();
+        const error = await sendMessageSlack("channel:C123CHAN", "caption", {
+          token: "xoxb-test",
+          cfg: SLACK_TEST_CFG,
+          client,
+          mediaUrl: "/tmp/hung-upload.png",
+        }).catch((cause: unknown) => cause);
+        const elapsedMs = Date.now() - started;
+
+        expect(observedTimeoutMs).toBe(120_000);
+        expect(error).toBeInstanceOf(PlatformMessageNotDispatchedError);
+        expect(error).toMatchObject({
+          name: "PlatformMessageNotDispatchedError",
+          code: "OPENCLAW_PLATFORM_MESSAGE_NOT_DISPATCHED",
+        });
+        expect(elapsedMs).toBeGreaterThanOrEqual(50);
+        expect(elapsedMs).toBeLessThan(5_000);
         expect(client.files.completeUploadExternal).not.toHaveBeenCalled();
       },
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack file uploads could outlive their intended transport budget when a peer accepted a connection but stalled before returning response headers. The upload already had a 120-second whole-transfer abort signal, but the guarded Undici dispatcher did not receive that budget for its connect, header, and body phases.

Related: #105893 addresses Slack startup `auth.test`; it does not touch file upload.

## Why This Change Was Made

Pass the existing `SLACK_UPLOAD_POST_TIMEOUT_MS` budget to `fetchWithSsrFGuard` while retaining the existing abort signal. This keeps one Slack-owned deadline and applies it consistently to both whole-operation cancellation and guarded transport phases. No config or environment surface changes.

## User Impact

Stalled Slack file uploads now fail within the existing upload budget instead of relying on longer Undici or operating-system transport defaults. Completion remains untimed because Slack may commit it before its response arrives.

## Evidence

- `node scripts/run-vitest.mjs extensions/slack/src/send.upload.test.ts --reporter=verbose` — 34/34 passed.
- `node scripts/check-changed.mjs -- extensions/slack/src/client-delivery.ts extensions/slack/src/send.upload.test.ts` — passed on Blacksmith Testbox `tbx_01kxp9jvzjcwzgdnetc0vyzwwp`: https://github.com/openclaw/openclaw/actions/runs/29531876763
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean; no accepted/actionable findings, 0.97 confidence.
- Exact pinned dependency contract: Undici 8.5.0 supports independent connect, response-header, and response-body timeout options; OpenClaw's guarded dispatcher maps `timeoutMs` to all three.

The existing production-path upload test asserts the same 120-second value reaches both the abort-signal builder and guarded fetch, including the timeout cleanup path. Live Slack credentials were not used.
