### PR TITLE
refactor(ui): privatize settings internals

### DIFF
--- a/ui/src/components/config-form.ts
+++ b/ui/src/components/config-form.ts
@@ -1,6 +1,5 @@
 // Control UI view renders config form screen content.
 export { renderConfigForm } from "./config-form.render.ts";
-export { SECTION_META } from "./config-form.meta.ts";
 export { analyzeConfigSchema, type ConfigSchemaAnalysis } from "./config-form.analyze.ts";
 export { renderNode } from "./config-form.node.ts";
 export { schemaType, type JsonSchema } from "./config-form.shared.ts";

--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -7,9 +7,9 @@ import { icons } from "./icons.ts";
 
 type SettingsStatusKind = "ok" | "warn" | "danger" | "accent" | "muted";
 
-export type SettingsRowControl = TemplateResult | typeof nothing;
+type SettingsRowControl = TemplateResult | typeof nothing;
 
-export type SettingsRowProps = {
+type SettingsRowProps = {
   title: unknown;
   description?: unknown;
   control?: SettingsRowControl;


### PR DESCRIPTION
## What Problem This Solves

Resolves a current-`main` dead-export ratchet failure introduced by the settings UI refactor. Production Knip reports three new unused UI exports, which blocks dependency checks for unrelated pull requests.

## Why This Change Was Made

The config-form barrel no longer re-exports section metadata that consumers already import from its owner module. Two settings-row helper types remain module-private because no production or test consumer imports them. The shrink-only baseline is unchanged.

## User Impact

No user-visible behavior changes. The Control UI keeps the same runtime behavior while the dead-export gate returns to its 2,531-entry baseline.

## Evidence

- Blacksmith Testbox run 29264307619 (`tbx_01kxe32dtqseayp0q4n27ng3rw`): `pnpm deadcode:exports:update` byte-stable at 2,531, `pnpm deadcode:exports`, targeted `oxfmt`, `pnpm tsgo:ui`, `pnpm tsgo:test:ui`, Control UI tests, and `pnpm ui:build` all passed.
- Repository-wide symbol search found no import, dynamic lookup, or string-based consumer of the removed exports.
- Fresh structured autoreview: clean, no accepted/actionable findings (0.93).

AI-assisted maintenance change; reviewed and validated against the complete two-file diff.
