### PR TITLE
improve: speed up lifecycle tests

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -2336,47 +2336,55 @@ describe("TelegramPollingSession", () => {
   });
 
   it("replays claimed spooled updates after a crash before adoption", async () => {
-    await withTempSpool(async (tempDir) => {
-      const abort = new AbortController();
-      const participants: TelegramSpooledReplayDeferredParticipant[] = [];
-      await writeSpooledTestUpdates(tempDir, [topicUpdate(42, 10, "pre-adoption crash")]);
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      await withTempSpool(async (tempDir) => {
+        const abort = new AbortController();
+        const participants: TelegramSpooledReplayDeferredParticipant[] = [];
+        await writeSpooledTestUpdates(tempDir, [topicUpdate(42, 10, "pre-adoption crash")]);
 
-      const { runPromise, stopWorker } = startIsolatedIngressSession({
-        abort,
-        spoolDir: tempDir,
-        drainIntervalMs: 10,
-        handleUpdate: async (update) => {
-          const participant = createTelegramSpooledReplayDeferredParticipant(
-            `test-pre-crash:${update.update_id}`,
-          );
-          if (!participant) {
-            throw new Error("expected spooled replay participant");
-          }
-          participants.push(participant);
-          // Never adopt: process dies with claim held.
-        },
+        const { runPromise, stopWorker } = startIsolatedIngressSession({
+          abort,
+          spoolDir: tempDir,
+          drainIntervalMs: 10,
+          handleUpdate: async (update) => {
+            const participant = createTelegramSpooledReplayDeferredParticipant(
+              `test-pre-crash:${update.update_id}`,
+            );
+            if (!participant) {
+              throw new Error("expected spooled replay participant");
+            }
+            participants.push(participant);
+            // Never adopt: process dies with claim held.
+          },
+        });
+
+        await vi.waitFor(() => expect(participants).toHaveLength(1));
+        await vi.waitFor(async () =>
+          expect(
+            (await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).map((c) => c.updateId),
+          ).toEqual([42]),
+        );
+
+        abort.abort();
+        stopWorker();
+        // Establish the same post-stop boundary as production without burning
+        // the real 15-second graceful-stop ceiling on the abandoned handler.
+        await vi.advanceTimersByTimeAsync(15_000);
+        await runPromise;
+
+        // Stale-claim recovery after crash: row is still claimed → replayable.
+        const recovered = await recoverStaleTelegramSpooledUpdateClaims({
+          spoolDir: tempDir,
+          staleMs: 0,
+        });
+        expect(recovered).toBeGreaterThanOrEqual(1);
+        expect(await pendingUpdateIds(tempDir, "all")).toEqual([42]);
+        expect(await failedUpdateIds(tempDir)).toEqual([]);
       });
-
-      await vi.waitFor(() => expect(participants).toHaveLength(1));
-      await vi.waitFor(async () =>
-        expect(
-          (await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).map((c) => c.updateId),
-        ).toEqual([42]),
-      );
-
-      abort.abort();
-      stopWorker();
-      await runPromise;
-
-      // Stale-claim recovery after crash: row is still claimed → replayable.
-      const recovered = await recoverStaleTelegramSpooledUpdateClaims({
-        spoolDir: tempDir,
-        staleMs: 0,
-      });
-      expect(recovered).toBeGreaterThanOrEqual(1);
-      expect(await pendingUpdateIds(tempDir, "all")).toEqual([42]);
-      expect(await failedUpdateIds(tempDir)).toEqual([]);
-    });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not replay spooled updates after crash post-adoption (row already tombstoned)", async () => {

--- a/src/cron/command-runner.test.ts
+++ b/src/cron/command-runner.test.ts
@@ -27,7 +27,16 @@ function isProcessRunning(pid: number): boolean {
   if (result.error) {
     throw result.error;
   }
-  return result.status === 0 && !result.stdout.trimStart().startsWith("Z");
+  const state = result.stdout.trim();
+  if (result.status === 0) {
+    return !state.startsWith("Z");
+  }
+  if (result.status === 1 && state === "" && result.stderr.trim() === "") {
+    return false;
+  }
+  throw new Error(
+    `ps failed with status ${result.status ?? "unknown"}: ${result.stderr.trim() || "no output"}`,
+  );
 }
 
 describe("runCronCommandJob", () => {

--- a/src/cron/command-runner.test.ts
+++ b/src/cron/command-runner.test.ts
@@ -1,7 +1,7 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { setTimeout as delay } from "node:timers/promises";
 import { describe, expect, it } from "vitest";
 import { runCronCommandJob } from "./command-runner.js";
 import type { CronJob } from "./types.js";
@@ -20,6 +20,14 @@ function makeCommandJob(payload: Extract<CronJob["payload"], { kind: "command" }
     payload,
     state: {},
   };
+}
+
+function isProcessRunning(pid: number): boolean {
+  const result = spawnSync("ps", ["-o", "state=", "-p", String(pid)], { encoding: "utf8" });
+  if (result.error) {
+    throw result.error;
+  }
+  return result.status === 0 && !result.stdout.trimStart().startsWith("Z");
 }
 
 describe("runCronCommandJob", () => {
@@ -121,26 +129,29 @@ describe("runCronCommandJob", () => {
 
   it.skipIf(process.platform === "win32")("kills shell process groups on timeout", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-command-"));
-    const markerPath = path.join(tempDir, "survived");
-    const childScript = [
-      `setTimeout(() => require("node:fs").writeFileSync(${JSON.stringify(markerPath)}, "alive"), 350)`,
-      "setInterval(() => {}, 1000)",
-    ].join(";");
-    const shellCommand = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(childScript)}`;
+    const childPidPath = path.join(tempDir, "child.pid");
+    const childScript = "setInterval(() => {}, 1000)";
+    const shellCommand = [
+      `${JSON.stringify(process.execPath)} -e ${JSON.stringify(childScript)} &`,
+      "child_pid=$!",
+      `printf '%s' "$child_pid" > ${JSON.stringify(childPidPath)}`,
+      'wait "$child_pid"',
+    ].join("\n");
 
     const result = await runCronCommandJob({
       job: makeCommandJob({
         kind: "command",
         argv: ["sh", "-lc", shellCommand],
-        timeoutSeconds: 0.05,
+        timeoutSeconds: 0.2,
       }),
     });
 
     expect(result.status).toBe("error");
     expect(result.error).toBe("command timed out");
 
-    await delay(700);
-    await expect(fs.access(markerPath)).rejects.toThrow();
+    const childPid = Number.parseInt(await fs.readFile(childPidPath, "utf8"), 10);
+    expect(Number.isSafeInteger(childPid)).toBe(true);
+    await expect.poll(() => isProcessRunning(childPid)).toBe(false);
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 

--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -498,6 +498,7 @@ describePosix("scripts/pr per-PR operation lock", () => {
   it("serializes the same PR and releases the waiter after SIGTERM", async () => {
     const repoDir = createRepo();
     const held = join(repoDir, "held");
+    const blocked = join(repoDir, "blocked");
     const acquired = join(repoDir, "acquired");
     const holder = spawnHolder(repoDir, held);
     let waiter: ChildProcess | undefined;
@@ -510,6 +511,7 @@ describePosix("scripts/pr per-PR operation lock", () => {
           "-c",
           [
             ...bashSource(repoDir),
+            `sleep() { printf 'blocked\\n' >'${blocked}'; command sleep 0.01; }`,
             "acquire_pr_operation_lock 42",
             `printf 'acquired\\n' >'${acquired}'`,
             "release_pr_operation_lock",
@@ -517,7 +519,7 @@ describePosix("scripts/pr per-PR operation lock", () => {
         ],
         { cwd: repoDir, stdio: "ignore" },
       );
-      await new Promise((resolve) => setTimeout(resolve, 250));
+      expect(await waitFor(() => existsSync(blocked))).toBe(true);
       expect(existsSync(acquired)).toBe(false);
 
       await stopChild(holder, "SIGTERM");


### PR DESCRIPTION
## What Problem This Solves

Several lifecycle tests spent fixed wall-clock time waiting for timeouts or proving that background work stayed blocked. The three affected suites consumed about 36.17 seconds of test time, slowing focused local runs and CI feedback.

## Why This Change Was Made

The Telegram crash-recovery test now advances the graceful-stop ceiling with fake time and still waits for the polling session to stop before recovering the claim. The cron process-group test polls the spawned child state, treating zombies as terminated, and the PR-operation-lock test waits for an explicit contention signal while using a test-local short retry sleep.

No production behavior changes.

## User Impact

No user-visible behavior change. Contributors and maintainers get faster lifecycle-test feedback with stronger deterministic synchronization.

## Evidence

- Baseline Testbox `tbx_01kxdzega6peegpmq5vfwjbnda`:
  - Telegram polling: 29,186 ms
  - Cron command runner: 1,052 ms
  - PR operation lock: 5,931 ms
  - Total test time: 36,169 ms
- Fresh exact-base Testbox `tbx_01kxe1b4zs8d2qfkzds7txjb3v` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/29262185285)):
  - Telegram polling: 13,751 ms
  - Cron command runner: 469 ms
  - PR operation lock: 5,677 ms
  - Total test time: 19,897 ms, about 45% faster
  - 139 tests passed
  - Targeted oxfmt and oxlint passed
- Core-test, extension-test, and root-test tsgo lanes passed.
- Fresh branch autoreview: no actionable findings.

AI-assisted. I reviewed the implementation and validation results.
