### PR TITLE
fix(gateway): restore revokeAttachGrantsForSession export in mcp-grant-store

### DIFF
--- a/src/gateway/mcp-grant-store.ts
+++ b/src/gateway/mcp-grant-store.ts
@@ -122,6 +122,18 @@ export function revokeAttachGrant(token: string): boolean {
   return grantsByToken.delete(token);
 }
 
+export function revokeAttachGrantsForSession(sessionKey: string): number {
+  const key = sessionKey.trim();
+  let removed = 0;
+  for (const [token, grant] of grantsByToken) {
+    if (grant.sessionKey === key) {
+      grantsByToken.delete(token);
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
 function sweepExpiredAttachGrants(nowMs: number = Date.now()): number {
   let removed = 0;
   for (const [token, grant] of grantsByToken) {


### PR DESCRIPTION
## Problem

Commit 26312fd0b0 removed the exported `revokeAttachGrantsForSession` from `src/gateway/mcp-grant-store.ts`, but the function is still imported and called at two call sites in `server.impl.ts` (line 88 and line 1603). This causes tsdown to fail with `MISSING_EXPORT` during build.

## Fix

Restore the `revokeAttachGrantsForSession` export. The function iterates through all attach grants and revokes those matching the given session key. No other changes to the function body.

## Evidence

Build succeeds after the fix. Verified locally with `pnpm run dev`.
