### PR TITLE
fix(sqlite): migration flags unstarted sessions as missing transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,7 @@ Docs: https://docs.openclaw.ai
 - **Reply pre-delivery recovery:** bound each pre-delivery callback with an owner-overridable deadline, release serialized reply lanes after hung plugin work, and preserve durable final-delivery retry state only when transport never started. (#104256) Thanks @NianJiuZst.
 - **Signal native quote replies:** preserve the active inbound message as a native quote across agent, explicit, durable, and chunked sends while keeping reply-mode policy inside the Signal plugin. (#105347) Thanks @jesse-merhi.
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
+- **Session SQLite migration:** accept reset-shaped unstarted legacy sessions whose lazy transcript was never created as valid empty sessions, avoiding false missing-transcript warnings and failure reports while preserving warnings for sessions with activity.
 
 ## 2026.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,7 +254,6 @@ Docs: https://docs.openclaw.ai
 - **Reply pre-delivery recovery:** bound each pre-delivery callback with an owner-overridable deadline, release serialized reply lanes after hung plugin work, and preserve durable final-delivery retry state only when transport never started. (#104256) Thanks @NianJiuZst.
 - **Signal native quote replies:** preserve the active inbound message as a native quote across agent, explicit, durable, and chunked sends while keeping reply-mode policy inside the Signal plugin. (#105347) Thanks @jesse-merhi.
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
-- **Session SQLite migration:** accept reset-shaped unstarted legacy sessions whose lazy transcript was never created as valid empty sessions, avoiding false missing-transcript warnings and failure reports while preserving warnings for sessions with activity.
 
 ## 2026.7.1
 

--- a/src/commands/doctor-session-sqlite-readers.ts
+++ b/src/commands/doctor-session-sqlite-readers.ts
@@ -46,9 +46,14 @@ type TranscriptEventCountResult =
   | { status: "missing" }
   | { status: "malformed"; message: string };
 
+type LegacyTranscriptEventCountResult =
+  | { status: "ok"; events: number; hasTranscript: boolean }
+  | { status: "missing" }
+  | { status: "malformed"; message: string };
+
 const JSONL_READ_CHUNK_BYTES = 64 * 1024;
 
-export function countTranscriptEventsForPath(
+function countTranscriptEventsForPath(
   transcriptPath: string | undefined,
 ): TranscriptEventCountResult {
   if (!transcriptPath) {
@@ -69,6 +74,34 @@ export function countTranscriptEventsForPath(
   } catch (err) {
     return { status: "malformed", message: String(err) };
   }
+}
+
+export function countLegacyTranscriptEvents(params: {
+  entry: SessionEntry;
+  transcriptPath?: string;
+}): LegacyTranscriptEventCountResult {
+  const result = countTranscriptEventsForPath(params.transcriptPath);
+  // File-backed resets historically published the fresh session entry before
+  // the first append created its transcript. That reset-shaped entry is a
+  // valid empty session, not evidence that transcript events were lost.
+  if (result.status === "missing" && isUnstartedLegacySession(params.entry)) {
+    return { status: "ok", events: 0, hasTranscript: false };
+  }
+  if (result.status === "ok") {
+    return { ...result, hasTranscript: true };
+  }
+  return result;
+}
+
+function isUnstartedLegacySession(entry: SessionEntry): boolean {
+  const startedAt = entry.sessionStartedAt;
+  return (
+    entry.systemSent === false &&
+    typeof startedAt === "number" &&
+    entry.updatedAt >= startedAt &&
+    (entry.lastInteractionAt === undefined || entry.lastInteractionAt === startedAt) &&
+    (entry.compactionCount === undefined || entry.compactionCount === 0)
+  );
 }
 
 export function createTranscriptEventReader(

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -1648,6 +1648,52 @@ describe("runDoctorSessionSqlite", () => {
     ).toEqual([]);
   });
 
+  it("accepts an unstarted legacy session without a transcript sidecar", async () => {
+    const store = createLegacyStore({
+      entryOverrides: {
+        compactionCount: 0,
+        lastInteractionAt: 1000,
+        sessionStartedAt: 1000,
+        systemSent: false,
+        updatedAt: 1000,
+      },
+    });
+    fs.rmSync(store.transcriptPath);
+
+    const dryRun = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "dry-run",
+      store: store.storePath,
+    });
+    expect(dryRun.totals).toMatchObject({
+      issues: 0,
+      validatedEntries: 1,
+      validatedTranscriptEvents: 0,
+    });
+
+    const report = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+
+    expect(report.totals).toMatchObject({
+      importedEntries: 1,
+      importedTranscriptEvents: 0,
+      issues: 0,
+      sqliteEntries: 1,
+    });
+    expect(report.migrationRun?.failureReportMarkdownPath).toBeUndefined();
+    expect(
+      loadSqliteTranscriptEventsSync({
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        storePath: store.storePath,
+      }),
+    ).toEqual([]);
+  });
+
   it("keeps a shared legacy store intact when importing only one agent", async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-session-sqlite-"));
     try {

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -1648,14 +1648,14 @@ describe("runDoctorSessionSqlite", () => {
     ).toEqual([]);
   });
 
-  it("accepts an unstarted legacy session without a transcript sidecar", async () => {
+  it("accepts an unstarted legacy session with a later metadata timestamp", async () => {
     const store = createLegacyStore({
       entryOverrides: {
         compactionCount: 0,
         lastInteractionAt: 1000,
         sessionStartedAt: 1000,
         systemSent: false,
-        updatedAt: 1000,
+        updatedAt: 1001,
       },
     });
     fs.rmSync(store.transcriptPath);

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -429,6 +429,17 @@ function resolveLegacyTranscriptPath(
   return entry.sessionFile?.trim() ? defaultPath : undefined;
 }
 
+function isUnstartedLegacySession(entry: SessionEntry): boolean {
+  const startedAt = entry.sessionStartedAt;
+  return (
+    entry.systemSent === false &&
+    typeof startedAt === "number" &&
+    entry.updatedAt === startedAt &&
+    (entry.lastInteractionAt === undefined || entry.lastInteractionAt === startedAt) &&
+    (entry.compactionCount === undefined || entry.compactionCount === 0)
+  );
+}
+
 function countLegacyTranscript(
   record: LegacySessionRecord,
   report: DoctorSessionSqliteTargetReport,
@@ -508,7 +519,7 @@ async function importLegacySessionRecord(
     entry: record.entry,
     sessionKey: record.sessionKey,
     storePath: target.storePath,
-    ...(record.transcriptPath && result.status === "ok"
+    ...(record.transcriptPath && result.status === "ok" && result.hasTranscript
       ? { readTranscriptEvents: createTranscriptEventReader(record.transcriptPath) }
       : {}),
     ...(transcriptMtimeMs !== undefined ? { transcriptMtimeMs } : {}),
@@ -899,10 +910,20 @@ function countAlreadyMigratedTranscriptEventsForValidate(
 function countTranscriptEvents(
   record: LegacySessionRecord,
 ):
-  | { status: "ok"; events: number }
+  | { status: "ok"; events: number; hasTranscript: boolean }
   | { status: "missing" }
   | { status: "malformed"; message: string } {
-  return countTranscriptEventsForPath(record.transcriptPath);
+  const result = countTranscriptEventsForPath(record.transcriptPath);
+  // File-backed resets historically published the fresh session entry before
+  // the first append created its transcript. That reset-shaped entry is a
+  // valid empty session, not evidence that transcript events were lost.
+  if (result.status === "missing" && isUnstartedLegacySession(record.entry)) {
+    return { status: "ok", events: 0, hasTranscript: false };
+  }
+  if (result.status === "ok") {
+    return { ...result, hasTranscript: true };
+  }
+  return result;
 }
 
 function readLegacyTranscriptMtimeMs(record: LegacySessionRecord): number | undefined {

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -434,7 +434,7 @@ function isUnstartedLegacySession(entry: SessionEntry): boolean {
   return (
     entry.systemSent === false &&
     typeof startedAt === "number" &&
-    entry.updatedAt === startedAt &&
+    entry.updatedAt >= startedAt &&
     (entry.lastInteractionAt === undefined || entry.lastInteractionAt === startedAt) &&
     (entry.compactionCount === undefined || entry.compactionCount === 0)
   );

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -43,7 +43,7 @@ import {
   type SessionSqliteMigrationTargetInput,
 } from "./doctor-session-sqlite-migration-run.js";
 import {
-  countTranscriptEventsForPath,
+  countLegacyTranscriptEvents,
   createTranscriptEventReader,
   createTranscriptEventPrefixReader,
   readOnlySqliteDbStats,
@@ -429,22 +429,11 @@ function resolveLegacyTranscriptPath(
   return entry.sessionFile?.trim() ? defaultPath : undefined;
 }
 
-function isUnstartedLegacySession(entry: SessionEntry): boolean {
-  const startedAt = entry.sessionStartedAt;
-  return (
-    entry.systemSent === false &&
-    typeof startedAt === "number" &&
-    entry.updatedAt >= startedAt &&
-    (entry.lastInteractionAt === undefined || entry.lastInteractionAt === startedAt) &&
-    (entry.compactionCount === undefined || entry.compactionCount === 0)
-  );
-}
-
 function countLegacyTranscript(
   record: LegacySessionRecord,
   report: DoctorSessionSqliteTargetReport,
 ): void {
-  const result = countTranscriptEvents(record);
+  const result = countLegacyTranscriptEvents(record);
   if (result.status === "missing") {
     report.issues.push({
       code: "transcript_missing",
@@ -474,7 +463,7 @@ async function importLegacySessionRecord(
   record: LegacySessionRecord,
   report: DoctorSessionSqliteTargetReport,
 ): Promise<void> {
-  const result = countTranscriptEvents(record);
+  const result = countLegacyTranscriptEvents(record);
   const transcriptMtimeMs = readLegacyTranscriptMtimeMs(record);
   if (result.status === "missing") {
     if (markAlreadyMigratedTranscript(target, record, report)) {
@@ -581,7 +570,7 @@ function validateImportedRecordBeforeArchive(
     });
     return;
   }
-  const result = countTranscriptEvents(record);
+  const result = countLegacyTranscriptEvents(record);
   if (result.status === "missing") {
     return;
   }
@@ -831,7 +820,7 @@ function validateTranscriptEventCount(
   record: LegacySessionRecord,
   report: DoctorSessionSqliteTargetReport,
 ): void {
-  const result = countTranscriptEvents(record);
+  const result = countLegacyTranscriptEvents(record);
   if (result.status === "missing") {
     const migratedEvents = countAlreadyMigratedTranscriptEventsForValidate(target, record);
     if (migratedEvents !== undefined) {
@@ -905,25 +894,6 @@ function countAlreadyMigratedTranscriptEventsForValidate(
   }
   const eventCount = readOnlySqliteTranscriptEventCount(target, record.entry.sessionId);
   return eventCount.ok ? eventCount.events : undefined;
-}
-
-function countTranscriptEvents(
-  record: LegacySessionRecord,
-):
-  | { status: "ok"; events: number; hasTranscript: boolean }
-  | { status: "missing" }
-  | { status: "malformed"; message: string } {
-  const result = countTranscriptEventsForPath(record.transcriptPath);
-  // File-backed resets historically published the fresh session entry before
-  // the first append created its transcript. That reset-shaped entry is a
-  // valid empty session, not evidence that transcript events were lost.
-  if (result.status === "missing" && isUnstartedLegacySession(record.entry)) {
-    return { status: "ok", events: 0, hasTranscript: false };
-  }
-  if (result.status === "ok") {
-    return { ...result, hasTranscript: true };
-  }
-  return result;
 }
 
 function readLegacyTranscriptMtimeMs(record: LegacySessionRecord): number | undefined {


### PR DESCRIPTION
Related: #55817
Related: #98236

## What Problem This Solves

Fixes an issue where users migrating historical file-backed sessions to SQLite would receive a `transcript_missing` warning and a failure report for a session that had been reset but never started.

## Why This Change Was Made

Historical reset flows could persist a fresh session entry before the first append lazily created its transcript. The migration now recognizes the conservative reset-shaped, unstarted entry signature as a valid empty session while continuing to report missing transcripts for sessions that show activity.

The import path explicitly distinguishes a valid empty session from a readable transcript, so existing transcript files are still imported normally.

## User Impact

SQLite migration no longer reports false transcript-loss warnings for these empty historical sessions. Missing transcript files for active or otherwise non-empty sessions remain visible.

## Evidence

- Added a regression test that failed before the fix with one `transcript_missing` issue and zero validated entries.
- After the fix, the full `doctor-session-sqlite` test file passes: 63 passed, 2 skipped.
- Focused formatting and lint checks pass for the changed files.
- Verified the branch is rebased onto the current upstream `main` before submission.

AI-assisted change. I reviewed and understand the code and tests in this pull request.
