### PR TITLE
refactor(agents): decompose embedded attempt phases

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-after-turn.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-after-turn.ts
@@ -40,7 +40,7 @@ type AttemptSessionLockController = Awaited<
 type PromptCacheInfo = ReturnType<typeof buildContextEnginePromptCacheInfo>;
 type WithOwnedSessionWriteLock = <T>(operation: () => Promise<T> | T) => Promise<T>;
 
-export type CompleteEmbeddedAttemptAfterTurnInput = {
+type CompleteEmbeddedAttemptAfterTurnInput = {
   attempt: EmbeddedRunAttemptParams;
   activeContextEngine?: ContextEngine;
   activeSession: AgentSession;

--- a/src/agents/embedded-agent-runner/run/attempt-after-turn.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-after-turn.ts
@@ -1,0 +1,235 @@
+/**
+ * Runs post-stream context-engine, transcript, cache, and lifecycle work.
+ */
+import { OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST } from "../../../context-engine/host-compat.js";
+import type { ContextEngine } from "../../../context-engine/types.js";
+import { freezeDiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
+import { formatErrorMessage } from "../../../infra/errors.js";
+import type { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
+import type { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
+import { FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE } from "../../bootstrap-files.js";
+import { isHeartbeatLifecycleRunKind } from "../../bootstrap-mode.js";
+import type { createCacheTrace } from "../../cache-trace.js";
+import { runAgentEndSideEffects } from "../../harness/agent-end-side-effects.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import type { AgentSession, SessionManager } from "../../sessions/index.js";
+import type { NormalizedUsage } from "../../usage.js";
+import {
+  rotateTranscriptAfterCompaction,
+  shouldRotateCompactionTranscript,
+} from "../compaction-successor-transcript.js";
+import { runContextEngineMaintenance } from "../context-engine-maintenance.js";
+import { log } from "../logger.js";
+import { updateActiveEmbeddedRunSessionFile } from "../runs.js";
+import { buildEmbeddedAgentEndContext } from "./agent-end-context.js";
+import {
+  finalizeAttemptContextEngineTurn,
+  type buildContextEnginePromptCacheInfo,
+} from "./attempt.context-engine-helpers.js";
+import { buildAfterTurnRuntimeContextFromUsage } from "./attempt.prompt-helpers.js";
+import type { createEmbeddedAttemptSessionLockController } from "./attempt.session-lock.js";
+import { shouldPersistCompletedBootstrapTurn } from "./attempt.thread-helpers.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type CacheTrace = ReturnType<typeof createCacheTrace>;
+type AnthropicPayloadLogger = ReturnType<typeof createAnthropicPayloadLogger>;
+type HookRunner = ReturnType<typeof getGlobalHookRunner>;
+type AttemptSessionLockController = Awaited<
+  ReturnType<typeof createEmbeddedAttemptSessionLockController>
+>;
+type PromptCacheInfo = ReturnType<typeof buildContextEnginePromptCacheInfo>;
+type WithOwnedSessionWriteLock = <T>(operation: () => Promise<T> | T) => Promise<T>;
+
+export type CompleteEmbeddedAttemptAfterTurnInput = {
+  attempt: EmbeddedRunAttemptParams;
+  activeContextEngine?: ContextEngine;
+  activeSession: AgentSession;
+  sessionManager: SessionManager;
+  sessionLockController: AttemptSessionLockController;
+  withOwnedSessionWriteLock: WithOwnedSessionWriteLock;
+  state: {
+    promptError: unknown;
+    yieldAborted: boolean;
+    sessionIdUsed: string;
+    sessionFileUsed?: string;
+    messagesSnapshot: AgentMessage[];
+    prePromptMessageCount: number;
+    contextEngineAfterTurnCheckpoint: number | null;
+    lastCallUsage?: NormalizedUsage;
+    promptCache?: PromptCacheInfo;
+    beforeAgentFinalizeRevisionReason?: string;
+    compactionOccurredThisAttempt: boolean;
+  };
+  readLifecycleState: () => {
+    aborted: boolean;
+    timedOut: boolean;
+    idleTimedOut: boolean;
+    timedOutDuringCompaction: boolean;
+  };
+  runtime: {
+    effectiveWorkspace: string;
+    agentDir: string;
+    sessionAgentId: string;
+    resolveActiveContextEnginePluginId: () => string | undefined;
+    shouldRecordCompletedBootstrapTurn: boolean;
+    cacheTrace: CacheTrace;
+    anthropicPayloadLogger: AnthropicPayloadLogger;
+    hookAgentId: string;
+    diagnosticTrace: Parameters<typeof freezeDiagnosticTraceContext>[0];
+    skillWorkshopAvailable: boolean;
+    hookRunner: HookRunner;
+    promptStartedAt: number;
+  };
+};
+
+export async function completeEmbeddedAttemptAfterTurn(
+  input: CompleteEmbeddedAttemptAfterTurnInput,
+): Promise<{ sessionIdUsed: string; sessionFileUsed?: string }> {
+  const { attempt, activeContextEngine, activeSession, sessionManager, state, runtime } = input;
+  let { sessionIdUsed, sessionFileUsed } = state;
+
+  // Context-engine hooks may call runtime LLM capabilities. Only the transcript
+  // rewrite callback reacquires the synchronous session write boundary.
+  if (activeContextEngine && !state.beforeAgentFinalizeRevisionReason) {
+    const lifecycleState = input.readLifecycleState();
+    const afterTurnRuntimeContext = buildAfterTurnRuntimeContextFromUsage({
+      attempt,
+      workspaceDir: runtime.effectiveWorkspace,
+      agentDir: runtime.agentDir,
+      tokenBudget: attempt.contextTokenBudget,
+      lastCallUsage: state.lastCallUsage,
+      promptCache: state.promptCache,
+      activeAgentId: runtime.sessionAgentId,
+      contextEnginePluginId: runtime.resolveActiveContextEnginePluginId(),
+    });
+    await finalizeAttemptContextEngineTurn({
+      contextEngine: activeContextEngine,
+      promptError: Boolean(state.promptError),
+      aborted: lifecycleState.aborted,
+      yieldAborted: state.yieldAborted,
+      sessionIdUsed,
+      sessionKey: attempt.sessionKey,
+      sessionTarget: attempt.sessionTarget,
+      sessionFile: attempt.sessionFile,
+      messagesSnapshot: state.messagesSnapshot,
+      prePromptMessageCount: state.contextEngineAfterTurnCheckpoint ?? state.prePromptMessageCount,
+      tokenBudget: attempt.contextTokenBudget,
+      runtimeContext: afterTurnRuntimeContext,
+      contextEngineHostSupport: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
+      providerId: attempt.provider,
+      requestedModelId: attempt.requestedModelId,
+      modelId: attempt.modelId,
+      fallbackReason: attempt.fallbackReason,
+      degradedReason: attempt.degradedReason,
+      runMaintenance: async (contextParams) =>
+        await runContextEngineMaintenance({
+          contextEngine: contextParams.contextEngine as never,
+          sessionId: contextParams.sessionId,
+          sessionKey: contextParams.sessionKey,
+          sessionTarget: contextParams.sessionTarget,
+          sessionFile: contextParams.sessionFile,
+          reason: contextParams.reason,
+          sessionManager: contextParams.sessionManager as never,
+          withSessionManagerRewriteLock: async (operation) =>
+            await input.withOwnedSessionWriteLock(operation),
+          runtimeContext: contextParams.runtimeContext,
+          runtimeSettings: contextParams.runtimeSettings,
+          config: attempt.config,
+          agentId: runtime.sessionAgentId,
+        }),
+      sessionManager,
+      config: attempt.config,
+      warn: (message) => log.warn(message),
+      isHeartbeat: isHeartbeatLifecycleRunKind(attempt.bootstrapContextRunKind),
+    });
+  }
+
+  if (!state.beforeAgentFinalizeRevisionReason) {
+    await input.sessionLockController.waitForSessionEvents(activeSession);
+    await input.withOwnedSessionWriteLock(async () => {
+      const lifecycleState = input.readLifecycleState();
+      if (
+        shouldPersistCompletedBootstrapTurn({
+          shouldRecordCompletedBootstrapTurn: runtime.shouldRecordCompletedBootstrapTurn,
+          promptError: state.promptError,
+          aborted: lifecycleState.aborted,
+          timedOutDuringCompaction: lifecycleState.timedOutDuringCompaction,
+          compactionOccurredThisAttempt: state.compactionOccurredThisAttempt,
+        })
+      ) {
+        try {
+          sessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, {
+            timestamp: Date.now(),
+            runId: attempt.runId,
+            sessionId: attempt.sessionId,
+          });
+        } catch (entryErr) {
+          log.warn(`failed to persist bootstrap completion entry: ${String(entryErr)}`);
+        }
+      }
+
+      if (
+        state.compactionOccurredThisAttempt &&
+        !state.promptError &&
+        !lifecycleState.aborted &&
+        !lifecycleState.timedOut &&
+        !lifecycleState.idleTimedOut &&
+        !lifecycleState.timedOutDuringCompaction &&
+        shouldRotateCompactionTranscript(attempt.config)
+      ) {
+        try {
+          const rotation = await rotateTranscriptAfterCompaction({
+            sessionManager,
+            sessionFile: attempt.sessionFile,
+          });
+          if (rotation.rotated) {
+            sessionIdUsed = rotation.sessionId ?? sessionIdUsed;
+            sessionFileUsed = rotation.sessionFile ?? sessionFileUsed;
+            updateActiveEmbeddedRunSessionFile(attempt.sessionId, sessionFileUsed);
+            log.info(
+              `[compaction] rotated active transcript after automatic compaction ` +
+                `(sessionKey=${attempt.sessionKey ?? attempt.sessionId})`,
+            );
+          }
+        } catch (err) {
+          log.warn("[compaction] automatic transcript rotation failed", {
+            errorMessage: formatErrorMessage(err),
+          });
+        }
+      }
+    });
+  }
+
+  const lifecycleAfterTurn = input.readLifecycleState();
+  runtime.cacheTrace?.recordStage("session:after", {
+    messages: state.messagesSnapshot,
+    note: lifecycleAfterTurn.timedOutDuringCompaction
+      ? "compaction timeout"
+      : state.promptError
+        ? "prompt error"
+        : undefined,
+  });
+  runtime.anthropicPayloadLogger?.recordUsage(state.messagesSnapshot, state.promptError);
+
+  if (!state.beforeAgentFinalizeRevisionReason) {
+    const lifecycleForAgentEnd = input.readLifecycleState();
+    runAgentEndSideEffects({
+      event: {
+        messages: state.messagesSnapshot,
+        success: !lifecycleForAgentEnd.aborted && !state.promptError,
+        error: state.promptError ? formatErrorMessage(state.promptError) : undefined,
+        durationMs: Date.now() - runtime.promptStartedAt,
+      },
+      ctx: buildEmbeddedAgentEndContext({
+        run: attempt,
+        agentId: runtime.hookAgentId,
+        trace: freezeDiagnosticTraceContext(runtime.diagnosticTrace),
+        skillWorkshopAvailable: runtime.skillWorkshopAvailable,
+        compacted: state.compactionOccurredThisAttempt,
+      }),
+      hookRunner: runtime.hookRunner,
+    });
+  }
+
+  return { sessionIdUsed, sessionFileUsed };
+}

--- a/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
@@ -137,7 +137,7 @@ describe("embedded attempt phase lifecycle state", () => {
         hookAgentId: "main",
         diagnosticTrace: { traceId: "trace-1", spanId: "span-1" } as never,
         skillWorkshopAvailable: false,
-        hookRunner: undefined,
+        hookRunner: null,
         promptStartedAt: Date.now(),
       },
     });

--- a/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  runAgentEndSideEffects: vi.fn(),
+}));
+
+vi.mock("../../harness/agent-end-side-effects.js", () => ({
+  runAgentEndSideEffects: hoisted.runAgentEndSideEffects,
+}));
+vi.mock("./agent-end-context.js", () => ({
+  buildEmbeddedAgentEndContext: () => ({}),
+}));
+
+import { completeEmbeddedAttemptAfterTurn } from "./attempt-after-turn.js";
+import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
+
+describe("embedded attempt phase lifecycle state", () => {
+  beforeEach(() => {
+    hoisted.runAgentEndSideEffects.mockReset();
+  });
+
+  it("re-reads compaction timeout state after the retry wait", async () => {
+    let timedOut = false;
+    let timedOutDuringCompaction = false;
+    const messages: never[] = [];
+    const removeTrailingEntries = vi.fn(() => 0);
+    const sessionManager = {
+      appendCustomEntry: vi.fn(),
+      buildSessionContext: () => ({ messages }),
+      getEntries: () => [],
+      removeTrailingEntries,
+    };
+    const activeSession = {
+      agent: { state: { messages } },
+      isCompacting: false,
+      isStreaming: false,
+      messages,
+      sessionId: "session-1",
+    };
+
+    const result = await settleEmbeddedAttemptStream({
+      attempt: {
+        runId: "run-1",
+        sessionId: "session-1",
+        sessionFile: "/tmp/session.jsonl",
+        provider: "test",
+        modelId: "model",
+        model: { api: "openai-responses" },
+      } as never,
+      activeSession: activeSession as never,
+      sessionManager: sessionManager as never,
+      sessionLockController: {
+        waitForSessionEvents: async () => {},
+      } as never,
+      withOwnedSessionWriteLock: async (operation) => await operation(),
+      subscription: {
+        toolMetas: [],
+        waitForCompactionRetry: async () => {
+          timedOut = true;
+          timedOutDuringCompaction = true;
+        },
+        isCompactionInFlight: () => false,
+        getCompactionCount: () => 0,
+        getUsageTotals: () => undefined,
+      } as never,
+      state: {
+        promptError: null,
+        promptErrorSource: null,
+        yieldAborted: false,
+        sessionIdUsed: "session-1",
+      },
+      readLifecycleState: () => ({
+        aborted: timedOut,
+        timedOut,
+        timedOutDuringCompaction,
+      }),
+      markTimedOutDuringCompaction: () => {
+        timedOutDuringCompaction = true;
+      },
+      runAbortDeadlineAtMs: Date.now() + 60_000,
+      runAbortSignal: new AbortController().signal,
+      isProbeSession: true,
+      abortable: async (promise) => await promise,
+      prePromptMessageCount: 0,
+      toolSearchTargetTranscriptProjections: [],
+      cache: {
+        observabilityEnabled: false,
+        changesForTurn: null,
+        retention: undefined,
+      },
+      shouldFlushForContextEngine: false,
+    });
+
+    expect(result.timedOutDuringCompaction).toBe(true);
+    expect(removeTrailingEntries).toHaveBeenCalledOnce();
+  });
+
+  it("re-reads abort state after post-turn session draining", async () => {
+    let aborted = false;
+    await completeEmbeddedAttemptAfterTurn({
+      attempt: {
+        runId: "run-1",
+        sessionId: "session-1",
+        sessionFile: "/tmp/session.jsonl",
+      } as never,
+      activeSession: {} as never,
+      sessionManager: { appendCustomEntry: vi.fn() } as never,
+      sessionLockController: {
+        waitForSessionEvents: async () => {
+          aborted = true;
+        },
+      } as never,
+      withOwnedSessionWriteLock: async (operation) => await operation(),
+      state: {
+        promptError: null,
+        yieldAborted: false,
+        sessionIdUsed: "session-1",
+        messagesSnapshot: [],
+        prePromptMessageCount: 0,
+        contextEngineAfterTurnCheckpoint: null,
+        compactionOccurredThisAttempt: false,
+      },
+      readLifecycleState: () => ({
+        aborted,
+        timedOut: aborted,
+        idleTimedOut: false,
+        timedOutDuringCompaction: false,
+      }),
+      runtime: {
+        effectiveWorkspace: "/tmp/workspace",
+        agentDir: "/tmp/agent",
+        sessionAgentId: "main",
+        resolveActiveContextEnginePluginId: () => undefined,
+        shouldRecordCompletedBootstrapTurn: false,
+        cacheTrace: null,
+        anthropicPayloadLogger: null,
+        hookAgentId: "main",
+        diagnosticTrace: { traceId: "trace-1", spanId: "span-1" } as never,
+        skillWorkshopAvailable: false,
+        hookRunner: undefined,
+        promptStartedAt: Date.now(),
+      },
+    });
+
+    expect(hoisted.runAgentEndSideEffects).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({ success: false }),
+      }),
+    );
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-assembly.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-assembly.ts
@@ -46,12 +46,12 @@ type OrphanRepairPlan = ReturnType<typeof resolveOrphanRepairPlan>;
 type CacheRetention = Parameters<typeof beginPromptCacheObservation>[0]["cacheRetention"];
 type PromptBuildHookContext = Parameters<typeof resolvePromptBuildHookResult>[0]["hookCtx"];
 
-export type EmbeddedAttemptSteeringLease = {
+type EmbeddedAttemptSteeringLease = {
   leaseId: string;
   runIds: string[];
 };
 
-export type EmbeddedAttemptPromptAssembly = {
+type EmbeddedAttemptPromptAssembly = {
   hookCtx: PromptBuildHookContext;
   effectivePrompt: string;
   promptBeforePromptBuildHooks: string;

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-assembly.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-assembly.ts
@@ -1,0 +1,343 @@
+/**
+ * Assembles hook, orphan-repair, steering, and cache inputs for one prompt.
+ */
+import { ensureSystemPromptCacheBoundary } from "@openclaw/ai/internal/shared";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { getRuntimeConfig } from "../../../config/config.js";
+import type { DiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
+import { freezeDiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
+import { resolveHeartbeatSummaryForAgent } from "../../../infra/heartbeat-summary.js";
+import {
+  buildAgentHookContextChannelFields,
+  buildAgentHookContextIdentityFields,
+} from "../../../plugins/hook-agent-context.js";
+import type { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
+import { annotateInterSessionPromptText } from "../../../sessions/input-provenance.js";
+import type { createCacheTrace } from "../../cache-trace.js";
+import { describeProviderRequestRoutingSummary } from "../../provider-attribution.js";
+import type { AgentSession, SessionManager } from "../../sessions/index.js";
+import {
+  leasePendingAgentSteeringItems,
+  prependAgentSteeringPrompt,
+} from "../../subagent-registry.js";
+import {
+  appendModelIdentitySystemPrompt,
+  buildModelIdentityPromptLine,
+} from "../../system-prompt.js";
+import { log } from "../logger.js";
+import {
+  beginPromptCacheObservation,
+  type PromptCacheChange,
+} from "../prompt-cache-observability.js";
+import type { resolveOrphanRepairPlan } from "./attempt-orphan-repair.js";
+import {
+  prependSystemPromptAddition,
+  resolveAttemptMediaTaskSystemPromptAddition,
+  resolvePromptBuildHookResult,
+  shouldWarnOnOrphanedUserRepair,
+} from "./attempt.prompt-helpers.js";
+import { composeSystemPromptWithHookContext } from "./attempt.thread-helpers.js";
+import { pruneProcessedHistoryImages } from "./history-image-prune.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type HookRunner = ReturnType<typeof getGlobalHookRunner>;
+type CacheTrace = ReturnType<typeof createCacheTrace>;
+type OrphanRepairPlan = ReturnType<typeof resolveOrphanRepairPlan>;
+type CacheRetention = Parameters<typeof beginPromptCacheObservation>[0]["cacheRetention"];
+type PromptBuildHookContext = Parameters<typeof resolvePromptBuildHookResult>[0]["hookCtx"];
+
+export type EmbeddedAttemptSteeringLease = {
+  leaseId: string;
+  runIds: string[];
+};
+
+export type EmbeddedAttemptPromptAssembly = {
+  hookCtx: PromptBuildHookContext;
+  effectivePrompt: string;
+  promptBeforePromptBuildHooks: string;
+  promptBuildPrependContext?: string;
+  promptBuildAppendContext?: string;
+  hasPromptBuildContext: boolean;
+  effectiveTranscriptPrompt?: string;
+  transcriptPromptForRuntimeSplit?: string;
+  promptForRuntimeContextSplit: string;
+  promptForModelBeforeRuntimeContextSplit: string;
+  promptForRuntimeContextBeforeAnnotation: string;
+  transcriptLeafId: string | null;
+  heartbeatSummary?: ReturnType<typeof resolveHeartbeatSummaryForAgent>;
+  promptCacheChangesForTurn: PromptCacheChange[] | null;
+  leasedSteering?: EmbeddedAttemptSteeringLease;
+};
+
+export async function prepareEmbeddedAttemptPromptAssembly(input: {
+  attempt: EmbeddedRunAttemptParams;
+  activeSession: AgentSession;
+  sessionManager: SessionManager;
+  hookRunner: HookRunner;
+  hookAgentId: string;
+  diagnosticTrace: DiagnosticTraceContext;
+  isRawModelRun: boolean;
+  orphanRepair?: OrphanRepairPlan;
+  sessionAgentId: string;
+  runtimeModel: string;
+  systemPromptText: string;
+  setActiveSessionSystemPrompt: (systemPrompt: string) => void;
+  setLeasedSteering: (lease: EmbeddedAttemptSteeringLease) => void;
+  cache: {
+    observabilityEnabled: boolean;
+    retention: CacheRetention;
+    streamStrategy: string;
+    transport: AgentSession["agent"]["transport"];
+    toolNames: string[];
+    trace: CacheTrace;
+  };
+}): Promise<EmbeddedAttemptPromptAssembly> {
+  const { attempt } = input;
+  let systemPromptText = input.systemPromptText;
+  const setSystemPrompt = (next: string) => {
+    systemPromptText = next;
+    input.setActiveSessionSystemPrompt(next);
+  };
+  let effectivePrompt = attempt.prompt;
+  const hookCtx = {
+    runId: attempt.runId,
+    trace: freezeDiagnosticTraceContext(input.diagnosticTrace),
+    agentId: input.hookAgentId,
+    sessionKey: attempt.sessionKey,
+    sessionId: attempt.sessionId,
+    workspaceDir: attempt.workspaceDir,
+    modelProviderId: attempt.model.provider,
+    modelId: attempt.model.id,
+    trigger: attempt.trigger,
+    ...buildAgentHookContextChannelFields(attempt),
+    ...buildAgentHookContextIdentityFields({
+      trigger: attempt.trigger,
+      senderId: attempt.senderId,
+      chatId: attempt.chatId,
+      channelContext: attempt.channelContext,
+    }),
+  };
+  const promptBuildMessages =
+    pruneProcessedHistoryImages(input.activeSession.messages) ?? input.activeSession.messages;
+  const hookResult = input.isRawModelRun
+    ? undefined
+    : await resolvePromptBuildHookResult({
+        config: attempt.config ?? getRuntimeConfig(),
+        prompt: attempt.prompt,
+        messages: promptBuildMessages,
+        hookCtx,
+        hookRunner: input.hookRunner,
+        beforeAgentStartResult: attempt.beforeAgentStartResult,
+        bootstrapContextRunKind: attempt.bootstrapContextRunKind,
+      });
+  const promptBeforePromptBuildHooks = effectivePrompt;
+  const promptBuildPrependContext = hookResult?.prependContext;
+  const promptBuildAppendContext = hookResult?.appendContext;
+  const hasPromptBuildContext =
+    Boolean(promptBuildPrependContext?.trim()) || Boolean(promptBuildAppendContext?.trim());
+
+  if (hookResult?.prependContext) {
+    effectivePrompt = `${hookResult.prependContext}\n\n${effectivePrompt}`;
+    log.debug(`hooks: prepended context to prompt (${hookResult.prependContext.length} chars)`);
+  }
+  if (hookResult?.appendContext) {
+    effectivePrompt = `${effectivePrompt}\n\n${hookResult.appendContext}`;
+    log.debug(`hooks: appended context to prompt (${hookResult.appendContext.length} chars)`);
+  }
+  const legacySystemPrompt = normalizeOptionalString(hookResult?.systemPrompt) ?? "";
+  if (legacySystemPrompt) {
+    setSystemPrompt(legacySystemPrompt);
+    log.debug(`hooks: applied systemPrompt (${legacySystemPrompt.length} chars)`);
+  }
+  const composedSystemPrompt = composeSystemPromptWithHookContext({
+    baseSystemPrompt: systemPromptText,
+    prependSystemContext: hookResult?.prependSystemContext,
+    appendSystemContext: hookResult?.appendSystemContext,
+  });
+  if (composedSystemPrompt) {
+    setSystemPrompt(composedSystemPrompt);
+    log.debug(
+      `hooks: applied prependSystemContext/appendSystemContext ` +
+        `(${hookResult?.prependSystemContext?.trim().length ?? 0}+${hookResult?.appendSystemContext?.trim().length ?? 0} chars)`,
+    );
+  }
+  const mediaTaskSystemPromptAddition = resolveAttemptMediaTaskSystemPromptAddition({
+    sessionKey: attempt.sessionKey,
+    trigger: attempt.trigger,
+  });
+  if (mediaTaskSystemPromptAddition) {
+    setSystemPrompt(
+      prependSystemPromptAddition({
+        systemPrompt: ensureSystemPromptCacheBoundary(systemPromptText),
+        systemPromptAddition: mediaTaskSystemPromptAddition,
+      }),
+    );
+  }
+
+  // Keep model identity after the stable cache boundary so media-only dynamic
+  // context cannot change the cached prefix between adjacent turns.
+  const modelAwareSystemPrompt = appendModelIdentitySystemPrompt({
+    systemPrompt:
+      buildModelIdentityPromptLine(input.runtimeModel) && systemPromptText.trim().length > 0
+        ? ensureSystemPromptCacheBoundary(systemPromptText)
+        : systemPromptText,
+    model: input.runtimeModel,
+  });
+  if (modelAwareSystemPrompt !== systemPromptText) {
+    setSystemPrompt(modelAwareSystemPrompt);
+  }
+
+  let promptCacheChangesForTurn: PromptCacheChange[] | null = null;
+  if (input.cache.observabilityEnabled) {
+    const cacheObservation = beginPromptCacheObservation({
+      sessionId: attempt.sessionId,
+      promptCacheKey: attempt.promptCacheKey,
+      sessionKey: attempt.sessionKey,
+      provider: attempt.provider,
+      modelId: attempt.modelId,
+      modelApi: attempt.model.api,
+      cacheRetention: input.cache.retention,
+      streamStrategy: input.cache.streamStrategy,
+      transport: input.cache.transport,
+      systemPrompt: systemPromptText,
+      toolNames: input.cache.toolNames,
+    });
+    promptCacheChangesForTurn = cacheObservation.changes;
+    input.cache.trace?.recordStage("cache:state", {
+      options: {
+        snapshot: cacheObservation.snapshot,
+        previousCacheRead: cacheObservation.previousCacheRead ?? undefined,
+        changes: cacheObservation.changes?.map((change) => ({
+          code: change.code,
+          detail: change.detail,
+        })),
+      },
+    });
+  }
+
+  const routingSummary = describeProviderRequestRoutingSummary({
+    provider: attempt.provider,
+    api: attempt.model.api,
+    baseUrl: attempt.model.baseUrl,
+    capability: "llm",
+    transport: "stream",
+  });
+  log.debug(
+    `embedded run prompt start: runId=${attempt.runId} sessionId=${attempt.sessionId} ${routingSummary}`,
+  );
+
+  const effectiveTranscriptPrompt = attempt.transcriptPrompt;
+  let transcriptPromptForRuntimeSplit = effectiveTranscriptPrompt;
+  let promptForRuntimeContextSplit = promptBeforePromptBuildHooks;
+  const leafEntry = input.orphanRepair?.messageEntry;
+  if (leafEntry && input.orphanRepair) {
+    const messageMergeStrategy = input.orphanRepair.strategy;
+    const orphanPromptMerge = messageMergeStrategy.mergeOrphanedTrailingUserPrompt({
+      prompt: effectivePrompt,
+      trigger: attempt.trigger,
+      leafMessage: leafEntry.message,
+    });
+    const runtimePromptMerge = messageMergeStrategy.mergeOrphanedTrailingUserPrompt({
+      prompt: promptForRuntimeContextSplit,
+      trigger: attempt.trigger,
+      leafMessage: leafEntry.message,
+    });
+    const transcriptPromptMerge =
+      effectiveTranscriptPrompt === undefined
+        ? undefined
+        : messageMergeStrategy.mergeOrphanedTrailingUserPrompt({
+            prompt: effectiveTranscriptPrompt,
+            trigger: attempt.trigger,
+            leafMessage: leafEntry.message,
+          });
+    effectivePrompt = orphanPromptMerge.prompt;
+    promptForRuntimeContextSplit = runtimePromptMerge.prompt;
+    transcriptPromptForRuntimeSplit =
+      transcriptPromptMerge?.prompt ?? transcriptPromptForRuntimeSplit;
+    const action = input.orphanRepair.removeLeaf
+      ? orphanPromptMerge.merged
+        ? "Merged and removed"
+        : "Removed already-queued"
+      : "Preserved";
+    const message =
+      `${action} orphaned user message` +
+      (input.orphanRepair.removeLeaf
+        ? " to prevent consecutive user turns. "
+        : " without removing the active session leaf. ") +
+      `runId=${attempt.runId} sessionId=${attempt.sessionId} trigger=${attempt.trigger}`;
+    if (shouldWarnOnOrphanedUserRepair(attempt.trigger)) {
+      log.warn(message);
+    } else {
+      log.debug(message);
+    }
+  }
+
+  let leasedSteering: EmbeddedAttemptSteeringLease | undefined;
+  if (
+    attempt.sessionKey &&
+    !input.isRawModelRun &&
+    attempt.bootstrapContextRunKind !== "commitment-only"
+  ) {
+    const leaseId = `${attempt.runId}:agent-steering`;
+    const leased = leasePendingAgentSteeringItems({
+      requesterSessionKey: attempt.sessionKey,
+      leaseId,
+    });
+    if (leased) {
+      leasedSteering = { leaseId, runIds: leased.runIds };
+      // Transfer cleanup ownership before any prompt mutation can throw.
+      input.setLeasedSteering(leasedSteering);
+      effectivePrompt = prependAgentSteeringPrompt({
+        steeringPrompt: leased.prompt,
+        prompt: effectivePrompt,
+      });
+      promptForRuntimeContextSplit = prependAgentSteeringPrompt({
+        steeringPrompt: leased.prompt,
+        prompt: promptForRuntimeContextSplit,
+      });
+      if (transcriptPromptForRuntimeSplit !== undefined) {
+        transcriptPromptForRuntimeSplit = prependAgentSteeringPrompt({
+          steeringPrompt: leased.prompt,
+          prompt: transcriptPromptForRuntimeSplit,
+        });
+      }
+      log.debug(
+        `agent steering: injected ${leased.runIds.length} queued item(s) into parent turn ` +
+          `runId=${attempt.runId} sessionKey=${attempt.sessionKey}`,
+      );
+    }
+  }
+
+  const promptForModelBeforeRuntimeContextSplit = effectivePrompt;
+  const promptForRuntimeContextBeforeAnnotation = promptForRuntimeContextSplit;
+  if (!input.isRawModelRun) {
+    promptForRuntimeContextSplit = annotateInterSessionPromptText(
+      promptForRuntimeContextSplit,
+      attempt.inputProvenance,
+    );
+  }
+  const transcriptLeafId =
+    (input.sessionManager.getLeafEntry() as { id?: string } | null | undefined)?.id ?? null;
+  const heartbeatSummary =
+    attempt.config && input.sessionAgentId
+      ? resolveHeartbeatSummaryForAgent(attempt.config, input.sessionAgentId)
+      : undefined;
+
+  return {
+    hookCtx,
+    effectivePrompt,
+    promptBeforePromptBuildHooks,
+    promptBuildPrependContext,
+    promptBuildAppendContext,
+    hasPromptBuildContext,
+    effectiveTranscriptPrompt,
+    transcriptPromptForRuntimeSplit,
+    promptForRuntimeContextSplit,
+    promptForModelBeforeRuntimeContextSplit,
+    promptForRuntimeContextBeforeAnnotation,
+    transcriptLeafId,
+    heartbeatSummary,
+    promptCacheChangesForTurn,
+    leasedSteering,
+  };
+}

--- a/src/agents/embedded-agent-runner/run/attempt-result.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectCompletedClientToolCalls,
+  hasVisiblePendingToolMediaReply,
+  normalizeEmbeddedAttemptToolMetas,
+} from "./attempt-result.js";
+
+describe("attempt result projection", () => {
+  it("keeps completed client tool calls in reserved source order", () => {
+    expect(
+      collectCompletedClientToolCalls([
+        { toolCallId: "first", name: "search", params: { query: "one" }, completed: true },
+        { toolCallId: "second", name: "search", completed: false },
+        { toolCallId: "third", name: "fetch", params: { id: 3 }, completed: true },
+      ]),
+    ).toEqual([
+      { name: "search", params: { query: "one" } },
+      { name: "fetch", params: { id: 3 } },
+    ]);
+  });
+
+  it("filters invalid tool metadata and preserves terminal flags", () => {
+    expect(
+      normalizeEmbeddedAttemptToolMetas([
+        { toolName: "", replaySafe: true },
+        {
+          toolName: "exec",
+          meta: "done",
+          replaySafe: true,
+          isError: true,
+          asyncStarted: true,
+          asyncTaskRunId: "run-1",
+          asyncTaskId: "task-1",
+        },
+      ]),
+    ).toEqual([
+      {
+        toolName: "exec",
+        meta: "done",
+        replaySafe: true,
+        isError: true,
+        asyncStarted: true,
+        asyncTaskRunId: "run-1",
+        asyncTaskId: "task-1",
+      },
+    ]);
+  });
+
+  it("only counts visible media or voice replies", () => {
+    expect(hasVisiblePendingToolMediaReply(undefined)).toBe(false);
+    expect(hasVisiblePendingToolMediaReply({ mediaUrls: [" "] })).toBe(false);
+    expect(hasVisiblePendingToolMediaReply({ mediaUrls: ["file:///tmp/result.png"] })).toBe(true);
+    expect(hasVisiblePendingToolMediaReply({ audioAsVoice: true })).toBe(true);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-result.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.test.ts
@@ -1,18 +1,96 @@
 import { describe, expect, it } from "vitest";
-import {
-  collectCompletedClientToolCalls,
-  hasVisiblePendingToolMediaReply,
-  normalizeEmbeddedAttemptToolMetas,
-} from "./attempt-result.js";
+import { completeEmbeddedAttemptResult } from "./attempt-result.js";
+
+function completeResult(params?: {
+  clientToolCallSlots?: Array<{
+    toolCallId: string;
+    name: string;
+    params?: Record<string, unknown>;
+    completed: boolean;
+  }>;
+  pendingToolMediaReply?: { mediaUrls?: string[]; audioAsVoice?: boolean };
+  toolMetas?: Array<{
+    toolName: string;
+    meta?: string;
+    replaySafe?: boolean;
+    isError?: true;
+    asyncStarted?: boolean;
+    asyncTaskRunId?: string;
+    asyncTaskId?: string;
+  }>;
+}) {
+  return completeEmbeddedAttemptResult({
+    attempt: {
+      runId: "run-1",
+      sessionId: "session-1",
+      provider: "test",
+      modelId: "model",
+      model: { api: "openai-responses" },
+      trigger: "user",
+    } as never,
+    subscription: {
+      assistantTexts: [],
+      didSendDeterministicApprovalPrompt: () => false,
+      didSendViaMessagingTool: () => false,
+      getAcceptedSessionSpawns: () => [],
+      getCompactionCount: () => 0,
+      getHeartbeatToolResponse: () => undefined,
+      getItemLifecycle: () => undefined,
+      getLastAssistantTextMessageIndex: () => undefined,
+      getLastCompactionTokensAfter: () => undefined,
+      getLastToolError: () => undefined,
+      getMessagingToolSentMediaUrls: () => [],
+      getMessagingToolSentTargets: () => [],
+      getMessagingToolSentTexts: () => [],
+      getMessagingToolSourceReplyPayloads: () => [],
+      getPendingToolMediaReply: () => params?.pendingToolMediaReply,
+      getReplayState: () => ({ replayInvalid: false, hadPotentialSideEffects: false }),
+      getSuccessfulCronAdds: () => [],
+      getVisibleBlockReplyCount: () => 0,
+      hasToolMediaBlockReply: () => false,
+      setTerminalLifecycleMeta: () => {},
+      toolMetas: params?.toolMetas ?? [],
+    } as never,
+    state: {
+      aborted: false,
+      externalAbort: false,
+      timedOut: false,
+      idleTimedOut: false,
+      timedOutDuringCompaction: false,
+      timedOutDuringToolExecution: false,
+      timedOutByRunBudget: false,
+      promptError: null,
+      promptErrorSource: null,
+      sessionIdUsed: "session-1",
+      messagesSnapshot: [],
+      yieldDetected: false,
+      didDeliverSourceReplyViaMessageTool: false,
+      diagnosticTrace: { traceId: "trace-1", spanId: "span-1" },
+    } as never,
+    clientToolCallSlots: params?.clientToolCallSlots ?? [],
+    hookRunner: null,
+    hookAgentId: "main",
+    bootstrapPromptWarning: {},
+    cache: {
+      observabilityEnabled: false,
+      trace: null,
+      break: null,
+      changesForTurn: null,
+      streamStrategy: "default",
+    },
+  });
+}
 
 describe("attempt result projection", () => {
   it("keeps completed client tool calls in reserved source order", () => {
     expect(
-      collectCompletedClientToolCalls([
-        { toolCallId: "first", name: "search", params: { query: "one" }, completed: true },
-        { toolCallId: "second", name: "search", completed: false },
-        { toolCallId: "third", name: "fetch", params: { id: 3 }, completed: true },
-      ]),
+      completeResult({
+        clientToolCallSlots: [
+          { toolCallId: "first", name: "search", params: { query: "one" }, completed: true },
+          { toolCallId: "second", name: "search", completed: false },
+          { toolCallId: "third", name: "fetch", params: { id: 3 }, completed: true },
+        ],
+      }).clientToolCalls,
     ).toEqual([
       { name: "search", params: { query: "one" } },
       { name: "fetch", params: { id: 3 } },
@@ -21,18 +99,20 @@ describe("attempt result projection", () => {
 
   it("filters invalid tool metadata and preserves terminal flags", () => {
     expect(
-      normalizeEmbeddedAttemptToolMetas([
-        { toolName: "", replaySafe: true },
-        {
-          toolName: "exec",
-          meta: "done",
-          replaySafe: true,
-          isError: true,
-          asyncStarted: true,
-          asyncTaskRunId: "run-1",
-          asyncTaskId: "task-1",
-        },
-      ]),
+      completeResult({
+        toolMetas: [
+          { toolName: "", replaySafe: true },
+          {
+            toolName: "exec",
+            meta: "done",
+            replaySafe: true,
+            isError: true,
+            asyncStarted: true,
+            asyncTaskRunId: "run-1",
+            asyncTaskId: "task-1",
+          },
+        ],
+      }).toolMetas,
     ).toEqual([
       {
         toolName: "exec",
@@ -46,10 +126,17 @@ describe("attempt result projection", () => {
     ]);
   });
 
-  it("only counts visible media or voice replies", () => {
-    expect(hasVisiblePendingToolMediaReply(undefined)).toBe(false);
-    expect(hasVisiblePendingToolMediaReply({ mediaUrls: [" "] })).toBe(false);
-    expect(hasVisiblePendingToolMediaReply({ mediaUrls: ["file:///tmp/result.png"] })).toBe(true);
-    expect(hasVisiblePendingToolMediaReply({ audioAsVoice: true })).toBe(true);
+  it("projects pending media and voice fields", () => {
+    expect(completeResult().toolMediaUrls).toBeUndefined();
+    expect(completeResult({ pendingToolMediaReply: { mediaUrls: [" "] } }).toolMediaUrls).toEqual([
+      " ",
+    ]);
+    expect(
+      completeResult({ pendingToolMediaReply: { mediaUrls: ["file:///tmp/result.png"] } })
+        .toolMediaUrls,
+    ).toEqual(["file:///tmp/result.png"]);
+    expect(completeResult({ pendingToolMediaReply: { audioAsVoice: true } }).toolAudioAsVoice).toBe(
+      true,
+    );
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -1,0 +1,418 @@
+/**
+ * Projects stream state into the stable embedded-attempt result contract.
+ */
+import { freezeDiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
+import type { DiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
+import {
+  buildAgentHookContextChannelFields,
+  buildAgentHookContextIdentityFields,
+} from "../../../plugins/hook-agent-context.js";
+import type { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
+import type { createCacheTrace } from "../../cache-trace.js";
+import { isCloudCodeAssistFormatError } from "../../embedded-agent-helpers.js";
+import type { subscribeEmbeddedAgentSession } from "../../embedded-agent-subscribe.js";
+import { log } from "../logger.js";
+import type { PromptCacheBreak, PromptCacheChange } from "../prompt-cache-observability.js";
+import { observeReplayMetadata, replayMetadataFromState } from "../replay-state.js";
+import { finalizeEmbeddedAttempt } from "./attempt-finalize.js";
+import { shouldRunLlmOutputHooksForAttempt } from "./attempt.run-decisions.js";
+import {
+  buildAttemptReplayMetadata,
+  hasAttemptTerminalState,
+  resolveSilentToolResultReplyPayload,
+  shouldTreatEmptyAssistantReplyAsSilent,
+} from "./incomplete-turn.js";
+import type {
+  EmbeddedRunAttemptParams,
+  EmbeddedRunAttemptResult,
+  EmbeddedRunAttemptTrajectoryRecorder,
+} from "./types.js";
+
+type EmbeddedAttemptSubscription = ReturnType<typeof subscribeEmbeddedAgentSession>;
+type CacheTrace = ReturnType<typeof createCacheTrace>;
+type HookRunner = ReturnType<typeof getGlobalHookRunner>;
+
+export type EmbeddedAttemptClientToolCallSlot = {
+  toolCallId: string;
+  name: string;
+  params?: Record<string, unknown>;
+  completed: boolean;
+};
+
+type EmbeddedAttemptResultState = Pick<
+  EmbeddedRunAttemptResult,
+  | "aborted"
+  | "externalAbort"
+  | "timedOut"
+  | "idleTimedOut"
+  | "timedOutDuringCompaction"
+  | "timedOutDuringToolExecution"
+  | "timedOutByRunBudget"
+  | "promptError"
+  | "promptErrorSource"
+  | "preflightRecovery"
+  | "sessionIdUsed"
+  | "sessionFileUsed"
+  | "systemPromptReport"
+  | "finalPromptText"
+  | "messagesSnapshot"
+  | "beforeAgentFinalizeRevisionReason"
+  | "lastAssistant"
+  | "currentAttemptAssistant"
+  | "attemptUsage"
+  | "promptCache"
+  | "contextBudgetStatus"
+  | "yieldDetected"
+  | "didDeliverSourceReplyViaMessageTool"
+> & {
+  diagnosticTrace: DiagnosticTraceContext;
+};
+
+export type CompleteEmbeddedAttemptResultInput = {
+  attempt: EmbeddedRunAttemptParams;
+  subscription: EmbeddedAttemptSubscription;
+  state: EmbeddedAttemptResultState;
+  clientToolCallSlots: readonly EmbeddedAttemptClientToolCallSlot[];
+  hookRunner: HookRunner;
+  hookAgentId: string;
+  bootstrapPromptWarning: {
+    warningSignaturesSeen?: string[];
+    signature?: string;
+  };
+  cache: {
+    observabilityEnabled: boolean;
+    trace: CacheTrace;
+    break: PromptCacheBreak | null;
+    changesForTurn: PromptCacheChange[] | null;
+    streamStrategy: string;
+  };
+  trajectoryRecorder?: EmbeddedRunAttemptTrajectoryRecorder | null;
+};
+
+export function normalizeEmbeddedAttemptToolMetas(
+  entries: EmbeddedAttemptSubscription["toolMetas"],
+): EmbeddedRunAttemptResult["toolMetas"] {
+  return entries
+    .filter(
+      (
+        entry,
+      ): entry is {
+        toolName: string;
+        meta?: string;
+        replaySafe?: boolean;
+        isError?: true;
+        asyncStarted?: boolean;
+        asyncTaskRunId?: string;
+        asyncTaskId?: string;
+      } => typeof entry.toolName === "string" && entry.toolName.trim().length > 0,
+    )
+    .map((entry) => {
+      const normalized: EmbeddedRunAttemptResult["toolMetas"][number] = {
+        toolName: entry.toolName,
+        meta: entry.meta,
+        replaySafe: entry.replaySafe === true,
+      };
+      if (entry.isError === true) {
+        normalized.isError = true;
+      }
+      if (entry.asyncStarted === true) {
+        normalized.asyncStarted = true;
+      }
+      if (entry.asyncTaskRunId) {
+        normalized.asyncTaskRunId = entry.asyncTaskRunId;
+      }
+      if (entry.asyncTaskId) {
+        normalized.asyncTaskId = entry.asyncTaskId;
+      }
+      return normalized;
+    });
+}
+
+export function collectCompletedClientToolCalls(
+  slots: readonly EmbeddedAttemptClientToolCallSlot[],
+): NonNullable<EmbeddedRunAttemptResult["clientToolCalls"]> {
+  return slots.flatMap((slot) =>
+    slot.completed && slot.params ? [{ name: slot.name, params: slot.params }] : [],
+  );
+}
+
+export function hasVisiblePendingToolMediaReply(
+  reply: { mediaUrls?: string[]; audioAsVoice?: boolean } | null | undefined,
+): boolean {
+  return Boolean(
+    reply &&
+    ((reply.mediaUrls ?? []).some((url) => url.trim().length > 0) || reply.audioAsVoice === true),
+  );
+}
+
+/** Runs output hooks, classifies terminal effects, and returns the finalized attempt result. */
+export function completeEmbeddedAttemptResult(
+  input: CompleteEmbeddedAttemptResultInput,
+): EmbeddedRunAttemptResult {
+  const { attempt, state, subscription } = input;
+  const {
+    assistantTexts,
+    didSendDeterministicApprovalPrompt,
+    didSendViaMessagingTool,
+    getAcceptedSessionSpawns,
+    getCompactionCount,
+    getHeartbeatToolResponse,
+    getItemLifecycle,
+    getLastAssistantTextMessageIndex,
+    getLastCompactionTokensAfter,
+    getLastToolError,
+    getMessagingToolSentMediaUrls,
+    getMessagingToolSentTargets,
+    getMessagingToolSentTexts,
+    getMessagingToolSourceReplyPayloads,
+    getPendingToolMediaReply,
+    getReplayState,
+    getSuccessfulCronAdds,
+    getVisibleBlockReplyCount,
+    hasToolMediaBlockReply,
+    setTerminalLifecycleMeta,
+    toolMetas,
+  } = subscription;
+  const toolMetasNormalized = normalizeEmbeddedAttemptToolMetas(toolMetas);
+
+  if (input.cache.observabilityEnabled) {
+    const cacheBreak = input.cache.break;
+    if (cacheBreak) {
+      const changeSummary =
+        cacheBreak.changes?.map((change) => `${change.code}(${change.detail})`).join(", ") ??
+        "no tracked cache input change";
+      log.warn(
+        `[prompt-cache] cache read dropped ${cacheBreak.previousCacheRead} -> ${cacheBreak.cacheRead} ` +
+          `for ${attempt.provider}/${attempt.modelId} via ${input.cache.streamStrategy}; ${changeSummary}`,
+      );
+      input.cache.trace?.recordStage("cache:result", {
+        options: {
+          previousCacheRead: cacheBreak.previousCacheRead,
+          cacheRead: cacheBreak.cacheRead,
+          changes: cacheBreak.changes?.map((change) => ({
+            code: change.code,
+            detail: change.detail,
+          })),
+        },
+      });
+    } else if (input.cache.trace && input.cache.changesForTurn) {
+      input.cache.trace.recordStage("cache:result", {
+        note: "state changed without a cache-read break",
+        options: {
+          cacheRead: state.attemptUsage?.cacheRead ?? 0,
+          changes: input.cache.changesForTurn.map((change) => ({
+            code: change.code,
+            detail: change.detail,
+          })),
+        },
+      });
+    } else if (input.cache.trace) {
+      input.cache.trace.recordStage("cache:result", {
+        note: "stable cache inputs",
+        options: { cacheRead: state.attemptUsage?.cacheRead ?? 0 },
+      });
+    }
+  }
+
+  if (
+    input.hookRunner?.hasHooks("llm_output") &&
+    shouldRunLlmOutputHooksForAttempt({ promptErrorSource: state.promptErrorSource })
+  ) {
+    input.hookRunner
+      .runLlmOutput(
+        {
+          runId: attempt.runId,
+          sessionId: attempt.sessionId,
+          provider: attempt.provider,
+          model: attempt.modelId,
+          ...(attempt.contextWindowInfo?.tokens
+            ? { contextTokenBudget: attempt.contextWindowInfo.tokens }
+            : {}),
+          ...(attempt.contextWindowInfo?.source
+            ? { contextWindowSource: attempt.contextWindowInfo.source }
+            : {}),
+          ...(attempt.contextWindowInfo?.referenceTokens
+            ? { contextWindowReferenceTokens: attempt.contextWindowInfo.referenceTokens }
+            : {}),
+          resolvedRef:
+            attempt.runtimePlan?.observability.resolvedRef ??
+            `${attempt.provider}/${attempt.modelId}`,
+          ...(attempt.runtimePlan?.observability.harnessId
+            ? { harnessId: attempt.runtimePlan.observability.harnessId }
+            : {}),
+          assistantTexts,
+          lastAssistant: state.lastAssistant,
+          usage: state.attemptUsage,
+        },
+        {
+          runId: attempt.runId,
+          trace: freezeDiagnosticTraceContext(state.diagnosticTrace),
+          agentId: input.hookAgentId,
+          sessionKey: attempt.sessionKey,
+          sessionId: attempt.sessionId,
+          workspaceDir: attempt.workspaceDir,
+          trigger: attempt.trigger,
+          ...(attempt.contextWindowInfo?.tokens
+            ? { contextTokenBudget: attempt.contextWindowInfo.tokens }
+            : {}),
+          ...(attempt.contextWindowInfo?.source
+            ? { contextWindowSource: attempt.contextWindowInfo.source }
+            : {}),
+          ...(attempt.contextWindowInfo?.referenceTokens
+            ? { contextWindowReferenceTokens: attempt.contextWindowInfo.referenceTokens }
+            : {}),
+          ...buildAgentHookContextChannelFields(attempt),
+          ...buildAgentHookContextIdentityFields({
+            trigger: attempt.trigger,
+            senderId: attempt.senderId,
+            chatId: attempt.chatId,
+            channelContext: attempt.channelContext,
+          }),
+        },
+      )
+      .catch((err: unknown) => {
+        log.warn(`llm_output hook failed: ${String(err)}`);
+      });
+  }
+
+  const acceptedSessionSpawns = getAcceptedSessionSpawns();
+  const observedReplayMetadata = buildAttemptReplayMetadata({
+    // Structured start arguments already updated replayState for mutations and async work.
+    // Reclassifying by tool name would incorrectly mark read-only cron actions as unsafe.
+    toolMetas: [],
+    didSendViaMessagingTool: didSendViaMessagingTool(),
+    messagingToolSentTexts: getMessagingToolSentTexts(),
+    messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
+    acceptedSessionSpawns,
+    successfulCronAdds: getSuccessfulCronAdds(),
+  });
+  const pendingToolMediaReply = getPendingToolMediaReply();
+  const replayMetadata = replayMetadataFromState(
+    observeReplayMetadata(getReplayState(), observedReplayMetadata),
+  );
+  const currentAttemptReplayMetadata = buildAttemptReplayMetadata({
+    toolMetas: toolMetasNormalized,
+    didSendViaMessagingTool: didSendViaMessagingTool(),
+    messagingToolSentTexts: getMessagingToolSentTexts(),
+    messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
+    acceptedSessionSpawns,
+    successfulCronAdds: getSuccessfulCronAdds(),
+  });
+  const completedClientToolCalls = collectCompletedClientToolCalls(input.clientToolCallSlots);
+  const clientToolCalls =
+    completedClientToolCalls.length > 0 ? completedClientToolCalls : undefined;
+  const didSendDeterministicApprovalPromptNow = didSendDeterministicApprovalPrompt();
+  const lastToolError = getLastToolError();
+  const heartbeatToolResponse = getHeartbeatToolResponse();
+  const messagingToolSourceReplyPayloads = getMessagingToolSourceReplyPayloads();
+  const hasToolMediaBlockReplyNow = hasToolMediaBlockReply();
+  const hasTerminalOutput = hasAttemptTerminalState({
+    clientToolCalls,
+    yieldDetected: state.yieldDetected,
+    didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
+    heartbeatToolResponse,
+    lastToolError,
+    toolMediaUrls: pendingToolMediaReply?.mediaUrls,
+    toolAudioAsVoice: pendingToolMediaReply?.audioAsVoice,
+    toolTrustedLocalMedia: pendingToolMediaReply?.trustedLocalMedia,
+    hasToolMediaBlockReply: hasToolMediaBlockReplyNow,
+    didDeliverSourceReplyViaMessageTool: state.didDeliverSourceReplyViaMessageTool,
+    messagingToolSourceReplyPayloads,
+    messagingToolSentTexts: getMessagingToolSentTexts(),
+    messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
+    messagingToolSentTargets: getMessagingToolSentTargets(),
+    acceptedSessionSpawns,
+    successfulCronAdds: getSuccessfulCronAdds(),
+    toolMetas: toolMetasNormalized,
+  });
+  const pendingToolMediaPayloadCount = hasVisiblePendingToolMediaReply(pendingToolMediaReply)
+    ? 1
+    : 0;
+  const visibleBlockReplyCount = getVisibleBlockReplyCount();
+  const silentToolResultReplyPayload = resolveSilentToolResultReplyPayload({
+    isCronTrigger: attempt.trigger === "cron",
+    payloadCount: pendingToolMediaPayloadCount,
+    aborted: state.aborted,
+    timedOut: state.timedOut,
+    attempt: {
+      clientToolCalls,
+      yieldDetected: state.yieldDetected,
+      didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
+      lastToolError,
+      messagesSnapshot: state.messagesSnapshot,
+      toolMetas: toolMetasNormalized,
+    },
+  });
+  const synthesizedPayloadCount =
+    visibleBlockReplyCount +
+    pendingToolMediaPayloadCount +
+    messagingToolSourceReplyPayloads.length +
+    (silentToolResultReplyPayload ? 1 : 0);
+  const emptyAssistantReplyIsSilent = shouldTreatEmptyAssistantReplyAsSilent({
+    allowEmptyAssistantReplyAsSilent: attempt.allowEmptyAssistantReplyAsSilent,
+    payloadCount: 0,
+    aborted: state.aborted,
+    timedOut: state.timedOut,
+    attempt: {
+      assistantTexts,
+      clientToolCalls,
+      currentAttemptAssistant: state.currentAttemptAssistant,
+      yieldDetected: state.yieldDetected,
+      didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
+      didSendViaMessagingTool: didSendViaMessagingTool(),
+      messagingToolSentTexts: getMessagingToolSentTexts(),
+      messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
+      messagingToolSentTargets: getMessagingToolSentTargets(),
+      acceptedSessionSpawns,
+      lastToolError,
+      lastAssistant: state.lastAssistant,
+      itemLifecycle: getItemLifecycle(),
+      toolMetas: toolMetasNormalized,
+      replayMetadata,
+      promptErrorSource: state.promptErrorSource,
+      timedOutDuringCompaction: state.timedOutDuringCompaction,
+    },
+  });
+  const result: EmbeddedRunAttemptResult = {
+    ...state,
+    replayMetadata,
+    currentAttemptReplayMetadata,
+    itemLifecycle: getItemLifecycle(),
+    setTerminalLifecycleMeta,
+    bootstrapPromptWarningSignaturesSeen: input.bootstrapPromptWarning.warningSignaturesSeen,
+    bootstrapPromptWarningSignature: input.bootstrapPromptWarning.signature,
+    assistantTexts,
+    lastAssistantTextMessageIndex: getLastAssistantTextMessageIndex(),
+    toolMetas: toolMetasNormalized,
+    acceptedSessionSpawns,
+    lastToolError,
+    didSendViaMessagingTool: didSendViaMessagingTool(),
+    didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
+    messagingToolSentTexts: getMessagingToolSentTexts(),
+    messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
+    messagingToolSentTargets: getMessagingToolSentTargets(),
+    messagingToolSourceReplyPayloads,
+    heartbeatToolResponse,
+    toolMediaUrls: pendingToolMediaReply?.mediaUrls,
+    toolAudioAsVoice: pendingToolMediaReply?.audioAsVoice,
+    toolTrustedLocalMedia: pendingToolMediaReply?.trustedLocalMedia,
+    hasToolMediaBlockReply: hasToolMediaBlockReplyNow,
+    successfulCronAdds: getSuccessfulCronAdds(),
+    cloudCodeAssistFormatError: Boolean(
+      state.lastAssistant?.errorMessage &&
+      isCloudCodeAssistFormatError(state.lastAssistant.errorMessage),
+    ),
+    compactionCount: getCompactionCount(),
+    compactionTokensAfter: getLastCompactionTokensAfter(),
+    clientToolCalls,
+    yieldDetected: state.yieldDetected || undefined,
+  };
+  return finalizeEmbeddedAttempt({
+    result,
+    trajectoryRecorder: input.trajectoryRecorder,
+    synthesizedPayloadCount,
+    emptyAssistantReplyIsSilent,
+    hasTerminalOutput,
+    silentExpected: attempt.silentExpected,
+  });
+}

--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -68,7 +68,7 @@ type EmbeddedAttemptResultState = Pick<
   diagnosticTrace: DiagnosticTraceContext;
 };
 
-export type CompleteEmbeddedAttemptResultInput = {
+type CompleteEmbeddedAttemptResultInput = {
   attempt: EmbeddedRunAttemptParams;
   subscription: EmbeddedAttemptSubscription;
   state: EmbeddedAttemptResultState;
@@ -89,7 +89,7 @@ export type CompleteEmbeddedAttemptResultInput = {
   trajectoryRecorder?: EmbeddedRunAttemptTrajectoryRecorder | null;
 };
 
-export function normalizeEmbeddedAttemptToolMetas(
+function normalizeEmbeddedAttemptToolMetas(
   entries: EmbeddedAttemptSubscription["toolMetas"],
 ): EmbeddedRunAttemptResult["toolMetas"] {
   return entries
@@ -128,7 +128,7 @@ export function normalizeEmbeddedAttemptToolMetas(
     });
 }
 
-export function collectCompletedClientToolCalls(
+function collectCompletedClientToolCalls(
   slots: readonly EmbeddedAttemptClientToolCallSlot[],
 ): NonNullable<EmbeddedRunAttemptResult["clientToolCalls"]> {
   return slots.flatMap((slot) =>
@@ -136,7 +136,7 @@ export function collectCompletedClientToolCalls(
   );
 }
 
-export function hasVisiblePendingToolMediaReply(
+function hasVisiblePendingToolMediaReply(
   reply: { mediaUrls?: string[]; audioAsVoice?: boolean } | null | undefined,
 ): boolean {
   return Boolean(

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
@@ -1,0 +1,364 @@
+/**
+ * Settles async tools and compaction, then snapshots the completed stream.
+ */
+import { formatErrorMessage } from "../../../infra/errors.js";
+import type { AssistantMessage } from "../../../llm/types.js";
+import type { subscribeEmbeddedAgentSession } from "../../embedded-agent-subscribe.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import type { AgentSession, SessionManager } from "../../sessions/index.js";
+import { projectToolSearchTargetTranscriptMessages } from "../../tool-search.js";
+import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
+import { isRunnerAbortError } from "../abort.js";
+import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "../cache-ttl.js";
+import { log } from "../logger.js";
+import {
+  completePromptCacheObservation,
+  type PromptCacheBreak,
+  type PromptCacheChange,
+} from "../prompt-cache-observability.js";
+import {
+  flushSessionManagerTranscript,
+  normalizeCompactionRecoveryTranscriptTail,
+} from "./attempt-transcript-helpers.js";
+import {
+  shouldWaitForCompletionRequiredAsyncTasks,
+  waitForCompletionRequiredAsyncTasks,
+  type CompletionRequiredAsyncTaskWaitResult,
+} from "./attempt.async-tasks.js";
+import {
+  buildContextEnginePromptCacheInfo,
+  findCurrentAttemptAssistantMessage,
+  resolvePromptCacheTouchTimestamp,
+} from "./attempt.context-engine-helpers.js";
+import type { createEmbeddedAttemptSessionLockController } from "./attempt.session-lock.js";
+import { appendAttemptCacheTtlIfNeeded } from "./attempt.thread-helpers.js";
+import {
+  hasActiveCompactionRetryWork,
+  waitForCompactionRetryWithAggregateTimeout,
+} from "./compaction-retry-aggregate-timeout.js";
+import { selectCompactionTimeoutSnapshot } from "./compaction-timeout.js";
+import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
+
+type EmbeddedAttemptSubscription = ReturnType<typeof subscribeEmbeddedAgentSession>;
+type AttemptSessionLockController = Awaited<
+  ReturnType<typeof createEmbeddedAttemptSessionLockController>
+>;
+type PromptCacheRetention = Parameters<typeof buildContextEnginePromptCacheInfo>[0]["retention"];
+type ToolSearchTargetTranscriptProjections = Parameters<
+  typeof projectToolSearchTargetTranscriptMessages
+>[1];
+type WithOwnedSessionWriteLock = <T>(operation: () => Promise<T> | T) => Promise<T>;
+
+type StreamSettleResult = {
+  promptError: unknown;
+  promptErrorSource: EmbeddedRunAttemptResult["promptErrorSource"];
+  timedOutDuringCompaction: boolean;
+  compactionOccurredThisAttempt: boolean;
+  messagesSnapshot: AgentMessage[];
+  sessionIdUsed: string;
+  lastAssistant: EmbeddedRunAttemptResult["lastAssistant"];
+  currentAttemptAssistant: EmbeddedRunAttemptResult["currentAttemptAssistant"];
+  attemptUsage: EmbeddedRunAttemptResult["attemptUsage"];
+  cacheBreak: PromptCacheBreak | null;
+  lastCallUsage: NormalizedUsage | undefined;
+  promptCache: EmbeddedRunAttemptResult["promptCache"];
+};
+
+export async function settleEmbeddedAttemptStream(input: {
+  attempt: EmbeddedRunAttemptParams;
+  activeSession: AgentSession;
+  sessionManager: SessionManager;
+  sessionLockController: AttemptSessionLockController;
+  withOwnedSessionWriteLock: WithOwnedSessionWriteLock;
+  subscription: EmbeddedAttemptSubscription;
+  state: {
+    promptError: unknown;
+    promptErrorSource: EmbeddedRunAttemptResult["promptErrorSource"];
+    yieldAborted: boolean;
+    sessionIdUsed: string;
+  };
+  readLifecycleState: () => {
+    aborted: boolean;
+    timedOut: boolean;
+    timedOutDuringCompaction: boolean;
+  };
+  markTimedOutDuringCompaction: () => void;
+  runAbortDeadlineAtMs: number;
+  runAbortSignal: AbortSignal;
+  isProbeSession: boolean;
+  onBlockReplyFlush?: (payload: {
+    reason: "pre_compaction";
+    attemptAccepted: boolean;
+  }) => Promise<void> | void;
+  abortable: <T>(promise: Promise<T>) => Promise<T>;
+  prePromptMessageCount: number;
+  toolSearchTargetTranscriptProjections: ToolSearchTargetTranscriptProjections;
+  cache: {
+    observabilityEnabled: boolean;
+    changesForTurn: PromptCacheChange[] | null;
+    retention: PromptCacheRetention;
+  };
+  shouldFlushForContextEngine: boolean;
+}): Promise<StreamSettleResult> {
+  const { attempt, activeSession, sessionManager, subscription, state } = input;
+  let { promptError, promptErrorSource, sessionIdUsed } = state;
+
+  if (
+    shouldWaitForCompletionRequiredAsyncTasks({
+      sessionKey: attempt.sessionKey,
+      toolMetas: subscription.toolMetas,
+      yieldDetected: state.yieldAborted,
+    })
+  ) {
+    const getAsyncStartedToolMetas = () =>
+      subscription.toolMetas
+        .filter(
+          (
+            entry,
+          ): entry is {
+            toolName: string;
+            asyncStarted?: boolean;
+            asyncTaskRunId?: string;
+            asyncTaskId?: string;
+          } => typeof entry.toolName === "string" && entry.toolName.trim().length > 0,
+        )
+        .map((entry) => ({
+          toolName: entry.toolName,
+          asyncStarted: entry.asyncStarted,
+          asyncTaskRunId: entry.asyncTaskRunId,
+          asyncTaskId: entry.asyncTaskId,
+        }));
+    const completionRequiredAsyncDeadlineAtMs = Math.max(
+      Date.now(),
+      input.runAbortDeadlineAtMs - 500,
+    );
+    let asyncTaskWait: CompletionRequiredAsyncTaskWaitResult;
+    try {
+      asyncTaskWait = await waitForCompletionRequiredAsyncTasks({
+        getToolMetas: getAsyncStartedToolMetas,
+        sessionKey: attempt.sessionKey,
+        deadlineAtMs: completionRequiredAsyncDeadlineAtMs,
+        abortSignal: input.runAbortSignal,
+      });
+    } catch (err) {
+      if (!input.readLifecycleState().timedOut || !isRunnerAbortError(err)) {
+        throw err;
+      }
+      asyncTaskWait = await waitForCompletionRequiredAsyncTasks({
+        getToolMetas: getAsyncStartedToolMetas,
+        sessionKey: attempt.sessionKey,
+        deadlineAtMs: Date.now(),
+      });
+    }
+    if (asyncTaskWait.timedOutRunIds.length > 0) {
+      promptError = new Error(
+        `Timed out waiting for async task completion: ${asyncTaskWait.timedOutRunIds.join(", ")}`,
+      );
+      promptErrorSource = "prompt";
+      state.promptError = promptError;
+      state.promptErrorSource = promptErrorSource;
+    } else if (asyncTaskWait.waitedRunIds.length > 0) {
+      await input.sessionLockController.waitForSessionEvents(activeSession);
+    }
+  }
+
+  // Snapshot only outside compaction. Compaction rewrites history in place and
+  // cannot be allowed to leave the timeout result with a half-written view.
+  const wasCompactingBefore = activeSession.isCompacting;
+  const snapshot = activeSession.messages.slice();
+  const wasCompactingAfter = activeSession.isCompacting;
+  const preCompactionSnapshot = wasCompactingBefore || wasCompactingAfter ? null : snapshot;
+  const preCompactionSessionId = activeSession.sessionId;
+  const aggregateTimeoutMs = 60_000;
+
+  try {
+    if (input.onBlockReplyFlush) {
+      const currentAssistant = findCurrentAttemptAssistantMessage({
+        messagesSnapshot: snapshot,
+        prePromptMessageCount: input.prePromptMessageCount,
+      });
+      const attemptAccepted =
+        !promptError &&
+        !input.readLifecycleState().aborted &&
+        !input.readLifecycleState().timedOut &&
+        !state.yieldAborted &&
+        currentAssistant?.stopReason === "stop";
+      await input.onBlockReplyFlush({ reason: "pre_compaction", attemptAccepted });
+    }
+
+    const compactionRetryWait = state.yieldAborted
+      ? { timedOut: false }
+      : await waitForCompactionRetryWithAggregateTimeout({
+          waitForCompactionRetry: subscription.waitForCompactionRetry,
+          abortable: input.abortable,
+          aggregateTimeoutMs,
+          isCompactionRetryStillActive: () =>
+            hasActiveCompactionRetryWork({
+              isCompactionInFlight: subscription.isCompactionInFlight(),
+              isSessionStreaming: activeSession.isStreaming,
+            }),
+        });
+    if (compactionRetryWait.timedOut) {
+      input.markTimedOutDuringCompaction();
+      if (!input.isProbeSession) {
+        log.warn(
+          `compaction retry aggregate timeout (${aggregateTimeoutMs}ms): ` +
+            `proceeding with pre-compaction state runId=${attempt.runId} sessionId=${attempt.sessionId}`,
+        );
+      }
+    }
+  } catch (err) {
+    if (!isRunnerAbortError(err)) {
+      throw err;
+    }
+    if (!promptError) {
+      promptError = err;
+      promptErrorSource = "compaction";
+      state.promptError = promptError;
+      state.promptErrorSource = promptErrorSource;
+    }
+    if (!input.isProbeSession) {
+      log.debug(`compaction wait aborted: runId=${attempt.runId} sessionId=${attempt.sessionId}`);
+    }
+  }
+
+  let compactionOccurredThisAttempt = false;
+  let messagesSnapshot: AgentMessage[] = [];
+  let lastAssistant: AssistantMessage | undefined;
+  let currentAttemptAssistant: AssistantMessage | undefined;
+  let attemptUsage: EmbeddedRunAttemptResult["attemptUsage"];
+  let cacheBreak: PromptCacheBreak | null = null;
+  let lastCallUsage: NormalizedUsage | undefined;
+  let promptCache: EmbeddedRunAttemptResult["promptCache"];
+
+  await input.sessionLockController.waitForSessionEvents(activeSession);
+  await input.withOwnedSessionWriteLock(async () => {
+    const { timedOutDuringCompaction } = input.readLifecycleState();
+    compactionOccurredThisAttempt = subscription.getCompactionCount() > 0;
+    appendAttemptCacheTtlIfNeeded({
+      sessionManager,
+      timedOutDuringCompaction,
+      compactionOccurredThisAttempt,
+      config: attempt.config,
+      provider: attempt.provider,
+      modelId: attempt.modelId,
+      modelApi: attempt.model.api,
+      isCacheTtlEligibleProvider,
+    });
+
+    if (timedOutDuringCompaction) {
+      const removedEntries = normalizeCompactionRecoveryTranscriptTail({
+        activeSession,
+        sessionManager,
+      });
+      if (removedEntries > 0 && !input.isProbeSession) {
+        log.warn(
+          `normalized compaction timeout transcript tail: removedEntries=${removedEntries} ` +
+            `runId=${attempt.runId} sessionId=${attempt.sessionId}`,
+        );
+      }
+    }
+
+    const snapshotSelection = selectCompactionTimeoutSnapshot({
+      timedOutDuringCompaction,
+      preCompactionSnapshot,
+      preCompactionSessionId,
+      currentSnapshot: activeSession.messages.slice(),
+      currentSessionId: activeSession.sessionId,
+    });
+    if (timedOutDuringCompaction && !input.isProbeSession) {
+      log.warn(
+        `using ${snapshotSelection.source} snapshot: timed out during compaction ` +
+          `runId=${attempt.runId} sessionId=${attempt.sessionId}`,
+      );
+    }
+    messagesSnapshot = projectToolSearchTargetTranscriptMessages(
+      snapshotSelection.messagesSnapshot,
+      input.toolSearchTargetTranscriptProjections,
+    );
+    sessionIdUsed = snapshotSelection.sessionIdUsed;
+    lastAssistant = messagesSnapshot
+      .slice()
+      .toReversed()
+      .find((message): message is AssistantMessage => message.role === "assistant");
+    currentAttemptAssistant = findCurrentAttemptAssistantMessage({
+      messagesSnapshot,
+      prePromptMessageCount: input.prePromptMessageCount,
+    });
+    attemptUsage = subscription.getUsageTotals();
+    cacheBreak = input.cache.observabilityEnabled
+      ? completePromptCacheObservation({
+          sessionId: attempt.sessionId,
+          promptCacheKey: attempt.promptCacheKey,
+          sessionKey: attempt.sessionKey,
+          usage: attemptUsage,
+        })
+      : null;
+    lastCallUsage = normalizeUsage(currentAttemptAssistant?.usage);
+    const promptCacheObservation =
+      input.cache.observabilityEnabled &&
+      (cacheBreak || input.cache.changesForTurn || typeof attemptUsage?.cacheRead === "number")
+        ? {
+            broke: Boolean(cacheBreak),
+            ...(typeof cacheBreak?.previousCacheRead === "number"
+              ? { previousCacheRead: cacheBreak.previousCacheRead }
+              : {}),
+            ...(typeof cacheBreak?.cacheRead === "number"
+              ? { cacheRead: cacheBreak.cacheRead }
+              : typeof attemptUsage?.cacheRead === "number"
+                ? { cacheRead: attemptUsage.cacheRead }
+                : {}),
+            changes: cacheBreak?.changes ?? input.cache.changesForTurn,
+          }
+        : undefined;
+    const fallbackLastCacheTouchAt = readLastCacheTtlTimestamp(sessionManager, {
+      provider: attempt.provider,
+      modelId: attempt.modelId,
+    });
+    promptCache = buildContextEnginePromptCacheInfo({
+      retention: input.cache.retention,
+      lastCallUsage,
+      observation: promptCacheObservation,
+      lastCacheTouchAt: resolvePromptCacheTouchTimestamp({
+        lastCallUsage,
+        assistantTimestamp: currentAttemptAssistant?.timestamp,
+        fallbackLastCacheTouchAt,
+      }),
+    });
+
+    if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {
+      try {
+        sessionManager.appendCustomEntry("openclaw:prompt-error", {
+          timestamp: Date.now(),
+          runId: attempt.runId,
+          sessionId: attempt.sessionId,
+          provider: attempt.provider,
+          model: attempt.modelId,
+          api: attempt.model.api,
+          error: formatErrorMessage(promptError),
+        });
+      } catch (entryErr) {
+        log.warn(`failed to persist prompt error entry: ${String(entryErr)}`);
+      }
+    }
+
+    if (input.shouldFlushForContextEngine) {
+      flushSessionManagerTranscript(sessionManager);
+    }
+  });
+
+  return {
+    promptError,
+    promptErrorSource,
+    timedOutDuringCompaction: input.readLifecycleState().timedOutDuringCompaction,
+    compactionOccurredThisAttempt,
+    messagesSnapshot,
+    sessionIdUsed,
+    lastAssistant,
+    currentAttemptAssistant,
+    attemptUsage,
+    cacheBreak,
+    lastCallUsage,
+    promptCache,
+  };
+}

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1,13 +1,11 @@
 /**
  * Orchestrates one embedded-agent attempt from prompt setup through stream result.
  */
-import { ensureSystemPromptCacheBoundary } from "@openclaw/ai/internal/shared";
 import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { buildHierarchyReinforcementMessage } from "../../../auto-reply/handoff-summarizer.js";
 import { filterHeartbeatTranscriptArtifacts } from "../../../auto-reply/heartbeat-filter.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
-import { getRuntimeConfig } from "../../../config/config.js";
 import { resolveStorePath } from "../../../config/sessions/paths.js";
 import {
   listSessionEntries,
@@ -50,7 +48,6 @@ import {
 import { resolveBlockMessage } from "../../../plugins/hook-decision-types.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import { copyPluginToolMeta, getPluginToolMeta } from "../../../plugins/tools.js";
-import { annotateInterSessionPromptText } from "../../../sessions/input-provenance.js";
 import { resolveSkillsPromptForRun } from "../../../skills/loading/workspace.js";
 import { resolveEmbeddedRunSkillEntries } from "../../../skills/runtime/embedded-run-entries.js";
 import {
@@ -87,7 +84,6 @@ import {
 } from "../../agent-tools.before-tool-call.js";
 import { resolveToolLoopDetectionConfig } from "../../agent-tools.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
-import { FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE } from "../../bootstrap-files.js";
 import { isHeartbeatLifecycleRunKind } from "../../bootstrap-mode.js";
 import { createCacheTrace } from "../../cache-trace.js";
 import { copyChannelAgentToolMeta } from "../../channel-tools.js";
@@ -101,11 +97,9 @@ import {
 } from "../../code-mode.js";
 import { resolveUserTimezone } from "../../date-time.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
-import { isCloudCodeAssistFormatError } from "../../embedded-agent-helpers.js";
 import { countActiveToolExecutions } from "../../embedded-agent-subscribe.handlers.tools.js";
 import { subscribeEmbeddedAgentSession } from "../../embedded-agent-subscribe.js";
 import { isSignalTimeoutReason } from "../../failover-error.js";
-import { runAgentEndSideEffects } from "../../harness/agent-end-side-effects.js";
 import { runAgentHarnessBeforeAgentFinalizeHook } from "../../harness/lifecycle-hook-helpers.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import { relocateCurrentRuntimeContextCarrierToTail } from "../../internal-runtime-context.js";
@@ -113,7 +107,6 @@ import {
   filterLocalModelLeanTools,
   shouldCatalogToolForLocalModelLean,
 } from "../../local-model-lean.js";
-import { describeProviderRequestRoutingSummary } from "../../provider-attribution.js";
 import {
   AGENT_RUN_RESTART_ABORT_STOP_REASON,
   createAgentRunRestartAbortError,
@@ -135,14 +128,8 @@ import { wrapToolDefinition } from "../../sessions/tools/tool-definition-wrapper
 import { buildActiveSubagentSystemPromptAddition } from "../../subagent-active-context.js";
 import {
   ackPendingAgentSteeringItems,
-  leasePendingAgentSteeringItems,
-  prependAgentSteeringPrompt,
   releasePendingAgentSteeringItems,
 } from "../../subagent-registry.js";
-import {
-  appendModelIdentitySystemPrompt,
-  buildModelIdentityPromptLine,
-} from "../../system-prompt.js";
 import { buildEmptyExplicitToolAllowlistError } from "../../tool-allowlist-guard.js";
 import { collectReplaySafeToolNames, isAgentToolReplaySafe } from "../../tool-replay-safety.js";
 import { filterRuntimeCompatibleTools } from "../../tool-schema-projection.js";
@@ -164,39 +151,27 @@ import {
 import { copyToolTerminalPresentation } from "../../tool-terminal-presentation.js";
 import { invalidateComputerFrameIfMissing } from "../../tools/computer-tool.js";
 import { replaceWithEffectiveCronCreatorToolAllowlist } from "../../tools/cron-tool.js";
-import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
-import { isRunnerAbortError } from "../abort.js";
-import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "../cache-ttl.js";
+import type { NormalizedUsage } from "../../usage.js";
+import { readLastCacheTtlTimestamp } from "../cache-ttl.js";
 import { resolveCompactionTimeoutMs } from "../compaction-safety-timeout.js";
-import {
-  rotateTranscriptAfterCompaction,
-  shouldRotateCompactionTranscript,
-} from "../compaction-successor-transcript.js";
 import { runContextEngineMaintenance } from "../context-engine-maintenance.js";
 import { applyFinalEffectiveToolPolicy } from "../effective-tool-policy.js";
 import { buildEmbeddedExtensionFactories } from "../extensions.js";
 import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
 import { getHistoryLimitFromSessionKey, limitHistoryTurns } from "../history.js";
 import { log } from "../logger.js";
-import {
-  beginPromptCacheObservation,
-  completePromptCacheObservation,
-  type PromptCacheBreak,
-  type PromptCacheChange,
-} from "../prompt-cache-observability.js";
+import type { PromptCacheBreak, PromptCacheChange } from "../prompt-cache-observability.js";
 import {
   normalizeAssistantReplayContent,
   sanitizeSessionHistory,
   validateReplayTurns,
 } from "../replay-history.js";
-import { observeReplayMetadata, replayMetadataFromState } from "../replay-state.js";
 import { createEmbeddedAgentResourceLoader } from "../resource-loader.js";
 import {
   clearActiveEmbeddedRun,
   type EmbeddedAgentQueueHandle,
   markActiveEmbeddedRunAbandoned,
   setActiveEmbeddedRun,
-  updateActiveEmbeddedRunSessionFile,
   updateActiveEmbeddedRunSnapshot,
 } from "../runs.js";
 import {
@@ -233,18 +208,23 @@ import {
 import { splitSdkTools } from "../tool-split.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
 import { abortable as abortableWithSignal } from "./abortable.js";
-import { buildEmbeddedAgentEndContext } from "./agent-end-context.js";
 import { releaseEmbeddedAttemptSessionLockForAbort } from "./attempt-abort.js";
+import { completeEmbeddedAttemptAfterTurn } from "./attempt-after-turn.js";
 import { prepareEmbeddedAttemptBootstrap } from "./attempt-bootstrap-prepare.js";
 import { snapshotRecentMessages, summarizeSessionContext } from "./attempt-context-summary.js";
-import { finalizeEmbeddedAttempt } from "./attempt-finalize.js";
 import {
   replayTrailingEntriesForOrphanRepair,
   resolveOrphanRepairPlan,
 } from "./attempt-orphan-repair.js";
+import { prepareEmbeddedAttemptPromptAssembly } from "./attempt-prompt-assembly.js";
+import {
+  completeEmbeddedAttemptResult,
+  type EmbeddedAttemptClientToolCallSlot,
+} from "./attempt-result.js";
 import { createEmbeddedAgentSessionWithResourceLoader } from "./attempt-session.js";
 import { prepareEmbeddedAttemptSetup } from "./attempt-setup.js";
 import { createEmbeddedRunStageTracker } from "./attempt-stage-timing.js";
+import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
 import { prepareEmbeddedAttemptTransport } from "./attempt-stream-transport.js";
 import { installEmbeddedAttemptStreamGuards } from "./attempt-stream.js";
 import { prepareEmbeddedAttemptSystemPrompt } from "./attempt-system-prompt-prepare.js";
@@ -260,7 +240,6 @@ import {
   cloneHookMessages,
   flushSessionManagerTranscript,
   loadAttemptSessionEntryAfterQuotaMaintenance,
-  normalizeCompactionRecoveryTranscriptTail,
   removeTrailingMidTurnPrecheckAssistantError,
   repairAttemptToolUseResultPairing,
   resolveAttemptTrajectorySessionFile,
@@ -268,18 +247,11 @@ import {
 } from "./attempt-transcript-helpers.js";
 import {
   requiresCompletionRequiredAsyncTaskWait,
-  shouldWaitForCompletionRequiredAsyncTasks,
-  waitForCompletionRequiredAsyncTasks,
   type AsyncStartedToolMeta,
-  type CompletionRequiredAsyncTaskWaitResult,
 } from "./attempt.async-tasks.js";
 import {
   assembleAttemptContextEngine,
   buildLoopPromptCacheInfo,
-  buildContextEnginePromptCacheInfo,
-  findCurrentAttemptAssistantMessage,
-  finalizeAttemptContextEngineTurn,
-  resolvePromptCacheTouchTimestamp,
   runAttemptContextEngineBootstrap,
 } from "./attempt.context-engine-helpers.js";
 import {
@@ -291,18 +263,11 @@ import {
 } from "./attempt.llm-boundary.js";
 import {
   buildAfterTurnRuntimeContext,
-  buildAfterTurnRuntimeContextFromUsage,
   prependSystemPromptAddition,
-  resolveAttemptMediaTaskSystemPromptAddition,
-  resolvePromptBuildHookResult,
   resolvePromptSubmissionSkipReason,
-  shouldWarnOnOrphanedUserRepair,
 } from "./attempt.prompt-helpers.js";
 import { steerActiveSessionWithOptionalDeliveryWait } from "./attempt.queue-message.js";
-import {
-  resolveEmbeddedAttemptSessionWriteLockOptions,
-  shouldRunLlmOutputHooksForAttempt,
-} from "./attempt.run-decisions.js";
+import { resolveEmbeddedAttemptSessionWriteLockOptions } from "./attempt.run-decisions.js";
 import {
   acquireEmbeddedAttemptSessionFileOwner,
   EmbeddedAttemptSessionTakeoverError,
@@ -322,20 +287,11 @@ import {
   buildEmbeddedSubscriptionParams,
   cleanupEmbeddedAttemptResources,
 } from "./attempt.subscription-cleanup.js";
-import {
-  appendAttemptCacheTtlIfNeeded,
-  composeSystemPromptWithHookContext,
-  shouldPersistCompletedBootstrapTurn,
-} from "./attempt.thread-helpers.js";
+import { composeSystemPromptWithHookContext } from "./attempt.thread-helpers.js";
 import { buildToolSearchRunPlan } from "./attempt.tool-search-run-plan.js";
 import { resolveAttemptTranscriptPolicy } from "./attempt.transcript-policy.js";
 import {
-  hasActiveCompactionRetryWork,
-  waitForCompactionRetryWithAggregateTimeout,
-} from "./compaction-retry-aggregate-timeout.js";
-import {
   resolveRunTimeoutDuringCompaction,
-  selectCompactionTimeoutSnapshot,
   shouldFlagCompactionTimeout,
 } from "./compaction-timeout.js";
 import {
@@ -343,17 +299,8 @@ import {
   resolveFinalAssistantVisibleText,
   resolveReportedModelRef,
 } from "./helpers.js";
-import {
-  installHistoryImagePruneContextTransform,
-  pruneProcessedHistoryImages,
-} from "./history-image-prune.js";
+import { installHistoryImagePruneContextTransform } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
-import {
-  buildAttemptReplayMetadata,
-  hasAttemptTerminalState,
-  resolveSilentToolResultReplyPayload,
-  shouldTreatEmptyAssistantReplyAsSilent,
-} from "./incomplete-turn.js";
 import { installMessageToolOnlyTerminalHook } from "./message-tool-terminal.js";
 import { wrapStreamFnWithMessageTransform } from "./message-transform-stream-wrapper.js";
 import { isMidTurnPrecheckSignal, type MidTurnPrecheckRequest } from "./midturn-precheck.js";
@@ -415,15 +362,6 @@ class EmbeddedAttemptPromptErrorWithCleanupTakeoverError extends Error {
     this.promptError = params.promptError;
     this.cleanupError = params.cleanupError;
   }
-}
-
-function hasVisiblePendingToolMediaReply(
-  reply: { mediaUrls?: string[]; audioAsVoice?: boolean } | null | undefined,
-): boolean {
-  return Boolean(
-    reply &&
-    ((reply.mediaUrls ?? []).some((url) => url.trim().length > 0) || reply.audioAsVoice === true),
-  );
 }
 
 export async function runEmbeddedAttempt(
@@ -1406,12 +1344,7 @@ export async function runEmbeddedAttempt(
       // Reserve slots synchronously at tool execution entry, before async
       // before_tool_call hooks run, so parallel client-tool batches preserve
       // assistant source order even when later hooks finish first.
-      const clientToolCallSlots: Array<{
-        toolCallId: string;
-        name: string;
-        params?: Record<string, unknown>;
-        completed: boolean;
-      }> = [];
+      const clientToolCallSlots: EmbeddedAttemptClientToolCallSlot[] = [];
       const clientToolCallSlotIndexes = new Map<string, number>();
       const reserveClientToolCallSlot = (toolCallId: string, toolName: string) => {
         if (clientToolCallSlotIndexes.has(toolCallId)) {
@@ -2478,35 +2411,7 @@ export async function runEmbeddedAttempt(
         }),
       );
 
-      const {
-        assistantTexts,
-        getLastAssistantTextMessageIndex,
-        toolMetas,
-        getAcceptedSessionSpawns,
-        runToolLifecycle,
-        unsubscribe,
-        waitForCompactionRetry,
-        isCompactionInFlight,
-        getItemLifecycle,
-        getMessagingToolSentTexts,
-        getMessagingToolSentMediaUrls,
-        getMessagingToolSentTargets,
-        getMessagingToolSourceReplyPayloads,
-        getHeartbeatToolResponse,
-        getPendingToolMediaReply,
-        hasToolMediaBlockReply,
-        getVisibleBlockReplyCount,
-        getSuccessfulCronAdds,
-        getReplayState,
-        didSendViaMessagingTool,
-        didSendDeterministicApprovalPrompt,
-        getLastToolError,
-        setTerminalLifecycleMeta,
-        getUsageTotals,
-        getCompactionCount,
-        getLastCompactionTokensAfter,
-        waitForPendingEvents,
-      } = subscription;
+      const { toolMetas, runToolLifecycle, unsubscribe, waitForPendingEvents } = subscription;
       toolMetasForTerminal = toolMetas;
       isCompactionPendingForExternalSignal = subscription.isCompacting;
       isCompactionInFlightForExternalSignal = () => activeSession.isCompacting;
@@ -2797,243 +2702,48 @@ export async function runEmbeddedAttempt(
           log.warn(`[tools] ${emptyExplicitToolAllowlistError.message}`);
         }
 
-        // Run before_prompt_build hooks to allow plugins to inject prompt context.
-        // Legacy compatibility: before_agent_start is also checked for context fields.
-        let effectivePrompt = params.prompt;
-        const hookCtx = {
-          runId: params.runId,
-          trace: freezeDiagnosticTraceContext(diagnosticTrace),
-          agentId: hookAgentId,
-          sessionKey: params.sessionKey,
-          sessionId: params.sessionId,
-          workspaceDir: params.workspaceDir,
-          modelProviderId: params.model.provider,
-          modelId: params.model.id,
-          trigger: params.trigger,
-          ...buildAgentHookContextChannelFields(params),
-          ...buildAgentHookContextIdentityFields({
-            trigger: params.trigger,
-            senderId: params.senderId,
-            chatId: params.chatId,
-            channelContext: params.channelContext,
-          }),
-        };
-        const promptBuildMessages =
-          pruneProcessedHistoryImages(activeSession.messages) ?? activeSession.messages;
-        const hookResult = isRawModelRun
-          ? undefined
-          : await resolvePromptBuildHookResult({
-              config: params.config ?? getRuntimeConfig(),
-              prompt: params.prompt,
-              messages: promptBuildMessages,
-              hookCtx,
-              hookRunner,
-              beforeAgentStartResult: params.beforeAgentStartResult,
-              bootstrapContextRunKind: params.bootstrapContextRunKind,
-            });
-        const promptBeforePromptBuildHooks = effectivePrompt;
-        const promptBuildPrependContext = hookResult?.prependContext;
-        const promptBuildAppendContext = hookResult?.appendContext;
-        const hasPromptBuildContext =
-          Boolean(promptBuildPrependContext?.trim()) || Boolean(promptBuildAppendContext?.trim());
-        {
-          if (hookResult?.prependContext) {
-            effectivePrompt = `${hookResult.prependContext}\n\n${effectivePrompt}`;
-            log.debug(
-              `hooks: prepended context to prompt (${hookResult.prependContext.length} chars)`,
-            );
-          }
-          if (hookResult?.appendContext) {
-            effectivePrompt = `${effectivePrompt}\n\n${hookResult.appendContext}`;
-            log.debug(
-              `hooks: appended context to prompt (${hookResult.appendContext.length} chars)`,
-            );
-          }
-          const legacySystemPrompt = normalizeOptionalString(hookResult?.systemPrompt) ?? "";
-          if (legacySystemPrompt) {
-            setActiveSessionSystemPrompt(legacySystemPrompt);
-            log.debug(`hooks: applied systemPrompt (${legacySystemPrompt.length} chars)`);
-          }
-          const prependedOrAppendedSystemPrompt = composeSystemPromptWithHookContext({
-            baseSystemPrompt: systemPromptText,
-            prependSystemContext: hookResult?.prependSystemContext,
-            appendSystemContext: hookResult?.appendSystemContext,
-          });
-          if (prependedOrAppendedSystemPrompt) {
-            const prependSystemLen = hookResult?.prependSystemContext?.trim().length ?? 0;
-            const appendSystemLen = hookResult?.appendSystemContext?.trim().length ?? 0;
-            setActiveSessionSystemPrompt(prependedOrAppendedSystemPrompt);
-            log.debug(
-              `hooks: applied prependSystemContext/appendSystemContext (${prependSystemLen}+${appendSystemLen} chars)`,
-            );
-          }
-          const mediaTaskSystemPromptAddition = resolveAttemptMediaTaskSystemPromptAddition({
-            sessionKey: params.sessionKey,
-            trigger: params.trigger,
-          });
-          if (mediaTaskSystemPromptAddition) {
-            setActiveSessionSystemPrompt(
-              prependSystemPromptAddition({
-                systemPrompt: ensureSystemPromptCacheBoundary(systemPromptText),
-                systemPromptAddition: mediaTaskSystemPromptAddition,
-              }),
-            );
-          }
-        }
-        // The model identity line is appended below; for a marker-free hook systemPrompt
-        // override ensure the cache boundary first so the identity lands in the dynamic
-        // suffix, not the cached prefix — otherwise an idle turn's prefix (O + identity)
-        // diverges from an active media turn's prefix (O) and breaks prompt caching. Skip
-        // empty prompts (raw/gateway runs) and turns with no identity line, which need none.
-        const modelAwareSystemPrompt = appendModelIdentitySystemPrompt({
-          systemPrompt:
-            buildModelIdentityPromptLine(runtimeInfo.model) && systemPromptText.trim().length > 0
-              ? ensureSystemPromptCacheBoundary(systemPromptText)
-              : systemPromptText,
-          model: runtimeInfo.model,
-        });
-        if (modelAwareSystemPrompt !== systemPromptText) {
-          setActiveSessionSystemPrompt(modelAwareSystemPrompt);
-        }
-
-        if (cacheObservabilityEnabled) {
-          const cacheObservation = beginPromptCacheObservation({
-            sessionId: params.sessionId,
-            promptCacheKey: params.promptCacheKey,
-            sessionKey: params.sessionKey,
-            provider: params.provider,
-            modelId: params.modelId,
-            modelApi: params.model.api,
-            cacheRetention: effectivePromptCacheRetention,
+        const promptAssembly = await prepareEmbeddedAttemptPromptAssembly({
+          attempt: params,
+          activeSession,
+          sessionManager,
+          hookRunner,
+          hookAgentId,
+          diagnosticTrace,
+          isRawModelRun,
+          ...(orphanRepair ? { orphanRepair } : {}),
+          sessionAgentId,
+          runtimeModel: runtimeInfo.model,
+          systemPromptText,
+          setActiveSessionSystemPrompt,
+          setLeasedSteering: (lease) => {
+            leasedSteering = lease;
+          },
+          cache: {
+            observabilityEnabled: cacheObservabilityEnabled,
+            retention: effectivePromptCacheRetention,
             streamStrategy,
             transport: effectiveAgentTransport,
-            systemPrompt: systemPromptText,
             toolNames: promptCacheToolNames,
-          });
-          promptCacheChangesForTurn = cacheObservation.changes;
-          cacheTrace?.recordStage("cache:state", {
-            options: {
-              snapshot: cacheObservation.snapshot,
-              previousCacheRead: cacheObservation.previousCacheRead ?? undefined,
-              changes:
-                cacheObservation.changes?.map((change) => ({
-                  code: change.code,
-                  detail: change.detail,
-                })) ?? undefined,
-            },
-          });
-        }
-
-        const routingSummary = describeProviderRequestRoutingSummary({
-          provider: params.provider,
-          api: params.model.api,
-          baseUrl: params.model.baseUrl,
-          capability: "llm",
-          transport: "stream",
+            trace: cacheTrace,
+          },
         });
-        log.debug(
-          `embedded run prompt start: runId=${params.runId} sessionId=${params.sessionId} ` +
-            routingSummary,
-        );
-        const effectiveTranscriptPrompt =
-          params.transcriptPrompt === undefined ? undefined : params.transcriptPrompt;
-        let transcriptPromptForRuntimeSplit = effectiveTranscriptPrompt;
-        let promptForRuntimeContextSplit = promptBeforePromptBuildHooks;
-        const leafEntry = orphanRepair?.messageEntry;
-        if (leafEntry) {
-          const messageMergeStrategy = orphanRepair.strategy;
-          const orphanPromptMerge = messageMergeStrategy.mergeOrphanedTrailingUserPrompt({
-            prompt: effectivePrompt,
-            trigger: params.trigger,
-            leafMessage: leafEntry.message,
-          });
-          const runtimePromptMerge = messageMergeStrategy.mergeOrphanedTrailingUserPrompt({
-            prompt: promptForRuntimeContextSplit,
-            trigger: params.trigger,
-            leafMessage: leafEntry.message,
-          });
-          const transcriptPromptMerge =
-            effectiveTranscriptPrompt === undefined
-              ? undefined
-              : messageMergeStrategy.mergeOrphanedTrailingUserPrompt({
-                  prompt: effectiveTranscriptPrompt,
-                  trigger: params.trigger,
-                  leafMessage: leafEntry.message,
-                });
-          effectivePrompt = orphanPromptMerge.prompt;
-          promptForRuntimeContextSplit = runtimePromptMerge.prompt;
-          if (transcriptPromptMerge) {
-            transcriptPromptForRuntimeSplit = transcriptPromptMerge.prompt;
-          }
-          const orphanRepairMessage =
-            `${
-              orphanRepair.removeLeaf
-                ? orphanPromptMerge.merged
-                  ? "Merged and removed"
-                  : "Removed already-queued"
-                : "Preserved"
-            } orphaned user message` +
-            (orphanRepair.removeLeaf
-              ? " to prevent consecutive user turns. "
-              : " without removing the active session leaf. ") +
-            `runId=${params.runId} sessionId=${params.sessionId} trigger=${params.trigger}`;
-          if (shouldWarnOnOrphanedUserRepair(params.trigger)) {
-            log.warn(orphanRepairMessage);
-          } else {
-            log.debug(orphanRepairMessage);
-          }
-        }
-        // Commitment fan-out must leave parent-turn steering queued for the
-        // next normal turn instead of consuming it as commitment context.
-        if (
-          params.sessionKey &&
-          !isRawModelRun &&
-          params.bootstrapContextRunKind !== "commitment-only"
-        ) {
-          const leaseId = `${params.runId}:agent-steering`;
-          const leased = leasePendingAgentSteeringItems({
-            requesterSessionKey: params.sessionKey,
-            leaseId,
-          });
-          if (leased) {
-            leasedSteering = {
-              leaseId,
-              runIds: leased.runIds,
-            };
-            effectivePrompt = prependAgentSteeringPrompt({
-              steeringPrompt: leased.prompt,
-              prompt: effectivePrompt,
-            });
-            promptForRuntimeContextSplit = prependAgentSteeringPrompt({
-              steeringPrompt: leased.prompt,
-              prompt: promptForRuntimeContextSplit,
-            });
-            if (transcriptPromptForRuntimeSplit !== undefined) {
-              transcriptPromptForRuntimeSplit = prependAgentSteeringPrompt({
-                steeringPrompt: leased.prompt,
-                prompt: transcriptPromptForRuntimeSplit,
-              });
-            }
-            log.debug(
-              `agent steering: injected ${leased.runIds.length} queued item(s) into parent turn ` +
-                `runId=${params.runId} sessionKey=${params.sessionKey}`,
-            );
-          }
-        }
-        const promptForModelBeforeRuntimeContextSplit = effectivePrompt;
-        const promptForRuntimeContextBeforeAnnotation = promptForRuntimeContextSplit;
-        if (!isRawModelRun) {
-          promptForRuntimeContextSplit = annotateInterSessionPromptText(
-            promptForRuntimeContextSplit,
-            params.inputProvenance,
-          );
-        }
-        const transcriptLeafId =
-          (sessionManager.getLeafEntry() as { id?: string } | null | undefined)?.id ?? null;
-        const heartbeatSummary =
-          params.config && sessionAgentId
-            ? resolveHeartbeatSummaryForAgent(params.config, sessionAgentId)
-            : undefined;
+        const {
+          hookCtx,
+          effectivePrompt,
+          promptBeforePromptBuildHooks,
+          promptBuildPrependContext,
+          promptBuildAppendContext,
+          hasPromptBuildContext,
+          effectiveTranscriptPrompt,
+          transcriptPromptForRuntimeSplit,
+          promptForRuntimeContextSplit,
+          promptForModelBeforeRuntimeContextSplit,
+          promptForRuntimeContextBeforeAnnotation,
+          transcriptLeafId,
+          heartbeatSummary,
+        } = promptAssembly;
+        leasedSteering = promptAssembly.leasedSteering ?? leasedSteering;
+        promptCacheChangesForTurn = promptAssembly.promptCacheChangesForTurn;
 
         try {
           const filteredMessages = filterHeartbeatTranscriptArtifacts(
@@ -3843,405 +3553,108 @@ export async function runEmbeddedAttempt(
         }
         await sessionLockController.releaseForPrompt();
 
-        if (
-          shouldWaitForCompletionRequiredAsyncTasks({
-            sessionKey: params.sessionKey,
-            toolMetas,
-            yieldDetected: yieldAborted,
-          })
-        ) {
-          const getAsyncStartedToolMetas = () =>
-            toolMetas
-              .filter(
-                (
-                  entry,
-                ): entry is {
-                  toolName: string;
-                  asyncStarted?: boolean;
-                  asyncTaskRunId?: string;
-                  asyncTaskId?: string;
-                } => typeof entry.toolName === "string" && entry.toolName.trim().length > 0,
-              )
-              .map((entry) => ({
-                toolName: entry.toolName,
-                asyncStarted: entry.asyncStarted,
-                asyncTaskRunId: entry.asyncTaskRunId,
-                asyncTaskId: entry.asyncTaskId,
-              }));
-          const completionRequiredAsyncDeadlineAtMs = Math.max(
-            Date.now(),
-            runAbortDeadlineAtMs - 500,
-          );
-          let asyncTaskWait: CompletionRequiredAsyncTaskWaitResult;
-          try {
-            asyncTaskWait = await waitForCompletionRequiredAsyncTasks({
-              getToolMetas: getAsyncStartedToolMetas,
-              sessionKey: params.sessionKey,
-              deadlineAtMs: completionRequiredAsyncDeadlineAtMs,
-              abortSignal: runAbortController.signal,
-            });
-          } catch (err) {
-            if (!timedOut || !isRunnerAbortError(err)) {
-              throw err;
-            }
-            asyncTaskWait = await waitForCompletionRequiredAsyncTasks({
-              getToolMetas: getAsyncStartedToolMetas,
-              sessionKey: params.sessionKey,
-              deadlineAtMs: Date.now(),
-            });
-          }
-          if (asyncTaskWait.timedOutRunIds.length > 0) {
-            promptError = new Error(
-              `Timed out waiting for async task completion: ${asyncTaskWait.timedOutRunIds.join(", ")}`,
-            );
-            promptErrorSource = "prompt";
-          } else if (asyncTaskWait.waitedRunIds.length > 0) {
-            await sessionLockController.waitForSessionEvents(activeSession);
-          }
-        }
-
-        // Capture snapshot before compaction wait so we have complete messages if timeout occurs
-        // Check compaction state before and after to avoid race condition where compaction starts during capture
-        // Use session state (not subscription) for snapshot decisions - need instantaneous compaction status
-        const wasCompactingBefore = activeSession.isCompacting;
-        const snapshot = activeSession.messages.slice();
-        const wasCompactingAfter = activeSession.isCompacting;
-        // Only trust snapshot if compaction wasn't running before or after capture
-        const preCompactionSnapshot = wasCompactingBefore || wasCompactingAfter ? null : snapshot;
-        const preCompactionSessionId = activeSession.sessionId;
-        const COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS = 60_000;
-
-        try {
-          // Flush or discard buffered block replies before waiting for
-          // compaction. Side-effecting consumers may deliver only a completed
-          // assistant attempt; retries must not leak rejected output.
-          if (onBlockReplyFlush) {
-            const currentAssistant = findCurrentAttemptAssistantMessage({
-              messagesSnapshot: snapshot,
-              prePromptMessageCount,
-            });
-            const attemptAccepted =
-              !promptError &&
-              !aborted &&
-              !timedOut &&
-              !yieldAborted &&
-              currentAssistant?.stopReason === "stop";
-            await onBlockReplyFlush({ reason: "pre_compaction", attemptAccepted });
-          }
-
-          // Skip compaction wait when yield aborted the run — the signal is
-          // already tripped and abortable() would immediately reject.
-          const compactionRetryWait = yieldAborted
-            ? { timedOut: false }
-            : await waitForCompactionRetryWithAggregateTimeout({
-                waitForCompactionRetry,
-                abortable,
-                aggregateTimeoutMs: COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS,
-                isCompactionRetryStillActive: () =>
-                  hasActiveCompactionRetryWork({
-                    isCompactionInFlight: isCompactionInFlight(),
-                    isSessionStreaming: activeSession.isStreaming,
-                  }),
-              });
-          if (compactionRetryWait.timedOut) {
-            timedOutDuringCompaction = true;
-            if (!isProbeSession) {
-              log.warn(
-                `compaction retry aggregate timeout (${COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS}ms): ` +
-                  `proceeding with pre-compaction state runId=${params.runId} sessionId=${params.sessionId}`,
-              );
-            }
-          }
-        } catch (err) {
-          if (isRunnerAbortError(err)) {
-            if (!promptError) {
-              promptError = err;
-              promptErrorSource = "compaction";
-            }
-            if (!isProbeSession) {
-              log.debug(
-                `compaction wait aborted: runId=${params.runId} sessionId=${params.sessionId}`,
-              );
-            }
-          } else {
-            throw err;
-          }
-        }
-
-        await sessionLockController.waitForSessionEvents(activeSession);
-        await withOwnedSessionWriteLock(async () => {
-          // Check if ANY compaction occurred during the entire attempt (prompt + retry).
-          // Using a cumulative count (> 0) instead of a delta check avoids missing
-          // compactions that complete during activeSession.prompt() before the delta
-          // baseline is sampled.
-          compactionOccurredThisAttempt = getCompactionCount() > 0;
-          // Append cache-TTL timestamp AFTER prompt + compaction retry completes.
-          // Previously this was before the prompt, which caused a custom entry to be
-          // inserted between compaction and the next prompt — breaking the
-          // prepareCompaction() guard that checks the last entry type, leading to
-          // double-compaction. See: https://github.com/openclaw/openclaw/issues/9282
-          // Skip when timed out during compaction — session state may be inconsistent.
-          // Also skip when compaction ran this attempt — appending a custom entry
-          // after compaction would break the guard again. See: #28491
-          appendAttemptCacheTtlIfNeeded({
-            sessionManager: activeSessionManager,
-            timedOutDuringCompaction,
-            compactionOccurredThisAttempt,
-            config: params.config,
-            provider: params.provider,
-            modelId: params.modelId,
-            modelApi: params.model.api,
-            isCacheTtlEligibleProvider,
-          });
-
-          if (timedOutDuringCompaction) {
-            const removedEntries = normalizeCompactionRecoveryTranscriptTail({
-              activeSession,
-              sessionManager: activeSessionManager,
-            });
-            if (removedEntries > 0 && !isProbeSession) {
-              log.warn(
-                `normalized compaction timeout transcript tail: ` +
-                  `removedEntries=${removedEntries} runId=${params.runId} sessionId=${params.sessionId}`,
-              );
-            }
-          }
-
-          // If timeout occurred during compaction, use pre-compaction snapshot when available
-          // (compaction restructures messages but does not add user/assistant turns).
-          const snapshotSelection = selectCompactionTimeoutSnapshot({
-            timedOutDuringCompaction,
-            preCompactionSnapshot,
-            preCompactionSessionId,
-            currentSnapshot: activeSession.messages.slice(),
-            currentSessionId: activeSession.sessionId,
-          });
-          if (timedOutDuringCompaction) {
-            if (!isProbeSession) {
-              log.warn(
-                `using ${snapshotSelection.source} snapshot: timed out during compaction runId=${params.runId} sessionId=${params.sessionId}`,
-              );
-            }
-          }
-          messagesSnapshot = projectToolSearchTargetTranscriptMessages(
-            snapshotSelection.messagesSnapshot,
-            toolSearchTargetTranscriptProjections,
-          );
-          sessionIdUsed = snapshotSelection.sessionIdUsed;
-
-          lastAssistant = messagesSnapshot
-            .slice()
-            .toReversed()
-            .find((message): message is AssistantMessage => message.role === "assistant");
-          currentAttemptAssistant = findCurrentAttemptAssistantMessage({
-            messagesSnapshot,
-            prePromptMessageCount,
-          });
-          attemptUsage = getUsageTotals();
-          cacheBreak = cacheObservabilityEnabled
-            ? completePromptCacheObservation({
-                sessionId: params.sessionId,
-                promptCacheKey: params.promptCacheKey,
-                sessionKey: params.sessionKey,
-                usage: attemptUsage,
-              })
-            : null;
-          lastCallUsage = normalizeUsage(currentAttemptAssistant?.usage);
-          const promptCacheObservation =
-            cacheObservabilityEnabled &&
-            (cacheBreak || promptCacheChangesForTurn || typeof attemptUsage?.cacheRead === "number")
-              ? {
-                  broke: Boolean(cacheBreak),
-                  ...(typeof cacheBreak?.previousCacheRead === "number"
-                    ? { previousCacheRead: cacheBreak.previousCacheRead }
-                    : {}),
-                  ...(typeof cacheBreak?.cacheRead === "number"
-                    ? { cacheRead: cacheBreak.cacheRead }
-                    : typeof attemptUsage?.cacheRead === "number"
-                      ? { cacheRead: attemptUsage.cacheRead }
-                      : {}),
-                  changes: cacheBreak?.changes ?? promptCacheChangesForTurn,
-                }
-              : undefined;
-          const fallbackLastCacheTouchAt = readLastCacheTtlTimestamp(activeSessionManager, {
-            provider: params.provider,
-            modelId: params.modelId,
-          });
-          promptCache = buildContextEnginePromptCacheInfo({
-            retention: effectivePromptCacheRetention,
-            lastCallUsage,
-            observation: promptCacheObservation,
-            lastCacheTouchAt: resolvePromptCacheTouchTimestamp({
-              lastCallUsage,
-              assistantTimestamp: currentAttemptAssistant?.timestamp,
-              fallbackLastCacheTouchAt,
-            }),
-          });
-
-          if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {
-            try {
-              activeSessionManager.appendCustomEntry("openclaw:prompt-error", {
-                timestamp: Date.now(),
-                runId: params.runId,
-                sessionId: params.sessionId,
-                provider: params.provider,
-                model: params.modelId,
-                api: params.model.api,
-                error: formatErrorMessage(promptError),
-              });
-            } catch (entryErr) {
-              log.warn(`failed to persist prompt error entry: ${String(entryErr)}`);
-            }
-          }
-
-          if (activeContextEngine && !beforeAgentFinalizeRevisionReason) {
-            // Context-engine afterTurn hooks may reconcile against persisted
-            // transcript state, so materialize the active turn first.
-            flushSessionManagerTranscript(activeSessionManager);
-          }
-        });
-
-        // Let the active context engine run its post-turn lifecycle. These hooks
-        // may call runtime LLM capabilities, so only their transcript rewrite
-        // helper reacquires the session write lock.
-        if (activeContextEngine && !beforeAgentFinalizeRevisionReason) {
-          const afterTurnRuntimeContext = buildAfterTurnRuntimeContextFromUsage({
-            attempt: params,
-            workspaceDir: effectiveWorkspace,
-            agentDir,
-            tokenBudget: params.contextTokenBudget,
-            lastCallUsage,
-            promptCache,
-            activeAgentId: sessionAgentId,
-            contextEnginePluginId: resolveActiveContextEnginePluginId(),
-          });
-          await finalizeAttemptContextEngineTurn({
-            contextEngine: activeContextEngine,
-            promptError: Boolean(promptError),
+        const streamSettleState = {
+          promptError,
+          promptErrorSource,
+          yieldAborted,
+          sessionIdUsed,
+        };
+        const settledStream = await settleEmbeddedAttemptStream({
+          attempt: params,
+          activeSession,
+          sessionManager: activeSessionManager,
+          sessionLockController,
+          withOwnedSessionWriteLock,
+          subscription,
+          state: streamSettleState,
+          readLifecycleState: () => ({
             aborted,
+            timedOut,
+            timedOutDuringCompaction,
+          }),
+          markTimedOutDuringCompaction: () => {
+            timedOutDuringCompaction = true;
+          },
+          runAbortDeadlineAtMs,
+          runAbortSignal: runAbortController.signal,
+          isProbeSession,
+          onBlockReplyFlush,
+          abortable,
+          prePromptMessageCount,
+          toolSearchTargetTranscriptProjections,
+          cache: {
+            observabilityEnabled: cacheObservabilityEnabled,
+            changesForTurn: promptCacheChangesForTurn,
+            retention: effectivePromptCacheRetention,
+          },
+          shouldFlushForContextEngine: Boolean(
+            activeContextEngine && !beforeAgentFinalizeRevisionReason,
+          ),
+        }).catch((err: unknown) => {
+          // Preserve the outer lifecycle flags when settlement fails after
+          // recording a timeout or prompt error.
+          promptError = streamSettleState.promptError;
+          promptErrorSource = streamSettleState.promptErrorSource;
+          throw err;
+        });
+        promptError = settledStream.promptError;
+        promptErrorSource = settledStream.promptErrorSource;
+        timedOutDuringCompaction = settledStream.timedOutDuringCompaction;
+        compactionOccurredThisAttempt = settledStream.compactionOccurredThisAttempt;
+        messagesSnapshot = settledStream.messagesSnapshot;
+        sessionIdUsed = settledStream.sessionIdUsed;
+        lastAssistant = settledStream.lastAssistant;
+        currentAttemptAssistant = settledStream.currentAttemptAssistant;
+        attemptUsage = settledStream.attemptUsage;
+        cacheBreak = settledStream.cacheBreak;
+        lastCallUsage = settledStream.lastCallUsage;
+        promptCache = settledStream.promptCache;
+
+        const afterTurn = await completeEmbeddedAttemptAfterTurn({
+          attempt: params,
+          activeContextEngine,
+          activeSession,
+          sessionManager: activeSessionManager,
+          sessionLockController,
+          withOwnedSessionWriteLock,
+          state: {
+            promptError,
             yieldAborted,
             sessionIdUsed,
-            sessionKey: params.sessionKey,
-            sessionTarget: params.sessionTarget,
-            sessionFile: params.sessionFile,
+            sessionFileUsed,
             messagesSnapshot,
-            prePromptMessageCount: contextEngineAfterTurnCheckpoint ?? prePromptMessageCount,
-            tokenBudget: params.contextTokenBudget,
-            runtimeContext: afterTurnRuntimeContext,
-            contextEngineHostSupport: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
-            providerId: params.provider,
-            requestedModelId: params.requestedModelId,
-            modelId: params.modelId,
-            fallbackReason: params.fallbackReason,
-            degradedReason: params.degradedReason,
-            runMaintenance: async (contextParams) =>
-              await runContextEngineMaintenance({
-                contextEngine: contextParams.contextEngine as never,
-                sessionId: contextParams.sessionId,
-                sessionKey: contextParams.sessionKey,
-                sessionTarget: contextParams.sessionTarget,
-                sessionFile: contextParams.sessionFile,
-                reason: contextParams.reason,
-                sessionManager: contextParams.sessionManager as never,
-                withSessionManagerRewriteLock: async (operation) =>
-                  await withOwnedSessionWriteLock(operation),
-                runtimeContext: contextParams.runtimeContext,
-                runtimeSettings: contextParams.runtimeSettings,
-                config: params.config,
-                agentId: sessionAgentId,
-              }),
-            sessionManager: activeSessionManager,
-            config: params.config,
-            warn: (message) => log.warn(message),
-            isHeartbeat: isHeartbeatLifecycleRunKind(params.bootstrapContextRunKind),
-          });
-        }
-
-        if (!beforeAgentFinalizeRevisionReason) {
-          await sessionLockController.waitForSessionEvents(activeSession);
-          await withOwnedSessionWriteLock(async () => {
-            if (
-              shouldPersistCompletedBootstrapTurn({
-                shouldRecordCompletedBootstrapTurn,
-                promptError,
-                aborted,
-                timedOutDuringCompaction,
-                compactionOccurredThisAttempt,
-              })
-            ) {
-              try {
-                activeSessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, {
-                  timestamp: Date.now(),
-                  runId: params.runId,
-                  sessionId: params.sessionId,
-                });
-              } catch (entryErr) {
-                log.warn(`failed to persist bootstrap completion entry: ${String(entryErr)}`);
-              }
-            }
-
-            if (
-              compactionOccurredThisAttempt &&
-              !promptError &&
-              !aborted &&
-              !timedOut &&
-              !idleTimedOut &&
-              !timedOutDuringCompaction &&
-              shouldRotateCompactionTranscript(params.config)
-            ) {
-              try {
-                const rotation = await rotateTranscriptAfterCompaction({
-                  sessionManager: activeSessionManager,
-                  sessionFile: params.sessionFile,
-                });
-                if (rotation.rotated) {
-                  sessionIdUsed = rotation.sessionId ?? sessionIdUsed;
-                  sessionFileUsed = rotation.sessionFile ?? sessionFileUsed;
-                  updateActiveEmbeddedRunSessionFile(params.sessionId, sessionFileUsed);
-                  log.info(
-                    `[compaction] rotated active transcript after automatic compaction ` +
-                      `(sessionKey=${params.sessionKey ?? params.sessionId})`,
-                  );
-                }
-              } catch (err) {
-                log.warn("[compaction] automatic transcript rotation failed", {
-                  errorMessage: formatErrorMessage(err),
-                });
-              }
-            }
-          });
-        }
-
-        cacheTrace?.recordStage("session:after", {
-          messages: messagesSnapshot,
-          note: timedOutDuringCompaction
-            ? "compaction timeout"
-            : promptError
-              ? "prompt error"
-              : undefined,
-        });
-        anthropicPayloadLogger?.recordUsage(messagesSnapshot, promptError);
-
-        if (!beforeAgentFinalizeRevisionReason) {
-          runAgentEndSideEffects({
-            event: {
-              messages: messagesSnapshot,
-              success: !aborted && !promptError,
-              error: promptError ? formatErrorMessage(promptError) : undefined,
-              durationMs: Date.now() - promptStartedAt,
-            },
-            ctx: buildEmbeddedAgentEndContext({
-              run: params,
-              agentId: hookAgentId,
-              trace: freezeDiagnosticTraceContext(diagnosticTrace),
-              skillWorkshopAvailable: uncompactedEffectiveTools.some(
-                (tool) => tool.name === "skill_workshop",
-              ),
-              compacted: compactionOccurredThisAttempt,
-            }),
+            prePromptMessageCount,
+            contextEngineAfterTurnCheckpoint,
+            lastCallUsage,
+            promptCache,
+            ...(beforeAgentFinalizeRevisionReason ? { beforeAgentFinalizeRevisionReason } : {}),
+            compactionOccurredThisAttempt,
+          },
+          readLifecycleState: () => ({
+            aborted,
+            timedOut,
+            idleTimedOut,
+            timedOutDuringCompaction,
+          }),
+          runtime: {
+            effectiveWorkspace,
+            agentDir,
+            sessionAgentId,
+            resolveActiveContextEnginePluginId,
+            shouldRecordCompletedBootstrapTurn,
+            cacheTrace,
+            anthropicPayloadLogger,
+            hookAgentId,
+            diagnosticTrace,
+            skillWorkshopAvailable: uncompactedEffectiveTools.some(
+              (tool) => tool.name === "skill_workshop",
+            ),
             hookRunner,
-          });
-        }
+            promptStartedAt,
+          },
+        });
+        sessionIdUsed = afterTurn.sessionIdUsed;
+        sessionFileUsed = afterTurn.sessionFileUsed;
       } finally {
         clearTimeout(abortTimer);
         if (abortWarnTimer) {
@@ -4274,326 +3687,47 @@ export async function runEmbeddedAttempt(
         params.abortSignal?.removeEventListener?.("abort", onAbort);
       }
 
-      const toolMetasNormalized = toolMetas
-        .filter(
-          (
-            entry,
-          ): entry is {
-            toolName: string;
-            meta?: string;
-            replaySafe?: boolean;
-            isError?: true;
-            asyncStarted?: boolean;
-            asyncTaskRunId?: string;
-            asyncTaskId?: string;
-          } => typeof entry.toolName === "string" && entry.toolName.trim().length > 0,
-        )
-        .map((entry) => {
-          const normalized: {
-            toolName: string;
-            meta?: string;
-            replaySafe: boolean;
-            isError?: true;
-            asyncStarted?: true;
-            asyncTaskRunId?: string;
-            asyncTaskId?: string;
-          } = {
-            toolName: entry.toolName,
-            meta: entry.meta,
-            replaySafe: entry.replaySafe === true,
-          };
-          if (entry.isError === true) {
-            normalized.isError = true;
-          }
-          if (entry.asyncStarted === true) {
-            normalized.asyncStarted = true;
-          }
-          if (entry.asyncTaskRunId) {
-            normalized.asyncTaskRunId = entry.asyncTaskRunId;
-          }
-          if (entry.asyncTaskId) {
-            normalized.asyncTaskId = entry.asyncTaskId;
-          }
-          return normalized;
-        });
-      if (cacheObservabilityEnabled) {
-        const cacheBreakForLog = cacheBreak as PromptCacheBreak | null;
-        if (cacheBreakForLog) {
-          const changeSummary =
-            cacheBreakForLog.changes
-              ?.map((change) => `${change.code}(${change.detail})`)
-              .join(", ") ?? "no tracked cache input change";
-          log.warn(
-            `[prompt-cache] cache read dropped ${cacheBreakForLog.previousCacheRead} -> ${cacheBreakForLog.cacheRead} ` +
-              `for ${params.provider}/${params.modelId} via ${streamStrategy}; ${changeSummary}`,
-          );
-          cacheTrace?.recordStage("cache:result", {
-            options: {
-              previousCacheRead: cacheBreakForLog.previousCacheRead,
-              cacheRead: cacheBreakForLog.cacheRead,
-              changes:
-                cacheBreakForLog.changes?.map((change) => ({
-                  code: change.code,
-                  detail: change.detail,
-                })) ?? undefined,
-            },
-          });
-        } else if (cacheTrace && promptCacheChangesForTurn) {
-          cacheTrace.recordStage("cache:result", {
-            note: "state changed without a cache-read break",
-            options: {
-              cacheRead: attemptUsage?.cacheRead ?? 0,
-              changes: promptCacheChangesForTurn.map((change) => ({
-                code: change.code,
-                detail: change.detail,
-              })),
-            },
-          });
-        } else if (cacheTrace) {
-          cacheTrace.recordStage("cache:result", {
-            note: "stable cache inputs",
-            options: {
-              cacheRead: attemptUsage?.cacheRead ?? 0,
-            },
-          });
-        }
-      }
-
-      if (
-        hookRunner?.hasHooks("llm_output") &&
-        shouldRunLlmOutputHooksForAttempt({ promptErrorSource })
-      ) {
-        hookRunner
-          .runLlmOutput(
-            {
-              runId: params.runId,
-              sessionId: params.sessionId,
-              provider: params.provider,
-              model: params.modelId,
-              ...(params.contextWindowInfo?.tokens
-                ? { contextTokenBudget: params.contextWindowInfo.tokens }
-                : {}),
-              ...(params.contextWindowInfo?.source
-                ? { contextWindowSource: params.contextWindowInfo.source }
-                : {}),
-              ...(params.contextWindowInfo?.referenceTokens
-                ? { contextWindowReferenceTokens: params.contextWindowInfo.referenceTokens }
-                : {}),
-              resolvedRef:
-                params.runtimePlan?.observability.resolvedRef ??
-                `${params.provider}/${params.modelId}`,
-              ...(params.runtimePlan?.observability.harnessId
-                ? { harnessId: params.runtimePlan.observability.harnessId }
-                : {}),
-              assistantTexts,
-              lastAssistant,
-              usage: attemptUsage,
-            },
-            {
-              runId: params.runId,
-              trace: freezeDiagnosticTraceContext(diagnosticTrace),
-              agentId: hookAgentId,
-              sessionKey: params.sessionKey,
-              sessionId: params.sessionId,
-              workspaceDir: params.workspaceDir,
-              trigger: params.trigger,
-              ...(params.contextWindowInfo?.tokens
-                ? { contextTokenBudget: params.contextWindowInfo.tokens }
-                : {}),
-              ...(params.contextWindowInfo?.source
-                ? { contextWindowSource: params.contextWindowInfo.source }
-                : {}),
-              ...(params.contextWindowInfo?.referenceTokens
-                ? { contextWindowReferenceTokens: params.contextWindowInfo.referenceTokens }
-                : {}),
-              ...buildAgentHookContextChannelFields(params),
-              ...buildAgentHookContextIdentityFields({
-                trigger: params.trigger,
-                senderId: params.senderId,
-                chatId: params.chatId,
-                channelContext: params.channelContext,
-              }),
-            },
-          )
-          .catch((err: unknown) => {
-            log.warn(`llm_output hook failed: ${String(err)}`);
-          });
-      }
-
-      const acceptedSessionSpawns = getAcceptedSessionSpawns();
-      const observedReplayMetadata = buildAttemptReplayMetadata({
-        // Structured start arguments already updated replayState for mutations and async work.
-        // Reclassifying by tool name would incorrectly mark read-only cron actions as unsafe.
-        toolMetas: [],
-        didSendViaMessagingTool: didSendViaMessagingTool(),
-        messagingToolSentTexts: getMessagingToolSentTexts(),
-        messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
-        acceptedSessionSpawns,
-        successfulCronAdds: getSuccessfulCronAdds(),
-      });
-      const pendingToolMediaReply = getPendingToolMediaReply();
-      const replayMetadata = replayMetadataFromState(
-        observeReplayMetadata(getReplayState(), observedReplayMetadata),
-      );
-      // Keep current-attempt effects separate from cumulative replay state so
-      // a later clean provider failure remains retryable.
-      const currentAttemptReplayMetadata = buildAttemptReplayMetadata({
-        toolMetas: toolMetasNormalized,
-        didSendViaMessagingTool: didSendViaMessagingTool(),
-        messagingToolSentTexts: getMessagingToolSentTexts(),
-        messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
-        acceptedSessionSpawns,
-        successfulCronAdds: getSuccessfulCronAdds(),
-      });
-      const completedClientToolCalls = clientToolCallSlots.flatMap((slot) =>
-        slot.completed && slot.params
-          ? [
-              {
-                name: slot.name,
-                params: slot.params,
-              },
-            ]
-          : [],
-      );
-      const completedClientToolCallsForAttempt =
-        completedClientToolCalls.length > 0 ? completedClientToolCalls : undefined;
-      const didSendDeterministicApprovalPromptNow = didSendDeterministicApprovalPrompt();
-      const lastToolError = getLastToolError?.();
-      const heartbeatToolResponse = getHeartbeatToolResponse();
-      const messagingToolSourceReplyPayloads = getMessagingToolSourceReplyPayloads();
-      const hasToolMediaBlockReplyNow = hasToolMediaBlockReply();
-      const hasTerminalOutput = hasAttemptTerminalState({
-        clientToolCalls: completedClientToolCallsForAttempt,
-        yieldDetected,
-        didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
-        heartbeatToolResponse,
-        lastToolError,
-        toolMediaUrls: pendingToolMediaReply?.mediaUrls,
-        toolAudioAsVoice: pendingToolMediaReply?.audioAsVoice,
-        toolTrustedLocalMedia: pendingToolMediaReply?.trustedLocalMedia,
-        hasToolMediaBlockReply: hasToolMediaBlockReplyNow,
-        didDeliverSourceReplyViaMessageTool,
-        messagingToolSourceReplyPayloads,
-        messagingToolSentTexts: getMessagingToolSentTexts(),
-        messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
-        messagingToolSentTargets: getMessagingToolSentTargets(),
-        acceptedSessionSpawns,
-        successfulCronAdds: getSuccessfulCronAdds(),
-        toolMetas: toolMetasNormalized,
-      });
-      const pendingToolMediaPayloadCount = hasVisiblePendingToolMediaReply(pendingToolMediaReply)
-        ? 1
-        : 0;
-      const visibleBlockReplyCount = getVisibleBlockReplyCount();
-      const silentToolResultReplyPayload = resolveSilentToolResultReplyPayload({
-        isCronTrigger: params.trigger === "cron",
-        payloadCount: pendingToolMediaPayloadCount,
-        aborted,
-        timedOut,
-        attempt: {
-          clientToolCalls: completedClientToolCallsForAttempt,
-          yieldDetected,
-          didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
-          lastToolError,
-          messagesSnapshot,
-          toolMetas: toolMetasNormalized,
-        },
-      });
-      const synthesizedPayloadCount =
-        visibleBlockReplyCount +
-        pendingToolMediaPayloadCount +
-        messagingToolSourceReplyPayloads.length +
-        (silentToolResultReplyPayload ? 1 : 0);
-      const emptyAssistantReplyIsSilent = shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: params.allowEmptyAssistantReplyAsSilent,
-        payloadCount: 0,
-        aborted,
-        timedOut,
-        attempt: {
-          assistantTexts,
-          clientToolCalls: completedClientToolCallsForAttempt,
-          currentAttemptAssistant,
-          yieldDetected,
-          didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
-          didSendViaMessagingTool: didSendViaMessagingTool(),
-          messagingToolSentTexts: getMessagingToolSentTexts(),
-          messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
-          messagingToolSentTargets: getMessagingToolSentTargets(),
-          acceptedSessionSpawns,
-          lastToolError,
-          lastAssistant,
-          itemLifecycle: getItemLifecycle(),
-          toolMetas: toolMetasNormalized,
-          replayMetadata,
-          promptErrorSource,
+      const finalizedResult = completeEmbeddedAttemptResult({
+        attempt: params,
+        subscription,
+        state: {
+          aborted,
+          externalAbort,
+          timedOut,
+          idleTimedOut,
           timedOutDuringCompaction,
+          timedOutDuringToolExecution,
+          timedOutByRunBudget,
+          promptError,
+          promptErrorSource,
+          preflightRecovery,
+          sessionIdUsed,
+          sessionFileUsed,
+          diagnosticTrace,
+          systemPromptReport,
+          finalPromptText,
+          messagesSnapshot,
+          ...(beforeAgentFinalizeRevisionReason ? { beforeAgentFinalizeRevisionReason } : {}),
+          lastAssistant,
+          currentAttemptAssistant,
+          attemptUsage,
+          promptCache,
+          contextBudgetStatus,
+          yieldDetected,
+          didDeliverSourceReplyViaMessageTool,
         },
-      });
-      const result: EmbeddedRunAttemptResult = {
-        replayMetadata,
-        currentAttemptReplayMetadata,
-        itemLifecycle: getItemLifecycle(),
-        setTerminalLifecycleMeta,
-        aborted,
-        externalAbort,
-        timedOut,
-        idleTimedOut,
-        timedOutDuringCompaction,
-        timedOutDuringToolExecution,
-        timedOutByRunBudget,
-        promptError,
-        promptErrorSource,
-        preflightRecovery,
-        sessionIdUsed,
-        sessionFileUsed,
-        diagnosticTrace,
-        bootstrapPromptWarningSignaturesSeen: bootstrapPromptWarning.warningSignaturesSeen,
-        bootstrapPromptWarningSignature: bootstrapPromptWarning.signature,
-        systemPromptReport,
-        finalPromptText,
-        messagesSnapshot,
-        ...(beforeAgentFinalizeRevisionReason ? { beforeAgentFinalizeRevisionReason } : {}),
-        assistantTexts,
-        lastAssistantTextMessageIndex: getLastAssistantTextMessageIndex(),
-        toolMetas: toolMetasNormalized,
-        acceptedSessionSpawns,
-        lastAssistant,
-        currentAttemptAssistant,
-        lastToolError,
-        didSendViaMessagingTool: didSendViaMessagingTool(),
-        didDeliverSourceReplyViaMessageTool,
-        didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
-        messagingToolSentTexts: getMessagingToolSentTexts(),
-        messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
-        messagingToolSentTargets: getMessagingToolSentTargets(),
-        messagingToolSourceReplyPayloads,
-        heartbeatToolResponse,
-        toolMediaUrls: pendingToolMediaReply?.mediaUrls,
-        toolAudioAsVoice: pendingToolMediaReply?.audioAsVoice,
-        toolTrustedLocalMedia: pendingToolMediaReply?.trustedLocalMedia,
-        hasToolMediaBlockReply: hasToolMediaBlockReplyNow,
-        successfulCronAdds: getSuccessfulCronAdds(),
-        cloudCodeAssistFormatError: Boolean(
-          lastAssistant?.errorMessage && isCloudCodeAssistFormatError(lastAssistant.errorMessage),
-        ),
-        attemptUsage,
-        promptCache,
-        contextBudgetStatus,
-        compactionCount: getCompactionCount(),
-        compactionTokensAfter: getLastCompactionTokensAfter(),
-        // Client tool calls detected (OpenResponses hosted tools).
-        // Stay `undefined` (not `[]`) when none were detected so downstream
-        // truthiness predicates keep working without a `.length` check.
-        clientToolCalls: completedClientToolCalls.length > 0 ? completedClientToolCalls : undefined,
-        yieldDetected: yieldDetected || undefined,
-      };
-      const finalizedResult = finalizeEmbeddedAttempt({
-        result,
+        clientToolCallSlots,
+        hookRunner,
+        hookAgentId,
+        bootstrapPromptWarning,
+        cache: {
+          observabilityEnabled: cacheObservabilityEnabled,
+          trace: cacheTrace,
+          break: cacheBreak,
+          changesForTurn: promptCacheChangesForTurn,
+          streamStrategy,
+        },
         trajectoryRecorder,
-        synthesizedPayloadCount,
-        emptyAssistantReplyIsSilent,
-        hasTerminalOutput,
-        silentExpected: params.silentExpected,
       });
       trajectoryEndRecorded = true;
       return finalizedResult;


### PR DESCRIPTION
Related: #106449, #11517, #72072

## What Problem This Solves

The embedded attempt path concentrated prompt assembly, stream settlement, post-turn work, and terminal result projection in one roughly 4,300-line function. High-churn changes therefore crossed unrelated lifecycle concerns and made timeout/abort ordering difficult to review.

## Why This Change Was Made

This staged slice moves prompt assembly, stream settlement, after-turn work, and result finalization behind typed phase boundaries, building on the existing setup phase. Every new production module stays below the TypeScript LOC ratchet, and live abort/timeout state remains getter-backed across asynchronous phase boundaries. The outer runner still owns inline setup/tool-execution scaffolding; later slices can shrink that without mixing more lifecycle movement into this review.

## User Impact

No intended user-visible behavior change. Maintainers get smaller ownership boundaries and focused lifecycle tests while transcript, provider, context-engine, session-lock, and terminal-result contracts remain unchanged.

## Evidence

- `attempt.ts`: 4,733 -> 3,867 LOC; `runEmbeddedAttempt`: 4,305 -> 3,501 LOC
- New production phase modules: 235-418 LOC each; TypeScript LOC ratchet passed
- Blacksmith Testbox `tbx_01kxe1xpg8qx7x1nbxf928nvzw`: 210 focused tests passed
- `pnpm check:changed` for all seven touched files: passed, including production/test typechecks, formatting, lint, import-cycle, and database-first guards
- `pnpm build`: passed
- Fresh autoreview: clean; earlier timeout-state findings fixed with live getters and regression tests
