### PR TITLE
refactor(cli): remove obsolete gateway call options export

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -1280,7 +1280,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/cli/cron-cli/register.cron-simple.ts: loadCronJobForShow",
   "src/cli/daemon-cli/launchd-recovery.ts: LAUNCH_AGENT_RECOVERY_MESSAGE",
   "src/cli/daemon-cli/response.ts: buildDaemonHintItems",
-  "src/cli/gateway-cli/call.ts: gatewayCallOpts",
   "src/cli/gateway-cli/qa-parent-watchdog.ts: QA_PARENT_PID_ENV",
   "src/cli/gateway-cli/qa-parent-watchdog.ts: QA_STAGED_RUNTIME_ROOT_ENV",
   "src/cli/gateway-cli/qa-parent-watchdog.ts: QA_TEMP_ROOT_ENV",

--- a/src/cli/gateway-cli/call.ts
+++ b/src/cli/gateway-cli/call.ts
@@ -1,5 +1,4 @@
-// Shared gateway RPC command options and progress-wrapped CLI call helper.
-import type { Command } from "commander";
+// Progress-wrapped Gateway RPC helper shared by CLI command surfaces.
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
@@ -21,15 +20,6 @@ export type GatewayRpcOpts = {
 };
 
 const DEFAULT_GATEWAY_RPC_TIMEOUT_MS = 10_000;
-
-export const gatewayCallOpts = (cmd: Command) =>
-  cmd
-    .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
-    .option("--token <token>", "Gateway token (if required)")
-    .option("--password <password>", "Gateway password (password auth)")
-    .option("--timeout <ms>", "Timeout in ms", "10000")
-    .option("--expect-final", "Wait for final response (agent)", false)
-    .option("--json", "Output JSON", false);
 
 export const callGatewayCli = async (method: string, opts: GatewayRpcOpts, params?: unknown) => {
   const timeoutMs =

--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -46,14 +46,6 @@ vi.mock("../../commands/gateway-status.js", () => ({
 }));
 
 vi.mock("./call.js", () => ({
-  gatewayCallOpts: (cmd: Command) =>
-    cmd
-      .option("--url <url>", "Gateway WebSocket URL")
-      .option("--token <token>", "Gateway token")
-      .option("--password <password>", "Gateway password")
-      .option("--timeout <ms>", "Timeout in ms", "10000")
-      .option("--expect-final", "Wait for final response (agent)", false)
-      .option("--json", "Output JSON", false),
   callGatewayCli: (method: string, opts: unknown, params?: unknown) =>
     mocks.callGatewayCli(method, opts, params),
 }));


### PR DESCRIPTION
## What Problem This Solves

The gateway CLI exposed a second `gatewayCallOpts` helper that had no production caller. The live command tree owns a separate options helper with timeout customization, while the dead export remained in the unused-export baseline and in a stale test mock.

## Why This Change Was Made

Remove the unused export, its obsolete mock, and its baseline entry. Keep `callGatewayCli` unchanged, and leave gateway option registration with the `register.ts` owner that all four command paths already use.

## User Impact

No user-visible behavior changes. Gateway command options, timeout handling, RPC calls, progress output, and cold-help imports remain unchanged.

## Evidence

- Refreshed codebase-memory graph: 311,773 nodes and 1,288,391 edges. Exact symbol queries find `gatewayCallOpts` only in `src/cli/gateway-cli/register.ts`; the dead export and mock nodes are gone.
- Blacksmith Testbox `tbx_01kxe4h35za94sc57ztdsg0qcy`, run https://github.com/openclaw/openclaw/actions/runs/29266070881: 48/48 focused CLI tests passed.
- The same Testbox passed `pnpm deadcode:exports` at the 2,527-entry baseline and the complete `pnpm check:changed` gate for all three touched paths.
- Fresh `gpt-5.6-sol` medium branch autoreview on head `5b8fb0b5567a4d3b7dbce2efb1a43de4e6ca77fe`: clean, confidence 0.98.
- `git diff --check`
- Current `main` and the live open-PR scan found no touched-file or symbol overlap.

AI-assisted: yes. I reviewed the complete change and validation evidence. No transcript is attached.
