### PR TITLE
fix(ui): align settings page headline with the content column

### DIFF
--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -46,6 +46,20 @@
   flex-direction: column;
 }
 
+/* The page headline adopts the column of the page below it; without this the
+   shell caps headers at 1120px while narrow pages use a 760px column, leaving
+   the title floating left of the content. */
+.shell--settings .content:has(.settings-page) .content-header,
+.shell--settings .content:has(.settings-page) .config-view-toggle-row {
+  max-width: 760px;
+  padding-inline: var(--space-4);
+}
+
+.shell--settings .content:has(.settings-page--wide) .content-header,
+.shell--settings .content:has(.settings-page--wide) .config-view-toggle-row {
+  max-width: 1120px;
+}
+
 /* ── Page ── */
 
 .settings-page {


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #106470: the settings page headline ("General", "Sessions", …) sat at the shell's 1120px header column while narrow settings pages center a 760px content column — so the title floated visibly left of the content it labels.

## Why This Change Was Made

The header now adopts the column of the page below it via `:has()` in `settings.css`: 760px (plus the column's `--space-4` inline padding) for standard pages, 1120px for `settings-page--wide` tables, and unchanged for fill-height surfaces (Logs/Activity) that span the full workspace. This matches the reference behavior where the headline, section labels, and group edges share one left edge.

## User Impact

Settings page titles and their header actions (Simple/Advanced toggle, agent scope control) now align exactly with the content column on every settings page, in both column widths. CSS-only; no behavior changes.

## Evidence

| Page | Before | After |
| --- | --- | --- |
| General (760px column) | ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-settings-design-language/header-general-before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-settings-design-language/header-general-after.png) |
| Sessions (1120px column) | ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-settings-design-language/header-sessions-before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-settings-design-language/header-sessions-after.png) |

Visually verified against the mock gateway (`pnpm dev:ui:mock`) on General (narrow), Sessions (wide + agent-scope header control), and Logs (fill-height, unchanged). CSS-only diff (+14 lines); `:has()` is already used by shipped rules in this stylesheet family.
