### PR TITLE
fix(voice-call): reject malformed media base64

### DIFF
--- a/extensions/voice-call/src/media-base64.test.ts
+++ b/extensions/voice-call/src/media-base64.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { canonicalizeVoiceCallMediaBase64, decodeVoiceCallMediaBase64 } from "./media-base64.js";
+
+describe("voice-call media base64", () => {
+  it("canonicalizes and decodes valid media payloads", () => {
+    expect(canonicalizeVoiceCallMediaBase64(" aGVs bG8 \n")).toBe("aGVsbG8=");
+    expect(decodeVoiceCallMediaBase64("aGVsbG8", "test").toString("utf8")).toBe("hello");
+  });
+
+  it("rejects malformed media payloads instead of letting Buffer decode partial bytes", () => {
+    expect(canonicalizeVoiceCallMediaBase64("aGVsbG8!")).toBeUndefined();
+    expect(() => decodeVoiceCallMediaBase64("aGVsbG8!", "test")).toThrow(
+      "test media payload was not valid base64",
+    );
+  });
+});

--- a/extensions/voice-call/src/media-base64.ts
+++ b/extensions/voice-call/src/media-base64.ts
@@ -1,0 +1,13 @@
+import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
+
+export function canonicalizeVoiceCallMediaBase64(payloadBase64: string): string | undefined {
+  return canonicalizeBase64(payloadBase64);
+}
+
+export function decodeVoiceCallMediaBase64(payloadBase64: string, context: string): Buffer {
+  const canonicalBase64 = canonicalizeVoiceCallMediaBase64(payloadBase64);
+  if (!canonicalBase64) {
+    throw new Error(`${context} media payload was not valid base64`);
+  }
+  return Buffer.from(canonicalBase64, "base64");
+}

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -25,6 +25,7 @@ import {
 } from "openclaw/plugin-sdk/realtime-voice";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { type RawData, WebSocket, WebSocketServer } from "ws";
+import { decodeVoiceCallMediaBase64 } from "./media-base64.js";
 
 /**
  * Configuration for the media stream handler.
@@ -52,13 +53,10 @@ export interface MediaStreamConfig {
   onTranscript?: (callId: string, transcript: string) => void;
   /** Callback for partial transcripts (streaming UI) */
   onPartialTranscript?: (callId: string, partial: string) => void;
-  /** Callback when stream connects */
   onConnect?: (callId: string, streamSid: string) => void;
-  /** Callback when realtime transcription is ready for the stream */
   onTranscriptionReady?: (callId: string, streamSid: string) => void;
   /** Callback when speech starts (barge-in) */
   onSpeechStart?: (callId: string) => void;
-  /** Callback when stream disconnects */
   onDisconnect?: (callId: string, streamSid: string) => void;
   /** Callback for common Talk events emitted by the telephony STT/TTS adapter. */
   onTalkEvent?: (callId: string, streamSid: string, event: TalkEvent) => void;
