### PR TITLE
refactor(codex): split app-server attempt helpers

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-lifecycle.ts
+++ b/extensions/codex/src/app-server/run-attempt-lifecycle.ts
@@ -1,0 +1,117 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  awaitAgentEndSideEffects,
+  embeddedAgentLog,
+  emitAgentEvent as emitGlobalAgentEvent,
+  runAgentEndSideEffects,
+  type EmbeddedRunAttemptParams,
+  type EmbeddedRunAttemptResult,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { CodexAppServerRuntimeOptions } from "./config.js";
+import { codexWorkspaceDirCache } from "./workspace-dir-cache.js";
+
+const CODEX_APP_SERVER_PROJECTED_CHARS_PER_TOKEN = 4;
+
+export function shouldKeepCodexSharedAbortOpen(params: {
+  trigger: EmbeddedRunAttemptParams["trigger"];
+  result: EmbeddedRunAttemptResult;
+  attemptSucceeded: boolean;
+  explicitCancellationObserved: boolean;
+}): boolean {
+  if (params.explicitCancellationObserved || params.result.aborted || params.result.externalAbort) {
+    return false;
+  }
+  // Memory attempts are preparatory. Failed attempts can still enter runner
+  // retries or model fallback. The reply orchestrator owns the shared terminal
+  // freeze after those paths settle.
+  return params.trigger === "memory" || !params.attemptSucceeded;
+}
+
+export function withCodexAppServerFastModeServiceTier(
+  appServer: CodexAppServerRuntimeOptions,
+  params: EmbeddedRunAttemptParams,
+): CodexAppServerRuntimeOptions {
+  const fastMode = typeof params.fastMode === "function" ? params.fastMode() : params.fastMode;
+  const serviceTier =
+    fastMode === undefined ? appServer.serviceTier : fastMode ? "priority" : undefined;
+  if (serviceTier === appServer.serviceTier) {
+    return appServer;
+  }
+  if (serviceTier) {
+    return { ...appServer, serviceTier };
+  }
+  return { ...appServer, serviceTier: null };
+}
+
+export function estimateCodexAppServerProjectedTurnTokens(params: {
+  prompt: string;
+  developerInstructions?: string;
+}): number {
+  const inputChars = params.prompt.length + (params.developerInstructions?.length ?? 0);
+  return Math.max(1, Math.ceil(inputChars / CODEX_APP_SERVER_PROJECTED_CHARS_PER_TOKEN));
+}
+
+export async function ensureCodexWorkspaceDirOnce(workspaceDir: string): Promise<void> {
+  const normalized = path.resolve(workspaceDir);
+  if (codexWorkspaceDirCache.has(normalized)) {
+    try {
+      const stat = await fs.stat(normalized);
+      if (stat.isDirectory()) {
+        return;
+      }
+    } catch (error) {
+      const code =
+        typeof error === "object" && error ? (error as { code?: unknown }).code : undefined;
+      if (code !== "ENOENT") {
+        throw error;
+      }
+    }
+    codexWorkspaceDirCache.delete(normalized);
+  }
+  // Codex attempts re-enter the same workspace repeatedly; caching successful
+  // mkdirs avoids repeated fs work while still recovering if cleanup prunes
+  // the directory between attempts.
+  await fs.mkdir(normalized, { recursive: true });
+  codexWorkspaceDirCache.add(normalized);
+}
+
+export async function emitCodexAppServerEvent(
+  params: EmbeddedRunAttemptParams,
+  event: Parameters<NonNullable<EmbeddedRunAttemptParams["onAgentEvent"]>>[0],
+): Promise<void> {
+  try {
+    emitGlobalAgentEvent({
+      runId: params.runId,
+      stream: event.stream,
+      data: event.data,
+      ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+    });
+  } catch (error) {
+    embeddedAgentLog.debug("codex app-server global agent event emit failed", { error });
+  }
+  try {
+    await params.onAgentEvent?.(event);
+  } catch (error) {
+    // Event consumers are observational; they must not abort or strand the
+    // canonical app-server turn lifecycle.
+    embeddedAgentLog.debug("codex app-server agent event handler threw", { error });
+  }
+}
+
+type CodexAgentEndHookParams = Parameters<typeof runAgentEndSideEffects>[0];
+
+export async function runCodexAgentEndHook(
+  params: EmbeddedRunAttemptParams,
+  hookParams: CodexAgentEndHookParams,
+): Promise<void> {
+  const sideEffectParams = {
+    ...hookParams,
+    ctx: { ...hookParams.ctx, config: params.config },
+  };
+  if (!params.messageChannel && !params.messageProvider) {
+    await awaitAgentEndSideEffects(sideEffectParams);
+    return;
+  }
+  runAgentEndSideEffects(sideEffectParams);
+}

