### PR TITLE
fix(config): improve validation error messages with line numbers, bracket paths, and received values

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1195,6 +1195,7 @@ describe("config cli", () => {
           issues: [
             {
               path: "agents.list.3.tools.profile",
+              pathSegments: ["agents", "list", 3, "tools", "profile"],
               message: 'Invalid input (allowed: "minimal", "coding", "messaging", "full")',
               allowedValues: ["minimal", "coding", "messaging", "full"],
             },

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -312,6 +312,7 @@ function makeInvalidSnapshot(params: {
   path?: string;
   raw?: string;
   parsed?: unknown;
+  sourceConfig?: OpenClawConfig;
 }): ConfigFileSnapshot {
   const parsed = params.parsed ?? {};
   return {
@@ -319,7 +320,7 @@ function makeInvalidSnapshot(params: {
     exists: true,
     raw: params.raw ?? "{}",
     parsed,
-    sourceConfig: parsed as OpenClawConfig,
+    sourceConfig: params.sourceConfig ?? (parsed as OpenClawConfig),
     resolved: parsed as OpenClawConfig,
     valid: false,
     runtimeConfig: {},

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -310,14 +310,17 @@ function makeInvalidSnapshot(params: {
   issues: ConfigFileSnapshot["issues"];
   warnings?: ConfigFileSnapshot["warnings"];
   path?: string;
+  raw?: string;
+  parsed?: unknown;
 }): ConfigFileSnapshot {
+  const parsed = params.parsed ?? {};
   return {
     path: params.path ?? "/tmp/custom-openclaw.json",
     exists: true,
-    raw: "{}",
-    parsed: {},
-    sourceConfig: {},
-    resolved: {},
+    raw: params.raw ?? "{}",
+    parsed,
+    sourceConfig: parsed as OpenClawConfig,
+    resolved: parsed as OpenClawConfig,
     valid: false,
     runtimeConfig: {},
     config: {},
@@ -1163,6 +1166,46 @@ describe("config cli", () => {
         "openclaw doctor --fix",
       );
       expect(mockLog).not.toHaveBeenCalled();
+    });
+
+    it("prints line numbers, bracket array paths, and safe received values", async () => {
+      const parsed = {
+        agents: {
+          list: [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d", tools: { profile: "none" } }],
+        },
+      };
+      const raw = [
+        "{",
+        '  "agents": {',
+        '    "list": [',
+        '      { "id": "a" },',
+        '      { "id": "b" },',
+        '      { "id": "c" },',
+        '      { "id": "d", "tools": { "profile": "none" } }',
+        "    ]",
+        "  }",
+        "}",
+      ].join("\n");
+      setSnapshotOnce(
+        makeInvalidSnapshot({
+          raw,
+          parsed,
+          path: "/tmp/openclaw.json",
+          issues: [
+            {
+              path: "agents.list.3.tools.profile",
+              message: 'Invalid input (allowed: "minimal", "coding", "messaging", "full")',
+              allowedValues: ["minimal", "coding", "messaging", "full"],
+            },
+          ],
+        }),
+      );
+
+      await expect(runConfigCommand(["config", "validate"])).rejects.toThrow("__exit__:1");
+
+      expectErrorIncludes(
+        'openclaw.json:7 — agents.list[3].tools.profile: Invalid input (allowed: "minimal", "coding", "messaging", "full"), got: "none"',
+      );
     });
 
     it("returns machine-readable JSON with --json for invalid config", async () => {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -19,6 +19,7 @@ import {
 } from "../config/config.js";
 import { AUTO_MANAGED_CONFIG_META_PATHS } from "../config/io.meta.js";
 import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-format.js";
+import { attachConfigIssueDiagnostics } from "../config/issue-location.js";
 import {
   normalizeAgentModelMapForConfig,
   normalizeAgentModelRefForConfig,
@@ -952,7 +953,14 @@ async function loadValidConfig(runtime: RuntimeEnv = defaultRuntime) {
     return snapshot;
   }
   runtime.error(`OpenClaw config is invalid: ${shortenHomePath(snapshot.path)}`);
-  for (const line of formatConfigIssueLines(snapshot.issues, "-", { normalizeRoot: true })) {
+  const displayIssues = attachConfigIssueDiagnostics(snapshot.issues, {
+    raw: snapshot.raw,
+    parsed: snapshot.parsed,
+    configPath: snapshot.path,
+    formatPathForDisplay: true,
+    includeReceivedValueHint: true,
+  });
+  for (const line of formatConfigIssueLines(displayIssues, "-", { normalizeRoot: true })) {
     runtime.error(line);
   }
   runtime.error(formatInvalidConfigRepairHint(snapshot, "to repair, then retry."));
@@ -2626,8 +2634,17 @@ async function runConfigValidate(opts: { json?: boolean; runtime?: RuntimeEnv } 
       if (opts.json) {
         writeRuntimeJson(runtime, { valid: false, path: outputPath, issues });
       } else {
+        const displayIssues = attachConfigIssueDiagnostics(snapshot.issues, {
+          raw: snapshot.raw,
+          parsed: snapshot.parsed,
+          configPath: snapshot.path,
+          formatPathForDisplay: true,
+          includeReceivedValueHint: true,
+        });
         runtime.error(danger(`OpenClaw config is invalid: ${shortPath}`));
-        for (const line of formatConfigIssueLines(issues, danger("×"), { normalizeRoot: true })) {
+        for (const line of formatConfigIssueLines(displayIssues, danger("×"), {
+          normalizeRoot: true,
+        })) {
           runtime.error(`  ${line}`);
         }
         runtime.error("");

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -2635,7 +2635,7 @@ async function runConfigValidate(opts: { json?: boolean; runtime?: RuntimeEnv } 
       if (opts.json) {
         writeRuntimeJson(runtime, { valid: false, path: outputPath, issues });
       } else {
-        const displayIssues = attachConfigIssueDiagnostics(snapshot.issues, {
+        const displayIssues = attachConfigIssueDiagnostics(issues, {
           raw: snapshot.raw,
           parsed: snapshot.parsed,
           effective: snapshot.sourceConfig,

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -956,6 +956,7 @@ async function loadValidConfig(runtime: RuntimeEnv = defaultRuntime) {
   const displayIssues = attachConfigIssueDiagnostics(snapshot.issues, {
     raw: snapshot.raw,
     parsed: snapshot.parsed,
+    effective: snapshot.sourceConfig,
     configPath: snapshot.path,
     formatPathForDisplay: true,
     includeReceivedValueHint: true,
@@ -2637,6 +2638,7 @@ async function runConfigValidate(opts: { json?: boolean; runtime?: RuntimeEnv } 
         const displayIssues = attachConfigIssueDiagnostics(snapshot.issues, {
           raw: snapshot.raw,
           parsed: snapshot.parsed,
+          effective: snapshot.sourceConfig,
           configPath: snapshot.path,
           formatPathForDisplay: true,
           includeReceivedValueHint: true,

--- a/src/config/issue-format.test.ts
+++ b/src/config/issue-format.test.ts
@@ -70,15 +70,18 @@ describe("config issue format", () => {
   });
 
   it("normalizes issue collections for machine output", () => {
-    expect(
-      normalizeConfigIssues([
-        {
-          path: "update.channel",
-          message: "invalid",
-          allowedValues: [],
-          allowedValuesHiddenCount: 2,
-        },
-      ]),
-    ).toEqual([{ path: "update.channel", message: "invalid" }]);
+    const issues = normalizeConfigIssues([
+      {
+        path: "update.channel",
+        pathSegments: ["update", "channel"],
+        message: "invalid",
+        allowedValues: [],
+        allowedValuesHiddenCount: 2,
+      },
+    ]);
+
+    expect(issues).toEqual([{ path: "update.channel", message: "invalid" }]);
+    expect(issues[0]?.pathSegments).toEqual(["update", "channel"]);
+    expect(JSON.stringify(issues)).not.toContain("pathSegments");
   });
 });

--- a/src/config/issue-format.test.ts
+++ b/src/config/issue-format.test.ts
@@ -8,6 +8,21 @@ import {
 } from "./issue-format.js";
 
 describe("config issue format", () => {
+  it("formats issue lines with source locations", () => {
+    expect(
+      formatConfigIssueLine(
+        {
+          path: "agents.list[3].tools.profile",
+          message: 'Invalid input, got: "none"',
+          line: 247,
+          sourceFile: "openclaw.json",
+        },
+        "×",
+        { normalizeRoot: true },
+      ),
+    ).toBe('× openclaw.json:247 — agents.list[3].tools.profile: Invalid input, got: "none"');
+  });
+
   it("formats issue lines with and without markers", () => {
     expect(formatConfigIssueLine({ path: "", message: "broken" }, "-")).toBe("- : broken");
     expect(

--- a/src/config/issue-format.ts
+++ b/src/config/issue-format.ts
@@ -5,6 +5,8 @@ import type { ConfigValidationIssue } from "./types.js";
 type ConfigIssueLineInput = {
   path?: string | null;
   message: string;
+  line?: number;
+  sourceFile?: string;
 };
 
 type ConfigIssueFormatOptions = {
@@ -46,6 +48,22 @@ export function normalizeConfigIssues(
   return issues.map((issue) => normalizeConfigIssue(issue));
 }
 
+function resolveIssueLocationPrefix(
+  issue: ConfigIssueLineInput,
+  opts?: ConfigIssueFormatOptions,
+): string {
+  const sourceFile =
+    typeof issue.sourceFile === "string" && issue.sourceFile.trim()
+      ? issue.sourceFile.trim()
+      : typeof opts?.sourceFile === "string" && opts.sourceFile.trim()
+        ? opts.sourceFile.trim()
+        : "";
+  if (!sourceFile || typeof issue.line !== "number" || issue.line <= 0) {
+    return "";
+  }
+  return `${sanitizeTerminalText(sourceFile)}:${issue.line} — `;
+}
+
 function resolveIssuePathForLine(
   path: string | null | undefined,
   opts?: ConfigIssueFormatOptions,
@@ -66,9 +84,10 @@ export function formatConfigIssueLine(
   opts?: ConfigIssueFormatOptions,
 ): string {
   const prefix = marker ? `${marker} ` : "";
+  const locationPrefix = resolveIssueLocationPrefix(issue, opts);
   const path = sanitizeTerminalText(resolveIssuePathForLine(issue.path, opts));
   const message = sanitizeTerminalText(issue.message);
-  return `${prefix}${path}: ${message}`;
+  return `${prefix}${locationPrefix}${path}: ${message}`;
 }
 
 /** Format config issues as terminal-safe lines with a shared marker prefix. */

--- a/src/config/issue-format.ts
+++ b/src/config/issue-format.ts
@@ -30,7 +30,7 @@ function normalizeConfigIssuePath(path: string | null | undefined): string {
 /** Return the public config issue shape with a normalized path and non-empty allowed values. */
 function normalizeConfigIssue(issue: ConfigValidationIssue): ConfigValidationIssue {
   const hasAllowedValues = Array.isArray(issue.allowedValues) && issue.allowedValues.length > 0;
-  return {
+  const normalized: ConfigValidationIssue = {
     path: normalizeConfigIssuePath(issue.path),
     message: issue.message,
     ...(hasAllowedValues ? { allowedValues: issue.allowedValues } : {}),
@@ -40,6 +40,13 @@ function normalizeConfigIssue(issue: ConfigValidationIssue): ConfigValidationIss
       ? { allowedValuesHiddenCount: issue.allowedValuesHiddenCount }
       : {}),
   };
+  if (issue.pathSegments) {
+    Object.defineProperty(normalized, "pathSegments", {
+      value: issue.pathSegments,
+      enumerable: false,
+    });
+  }
+  return normalized;
 }
 
 /** Normalize a batch of config validation issues for display or JSON output. */

--- a/src/config/issue-format.ts
+++ b/src/config/issue-format.ts
@@ -11,6 +11,7 @@ type ConfigIssueLineInput = {
 
 type ConfigIssueFormatOptions = {
   normalizeRoot?: boolean;
+  sourceFile?: string;
 };
 
 type ConfigIssueSummaryOptions = ConfigIssueFormatOptions & {

--- a/src/config/issue-location.test.ts
+++ b/src/config/issue-location.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendReceivedValueHint,
+  attachConfigIssueDiagnostics,
+  formatConfigIssuePath,
+  parseConfigIssuePath,
+  resolveConfigIssueLineInRaw,
+} from "./issue-location.js";
+
+describe("formatConfigIssuePath", () => {
+  it("formats numeric segments with bracket notation", () => {
+    expect(formatConfigIssuePath(["agents", "list", 3, "tools", "profile"])).toBe(
+      "agents.list[3].tools.profile",
+    );
+  });
+
+  it("handles consecutive numeric indices", () => {
+    expect(formatConfigIssuePath(["a", 0, "b", 1])).toBe("a[0].b[1]");
+  });
+
+  it("returns empty string for empty path", () => {
+    expect(formatConfigIssuePath([])).toBe("");
+  });
+
+  it("handles all-string path", () => {
+    expect(formatConfigIssuePath(["foo", "bar", "baz"])).toBe("foo.bar.baz");
+  });
+});
+
+describe("parseConfigIssuePath", () => {
+  it("parses bracket notation", () => {
+    expect(parseConfigIssuePath("agents.list[3].tools.profile")).toEqual([
+      "agents",
+      "list",
+      3,
+      "tools",
+      "profile",
+    ]);
+  });
+
+  it("parses legacy dot notation with numericDotSegments", () => {
+    expect(
+      parseConfigIssuePath("agents.list.3.tools.profile", { numericDotSegments: true }),
+    ).toEqual(["agents", "list", 3, "tools", "profile"]);
+  });
+
+  it("returns empty for root marker", () => {
+    expect(parseConfigIssuePath("<root>")).toEqual([]);
+  });
+
+  it("returns empty for empty string", () => {
+    expect(parseConfigIssuePath("")).toEqual([]);
+  });
+
+  it("preserves string segments that look like numbers without option", () => {
+    expect(parseConfigIssuePath("plugins.entries.123.config")).toEqual([
+      "plugins",
+      "entries",
+      "123",
+      "config",
+    ]);
+  });
+});
+
+describe("resolveConfigIssueLineInRaw", () => {
+  it("resolves line number for nested array object values", () => {
+    const raw = [
+      "{",
+      '  "agents": {',
+      '    "list": [',
+      "      {",
+      '        "id": "main"',
+      "      },",
+      "      {",
+      '        "tools": {',
+      '          "profile": "none"',
+      "        }",
+      "      }",
+      "    ]",
+      "  }",
+      "}",
+    ].join("\n");
+
+    expect(resolveConfigIssueLineInRaw(raw, ["agents", "list", 1, "tools", "profile"])).toBe(9);
+  });
+
+  it("resolves line number for top-level key", () => {
+    const raw = ["{", '  "update": {', '    "channel": "nightly"', "  }", "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["update", "channel"])).toBe(3);
+  });
+
+  it("returns undefined for path not in raw text", () => {
+    const raw = ["{", "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["nonexistent"])).toBeUndefined();
+  });
+
+  it("handles JSON5 comments", () => {
+    const raw = [
+      "{",
+      '  // comment',
+      '  "key": "value"',
+      "}",
+    ].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["key"])).toBe(3);
+  });
+
+  it("handles single-quoted strings", () => {
+    const raw = [
+      "{",
+      "  'key': 'value'",
+      "}",
+    ].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["key"])).toBe(2);
+  });
+});
+
+describe("appendReceivedValueHint", () => {
+  it("appends got: for simple values", () => {
+    expect(
+      appendReceivedValueHint(
+        'Invalid input (allowed: "minimal", "coding")',
+        "agents.list[0].tools.profile",
+        "none",
+      ),
+    ).toBe('Invalid input (allowed: "minimal", "coding"), got: "none"');
+  });
+
+  it("skips when message already mentions received", () => {
+    expect(
+      appendReceivedValueHint("expected string, received number", "gateway.port", 18789),
+    ).toBe("expected string, received number");
+  });
+
+  it("skips sensitive paths", () => {
+    expect(
+      appendReceivedValueHint("invalid token", "channels.telegram.botToken", "abc123"),
+    ).toBe("invalid token");
+  });
+
+  it("skips secret ref objects", () => {
+    expect(
+      appendReceivedValueHint("invalid input", "models.providers.openai.apiKey", {
+        source: "env",
+        provider: "default",
+        id: "OPENAI_API_KEY",
+      }),
+    ).toBe("invalid input");
+  });
+
+  it("skips object values", () => {
+    expect(
+      appendReceivedValueHint("invalid input", "some.path", { nested: true }),
+    ).toBe("invalid input");
+  });
+
+  it("skips undefined values", () => {
+    expect(
+      appendReceivedValueHint("invalid input", "some.path", undefined),
+    ).toBe("invalid input");
+  });
+
+  it("skips when message already has got:", () => {
+    expect(
+      appendReceivedValueHint("already got: something", "some.path", "value"),
+    ).toBe("already got: something");
+  });
+});
+
+describe("attachConfigIssueDiagnostics", () => {
+  const raw = [
+    "{",
+    '  "agents": {',
+    '    "list": [',
+    '      { "tools": { "profile": "none" } }',
+    "    ]",
+    "  }",
+    "}",
+  ].join("\n");
+
+  const parsed = {
+    agents: { list: [{ tools: { profile: "none" } }] },
+  };
+
+  it("preserves internal path by default", () => {
+    const issues = attachConfigIssueDiagnostics(
+      [
+        {
+          path: "agents.list.0.tools.profile",
+          message: 'Invalid input (allowed: "minimal", "coding")',
+          allowedValues: ["minimal", "coding"],
+        },
+      ],
+      { raw, parsed, configPath: "/tmp/openclaw.json" },
+    );
+
+    expect(issues[0]?.path).toBe("agents.list.0.tools.profile");
+    expect(issues[0]?.message).toBe('Invalid input (allowed: "minimal", "coding")');
+    expect(issues[0]?.line).toBe(4);
+    expect(issues[0]?.sourceFile).toBe("openclaw.json");
+  });
+
+  it("formats display path when requested", () => {
+    const issues = attachConfigIssueDiagnostics(
+      [
+        {
+          path: "agents.list.0.tools.profile",
+          message: 'Invalid input (allowed: "minimal", "coding")',
+          allowedValues: ["minimal", "coding"],
+        },
+      ],
+      {
+        raw,
+        parsed,
+        configPath: "/tmp/openclaw.json",
+        formatPathForDisplay: true,
+        includeReceivedValueHint: true,
+      },
+    );
+
+    expect(issues[0]?.path).toBe("agents.list[0].tools.profile");
+    expect(issues[0]?.message).toContain('got: "none"');
+    expect(issues[0]?.line).toBe(4);
+  });
+
+  it("handles empty raw gracefully", () => {
+    const issues = attachConfigIssueDiagnostics(
+      [{ path: "foo", message: "error" }],
+      { raw: null, parsed: {}, configPath: "/tmp/openclaw.json" },
+    );
+
+    expect(issues[0]?.line).toBeUndefined();
+    expect(issues[0]?.sourceFile).toBeUndefined();
+  });
+
+  it("handles $include'd paths gracefully (navigator returns undefined)", () => {
+    const issues = attachConfigIssueDiagnostics(
+      [
+        {
+          path: "models.providers.openai.api",
+          message: 'Invalid input (allowed: "openai-chatgpt")',
+        },
+      ],
+      {
+        raw: ['{', '  "$include": "./models.json"', "}"].join("\n"),
+        parsed: { models: { providers: { openai: { api: "bad" } } } },
+        configPath: "/tmp/openclaw.json",
+        formatPathForDisplay: true,
+        includeReceivedValueHint: true,
+      },
+    );
+
+    // Path exists in parsed but not in raw — no line number, no received value
+    expect(issues[0]?.line).toBeUndefined();
+    expect(issues[0]?.sourceFile).toBeUndefined();
+    expect(issues[0]?.message).toBe('Invalid input (allowed: "openai-chatgpt")');
+  });
+
+  it("preserves numeric record keys (not array indices)", () => {
+    const issues = attachConfigIssueDiagnostics(
+      [
+        {
+          path: "plugins.entries.123.config.mode",
+          message: 'Invalid input (allowed: "good")',
+        },
+      ],
+      {
+        raw: [
+          "{",
+          '  "plugins": {',
+          '    "entries": {',
+          '      "123": { "config": { "mode": "bad" } }',
+          "    }",
+          "  }",
+          "}",
+        ].join("\n"),
+        parsed: { plugins: { entries: { "123": { config: { mode: "bad" } } } } },
+        configPath: "/tmp/openclaw.json",
+        formatPathForDisplay: true,
+        includeReceivedValueHint: true,
+      },
+    );
+
+    expect(issues[0]?.path).toBe("plugins.entries.123.config.mode");
+    expect(issues[0]?.message).toContain('got: "bad"');
+    expect(issues[0]?.line).toBe(4);
+  });
+});

--- a/src/config/issue-location.test.ts
+++ b/src/config/issue-location.test.ts
@@ -95,21 +95,12 @@ describe("resolveConfigIssueLineInRaw", () => {
   });
 
   it("handles JSON5 comments", () => {
-    const raw = [
-      "{",
-      '  // comment',
-      '  "key": "value"',
-      "}",
-    ].join("\n");
+    const raw = ["{", "  // comment", '  "key": "value"', "}"].join("\n");
     expect(resolveConfigIssueLineInRaw(raw, ["key"])).toBe(3);
   });
 
   it("handles single-quoted strings", () => {
-    const raw = [
-      "{",
-      "  'key': 'value'",
-      "}",
-    ].join("\n");
+    const raw = ["{", "  'key': 'value'", "}"].join("\n");
     expect(resolveConfigIssueLineInRaw(raw, ["key"])).toBe(2);
   });
 });
@@ -126,15 +117,15 @@ describe("appendReceivedValueHint", () => {
   });
 
   it("skips when message already mentions received", () => {
-    expect(
-      appendReceivedValueHint("expected string, received number", "gateway.port", 18789),
-    ).toBe("expected string, received number");
+    expect(appendReceivedValueHint("expected string, received number", "gateway.port", 18789)).toBe(
+      "expected string, received number",
+    );
   });
 
   it("skips sensitive paths", () => {
-    expect(
-      appendReceivedValueHint("invalid token", "channels.telegram.botToken", "abc123"),
-    ).toBe("invalid token");
+    expect(appendReceivedValueHint("invalid token", "channels.telegram.botToken", "abc123")).toBe(
+      "invalid token",
+    );
   });
 
   it("skips secret ref objects", () => {
@@ -148,21 +139,19 @@ describe("appendReceivedValueHint", () => {
   });
 
   it("skips object values", () => {
-    expect(
-      appendReceivedValueHint("invalid input", "some.path", { nested: true }),
-    ).toBe("invalid input");
+    expect(appendReceivedValueHint("invalid input", "some.path", { nested: true })).toBe(
+      "invalid input",
+    );
   });
 
   it("skips undefined values", () => {
-    expect(
-      appendReceivedValueHint("invalid input", "some.path", undefined),
-    ).toBe("invalid input");
+    expect(appendReceivedValueHint("invalid input", "some.path", undefined)).toBe("invalid input");
   });
 
   it("skips when message already has got:", () => {
-    expect(
-      appendReceivedValueHint("already got: something", "some.path", "value"),
-    ).toBe("already got: something");
+    expect(appendReceivedValueHint("already got: something", "some.path", "value")).toBe(
+      "already got: something",
+    );
   });
 });
 
@@ -223,10 +212,11 @@ describe("attachConfigIssueDiagnostics", () => {
   });
 
   it("handles empty raw gracefully", () => {
-    const issues = attachConfigIssueDiagnostics(
-      [{ path: "foo", message: "error" }],
-      { raw: null, parsed: {}, configPath: "/tmp/openclaw.json" },
-    );
+    const issues = attachConfigIssueDiagnostics([{ path: "foo", message: "error" }], {
+      raw: null,
+      parsed: {},
+      configPath: "/tmp/openclaw.json",
+    });
 
     expect(issues[0]?.line).toBeUndefined();
     expect(issues[0]?.sourceFile).toBeUndefined();
@@ -241,7 +231,7 @@ describe("attachConfigIssueDiagnostics", () => {
         },
       ],
       {
-        raw: ['{', '  "$include": "./models.json"', "}"].join("\n"),
+        raw: ["{", '  "$include": "./models.json"', "}"].join("\n"),
         parsed: { models: { providers: { openai: { api: "bad" } } } },
         configPath: "/tmp/openclaw.json",
         formatPathForDisplay: true,

--- a/src/config/issue-location.test.ts
+++ b/src/config/issue-location.test.ts
@@ -105,23 +105,23 @@ describe("resolveConfigIssueLineInRaw", () => {
   });
 
   it("handles hex numbers as values", () => {
-    const raw = ["{", '  "a": 0x1A', "}"].join("\n");
-    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+    const raw = ["{", '  "a": 0x1A,', '  "b": 1', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["b"])).toBe(3);
   });
 
   it("handles leading decimal numbers", () => {
-    const raw = ["{", '  "a": .5', "}"].join("\n");
-    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+    const raw = ["{", '  "a": .5,', '  "b": 1', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["b"])).toBe(3);
   });
 
   it("handles Infinity value", () => {
-    const raw = ["{", '  "a": Infinity', "}"].join("\n");
-    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+    const raw = ["{", '  "a": Infinity,', '  "b": 1', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["b"])).toBe(3);
   });
 
   it("handles NaN value", () => {
-    const raw = ["{", '  "a": NaN', "}"].join("\n");
-    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+    const raw = ["{", '  "a": NaN,', '  "b": 1', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["b"])).toBe(3);
   });
 
   it("handles null and boolean values", () => {
@@ -147,13 +147,13 @@ describe("resolveConfigIssueLineInRaw", () => {
   });
 
   it("handles unicode escape sequences in strings", () => {
-    const raw = ["{", '  "a": "hello \\u0041"', "}"].join("\n");
-    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+    const raw = ["{", '  "a": "hello \\u0041",', '  "b": 1', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["b"])).toBe(3);
   });
 
   it("handles multi-line string continuation", () => {
-    const raw = ["{", '  "a": "hello \\', 'world"', "}"].join("\n");
-    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+    const raw = ["{", '  "a": "hello \\', 'world",', '  "b": 1', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["b"])).toBe(4);
   });
 
   it("handles unicode keys", () => {
@@ -162,13 +162,8 @@ describe("resolveConfigIssueLineInRaw", () => {
   });
 
   it("handles escaped quotes in strings", () => {
-    const raw = ["{", '  "a": "hello \\"world\\""', "}"].join("\n");
-    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
-  });
-
-  it("handles numeric separators in values", () => {
-    const raw = ["{", '  "a": 1_000', "}"].join("\n");
-    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+    const raw = ["{", '  "a": "hello \\"world\\"",', '  "b": 1', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["b"])).toBe(3);
   });
 
   it("handles block comments before keys", () => {

--- a/src/config/issue-location.test.ts
+++ b/src/config/issue-location.test.ts
@@ -3,7 +3,6 @@ import {
   appendReceivedValueHint,
   attachConfigIssueDiagnostics,
   formatConfigIssuePath,
-  parseConfigIssuePath,
   resolveConfigIssueLineInRaw,
 } from "./issue-location.js";
 
@@ -24,45 +23,6 @@ describe("formatConfigIssuePath", () => {
 
   it("handles all-string path", () => {
     expect(formatConfigIssuePath(["foo", "bar", "baz"])).toBe("foo.bar.baz");
-  });
-});
-
-describe("parseConfigIssuePath", () => {
-  it("parses bracket notation", () => {
-    expect(parseConfigIssuePath("agents.list[3].tools.profile")).toEqual([
-      "agents",
-      "list",
-      3,
-      "tools",
-      "profile",
-    ]);
-  });
-
-  it("preserves numeric dot segments until the parent type is known", () => {
-    expect(parseConfigIssuePath("agents.list.3.tools.profile")).toEqual([
-      "agents",
-      "list",
-      "3",
-      "tools",
-      "profile",
-    ]);
-  });
-
-  it("returns empty for root marker", () => {
-    expect(parseConfigIssuePath("<root>")).toEqual([]);
-  });
-
-  it("returns empty for empty string", () => {
-    expect(parseConfigIssuePath("")).toEqual([]);
-  });
-
-  it("preserves string segments that look like numbers without option", () => {
-    expect(parseConfigIssuePath("plugins.entries.123.config")).toEqual([
-      "plugins",
-      "entries",
-      "123",
-      "config",
-    ]);
   });
 });
 
@@ -300,6 +260,11 @@ describe("appendReceivedValueHint", () => {
 });
 
 describe("attachConfigIssueDiagnostics", () => {
+  const issue = (
+    pathSegments: Array<string | number>,
+    message: string,
+    extra: { allowedValues?: string[] } = {},
+  ) => ({ path: pathSegments.join("."), pathSegments, message, ...extra });
   const raw = [
     "{",
     '  "agents": {',
@@ -317,11 +282,13 @@ describe("attachConfigIssueDiagnostics", () => {
   it("preserves internal path by default", () => {
     const issues = attachConfigIssueDiagnostics(
       [
-        {
-          path: "agents.list.0.tools.profile",
-          message: 'Invalid input (allowed: "minimal", "coding")',
-          allowedValues: ["minimal", "coding"],
-        },
+        issue(
+          ["agents", "list", 0, "tools", "profile"],
+          'Invalid input (allowed: "minimal", "coding")',
+          {
+            allowedValues: ["minimal", "coding"],
+          },
+        ),
       ],
       { raw, parsed, effective: parsed, configPath: "/tmp/openclaw.json" },
     );
@@ -335,11 +302,13 @@ describe("attachConfigIssueDiagnostics", () => {
   it("formats display path when requested", () => {
     const issues = attachConfigIssueDiagnostics(
       [
-        {
-          path: "agents.list.0.tools.profile",
-          message: 'Invalid input (allowed: "minimal", "coding")',
-          allowedValues: ["minimal", "coding"],
-        },
+        issue(
+          ["agents", "list", 0, "tools", "profile"],
+          'Invalid input (allowed: "minimal", "coding")',
+          {
+            allowedValues: ["minimal", "coding"],
+          },
+        ),
       ],
       {
         raw,
@@ -357,7 +326,7 @@ describe("attachConfigIssueDiagnostics", () => {
   });
 
   it("handles empty raw gracefully", () => {
-    const issues = attachConfigIssueDiagnostics([{ path: "foo", message: "error" }], {
+    const issues = attachConfigIssueDiagnostics([issue(["foo"], "error")], {
       raw: null,
       parsed: {},
       effective: {},
@@ -371,10 +340,10 @@ describe("attachConfigIssueDiagnostics", () => {
   it("handles $include'd paths gracefully (navigator returns undefined)", () => {
     const issues = attachConfigIssueDiagnostics(
       [
-        {
-          path: "models.providers.openai.api",
-          message: 'Invalid input (allowed: "openai-chatgpt")',
-        },
+        issue(
+          ["models", "providers", "openai", "api"],
+          'Invalid input (allowed: "openai-chatgpt")',
+        ),
       ],
       {
         raw: ["{", '  "$include": "./models.json"', "}"].join("\n"),
@@ -394,12 +363,7 @@ describe("attachConfigIssueDiagnostics", () => {
 
   it("preserves numeric record keys (not array indices)", () => {
     const issues = attachConfigIssueDiagnostics(
-      [
-        {
-          path: "plugins.entries.123.config.mode",
-          message: 'Invalid input (allowed: "good")',
-        },
-      ],
+      [issue(["plugins", "entries", "123", "config", "mode"], 'Invalid input (allowed: "good")')],
       {
         raw: [
           "{",
@@ -426,7 +390,7 @@ describe("attachConfigIssueDiagnostics", () => {
   it("preserves non-canonical numeric record keys", () => {
     const parsed = { records: { "01": { mode: "bad" }, "1": { mode: "good" } } };
     const issues = attachConfigIssueDiagnostics(
-      [{ path: "records.01.mode", message: "Invalid input" }],
+      [issue(["records", "01", "mode"], "Invalid input")],
       {
         raw: '{ records: { "01": { mode: "bad" }, "1": { mode: "good" } } }',
         parsed,
@@ -444,10 +408,60 @@ describe("attachConfigIssueDiagnostics", () => {
     });
   });
 
+  it("uses structured paths to distinguish dotted keys from nested keys", () => {
+    const parsed = { "foo.bar": "literal", foo: { bar: "nested" } };
+    const params = {
+      raw: ['{ "foo.bar": "literal",', '  foo: { bar: "nested" } }'].join("\n"),
+      parsed,
+      effective: parsed,
+      configPath: "/tmp/openclaw.json",
+      formatPathForDisplay: true,
+      includeReceivedValueHint: true,
+    };
+
+    expect(
+      attachConfigIssueDiagnostics([issue(["foo.bar"], "Invalid input")], params)[0],
+    ).toMatchObject({
+      message: 'Invalid input, got: "literal"',
+      line: 1,
+    });
+    expect(
+      attachConfigIssueDiagnostics([issue(["foo", "bar"], "Invalid input")], params)[0],
+    ).toMatchObject({
+      message: 'Invalid input, got: "nested"',
+      line: 2,
+    });
+  });
+
+  it("does not let existing values steal missing dotted or nested paths", () => {
+    const parsed = { "foo.bar": "literal", foo: {} };
+    const params = {
+      raw: ['{ "foo.bar": "literal",', "  foo: {} }"].join("\n"),
+      parsed,
+      effective: parsed,
+      configPath: "/tmp/openclaw.json",
+      formatPathForDisplay: true,
+      includeReceivedValueHint: true,
+    };
+
+    expect(attachConfigIssueDiagnostics([issue(["foo", "bar"], "Required")], params)[0]).toEqual(
+      issue(["foo", "bar"], "Required"),
+    );
+    const nestedOnly = { foo: { bar: "nested" } };
+    expect(
+      attachConfigIssueDiagnostics([issue(["foo.bar"], "Required")], {
+        ...params,
+        raw: '{ foo: { bar: "nested" } }',
+        parsed: nestedOnly,
+        effective: nestedOnly,
+      })[0],
+    ).toEqual(issue(["foo.bar"], "Required"));
+  });
+
   it("omits values changed by environment substitution", () => {
     const envRaw = raw.replace('"none"', '"${PROFILE}"');
     const issues = attachConfigIssueDiagnostics(
-      [{ path: "agents.list.0.tools.profile", message: "Invalid input" }],
+      [issue(["agents", "list", 0, "tools", "profile"], "Invalid input")],
       {
         raw: envRaw,
         parsed: { agents: { list: [{ tools: { profile: "${PROFILE}" } }] } },
@@ -467,7 +481,7 @@ describe("attachConfigIssueDiagnostics", () => {
       plugins: { entries: { custom: { config: { accessCode: "private" } } } },
     };
     const issues = attachConfigIssueDiagnostics(
-      [{ path: "plugins.entries.custom.config.accessCode", message: "Invalid input" }],
+      [issue(["plugins", "entries", "custom", "config", "accessCode"], "Invalid input")],
       {
         raw: '{ plugins: { entries: { custom: { config: { accessCode: "private" } } } } }',
         parsed: pluginConfig,

--- a/src/config/issue-location.test.ts
+++ b/src/config/issue-location.test.ts
@@ -495,4 +495,24 @@ describe("attachConfigIssueDiagnostics", () => {
     expect(issues[0]?.message).toBe("Invalid input");
     expect(issues[0]?.line).toBe(1);
   });
+
+  it("omits plugin-owned values when the plugin id contains dots", () => {
+    const pluginConfig = {
+      plugins: { entries: { "vendor.plugin": { config: { sessionValue: "private" } } } },
+    };
+    const issues = attachConfigIssueDiagnostics(
+      [issue(["plugins", "entries", "vendor.plugin", "config", "sessionValue"], "Invalid input")],
+      {
+        raw: '{ plugins: { entries: { "vendor.plugin": { config: { sessionValue: "private" } } } } }',
+        parsed: pluginConfig,
+        effective: pluginConfig,
+        configPath: "/tmp/openclaw.json",
+        formatPathForDisplay: true,
+        includeReceivedValueHint: true,
+      },
+    );
+
+    expect(issues[0]?.message).toBe("Invalid input");
+    expect(issues[0]?.line).toBe(1);
+  });
 });

--- a/src/config/issue-location.test.ts
+++ b/src/config/issue-location.test.ts
@@ -1,10 +1,50 @@
+import JSON5 from "json5";
 import { describe, expect, it } from "vitest";
-import {
-  appendReceivedValueHint,
-  attachConfigIssueDiagnostics,
-  formatConfigIssuePath,
-  resolveConfigIssueLineInRaw,
-} from "./issue-location.js";
+import { attachConfigIssueDiagnostics } from "./issue-location.js";
+
+type PathSegment = string | number;
+
+function formatConfigIssuePath(pathSegments: PathSegment[]): string {
+  return (
+    attachConfigIssueDiagnostics(
+      [{ path: pathSegments.join("."), pathSegments, message: "Invalid input" }],
+      { raw: null, parsed: {}, effective: {}, formatPathForDisplay: true },
+    )[0]?.path ?? ""
+  );
+}
+
+function resolveConfigIssueLineInRaw(raw: string, pathSegments: PathSegment[]): number | undefined {
+  let parsed: unknown = {};
+  try {
+    parsed = JSON5.parse(raw);
+  } catch {
+    // Malformed or empty text cannot own a source location.
+  }
+  return attachConfigIssueDiagnostics(
+    [{ path: pathSegments.join("."), pathSegments, message: "Invalid input" }],
+    { raw, parsed, effective: parsed },
+  )[0]?.line;
+}
+
+function appendReceivedValueHint(message: string, pathValue: string, value: unknown): string {
+  const pathSegments = pathValue.split(".");
+  const root: Record<string, unknown> = {};
+  let current = root;
+  for (const segment of pathSegments.slice(0, -1)) {
+    const child: Record<string, unknown> = {};
+    current[segment] = child;
+    current = child;
+  }
+  current[pathSegments.at(-1) ?? ""] = value;
+  return (
+    attachConfigIssueDiagnostics([{ path: pathValue, pathSegments, message }], {
+      raw: JSON5.stringify(root),
+      parsed: root,
+      effective: root,
+      includeReceivedValueHint: true,
+    })[0]?.message ?? message
+  );
+}
 
 describe("formatConfigIssuePath", () => {
   it("formats numeric segments with bracket notation", () => {

--- a/src/config/issue-location.test.ts
+++ b/src/config/issue-location.test.ts
@@ -388,13 +388,13 @@ describe("attachConfigIssueDiagnostics", () => {
   });
 
   it("preserves non-canonical numeric record keys", () => {
-    const parsed = { records: { "01": { mode: "bad" }, "1": { mode: "good" } } };
+    const recordConfig = { records: { "01": { mode: "bad" }, "1": { mode: "good" } } };
     const issues = attachConfigIssueDiagnostics(
       [issue(["records", "01", "mode"], "Invalid input")],
       {
         raw: '{ records: { "01": { mode: "bad" }, "1": { mode: "good" } } }',
-        parsed,
-        effective: parsed,
+        parsed: recordConfig,
+        effective: recordConfig,
         configPath: "/tmp/openclaw.json",
         formatPathForDisplay: true,
         includeReceivedValueHint: true,
@@ -409,11 +409,11 @@ describe("attachConfigIssueDiagnostics", () => {
   });
 
   it("uses structured paths to distinguish dotted keys from nested keys", () => {
-    const parsed = { "foo.bar": "literal", foo: { bar: "nested" } };
+    const dottedConfig = { "foo.bar": "literal", foo: { bar: "nested" } };
     const params = {
       raw: ['{ "foo.bar": "literal",', '  foo: { bar: "nested" } }'].join("\n"),
-      parsed,
-      effective: parsed,
+      parsed: dottedConfig,
+      effective: dottedConfig,
       configPath: "/tmp/openclaw.json",
       formatPathForDisplay: true,
       includeReceivedValueHint: true,
@@ -434,11 +434,11 @@ describe("attachConfigIssueDiagnostics", () => {
   });
 
   it("does not let existing values steal missing dotted or nested paths", () => {
-    const parsed = { "foo.bar": "literal", foo: {} };
+    const dottedConfig = { "foo.bar": "literal", foo: {} };
     const params = {
       raw: ['{ "foo.bar": "literal",', "  foo: {} }"].join("\n"),
-      parsed,
-      effective: parsed,
+      parsed: dottedConfig,
+      effective: dottedConfig,
       configPath: "/tmp/openclaw.json",
       formatPathForDisplay: true,
       includeReceivedValueHint: true,

--- a/src/config/issue-location.test.ts
+++ b/src/config/issue-location.test.ts
@@ -99,6 +99,16 @@ describe("resolveConfigIssueLineInRaw", () => {
     expect(resolveConfigIssueLineInRaw(raw, ["key"])).toBe(3);
   });
 
+  it("handles comments between unquoted keys and colons", () => {
+    const raw = ["{", "  key // comment", '  : "value"', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["key"])).toBe(3);
+  });
+
+  it("handles comments directly after scalar values", () => {
+    const raw = ["{", "  ignored: 1 // comment", '  , target: "bad"', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["target"])).toBe(3);
+  });
+
   it("handles single-quoted strings", () => {
     const raw = ["{", "  'key': 'value'", "}"].join("\n");
     expect(resolveConfigIssueLineInRaw(raw, ["key"])).toBe(2);
@@ -293,7 +303,7 @@ describe("attachConfigIssueDiagnostics", () => {
           allowedValues: ["minimal", "coding"],
         },
       ],
-      { raw, parsed, configPath: "/tmp/openclaw.json" },
+      { raw, parsed, effective: parsed, configPath: "/tmp/openclaw.json" },
     );
 
     expect(issues[0]?.path).toBe("agents.list.0.tools.profile");
@@ -314,6 +324,7 @@ describe("attachConfigIssueDiagnostics", () => {
       {
         raw,
         parsed,
+        effective: parsed,
         configPath: "/tmp/openclaw.json",
         formatPathForDisplay: true,
         includeReceivedValueHint: true,
@@ -329,6 +340,7 @@ describe("attachConfigIssueDiagnostics", () => {
     const issues = attachConfigIssueDiagnostics([{ path: "foo", message: "error" }], {
       raw: null,
       parsed: {},
+      effective: {},
       configPath: "/tmp/openclaw.json",
     });
 
@@ -347,6 +359,7 @@ describe("attachConfigIssueDiagnostics", () => {
       {
         raw: ["{", '  "$include": "./models.json"', "}"].join("\n"),
         parsed: { models: { providers: { openai: { api: "bad" } } } },
+        effective: { models: { providers: { openai: { api: "bad" } } } },
         configPath: "/tmp/openclaw.json",
         formatPathForDisplay: true,
         includeReceivedValueHint: true,
@@ -378,6 +391,7 @@ describe("attachConfigIssueDiagnostics", () => {
           "}",
         ].join("\n"),
         parsed: { plugins: { entries: { "123": { config: { mode: "bad" } } } } },
+        effective: { plugins: { entries: { "123": { config: { mode: "bad" } } } } },
         configPath: "/tmp/openclaw.json",
         formatPathForDisplay: true,
         includeReceivedValueHint: true,
@@ -385,7 +399,45 @@ describe("attachConfigIssueDiagnostics", () => {
     );
 
     expect(issues[0]?.path).toBe("plugins.entries.123.config.mode");
-    expect(issues[0]?.message).toContain('got: "bad"');
+    expect(issues[0]?.message).toBe('Invalid input (allowed: "good")');
     expect(issues[0]?.line).toBe(4);
+  });
+
+  it("omits values changed by environment substitution", () => {
+    const envRaw = raw.replace('"none"', '"${PROFILE}"');
+    const issues = attachConfigIssueDiagnostics(
+      [{ path: "agents.list.0.tools.profile", message: "Invalid input" }],
+      {
+        raw: envRaw,
+        parsed: { agents: { list: [{ tools: { profile: "${PROFILE}" } }] } },
+        effective: { agents: { list: [{ tools: { profile: "none" } }] } },
+        configPath: "/tmp/openclaw.json",
+        formatPathForDisplay: true,
+        includeReceivedValueHint: true,
+      },
+    );
+
+    expect(issues[0]?.message).toBe("Invalid input");
+    expect(issues[0]?.line).toBe(4);
+  });
+
+  it("omits arbitrary plugin-owned values", () => {
+    const pluginConfig = {
+      plugins: { entries: { custom: { config: { accessCode: "private" } } } },
+    };
+    const issues = attachConfigIssueDiagnostics(
+      [{ path: "plugins.entries.custom.config.accessCode", message: "Invalid input" }],
+      {
+        raw: '{ plugins: { entries: { custom: { config: { accessCode: "private" } } } } }',
+        parsed: pluginConfig,
+        effective: pluginConfig,
+        configPath: "/tmp/openclaw.json",
+        formatPathForDisplay: true,
+        includeReceivedValueHint: true,
+      },
+    );
+
+    expect(issues[0]?.message).toBe("Invalid input");
+    expect(issues[0]?.line).toBe(1);
   });
 });

--- a/src/config/issue-location.test.ts
+++ b/src/config/issue-location.test.ts
@@ -38,10 +38,14 @@ describe("parseConfigIssuePath", () => {
     ]);
   });
 
-  it("parses legacy dot notation with numericDotSegments", () => {
-    expect(
-      parseConfigIssuePath("agents.list.3.tools.profile", { numericDotSegments: true }),
-    ).toEqual(["agents", "list", 3, "tools", "profile"]);
+  it("preserves numeric dot segments until the parent type is known", () => {
+    expect(parseConfigIssuePath("agents.list.3.tools.profile")).toEqual([
+      "agents",
+      "list",
+      "3",
+      "tools",
+      "profile",
+    ]);
   });
 
   it("returns empty for root marker", () => {
@@ -107,6 +111,11 @@ describe("resolveConfigIssueLineInRaw", () => {
   it("handles comments directly after scalar values", () => {
     const raw = ["{", "  ignored: 1 // comment", '  , target: "bad"', "}"].join("\n");
     expect(resolveConfigIssueLineInRaw(raw, ["target"])).toBe(3);
+  });
+
+  it("uses the active value when an object repeats a key", () => {
+    const raw = ["{", '  key: "old",', '  key: "bad"', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["key"])).toBe(3);
   });
 
   it("handles single-quoted strings", () => {
@@ -277,6 +286,17 @@ describe("appendReceivedValueHint", () => {
       "already got: something",
     );
   });
+
+  it.each([
+    [Number.NaN, "NaN"],
+    [Number.POSITIVE_INFINITY, "Infinity"],
+    [Number.NEGATIVE_INFINITY, "-Infinity"],
+    [-0, "-0"],
+  ])("renders JSON5 number %s without coercing it to null", (value, label) => {
+    expect(appendReceivedValueHint("invalid input", "some.path", value)).toBe(
+      `invalid input, got: ${label}`,
+    );
+  });
 });
 
 describe("attachConfigIssueDiagnostics", () => {
@@ -401,6 +421,27 @@ describe("attachConfigIssueDiagnostics", () => {
     expect(issues[0]?.path).toBe("plugins.entries.123.config.mode");
     expect(issues[0]?.message).toBe('Invalid input (allowed: "good")');
     expect(issues[0]?.line).toBe(4);
+  });
+
+  it("preserves non-canonical numeric record keys", () => {
+    const parsed = { records: { "01": { mode: "bad" }, "1": { mode: "good" } } };
+    const issues = attachConfigIssueDiagnostics(
+      [{ path: "records.01.mode", message: "Invalid input" }],
+      {
+        raw: '{ records: { "01": { mode: "bad" }, "1": { mode: "good" } } }',
+        parsed,
+        effective: parsed,
+        configPath: "/tmp/openclaw.json",
+        formatPathForDisplay: true,
+        includeReceivedValueHint: true,
+      },
+    );
+
+    expect(issues[0]).toMatchObject({
+      path: "records.01.mode",
+      message: 'Invalid input, got: "bad"',
+      line: 1,
+    });
   });
 
   it("omits values changed by environment substitution", () => {

--- a/src/config/issue-location.test.ts
+++ b/src/config/issue-location.test.ts
@@ -103,6 +103,125 @@ describe("resolveConfigIssueLineInRaw", () => {
     const raw = ["{", "  'key': 'value'", "}"].join("\n");
     expect(resolveConfigIssueLineInRaw(raw, ["key"])).toBe(2);
   });
+
+  it("handles hex numbers as values", () => {
+    const raw = ["{", '  "a": 0x1A', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+  });
+
+  it("handles leading decimal numbers", () => {
+    const raw = ["{", '  "a": .5', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+  });
+
+  it("handles Infinity value", () => {
+    const raw = ["{", '  "a": Infinity', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+  });
+
+  it("handles NaN value", () => {
+    const raw = ["{", '  "a": NaN', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+  });
+
+  it("handles null and boolean values", () => {
+    const raw = ["{", '  "a": null, "b": true, "c": false', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+    expect(resolveConfigIssueLineInRaw(raw, ["b"])).toBe(2);
+    expect(resolveConfigIssueLineInRaw(raw, ["c"])).toBe(2);
+  });
+
+  it("handles trailing commas in objects", () => {
+    const raw = ["{", '  "a": 1,', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+  });
+
+  it("handles trailing commas in arrays", () => {
+    const raw = ["{", '  "a": [1, 2,]', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+  });
+
+  it("handles deeply nested arrays", () => {
+    const raw = ["{", '  "a": { "b": { "c": [1, [2, [3]]] } } }', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["a", "b", "c", 1, 0])).toBe(2);
+  });
+
+  it("handles unicode escape sequences in strings", () => {
+    const raw = ["{", '  "a": "hello \\u0041"', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+  });
+
+  it("handles multi-line string continuation", () => {
+    const raw = ["{", '  "a": "hello \\', 'world"', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+  });
+
+  it("handles unicode keys", () => {
+    const raw = ["{", '  "café": 1', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["café"])).toBe(2);
+  });
+
+  it("handles escaped quotes in strings", () => {
+    const raw = ["{", '  "a": "hello \\"world\\""', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+  });
+
+  it("handles numeric separators in values", () => {
+    const raw = ["{", '  "a": 1_000', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+  });
+
+  it("handles block comments before keys", () => {
+    const raw = ["{", "  /* comment */", '  "key": "value"', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["key"])).toBe(3);
+  });
+
+  it("handles mixed single/double quotes", () => {
+    const raw = ["{", "  'key': \"value\"", "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["key"])).toBe(2);
+  });
+
+  it("handles empty object value", () => {
+    const raw = ["{", '  "a": {}', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+  });
+
+  it("handles empty array value", () => {
+    const raw = ["{", '  "a": []', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
+  });
+
+  it("handles array index navigation with nested objects", () => {
+    const raw = [
+      "{",
+      '  "agents": {',
+      '    "list": [',
+      "      {",
+      '        "id": "main"',
+      "      },",
+      "      {",
+      '        "tools": {',
+      '          "profile": "none"',
+      "        }",
+      "      }",
+      "    ]",
+      "  }",
+      "}",
+    ].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["agents", "list", 1, "tools", "profile"])).toBe(9);
+  });
+
+  it("gracefully degrades for unresolvable paths", () => {
+    const raw = ["{", '  "a": 1', "}"].join("\n");
+    expect(resolveConfigIssueLineInRaw(raw, ["nonexistent"])).toBeUndefined();
+    expect(resolveConfigIssueLineInRaw(raw, ["a", "b"])).toBeUndefined();
+    expect(resolveConfigIssueLineInRaw(raw, ["a", 0])).toBeUndefined();
+  });
+
+  it("handles empty raw text", () => {
+    expect(resolveConfigIssueLineInRaw("", ["a"])).toBeUndefined();
+    expect(resolveConfigIssueLineInRaw("  ", ["a"])).toBeUndefined();
+  });
 });
 
 describe("appendReceivedValueHint", () => {

--- a/src/config/issue-location.ts
+++ b/src/config/issue-location.ts
@@ -1,0 +1,464 @@
+// JSON5-aware config issue path navigator and display enrichment.
+// Walks raw config text to resolve line numbers and received values
+// for config validation issues, without a full parser.
+import path from "node:path";
+import { isSensitiveConfigPath } from "./sensitive-paths.js";
+import type { ConfigValidationIssue } from "./types.js";
+import { isSecretRef } from "./types.secrets.js";
+
+export type ConfigIssuePathSegment = string | number;
+
+// ---------------------------------------------------------------------------
+// JSON5 text navigator
+// ---------------------------------------------------------------------------
+
+type Cursor = { pos: number };
+
+function lineAtOffset(raw: string, offset: number): number {
+  let line = 1;
+  for (let i = 0; i < offset && i < raw.length; i++) {
+    if (raw[i] === "\n") line++;
+  }
+  return line;
+}
+
+/** Skip whitespace and JSON5 comments. */
+function skipWS(raw: string, c: Cursor): void {
+  while (c.pos < raw.length) {
+    const ch = raw[c.pos];
+    if (ch === " " || ch === "\t" || ch === "\r" || ch === "\n") {
+      c.pos++;
+      continue;
+    }
+    if (ch === "/" && raw[c.pos + 1] === "/") {
+      c.pos += 2;
+      while (c.pos < raw.length && raw[c.pos] !== "\n") c.pos++;
+      continue;
+    }
+    if (ch === "/" && raw[c.pos + 1] === "*") {
+      c.pos += 2;
+      while (c.pos < raw.length - 1) {
+        if (raw[c.pos] === "*" && raw[c.pos + 1] === "/") {
+          c.pos += 2;
+          break;
+        }
+        c.pos++;
+      }
+      continue;
+    }
+    break;
+  }
+}
+
+/** Skip a JSON5 string (single or double quoted). */
+function skipStr(raw: string, c: Cursor): void {
+  const quote = raw[c.pos];
+  c.pos++;
+  while (c.pos < raw.length) {
+    const ch = raw[c.pos];
+    if (ch === "\\") {
+      c.pos += 2;
+    } else if (ch === quote) {
+      c.pos++;
+      return;
+    } else {
+      c.pos++;
+    }
+  }
+}
+
+/** Skip a JSON5 value (string, number, boolean, null, object, array). */
+function skipVal(raw: string, c: Cursor): void {
+  skipWS(raw, c);
+  if (c.pos >= raw.length) return;
+  const ch = raw[c.pos];
+  if (ch === '"' || ch === "'") {
+    skipStr(raw, c);
+  } else if (ch === "{" || ch === "[") {
+    skipComposite(raw, c);
+  } else {
+    while (c.pos < raw.length) {
+      const ch2 = raw[c.pos];
+      if (ch2 === "," || ch2 === "}" || ch2 === "]" || ch2 === "/" || ch2 === " " || ch2 === "\t" || ch2 === "\r" || ch2 === "\n") return;
+      c.pos++;
+    }
+  }
+}
+
+/** Skip a composite value (object or array), correctly tracking nesting. */
+function skipComposite(raw: string, c: Cursor): void {
+  const open = raw[c.pos];
+  const close = open === "{" ? "}" : "]";
+  let depth = 1;
+  c.pos++;
+  while (c.pos < raw.length && depth > 0) {
+    const ch = raw[c.pos];
+    if (ch === '"' || ch === "'") {
+      skipStr(raw, c);
+    } else if (ch === "\\") {
+      c.pos += 2;
+    } else if (ch === open) {
+      depth++;
+      c.pos++;
+    } else if (ch === close) {
+      depth--;
+      c.pos++;
+    } else if (ch === "/" && raw[c.pos + 1] === "/") {
+      c.pos += 2;
+      while (c.pos < raw.length && raw[c.pos] !== "\n") c.pos++;
+    } else if (ch === "/" && raw[c.pos + 1] === "*") {
+      c.pos += 2;
+      while (c.pos < raw.length - 1) {
+        if (raw[c.pos] === "*" && raw[c.pos + 1] === "/") {
+          c.pos += 2;
+          break;
+        }
+        c.pos++;
+      }
+    } else {
+      c.pos++;
+    }
+  }
+}
+
+/** Read a JSON5 string value (single or double quoted). */
+function readStr(raw: string, c: Cursor): string | null {
+  skipWS(raw, c);
+  const quote = raw[c.pos];
+  if (quote !== '"' && quote !== "'") return null;
+  c.pos++;
+  let value = "";
+  while (c.pos < raw.length) {
+    const ch = raw[c.pos];
+    if (ch === "\\") {
+      const next = raw[c.pos + 1];
+      if (next !== undefined) value += next;
+      c.pos += 2;
+    } else if (ch === quote) {
+      c.pos++;
+      return value;
+    } else {
+      value += ch;
+      c.pos++;
+    }
+  }
+  return null;
+}
+
+/** Read a JSON5 object key (quoted string or unquoted identifier). */
+function readKey(raw: string, c: Cursor): string | null {
+  skipWS(raw, c);
+  const ch = raw[c.pos];
+  if (ch === '"' || ch === "'") return readStr(raw, c);
+  if (ch !== undefined && /[A-Za-z_$]/.test(ch)) {
+    const start = c.pos;
+    c.pos++;
+    while (c.pos < raw.length && /[A-Za-z0-9_$]/.test(raw[c.pos])) c.pos++;
+    return raw.slice(start, c.pos);
+  }
+  return null;
+}
+
+/** Expect and consume a specific character (skipping whitespace). */
+function expect(raw: string, c: Cursor, ch: string): boolean {
+  skipWS(raw, c);
+  if (raw[c.pos] !== ch) return false;
+  c.pos++;
+  return true;
+}
+
+/**
+ * Navigate raw JSON5 text to find the byte offset of a value at the given path.
+ * Returns undefined when the path cannot be resolved.
+ */
+function navigateToOffset(
+  raw: string,
+  segments: readonly ConfigIssuePathSegment[],
+): number | undefined {
+  if (segments.length === 0 || raw.trim().length === 0) return undefined;
+  const c: Cursor = { pos: 0 };
+  skipWS(raw, c);
+  return navigateAt(raw, c, segments, 0);
+}
+
+function navigateAt(
+  raw: string,
+  c: Cursor,
+  segments: readonly ConfigIssuePathSegment[],
+  depth: number,
+): number | undefined {
+  const segment = segments[depth];
+  const isLeaf = depth === segments.length - 1;
+
+  if (typeof segment === "number") {
+    if (!expect(raw, c, "[")) return undefined;
+    for (let i = 0; i < segment; i++) {
+      skipVal(raw, c);
+      if (!expect(raw, c, ",")) return undefined;
+    }
+    if (isLeaf) {
+      skipWS(raw, c);
+      return c.pos;
+    }
+    return navigateAt(raw, c, segments, depth + 1);
+  }
+
+  if (!expect(raw, c, "{")) return undefined;
+  while (c.pos < raw.length) {
+    skipWS(raw, c);
+    if (raw[c.pos] === "}") return undefined;
+    const key = readKey(raw, c);
+    if (key === null) return undefined;
+    if (!expect(raw, c, ":")) return undefined;
+    if (key === segment) {
+      if (isLeaf) {
+        skipWS(raw, c);
+        return c.pos;
+      }
+      return navigateAt(raw, c, segments, depth + 1);
+    }
+    skipVal(raw, c);
+    skipWS(raw, c);
+    if (raw[c.pos] === ",") {
+      c.pos++;
+      continue;
+    }
+    if (raw[c.pos] === "}") return undefined;
+    return undefined;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Path formatting
+// ---------------------------------------------------------------------------
+
+/** Format config issue path segments with bracket notation for array indexes. */
+export function formatConfigIssuePath(segments: readonly ConfigIssuePathSegment[]): string {
+  if (segments.length === 0) return "";
+  let out = "";
+  for (const s of segments) {
+    if (typeof s === "number") {
+      out += `[${s}]`;
+    } else {
+      out = out ? `${out}.${s}` : s;
+    }
+  }
+  return out;
+}
+
+/**
+ * Parse a display-formatted issue path back into traversal segments.
+ * Supports both bracket notation (`agents.list[3]`) and legacy dot-notation
+ * (`agents.list.3` with numericDotSegments option).
+ */
+export function parseConfigIssuePath(
+  pathValue: string,
+  opts?: { numericDotSegments?: boolean },
+): ConfigIssuePathSegment[] {
+  const trimmed = pathValue.trim();
+  if (!trimmed || trimmed === "<root>") return [];
+  const segments: ConfigIssuePathSegment[] = [];
+  let i = 0;
+  while (i < trimmed.length) {
+    if (trimmed[i] === ".") {
+      i++;
+      continue;
+    }
+    if (trimmed[i] === "[") {
+      const close = trimmed.indexOf("]", i + 1);
+      if (close === -1) break;
+      const n = Number(trimmed.slice(i + 1, close));
+      if (Number.isInteger(n) && n >= 0) segments.push(n);
+      i = close + 1;
+      continue;
+    }
+    let end = i;
+    while (end < trimmed.length && trimmed[end] !== "." && trimmed[end] !== "[") end++;
+    const seg = trimmed.slice(i, end);
+    if (seg) {
+      const n = Number(seg);
+      if (opts?.numericDotSegments && Number.isInteger(n) && n >= 0) {
+        segments.push(n);
+      } else {
+        segments.push(seg);
+      }
+    }
+    i = end;
+  }
+  return segments;
+}
+
+// ---------------------------------------------------------------------------
+// Value resolution from parsed config
+// ---------------------------------------------------------------------------
+
+/** Resolve the actual value at a path in the parsed config object. */
+export function resolveConfigValueAtPath(
+  root: unknown,
+  segments: readonly ConfigIssuePathSegment[],
+): unknown {
+  let current: unknown = root;
+  for (const s of segments) {
+    if (typeof s === "number") {
+      if (!Array.isArray(current) || s < 0 || s >= current.length) return undefined;
+      current = current[s];
+    } else {
+      if (!current || typeof current !== "object" || Array.isArray(current))
+        return undefined;
+      current = (current as Record<string, unknown>)[s];
+    }
+  }
+  return current;
+}
+
+/**
+ * Resolve raw path segments against the parsed config to distinguish array
+ * indices from numeric record keys. A numeric segment is treated as an array
+ * index only when the parent value is actually an array.
+ */
+function resolveSegmentsAgainstParsed(
+  root: unknown,
+  rawSegments: readonly ConfigIssuePathSegment[],
+): ConfigIssuePathSegment[] {
+  const resolved: ConfigIssuePathSegment[] = [];
+  let current: unknown = root;
+  for (const s of rawSegments) {
+    if (typeof s === "number") {
+      if (Array.isArray(current)) {
+        resolved.push(s);
+        current = current[s];
+      } else {
+        const key = String(s);
+        resolved.push(key);
+        current =
+          current && typeof current === "object"
+            ? (current as Record<string, unknown>)[key]
+            : undefined;
+      }
+    } else {
+      resolved.push(s);
+      current =
+        current && typeof current === "object" && !Array.isArray(current)
+          ? (current as Record<string, unknown>)[s]
+          : undefined;
+    }
+  }
+  return resolved;
+}
+
+// ---------------------------------------------------------------------------
+// Received value hint
+// ---------------------------------------------------------------------------
+
+function safeStringify(v: unknown): string | null {
+  if (v === undefined) return null;
+  try {
+    const s = JSON.stringify(v);
+    if (s === undefined) return null;
+    return s.length > 160 ? `${s.slice(0, 157)}...` : s;
+  } catch {
+    return null;
+  }
+}
+
+function messageAlreadyHasReceived(message: string): boolean {
+  const lower = message.toLowerCase();
+  return lower.includes("got:") || /\breceived\b/.test(lower);
+}
+
+function shouldOmitReceivedValue(pathValue: string, value: unknown): boolean {
+  if (value === undefined) return true;
+  if (isSecretRef(value)) return true;
+  if (isSensitiveConfigPath(pathValue)) return true;
+  if (typeof value === "object" && value !== null) return true;
+  return safeStringify(value) === null;
+}
+
+/** Append a compact `got: <value>` hint when safe and not already present. */
+export function appendReceivedValueHint(
+  message: string,
+  pathValue: string,
+  value: unknown,
+): string {
+  if (shouldOmitReceivedValue(pathValue, value)) return message;
+  const label = safeStringify(value);
+  if (!label || messageAlreadyHasReceived(message)) return message;
+  return `${message}, got: ${label}`;
+}
+
+// ---------------------------------------------------------------------------
+// Line number resolution
+// ---------------------------------------------------------------------------
+
+/** Resolve the 1-based source line number for a value at the given path. */
+export function resolveConfigIssueLineInRaw(
+  raw: string,
+  segments: readonly ConfigIssuePathSegment[],
+): number | undefined {
+  const offset = navigateToOffset(raw, segments);
+  if (offset === undefined) return undefined;
+  return lineAtOffset(raw, offset);
+}
+
+// ---------------------------------------------------------------------------
+// Issue enrichment
+// ---------------------------------------------------------------------------
+
+export type AttachConfigIssueDiagnosticsParams = {
+  raw: string | null | undefined;
+  parsed: unknown;
+  configPath?: string | null;
+  formatPathForDisplay?: boolean;
+  includeReceivedValueHint?: boolean;
+};
+
+export type ConfigIssueDiagnostics = ConfigValidationIssue & {
+  line?: number;
+  sourceFile?: string;
+};
+
+/**
+ * Enrich config validation issues with display-friendly diagnostics:
+ * - Bracket notation for array indices (when formatPathForDisplay is true)
+ * - Received value hints (when includeReceivedValueHint is true)
+ * - Source line numbers and file name
+ *
+ * Line numbers and received values are only attached when the value can be
+ * resolved in the raw config text. Paths in $include'd files gracefully
+ * degrade — the navigator won't find them in the raw text, so no line
+ * number or received value is shown for those issues.
+ */
+export function attachConfigIssueDiagnostics(
+  issues: readonly ConfigValidationIssue[],
+  params: AttachConfigIssueDiagnosticsParams,
+): ConfigIssueDiagnostics[] {
+  const raw = typeof params.raw === "string" ? params.raw : null;
+  const configBasename =
+    typeof params.configPath === "string" && params.configPath.trim()
+      ? path.basename(params.configPath)
+      : "openclaw.json";
+
+  return issues.map((issue) => {
+    const rawSegments = parseConfigIssuePath(issue.path, { numericDotSegments: true });
+    // Resolve segments against the parsed config to distinguish array indices
+    // from numeric record keys (e.g., plugins.entries.123 is a string key, not
+    // an array index).
+    const segments = resolveSegmentsAgainstParsed(params.parsed, rawSegments);
+    const receivedValue = resolveConfigValueAtPath(params.parsed, segments);
+    const line = raw === null ? undefined : resolveConfigIssueLineInRaw(raw, segments);
+    const canResolve = line !== undefined;
+
+    const message =
+      params.includeReceivedValueHint && canResolve
+        ? appendReceivedValueHint(issue.message, issue.path, receivedValue)
+        : issue.message;
+
+    return {
+      ...issue,
+      path: params.formatPathForDisplay ? formatConfigIssuePath(segments) : issue.path,
+      message,
+      ...(canResolve ? { line, sourceFile: configBasename } : {}),
+    };
+  });
+}

--- a/src/config/issue-location.ts
+++ b/src/config/issue-location.ts
@@ -165,28 +165,33 @@ function locateValueOffset(
   if (!consume(raw, cursor, "{")) {
     return undefined;
   }
+  let lastMatch: number | undefined;
   while (cursor.pos < raw.length) {
     skipTrivia(raw, cursor);
     if (raw[cursor.pos] === "}") {
-      return undefined;
+      return lastMatch;
     }
     const key = readObjectKey(raw, cursor);
     if (key === null || !consume(raw, cursor, ":")) {
       return undefined;
     }
     skipTrivia(raw, cursor);
+    const valueStart = cursor.pos;
     if (key === segment) {
-      return isLeaf ? cursor.pos : locateValueOffset(raw, cursor, segments, depth + 1);
+      lastMatch = isLeaf
+        ? valueStart
+        : locateValueOffset(raw, { pos: valueStart }, segments, depth + 1);
     }
+    cursor.pos = valueStart;
     skipValue(raw, cursor);
     skipTrivia(raw, cursor);
     if (raw[cursor.pos] === ",") {
       cursor.pos++;
       continue;
     }
-    return undefined;
+    return lastMatch;
   }
-  return undefined;
+  return lastMatch;
 }
 
 function lineAtOffset(raw: string, offset: number): number {
@@ -217,10 +222,7 @@ export function formatConfigIssuePath(segments: readonly ConfigIssuePathSegment[
   );
 }
 
-export function parseConfigIssuePath(
-  pathValue: string,
-  opts?: { numericDotSegments?: boolean },
-): ConfigIssuePathSegment[] {
+export function parseConfigIssuePath(pathValue: string): ConfigIssuePathSegment[] {
   const trimmed = pathValue.trim();
   if (!trimmed || trimmed === "<root>") {
     return [];
@@ -229,12 +231,7 @@ export function parseConfigIssuePath(
   for (const match of trimmed.matchAll(/(?:^|\.)([^.\[]+)|\[(\d+)\]/g)) {
     const dotSegment = match[1];
     if (dotSegment !== undefined) {
-      const numeric = Number(dotSegment);
-      segments.push(
-        opts?.numericDotSegments && Number.isInteger(numeric) && numeric >= 0
-          ? numeric
-          : dotSegment,
-      );
+      segments.push(dotSegment);
       continue;
     }
     const index = Number(match[2]);
@@ -273,6 +270,14 @@ function resolveSegmentsAgainstParsed(
   const resolved: ConfigIssuePathSegment[] = [];
   let current = root;
   for (const segment of rawSegments) {
+    if (typeof segment === "string" && Array.isArray(current)) {
+      const index = Number(segment);
+      if (Number.isSafeInteger(index) && index >= 0 && String(index) === segment) {
+        resolved.push(index);
+        current = current[index];
+        continue;
+      }
+    }
     if (typeof segment === "number" && !Array.isArray(current)) {
       const key = String(segment);
       resolved.push(key);
@@ -291,6 +296,9 @@ function resolveSegmentsAgainstParsed(
 function stringifyReceivedValue(value: unknown): string | null {
   if (value === undefined) {
     return null;
+  }
+  if (typeof value === "number" && (!Number.isFinite(value) || Object.is(value, -0))) {
+    return Object.is(value, -0) ? "-0" : String(value);
   }
   try {
     const serialized = JSON.stringify(value);
@@ -371,7 +379,7 @@ export function attachConfigIssueDiagnostics(
       ? path.basename(params.configPath)
       : "openclaw.json";
   return issues.map((issue) => {
-    const rawSegments = parseConfigIssuePath(issue.path, { numericDotSegments: true });
+    const rawSegments = parseConfigIssuePath(issue.path);
     const segments = resolveSegmentsAgainstParsed(params.parsed, rawSegments);
     const literalValue = resolveConfigValueAtPath(params.parsed, segments);
     const effectiveValue = resolveConfigValueAtPath(params.effective, segments);

--- a/src/config/issue-location.ts
+++ b/src/config/issue-location.ts
@@ -17,7 +17,9 @@ type Cursor = { pos: number };
 function lineAtOffset(raw: string, offset: number): number {
   let line = 1;
   for (let i = 0; i < offset && i < raw.length; i++) {
-    if (raw[i] === "\n") line++;
+    if (raw[i] === "\n") {
+      line++;
+    }
   }
   return line;
 }
@@ -32,7 +34,9 @@ function skipWS(raw: string, c: Cursor): void {
     }
     if (ch === "/" && raw[c.pos + 1] === "/") {
       c.pos += 2;
-      while (c.pos < raw.length && raw[c.pos] !== "\n") c.pos++;
+      while (c.pos < raw.length && raw[c.pos] !== "\n") {
+        c.pos++;
+      }
       continue;
     }
     if (ch === "/" && raw[c.pos + 1] === "*") {
@@ -70,7 +74,9 @@ function skipStr(raw: string, c: Cursor): void {
 /** Skip a JSON5 value (string, number, boolean, null, object, array). */
 function skipVal(raw: string, c: Cursor): void {
   skipWS(raw, c);
-  if (c.pos >= raw.length) return;
+  if (c.pos >= raw.length) {
+    return;
+  }
   const ch = raw[c.pos];
   if (ch === '"' || ch === "'") {
     skipStr(raw, c);
@@ -79,7 +85,18 @@ function skipVal(raw: string, c: Cursor): void {
   } else {
     while (c.pos < raw.length) {
       const ch2 = raw[c.pos];
-      if (ch2 === "," || ch2 === "}" || ch2 === "]" || ch2 === "/" || ch2 === " " || ch2 === "\t" || ch2 === "\r" || ch2 === "\n") return;
+      if (
+        ch2 === "," ||
+        ch2 === "}" ||
+        ch2 === "]" ||
+        ch2 === "/" ||
+        ch2 === " " ||
+        ch2 === "\t" ||
+        ch2 === "\r" ||
+        ch2 === "\n"
+      ) {
+        return;
+      }
       c.pos++;
     }
   }
@@ -105,7 +122,9 @@ function skipComposite(raw: string, c: Cursor): void {
       c.pos++;
     } else if (ch === "/" && raw[c.pos + 1] === "/") {
       c.pos += 2;
-      while (c.pos < raw.length && raw[c.pos] !== "\n") c.pos++;
+      while (c.pos < raw.length && raw[c.pos] !== "\n") {
+        c.pos++;
+      }
     } else if (ch === "/" && raw[c.pos + 1] === "*") {
       c.pos += 2;
       while (c.pos < raw.length - 1) {
@@ -125,14 +144,18 @@ function skipComposite(raw: string, c: Cursor): void {
 function readStr(raw: string, c: Cursor): string | null {
   skipWS(raw, c);
   const quote = raw[c.pos];
-  if (quote !== '"' && quote !== "'") return null;
+  if (quote !== '"' && quote !== "'") {
+    return null;
+  }
   c.pos++;
   let value = "";
   while (c.pos < raw.length) {
     const ch = raw[c.pos];
     if (ch === "\\") {
       const next = raw[c.pos + 1];
-      if (next !== undefined) value += next;
+      if (next !== undefined) {
+        value += next;
+      }
       c.pos += 2;
     } else if (ch === quote) {
       c.pos++;
@@ -149,11 +172,15 @@ function readStr(raw: string, c: Cursor): string | null {
 function readKey(raw: string, c: Cursor): string | null {
   skipWS(raw, c);
   const ch = raw[c.pos];
-  if (ch === '"' || ch === "'") return readStr(raw, c);
+  if (ch === '"' || ch === "'") {
+    return readStr(raw, c);
+  }
   if (ch !== undefined && /[A-Za-z_$]/.test(ch)) {
     const start = c.pos;
     c.pos++;
-    while (c.pos < raw.length && /[A-Za-z0-9_$]/.test(raw[c.pos] ?? "")) c.pos++;
+    while (c.pos < raw.length && /[A-Za-z0-9_$]/.test(raw[c.pos] ?? "")) {
+      c.pos++;
+    }
     return raw.slice(start, c.pos);
   }
   return null;
@@ -162,7 +189,9 @@ function readKey(raw: string, c: Cursor): string | null {
 /** Expect and consume a specific character (skipping whitespace). */
 function expect(raw: string, c: Cursor, ch: string): boolean {
   skipWS(raw, c);
-  if (raw[c.pos] !== ch) return false;
+  if (raw[c.pos] !== ch) {
+    return false;
+  }
   c.pos++;
   return true;
 }
@@ -175,7 +204,9 @@ function navigateToOffset(
   raw: string,
   segments: readonly ConfigIssuePathSegment[],
 ): number | undefined {
-  if (segments.length === 0 || raw.trim().length === 0) return undefined;
+  if (segments.length === 0 || raw.trim().length === 0) {
+    return undefined;
+  }
   const c: Cursor = { pos: 0 };
   skipWS(raw, c);
   return navigateAt(raw, c, segments, 0);
@@ -191,10 +222,14 @@ function navigateAt(
   const isLeaf = depth === segments.length - 1;
 
   if (typeof segment === "number") {
-    if (!expect(raw, c, "[")) return undefined;
+    if (!expect(raw, c, "[")) {
+      return undefined;
+    }
     for (let i = 0; i < segment; i++) {
       skipVal(raw, c);
-      if (!expect(raw, c, ",")) return undefined;
+      if (!expect(raw, c, ",")) {
+        return undefined;
+      }
     }
     if (isLeaf) {
       skipWS(raw, c);
@@ -203,13 +238,21 @@ function navigateAt(
     return navigateAt(raw, c, segments, depth + 1);
   }
 
-  if (!expect(raw, c, "{")) return undefined;
+  if (!expect(raw, c, "{")) {
+    return undefined;
+  }
   while (c.pos < raw.length) {
     skipWS(raw, c);
-    if (raw[c.pos] === "}") return undefined;
+    if (raw[c.pos] === "}") {
+      return undefined;
+    }
     const key = readKey(raw, c);
-    if (key === null) return undefined;
-    if (!expect(raw, c, ":")) return undefined;
+    if (key === null) {
+      return undefined;
+    }
+    if (!expect(raw, c, ":")) {
+      return undefined;
+    }
     if (key === segment) {
       if (isLeaf) {
         skipWS(raw, c);
@@ -223,7 +266,9 @@ function navigateAt(
       c.pos++;
       continue;
     }
-    if (raw[c.pos] === "}") return undefined;
+    if (raw[c.pos] === "}") {
+      return undefined;
+    }
     return undefined;
   }
   return undefined;
@@ -235,7 +280,9 @@ function navigateAt(
 
 /** Format config issue path segments with bracket notation for array indexes. */
 export function formatConfigIssuePath(segments: readonly ConfigIssuePathSegment[]): string {
-  if (segments.length === 0) return "";
+  if (segments.length === 0) {
+    return "";
+  }
   let out = "";
   for (const s of segments) {
     if (typeof s === "number") {
@@ -257,7 +304,9 @@ export function parseConfigIssuePath(
   opts?: { numericDotSegments?: boolean },
 ): ConfigIssuePathSegment[] {
   const trimmed = pathValue.trim();
-  if (!trimmed || trimmed === "<root>") return [];
+  if (!trimmed || trimmed === "<root>") {
+    return [];
+  }
   const segments: ConfigIssuePathSegment[] = [];
   let i = 0;
   while (i < trimmed.length) {
@@ -267,14 +316,20 @@ export function parseConfigIssuePath(
     }
     if (trimmed[i] === "[") {
       const close = trimmed.indexOf("]", i + 1);
-      if (close === -1) break;
+      if (close === -1) {
+        break;
+      }
       const n = Number(trimmed.slice(i + 1, close));
-      if (Number.isInteger(n) && n >= 0) segments.push(n);
+      if (Number.isInteger(n) && n >= 0) {
+        segments.push(n);
+      }
       i = close + 1;
       continue;
     }
     let end = i;
-    while (end < trimmed.length && trimmed[end] !== "." && trimmed[end] !== "[") end++;
+    while (end < trimmed.length && trimmed[end] !== "." && trimmed[end] !== "[") {
+      end++;
+    }
     const seg = trimmed.slice(i, end);
     if (seg) {
       const n = Number(seg);
@@ -301,11 +356,14 @@ export function resolveConfigValueAtPath(
   let current: unknown = root;
   for (const s of segments) {
     if (typeof s === "number") {
-      if (!Array.isArray(current) || s < 0 || s >= current.length) return undefined;
+      if (!Array.isArray(current) || s < 0 || s >= current.length) {
+        return undefined;
+      }
       current = current[s];
     } else {
-      if (!current || typeof current !== "object" || Array.isArray(current))
+      if (!current || typeof current !== "object" || Array.isArray(current)) {
         return undefined;
+      }
       current = (current as Record<string, unknown>)[s];
     }
   }
@@ -352,10 +410,14 @@ function resolveSegmentsAgainstParsed(
 // ---------------------------------------------------------------------------
 
 function safeStringify(v: unknown): string | null {
-  if (v === undefined) return null;
+  if (v === undefined) {
+    return null;
+  }
   try {
     const s = JSON.stringify(v);
-    if (s === undefined) return null;
+    if (s === undefined) {
+      return null;
+    }
     return s.length > 160 ? `${s.slice(0, 157)}...` : s;
   } catch {
     return null;
@@ -368,10 +430,18 @@ function messageAlreadyHasReceived(message: string): boolean {
 }
 
 function shouldOmitReceivedValue(pathValue: string, value: unknown): boolean {
-  if (value === undefined) return true;
-  if (isSecretRef(value)) return true;
-  if (isSensitiveConfigPath(pathValue)) return true;
-  if (typeof value === "object" && value !== null) return true;
+  if (value === undefined) {
+    return true;
+  }
+  if (isSecretRef(value)) {
+    return true;
+  }
+  if (isSensitiveConfigPath(pathValue)) {
+    return true;
+  }
+  if (typeof value === "object" && value !== null) {
+    return true;
+  }
   return safeStringify(value) === null;
 }
 
@@ -381,9 +451,13 @@ export function appendReceivedValueHint(
   pathValue: string,
   value: unknown,
 ): string {
-  if (shouldOmitReceivedValue(pathValue, value)) return message;
+  if (shouldOmitReceivedValue(pathValue, value)) {
+    return message;
+  }
   const label = safeStringify(value);
-  if (!label || messageAlreadyHasReceived(message)) return message;
+  if (!label || messageAlreadyHasReceived(message)) {
+    return message;
+  }
   return `${message}, got: ${label}`;
 }
 
@@ -397,7 +471,9 @@ export function resolveConfigIssueLineInRaw(
   segments: readonly ConfigIssuePathSegment[],
 ): number | undefined {
   const offset = navigateToOffset(raw, segments);
-  if (offset === undefined) return undefined;
+  if (offset === undefined) {
+    return undefined;
+  }
   return lineAtOffset(raw, offset);
 }
 

--- a/src/config/issue-location.ts
+++ b/src/config/issue-location.ts
@@ -4,7 +4,7 @@ import { isSensitiveConfigPath } from "./sensitive-paths.js";
 import type { ConfigValidationIssue } from "./types.js";
 import { isSecretRef } from "./types.secrets.js";
 
-export type ConfigIssuePathSegment = string | number;
+type ConfigIssuePathSegment = string | number;
 
 type Cursor = { pos: number };
 
@@ -210,7 +210,7 @@ function lineAtOffset(raw: string, offset: number): number {
   return line;
 }
 
-export function formatConfigIssuePath(segments: readonly ConfigIssuePathSegment[]): string {
+function formatConfigIssuePath(segments: readonly ConfigIssuePathSegment[]): string {
   return segments.reduce<string>(
     (result, segment) =>
       typeof segment === "number"
@@ -222,7 +222,7 @@ export function formatConfigIssuePath(segments: readonly ConfigIssuePathSegment[
   );
 }
 
-export function resolveConfigValueAtPath(
+function resolveConfigValueAtPath(
   root: unknown,
   segments: readonly ConfigIssuePathSegment[],
 ): unknown {
@@ -293,7 +293,7 @@ function shouldOmitReceivedValue(
   );
 }
 
-export function appendReceivedValueHint(
+function appendReceivedValueHint(
   message: string,
   pathValue: string,
   value: unknown,
@@ -310,7 +310,7 @@ export function appendReceivedValueHint(
   return label ? `${message}, got: ${label}` : message;
 }
 
-export function resolveConfigIssueLineInRaw(
+function resolveConfigIssueLineInRaw(
   raw: string,
   segments: readonly ConfigIssuePathSegment[],
 ): number | undefined {
@@ -321,7 +321,7 @@ export function resolveConfigIssueLineInRaw(
   return offset === undefined ? undefined : lineAtOffset(raw, offset);
 }
 
-export type AttachConfigIssueDiagnosticsParams = {
+type AttachConfigIssueDiagnosticsParams = {
   raw: string | null | undefined;
   parsed: unknown;
   effective: unknown;
@@ -330,7 +330,7 @@ export type AttachConfigIssueDiagnosticsParams = {
   includeReceivedValueHint?: boolean;
 };
 
-export type ConfigIssueDiagnostics = ConfigValidationIssue & {
+type ConfigIssueDiagnostics = ConfigValidationIssue & {
   line?: number;
   sourceFile?: string;
 };

--- a/src/config/issue-location.ts
+++ b/src/config/issue-location.ts
@@ -261,18 +261,33 @@ function stringifyReceivedValue(value: unknown): string | null {
   }
 }
 
-function isPluginOwnedConfigPath(pathValue: string): boolean {
+function isPluginOwnedConfigPath(
+  pathValue: string,
+  pathSegments?: readonly ConfigIssuePathSegment[],
+): boolean {
+  if (pathSegments) {
+    return (
+      pathSegments[0] === "channels" ||
+      (pathSegments[0] === "plugins" &&
+        pathSegments[1] === "entries" &&
+        pathSegments[3] === "config")
+    );
+  }
   return (
     pathValue.startsWith("channels.") || /^plugins\.entries\.[^.]+\.config(?:\.|$)/.test(pathValue)
   );
 }
 
-function shouldOmitReceivedValue(pathValue: string, value: unknown): boolean {
+function shouldOmitReceivedValue(
+  pathValue: string,
+  value: unknown,
+  pathSegments?: readonly ConfigIssuePathSegment[],
+): boolean {
   return (
     value === undefined ||
     isSecretRef(value) ||
     isSensitiveConfigPath(pathValue) ||
-    isPluginOwnedConfigPath(pathValue) ||
+    isPluginOwnedConfigPath(pathValue, pathSegments) ||
     (typeof value === "object" && value !== null) ||
     stringifyReceivedValue(value) === null
   );
@@ -282,9 +297,10 @@ export function appendReceivedValueHint(
   message: string,
   pathValue: string,
   value: unknown,
+  pathSegments?: readonly ConfigIssuePathSegment[],
 ): string {
   if (
-    shouldOmitReceivedValue(pathValue, value) ||
+    shouldOmitReceivedValue(pathValue, value, pathSegments) ||
     message.toLowerCase().includes("got:") ||
     /\breceived\b/i.test(message)
   ) {
@@ -341,7 +357,7 @@ export function attachConfigIssueDiagnostics(
     const canShowReceivedValue = line !== undefined && Object.is(literalValue, effectiveValue);
     const message =
       params.includeReceivedValueHint && canShowReceivedValue
-        ? appendReceivedValueHint(issue.message, issue.path, effectiveValue)
+        ? appendReceivedValueHint(issue.message, issue.path, effectiveValue, segments)
         : issue.message;
     return {
       ...issue,

--- a/src/config/issue-location.ts
+++ b/src/config/issue-location.ts
@@ -222,26 +222,6 @@ export function formatConfigIssuePath(segments: readonly ConfigIssuePathSegment[
   );
 }
 
-export function parseConfigIssuePath(pathValue: string): ConfigIssuePathSegment[] {
-  const trimmed = pathValue.trim();
-  if (!trimmed || trimmed === "<root>") {
-    return [];
-  }
-  const segments: ConfigIssuePathSegment[] = [];
-  for (const match of trimmed.matchAll(/(?:^|\.)([^.\[]+)|\[(\d+)\]/g)) {
-    const dotSegment = match[1];
-    if (dotSegment !== undefined) {
-      segments.push(dotSegment);
-      continue;
-    }
-    const index = Number(match[2]);
-    if (Number.isInteger(index) && index >= 0) {
-      segments.push(index);
-    }
-  }
-  return segments;
-}
-
 export function resolveConfigValueAtPath(
   root: unknown,
   segments: readonly ConfigIssuePathSegment[],
@@ -261,36 +241,6 @@ export function resolveConfigValueAtPath(
     current = (current as Record<string, unknown>)[segment];
   }
   return current;
-}
-
-function resolveSegmentsAgainstParsed(
-  root: unknown,
-  rawSegments: readonly ConfigIssuePathSegment[],
-): ConfigIssuePathSegment[] {
-  const resolved: ConfigIssuePathSegment[] = [];
-  let current = root;
-  for (const segment of rawSegments) {
-    if (typeof segment === "string" && Array.isArray(current)) {
-      const index = Number(segment);
-      if (Number.isSafeInteger(index) && index >= 0 && String(index) === segment) {
-        resolved.push(index);
-        current = current[index];
-        continue;
-      }
-    }
-    if (typeof segment === "number" && !Array.isArray(current)) {
-      const key = String(segment);
-      resolved.push(key);
-      current =
-        current && typeof current === "object"
-          ? (current as Record<string, unknown>)[key]
-          : undefined;
-      continue;
-    }
-    resolved.push(segment);
-    current = resolveConfigValueAtPath(current, [segment]);
-  }
-  return resolved;
 }
 
 function stringifyReceivedValue(value: unknown): string | null {
@@ -379,8 +329,10 @@ export function attachConfigIssueDiagnostics(
       ? path.basename(params.configPath)
       : "openclaw.json";
   return issues.map((issue) => {
-    const rawSegments = parseConfigIssuePath(issue.path);
-    const segments = resolveSegmentsAgainstParsed(params.parsed, rawSegments);
+    const segments = issue.pathSegments;
+    if (!segments || segments.length === 0) {
+      return issue;
+    }
     const literalValue = resolveConfigValueAtPath(params.parsed, segments);
     const effectiveValue = resolveConfigValueAtPath(params.effective, segments);
     const line = raw === null ? undefined : resolveConfigIssueLineInRaw(raw, segments);

--- a/src/config/issue-location.ts
+++ b/src/config/issue-location.ts
@@ -1,28 +1,5 @@
-// JSON5-aware config issue path navigator and display enrichment.
-//
-// Supported JSON5 subset for path navigation:
-// - Objects: { key: value } with quoted (" "), single-quoted (' '), or unquoted
-//   identifier-like keys (A-Z, a-z, _, $, 0-9)
-// - Arrays: [value, ...] with bracket notation
-// - Strings: double-quoted and single-quoted, with \n, \t, \", \', \\, \uXXXX,
-//   \xXX escape sequences, and multi-line (backslash-newline continuation)
-// - Numbers: integers, floats, hex (0x), leading decimal (.5), Infinity, NaN
-// - Comments: // line and /* block */
-// - Trailing commas in objects and arrays
-// - null, true, false literals
-//
-// The navigator only needs to find the byte offset of a value at a given path.
-// It does NOT need to fully parse every value — it skips over values using
-// skipVal/skipComposite. This means value-level syntax (hex numbers, special
-// values) is handled naturally by the value skipper.
-//
-// Known limitations (navigator fails gracefully, returns undefined):
-// - Unquoted keys with non-ASCII characters (Unicode letters outside A-Z, a-z,
-//   _, $). Quoted Unicode keys ("café") work fine.
-// - The navigator's scalar skipper is permissive and may skip past text that
-//   the canonical JSON5 parser would reject. This is safe because the navigator
-//   only runs on configs that have already been successfully parsed.
 import path from "node:path";
+import JSON5 from "json5";
 import { isSensitiveConfigPath } from "./sensitive-paths.js";
 import type { ConfigValidationIssue } from "./types.js";
 import { isSecretRef } from "./types.secrets.js";
@@ -31,266 +8,213 @@ export type ConfigIssuePathSegment = string | number;
 
 type Cursor = { pos: number };
 
-function lineAtOffset(raw: string, offset: number): number {
-  let line = 1;
-  for (let i = 0; i < offset && i < raw.length; i++) {
-    if (raw[i] === "\n") {
-      line++;
-    }
-  }
-  return line;
-}
-
-function skipWS(raw: string, c: Cursor): void {
-  while (c.pos < raw.length) {
-    const ch = raw[c.pos];
-    if (ch === " " || ch === "\t" || ch === "\r" || ch === "\n") {
-      c.pos++;
+function skipTrivia(raw: string, cursor: Cursor): void {
+  while (cursor.pos < raw.length) {
+    const char = raw[cursor.pos];
+    if (/\s/u.test(char ?? "")) {
+      cursor.pos++;
       continue;
     }
-    if (ch === "/" && raw[c.pos + 1] === "/") {
-      c.pos += 2;
-      while (c.pos < raw.length && raw[c.pos] !== "\n") {
-        c.pos++;
+    if (char === "/" && raw[cursor.pos + 1] === "/") {
+      cursor.pos += 2;
+      while (cursor.pos < raw.length && !/[\n\r\u2028\u2029]/u.test(raw[cursor.pos] ?? "")) {
+        cursor.pos++;
       }
       continue;
     }
-    if (ch === "/" && raw[c.pos + 1] === "*") {
-      c.pos += 2;
-      while (c.pos < raw.length - 1) {
-        if (raw[c.pos] === "*" && raw[c.pos + 1] === "/") {
-          c.pos += 2;
-          break;
-        }
-        c.pos++;
-      }
+    if (char === "/" && raw[cursor.pos + 1] === "*") {
+      const close = raw.indexOf("*/", cursor.pos + 2);
+      cursor.pos = close === -1 ? raw.length : close + 2;
       continue;
     }
-    break;
-  }
-}
-
-function skipStr(raw: string, c: Cursor): void {
-  const quote = raw[c.pos];
-  c.pos++;
-  while (c.pos < raw.length) {
-    const ch = raw[c.pos];
-    if (ch === "\\") {
-      c.pos += 2;
-    } else if (ch === quote) {
-      c.pos++;
-      return;
-    } else {
-      c.pos++;
-    }
-  }
-}
-
-function skipVal(raw: string, c: Cursor): void {
-  skipWS(raw, c);
-  if (c.pos >= raw.length) {
     return;
   }
-  const ch = raw[c.pos];
-  if (ch === '"' || ch === "'") {
-    skipStr(raw, c);
-  } else if (ch === "{" || ch === "[") {
-    skipComposite(raw, c);
-  } else {
-    while (c.pos < raw.length) {
-      const ch2 = raw[c.pos];
-      if (
-        ch2 === "," ||
-        ch2 === "}" ||
-        ch2 === "]" ||
-        ch2 === "/" ||
-        ch2 === " " ||
-        ch2 === "\t" ||
-        ch2 === "\r" ||
-        ch2 === "\n"
-      ) {
-        return;
-      }
-      c.pos++;
+}
+
+function scanQuoted(raw: string, cursor: Cursor): void {
+  const quote = raw[cursor.pos++];
+  while (cursor.pos < raw.length) {
+    const char = raw[cursor.pos++];
+    if (char === "\\") {
+      cursor.pos++;
+    } else if (char === quote) {
+      return;
     }
   }
 }
 
-function skipComposite(raw: string, c: Cursor): void {
-  const open = raw[c.pos];
-  const close = open === "{" ? "}" : "]";
-  let depth = 1;
-  c.pos++;
-  while (c.pos < raw.length && depth > 0) {
-    const ch = raw[c.pos];
-    if (ch === '"' || ch === "'") {
-      skipStr(raw, c);
-    } else if (ch === "\\") {
-      c.pos += 2;
-    } else if (ch === open) {
-      depth++;
-      c.pos++;
-    } else if (ch === close) {
-      depth--;
-      c.pos++;
-    } else if (ch === "/" && raw[c.pos + 1] === "/") {
-      c.pos += 2;
-      while (c.pos < raw.length && raw[c.pos] !== "\n") {
-        c.pos++;
-      }
-    } else if (ch === "/" && raw[c.pos + 1] === "*") {
-      c.pos += 2;
-      while (c.pos < raw.length - 1) {
-        if (raw[c.pos] === "*" && raw[c.pos + 1] === "/") {
-          c.pos += 2;
-          break;
-        }
-        c.pos++;
-      }
-    } else {
-      c.pos++;
-    }
-  }
-}
-
-function readStr(raw: string, c: Cursor): string | null {
-  skipWS(raw, c);
-  const quote = raw[c.pos];
-  if (quote !== '"' && quote !== "'") {
-    return null;
-  }
-  c.pos++;
-  let value = "";
-  while (c.pos < raw.length) {
-    const ch = raw[c.pos];
-    if (ch === "\\") {
-      const next = raw[c.pos + 1];
-      if (next !== undefined) {
-        value += next;
-      }
-      c.pos += 2;
-    } else if (ch === quote) {
-      c.pos++;
-      return value;
-    } else {
-      value += ch;
-      c.pos++;
-    }
-  }
-  return null;
-}
-
-function readKey(raw: string, c: Cursor): string | null {
-  skipWS(raw, c);
-  const ch = raw[c.pos];
-  if (ch === '"' || ch === "'") {
-    return readStr(raw, c);
-  }
-  if (ch !== undefined && /[A-Za-z_$]/.test(ch)) {
-    const start = c.pos;
-    c.pos++;
-    while (c.pos < raw.length && /[A-Za-z0-9_$]/.test(raw[c.pos] ?? "")) {
-      c.pos++;
-    }
-    return raw.slice(start, c.pos);
-  }
-  return null;
-}
-
-function expect(raw: string, c: Cursor, ch: string): boolean {
-  skipWS(raw, c);
-  if (raw[c.pos] !== ch) {
+function consume(raw: string, cursor: Cursor, expected: string): boolean {
+  skipTrivia(raw, cursor);
+  if (raw[cursor.pos] !== expected) {
     return false;
   }
-  c.pos++;
+  cursor.pos++;
   return true;
 }
 
-function navigateToOffset(
-  raw: string,
-  segments: readonly ConfigIssuePathSegment[],
-): number | undefined {
-  if (segments.length === 0 || raw.trim().length === 0) {
-    return undefined;
+function readObjectKey(raw: string, cursor: Cursor): string | null {
+  skipTrivia(raw, cursor);
+  const start = cursor.pos;
+  const char = raw[cursor.pos];
+  if (char === '"' || char === "'") {
+    scanQuoted(raw, cursor);
+  } else {
+    while (
+      cursor.pos < raw.length &&
+      !/[\s:]/u.test(raw[cursor.pos] ?? "") &&
+      !(raw[cursor.pos] === "/" && /[/*]/u.test(raw[cursor.pos + 1] ?? ""))
+    ) {
+      cursor.pos++;
+    }
   }
-  const c: Cursor = { pos: 0 };
-  skipWS(raw, c);
-  return navigateAt(raw, c, segments, 0);
+  if (cursor.pos === start) {
+    return null;
+  }
+  const token = raw.slice(start, cursor.pos);
+  try {
+    if (char === '"' || char === "'") {
+      const parsed = JSON5.parse(token);
+      return typeof parsed === "string" ? parsed : null;
+    }
+    const parsed = JSON5.parse(`{${token}:null}`) as Record<string, unknown>;
+    return Object.keys(parsed)[0] ?? null;
+  } catch {
+    return null;
+  }
 }
 
-function navigateAt(
+function skipValue(raw: string, cursor: Cursor): void {
+  skipTrivia(raw, cursor);
+  const char = raw[cursor.pos];
+  if (char === '"' || char === "'") {
+    scanQuoted(raw, cursor);
+    return;
+  }
+  if (char === "{") {
+    cursor.pos++;
+    while (cursor.pos < raw.length) {
+      skipTrivia(raw, cursor);
+      if (raw[cursor.pos] === "}") {
+        cursor.pos++;
+        return;
+      }
+      if (readObjectKey(raw, cursor) === null || !consume(raw, cursor, ":")) {
+        return;
+      }
+      skipValue(raw, cursor);
+      skipTrivia(raw, cursor);
+      if (raw[cursor.pos] === ",") {
+        cursor.pos++;
+      }
+    }
+    return;
+  }
+  if (char === "[") {
+    cursor.pos++;
+    while (cursor.pos < raw.length) {
+      skipTrivia(raw, cursor);
+      if (raw[cursor.pos] === "]") {
+        cursor.pos++;
+        return;
+      }
+      skipValue(raw, cursor);
+      skipTrivia(raw, cursor);
+      if (raw[cursor.pos] === ",") {
+        cursor.pos++;
+      }
+    }
+    return;
+  }
+  while (
+    cursor.pos < raw.length &&
+    !/[,}\]\s]/u.test(raw[cursor.pos] ?? "") &&
+    !(raw[cursor.pos] === "/" && /[/*]/u.test(raw[cursor.pos + 1] ?? ""))
+  ) {
+    cursor.pos++;
+  }
+}
+
+function locateValueOffset(
   raw: string,
-  c: Cursor,
+  cursor: Cursor,
   segments: readonly ConfigIssuePathSegment[],
   depth: number,
 ): number | undefined {
   const segment = segments[depth];
   const isLeaf = depth === segments.length - 1;
   if (typeof segment === "number") {
-    if (!expect(raw, c, "[")) {
+    if (!consume(raw, cursor, "[")) {
       return undefined;
     }
-    for (let i = 0; i < segment; i++) {
-      skipVal(raw, c);
-      if (!expect(raw, c, ",")) {
+    for (let index = 0; cursor.pos < raw.length; index++) {
+      skipTrivia(raw, cursor);
+      if (raw[cursor.pos] === "]") {
+        return undefined;
+      }
+      if (index === segment) {
+        return isLeaf ? cursor.pos : locateValueOffset(raw, cursor, segments, depth + 1);
+      }
+      skipValue(raw, cursor);
+      if (!consume(raw, cursor, ",")) {
         return undefined;
       }
     }
-    if (isLeaf) {
-      skipWS(raw, c);
-      return c.pos;
-    }
-    return navigateAt(raw, c, segments, depth + 1);
-  }
-  if (!expect(raw, c, "{")) {
     return undefined;
   }
-  while (c.pos < raw.length) {
-    skipWS(raw, c);
-    if (raw[c.pos] === "}") {
+
+  if (!consume(raw, cursor, "{")) {
+    return undefined;
+  }
+  while (cursor.pos < raw.length) {
+    skipTrivia(raw, cursor);
+    if (raw[cursor.pos] === "}") {
       return undefined;
     }
-    const key = readKey(raw, c);
-    if (key === null) {
+    const key = readObjectKey(raw, cursor);
+    if (key === null || !consume(raw, cursor, ":")) {
       return undefined;
     }
-    if (!expect(raw, c, ":")) {
-      return undefined;
-    }
+    skipTrivia(raw, cursor);
     if (key === segment) {
-      if (isLeaf) {
-        skipWS(raw, c);
-        return c.pos;
-      }
-      return navigateAt(raw, c, segments, depth + 1);
+      return isLeaf ? cursor.pos : locateValueOffset(raw, cursor, segments, depth + 1);
     }
-    skipVal(raw, c);
-    skipWS(raw, c);
-    if (raw[c.pos] === ",") {
-      c.pos++;
+    skipValue(raw, cursor);
+    skipTrivia(raw, cursor);
+    if (raw[cursor.pos] === ",") {
+      cursor.pos++;
       continue;
-    }
-    if (raw[c.pos] === "}") {
-      return undefined;
     }
     return undefined;
   }
   return undefined;
 }
 
-export function formatConfigIssuePath(segments: readonly ConfigIssuePathSegment[]): string {
-  if (segments.length === 0) {
-    return "";
-  }
-  let out = "";
-  for (const s of segments) {
-    if (typeof s === "number") {
-      out += `[${s}]`;
-    } else {
-      out = out ? `${out}.${s}` : s;
+function lineAtOffset(raw: string, offset: number): number {
+  let line = 1;
+  for (let index = 0; index < offset; index++) {
+    const char = raw[index];
+    if (char === "\r") {
+      line++;
+      if (raw[index + 1] === "\n") {
+        index++;
+      }
+    } else if (char === "\n" || char === "\u2028" || char === "\u2029") {
+      line++;
     }
   }
-  return out;
+  return line;
+}
+
+export function formatConfigIssuePath(segments: readonly ConfigIssuePathSegment[]): string {
+  return segments.reduce<string>(
+    (result, segment) =>
+      typeof segment === "number"
+        ? `${result}[${segment}]`
+        : result
+          ? `${result}.${segment}`
+          : segment,
+    "",
+  );
 }
 
 export function parseConfigIssuePath(
@@ -302,38 +226,21 @@ export function parseConfigIssuePath(
     return [];
   }
   const segments: ConfigIssuePathSegment[] = [];
-  let i = 0;
-  while (i < trimmed.length) {
-    if (trimmed[i] === ".") {
-      i++;
+  for (const match of trimmed.matchAll(/(?:^|\.)([^.\[]+)|\[(\d+)\]/g)) {
+    const dotSegment = match[1];
+    if (dotSegment !== undefined) {
+      const numeric = Number(dotSegment);
+      segments.push(
+        opts?.numericDotSegments && Number.isInteger(numeric) && numeric >= 0
+          ? numeric
+          : dotSegment,
+      );
       continue;
     }
-    if (trimmed[i] === "[") {
-      const close = trimmed.indexOf("]", i + 1);
-      if (close === -1) {
-        break;
-      }
-      const n = Number(trimmed.slice(i + 1, close));
-      if (Number.isInteger(n) && n >= 0) {
-        segments.push(n);
-      }
-      i = close + 1;
-      continue;
+    const index = Number(match[2]);
+    if (Number.isInteger(index) && index >= 0) {
+      segments.push(index);
     }
-    let end = i;
-    while (end < trimmed.length && trimmed[end] !== "." && trimmed[end] !== "[") {
-      end++;
-    }
-    const seg = trimmed.slice(i, end);
-    if (seg) {
-      const n = Number(seg);
-      if (opts?.numericDotSegments && Number.isInteger(n) && n >= 0) {
-        segments.push(n);
-      } else {
-        segments.push(seg);
-      }
-    }
-    i = end;
   }
   return segments;
 }
@@ -342,19 +249,19 @@ export function resolveConfigValueAtPath(
   root: unknown,
   segments: readonly ConfigIssuePathSegment[],
 ): unknown {
-  let current: unknown = root;
-  for (const s of segments) {
-    if (typeof s === "number") {
-      if (!Array.isArray(current) || s < 0 || s >= current.length) {
+  let current = root;
+  for (const segment of segments) {
+    if (typeof segment === "number") {
+      if (!Array.isArray(current) || segment >= current.length) {
         return undefined;
       }
-      current = current[s];
-    } else {
-      if (!current || typeof current !== "object" || Array.isArray(current)) {
-        return undefined;
-      }
-      current = (current as Record<string, unknown>)[s];
+      current = current[segment];
+      continue;
     }
+    if (!current || typeof current !== "object" || Array.isArray(current)) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
   }
   return current;
 }
@@ -364,64 +271,53 @@ function resolveSegmentsAgainstParsed(
   rawSegments: readonly ConfigIssuePathSegment[],
 ): ConfigIssuePathSegment[] {
   const resolved: ConfigIssuePathSegment[] = [];
-  let current: unknown = root;
-  for (const s of rawSegments) {
-    if (typeof s === "number") {
-      if (Array.isArray(current)) {
-        resolved.push(s);
-        current = current[s];
-      } else {
-        const key = String(s);
-        resolved.push(key);
-        current =
-          current && typeof current === "object"
-            ? (current as Record<string, unknown>)[key]
-            : undefined;
-      }
-    } else {
-      resolved.push(s);
+  let current = root;
+  for (const segment of rawSegments) {
+    if (typeof segment === "number" && !Array.isArray(current)) {
+      const key = String(segment);
+      resolved.push(key);
       current =
-        current && typeof current === "object" && !Array.isArray(current)
-          ? (current as Record<string, unknown>)[s]
+        current && typeof current === "object"
+          ? (current as Record<string, unknown>)[key]
           : undefined;
+      continue;
     }
+    resolved.push(segment);
+    current = resolveConfigValueAtPath(current, [segment]);
   }
   return resolved;
 }
 
-function safeStringify(v: unknown): string | null {
-  if (v === undefined) {
+function stringifyReceivedValue(value: unknown): string | null {
+  if (value === undefined) {
     return null;
   }
   try {
-    const s = JSON.stringify(v);
-    if (s === undefined) {
+    const serialized = JSON.stringify(value);
+    if (serialized === undefined) {
       return null;
     }
-    return s.length > 160 ? `${s.slice(0, 157)}...` : s;
+    return serialized.length > 160 ? `${serialized.slice(0, 157)}...` : serialized;
   } catch {
     return null;
   }
 }
 
-function messageAlreadyHasReceived(message: string): boolean {
-  return message.toLowerCase().includes("got:") || /\breceived\b/.test(message.toLowerCase());
+function isPluginOwnedConfigPath(pathValue: string): boolean {
+  return (
+    pathValue.startsWith("channels.") || /^plugins\.entries\.[^.]+\.config(?:\.|$)/.test(pathValue)
+  );
 }
 
 function shouldOmitReceivedValue(pathValue: string, value: unknown): boolean {
-  if (value === undefined) {
-    return true;
-  }
-  if (isSecretRef(value)) {
-    return true;
-  }
-  if (isSensitiveConfigPath(pathValue)) {
-    return true;
-  }
-  if (typeof value === "object" && value !== null) {
-    return true;
-  }
-  return safeStringify(value) === null;
+  return (
+    value === undefined ||
+    isSecretRef(value) ||
+    isSensitiveConfigPath(pathValue) ||
+    isPluginOwnedConfigPath(pathValue) ||
+    (typeof value === "object" && value !== null) ||
+    stringifyReceivedValue(value) === null
+  );
 }
 
 export function appendReceivedValueHint(
@@ -429,30 +325,32 @@ export function appendReceivedValueHint(
   pathValue: string,
   value: unknown,
 ): string {
-  if (shouldOmitReceivedValue(pathValue, value)) {
+  if (
+    shouldOmitReceivedValue(pathValue, value) ||
+    message.toLowerCase().includes("got:") ||
+    /\breceived\b/i.test(message)
+  ) {
     return message;
   }
-  const label = safeStringify(value);
-  if (!label || messageAlreadyHasReceived(message)) {
-    return message;
-  }
-  return `${message}, got: ${label}`;
+  const label = stringifyReceivedValue(value);
+  return label ? `${message}, got: ${label}` : message;
 }
 
 export function resolveConfigIssueLineInRaw(
   raw: string,
   segments: readonly ConfigIssuePathSegment[],
 ): number | undefined {
-  const offset = navigateToOffset(raw, segments);
-  if (offset === undefined) {
+  if (segments.length === 0 || raw.trim().length === 0) {
     return undefined;
   }
-  return lineAtOffset(raw, offset);
+  const offset = locateValueOffset(raw, { pos: 0 }, segments, 0);
+  return offset === undefined ? undefined : lineAtOffset(raw, offset);
 }
 
 export type AttachConfigIssueDiagnosticsParams = {
   raw: string | null | undefined;
   parsed: unknown;
+  effective: unknown;
   configPath?: string | null;
   formatPathForDisplay?: boolean;
   includeReceivedValueHint?: boolean;
@@ -468,25 +366,28 @@ export function attachConfigIssueDiagnostics(
   params: AttachConfigIssueDiagnosticsParams,
 ): ConfigIssueDiagnostics[] {
   const raw = typeof params.raw === "string" ? params.raw : null;
-  const configBasename =
+  const sourceFile =
     typeof params.configPath === "string" && params.configPath.trim()
       ? path.basename(params.configPath)
       : "openclaw.json";
   return issues.map((issue) => {
     const rawSegments = parseConfigIssuePath(issue.path, { numericDotSegments: true });
     const segments = resolveSegmentsAgainstParsed(params.parsed, rawSegments);
-    const receivedValue = resolveConfigValueAtPath(params.parsed, segments);
+    const literalValue = resolveConfigValueAtPath(params.parsed, segments);
+    const effectiveValue = resolveConfigValueAtPath(params.effective, segments);
     const line = raw === null ? undefined : resolveConfigIssueLineInRaw(raw, segments);
-    const canResolve = line !== undefined;
+    // Validation follows includes, env substitution, and migrations. Only a
+    // matching root-file literal is both accurate and safe to echo here.
+    const canShowReceivedValue = line !== undefined && Object.is(literalValue, effectiveValue);
     const message =
-      params.includeReceivedValueHint && canResolve
-        ? appendReceivedValueHint(issue.message, issue.path, receivedValue)
+      params.includeReceivedValueHint && canShowReceivedValue
+        ? appendReceivedValueHint(issue.message, issue.path, effectiveValue)
         : issue.message;
     return {
       ...issue,
       path: params.formatPathForDisplay ? formatConfigIssuePath(segments) : issue.path,
       message,
-      ...(canResolve ? { line, sourceFile: configBasename } : {}),
+      ...(line === undefined ? {} : { line, sourceFile }),
     };
   });
 }

--- a/src/config/issue-location.ts
+++ b/src/config/issue-location.ts
@@ -274,7 +274,11 @@ export function formatConfigIssuePath(segments: readonly ConfigIssuePathSegment[
   }
   let out = "";
   for (const s of segments) {
-    out += typeof s === "number" ? `[${s}]` : out ? `${out}.${s}` : s;
+    if (typeof s === "number") {
+      out += `[${s}]`;
+    } else {
+      out = out ? `${out}.${s}` : s;
+    }
   }
   return out;
 }

--- a/src/config/issue-location.ts
+++ b/src/config/issue-location.ts
@@ -6,8 +6,7 @@
 // - Arrays: [value, ...] with bracket notation
 // - Strings: double-quoted and single-quoted, with \n, \t, \", \', \\, \uXXXX,
 //   \xXX escape sequences, and multi-line (backslash-newline continuation)
-// - Numbers: integers, floats, hex (0x), leading decimal (.5), Infinity, NaN,
-//   numeric separators (1_000)
+// - Numbers: integers, floats, hex (0x), leading decimal (.5), Infinity, NaN
 // - Comments: // line and /* block */
 // - Trailing commas in objects and arrays
 // - null, true, false literals
@@ -15,13 +14,14 @@
 // The navigator only needs to find the byte offset of a value at a given path.
 // It does NOT need to fully parse every value — it skips over values using
 // skipVal/skipComposite. This means value-level syntax (hex numbers, special
-// values, numeric separators) is handled naturally by the value skipper.
+// values) is handled naturally by the value skipper.
 //
-// Unsupported syntax that would cause the navigator to fail gracefully
-// (returns undefined, no crash):
-// - None known — the navigator handles all JSON5 syntax that can appear in
-//   OpenClaw config files. If a path cannot be resolved, the issue degrades
-//   gracefully (no line number, no received value hint).
+// Known limitations (navigator fails gracefully, returns undefined):
+// - Unquoted keys with non-ASCII characters (Unicode letters outside A-Z, a-z,
+//   _, $). Quoted Unicode keys ("café") work fine.
+// - The navigator's scalar skipper is permissive and may skip past text that
+//   the canonical JSON5 parser would reject. This is safe because the navigator
+//   only runs on configs that have already been successfully parsed.
 import path from "node:path";
 import { isSensitiveConfigPath } from "./sensitive-paths.js";
 import type { ConfigValidationIssue } from "./types.js";

--- a/src/config/issue-location.ts
+++ b/src/config/issue-location.ts
@@ -1,4 +1,27 @@
 // JSON5-aware config issue path navigator and display enrichment.
+//
+// Supported JSON5 subset for path navigation:
+// - Objects: { key: value } with quoted (" "), single-quoted (' '), or unquoted
+//   identifier-like keys (A-Z, a-z, _, $, 0-9)
+// - Arrays: [value, ...] with bracket notation
+// - Strings: double-quoted and single-quoted, with \n, \t, \", \', \\, \uXXXX,
+//   \xXX escape sequences, and multi-line (backslash-newline continuation)
+// - Numbers: integers, floats, hex (0x), leading decimal (.5), Infinity, NaN,
+//   numeric separators (1_000)
+// - Comments: // line and /* block */
+// - Trailing commas in objects and arrays
+// - null, true, false literals
+//
+// The navigator only needs to find the byte offset of a value at a given path.
+// It does NOT need to fully parse every value — it skips over values using
+// skipVal/skipComposite. This means value-level syntax (hex numbers, special
+// values, numeric separators) is handled naturally by the value skipper.
+//
+// Unsupported syntax that would cause the navigator to fail gracefully
+// (returns undefined, no crash):
+// - None known — the navigator handles all JSON5 syntax that can appear in
+//   OpenClaw config files. If a path cannot be resolved, the issue degrades
+//   gracefully (no line number, no received value hint).
 import path from "node:path";
 import { isSensitiveConfigPath } from "./sensitive-paths.js";
 import type { ConfigValidationIssue } from "./types.js";

--- a/src/config/issue-location.ts
+++ b/src/config/issue-location.ts
@@ -153,7 +153,7 @@ function readKey(raw: string, c: Cursor): string | null {
   if (ch !== undefined && /[A-Za-z_$]/.test(ch)) {
     const start = c.pos;
     c.pos++;
-    while (c.pos < raw.length && /[A-Za-z0-9_$]/.test(raw[c.pos])) c.pos++;
+    while (c.pos < raw.length && /[A-Za-z0-9_$]/.test(raw[c.pos] ?? "")) c.pos++;
     return raw.slice(start, c.pos);
   }
   return null;

--- a/src/config/issue-location.ts
+++ b/src/config/issue-location.ts
@@ -47,7 +47,6 @@ function skipWS(raw: string, c: Cursor): void {
   }
 }
 
-/** Skip a JSON5 string (single or double quoted). */
 function skipStr(raw: string, c: Cursor): void {
   const quote = raw[c.pos];
   c.pos++;
@@ -64,7 +63,6 @@ function skipStr(raw: string, c: Cursor): void {
   }
 }
 
-/** Skip a JSON5 value (string, number, boolean, null, object, array). */
 function skipVal(raw: string, c: Cursor): void {
   skipWS(raw, c);
   if (c.pos >= raw.length) {
@@ -95,7 +93,6 @@ function skipVal(raw: string, c: Cursor): void {
   }
 }
 
-/** Skip a composite value (object or array), correctly tracking nesting. */
 function skipComposite(raw: string, c: Cursor): void {
   const open = raw[c.pos];
   const close = open === "{" ? "}" : "]";
@@ -133,7 +130,6 @@ function skipComposite(raw: string, c: Cursor): void {
   }
 }
 
-/** Read a JSON5 string value (single or double quoted). */
 function readStr(raw: string, c: Cursor): string | null {
   skipWS(raw, c);
   const quote = raw[c.pos];
@@ -161,7 +157,6 @@ function readStr(raw: string, c: Cursor): string | null {
   return null;
 }
 
-/** Read a JSON5 object key (quoted string or unquoted identifier). */
 function readKey(raw: string, c: Cursor): string | null {
   skipWS(raw, c);
   const ch = raw[c.pos];
@@ -179,7 +174,6 @@ function readKey(raw: string, c: Cursor): string | null {
   return null;
 }
 
-/** Expect and consume a specific character (skipping whitespace). */
 function expect(raw: string, c: Cursor, ch: string): boolean {
   skipWS(raw, c);
   if (raw[c.pos] !== ch) {
@@ -189,10 +183,6 @@ function expect(raw: string, c: Cursor, ch: string): boolean {
   return true;
 }
 
-/**
- * Navigate raw JSON5 text to find the byte offset of a value at the given path.
- * Returns undefined when the path cannot be resolved.
- */
 function navigateToOffset(
   raw: string,
   segments: readonly ConfigIssuePathSegment[],
@@ -213,7 +203,6 @@ function navigateAt(
 ): number | undefined {
   const segment = segments[depth];
   const isLeaf = depth === segments.length - 1;
-
   if (typeof segment === "number") {
     if (!expect(raw, c, "[")) {
       return undefined;
@@ -230,7 +219,6 @@ function navigateAt(
     }
     return navigateAt(raw, c, segments, depth + 1);
   }
-
   if (!expect(raw, c, "{")) {
     return undefined;
   }
@@ -267,7 +255,6 @@ function navigateAt(
   return undefined;
 }
 
-/** Format config issue path segments with bracket notation for array indexes. */
 export function formatConfigIssuePath(segments: readonly ConfigIssuePathSegment[]): string {
   if (segments.length === 0) {
     return "";
@@ -283,11 +270,6 @@ export function formatConfigIssuePath(segments: readonly ConfigIssuePathSegment[
   return out;
 }
 
-/**
- * Parse a display-formatted issue path back into traversal segments.
- * Supports bracket notation (`agents.list[3]`) and legacy dot-notation
- * (`agents.list.3` with numericDotSegments option).
- */
 export function parseConfigIssuePath(
   pathValue: string,
   opts?: { numericDotSegments?: boolean },
@@ -333,7 +315,6 @@ export function parseConfigIssuePath(
   return segments;
 }
 
-/** Resolve the actual value at a path in the parsed config object. */
 export function resolveConfigValueAtPath(
   root: unknown,
   segments: readonly ConfigIssuePathSegment[],
@@ -355,11 +336,6 @@ export function resolveConfigValueAtPath(
   return current;
 }
 
-/**
- * Resolve raw path segments against the parsed config to distinguish array
- * indices from numeric record keys. A numeric segment is treated as an array
- * index only when the parent value is actually an array.
- */
 function resolveSegmentsAgainstParsed(
   root: unknown,
   rawSegments: readonly ConfigIssuePathSegment[],
@@ -406,8 +382,7 @@ function safeStringify(v: unknown): string | null {
 }
 
 function messageAlreadyHasReceived(message: string): boolean {
-  const lower = message.toLowerCase();
-  return lower.includes("got:") || /\breceived\b/.test(lower);
+  return message.toLowerCase().includes("got:") || /\breceived\b/.test(message.toLowerCase());
 }
 
 function shouldOmitReceivedValue(pathValue: string, value: unknown): boolean {
@@ -426,7 +401,6 @@ function shouldOmitReceivedValue(pathValue: string, value: unknown): boolean {
   return safeStringify(value) === null;
 }
 
-/** Append a compact `got: <value>` hint when safe and not already present. */
 export function appendReceivedValueHint(
   message: string,
   pathValue: string,
@@ -442,7 +416,6 @@ export function appendReceivedValueHint(
   return `${message}, got: ${label}`;
 }
 
-/** Resolve the 1-based source line number for a value at the given path. */
 export function resolveConfigIssueLineInRaw(
   raw: string,
   segments: readonly ConfigIssuePathSegment[],
@@ -467,13 +440,6 @@ export type ConfigIssueDiagnostics = ConfigValidationIssue & {
   sourceFile?: string;
 };
 
-/**
- * Enrich config validation issues with display-friendly diagnostics:
- * bracket notation, received value hints, and source line numbers.
- * Line numbers and received values are only attached when the value can be
- * resolved in the raw config text. Paths in $include'd files gracefully
- * degrade — the navigator won't find them in the raw text.
- */
 export function attachConfigIssueDiagnostics(
   issues: readonly ConfigValidationIssue[],
   params: AttachConfigIssueDiagnosticsParams,
@@ -483,7 +449,6 @@ export function attachConfigIssueDiagnostics(
     typeof params.configPath === "string" && params.configPath.trim()
       ? path.basename(params.configPath)
       : "openclaw.json";
-
   return issues.map((issue) => {
     const rawSegments = parseConfigIssuePath(issue.path, { numericDotSegments: true });
     const segments = resolveSegmentsAgainstParsed(params.parsed, rawSegments);

--- a/src/config/issue-location.ts
+++ b/src/config/issue-location.ts
@@ -1,16 +1,10 @@
 // JSON5-aware config issue path navigator and display enrichment.
-// Walks raw config text to resolve line numbers and received values
-// for config validation issues, without a full parser.
 import path from "node:path";
 import { isSensitiveConfigPath } from "./sensitive-paths.js";
 import type { ConfigValidationIssue } from "./types.js";
 import { isSecretRef } from "./types.secrets.js";
 
 export type ConfigIssuePathSegment = string | number;
-
-// ---------------------------------------------------------------------------
-// JSON5 text navigator
-// ---------------------------------------------------------------------------
 
 type Cursor = { pos: number };
 
@@ -24,7 +18,6 @@ function lineAtOffset(raw: string, offset: number): number {
   return line;
 }
 
-/** Skip whitespace and JSON5 comments. */
 function skipWS(raw: string, c: Cursor): void {
   while (c.pos < raw.length) {
     const ch = raw[c.pos];
@@ -274,10 +267,6 @@ function navigateAt(
   return undefined;
 }
 
-// ---------------------------------------------------------------------------
-// Path formatting
-// ---------------------------------------------------------------------------
-
 /** Format config issue path segments with bracket notation for array indexes. */
 export function formatConfigIssuePath(segments: readonly ConfigIssuePathSegment[]): string {
   if (segments.length === 0) {
@@ -285,18 +274,14 @@ export function formatConfigIssuePath(segments: readonly ConfigIssuePathSegment[
   }
   let out = "";
   for (const s of segments) {
-    if (typeof s === "number") {
-      out += `[${s}]`;
-    } else {
-      out = out ? `${out}.${s}` : s;
-    }
+    out += typeof s === "number" ? `[${s}]` : out ? `${out}.${s}` : s;
   }
   return out;
 }
 
 /**
  * Parse a display-formatted issue path back into traversal segments.
- * Supports both bracket notation (`agents.list[3]`) and legacy dot-notation
+ * Supports bracket notation (`agents.list[3]`) and legacy dot-notation
  * (`agents.list.3` with numericDotSegments option).
  */
 export function parseConfigIssuePath(
@@ -343,10 +328,6 @@ export function parseConfigIssuePath(
   }
   return segments;
 }
-
-// ---------------------------------------------------------------------------
-// Value resolution from parsed config
-// ---------------------------------------------------------------------------
 
 /** Resolve the actual value at a path in the parsed config object. */
 export function resolveConfigValueAtPath(
@@ -405,10 +386,6 @@ function resolveSegmentsAgainstParsed(
   return resolved;
 }
 
-// ---------------------------------------------------------------------------
-// Received value hint
-// ---------------------------------------------------------------------------
-
 function safeStringify(v: unknown): string | null {
   if (v === undefined) {
     return null;
@@ -461,10 +438,6 @@ export function appendReceivedValueHint(
   return `${message}, got: ${label}`;
 }
 
-// ---------------------------------------------------------------------------
-// Line number resolution
-// ---------------------------------------------------------------------------
-
 /** Resolve the 1-based source line number for a value at the given path. */
 export function resolveConfigIssueLineInRaw(
   raw: string,
@@ -476,10 +449,6 @@ export function resolveConfigIssueLineInRaw(
   }
   return lineAtOffset(raw, offset);
 }
-
-// ---------------------------------------------------------------------------
-// Issue enrichment
-// ---------------------------------------------------------------------------
 
 export type AttachConfigIssueDiagnosticsParams = {
   raw: string | null | undefined;
@@ -496,14 +465,10 @@ export type ConfigIssueDiagnostics = ConfigValidationIssue & {
 
 /**
  * Enrich config validation issues with display-friendly diagnostics:
- * - Bracket notation for array indices (when formatPathForDisplay is true)
- * - Received value hints (when includeReceivedValueHint is true)
- * - Source line numbers and file name
- *
+ * bracket notation, received value hints, and source line numbers.
  * Line numbers and received values are only attached when the value can be
  * resolved in the raw config text. Paths in $include'd files gracefully
- * degrade — the navigator won't find them in the raw text, so no line
- * number or received value is shown for those issues.
+ * degrade — the navigator won't find them in the raw text.
  */
 export function attachConfigIssueDiagnostics(
   issues: readonly ConfigValidationIssue[],
@@ -517,19 +482,14 @@ export function attachConfigIssueDiagnostics(
 
   return issues.map((issue) => {
     const rawSegments = parseConfigIssuePath(issue.path, { numericDotSegments: true });
-    // Resolve segments against the parsed config to distinguish array indices
-    // from numeric record keys (e.g., plugins.entries.123 is a string key, not
-    // an array index).
     const segments = resolveSegmentsAgainstParsed(params.parsed, rawSegments);
     const receivedValue = resolveConfigValueAtPath(params.parsed, segments);
     const line = raw === null ? undefined : resolveConfigIssueLineInRaw(raw, segments);
     const canResolve = line !== undefined;
-
     const message =
       params.includeReceivedValueHint && canResolve
         ? appendReceivedValueHint(issue.message, issue.path, receivedValue)
         : issue.message;
-
     return {
       ...issue,
       path: params.formatPathForDisplay ? formatConfigIssuePath(segments) : issue.path,

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -278,6 +278,8 @@ export type RuntimeConfig = BrandedConfigState<"runtime">;
 export type ConfigValidationIssue = {
   /** Dot-path to the invalid or legacy config value. */
   path: string;
+  /** Structured validator path used internally for lossless source diagnostics. */
+  pathSegments?: Array<string | number>;
   /** Human-readable validation message. */
   message: string;
   /** Optional allowed values shown to the operator. */

--- a/src/config/validation.allowed-values.test.ts
+++ b/src/config/validation.allowed-values.test.ts
@@ -27,6 +27,8 @@ describe("config validation allowed-values metadata", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       const issue = requireIssue(result.issues, "update.channel");
+      expect(issue.pathSegments).toEqual(["update", "channel"]);
+      expect(JSON.stringify(issue)).not.toContain("pathSegments");
       expect(issue.message).toContain('(allowed: "stable", "extended-stable", "beta", "dev")');
       expect(issue.allowedValues).toEqual(["stable", "extended-stable", "beta", "dev"]);
       expect(issue.allowedValuesHiddenCount).toBe(0);

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -207,6 +207,17 @@ function formatConfigPath(segments: readonly ConfigPathSegment[]): string {
   return segments.join(".");
 }
 
+function withConfigIssuePath(
+  issue: ConfigValidationIssue,
+  pathSegments: readonly ConfigPathSegment[],
+): ConfigValidationIssue {
+  Object.defineProperty(issue, "pathSegments", {
+    value: [...pathSegments],
+    enumerable: false,
+  });
+  return issue;
+}
+
 function formatMissingOfficialExternalPluginWarning(
   pluginId: string,
   opts?: { selectedMissingMemorySlot?: boolean },
@@ -631,7 +642,7 @@ function isRouteTypeMismatchIssue(issue: UnknownIssueRecord): boolean {
 
 function extractBindingsSpecificUnionIssue(
   record: UnknownIssueRecord,
-  parentPath: string,
+  parentPathSegments: readonly ConfigPathSegment[],
 ): ConfigValidationIssue | null {
   if (!isBindingsIssuePath(toConfigPathSegments(record.path)) || !Array.isArray(record.errors)) {
     return null;
@@ -700,11 +711,16 @@ function extractBindingsSpecificUnionIssue(
     return null;
   }
 
-  const subPath = formatConfigPath(toConfigPathSegments(matchingBranchIssue.path));
-  const fullPath = parentPath && subPath ? `${parentPath}.${subPath}` : parentPath || subPath;
+  const fullPathSegments = [
+    ...parentPathSegments,
+    ...toConfigPathSegments(matchingBranchIssue.path),
+  ];
   const subMessage =
     typeof matchingBranchIssue.message === "string" ? matchingBranchIssue.message : "Invalid input";
-  return { path: fullPath, message: subMessage };
+  return withConfigIssuePath(
+    { path: formatConfigPath(fullPathSegments), message: subMessage },
+    fullPathSegments,
+  );
 }
 
 function isObjectSecretRefCandidate(value: unknown): boolean {
@@ -824,7 +840,8 @@ export function collectUnsupportedSecretRefPolicyIssues(raw: unknown): ConfigVal
 
 function mapZodIssueToConfigIssue(issue: unknown): ConfigValidationIssue {
   const record = toIssueRecord(issue);
-  const pathItem = formatConfigPath(toConfigPathSegments(record?.path));
+  const pathSegments = toConfigPathSegments(record?.path);
+  const pathItem = formatConfigPath(pathSegments);
   const message = typeof record?.message === "string" ? record.message : "Invalid input";
 
   // Numeric ceiling/floor hints (too_big / too_small with numeric origin).
@@ -843,22 +860,25 @@ function mapZodIssueToConfigIssue(issue: unknown): ConfigValidationIssue {
     record.code === "invalid_union" &&
     !allowedValuesSummary
   ) {
-    const betterIssue = extractBindingsSpecificUnionIssue(record, pathItem);
+    const betterIssue = extractBindingsSpecificUnionIssue(record, pathSegments);
     if (betterIssue) {
       return betterIssue;
     }
   }
 
   if (!allowedValuesSummary) {
-    return { path: pathItem, message: enrichedMessage };
+    return withConfigIssuePath({ path: pathItem, message: enrichedMessage }, pathSegments);
   }
 
-  return {
-    path: pathItem,
-    message: appendAllowedValuesHint(enrichedMessage, allowedValuesSummary),
-    allowedValues: allowedValuesSummary.values,
-    allowedValuesHiddenCount: allowedValuesSummary.hiddenCount,
-  };
+  return withConfigIssuePath(
+    {
+      path: pathItem,
+      message: appendAllowedValuesHint(enrichedMessage, allowedValuesSummary),
+      allowedValues: allowedValuesSummary.values,
+      allowedValuesHiddenCount: allowedValuesSummary.hiddenCount,
+    },
+    pathSegments,
+  );
 }
 
 function collectExplicitPluginReferences(raw: unknown): ExplicitPluginReferences {


### PR DESCRIPTION
## What Problem This Solves

`openclaw config validate` reported lossy dot paths without source locations, making nested and array validation failures difficult to find. It also omitted the rejected scalar value even when that value was safe to display.

## Why This Change Was Made

This improves human-readable validation errors without changing the config schema, parser, or machine-readable issue shape:

- array indices use bracket notation, such as `agents.list[3].tools.profile`
- root-file values include `openclaw.json:<line>` when the exact JSON5 value can be located
- safe scalar values add a `got:` hint
- structured Zod paths are retained internally so dotted record keys and numeric record keys cannot be confused
- the locator follows canonical JSON5 key parsing and last-duplicate-key semantics

Received values are omitted for sensitive paths, SecretRefs, plugin-owned config, channel config, objects, environment-substituted values, included-only values, and migrated values. Plugin IDs containing dots remain inside the same redaction boundary.

## User Impact

A safe root-file failure can now render as:

```text
openclaw.json:247 — agents.list[3].tools.profile: Invalid input (allowed: "minimal", "coding"), got: "none"
```

When source ownership or value safety cannot be proven, output degrades to the existing path and message without a line or received value.

## Evidence

- `node scripts/run-vitest.mjs src/config/issue-location.test.ts src/config/issue-format.test.ts src/config/validation.allowed-values.test.ts src/cli/config-cli.test.ts` — 199 tests passed on rebased head `2490aa0fc37e`
- `node scripts/check-changed.mjs -- <changed config files>` — guards, formatting, core and core-test typechecks, full core lint, and database/runtime guards passed in [hosted Testbox](https://github.com/openclaw/openclaw/actions/runs/29552033432)
- exact-head CI passed, including dependency deadcode, in [CI run 29553384563](https://github.com/openclaw/openclaw/actions/runs/29553384563)
- fresh full-branch autoreview on rebased head: no actionable findings

_AI-assisted: implementation by Luci (OpenClaw agent), improved and reviewed by OpenClaw maintainers._

Closes #104854
