### PR TITLE
fix(reef): bound inbox websocket open waits at 30s

### DIFF
--- a/extensions/reef/src/transport.test.ts
+++ b/extensions/reef/src/transport.test.ts
@@ -1,7 +1,10 @@
 import { createPublicKey, verify as verifySignature } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import net from "node:net";
+import type { AddressInfo } from "node:net";
 import { describe, expect, it, vi } from "vitest";
 import { canonicalBytes, fromBase64url, sha256Hex } from "../protocol/index.js";
-import { ReefTransportClient } from "./transport.js";
+import { ReefInboxConnection, ReefTransportClient, type WebSocketLike } from "./transport.js";
 import type { ReefKeys } from "./types.js";
 
 const ts = 1_752_300_000;
@@ -127,4 +130,124 @@ describe("ReefTransportClient device authentication", () => {
     expect(seenTs).toEqual([String(ts), String(ts + 1), String(ts + 2)]);
     expect(new Set(seenTs).size).toBe(3);
   });
+});
+
+class HangWebSocket implements WebSocketLike {
+  private readonly handlers = new Map<string, Array<(event?: { data: unknown }) => void>>();
+  closed = false;
+
+  addEventListener(
+    type: "message" | "open" | "close" | "error",
+    listener: ((event: { data: unknown }) => void) | (() => void),
+  ): void {
+    const list = this.handlers.get(type) ?? [];
+    list.push(listener as (event?: { data: unknown }) => void);
+    this.handlers.set(type, list);
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    for (const listener of this.handlers.get("close") ?? []) {
+      listener();
+    }
+  }
+}
+
+describe("ReefInboxConnection open timeout", () => {
+  it("uses a 30s open-wait floor because WHATWG WebSocket has no handshakeTimeout", async () => {
+    const source = await readFile(new URL("./transport.ts", import.meta.url), "utf8");
+    expect(source).toMatch(/const REEF_INBOX_WEBSOCKET_OPEN_TIMEOUT_MS = 30_000/);
+    expect(source).toMatch(/reef inbox websocket open timed out/);
+    expect(source).toMatch(/clearTimeout\(openTimer\)/);
+  });
+
+  it("returns control to reconnect when the websocket never opens", async () => {
+    // Missing open-wait would leave start() forever on await live().
+    const sockets: HangWebSocket[] = [];
+    const client = {
+      pull: async () => ({ entries: [], cursor: 0 }),
+      websocketUrl: () => "ws://reef.example/v1/mail/ws",
+    } as unknown as ReefTransportClient;
+    const abort = new AbortController();
+    const inbox = new ReefInboxConnection(
+      client,
+      async () => {},
+      () => {
+        const socket = new HangWebSocket();
+        sockets.push(socket);
+        return socket;
+      },
+      undefined,
+      40,
+    );
+
+    const started = inbox.start(abort.signal);
+    await vi.waitFor(() => {
+      expect(sockets.length).toBeGreaterThanOrEqual(2);
+    });
+    expect(sockets[0]?.closed).toBe(true);
+    abort.abort();
+    await started;
+    console.log(
+      `[reef open-wait proof] timeout_then_reconnect=true socket_attempts=${sockets.length} openTimeout_ms=40`,
+    );
+  });
+
+  it("fails open against a TCP peer that never completes the websocket upgrade", async () => {
+    const accepted: net.Socket[] = [];
+    const server = net.createServer((socket) => {
+      accepted.push(socket);
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+    const client = {
+      pull: async () => ({ entries: [], cursor: 0 }),
+      websocketUrl: () => `ws://127.0.0.1:${port}`,
+    } as unknown as ReefTransportClient;
+    const abort = new AbortController();
+    const inbox = new ReefInboxConnection(
+      client,
+      async () => {},
+      (url) => new WebSocket(url) as unknown as WebSocketLike,
+      undefined,
+      200,
+    );
+
+    try {
+      const startedAt = Date.now();
+      const started = inbox.start(abort.signal);
+      await vi.waitFor(
+        () => {
+          // First open timeout rejects live(); start() sleeps then retries drain+live.
+          expect(Date.now() - startedAt).toBeGreaterThanOrEqual(180);
+        },
+        { timeout: 2_000 },
+      );
+      // Give the reconnect loop one backoff tick, then stop.
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 300);
+      });
+      abort.abort();
+      await started;
+      const elapsedMs = Date.now() - startedAt;
+      expect(elapsedMs).toBeGreaterThanOrEqual(180);
+      expect(elapsedMs).toBeLessThan(3_000);
+      console.log(
+        `[reef open-wait live proof] timed_out=true elapsed_ms=${elapsedMs} openTimeout_ms=200`,
+      );
+    } finally {
+      for (const socket of accepted) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
+  }, 10_000);
 });

--- a/extensions/reef/src/transport.ts
+++ b/extensions/reef/src/transport.ts
@@ -164,6 +164,11 @@ export interface WebSocketLike {
   close(): void;
 }
 
