### PR TITLE
docs(triage): verify maintainer access before surfacing PRs

### DIFF
--- a/.agents/skills/openclaw-pr-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-pr-maintainer/SKILL.md
@@ -80,7 +80,7 @@ gh api -X POST "repos/openclaw/openclaw/issues/<number>/assignees" -f 'assignees
 
 In generic issue/PR triage, hot queues, landable shortlists, or "what is still open", exclude PRs authored by maintainers with broad repository access until 14 days after `created_at`. Prefer external contributors' PRs. An ordinary request for landing candidates does not override the age gate. Continue suppressing maintainer-authored issues by default.
 
-Treat live repository permission as the source of truth. Before surfacing a finalist whose access is not already known, check `gh api repos/openclaw/openclaw/collaborators/<login>/permission`; suppress write, maintain, or admin access even when the login is absent from the fast-path list below. Read or triage access alone does not trigger suppression.
+Treat live repository permission as the source of truth. Before surfacing a finalist whose access is not already known, check `gh api repos/openclaw/openclaw/collaborators/<login>/permission`; suppress write, maintain, or admin access even when the login is absent from the fast-path list below. Read or triage access alone does not trigger suppression unless the login is explicitly listed.
 
 Suppress by default when the opener/author is one of:
 
@@ -92,6 +92,7 @@ Suppress by default when the opener/author is one of:
 - `@mbelinky`
 - `@joshavant`
 - `@pgondhi987`
+- `@mmaps`
 - `@ngutman`
 - `@vignesh07`
 - `@huntharo`

--- a/.agents/skills/openclaw-pr-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-pr-maintainer/SKILL.md
@@ -80,6 +80,8 @@ gh api -X POST "repos/openclaw/openclaw/issues/<number>/assignees" -f 'assignees
 
 In generic issue/PR triage, hot queues, landable shortlists, or "what is still open", exclude PRs authored by maintainers with broad repository access until 14 days after `created_at`. Prefer external contributors' PRs. An ordinary request for landing candidates does not override the age gate. Continue suppressing maintainer-authored issues by default.
 
+Treat live repository permission as the source of truth. Before surfacing a finalist whose access is not already known, check `gh api repos/openclaw/openclaw/collaborators/<login>/permission`; suppress write, maintain, or admin access even when the login is absent from the fast-path list below. Read or triage access alone does not trigger suppression.
+
 Suppress by default when the opener/author is one of:
 
 - `@vincentkoc`
@@ -89,6 +91,7 @@ Suppress by default when the opener/author is one of:
 - `@shakkernerd`
 - `@mbelinky`
 - `@joshavant`
+- `@pgondhi987`
 - `@ngutman`
 - `@vignesh07`
 - `@huntharo`


### PR DESCRIPTION
## What Problem This Solves

Generic triage could surface recent PRs from newly added maintainers when the static suppression list lagged current repository access, causing agents to pick up work maintainers already owned.

## Why This Change Was Made

Live repository permission is now the source of truth before a finalist is surfaced. The existing login list remains a fast path, `@pgondhi987` and `@mmaps` are added explicitly, and read-only or triage-only access otherwise remains outside the suppression rule.

## User Impact

Generic triage prioritizes external contributors without accidentally selecting recent maintainer-authored PRs merely because a local list is stale. Named PR requests and the existing 14-day exception still work unchanged.

## Evidence

- Verified the reported public PR: #106056 was authored by `@pgondhi987` and merged on 2026-07-13.
- Verified current repository permission through the GitHub collaborator permission API before adding the access-derived fast-path entry; added the second explicit identity on maintainer request.
- `git diff --check`
- Documentation/skill-only change; no runtime code changed.
