### PR TITLE
refactor(agents): split embedded runner orchestration

### DIFF
--- a/scripts/lib/extension-test-plan.mjs
+++ b/scripts/lib/extension-test-plan.mjs
@@ -104,6 +104,9 @@ function isSkippedTrackedTestFile(relativePath) {
 }
 
 let trackedRepoTestFiles;
+// Large checkouts exceed Node's 1 MiB spawnSync default. Preserve the Git inventory path;
+// ENOBUFS would otherwise trigger expensive extension-directory walks.
+const GIT_LS_FILES_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
 
 function loadTrackedRepoTestFiles() {
   if (trackedRepoTestFiles !== undefined) {
@@ -113,6 +116,7 @@ function loadTrackedRepoTestFiles() {
   const result = spawnSync("git", ["ls-files"], {
     cwd: repoRoot,
     encoding: "utf8",
+    maxBuffer: GIT_LS_FILES_MAX_BUFFER_BYTES,
     stdio: ["ignore", "pipe", "ignore"],
   });
   if (result.status !== 0) {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -174,11 +174,6 @@ import {
   isShortWindowRateLimitMessage,
 } from "./run/assistant-failover.js";
 import {
-  buildTraceToolSummary,
-  hasCompletedModelProgressForIdleBreaker,
-  normalizeEmbeddedRunAttemptResult,
-} from "./run/run-attempt-result.js";
-import {
   createEmbeddedRunStageTracker,
   EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE,
   formatEmbeddedRunStageSummary,
@@ -250,6 +245,11 @@ import type { RunEmbeddedAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
 import { createEmbeddedRunProgressController } from "./run/progress-controller.js";
 import { handleRetryLimitExhaustion } from "./run/retry-limit.js";
+import {
+  buildTraceToolSummary,
+  hasCompletedModelProgressForIdleBreaker,
+  normalizeEmbeddedRunAttemptResult,
+} from "./run/run-attempt-result.js";
 import {
   CODEX_HARNESS_ID,
   resolveAttemptTrajectoryAttribution,

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3,23 +3,14 @@
  */
 import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
-import {
-  addTimerTimeoutGraceMs,
-  MAX_TIMER_TIMEOUT_MS,
-} from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeForLog } from "../../../packages/terminal-core/src/ansi.js";
-import { FAST_MODE_AUTO_PROGRESS_KIND, type ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { getRuntimeConfigSnapshot } from "../../config/config.js";
 import { resolveStorePath } from "../../config/sessions.js";
-import {
-  loadSessionEntry,
-  resolveSessionTranscriptRuntimeReadTarget,
-  updateSessionEntry,
-} from "../../config/sessions/session-accessor.js";
+import { resolveSessionTranscriptRuntimeReadTarget } from "../../config/sessions/session-accessor.js";
 import { parseSqliteSessionFileMarker } from "../../config/sessions/sqlite-marker.js";
 import { OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST } from "../../context-engine/host-compat.js";
 import { ensureContextEnginesInitialized } from "../../context-engine/init.js";
@@ -33,12 +24,8 @@ import {
   resolveCompactionSuccessorTranscript,
 } from "../../context-engine/types.js";
 import {
-  assertAgentRunLifecycleGenerationCurrent,
   captureAgentRunLifecycleGeneration,
-  claimAgentRunContext,
-  emitAgentItemEvent,
   getAgentEventLifecycleGeneration,
-  getAgentRunContext,
   registerAgentRunContext,
   withAgentRunLifecycleGeneration,
 } from "../../infra/agent-events.js";
@@ -49,9 +36,6 @@ import { redactIdentifier } from "../../logging/redact-identifier.js";
 import { buildAgentHookContextChannelFields } from "../../plugins/hook-agent-context.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveProviderAuthProfileId } from "../../plugins/provider-runtime.js";
-import { enqueueCommandInLane, getCommandLaneSnapshot } from "../../process/command-queue.js";
-import type { CommandQueueEnqueueOptions } from "../../process/command-queue.types.js";
-import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { looksLikeSecretSentinel, resolveSecretSentinel } from "../../secrets/sentinel.js";
 import { createAgentHarnessTaskRuntimeScope } from "../../tasks/agent-harness-task-runtime-scope.js";
 import { createTrajectoryRuntimeRecorder } from "../../trajectory/runtime.js";
@@ -77,10 +61,6 @@ import {
 } from "../auth-profiles.js";
 import { resolveExternalCliAuthOverlayScopeFromSelection } from "../auth-profiles/external-cli-auth-selection.js";
 import { listActiveProcessSessionReferences } from "../bash-process-references.js";
-import {
-  resolveSessionKeyForRequest,
-  resolveStoredSessionKeyForSessionId,
-} from "../command/session.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import {
   classifyAssistantFailoverReason,
@@ -114,12 +94,6 @@ import {
   FailoverError,
   resolveFailoverStatus,
 } from "../failover-error.js";
-import {
-  DEFAULT_FAST_MODE_AUTO_ON_SECONDS,
-  type FastModeAutoProgressState,
-  formatFastModeAutoProgressText,
-  resolveFastModeForElapsed,
-} from "../fast-mode.js";
 import { ensureSelectedAgentHarnessPlugin } from "../harness/runtime-plugin.js";
 import {
   agentHarnessBuildsOpenClawTools,
@@ -139,12 +113,6 @@ import {
   ensureAuthProfileStoreWithoutExternalProfiles,
   type ResolvedProviderAuth,
 } from "../model-auth.js";
-import {
-  buildModelAliasIndex,
-  resolveDefaultModelForAgent,
-  resolveModelRefFromString,
-} from "../model-selection.js";
-import { resolveThinkingDefault } from "../model-thinking-default.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import {
   OPENAI_PROVIDER_ID,
@@ -165,10 +133,8 @@ import {
   prepareAgentRuntimeAuth,
   type PreparedAgentRuntimeAuthAttempt,
 } from "../runtime-plan/prepare-auth.js";
-import type { AgentRuntimePlan } from "../runtime-plan/types.js";
 import type { AgentRuntimeAuthPlan } from "../runtime-plan/types.js";
 import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
-import { withSessionPlacementTurnAdmission } from "../session-placement-admission.js";
 import {
   resolveSessionSuspensionReason,
   resolveSessionSuspensionTarget,
@@ -176,7 +142,6 @@ import {
   type SessionSuspensionParams,
 } from "../session-suspension.js";
 import { resolveCandidateThinkingLevel } from "../thinking-runtime.js";
-import { DEFAULT_AGENT_TIMEOUT_MS } from "../timeout.js";
 import { resolveToolLoopDetectionConfig } from "../tool-loop-detection-config.js";
 import { deriveContextPromptTokens, normalizeUsage, type UsageLike } from "../usage.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
@@ -209,6 +174,11 @@ import {
   isShortWindowRateLimitMessage,
 } from "./run/assistant-failover.js";
 import {
+  buildTraceToolSummary,
+  hasCompletedModelProgressForIdleBreaker,
+  normalizeEmbeddedRunAttemptResult,
+} from "./run/run-attempt-result.js";
+import {
   createEmbeddedRunStageTracker,
   EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE,
   formatEmbeddedRunStageSummary,
@@ -220,6 +190,7 @@ import {
   resolveEmbeddedAuthCooldownProbePolicy,
 } from "./run/auth-controller.js";
 import { resolveAuthProfileFailureReason } from "./run/auth-profile-failure-policy.js";
+import { createScopedAuthProfileStore, resolveAttemptDispatchApiKey } from "./run/auth-store.js";
 import { runEmbeddedAttemptWithBackend } from "./run/backend.js";
 import {
   hasCodexAppServerRecoveryRetryBudget,
@@ -269,14 +240,34 @@ import {
   shouldRetrySilentErrorAssistantTurn,
   shouldTreatEmptyAssistantReplyAsSilent,
 } from "./run/incomplete-turn.js";
+import { createEmbeddedRunLaneController } from "./run/lane-controller.js";
+import {
+  EMBEDDED_RUN_LANE_HEARTBEAT_MS,
+  EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
+  resolveEmbeddedRunLaneTimeoutMs,
+} from "./run/lane-runtime.js";
 import type { RunEmbeddedAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
+import { createEmbeddedRunProgressController } from "./run/progress-controller.js";
 import { handleRetryLimitExhaustion } from "./run/retry-limit.js";
+import {
+  CODEX_HARNESS_ID,
+  resolveAttemptTrajectoryAttribution,
+  resolveInitialEmbeddedRunModel,
+  resolveInitialThinkLevel,
+  resolveRequestStreamTransportOverrides,
+} from "./run/runtime-resolution.js";
+import {
+  assertAgentHarnessRunAdmission,
+  backfillSessionKey,
+  buildContextEngineCompactionSessionTarget,
+  isNoRealConversationCompactionNoop,
+  resetNoRealConversationTokenSnapshot,
+} from "./run/session-bootstrap.js";
 import {
   buildBeforeModelResolveAttachments,
   createNativeModelOwnedRuntimeModel,
   resolveEmbeddedRuntimeModelPolicy,
-  resolveAgentHarnessRunAdmissionError,
   resolveHookModelSelection,
   resolveNativeModelOwnedHarnessId,
 } from "./run/setup.js";
@@ -287,38 +278,25 @@ import {
   resolveEmbeddedRunAttemptTerminalOutcome,
 } from "./run/terminal-outcome.js";
 import { mergeAttemptToolMediaPayloads } from "./run/tool-media-payloads.js";
-import type { EmbeddedRunFastModeParam } from "./run/types.js";
 import {
   resolveLiveToolResultMaxChars,
   sessionLikelyHasOversizedToolResults,
   truncateOversizedToolResultsInActiveTarget,
 } from "./tool-result-truncation.js";
-import type {
-  EmbeddedAgentMeta,
-  EmbeddedAgentRunResult,
-  TraceAttempt,
-  ToolSummaryTrace,
-} from "./types.js";
+import type { EmbeddedAgentMeta, EmbeddedAgentRunResult, TraceAttempt } from "./types.js";
 import { createUsageAccumulator, mergeUsageIntoAccumulator } from "./usage-accumulator.js";
 import { mapThinkingLevelForProvider } from "./utils.js";
 
 type ApiKeyInfo = ResolvedProviderAuth;
 
-const CODEX_HARNESS_ID = "codex";
-const OPENAI_RESPONSES_API = "openai-responses";
-const OPENAI_CODEX_RESPONSES_API = "openai-chatgpt-responses";
 const MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES = 1;
-const EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS = 30_000;
-const EMBEDDED_RUN_LANE_HEARTBEAT_MS = EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS / 2;
 const MID_TURN_PRECHECK_CONTINUATION_PROMPT =
   "Continue from the current transcript after the latest tool result. Do not repeat the original user request, and do not rerun completed tools unless the transcript shows they are still needed.";
 const COMPACTION_CONTINUATION_RETRY_INSTRUCTION =
   "The previous attempt compacted the conversation context before producing a final user-visible answer. Continue from the compacted transcript and produce the final answer now. Do not restart from scratch, do not repeat completed work, and do not rerun tools unless the transcript clearly lacks required evidence.";
-const NO_REAL_CONVERSATION_MESSAGES_REASON = "no real conversation messages";
 const BEFORE_AGENT_FINALIZE_RETRY_PROMPT_PREFIX =
   "Before accepting the previous final answer, apply this revision request and produce the revised final answer. Do not repeat completed work or rerun tools unless the request explicitly requires it.";
 const MAX_BEFORE_AGENT_FINALIZE_REVISIONS = 3;
-type EmbeddedRunAttemptForRunner = Awaited<ReturnType<typeof runEmbeddedAttemptWithBackend>>;
 type RunEmbeddedAgentInternalParams = RunEmbeddedAgentParams & {
   onSuccessfulAuthBinding?: (
     binding: import("../execution-auth-binding.js").AgentExecutionAuthBinding,
@@ -331,436 +309,8 @@ type RunEmbeddedAgentParamsWithSessionFile = RunEmbeddedAgentInternalParams & {
   sessionFile: string;
 };
 
-function normalizeRuntimeId(value: string | undefined): string {
-  return value?.trim().toLowerCase() ?? "";
-}
-
-function resolveAttemptTrajectoryAttribution(params: {
-  model: { api?: string; provider?: string };
-  modelId: string;
-  provider: string;
-  runtimePlan: {
-    auth?: Pick<AgentRuntimePlan["auth"], "authProfileProviderForAuth">;
-    observability?: Pick<AgentRuntimePlan["observability"], "harnessId">;
-  };
-}): { modelApi?: string; modelId: string; provider: string } {
-  const authProfileProvider = normalizeRuntimeId(
-    params.runtimePlan.auth?.authProfileProviderForAuth,
-  );
-  const harnessId = normalizeRuntimeId(params.runtimePlan.observability?.harnessId);
-  if (
-    harnessId === CODEX_HARNESS_ID &&
-    authProfileProvider !== OPENAI_PROVIDER_ID &&
-    normalizeRuntimeId(params.model.provider) === OPENAI_PROVIDER_ID &&
-    normalizeRuntimeId(params.model.api) === OPENAI_RESPONSES_API
-  ) {
-    return {
-      modelApi: OPENAI_CODEX_RESPONSES_API,
-      modelId: params.modelId,
-      provider: OPENAI_PROVIDER_ID,
-    };
-  }
-  return {
-    ...(params.model.api ? { modelApi: params.model.api } : {}),
-    modelId: params.modelId,
-    provider: params.provider,
-  };
-}
-
-function buildContextEngineCompactionSessionTarget(params: {
-  agentId: string;
-  config?: RunEmbeddedAgentParams["config"];
-  sessionFile: string;
-  sessionId: string;
-  sessionKey?: string;
-  sessionTarget?: RunEmbeddedAgentParams["sessionTarget"];
-}): ContextEngineSessionTarget {
-  const sqliteMarker = parseSqliteSessionFileMarker(params.sessionFile);
-  const agentId = params.sessionTarget?.agentId ?? sqliteMarker?.agentId ?? params.agentId;
-  const sessionKey = params.sessionTarget?.sessionKey ?? params.sessionKey ?? params.sessionId;
-  const storePath =
-    params.sessionTarget?.storePath ??
-    sqliteMarker?.storePath ??
-    resolveStorePath(params.config?.session?.store, { agentId });
-  return {
-    agentId,
-    sessionId: params.sessionTarget?.sessionId ?? sqliteMarker?.sessionId ?? params.sessionId,
-    ...(sessionKey ? { sessionKey } : {}),
-    ...(storePath ? { storePath } : {}),
-    ...(params.sessionTarget?.threadId !== undefined
-      ? { threadId: params.sessionTarget.threadId }
-      : {}),
-  };
-}
-
-function isNoRealConversationCompactionNoop(params: {
-  ok?: boolean;
-  compacted?: boolean;
-  reason?: string;
-}): boolean {
-  return (
-    params.ok === true &&
-    params.compacted === false &&
-    params.reason === NO_REAL_CONVERSATION_MESSAGES_REASON
-  );
-}
-
-function resolveInitialThinkLevel(params: {
-  requested?: ThinkLevel;
-  config?: RunEmbeddedAgentParams["config"];
-  provider: string;
-  modelId: string;
-  model: { reasoning?: boolean };
-}): ThinkLevel {
-  if (params.requested) {
-    return params.requested;
-  }
-  return resolveThinkingDefault({
-    cfg: params.config ?? {},
-    provider: params.provider,
-    model: params.modelId,
-    catalog: [
-      {
-        provider: params.provider,
-        id: params.modelId,
-        name: params.modelId,
-        reasoning: params.model.reasoning,
-      },
-    ],
-  });
-}
-
-async function resetNoRealConversationTokenSnapshot(params: {
-  config?: RunEmbeddedAgentParams["config"];
-  sessionKey?: string;
-  agentId?: string;
-}): Promise<void> {
-  if (!params.sessionKey) {
-    return;
-  }
-  const storePath = resolveStorePath(params.config?.session?.store, { agentId: params.agentId });
-  try {
-    await updateSessionEntry(
-      {
-        storePath,
-        sessionKey: params.sessionKey,
-      },
-      async () => ({
-        totalTokens: 0,
-        totalTokensFresh: true,
-        inputTokens: undefined,
-        outputTokens: undefined,
-        cacheRead: undefined,
-        cacheWrite: undefined,
-        contextBudgetStatus: undefined,
-        updatedAt: Date.now(),
-      }),
-      {
-        skipMaintenance: true,
-        takeCacheOwnership: true,
-      },
-    );
-  } catch (err) {
-    log.warn(
-      `[context-overflow-precheck] failed to reset stale context snapshot for ` +
-        `${params.sessionKey}: ${String(err)}`,
-    );
-  }
-}
-
-function resolveAttemptDispatchApiKey(params: {
-  apiKeyInfo: ApiKeyInfo | null;
-  runtimeAuthState: RuntimeAuthState | null;
-}): string | undefined {
-  if (params.runtimeAuthState) {
-    return undefined;
-  }
-  return params.apiKeyInfo?.apiKey;
-}
-
 function buildBeforeAgentFinalizeRetryPrompt(reason: string): string {
   return `${BEFORE_AGENT_FINALIZE_RETRY_PROMPT_PREFIX}\n\n${reason}`;
-}
-
-function resolveEmbeddedRunLaneTimeoutMs(timeoutMs: number): number {
-  const defaultLaneTimeoutMs = DEFAULT_AGENT_TIMEOUT_MS + EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS;
-  // "No timeout" resolves to the timer-safe MAX_TIMER sentinel upstream.
-  // Lane ownership still caps at the default agent deadline in that case.
-  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0 || timeoutMs >= MAX_TIMER_TIMEOUT_MS) {
-    return defaultLaneTimeoutMs;
-  }
-  return (
-    addTimerTimeoutGraceMs(Math.floor(timeoutMs), EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS) ??
-    defaultLaneTimeoutMs
-  );
-}
-
-function withEmbeddedRunLaneTimeout(
-  opts: CommandQueueEnqueueOptions | undefined,
-  laneTaskTimeoutMs: number,
-): CommandQueueEnqueueOptions | undefined {
-  if (opts?.taskTimeoutMs !== undefined) {
-    return opts;
-  }
-  return { ...opts, taskTimeoutMs: laneTaskTimeoutMs };
-}
-
-function resolveEmbeddedRunSessionQueuePriority(
-  trigger: RunEmbeddedAgentParams["trigger"],
-): CommandQueueEnqueueOptions["priority"] {
-  switch (trigger) {
-    case "user":
-    case "manual":
-      return "foreground";
-    case "cron":
-    case "heartbeat":
-    case "memory":
-    case "overflow":
-      return "background";
-    default:
-      return "normal";
-  }
-}
-
-function normalizeEmbeddedRunAttemptResult(
-  attempt: EmbeddedRunAttemptForRunner,
-): EmbeddedRunAttemptForRunner {
-  const raw = attempt as EmbeddedRunAttemptForRunner & {
-    assistantTexts?: EmbeddedRunAttemptForRunner["assistantTexts"] | null;
-    toolMetas?: EmbeddedRunAttemptForRunner["toolMetas"] | null;
-    acceptedSessionSpawns?: EmbeddedRunAttemptForRunner["acceptedSessionSpawns"] | null;
-    messagesSnapshot?: EmbeddedRunAttemptForRunner["messagesSnapshot"] | null;
-    messagingToolSentTexts?: EmbeddedRunAttemptForRunner["messagingToolSentTexts"] | null;
-    messagingToolSentMediaUrls?: EmbeddedRunAttemptForRunner["messagingToolSentMediaUrls"] | null;
-    messagingToolSentTargets?: EmbeddedRunAttemptForRunner["messagingToolSentTargets"] | null;
-    messagingToolSourceReplyPayloads?:
-      | EmbeddedRunAttemptForRunner["messagingToolSourceReplyPayloads"]
-      | null;
-    didDeliverSourceReplyViaMessageTool?: boolean | null;
-    itemLifecycle?: EmbeddedRunAttemptForRunner["itemLifecycle"] | null;
-    currentAttemptReplayMetadata?:
-      | EmbeddedRunAttemptForRunner["currentAttemptReplayMetadata"]
-      | null;
-  };
-  return {
-    ...attempt,
-    assistantTexts: raw.assistantTexts ?? [],
-    toolMetas: raw.toolMetas ?? [],
-    acceptedSessionSpawns: raw.acceptedSessionSpawns ?? [],
-    messagesSnapshot: raw.messagesSnapshot ?? [],
-    messagingToolSentTexts: raw.messagingToolSentTexts ?? [],
-    messagingToolSentMediaUrls: raw.messagingToolSentMediaUrls ?? [],
-    messagingToolSentTargets: raw.messagingToolSentTargets ?? [],
-    messagingToolSourceReplyPayloads: raw.messagingToolSourceReplyPayloads ?? [],
-    didDeliverSourceReplyViaMessageTool: raw.didDeliverSourceReplyViaMessageTool === true,
-    itemLifecycle: raw.itemLifecycle ?? {
-      startedCount: 0,
-      completedCount: 0,
-      activeCount: 0,
-    },
-    replayMetadata: resolveAttemptReplayMetadata(raw),
-    currentAttemptReplayMetadata: raw.currentAttemptReplayMetadata ?? undefined,
-  };
-}
-
-function hasCompletedModelProgressForIdleBreaker(attempt: EmbeddedRunAttemptForRunner): boolean {
-  return (
-    attempt.assistantTexts.some((text) => text.trim().length > 0) ||
-    attempt.toolMetas.length > 0 ||
-    (attempt.clientToolCalls?.length ?? 0) > 0 ||
-    hasOutboundDeliveryEvidence(attempt) ||
-    attempt.itemLifecycle.completedCount > 0
-  );
-}
-
-function createEmptyAuthProfileStore(): AuthProfileStore {
-  return {
-    version: 1,
-    profiles: {},
-  };
-}
-
-function createScopedAuthProfileStore(
-  store: AuthProfileStore,
-  profileIds: string | undefined | string[],
-): AuthProfileStore {
-  const profiles = store.profiles ?? {};
-  const normalizedProfileIds = (Array.isArray(profileIds) ? profileIds : [profileIds])
-    .map((profileId) => profileId?.trim())
-    .filter((profileId): profileId is string => Boolean(profileId));
-  const scopedProfiles = Object.fromEntries(
-    normalizedProfileIds.flatMap((profileId) => {
-      const credential = profiles[profileId];
-      return credential ? [[profileId, credential] as const] : [];
-    }),
-  );
-  const scopedRuntimeExternalProfileIds = (store.runtimeExternalProfileIds ?? []).filter(
-    (profileId) => scopedProfiles[profileId],
-  );
-  const scopedRuntimePersistedProfileIds = (store.runtimePersistedProfileIds ?? []).filter(
-    (profileId) => scopedProfiles[profileId],
-  );
-  return Object.keys(scopedProfiles).length > 0
-    ? {
-        version: store.version,
-        profiles: scopedProfiles,
-        ...(scopedRuntimePersistedProfileIds.length > 0
-          ? { runtimePersistedProfileIds: scopedRuntimePersistedProfileIds }
-          : {}),
-        ...(scopedRuntimeExternalProfileIds.length > 0 ||
-        store.runtimeExternalProfileIdsAuthoritative === true
-          ? { runtimeExternalProfileIds: scopedRuntimeExternalProfileIds }
-          : {}),
-        ...(store.runtimeExternalProfileIdsAuthoritative === true
-          ? { runtimeExternalProfileIdsAuthoritative: true }
-          : {}),
-      }
-    : createEmptyAuthProfileStore();
-}
-
-function buildTraceToolSummary(params: {
-  toolMetas?: EmbeddedRunAttemptForRunner["toolMetas"];
-  fallbackHadFailure: boolean;
-}): ToolSummaryTrace | undefined {
-  if (!params.toolMetas?.length) {
-    return undefined;
-  }
-  const tools: string[] = [];
-  const seen = new Set<string>();
-  for (const entry of params.toolMetas) {
-    const toolName = normalizeOptionalString(entry.toolName);
-    if (!toolName || seen.has(toolName)) {
-      continue;
-    }
-    seen.add(toolName);
-    tools.push(toolName);
-  }
-  const failedToolCalls = params.toolMetas.filter((entry) => entry.isError === true).length;
-  return {
-    calls: params.toolMetas?.length ?? 0,
-    tools,
-    // Per-call error metadata is additive to the shipped harness result contract.
-    // Keep the prior any-failure signal for external harnesses that do not emit it yet.
-    failures: failedToolCalls || Number(params.fallbackHadFailure),
-  };
-}
-
-/**
- * Best-effort backfill of sessionKey from sessionId when not explicitly provided.
- * The return value is normalized: whitespace-only inputs collapse to undefined, and
- * successful resolution returns a trimmed session key. This is a read-only lookup
- * with no side effects.
- * See: https://github.com/openclaw/openclaw/issues/60552
- */
-function backfillSessionKey(params: {
-  config: RunEmbeddedAgentParams["config"];
-  sessionId: string;
-  sessionKey?: string;
-  agentId?: string;
-}): string | undefined {
-  const trimmed = normalizeOptionalString(params.sessionKey);
-  if (trimmed) {
-    return trimmed;
-  }
-  if (!params.config || !params.sessionId) {
-    return undefined;
-  }
-  try {
-    const resolved = normalizeOptionalString(params.agentId)
-      ? resolveStoredSessionKeyForSessionId({
-          cfg: params.config,
-          sessionId: params.sessionId,
-          agentId: params.agentId,
-        })
-      : resolveSessionKeyForRequest({
-          cfg: params.config,
-          sessionId: params.sessionId,
-          clone: false,
-        });
-    return normalizeOptionalString(resolved.sessionKey);
-  } catch (err) {
-    log.warn(
-      `[backfillSessionKey] Failed to resolve sessionKey for sessionId=${redactRunIdentifier(sanitizeForLog(params.sessionId))}: ${formatErrorMessage(err)}`,
-    );
-    return undefined;
-  }
-}
-
-function assertAgentHarnessRunAdmission(params: RunEmbeddedAgentParams): void {
-  const sessionKey = normalizeOptionalString(params.sessionKey);
-  if (!sessionKey) {
-    return;
-  }
-  const admissionAgentId = params.agentId ?? resolveAgentIdFromSessionKey(sessionKey);
-  const storePath =
-    normalizeOptionalString(params.sessionTarget?.storePath) ??
-    resolveStorePath(params.config?.session?.store, { agentId: admissionAgentId });
-  const durableEntry = loadSessionEntry({
-    ...(admissionAgentId ? { agentId: admissionAgentId } : {}),
-    readConsistency: "latest",
-    sessionKey,
-    storePath,
-  });
-  const admissionError = resolveAgentHarnessRunAdmissionError({
-    agentHarnessId: params.agentHarnessId,
-    entry: durableEntry,
-    modelSelectionLocked: params.modelSelectionLocked,
-    sessionId: params.sessionId,
-    sessionKey,
-  });
-  if (admissionError) {
-    throw new Error(admissionError);
-  }
-}
-
-/** Marks only request parameters that OpenClaw applies to provider egress. */
-function resolveRequestStreamTransportOverrides(
-  streamParams: RunEmbeddedAgentParams["streamParams"],
-): "present" | undefined {
-  return streamParams && Object.keys(streamParams).length > 0 ? "present" : undefined;
-}
-
-function resolveInitialEmbeddedRunModel(params: {
-  config: RunEmbeddedAgentParams["config"];
-  agentId?: string;
-  provider?: string;
-  model?: string;
-}): { provider: string; modelId: string } {
-  const cfg = params.config ?? {};
-  const configuredDefault = resolveDefaultModelForAgent({
-    cfg,
-    agentId: params.agentId,
-  });
-  const explicitProvider = normalizeOptionalString(params.provider);
-  const explicitModel = normalizeOptionalString(params.model);
-  const defaultProvider = configuredDefault.provider || DEFAULT_PROVIDER;
-
-  if (explicitProvider && explicitModel) {
-    return { provider: explicitProvider, modelId: explicitModel };
-  }
-
-  if (explicitModel) {
-    const provider = explicitProvider ?? defaultProvider;
-    const aliasIndex = buildModelAliasIndex({
-      cfg,
-      defaultProvider: provider,
-    });
-    const resolved = resolveModelRefFromString({
-      cfg,
-      raw: explicitModel,
-      defaultProvider: provider,
-      aliasIndex,
-    });
-    return {
-      provider: explicitProvider ?? resolved?.ref.provider ?? provider,
-      modelId: resolved?.ref.model ?? explicitModel,
-    };
-  }
-
-  return {
-    provider: explicitProvider ?? defaultProvider,
-    modelId: configuredDefault.model || DEFAULT_MODEL,
-  };
 }
 
 const POST_RUN_AUTH_PROFILE_SUCCESS_SLOW_MS = 1_000;
@@ -831,139 +381,26 @@ async function runEmbeddedAgentInternal(
     }
     void suspendSession(suspension);
   };
-  const sessionQueuePriority = resolveEmbeddedRunSessionQueuePriority(params.trigger);
-  const laneTaskTimeoutMs = resolveEmbeddedRunLaneTimeoutMs(params.timeoutMs);
-  const laneTaskAbortController = new AbortController();
-  const laneTaskReleaseController = new AbortController();
-  let laneTaskProgressAtMs = Date.now();
-  const noteLaneTaskProgress = () => {
-    laneTaskProgressAtMs = Date.now();
-  };
-  const throwIfAborted = () => {
-    if (!params.abortSignal?.aborted) {
-      return;
-    }
-    const reason = params.abortSignal.reason;
-    if (reason instanceof Error) {
-      throw reason;
-    }
-    const abortErr =
-      reason !== undefined
-        ? new Error("Operation aborted", { cause: reason })
-        : new Error("Operation aborted");
-    abortErr.name = "AbortError";
-    throw abortErr;
-  };
-  const withLaneTimeout = (opts?: CommandQueueEnqueueOptions) =>
-    withEmbeddedRunLaneTimeout(
-      {
-        ...opts,
-        taskTimeoutProgressAtMs: () => laneTaskProgressAtMs,
-        taskTimeoutAbortSignal: laneTaskAbortController.signal,
-        taskTimeoutAbortGraceMs: EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
-        taskTimeoutReleaseSignal: laneTaskReleaseController.signal,
-      },
-      laneTaskTimeoutMs,
-    );
-  const withRunLaneWait = (opts?: CommandQueueEnqueueOptions) => {
-    if (!opts?.onWait && !params.onLaneWait) {
-      return opts;
-    }
-    return {
-      ...opts,
-      onWait: (waitMs, queuedAhead) => {
-        opts?.onWait?.(waitMs, queuedAhead);
-        params.onLaneWait?.({ waitMs, queuedAhead, waiting: true });
-      },
-    } satisfies CommandQueueEnqueueOptions;
-  };
-  const noteLaneWaitIfBusy = (lane: string) => {
-    if (!params.onLaneWait) {
-      return;
-    }
-    const snapshot = getCommandLaneSnapshot(lane);
-    if (snapshot.queuedCount > 0 || snapshot.activeCount >= snapshot.maxConcurrent) {
-      params.onLaneWait({
-        waitMs: 0,
-        queuedAhead: snapshot.queuedCount + snapshot.activeCount,
-        waiting: true,
-      });
-    }
-  };
-  const enqueueGlobal = (
-    task: () => Promise<EmbeddedAgentRunResult>,
-    opts?: CommandQueueEnqueueOptions,
-  ) => {
-    const globalOpts: CommandQueueEnqueueOptions = {
-      ...opts,
-      priority: sessionQueuePriority,
-    };
-    const taskWithCurrentLifecycle = async () => {
-      params.onLaneWait?.({ waitMs: 0, queuedAhead: 0, waiting: false });
-      throwIfAborted();
-      const currentLifecycleGeneration = getAgentEventLifecycleGeneration();
-      const existingContext = getAgentRunContext(params.runId);
-      if (lifecycleGeneration !== currentLifecycleGeneration) {
-        const wasQueuedBeforeRotation = queuedLifecycleGeneration === lifecycleGeneration;
-        const canResumeAcrossRotation = sessionQueuePriority === "foreground";
-        const newerSameIdExecutionOwnsContext =
-          existingContext?.lifecycleGeneration === currentLifecycleGeneration;
-        if (
-          !wasQueuedBeforeRotation ||
-          !canResumeAcrossRotation ||
-          newerSameIdExecutionOwnsContext
-        ) {
-          assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
-        }
-        lifecycleGeneration = currentLifecycleGeneration;
-        params = { ...params, lifecycleGeneration };
-      }
-      // Queue waits can outlive durable harness and placement bindings.
-      // Recheck and claim only after lifecycle admission, before context or hooks execute.
-      assertAgentHarnessRunAdmission(params);
-      return await withAgentRunLifecycleGeneration(lifecycleGeneration, () =>
-        withSessionPlacementTurnAdmission(
-          {
-            sessionId: params.sessionId,
-            ...(params.agentId ? { agentId: params.agentId } : {}),
-            ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-            runId: params.runId,
-          },
-          params,
-          () => {
-            claimAgentRunContext(params.runId, {
-              ...existingContext,
-              sessionKey: params.sessionKey ?? existingContext?.sessionKey,
-              sessionId: params.sessionId ?? existingContext?.sessionId,
-              lifecycleGeneration,
-            });
-            return task();
-          },
-        ),
-      );
-    };
-    if (params.enqueue) {
-      return params.enqueue(taskWithCurrentLifecycle, withLaneTimeout(withRunLaneWait(globalOpts)));
-    }
-    noteLaneWaitIfBusy(globalLane);
-    return enqueueCommandInLane(
-      globalLane,
-      taskWithCurrentLifecycle,
-      withLaneTimeout(withRunLaneWait(globalOpts)),
-    );
-  };
-  const enqueueSession = <T>(task: () => Promise<T>, opts?: CommandQueueEnqueueOptions) => {
-    const sessionOpts: CommandQueueEnqueueOptions = { ...opts, priority: sessionQueuePriority };
-    const taskWithLaneAdmission = () => {
-      params.onLaneWait?.({ waitMs: 0, queuedAhead: 0, waiting: false });
-      return task();
-    };
-    if (params.enqueue) {
-      return params.enqueue(taskWithLaneAdmission, withRunLaneWait(sessionOpts));
-    }
-    noteLaneWaitIfBusy(sessionLane);
-    return enqueueCommandInLane(sessionLane, taskWithLaneAdmission, withRunLaneWait(sessionOpts));
-  };
+  const {
+    enqueueGlobal,
+    enqueueSession,
+    laneTaskAbortController,
+    laneTaskReleaseController,
+    noteLaneTaskProgress,
+    throwIfAborted,
+  } = createEmbeddedRunLaneController({
+    getLifecycleGeneration: () => lifecycleGeneration,
+    getParams: () => params,
+    globalLane,
+    initialQueuedLifecycleGeneration: queuedLifecycleGeneration,
+    sessionLane,
+    setLifecycleGeneration: (generation) => {
+      lifecycleGeneration = generation;
+    },
+    setParams: (nextParams) => {
+      params = nextParams;
+    },
+  });
   const channelHint = params.messageChannel ?? params.messageProvider;
   const resolvedToolResultFormat =
     params.toolResultFormat ??
@@ -991,140 +428,24 @@ async function runEmbeddedAgentInternal(
     return enqueueGlobal(async () => {
       throwIfAborted();
       const started = Date.now();
-      const fastModeStarted = params.fastModeStartedAtMs ?? started;
-      const fastModeAutoOnSeconds =
-        params.fastModeAutoOnSeconds ?? DEFAULT_FAST_MODE_AUTO_ON_SECONDS;
-      const fastModeAutoProgressState: FastModeAutoProgressState =
-        params.fastModeAutoProgressState ?? {
-          offAnnounced: false,
-          resetAnnounced: false,
-        };
       const startupStages = createEmbeddedRunStageTracker();
       let startupStagesEmitted = false;
-      const notifyExecutionPhase = (
-        phase: Parameters<NonNullable<RunEmbeddedAgentParams["onExecutionPhase"]>>[0]["phase"],
-        extra?: Omit<
-          Parameters<NonNullable<RunEmbeddedAgentParams["onExecutionPhase"]>>[0],
-          "phase"
-        >,
-      ) => {
-        noteLaneTaskProgress();
-        params.onExecutionPhase?.({ phase, ...extra });
-      };
-      const notifyRunProgress = (
-        info: Parameters<NonNullable<RunEmbeddedAgentParams["onRunProgress"]>>[0],
-      ) => {
-        noteLaneTaskProgress();
-        params.onRunProgress?.(info);
-      };
-      const emitFastModeAutoProgress = async (payload: {
-        enabled: boolean;
-        elapsedSeconds: number;
-        fastAutoOnSeconds?: number;
-      }) => {
-        const summary = formatFastModeAutoProgressText(payload);
-        try {
-          emitAgentItemEvent({
-            runId: params.runId,
-            ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-            data: {
-              itemId: `fast-mode-auto:${payload.enabled ? "on" : "off"}`,
-              kind: "status",
-              title: "Fast",
-              phase: "update",
-              status: "running",
-              summary,
-            },
-          });
-        } catch (error) {
-          log.debug(
-            `embedded run fast mode auto global event failed: ${formatErrorMessage(error)}`,
-          );
-        }
-        try {
-          await params.onAgentEvent?.({
-            stream: "item",
-            data: {
-              kind: "status",
-              title: "Fast",
-              phase: "update",
-              summary,
-            },
-            ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-          });
-        } catch (error) {
-          log.debug(`embedded run fast mode auto event failed: ${formatErrorMessage(error)}`);
-        }
-        try {
-          await params.onToolResult?.({
-            text: summary,
-            channelData: { openclawProgressKind: FAST_MODE_AUTO_PROGRESS_KIND },
-          });
-        } catch (error) {
-          log.debug(`embedded run fast mode auto progress failed: ${formatErrorMessage(error)}`);
-        }
-      };
-      const maybeAnnounceFastModeAutoOff = async () => {
-        if (params.fastMode !== "auto" || fastModeAutoProgressState.offAnnounced) {
-          return;
-        }
-        const next = resolveFastModeForElapsed({
-          mode: "auto",
-          startedAtMs: fastModeStarted,
-          fastAutoOnSeconds: fastModeAutoOnSeconds,
-        });
-        if (next.enabled) {
-          return;
-        }
-        fastModeAutoProgressState.offAnnounced = true;
-        await emitFastModeAutoProgress(next);
-      };
-      const notifyToolResult = async (payload: ReplyPayload) => {
-        await params.onToolResult?.(payload);
-      };
-      const notifyAgentEvent = async (
-        event: Parameters<NonNullable<RunEmbeddedAgentParams["onAgentEvent"]>>[0],
-      ) => {
-        await params.onAgentEvent?.(event);
-      };
-      const resolveAttemptFastMode = (): boolean | undefined => {
-        const resolved = resolveFastModeForElapsed({
-          mode: params.fastMode,
-          startedAtMs: fastModeStarted,
-          fastAutoOnSeconds: fastModeAutoOnSeconds,
-        });
-        return resolved.mode === undefined ? undefined : resolved.enabled;
-      };
-      const resolveAttemptFastModeParam = (): EmbeddedRunFastModeParam | undefined => {
-        if (params.fastMode === "auto") {
-          return resolveAttemptFastMode;
-        }
-        return resolveAttemptFastMode();
-      };
-      const maybeEmitFastModeAutoReset = async () => {
-        if (
-          params.fastMode !== "auto" ||
-          !fastModeAutoProgressState.offAnnounced ||
-          fastModeAutoProgressState.resetAnnounced
-        ) {
-          return;
-        }
-        fastModeAutoProgressState.resetAnnounced = true;
-        await emitFastModeAutoProgress({
-          enabled: true,
-          elapsedSeconds: 0,
-          fastAutoOnSeconds: fastModeAutoOnSeconds,
-        });
-      };
-      const maybeEmitFastModeAutoResetBestEffort = async () => {
-        try {
-          await maybeEmitFastModeAutoReset();
-        } catch (error) {
-          log.warn(
-            `embedded run fast mode auto reset progress failed: ${formatErrorMessage(error)}`,
-          );
-        }
-      };
+      const {
+        fastModeAutoOnSeconds,
+        fastModeAutoProgressState,
+        fastModeStartedAtMs: fastModeStarted,
+        maybeAnnounceFastModeAutoOff,
+        maybeEmitFastModeAutoResetBestEffort,
+        notifyAgentEvent,
+        notifyExecutionPhase,
+        notifyRunProgress,
+        notifyToolResult,
+        resolveAttemptFastModeParam,
+      } = createEmbeddedRunProgressController({
+        attempt: params,
+        noteLaneTaskProgress,
+        startedAtMs: started,
+      });
       const emitStartupStageSummary = (phase: string) => {
         const summary = startupStages.snapshot();
         const shouldWarn = shouldWarnEmbeddedRunStageSummary(summary);

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createBundleLspToolRuntime: vi.fn(),
+  getOrCreateSessionMcpRuntime: vi.fn(),
+  materializeBundleMcpToolsForRun: vi.fn(),
+  applyFinalEffectiveToolPolicy: vi.fn(),
+}));
+
+vi.mock("../../agent-bundle-lsp-runtime.js", () => ({
+  createBundleLspToolRuntime: mocks.createBundleLspToolRuntime,
+}));
+
+vi.mock("../../agent-bundle-mcp-tools.js", () => ({
+  getOrCreateSessionMcpRuntime: mocks.getOrCreateSessionMcpRuntime,
+  materializeBundleMcpToolsForRun: mocks.materializeBundleMcpToolsForRun,
+}));
+
+vi.mock("../../runtime-plan/tools.js", () => ({
+  normalizeAgentRuntimeTools: vi.fn(() => []),
+}));
+
+vi.mock("../effective-tool-policy.js", () => ({
+  applyFinalEffectiveToolPolicy: mocks.applyFinalEffectiveToolPolicy,
+}));
+
+vi.mock("./attempt-tool-construction-plan.js", () => ({
+  applyEmbeddedAttemptToolsAllow: vi.fn((tools: unknown[]) => tools),
+  shouldCreateBundleLspRuntimeForAttempt: vi.fn(() => true),
+  shouldCreateBundleMcpRuntimeForAttempt: vi.fn(() => true),
+}));
+
+import { prepareEmbeddedAttemptBundleTools } from "./attempt-bundle-tools.js";
+
+describe("prepareEmbeddedAttemptBundleTools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("disposes prepared bundle runtimes when later policy setup fails", async () => {
+    const disposeMcp = vi.fn(async () => {});
+    const disposeLsp = vi.fn(async () => {});
+    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue({});
+    mocks.materializeBundleMcpToolsForRun.mockResolvedValue({
+      tools: [],
+      dispose: disposeMcp,
+    });
+    mocks.createBundleLspToolRuntime.mockResolvedValue({
+      tools: [],
+      dispose: disposeLsp,
+    });
+    mocks.applyFinalEffectiveToolPolicy.mockImplementation(() => {
+      throw new Error("bundle policy failed");
+    });
+
+    const input = {
+      agentDir: "/tmp/agent",
+      attempt: {
+        config: {},
+        model: {},
+        modelId: "model",
+        provider: "provider",
+        runId: "run",
+        runtimePlan: {},
+        sessionId: "session",
+      },
+      effectiveWorkspace: "/tmp/workspace",
+      getCurrentAttemptPluginMetadataSnapshot: () => undefined,
+      getProviderRuntimeHandle: () => undefined,
+      isRawModelRun: false,
+      preparedToolBase: {
+        cronCreatorToolAllowlist: [],
+        effectiveToolsAllow: undefined,
+        localModelLeanPreserveToolNames: [],
+        runtimeCapabilityProfile: undefined,
+        toolsEnabled: true,
+        toolsRaw: [],
+      },
+      sessionAgentId: "main",
+    } as unknown as Parameters<typeof prepareEmbeddedAttemptBundleTools>[0];
+
+    await expect(prepareEmbeddedAttemptBundleTools(input)).rejects.toThrow("bundle policy failed");
+    expect(disposeMcp).toHaveBeenCalledOnce();
+    expect(disposeLsp).toHaveBeenCalledOnce();
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
@@ -1,0 +1,220 @@
+import { getPluginToolMeta } from "../../../plugins/tools.js";
+import { createBundleLspToolRuntime } from "../../agent-bundle-lsp-runtime.js";
+import {
+  getOrCreateSessionMcpRuntime,
+  materializeBundleMcpToolsForRun,
+} from "../../agent-bundle-mcp-tools.js";
+import { filterLocalModelLeanTools } from "../../local-model-lean.js";
+import { normalizeAgentRuntimeTools } from "../../runtime-plan/tools.js";
+import { filterRuntimeCompatibleTools } from "../../tool-schema-projection.js";
+import { logRuntimeToolSchemaQuarantine } from "../../tool-schema-quarantine.js";
+import { replaceWithEffectiveCronCreatorToolAllowlist } from "../../tools/cron-tool.js";
+import { applyFinalEffectiveToolPolicy } from "../effective-tool-policy.js";
+import { log } from "../logger.js";
+import type { prepareEmbeddedAttemptSetup } from "./attempt-setup.js";
+import type { prepareEmbeddedAttemptToolBase } from "./attempt-tool-base-prepare.js";
+import {
+  applyEmbeddedAttemptToolsAllow,
+  shouldCreateBundleLspRuntimeForAttempt,
+  shouldCreateBundleMcpRuntimeForAttempt,
+} from "./attempt-tool-construction-plan.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type AttemptSetup = Awaited<ReturnType<typeof prepareEmbeddedAttemptSetup>>;
+type PreparedToolBase = ReturnType<typeof prepareEmbeddedAttemptToolBase>;
+
+export async function prepareEmbeddedAttemptBundleTools(params: {
+  agentDir: string;
+  attempt: EmbeddedRunAttemptParams;
+  effectiveWorkspace: string;
+  getCurrentAttemptPluginMetadataSnapshot: AttemptSetup["getCurrentAttemptPluginMetadataSnapshot"];
+  getProviderRuntimeHandle: AttemptSetup["getProviderRuntimeHandle"];
+  isRawModelRun: boolean;
+  preparedToolBase: PreparedToolBase;
+  sessionAgentId: string;
+}) {
+  const {
+    cronCreatorToolAllowlist,
+    effectiveToolsAllow,
+    localModelLeanPreserveToolNames,
+    runtimeCapabilityProfile,
+    toolsEnabled,
+    toolsRaw,
+  } = params.preparedToolBase;
+  const tools = normalizeAgentRuntimeTools({
+    runtimePlan: params.attempt.runtimePlan,
+    tools: toolsEnabled ? toolsRaw : [],
+    provider: params.attempt.provider,
+    config: params.attempt.config,
+    workspaceDir: params.effectiveWorkspace,
+    env: process.env,
+    modelId: params.attempt.modelId,
+    modelApi: params.attempt.model.api,
+    model: params.attempt.model,
+    runtimeHandle: params.getProviderRuntimeHandle(),
+    onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) =>
+      logRuntimeToolSchemaQuarantine({
+        diagnostics,
+        tools: sourceTools,
+        runId: params.attempt.runId,
+        agentId: params.sessionAgentId,
+        sessionKey: params.attempt.sessionKey,
+        sessionId: params.attempt.sessionId,
+      }),
+  });
+  const clientTools =
+    toolsEnabled && !params.isRawModelRun && !params.attempt.forceRestartSafeTools
+      ? params.attempt.clientTools
+      : undefined;
+  const bundleMcpEnabled =
+    !params.attempt.forceRestartSafeTools &&
+    shouldCreateBundleMcpRuntimeForAttempt({
+      toolsEnabled,
+      disableTools: params.attempt.disableTools || params.isRawModelRun,
+      toolsAllow: params.attempt.toolsAllow,
+    });
+  const bundleMetadataSnapshot = params.getCurrentAttemptPluginMetadataSnapshot();
+  // Scoped registries are partial views; only complete snapshots can bypass bundle discovery.
+  const bundleManifestRegistry =
+    bundleMetadataSnapshot?.pluginIds === undefined
+      ? bundleMetadataSnapshot?.manifestRegistry
+      : undefined;
+  const bundleMcpSessionRuntime = bundleMcpEnabled
+    ? await getOrCreateSessionMcpRuntime({
+        sessionId: params.attempt.sessionId,
+        sessionKey: params.attempt.sessionKey,
+        workspaceDir: params.effectiveWorkspace,
+        agentDir: params.agentDir,
+        cfg: params.attempt.config,
+        manifestRegistry: bundleManifestRegistry,
+      })
+    : undefined;
+  const bundleMcpRuntime = bundleMcpSessionRuntime
+    ? await materializeBundleMcpToolsForRun({
+        runtime: bundleMcpSessionRuntime,
+        reservedToolNames: [
+          ...tools.map((tool) => tool.name),
+          ...(clientTools?.map((tool) => tool.function.name) ?? []),
+        ],
+      })
+    : undefined;
+  let bundleLspRuntime: Awaited<ReturnType<typeof createBundleLspToolRuntime>> | undefined;
+  try {
+    const bundleLspEnabled =
+      !params.attempt.forceRestartSafeTools &&
+      shouldCreateBundleLspRuntimeForAttempt({
+        toolsEnabled,
+        disableTools: params.attempt.disableTools || params.isRawModelRun,
+        toolsAllow: params.attempt.toolsAllow,
+      });
+    bundleLspRuntime = bundleLspEnabled
+      ? await createBundleLspToolRuntime({
+          workspaceDir: params.effectiveWorkspace,
+          cfg: params.attempt.config,
+          manifestRegistry: bundleManifestRegistry,
+          reservedToolNames: [
+            ...tools.map((tool) => tool.name),
+            ...(clientTools?.map((tool) => tool.function.name) ?? []),
+            ...(bundleMcpRuntime?.tools.map((tool) => tool.name) ?? []),
+          ],
+        })
+      : undefined;
+    const allowedBundleMcpTools = applyEmbeddedAttemptToolsAllow(
+      bundleMcpRuntime?.tools ?? [],
+      effectiveToolsAllow,
+      { toolMeta: (tool) => getPluginToolMeta(tool) },
+    );
+    const allowedBundleLspTools = applyEmbeddedAttemptToolsAllow(
+      bundleLspRuntime?.tools ?? [],
+      effectiveToolsAllow,
+      { toolMeta: (tool) => getPluginToolMeta(tool) },
+    );
+    const filteredBundledTools = applyFinalEffectiveToolPolicy({
+      bundledTools: [...allowedBundleMcpTools, ...allowedBundleLspTools],
+      config: params.attempt.config,
+      conversationCapabilityProfile: runtimeCapabilityProfile,
+      warn: (message) => log.warn(message),
+    });
+    if (bundleMcpRuntime?.restrictAppTools) {
+      const runtimeAllowedAppTools = applyEmbeddedAttemptToolsAllow(
+        bundleMcpRuntime.appTools ?? bundleMcpRuntime.tools,
+        effectiveToolsAllow,
+        { toolMeta: (tool) => getPluginToolMeta(tool) },
+      );
+      const allowedAppTools = applyFinalEffectiveToolPolicy({
+        bundledTools: runtimeAllowedAppTools,
+        config: params.attempt.config,
+        conversationCapabilityProfile: runtimeCapabilityProfile,
+        warn: (message) => log.warn(message),
+      });
+      // The view outlives this attempt; capture policy against the complete MCP catalog now.
+      bundleMcpRuntime.restrictAppTools(allowedAppTools);
+    }
+    const normalizedBundledTools =
+      filteredBundledTools.length > 0
+        ? normalizeAgentRuntimeTools({
+            runtimePlan: params.attempt.runtimePlan,
+            tools: filteredBundledTools,
+            provider: params.attempt.provider,
+            config: params.attempt.config,
+            workspaceDir: params.effectiveWorkspace,
+            env: process.env,
+            modelId: params.attempt.modelId,
+            modelApi: params.attempt.model.api,
+            model: params.attempt.model,
+            runtimeHandle: params.getProviderRuntimeHandle(),
+            onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) =>
+              logRuntimeToolSchemaQuarantine({
+                diagnostics,
+                tools: sourceTools,
+                runId: params.attempt.runId,
+                agentId: params.sessionAgentId,
+                sessionKey: params.attempt.sessionKey,
+                sessionId: params.attempt.sessionId,
+              }),
+          })
+        : filteredBundledTools;
+    const projectedTools = filterLocalModelLeanTools({
+      tools: [...tools, ...normalizedBundledTools],
+      config: params.attempt.config,
+      agentId: params.sessionAgentId,
+      preserveToolNames: localModelLeanPreserveToolNames,
+    });
+    if (cronCreatorToolAllowlist.length > 0) {
+      // Cron is built before bundled tools; refresh its cap against the complete surface.
+      replaceWithEffectiveCronCreatorToolAllowlist(
+        cronCreatorToolAllowlist,
+        projectedTools,
+        (tool) => getPluginToolMeta(tool),
+      );
+    }
+    const schemaProjection = filterRuntimeCompatibleTools(projectedTools);
+    logRuntimeToolSchemaQuarantine({
+      diagnostics: schemaProjection.diagnostics,
+      tools: projectedTools,
+      runId: params.attempt.runId,
+      agentId: params.sessionAgentId,
+      sessionKey: params.attempt.sessionKey,
+      sessionId: params.attempt.sessionId,
+    });
+    return {
+      bundleLspRuntime,
+      bundleMcpRuntime,
+      clientTools,
+      tools,
+      uncompactedEffectiveTools: [...schemaProjection.tools],
+    };
+  } catch (error) {
+    try {
+      await bundleMcpRuntime?.dispose();
+    } catch {
+      // Preserve the preparation error; cleanup is best-effort.
+    }
+    try {
+      await bundleLspRuntime?.dispose();
+    } catch {
+      // Preserve the preparation error; cleanup is best-effort.
+    }
+    throw error;
+  }
+}

--- a/src/agents/embedded-agent-runner/run/attempt-client-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-client-tools.ts
@@ -1,0 +1,180 @@
+import { getPluginToolMeta } from "../../../plugins/tools.js";
+import {
+  createClientToolNameConflictError,
+  findClientToolNameConflicts,
+  toClientToolDefinitions,
+} from "../../agent-tool-definition-adapter.js";
+import { resolveToolLoopDetectionConfig } from "../../agent-tools.js";
+import { addClientToolsToCodeModeCatalog } from "../../code-mode.js";
+import type { AgentTool } from "../../runtime/index.js";
+import { collectReplaySafeToolNames, isAgentToolReplaySafe } from "../../tool-replay-safety.js";
+import { addClientToolsToToolSearchCatalog, type ToolSearchCatalogRef } from "../../tool-search.js";
+import { log } from "../logger.js";
+import {
+  AGENT_RESERVED_TOOL_NAMES,
+  collectCoreBuiltinToolNames,
+  collectRegisteredToolNames,
+  toSessionToolAllowlist,
+} from "../tool-name-allowlist.js";
+import { splitSdkTools } from "../tool-split.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+export type ClientToolCallSlot = {
+  toolCallId: string;
+  name: string;
+  params?: Record<string, unknown>;
+  completed: boolean;
+};
+
+export function prepareEmbeddedAttemptClientTools(params: {
+  attempt: EmbeddedRunAttemptParams;
+  catalogToolHookContext: Parameters<typeof splitSdkTools>[0]["toolHookContext"];
+  codeModeControlsEnabledForRun: boolean;
+  deferredDirectoryToolsCallable: boolean;
+  effectiveTools: AgentTool[];
+  replaySafetyOptions: Parameters<typeof isAgentToolReplaySafe>[1];
+  sandboxEnabled: boolean;
+  sandboxSessionKey?: string;
+  sessionAgentId: string;
+  toolSearchCatalogRef?: ToolSearchCatalogRef;
+  toolSearchRuntimeConfig: EmbeddedRunAttemptParams["config"];
+  uncompactedEffectiveTools: AgentTool[];
+  clientTools: EmbeddedRunAttemptParams["clientTools"];
+}) {
+  const { customTools } = splitSdkTools({
+    tools: params.effectiveTools,
+    sandboxEnabled: params.sandboxEnabled,
+    toolHookContext: params.catalogToolHookContext,
+  });
+
+  // Reserve synchronously so parallel client-tool batches preserve assistant source order.
+  const clientToolCallSlots: ClientToolCallSlot[] = [];
+  const clientToolCallSlotIndexes = new Map<string, number>();
+  const reserveClientToolCallSlot = (toolCallId: string, toolName: string) => {
+    if (clientToolCallSlotIndexes.has(toolCallId)) {
+      return;
+    }
+    clientToolCallSlotIndexes.set(toolCallId, clientToolCallSlots.length);
+    clientToolCallSlots.push({
+      toolCallId,
+      name: toolName,
+      completed: false,
+    });
+  };
+  const clientToolLoopDetection = resolveToolLoopDetectionConfig({
+    cfg: params.attempt.config,
+    agentId: params.sessionAgentId,
+  });
+  // Raw names gate trusted local media passthrough; normalized aliases are insufficient.
+  const builtinToolNames = new Set(
+    params.uncompactedEffectiveTools.flatMap((tool) => {
+      const name = (tool.name ?? "").trim();
+      return name ? [name] : [];
+    }),
+  );
+  const coreBuiltinToolNames = collectCoreBuiltinToolNames(params.uncompactedEffectiveTools, {
+    isPluginTool: (tool) =>
+      Boolean(getPluginToolMeta(tool as Parameters<typeof getPluginToolMeta>[0])),
+  });
+  const isReplaySafeTool = (tool: { name?: string }) =>
+    isAgentToolReplaySafe(tool, params.replaySafetyOptions);
+  const replaySafeTools = new Set(params.uncompactedEffectiveTools.filter(isReplaySafeTool));
+  const replaySafeToolNames = collectReplaySafeToolNames(
+    params.uncompactedEffectiveTools,
+    params.replaySafetyOptions,
+  );
+  const clientConflictToolNames = params.deferredDirectoryToolsCallable
+    ? builtinToolNames
+    : coreBuiltinToolNames;
+  const clientToolNameConflicts = findClientToolNameConflicts({
+    tools: params.clientTools ?? [],
+    existingToolNames: [...clientConflictToolNames, ...AGENT_RESERVED_TOOL_NAMES],
+  });
+  if (clientToolNameConflicts.length > 0) {
+    throw createClientToolNameConflictError(clientToolNameConflicts);
+  }
+
+  let clientToolDefs = params.clientTools
+    ? toClientToolDefinitions(
+        params.clientTools,
+        {
+          reserve: reserveClientToolCallSlot,
+          complete: (toolCallId, toolName, toolParams) => {
+            reserveClientToolCallSlot(toolCallId, toolName);
+            const slotIndex = clientToolCallSlotIndexes.get(toolCallId);
+            if (slotIndex === undefined) {
+              return;
+            }
+            const slot = clientToolCallSlots[slotIndex];
+            if (!slot) {
+              return;
+            }
+            slot.name = toolName;
+            slot.params = toolParams;
+            slot.completed = true;
+          },
+          discard: (toolCallId) => {
+            const slotIndex = clientToolCallSlotIndexes.get(toolCallId);
+            if (slotIndex === undefined) {
+              return;
+            }
+            const slot = clientToolCallSlots[slotIndex];
+            if (slot) {
+              slot.completed = false;
+              slot.params = undefined;
+            }
+          },
+        },
+        {
+          agentId: params.sessionAgentId,
+          sessionKey: params.sandboxSessionKey,
+          config: params.toolSearchRuntimeConfig,
+          sessionId: params.attempt.sessionId,
+          runId: params.attempt.runId,
+          loopDetection: clientToolLoopDetection,
+          onToolOutcome: params.attempt.onToolOutcome,
+          allocateToolOutcomeOrdinal: params.attempt.allocateToolOutcomeOrdinal,
+        },
+      )
+    : [];
+  const clientToolSearch = params.codeModeControlsEnabledForRun
+    ? addClientToolsToCodeModeCatalog({
+        tools: clientToolDefs,
+        config: params.attempt.config,
+        sessionId: params.attempt.sessionId,
+        sessionKey: params.sandboxSessionKey,
+        agentId: params.sessionAgentId,
+        runId: params.attempt.runId,
+        catalogRef: params.toolSearchCatalogRef,
+      })
+    : addClientToolsToToolSearchCatalog({
+        tools: clientToolDefs,
+        config: params.toolSearchRuntimeConfig,
+        sessionId: params.attempt.sessionId,
+        sessionKey: params.sandboxSessionKey,
+        agentId: params.sessionAgentId,
+        runId: params.attempt.runId,
+        catalogRef: params.toolSearchCatalogRef,
+      });
+  clientToolDefs = clientToolSearch.tools;
+  if (clientToolSearch.compacted) {
+    log.info(
+      params.codeModeControlsEnabledForRun
+        ? `code-mode: cataloged ${clientToolSearch.catalogToolCount} client tools behind exec/wait`
+        : `tool-search: cataloged ${clientToolSearch.catalogToolCount} client tools behind compact prompt surface`,
+    );
+  }
+
+  const allCustomTools = [...customTools, ...clientToolDefs];
+  const sessionToolAllowlist = toSessionToolAllowlist(collectRegisteredToolNames(allCustomTools));
+  return {
+    allCustomTools,
+    builtinToolNames,
+    clientToolCallSlots,
+    clientToolDefs,
+    clientToolLoopDetection,
+    replaySafeToolNames,
+    replaySafeTools,
+    sessionToolAllowlist,
+  };
+}

--- a/src/agents/embedded-agent-runner/run/attempt-client-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-client-tools.ts
@@ -17,14 +17,8 @@ import {
   toSessionToolAllowlist,
 } from "../tool-name-allowlist.js";
 import { splitSdkTools } from "../tool-split.js";
+import type { EmbeddedAttemptClientToolCallSlot } from "./attempt-result.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
-
-export type ClientToolCallSlot = {
-  toolCallId: string;
-  name: string;
-  params?: Record<string, unknown>;
-  completed: boolean;
-};
 
 export function prepareEmbeddedAttemptClientTools(params: {
   attempt: EmbeddedRunAttemptParams;
@@ -48,7 +42,7 @@ export function prepareEmbeddedAttemptClientTools(params: {
   });
 
   // Reserve synchronously so parallel client-tool batches preserve assistant source order.
-  const clientToolCallSlots: ClientToolCallSlot[] = [];
+  const clientToolCallSlots: EmbeddedAttemptClientToolCallSlot[] = [];
   const clientToolCallSlotIndexes = new Map<string, number>();
   const reserveClientToolCallSlot = (toolCallId: string, toolName: string) => {
     if (clientToolCallSlotIndexes.has(toolCallId)) {

--- a/src/agents/embedded-agent-runner/run/attempt-startup.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-startup.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+const mocks = vi.hoisted(() => ({
+  applySkillEnvOverrides: vi.fn(),
+  mapSandboxSkillEntriesForPrompt: vi.fn(),
+}));
+
+vi.mock("../../../skills/runtime/env-overrides.js", () => ({
+  applySkillEnvOverrides: mocks.applySkillEnvOverrides,
+  applySkillEnvOverridesFromSnapshot: vi.fn(),
+}));
+
+vi.mock("../../../skills/runtime/embedded-run-entries.js", () => ({
+  resolveEmbeddedRunSkillEntries: vi.fn(() => ({
+    shouldLoadSkillEntries: true,
+    skillEntries: [],
+  })),
+}));
+
+vi.mock("../../../skills/loading/workspace.js", () => ({
+  resolveSkillsPromptForRun: vi.fn(() => "skills prompt"),
+}));
+
+vi.mock("../sandbox-skills.js", () => ({
+  resolveSandboxSkillRuntimeInputs: vi.fn(() => ({
+    skillsEligibility: undefined,
+    skillsPromptWorkspaceDir: "/tmp/workspace",
+    skillsSnapshot: undefined,
+    skillsWorkspaceDir: "/tmp/workspace",
+    workspaceOnly: false,
+  })),
+  mapSandboxSkillEntriesForPrompt: mocks.mapSandboxSkillEntriesForPrompt,
+  mapSandboxSkillUsagePaths: vi.fn(() => []),
+}));
+
+import { prepareEmbeddedAttemptSkills } from "./attempt-startup.js";
+
+describe("prepareEmbeddedAttemptSkills", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("restores environment overrides when later preparation fails", () => {
+    const restore = vi.fn();
+    mocks.applySkillEnvOverrides.mockReturnValue(restore);
+    mocks.mapSandboxSkillEntriesForPrompt.mockImplementation(() => {
+      throw new Error("skill prompt mapping failed");
+    });
+
+    expect(() =>
+      prepareEmbeddedAttemptSkills({
+        attempt: { config: {} } as EmbeddedRunAttemptParams,
+        effectiveWorkspace: "/tmp/workspace",
+        sandbox: undefined,
+        sessionAgentId: "main",
+      }),
+    ).toThrow("skill prompt mapping failed");
+    expect(restore).toHaveBeenCalledOnce();
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-startup.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-startup.test.ts
@@ -52,7 +52,7 @@ describe("prepareEmbeddedAttemptSkills", () => {
       prepareEmbeddedAttemptSkills({
         attempt: { config: {} } as EmbeddedRunAttemptParams,
         effectiveWorkspace: "/tmp/workspace",
-        sandbox: undefined,
+        sandbox: null,
         sessionAgentId: "main",
       }),
     ).toThrow("skill prompt mapping failed");

--- a/src/agents/embedded-agent-runner/run/attempt-startup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-startup.ts
@@ -1,0 +1,149 @@
+import {
+  diagnosticErrorCategory,
+  diagnosticErrorMessage,
+} from "../../../infra/diagnostic-error-metadata.js";
+import {
+  emitTrustedDiagnosticEvent,
+  emitTrustedDiagnosticEventWithPrivateData,
+} from "../../../infra/diagnostic-events.js";
+import {
+  createChildDiagnosticTraceContext,
+  createDiagnosticTraceContext,
+  freezeDiagnosticTraceContext,
+  getActiveDiagnosticTraceContext,
+} from "../../../infra/diagnostic-trace-context.js";
+import { resolveSkillsPromptForRun } from "../../../skills/loading/workspace.js";
+import { resolveEmbeddedRunSkillEntries } from "../../../skills/runtime/embedded-run-entries.js";
+import {
+  applySkillEnvOverrides,
+  applySkillEnvOverridesFromSnapshot,
+} from "../../../skills/runtime/env-overrides.js";
+import {
+  mapSandboxSkillEntriesForPrompt,
+  mapSandboxSkillUsagePaths,
+  resolveSandboxSkillRuntimeInputs,
+} from "../sandbox-skills.js";
+import type { prepareEmbeddedAttemptSetup } from "./attempt-setup.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type AttemptSetup = Awaited<ReturnType<typeof prepareEmbeddedAttemptSetup>>;
+
+export function prepareEmbeddedAttemptSkills(params: {
+  attempt: EmbeddedRunAttemptParams;
+  effectiveWorkspace: string;
+  sandbox: AttemptSetup["sandbox"];
+  sessionAgentId: string;
+}) {
+  const {
+    skillsEligibility,
+    skillsPromptWorkspaceDir,
+    skillsSnapshot,
+    skillsWorkspaceDir,
+    workspaceOnly,
+  } = resolveSandboxSkillRuntimeInputs({
+    sandbox: params.sandbox,
+    effectiveWorkspace: params.effectiveWorkspace,
+    skillsSnapshot: params.attempt.skillsSnapshot,
+  });
+  const { shouldLoadSkillEntries, skillEntries } = resolveEmbeddedRunSkillEntries({
+    workspaceDir: skillsWorkspaceDir,
+    config: params.attempt.config,
+    agentId: params.sessionAgentId,
+    eligibility: skillsEligibility,
+    skillsSnapshot,
+    workspaceOnly,
+  });
+  const restoreSkillEnv = skillsSnapshot
+    ? applySkillEnvOverridesFromSnapshot({
+        snapshot: skillsSnapshot,
+        config: params.attempt.config,
+      })
+    : applySkillEnvOverrides({
+        skills: skillEntries ?? [],
+        config: params.attempt.config,
+      });
+  try {
+    const promptSkillEntries = mapSandboxSkillEntriesForPrompt({
+      entries: shouldLoadSkillEntries ? skillEntries : undefined,
+      skillsWorkspaceDir,
+      skillsPromptWorkspaceDir,
+    });
+    const skillUsagePaths = mapSandboxSkillUsagePaths({
+      paths: params.sandbox?.skillUsagePaths,
+      skillsWorkspaceDir,
+      skillsPromptWorkspaceDir,
+    });
+    const skillsPrompt = resolveSkillsPromptForRun({
+      skillsSnapshot,
+      entries: promptSkillEntries,
+      config: params.attempt.config,
+      workspaceDir: skillsPromptWorkspaceDir,
+      agentId: params.sessionAgentId,
+      eligibility: skillsEligibility,
+    });
+    return {
+      restoreSkillEnv,
+      skillUsagePaths,
+      skillsPrompt,
+      skillsSnapshotForRun: skillsSnapshot,
+    };
+  } catch (error) {
+    restoreSkillEnv();
+    throw error;
+  }
+}
+
+export type EmitDiagnosticRunCompleted = (
+  outcome: "completed" | "aborted" | "blocked" | "error",
+  err?: unknown,
+  extra?: { blockedBy?: string },
+) => void;
+
+export function startEmbeddedAttemptDiagnostics(params: EmbeddedRunAttemptParams): {
+  diagnosticTrace: ReturnType<typeof freezeDiagnosticTraceContext>;
+  runTrace: ReturnType<typeof freezeDiagnosticTraceContext>;
+  emitCompleted: EmitDiagnosticRunCompleted;
+} {
+  const diagnosticTrace = freezeDiagnosticTraceContext(
+    getActiveDiagnosticTraceContext() ?? createDiagnosticTraceContext(),
+  );
+  const runTrace = freezeDiagnosticTraceContext(createChildDiagnosticTraceContext(diagnosticTrace));
+  const diagnosticRunBase = {
+    runId: params.runId,
+    ...(params.sessionKey && { sessionKey: params.sessionKey }),
+    ...(params.sessionId && { sessionId: params.sessionId }),
+    provider: params.provider,
+    model: params.modelId,
+    trigger: params.trigger,
+    ...((params.messageChannel ?? params.messageProvider)
+      ? { channel: params.messageChannel ?? params.messageProvider }
+      : {}),
+    trace: runTrace,
+  };
+  emitTrustedDiagnosticEvent({
+    type: "run.started",
+    ...diagnosticRunBase,
+  });
+  const startedAt = Date.now();
+  let completed = false;
+  const emitCompleted: EmitDiagnosticRunCompleted = (outcome, err, extra) => {
+    if (completed) {
+      return;
+    }
+    completed = true;
+    const failed = err != null && outcome !== "blocked";
+    const errorMessage = failed ? diagnosticErrorMessage(err) : undefined;
+    emitTrustedDiagnosticEventWithPrivateData(
+      {
+        type: "run.completed",
+        ...diagnosticRunBase,
+        durationMs: Date.now() - startedAt,
+        outcome,
+        ...(extra?.blockedBy ? { blockedBy: extra.blockedBy } : {}),
+        ...(failed ? { errorCategory: diagnosticErrorCategory(err) } : {}),
+      },
+      errorMessage ? { errorMessage } : undefined,
+    );
+  };
+  return { diagnosticTrace, runTrace, emitCompleted };
+}

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -2758,6 +2758,15 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       attemptOverrides: {
         promptMode: "none",
         disableTools: true,
+        clientTools: [
+          {
+            type: "function",
+            function: {
+              name: "unsafe_client_tool",
+              parameters: { type: "object", properties: {} },
+            },
+          },
+        ],
         inputProvenance: {
           kind: "inter_session",
           sourceSessionKey: "agent:main:discord:source",
@@ -2782,6 +2791,12 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(result.finalPromptText).toBe("hello");
     expect(result.systemPromptReport?.systemPrompt ?? "").toBe("");
     expect(result.messagesSnapshot).toHaveLength(1);
+    const sessionOptions = mockParams(
+      hoisted.createAgentSessionMock,
+      0,
+      "raw model createAgentSession options",
+    );
+    expect(sessionOptions.customTools).toStrictEqual([]);
     expectFields(requireRecord(result.messagesSnapshot[0], "gateway model snapshot"), {
       role: "assistant",
       content: "pong",

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -181,12 +181,12 @@ import { completeEmbeddedAttemptResult } from "./attempt-result.js";
 import { createEmbeddedAgentSessionWithResourceLoader } from "./attempt-session.js";
 import { prepareEmbeddedAttemptSetup } from "./attempt-setup.js";
 import { createEmbeddedRunStageTracker } from "./attempt-stage-timing.js";
-import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
 import {
   prepareEmbeddedAttemptSkills,
   startEmbeddedAttemptDiagnostics,
   type EmitDiagnosticRunCompleted,
 } from "./attempt-startup.js";
+import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
 import { prepareEmbeddedAttemptTransport } from "./attempt-stream-transport.js";
 import { installEmbeddedAttemptStreamGuards } from "./attempt-stream.js";
 import { prepareEmbeddedAttemptSystemPrompt } from "./attempt-system-prompt-prepare.js";

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -24,18 +24,9 @@ import {
 import { resolveContextEngineOwnerPluginId } from "../../../context-engine/registry.js";
 import { buildContextEngineRuntimeSettings } from "../../../context-engine/runtime-settings.js";
 import type { AssembleResult } from "../../../context-engine/types.js";
-import {
-  diagnosticErrorCategory,
-  diagnosticErrorMessage,
-} from "../../../infra/diagnostic-error-metadata.js";
-import {
-  emitTrustedDiagnosticEvent,
-  emitTrustedDiagnosticEventWithPrivateData,
-} from "../../../infra/diagnostic-events.js";
+import { emitTrustedDiagnosticEvent } from "../../../infra/diagnostic-events.js";
 import {
   createChildDiagnosticTraceContext,
-  createDiagnosticTraceContext,
-  getActiveDiagnosticTraceContext,
   freezeDiagnosticTraceContext,
 } from "../../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage, toErrorObject } from "../../../infra/errors.js";
@@ -47,23 +38,15 @@ import {
 } from "../../../plugins/hook-agent-context.js";
 import { resolveBlockMessage } from "../../../plugins/hook-decision-types.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
-import { copyPluginToolMeta, getPluginToolMeta } from "../../../plugins/tools.js";
-import { resolveSkillsPromptForRun } from "../../../skills/loading/workspace.js";
-import { resolveEmbeddedRunSkillEntries } from "../../../skills/runtime/embedded-run-entries.js";
-import {
-  applySkillEnvOverrides,
-  applySkillEnvOverridesFromSnapshot,
-} from "../../../skills/runtime/env-overrides.js";
+import { copyPluginToolMeta } from "../../../plugins/tools.js";
+import { annotateInterSessionPromptText } from "../../../sessions/input-provenance.js";
 import { buildTrajectoryRunMetadata } from "../../../trajectory/metadata.js";
 import {
   createTrajectoryRuntimeRecorder,
   toTrajectoryToolDefinitions,
 } from "../../../trajectory/runtime.js";
 import { createBundleLspToolRuntime } from "../../agent-bundle-lsp-runtime.js";
-import {
-  getOrCreateSessionMcpRuntime,
-  materializeBundleMcpToolsForRun,
-} from "../../agent-bundle-mcp-tools.js";
+import { materializeBundleMcpToolsForRun } from "../../agent-bundle-mcp-tools.js";
 import { createPreparedEmbeddedAgentSettingsManager } from "../../agent-project-settings.js";
 import { resolveAgentDir, resolveSessionAgentIds } from "../../agent-scope.js";
 import {
@@ -72,12 +55,7 @@ import {
   isSilentOverflowProneModel,
   resolveEffectiveCompactionMode,
 } from "../../agent-settings.js";
-import {
-  createClientToolNameConflictError,
-  findClientToolNameConflicts,
-  toClientToolDefinitions,
-  toToolDefinitions,
-} from "../../agent-tool-definition-adapter.js";
+import { toToolDefinitions } from "../../agent-tool-definition-adapter.js";
 import {
   copyBeforeToolCallHookMarker,
   recordStructuredReplayTrustForToolCall,
@@ -89,7 +67,6 @@ import { createCacheTrace } from "../../cache-trace.js";
 import { copyChannelAgentToolMeta } from "../../channel-tools.js";
 import { copyCodeModeControlToolIdentity } from "../../code-mode-control-tools.js";
 import {
-  addClientToolsToCodeModeCatalog,
   applyCodeModeCatalog,
   CODE_MODE_EXEC_TOOL_NAME,
   CODE_MODE_WAIT_TOOL_NAME,
@@ -112,10 +89,7 @@ import {
   createAgentRunRestartAbortError,
   isAgentRunRestartAbortReason,
 } from "../../run-termination.js";
-import {
-  logAgentRuntimeToolDiagnostics,
-  normalizeAgentRuntimeTools,
-} from "../../runtime-plan/tools.js";
+import { logAgentRuntimeToolDiagnostics } from "../../runtime-plan/tools.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import {
   invalidateSessionFileRepairCache,
@@ -131,11 +105,9 @@ import {
   releasePendingAgentSteeringItems,
 } from "../../subagent-registry.js";
 import { buildEmptyExplicitToolAllowlistError } from "../../tool-allowlist-guard.js";
-import { collectReplaySafeToolNames, isAgentToolReplaySafe } from "../../tool-replay-safety.js";
 import { filterRuntimeCompatibleTools } from "../../tool-schema-projection.js";
 import { logRuntimeToolSchemaQuarantine } from "../../tool-schema-quarantine.js";
 import {
-  addClientToolsToToolSearchCatalog,
   applyToolSchemaDirectoryCatalog,
   applyToolSearchCatalog,
   clearToolSearchCatalog,
@@ -150,12 +122,10 @@ import {
 } from "../../tool-search.js";
 import { copyToolTerminalPresentation } from "../../tool-terminal-presentation.js";
 import { invalidateComputerFrameIfMissing } from "../../tools/computer-tool.js";
-import { replaceWithEffectiveCronCreatorToolAllowlist } from "../../tools/cron-tool.js";
 import type { NormalizedUsage } from "../../usage.js";
 import { readLastCacheTtlTimestamp } from "../cache-ttl.js";
 import { resolveCompactionTimeoutMs } from "../compaction-safety-timeout.js";
 import { runContextEngineMaintenance } from "../context-engine-maintenance.js";
-import { applyFinalEffectiveToolPolicy } from "../effective-tool-policy.js";
 import { buildEmbeddedExtensionFactories } from "../extensions.js";
 import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
 import { getHistoryLimitFromSessionKey, limitHistoryTurns } from "../history.js";
@@ -174,11 +144,6 @@ import {
   setActiveEmbeddedRun,
   updateActiveEmbeddedRunSnapshot,
 } from "../runs.js";
-import {
-  mapSandboxSkillEntriesForPrompt,
-  mapSandboxSkillUsagePaths,
-  resolveSandboxSkillRuntimeInputs,
-} from "../sandbox-skills.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "../session-manager-cache.js";
 import { prepareSessionManagerForRun } from "../session-manager-init.js";
 import {
@@ -190,12 +155,6 @@ import {
 import { resolveEmbeddedAgentApiKey } from "../stream-resolution.js";
 import { applySystemPromptToSession } from "../system-prompt.js";
 import {
-  collectCoreBuiltinToolNames,
-  collectRegisteredToolNames,
-  AGENT_RESERVED_TOOL_NAMES,
-  toSessionToolAllowlist,
-} from "../tool-name-allowlist.js";
-import {
   installContextEngineLoopHook,
   installToolResultContextGuard,
 } from "../tool-result-context-guard.js";
@@ -205,36 +164,34 @@ import {
   truncateOversizedToolResultsInMessages,
   truncateOversizedToolResultsInSessionManager,
 } from "../tool-result-truncation.js";
-import { splitSdkTools } from "../tool-split.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
 import { abortable as abortableWithSignal } from "./abortable.js";
 import { releaseEmbeddedAttemptSessionLockForAbort } from "./attempt-abort.js";
 import { completeEmbeddedAttemptAfterTurn } from "./attempt-after-turn.js";
 import { prepareEmbeddedAttemptBootstrap } from "./attempt-bootstrap-prepare.js";
+import { prepareEmbeddedAttemptBundleTools } from "./attempt-bundle-tools.js";
+import { prepareEmbeddedAttemptClientTools } from "./attempt-client-tools.js";
 import { snapshotRecentMessages, summarizeSessionContext } from "./attempt-context-summary.js";
 import {
   replayTrailingEntriesForOrphanRepair,
   resolveOrphanRepairPlan,
 } from "./attempt-orphan-repair.js";
 import { prepareEmbeddedAttemptPromptAssembly } from "./attempt-prompt-assembly.js";
-import {
-  completeEmbeddedAttemptResult,
-  type EmbeddedAttemptClientToolCallSlot,
-} from "./attempt-result.js";
+import { completeEmbeddedAttemptResult } from "./attempt-result.js";
 import { createEmbeddedAgentSessionWithResourceLoader } from "./attempt-session.js";
 import { prepareEmbeddedAttemptSetup } from "./attempt-setup.js";
 import { createEmbeddedRunStageTracker } from "./attempt-stage-timing.js";
 import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
+import {
+  prepareEmbeddedAttemptSkills,
+  startEmbeddedAttemptDiagnostics,
+  type EmitDiagnosticRunCompleted,
+} from "./attempt-startup.js";
 import { prepareEmbeddedAttemptTransport } from "./attempt-stream-transport.js";
 import { installEmbeddedAttemptStreamGuards } from "./attempt-stream.js";
 import { prepareEmbeddedAttemptSystemPrompt } from "./attempt-system-prompt-prepare.js";
 import { collectAttemptExplicitToolAllowlistSources } from "./attempt-tool-allowlist.js";
 import { prepareEmbeddedAttemptToolBase } from "./attempt-tool-base-prepare.js";
-import {
-  applyEmbeddedAttemptToolsAllow,
-  shouldCreateBundleLspRuntimeForAttempt,
-  shouldCreateBundleMcpRuntimeForAttempt,
-} from "./attempt-tool-construction-plan.js";
 import { flushEmbeddedAttemptTrajectoryRecorder } from "./attempt-trajectory-flush-cleanup.js";
 import {
   cloneHookMessages,
@@ -395,13 +352,7 @@ export async function runEmbeddedAttempt(
   let timedOutDuringToolExecution = false;
   let timedOutByRunBudget = false;
   let promptError: unknown = null;
-  let emitDiagnosticRunCompleted:
-    | ((
-        outcome: "completed" | "aborted" | "blocked" | "error",
-        err?: unknown,
-        extra?: { blockedBy?: string },
-      ) => void)
-    | undefined;
+  let emitDiagnosticRunCompleted: EmitDiagnosticRunCompleted | undefined;
   let beforeAgentRunBlocked = false;
   let beforeAgentRunBlockedBy: string | undefined;
   // Releases the eager session lock if post-prompt code exits before cleanup.
@@ -518,53 +469,14 @@ export async function runEmbeddedAttempt(
     }
   };
   try {
-    const {
-      skillsEligibility,
-      skillsPromptWorkspaceDir: effectiveSkillsPromptWorkspace,
-      skillsSnapshot: skillsSnapshotForRun,
-      skillsWorkspaceDir: effectiveSkillsWorkspace,
-      workspaceOnly: loadSkillsWorkspaceOnly,
-    } = resolveSandboxSkillRuntimeInputs({
-      sandbox,
+    const preparedSkills = prepareEmbeddedAttemptSkills({
+      attempt: params,
       effectiveWorkspace,
-      skillsSnapshot: params.skillsSnapshot,
+      sandbox,
+      sessionAgentId,
     });
-    const { shouldLoadSkillEntries, skillEntries } = resolveEmbeddedRunSkillEntries({
-      workspaceDir: effectiveSkillsWorkspace,
-      config: params.config,
-      agentId: sessionAgentId,
-      eligibility: skillsEligibility,
-      skillsSnapshot: skillsSnapshotForRun,
-      workspaceOnly: loadSkillsWorkspaceOnly,
-    });
-    restoreSkillEnv = skillsSnapshotForRun
-      ? applySkillEnvOverridesFromSnapshot({
-          snapshot: skillsSnapshotForRun,
-          config: params.config,
-        })
-      : applySkillEnvOverrides({
-          skills: skillEntries ?? [],
-          config: params.config,
-        });
-    const promptSkillEntries = mapSandboxSkillEntriesForPrompt({
-      entries: shouldLoadSkillEntries ? skillEntries : undefined,
-      skillsWorkspaceDir: effectiveSkillsWorkspace,
-      skillsPromptWorkspaceDir: effectiveSkillsPromptWorkspace,
-    });
-    const skillUsagePaths = mapSandboxSkillUsagePaths({
-      paths: sandbox?.skillUsagePaths,
-      skillsWorkspaceDir: effectiveSkillsWorkspace,
-      skillsPromptWorkspaceDir: effectiveSkillsPromptWorkspace,
-    });
-
-    const skillsPrompt = resolveSkillsPromptForRun({
-      skillsSnapshot: skillsSnapshotForRun,
-      entries: promptSkillEntries,
-      config: params.config,
-      workspaceDir: effectiveSkillsPromptWorkspace,
-      agentId: sessionAgentId,
-      eligibility: skillsEligibility,
-    });
+    restoreSkillEnv = preparedSkills.restoreSkillEnv;
+    const { skillUsagePaths, skillsPrompt, skillsSnapshotForRun } = preparedSkills;
     prepStages.mark("skills");
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
@@ -585,49 +497,8 @@ export async function runEmbeddedAttempt(
     const resolveActiveContextEnginePluginId = () =>
       resolveContextEngineOwnerPluginId(activeContextEngine);
     const agentDir = params.agentDir ?? resolveAgentDir(params.config ?? {}, sessionAgentId);
-    const diagnosticTrace = freezeDiagnosticTraceContext(
-      getActiveDiagnosticTraceContext() ?? createDiagnosticTraceContext(),
-    );
-    const runTrace = freezeDiagnosticTraceContext(
-      createChildDiagnosticTraceContext(diagnosticTrace),
-    );
-    const diagnosticRunBase = {
-      runId: params.runId,
-      ...(params.sessionKey && { sessionKey: params.sessionKey }),
-      ...(params.sessionId && { sessionId: params.sessionId }),
-      provider: params.provider,
-      model: params.modelId,
-      trigger: params.trigger,
-      ...((params.messageChannel ?? params.messageProvider)
-        ? { channel: params.messageChannel ?? params.messageProvider }
-        : {}),
-      trace: runTrace,
-    };
-    emitTrustedDiagnosticEvent({
-      type: "run.started",
-      ...diagnosticRunBase,
-    });
-    const diagnosticRunStartedAt = Date.now();
-    let diagnosticRunCompleted = false;
-    emitDiagnosticRunCompleted = (outcome, err, extra) => {
-      if (diagnosticRunCompleted) {
-        return;
-      }
-      diagnosticRunCompleted = true;
-      const failed = err != null && outcome !== "blocked";
-      const errorMessage = failed ? diagnosticErrorMessage(err) : undefined;
-      emitTrustedDiagnosticEventWithPrivateData(
-        {
-          type: "run.completed",
-          ...diagnosticRunBase,
-          durationMs: Date.now() - diagnosticRunStartedAt,
-          outcome,
-          ...(extra?.blockedBy ? { blockedBy: extra.blockedBy } : {}),
-          ...(failed ? { errorCategory: diagnosticErrorCategory(err) } : {}),
-        },
-        errorMessage ? { errorMessage } : undefined,
-      );
-    };
+    const { diagnosticTrace, runTrace, emitCompleted } = startEmbeddedAttemptDiagnostics(params);
+    emitDiagnosticRunCompleted = emitCompleted;
     const corePluginToolStages = createEmbeddedRunStageTracker();
     let toolSearchCatalogExecutor: ToolSearchCatalogToolExecutor | undefined;
     const preparedToolBase = prepareEmbeddedAttemptToolBase({
@@ -662,8 +533,6 @@ export async function runEmbeddedAttempt(
     const {
       codeModeControlsEnabledForRun,
       computerContextEpoch,
-      cronCreatorToolAllowlist,
-      effectiveToolsAllow,
       localModelLeanEnabled,
       localModelLeanPreserveToolNames,
       replaySafetyOptions,
@@ -706,171 +575,19 @@ export async function runEmbeddedAttempt(
       modelApi: params.model.api,
       model: params.model,
     };
-    const tools = normalizeAgentRuntimeTools({
-      runtimePlan: params.runtimePlan,
-      tools: toolsEnabled ? toolsRaw : [],
-      provider: params.provider,
-      config: params.config,
-      workspaceDir: effectiveWorkspace,
-      env: process.env,
-      modelId: params.modelId,
-      modelApi: params.model.api,
-      model: params.model,
-      runtimeHandle: getProviderRuntimeHandle(),
-      onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) =>
-        logRuntimeToolSchemaQuarantine({
-          diagnostics,
-          tools: sourceTools,
-          runId: params.runId,
-          agentId: sessionAgentId,
-          sessionKey: params.sessionKey,
-          sessionId: params.sessionId,
-        }),
+    const preparedBundleTools = await prepareEmbeddedAttemptBundleTools({
+      agentDir,
+      attempt: params,
+      effectiveWorkspace,
+      getCurrentAttemptPluginMetadataSnapshot,
+      getProviderRuntimeHandle,
+      isRawModelRun,
+      preparedToolBase,
+      sessionAgentId,
     });
-    const clientTools =
-      toolsEnabled && !isRawModelRun && !params.forceRestartSafeTools
-        ? params.clientTools
-        : undefined;
-    const bundleMcpEnabled =
-      !params.forceRestartSafeTools &&
-      shouldCreateBundleMcpRuntimeForAttempt({
-        toolsEnabled,
-        disableTools: params.disableTools || isRawModelRun,
-        toolsAllow: params.toolsAllow,
-      });
-    const bundleMetadataSnapshot = getCurrentAttemptPluginMetadataSnapshot();
-    // Scoped registries are partial views. Bundle discovery can skip its own scan only when
-    // the attempt snapshot covers every plugin; otherwise MCP/LSP bundles can disappear.
-    const bundleManifestRegistry =
-      bundleMetadataSnapshot?.pluginIds === undefined
-        ? bundleMetadataSnapshot?.manifestRegistry
-        : undefined;
-    const bundleMcpSessionRuntime = bundleMcpEnabled
-      ? await getOrCreateSessionMcpRuntime({
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          workspaceDir: effectiveWorkspace,
-          agentDir,
-          cfg: params.config,
-          manifestRegistry: bundleManifestRegistry,
-        })
-      : undefined;
-    bundleMcpRuntime = bundleMcpSessionRuntime
-      ? await materializeBundleMcpToolsForRun({
-          runtime: bundleMcpSessionRuntime,
-          reservedToolNames: [
-            ...tools.map((tool) => tool.name),
-            ...(clientTools?.map((tool) => tool.function.name) ?? []),
-          ],
-        })
-      : undefined;
-    const bundleLspEnabled =
-      !params.forceRestartSafeTools &&
-      shouldCreateBundleLspRuntimeForAttempt({
-        toolsEnabled,
-        disableTools: params.disableTools || isRawModelRun,
-        toolsAllow: params.toolsAllow,
-      });
-    bundleLspRuntime = bundleLspEnabled
-      ? await createBundleLspToolRuntime({
-          workspaceDir: effectiveWorkspace,
-          cfg: params.config,
-          manifestRegistry: bundleManifestRegistry,
-          reservedToolNames: [
-            ...tools.map((tool) => tool.name),
-            ...(clientTools?.map((tool) => tool.function.name) ?? []),
-            ...(bundleMcpRuntime?.tools.map((tool) => tool.name) ?? []),
-          ],
-        })
-      : undefined;
-    const allowedBundleMcpTools = applyEmbeddedAttemptToolsAllow(
-      bundleMcpRuntime?.tools ?? [],
-      effectiveToolsAllow,
-      {
-        toolMeta: (tool) => getPluginToolMeta(tool),
-      },
-    );
-    const allowedBundleLspTools = applyEmbeddedAttemptToolsAllow(
-      bundleLspRuntime?.tools ?? [],
-      effectiveToolsAllow,
-      {
-        toolMeta: (tool) => getPluginToolMeta(tool),
-      },
-    );
-    const allowedBundledTools = [...allowedBundleMcpTools, ...allowedBundleLspTools];
-    const filteredBundledTools = applyFinalEffectiveToolPolicy({
-      bundledTools: allowedBundledTools,
-      config: params.config,
-      conversationCapabilityProfile: runtimeCapabilityProfile,
-      warn: (message) => log.warn(message),
-    });
-    if (bundleMcpRuntime?.restrictAppTools) {
-      const runtimeAllowedAppTools = applyEmbeddedAttemptToolsAllow(
-        bundleMcpRuntime.appTools ?? bundleMcpRuntime.tools,
-        effectiveToolsAllow,
-        { toolMeta: (tool) => getPluginToolMeta(tool) },
-      );
-      const allowedAppTools = applyFinalEffectiveToolPolicy({
-        bundledTools: runtimeAllowedAppTools,
-        config: params.config,
-        conversationCapabilityProfile: runtimeCapabilityProfile,
-        warn: (message) => log.warn(message),
-      });
-      // The view outlives this attempt. Capture policy against the complete MCP
-      // catalog now, including App-only tools that never enter the model surface.
-      bundleMcpRuntime.restrictAppTools(allowedAppTools);
-    }
-    const normalizedBundledTools =
-      filteredBundledTools.length > 0
-        ? normalizeAgentRuntimeTools({
-            runtimePlan: params.runtimePlan,
-            tools: filteredBundledTools,
-            provider: params.provider,
-            config: params.config,
-            workspaceDir: effectiveWorkspace,
-            env: process.env,
-            modelId: params.modelId,
-            modelApi: params.model.api,
-            model: params.model,
-            runtimeHandle: getProviderRuntimeHandle(),
-            onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) =>
-              logRuntimeToolSchemaQuarantine({
-                diagnostics,
-                tools: sourceTools,
-                runId: params.runId,
-                agentId: sessionAgentId,
-                sessionKey: params.sessionKey,
-                sessionId: params.sessionId,
-              }),
-          })
-        : filteredBundledTools;
-    const projectedUncompactedEffectiveTools = filterLocalModelLeanTools({
-      tools: [...tools, ...normalizedBundledTools],
-      config: params.config,
-      agentId: sessionAgentId,
-      preserveToolNames: localModelLeanPreserveToolNames,
-    });
-    if (cronCreatorToolAllowlist.length > 0) {
-      // Cron is constructed before bundled MCP/LSP tools are appended; refresh
-      // the shared cap so scheduled turns preserve the creator's full surface.
-      replaceWithEffectiveCronCreatorToolAllowlist(
-        cronCreatorToolAllowlist,
-        projectedUncompactedEffectiveTools,
-        (tool) => getPluginToolMeta(tool),
-      );
-    }
-    const uncompactedToolSchemaProjection = filterRuntimeCompatibleTools(
-      projectedUncompactedEffectiveTools,
-    );
-    logRuntimeToolSchemaQuarantine({
-      diagnostics: uncompactedToolSchemaProjection.diagnostics,
-      tools: projectedUncompactedEffectiveTools,
-      runId: params.runId,
-      agentId: sessionAgentId,
-      sessionKey: params.sessionKey,
-      sessionId: params.sessionId,
-    });
-    const uncompactedEffectiveTools = [...uncompactedToolSchemaProjection.tools];
+    bundleMcpRuntime = preparedBundleTools.bundleMcpRuntime;
+    bundleLspRuntime = preparedBundleTools.bundleLspRuntime;
+    const { clientTools, tools, uncompactedEffectiveTools } = preparedBundleTools;
     let effectiveTools = uncompactedEffectiveTools;
     const catalogToolHookContext = {
       agentId: sessionAgentId,
@@ -1334,145 +1051,30 @@ export async function runEmbeddedAttempt(
       // Get hook runner early so it's available when creating tools
       const hookRunner = getGlobalHookRunner();
 
-      const { customTools } = splitSdkTools({
-        tools: effectiveTools,
-        sandboxEnabled: Boolean(sandbox?.enabled),
-        toolHookContext: catalogToolHookContext,
-      });
-
-      // Add client tools (OpenResponses hosted tools) to customTools.
-      // Reserve slots synchronously at tool execution entry, before async
-      // before_tool_call hooks run, so parallel client-tool batches preserve
-      // assistant source order even when later hooks finish first.
-      const clientToolCallSlots: EmbeddedAttemptClientToolCallSlot[] = [];
-      const clientToolCallSlotIndexes = new Map<string, number>();
-      const reserveClientToolCallSlot = (toolCallId: string, toolName: string) => {
-        if (clientToolCallSlotIndexes.has(toolCallId)) {
-          return;
-        }
-        clientToolCallSlotIndexes.set(toolCallId, clientToolCallSlots.length);
-        clientToolCallSlots.push({
-          toolCallId,
-          name: toolName,
-          completed: false,
-        });
-      };
-      const clientToolLoopDetection = resolveToolLoopDetectionConfig({
-        cfg: params.config,
-        agentId: sessionAgentId,
-      });
-      // Exact raw names of every tool registered for this run, including
-      // bundled/plugin tools. Used as the raw-name set for the trusted local
-      // media passthrough gate: a normalized alias is not sufficient — the
-      // emitted tool name must match an exact registration of this run.
-      const builtinToolNames = new Set(
-        uncompactedEffectiveTools.flatMap((tool) => {
-          const name = (tool.name ?? "").trim();
-          return name ? [name] : [];
-        }),
-      );
-      const coreBuiltinToolNames = collectCoreBuiltinToolNames(uncompactedEffectiveTools, {
-        isPluginTool: (tool) =>
-          Boolean(getPluginToolMeta(tool as Parameters<typeof getPluginToolMeta>[0])),
-      });
-      const isReplaySafeTool = (tool: { name?: string }) =>
-        isAgentToolReplaySafe(tool, replaySafetyOptions);
-      const replaySafeTools = new Set(uncompactedEffectiveTools.filter(isReplaySafeTool));
-      const replaySafeToolNames = collectReplaySafeToolNames(
-        uncompactedEffectiveTools,
+      const {
+        allCustomTools,
+        builtinToolNames,
+        clientToolCallSlots,
+        clientToolDefs,
+        clientToolLoopDetection,
+        replaySafeToolNames,
+        replaySafeTools,
+        sessionToolAllowlist,
+      } = prepareEmbeddedAttemptClientTools({
+        attempt: params,
+        catalogToolHookContext,
+        clientTools,
+        codeModeControlsEnabledForRun,
+        deferredDirectoryToolsCallable,
+        effectiveTools,
         replaySafetyOptions,
-      );
-      // Directory exact-name hydration cannot distinguish a hidden catalog tool
-      // from a visible client tool that shadows it. Other modes preserve the
-      // existing client/plugin coexistence behavior and use core conflicts only.
-      const clientConflictToolNames = deferredDirectoryToolsCallable
-        ? builtinToolNames
-        : coreBuiltinToolNames;
-      const clientToolNameConflicts = findClientToolNameConflicts({
-        tools: clientTools ?? [],
-        existingToolNames: [...clientConflictToolNames, ...AGENT_RESERVED_TOOL_NAMES],
+        sandboxEnabled: Boolean(sandbox?.enabled),
+        sandboxSessionKey,
+        sessionAgentId,
+        toolSearchCatalogRef,
+        toolSearchRuntimeConfig,
+        uncompactedEffectiveTools,
       });
-      if (clientToolNameConflicts.length > 0) {
-        throw createClientToolNameConflictError(clientToolNameConflicts);
-      }
-      let clientToolDefs = clientTools
-        ? toClientToolDefinitions(
-            clientTools,
-            {
-              reserve: reserveClientToolCallSlot,
-              complete: (toolCallId, toolName, toolParams) => {
-                reserveClientToolCallSlot(toolCallId, toolName);
-                const slotIndex = clientToolCallSlotIndexes.get(toolCallId);
-                if (slotIndex === undefined) {
-                  return;
-                }
-                const slot = clientToolCallSlots[slotIndex];
-                if (!slot) {
-                  return;
-                }
-                slot.name = toolName;
-                slot.params = toolParams;
-                slot.completed = true;
-              },
-              discard: (toolCallId) => {
-                const slotIndex = clientToolCallSlotIndexes.get(toolCallId);
-                if (slotIndex === undefined) {
-                  return;
-                }
-                const slot = clientToolCallSlots[slotIndex];
-                if (slot) {
-                  slot.completed = false;
-                  slot.params = undefined;
-                }
-              },
-            },
-            {
-              agentId: sessionAgentId,
-              sessionKey: sandboxSessionKey,
-              config: toolSearchRuntimeConfig,
-              sessionId: params.sessionId,
-              runId: params.runId,
-              loopDetection: clientToolLoopDetection,
-              onToolOutcome: params.onToolOutcome,
-              allocateToolOutcomeOrdinal: params.allocateToolOutcomeOrdinal,
-            },
-          )
-        : [];
-      const clientToolSearch = codeModeControlsEnabledForRun
-        ? addClientToolsToCodeModeCatalog({
-            tools: clientToolDefs,
-            config: params.config,
-            sessionId: params.sessionId,
-            sessionKey: sandboxSessionKey,
-            agentId: sessionAgentId,
-            runId: params.runId,
-            catalogRef: toolSearchCatalogRef,
-          })
-        : addClientToolsToToolSearchCatalog({
-            tools: clientToolDefs,
-            config: toolSearchRuntimeConfig,
-            sessionId: params.sessionId,
-            sessionKey: sandboxSessionKey,
-            agentId: sessionAgentId,
-            runId: params.runId,
-            catalogRef: toolSearchCatalogRef,
-          });
-      clientToolDefs = clientToolSearch.tools;
-      if (clientToolSearch.compacted) {
-        log.info(
-          codeModeControlsEnabledForRun
-            ? `code-mode: cataloged ${clientToolSearch.catalogToolCount} client tools behind exec/wait`
-            : `tool-search: cataloged ${clientToolSearch.catalogToolCount} client tools behind compact prompt surface`,
-        );
-      }
-
-      const allCustomTools = [...customTools, ...clientToolDefs];
-      // The session runtime treats `tools` as a name allowlist during session creation. Pass the
-      // exact OpenClaw-managed registrations so custom tools survive startup and
-      // client-provided names do not broaden the prompt/runtime boundary.
-      const sessionToolAllowlist = toSessionToolAllowlist(
-        collectRegisteredToolNames(allCustomTools),
-      );
 
       const createdSession = await createEmbeddedAgentSessionWithResourceLoader<
         Awaited<ReturnType<typeof createAgentSession>>

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -39,7 +39,6 @@ import {
 import { resolveBlockMessage } from "../../../plugins/hook-decision-types.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import { copyPluginToolMeta } from "../../../plugins/tools.js";
-import { annotateInterSessionPromptText } from "../../../sessions/input-provenance.js";
 import { buildTrajectoryRunMetadata } from "../../../trajectory/metadata.js";
 import {
   createTrajectoryRuntimeRecorder,

--- a/src/agents/embedded-agent-runner/run/auth-store.ts
+++ b/src/agents/embedded-agent-runner/run/auth-store.ts
@@ -1,0 +1,58 @@
+import type { AuthProfileStore } from "../../auth-profiles.js";
+import type { ResolvedProviderAuth } from "../../model-auth.js";
+import type { RuntimeAuthState } from "./helpers.js";
+
+export function resolveAttemptDispatchApiKey(params: {
+  apiKeyInfo: ResolvedProviderAuth | null;
+  runtimeAuthState: RuntimeAuthState | null;
+}): string | undefined {
+  if (params.runtimeAuthState) {
+    return undefined;
+  }
+  return params.apiKeyInfo?.apiKey;
+}
+
+function createEmptyAuthProfileStore(): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: {},
+  };
+}
+
+export function createScopedAuthProfileStore(
+  store: AuthProfileStore,
+  profileIds: string | undefined | string[],
+): AuthProfileStore {
+  const profiles = store.profiles ?? {};
+  const normalizedProfileIds = (Array.isArray(profileIds) ? profileIds : [profileIds])
+    .map((profileId) => profileId?.trim())
+    .filter((profileId): profileId is string => Boolean(profileId));
+  const scopedProfiles = Object.fromEntries(
+    normalizedProfileIds.flatMap((profileId) => {
+      const credential = profiles[profileId];
+      return credential ? [[profileId, credential] as const] : [];
+    }),
+  );
+  const scopedRuntimeExternalProfileIds = (store.runtimeExternalProfileIds ?? []).filter(
+    (profileId) => scopedProfiles[profileId],
+  );
+  const scopedRuntimePersistedProfileIds = (store.runtimePersistedProfileIds ?? []).filter(
+    (profileId) => scopedProfiles[profileId],
+  );
+  return Object.keys(scopedProfiles).length > 0
+    ? {
+        version: store.version,
+        profiles: scopedProfiles,
+        ...(scopedRuntimePersistedProfileIds.length > 0
+          ? { runtimePersistedProfileIds: scopedRuntimePersistedProfileIds }
+          : {}),
+        ...(scopedRuntimeExternalProfileIds.length > 0 ||
+        store.runtimeExternalProfileIdsAuthoritative === true
+          ? { runtimeExternalProfileIds: scopedRuntimeExternalProfileIds }
+          : {}),
+        ...(store.runtimeExternalProfileIdsAuthoritative === true
+          ? { runtimeExternalProfileIdsAuthoritative: true }
+          : {}),
+      }
+    : createEmptyAuthProfileStore();
+}

--- a/src/agents/embedded-agent-runner/run/lane-controller.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.ts
@@ -1,0 +1,192 @@
+import {
+  assertAgentRunLifecycleGenerationCurrent,
+  claimAgentRunContext,
+  getAgentEventLifecycleGeneration,
+  getAgentRunContext,
+  withAgentRunLifecycleGeneration,
+} from "../../../infra/agent-events.js";
+import { enqueueCommandInLane, getCommandLaneSnapshot } from "../../../process/command-queue.js";
+import type { CommandQueueEnqueueOptions } from "../../../process/command-queue.types.js";
+import { withSessionPlacementTurnAdmission } from "../../session-placement-admission.js";
+import type { EmbeddedAgentRunResult } from "../types.js";
+import {
+  EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
+  resolveEmbeddedRunLaneTimeoutMs,
+  resolveEmbeddedRunSessionQueuePriority,
+  withEmbeddedRunLaneTimeout,
+} from "./lane-runtime.js";
+import type { RunEmbeddedAgentParams } from "./params.js";
+import { assertAgentHarnessRunAdmission } from "./session-bootstrap.js";
+
+type LaneParams = RunEmbeddedAgentParams & {
+  sessionFile: string;
+};
+
+export function createEmbeddedRunLaneController<TParams extends LaneParams>(options: {
+  getLifecycleGeneration: () => string;
+  getParams: () => TParams;
+  globalLane: string;
+  initialQueuedLifecycleGeneration: string;
+  sessionLane: string;
+  setLifecycleGeneration: (generation: string) => void;
+  setParams: (params: TParams) => void;
+}) {
+  const initialParams = options.getParams();
+  const sessionQueuePriority = resolveEmbeddedRunSessionQueuePriority(initialParams.trigger);
+  const laneTaskTimeoutMs = resolveEmbeddedRunLaneTimeoutMs(initialParams.timeoutMs);
+  const laneTaskAbortController = new AbortController();
+  const laneTaskReleaseController = new AbortController();
+  let laneTaskProgressAtMs = Date.now();
+
+  const noteLaneTaskProgress = () => {
+    laneTaskProgressAtMs = Date.now();
+  };
+  const throwIfAborted = () => {
+    const params = options.getParams();
+    if (!params.abortSignal?.aborted) {
+      return;
+    }
+    const reason = params.abortSignal.reason;
+    if (reason instanceof Error) {
+      throw reason;
+    }
+    const abortError =
+      reason !== undefined
+        ? new Error("Operation aborted", { cause: reason })
+        : new Error("Operation aborted");
+    abortError.name = "AbortError";
+    throw abortError;
+  };
+  const withLaneTimeout = (opts?: CommandQueueEnqueueOptions) =>
+    withEmbeddedRunLaneTimeout(
+      {
+        ...opts,
+        taskTimeoutProgressAtMs: () => laneTaskProgressAtMs,
+        taskTimeoutAbortSignal: laneTaskAbortController.signal,
+        taskTimeoutAbortGraceMs: EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
+        taskTimeoutReleaseSignal: laneTaskReleaseController.signal,
+      },
+      laneTaskTimeoutMs,
+    );
+  const withRunLaneWait = (opts?: CommandQueueEnqueueOptions) => {
+    const params = options.getParams();
+    if (!opts?.onWait && !params.onLaneWait) {
+      return opts;
+    }
+    return {
+      ...opts,
+      onWait: (waitMs, queuedAhead) => {
+        opts?.onWait?.(waitMs, queuedAhead);
+        options.getParams().onLaneWait?.({ waitMs, queuedAhead, waiting: true });
+      },
+    } satisfies CommandQueueEnqueueOptions;
+  };
+  const noteLaneWaitIfBusy = (lane: string) => {
+    const params = options.getParams();
+    if (!params.onLaneWait) {
+      return;
+    }
+    const snapshot = getCommandLaneSnapshot(lane);
+    if (snapshot.queuedCount > 0 || snapshot.activeCount >= snapshot.maxConcurrent) {
+      params.onLaneWait({
+        waitMs: 0,
+        queuedAhead: snapshot.queuedCount + snapshot.activeCount,
+        waiting: true,
+      });
+    }
+  };
+  const enqueueGlobal = (
+    task: () => Promise<EmbeddedAgentRunResult>,
+    opts?: CommandQueueEnqueueOptions,
+  ) => {
+    const globalOpts: CommandQueueEnqueueOptions = {
+      ...opts,
+      priority: sessionQueuePriority,
+    };
+    const taskWithCurrentLifecycle = async () => {
+      let params = options.getParams();
+      params.onLaneWait?.({ waitMs: 0, queuedAhead: 0, waiting: false });
+      throwIfAborted();
+      let lifecycleGeneration = options.getLifecycleGeneration();
+      const currentLifecycleGeneration = getAgentEventLifecycleGeneration();
+      const existingContext = getAgentRunContext(params.runId);
+      if (lifecycleGeneration !== currentLifecycleGeneration) {
+        const wasQueuedBeforeRotation =
+          options.initialQueuedLifecycleGeneration === lifecycleGeneration;
+        const canResumeAcrossRotation = sessionQueuePriority === "foreground";
+        const newerSameIdExecutionOwnsContext =
+          existingContext?.lifecycleGeneration === currentLifecycleGeneration;
+        if (
+          !wasQueuedBeforeRotation ||
+          !canResumeAcrossRotation ||
+          newerSameIdExecutionOwnsContext
+        ) {
+          assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
+        }
+        lifecycleGeneration = currentLifecycleGeneration;
+        options.setLifecycleGeneration(lifecycleGeneration);
+        params = { ...params, lifecycleGeneration };
+        options.setParams(params);
+      }
+      // Queue waits can outlive durable harness and placement bindings.
+      // Recheck and claim only after lifecycle admission, before context or hooks execute.
+      assertAgentHarnessRunAdmission(params);
+      return await withAgentRunLifecycleGeneration(lifecycleGeneration, () =>
+        withSessionPlacementTurnAdmission(
+          {
+            sessionId: params.sessionId,
+            ...(params.agentId ? { agentId: params.agentId } : {}),
+            ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+            runId: params.runId,
+          },
+          params,
+          () => {
+            claimAgentRunContext(params.runId, {
+              ...existingContext,
+              sessionKey: params.sessionKey ?? existingContext?.sessionKey,
+              sessionId: params.sessionId ?? existingContext?.sessionId,
+              lifecycleGeneration,
+            });
+            return task();
+          },
+        ),
+      );
+    };
+    const params = options.getParams();
+    if (params.enqueue) {
+      return params.enqueue(taskWithCurrentLifecycle, withLaneTimeout(withRunLaneWait(globalOpts)));
+    }
+    noteLaneWaitIfBusy(options.globalLane);
+    return enqueueCommandInLane(
+      options.globalLane,
+      taskWithCurrentLifecycle,
+      withLaneTimeout(withRunLaneWait(globalOpts)),
+    );
+  };
+  const enqueueSession = <T>(task: () => Promise<T>, opts?: CommandQueueEnqueueOptions) => {
+    const sessionOpts: CommandQueueEnqueueOptions = { ...opts, priority: sessionQueuePriority };
+    const taskWithLaneAdmission = () => {
+      options.getParams().onLaneWait?.({ waitMs: 0, queuedAhead: 0, waiting: false });
+      return task();
+    };
+    const params = options.getParams();
+    if (params.enqueue) {
+      return params.enqueue(taskWithLaneAdmission, withRunLaneWait(sessionOpts));
+    }
+    noteLaneWaitIfBusy(options.sessionLane);
+    return enqueueCommandInLane(
+      options.sessionLane,
+      taskWithLaneAdmission,
+      withRunLaneWait(sessionOpts),
+    );
+  };
+
+  return {
+    enqueueGlobal,
+    enqueueSession,
+    laneTaskAbortController,
+    laneTaskReleaseController,
+    noteLaneTaskProgress,
+    throwIfAborted,
+  };
+}

--- a/src/agents/embedded-agent-runner/run/lane-runtime.ts
+++ b/src/agents/embedded-agent-runner/run/lane-runtime.ts
@@ -1,0 +1,50 @@
+import {
+  addTimerTimeoutGraceMs,
+  MAX_TIMER_TIMEOUT_MS,
+} from "@openclaw/normalization-core/number-coercion";
+import type { CommandQueueEnqueueOptions } from "../../../process/command-queue.types.js";
+import { DEFAULT_AGENT_TIMEOUT_MS } from "../../timeout.js";
+import type { RunEmbeddedAgentParams } from "./params.js";
+
+export const EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS = 30_000;
+export const EMBEDDED_RUN_LANE_HEARTBEAT_MS = EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS / 2;
+
+export function resolveEmbeddedRunLaneTimeoutMs(timeoutMs: number): number {
+  const defaultLaneTimeoutMs = DEFAULT_AGENT_TIMEOUT_MS + EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS;
+  // "No timeout" resolves to the timer-safe MAX_TIMER sentinel upstream.
+  // Lane ownership still caps at the default agent deadline in that case.
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0 || timeoutMs >= MAX_TIMER_TIMEOUT_MS) {
+    return defaultLaneTimeoutMs;
+  }
+  return (
+    addTimerTimeoutGraceMs(Math.floor(timeoutMs), EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS) ??
+    defaultLaneTimeoutMs
+  );
+}
+
+export function withEmbeddedRunLaneTimeout(
+  opts: CommandQueueEnqueueOptions | undefined,
+  laneTaskTimeoutMs: number,
+): CommandQueueEnqueueOptions | undefined {
+  if (opts?.taskTimeoutMs !== undefined) {
+    return opts;
+  }
+  return { ...opts, taskTimeoutMs: laneTaskTimeoutMs };
+}
+
+export function resolveEmbeddedRunSessionQueuePriority(
+  trigger: RunEmbeddedAgentParams["trigger"],
+): CommandQueueEnqueueOptions["priority"] {
+  switch (trigger) {
+    case "user":
+    case "manual":
+      return "foreground";
+    case "cron":
+    case "heartbeat":
+    case "memory":
+    case "overflow":
+      return "background";
+    default:
+      return "normal";
+  }
+}

--- a/src/agents/embedded-agent-runner/run/progress-controller.ts
+++ b/src/agents/embedded-agent-runner/run/progress-controller.ts
@@ -1,0 +1,160 @@
+import {
+  FAST_MODE_AUTO_PROGRESS_KIND,
+  type ReplyPayload,
+} from "../../../auto-reply/reply-payload.js";
+import { emitAgentItemEvent } from "../../../infra/agent-events.js";
+import { formatErrorMessage } from "../../../infra/errors.js";
+import {
+  DEFAULT_FAST_MODE_AUTO_ON_SECONDS,
+  type FastModeAutoProgressState,
+  formatFastModeAutoProgressText,
+  resolveFastModeForElapsed,
+} from "../../fast-mode.js";
+import { log } from "../logger.js";
+import type { RunEmbeddedAgentParams } from "./params.js";
+import type { EmbeddedRunFastModeParam } from "./types.js";
+
+export function createEmbeddedRunProgressController(params: {
+  attempt: RunEmbeddedAgentParams;
+  noteLaneTaskProgress: () => void;
+  startedAtMs: number;
+}) {
+  const fastModeStartedAtMs = params.attempt.fastModeStartedAtMs ?? params.startedAtMs;
+  const fastModeAutoOnSeconds =
+    params.attempt.fastModeAutoOnSeconds ?? DEFAULT_FAST_MODE_AUTO_ON_SECONDS;
+  const fastModeAutoProgressState: FastModeAutoProgressState = params.attempt
+    .fastModeAutoProgressState ?? {
+    offAnnounced: false,
+    resetAnnounced: false,
+  };
+  const notifyExecutionPhase = (
+    phase: Parameters<NonNullable<RunEmbeddedAgentParams["onExecutionPhase"]>>[0]["phase"],
+    extra?: Omit<Parameters<NonNullable<RunEmbeddedAgentParams["onExecutionPhase"]>>[0], "phase">,
+  ) => {
+    params.noteLaneTaskProgress();
+    params.attempt.onExecutionPhase?.({ phase, ...extra });
+  };
+  const notifyRunProgress = (
+    info: Parameters<NonNullable<RunEmbeddedAgentParams["onRunProgress"]>>[0],
+  ) => {
+    params.noteLaneTaskProgress();
+    params.attempt.onRunProgress?.(info);
+  };
+  const emitFastModeAutoProgress = async (payload: {
+    enabled: boolean;
+    elapsedSeconds: number;
+    fastAutoOnSeconds?: number;
+  }) => {
+    const summary = formatFastModeAutoProgressText(payload);
+    try {
+      emitAgentItemEvent({
+        runId: params.attempt.runId,
+        ...(params.attempt.sessionKey ? { sessionKey: params.attempt.sessionKey } : {}),
+        data: {
+          itemId: `fast-mode-auto:${payload.enabled ? "on" : "off"}`,
+          kind: "status",
+          title: "Fast",
+          phase: "update",
+          status: "running",
+          summary,
+        },
+      });
+    } catch (error) {
+      log.debug(`embedded run fast mode auto global event failed: ${formatErrorMessage(error)}`);
+    }
+    try {
+      await params.attempt.onAgentEvent?.({
+        stream: "item",
+        data: {
+          kind: "status",
+          title: "Fast",
+          phase: "update",
+          summary,
+        },
+        ...(params.attempt.sessionKey ? { sessionKey: params.attempt.sessionKey } : {}),
+      });
+    } catch (error) {
+      log.debug(`embedded run fast mode auto event failed: ${formatErrorMessage(error)}`);
+    }
+    try {
+      await params.attempt.onToolResult?.({
+        text: summary,
+        channelData: { openclawProgressKind: FAST_MODE_AUTO_PROGRESS_KIND },
+      });
+    } catch (error) {
+      log.debug(`embedded run fast mode auto progress failed: ${formatErrorMessage(error)}`);
+    }
+  };
+  const maybeAnnounceFastModeAutoOff = async () => {
+    if (params.attempt.fastMode !== "auto" || fastModeAutoProgressState.offAnnounced) {
+      return;
+    }
+    const next = resolveFastModeForElapsed({
+      mode: "auto",
+      startedAtMs: fastModeStartedAtMs,
+      fastAutoOnSeconds: fastModeAutoOnSeconds,
+    });
+    if (next.enabled) {
+      return;
+    }
+    fastModeAutoProgressState.offAnnounced = true;
+    await emitFastModeAutoProgress(next);
+  };
+  const notifyToolResult = async (payload: ReplyPayload) => {
+    await params.attempt.onToolResult?.(payload);
+  };
+  const notifyAgentEvent = async (
+    event: Parameters<NonNullable<RunEmbeddedAgentParams["onAgentEvent"]>>[0],
+  ) => {
+    await params.attempt.onAgentEvent?.(event);
+  };
+  const resolveAttemptFastMode = (): boolean | undefined => {
+    const resolved = resolveFastModeForElapsed({
+      mode: params.attempt.fastMode,
+      startedAtMs: fastModeStartedAtMs,
+      fastAutoOnSeconds: fastModeAutoOnSeconds,
+    });
+    return resolved.mode === undefined ? undefined : resolved.enabled;
+  };
+  const resolveAttemptFastModeParam = (): EmbeddedRunFastModeParam | undefined => {
+    if (params.attempt.fastMode === "auto") {
+      return resolveAttemptFastMode;
+    }
+    return resolveAttemptFastMode();
+  };
+  const maybeEmitFastModeAutoReset = async () => {
+    if (
+      params.attempt.fastMode !== "auto" ||
+      !fastModeAutoProgressState.offAnnounced ||
+      fastModeAutoProgressState.resetAnnounced
+    ) {
+      return;
+    }
+    fastModeAutoProgressState.resetAnnounced = true;
+    await emitFastModeAutoProgress({
+      enabled: true,
+      elapsedSeconds: 0,
+      fastAutoOnSeconds: fastModeAutoOnSeconds,
+    });
+  };
+  const maybeEmitFastModeAutoResetBestEffort = async () => {
+    try {
+      await maybeEmitFastModeAutoReset();
+    } catch (error) {
+      log.warn(`embedded run fast mode auto reset progress failed: ${formatErrorMessage(error)}`);
+    }
+  };
+
+  return {
+    fastModeAutoOnSeconds,
+    fastModeAutoProgressState,
+    fastModeStartedAtMs,
+    maybeAnnounceFastModeAutoOff,
+    maybeEmitFastModeAutoResetBestEffort,
+    notifyAgentEvent,
+    notifyExecutionPhase,
+    notifyRunProgress,
+    notifyToolResult,
+    resolveAttemptFastModeParam,
+  };
+}

--- a/src/agents/embedded-agent-runner/run/run-attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-result.ts
@@ -1,0 +1,87 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { hasOutboundDeliveryEvidence } from "../delivery-evidence.js";
+import type { ToolSummaryTrace } from "../types.js";
+import { runEmbeddedAttemptWithBackend } from "./backend.js";
+import { resolveAttemptReplayMetadata } from "./incomplete-turn.js";
+
+export type EmbeddedRunAttemptForRunner = Awaited<ReturnType<typeof runEmbeddedAttemptWithBackend>>;
+
+export function normalizeEmbeddedRunAttemptResult(
+  attempt: EmbeddedRunAttemptForRunner,
+): EmbeddedRunAttemptForRunner {
+  const raw = attempt as EmbeddedRunAttemptForRunner & {
+    assistantTexts?: EmbeddedRunAttemptForRunner["assistantTexts"] | null;
+    toolMetas?: EmbeddedRunAttemptForRunner["toolMetas"] | null;
+    acceptedSessionSpawns?: EmbeddedRunAttemptForRunner["acceptedSessionSpawns"] | null;
+    messagesSnapshot?: EmbeddedRunAttemptForRunner["messagesSnapshot"] | null;
+    messagingToolSentTexts?: EmbeddedRunAttemptForRunner["messagingToolSentTexts"] | null;
+    messagingToolSentMediaUrls?: EmbeddedRunAttemptForRunner["messagingToolSentMediaUrls"] | null;
+    messagingToolSentTargets?: EmbeddedRunAttemptForRunner["messagingToolSentTargets"] | null;
+    messagingToolSourceReplyPayloads?:
+      | EmbeddedRunAttemptForRunner["messagingToolSourceReplyPayloads"]
+      | null;
+    didDeliverSourceReplyViaMessageTool?: boolean | null;
+    itemLifecycle?: EmbeddedRunAttemptForRunner["itemLifecycle"] | null;
+    currentAttemptReplayMetadata?:
+      | EmbeddedRunAttemptForRunner["currentAttemptReplayMetadata"]
+      | null;
+  };
+  return {
+    ...attempt,
+    assistantTexts: raw.assistantTexts ?? [],
+    toolMetas: raw.toolMetas ?? [],
+    acceptedSessionSpawns: raw.acceptedSessionSpawns ?? [],
+    messagesSnapshot: raw.messagesSnapshot ?? [],
+    messagingToolSentTexts: raw.messagingToolSentTexts ?? [],
+    messagingToolSentMediaUrls: raw.messagingToolSentMediaUrls ?? [],
+    messagingToolSentTargets: raw.messagingToolSentTargets ?? [],
+    messagingToolSourceReplyPayloads: raw.messagingToolSourceReplyPayloads ?? [],
+    didDeliverSourceReplyViaMessageTool: raw.didDeliverSourceReplyViaMessageTool === true,
+    itemLifecycle: raw.itemLifecycle ?? {
+      startedCount: 0,
+      completedCount: 0,
+      activeCount: 0,
+    },
+    replayMetadata: resolveAttemptReplayMetadata(raw),
+    currentAttemptReplayMetadata: raw.currentAttemptReplayMetadata ?? undefined,
+  };
+}
+
+export function hasCompletedModelProgressForIdleBreaker(
+  attempt: EmbeddedRunAttemptForRunner,
+): boolean {
+  return (
+    attempt.assistantTexts.some((text) => text.trim().length > 0) ||
+    attempt.toolMetas.length > 0 ||
+    (attempt.clientToolCalls?.length ?? 0) > 0 ||
+    hasOutboundDeliveryEvidence(attempt) ||
+    attempt.itemLifecycle.completedCount > 0
+  );
+}
+
+export function buildTraceToolSummary(params: {
+  toolMetas?: EmbeddedRunAttemptForRunner["toolMetas"];
+  fallbackHadFailure: boolean;
+}): ToolSummaryTrace | undefined {
+  if (!params.toolMetas?.length) {
+    return undefined;
+  }
+  const tools: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of params.toolMetas) {
+    const toolName = normalizeOptionalString(entry.toolName);
+    if (!toolName || seen.has(toolName)) {
+      continue;
+    }
+    seen.add(toolName);
+    tools.push(toolName);
+  }
+  const failedToolCalls = params.toolMetas.filter((entry) => entry.isError === true).length;
+  return {
+    calls: params.toolMetas.length,
+    tools,
+    // Per-call error metadata is additive to the shipped harness result contract.
+    // Keep the prior any-failure signal for external harnesses that do not emit it yet.
+    failures: failedToolCalls || Number(params.fallbackHadFailure),
+  };
+}

--- a/src/agents/embedded-agent-runner/run/run-attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-result.ts
@@ -4,7 +4,7 @@ import type { ToolSummaryTrace } from "../types.js";
 import { runEmbeddedAttemptWithBackend } from "./backend.js";
 import { resolveAttemptReplayMetadata } from "./incomplete-turn.js";
 
-export type EmbeddedRunAttemptForRunner = Awaited<ReturnType<typeof runEmbeddedAttemptWithBackend>>;
+type EmbeddedRunAttemptForRunner = Awaited<ReturnType<typeof runEmbeddedAttemptWithBackend>>;
 
 export function normalizeEmbeddedRunAttemptResult(
   attempt: EmbeddedRunAttemptForRunner,

--- a/src/agents/embedded-agent-runner/run/runtime-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-resolution.ts
@@ -1,0 +1,127 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { ThinkLevel } from "../../../auto-reply/thinking.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../defaults.js";
+import {
+  buildModelAliasIndex,
+  resolveDefaultModelForAgent,
+  resolveModelRefFromString,
+} from "../../model-selection.js";
+import { resolveThinkingDefault } from "../../model-thinking-default.js";
+import { OPENAI_PROVIDER_ID } from "../../openai-routing.js";
+import type { AgentRuntimePlan } from "../../runtime-plan/types.js";
+import type { RunEmbeddedAgentParams } from "./params.js";
+
+export const CODEX_HARNESS_ID = "codex";
+const OPENAI_RESPONSES_API = "openai-responses";
+const OPENAI_CODEX_RESPONSES_API = "openai-chatgpt-responses";
+
+function normalizeRuntimeId(value: string | undefined): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+export function resolveAttemptTrajectoryAttribution(params: {
+  model: { api?: string; provider?: string };
+  modelId: string;
+  provider: string;
+  runtimePlan: {
+    auth?: Pick<AgentRuntimePlan["auth"], "authProfileProviderForAuth">;
+    observability?: Pick<AgentRuntimePlan["observability"], "harnessId">;
+  };
+}): { modelApi?: string; modelId: string; provider: string } {
+  const authProfileProvider = normalizeRuntimeId(
+    params.runtimePlan.auth?.authProfileProviderForAuth,
+  );
+  const harnessId = normalizeRuntimeId(params.runtimePlan.observability?.harnessId);
+  if (
+    harnessId === CODEX_HARNESS_ID &&
+    authProfileProvider !== OPENAI_PROVIDER_ID &&
+    normalizeRuntimeId(params.model.provider) === OPENAI_PROVIDER_ID &&
+    normalizeRuntimeId(params.model.api) === OPENAI_RESPONSES_API
+  ) {
+    return {
+      modelApi: OPENAI_CODEX_RESPONSES_API,
+      modelId: params.modelId,
+      provider: OPENAI_PROVIDER_ID,
+    };
+  }
+  return {
+    ...(params.model.api ? { modelApi: params.model.api } : {}),
+    modelId: params.modelId,
+    provider: params.provider,
+  };
+}
+
+export function resolveInitialThinkLevel(params: {
+  requested?: ThinkLevel;
+  config?: RunEmbeddedAgentParams["config"];
+  provider: string;
+  modelId: string;
+  model: { reasoning?: boolean };
+}): ThinkLevel {
+  if (params.requested) {
+    return params.requested;
+  }
+  return resolveThinkingDefault({
+    cfg: params.config ?? {},
+    provider: params.provider,
+    model: params.modelId,
+    catalog: [
+      {
+        provider: params.provider,
+        id: params.modelId,
+        name: params.modelId,
+        reasoning: params.model.reasoning,
+      },
+    ],
+  });
+}
+
+/** Marks only request parameters that OpenClaw applies to provider egress. */
+export function resolveRequestStreamTransportOverrides(
+  streamParams: RunEmbeddedAgentParams["streamParams"],
+): "present" | undefined {
+  return streamParams && Object.keys(streamParams).length > 0 ? "present" : undefined;
+}
+
+export function resolveInitialEmbeddedRunModel(params: {
+  config: RunEmbeddedAgentParams["config"];
+  agentId?: string;
+  provider?: string;
+  model?: string;
+}): { provider: string; modelId: string } {
+  const cfg = params.config ?? {};
+  const configuredDefault = resolveDefaultModelForAgent({
+    cfg,
+    agentId: params.agentId,
+  });
+  const explicitProvider = normalizeOptionalString(params.provider);
+  const explicitModel = normalizeOptionalString(params.model);
+  const defaultProvider = configuredDefault.provider || DEFAULT_PROVIDER;
+
+  if (explicitProvider && explicitModel) {
+    return { provider: explicitProvider, modelId: explicitModel };
+  }
+
+  if (explicitModel) {
+    const provider = explicitProvider ?? defaultProvider;
+    const aliasIndex = buildModelAliasIndex({
+      cfg,
+      defaultProvider: provider,
+    });
+    const resolved = resolveModelRefFromString({
+      cfg,
+      raw: explicitModel,
+      defaultProvider: provider,
+      aliasIndex,
+    });
+    return {
+      provider: explicitProvider ?? resolved?.ref.provider ?? provider,
+      modelId: resolved?.ref.model ?? explicitModel,
+    };
+  }
+
+  return {
+    provider: explicitProvider ?? defaultProvider,
+    modelId: configuredDefault.model || DEFAULT_MODEL,
+  };
+}

--- a/src/agents/embedded-agent-runner/run/session-bootstrap.ts
+++ b/src/agents/embedded-agent-runner/run/session-bootstrap.ts
@@ -1,0 +1,156 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
+import { resolveStorePath } from "../../../config/sessions.js";
+import { loadSessionEntry, updateSessionEntry } from "../../../config/sessions/session-accessor.js";
+import { parseSqliteSessionFileMarker } from "../../../config/sessions/sqlite-marker.js";
+import type { ContextEngineSessionTarget } from "../../../context-engine/types.js";
+import { formatErrorMessage } from "../../../infra/errors.js";
+import { resolveAgentIdFromSessionKey } from "../../../routing/session-key.js";
+import {
+  resolveSessionKeyForRequest,
+  resolveStoredSessionKeyForSessionId,
+} from "../../command/session.js";
+import { redactRunIdentifier } from "../../workspace-run.js";
+import { log } from "../logger.js";
+import type { RunEmbeddedAgentParams } from "./params.js";
+import { resolveAgentHarnessRunAdmissionError } from "./setup.js";
+
+const NO_REAL_CONVERSATION_MESSAGES_REASON = "no real conversation messages";
+
+export function buildContextEngineCompactionSessionTarget(params: {
+  agentId: string;
+  config?: RunEmbeddedAgentParams["config"];
+  sessionFile: string;
+  sessionId: string;
+  sessionKey?: string;
+  sessionTarget?: RunEmbeddedAgentParams["sessionTarget"];
+}): ContextEngineSessionTarget {
+  const sqliteMarker = parseSqliteSessionFileMarker(params.sessionFile);
+  const agentId = params.sessionTarget?.agentId ?? sqliteMarker?.agentId ?? params.agentId;
+  const sessionKey = params.sessionTarget?.sessionKey ?? params.sessionKey ?? params.sessionId;
+  const storePath =
+    params.sessionTarget?.storePath ??
+    sqliteMarker?.storePath ??
+    resolveStorePath(params.config?.session?.store, { agentId });
+  return {
+    agentId,
+    sessionId: params.sessionTarget?.sessionId ?? sqliteMarker?.sessionId ?? params.sessionId,
+    ...(sessionKey ? { sessionKey } : {}),
+    ...(storePath ? { storePath } : {}),
+    ...(params.sessionTarget?.threadId !== undefined
+      ? { threadId: params.sessionTarget.threadId }
+      : {}),
+  };
+}
+
+export function isNoRealConversationCompactionNoop(params: {
+  ok?: boolean;
+  compacted?: boolean;
+  reason?: string;
+}): boolean {
+  return (
+    params.ok === true &&
+    params.compacted === false &&
+    params.reason === NO_REAL_CONVERSATION_MESSAGES_REASON
+  );
+}
+
+export async function resetNoRealConversationTokenSnapshot(params: {
+  config?: RunEmbeddedAgentParams["config"];
+  sessionKey?: string;
+  agentId?: string;
+}): Promise<void> {
+  if (!params.sessionKey) {
+    return;
+  }
+  const storePath = resolveStorePath(params.config?.session?.store, { agentId: params.agentId });
+  try {
+    await updateSessionEntry(
+      {
+        storePath,
+        sessionKey: params.sessionKey,
+      },
+      async () => ({
+        totalTokens: 0,
+        totalTokensFresh: true,
+        inputTokens: undefined,
+        outputTokens: undefined,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+        contextBudgetStatus: undefined,
+        updatedAt: Date.now(),
+      }),
+      {
+        skipMaintenance: true,
+        takeCacheOwnership: true,
+      },
+    );
+  } catch (err) {
+    log.warn(
+      `[context-overflow-precheck] failed to reset stale context snapshot for ` +
+        `${params.sessionKey}: ${String(err)}`,
+    );
+  }
+}
+
+/** Best-effort read-only session-key lookup for callers that only provide sessionId. */
+export function backfillSessionKey(params: {
+  config: RunEmbeddedAgentParams["config"];
+  sessionId: string;
+  sessionKey?: string;
+  agentId?: string;
+}): string | undefined {
+  const trimmed = normalizeOptionalString(params.sessionKey);
+  if (trimmed) {
+    return trimmed;
+  }
+  if (!params.config || !params.sessionId) {
+    return undefined;
+  }
+  try {
+    const resolved = normalizeOptionalString(params.agentId)
+      ? resolveStoredSessionKeyForSessionId({
+          cfg: params.config,
+          sessionId: params.sessionId,
+          agentId: params.agentId,
+        })
+      : resolveSessionKeyForRequest({
+          cfg: params.config,
+          sessionId: params.sessionId,
+          clone: false,
+        });
+    return normalizeOptionalString(resolved.sessionKey);
+  } catch (err) {
+    log.warn(
+      `[backfillSessionKey] Failed to resolve sessionKey for sessionId=${redactRunIdentifier(sanitizeForLog(params.sessionId))}: ${formatErrorMessage(err)}`,
+    );
+    return undefined;
+  }
+}
+
+export function assertAgentHarnessRunAdmission(params: RunEmbeddedAgentParams): void {
+  const sessionKey = normalizeOptionalString(params.sessionKey);
+  if (!sessionKey) {
+    return;
+  }
+  const admissionAgentId = params.agentId ?? resolveAgentIdFromSessionKey(sessionKey);
+  const storePath =
+    normalizeOptionalString(params.sessionTarget?.storePath) ??
+    resolveStorePath(params.config?.session?.store, { agentId: admissionAgentId });
+  const durableEntry = loadSessionEntry({
+    ...(admissionAgentId ? { agentId: admissionAgentId } : {}),
+    readConsistency: "latest",
+    sessionKey,
+    storePath,
+  });
+  const admissionError = resolveAgentHarnessRunAdmissionError({
+    agentHarnessId: params.agentHarnessId,
+    entry: durableEntry,
+    modelSelectionLocked: params.modelSelectionLocked,
+    sessionId: params.sessionId,
+    sessionKey,
+  });
+  if (admissionError) {
+    throw new Error(admissionError);
+  }
+}


### PR DESCRIPTION
Related: #72072

## What Problem This Solves

The embedded runner entry points mixed queue admission, lifecycle ownership, session bootstrap, progress reporting, model resolution, auth scoping, skill startup, and tool-runtime preparation into two very large orchestration modules. That made ordering and cleanup invariants difficult to review.

## Why This Change Was Made

Extract cohesive, narrow helpers while keeping the retry loop and per-attempt stream sequence visible in their owning orchestrators. `run.ts` drops from 5,092 to 4,413 lines; `run/attempt.ts` drops from 3,867 to 3,469 lines against current `main`. Every new production helper is 220 lines or smaller.

The extraction also makes two existing cleanup obligations explicit: restore skill environment overrides when later startup preparation throws, and dispose partially created MCP/LSP runtimes when later bundle preparation fails.

The test-planner guard now gives `git ls-files` a 16 MiB output buffer. The repository inventory crossed Node's 1 MiB `spawnSync` default, which truncated discovery and incorrectly forced a filesystem fallback.

## User Impact

No intended user-visible behavior change. Internal runner ownership and review surfaces become smaller; existing API, config, protocol, provider, and tool behavior remain unchanged.

## Evidence

- Exact head: `7e66f090fdac712241518d85cdf556ea58cdd6ff`
- Blacksmith Testbox lease: `tbx_01kxe70qwrrt6vkm3m8jehfsrk`
- Focused exact-head proof: 365 tests passed across lane timeout, fast-mode progress, attempt orchestration, bundle cleanup, skill startup cleanup, context-engine raw-model gating, extension test planning, and embedded-runner E2E ([run](https://github.com/openclaw/openclaw/actions/runs/29269018610)).
- Hosted exact-head CI: 72 successful checks, 41 skipped, 1 neutral, 0 failed or pending.
- `git diff --check` passed.
- Structured autoreview: clean, patch correct, confidence 0.96.
- Full exact-head `pnpm check:changed` passed on the same Testbox lease in 12m36.856s, including core/core-test typechecks, tooling checks, all core lint shards, database-first guards, and import-cycle checks.
- Direct Codex contract inspection: Responses is the only wire API and ChatGPT auth selects the Codex backend ([provider source](https://github.com/openai/codex/blob/c7a4a7e136d96554e1fc6f66532e6060fd2aaf15/codex-rs/model-provider-info/src/lib.rs#L38-L60), [auth routing](https://github.com/openai/codex/blob/c7a4a7e136d96554e1fc6f66532e6060fd2aaf15/codex-rs/model-provider-info/src/lib.rs#L241-L259)); requests still use the Responses transport ([client](https://github.com/openai/codex/blob/c7a4a7e136d96554e1fc6f66532e6060fd2aaf15/codex-rs/core/src/client.rs#L1395-L1438), [request contract](https://github.com/openai/codex/blob/c7a4a7e136d96554e1fc6f66532e6060fd2aaf15/codex-rs/codex-api/src/common.rs#L215-L239)).
