### PR TITLE
fix(ui): trim unused settings exports

### DIFF
--- a/ui/src/components/config-form.ts
+++ b/ui/src/components/config-form.ts
@@ -1,6 +1,5 @@
 // Control UI view renders config form screen content.
 export { renderConfigForm } from "./config-form.render.ts";
-export { SECTION_META } from "./config-form.meta.ts";
 export { analyzeConfigSchema, type ConfigSchemaAnalysis } from "./config-form.analyze.ts";
 export { renderNode } from "./config-form.node.ts";
 export { schemaType, type JsonSchema } from "./config-form.shared.ts";

--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -7,9 +7,9 @@ import { icons } from "./icons.ts";
 
 type SettingsStatusKind = "ok" | "warn" | "danger" | "accent" | "muted";
 
-export type SettingsRowControl = TemplateResult | typeof nothing;
+type SettingsRowControl = TemplateResult | typeof nothing;
 
-export type SettingsRowProps = {
+type SettingsRowProps = {
   title: unknown;
   description?: unknown;
   control?: SettingsRowControl;


### PR DESCRIPTION
## What Problem This Solves

The Control UI settings refactor left three internal-only symbols exported. The repository dead-export gate now fails on every branch containing that mainline change, blocking otherwise unrelated PRs.

## Why This Change Was Made

The implementations remain unchanged. This removes the unused `SECTION_META` barrel re-export and keeps the two settings-row helper types module-private, matching their actual ownership and callers.

## User Impact

No runtime or visible UI change. CI dependency checks return to green for current `main` and dependent PRs.

## Evidence

- Blacksmith Testbox `tbx_01kxe36xk5w04z2s7qrf2tj3re`: `pnpm deadcode:exports`, `pnpm tsgo:ui`, targeted `oxlint`, and targeted `oxfmt --check` passed.
- Fresh structured autoreview: clean, 0.93 confidence.
- Run: https://github.com/openclaw/openclaw/actions/runs/29264480686
