### PR TITLE
refactor(gateway): split agent runtime helpers

### DIFF
--- a/src/gateway/server-methods/agent-run-dispatch.ts
+++ b/src/gateway/server-methods/agent-run-dispatch.ts
@@ -1,0 +1,261 @@
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import {
+  buildAgentRunTerminalOutcome,
+  type AgentRunTerminalOutcome,
+} from "../../agents/agent-run-terminal-outcome.js";
+import { isAgentRunRestartAbortReason } from "../../agents/run-termination.js";
+import {
+  normalizeAgentRunTimeoutPhase,
+  normalizeProviderStarted,
+} from "../../agents/run-timeout-attribution.js";
+import { agentCommandFromIngress } from "../../commands/agent.js";
+import { isAbortError } from "../../infra/abort-signal.js";
+import { clearAgentRunContext } from "../../infra/agent-events.js";
+import { readErrorName } from "../../infra/errors.js";
+import { defaultRuntime } from "../../runtime.js";
+import { createRunningTaskRun } from "../../tasks/detached-task-runtime.js";
+import { normalizeDeliveryContext } from "../../utils/delivery-context.shared.js";
+import type { ChatAbortControllerEntry } from "../chat-abort.js";
+import { formatForLog } from "../ws-log.js";
+import { setGatewayDedupeEntries } from "./agent-dedupe.js";
+import {
+  resolveFailedTrackedAgentTaskStatus,
+  tryFinalizeTrackedAgentTask,
+  type GatewayAgentTaskTrackingMode,
+} from "./agent-task-tracking.js";
+import type { GatewayRequestContext, GatewayRequestHandlerOptions } from "./types.js";
+
+function readAgentRunTimeoutAttribution(meta: unknown) {
+  const record =
+    meta && typeof meta === "object" && !Array.isArray(meta)
+      ? (meta as Record<string, unknown>)
+      : undefined;
+  return {
+    timeoutPhase: normalizeAgentRunTimeoutPhase(record?.timeoutPhase),
+    providerStarted: normalizeProviderStarted(record?.providerStarted),
+  };
+}
+
+function isGatewayAbortSignalReason(reason: unknown): boolean {
+  return reason === undefined || isAbortError(reason) || readErrorName(reason) === "TimeoutError";
+}
+
+function isGatewayAgentAbortRejection(error: unknown, signal: AbortSignal): boolean {
+  if (!signal.aborted) {
+    return false;
+  }
+  if (isAgentRunRestartAbortReason(signal.reason)) {
+    return true;
+  }
+  if (readErrorName(signal.reason) === "TimeoutError") {
+    return true;
+  }
+  if (!isGatewayAbortSignalReason(signal.reason)) {
+    return false;
+  }
+  return isAbortError(error) || readErrorName(error) === "TimeoutError";
+}
+
+function resolveGatewayAgentAbortStopReason(signal: AbortSignal): "restart" | "rpc" | "timeout" {
+  if (isAgentRunRestartAbortReason(signal.reason)) {
+    return "restart";
+  }
+  return readErrorName(signal.reason) === "TimeoutError" ? "timeout" : "rpc";
+}
+
+export function resolveAbortedAgentStopReason(entry?: ChatAbortControllerEntry): string {
+  return entry?.abortStopReason?.trim() || "rpc";
+}
+
+export function deleteGatewayDedupeEntries(params: {
+  dedupe: GatewayRequestContext["dedupe"];
+  keys: readonly string[];
+}) {
+  for (const key of params.keys) {
+    params.dedupe.delete(key);
+  }
+}
+
+export function dispatchAgentRunFromGateway(params: {
+  ingressOpts: Parameters<typeof agentCommandFromIngress>[0];
+  runId: string;
+  dedupeKeys: readonly string[];
+  /**
+   * Controller whose signal is wired into `ingressOpts.abortSignal`. Used on
+   * completion to drop the matching `chatAbortControllers` entry without
+   * touching a same-runId entry owned by a concurrent chat.send.
+   */
+  abortController: AbortController;
+  cleanupAbortController: () => void;
+  respond: GatewayRequestHandlerOptions["respond"];
+  context: GatewayRequestHandlerOptions["context"];
+  taskTrackingMode: Exclude<GatewayAgentTaskTrackingMode, "plugin_subagent">;
+  onSettled?: (outcome: {
+    terminalOutcome: AgentRunTerminalOutcome;
+    onRecovered?: () => void;
+  }) => Promise<boolean> | boolean;
+}) {
+  const shouldTrackTask = params.taskTrackingMode === "cli";
+  let taskTracked = false;
+  if (shouldTrackTask) {
+    try {
+      taskTracked = Boolean(
+        createRunningTaskRun({
+          runtime: "cli",
+          sourceId: params.runId,
+          ownerKey: params.ingressOpts.sessionKey,
+          scopeKind: "session",
+          requesterOrigin: normalizeDeliveryContext({
+            channel: params.ingressOpts.channel,
+            to: params.ingressOpts.to,
+            accountId: params.ingressOpts.accountId,
+            threadId: params.ingressOpts.threadId,
+          }),
+          childSessionKey: params.ingressOpts.sessionKey,
+          runId: params.runId,
+          task: params.ingressOpts.message,
+          deliveryStatus: "not_applicable",
+          startedAt: Date.now(),
+        }),
+      );
+    } catch (err) {
+      // Best-effort only: background task tracking must not block agent runs.
+      // Still surface the swallowed error so non-transient tracking failures stay observable.
+      params.context.logGateway.warn(
+        `failed to start tracked agent task ${params.runId}: ${formatForLog(err)}`,
+      );
+    }
+  }
+  const settle = async (outcome: {
+    terminalOutcome: AgentRunTerminalOutcome;
+    onRecovered?: () => void;
+  }): Promise<boolean> => {
+    try {
+      return (await params.onSettled?.(outcome)) ?? true;
+    } catch (error) {
+      params.context.logGateway.warn(
+        `failed to settle agent continuation ${params.runId}: ${formatForLog(error)}`,
+      );
+      return false;
+    }
+  };
+  void agentCommandFromIngress(params.ingressOpts, defaultRuntime, params.context.deps)
+    .then(async (result) => {
+      const aborted = result?.meta?.aborted === true;
+      const timeoutAttribution = readAgentRunTimeoutAttribution(result?.meta);
+      if (taskTracked) {
+        tryFinalizeTrackedAgentTask({
+          runId: params.runId,
+          status: aborted ? "timed_out" : "succeeded",
+          terminalSummary: aborted ? "aborted" : "completed",
+          log: params.context.logGateway,
+        });
+      }
+      const payload = {
+        runId: params.runId,
+        status: aborted ? ("timeout" as const) : ("ok" as const),
+        summary: aborted ? "aborted" : "completed",
+        ...(aborted ? { stopReason: result?.meta?.stopReason ?? "rpc" } : {}),
+        ...(aborted && timeoutAttribution.timeoutPhase
+          ? { timeoutPhase: timeoutAttribution.timeoutPhase }
+          : {}),
+        ...(aborted && timeoutAttribution.providerStarted !== undefined
+          ? { providerStarted: timeoutAttribution.providerStarted }
+          : {}),
+        result,
+      };
+      const terminalOutcome = buildAgentRunTerminalOutcome({
+        status:
+          aborted || result?.meta?.stopReason === "timeout" || timeoutAttribution.timeoutPhase
+            ? "timeout"
+            : result?.meta?.error || result?.meta?.stopReason === "error"
+              ? "error"
+              : "ok",
+        error: result?.meta?.error,
+        stopReason: result?.meta?.stopReason,
+        livenessState: result?.meta?.livenessState,
+        timeoutPhase: timeoutAttribution.timeoutPhase,
+        providerStarted: timeoutAttribution.providerStarted,
+      });
+      const persistTerminalDedupe = () => {
+        setGatewayDedupeEntries({
+          dedupe: params.context.dedupe,
+          keys: params.dedupeKeys,
+          entry: {
+            ts: Date.now(),
+            ok: true,
+            payload,
+          },
+        });
+      };
+      const settled = await settle({ terminalOutcome, onRecovered: persistTerminalDedupe });
+      if (!settled) {
+        const summary = "failed to persist cron continuation settlement";
+        const error = errorShape(ErrorCodes.UNAVAILABLE, summary);
+        const failedPayload = { runId: params.runId, status: "error" as const, summary };
+        setGatewayDedupeEntries({
+          dedupe: params.context.dedupe,
+          keys: params.dedupeKeys,
+          entry: { ts: Date.now(), ok: false, payload: failedPayload, error },
+        });
+        params.respond(false, failedPayload, error, { runId: params.runId, error: summary });
+        return;
+      }
+      persistTerminalDedupe();
+      // Send a second res frame (same id) so TS clients with expectFinal can wait.
+      // Swift clients will typically treat the first res as the result and ignore this.
+      params.respond(true, payload, undefined, { runId: params.runId });
+    })
+    .catch(async (err: unknown) => {
+      const aborted = isGatewayAgentAbortRejection(err, params.abortController.signal);
+      const renderedErr = formatForLog(err);
+      if (taskTracked) {
+        tryFinalizeTrackedAgentTask({
+          runId: params.runId,
+          status: aborted ? "timed_out" : resolveFailedTrackedAgentTaskStatus(err),
+          error: renderedErr,
+          terminalSummary: renderedErr,
+          log: params.context.logGateway,
+        });
+      }
+      const error = errorShape(ErrorCodes.UNAVAILABLE, renderedErr);
+      const stopReason = resolveGatewayAgentAbortStopReason(params.abortController.signal);
+      const terminalOutcome = buildAgentRunTerminalOutcome({
+        status: aborted ? "timeout" : "error",
+        error: renderedErr,
+        stopReason,
+        timeoutPhase: aborted ? "gateway_draining" : undefined,
+      });
+      const payload = {
+        runId: params.runId,
+        status: aborted ? ("timeout" as const) : ("error" as const),
+        summary: aborted ? "aborted" : renderedErr,
+        ...(aborted ? { stopReason, timeoutPhase: "gateway_draining" as const } : {}),
+      };
+      const persistTerminalDedupe = (settlementPersisted: boolean) => {
+        setGatewayDedupeEntries({
+          dedupe: params.context.dedupe,
+          keys: params.dedupeKeys,
+          entry: {
+            ts: Date.now(),
+            ok: aborted && settlementPersisted,
+            payload,
+            ...(aborted ? {} : { error }),
+          },
+        });
+      };
+      const settled = await settle({
+        terminalOutcome,
+        onRecovered: () => persistTerminalDedupe(true),
+      });
+      persistTerminalDedupe(settled);
+      params.respond(aborted && settled, payload, aborted && settled ? undefined : error, {
+        runId: params.runId,
+        ...(aborted ? {} : { error: formatForLog(err) }),
+      });
+    })
+    .finally(() => {
+      clearAgentRunContext(params.runId, params.ingressOpts.lifecycleGeneration);
+      params.cleanupAbortController();
+    });
+}

