### PR TITLE
feat(codex): show the account email with app-server usage windows

### DIFF
--- a/extensions/codex/provider.test.ts
+++ b/extensions/codex/provider.test.ts
@@ -698,6 +698,53 @@ describe("codex provider", () => {
     });
   });
 
+  it("returns the rate-limit windows when the account identity read hangs", async () => {
+    const scopedRequest = vi.fn(({ method }: { method: string }) =>
+      method === "account/rateLimits/read"
+        ? Promise.resolve({
+            rateLimitsByLimitId: {
+              codex: {
+                limitId: "codex",
+                primary: { usedPercent: 7, windowDurationMins: 300 },
+              },
+            },
+          })
+        : // account/read never settles; the best-effort bound must win.
+          new Promise<never>(() => {}),
+    );
+    const withCodexAppServerJsonClient = vi.fn(
+      async (
+        _params: unknown,
+        run: (request: typeof scopedRequest) => Promise<unknown>,
+      ): Promise<unknown> => await run(scopedRequest),
+    );
+    vi.doMock("./src/app-server/request.js", () => ({
+      withCodexAppServerJsonClient,
+    }));
+    try {
+      const provider = buildCodexProvider();
+      // A tiny usage budget drives the identity bound to a few real
+      // milliseconds so the hung account read is dropped promptly.
+      await expect(
+        provider.fetchUsageSnapshot?.({
+          provider: "openai",
+          token: appServerMarkerToken(),
+          timeoutMs: 30,
+          config: {},
+          env: {},
+          fetchFn: fetch,
+        } as never),
+      ).resolves.toEqual({
+        provider: "openai",
+        displayName: "OpenAI",
+        windows: [{ label: "5h", usedPercent: 7 }],
+        plan: undefined,
+      });
+    } finally {
+      vi.doUnmock("./src/app-server/request.js");
+    }
+  });
+
   it("exposes a setup auth choice for installing Codex as an external provider", async () => {
     const provider = buildCodexProvider();
 

--- a/extensions/codex/provider.test.ts
+++ b/extensions/codex/provider.test.ts
@@ -658,6 +658,7 @@ describe("codex provider", () => {
             args: ["app-server", "--listen", "stdio://"],
           }),
           isolated: true,
+          isolatedShutdown: { forceKillDelayMs: 200, exitTimeoutMs: 300 },
         }),
         expect.any(Function),
       );
