### PR TITLE
refactor(gateway): adopt closedObject in recently added schema files

### DIFF
--- a/packages/gateway-protocol/src/schema/nodes.test.ts
+++ b/packages/gateway-protocol/src/schema/nodes.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { validateNodeInvokeProgressParams } from "../index.js";
+
+describe("node protocol schemas", () => {
+  it("accepts bounded progress chunks and rejects extra fields", () => {
+    expect(
+      validateNodeInvokeProgressParams({
+        invokeId: "invoke-1",
+        nodeId: "node-1",
+        seq: 0,
+        chunk: "stdout line",
+      }),
+    ).toBe(true);
+
+    expect(
+      validateNodeInvokeProgressParams({
+        invokeId: "invoke-1",
+        nodeId: "node-1",
+        seq: 0,
+        chunk: "x".repeat(16 * 1024 + 1),
+      }),
+    ).toBe(false);
+
+    expect(
+      validateNodeInvokeProgressParams({
+        invokeId: "invoke-1",
+        nodeId: "node-1",
+        seq: 0,
+        chunk: "stdout line",
+        extra: "not allowed",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/gateway-protocol/src/schema/nodes.ts
+++ b/packages/gateway-protocol/src/schema/nodes.ts
@@ -164,16 +164,13 @@ export const NodeInvokeResultParamsSchema = closedObject({
 });
 
 /** Ordered UTF-8 output emitted while a node command invocation is running. */
-export const NodeInvokeProgressParamsSchema = Type.Object(
-  {
-    invokeId: NonEmptyString,
-    nodeId: NonEmptyString,
-    seq: Type.Integer({ minimum: 0 }),
-    // Empty chunks are liveness heartbeats for captured stderr or capped stdout.
-    chunk: Type.String({ maxLength: 16 * 1024 }),
-  },
-  { additionalProperties: false },
-);
+export const NodeInvokeProgressParamsSchema = closedObject({
+  invokeId: NonEmptyString,
+  nodeId: NonEmptyString,
+  seq: Type.Integer({ minimum: 0 }),
+  // Empty chunks are liveness heartbeats for captured stderr or capped stdout.
+  chunk: Type.String({ maxLength: 16 * 1024 }),
+});
 
 /** Generic node event envelope accepted by the gateway. */
 export const NodeEventParamsSchema = closedObject({

--- a/packages/gateway-protocol/src/schema/session-placement.test.ts
+++ b/packages/gateway-protocol/src/schema/session-placement.test.ts
@@ -252,4 +252,28 @@ describe("session dispatch protocol schemas", () => {
       }),
     ).toBe(false);
   });
+
+  it("rejects extra fields in dispatch params and results", () => {
+    const active = {
+      state: "active" as const,
+      ...basePlacement,
+      ...workerOwnedFields,
+    };
+    expect(
+      validateSessionsDispatchResult({
+        ok: true,
+        key: "agent:main:dispatch",
+        sessionId: "session-1",
+        placement: active,
+        extra: true,
+      }),
+    ).toBe(false);
+    expect(
+      validateSessionsDispatchParams({
+        key: "agent:main:dispatch",
+        profileId: "development",
+        extra: true,
+      }),
+    ).toBe(false);
+  });
 });

--- a/packages/gateway-protocol/src/schema/session-placement.ts
+++ b/packages/gateway-protocol/src/schema/session-placement.ts
@@ -1,5 +1,6 @@
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
 /** Durable gateway ownership states for one session execution placement. */
@@ -60,85 +61,64 @@ const TerminalSessionPlacementProperties = {
 function createUnownedSessionPlacementSchema<const State extends "local" | "requested">(
   state: State,
 ) {
-  return Type.Object(
-    { state: Type.Literal(state), ...SessionPlacementTimingProperties },
-    { additionalProperties: false },
-  );
+  return closedObject({ state: Type.Literal(state), ...SessionPlacementTimingProperties });
 }
 
 function createWorkerOwnedSessionPlacementSchema<
   const State extends "active" | "draining" | "reconciling",
 >(state: State) {
-  return Type.Object(
-    {
-      state: Type.Literal(state),
-      ...SessionPlacementTimingProperties,
-      environmentId: NonEmptyString,
-      activeOwnerEpoch: SessionPlacementOwnerEpochSchema,
-      workerBundleHash: WorkerBundleHashSchema,
-      ...SessionPlacementWorkspaceProperties,
-      ...SessionPlacementAckProperties,
-    },
-    { additionalProperties: false },
-  );
+  return closedObject({
+    state: Type.Literal(state),
+    ...SessionPlacementTimingProperties,
+    environmentId: NonEmptyString,
+    activeOwnerEpoch: SessionPlacementOwnerEpochSchema,
+    workerBundleHash: WorkerBundleHashSchema,
+    ...SessionPlacementWorkspaceProperties,
+    ...SessionPlacementAckProperties,
+  });
 }
 
 export const LocalSessionPlacementSchema = createUnownedSessionPlacementSchema("local");
 export const RequestedSessionPlacementSchema = createUnownedSessionPlacementSchema("requested");
 
-export const ProvisioningSessionPlacementSchema = Type.Object(
-  {
-    state: Type.Literal("provisioning"),
-    ...SessionPlacementTimingProperties,
-    environmentId: Type.Optional(NonEmptyString),
-  },
-  { additionalProperties: false },
-);
+export const ProvisioningSessionPlacementSchema = closedObject({
+  state: Type.Literal("provisioning"),
+  ...SessionPlacementTimingProperties,
+  environmentId: Type.Optional(NonEmptyString),
+});
 
-export const SyncingSessionPlacementSchema = Type.Object(
-  {
-    state: Type.Literal("syncing"),
-    ...SessionPlacementTimingProperties,
-    environmentId: NonEmptyString,
-    workerBundleHash: WorkerBundleHashSchema,
-  },
-  { additionalProperties: false },
-);
+export const SyncingSessionPlacementSchema = closedObject({
+  state: Type.Literal("syncing"),
+  ...SessionPlacementTimingProperties,
+  environmentId: NonEmptyString,
+  workerBundleHash: WorkerBundleHashSchema,
+});
 
-export const StartingSessionPlacementSchema = Type.Object(
-  {
-    state: Type.Literal("starting"),
-    ...SessionPlacementTimingProperties,
-    environmentId: NonEmptyString,
-    workerBundleHash: WorkerBundleHashSchema,
-    ...SessionPlacementWorkspaceProperties,
-  },
-  { additionalProperties: false },
-);
+export const StartingSessionPlacementSchema = closedObject({
+  state: Type.Literal("starting"),
+  ...SessionPlacementTimingProperties,
+  environmentId: NonEmptyString,
+  workerBundleHash: WorkerBundleHashSchema,
+  ...SessionPlacementWorkspaceProperties,
+});
 
 export const ActiveWorkerSessionPlacementSchema = createWorkerOwnedSessionPlacementSchema("active");
 export const DrainingSessionPlacementSchema = createWorkerOwnedSessionPlacementSchema("draining");
 export const ReconcilingSessionPlacementSchema =
   createWorkerOwnedSessionPlacementSchema("reconciling");
 
-export const ReclaimedSessionPlacementSchema = Type.Object(
-  {
-    state: Type.Literal("reclaimed"),
-    ...SessionPlacementTimingProperties,
-    ...TerminalSessionPlacementProperties,
-  },
-  { additionalProperties: false },
-);
+export const ReclaimedSessionPlacementSchema = closedObject({
+  state: Type.Literal("reclaimed"),
+  ...SessionPlacementTimingProperties,
+  ...TerminalSessionPlacementProperties,
+});
 
-export const FailedSessionPlacementSchema = Type.Object(
-  {
-    state: Type.Literal("failed"),
-    ...SessionPlacementTimingProperties,
-    ...TerminalSessionPlacementProperties,
-    recoveryError: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const FailedSessionPlacementSchema = closedObject({
+  state: Type.Literal("failed"),
+  ...SessionPlacementTimingProperties,
+  ...TerminalSessionPlacementProperties,
+  recoveryError: NonEmptyString,
+});
 
 /** Gateway-visible placement projection; `state` remains the closed discriminator. */
 export const SessionPlacementSchema = Type.Union([
@@ -155,25 +135,19 @@ export const SessionPlacementSchema = Type.Union([
 ]);
 
 /** Requests one-way dispatch of an existing local session to a configured worker profile. */
-export const SessionsDispatchParamsSchema = Type.Object(
-  {
-    key: NonEmptyString,
-    agentId: Type.Optional(NonEmptyString),
-    profileId: NonEmptyString,
-  },
-  { additionalProperties: false },
-);
+export const SessionsDispatchParamsSchema = closedObject({
+  key: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  profileId: NonEmptyString,
+});
 
 /** Result returned once session dispatch reaches durable worker ownership. */
-export const SessionsDispatchResultSchema = Type.Object(
-  {
-    ok: Type.Literal(true),
-    key: NonEmptyString,
-    sessionId: NonEmptyString,
-    placement: ActiveWorkerSessionPlacementSchema,
-  },
-  { additionalProperties: false },
-);
+export const SessionsDispatchResultSchema = closedObject({
+  ok: Type.Literal(true),
+  key: NonEmptyString,
+  sessionId: NonEmptyString,
+  placement: ActiveWorkerSessionPlacementSchema,
+});
 
 export const SessionPlacementProtocolSchemas = {
   SessionPlacementState: SessionPlacementStateSchema,


### PR DESCRIPTION
## What Problem This Solves

Two gateway protocol schema files added shortly after the repo-wide `closedObject` migration still use the raw `Type.Object(properties, { additionalProperties: false })` form. This leaves inconsistent duplication in the schema layer and makes it harder to keep the protocol schemas uniformly closed.

## Why This Change Was Made

PR #106441 introduced a shared `closedObject` helper and converted the bulk of gateway protocol schemas. `packages/gateway-protocol/src/schema/session-placement.ts` (added by #106332) and the `NodeInvokeProgressParamsSchema` shape in `packages/gateway-protocol/src/schema/nodes.ts` (added by #105833) landed shortly after and were missed by that sweep. This change converts those remaining raw calls to the shared helper so all closed object schemas use the same abstraction.

No behavior change: `closedObject` is exactly `Type.Object(properties, { additionalProperties: false })` under the hood.

## User Impact

No user-visible impact. This is an internal refactor that improves consistency in the gateway protocol schema code.

## Evidence

Exact head `eb5572541c049819f68739ea649c2e813436a8ab` (rebased onto `upstream/main` `851f76cb0d0`):

- Live gateway proof from the exact-head `dist` build: spawned the real gateway (`node dist/index.js gateway --port <random> --bind loopback --allow-unconfigured`) with isolated `HOME`/`OPENCLAW_STATE_DIR`/`OPENCLAW_CONFIG_PATH` and throwaway shared-token auth, then drove it with real WS clients (operator role with `operator.admin` scope; node-role client):
  - `node.invoke.progress` valid payload → `{"ok":true,"ignored":true}`; extra field → `INVALID_REQUEST: invalid node.invoke.progress params: at root: unexpected property 'bogus'`; oversized 16385-char chunk → `INVALID_REQUEST: invalid node.invoke.progress params: at /chunk: must not have more than 16384 characters`.
  - `sessions.dispatch` valid payload → passes schema validation and reaches handler business logic (`session not found: agent:main:proof` in the throwaway instance); extra field → `INVALID_REQUEST: invalid sessions.dispatch params: at root: unexpected property 'bogus'`.
- Focused tests (`node scripts/run-vitest.mjs <files> --run`): `packages/gateway-protocol/src/schema/nodes.test.ts` (1) + `packages/gateway-protocol/src/schema/session-placement.test.ts` (14) + `src/gateway/server-methods/sessions.dispatch.test.ts` (10) — 25 passed. The schema tests cover the receive-side `SessionsDispatchResultSchema` and all per-state placement schemas (valid accepted, extra fields rejected).
- `oxfmt --check` and `oxlint` are clean on the four changed files.