@@ -251,8 +249,10 @@ export class MediaStreamHandler {
 
           case "media":
             if (session && message.media?.payload) {
-              // Forward audio to STT
-              const audioBuffer = Buffer.from(message.media.payload, "base64");
+              const audioBuffer = decodeVoiceCallMediaBase64(
+                message.media.payload,
+                "Twilio media stream",
+              );
               const turnId = this.ensureActiveTurn(session);
               this.emitTalkEvent(session, {
                 type: "input.audio.delta",

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -32,6 +32,7 @@ import { normalizeWebhookPath } from "openclaw/plugin-sdk/webhook-ingress";
 import WebSocket, { WebSocketServer } from "ws";
 import type { VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
+import { decodeVoiceCallMediaBase64 } from "../media-base64.js";
 import type { VoiceCallProvider } from "../providers/base.js";
 import type { CallRecord, NormalizedEvent } from "../types.js";
 import type { WebhookResponsePayload } from "../webhook.types.js";
@@ -41,7 +42,6 @@ import {
   TelnyxStreamFrameAdapter,
   TwilioStreamFrameAdapter,
 } from "./stream-frame-adapter.js";
-
 export type ToolHandlerContext = {
   partialUserTranscript?: string;
 };
@@ -452,7 +452,7 @@ export class RealtimeCallHandler {
             return;
           }
           if (frame.kind === "media") {
-            const audio = Buffer.from(frame.payloadBase64, "base64");
+            const audio = decodeVoiceCallMediaBase64(frame.payloadBase64, "Realtime voice bridge");
             bridge.sendAudio(audio);
             if (frame.timestampMs !== undefined) {
               if (lastMediaTimestamp !== undefined) {

--- a/extensions/voice-call/src/webhook/stream-frame-adapter.test.ts
+++ b/extensions/voice-call/src/webhook/stream-frame-adapter.test.ts
@@ -58,6 +58,19 @@ describe("TwilioStreamFrameAdapter", () => {
     ).toEqual({ kind: "media", payloadBase64: "AAA=" });
   });
 
+  it("canonicalizes accepted media payloads before realtime decoding", () => {
+    const adapter = new TwilioStreamFrameAdapter();
+
+    expect(
+      adapter.parseInbound(
+        JSON.stringify({
+          event: "media",
+          media: { payload: " AA A \n" },
+        }),
+      ),
+    ).toEqual({ kind: "media", payloadBase64: "AAA=" });
+  });
+
   it("serializes outbound frames with the streamSid captured at start", () => {
     const adapter = new TwilioStreamFrameAdapter();
     adapter.parseInbound(

--- a/extensions/voice-call/src/webhook/stream-frame-adapter.ts
+++ b/extensions/voice-call/src/webhook/stream-frame-adapter.ts
@@ -1,5 +1,7 @@
 // Provider-specific media stream frame parsing and serialization.
 
+import { canonicalizeVoiceCallMediaBase64 } from "../media-base64.js";
+
 /** Normalized inbound media stream frame. */
 type StreamFrame =
   | { kind: "start"; streamId: string; providerCallId: string }
@@ -59,27 +61,17 @@ function readRecordField(
     : undefined;
 }
 
-/** Normalize base64/base64url padding differences for validation. */
-function normalizeBase64ForCompare(value: string): string {
-  return value.replace(/=+$/u, "").replace(/-/gu, "+").replace(/_/gu, "/");
-}
-
-/** Return true when a payload round-trips as base64. */
-function isValidBase64Payload(value: string): boolean {
-  const buffer = Buffer.from(value, "base64");
-  return normalizeBase64ForCompare(buffer.toString("base64")) === normalizeBase64ForCompare(value);
-}
-
 /** Parse a common provider media frame. */
 function parseMediaFrame(msg: Record<string, unknown>): StreamFrame {
   const mediaData = readRecordField(msg, "media");
   const payload = typeof mediaData?.payload === "string" ? mediaData.payload : undefined;
-  if (!payload || !isValidBase64Payload(payload)) {
+  const canonicalPayload = payload ? canonicalizeVoiceCallMediaBase64(payload) : undefined;
+  if (!canonicalPayload) {
     return { kind: "ignored" };
   }
   return {
     kind: "media",
-    payloadBase64: payload,
+    payloadBase64: canonicalPayload,
     timestampMs: parseTimestampMs(mediaData?.timestamp),
     track: typeof mediaData?.track === "string" ? mediaData.track : undefined,
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where malformed voice-call media payloads could be silently decoded by Node and forwarded as audio bytes into realtime or transcription sessions.

## Why This Change Was Made

Voice-call media payloads now share the SDK base64 canonicalizer before decoding. Provider stream adapters ignore malformed media frames, and the direct Twilio/realtime decode boundaries fail closed instead of relying on permissive `Buffer.from(..., "base64")` behavior.

## User Impact

Voice-call sessions reject corrupted media frames without delivering partial or garbage audio to STT/realtime providers, while valid payloads continue to stream normally.

## Evidence

- Real module proof used the actual `MediaStreamHandler` WebSocket upgrade path with a malformed Twilio media payload; STT delivery and `input.audio.delta` stayed at zero, then a valid payload still reached STT as `ok`.

```text
$ node --import tsx --input-type=module - < proof-live.mjs
invalid-stt-audio=0
invalid-input-deltas=0
valid-stt-audio=ok
adapter-invalid-kind=ignored
realtime-decode-error=Realtime voice bridge media payload was not valid base64
```

<details>
<summary>proof-live.mjs</summary>

```js
import { Buffer } from "node:buffer";
import { MediaStreamHandler } from "./extensions/voice-call/src/media-stream.ts";
import { decodeVoiceCallMediaBase64 } from "./extensions/voice-call/src/media-base64.ts";
import { TwilioStreamFrameAdapter } from "./extensions/voice-call/src/webhook/stream-frame-adapter.ts";
import {
  connectWs,
  startUpgradeWsServer,
  waitForClose,
} from "./extensions/voice-call/src/websocket-test-support.ts";

const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
const sentAudio = [];
const talkEvents = [];
const handler = new MediaStreamHandler({
  transcriptionProvider: {
    id: "proof-stt",
    label: "Proof STT",
    isConfigured: () => true,
    createSession: () => ({
      connect: async () => undefined,
      sendAudio: (audio) => sentAudio.push(Buffer.from(audio)),
      close: () => undefined,
      isConnected: () => true,
    }),
  },
  providerConfig: {},
  shouldAcceptStream: () => true,
  onTalkEvent: (_callId, _streamSid, event) => talkEvents.push(event),
});
const server = await startUpgradeWsServer({
  urlPath: "/voice/stream",
  onUpgrade: (request, socket, head) => handler.handleUpgrade(request, socket, head),
});

try {
  const ws = await connectWs(server.url);
  ws.send(JSON.stringify({ event: "start", streamSid: "MZ-proof", start: { callSid: "CA-proof" } }));
  await wait(50);
  talkEvents.length = 0;
  ws.send(JSON.stringify({ event: "media", streamSid: "MZ-proof", media: { payload: "not-base64!" } }));
  await wait(50);
  console.log(`invalid-stt-audio=${sentAudio.length}`);
  console.log(`invalid-input-deltas=${talkEvents.filter((event) => event.type === "input.audio.delta").length}`);
  ws.send(
    JSON.stringify({
      event: "media",
      streamSid: "MZ-proof",
      media: { payload: Buffer.from("ok").toString("base64") },
    }),
  );
  await wait(50);
  console.log(`valid-stt-audio=${Buffer.concat(sentAudio).toString("utf8")}`);
  ws.close();
  await waitForClose(ws);
} finally {
  await server.close();
}

const adapter = new TwilioStreamFrameAdapter();
console.log(
  `adapter-invalid-kind=${adapter.parseInbound(JSON.stringify({ event: "media", media: { payload: "not-base64!" } })).kind}`,
);
try {
  decodeVoiceCallMediaBase64("not-base64!", "Realtime voice bridge");
} catch (error) {
  console.log(`realtime-decode-error=${error instanceof Error ? error.message : String(error)}`);
}
```

</details>

- `pnpm vitest run extensions/voice-call/src/media-base64.test.ts extensions/voice-call/src/webhook/stream-frame-adapter.test.ts`: 2 files, 12 tests passed.
- `pnpm vitest run extensions/voice-call/src/media-stream.test.ts extensions/voice-call/src/webhook/realtime-handler.test.ts`: 2 files, 46 tests passed.
- Local `check:changed` child lane: completed successfully without remote Testbox delegation.

AI-assisted: built with Codex
