### PR TITLE
refactor(plugins): privatize session catalog params

### DIFF
--- a/src/plugins/session-catalog.ts
+++ b/src/plugins/session-catalog.ts
@@ -22,7 +22,7 @@ export type SessionCatalogCreateTarget = {
   agentRuntime: string;
 };
 
-export type SessionCatalogCreateParams = {
+type SessionCatalogCreateParams = {
   /** Agent whose model/runtime policy must authorize the catalog target. */
   agentId?: string;
 };


### PR DESCRIPTION
Related: #105595

## What Problem This Solves

Resolves a current-main regression where the production dead-export ratchet finds a newly unused `SessionCatalogCreateParams` export after catalog session creation landed.

## Why This Change Was Made

The type is used only by `SessionCatalogProvider` in the same module, so it remains module-local. Runtime behavior and the public Plugin SDK surface are unchanged.

## User Impact

No user-visible behavior changes. The shrink-only dead-export gate is exact again.

## Evidence

- Blacksmith Testbox `tbx_01kxe1mm6fncfs1b6tfm02bvwq`, [run 29262548477](https://github.com/openclaw/openclaw/actions/runs/29262548477): deadcode regeneration byte-stable at 2,541 entries, `src/plugins` baseline zero, production deadcode green.
- Targeted oxfmt, type-aware oxlint, and `pnpm tsgo:core` green.
- Fresh autoreview clean with no actionable findings, 0.98 confidence.
- AI-assisted; implementation and proof reviewed before submission.
