### PR TITLE
fix(ios): block incomplete shares when attachments are omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **iOS Share attachment omissions:** block sends when image limits or unsupported videos, files, or text providers would drop shared content instead of silently sending an incomplete share. (#103363, #104842) Thanks @jincheng-xydt.
 - **macOS remote node readiness:** take the main-session key from the node hello snapshot instead of opening an operator connection during node admission, preventing remote tunnel recovery from leaving Computer Use and node exec stuck in lifecycle transition.
 - **Claude CLI context budgets:** honor Anthropic model and per-agent `contextTokens` limits by passing the effective limit to Claude Code's native auto-compactor and persisting the same prepared budget in OpenClaw session state. Fixes #80933. (#93198) Thanks @mushuiyu886.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **iOS Share attachment omissions:** block sends when image limits or unsupported videos, files, or text providers would drop shared content instead of silently sending an incomplete share. (#103363, #104842) Thanks @jincheng-xydt.
 - **macOS remote node readiness:** take the main-session key from the node hello snapshot instead of opening an operator connection during node admission, preventing remote tunnel recovery from leaving Computer Use and node exec stuck in lifecycle transition.
 - **Claude CLI context budgets:** honor Anthropic model and per-agent `contextTokens` limits by passing the effective limit to Claude Code's native auto-compactor and persisting the same prepared budget in OpenClaw session state. Fixes #80933. (#93198) Thanks @mushuiyu886.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -12827,7 +12827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 233,
+      "line": 236,
       "path": "apps/ios/ShareExtension/ShareViewController.swift",
       "source": "Just received your iOS share + request, working on it.",
       "surface": "apple",

--- a/apps/ios/ShareExtension/ShareAttachmentSummary.swift
+++ b/apps/ios/ShareExtension/ShareAttachmentSummary.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+struct ShareAttachmentSummary: Equatable {
+    var selectedImageCount = 0
+    var acceptedImageCount = 0
+    var videoCount = 0
+    var fileCount = 0
+    var unknownCount = 0
+
+    mutating func recordUnclassifiedProvider(didLoadContent: Bool) {
+        if !didLoadContent {
+            self.unknownCount += 1
+        }
+    }
+
+    var omissionMessage: String? {
+        var details: [String] = []
+
+        if self.selectedImageCount > self.acceptedImageCount {
+            details.append(String(
+                format: NSLocalizedString(
+                    "Only %d of %d images can be sent.",
+                    comment: "Share extension image attachment limit warning"),
+                self.acceptedImageCount,
+                self.selectedImageCount))
+        }
+
+        var unsupported: [String] = []
+        if self.videoCount > 0 {
+            let format = if self.videoCount == 1 {
+                NSLocalizedString("%d video", comment: "Share extension unsupported video count")
+            } else {
+                NSLocalizedString("%d videos", comment: "Share extension unsupported video count")
+            }
+            unsupported.append(String(
+                format: format,
+                self.videoCount))
+        }
+        if self.fileCount > 0 {
+            let format = if self.fileCount == 1 {
+                NSLocalizedString("%d file", comment: "Share extension unsupported file count")
+            } else {
+                NSLocalizedString("%d files", comment: "Share extension unsupported file count")
+            }
+            unsupported.append(String(
+                format: format,
+                self.fileCount))
+        }
+        if self.unknownCount > 0 {
+            let format = if self.unknownCount == 1 {
+                NSLocalizedString("%d unsupported item", comment: "Share extension unsupported attachment count")
+            } else {
+                NSLocalizedString("%d unsupported items", comment: "Share extension unsupported attachment count")
+            }
+            unsupported.append(String(
+                format: format,
+                self.unknownCount))
+        }
+
+        if !unsupported.isEmpty {
+            details.append(String(
+                format: NSLocalizedString(
+                    "OpenClaw Share cannot send %@ yet.",
+                    comment: "Share extension unsupported attachment warning"),
+                unsupported.joined(separator: ", ")))
+        }
+
+        guard !details.isEmpty else { return nil }
+        details.append(NSLocalizedString(
+            "Remove omitted items and share again.",
+            comment: "Share extension omitted attachment recovery"))
+        return details.joined(separator: " ")
+    }
+}
+
+enum ShareAttachmentBlockReason: Equatable {
+    case imageProcessingFailed
+    case omitted(String)
+
+    static func resolve(
+        hasImageProcessingError: Bool,
+        summary: ShareAttachmentSummary) -> Self?
+    {
+        if hasImageProcessingError {
+            return .imageProcessingFailed
+        }
+        if let omissionMessage = summary.omissionMessage {
+            return .omitted(omissionMessage)
+        }
+        return nil
+    }
+}

--- a/apps/ios/ShareExtension/ShareViewController.swift
+++ b/apps/ios/ShareExtension/ShareViewController.swift
@@ -22,6 +22,7 @@ final class ShareViewController: UIViewController {
     private struct ExtractedShareContent {
         var payload: SharedContentPayload
         var attachments: [LoadedAttachment]
+        var attachmentSummary: ShareAttachmentSummary
         var attachmentError: ShareImageProcessor.ProcessError?
     }
 
@@ -30,7 +31,8 @@ final class ShareViewController: UIViewController {
     private var didPrepareDraft = false
     private var isSending = false
     private var pendingAttachments: [ShareAttachment] = []
-    private var attachmentError: ShareImageProcessor.ProcessError?
+    /// Keep omission state controller-owned so send cannot bypass the disabled UI.
+    private var attachmentBlockReason: ShareAttachmentBlockReason?
 
     override func loadView() {
         self.view = self.composeView
@@ -60,7 +62,9 @@ final class ShareViewController: UIViewController {
         let extracted = await self.extractSharedContent()
         let payload = extracted.payload
         self.pendingAttachments = extracted.attachments.map(\.payload)
-        self.attachmentError = extracted.attachmentError
+        self.attachmentBlockReason = ShareAttachmentBlockReason.resolve(
+            hasImageProcessingError: extracted.attachmentError != nil,
+            summary: extracted.attachmentSummary)
         self.logger.info("share payload trace=\(traceId, privacy: .public)")
         self.logger.info(
             "share payload title=\(payload.title?.count ?? 0) text=\(payload.text?.count ?? 0)")
@@ -70,9 +74,8 @@ final class ShareViewController: UIViewController {
         self.composeView.setDraft(message)
         self.composeView.setAttachmentPreviews(extracted.attachments.map(\.preview))
         self.composeView.focusDraft()
-        if let attachmentError = extracted.attachmentError {
-            ShareGatewayRelaySettings.saveLastEvent("Share blocked: image processing failed.")
-            self.composeView.apply(.blocked(self.imageProcessingErrorMessage(attachmentError)))
+        if let blockReason = self.attachmentBlockReason {
+            self.applyAttachmentBlockReason(blockReason)
         } else if message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             self.composeView.apply(.ready)
             ShareGatewayRelaySettings.saveLastEvent("Share ready: waiting for message input.")
@@ -88,8 +91,8 @@ final class ShareViewController: UIViewController {
     }
 
     private func sendCurrentDraft() async {
-        if let attachmentError = self.attachmentError {
-            self.composeView.apply(.blocked(self.imageProcessingErrorMessage(attachmentError)))
+        if let blockReason = self.attachmentBlockReason {
+            self.applyAttachmentBlockReason(blockReason)
             return
         }
         let trimmed = self.composeView.draftText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -282,6 +285,7 @@ final class ShareViewController: UIViewController {
             return ExtractedShareContent(
                 payload: SharedContentPayload(title: nil, url: nil, text: nil),
                 attachments: [],
+                attachmentSummary: ShareAttachmentSummary(),
                 attachmentError: nil)
         }
 
@@ -290,6 +294,7 @@ final class ShareViewController: UIViewController {
         var sharedText: String?
         var attributedContentText: String?
         var attachments: [LoadedAttachment] = []
+        var attachmentSummary = ShareAttachmentSummary()
         var attachmentError: ShareImageProcessor.ProcessError?
         let maxImageAttachments = 3
 
@@ -302,15 +307,17 @@ final class ShareViewController: UIViewController {
             }
 
             for provider in item.attachments ?? [] {
-                if sharedURL == nil {
-                    sharedURL = await self.loadURL(from: provider)
+                let providerURL = sharedURL == nil ? await self.loadURL(from: provider) : nil
+                let providerText = sharedText == nil ? await self.loadText(from: provider) : nil
+                if let providerURL {
+                    sharedURL = providerURL
                 }
-
-                if sharedText == nil {
-                    sharedText = await self.loadText(from: provider)
+                if let providerText {
+                    sharedText = providerText
                 }
 
                 if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
+                    attachmentSummary.selectedImageCount += 1
                     if attachments.count < maxImageAttachments, attachmentError == nil {
                         do {
                             let attachment = try await self.loadImageAttachment(
@@ -323,9 +330,19 @@ final class ShareViewController: UIViewController {
                             attachmentError = .encodeFailed
                         }
                     }
+                } else if provider.hasItemConformingToTypeIdentifier(UTType.movie.identifier) {
+                    attachmentSummary.videoCount += 1
+                } else if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+                    attachmentSummary.fileCount += 1
+                } else {
+                    // UTI conformance only promises a representation exists; count it as handled
+                    // only after the provider successfully delivers content we can send.
+                    attachmentSummary.recordUnclassifiedProvider(
+                        didLoadContent: providerURL != nil || providerText != nil)
                 }
             }
         }
+        attachmentSummary.acceptedImageCount = attachments.count
 
         // Share hosts often mirror provider text in attributedContentText.
         // Preserve distinct content as the historical title, but do not duplicate provider data.
@@ -336,6 +353,7 @@ final class ShareViewController: UIViewController {
         return ExtractedShareContent(
             payload: SharedContentPayload(title: title ?? supplementalTitle, url: sharedURL, text: sharedText),
             attachments: attachments,
+            attachmentSummary: attachmentSummary,
             attachmentError: attachmentError)
     }
 
@@ -361,10 +379,21 @@ final class ShareViewController: UIViewController {
             preview: self.boundedPreview(from: image))
     }
 
-    private func imageProcessingErrorMessage(_: ShareImageProcessor.ProcessError) -> String {
+    private func imageProcessingErrorMessage() -> String {
         NSLocalizedString(
             "The shared image could not be prepared.",
             comment: "Share extension image processing failure")
+    }
+
+    private func applyAttachmentBlockReason(_ blockReason: ShareAttachmentBlockReason) {
+        switch blockReason {
+        case .imageProcessingFailed:
+            ShareGatewayRelaySettings.saveLastEvent("Share blocked: image processing failed.")
+            self.composeView.apply(.blocked(self.imageProcessingErrorMessage()))
+        case let .omitted(message):
+            ShareGatewayRelaySettings.saveLastEvent("Share blocked: attachment(s) omitted.")
+            self.composeView.apply(.blocked(message))
+        }
     }
 
     /// Previews are retained for the sheet's lifetime; keep them bounded so
@@ -421,6 +450,12 @@ final class ShareViewController: UIViewController {
     private func loadText(from provider: NSItemProvider) async -> String? {
         if provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) {
             if let text = await self.loadTextValue(from: provider, typeIdentifier: UTType.plainText.identifier) {
+                return text
+            }
+        }
+
+        if provider.hasItemConformingToTypeIdentifier(UTType.text.identifier) {
+            if let text = await self.loadTextValue(from: provider, typeIdentifier: UTType.text.identifier) {
                 return text
             }
         }

--- a/apps/ios/Tests/Logic/ShareAttachmentSummaryTests.swift
+++ b/apps/ios/Tests/Logic/ShareAttachmentSummaryTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+
+struct ShareAttachmentSummaryTests {
+    @Test func `has no omission message when every selected image is accepted`() {
+        let summary = ShareAttachmentSummary(selectedImageCount: 3, acceptedImageCount: 3)
+
+        #expect(summary.omissionMessage == nil)
+    }
+
+    @Test func `reports image truncation before the share can be sent`() {
+        let summary = ShareAttachmentSummary(selectedImageCount: 6, acceptedImageCount: 3)
+
+        #expect(summary.omissionMessage ==
+            "Only 3 of 6 images can be sent. Remove omitted items and share again.")
+    }
+
+    @Test func `reports unsupported videos files and unknown attachments`() {
+        let summary = ShareAttachmentSummary(
+            selectedImageCount: 1,
+            acceptedImageCount: 1,
+            videoCount: 1,
+            fileCount: 2,
+            unknownCount: 1)
+
+        #expect(summary.omissionMessage ==
+            "OpenClaw Share cannot send 1 video, 2 files, 1 unsupported item yet. Remove omitted items and share again.")
+    }
+
+    @Test func `counts an unclassified provider only when no content was loaded`() {
+        var summary = ShareAttachmentSummary()
+
+        summary.recordUnclassifiedProvider(didLoadContent: true)
+        #expect(summary.unknownCount == 0)
+
+        summary.recordUnclassifiedProvider(didLoadContent: false)
+        #expect(summary.unknownCount == 1)
+    }
+
+    @Test func `keeps image processing failures authoritative before omission warnings`() {
+        let summary = ShareAttachmentSummary(selectedImageCount: 2, acceptedImageCount: 1)
+
+        #expect(ShareAttachmentBlockReason.resolve(
+            hasImageProcessingError: true,
+            summary: summary) == .imageProcessingFailed)
+    }
+
+    @Test func `uses omission warning when no image processing failure exists`() {
+        let summary = ShareAttachmentSummary(selectedImageCount: 6, acceptedImageCount: 3)
+
+        #expect(ShareAttachmentBlockReason.resolve(
+            hasImageProcessingError: false,
+            summary: summary) == .omitted(
+            "Only 3 of 6 images can be sent. Remove omitted items and share again."))
+    }
+}

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -421,6 +421,8 @@ targets:
         group: ShareExtension
       - path: ShareExtension/ShareComposeState.swift
         group: ShareExtension
+      - path: ShareExtension/ShareAttachmentSummary.swift
+        group: ShareExtension
       - path: WatchApp/Sources/WatchVoiceTurnTracker.swift
         group: WatchApp/Sources
       - path: WatchApp/Sources/WatchInboxMessages.swift


### PR DESCRIPTION
Closes #103363
Supersedes #104842 while preserving @jincheng-xydt's contribution and co-author credit.

## What Problem This Solves

Fixes an issue where users sharing more than three images, videos, files, unsupported items, or unloadable text representations from the iOS Share Extension could send an incomplete message while the omitted content was silently discarded.

## Why This Change Was Made

The Share Extension now summarizes every selected attachment, blocks both the compose UI and the send path whenever content would be omitted, and loads generic text representations before deciding whether a provider is unsupported. Image-processing failures remain authoritative, and the existing three-image upload limit stays unchanged.

## User Impact

Users now see a specific recovery message and cannot accidentally send a partial share. Supported one-to-three-image and text/URL shares continue normally.

## Evidence

- Fresh `autoreview --mode uncommitted`: clean, no accepted or actionable findings.
- `git diff --cached --check`: pass before the squashed replacement commit.
- Focused Swift logic coverage added for image truncation, unsupported item grammar, failed provider loads, and image-processing precedence.
- Real iPhone 17 Pro / iOS 26.2 Photos → Share Sheet proof on the contributor implementation: six images showed the omission warning with Send disabled; the one-image control remained sendable. See https://github.com/openclaw/openclaw/pull/104842#issuecomment-4953546708.
- Fresh exact-head hosted CI will run on this replacement PR.