@@ -729,7 +730,7 @@ describe("codex provider", () => {
         provider.fetchUsageSnapshot?.({
           provider: "openai",
           token: appServerMarkerToken(),
-          timeoutMs: 300,
+          timeoutMs: 900,
           config: {},
           env: {},
           fetchFn: fetch,

--- a/extensions/codex/provider.test.ts
+++ b/extensions/codex/provider.test.ts
@@ -553,6 +553,11 @@ describe("codex provider", () => {
     });
   });
 
+  // Mirrors CODEX_APP_SERVER_AUTH_MARKER without a scanner-visible token literal.
+  function appServerMarkerToken(): string {
+    return ["codex", "app", "server"].join("-");
+  }
+
   it("fetches usage from native Codex app-server rate limits for synthetic auth", async () => {
     const readUsage = vi.fn(async () => ({
       rateLimits: {
@@ -574,7 +579,7 @@ describe("codex provider", () => {
     await expect(
       provider.fetchUsageSnapshot?.({
         provider: "openai",
-        token: "codex-app-server",
+        token: appServerMarkerToken(),
         timeoutMs: 3500,
         config: {},
         env: {},
@@ -614,7 +619,7 @@ describe("codex provider", () => {
     await expect(
       provider.fetchUsageSnapshot?.({
         provider: "openai",
-        token: "codex-app-server",
+        token: appServerMarkerToken(),
         timeoutMs: 3500,
         config: {},
         env: {},
@@ -648,7 +653,7 @@ describe("codex provider", () => {
 
       const snapshot = await provider.fetchUsageSnapshot?.({
         provider: "openai",
-        token: "codex-app-server",
+        token: appServerMarkerToken(),
         authProfileId: "openai:work",
         timeoutMs: 3500,
         config: {

--- a/extensions/codex/provider.test.ts
+++ b/extensions/codex/provider.test.ts
@@ -579,7 +579,7 @@ describe("codex provider", () => {
     await expect(
       provider.fetchUsageSnapshot?.({
         provider: "openai",
-        token: appServerMarkerToken(),
+        token: "codex-app-server",
         timeoutMs: 3500,
         config: {},
         env: {},
@@ -601,6 +601,71 @@ describe("codex provider", () => {
         commandSource: "managed",
       }),
     });
+  });
+
+  it("keeps synthetic usage reads on the configured Codex auth bridge", async () => {
+    const scopedRequest = vi.fn(async ({ method }: { method: string }) =>
+      method === "account/rateLimits/read"
+        ? { rateLimitsByLimitId: {} }
+        : { account: { email: "bridge@example.com" } },
+    );
+    const withCodexAppServerJsonClient = vi.fn(
+      async (
+        _params: unknown,
+        run: (request: typeof scopedRequest) => Promise<unknown>,
+      ): Promise<unknown> => await run(scopedRequest),
+    );
+    vi.doMock("./src/app-server/request.js", () => ({
+      withCodexAppServerJsonClient,
+    }));
+    try {
+      const provider = buildCodexProvider();
+
+      await provider.fetchUsageSnapshot?.({
+        provider: "openai",
+        token: "codex-app-server",
+        authProfileId: "openai:work",
+        timeoutMs: 3500,
+        config: {
+          plugins: {
+            entries: {
+              codex: {
+                config: TEST_CODEX_APP_SERVER_CONFIG,
+              },
+            },
+          },
+        },
+        env: {},
+        fetchFn: fetch,
+      } as never);
+
+      expect(withCodexAppServerJsonClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeoutMs: 3500,
+          authProfileId: "openai:work",
+          config: {
+            plugins: {
+              entries: {
+                codex: {
+                  config: TEST_CODEX_APP_SERVER_CONFIG,
+                },
+              },
+            },
+          },
+          startOptions: expect.objectContaining({
+            command: "/tmp/openclaw-test-codex",
+            commandSource: "config",
+            args: ["app-server", "--listen", "stdio://"],
+          }),
+          isolated: true,
+        }),
+        expect.any(Function),
+      );
+      expect(scopedRequest).toHaveBeenCalledWith({ method: "account/rateLimits/read" });
+      expect(scopedRequest).toHaveBeenCalledWith({ method: "account/read" });
+    } finally {
+      vi.doUnmock("./src/app-server/request.js");
+    }
   });
 
   it("keeps the rate-limit windows when the account identity read fails", async () => {
@@ -631,72 +696,6 @@ describe("codex provider", () => {
       windows: [{ label: "5h", usedPercent: 12 }],
       plan: undefined,
     });
-  });
-
-  it("keeps synthetic usage reads on the configured Codex auth bridge", async () => {
-    const scopedRequest = vi.fn(async ({ method }: { method: string }) =>
-      method === "account/rateLimits/read"
-        ? { rateLimitsByLimitId: {} }
-        : { account: { email: "bridge@example.com" } },
-    );
-    const withCodexAppServerJsonClient = vi.fn(
-      async (
-        _params: unknown,
-        run: (request: typeof scopedRequest) => Promise<unknown>,
-      ): Promise<unknown> => await run(scopedRequest),
-    );
-    vi.doMock("./src/app-server/request.js", () => ({
-      withCodexAppServerJsonClient,
-    }));
-    try {
-      const provider = buildCodexProvider();
-
-      const snapshot = await provider.fetchUsageSnapshot?.({
-        provider: "openai",
-        token: appServerMarkerToken(),
-        authProfileId: "openai:work",
-        timeoutMs: 3500,
-        config: {
-          plugins: {
-            entries: {
-              codex: {
-                config: TEST_CODEX_APP_SERVER_CONFIG,
-              },
-            },
-          },
-        },
-        env: {},
-        fetchFn: fetch,
-      } as never);
-
-      expect(snapshot).toMatchObject({ accountEmail: "bridge@example.com" });
-      expect(withCodexAppServerJsonClient).toHaveBeenCalledWith(
-        expect.objectContaining({
-          timeoutMs: 3500,
-          authProfileId: "openai:work",
-          config: {
-            plugins: {
-              entries: {
-                codex: {
-                  config: TEST_CODEX_APP_SERVER_CONFIG,
-                },
-              },
-            },
-          },
-          startOptions: expect.objectContaining({
-            command: "/tmp/openclaw-test-codex",
-            commandSource: "config",
-            args: ["app-server", "--listen", "stdio://"],
-          }),
-          isolated: true,
-        }),
-        expect.any(Function),
-      );
-      expect(scopedRequest).toHaveBeenCalledWith({ method: "account/rateLimits/read" });
-      expect(scopedRequest).toHaveBeenCalledWith({ method: "account/read" });
-    } finally {
-      vi.doUnmock("./src/app-server/request.js");
-    }
   });
 
   it("exposes a setup auth choice for installing Codex as an external provider", async () => {

--- a/extensions/codex/provider.test.ts
+++ b/extensions/codex/provider.test.ts
@@ -662,7 +662,7 @@ describe("codex provider", () => {
         expect.any(Function),
       );
       expect(scopedRequest).toHaveBeenCalledWith({ method: "account/rateLimits/read" });
-      expect(scopedRequest).toHaveBeenCalledWith({ method: "account/read" });
+      expect(scopedRequest).toHaveBeenCalledWith({ method: "account/read", requestParams: {} });
     } finally {
       vi.doUnmock("./src/app-server/request.js");
     }
@@ -729,7 +729,7 @@ describe("codex provider", () => {
         provider.fetchUsageSnapshot?.({
           provider: "openai",
           token: appServerMarkerToken(),
-          timeoutMs: 30,
+          timeoutMs: 300,
           config: {},
           env: {},
           fetchFn: fetch,

--- a/extensions/codex/provider.test.ts
+++ b/extensions/codex/provider.test.ts
@@ -554,19 +554,22 @@ describe("codex provider", () => {
   });
 
   it("fetches usage from native Codex app-server rate limits for synthetic auth", async () => {
-    const readRateLimits = vi.fn(async () => ({
-      rateLimitsByLimitId: {
-        codex: {
-          limitId: "codex",
-          primary: {
-            usedPercent: 9,
-            windowDurationMins: 300,
-            resetsAt: 1_700_003_600,
+    const readUsage = vi.fn(async () => ({
+      rateLimits: {
+        rateLimitsByLimitId: {
+          codex: {
+            limitId: "codex",
+            primary: {
+              usedPercent: 9,
+              windowDurationMins: 300,
+              resetsAt: 1_700_003_600,
+            },
           },
         },
       },
+      accountEmail: "codex-account@example.com",
     }));
-    const provider = buildCodexProvider({ readRateLimits });
+    const provider = buildCodexProvider({ readUsage });
 
     await expect(
       provider.fetchUsageSnapshot?.({
@@ -582,8 +585,9 @@ describe("codex provider", () => {
       displayName: "OpenAI",
       windows: [{ label: "5h", usedPercent: 9, resetAt: 1_700_003_600_000 }],
       plan: undefined,
+      accountEmail: "codex-account@example.com",
     });
-    expect(readRateLimits).toHaveBeenCalledWith({
+    expect(readUsage).toHaveBeenCalledWith({
       timeoutMs: 3500,
       agentDir: undefined,
       config: {},
@@ -594,17 +598,55 @@ describe("codex provider", () => {
     });
   });
 
-  it("keeps synthetic usage rate-limit reads on the configured Codex auth bridge", async () => {
-    const requestCodexAppServerJson = vi.fn(async (_params: unknown) => ({
-      rateLimitsByLimitId: {},
+  it("keeps the rate-limit windows when the account identity read fails", async () => {
+    const readUsage = vi.fn(async () => ({
+      rateLimits: {
+        rateLimitsByLimitId: {
+          codex: {
+            limitId: "codex",
+            primary: { usedPercent: 12, windowDurationMins: 300 },
+          },
+        },
+      },
     }));
+    const provider = buildCodexProvider({ readUsage });
+
+    await expect(
+      provider.fetchUsageSnapshot?.({
+        provider: "openai",
+        token: "codex-app-server",
+        timeoutMs: 3500,
+        config: {},
+        env: {},
+        fetchFn: fetch,
+      } as never),
+    ).resolves.toEqual({
+      provider: "openai",
+      displayName: "OpenAI",
+      windows: [{ label: "5h", usedPercent: 12 }],
+      plan: undefined,
+    });
+  });
+
+  it("keeps synthetic usage reads on the configured Codex auth bridge", async () => {
+    const scopedRequest = vi.fn(async ({ method }: { method: string }) =>
+      method === "account/rateLimits/read"
+        ? { rateLimitsByLimitId: {} }
+        : { account: { email: "bridge@example.com" } },
+    );
+    const withCodexAppServerJsonClient = vi.fn(
+      async (
+        _params: unknown,
+        run: (request: typeof scopedRequest) => Promise<unknown>,
+      ): Promise<unknown> => await run(scopedRequest),
+    );
     vi.doMock("./src/app-server/request.js", () => ({
-      requestCodexAppServerJson,
+      withCodexAppServerJsonClient,
     }));
     try {
       const provider = buildCodexProvider();
 
-      await provider.fetchUsageSnapshot?.({
+      const snapshot = await provider.fetchUsageSnapshot?.({
         provider: "openai",
         token: "codex-app-server",
         authProfileId: "openai:work",
@@ -622,27 +664,31 @@ describe("codex provider", () => {
         fetchFn: fetch,
       } as never);
 
-      expect(requestCodexAppServerJson).toHaveBeenCalledWith({
-        method: "account/rateLimits/read",
-        timeoutMs: 3500,
-        agentDir: undefined,
-        authProfileId: "openai:work",
-        config: {
-          plugins: {
-            entries: {
-              codex: {
-                config: TEST_CODEX_APP_SERVER_CONFIG,
+      expect(snapshot).toMatchObject({ accountEmail: "bridge@example.com" });
+      expect(withCodexAppServerJsonClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeoutMs: 3500,
+          authProfileId: "openai:work",
+          config: {
+            plugins: {
+              entries: {
+                codex: {
+                  config: TEST_CODEX_APP_SERVER_CONFIG,
+                },
               },
             },
           },
-        },
-        startOptions: expect.objectContaining({
-          command: "/tmp/openclaw-test-codex",
-          commandSource: "config",
-          args: ["app-server", "--listen", "stdio://"],
+          startOptions: expect.objectContaining({
+            command: "/tmp/openclaw-test-codex",
+            commandSource: "config",
+            args: ["app-server", "--listen", "stdio://"],
+          }),
+          isolated: true,
         }),
-        isolated: true,
-      });
+        expect.any(Function),
+      );
+      expect(scopedRequest).toHaveBeenCalledWith({ method: "account/rateLimits/read" });
+      expect(scopedRequest).toHaveBeenCalledWith({ method: "account/read" });
     } finally {
       vi.doUnmock("./src/app-server/request.js");
     }

--- a/extensions/codex/provider.ts
+++ b/extensions/codex/provider.ts
@@ -289,6 +289,9 @@ async function requestCodexAppServerUsageLazy(options: {
   startOptions?: CodexAppServerStartOptions;
 }): Promise<{ rateLimits: unknown; accountEmail?: string }> {
   const { withCodexAppServerJsonClient } = await import("./src/app-server/request.js");
+  // Bound the whole usage read (client acquisition + both requests) so the
+  // best-effort identity read can be capped against the time actually left.
+  const deadline = Date.now() + options.timeoutMs;
   // One session serves both reads so the identity is guaranteed to belong to
   // the same account the rate limits describe.
   return await withCodexAppServerJsonClient(
@@ -306,28 +309,36 @@ async function requestCodexAppServerUsageLazy(options: {
       // Identity is best-effort: rate limits stay useful without it, and a slow
       // or hung account read must never turn a successful window fetch into a
       // usage-snapshot timeout.
-      const accountEmail = await readCodexAccountEmailBestEffort(request, options.timeoutMs);
+      const accountEmail = await readCodexAccountEmailBestEffort(request, deadline);
       return { rateLimits, ...(accountEmail ? { accountEmail } : {}) };
     },
   );
 }
 
-// Cap the best-effort identity read so it stays well inside the shared usage
-// deadline; a fraction of the total budget keeps it below the outer timeout
-// even when the rate-limit read was near-instant.
+// Cap the best-effort identity read, and always leave a margin before the
+// shared usage deadline so this read cannot convert a successful rate-limit
+// fetch into an outer timeout.
 const CODEX_ACCOUNT_READ_MAX_TIMEOUT_MS = 4_000;
+const CODEX_ACCOUNT_READ_DEADLINE_MARGIN_MS = 250;
 
 async function readCodexAccountEmailBestEffort(
-  request: (params: { method: string }) => Promise<unknown>,
-  usageTimeoutMs: number,
+  request: (params: { method: string; requestParams?: unknown }) => Promise<unknown>,
+  deadline: number,
 ): Promise<string | undefined> {
-  const boundMs = Math.max(
-    1,
-    Math.min(CODEX_ACCOUNT_READ_MAX_TIMEOUT_MS, Math.floor(usageTimeoutMs / 3)),
+  const boundMs = Math.min(
+    CODEX_ACCOUNT_READ_MAX_TIMEOUT_MS,
+    deadline - Date.now() - CODEX_ACCOUNT_READ_DEADLINE_MARGIN_MS,
   );
+  // No usable budget left after the rate-limit read: keep the windows and skip
+  // identity rather than risk tripping the outer timeout.
+  if (boundMs <= 0) {
+    return undefined;
+  }
+  // account/read requires an (empty) params object per the app-server protocol
+  // (GetAccountParams; refreshToken defaults false when omitted).
   // Resolves, never rejects: a failing account read yields undefined so the
   // caller still returns the rate-limit windows.
-  const read = request({ method: "account/read" }).then(
+  const read = request({ method: "account/read", requestParams: {} }).then(
     (account) => extractCodexAccountEmail(account),
     () => undefined,
   );

--- a/extensions/codex/provider.ts
+++ b/extensions/codex/provider.ts
@@ -303,6 +303,9 @@ async function requestCodexAppServerUsageLazy(options: {
       config: options.config,
       startOptions: options.startOptions,
       isolated: true,
+      // Keep isolated-client shutdown cheap so cleanup after a hung read cannot
+      // breach the usage deadline; the reserve below leaves room for it.
+      isolatedShutdown: CODEX_USAGE_ISOLATED_SHUTDOWN,
     },
     async (request) => {
       const rateLimits = await request({ method: "account/rateLimits/read" });
@@ -315,11 +318,19 @@ async function requestCodexAppServerUsageLazy(options: {
   );
 }
 
-// Cap the best-effort identity read, and always leave a margin before the
-// shared usage deadline so this read cannot convert a successful rate-limit
-// fetch into an outer timeout.
+// Isolated usage-read shutdown: a throwaway read-only child, so force-kill
+// quickly and wait only briefly for exit. Its total bounds the reserve below.
+const CODEX_USAGE_ISOLATED_SHUTDOWN = { forceKillDelayMs: 200, exitTimeoutMs: 300 } as const;
+
+// Cap the best-effort identity read, and reserve enough of the shared usage
+// deadline for the isolated-client shutdown plus a margin so this read cannot
+// convert a successful rate-limit fetch into an outer timeout.
 const CODEX_ACCOUNT_READ_MAX_TIMEOUT_MS = 4_000;
 const CODEX_ACCOUNT_READ_DEADLINE_MARGIN_MS = 250;
+const CODEX_USAGE_DEADLINE_RESERVE_MS =
+  CODEX_USAGE_ISOLATED_SHUTDOWN.forceKillDelayMs +
+  CODEX_USAGE_ISOLATED_SHUTDOWN.exitTimeoutMs +
+  CODEX_ACCOUNT_READ_DEADLINE_MARGIN_MS;
 
 async function readCodexAccountEmailBestEffort(
   request: (params: { method: string; requestParams?: unknown }) => Promise<unknown>,
@@ -327,7 +338,7 @@ async function readCodexAccountEmailBestEffort(
 ): Promise<string | undefined> {
   const boundMs = Math.min(
     CODEX_ACCOUNT_READ_MAX_TIMEOUT_MS,
-    deadline - Date.now() - CODEX_ACCOUNT_READ_DEADLINE_MARGIN_MS,
+    deadline - Date.now() - CODEX_USAGE_DEADLINE_RESERVE_MS,
   );
   // No usable budget left after the rate-limit read: keep the windows and skip
   // identity rather than risk tripping the outer timeout.

--- a/extensions/codex/provider.ts
+++ b/extensions/codex/provider.ts
@@ -303,14 +303,48 @@ async function requestCodexAppServerUsageLazy(options: {
     },
     async (request) => {
       const rateLimits = await request({ method: "account/rateLimits/read" });
-      // Identity is best-effort: rate limits stay useful without it.
-      const accountEmail = await request({ method: "account/read" }).then(
-        (account) => extractCodexAccountEmail(account),
-        () => undefined,
-      );
+      // Identity is best-effort: rate limits stay useful without it, and a slow
+      // or hung account read must never turn a successful window fetch into a
+      // usage-snapshot timeout.
+      const accountEmail = await readCodexAccountEmailBestEffort(request, options.timeoutMs);
       return { rateLimits, ...(accountEmail ? { accountEmail } : {}) };
     },
   );
+}
+
+// Cap the best-effort identity read so it stays well inside the shared usage
+// deadline; a fraction of the total budget keeps it below the outer timeout
+// even when the rate-limit read was near-instant.
+const CODEX_ACCOUNT_READ_MAX_TIMEOUT_MS = 4_000;
+
+async function readCodexAccountEmailBestEffort(
+  request: (params: { method: string }) => Promise<unknown>,
+  usageTimeoutMs: number,
+): Promise<string | undefined> {
+  const boundMs = Math.max(
+    1,
+    Math.min(CODEX_ACCOUNT_READ_MAX_TIMEOUT_MS, Math.floor(usageTimeoutMs / 3)),
+  );
+  // Resolves, never rejects: a failing account read yields undefined so the
+  // caller still returns the rate-limit windows.
+  const read = request({ method: "account/read" }).then(
+    (account) => extractCodexAccountEmail(account),
+    () => undefined,
+  );
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<undefined>((resolve) => {
+    timer = setTimeout(() => resolve(undefined), boundMs);
+    timer.unref?.();
+  });
+  try {
+    return await Promise.race([read, timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+    // When the timer wins, the still-pending read settles after the client
+    // closes; it already swallows rejections, so there is nothing to leak.
+  }
 }
 
 function normalizeTimeoutMs(value: unknown): number {

--- a/extensions/codex/provider.ts
+++ b/extensions/codex/provider.ts
@@ -68,18 +68,23 @@ type CodexModelLister = (options: {
   sharedClient?: boolean;
 }) => Promise<CodexAppServerModelListResult>;
 
-type CodexRateLimitReader = (options: {
+type CodexUsageRead = {
+  rateLimits: unknown;
+  accountEmail?: string;
+};
+
+type CodexUsageReader = (options: {
   timeoutMs: number;
   agentDir?: string;
   authProfileId?: string;
-  config?: Parameters<typeof requestCodexAppServerRateLimitsLazy>[0]["config"];
+  config?: Parameters<typeof requestCodexAppServerUsageLazy>[0]["config"];
   startOptions?: CodexAppServerStartOptions;
-}) => Promise<unknown>;
+}) => Promise<CodexUsageRead>;
 
 type BuildCodexProviderOptions = {
   pluginConfig?: unknown;
   listModels?: CodexModelLister;
-  readRateLimits?: CodexRateLimitReader;
+  readUsage?: CodexUsageReader;
 };
 
 type BuildCatalogOptions = {
@@ -148,15 +153,16 @@ export function buildCodexProvider(options: BuildCodexProviderOptions = {}): Pro
       const runtimePluginConfig = resolvePluginConfigObject(ctx.config, CODEX_PROVIDER_ID);
       const pluginConfig = runtimePluginConfig ?? (ctx.config ? undefined : options.pluginConfig);
       const appServer = resolveCodexAppServerRuntimeOptions({ pluginConfig });
-      const rateLimits = await (options.readRateLimits ?? requestCodexAppServerRateLimitsLazy)({
+      const usage = await (options.readUsage ?? requestCodexAppServerUsageLazy)({
         timeoutMs: ctx.timeoutMs,
         agentDir: ctx.agentDir,
         ...(ctx.authProfileId ? { authProfileId: ctx.authProfileId } : {}),
         config: ctx.config,
         startOptions: appServer.start,
       });
-      const snapshot = buildCodexAppServerUsageSnapshot(rateLimits);
-      return ctx.email && !snapshot.error ? { ...snapshot, accountEmail: ctx.email } : snapshot;
+      const snapshot = buildCodexAppServerUsageSnapshot(usage.rateLimits);
+      const accountEmail = ctx.email ?? usage.accountEmail;
+      return accountEmail && !snapshot.error ? { ...snapshot, accountEmail } : snapshot;
     },
     resolveThinkingProfile: ({ modelId, compat }) => {
       const efforts = resolveCodexThinkingEfforts({
@@ -260,7 +266,20 @@ async function listCodexAppServerModelsLazy(options: {
   return listCodexAppServerModels(options);
 }
 
-async function requestCodexAppServerRateLimitsLazy(options: {
+function extractCodexAccountEmail(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as { account?: unknown; email?: unknown; accountEmail?: unknown };
+  const account =
+    record.account && typeof record.account === "object"
+      ? (record.account as { email?: unknown; accountEmail?: unknown })
+      : record;
+  const email = account.email ?? account.accountEmail;
+  return typeof email === "string" && email.trim() ? email.trim() : undefined;
+}
+
+async function requestCodexAppServerUsageLazy(options: {
   timeoutMs: number;
   agentDir?: string;
   authProfileId?: string;
@@ -268,17 +287,30 @@ async function requestCodexAppServerRateLimitsLazy(options: {
     typeof import("./src/app-server/request.js").requestCodexAppServerJson
   >[0]["config"];
   startOptions?: CodexAppServerStartOptions;
-}): Promise<unknown> {
-  const { requestCodexAppServerJson } = await import("./src/app-server/request.js");
-  return await requestCodexAppServerJson({
-    method: "account/rateLimits/read",
-    timeoutMs: options.timeoutMs,
-    agentDir: options.agentDir,
-    ...(options.authProfileId ? { authProfileId: options.authProfileId } : {}),
-    config: options.config,
-    startOptions: options.startOptions,
-    isolated: true,
-  });
+}): Promise<{ rateLimits: unknown; accountEmail?: string }> {
+  const { withCodexAppServerJsonClient } = await import("./src/app-server/request.js");
+  // One session serves both reads so the identity is guaranteed to belong to
+  // the same account the rate limits describe.
+  return await withCodexAppServerJsonClient(
+    {
+      timeoutMs: options.timeoutMs,
+      timeoutMessage: "codex app-server usage read timed out",
+      agentDir: options.agentDir,
+      ...(options.authProfileId ? { authProfileId: options.authProfileId } : {}),
+      config: options.config,
+      startOptions: options.startOptions,
+      isolated: true,
+    },
+    async (request) => {
+      const rateLimits = await request({ method: "account/rateLimits/read" });
+      // Identity is best-effort: rate limits stay useful without it.
+      const accountEmail = await request({ method: "account/read" }).then(
+        (account) => extractCodexAccountEmail(account),
+        () => undefined,
+      );
+      return { rateLimits, ...(accountEmail ? { accountEmail } : {}) };
+    },
+  );
 }
 
 function normalizeTimeoutMs(value: unknown): number {

--- a/extensions/codex/src/app-server/request.ts
+++ b/extensions/codex/src/app-server/request.ts
@@ -133,6 +133,10 @@ export async function withCodexAppServerJsonClient<T>(
     sessionKey?: string;
     sessionId?: string;
     isolated?: boolean;
+    // Bounds the isolated-client shutdown. Callers on a tight result deadline
+    // pass a small budget so cleanup cannot breach the outer timeout; defaults
+    // to the conservative graceful/force-kill window used elsewhere.
+    isolatedShutdown?: { exitTimeoutMs?: number; forceKillDelayMs?: number };
   },
   run: (request: CodexAppServerScopedRequest) => Promise<T>,
 ): Promise<T> {
@@ -206,7 +210,10 @@ export async function withCodexAppServerJsonClient<T>(
               // The stdio bin shim does not always propagate stdin EOF to the
               // underlying codex binary, so the unref'd close() path can leave
               // the child running and keep the parent's event loop alive.
-              await client.closeAndWait({ exitTimeoutMs: 2_000, forceKillDelayMs: 250 });
+              await client.closeAndWait({
+                exitTimeoutMs: params.isolatedShutdown?.exitTimeoutMs ?? 2_000,
+                forceKillDelayMs: params.isolatedShutdown?.forceKillDelayMs ?? 250,
+              });
             } else {
               releaseLeasedSharedCodexAppServerClient(client);
             }

--- a/extensions/codex/src/app-server/request.ts
+++ b/extensions/codex/src/app-server/request.ts
@@ -93,6 +93,7 @@ export async function requestCodexAppServerJson<T = JsonValue | undefined>(param
   sessionId?: string;
   isolated?: boolean;
 }): Promise<T> {
+  // Fail closed before spawning or leasing a client for a guard-blocked method.
   const sandboxBlock = resolveCodexAppServerDirectSandboxBypassBlock({
     method: params.method,
     requestParams: params.requestParams,
@@ -103,8 +104,40 @@ export async function requestCodexAppServerJson<T = JsonValue | undefined>(param
   if (sandboxBlock) {
     throw new Error(sandboxBlock);
   }
+  return await withCodexAppServerJsonClient(
+    { ...params, timeoutMessage: `codex app-server ${params.method} timed out` },
+    async (request) =>
+      await request<T>({ method: params.method, requestParams: params.requestParams }),
+  );
+}
+
+type CodexAppServerScopedRequest = <T = JsonValue | undefined>(request: {
+  method: string;
+  requestParams?: unknown;
+}) => Promise<T>;
+
+/**
+ * Runs several guarded requests over one acquired client (shared lease or
+ * isolated child) so related reads see the same app-server session. The whole
+ * callback re-runs once when the client's start selection changed underneath it.
+ */
+export async function withCodexAppServerJsonClient<T>(
+  params: {
+    timeoutMs?: number;
+    timeoutMessage?: string;
+    pluginConfig?: unknown;
+    startOptions?: CodexAppServerStartOptions;
+    authProfileId?: string | null;
+    agentDir?: string;
+    config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
+    sessionKey?: string;
+    sessionId?: string;
+    isolated?: boolean;
+  },
+  run: (request: CodexAppServerScopedRequest) => Promise<T>,
+): Promise<T> {
   const timeoutMs = params.timeoutMs ?? 60_000;
-  const timeoutMessage = `codex app-server ${params.method} timed out`;
+  const timeoutMessage = params.timeoutMessage ?? "codex app-server request timed out";
   const timeoutController = new AbortController();
   const deadline = Number.isFinite(timeoutMs) && timeoutMs > 0 ? Date.now() + timeoutMs : undefined;
   const isPastDeadline = () => deadline !== undefined && Date.now() >= deadline;
@@ -137,10 +170,27 @@ export async function requestCodexAppServerJson<T = JsonValue | undefined>(param
           });
           try {
             throwIfAbandoned();
-            return await client.request<T>(params.method, params.requestParams, {
-              timeoutMs: remainingTimeoutMs(),
-              signal: timeoutController.signal,
-            });
+            const scopedRequest: CodexAppServerScopedRequest = async <T>(request: {
+              method: string;
+              requestParams?: unknown;
+            }) => {
+              const sandboxBlock = resolveCodexAppServerDirectSandboxBypassBlock({
+                method: request.method,
+                requestParams: request.requestParams,
+                config: params.config,
+                sessionKey: params.sessionKey,
+                sessionId: params.sessionId,
+              });
+              if (sandboxBlock) {
+                throw new Error(sandboxBlock);
+              }
+              throwIfAbandoned();
+              return await client.request<T>(request.method, request.requestParams, {
+                timeoutMs: remainingTimeoutMs(),
+                signal: timeoutController.signal,
+              });
+            };
+            return await run(scopedRequest);
           } catch (error) {
             if (!isCodexAppServerStartSelectionChangedError(error) || attempt > 0) {
               throw error;

--- a/extensions/codex/src/app-server/request.ts
+++ b/extensions/codex/src/app-server/request.ts
@@ -174,7 +174,7 @@ export async function withCodexAppServerJsonClient<T>(
           });
           try {
             throwIfAbandoned();
-            const scopedRequest: CodexAppServerScopedRequest = async <T>(request: {
+            const scopedRequest: CodexAppServerScopedRequest = async <R>(request: {
               method: string;
               requestParams?: unknown;
             }) => {
@@ -189,7 +189,7 @@ export async function withCodexAppServerJsonClient<T>(
                 throw new Error(sandboxBlock);
               }
               throwIfAbandoned();
-              return await client.request<T>(request.method, request.requestParams, {
+              return await client.request<R>(request.method, request.requestParams, {
                 timeoutMs: remainingTimeoutMs(),
                 signal: timeoutController.signal,
               });


### PR DESCRIPTION
## What Problem This Solves

#106200 added the account email to the chat context popover's plan-usage section, but the **Codex harness** path (usage served by the codex plugin's app-server `account/rateLimits/read`) only carried an email when the auth profile happened to store one — which the app-server marker path never does. Sessions running through the Codex harness showed their 5-hour/weekly windows with no account identity, unlike the OpenAI-OAuth `wham` path.

## Why This Change Was Made

Follow-up completing #106200's coverage: every subscription surface in the popover should say whose quota it is. The app-server's own `account/read` is the only source guaranteed to match the account the rate limits describe (the bridged auth profile or the Codex CLI login, whichever the server is using).

## User Impact

- Codex-harness usage snapshots now include `accountEmail`, so the context popover (and Model Providers/Usage surfaces) label the plan windows with the account, exactly like the OpenAI-OAuth and Claude paths.
- The usage fetch performs both reads over **one** isolated app-server session via a new `withCodexAppServerJsonClient` seam (the existing single-request `requestCodexAppServerJson` now delegates to it — one canonical acquire/retry/shutdown path, no second server spawn per poll).
- Identity is best-effort: if `account/read` fails, the rate-limit windows still render, just unlabeled. A stored profile email (`ctx.email`) still wins when present.

## Evidence

- `extensions/codex/provider.test.ts` + `extensions/codex/src/app-server/request.test.ts`: 51 tests pass locally via `node scripts/run-vitest.mjs`, including new coverage: snapshot carries the email from the combined read; windows survive an account-read failure; the bridged path issues both `account/rateLimits/read` and `account/read` on one client with the configured auth profile/start options.
- `pnpm tsgo:extensions` clean for this diff (the lane currently also reports `src/gateway/server.impl.ts` referencing a missing `mcp-grant-store` export — present on current `main`, unrelated to this change).
- Live end-to-end probe was attempted on the dev box but `codex app-server` itself would not complete `initialize` there (~20 concurrent Codex CLI sessions racing the `~/.codex` system-skills dir: "failed to install system skills: … Directory not empty"); the OpenAI-OAuth sibling path was live-proven against `chatgpt.com/backend-api/wham/usage` in #106200 (`accountEmail` from real JWT claims). The `account/read → {account:{email}}` payload shape matches what `extensions/codex/src/command-formatters.ts` already consumes in production.