--- a/src/gateway/server-methods/agent-session-reset.ts
+++ b/src/gateway/server-methods/agent-session-reset.ts
@@ -1,0 +1,269 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import type { AgentCommandOpts } from "../../agents/command/types.js";
+import { agentCommandFromIngress } from "../../commands/agent.js";
+import {
+  resolveAgentIdFromSessionKey,
+  resolveAgentMainSessionKey,
+  type SessionEntry,
+} from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveAgentDeliveryPlanWithSessionRoute } from "../../infra/outbound/agent-delivery.js";
+import { defaultRuntime } from "../../runtime.js";
+import { resolveSendPolicy } from "../../sessions/send-policy.js";
+import { performGatewaySessionReset } from "../session-reset-service.js";
+import { loadSessionEntry } from "../session-utils.js";
+import type { GatewayRequestHandlerOptions, GatewayRequestHandlers } from "./types.js";
+
+export async function runSessionResetFromAgent(params: {
+  key: string;
+  agentId?: string;
+  reason: "new" | "reset";
+  assertCurrent?: () => void;
+  onCommitted?: (commit: { key: string; sessionId: string }) => void;
+}) {
+  const result = await performGatewaySessionReset({
+    key: params.key,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    reason: params.reason,
+    commandSource: "gateway:agent",
+    assertCurrent: params.assertCurrent,
+    onCommitted: params.onCommitted,
+  });
+  if (!result.ok) {
+    return result;
+  }
+  return {
+    ok: true as const,
+    key: result.key,
+    sessionId: result.entry.sessionId,
+  };
+}
+
+export function sessionResetAckText(reason: "new" | "reset"): string {
+  return reason === "new" ? "✅ New session started." : "✅ Session reset.";
+}
+
+export function buildBareSessionResetResult(params: {
+  reason: "new" | "reset";
+  sessionId?: string;
+  ackText?: string;
+}) {
+  return {
+    payloads: [{ text: params.ackText ?? sessionResetAckText(params.reason) }],
+    meta: {
+      durationMs: 0,
+      ...(params.sessionId
+        ? {
+            agentMeta: {
+              sessionId: params.sessionId,
+            },
+          }
+        : {}),
+    },
+  };
+}
+
+export function buildBareSessionResetResponse(params: {
+  runId: string;
+  result:
+    | ReturnType<typeof buildBareSessionResetResult>
+    | Awaited<ReturnType<typeof agentCommandFromIngress>>;
+}) {
+  return {
+    runId: params.runId,
+    status: "ok" as const,
+    summary: "completed",
+    result: params.result,
+  };
+}
+
+async function deliverBareSessionResetResult(params: {
+  cfg: OpenClawConfig;
+  context: GatewayRequestHandlerOptions["context"];
+  reason: "new" | "reset";
+  sessionId?: string;
+  sessionKey: string;
+  agentId?: string;
+  sessionEntry?: SessionEntry;
+  request: {
+    replyTo?: string;
+    to?: string;
+    replyChannel?: string;
+    channel?: string;
+    replyAccountId?: string;
+    accountId?: string;
+    threadId?: string | number;
+    bestEffortDeliver?: boolean;
+  };
+  bestEffortDeliver?: boolean;
+  deliveryTargetMode?: AgentCommandOpts["deliveryTargetMode"];
+  originMessageChannel?: string;
+  runId: string;
+  assertCurrent?: () => void;
+  ackText?: string;
+}) {
+  const { deliverAgentCommandResult } = await import("../../agents/command/delivery.runtime.js");
+  params.assertCurrent?.();
+  const result = buildBareSessionResetResult({
+    reason: params.reason,
+    sessionId: params.sessionId,
+    ackText: params.ackText,
+  });
+  return await deliverAgentCommandResult({
+    cfg: params.cfg,
+    deps: params.context.deps,
+    runtime: defaultRuntime,
+    opts: {
+      message: params.ackText ?? sessionResetAckText(params.reason),
+      ...(params.agentId ? { agentId: params.agentId } : {}),
+      ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+      sessionKey: params.sessionKey,
+      deliver: true,
+      replyTo: params.request.replyTo,
+      to: params.request.to,
+      replyChannel: params.request.replyChannel,
+      channel: params.request.channel,
+      replyAccountId: params.request.replyAccountId,
+      accountId: params.request.accountId,
+      threadId: params.request.threadId,
+      deliveryTargetMode: params.deliveryTargetMode,
+      bestEffortDeliver: params.bestEffortDeliver,
+      runId: params.runId,
+      messageChannel: params.originMessageChannel,
+      runContext: {
+        messageChannel: params.originMessageChannel,
+        accountId: params.request.replyAccountId ?? params.request.accountId,
+        currentThreadTs:
+          params.request.threadId != null ? String(params.request.threadId) : undefined,
+      },
+      allowModelOverride: false,
+    },
+    outboundSession: undefined,
+    sessionEntry: params.sessionEntry,
+    result: result as never,
+    payloads: result.payloads as never,
+    assertDeliveryCurrent: params.assertCurrent,
+  });
+}
+
+export async function resolveBareSessionResetResult(params: {
+  cfg: OpenClawConfig;
+  context: GatewayRequestHandlerOptions["context"];
+  reason: "new" | "reset";
+  sessionId?: string;
+  sessionKey: string;
+  agentId?: string;
+  sessionEntry?: SessionEntry;
+  request: Parameters<GatewayRequestHandlers["agent"]>[0]["params"];
+  originMessageChannel?: string;
+  runId: string;
+  assertCurrent?: () => void;
+  ackText?: string;
+}) {
+  params.assertCurrent?.();
+  if (params.request.deliver !== true) {
+    return buildBareSessionResetResult({
+      reason: params.reason,
+      sessionId: params.sessionId,
+      ackText: params.ackText,
+    });
+  }
+  const sendPolicy = resolveSendPolicy({
+    cfg: params.cfg,
+    entry: params.sessionEntry,
+    sessionKey: params.sessionKey,
+    channel: params.sessionEntry?.channel,
+    chatType: params.sessionEntry?.chatType,
+  });
+  if (sendPolicy === "deny") {
+    throw new Error("send blocked by session policy");
+  }
+  const deliveryPlan = await resolveAgentDeliveryPlanWithSessionRoute({
+    cfg: params.cfg,
+    agentId: params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey),
+    currentSessionKey: params.sessionKey,
+    sessionEntry: params.sessionEntry,
+    requestedChannel:
+      normalizeOptionalString(params.request.replyChannel) ??
+      normalizeOptionalString(params.request.channel),
+    explicitTo:
+      normalizeOptionalString(params.request.replyTo) ?? normalizeOptionalString(params.request.to),
+    explicitThreadId: normalizeOptionalString(params.request.threadId),
+    accountId:
+      normalizeOptionalString(params.request.replyAccountId) ??
+      normalizeOptionalString(params.request.accountId),
+    wantsDelivery: true,
+    turnSourceChannel: normalizeOptionalString(params.request.channel),
+    turnSourceTo: normalizeOptionalString(params.request.to),
+    turnSourceAccountId: normalizeOptionalString(params.request.accountId),
+    turnSourceThreadId: normalizeOptionalString(params.request.threadId),
+  });
+  params.assertCurrent?.();
+  const mainSessionKey = resolveAgentMainSessionKey({
+    cfg: params.cfg,
+    agentId: params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey),
+  });
+  // Main/global resets default to best-effort delivery because no caller session may remain.
+  const bestEffortDeliver =
+    typeof params.request.bestEffortDeliver === "boolean"
+      ? params.request.bestEffortDeliver
+      : params.sessionKey === mainSessionKey || params.sessionKey === "global"
+        ? true
+        : undefined;
+  return await deliverBareSessionResetResult({
+    cfg: params.cfg,
+    context: params.context,
+    reason: params.reason,
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+    sessionEntry: params.sessionEntry,
+    request: {
+      ...params.request,
+      channel: deliveryPlan.resolvedChannel,
+      to: deliveryPlan.resolvedTo ?? deliveryPlan.baseDelivery.to,
+      accountId: deliveryPlan.resolvedAccountId ?? deliveryPlan.baseDelivery.accountId,
+      threadId: deliveryPlan.resolvedThreadId,
+    },
+    bestEffortDeliver,
+    deliveryTargetMode: deliveryPlan.deliveryTargetMode ?? deliveryPlan.baseDelivery.mode,
+    originMessageChannel: params.originMessageChannel ?? deliveryPlan.resolvedChannel,
+    runId: params.runId,
+    assertCurrent: params.assertCurrent,
+    ackText: params.ackText,
+  });
+}
+
+export function loadBareSessionResetDeliverySession(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  agentId?: string;
+}): {
+  cfg: OpenClawConfig;
+  entry?: SessionEntry;
+  agentId: string;
+} {
+  const selectedGlobalAgentId =
+    params.sessionKey === "global" && params.agentId ? params.agentId : undefined;
+  const loaded = loadSessionEntry(params.sessionKey, {
+    clone: false,
+    ...(selectedGlobalAgentId ? { agentId: selectedGlobalAgentId } : {}),
+  });
+  const loadedCfg = loaded?.cfg ?? params.cfg;
+  return {
+    cfg: loadedCfg,
+    entry: loaded?.entry,
+    agentId:
+      selectedGlobalAgentId ??
+      resolveAgentIdFromSessionKey(params.sessionKey) ??
+      resolveDefaultAgentId(loadedCfg),
+  };
+}
+
+export function resolveSessionRuntimeCwd(params: {
+  requestedCwd?: string;
+  sessionEntry?: SessionEntry;
+}): string | undefined {
+  return normalizeOptionalString(params.requestedCwd ?? params.sessionEntry?.spawnedCwd);
+}

