### PR TITLE
fix(talk): reject malformed relay audio base64

### DIFF
--- a/src/gateway/talk-realtime-relay.ts
+++ b/src/gateway/talk-realtime-relay.ts
@@ -59,12 +59,12 @@ import {
   buildTalkRealtimeRelayIssuePayload as relayIssuePayload,
   createTalkRealtimeRelayIssue as realtimeRelayIssue,
 } from "./talk-realtime-relay-issues.js";
+import { decodeTalkRelayAudioBase64 } from "./talk-relay-audio-base64.js";
 import {
   closeExpiredTalkRelaySessions,
   requireActiveTalkRelaySession,
 } from "./talk-relay-session-lifecycle.js";
 import { forgetUnifiedTalkSession } from "./talk-session-registry.js";
-
 const RELAY_SESSION_TTL_MS = 30 * 60 * 1000;
 const MAX_AUDIO_BASE64_BYTES = 512 * 1024;
 const MAX_RELAY_SESSIONS_PER_CONN = 2;
@@ -1249,8 +1249,8 @@ export function sendTalkRealtimeRelayAudio(params: {
     throw new Error("Realtime relay audio frame is too large");
   }
   const session = getRelaySession(params.relaySessionId, params.connId);
+  const audio = decodeTalkRelayAudioBase64(params.audioBase64, "Realtime relay");
   const turnId = ensureRelayTurn(session);
-  const audio = Buffer.from(params.audioBase64, "base64");
   session.bridge.sendAudio(audio);
   broadcastToOwner(session.context, session.connId, {
     relaySessionId: session.id,

--- a/src/gateway/talk-relay-audio-base64.test.ts
+++ b/src/gateway/talk-relay-audio-base64.test.ts
@@ -1,33 +1,82 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { RealtimeTranscriptionProviderPlugin, RealtimeVoiceProviderPlugin } from "../plugins/types.js";
-import { createTalkRealtimeRelaySession, sendTalkRealtimeRelayAudio, stopTalkRealtimeRelaySession } from "./talk-realtime-relay.js";
-import { createTalkTranscriptionRelaySession, sendTalkTranscriptionRelayAudio, stopTalkTranscriptionRelaySession } from "./talk-transcription-relay.js";
+import type {
+  RealtimeTranscriptionProviderPlugin,
+  RealtimeVoiceProviderPlugin,
+} from "../plugins/types.js";
+import {
+  createTalkRealtimeRelaySession,
+  sendTalkRealtimeRelayAudio,
+  stopTalkRealtimeRelaySession,
+} from "./talk-realtime-relay.js";
 import { decodeTalkRelayAudioBase64 } from "./talk-relay-audio-base64.js";
+import {
+  createTalkTranscriptionRelaySession,
+  sendTalkTranscriptionRelayAudio,
+  stopTalkTranscriptionRelaySession,
+} from "./talk-transcription-relay.js";
 
 const realtime = new Map<string, string>();
 const transcription = new Map<string, string>();
 
 function context() {
   const events: unknown[] = [];
-  return { events, context: { getRuntimeConfig: () => ({}), broadcastToConnIds: (_event: string, payload: unknown) => events.push(payload) } as never };
+  return {
+    events,
+    context: {
+      getRuntimeConfig: () => ({}),
+      broadcastToConnIds: (_event: string, payload: unknown) => events.push(payload),
+    } as never,
+  };
 }
 
 function voiceProvider(sendAudio: ReturnType<typeof vi.fn>): RealtimeVoiceProviderPlugin {
-  return { id: "test", label: "Test", isConfigured: () => true, createBridge: () => ({ connect: async () => {}, sendAudio, setMediaTimestamp: () => {}, handleBargeIn: () => {}, submitToolResult: () => {}, acknowledgeMark: () => {}, close: () => {}, isConnected: () => true }) };
+  return {
+    id: "test",
+    label: "Test",
+    isConfigured: () => true,
+    createBridge: () => ({
+      connect: async () => {},
+      sendAudio,
+      setMediaTimestamp: () => {},
+      handleBargeIn: () => {},
+      submitToolResult: () => {},
+      acknowledgeMark: () => {},
+      close: () => {},
+      isConnected: () => true,
+    }),
+  };
 }
 
-function transcriptionProvider(sendAudio: ReturnType<typeof vi.fn>): RealtimeTranscriptionProviderPlugin {
-  return { id: "test", label: "Test", isConfigured: () => true, createSession: () => ({ connect: async () => {}, sendAudio, close: () => {}, isConnected: () => true }) };
+function transcriptionProvider(
+  sendAudio: ReturnType<typeof vi.fn>,
+): RealtimeTranscriptionProviderPlugin {
+  return {
+    id: "test",
+    label: "Test",
+    isConfigured: () => true,
+    createSession: () => ({
+      connect: async () => {},
+      sendAudio,
+      close: () => {},
+      isConnected: () => true,
+    }),
+  };
 }
 
 describe("Talk relay audio base64", () => {
   afterEach(() => {
-    for (const [relaySessionId, connId] of realtime) stopTalkRealtimeRelaySession({ relaySessionId, connId });
-    for (const [transcriptionSessionId, connId] of transcription) stopTalkTranscriptionRelaySession({ transcriptionSessionId, connId });
-    realtime.clear(); transcription.clear();
+    for (const [relaySessionId, connId] of realtime)
+      stopTalkRealtimeRelaySession({ relaySessionId, connId });
+    for (const [transcriptionSessionId, connId] of transcription)
+      stopTalkTranscriptionRelaySession({ transcriptionSessionId, connId });
+    realtime.clear();
+    transcription.clear();
   });
 
-  it.each([["YXVkaW8taW4=", Buffer.from("audio-in")], ["-_8", Buffer.from([0xfb, 0xff])]])("decodes valid input", (input, expected) => {
+  it.each([
+    ["YXVkaW8taW4=", Buffer.from("audio-in")],
+    ["-_8", Buffer.from([0xfb, 0xff])],
+  ])("decodes valid input", (input, expected) => {
     expect(decodeTalkRelayAudioBase64(input, "Talk")).toEqual(expected);
   });
 
@@ -38,35 +87,93 @@ describe("Talk relay audio base64", () => {
   });
 
   it("rejects non-round-tripping realtime audio before delivery", async () => {
-    const sendAudio = vi.fn(); const { context: relayContext, events } = context();
-    const session = createTalkRealtimeRelaySession({ context: relayContext, connId: "conn", provider: voiceProvider(sendAudio), providerConfig: {}, instructions: "brief", tools: [] });
-    realtime.set(session.relaySessionId, "conn"); await Promise.resolve(); events.length = 0;
-    expect(() => sendTalkRealtimeRelayAudio({ relaySessionId: session.relaySessionId, connId: "conn", audioBase64: "AB" })).toThrow("Realtime relay audio frame is invalid base64");
-    expect(sendAudio).not.toHaveBeenCalled(); expect(events).toEqual([]);
+    const sendAudio = vi.fn();
+    const { context: relayContext, events } = context();
+    const session = createTalkRealtimeRelaySession({
+      context: relayContext,
+      connId: "conn",
+      provider: voiceProvider(sendAudio),
+      providerConfig: {},
+      instructions: "brief",
+      tools: [],
+    });
+    realtime.set(session.relaySessionId, "conn");
+    await Promise.resolve();
+    events.length = 0;
+    expect(() =>
+      sendTalkRealtimeRelayAudio({
+        relaySessionId: session.relaySessionId,
+        connId: "conn",
+        audioBase64: "AB",
+      }),
+    ).toThrow("Realtime relay audio frame is invalid base64");
+    expect(sendAudio).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
   });
 
   it("forwards valid realtime audio", async () => {
-    const sendAudio = vi.fn(); const { context: relayContext, events } = context();
-    const session = createTalkRealtimeRelaySession({ context: relayContext, connId: "conn", provider: voiceProvider(sendAudio), providerConfig: {}, instructions: "brief", tools: [] });
-    realtime.set(session.relaySessionId, "conn"); await Promise.resolve(); events.length = 0;
-    sendTalkRealtimeRelayAudio({ relaySessionId: session.relaySessionId, connId: "conn", audioBase64: "YXVkaW8taW4=" });
+    const sendAudio = vi.fn();
+    const { context: relayContext, events } = context();
+    const session = createTalkRealtimeRelaySession({
+      context: relayContext,
+      connId: "conn",
+      provider: voiceProvider(sendAudio),
+      providerConfig: {},
+      instructions: "brief",
+      tools: [],
+    });
+    realtime.set(session.relaySessionId, "conn");
+    await Promise.resolve();
+    events.length = 0;
+    sendTalkRealtimeRelayAudio({
+      relaySessionId: session.relaySessionId,
+      connId: "conn",
+      audioBase64: "YXVkaW8taW4=",
+    });
     expect(sendAudio).toHaveBeenCalledWith(Buffer.from("audio-in"));
     expect(events).toContainEqual(expect.objectContaining({ type: "inputAudio", byteLength: 8 }));
   });
 
   it("rejects non-round-tripping transcription audio before delivery", async () => {
-    const sendAudio = vi.fn(); const { context: relayContext, events } = context();
-    const session = createTalkTranscriptionRelaySession({ context: relayContext, connId: "conn", provider: transcriptionProvider(sendAudio), providerConfig: {} });
-    transcription.set(session.transcriptionSessionId, "conn"); await Promise.resolve(); events.length = 0;
-    expect(() => sendTalkTranscriptionRelayAudio({ transcriptionSessionId: session.transcriptionSessionId, connId: "conn", audioBase64: "AB" })).toThrow("Transcription Talk audio frame is invalid base64");
-    expect(sendAudio).not.toHaveBeenCalled(); expect(events).toEqual([]);
+    const sendAudio = vi.fn();
+    const { context: relayContext, events } = context();
+    const session = createTalkTranscriptionRelaySession({
+      context: relayContext,
+      connId: "conn",
+      provider: transcriptionProvider(sendAudio),
+      providerConfig: {},
+    });
+    transcription.set(session.transcriptionSessionId, "conn");
+    await Promise.resolve();
+    events.length = 0;
+    expect(() =>
+      sendTalkTranscriptionRelayAudio({
+        transcriptionSessionId: session.transcriptionSessionId,
+        connId: "conn",
+        audioBase64: "AB",
+      }),
+    ).toThrow("Transcription Talk audio frame is invalid base64");
+    expect(sendAudio).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
   });
 
   it("forwards valid transcription audio", async () => {
-    const sendAudio = vi.fn(); const { context: relayContext, events } = context();
-    const session = createTalkTranscriptionRelaySession({ context: relayContext, connId: "conn", provider: transcriptionProvider(sendAudio), providerConfig: {} });
-    transcription.set(session.transcriptionSessionId, "conn"); await Promise.resolve(); events.length = 0;
-    sendTalkTranscriptionRelayAudio({ transcriptionSessionId: session.transcriptionSessionId, connId: "conn", audioBase64: "YXVkaW8taW4=" });
+    const sendAudio = vi.fn();
+    const { context: relayContext, events } = context();
+    const session = createTalkTranscriptionRelaySession({
+      context: relayContext,
+      connId: "conn",
+      provider: transcriptionProvider(sendAudio),
+      providerConfig: {},
+    });
+    transcription.set(session.transcriptionSessionId, "conn");
+    await Promise.resolve();
+    events.length = 0;
+    sendTalkTranscriptionRelayAudio({
+      transcriptionSessionId: session.transcriptionSessionId,
+      connId: "conn",
+      audioBase64: "YXVkaW8taW4=",
+    });
     expect(sendAudio).toHaveBeenCalledWith(Buffer.from("audio-in"));
     expect(events).toContainEqual(expect.objectContaining({ type: "inputAudio", byteLength: 8 }));
   });

--- a/src/gateway/talk-relay-audio-base64.test.ts
+++ b/src/gateway/talk-relay-audio-base64.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests Talk relay base64 guards before audio reaches providers.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RealtimeVoiceProviderPlugin } from "../plugins/types.js";
+import type { RealtimeTranscriptionProviderPlugin } from "../plugins/types.js";
+import {
+  createTalkRealtimeRelaySession,
+  sendTalkRealtimeRelayAudio,
+  stopTalkRealtimeRelaySession,
+} from "./talk-realtime-relay.js";
+import {
+  createTalkTranscriptionRelaySession,
+  sendTalkTranscriptionRelayAudio,
+  stopTalkTranscriptionRelaySession,
+} from "./talk-transcription-relay.js";
+
+type BroadcastEvent = { event: string; payload: unknown; connIds: string[] };
+
+const realtimeSessions = new Map<string, string>();
+const transcriptionSessions = new Map<string, string>();
+
+function createBroadcastContext() {
+  const events: BroadcastEvent[] = [];
+  const context = {
+    getRuntimeConfig: () => ({}),
+    broadcastToConnIds: (event: string, payload: unknown, connIds: ReadonlySet<string>) => {
+      events.push({ event, payload, connIds: [...connIds] });
+    },
+  } as never;
+  return { context, events };
+}
+
+function createRealtimeProvider(sendAudio = vi.fn()): RealtimeVoiceProviderPlugin {
+  return {
+    id: "relay-test",
+    label: "Relay Test",
+    isConfigured: () => true,
+    createBridge: () => ({
+      connect: vi.fn(async () => undefined),
+      sendAudio,
+      setMediaTimestamp: vi.fn(),
+      handleBargeIn: vi.fn(),
+      submitToolResult: vi.fn(),
+      acknowledgeMark: vi.fn(),
+      close: vi.fn(),
+      isConnected: vi.fn(() => true),
+    }),
+  };
+}
+
+function createTranscriptionProvider(sendAudio = vi.fn()): RealtimeTranscriptionProviderPlugin {
+  return {
+    id: "stt-test",
+    label: "STT Test",
+    isConfigured: () => true,
+    createSession: () => ({
+      connect: vi.fn(async () => undefined),
+      sendAudio,
+      close: vi.fn(),
+      isConnected: vi.fn(() => true),
+    }),
+  };
+}
+
+function inputAudioEvents(events: BroadcastEvent[]): BroadcastEvent[] {
+  return events.filter(
+    (event) =>
+      typeof event.payload === "object" &&
+      event.payload !== null &&
+      "type" in event.payload &&
+      event.payload.type === "inputAudio",
+  );
+}
+
+function hasInputAudioByteLength(events: BroadcastEvent[], byteLength: number): boolean {
+  return inputAudioEvents(events).some(
+    (event) =>
+      typeof event.payload === "object" &&
+      event.payload !== null &&
+      "byteLength" in event.payload &&
+      event.payload.byteLength === byteLength,
+  );
+}
+
+describe("talk relay audio base64 guards", () => {
+  afterEach(() => {
+    for (const [relaySessionId, connId] of realtimeSessions) {
+      stopTalkRealtimeRelaySession({ relaySessionId, connId });
+    }
+    realtimeSessions.clear();
+    for (const [transcriptionSessionId, connId] of transcriptionSessions) {
+      stopTalkTranscriptionRelaySession({ transcriptionSessionId, connId });
+    }
+    transcriptionSessions.clear();
+  });
+
+  it("rejects malformed realtime relay audio before provider delivery", async () => {
+    const sendAudio = vi.fn();
+    const { context, events } = createBroadcastContext();
+    const session = createTalkRealtimeRelaySession({
+      context,
+      connId: "conn-1",
+      provider: createRealtimeProvider(sendAudio),
+      providerConfig: {},
+      instructions: "brief",
+      tools: [],
+    });
+    realtimeSessions.set(session.relaySessionId, "conn-1");
+    await Promise.resolve();
+    events.length = 0;
+
+    expect(() =>
+      sendTalkRealtimeRelayAudio({
+        relaySessionId: session.relaySessionId,
+        connId: "conn-1",
+        audioBase64: "not-base64!",
+      }),
+    ).toThrow("Realtime relay audio frame is invalid base64");
+
+    expect(sendAudio).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
+  });
+
+  it("rejects base64url realtime relay audio before provider delivery", async () => {
+    const sendAudio = vi.fn();
+    const { context, events } = createBroadcastContext();
+    const session = createTalkRealtimeRelaySession({
+      context,
+      connId: "conn-1",
+      provider: createRealtimeProvider(sendAudio),
+      providerConfig: {},
+      instructions: "brief",
+      tools: [],
+    });
+    realtimeSessions.set(session.relaySessionId, "conn-1");
+    await Promise.resolve();
+    events.length = 0;
+
+    expect(() =>
+      sendTalkRealtimeRelayAudio({
+        relaySessionId: session.relaySessionId,
+        connId: "conn-1",
+        audioBase64: "-_8",
+      }),
+    ).toThrow("Realtime relay audio frame is invalid base64");
+
+    expect(sendAudio).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
+  });
+
+  it("continues to forward valid realtime relay audio", async () => {
+    const sendAudio = vi.fn();
+    const { context, events } = createBroadcastContext();
+    const session = createTalkRealtimeRelaySession({
+      context,
+      connId: "conn-1",
+      provider: createRealtimeProvider(sendAudio),
+      providerConfig: {},
+      instructions: "brief",
+      tools: [],
+    });
+    realtimeSessions.set(session.relaySessionId, "conn-1");
+    await Promise.resolve();
+    events.length = 0;
+
+    sendTalkRealtimeRelayAudio({
+      relaySessionId: session.relaySessionId,
+      connId: "conn-1",
+      audioBase64: Buffer.from("audio-in").toString("base64"),
+    });
+
+    expect(sendAudio).toHaveBeenCalledWith(Buffer.from("audio-in"));
+    expect(hasInputAudioByteLength(events, 8)).toBe(true);
+  });
+
+  it("rejects malformed transcription relay audio before STT delivery", async () => {
+    const sendAudio = vi.fn();
+    const { context, events } = createBroadcastContext();
+    const session = createTalkTranscriptionRelaySession({
+      context,
+      connId: "conn-1",
+      provider: createTranscriptionProvider(sendAudio),
+      providerConfig: {},
+    });
+    transcriptionSessions.set(session.transcriptionSessionId, "conn-1");
+    await Promise.resolve();
+    events.length = 0;
+
+    expect(() =>
+      sendTalkTranscriptionRelayAudio({
+        transcriptionSessionId: session.transcriptionSessionId,
+        connId: "conn-1",
+        audioBase64: "not-base64!",
+      }),
+    ).toThrow("Transcription Talk audio frame is invalid base64");
+
+    expect(sendAudio).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
+  });
+
+  it("rejects base64url transcription relay audio before STT delivery", async () => {
+    const sendAudio = vi.fn();
+    const { context, events } = createBroadcastContext();
+    const session = createTalkTranscriptionRelaySession({
+      context,
+      connId: "conn-1",
+      provider: createTranscriptionProvider(sendAudio),
+      providerConfig: {},
+    });
+    transcriptionSessions.set(session.transcriptionSessionId, "conn-1");
+    await Promise.resolve();
+    events.length = 0;
+
+    expect(() =>
+      sendTalkTranscriptionRelayAudio({
+        transcriptionSessionId: session.transcriptionSessionId,
+        connId: "conn-1",
+        audioBase64: "-_8",
+      }),
+    ).toThrow("Transcription Talk audio frame is invalid base64");
+
+    expect(sendAudio).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
+  });
+
+  it("continues to forward valid transcription relay audio", async () => {
+    const sendAudio = vi.fn();
+    const { context, events } = createBroadcastContext();
+    const session = createTalkTranscriptionRelaySession({
+      context,
+      connId: "conn-1",
+      provider: createTranscriptionProvider(sendAudio),
+      providerConfig: {},
+    });
+    transcriptionSessions.set(session.transcriptionSessionId, "conn-1");
+    await Promise.resolve();
+    events.length = 0;
+
+    sendTalkTranscriptionRelayAudio({
+      transcriptionSessionId: session.transcriptionSessionId,
+      connId: "conn-1",
+      audioBase64: Buffer.from("audio-in").toString("base64"),
+    });
+
+    expect(sendAudio).toHaveBeenCalledWith(Buffer.from("audio-in"));
+    expect(hasInputAudioByteLength(events, 8)).toBe(true);
+  });
+});

--- a/src/gateway/talk-relay-audio-base64.test.ts
+++ b/src/gateway/talk-relay-audio-base64.test.ts
@@ -29,7 +29,7 @@ function context() {
   };
 }
 
-function voiceProvider(sendAudio: ReturnType<typeof vi.fn>): RealtimeVoiceProviderPlugin {
+function voiceProvider(sendAudio: (audio: Buffer) => void): RealtimeVoiceProviderPlugin {
   return {
     id: "test",
     label: "Test",
@@ -48,7 +48,7 @@ function voiceProvider(sendAudio: ReturnType<typeof vi.fn>): RealtimeVoiceProvid
 }
 
 function transcriptionProvider(
-  sendAudio: ReturnType<typeof vi.fn>,
+  sendAudio: (audio: Buffer) => void,
 ): RealtimeTranscriptionProviderPlugin {
   return {
     id: "test",

--- a/src/gateway/talk-relay-audio-base64.test.ts
+++ b/src/gateway/talk-relay-audio-base64.test.ts
@@ -65,10 +65,12 @@ function transcriptionProvider(
 
 describe("Talk relay audio base64", () => {
   afterEach(() => {
-    for (const [relaySessionId, connId] of realtime)
+    for (const [relaySessionId, connId] of realtime) {
       stopTalkRealtimeRelaySession({ relaySessionId, connId });
-    for (const [transcriptionSessionId, connId] of transcription)
+    }
+    for (const [transcriptionSessionId, connId] of transcription) {
       stopTalkTranscriptionRelaySession({ transcriptionSessionId, connId });
+    }
     realtime.clear();
     transcription.clear();
   });

--- a/src/gateway/talk-relay-audio-base64.test.ts
+++ b/src/gateway/talk-relay-audio-base64.test.ts
@@ -1,297 +1,73 @@
-/**
- * Tests Talk relay base64 guards before audio reaches providers.
- */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { RealtimeVoiceProviderPlugin } from "../plugins/types.js";
-import type { RealtimeTranscriptionProviderPlugin } from "../plugins/types.js";
-import {
-  createTalkRealtimeRelaySession,
-  sendTalkRealtimeRelayAudio,
-  stopTalkRealtimeRelaySession,
-} from "./talk-realtime-relay.js";
-import {
-  createTalkTranscriptionRelaySession,
-  sendTalkTranscriptionRelayAudio,
-  stopTalkTranscriptionRelaySession,
-} from "./talk-transcription-relay.js";
+import type { RealtimeTranscriptionProviderPlugin, RealtimeVoiceProviderPlugin } from "../plugins/types.js";
+import { createTalkRealtimeRelaySession, sendTalkRealtimeRelayAudio, stopTalkRealtimeRelaySession } from "./talk-realtime-relay.js";
+import { createTalkTranscriptionRelaySession, sendTalkTranscriptionRelayAudio, stopTalkTranscriptionRelaySession } from "./talk-transcription-relay.js";
+import { decodeTalkRelayAudioBase64 } from "./talk-relay-audio-base64.js";
 
-type BroadcastEvent = { event: string; payload: unknown; connIds: string[] };
+const realtime = new Map<string, string>();
+const transcription = new Map<string, string>();
 
-const realtimeSessions = new Map<string, string>();
-const transcriptionSessions = new Map<string, string>();
-
-function createBroadcastContext() {
-  const events: BroadcastEvent[] = [];
-  const context = {
-    getRuntimeConfig: () => ({}),
-    broadcastToConnIds: (event: string, payload: unknown, connIds: ReadonlySet<string>) => {
-      events.push({ event, payload, connIds: [...connIds] });
-    },
-  } as never;
-  return { context, events };
+function context() {
+  const events: unknown[] = [];
+  return { events, context: { getRuntimeConfig: () => ({}), broadcastToConnIds: (_event: string, payload: unknown) => events.push(payload) } as never };
 }
 
-function createRealtimeProvider(sendAudio = vi.fn()): RealtimeVoiceProviderPlugin {
-  return {
-    id: "relay-test",
-    label: "Relay Test",
-    isConfigured: () => true,
-    createBridge: () => ({
-      connect: vi.fn(async () => undefined),
-      sendAudio,
-      setMediaTimestamp: vi.fn(),
-      handleBargeIn: vi.fn(),
-      submitToolResult: vi.fn(),
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    }),
-  };
+function voiceProvider(sendAudio: ReturnType<typeof vi.fn>): RealtimeVoiceProviderPlugin {
+  return { id: "test", label: "Test", isConfigured: () => true, createBridge: () => ({ connect: async () => {}, sendAudio, setMediaTimestamp: () => {}, handleBargeIn: () => {}, submitToolResult: () => {}, acknowledgeMark: () => {}, close: () => {}, isConnected: () => true }) };
 }
 
-function createTranscriptionProvider(sendAudio = vi.fn()): RealtimeTranscriptionProviderPlugin {
-  return {
-    id: "stt-test",
-    label: "STT Test",
-    isConfigured: () => true,
-    createSession: () => ({
-      connect: vi.fn(async () => undefined),
-      sendAudio,
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    }),
-  };
+function transcriptionProvider(sendAudio: ReturnType<typeof vi.fn>): RealtimeTranscriptionProviderPlugin {
+  return { id: "test", label: "Test", isConfigured: () => true, createSession: () => ({ connect: async () => {}, sendAudio, close: () => {}, isConnected: () => true }) };
 }
 
-function inputAudioEvents(events: BroadcastEvent[]): BroadcastEvent[] {
-  return events.filter(
-    (event) =>
-      typeof event.payload === "object" &&
-      event.payload !== null &&
-      "type" in event.payload &&
-      event.payload.type === "inputAudio",
-  );
-}
-
-function hasInputAudioByteLength(events: BroadcastEvent[], byteLength: number): boolean {
-  return inputAudioEvents(events).some(
-    (event) =>
-      typeof event.payload === "object" &&
-      event.payload !== null &&
-      "byteLength" in event.payload &&
-      event.payload.byteLength === byteLength,
-  );
-}
-
-describe("talk relay audio base64 guards", () => {
+describe("Talk relay audio base64", () => {
   afterEach(() => {
-    for (const [relaySessionId, connId] of realtimeSessions) {
-      stopTalkRealtimeRelaySession({ relaySessionId, connId });
-    }
-    realtimeSessions.clear();
-    for (const [transcriptionSessionId, connId] of transcriptionSessions) {
-      stopTalkTranscriptionRelaySession({ transcriptionSessionId, connId });
-    }
-    transcriptionSessions.clear();
+    for (const [relaySessionId, connId] of realtime) stopTalkRealtimeRelaySession({ relaySessionId, connId });
+    for (const [transcriptionSessionId, connId] of transcription) stopTalkTranscriptionRelaySession({ transcriptionSessionId, connId });
+    realtime.clear(); transcription.clear();
   });
 
-  it("rejects malformed realtime relay audio before provider delivery", async () => {
-    const sendAudio = vi.fn();
-    const { context, events } = createBroadcastContext();
-    const session = createTalkRealtimeRelaySession({
-      context,
-      connId: "conn-1",
-      provider: createRealtimeProvider(sendAudio),
-      providerConfig: {},
-      instructions: "brief",
-      tools: [],
-    });
-    realtimeSessions.set(session.relaySessionId, "conn-1");
-    await Promise.resolve();
-    events.length = 0;
-
-    expect(() =>
-      sendTalkRealtimeRelayAudio({
-        relaySessionId: session.relaySessionId,
-        connId: "conn-1",
-        audioBase64: "not-base64!",
-      }),
-    ).toThrow("Realtime relay audio frame is invalid base64");
-
-    expect(sendAudio).not.toHaveBeenCalled();
-    expect(events).toEqual([]);
+  it.each([["YXVkaW8taW4=", Buffer.from("audio-in")], ["-_8", Buffer.from([0xfb, 0xff])]])("decodes valid input", (input, expected) => {
+    expect(decodeTalkRelayAudioBase64(input, "Talk")).toEqual(expected);
   });
 
-  it("continues to forward base64url realtime relay audio", async () => {
-    const sendAudio = vi.fn();
-    const { context, events } = createBroadcastContext();
-    const session = createTalkRealtimeRelaySession({
-      context,
-      connId: "conn-1",
-      provider: createRealtimeProvider(sendAudio),
-      providerConfig: {},
-      instructions: "brief",
-      tools: [],
-    });
-    realtimeSessions.set(session.relaySessionId, "conn-1");
-    await Promise.resolve();
-    events.length = 0;
-
-    sendTalkRealtimeRelayAudio({
-      relaySessionId: session.relaySessionId,
-      connId: "conn-1",
-      audioBase64: "-_8",
-    });
-
-    expect(sendAudio).toHaveBeenCalledWith(Buffer.from([0xfb, 0xff]));
-    expect(hasInputAudioByteLength(events, 2)).toBe(true);
+  it.each(["not-base64!", "AB"])("rejects malformed input: %s", (input) => {
+    expect(() => decodeTalkRelayAudioBase64(input, "Talk")).toThrow(
+      "Talk audio frame is invalid base64",
+    );
   });
 
-  it("rejects non-round-tripping realtime relay audio before provider delivery", async () => {
-    const sendAudio = vi.fn();
-    const { context, events } = createBroadcastContext();
-    const session = createTalkRealtimeRelaySession({
-      context,
-      connId: "conn-1",
-      provider: createRealtimeProvider(sendAudio),
-      providerConfig: {},
-      instructions: "brief",
-      tools: [],
-    });
-    realtimeSessions.set(session.relaySessionId, "conn-1");
-    await Promise.resolve();
-    events.length = 0;
-
-    expect(() =>
-      sendTalkRealtimeRelayAudio({
-        relaySessionId: session.relaySessionId,
-        connId: "conn-1",
-        audioBase64: "AB",
-      }),
-    ).toThrow("Realtime relay audio frame is invalid base64");
-
-    expect(sendAudio).not.toHaveBeenCalled();
-    expect(events).toEqual([]);
+  it("rejects non-round-tripping realtime audio before delivery", async () => {
+    const sendAudio = vi.fn(); const { context: relayContext, events } = context();
+    const session = createTalkRealtimeRelaySession({ context: relayContext, connId: "conn", provider: voiceProvider(sendAudio), providerConfig: {}, instructions: "brief", tools: [] });
+    realtime.set(session.relaySessionId, "conn"); await Promise.resolve(); events.length = 0;
+    expect(() => sendTalkRealtimeRelayAudio({ relaySessionId: session.relaySessionId, connId: "conn", audioBase64: "AB" })).toThrow("Realtime relay audio frame is invalid base64");
+    expect(sendAudio).not.toHaveBeenCalled(); expect(events).toEqual([]);
   });
 
-  it("continues to forward valid realtime relay audio", async () => {
-    const sendAudio = vi.fn();
-    const { context, events } = createBroadcastContext();
-    const session = createTalkRealtimeRelaySession({
-      context,
-      connId: "conn-1",
-      provider: createRealtimeProvider(sendAudio),
-      providerConfig: {},
-      instructions: "brief",
-      tools: [],
-    });
-    realtimeSessions.set(session.relaySessionId, "conn-1");
-    await Promise.resolve();
-    events.length = 0;
-
-    sendTalkRealtimeRelayAudio({
-      relaySessionId: session.relaySessionId,
-      connId: "conn-1",
-      audioBase64: Buffer.from("audio-in").toString("base64"),
-    });
-
+  it("forwards valid realtime audio", async () => {
+    const sendAudio = vi.fn(); const { context: relayContext, events } = context();
+    const session = createTalkRealtimeRelaySession({ context: relayContext, connId: "conn", provider: voiceProvider(sendAudio), providerConfig: {}, instructions: "brief", tools: [] });
+    realtime.set(session.relaySessionId, "conn"); await Promise.resolve(); events.length = 0;
+    sendTalkRealtimeRelayAudio({ relaySessionId: session.relaySessionId, connId: "conn", audioBase64: "YXVkaW8taW4=" });
     expect(sendAudio).toHaveBeenCalledWith(Buffer.from("audio-in"));
-    expect(hasInputAudioByteLength(events, 8)).toBe(true);
+    expect(events).toContainEqual(expect.objectContaining({ type: "inputAudio", byteLength: 8 }));
   });
 
-  it("rejects malformed transcription relay audio before STT delivery", async () => {
-    const sendAudio = vi.fn();
-    const { context, events } = createBroadcastContext();
-    const session = createTalkTranscriptionRelaySession({
-      context,
-      connId: "conn-1",
-      provider: createTranscriptionProvider(sendAudio),
-      providerConfig: {},
-    });
-    transcriptionSessions.set(session.transcriptionSessionId, "conn-1");
-    await Promise.resolve();
-    events.length = 0;
-
-    expect(() =>
-      sendTalkTranscriptionRelayAudio({
-        transcriptionSessionId: session.transcriptionSessionId,
-        connId: "conn-1",
-        audioBase64: "not-base64!",
-      }),
-    ).toThrow("Transcription Talk audio frame is invalid base64");
-
-    expect(sendAudio).not.toHaveBeenCalled();
-    expect(events).toEqual([]);
+  it("rejects non-round-tripping transcription audio before delivery", async () => {
+    const sendAudio = vi.fn(); const { context: relayContext, events } = context();
+    const session = createTalkTranscriptionRelaySession({ context: relayContext, connId: "conn", provider: transcriptionProvider(sendAudio), providerConfig: {} });
+    transcription.set(session.transcriptionSessionId, "conn"); await Promise.resolve(); events.length = 0;
+    expect(() => sendTalkTranscriptionRelayAudio({ transcriptionSessionId: session.transcriptionSessionId, connId: "conn", audioBase64: "AB" })).toThrow("Transcription Talk audio frame is invalid base64");
+    expect(sendAudio).not.toHaveBeenCalled(); expect(events).toEqual([]);
   });
 
-  it("continues to forward base64url transcription relay audio", async () => {
-    const sendAudio = vi.fn();
-    const { context, events } = createBroadcastContext();
-    const session = createTalkTranscriptionRelaySession({
-      context,
-      connId: "conn-1",
-      provider: createTranscriptionProvider(sendAudio),
-      providerConfig: {},
-    });
-    transcriptionSessions.set(session.transcriptionSessionId, "conn-1");
-    await Promise.resolve();
-    events.length = 0;
-
-    sendTalkTranscriptionRelayAudio({
-      transcriptionSessionId: session.transcriptionSessionId,
-      connId: "conn-1",
-      audioBase64: "-_8",
-    });
-
-    expect(sendAudio).toHaveBeenCalledWith(Buffer.from([0xfb, 0xff]));
-    expect(hasInputAudioByteLength(events, 2)).toBe(true);
-  });
-
-  it("rejects non-round-tripping transcription relay audio before STT delivery", async () => {
-    const sendAudio = vi.fn();
-    const { context, events } = createBroadcastContext();
-    const session = createTalkTranscriptionRelaySession({
-      context,
-      connId: "conn-1",
-      provider: createTranscriptionProvider(sendAudio),
-      providerConfig: {},
-    });
-    transcriptionSessions.set(session.transcriptionSessionId, "conn-1");
-    await Promise.resolve();
-    events.length = 0;
-
-    expect(() =>
-      sendTalkTranscriptionRelayAudio({
-        transcriptionSessionId: session.transcriptionSessionId,
-        connId: "conn-1",
-        audioBase64: "AB",
-      }),
-    ).toThrow("Transcription Talk audio frame is invalid base64");
-
-    expect(sendAudio).not.toHaveBeenCalled();
-    expect(events).toEqual([]);
-  });
-
-  it("continues to forward valid transcription relay audio", async () => {
-    const sendAudio = vi.fn();
-    const { context, events } = createBroadcastContext();
-    const session = createTalkTranscriptionRelaySession({
-      context,
-      connId: "conn-1",
-      provider: createTranscriptionProvider(sendAudio),
-      providerConfig: {},
-    });
-    transcriptionSessions.set(session.transcriptionSessionId, "conn-1");
-    await Promise.resolve();
-    events.length = 0;
-
-    sendTalkTranscriptionRelayAudio({
-      transcriptionSessionId: session.transcriptionSessionId,
-      connId: "conn-1",
-      audioBase64: Buffer.from("audio-in").toString("base64"),
-    });
-
+  it("forwards valid transcription audio", async () => {
+    const sendAudio = vi.fn(); const { context: relayContext, events } = context();
+    const session = createTalkTranscriptionRelaySession({ context: relayContext, connId: "conn", provider: transcriptionProvider(sendAudio), providerConfig: {} });
+    transcription.set(session.transcriptionSessionId, "conn"); await Promise.resolve(); events.length = 0;
+    sendTalkTranscriptionRelayAudio({ transcriptionSessionId: session.transcriptionSessionId, connId: "conn", audioBase64: "YXVkaW8taW4=" });
     expect(sendAudio).toHaveBeenCalledWith(Buffer.from("audio-in"));
-    expect(hasInputAudioByteLength(events, 8)).toBe(true);
+    expect(events).toContainEqual(expect.objectContaining({ type: "inputAudio", byteLength: 8 }));
   });
 });

--- a/src/gateway/talk-relay-audio-base64.test.ts
+++ b/src/gateway/talk-relay-audio-base64.test.ts
@@ -122,7 +122,32 @@ describe("talk relay audio base64 guards", () => {
     expect(events).toEqual([]);
   });
 
-  it("rejects base64url realtime relay audio before provider delivery", async () => {
+  it("continues to forward base64url realtime relay audio", async () => {
+    const sendAudio = vi.fn();
+    const { context, events } = createBroadcastContext();
+    const session = createTalkRealtimeRelaySession({
+      context,
+      connId: "conn-1",
+      provider: createRealtimeProvider(sendAudio),
+      providerConfig: {},
+      instructions: "brief",
+      tools: [],
+    });
+    realtimeSessions.set(session.relaySessionId, "conn-1");
+    await Promise.resolve();
+    events.length = 0;
+
+    sendTalkRealtimeRelayAudio({
+      relaySessionId: session.relaySessionId,
+      connId: "conn-1",
+      audioBase64: "-_8",
+    });
+
+    expect(sendAudio).toHaveBeenCalledWith(Buffer.from([0xfb, 0xff]));
+    expect(hasInputAudioByteLength(events, 2)).toBe(true);
+  });
+
+  it("rejects non-round-tripping realtime relay audio before provider delivery", async () => {
     const sendAudio = vi.fn();
     const { context, events } = createBroadcastContext();
     const session = createTalkRealtimeRelaySession({
@@ -141,7 +166,7 @@ describe("talk relay audio base64 guards", () => {
       sendTalkRealtimeRelayAudio({
         relaySessionId: session.relaySessionId,
         connId: "conn-1",
-        audioBase64: "-_8",
+        audioBase64: "AB",
       }),
     ).toThrow("Realtime relay audio frame is invalid base64");
 
@@ -199,7 +224,30 @@ describe("talk relay audio base64 guards", () => {
     expect(events).toEqual([]);
   });
 
-  it("rejects base64url transcription relay audio before STT delivery", async () => {
+  it("continues to forward base64url transcription relay audio", async () => {
+    const sendAudio = vi.fn();
+    const { context, events } = createBroadcastContext();
+    const session = createTalkTranscriptionRelaySession({
+      context,
+      connId: "conn-1",
+      provider: createTranscriptionProvider(sendAudio),
+      providerConfig: {},
+    });
+    transcriptionSessions.set(session.transcriptionSessionId, "conn-1");
+    await Promise.resolve();
+    events.length = 0;
+
+    sendTalkTranscriptionRelayAudio({
+      transcriptionSessionId: session.transcriptionSessionId,
+      connId: "conn-1",
+      audioBase64: "-_8",
+    });
+
+    expect(sendAudio).toHaveBeenCalledWith(Buffer.from([0xfb, 0xff]));
+    expect(hasInputAudioByteLength(events, 2)).toBe(true);
+  });
+
+  it("rejects non-round-tripping transcription relay audio before STT delivery", async () => {
     const sendAudio = vi.fn();
     const { context, events } = createBroadcastContext();
     const session = createTalkTranscriptionRelaySession({
@@ -216,7 +264,7 @@ describe("talk relay audio base64 guards", () => {
       sendTalkTranscriptionRelayAudio({
         transcriptionSessionId: session.transcriptionSessionId,
         connId: "conn-1",
-        audioBase64: "-_8",
+        audioBase64: "AB",
       }),
     ).toThrow("Transcription Talk audio frame is invalid base64");
 

--- a/src/gateway/talk-relay-audio-base64.test.ts
+++ b/src/gateway/talk-relay-audio-base64.test.ts
@@ -87,7 +87,7 @@ describe("Talk relay audio base64", () => {
   });
 
   it("rejects non-round-tripping realtime audio before delivery", async () => {
-    const sendAudio = vi.fn();
+    const sendAudio = vi.fn<(audio: Buffer) => void>();
     const { context: relayContext, events } = context();
     const session = createTalkRealtimeRelaySession({
       context: relayContext,
@@ -112,7 +112,7 @@ describe("Talk relay audio base64", () => {
   });
 
   it("forwards valid realtime audio", async () => {
-    const sendAudio = vi.fn();
+    const sendAudio = vi.fn<(audio: Buffer) => void>();
     const { context: relayContext, events } = context();
     const session = createTalkRealtimeRelaySession({
       context: relayContext,
@@ -135,7 +135,7 @@ describe("Talk relay audio base64", () => {
   });
 
   it("rejects non-round-tripping transcription audio before delivery", async () => {
-    const sendAudio = vi.fn();
+    const sendAudio = vi.fn<(audio: Buffer) => void>();
     const { context: relayContext, events } = context();
     const session = createTalkTranscriptionRelaySession({
       context: relayContext,
@@ -158,7 +158,7 @@ describe("Talk relay audio base64", () => {
   });
 
   it("forwards valid transcription audio", async () => {
-    const sendAudio = vi.fn();
+    const sendAudio = vi.fn<(audio: Buffer) => void>();
     const { context: relayContext, events } = context();
     const session = createTalkTranscriptionRelaySession({
       context: relayContext,

--- a/src/gateway/talk-relay-audio-base64.ts
+++ b/src/gateway/talk-relay-audio-base64.ts
@@ -1,0 +1,10 @@
+// Shared guard for browser-provided Talk relay audio frames.
+import { canonicalizeBase64 } from "@openclaw/media-core/base64";
+
+export function decodeTalkRelayAudioBase64(base64: string, label: string): Buffer {
+  const canonicalBase64 = canonicalizeBase64(base64);
+  if (!canonicalBase64) {
+    throw new Error(`${label} audio frame is invalid base64`);
+  }
+  return Buffer.from(canonicalBase64, "base64");
+}

--- a/src/gateway/talk-relay-audio-base64.ts
+++ b/src/gateway/talk-relay-audio-base64.ts
@@ -2,9 +2,13 @@
 import { canonicalizeBase64 } from "@openclaw/media-core/base64";
 
 export function decodeTalkRelayAudioBase64(base64: string, label: string): Buffer {
-  const canonicalBase64 = canonicalizeBase64(base64);
+  const canonicalBase64 = canonicalizeBase64(base64.replace(/-/gu, "+").replace(/_/gu, "/"));
   if (!canonicalBase64) {
     throw new Error(`${label} audio frame is invalid base64`);
   }
-  return Buffer.from(canonicalBase64, "base64");
+  const audio = Buffer.from(canonicalBase64, "base64");
+  if (audio.toString("base64") !== canonicalBase64) {
+    throw new Error(`${label} audio frame is invalid base64`);
+  }
+  return audio;
 }

--- a/src/gateway/talk-transcription-relay.ts
+++ b/src/gateway/talk-transcription-relay.ts
@@ -15,6 +15,7 @@ import {
   createTalkSessionController,
 } from "../talk/talk-session-controller.js";
 import type { GatewayRequestContext } from "./server-methods/shared-types.js";
+import { decodeTalkRelayAudioBase64 } from "./talk-relay-audio-base64.js";
 import {
   closeExpiredTalkRelaySessions,
   requireActiveTalkRelaySession,
@@ -390,7 +391,7 @@ export function sendTalkTranscriptionRelayAudio(params: {
     throw new Error("Transcription Talk audio frame is too large");
   }
   const session = getTranscriptionSession(params.transcriptionSessionId, params.connId);
-  const audio = Buffer.from(params.audioBase64, "base64");
+  const audio = decodeTalkRelayAudioBase64(params.audioBase64, "Transcription Talk");
   const turnId = ensureTranscriptionTurn(session);
   session.sttSession.sendAudio(audio);
   broadcastToOwner(session.context, session.connId, {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where malformed browser audio frames sent through Talk realtime or transcription relays could be silently decoded and forwarded to provider audio streams.

## Why This Change Was Made

The relay now canonicalizes `audioBase64` before decoding it and rejects malformed or non-round-tripping frames before creating input-audio events or sending bytes to realtime/STT providers. It preserves the standard and URL-safe base64 alphabets accepted by the previous Node decoder.

## User Impact

Talk relays fail closed on malformed audio frames while valid microphone audio frames, including existing URL-safe base64 clients, continue to flow.

## Evidence

- Configured Google/Gemini realtime provider proof exercised the real Talk realtime relay and the real Google Live provider. A valid standard-base64 PCM frame forwarded 32000 bytes after provider readiness, a valid base64url frame still forwarded 2 bytes, and malformed input was rejected before `inputAudio`.

```text
$ GEMINI_API_KEY=<redacted> node --import tsx proof-google-realtime-relay.mjs
gemini-api-key-visible=true
provider=google
relay-session-created=true
provider-ready=true
valid-standard-forwarded=32000
valid-standard-events=[{"event":"talk.event","type":"inputAudio","byteLength":0},{"event":"talk.event","type":"inputAudio","byteLength":32000}]
valid-base64url-forwarded=2
valid-base64url-events=[{"event":"talk.event","type":"inputAudio","byteLength":2}]
malformed-rejected=true
malformed-error=Realtime relay audio frame is invalid base64
malformed-input-events=0
```

<details>
<summary>proof-google-realtime-relay.mjs</summary>

```js
import { buildGoogleRealtimeVoiceProvider } from "./extensions/google/realtime-voice-provider.ts";
import {
  createTalkRealtimeRelaySession,
  sendTalkRealtimeRelayAudio,
  stopTalkRealtimeRelaySession,
} from "./src/gateway/talk-realtime-relay.ts";

const apiKeyPresent = Boolean(process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY);
console.log(`gemini-api-key-visible=${apiKeyPresent}`);
if (!apiKeyPresent) {
  console.log("status=skipped missing GEMINI_API_KEY or GOOGLE_API_KEY");
  process.exit(2);
}

const events = [];
const context = {
  getRuntimeConfig: () => ({}),
  broadcastToConnIds: (event, payload, connIds) => {
    events.push({ event, payload, connIds: [...connIds] });
  },
};

function waitForEvent(predicate, timeoutMs = 20000) {
  const started = Date.now();
  return new Promise((resolve, reject) => {
    const tick = () => {
      const found = events.find(predicate);
      if (found) {
        resolve(found);
        return;
      }
      if (Date.now() - started > timeoutMs) {
        reject(new Error(`timed out after ${timeoutMs}ms`));
        return;
      }
      setTimeout(tick, 100);
    };
    tick();
  });
}

function summarizeEvents() {
  return events.map((entry) => ({
    event: entry.event,
    type: entry.payload?.type,
    byteLength: entry.payload?.byteLength,
  }));
}

const provider = buildGoogleRealtimeVoiceProvider();
const session = createTalkRealtimeRelaySession({
  context,
  connId: "proof-conn",
  provider,
  providerConfig: {
    model: "gemini-3.1-flash-live-preview",
    apiVersion: "v1beta",
    sessionResumption: false,
    contextWindowCompression: false,
    automaticActivityDetectionDisabled: true,
  },
  instructions: "Proof session. Do not respond unless asked.",
  tools: [],
});

try {
  console.log(`provider=${provider.id}`);
  console.log(`relay-session-created=${Boolean(session.relaySessionId)}`);
  await waitForEvent((entry) => entry.payload?.type === "ready");
  console.log("provider-ready=true");

  events.length = 0;
  const validPcm = Buffer.alloc(16_000 * 2);
  for (let offset = 0; offset < validPcm.length; offset += 2) {
    validPcm.writeInt16LE(offset % 512 === 0 ? 1200 : -1200, offset);
  }
  sendTalkRealtimeRelayAudio({
    relaySessionId: session.relaySessionId,
    connId: "proof-conn",
    audioBase64: validPcm.toString("base64"),
  });
  const validInput = events.find(
    (entry) => entry.payload?.type === "inputAudio" && entry.payload?.byteLength > 0,
  );
  console.log(`valid-standard-forwarded=${validInput?.payload?.byteLength ?? 0}`);
  console.log(`valid-standard-events=${JSON.stringify(summarizeEvents())}`);

  events.length = 0;
  sendTalkRealtimeRelayAudio({
    relaySessionId: session.relaySessionId,
    connId: "proof-conn",
    audioBase64: "-_8",
  });
  const urlInput = events.find((entry) => entry.payload?.type === "inputAudio");
  console.log(`valid-base64url-forwarded=${urlInput?.payload?.byteLength ?? 0}`);
  console.log(`valid-base64url-events=${JSON.stringify(summarizeEvents())}`);

  events.length = 0;
  try {
    sendTalkRealtimeRelayAudio({
      relaySessionId: session.relaySessionId,
      connId: "proof-conn",
      audioBase64: "not-base64!",
    });
    console.log("malformed-rejected=false");
  } catch (error) {
    console.log("malformed-rejected=true");
    console.log(`malformed-error=${error instanceof Error ? error.message : String(error)}`);
  }
  const malformedInput = events.find((entry) => entry.payload?.type === "inputAudio");
  console.log(`malformed-input-events=${malformedInput ? 1 : 0}`);
} finally {
  stopTalkRealtimeRelaySession({
    relaySessionId: session.relaySessionId,
    connId: "proof-conn",
  });
}
```

</details>

- Gateway RPC handler proof drove `talk.session.create` and `talk.session.appendAudio` for both realtime and transcription relay sessions. Malformed `not-base64!` frames were rejected before provider delivery or `inputAudio` broadcast; valid `audio-in` frames still reached providers and emitted input-audio events.

```text
$ node --import tsx proof-gateway-rpc.mjs
realtime-create-ok=true
realtime-malformed-ok=false
realtime-malformed-error=Error: Realtime relay audio frame is invalid base64
realtime-malformed-provider-audio=0
realtime-malformed-input-events=0
realtime-valid-ok=true
realtime-valid-provider-bytes=8
realtime-valid-input-events=2
transcription-create-ok=true
transcription-malformed-ok=false
transcription-malformed-error=Error: Transcription Talk audio frame is invalid base64
transcription-malformed-provider-audio=0
transcription-malformed-input-events=0
transcription-valid-ok=true
transcription-valid-provider-bytes=8
transcription-valid-input-events=1
```

<details>
<summary>proof-gateway-rpc.mjs</summary>

```js
import { createEmptyPluginRegistry } from "./src/plugins/registry-empty.ts";
import { setActivePluginRegistry } from "./src/plugins/runtime.ts";
import { talkHandlers } from "./src/gateway/server-methods/talk.ts";

const events = [];
const realtimeAudio = [];
const transcriptionAudio = [];

const registry = createEmptyPluginRegistry();
registry.plugins.push({ id: "proof-talk", status: "loaded", format: "bundle" });
registry.realtimeVoiceProviders.push({
  pluginId: "proof-talk",
  pluginName: "proof-talk",
  source: "proof",
  provider: {
    id: "proof-realtime",
    label: "Proof Realtime",
    isConfigured: () => true,
    createBridge: () => ({
      connect: async () => undefined,
      sendAudio: (audio) => realtimeAudio.push(audio),
      setMediaTimestamp: () => undefined,
      handleBargeIn: () => undefined,
      submitToolResult: () => undefined,
      acknowledgeMark: () => undefined,
      close: () => undefined,
      isConnected: () => true,
    }),
  },
});
registry.realtimeTranscriptionProviders.push({
  pluginId: "proof-talk",
  pluginName: "proof-talk",
  source: "proof",
  provider: {
    id: "proof-stt",
    label: "Proof STT",
    isConfigured: () => true,
    createSession: () => ({
      connect: async () => undefined,
      sendAudio: (audio) => transcriptionAudio.push(audio),
      close: () => undefined,
      isConnected: () => true,
    }),
  },
});
setActivePluginRegistry(registry, "proof-talk-registry");

const context = {
  getRuntimeConfig: () => ({
    talk: {
      realtime: {
        provider: "proof-realtime",
        providers: { "proof-realtime": {} },
      },
    },
    plugins: {
      entries: {
        "voice-call": {
          config: {
            streaming: {
              provider: "proof-stt",
              providers: { "proof-stt": {} },
            },
          },
        },
      },
    },
  }),
  broadcastToConnIds: (event, payload, connIds) => {
    events.push({ event, payload, connIds: [...connIds] });
  },
};
const client = { connId: "conn-1", connect: { scopes: ["operator.read"] } };

function inputAudioCount() {
  return events.filter((entry) => entry.payload?.type === "inputAudio").length;
}

async function call(method, params) {
  const handler = talkHandlers[method];
  if (!handler) {
    throw new Error(`missing handler ${method}`);
  }
  return await new Promise((resolve) => {
    handler({
      req: { type: "req", id: method, method },
      params,
      client,
      context,
      isWebchatConnect: () => false,
      respond: (ok, result, error) => resolve({ ok, result, error }),
    });
  });
}

async function proveRealtime() {
  const created = await call("talk.session.create", {
    mode: "realtime",
    transport: "gateway-relay",
    brain: "agent-consult",
  });
  const sessionId = created.result?.sessionId;
  events.length = 0;
  const malformed = await call("talk.session.appendAudio", {
    sessionId,
    audioBase64: "not-base64!",
  });
  const malformedEvents = inputAudioCount();
  const malformedProviderAudio = realtimeAudio.length;
  events.length = 0;
  const valid = await call("talk.session.appendAudio", {
    sessionId,
    audioBase64: Buffer.from("audio-in").toString("base64"),
  });
  console.log(`realtime-create-ok=${created.ok}`);
  console.log(`realtime-malformed-ok=${malformed.ok}`);
  console.log(`realtime-malformed-error=${malformed.error?.message}`);
  console.log(`realtime-malformed-provider-audio=${malformedProviderAudio}`);
  console.log(`realtime-malformed-input-events=${malformedEvents}`);
  console.log(`realtime-valid-ok=${valid.ok}`);
  console.log(`realtime-valid-provider-bytes=${realtimeAudio.at(-1)?.byteLength ?? 0}`);
  console.log(`realtime-valid-input-events=${inputAudioCount()}`);
  await call("talk.session.close", { sessionId });
}

async function proveTranscription() {
  const created = await call("talk.session.create", {
    mode: "transcription",
    transport: "gateway-relay",
    brain: "none",
  });
  const sessionId = created.result?.sessionId;
  events.length = 0;
  const malformed = await call("talk.session.appendAudio", {
    sessionId,
    audioBase64: "not-base64!",
  });
  const malformedEvents = inputAudioCount();
  const malformedProviderAudio = transcriptionAudio.length;
  events.length = 0;
  const valid = await call("talk.session.appendAudio", {
    sessionId,
    audioBase64: Buffer.from("audio-in").toString("base64"),
  });
  console.log(`transcription-create-ok=${created.ok}`);
  console.log(`transcription-malformed-ok=${malformed.ok}`);
  console.log(`transcription-malformed-error=${malformed.error?.message}`);
  console.log(`transcription-malformed-provider-audio=${malformedProviderAudio}`);
  console.log(`transcription-malformed-input-events=${malformedEvents}`);
  console.log(`transcription-valid-ok=${valid.ok}`);
  console.log(`transcription-valid-provider-bytes=${transcriptionAudio.at(-1)?.byteLength ?? 0}`);
  console.log(`transcription-valid-input-events=${inputAudioCount()}`);
  await call("talk.session.close", { sessionId });
}

await proveRealtime();
await proveTranscription();
```

</details>

- Compatibility check: focused tests now cover malformed input rejection, non-round-tripping input rejection, valid standard base64 forwarding, and valid base64url forwarding for both realtime and transcription relays.

- `node scripts/run-vitest.mjs src/gateway/talk-relay-audio-base64.test.ts`: 8 tests passed.

AI-assisted: built with Codex
