### PR TITLE
fix(zalo): make poll error backoff abort-aware

### DIFF
--- a/extensions/zalo/src/monitor.lifecycle.test.ts
+++ b/extensions/zalo/src/monitor.lifecycle.test.ts
@@ -99,34 +99,39 @@ describe("monitorZaloProvider lifecycle", () => {
     expect(runtime.log).toHaveBeenCalledWith("[default] Zalo provider stopped mode=polling");
   });
 
-  it("ends poll error backoff immediately when abort fires", async () => {
-    getUpdatesMock.mockReset();
-    getUpdatesMock.mockRejectedValue(new Error("zalo poll transport failed"));
+  it("clears poll error backoff on abort without retrying", async () => {
+    vi.useFakeTimers();
+    let abort: AbortController | undefined;
+    let run: Promise<void> | undefined;
+    try {
+      getUpdatesMock.mockReset();
+      getUpdatesMock.mockRejectedValue(new Error("zalo poll transport failed"));
 
-    let settled = false;
-    const { abort, runtime, run } = await startLifecycleMonitor();
-    const monitoredRun = run.then(() => {
-      settled = true;
-    });
+      const started = await startLifecycleMonitor();
+      abort = started.abort;
+      run = started.run;
 
-    await vi.waitFor(() =>
-      expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("Zalo polling error:")),
-    );
-    expect(runtime.error).toHaveBeenCalledWith(
-      expect.stringContaining("zalo poll transport failed"),
-    );
-    expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(started.runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("zalo poll transport failed"),
+      );
+      expect(getUpdatesMock).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(1);
 
-    // Abort during the 5s error backoff; sleepWithAbort must end immediately
-    // instead of waiting out the full setTimeout.
-    const started = Date.now();
-    abort.abort();
-    await monitoredRun;
-    const elapsedMs = Date.now() - started;
+      abort.abort();
+      await run;
 
-    expect(settled).toBe(true);
-    expect(elapsedMs).toBeLessThan(1_000);
-    expect(runtime.log).toHaveBeenCalledWith("[default] Zalo provider stopped mode=polling");
+      expect(vi.getTimerCount()).toBe(0);
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(getUpdatesMock).toHaveBeenCalledTimes(1);
+      expect(started.runtime.log).toHaveBeenCalledWith(
+        "[default] Zalo provider stopped mode=polling",
+      );
+    } finally {
+      abort?.abort();
+      await run?.catch(() => undefined);
+      vi.useRealTimers();
+    }
   });
 
   it("deletes an existing webhook before polling", async () => {

--- a/extensions/zalo/src/monitor.lifecycle.test.ts
+++ b/extensions/zalo/src/monitor.lifecycle.test.ts
@@ -72,6 +72,8 @@ async function startLifecycleMonitor(
 describe("monitorZaloProvider lifecycle", () => {
   afterEach(() => {
     vi.clearAllMocks();
+    getUpdatesMock.mockReset();
+    getUpdatesMock.mockImplementation(() => new Promise(() => {}));
     setActivePluginRegistry(createEmptyPluginRegistry());
   });
 
@@ -94,6 +96,36 @@ describe("monitorZaloProvider lifecycle", () => {
     await monitoredRun;
 
     expect(settled).toBe(true);
+    expect(runtime.log).toHaveBeenCalledWith("[default] Zalo provider stopped mode=polling");
+  });
+
+  it("ends poll error backoff immediately when abort fires", async () => {
+    getUpdatesMock.mockReset();
+    getUpdatesMock.mockRejectedValue(new Error("zalo poll transport failed"));
+
+    let settled = false;
+    const { abort, runtime, run } = await startLifecycleMonitor();
+    const monitoredRun = run.then(() => {
+      settled = true;
+    });
+
+    await vi.waitFor(() =>
+      expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("Zalo polling error:")),
+    );
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("zalo poll transport failed"),
+    );
+    expect(settled).toBe(false);
+
+    // Abort during the 5s error backoff; sleepWithAbort must end immediately
+    // instead of waiting out the full setTimeout.
+    const started = Date.now();
+    abort.abort();
+    await monitoredRun;
+    const elapsedMs = Date.now() - started;
+
+    expect(settled).toBe(true);
+    expect(elapsedMs).toBeLessThan(1_000);
     expect(runtime.log).toHaveBeenCalledWith("[default] Zalo provider stopped mode=polling");
   });
 

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -12,7 +12,7 @@ import {
   deliverTextOrMediaReply,
   type OutboundReplyPayload,
 } from "openclaw/plugin-sdk/reply-payload";
-import { waitForAbortSignal } from "openclaw/plugin-sdk/runtime-env";
+import { sleepWithAbort, waitForAbortSignal } from "openclaw/plugin-sdk/runtime-env";
 import {
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
@@ -281,9 +281,8 @@ function startPollingLoop(params: ZaloPollingLoopParams) {
         // no updates
       } else if (!isStopped() && !abortSignal.aborted) {
         runtime.error?.(`[${account.accountId}] Zalo polling error: ${formatZaloError(err)}`);
-        await new Promise((resolve) => {
-          setTimeout(resolve, 5000);
-        });
+        // Abort-aware backoff; bottom poll reschedule already checks stopped/aborted.
+        await sleepWithAbort(5000, abortSignal).catch(() => undefined);
       }
     }
 


### PR DESCRIPTION
## What Problem This Solves

Zalo polling error backoff used a bare `setTimeout(5000)` that ignored `abortSignal` / stop. After a non-timeout poll error, Gateway stop or account switch could leave the backoff sleep running for the full 5 seconds.

Open [#104017](https://github.com/openclaw/openclaw/pull/104017) adds Bot API request timeouts; it does not fix the poll-error backoff sleep.

## Why This Change Was Made

The polling loop now uses the shared abort-aware `sleepWithAbort` helper already used by sibling Signal and Slack reconnect paths. Its expected abort rejection is swallowed before the existing stopped/aborted reschedule guard.

The regression test uses fake timers to prove that abort clears the pending backoff timer and that advancing the full five seconds does not trigger another poll.

No new config or environment surface.

## User Impact

**Before:** After a poll transport error, abort/stop could leave a 5-second timer alive before the polling work fully wound down.

**After:** Abort during error backoff clears the timer immediately and schedules no retry.

## Evidence

- Head: `9073328354942bdf08e2924d395384c297f8e09d`
- Changed: `extensions/zalo/src/monitor.ts`
- Regression: `extensions/zalo/src/monitor.lifecycle.test.ts`
- Canonical path: `monitorZaloProvider` polling mode -> `startPollingLoop` -> poll error -> `sleepWithAbort(5000, abortSignal)`
- Sibling contract: `extensions/signal/src/sse-reconnect.ts`

### Focused Testbox proof

```bash
corepack pnpm test extensions/zalo/src/monitor.lifecycle.test.ts
```

```text
Test Files  1 passed (1)
Tests       5 passed (5)
```

Testbox: `tbx_01kxfydynhv3ms88ysa0e0v7pb`  
Run: https://github.com/openclaw/openclaw/actions/runs/29320914851

### Real process proof

A controlled polling process forced one `getUpdates` rejection, aborted during backoff, then measured natural process exit:

```text
main before fix: 5058 ms, polls=1
fixed:            121 ms, polls=1
fixed blind rerun: 30 ms, polls=1
```

The checked-in fake-timer regression additionally observes one pending timer before abort, zero timers after abort, and no second poll after a full 5-second clock advance.

Fresh `gpt-5.6-sol` high-effort autoreview on the rebased head reported no findings (0.97 confidence). The touched gate passed Zalo-relevant conflict, LOC, changelog-attribution, export, duplicate, dependency-pin, and formatting checks; the broader run then stopped on an unrelated Plugin SDK baseline hash drift already present outside this two-file PR diff. Earlier full `check:changed` proof for the patch passed extension/test typechecks and lint.

**Not tested:** Live Zalo Bot API credentials or production poll traffic.

Thanks @hugenshen for the fix.