--- a/src/gateway/server-methods/agent-task-tracking.ts
+++ b/src/gateway/server-methods/agent-task-tracking.ts
@@ -78,7 +78,7 @@ export function requestGroupMatchesTrusted(params: {
   return Boolean(params.trustedGroupId && requestGroupId === params.trustedGroupId);
 }
 
-export type GatewayAgentTaskTerminalStatus = Extract<
+type GatewayAgentTaskTerminalStatus = Extract<
   TaskStatus,
   "succeeded" | "failed" | "timed_out" | "cancelled"
 >;

--- a/src/gateway/server-methods/agent-task-tracking.ts
+++ b/src/gateway/server-methods/agent-task-tracking.ts
@@ -1,0 +1,215 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../../../packages/gateway-protocol/src/client-info.js";
+import { readAcpSessionMeta } from "../../acp/runtime/session-meta.js";
+import { isTimeoutError } from "../../agents/failover-error.js";
+import { resolveAgentIdFromSessionKey, resolveAgentMainSessionKey } from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isAbortError } from "../../infra/abort-signal.js";
+import { isAcpSessionKey } from "../../routing/session-key.js";
+import type { InputProvenance } from "../../sessions/input-provenance.js";
+import {
+  parseRawSessionConversationRef,
+  parseThreadSessionSuffix,
+} from "../../sessions/session-key-utils.js";
+import { finalizeTaskRunByRunId } from "../../tasks/detached-task-runtime.js";
+import type { TaskStatus } from "../../tasks/task-registry.types.js";
+import type { DeliveryContext } from "../../utils/delivery-context.shared.js";
+import { formatForLog } from "../ws-log.js";
+import type { GatewayRequestContext, GatewayRequestHandlerOptions } from "./types.js";
+
+export type TrustedGroupMetadata = {
+  groupId?: string;
+  groupChannel?: string;
+  groupSpace?: string;
+};
+
+export function normalizeTrustedGroupMetadata(value?: {
+  groupId?: unknown;
+  groupChannel?: unknown;
+  groupSpace?: unknown;
+  space?: unknown;
+}): TrustedGroupMetadata {
+  return {
+    groupId: normalizeOptionalString(value?.groupId),
+    groupChannel: normalizeOptionalString(value?.groupChannel),
+    groupSpace: normalizeOptionalString(value?.groupSpace ?? value?.space),
+  };
+}
+
+function resolveSessionKeyGroupId(sessionKey: string): string | undefined {
+  const { baseSessionKey } = parseThreadSessionSuffix(sessionKey);
+  const conversation = parseRawSessionConversationRef(baseSessionKey ?? sessionKey);
+  if (!conversation || (conversation.kind !== "group" && conversation.kind !== "channel")) {
+    return undefined;
+  }
+  return conversation.rawId;
+}
+
+export function resolveTrustedGroupMetadata(params: {
+  sessionKey: string;
+  spawnedBy?: string;
+  stored: TrustedGroupMetadata;
+  inherited?: TrustedGroupMetadata;
+}): TrustedGroupMetadata {
+  return {
+    // Group trust can be inherited from the parent run or recovered from conversation-shaped keys.
+    groupId:
+      params.stored.groupId ??
+      params.inherited?.groupId ??
+      resolveSessionKeyGroupId(params.sessionKey) ??
+      (params.spawnedBy ? resolveSessionKeyGroupId(params.spawnedBy) : undefined),
+    groupChannel: params.stored.groupChannel ?? params.inherited?.groupChannel,
+    groupSpace: params.stored.groupSpace ?? params.inherited?.groupSpace,
+  };
+}
+
+export function requestGroupMatchesTrusted(params: {
+  requestGroupId?: string;
+  trustedGroupId?: string;
+}): boolean {
+  const requestGroupId = params.requestGroupId?.trim();
+  if (!requestGroupId) {
+    // Missing group metadata is accepted so non-group channels keep the same send path.
+    return true;
+  }
+  return Boolean(params.trustedGroupId && requestGroupId === params.trustedGroupId);
+}
+
+export type GatewayAgentTaskTerminalStatus = Extract<
+  TaskStatus,
+  "succeeded" | "failed" | "timed_out" | "cancelled"
+>;
+export type GatewayAgentTaskTrackingMode = "cli" | "plugin_subagent" | "none";
+
+export function resolveGatewayAgentTaskTrackingMode(params: {
+  client: GatewayRequestHandlerOptions["client"];
+  sessionKey?: string;
+  inputProvenance?: InputProvenance;
+  confirmedAcpManualSpawn?: boolean;
+  modelRun?: boolean;
+}): GatewayAgentTaskTrackingMode {
+  // Model probes are stateless one-shot work. A terminal CLI task row would
+  // outlive the probe even when its session/transcript effects are internal.
+  if (params.modelRun === true) {
+    return "none";
+  }
+  if (!params.sessionKey?.trim() || params.inputProvenance?.kind === "inter_session") {
+    return "none";
+  }
+  if (params.client?.internal?.agentRunTracking === "plugin_subagent") {
+    return "plugin_subagent";
+  }
+  // A confirmed ACP manual-spawn child turn already owns its requester-visible
+  // `acp` task row from the spawn control plane (src/agents/acp-spawn.ts). The
+  // Gateway CLI path runs that same childRunId, so tracking it here would emit a
+  // duplicate row for one run. Suppress only the CLI branch; plugin-subagent and
+  // normal CLI tracking stay intact.
+  if (params.confirmedAcpManualSpawn) {
+    return "none";
+  }
+  return "cli";
+}
+
+function isTrustedBackendAcpSpawnClient(client: GatewayRequestHandlerOptions["client"]): boolean {
+  // The ACP spawn control plane reaches the gateway through the in-process
+  // backend client (src/gateway/call.ts -> mode "backend", id "gateway-client").
+  // Only that caller creates the replacement `acp` task row, so CLI suppression
+  // is gated to it. An operator-write UI/CLI/mobile or device-token client that
+  // merely sets acpTurnSource owns no such row and must keep CLI tracking.
+  return (
+    client?.connect?.client?.id === GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT &&
+    client.connect.client.mode === GATEWAY_CLIENT_MODES.BACKEND &&
+    client.isDeviceTokenAuth !== true
+  );
+}
+
+export function isConfirmedAcpManualSpawnTaskOwner(params: {
+  acpTurnSource?: string;
+  sessionKey?: string;
+  client: GatewayRequestHandlerOptions["client"];
+  logGateway: Pick<GatewayRequestContext["logGateway"], "warn">;
+}): boolean {
+  const sessionKey = params.sessionKey;
+  if (
+    !isTrustedBackendAcpSpawnClient(params.client) ||
+    params.acpTurnSource !== "manual_spawn" ||
+    sessionKey == null ||
+    !isAcpSessionKey(sessionKey)
+  ) {
+    return false;
+  }
+  try {
+    return readAcpSessionMeta({ sessionKey }) != null;
+  } catch (err) {
+    params.logGateway.warn(
+      `failed to read ACP session metadata for manual-spawn task tracking ${sessionKey}; falling back to cli task tracking: ${formatForLog(
+        err,
+      )}`,
+    );
+    return false;
+  }
+}
+
+export async function registerPluginSubagentRunFromGateway(params: {
+  cfg: OpenClawConfig;
+  runId: string;
+  childSessionKey: string;
+  task: string;
+  requesterOrigin?: DeliveryContext;
+  pluginId?: string;
+}): Promise<void> {
+  const childSessionKey = params.childSessionKey.trim();
+  if (!childSessionKey) {
+    return;
+  }
+  const ownerSessionKey = resolveAgentMainSessionKey({
+    cfg: params.cfg,
+    agentId: resolveAgentIdFromSessionKey(childSessionKey),
+  });
+  const { registerSubagentRun } = await import("../../agents/subagent-registry.js");
+  registerSubagentRun({
+    runId: params.runId,
+    childSessionKey,
+    controllerSessionKey: ownerSessionKey,
+    requesterSessionKey: ownerSessionKey,
+    requesterOrigin: params.requesterOrigin,
+    requesterDisplayKey: "main",
+    task: params.task,
+    cleanup: "keep",
+    ...(params.pluginId ? { label: `plugin:${params.pluginId}` } : {}),
+    expectsCompletionMessage: false,
+    spawnMode: "run",
+  });
+}
+
+export function resolveFailedTrackedAgentTaskStatus(
+  error: unknown,
+): GatewayAgentTaskTerminalStatus {
+  return isAbortError(error) || isTimeoutError(error) ? "timed_out" : "failed";
+}
+
+export function tryFinalizeTrackedAgentTask(params: {
+  runId: string;
+  status: GatewayAgentTaskTerminalStatus;
+  error?: string;
+  terminalSummary?: string;
+  log: Pick<GatewayRequestContext["logGateway"], "warn">;
+}): void {
+  try {
+    finalizeTaskRunByRunId({
+      runId: params.runId,
+      runtime: "cli",
+      status: params.status,
+      endedAt: Date.now(),
+      ...(params.error !== undefined ? { error: params.error } : {}),
+      ...(params.terminalSummary !== undefined ? { terminalSummary: params.terminalSummary } : {}),
+    });
+  } catch (err) {
+    // Best-effort only: background task tracking must not block agent runs.
+    // Still surface the swallowed error so non-transient finalize failures stay observable.
+    params.log.warn(`failed to finalize tracked agent task ${params.runId}: ${formatForLog(err)}`);
+  }
+}

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -12,7 +12,6 @@ import { normalizeStringEntries } from "@openclaw/normalization-core/string-norm
 import {
   GATEWAY_CLIENT_CAPS,
   GATEWAY_CLIENT_MODES,
-  GATEWAY_CLIENT_NAMES,
   hasGatewayClientCap,
 } from "../../../packages/gateway-protocol/src/client-info.js";
 import {
@@ -24,10 +23,7 @@ import {
   validateAgentWaitParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { readAcpSessionMeta } from "../../acp/runtime/session-meta.js";
-import {
-  buildAgentRunTerminalOutcome,
-  type AgentRunTerminalOutcome,
-} from "../../agents/agent-run-terminal-outcome.js";
+import type { AgentRunTerminalOutcome } from "../../agents/agent-run-terminal-outcome.js";
 import { listAgentIds, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { resolveTrustedGroupId } from "../../agents/agent-tools.policy.js";
 import {
@@ -36,13 +32,11 @@ import {
   parseExecApprovalFollowupApprovalId,
 } from "../../agents/bash-tools.exec-approval-followup-state.js";
 import { clearAllCliSessions, getCliSessionBinding } from "../../agents/cli-session.js";
-import type { AgentCommandOpts } from "../../agents/command/types.js";
 import {
   clearEmbeddedAgentRunAbortabilityForRunId,
   isEmbeddedAgentRunAbortableForRunId,
   retainEmbeddedAgentRunAbortabilityForRunId,
 } from "../../agents/embedded-agent-runner/runs.js";
-import { isTimeoutError } from "../../agents/failover-error.js";
 import { runAgentHarnessBeforeMessageWriteHook } from "../../agents/harness/hook-helpers.js";
 import { resolvePublicAgentAvatarSource } from "../../agents/identity-avatar.js";
 import {
@@ -56,18 +50,12 @@ import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js"
 import {
   AGENT_RUN_RESTART_ABORT_STOP_REASON,
   createAgentRunRestartAbortError,
-  isAgentRunRestartAbortReason,
 } from "../../agents/run-termination.js";
-import {
-  normalizeAgentRunTimeoutPhase,
-  normalizeProviderStarted,
-} from "../../agents/run-timeout-attribution.js";
 import {
   normalizeSpawnedRunMetadata,
   resolveIngressWorkspaceOverrideForSessionRun,
 } from "../../agents/spawned-context.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
-import { agentCommandFromIngress } from "../../commands/agent.js";
 import {
   evaluateSessionFreshness,
   hasTerminalMainSessionTranscriptNewerThanRegistrySync,
@@ -100,15 +88,13 @@ import {
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
 import { isRecoverableTerminalSessionStatus } from "../../config/sessions/terminal-status.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { isAbortError } from "../../infra/abort-signal.js";
 import {
   assertAgentRunLifecycleGenerationCurrent,
   claimAgentRunContext,
-  clearAgentRunContext,
   getAgentEventLifecycleGeneration,
 } from "../../infra/agent-events.js";
 import { emitDiagnosticEvent } from "../../infra/diagnostic-events.js";
-import { formatUncaughtError, readErrorName } from "../../infra/errors.js";
+import { formatUncaughtError } from "../../infra/errors.js";
 import {
   resolveAgentDeliveryPlanWithSessionRoute,
   resolveAgentExplicitRecipientSession,
@@ -132,7 +118,6 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../../routing/session-key.js";
-import { defaultRuntime } from "../../runtime.js";
 import {
   AGENT_HARNESS_MODEL_RUN_FORBIDDEN_MESSAGE,
   resolveAgentHarnessSessionContextError,
@@ -145,18 +130,12 @@ import {
   type InputProvenance,
 } from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
-import {
-  parseCronRunScopeSuffix,
-  parseRawSessionConversationRef,
-  parseThreadSessionSuffix,
-} from "../../sessions/session-key-utils.js";
+import { parseCronRunScopeSuffix } from "../../sessions/session-key-utils.js";
 import {
   beginSessionWorkAdmission,
   type SessionWorkAdmissionLease,
 } from "../../sessions/session-lifecycle-admission.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
-import { createRunningTaskRun, finalizeTaskRunByRunId } from "../../tasks/detached-task-runtime.js";
-import type { TaskStatus } from "../../tasks/task-registry.types.js";
 import {
   getGeneratedMediaTaskIdsForSessionKey,
   hasNewGeneratedMediaTaskForSessionKey,
@@ -165,7 +144,6 @@ import {
   mergeDeliveryContext,
   normalizeDeliveryContext,
   normalizeSessionDeliveryFields,
-  type DeliveryContext,
 } from "../../utils/delivery-context.shared.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
@@ -178,7 +156,6 @@ import { setSafeTimeout } from "../../utils/timer-delay.js";
 import { resolveGatewayAssistantAvatar } from "../assistant-avatar.js";
 import { resolveAssistantIdentity } from "../assistant-identity.js";
 import {
-  type ChatAbortControllerEntry,
   registerChatAbortController,
   resolveAgentRunExpiresAtMs,
   updateChatRunProvider,
@@ -192,7 +169,6 @@ import { ADMIN_SCOPE } from "../method-scopes.js";
 import {
   emitGatewaySessionEndPluginHook,
   emitGatewaySessionStartPluginHook,
-  performGatewaySessionReset,
 } from "../session-reset-service.js";
 import { reactivateCompletedSubagentSession } from "../session-subagent-reactivation.js";
 import {
@@ -220,6 +196,30 @@ import {
   validateExpectedExistingSessionTarget,
 } from "./agent-expected-session.js";
 import { waitForAgentJob } from "./agent-job.js";
+import {
+  deleteGatewayDedupeEntries,
+  dispatchAgentRunFromGateway,
+  resolveAbortedAgentStopReason,
+} from "./agent-run-dispatch.js";
+import {
+  buildBareSessionResetResponse,
+  buildBareSessionResetResult,
+  loadBareSessionResetDeliverySession,
+  resolveBareSessionResetResult,
+  resolveSessionRuntimeCwd,
+  runSessionResetFromAgent,
+  sessionResetAckText,
+} from "./agent-session-reset.js";
+import {
+  isConfirmedAcpManualSpawnTaskOwner,
+  normalizeTrustedGroupMetadata,
+  registerPluginSubagentRunFromGateway,
+  requestGroupMatchesTrusted,
+  resolveGatewayAgentTaskTrackingMode,
+  resolveTrustedGroupMetadata,
+  type GatewayAgentTaskTrackingMode,
+  type TrustedGroupMetadata,
+} from "./agent-task-tracking.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
 import { emitSessionsChanged } from "./session-change-event.js";
 import type {
@@ -436,689 +436,6 @@ function emitAgentSendSessionLifecycleTransition(
     sessionFile: transition.sessionFile,
     agentId: transition.agentId,
   });
-}
-
-async function runSessionResetFromAgent(params: {
-  key: string;
-  agentId?: string;
-  reason: "new" | "reset";
-  assertCurrent?: () => void;
-  onCommitted?: (commit: { key: string; sessionId: string }) => void;
-}): Promise<
-  | { ok: true; key: string; sessionId?: string }
-  | { ok: false; error: ReturnType<typeof errorShape> }
-> {
-  const result = await performGatewaySessionReset({
-    key: params.key,
-    ...(params.agentId ? { agentId: params.agentId } : {}),
-    reason: params.reason,
-    commandSource: "gateway:agent",
-    assertCurrent: params.assertCurrent,
-    onCommitted: params.onCommitted,
-  });
-  if (!result.ok) {
-    return result;
-  }
-  return {
-    ok: true,
-    key: result.key,
-    sessionId: result.entry.sessionId,
-  };
-}
-
-function sessionResetAckText(reason: "new" | "reset"): string {
-  return reason === "new" ? "✅ New session started." : "✅ Session reset.";
-}
-
-function buildBareSessionResetResult(params: {
-  reason: "new" | "reset";
-  sessionId?: string;
-  ackText?: string;
-}) {
-  return {
-    payloads: [{ text: params.ackText ?? sessionResetAckText(params.reason) }],
-    meta: {
-      durationMs: 0,
-      ...(params.sessionId
-        ? {
-            agentMeta: {
-              sessionId: params.sessionId,
-            },
-          }
-        : {}),
-    },
-  };
-}
-
-function buildBareSessionResetResponse(params: {
-  runId: string;
-  result:
-    | ReturnType<typeof buildBareSessionResetResult>
-    | Awaited<ReturnType<typeof agentCommandFromIngress>>;
-}) {
-  return {
-    runId: params.runId,
-    status: "ok" as const,
-    summary: "completed",
-    result: params.result,
-  };
-}
-
-async function deliverBareSessionResetResult(params: {
-  cfg: OpenClawConfig;
-  context: GatewayRequestHandlerOptions["context"];
-  reason: "new" | "reset";
-  sessionId?: string;
-  sessionKey: string;
-  agentId?: string;
-  sessionEntry?: SessionEntry;
-  request: {
-    replyTo?: string;
-    to?: string;
-    replyChannel?: string;
-    channel?: string;
-    replyAccountId?: string;
-    accountId?: string;
-    threadId?: string | number;
-    bestEffortDeliver?: boolean;
-  };
-  bestEffortDeliver?: boolean;
-  deliveryTargetMode?: AgentCommandOpts["deliveryTargetMode"];
-  originMessageChannel?: string;
-  runId: string;
-  assertCurrent?: () => void;
-  ackText?: string;
-}) {
-  const { deliverAgentCommandResult } = await import("../../agents/command/delivery.runtime.js");
-  params.assertCurrent?.();
-  const result = buildBareSessionResetResult({
-    reason: params.reason,
-    sessionId: params.sessionId,
-    ackText: params.ackText,
-  });
-  return await deliverAgentCommandResult({
-    cfg: params.cfg,
-    deps: params.context.deps,
-    runtime: defaultRuntime,
-    opts: {
-      message: params.ackText ?? sessionResetAckText(params.reason),
-      ...(params.agentId ? { agentId: params.agentId } : {}),
-      ...(params.sessionId ? { sessionId: params.sessionId } : {}),
-      sessionKey: params.sessionKey,
-      deliver: true,
-      replyTo: params.request.replyTo,
-      to: params.request.to,
-      replyChannel: params.request.replyChannel,
-      channel: params.request.channel,
-      replyAccountId: params.request.replyAccountId,
-      accountId: params.request.accountId,
-      threadId: params.request.threadId,
-      deliveryTargetMode: params.deliveryTargetMode,
-      bestEffortDeliver: params.bestEffortDeliver,
-      runId: params.runId,
-      messageChannel: params.originMessageChannel,
-      runContext: {
-        messageChannel: params.originMessageChannel,
-        accountId: params.request.replyAccountId ?? params.request.accountId,
-        currentThreadTs:
-          params.request.threadId != null ? String(params.request.threadId) : undefined,
-      },
-      allowModelOverride: false,
-    },
-    outboundSession: undefined,
-    sessionEntry: params.sessionEntry,
-    result: result as never,
-    payloads: result.payloads as never,
-    assertDeliveryCurrent: params.assertCurrent,
-  });
-}
-
-async function resolveBareSessionResetResult(params: {
-  cfg: OpenClawConfig;
-  context: GatewayRequestHandlerOptions["context"];
-  reason: "new" | "reset";
-  sessionId?: string;
-  sessionKey: string;
-  agentId?: string;
-  sessionEntry?: SessionEntry;
-  request: Parameters<GatewayRequestHandlers["agent"]>[0]["params"];
-  originMessageChannel?: string;
-  runId: string;
-  assertCurrent?: () => void;
-  ackText?: string;
-}) {
-  params.assertCurrent?.();
-  if (params.request.deliver !== true) {
-    return buildBareSessionResetResult({
-      reason: params.reason,
-      sessionId: params.sessionId,
-      ackText: params.ackText,
-    });
-  }
-  const sendPolicy = resolveSendPolicy({
-    cfg: params.cfg,
-    entry: params.sessionEntry,
-    sessionKey: params.sessionKey,
-    channel: params.sessionEntry?.channel,
-    chatType: params.sessionEntry?.chatType,
-  });
-  if (sendPolicy === "deny") {
-    throw new Error("send blocked by session policy");
-  }
-  const deliveryPlan = await resolveAgentDeliveryPlanWithSessionRoute({
-    cfg: params.cfg,
-    agentId: params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey),
-    currentSessionKey: params.sessionKey,
-    sessionEntry: params.sessionEntry,
-    requestedChannel:
-      normalizeOptionalString(params.request.replyChannel) ??
-      normalizeOptionalString(params.request.channel),
-    explicitTo:
-      normalizeOptionalString(params.request.replyTo) ?? normalizeOptionalString(params.request.to),
-    explicitThreadId: normalizeOptionalString(params.request.threadId),
-    accountId:
-      normalizeOptionalString(params.request.replyAccountId) ??
-      normalizeOptionalString(params.request.accountId),
-    wantsDelivery: true,
-    turnSourceChannel: normalizeOptionalString(params.request.channel),
-    turnSourceTo: normalizeOptionalString(params.request.to),
-    turnSourceAccountId: normalizeOptionalString(params.request.accountId),
-    turnSourceThreadId: normalizeOptionalString(params.request.threadId),
-  });
-  params.assertCurrent?.();
-  const mainSessionKey = resolveAgentMainSessionKey({
-    cfg: params.cfg,
-    agentId: params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey),
-  });
-  // Main/global resets default to best-effort delivery because no caller session may remain.
-  const bestEffortDeliver =
-    typeof params.request.bestEffortDeliver === "boolean"
-      ? params.request.bestEffortDeliver
-      : params.sessionKey === mainSessionKey || params.sessionKey === "global"
-        ? true
-        : undefined;
-  return await deliverBareSessionResetResult({
-    cfg: params.cfg,
-    context: params.context,
-    reason: params.reason,
-    sessionId: params.sessionId,
-    sessionKey: params.sessionKey,
-    agentId: params.agentId,
-    sessionEntry: params.sessionEntry,
-    request: {
-      ...params.request,
-      channel: deliveryPlan.resolvedChannel,
-      to: deliveryPlan.resolvedTo ?? deliveryPlan.baseDelivery.to,
-      accountId: deliveryPlan.resolvedAccountId ?? deliveryPlan.baseDelivery.accountId,
-      threadId: deliveryPlan.resolvedThreadId,
-    },
-    bestEffortDeliver,
-    deliveryTargetMode: deliveryPlan.deliveryTargetMode ?? deliveryPlan.baseDelivery.mode,
-    originMessageChannel: params.originMessageChannel ?? deliveryPlan.resolvedChannel,
-    runId: params.runId,
-    assertCurrent: params.assertCurrent,
-    ackText: params.ackText,
-  });
-}
-
-function loadBareSessionResetDeliverySession(params: {
-  cfg: OpenClawConfig;
-  sessionKey: string;
-  agentId?: string;
-}): {
-  cfg: OpenClawConfig;
-  entry?: SessionEntry;
-  agentId: string;
-} {
-  const selectedGlobalAgentId =
-    params.sessionKey === "global" && params.agentId ? params.agentId : undefined;
-  const loaded = loadSessionEntry(params.sessionKey, {
-    clone: false,
-    ...(selectedGlobalAgentId ? { agentId: selectedGlobalAgentId } : {}),
-  });
-  const loadedCfg = loaded?.cfg ?? params.cfg;
-  return {
-    cfg: loadedCfg,
-    entry: loaded?.entry,
-    agentId:
-      selectedGlobalAgentId ??
-      resolveAgentIdFromSessionKey(params.sessionKey) ??
-      resolveDefaultAgentId(loadedCfg),
-  };
-}
-
-function resolveSessionRuntimeCwd(params: {
-  requestedCwd?: string;
-  sessionEntry?: SessionEntry;
-}): string | undefined {
-  return normalizeOptionalString(params.requestedCwd ?? params.sessionEntry?.spawnedCwd);
-}
-
-type TrustedGroupMetadata = {
-  groupId?: string;
-  groupChannel?: string;
-  groupSpace?: string;
-};
-
-function normalizeTrustedGroupMetadata(value?: {
-  groupId?: unknown;
-  groupChannel?: unknown;
-  groupSpace?: unknown;
-  space?: unknown;
-}): TrustedGroupMetadata {
-  return {
-    groupId: normalizeOptionalString(value?.groupId),
-    groupChannel: normalizeOptionalString(value?.groupChannel),
-    groupSpace: normalizeOptionalString(value?.groupSpace ?? value?.space),
-  };
-}
-
-function resolveSessionKeyGroupId(sessionKey: string): string | undefined {
-  const { baseSessionKey } = parseThreadSessionSuffix(sessionKey);
-  const conversation = parseRawSessionConversationRef(baseSessionKey ?? sessionKey);
-  if (!conversation || (conversation.kind !== "group" && conversation.kind !== "channel")) {
-    return undefined;
-  }
-  return conversation.rawId;
-}
-
-function resolveTrustedGroupMetadata(params: {
-  sessionKey: string;
-  spawnedBy?: string;
-  stored: TrustedGroupMetadata;
-  inherited?: TrustedGroupMetadata;
-}): TrustedGroupMetadata {
-  return {
-    // Group trust can be inherited from the parent run or recovered from conversation-shaped keys.
-    groupId:
-      params.stored.groupId ??
-      params.inherited?.groupId ??
-      resolveSessionKeyGroupId(params.sessionKey) ??
-      (params.spawnedBy ? resolveSessionKeyGroupId(params.spawnedBy) : undefined),
-    groupChannel: params.stored.groupChannel ?? params.inherited?.groupChannel,
-    groupSpace: params.stored.groupSpace ?? params.inherited?.groupSpace,
-  };
-}
-
-function requestGroupMatchesTrusted(params: {
-  requestGroupId?: string;
-  trustedGroupId?: string;
-}): boolean {
-  const requestGroupId = params.requestGroupId?.trim();
-  if (!requestGroupId) {
-    // Missing group metadata is accepted so non-group channels keep the same send path.
-    return true;
-  }
-  return Boolean(params.trustedGroupId && requestGroupId === params.trustedGroupId);
-}
-
-type GatewayAgentTaskTerminalStatus = Extract<
-  TaskStatus,
-  "succeeded" | "failed" | "timed_out" | "cancelled"
->;
-type GatewayAgentTaskTrackingMode = "cli" | "plugin_subagent" | "none";
-
-function resolveGatewayAgentTaskTrackingMode(params: {
-  client: GatewayRequestHandlerOptions["client"];
-  sessionKey?: string;
-  inputProvenance?: InputProvenance;
-  confirmedAcpManualSpawn?: boolean;
-  modelRun?: boolean;
-}): GatewayAgentTaskTrackingMode {
-  // Model probes are stateless one-shot work. A terminal CLI task row would
-  // outlive the probe even when its session/transcript effects are internal.
-  if (params.modelRun === true) {
-    return "none";
-  }
-  if (!params.sessionKey?.trim() || params.inputProvenance?.kind === "inter_session") {
-    return "none";
-  }
-  if (params.client?.internal?.agentRunTracking === "plugin_subagent") {
-    return "plugin_subagent";
-  }
-  // A confirmed ACP manual-spawn child turn already owns its requester-visible
-  // `acp` task row from the spawn control plane (src/agents/acp-spawn.ts). The
-  // Gateway CLI path runs that same childRunId, so tracking it here would emit a
-  // duplicate row for one run. Suppress only the CLI branch; plugin-subagent and
-  // normal CLI tracking stay intact.
-  if (params.confirmedAcpManualSpawn) {
-    return "none";
-  }
-  return "cli";
-}
-
-function isTrustedBackendAcpSpawnClient(client: GatewayRequestHandlerOptions["client"]): boolean {
-  // The ACP spawn control plane reaches the gateway through the in-process
-  // backend client (src/gateway/call.ts -> mode "backend", id "gateway-client").
-  // Only that caller creates the replacement `acp` task row, so CLI suppression
-  // is gated to it. An operator-write UI/CLI/mobile or device-token client that
-  // merely sets acpTurnSource owns no such row and must keep CLI tracking.
-  return (
-    client?.connect?.client?.id === GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT &&
-    client.connect.client.mode === GATEWAY_CLIENT_MODES.BACKEND &&
-    client.isDeviceTokenAuth !== true
-  );
-}
-
-function isConfirmedAcpManualSpawnTaskOwner(params: {
-  acpTurnSource?: string;
-  sessionKey?: string;
-  client: GatewayRequestHandlerOptions["client"];
-  logGateway: Pick<GatewayRequestContext["logGateway"], "warn">;
-}): boolean {
-  const sessionKey = params.sessionKey;
-  if (
-    !isTrustedBackendAcpSpawnClient(params.client) ||
-    params.acpTurnSource !== "manual_spawn" ||
-    sessionKey == null ||
-    !isAcpSessionKey(sessionKey)
-  ) {
-    return false;
-  }
-  try {
-    return readAcpSessionMeta({ sessionKey }) != null;
-  } catch (err) {
-    params.logGateway.warn(
-      `failed to read ACP session metadata for manual-spawn task tracking ${sessionKey}; falling back to cli task tracking: ${formatForLog(
-        err,
-      )}`,
-    );
-    return false;
-  }
-}
-
-async function registerPluginSubagentRunFromGateway(params: {
-  cfg: OpenClawConfig;
-  runId: string;
-  childSessionKey: string;
-  task: string;
-  requesterOrigin?: DeliveryContext;
-  pluginId?: string;
-}): Promise<void> {
-  const childSessionKey = params.childSessionKey.trim();
-  if (!childSessionKey) {
-    return;
-  }
-  const ownerSessionKey = resolveAgentMainSessionKey({
-    cfg: params.cfg,
-    agentId: resolveAgentIdFromSessionKey(childSessionKey),
-  });
-  const { registerSubagentRun } = await import("../../agents/subagent-registry.js");
-  registerSubagentRun({
-    runId: params.runId,
-    childSessionKey,
-    controllerSessionKey: ownerSessionKey,
-    requesterSessionKey: ownerSessionKey,
-    requesterOrigin: params.requesterOrigin,
-    requesterDisplayKey: "main",
-    task: params.task,
-    cleanup: "keep",
-    ...(params.pluginId ? { label: `plugin:${params.pluginId}` } : {}),
-    expectsCompletionMessage: false,
-    spawnMode: "run",
-  });
-}
-
-function resolveFailedTrackedAgentTaskStatus(error: unknown): GatewayAgentTaskTerminalStatus {
-  return isAbortError(error) || isTimeoutError(error) ? "timed_out" : "failed";
-}
-
-function tryFinalizeTrackedAgentTask(params: {
-  runId: string;
-  status: GatewayAgentTaskTerminalStatus;
-  error?: string;
-  terminalSummary?: string;
-  log: Pick<GatewayRequestContext["logGateway"], "warn">;
-}): void {
-  try {
-    finalizeTaskRunByRunId({
-      runId: params.runId,
-      runtime: "cli",
-      status: params.status,
-      endedAt: Date.now(),
-      ...(params.error !== undefined ? { error: params.error } : {}),
-      ...(params.terminalSummary !== undefined ? { terminalSummary: params.terminalSummary } : {}),
-    });
-  } catch (err) {
-    // Best-effort only: background task tracking must not block agent runs.
-    // Still surface the swallowed error so non-transient finalize failures stay observable.
-    params.log.warn(`failed to finalize tracked agent task ${params.runId}: ${formatForLog(err)}`);
-  }
-}
-
-function readAgentRunTimeoutAttribution(meta: unknown) {
-  const record =
-    meta && typeof meta === "object" && !Array.isArray(meta)
-      ? (meta as Record<string, unknown>)
-      : undefined;
-  return {
-    timeoutPhase: normalizeAgentRunTimeoutPhase(record?.timeoutPhase),
-    providerStarted: normalizeProviderStarted(record?.providerStarted),
-  };
-}
-
-function isGatewayAbortSignalReason(reason: unknown): boolean {
-  return reason === undefined || isAbortError(reason) || readErrorName(reason) === "TimeoutError";
-}
-
-function isGatewayAgentAbortRejection(error: unknown, signal: AbortSignal): boolean {
-  if (!signal.aborted) {
-    return false;
-  }
-  if (isAgentRunRestartAbortReason(signal.reason)) {
-    return true;
-  }
-  if (readErrorName(signal.reason) === "TimeoutError") {
-    return true;
-  }
-  if (!isGatewayAbortSignalReason(signal.reason)) {
-    return false;
-  }
-  return isAbortError(error) || readErrorName(error) === "TimeoutError";
-}
-
-function resolveGatewayAgentAbortStopReason(signal: AbortSignal): "restart" | "rpc" | "timeout" {
-  if (isAgentRunRestartAbortReason(signal.reason)) {
-    return "restart";
-  }
-  return readErrorName(signal.reason) === "TimeoutError" ? "timeout" : "rpc";
-}
-
-function resolveAbortedAgentStopReason(entry?: ChatAbortControllerEntry): string {
-  return entry?.abortStopReason?.trim() || "rpc";
-}
-
-function deleteGatewayDedupeEntries(params: {
-  dedupe: GatewayRequestContext["dedupe"];
-  keys: readonly string[];
-}) {
-  for (const key of params.keys) {
-    params.dedupe.delete(key);
-  }
-}
-
-function dispatchAgentRunFromGateway(params: {
-  ingressOpts: Parameters<typeof agentCommandFromIngress>[0];
-  runId: string;
-  dedupeKeys: readonly string[];
-  /**
-   * Controller whose signal is wired into `ingressOpts.abortSignal`. Used on
-   * completion to drop the matching `chatAbortControllers` entry without
-   * touching a same-runId entry owned by a concurrent chat.send.
-   */
-  abortController: AbortController;
-  cleanupAbortController: () => void;
-  respond: GatewayRequestHandlerOptions["respond"];
-  context: GatewayRequestHandlerOptions["context"];
-  taskTrackingMode: Exclude<GatewayAgentTaskTrackingMode, "plugin_subagent">;
-  onSettled?: (outcome: {
-    terminalOutcome: AgentRunTerminalOutcome;
-    onRecovered?: () => void;
-  }) => Promise<boolean> | boolean;
-}) {
-  const shouldTrackTask = params.taskTrackingMode === "cli";
-  let taskTracked = false;
-  if (shouldTrackTask) {
-    try {
-      taskTracked = Boolean(
-        createRunningTaskRun({
-          runtime: "cli",
-          sourceId: params.runId,
-          ownerKey: params.ingressOpts.sessionKey,
-          scopeKind: "session",
-          requesterOrigin: normalizeDeliveryContext({
-            channel: params.ingressOpts.channel,
-            to: params.ingressOpts.to,
-            accountId: params.ingressOpts.accountId,
-            threadId: params.ingressOpts.threadId,
-          }),
-          childSessionKey: params.ingressOpts.sessionKey,
-          runId: params.runId,
-          task: params.ingressOpts.message,
-          deliveryStatus: "not_applicable",
-          startedAt: Date.now(),
-        }),
-      );
-    } catch (err) {
-      // Best-effort only: background task tracking must not block agent runs.
-      // Still surface the swallowed error so non-transient tracking failures stay observable.
-      params.context.logGateway.warn(
-        `failed to start tracked agent task ${params.runId}: ${formatForLog(err)}`,
-      );
-    }
-  }
-  const settle = async (outcome: {
-    terminalOutcome: AgentRunTerminalOutcome;
-    onRecovered?: () => void;
-  }): Promise<boolean> => {
-    try {
-      return (await params.onSettled?.(outcome)) ?? true;
-    } catch (error) {
-      params.context.logGateway.warn(
-        `failed to settle agent continuation ${params.runId}: ${formatForLog(error)}`,
-      );
-      return false;
-    }
-  };
-  void agentCommandFromIngress(params.ingressOpts, defaultRuntime, params.context.deps)
-    .then(async (result) => {
-      const aborted = result?.meta?.aborted === true;
-      const timeoutAttribution = readAgentRunTimeoutAttribution(result?.meta);
-      if (taskTracked) {
-        tryFinalizeTrackedAgentTask({
-          runId: params.runId,
-          status: aborted ? "timed_out" : "succeeded",
-          terminalSummary: aborted ? "aborted" : "completed",
-          log: params.context.logGateway,
-        });
-      }
-      const payload = {
-        runId: params.runId,
-        status: aborted ? ("timeout" as const) : ("ok" as const),
-        summary: aborted ? "aborted" : "completed",
-        ...(aborted ? { stopReason: result?.meta?.stopReason ?? "rpc" } : {}),
-        ...(aborted && timeoutAttribution.timeoutPhase
-          ? { timeoutPhase: timeoutAttribution.timeoutPhase }
-          : {}),
-        ...(aborted && timeoutAttribution.providerStarted !== undefined
-          ? { providerStarted: timeoutAttribution.providerStarted }
-          : {}),
-        result,
-      };
-      const terminalOutcome = buildAgentRunTerminalOutcome({
-        status:
-          aborted || result?.meta?.stopReason === "timeout" || timeoutAttribution.timeoutPhase
-            ? "timeout"
-            : result?.meta?.error || result?.meta?.stopReason === "error"
-              ? "error"
-              : "ok",
-        error: result?.meta?.error,
-        stopReason: result?.meta?.stopReason,
-        livenessState: result?.meta?.livenessState,
-        timeoutPhase: timeoutAttribution.timeoutPhase,
-        providerStarted: timeoutAttribution.providerStarted,
-      });
-      const persistTerminalDedupe = () => {
-        setGatewayDedupeEntries({
-          dedupe: params.context.dedupe,
-          keys: params.dedupeKeys,
-          entry: {
-            ts: Date.now(),
-            ok: true,
-            payload,
-          },
-        });
-      };
-      const settled = await settle({ terminalOutcome, onRecovered: persistTerminalDedupe });
-      if (!settled) {
-        const summary = "failed to persist cron continuation settlement";
-        const error = errorShape(ErrorCodes.UNAVAILABLE, summary);
-        const failedPayload = { runId: params.runId, status: "error" as const, summary };
-        setGatewayDedupeEntries({
-          dedupe: params.context.dedupe,
-          keys: params.dedupeKeys,
-          entry: { ts: Date.now(), ok: false, payload: failedPayload, error },
-        });
-        params.respond(false, failedPayload, error, { runId: params.runId, error: summary });
-        return;
-      }
-      persistTerminalDedupe();
-      // Send a second res frame (same id) so TS clients with expectFinal can wait.
-      // Swift clients will typically treat the first res as the result and ignore this.
-      params.respond(true, payload, undefined, { runId: params.runId });
-    })
-    .catch(async (err: unknown) => {
-      const aborted = isGatewayAgentAbortRejection(err, params.abortController.signal);
-      const renderedErr = formatForLog(err);
-      if (taskTracked) {
-        tryFinalizeTrackedAgentTask({
-          runId: params.runId,
-          status: aborted ? "timed_out" : resolveFailedTrackedAgentTaskStatus(err),
-          error: renderedErr,
-          terminalSummary: renderedErr,
-          log: params.context.logGateway,
-        });
-      }
-      const error = errorShape(ErrorCodes.UNAVAILABLE, renderedErr);
-      const stopReason = resolveGatewayAgentAbortStopReason(params.abortController.signal);
-      const terminalOutcome = buildAgentRunTerminalOutcome({
-        status: aborted ? "timeout" : "error",
-        error: renderedErr,
-        stopReason,
-        timeoutPhase: aborted ? "gateway_draining" : undefined,
-      });
-      const payload = {
-        runId: params.runId,
-        status: aborted ? ("timeout" as const) : ("error" as const),
-        summary: aborted ? "aborted" : renderedErr,
-        ...(aborted ? { stopReason, timeoutPhase: "gateway_draining" as const } : {}),
-      };
-      const persistTerminalDedupe = (settlementPersisted: boolean) => {
-        setGatewayDedupeEntries({
-          dedupe: params.context.dedupe,
-          keys: params.dedupeKeys,
-          entry: {
-            ts: Date.now(),
-            ok: aborted && settlementPersisted,
-            payload,
-            ...(aborted ? {} : { error }),
-          },
-        });
-      };
-      const settled = await settle({
-        terminalOutcome,
-        onRecovered: () => persistTerminalDedupe(true),
-      });
-      persistTerminalDedupe(settled);
-      params.respond(aborted && settled, payload, aborted && settled ? undefined : error, {
-        runId: params.runId,
-        ...(aborted ? {} : { error: formatForLog(err) }),
-      });
-    })
-    .finally(() => {
-      clearAgentRunContext(params.runId, params.ingressOpts.lifecycleGeneration);
-      params.cleanupAbortController();
-    });
 }
 
 function shouldSuppressAgentPromptPersistence(params: {


### PR DESCRIPTION
Related: #106503

## What Problem This Solves

The gateway agent method mixed session-reset delivery, task ownership, and terminal run dispatch into one 4,168-line method module, making independent lifecycle paths difficult to review.

## Why This Change Was Made

Moves reset handling, task tracking, and run dispatch into focused modules while leaving request orchestration in the handler. The original module drops from 4,168 to 3,485 lines; every new production TypeScript file remains below 500 lines. Control flow and lifecycle semantics remain unchanged.

## User Impact

No user-visible behavior change. Maintainers get smaller owner-aligned gateway lifecycle modules.

## Evidence

- Blacksmith Testbox `tbx_01kxe3nn9k106ex7wr5g4vd4ft`
- `pnpm tsgo:core`
- `pnpm test src/gateway/server-methods/agent.test.ts` — 237 tests passed
- `pnpm exec oxfmt --check` on all four touched files
- Autoreview: clean, no actionable findings

AI assistance used for refactoring and review.
