### PR TITLE
feat(mac): gate Peekaboo Bridge on Computer Control

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -264,8 +264,20 @@ final class AppState {
         didSet {
             self.ifNotPreview {
                 UserDefaults.standard.set(self.peekabooBridgeEnabled, forKey: peekabooBridgeEnabledKey)
-                Task { await PeekabooBridgeHostCoordinator.shared.setEnabled(self.peekabooBridgeEnabled) }
             }
+            self.applyPeekabooBridgeHostState()
+        }
+    }
+
+    /// PeekabooBridge shares Computer Control's local UI-automation surface, so the host only
+    /// runs while Computer Control is enabled. With Computer Control off, users drive Peekaboo
+    /// via its own Mac app instead of a second, separately toggled bridge here.
+    func applyPeekabooBridgeHostState() {
+        self.ifNotPreview {
+            let computerControlEnabled = UserDefaults.standard
+                .object(forKey: computerControlEnabledKey) as? Bool ?? false
+            let shouldRun = self.peekabooBridgeEnabled && computerControlEnabled
+            Task { await PeekabooBridgeHostCoordinator.shared.setEnabled(shouldRun) }
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -59,6 +59,10 @@ struct GeneralSettings: View {
                 CanvasManager.shared.hideAll()
             }
         }
+        .onChange(of: self.computerControlEnabled) { _, _ in
+            // Turning Computer Control on/off must start or stop the gated PeekabooBridge host.
+            self.state.applyPeekabooBridgeHostState()
+        }
         .onDisappear { self.gatewayDiscovery.stop() }
     }
 
@@ -114,9 +118,13 @@ struct GeneralSettings: View {
 
                 SettingsCardToggleRow(
                     title: "Enable Peekaboo Bridge",
-                    subtitle: "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
-                    binding: self.$state.peekabooBridgeEnabled,
+                    subtitle: """
+                    Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge. \
+                    Requires Computer Control; otherwise run Peekaboo's own Mac app.
+                    """,
+                    binding: self.peekabooBridgeBinding,
                     showsDivider: false)
+                    .disabled(!self.computerControlEnabled)
             }
 
             SettingsCardGroup("Browser") {
@@ -245,6 +253,14 @@ struct GeneralSettings: View {
         Binding(
             get: { !self.state.isPaused },
             set: { self.state.isPaused = !$0 })
+    }
+
+    // Reflect the effective bridge state: off (and disabled) whenever Computer Control is off,
+    // so the row matches the host that actually runs instead of a standalone toggle.
+    private var peekabooBridgeBinding: Binding<Bool> {
+        Binding(
+            get: { self.computerControlEnabled && self.state.peekabooBridgeEnabled },
+            set: { self.state.peekabooBridgeEnabled = $0 })
     }
 
     private func updateActiveWork(active: Bool) {

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -450,7 +450,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task { PresenceReporter.shared.start() }
         Task { await HealthStore.shared.refresh(onDemand: true) }
         Task { await PortGuardian.shared.sweep(mode: AppStateStore.shared.connectionMode) }
-        Task { await PeekabooBridgeHostCoordinator.shared.setEnabled(AppStateStore.shared.peekabooBridgeEnabled) }
+        AppStateStore.shared.applyPeekabooBridgeHostState()
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             CLIInstallPrompter.shared.checkAndPromptIfNeeded(reason: "launch")
         }

--- a/docs/platforms/mac/peekaboo.md
+++ b/docs/platforms/mac/peekaboo.md
@@ -29,9 +29,9 @@ Use Peekaboo for the broad macOS automation surface via OpenClaw.app's permissio
 
 ## Enable the bridge
 
-In the macOS app: **Settings -> Enable Peekaboo Bridge**.
+In the macOS app: **Settings -> Enable Peekaboo Bridge**. The toggle requires **Allow Computer Control** to be on, since both grant local UI automation; with Computer Control off the toggle is disabled and the host does not run. To drive Peekaboo without Computer Control, run Peekaboo's own Mac app as the host instead.
 
-When enabled, OpenClaw starts a local UNIX socket server at `~/Library/Application Support/OpenClaw/<socket-name>`. If disabled, the host stops and `peekaboo` falls back to other available hosts. The coordinator also maintains legacy socket symlinks (`clawdbot`, `clawdis`, `moltbot` under Application Support) pointing at the current socket for older `peekaboo` installs.
+When enabled (and Computer Control is on), OpenClaw starts a local UNIX socket server at `~/Library/Application Support/OpenClaw/<socket-name>`. If disabled, the host stops and `peekaboo` falls back to other available hosts. The coordinator also maintains legacy socket symlinks (`clawdbot`, `clawdis`, `moltbot` under Application Support) pointing at the current socket for older `peekaboo` installs.
 
 ## Client discovery order
 


### PR DESCRIPTION
## What Problem This Solves

In the macOS app's **Settings → Capabilities**, "Enable Peekaboo Bridge" and "Allow Computer Control" were two independent switches for the same underlying capability: letting something drive local UI automation on this Mac. The bridge even defaulted to on while Computer Control defaulted to off, so out of the box OpenClaw hosted the PeekabooBridge socket even though the user had not opted into computer control. Two overlapping toggles with mismatched defaults is confusing.

## Why This Change Was Made

Peekaboo Bridge is now subordinate to **Allow Computer Control**, since both grant the same local UI-automation surface. The bridge host only runs while Computer Control is on; when it is off, the toggle is disabled and reflects the effective (off) state. Users who want Peekaboo automation without turning on Computer Control run Peekaboo's own Mac app as the host instead. Gating is centralized in `AppState.applyPeekabooBridgeHostState()` and applied at launch, on either toggle change. The agent's own `computer.act` path is unaffected — it is gated separately and does not route through the bridge socket.

## User Impact

- When Computer Control is off, the "Enable Peekaboo Bridge" row shows off and is disabled, and OpenClaw does not host the bridge socket.
- When Computer Control is on, the bridge toggle works as before (independently on/off).
- To host Peekaboo without Computer Control, use Peekaboo's own Mac app.

## Evidence

- Code change is a focused SwiftUI/state gating in `apps/macos` (4 files, +34/-6) plus a docs note in `docs/platforms/mac/peekaboo.md`.
- Manual reasoning verified across the three call sites (launch in `MenuBar`, `peekabooBridgeEnabled` didSet in `AppState`, and the `computerControlEnabled` onChange in `GeneralSettings`) so the host state stays consistent with the effective gate.
- Proof gap: the native macOS app was not built in this repo-native PR worktree (no `node_modules`/build env); no screenshot attached. Change is UI/state-only with no new logic beyond the boolean gate.
