### PR TITLE
fix(ui): restore custom avatar after session switches

### DIFF
--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -2746,7 +2746,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
-  it("renders the authenticated assistant avatar after switching sessions", async () => {
+  it("renders the visible authenticated assistant avatar after switching sessions", async () => {
     const context = await newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -2757,38 +2757,69 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2nPcAAAAASUVORK5CYII=",
       "base64",
     );
+    let avatarRequestCount = 0;
     await page.route(/\/avatar\/main\?meta=1$/, (route) =>
       route.fulfill({
         contentType: "application/json",
         body: JSON.stringify({ avatarUrl: "/avatar/main", avatarStatus: "local" }),
       }),
     );
-    await page.route(/\/avatar\/main$/, (route) =>
-      route.fulfill({ contentType: "image/png", body: avatarBody }),
-    );
+    await page.route(/\/avatar\/main$/, (route) => {
+      avatarRequestCount += 1;
+      return route.fulfill({ contentType: "image/png", body: avatarBody });
+    });
     await installMockGateway(page, {
-      historyMessages: [{ role: "assistant", content: [{ type: "text", text: "Avatar check" }] }],
       methodResponses: { "sessions.list": chatSessionListResponse() },
       sessionKey: "agent:main:session-a",
     });
 
     try {
       await page.goto(`${server.baseUrl}chat`);
-      const avatar = page.locator("img.chat-avatar.assistant").first();
+      const documentMarker = await page.evaluate(() => {
+        const marker = crypto.randomUUID();
+        (window as Window & { __openclawAvatarTestDocument?: string })[
+          "__openclawAvatarTestDocument"
+        ] = marker;
+        return marker;
+      });
+      const avatar = page.locator("img.agent-chat__welcome-avatar");
+      await avatar.waitFor({ state: "visible" });
       await expect.poll(() => avatar.getAttribute("src")).toMatch(/^blob:/);
+      const initialAvatarSrc = await avatar.getAttribute("src");
+      const initialRequestCount = avatarRequestCount;
 
-      await page
-        .locator(
-          '.sidebar-recent-session[data-session-key="agent:main:session-b"] a.sidebar-recent-session__link',
-        )
-        .click();
-      await page
-        .locator(
-          '.sidebar-recent-session[data-session-key="agent:main:session-a"] a.sidebar-recent-session__link',
-        )
-        .click();
-
+      const sessionRow = (sessionKey: string) =>
+        page.locator(`.sidebar-recent-session[data-session-key="${sessionKey}"]`);
+      const sessionB = sessionRow("agent:main:session-b");
+      await sessionB.locator("a.sidebar-recent-session__link").click();
+      await expect
+        .poll(() => sessionB.getAttribute("class"))
+        .toContain("sidebar-recent-session--active");
+      await expect.poll(() => avatarRequestCount).toBeGreaterThan(initialRequestCount);
+      await expect.poll(() => avatar.getAttribute("src")).not.toBe(initialAvatarSrc);
       await expect.poll(() => avatar.getAttribute("src")).toMatch(/^blob:/);
+      await expect.poll(() => avatar.isVisible()).toBe(true);
+      const sessionBAvatarSrc = await avatar.getAttribute("src");
+      const sessionBRequestCount = avatarRequestCount;
+
+      const sessionA = sessionRow("agent:main:session-a");
+      await sessionA.locator("a.sidebar-recent-session__link").click();
+      await expect
+        .poll(() => sessionA.getAttribute("class"))
+        .toContain("sidebar-recent-session--active");
+
+      await expect.poll(() => avatarRequestCount).toBeGreaterThan(sessionBRequestCount);
+      await expect.poll(() => avatar.getAttribute("src")).not.toBe(sessionBAvatarSrc);
+      await expect.poll(() => avatar.getAttribute("src")).toMatch(/^blob:/);
+      await expect.poll(() => avatar.isVisible()).toBe(true);
+      expect(
+        await page.evaluate(
+          () =>
+            (window as Window & { __openclawAvatarTestDocument?: string })[
+              "__openclawAvatarTestDocument"
+            ],
+        ),
+      ).toBe(documentMarker);
     } finally {
       await closeBrowserContext(context);
     }

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -2746,6 +2746,54 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
+  it("renders the authenticated assistant avatar after switching sessions", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const avatarBody = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2nPcAAAAASUVORK5CYII=",
+      "base64",
+    );
+    await page.route(/\/avatar\/main\?meta=1$/, (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ avatarUrl: "/avatar/main", avatarStatus: "local" }),
+      }),
+    );
+    await page.route(/\/avatar\/main$/, (route) =>
+      route.fulfill({ contentType: "image/png", body: avatarBody }),
+    );
+    await installMockGateway(page, {
+      historyMessages: [{ role: "assistant", content: [{ type: "text", text: "Avatar check" }] }],
+      methodResponses: { "sessions.list": chatSessionListResponse() },
+      sessionKey: "agent:main:session-a",
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const avatar = page.locator("img.chat-avatar.assistant").first();
+      await expect.poll(() => avatar.getAttribute("src")).toMatch(/^blob:/);
+
+      await page
+        .locator(
+          '.sidebar-recent-session[data-session-key="agent:main:session-b"] a.sidebar-recent-session__link',
+        )
+        .click();
+      await page
+        .locator(
+          '.sidebar-recent-session[data-session-key="agent:main:session-a"] a.sidebar-recent-session__link',
+        )
+        .click();
+
+      await expect.poll(() => avatar.getAttribute("src")).toMatch(/^blob:/);
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
   it("shows a pending send while a model override update is still pending", async () => {
     const context = await newBrowserContext({
       locale: "en-US",

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -700,7 +700,7 @@ class ChatPane extends OpenClawLightDomElement {
       state.announceSessionSwitch?.(nextSessionKey, nextSessionLabel);
     }
     void state.loadAssistantIdentity();
-    void refreshChatAvatar(state);
+    void refreshChatAvatar(state).finally(() => state.requestUpdate?.());
     void refreshChatMetadata(state).finally(() => state.requestUpdate?.());
     const subscriptionSync = syncSelectedSessionMessageSubscription(state);
     const composerStorageError = state.chatError === CHAT_COMPOSER_DRAFT_STORAGE_ERROR;

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -700,7 +700,7 @@ class ChatPane extends OpenClawLightDomElement {
       state.announceSessionSwitch?.(nextSessionKey, nextSessionLabel);
     }
     void state.loadAssistantIdentity();
-    void refreshChatAvatar(state).finally(() => state.requestUpdate?.());
+    void refreshChatAvatar(state).finally(() => this.requestUpdate());
     void refreshChatMetadata(state).finally(() => state.requestUpdate?.());
     const subscriptionSync = syncSelectedSessionMessageSubscription(state);
     const composerStorageError = state.chatError === CHAT_COMPOSER_DRAFT_STORAGE_ERROR;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with a custom assistant avatar would see the stock OpenClaw avatar after switching away from a chat session and returning to it. A full page reload restored the custom avatar, but ordinary session navigation left the fallback image rendered indefinitely.

Reported and reproduced on OpenClaw 2026.7.1-beta.6 by @demonbane.

## Why This Change Was Made

The session-switch path already refreshes the authenticated avatar asynchronously, but unlike its adjacent metadata refresh, it did not request a Lit render when that work completed. This change requests the render after the avatar refresh settles and adds a mocked-Gateway browser regression covering navigation away from and back to a session.

## User Impact

Custom assistant avatars now reappear automatically after session switches; users no longer need to reload the Control UI to replace the stock fallback icon.

## Evidence

- Live reproduction on 2026.7.1-beta.6: initial/full-load assistant messages used an authenticated `blob:` avatar; switching sessions and returning left them on `/apple-touch-icon.png`.
- Regression test against unmodified `main`: failed with `expected '/apple-touch-icon.png' to match /^blob:/`.
- Same regression test with this change: passed.
- Focused existing pane tests: 27 passed.
- Formatting and `git diff --check`: passed.

Commands:

```text
/home/linuxbrew/.linuxbrew/opt/node@24/bin/node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.e2e.test.ts -t 'renders the authenticated assistant avatar after switching sessions'

/home/linuxbrew/.linuxbrew/opt/node@24/bin/node ../node_modules/vitest/vitest.mjs run --config vitest.config.ts --project unit src/pages/chat/chat-pane.test.ts

pnpm exec oxfmt --check src/pages/chat/chat-pane.ts src/e2e/chat-flow.e2e.test.ts
```

AI-assisted: yes. The change and regression test were produced with Codex/OpenClaw assistance and manually verified against both the failing and fixed behavior.
