### PR TITLE
refactor(telegram): split bot handler runtimes

### DIFF
--- a/extensions/telegram/src/bot-handlers.event-authorization.ts
+++ b/extensions/telegram/src/bot-handlers.event-authorization.ts
@@ -1,0 +1,355 @@
+import type {
+  DmPolicy,
+  OpenClawConfig,
+  TelegramAccountConfig,
+  TelegramGroupConfig,
+  TelegramTopicConfig,
+} from "openclaw/plugin-sdk/config-contracts";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { expandTelegramAllowFromWithAccessGroups } from "./access-groups.js";
+import { resolveTelegramAccount } from "./accounts.js";
+import {
+  normalizeDmAllowFromWithStore,
+  resolveTelegramEffectiveDmPolicy,
+  type NormalizedAllowFrom,
+} from "./bot-access.js";
+import { resolveTelegramMessageTurnSettings } from "./bot-message.js";
+import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
+import {
+  isTelegramCommandsAllowFromConfigured,
+  resolveTelegramCommandAuthorization,
+  resolveTelegramGroupAllowFromContext,
+} from "./bot/helpers.js";
+import {
+  evaluateTelegramGroupBaseAccess,
+  evaluateTelegramGroupPolicyAccess,
+} from "./group-access.js";
+import {
+  resolveTelegramCommandIngressAuthorization,
+  resolveTelegramEventIngressAuthorization,
+} from "./ingress.js";
+
+type TelegramGroupAllowContext = Awaited<ReturnType<typeof resolveTelegramGroupAllowFromContext>>;
+
+export type TelegramEventAuthorizationMode = "reaction" | "callback-scope" | "callback-allowlist";
+
+export type TelegramEventAuthorizationContext = TelegramGroupAllowContext & {
+  cfg: OpenClawConfig;
+  telegramCfg: TelegramAccountConfig;
+  allowFrom: ReturnType<typeof resolveTelegramMessageTurnSettings>["allowFrom"];
+  dmPolicy: DmPolicy;
+};
+
+const TELEGRAM_EVENT_AUTH_RULES: Record<
+  TelegramEventAuthorizationMode,
+  {
+    enforceDirectAuthorization: boolean;
+    enforceGroupAllowlistAuthorization: boolean;
+    deniedDmReason: string;
+    deniedGroupReason: string;
+  }
+> = {
+  reaction: {
+    enforceDirectAuthorization: true,
+    enforceGroupAllowlistAuthorization: false,
+    deniedDmReason: "reaction unauthorized by dm policy/allowlist",
+    deniedGroupReason: "reaction unauthorized by group allowlist",
+  },
+  "callback-scope": {
+    enforceDirectAuthorization: false,
+    enforceGroupAllowlistAuthorization: false,
+    deniedDmReason: "callback unauthorized by inlineButtonsScope",
+    deniedGroupReason: "callback unauthorized by inlineButtonsScope",
+  },
+  "callback-allowlist": {
+    enforceDirectAuthorization: true,
+    // Group messages already passed group policy and allowlist authorization.
+    enforceGroupAllowlistAuthorization: false,
+    deniedDmReason: "callback unauthorized by inlineButtonsScope allowlist",
+    deniedGroupReason: "callback unauthorized by inlineButtonsScope allowlist",
+  },
+};
+
+type TelegramGroupMessageGateParams = {
+  isGroup: boolean;
+  chatId: string | number;
+  chatTitle?: string;
+  resolvedThreadId?: number;
+  senderId: string;
+  senderUsername: string;
+  effectiveGroupAllow: NormalizedAllowFrom;
+  hasGroupAllowOverride: boolean;
+  groupConfig?: TelegramGroupConfig;
+  topicConfig?: TelegramTopicConfig;
+  cfg: OpenClawConfig;
+  telegramCfg: TelegramAccountConfig;
+};
+
+export function createTelegramEventAuthorizationRuntime(
+  params: Pick<
+    RegisterTelegramHandlerParams,
+    | "accountId"
+    | "logger"
+    | "opts"
+    | "resolveGroupPolicy"
+    | "resolveTelegramGroupConfig"
+    | "telegramDeps"
+  >,
+) {
+  const { accountId, logger, opts, resolveGroupPolicy, resolveTelegramGroupConfig, telegramDeps } =
+    params;
+
+  const shouldSkipGroupMessage = (gate: TelegramGroupMessageGateParams) => {
+    const baseAccess = evaluateTelegramGroupBaseAccess({
+      isGroup: gate.isGroup,
+      groupConfig: gate.groupConfig,
+      topicConfig: gate.topicConfig,
+      hasGroupAllowOverride: gate.hasGroupAllowOverride,
+      effectiveGroupAllow: gate.effectiveGroupAllow,
+      senderId: gate.senderId,
+      senderUsername: gate.senderUsername,
+      enforceAllowOverride: true,
+      requireSenderForAllowOverride: true,
+    });
+    if (!baseAccess.allowed) {
+      if (baseAccess.reason === "group-disabled") {
+        logVerbose(`Blocked telegram group ${gate.chatId} (group disabled)`);
+        return true;
+      }
+      if (baseAccess.reason === "topic-disabled") {
+        logVerbose(
+          `Blocked telegram topic ${gate.chatId} (${gate.resolvedThreadId ?? "unknown"}) (topic disabled)`,
+        );
+        return true;
+      }
+      logVerbose(
+        `Blocked telegram group sender ${gate.senderId || "unknown"} (group allowFrom override)`,
+      );
+      return true;
+    }
+    if (!gate.isGroup) {
+      return false;
+    }
+    const policyAccess = evaluateTelegramGroupPolicyAccess({
+      isGroup: gate.isGroup,
+      chatId: gate.chatId,
+      cfg: gate.cfg,
+      telegramCfg: gate.telegramCfg,
+      topicConfig: gate.topicConfig,
+      groupConfig: gate.groupConfig,
+      effectiveGroupAllow: gate.effectiveGroupAllow,
+      senderId: gate.senderId,
+      senderUsername: gate.senderUsername,
+      resolveGroupPolicy,
+      enforcePolicy: true,
+      useTopicAndGroupOverrides: true,
+      enforceAllowlistAuthorization: true,
+      allowEmptyAllowlistEntries: false,
+      requireSenderForAllowlistAuthorization: true,
+      checkChatAllowlist: true,
+    });
+    if (policyAccess.allowed) {
+      return false;
+    }
+    if (policyAccess.reason === "group-policy-disabled") {
+      logVerbose("Blocked telegram group message (groupPolicy: disabled)");
+    } else if (policyAccess.reason === "group-policy-allowlist-no-sender") {
+      logVerbose("Blocked telegram group message (no sender ID, groupPolicy: allowlist)");
+    } else if (policyAccess.reason === "group-policy-allowlist-empty") {
+      logVerbose(
+        "Blocked telegram group message (groupPolicy: allowlist, no group allowlist entries)",
+      );
+    } else if (policyAccess.reason === "group-policy-allowlist-unauthorized") {
+      logVerbose(`Blocked telegram group message from ${gate.senderId} (groupPolicy: allowlist)`);
+    } else {
+      logger.info(
+        { chatId: gate.chatId, title: gate.chatTitle, reason: "not-allowed" },
+        "skipping group message",
+      );
+    }
+    return true;
+  };
+
+  const resolveContext = async (input: {
+    cfg: OpenClawConfig;
+    chatId: number;
+    isGroup: boolean;
+    isForum: boolean;
+    senderId?: string;
+    messageThreadId?: number;
+  }): Promise<TelegramEventAuthorizationContext> => {
+    const telegramCfg = resolveTelegramAccount({ cfg: input.cfg, accountId }).config;
+    const settings = resolveTelegramMessageTurnSettings({
+      accountId,
+      cfg: input.cfg,
+      telegramCfg,
+      opts,
+    });
+    const groupContext = await resolveTelegramGroupAllowFromContext({
+      cfg: input.cfg,
+      chatId: input.chatId,
+      accountId,
+      dmPolicy: settings.dmPolicy,
+      allowFrom: settings.allowFrom,
+      senderId: input.senderId,
+      isGroup: input.isGroup,
+      isForum: input.isForum,
+      messageThreadId: input.messageThreadId,
+      groupAllowFrom: settings.groupAllowFrom,
+      readChannelAllowFromStore: telegramDeps.readChannelAllowFromStore,
+      resolveTelegramGroupConfig,
+    });
+    return {
+      cfg: input.cfg,
+      allowFrom: settings.allowFrom,
+      telegramCfg,
+      dmPolicy: resolveTelegramEffectiveDmPolicy({
+        isGroup: input.isGroup,
+        groupConfig: groupContext.groupConfig,
+        dmPolicy: settings.dmPolicy,
+      }),
+      ...groupContext,
+    };
+  };
+
+  const authorizeSender = async (input: {
+    chatId: number;
+    chatTitle?: string;
+    isGroup: boolean;
+    senderId: string;
+    senderUsername: string;
+    mode: TelegramEventAuthorizationMode;
+    context: TelegramEventAuthorizationContext;
+  }): Promise<boolean> => {
+    const context = input.context;
+    const rules = TELEGRAM_EVENT_AUTH_RULES[input.mode];
+    if (
+      shouldSkipGroupMessage({
+        isGroup: input.isGroup,
+        chatId: input.chatId,
+        chatTitle: input.chatTitle,
+        resolvedThreadId: context.resolvedThreadId,
+        senderId: input.senderId,
+        senderUsername: input.senderUsername,
+        effectiveGroupAllow: context.effectiveGroupAllow,
+        hasGroupAllowOverride: context.hasGroupAllowOverride,
+        groupConfig: context.groupConfig,
+        topicConfig: context.topicConfig,
+        cfg: context.cfg,
+        telegramCfg: context.telegramCfg,
+      })
+    ) {
+      return false;
+    }
+
+    if (!input.isGroup && rules.enforceDirectAuthorization) {
+      const expandedAllowFrom = await expandTelegramAllowFromWithAccessGroups({
+        cfg: context.cfg,
+        allowFrom: context.groupAllowOverride ?? context.allowFrom,
+        accountId,
+        senderId: input.senderId,
+      });
+      const eventAccess = await resolveTelegramEventIngressAuthorization({
+        accountId,
+        dmPolicy: context.dmPolicy,
+        isGroup: input.isGroup,
+        chatId: input.chatId,
+        resolvedThreadId: context.resolvedThreadId,
+        senderId: input.senderId,
+        effectiveDmAllow: normalizeDmAllowFromWithStore({
+          allowFrom: expandedAllowFrom,
+          storeAllowFrom: context.storeAllowFrom,
+          dmPolicy: context.dmPolicy,
+        }),
+        effectiveGroupAllow: context.effectiveGroupAllow,
+        enforceGroupAuthorization: false,
+        eventKind: input.mode === "reaction" ? "reaction" : "button",
+      });
+      if (eventAccess.decision !== "allow") {
+        const label =
+          eventAccess.reasonCode === "dm_policy_disabled" ? "direct event" : "direct sender";
+        logVerbose(
+          `Blocked telegram ${label} from ${input.senderId || "unknown"} (${rules.deniedDmReason})`,
+        );
+        return false;
+      }
+    }
+    if (input.isGroup && rules.enforceGroupAllowlistAuthorization) {
+      const eventAccess = await resolveTelegramEventIngressAuthorization({
+        accountId,
+        dmPolicy: context.dmPolicy,
+        isGroup: input.isGroup,
+        chatId: input.chatId,
+        resolvedThreadId: context.resolvedThreadId,
+        senderId: input.senderId,
+        effectiveDmAllow: normalizeDmAllowFromWithStore({
+          allowFrom: [],
+          dmPolicy: context.dmPolicy,
+        }),
+        effectiveGroupAllow: context.effectiveGroupAllow,
+        enforceGroupAuthorization: true,
+        eventKind: input.mode === "reaction" ? "reaction" : "button",
+      });
+      if (eventAccess.decision !== "allow") {
+        logVerbose(
+          `Blocked telegram group sender ${input.senderId || "unknown"} (${rules.deniedGroupReason})`,
+        );
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const isModelCallbackAuthorized = async (input: {
+    chatId: number;
+    isGroup: boolean;
+    senderId: string;
+    senderUsername: string;
+    context: TelegramEventAuthorizationContext;
+  }): Promise<boolean> => {
+    const context = input.context;
+    if (isTelegramCommandsAllowFromConfigured(context.cfg)) {
+      return resolveTelegramCommandAuthorization({
+        cfg: context.cfg,
+        accountId,
+        chatId: input.chatId,
+        isGroup: input.isGroup,
+        resolvedThreadId: context.resolvedThreadId,
+        senderId: input.senderId,
+        senderUsername: input.senderUsername,
+      }).isAuthorizedSender;
+    }
+    const expandedAllowFrom = await expandTelegramAllowFromWithAccessGroups({
+      cfg: context.cfg,
+      allowFrom: context.groupAllowOverride ?? context.allowFrom,
+      accountId,
+      senderId: input.senderId,
+    });
+    const dmAllow = normalizeDmAllowFromWithStore({
+      allowFrom: expandedAllowFrom,
+      storeAllowFrom: input.isGroup ? [] : context.storeAllowFrom,
+      dmPolicy: context.dmPolicy,
+    });
+    return (
+      await resolveTelegramCommandIngressAuthorization({
+        accountId,
+        cfg: context.cfg,
+        dmPolicy: context.dmPolicy,
+        isGroup: input.isGroup,
+        chatId: input.chatId,
+        resolvedThreadId: context.resolvedThreadId,
+        senderId: input.senderId,
+        effectiveDmAllow: dmAllow,
+        effectiveGroupAllow: context.effectiveGroupAllow,
+        ownerAccess: { ownerList: [], senderIsOwner: false },
+        eventKind: "button",
+      })
+    ).authorized;
+  };
+
+  return { authorizeSender, isModelCallbackAuthorized, resolveContext };
+}
+
+export type TelegramEventAuthorizationRuntime = ReturnType<
+  typeof createTelegramEventAuthorizationRuntime
+>;

--- a/extensions/telegram/src/bot-handlers.group-migration.ts
+++ b/extensions/telegram/src/bot-handlers.group-migration.ts
@@ -1,0 +1,64 @@
+import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-helpers";
+import { mutateConfigFile } from "openclaw/plugin-sdk/config-mutation";
+import { danger, warn } from "openclaw/plugin-sdk/runtime-env";
+import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
+import { migrateTelegramGroupConfig } from "./group-migration.js";
+
+export function registerTelegramGroupMigrationHandler(
+  params: Pick<
+    RegisterTelegramHandlerParams,
+    "accountId" | "bot" | "cfg" | "runtime" | "shouldSkipUpdate" | "telegramDeps"
+  >,
+) {
+  const { accountId, bot, cfg, runtime, shouldSkipUpdate, telegramDeps } = params;
+
+  bot.on("message:migrate_to_chat_id", async (ctx) => {
+    try {
+      const msg = ctx.message;
+      if (!msg?.migrate_to_chat_id || shouldSkipUpdate(ctx)) {
+        return;
+      }
+
+      const oldChatId = String(msg.chat.id);
+      const newChatId = String(msg.migrate_to_chat_id);
+      const chatTitle = msg.chat.title ?? "Unknown";
+      runtime.log?.(warn(`[telegram] Group migrated: "${chatTitle}" ${oldChatId} → ${newChatId}`));
+
+      if (!resolveChannelConfigWrites({ cfg, channelId: "telegram", accountId })) {
+        runtime.log?.(warn("[telegram] Config writes disabled; skipping group config migration."));
+        return;
+      }
+
+      const migration = migrateTelegramGroupConfig({
+        cfg: telegramDeps.getRuntimeConfig(),
+        accountId,
+        oldChatId,
+        newChatId,
+      });
+      if (migration.migrated) {
+        runtime.log?.(warn(`[telegram] Migrating group config from ${oldChatId} to ${newChatId}`));
+        migrateTelegramGroupConfig({ cfg, accountId, oldChatId, newChatId });
+        await mutateConfigFile({
+          afterWrite: { mode: "auto" },
+          mutate: (draft) => {
+            migrateTelegramGroupConfig({ cfg: draft, accountId, oldChatId, newChatId });
+          },
+        });
+        runtime.log?.(warn("[telegram] Group config migrated and saved successfully"));
+      } else if (migration.skippedExisting) {
+        runtime.log?.(
+          warn(
+            `[telegram] Group config already exists for ${newChatId}; leaving ${oldChatId} unchanged`,
+          ),
+        );
+      } else {
+        runtime.log?.(
+          warn(`[telegram] No config found for old group ID ${oldChatId}, migration logged only`),
+        );
+      }
+    } catch (err) {
+      runtime.error?.(danger(`[telegram] Group migration handler failed: ${String(err)}`));
+      throw err;
+    }
+  });
+}

--- a/extensions/telegram/src/bot-handlers.reactions.ts
+++ b/extensions/telegram/src/bot-handlers.reactions.ts
@@ -1,0 +1,137 @@
+import type { ReactionTypeEmoji } from "grammy/types";
+import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
+import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { resolveTelegramAccount } from "./accounts.js";
+import type { TelegramEventAuthorizationRuntime } from "./bot-handlers.event-authorization.js";
+import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
+import {
+  buildTelegramGroupPeerId,
+  buildTelegramParentPeer,
+  resolveTelegramForumThreadId,
+} from "./bot/helpers.js";
+
+export function registerTelegramReactionHandler(
+  params: Pick<
+    RegisterTelegramHandlerParams,
+    "accountId" | "bot" | "runtime" | "shouldSkipUpdate" | "telegramDeps"
+  >,
+  authorization: TelegramEventAuthorizationRuntime,
+) {
+  const { accountId, bot, runtime, shouldSkipUpdate, telegramDeps } = params;
+
+  bot.on("message_reaction", async (ctx) => {
+    try {
+      const reaction = ctx.messageReaction;
+      if (!reaction || shouldSkipUpdate(ctx)) {
+        return;
+      }
+
+      const chatId = reaction.chat.id;
+      const messageId = reaction.message_id;
+      const user = reaction.user;
+      const senderId = user?.id != null ? String(user.id) : "";
+      const senderUsername = user?.username ?? "";
+      const isGroup = reaction.chat.type === "group" || reaction.chat.type === "supergroup";
+      const isForum = reaction.chat.is_forum === true;
+      const cfg = telegramDeps.getRuntimeConfig();
+      const telegramCfg = resolveTelegramAccount({ cfg, accountId }).config;
+
+      const reactionMode = telegramCfg.reactionNotifications ?? "own";
+      if (reactionMode === "off" || user?.is_bot) {
+        return;
+      }
+      if (reactionMode === "own" && !telegramDeps.wasSentByBot(chatId, messageId, cfg)) {
+        logVerbose(
+          `telegram: skipped reaction on msg ${messageId} in chat ${chatId} (own mode, not sent by bot)`,
+        );
+        return;
+      }
+
+      const eventAuthContext = await authorization.resolveContext({
+        cfg,
+        chatId,
+        isGroup,
+        isForum,
+        senderId,
+      });
+      if (
+        !(await authorization.authorizeSender({
+          chatId,
+          chatTitle: reaction.chat.title,
+          isGroup,
+          senderId,
+          senderUsername,
+          mode: "reaction",
+          context: eventAuthContext,
+        }))
+      ) {
+        return;
+      }
+
+      // Telegram omits the topic id from reactions, so requireTopic DMs cannot be authorized.
+      if (
+        !isGroup &&
+        (eventAuthContext.groupConfig as { requireTopic?: boolean } | undefined)?.requireTopic ===
+          true
+      ) {
+        logVerbose(
+          `Blocked telegram reaction in DM ${chatId}: requireTopic=true but topic unknown for reactions`,
+        );
+        return;
+      }
+
+      const oldEmojis = new Set(
+        reaction.old_reaction
+          .filter((item): item is ReactionTypeEmoji => item.type === "emoji")
+          .map((item) => item.emoji),
+      );
+      const addedReactions = reaction.new_reaction
+        .filter((item): item is ReactionTypeEmoji => item.type === "emoji")
+        .filter((item) => !oldEmojis.has(item.emoji));
+      if (addedReactions.length === 0) {
+        return;
+      }
+
+      const senderName = user
+        ? [user.first_name, user.last_name].filter(Boolean).join(" ").trim() || user.username
+        : undefined;
+      const senderUsernameLabel = user?.username ? `@${user.username}` : undefined;
+      let senderLabel = senderName;
+      if (senderName && senderUsernameLabel) {
+        senderLabel = `${senderName} (${senderUsernameLabel})`;
+      } else if (!senderName && senderUsernameLabel) {
+        senderLabel = senderUsernameLabel;
+      }
+      if (!senderLabel && user?.id) {
+        senderLabel = `id:${user.id}`;
+      }
+      senderLabel ||= "unknown";
+
+      // Reaction payloads lack message_thread_id, so forum reactions use the chat session.
+      const resolvedThreadId = isForum
+        ? resolveTelegramForumThreadId({ isForum, messageThreadId: undefined })
+        : undefined;
+      const peerId = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : String(chatId);
+      const route = resolveAgentRoute({
+        cfg: eventAuthContext.cfg,
+        channel: "telegram",
+        accountId,
+        peer: { kind: isGroup ? "group" : "direct", id: peerId },
+        parentPeer: buildTelegramParentPeer({ isGroup, resolvedThreadId, chatId }),
+      });
+
+      for (const addedReaction of addedReactions) {
+        const emoji = addedReaction.emoji;
+        const text = `Telegram reaction added: ${emoji} by ${senderLabel} on msg ${messageId}`;
+        telegramDeps.enqueueSystemEvent(text, {
+          sessionKey: route.sessionKey,
+          contextKey: `telegram:reaction:add:${chatId}:${messageId}:${user?.id ?? "anon"}:${emoji}`,
+        });
+        logVerbose(`telegram: reaction event enqueued: ${text}`);
+      }
+    } catch (err) {
+      runtime.error?.(danger(`telegram reaction handler failed: ${String(err)}`));
+      throw err;
+    }
+  });
+}

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1,8 +1,7 @@
 // Telegram plugin module implements bot handlers behavior.
 import { randomUUID } from "node:crypto";
-import type { Message, ReactionTypeEmoji } from "grammy/types";
+import type { Message } from "grammy/types";
 import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
-import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-helpers";
 import {
   buildMentionRegexes,
   implicitMentionKindWhen,
@@ -27,7 +26,6 @@ import type {
   TelegramGroupConfig,
   TelegramTopicConfig,
 } from "openclaw/plugin-sdk/config-contracts";
-import { mutateConfigFile } from "openclaw/plugin-sdk/config-mutation";
 import { resolveChannelContextVisibilityMode } from "openclaw/plugin-sdk/context-visibility-runtime";
 import {
   buildPluginBindingResolvedText,
@@ -44,7 +42,6 @@ import {
 import { formatModelsAvailableHeader } from "openclaw/plugin-sdk/models-provider-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
-import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { danger, logVerbose, sleepWithAbort, warn } from "openclaw/plugin-sdk/runtime-env";
 import { evaluateSupplementalContextVisibility } from "openclaw/plugin-sdk/security-runtime";
@@ -75,7 +72,6 @@ import {
   firstDefined,
   isSenderAllowed,
   normalizeAllowFrom,
-  resolveTelegramEffectiveDmPolicy,
   type NormalizedAllowFrom,
 } from "./bot-access.js";
 import {
@@ -88,6 +84,12 @@ import {
   buildTelegramInboundDebounceKey,
 } from "./bot-handlers.debounce-key.js";
 import {
+  createTelegramEventAuthorizationRuntime,
+  type TelegramEventAuthorizationContext,
+  type TelegramEventAuthorizationMode,
+} from "./bot-handlers.event-authorization.js";
+import { registerTelegramGroupMigrationHandler } from "./bot-handlers.group-migration.js";
+import {
   hasInboundMedia,
   isDurablyRetryableInboundMediaError,
   isMediaSizeLimitError,
@@ -95,13 +97,13 @@ import {
   resolveInboundMediaFileId,
   TelegramBotApiFileTooLargeError,
 } from "./bot-handlers.media.js";
+import { registerTelegramReactionHandler } from "./bot-handlers.reactions.js";
 import type { TelegramMediaRef } from "./bot-message-context.js";
 import type {
   TelegramMessageContextOptions,
   TelegramPromptContextEntry,
 } from "./bot-message-context.types.js";
 import type { TelegramAmbientTranscriptWatermark } from "./bot-message-context.types.js";
-import { resolveTelegramMessageTurnSettings } from "./bot-message.js";
 import { parseTelegramNativeCommandCallbackData } from "./bot-native-commands.js";
 import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import {
@@ -125,13 +127,8 @@ import {
   getTelegramTextParts,
   hasBotMention,
   buildTelegramThreadParams,
-  buildTelegramGroupPeerId,
-  buildTelegramParentPeer,
-  isTelegramCommandsAllowFromConfigured,
-  resolveTelegramCommandAuthorization,
   resolveTelegramForumFlag,
   resolveTelegramForumThreadId,
-  resolveTelegramGroupAllowFromContext,
   resolveTelegramThreadSpec,
   resolveTelegramBotHasTopicsEnabled,
   resolveTelegramMediaPlaceholder,
@@ -156,21 +153,13 @@ import {
   isTelegramExecApprovalAuthorizedSender,
 } from "./exec-approvals.js";
 import { isTelegramForumServiceMessage } from "./forum-service-message.js";
-import {
-  evaluateTelegramGroupBaseAccess,
-  evaluateTelegramGroupPolicyAccess,
-} from "./group-access.js";
 import { resolveTelegramScopedGroupConfig } from "./group-config-helpers.js";
 import {
   buildTelegramSelfSenderName,
   isTelegramHistoryEntryAfterAmbientWatermark,
   isTelegramSelfSenderName,
 } from "./group-history-window.js";
-import { migrateTelegramGroupConfig } from "./group-migration.js";
-import {
-  resolveTelegramCommandIngressAuthorization,
-  resolveTelegramEventIngressAuthorization,
-} from "./ingress.js";
+import { resolveTelegramCommandIngressAuthorization } from "./ingress.js";
 import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
 import { dispatchTelegramPluginInteractiveHandler } from "./interactive-dispatch.js";
 import {
@@ -1846,148 +1835,21 @@ export const registerTelegramHandlers = ({
     }
   };
 
-  const shouldSkipGroupMessage = (params: {
-    isGroup: boolean;
-    chatId: string | number;
-    chatTitle?: string;
-    resolvedThreadId?: number;
-    senderId: string;
-    senderUsername: string;
-    effectiveGroupAllow: NormalizedAllowFrom;
-    hasGroupAllowOverride: boolean;
-    groupConfig?: TelegramGroupConfig;
-    topicConfig?: TelegramTopicConfig;
-    cfg: OpenClawConfig;
-    telegramCfg: TelegramAccountConfig;
-  }) => {
-    const {
-      isGroup,
-      chatId,
-      chatTitle,
-      resolvedThreadId,
-      senderId,
-      senderUsername,
-      effectiveGroupAllow,
-      hasGroupAllowOverride,
-      groupConfig,
-      topicConfig,
-      cfg: authorizationCfg,
-      telegramCfg: authorizationTelegramCfg,
-    } = params;
-    const baseAccess = evaluateTelegramGroupBaseAccess({
-      isGroup,
-      groupConfig,
-      topicConfig,
-      hasGroupAllowOverride,
-      effectiveGroupAllow,
-      senderId,
-      senderUsername,
-      enforceAllowOverride: true,
-      requireSenderForAllowOverride: true,
-    });
-    if (!baseAccess.allowed) {
-      if (baseAccess.reason === "group-disabled") {
-        logVerbose(`Blocked telegram group ${chatId} (group disabled)`);
-        return true;
-      }
-      if (baseAccess.reason === "topic-disabled") {
-        logVerbose(
-          `Blocked telegram topic ${chatId} (${resolvedThreadId ?? "unknown"}) (topic disabled)`,
-        );
-        return true;
-      }
-      logVerbose(
-        `Blocked telegram group sender ${senderId || "unknown"} (group allowFrom override)`,
-      );
-      return true;
-    }
-    if (!isGroup) {
-      return false;
-    }
-    const policyAccess = evaluateTelegramGroupPolicyAccess({
-      isGroup,
-      chatId,
-      cfg: authorizationCfg,
-      telegramCfg: authorizationTelegramCfg,
-      topicConfig,
-      groupConfig,
-      effectiveGroupAllow,
-      senderId,
-      senderUsername,
-      resolveGroupPolicy,
-      enforcePolicy: true,
-      useTopicAndGroupOverrides: true,
-      enforceAllowlistAuthorization: true,
-      allowEmptyAllowlistEntries: false,
-      requireSenderForAllowlistAuthorization: true,
-      checkChatAllowlist: true,
-    });
-    if (!policyAccess.allowed) {
-      if (policyAccess.reason === "group-policy-disabled") {
-        logVerbose("Blocked telegram group message (groupPolicy: disabled)");
-        return true;
-      }
-      if (policyAccess.reason === "group-policy-allowlist-no-sender") {
-        logVerbose("Blocked telegram group message (no sender ID, groupPolicy: allowlist)");
-        return true;
-      }
-      if (policyAccess.reason === "group-policy-allowlist-empty") {
-        logVerbose(
-          "Blocked telegram group message (groupPolicy: allowlist, no group allowlist entries)",
-        );
-        return true;
-      }
-      if (policyAccess.reason === "group-policy-allowlist-unauthorized") {
-        logVerbose(`Blocked telegram group message from ${senderId} (groupPolicy: allowlist)`);
-        return true;
-      }
-      logger.info({ chatId, title: chatTitle, reason: "not-allowed" }, "skipping group message");
-      return true;
-    }
-    return false;
-  };
-
-  type TelegramGroupAllowContext = Awaited<ReturnType<typeof resolveTelegramGroupAllowFromContext>>;
-  type TelegramEventAuthorizationMode = "reaction" | "callback-scope" | "callback-allowlist";
-  type TelegramEventAuthorizationContext = TelegramGroupAllowContext & {
-    cfg: OpenClawConfig;
-    telegramCfg: TelegramAccountConfig;
-    allowFrom: ReturnType<typeof resolveTelegramMessageTurnSettings>["allowFrom"];
-    dmPolicy: DmPolicy;
-  };
   const getChat: TelegramGetChat = bot.api.getChat.bind(bot.api);
 
-  const TELEGRAM_EVENT_AUTH_RULES: Record<
-    TelegramEventAuthorizationMode,
-    {
-      enforceDirectAuthorization: boolean;
-      enforceGroupAllowlistAuthorization: boolean;
-      deniedDmReason: string;
-      deniedGroupReason: string;
-    }
-  > = {
-    reaction: {
-      enforceDirectAuthorization: true,
-      enforceGroupAllowlistAuthorization: false,
-      deniedDmReason: "reaction unauthorized by dm policy/allowlist",
-      deniedGroupReason: "reaction unauthorized by group allowlist",
-    },
-    "callback-scope": {
-      enforceDirectAuthorization: false,
-      enforceGroupAllowlistAuthorization: false,
-      deniedDmReason: "callback unauthorized by inlineButtonsScope",
-      deniedGroupReason: "callback unauthorized by inlineButtonsScope",
-    },
-    "callback-allowlist": {
-      enforceDirectAuthorization: true,
-      // Group auth is already enforced by shouldSkipGroupMessage (group policy + allowlist).
-      // An extra allowlist gate here would block users whose original command was authorized.
-      enforceGroupAllowlistAuthorization: false,
-      deniedDmReason: "callback unauthorized by inlineButtonsScope allowlist",
-      deniedGroupReason: "callback unauthorized by inlineButtonsScope allowlist",
-    },
-  };
-
+  const eventAuthorization = createTelegramEventAuthorizationRuntime({
+    accountId,
+    logger,
+    opts,
+    resolveGroupPolicy,
+    resolveTelegramGroupConfig,
+    telegramDeps,
+  });
+  const {
+    authorizeSender: authorizeTelegramEventSender,
+    isModelCallbackAuthorized: isTelegramModelCallbackAuthorized,
+    resolveContext: resolveTelegramEventAuthorizationContext,
+  } = eventAuthorization;
   class TelegramRetryableCallbackError extends Error {
     public override readonly cause: unknown;
 
@@ -2081,351 +1943,11 @@ export const registerTelegramHandlers = ({
     }
   };
 
-  // Authorization owns one ingress snapshot. The agent turn intentionally
-  // captures again after batching so reloads during debounce apply to execution.
-  const resolveTelegramEventAuthorizationContext = async (params: {
-    cfg: OpenClawConfig;
-    chatId: number;
-    isGroup: boolean;
-    isForum: boolean;
-    senderId?: string;
-    messageThreadId?: number;
-  }): Promise<TelegramEventAuthorizationContext> => {
-    const authorizationCfg = params.cfg;
-    const authorizationTelegramCfg = resolveTelegramAccount({
-      cfg: authorizationCfg,
-      accountId,
-    }).config;
-    const authorizationSettings = resolveTelegramMessageTurnSettings({
-      accountId,
-      cfg: authorizationCfg,
-      telegramCfg: authorizationTelegramCfg,
-      opts,
-    });
-    const groupAllowContext = await resolveTelegramGroupAllowFromContext({
-      cfg: authorizationCfg,
-      chatId: params.chatId,
-      accountId,
-      dmPolicy: authorizationSettings.dmPolicy,
-      allowFrom: authorizationSettings.allowFrom,
-      senderId: params.senderId,
-      isGroup: params.isGroup,
-      isForum: params.isForum,
-      messageThreadId: params.messageThreadId,
-      groupAllowFrom: authorizationSettings.groupAllowFrom,
-      readChannelAllowFromStore: telegramDeps.readChannelAllowFromStore,
-      resolveTelegramGroupConfig,
-    });
-    const effectiveDmPolicy = resolveTelegramEffectiveDmPolicy({
-      isGroup: params.isGroup,
-      groupConfig: groupAllowContext.groupConfig,
-      dmPolicy: authorizationSettings.dmPolicy,
-    });
-    return {
-      cfg: authorizationCfg,
-      allowFrom: authorizationSettings.allowFrom,
-      telegramCfg: authorizationTelegramCfg,
-      dmPolicy: effectiveDmPolicy,
-      ...groupAllowContext,
-    };
-  };
+  registerTelegramReactionHandler(
+    { accountId, bot, runtime, shouldSkipUpdate, telegramDeps },
+    eventAuthorization,
+  );
 
-  const authorizeTelegramEventSender = async (params: {
-    chatId: number;
-    chatTitle?: string;
-    isGroup: boolean;
-    senderId: string;
-    senderUsername: string;
-    mode: TelegramEventAuthorizationMode;
-    context: TelegramEventAuthorizationContext;
-  }): Promise<boolean> => {
-    const { chatId, chatTitle, isGroup, senderId, senderUsername, mode, context } = params;
-    const {
-      dmPolicy,
-      resolvedThreadId,
-      storeAllowFrom,
-      groupConfig,
-      topicConfig,
-      groupAllowOverride,
-      effectiveGroupAllow,
-      hasGroupAllowOverride,
-      cfg: authorizationCfg,
-      telegramCfg: authorizationTelegramCfg,
-      allowFrom: authorizationAllowFrom,
-    } = context;
-    const authRules = TELEGRAM_EVENT_AUTH_RULES[mode];
-    const {
-      enforceDirectAuthorization,
-      enforceGroupAllowlistAuthorization,
-      deniedDmReason,
-      deniedGroupReason,
-    } = authRules;
-    if (
-      shouldSkipGroupMessage({
-        isGroup,
-        chatId,
-        chatTitle,
-        resolvedThreadId,
-        senderId,
-        senderUsername,
-        effectiveGroupAllow,
-        hasGroupAllowOverride,
-        groupConfig,
-        topicConfig,
-        cfg: authorizationCfg,
-        telegramCfg: authorizationTelegramCfg,
-      })
-    ) {
-      return false;
-    }
-
-    if (!isGroup && enforceDirectAuthorization) {
-      // For DMs, prefer per-DM/topic allowFrom (groupAllowOverride) over account-level allowFrom.
-      const dmAllowFrom = groupAllowOverride ?? authorizationAllowFrom;
-      const expandedDmAllowFrom = await expandTelegramAllowFromWithAccessGroups({
-        cfg: authorizationCfg,
-        allowFrom: dmAllowFrom,
-        accountId,
-        senderId,
-      });
-      const effectiveDmAllow = normalizeDmAllowFromWithStore({
-        allowFrom: expandedDmAllowFrom,
-        storeAllowFrom,
-        dmPolicy,
-      });
-      const eventAccess = await resolveTelegramEventIngressAuthorization({
-        accountId,
-        dmPolicy,
-        isGroup,
-        chatId,
-        resolvedThreadId,
-        senderId,
-        effectiveDmAllow,
-        effectiveGroupAllow,
-        enforceGroupAuthorization: false,
-        eventKind: mode === "reaction" ? "reaction" : "button",
-      });
-      if (eventAccess.decision !== "allow") {
-        if (eventAccess.reasonCode === "dm_policy_disabled") {
-          logVerbose(
-            `Blocked telegram direct event from ${senderId || "unknown"} (${deniedDmReason})`,
-          );
-          return false;
-        }
-        logVerbose(`Blocked telegram direct sender ${senderId || "unknown"} (${deniedDmReason})`);
-        return false;
-      }
-    }
-    if (isGroup && enforceGroupAllowlistAuthorization) {
-      const eventAccess = await resolveTelegramEventIngressAuthorization({
-        accountId,
-        dmPolicy,
-        isGroup,
-        chatId,
-        resolvedThreadId,
-        senderId,
-        effectiveDmAllow: normalizeDmAllowFromWithStore({ allowFrom: [], dmPolicy }),
-        effectiveGroupAllow,
-        enforceGroupAuthorization: true,
-        eventKind: mode === "reaction" ? "reaction" : "button",
-      });
-      if (eventAccess.decision !== "allow") {
-        logVerbose(`Blocked telegram group sender ${senderId || "unknown"} (${deniedGroupReason})`);
-        return false;
-      }
-    }
-    return true;
-  };
-
-  const isTelegramModelCallbackAuthorized = async (params: {
-    chatId: number;
-    isGroup: boolean;
-    senderId: string;
-    senderUsername: string;
-    context: TelegramEventAuthorizationContext;
-  }): Promise<boolean> => {
-    const { chatId, isGroup, senderId, senderUsername, context } = params;
-    const cfgLocal = context.cfg;
-    const dmAllowFrom = context.groupAllowOverride ?? context.allowFrom;
-    if (isTelegramCommandsAllowFromConfigured(cfgLocal)) {
-      return resolveTelegramCommandAuthorization({
-        cfg: cfgLocal,
-        accountId,
-        chatId,
-        isGroup,
-        resolvedThreadId: context.resolvedThreadId,
-        senderId,
-        senderUsername,
-      }).isAuthorizedSender;
-    }
-
-    const expandedDmAllowFrom = await expandTelegramAllowFromWithAccessGroups({
-      cfg: cfgLocal,
-      allowFrom: dmAllowFrom,
-      accountId,
-      senderId,
-    });
-    const dmAllow = normalizeDmAllowFromWithStore({
-      allowFrom: expandedDmAllowFrom,
-      storeAllowFrom: isGroup ? [] : context.storeAllowFrom,
-      dmPolicy: context.dmPolicy,
-    });
-    return (
-      await resolveTelegramCommandIngressAuthorization({
-        accountId,
-        cfg: cfgLocal,
-        dmPolicy: context.dmPolicy,
-        isGroup,
-        chatId,
-        resolvedThreadId: context.resolvedThreadId,
-        senderId,
-        effectiveDmAllow: dmAllow,
-        effectiveGroupAllow: context.effectiveGroupAllow,
-        ownerAccess: { ownerList: [], senderIsOwner: false },
-        eventKind: "button",
-      })
-    ).authorized;
-  };
-
-  // Handle emoji reactions to messages.
-  bot.on("message_reaction", async (ctx) => {
-    try {
-      const reaction = ctx.messageReaction;
-      if (!reaction) {
-        return;
-      }
-      if (shouldSkipUpdate(ctx)) {
-        return;
-      }
-
-      const chatId = reaction.chat.id;
-      const messageId = reaction.message_id;
-      const user = reaction.user;
-      const senderId = user?.id != null ? String(user.id) : "";
-      const senderUsername = user?.username ?? "";
-      const isGroup = reaction.chat.type === "group" || reaction.chat.type === "supergroup";
-      const isForum = reaction.chat.is_forum === true;
-      const authorizationCfg = telegramDeps.getRuntimeConfig();
-      const authorizationTelegramCfg = resolveTelegramAccount({
-        cfg: authorizationCfg,
-        accountId,
-      }).config;
-
-      // Resolve reaction notification mode (default: "own").
-      const reactionMode = authorizationTelegramCfg.reactionNotifications ?? "own";
-      if (reactionMode === "off") {
-        return;
-      }
-      if (user?.is_bot) {
-        return;
-      }
-      if (
-        reactionMode === "own" &&
-        !telegramDeps.wasSentByBot(chatId, messageId, authorizationCfg)
-      ) {
-        logVerbose(
-          `telegram: skipped reaction on msg ${messageId} in chat ${chatId} (own mode, not sent by bot)`,
-        );
-        return;
-      }
-      const eventAuthContext = await resolveTelegramEventAuthorizationContext({
-        cfg: authorizationCfg,
-        chatId,
-        isGroup,
-        isForum,
-        senderId,
-      });
-      const senderAuthorization = await authorizeTelegramEventSender({
-        chatId,
-        chatTitle: reaction.chat.title,
-        isGroup,
-        senderId,
-        senderUsername,
-        mode: "reaction",
-        context: eventAuthContext,
-      });
-      if (!senderAuthorization) {
-        return;
-      }
-
-      // Enforce requireTopic for DM reactions: since Telegram doesn't provide messageThreadId
-      // for reactions, we cannot determine if the reaction came from a topic, so block all
-      // reactions if requireTopic is enabled for this DM.
-      if (!isGroup) {
-        const requireTopic = (
-          eventAuthContext.groupConfig as { requireTopic?: boolean } | undefined
-        )?.requireTopic;
-        if (requireTopic === true) {
-          logVerbose(
-            `Blocked telegram reaction in DM ${chatId}: requireTopic=true but topic unknown for reactions`,
-          );
-          return;
-        }
-      }
-
-      // Detect added reactions.
-      const oldEmojis = new Set(
-        reaction.old_reaction
-          .filter((r): r is ReactionTypeEmoji => r.type === "emoji")
-          .map((r) => r.emoji),
-      );
-      const addedReactions = reaction.new_reaction
-        .filter((r): r is ReactionTypeEmoji => r.type === "emoji")
-        .filter((r) => !oldEmojis.has(r.emoji));
-
-      if (addedReactions.length === 0) {
-        return;
-      }
-
-      // Build sender label.
-      const senderName = user
-        ? [user.first_name, user.last_name].filter(Boolean).join(" ").trim() || user.username
-        : undefined;
-      const senderUsernameLabel = user?.username ? `@${user.username}` : undefined;
-      let senderLabel = senderName;
-      if (senderName && senderUsernameLabel) {
-        senderLabel = `${senderName} (${senderUsernameLabel})`;
-      } else if (!senderName && senderUsernameLabel) {
-        senderLabel = senderUsernameLabel;
-      }
-      if (!senderLabel && user?.id) {
-        senderLabel = `id:${user.id}`;
-      }
-      senderLabel = senderLabel || "unknown";
-
-      // Reactions target a specific message_id; the Telegram Bot API does not include
-      // message_thread_id on MessageReactionUpdated, so we route to the chat-level
-      // session (forum topic routing is not available for reactions).
-      const resolvedThreadId = isForum
-        ? resolveTelegramForumThreadId({ isForum, messageThreadId: undefined })
-        : undefined;
-      const peerId = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : String(chatId);
-      const parentPeer = buildTelegramParentPeer({ isGroup, resolvedThreadId, chatId });
-      // Fresh config for bindings lookup; other routing inputs are payload-derived.
-      const route = resolveAgentRoute({
-        cfg: eventAuthContext.cfg,
-        channel: "telegram",
-        accountId,
-        peer: { kind: isGroup ? "group" : "direct", id: peerId },
-        parentPeer,
-      });
-      const sessionKey = route.sessionKey;
-
-      // Enqueue system event for each added reaction.
-      for (const r of addedReactions) {
-        const emoji = r.emoji;
-        const text = `Telegram reaction added: ${emoji} by ${senderLabel} on msg ${messageId}`;
-        telegramDeps.enqueueSystemEvent(text, {
-          sessionKey,
-          contextKey: `telegram:reaction:add:${chatId}:${messageId}:${user?.id ?? "anon"}:${emoji}`,
-        });
-        logVerbose(`telegram: reaction event enqueued: ${text}`);
-      }
-    } catch (err) {
-      runtime.error?.(danger(`telegram reaction handler failed: ${String(err)}`));
-      throw err;
-    }
-  });
   const processInboundMessage = async (params: {
     authorizationCfg: OpenClawConfig;
     ctx: TelegramContext;
@@ -3730,62 +3252,13 @@ export const registerTelegramHandlers = ({
     }
   });
 
-  // Handle group migration to supergroup (chat ID changes)
-  bot.on("message:migrate_to_chat_id", async (ctx) => {
-    try {
-      const msg = ctx.message;
-      if (!msg?.migrate_to_chat_id) {
-        return;
-      }
-      if (shouldSkipUpdate(ctx)) {
-        return;
-      }
-
-      const oldChatId = String(msg.chat.id);
-      const newChatId = String(msg.migrate_to_chat_id);
-      const chatTitle = msg.chat.title ?? "Unknown";
-
-      runtime.log?.(warn(`[telegram] Group migrated: "${chatTitle}" ${oldChatId} → ${newChatId}`));
-
-      if (!resolveChannelConfigWrites({ cfg, channelId: "telegram", accountId })) {
-        runtime.log?.(warn("[telegram] Config writes disabled; skipping group config migration."));
-        return;
-      }
-
-      // Check if old chat ID has config and migrate it
-      const currentConfig = telegramDeps.getRuntimeConfig();
-      const migration = migrateTelegramGroupConfig({
-        cfg: currentConfig,
-        accountId,
-        oldChatId,
-        newChatId,
-      });
-
-      if (migration.migrated) {
-        runtime.log?.(warn(`[telegram] Migrating group config from ${oldChatId} to ${newChatId}`));
-        migrateTelegramGroupConfig({ cfg, accountId, oldChatId, newChatId });
-        await mutateConfigFile({
-          afterWrite: { mode: "auto" },
-          mutate: (draft) => {
-            migrateTelegramGroupConfig({ cfg: draft, accountId, oldChatId, newChatId });
-          },
-        });
-        runtime.log?.(warn(`[telegram] Group config migrated and saved successfully`));
-      } else if (migration.skippedExisting) {
-        runtime.log?.(
-          warn(
-            `[telegram] Group config already exists for ${newChatId}; leaving ${oldChatId} unchanged`,
-          ),
-        );
-      } else {
-        runtime.log?.(
-          warn(`[telegram] No config found for old group ID ${oldChatId}, migration logged only`),
-        );
-      }
-    } catch (err) {
-      runtime.error?.(danger(`[telegram] Group migration handler failed: ${String(err)}`));
-      throw err;
-    }
+  registerTelegramGroupMigrationHandler({
+    accountId,
+    bot,
+    cfg,
+    runtime,
+    shouldSkipUpdate,
+    telegramDeps,
   });
 
   type InboundTelegramEvent = {
@@ -3864,15 +3337,10 @@ export const registerTelegramHandlers = ({
     });
     const {
       dmPolicy,
-      resolvedThreadId,
       dmThreadId,
       storeAllowFrom,
       groupConfig,
-      topicConfig,
       groupAllowOverride,
-      effectiveGroupAllow,
-      hasGroupAllowOverride,
-      telegramCfg: authorizationTelegramCfg,
       allowFrom: authorizationAllowFrom,
     } = context;
     // For DMs, prefer per-DM/topic allowFrom (groupAllowOverride) over account-level allowFrom
@@ -3894,20 +3362,15 @@ export const registerTelegramHandlers = ({
     }
 
     if (
-      shouldSkipGroupMessage({
-        isGroup: params.isGroup,
+      !(await authorizeTelegramEventSender({
         chatId: params.chatId,
         chatTitle: params.msg.chat.title,
-        resolvedThreadId,
+        isGroup: params.isGroup,
         senderId: params.senderId,
         senderUsername: params.senderUsername,
-        effectiveGroupAllow,
-        hasGroupAllowOverride,
-        groupConfig,
-        topicConfig,
-        cfg: authorizationCfg,
-        telegramCfg: authorizationTelegramCfg,
-      })
+        mode: "callback-scope",
+        context,
+      }))
     ) {
       return { allowed: false };
     }


### PR DESCRIPTION
Related: #106503

## What Problem This Solves

The Telegram bot handler had accumulated authorization, reaction, and group-migration ownership in one 4,200-line runtime module, making those independent paths difficult to review and change safely.

## Why This Change Was Made

Moves event authorization into a focused runtime factory and registers reaction and group-migration handlers from dedicated modules. The main runtime drops from 4,200 to 3,663 lines; every new production TypeScript file remains below the 500-line limit. Registration order and behavior stay unchanged.

## User Impact

No user-visible behavior change. Maintainers get smaller owner-aligned modules for Telegram authorization and event handlers.

## Evidence

- Blacksmith Testbox `tbx_01kxe1d0xdye3e02s8dev4n51v`
- `pnpm tsgo:extensions`
- `pnpm test extensions/telegram/src/bot.test.ts extensions/telegram/src/bot-handlers.runtime.test.ts` — 121 tests passed
- `pnpm exec oxfmt --check` on all four touched files
- Autoreview: clean, no actionable findings

AI assistance used for refactoring and review.