--- a/extensions/codex/src/app-server/run-attempt-state.ts
+++ b/extensions/codex/src/app-server/run-attempt-state.ts
@@ -1,0 +1,200 @@
+import {
+  embeddedAgentLog,
+  formatErrorMessage,
+  type EmbeddedRunAttemptParams,
+  type EmbeddedRunAttemptResult,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { CodexAppServerRpcError } from "./client.js";
+import { isJsonObject, type CodexServerNotification } from "./protocol.js";
+import type {
+  CodexAppServerBindingIdentity,
+  CodexAppServerBindingStore,
+} from "./session-binding.js";
+import type { CodexAppServerThreadLifecycleBinding } from "./thread-lifecycle.js";
+
+export async function clearCodexBindingAfterInvalidImagePayload(
+  bindingStore: CodexAppServerBindingStore,
+  identity: CodexAppServerBindingIdentity,
+  fields: { phase: string; threadId?: string; turnId?: string; error?: string },
+): Promise<void> {
+  const currentBinding = await bindingStore.read(identity);
+  const expectedThreadId = fields.threadId ?? currentBinding?.threadId;
+  if (!expectedThreadId) {
+    return;
+  }
+  if (currentBinding && currentBinding.threadId !== expectedThreadId) {
+    embeddedAgentLog.warn(
+      "codex app-server image payload error detected for unbound thread; preserving thread binding",
+      { ...fields, boundThreadId: currentBinding.threadId },
+    );
+    return;
+  }
+  if (currentBinding?.connectionScope === "supervision") {
+    embeddedAgentLog.warn(
+      "codex app-server image payload error detected for supervised thread; preserving native binding",
+      fields,
+    );
+    return;
+  }
+  embeddedAgentLog.warn(
+    "codex app-server image payload error detected; clearing thread binding",
+    fields,
+  );
+  await bindingStore.mutate(identity, { kind: "clear", threadId: expectedThreadId });
+}
+
+export async function markCodexAppServerBindingCoveredThroughTurn(params: {
+  bindingStore: CodexAppServerBindingStore;
+  identity: CodexAppServerBindingIdentity;
+  threadId: string;
+}): Promise<void> {
+  await params.bindingStore.mutate(params.identity, {
+    kind: "patch",
+    threadId: params.threadId,
+    patch: { historyCoveredThrough: new Date().toISOString() },
+  });
+}
+
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+export function shouldUseFreshCodexThreadAfterContextEngineOverflow(params: {
+  error: unknown;
+  contextEngineActive: boolean;
+  thread: CodexAppServerThreadLifecycleBinding;
+}): boolean {
+  if (!params.contextEngineActive || params.thread.lifecycle.action !== "resumed") {
+    return false;
+  }
+  const message = formatErrorMessage(params.error);
+  return (
+    /ran out of room in the model'?s context window/iu.test(message) ||
+    /context window/iu.test(message) ||
+    /context length/iu.test(message) ||
+    /maximum context/iu.test(message) ||
+    /too many tokens/iu.test(message)
+  );
+}
+
+export function isCodexActiveCompactTurnError(error: unknown): boolean {
+  if (!(error instanceof CodexAppServerRpcError)) {
+    return false;
+  }
+  const data = isJsonObject(error.data) ? error.data : undefined;
+  const codexErrorInfo = isJsonObject(data?.codexErrorInfo) ? data.codexErrorInfo : undefined;
+  const activeTurn = isJsonObject(codexErrorInfo?.activeTurnNotSteerable)
+    ? codexErrorInfo.activeTurnNotSteerable
+    : undefined;
+  return activeTurn?.turnKind === "compact";
+}
+
+export function readCodexFinalizationHookNotification(
+  notification: CodexServerNotification,
+  threadId: string,
+  turnId: string,
+):
+  | { phase: "started"; runId: string }
+  | { phase: "completed"; runId: string; status: string | undefined }
+  | undefined {
+  if (notification.method !== "hook/started" && notification.method !== "hook/completed") {
+    return undefined;
+  }
+  const params = isJsonObject(notification.params) ? notification.params : undefined;
+  const run = params && isJsonObject(params.run) ? params.run : undefined;
+  // Codex selects exactly one of Stop or SubagentStop from the turn's session
+  // source, so these event names share aggregation state but cannot coexist.
+  if (
+    params?.threadId !== threadId ||
+    params.turnId !== turnId ||
+    (run?.eventName !== "stop" && run?.eventName !== "subagentStop") ||
+    typeof run.id !== "string" ||
+    !run.id
+  ) {
+    return undefined;
+  }
+  if (notification.method === "hook/started") {
+    return { phase: "started", runId: run.id };
+  }
+  return {
+    phase: "completed",
+    runId: run.id,
+    status: typeof run.status === "string" ? run.status : undefined,
+  };
+}
+
+export function joinPresentSections(...sections: Array<string | undefined>): string {
+  return sections.filter((section): section is string => Boolean(section?.trim())).join("\n\n");
+}
+
+export function prependCurrentInboundContext(
+  prompt: string,
+  context: EmbeddedRunAttemptParams["currentInboundContext"],
+): string {
+  const text = context?.text.trim();
+  return text ? [text, prompt].filter(Boolean).join("\n\n") : prompt;
+}
+
+export function waitForCodexNotificationDispatchTurn(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+export function buildCodexAppServerTimeoutDiagnostics(params: {
+  idleMs?: number;
+  timeoutMs?: number;
+  lastActivityReason?: string;
+  details?: Record<string, unknown>;
+}): NonNullable<EmbeddedRunAttemptResult["codexAppServerFailure"]>["diagnostics"] {
+  const readString = (key: string) => {
+    const value = params.details?.[key];
+    return typeof value === "string" && value.trim() ? value : undefined;
+  };
+  const readNumber = (key: string) => {
+    const value = params.details?.[key];
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  };
+  const readBoolean = (key: string) => {
+    const value = params.details?.[key];
+    return typeof value === "boolean" ? value : undefined;
+  };
+  return {
+    ...(params.idleMs !== undefined ? { idleMs: params.idleMs } : {}),
+    ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
+    ...(params.lastActivityReason ? { lastActivityReason: params.lastActivityReason } : {}),
+    ...(readString("lastNotificationMethod")
+      ? { lastNotificationMethod: readString("lastNotificationMethod") }
+      : {}),
+    ...(readString("lastNotificationItemId")
+      ? { lastNotificationItemId: readString("lastNotificationItemId") }
+      : {}),
+    ...(readString("lastNotificationItemType")
+      ? { lastNotificationItemType: readString("lastNotificationItemType") }
+      : {}),
+    ...(readString("lastNotificationItemRole")
+      ? { lastNotificationItemRole: readString("lastNotificationItemRole") }
+      : {}),
+    ...(readString("lastAssistantTextPreview")
+      ? { lastAssistantTextPreview: readString("lastAssistantTextPreview") }
+      : {}),
+    ...(readNumber("activeAppServerTurnRequests") !== undefined
+      ? { activeAppServerTurnRequests: readNumber("activeAppServerTurnRequests") }
+      : {}),
+    ...(readNumber("activeTurnItemCount") !== undefined
+      ? { activeTurnItemCount: readNumber("activeTurnItemCount") }
+      : {}),
+    ...(readBoolean("terminalTurnNotificationQueued") !== undefined
+      ? { terminalTurnNotificationQueued: readBoolean("terminalTurnNotificationQueued") }
+      : {}),
+    ...(readBoolean("completionIdleWatchArmed") !== undefined
+      ? { completionIdleWatchArmed: readBoolean("completionIdleWatchArmed") }
+      : {}),
+    ...(readBoolean("assistantCompletionIdleWatchArmed") !== undefined
+      ? { assistantCompletionIdleWatchArmed: readBoolean("assistantCompletionIdleWatchArmed") }
+      : {}),
+    ...(readBoolean("terminalIdleWatchArmed") !== undefined
+      ? { terminalIdleWatchArmed: readBoolean("terminalIdleWatchArmed") }
+      : {}),
+  };
+}

--- a/extensions/codex/src/app-server/run-attempt-tools.ts
+++ b/extensions/codex/src/app-server/run-attempt-tools.ts
@@ -1,0 +1,125 @@
+import {
+  type EmbeddedRunAttemptParams,
+  type NativeHookRelayRegistrationHandle,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { handleCodexAppServerApprovalRequest } from "./approval-bridge.js";
+import { isCrestodianOnlyCodexDynamicToolAllowlist } from "./dynamic-tool-profile.js";
+import type {
+  CodexDynamicToolCallParams,
+  CodexDynamicToolCallResponse,
+  JsonValue,
+} from "./protocol.js";
+import { sanitizeCodexToolResponse } from "./tool-progress-normalization.js";
+
+export function toTranscriptToolResult(
+  response: CodexDynamicToolCallResponse,
+): Record<string, unknown> {
+  const sanitized = sanitizeCodexToolResponse(response);
+  const contentItems = Array.isArray(sanitized.contentItems) ? sanitized.contentItems : [];
+  const result: Record<string, unknown> = {
+    ...sanitized,
+    // Progress events are UI/transcript-facing; map only sanitized content so
+    // event redaction cannot be bypassed by raw dynamic tool output.
+    content: contentItems.map(toTranscriptToolResultContentItem),
+  };
+  delete result.contentItems;
+  delete result.success;
+  return result;
+}
+
+function toTranscriptToolResultContentItem(item: unknown): Record<string, unknown> {
+  if (!item || typeof item !== "object") {
+    return { type: "text", text: "" };
+  }
+  const record = item as Record<string, unknown>;
+  if (record.type === "inputText") {
+    return { type: "text", text: typeof record.text === "string" ? record.text : "" };
+  }
+  if (record.type === "inputImage") {
+    return typeof record.imageUrl === "string"
+      ? { type: "image", url: record.imageUrl }
+      : { type: "text", text: formatUnsupportedCodexDynamicToolOutput(record.type) };
+  }
+  return { type: "text", text: formatUnsupportedCodexDynamicToolOutput(record.type) };
+}
+
+function formatUnsupportedCodexDynamicToolOutput(type: unknown): string {
+  const rawType = typeof type === "string" ? type.replace(/\s+/g, " ").trim() : "";
+  const label = rawType ? truncateUtf16Safe(rawType, 80) : "unknown";
+  const suffix = rawType.length > 80 ? "..." : "";
+  return `[Unsupported Codex dynamic tool output: ${label}${suffix}]`;
+}
+
+type CodexDynamicToolExecutionIdentity = Pick<
+  CodexDynamicToolCallParams,
+  "threadId" | "turnId" | "callId"
+>;
+
+export function createCodexDynamicToolExecutionRegistry() {
+  const executions = new Map<string, Promise<CodexDynamicToolCallResponse>>();
+  const keyFor = (call: CodexDynamicToolExecutionIdentity) =>
+    JSON.stringify([call.threadId, call.turnId, call.callId]);
+
+  return {
+    get(call: CodexDynamicToolExecutionIdentity) {
+      return executions.get(keyFor(call));
+    },
+    claim(
+      call: CodexDynamicToolExecutionIdentity,
+      start: () => Promise<CodexDynamicToolCallResponse>,
+    ) {
+      const existing = executions.get(keyFor(call));
+      if (existing) {
+        return { execution: existing, replayed: true } as const;
+      }
+      const execution = start();
+      executions.set(keyFor(call), execution);
+      return { execution, replayed: false } as const;
+    },
+  };
+}
+
+export function handleApprovalRequest(params: {
+  method: string;
+  params: JsonValue | undefined;
+  paramsForRun: EmbeddedRunAttemptParams;
+  threadId: string;
+  turnId: string;
+  nativeHookRelay?: NativeHookRelayRegistrationHandle;
+  autoApprove?: boolean;
+  signal?: AbortSignal;
+  onNativeToolFailureDisposition?: Parameters<
+    typeof handleCodexAppServerApprovalRequest
+  >[0]["onNativeToolFailureDisposition"];
+}): Promise<JsonValue | undefined> {
+  return handleCodexAppServerApprovalRequest({
+    method: params.method,
+    requestParams: params.params,
+    paramsForRun: params.paramsForRun,
+    threadId: params.threadId,
+    turnId: params.turnId,
+    nativeHookRelay: params.nativeHookRelay,
+    autoApprove: params.autoApprove,
+    signal: params.signal,
+    onNativeToolFailureDisposition: params.onNativeToolFailureDisposition,
+  });
+}
+
+export function resolveCodexDynamicToolDirectNames(
+  params: EmbeddedRunAttemptParams,
+  hostCrestodianActive = false,
+): string[] {
+  // Tools with catalogMode=direct-only use the model-only namespace. This list
+  // remains for control tools that intentionally live at the dynamic-tool root.
+  const names: string[] = [];
+  // Crestodian is the run's only tool and must stay callable when Codex tool
+  // search is unavailable. Exact toolsAllow is the public harness contract.
+  if (hostCrestodianActive && isCrestodianOnlyCodexDynamicToolAllowlist(params.toolsAllow)) {
+    names.push("crestodian");
+  }
+  if (params.sourceReplyDeliveryMode === "message_tool_only") {
+    names.push("message");
+  }
+  return names;
+}

--- a/extensions/codex/src/app-server/run-attempt-tools.ts
+++ b/extensions/codex/src/app-server/run-attempt-tools.ts
@@ -1,6 +1,6 @@
-import {
-  type EmbeddedRunAttemptParams,
-  type NativeHookRelayRegistrationHandle,
+import type {
+  EmbeddedRunAttemptParams,
+  NativeHookRelayRegistrationHandle,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { handleCodexAppServerApprovalRequest } from "./approval-bridge.js";

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1,6 +1,4 @@
 // Codex plugin module implements run attempt behavior.
-import fs from "node:fs/promises";
-import path from "node:path";
 import {
   assembleHarnessContextEngine,
   assertContextEngineHostSupport,
@@ -10,7 +8,6 @@ import {
   CODEX_APP_SERVER_CONTEXT_ENGINE_HOST,
   clearActiveEmbeddedRun,
   embeddedAgentLog,
-  emitAgentEvent as emitGlobalAgentEvent,
   finalizeHarnessContextEngineTurn,
   FAST_MODE_AUTO_PROGRESS_KIND,
   formatFastModeAutoProgressText,
@@ -26,8 +23,6 @@ import {
   resolveSandboxContext,
   resolveSessionAgentIds,
   resolveUserPath,
-  awaitAgentEndSideEffects,
-  runAgentEndSideEffects,
   runAgentHarnessLlmInputHook,
   runAgentHarnessLlmOutputHook,
   runHarnessContextEngineMaintenance,
@@ -51,12 +46,10 @@ import {
   resolveDiagnosticModelContentCapturePolicy,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { loadExecApprovals } from "openclaw/plugin-sdk/exec-approvals-runtime";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   resolveCodexAppServerForModelProvider,
   resolveCodexAppServerForOpenClawToolPolicy,
 } from "./app-server-policy.js";
-import { handleCodexAppServerApprovalRequest } from "./approval-bridge.js";
 import {
   CODEX_APP_SERVER_INTERRUPT_TIMEOUT_MS,
   CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
@@ -127,11 +120,7 @@ import {
   resolveCodexAppServerPreparedApiKeyCacheKey,
 } from "./auth-bridge.js";
 import { resolveCodexBindingAppServerConnection } from "./binding-connection.js";
-import {
-  CodexAppServerRpcError,
-  isCodexAppServerApprovalRequest,
-  type CodexAppServerClient,
-} from "./client.js";
+import { isCodexAppServerApprovalRequest, type CodexAppServerClient } from "./client.js";
 import {
   isCodexAppServerApprovalPolicyAllowedByRequirements,
   isCodexSandboxExecServerEnabled,
@@ -176,10 +165,7 @@ import {
   toCodexDynamicToolProgressResponse,
   toCodexDynamicToolProtocolResponse,
 } from "./dynamic-tool-execution.js";
-import {
-  isCrestodianOnlyCodexDynamicToolAllowlist,
-  resolveCodexDynamicToolsLoadingForRuntime,
-} from "./dynamic-tool-profile.js";
+import { resolveCodexDynamicToolsLoadingForRuntime } from "./dynamic-tool-profile.js";
 import { createCodexDynamicToolBridge } from "./dynamic-tools.js";
 import { handleCodexAppServerElicitationRequest } from "./elicitation-bridge.js";
 import {
@@ -205,7 +191,6 @@ import {
 } from "./protocol-validators.js";
 import {
   flattenCodexDynamicToolFunctions,
-  isJsonObject,
   type CodexSandboxPolicy,
   type CodexTurnEnvironmentParams,
   type CodexServerNotification,
@@ -217,6 +202,32 @@ import {
 } from "./protocol.js";
 import { resolveCodexProviderWebSearchSupport } from "./provider-capabilities.js";
 import { readCodexRateLimitsRevision, readRecentCodexRateLimits } from "./rate-limit-cache.js";
+import {
+  emitCodexAppServerEvent,
+  ensureCodexWorkspaceDirOnce,
+  estimateCodexAppServerProjectedTurnTokens,
+  runCodexAgentEndHook,
+  shouldKeepCodexSharedAbortOpen,
+  withCodexAppServerFastModeServiceTier,
+} from "./run-attempt-lifecycle.js";
+import {
+  buildCodexAppServerTimeoutDiagnostics,
+  clearCodexBindingAfterInvalidImagePayload,
+  isCodexActiveCompactTurnError,
+  isNonEmptyString,
+  joinPresentSections,
+  markCodexAppServerBindingCoveredThroughTurn,
+  prependCurrentInboundContext,
+  readCodexFinalizationHookNotification,
+  shouldUseFreshCodexThreadAfterContextEngineOverflow,
+  waitForCodexNotificationDispatchTurn,
+} from "./run-attempt-state.js";
+import {
+  createCodexDynamicToolExecutionRegistry,
+  handleApprovalRequest,
+  resolveCodexDynamicToolDirectNames,
+  toTranscriptToolResult,
+} from "./run-attempt-tools.js";
 import { releaseCodexSandboxExecServerEnvironment } from "./sandbox-exec-server.js";
 import {
   reclaimCurrentCodexSessionGeneration,
@@ -247,7 +258,6 @@ import {
   inferCodexDynamicToolMeta,
   resolveCodexToolProgressDetailMode,
   sanitizeCodexToolArguments,
-  sanitizeCodexToolResponse,
 } from "./tool-progress-normalization.js";
 import {
   createCodexTrajectoryRecorder,
@@ -276,183 +286,8 @@ import {
 } from "./usage-limit-error.js";
 import { createCodexUserInputBridge } from "./user-input-bridge.js";
 import { resolveCodexWebSearchPlan } from "./web-search.js";
-import { codexWorkspaceDirCache } from "./workspace-dir-cache.js";
 
 const CODEX_NATIVE_HOOK_RELAY_RENEW_INTERVAL_MS = 60_000;
-const CODEX_APP_SERVER_PROJECTED_CHARS_PER_TOKEN = 4;
-
-function shouldKeepCodexSharedAbortOpen(params: {
-  trigger: EmbeddedRunAttemptParams["trigger"];
-  result: EmbeddedRunAttemptResult;
-  attemptSucceeded: boolean;
-  explicitCancellationObserved: boolean;
-}): boolean {
-  if (params.explicitCancellationObserved || params.result.aborted || params.result.externalAbort) {
-    return false;
-  }
-  // Memory attempts are preparatory. Failed attempts can still enter runner
-  // retries or model fallback. The reply orchestrator owns the shared terminal
-  // freeze after those paths settle.
-  return params.trigger === "memory" || !params.attemptSucceeded;
-}
-
-function withCodexAppServerFastModeServiceTier(
-  appServer: CodexAppServerRuntimeOptions,
-  params: EmbeddedRunAttemptParams,
-): CodexAppServerRuntimeOptions {
-  const fastMode = typeof params.fastMode === "function" ? params.fastMode() : params.fastMode;
-  const serviceTier =
-    fastMode === undefined ? appServer.serviceTier : fastMode ? "priority" : undefined;
-  if (serviceTier === appServer.serviceTier) {
-    return appServer;
-  }
-  if (serviceTier) {
-    return { ...appServer, serviceTier };
-  }
-  return { ...appServer, serviceTier: null };
-}
-
-function estimateCodexAppServerProjectedTurnTokens(params: {
-  prompt: string;
-  developerInstructions?: string;
-}): number {
-  const inputChars = params.prompt.length + (params.developerInstructions?.length ?? 0);
-  return Math.max(1, Math.ceil(inputChars / CODEX_APP_SERVER_PROJECTED_CHARS_PER_TOKEN));
-}
-
-async function ensureCodexWorkspaceDirOnce(workspaceDir: string): Promise<void> {
-  const normalized = path.resolve(workspaceDir);
-  if (codexWorkspaceDirCache.has(normalized)) {
-    try {
-      const stat = await fs.stat(normalized);
-      if (stat.isDirectory()) {
-        return;
-      }
-    } catch (error) {
-      const code =
-        typeof error === "object" && error ? (error as { code?: unknown }).code : undefined;
-      if (code !== "ENOENT") {
-        throw error;
-      }
-    }
-    codexWorkspaceDirCache.delete(normalized);
-  }
-  // Codex attempts re-enter the same workspace repeatedly; caching successful
-  // mkdirs avoids repeated fs work while still recovering if cleanup prunes
-  // the directory between attempts.
-  await fs.mkdir(normalized, { recursive: true });
-  codexWorkspaceDirCache.add(normalized);
-}
-
-async function emitCodexAppServerEvent(
-  params: EmbeddedRunAttemptParams,
-  event: Parameters<NonNullable<EmbeddedRunAttemptParams["onAgentEvent"]>>[0],
-): Promise<void> {
-  try {
-    emitGlobalAgentEvent({
-      runId: params.runId,
-      stream: event.stream,
-      data: event.data,
-      ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-    });
-  } catch (error) {
-    embeddedAgentLog.debug("codex app-server global agent event emit failed", { error });
-  }
-  try {
-    await params.onAgentEvent?.(event);
-  } catch (error) {
-    // Event consumers are observational; they must not abort or strand the
-    // canonical app-server turn lifecycle.
-    embeddedAgentLog.debug("codex app-server agent event handler threw", { error });
-  }
-}
-
-function toTranscriptToolResult(response: CodexDynamicToolCallResponse): Record<string, unknown> {
-  const sanitized = sanitizeCodexToolResponse(response);
-  const contentItems = Array.isArray(sanitized.contentItems) ? sanitized.contentItems : [];
-  const result: Record<string, unknown> = {
-    ...sanitized,
-    // Progress events are UI/transcript-facing; map only sanitized content so
-    // event redaction cannot be bypassed by raw dynamic tool output.
-    content: contentItems.map(toTranscriptToolResultContentItem),
-  };
-  delete result.contentItems;
-  delete result.success;
-  return result;
-}
-
-function toTranscriptToolResultContentItem(item: unknown): Record<string, unknown> {
-  if (!item || typeof item !== "object") {
-    return { type: "text", text: "" };
-  }
-  const record = item as Record<string, unknown>;
-  if (record.type === "inputText") {
-    return { type: "text", text: typeof record.text === "string" ? record.text : "" };
-  }
-  if (record.type === "inputImage") {
-    return typeof record.imageUrl === "string"
-      ? { type: "image", url: record.imageUrl }
-      : { type: "text", text: formatUnsupportedCodexDynamicToolOutput(record.type) };
-  }
-  return { type: "text", text: formatUnsupportedCodexDynamicToolOutput(record.type) };
-}
-
-function formatUnsupportedCodexDynamicToolOutput(type: unknown): string {
-  const rawType = typeof type === "string" ? type.replace(/\s+/g, " ").trim() : "";
-  const label = rawType ? truncateUtf16Safe(rawType, 80) : "unknown";
-  const suffix = rawType.length > 80 ? "..." : "";
-  return `[Unsupported Codex dynamic tool output: ${label}${suffix}]`;
-}
-
-type CodexAgentEndHookParams = Parameters<typeof runAgentEndSideEffects>[0];
-
-type CodexDynamicToolExecutionIdentity = Pick<
-  CodexDynamicToolCallParams,
-  "threadId" | "turnId" | "callId"
->;
-
-function createCodexDynamicToolExecutionRegistry() {
-  const executions = new Map<string, Promise<CodexDynamicToolCallResponse>>();
-  const keyFor = (call: CodexDynamicToolExecutionIdentity) =>
-    JSON.stringify([call.threadId, call.turnId, call.callId]);
-
-  return {
-    get(call: CodexDynamicToolExecutionIdentity) {
-      return executions.get(keyFor(call));
-    },
-    claim(
-      call: CodexDynamicToolExecutionIdentity,
-      start: () => Promise<CodexDynamicToolCallResponse>,
-    ) {
-      const existing = executions.get(keyFor(call));
-      if (existing) {
-        return { execution: existing, replayed: true } as const;
-      }
-      const execution = start();
-      executions.set(keyFor(call), execution);
-      return { execution, replayed: false } as const;
-    },
-  };
-}
-
-function shouldAwaitCodexAgentEndHook(params: EmbeddedRunAttemptParams): boolean {
-  return !params.messageChannel && !params.messageProvider;
-}
-
-async function runCodexAgentEndHook(
-  params: EmbeddedRunAttemptParams,
-  hookParams: CodexAgentEndHookParams,
-): Promise<void> {
-  const sideEffectParams = {
-    ...hookParams,
-    ctx: { ...hookParams.ctx, config: params.config },
-  };
-  if (shouldAwaitCodexAgentEndHook(params)) {
-    await awaitAgentEndSideEffects(sideEffectParams);
-    return;
-  }
-  runAgentEndSideEffects(sideEffectParams);
-}
 
 export async function runCodexAppServerAttempt(
   params: EmbeddedRunAttemptParams,
@@ -2568,7 +2403,7 @@ export async function runCodexAppServerAttempt(
         }
         return undefined;
       }
-      const call = readDynamicToolCallParams(request.params);
+      const call = readCodexDynamicToolCallParams(request.params);
       if (!call || call.threadId !== thread.threadId || call.turnId !== turnId) {
         return undefined;
       }
@@ -3893,245 +3728,4 @@ export async function runCodexAppServerAttempt(
     params.replyOperation?.detachBackend(handle);
     clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
   }
-}
-
-function readDynamicToolCallParams(
-  value: JsonValue | undefined,
-): CodexDynamicToolCallParams | undefined {
-  return readCodexDynamicToolCallParams(value);
-}
-
-async function clearCodexBindingAfterInvalidImagePayload(
-  bindingStore: CodexAppServerBindingStore,
-  identity: CodexAppServerBindingIdentity,
-  fields: { phase: string; threadId?: string; turnId?: string; error?: string },
-): Promise<void> {
-  const currentBinding = await bindingStore.read(identity);
-  const expectedThreadId = fields.threadId ?? currentBinding?.threadId;
-  if (!expectedThreadId) {
-    return;
-  }
-  if (currentBinding && currentBinding.threadId !== expectedThreadId) {
-    embeddedAgentLog.warn(
-      "codex app-server image payload error detected for unbound thread; preserving thread binding",
-      { ...fields, boundThreadId: currentBinding.threadId },
-    );
-    return;
-  }
-  if (currentBinding?.connectionScope === "supervision") {
-    embeddedAgentLog.warn(
-      "codex app-server image payload error detected for supervised thread; preserving native binding",
-      fields,
-    );
-    return;
-  }
-  embeddedAgentLog.warn(
-    "codex app-server image payload error detected; clearing thread binding",
-    fields,
-  );
-  await bindingStore.mutate(identity, { kind: "clear", threadId: expectedThreadId });
-}
-
-async function markCodexAppServerBindingCoveredThroughTurn(params: {
-  bindingStore: CodexAppServerBindingStore;
-  identity: CodexAppServerBindingIdentity;
-  threadId: string;
-}): Promise<void> {
-  await params.bindingStore.mutate(params.identity, {
-    kind: "patch",
-    threadId: params.threadId,
-    patch: { historyCoveredThrough: new Date().toISOString() },
-  });
-}
-
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.length > 0;
-}
-
-function shouldUseFreshCodexThreadAfterContextEngineOverflow(params: {
-  error: unknown;
-  contextEngineActive: boolean;
-  thread: CodexAppServerThreadLifecycleBinding;
-}): boolean {
-  if (!params.contextEngineActive || params.thread.lifecycle.action !== "resumed") {
-    return false;
-  }
-  return isCodexContextWindowError(params.error);
-}
-
-function isCodexContextWindowError(error: unknown): boolean {
-  const message = formatErrorMessage(error);
-  return (
-    /ran out of room in the model'?s context window/iu.test(message) ||
-    /context window/iu.test(message) ||
-    /context length/iu.test(message) ||
-    /maximum context/iu.test(message) ||
-    /too many tokens/iu.test(message)
-  );
-}
-
-function isCodexActiveCompactTurnError(error: unknown): boolean {
-  if (!(error instanceof CodexAppServerRpcError)) {
-    return false;
-  }
-  const data = isJsonObject(error.data) ? error.data : undefined;
-  const codexErrorInfo = isJsonObject(data?.codexErrorInfo) ? data.codexErrorInfo : undefined;
-  const activeTurn = isJsonObject(codexErrorInfo?.activeTurnNotSteerable)
-    ? codexErrorInfo.activeTurnNotSteerable
-    : undefined;
-  return activeTurn?.turnKind === "compact";
-}
-
-function readCodexFinalizationHookNotification(
-  notification: CodexServerNotification,
-  threadId: string,
-  turnId: string,
-):
-  | { phase: "started"; runId: string }
-  | { phase: "completed"; runId: string; status: string | undefined }
-  | undefined {
-  if (notification.method !== "hook/started" && notification.method !== "hook/completed") {
-    return undefined;
-  }
-  const params = isJsonObject(notification.params) ? notification.params : undefined;
-  const run = params && isJsonObject(params.run) ? params.run : undefined;
-  // Codex selects exactly one of Stop or SubagentStop from the turn's session
-  // source, so these event names share aggregation state but cannot coexist.
-  if (
-    params?.threadId !== threadId ||
-    params.turnId !== turnId ||
-    (run?.eventName !== "stop" && run?.eventName !== "subagentStop") ||
-    typeof run.id !== "string" ||
-    !run.id
-  ) {
-    return undefined;
-  }
-  if (notification.method === "hook/started") {
-    return { phase: "started", runId: run.id };
-  }
-  return {
-    phase: "completed",
-    runId: run.id,
-    status: typeof run.status === "string" ? run.status : undefined,
-  };
-}
-
-function joinPresentSections(...sections: Array<string | undefined>): string {
-  return sections.filter((section): section is string => Boolean(section?.trim())).join("\n\n");
-}
-
-function prependCurrentInboundContext(
-  prompt: string,
-  context: EmbeddedRunAttemptParams["currentInboundContext"],
-): string {
-  const text = context?.text.trim();
-  return text ? [text, prompt].filter(Boolean).join("\n\n") : prompt;
-}
-
-function waitForCodexNotificationDispatchTurn(): Promise<void> {
-  return new Promise((resolve) => {
-    setImmediate(resolve);
-  });
-}
-
-function buildCodexAppServerTimeoutDiagnostics(params: {
-  idleMs?: number;
-  timeoutMs?: number;
-  lastActivityReason?: string;
-  details?: Record<string, unknown>;
-}): NonNullable<EmbeddedRunAttemptResult["codexAppServerFailure"]>["diagnostics"] {
-  const readString = (key: string) => {
-    const value = params.details?.[key];
-    return typeof value === "string" && value.trim() ? value : undefined;
-  };
-  const readNumber = (key: string) => {
-    const value = params.details?.[key];
-    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-  };
-  const readBoolean = (key: string) => {
-    const value = params.details?.[key];
-    return typeof value === "boolean" ? value : undefined;
-  };
-  return {
-    ...(params.idleMs !== undefined ? { idleMs: params.idleMs } : {}),
-    ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
-    ...(params.lastActivityReason ? { lastActivityReason: params.lastActivityReason } : {}),
-    ...(readString("lastNotificationMethod")
-      ? { lastNotificationMethod: readString("lastNotificationMethod") }
-      : {}),
-    ...(readString("lastNotificationItemId")
-      ? { lastNotificationItemId: readString("lastNotificationItemId") }
-      : {}),
-    ...(readString("lastNotificationItemType")
-      ? { lastNotificationItemType: readString("lastNotificationItemType") }
-      : {}),
-    ...(readString("lastNotificationItemRole")
-      ? { lastNotificationItemRole: readString("lastNotificationItemRole") }
-      : {}),
-    ...(readString("lastAssistantTextPreview")
-      ? { lastAssistantTextPreview: readString("lastAssistantTextPreview") }
-      : {}),
-    ...(readNumber("activeAppServerTurnRequests") !== undefined
-      ? { activeAppServerTurnRequests: readNumber("activeAppServerTurnRequests") }
-      : {}),
-    ...(readNumber("activeTurnItemCount") !== undefined
-      ? { activeTurnItemCount: readNumber("activeTurnItemCount") }
-      : {}),
-    ...(readBoolean("terminalTurnNotificationQueued") !== undefined
-      ? { terminalTurnNotificationQueued: readBoolean("terminalTurnNotificationQueued") }
-      : {}),
-    ...(readBoolean("completionIdleWatchArmed") !== undefined
-      ? { completionIdleWatchArmed: readBoolean("completionIdleWatchArmed") }
-      : {}),
-    ...(readBoolean("assistantCompletionIdleWatchArmed") !== undefined
-      ? { assistantCompletionIdleWatchArmed: readBoolean("assistantCompletionIdleWatchArmed") }
-      : {}),
-    ...(readBoolean("terminalIdleWatchArmed") !== undefined
-      ? { terminalIdleWatchArmed: readBoolean("terminalIdleWatchArmed") }
-      : {}),
-  };
-}
-
-function handleApprovalRequest(params: {
-  method: string;
-  params: JsonValue | undefined;
-  paramsForRun: EmbeddedRunAttemptParams;
-  threadId: string;
-  turnId: string;
-  nativeHookRelay?: NativeHookRelayRegistrationHandle;
-  autoApprove?: boolean;
-  signal?: AbortSignal;
-  onNativeToolFailureDisposition?: Parameters<
-    typeof handleCodexAppServerApprovalRequest
-  >[0]["onNativeToolFailureDisposition"];
-}): Promise<JsonValue | undefined> {
-  return handleCodexAppServerApprovalRequest({
-    method: params.method,
-    requestParams: params.params,
-    paramsForRun: params.paramsForRun,
-    threadId: params.threadId,
-    turnId: params.turnId,
-    nativeHookRelay: params.nativeHookRelay,
-    autoApprove: params.autoApprove,
-    signal: params.signal,
-    onNativeToolFailureDisposition: params.onNativeToolFailureDisposition,
-  });
-}
-
-function resolveCodexDynamicToolDirectNames(
-  params: EmbeddedRunAttemptParams,
-  hostCrestodianActive = false,
-): string[] {
-  // Tools with catalogMode=direct-only use the model-only namespace. This list
-  // remains for control tools that intentionally live at the dynamic-tool root.
-  const names: string[] = [];
-  // Crestodian is the run's only tool and must stay callable when Codex tool
-  // search is unavailable. Exact toolsAllow is the public harness contract.
-  if (hostCrestodianActive && isCrestodianOnlyCodexDynamicToolAllowlist(params.toolsAllow)) {
-    names.push("crestodian");
-  }
-  if (params.sourceReplyDeliveryMode === "message_tool_only") {
-    names.push("message");
-  }
-  return names;
 }


### PR DESCRIPTION
## What Problem This Solves

`extensions/codex/src/app-server/run-attempt.ts` mixed the main attempt orchestration with lifecycle delivery, binding/finalization state helpers, and dynamic-tool bridge helpers. At 4,137 lines, those owner boundaries were hard to review independently.

Related #106503.

## Why This Change Was Made

- move attempt lifecycle and workspace helpers into `run-attempt-lifecycle.ts`
- move binding, prompt, finalization-hook, and timeout-state helpers into `run-attempt-state.ts`
- move dynamic-tool transcript, replay registry, approval, and direct-name helpers into `run-attempt-tools.ts`
- keep `run-attempt.ts` as the orchestration owner, reduced from 4,137 to 3,731 lines
- keep every new production file below 500 lines

The split preserves one canonical path. No compatibility layer, protocol change, configuration change, or dependency change.

## User Impact

None expected. Internal refactor only; Codex app-server turn, approval, dynamic-tool, hook, and timeout behavior remains unchanged.

## Evidence

- Blacksmith Testbox `tbx_01kxe4d2jnmb5gg7t7e061kncf`: `pnpm tsgo:extensions`
- Blacksmith Testbox `tbx_01kxe4d2jnmb5gg7t7e061kncf`: `pnpm test extensions/codex/src/app-server/run-attempt.test.ts` — 115 passed
- `pnpm dlx oxfmt@0.58.0 --write` on all four touched files; `git diff --check`
- fresh autoreview: clean, no accepted/actionable findings
- direct Codex source inspection at `openai/codex@c7a4a7e136d96554e1fc6f66532e6060fd2aaf15`: `turn/start` request/response contract in `codex-rs/app-server-protocol/src/protocol/common.rs:805-810`; approval, input, and dynamic-tool server requests in `common.rs:1460-1496`; terminal notifications in `common.rs:1629-1632`; turn lifecycle dispatch in `codex-rs/app-server/src/bespoke_event_handling.rs:152-197`; turn-start submission and in-progress response in `codex-rs/app-server/src/request_processors/turn_processor.rs:446-579`

## Documentation

Not applicable. No user-visible behavior or public contract change.

## Changelog

Not required. Internal refactor only; root changelog remains release-owned.