+// Reef uses the WHATWG WebSocket (no `ws` handshakeTimeout). Bound the wait for
+// `open` so a peer that accepts TCP but never upgrades cannot pin start()'s
+// reconnect loop forever on await live().
+const REEF_INBOX_WEBSOCKET_OPEN_TIMEOUT_MS = 30_000;
+
 export function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise<void>((resolve) => {
     if (signal?.aborted) {
@@ -183,12 +188,16 @@ export function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> 
 export class ReefInboxConnection {
   private cursor = 0;
   private stopped = false;
+  private readonly openTimeoutMs: number;
   constructor(
     readonly client: ReefTransportClient,
     readonly onEntries: (entries: InboxEntry[]) => Promise<void>,
     readonly webSocketFactory: (url: string) => WebSocketLike,
     readonly onState?: (state: "connected" | "disconnected") => void,
-  ) {}
+    openTimeoutMs: number = REEF_INBOX_WEBSOCKET_OPEN_TIMEOUT_MS,
+  ) {
+    this.openTimeoutMs = openTimeoutMs;
+  }
 
   async start(signal?: AbortSignal): Promise<void> {
     let delay = 250;
@@ -233,11 +242,13 @@ export class ReefInboxConnection {
       // invocation settles, so late events from an abandoned socket cannot
       // overwrite the lifecycle state of its replacement (or of a stopped channel).
       let settled = false;
+      let opened = false;
       const settle = (error?: Error) => {
         if (settled) {
           return;
         }
         settled = true;
+        clearTimeout(openTimer);
         this.onState?.("disconnected");
         if (error) {
           reject(error);
@@ -245,6 +256,18 @@ export class ReefInboxConnection {
           resolve();
         }
       };
+      // WHATWG WebSocket has no handshakeTimeout; fail the open wait so start()
+      // can backoff/reconnect instead of hanging until channel abort.
+      const openTimer = setTimeout(() => {
+        if (opened || settled) {
+          return;
+        }
+        // Reject before close so the close listener cannot resolve a clean disconnect
+        // and skip start()'s backoff path for a stalled handshake.
+        settle(new Error("reef inbox websocket open timed out"));
+        socket.close();
+      }, this.openTimeoutMs);
+      openTimer.unref?.();
       signal?.addEventListener(
         "abort",
         () => {
@@ -254,9 +277,12 @@ export class ReefInboxConnection {
         { once: true },
       );
       socket.addEventListener("open", () => {
-        if (!settled) {
-          this.onState?.("connected");
+        if (settled) {
+          return;
         }
+        opened = true;
+        clearTimeout(openTimer);
+        this.onState?.("connected");
       });
       socket.addEventListener("message", (event) => {
         try {


### PR DESCRIPTION
## What Problem This Solves

Reef inbox monitoring uses the WHATWG `WebSocket` (not the `ws` package), so there is no `handshakeTimeout` option. `ReefInboxConnection.live()` only settles on `close` / `error` / channel `abort`. When a peer accepts TCP but never completes the websocket upgrade, `start()` waits forever on `await live()` and the reconnect backoff loop never advances.

## Why This Change Was Made

- Add a private `REEF_INBOX_WEBSOCKET_OPEN_TIMEOUT_MS = 30_000` open-wait floor inside `live()`.
- On timeout: reject with `reef inbox websocket open timed out` (before `close`) so `start()` takes the existing catch/backoff path.
- Clear the timer on successful `open` so healthy long-lived inbox sockets are unaffected.
- Optional constructor `openTimeoutMs` defaults to 30s for production; tests use a short stand-in.

No new config/env surface. Does not switch Reef onto the `ws` package.

Note: open [#106456](https://github.com/openclaw/openclaw/pull/106456) bounds relay HTTP JSON reads in the same `transport.ts`; this PR only touches the inbox websocket open wait and should rebase cleanly.

## User Impact

**Before:** A Reef relay that accepted TCP without completing the websocket handshake could pin the inbox reconnect loop forever until the channel aborted.

**After:** Open waits fail closed after 30s and the existing reconnect backoff continues.

## Evidence

- Changed: `extensions/reef/src/transport.ts`
- Production caller: `extensions/reef/src/channel.ts` → `ReefInboxConnection.start`
- Sibling intent: Slack/Mattermost/Signal 30s handshake floors (Reef cannot use `ws` `handshakeTimeout`)
- Regression: `extensions/reef/src/transport.test.ts`

### Caller-path Vitest

```bash
node scripts/run-vitest.mjs extensions/reef/src/transport.test.ts --reporter=verbose
```

```text
 ✓ uses a 30s open-wait floor because WHATWG WebSocket has no handshakeTimeout
[reef open-wait proof] timeout_then_reconnect=true socket_attempts=2 openTimeout_ms=40
 ✓ returns control to reconnect when the websocket never opens 309ms
[reef open-wait live proof] timed_out=true elapsed_ms=506 openTimeout_ms=200
 ✓ fails open against a TCP peer that never completes the websocket upgrade 532ms
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

## Real behavior proof

**Commands run:**
```bash
node scripts/run-vitest.mjs extensions/reef/src/transport.test.ts --reporter=verbose
```

**Before fix:**
`live()` had no open-wait timer; a never-opening socket left `start()` blocked until channel abort.

**After fix:**
Production default open-wait is 30s. Against a hang factory / TCP peer that never upgrades, `live()` rejects and `start()` reconnects.

**Evidence after fix:**
```text
[reef open-wait proof] timeout_then_reconnect=true socket_attempts=2 openTimeout_ms=40
[reef open-wait live proof] timed_out=true elapsed_ms=506 openTimeout_ms=200
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

**What was not tested:**
Live Reef relay credentials; full 30s production floor (tests use 40ms / 200ms stand-ins with source wiring asserting `30_000`); REST `fetch` hang floors on `ReefTransportClient.request` (separate surface; see also #106456).
