### PR TITLE
fix(gateway): hot-reload worktrees.cleanup config instead of restarting the gateway

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -110,6 +110,10 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
   // auth failure decision, so cooldown tuning needs a snapshot refresh but not
   // a gateway restart.
   { prefix: "auth.cooldowns", kind: "hot" },
+  // Worktree cleanup limits are read from the runtime config at each gc pass
+  // (hourly sweep and worktrees.gc), so a Settings stepper edit needs only a
+  // snapshot refresh; a restart here would drop live sessions per click.
+  { prefix: "worktrees", kind: "hot" },
   {
     prefix: "agents.list",
     kind: "hot",

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -234,6 +234,16 @@ describe("buildGatewayReloadPlan", () => {
       restartHeartbeat: true,
     },
     {
+      path: "worktrees.cleanup.maxCount",
+      restart: false,
+      hot: "worktrees.cleanup.maxCount",
+    },
+    {
+      path: "worktrees.cleanup.maxTotalSizeGb",
+      restart: false,
+      hot: "worktrees.cleanup.maxTotalSizeGb",
+    },
+    {
       path: "unknownField",
       restart: true,
       reason: "unknownField",

--- a/ui/src/components/config-form.ts
+++ b/ui/src/components/config-form.ts
@@ -1,6 +1,5 @@
 // Control UI view renders config form screen content.
 export { renderConfigForm } from "./config-form.render.ts";
-export { SECTION_META } from "./config-form.meta.ts";
 export { analyzeConfigSchema, type ConfigSchemaAnalysis } from "./config-form.analyze.ts";
 export { renderNode } from "./config-form.node.ts";
 export { schemaType, type JsonSchema } from "./config-form.shared.ts";

--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -7,9 +7,9 @@ import { icons } from "./icons.ts";
 
 type SettingsStatusKind = "ok" | "warn" | "danger" | "accent" | "muted";
 
-export type SettingsRowControl = TemplateResult | typeof nothing;
+type SettingsRowControl = TemplateResult | typeof nothing;
 
-export type SettingsRowProps = {
+type SettingsRowProps = {
   title: unknown;
   description?: unknown;
   control?: SettingsRowControl;


### PR DESCRIPTION
## What Problem This Solves

Editing `worktrees.cleanup.maxCount` / `worktrees.cleanup.maxTotalSizeGb` (added in #106224, issue #106213) restarts the whole gateway: the config reload plan has no rule for the `worktrees` prefix, and unmatched paths default to `restart`. Every stepper click on the Settings -> Worktrees Cleanup card therefore bounces the gateway, dropping live sessions and Control UI connections.

## Why This Change Was Made

Cleanup limits are read from the runtime config at each gc pass (hourly sweep and the `worktrees.gc` RPC read `getRuntimeConfig()` per run; the CLI loads config per invocation), so a snapshot refresh is all a change needs. Classifying the `worktrees` prefix as `kind: "hot"` (no actions) matches the existing `auth.cooldowns` precedent.

## User Impact

Adjusting worktree cleanup limits from the Settings UI (or editing `openclaw.json`) now hot-applies without a gateway restart; the next cleanup pass uses the new limits. No behavior change for any other config key.

## Evidence

- Found via a real-scenario Crabbox stress run of the shipped feature: gateway log showed `[reload] config change requires gateway restart (worktrees.cleanup.maxCount, worktrees.cleanup.maxTotalSizeGb)` followed by SIGUSR1 and a full process restart, which also failed the subsequent `worktrees.gc` RPC (`1006 abnormal closure`).
- After the fix, the same scenario shows no restart line, the gateway process stays alive across the config edit, and the `worktrees.gc` RPC returns a gc result; the eviction battery passes (active-session protection, dead-owner oldest-first eviction with snapshot, restore with dirty state, fractional size limit, manual-worktree immunity).
- `node scripts/run-vitest.mjs src/gateway/config-reload.test.ts`: 132 passed locally, including the two new classification cases (`worktrees.cleanup.maxCount` / `maxTotalSizeGb` -> hot, no restart).
- Codex autoreview (gpt-5.6-sol, xhigh) on the branch diff: clean, "patch is correct (0.97)".
