### PR TITLE
refactor(onboard): remove obsolete node manager options

### DIFF
--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -42,7 +42,7 @@ import { movePathToTrash } from "../infra/fs-safe.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveConfigDir, shortenHomeInString, shortenHomePath, sleep } from "../utils.js";
 import { VERSION } from "../version.js";
-import type { NodeManagerChoice, OnboardMode, ResetScope } from "./onboard-types.js";
+import type { OnboardMode, ResetScope } from "./onboard-types.js";
 export { randomToken } from "./random-token.js";
 
 export { detectBinary };
@@ -245,18 +245,6 @@ export async function ensureWorkspaceAndSessions(
   const sessionsDir = resolveSessionTranscriptsDirForAgent(options?.agentId);
   await fs.mkdir(sessionsDir, { recursive: true });
   runtime.log(`Sessions OK: ${shortenHomePath(sessionsDir)}`);
-}
-
-/** Returns package manager choices offered by onboarding. */
-export function resolveNodeManagerOptions(): Array<{
-  value: NodeManagerChoice;
-  label: string;
-}> {
-  return [
-    { value: "npm", label: "npm" },
-    { value: "pnpm", label: "pnpm" },
-    { value: "bun", label: "bun" },
-  ];
 }
 
 /** Moves a path to Trash when it exists, logging a manual-delete fallback on failure. */

--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -11,11 +11,6 @@ const mocks = vi.hoisted(() => ({
   detectBinary: vi.fn(),
   isContainerEnvironment: vi.fn(),
   resolveBrewExecutable: vi.fn(),
-  resolveNodeManagerOptions: vi.fn(() => [
-    { value: "npm", label: "npm" },
-    { value: "pnpm", label: "pnpm" },
-    { value: "bun", label: "bun" },
-  ]),
 }));
 
 // Module under test imports these at module scope.
@@ -35,7 +30,6 @@ vi.mock("../infra/brew.js", () => ({
 }));
 vi.mock("./onboard-helpers.js", () => ({
   detectBinary: mocks.detectBinary,
-  resolveNodeManagerOptions: mocks.resolveNodeManagerOptions,
 }));
 
 import { setupSkills, testing } from "./onboard-skills.js";


### PR DESCRIPTION
## What Problem This Solves

The onboarding module still exported a node-manager option builder after the interactive selector that consumed it was removed. That left a false internal API surface and matching test scaffolding with no runtime behavior behind either one.

## Why This Change Was Made

Remove the obsolete helper, its now-unused type import, and the stale mock entry. Node-manager selection remains owned by the existing `resolveDefaultNodeManager` path in skill onboarding; this change does not alter selection, validation, persistence, or installer behavior.

## User Impact

No user-visible behavior changes. The onboarding surface is smaller and no longer advertises an unused package-manager choice API.

## Evidence

- Fresh full code graph before the change: 312,020 nodes / 1,294,954 edges. `resolveNodeManagerOptions` had zero incoming `CALLS` or `USAGE` edges.
- Repository history shows `Streamline OpenClaw onboarding` (#98218) removed the helper's only caller when it replaced the interactive selector with `resolveDefaultNodeManager`.
- Fresh graph after the change: 312,024 nodes / 1,301,228 edges; searching for `resolveNodeManagerOptions` returns zero results.
- Blacksmith Testbox `tbx_01kxe5k8ry8ntqjeqqtybzecv6`, run https://github.com/openclaw/openclaw/actions/runs/29267341934:
  - `pnpm test:serial src/commands/onboard-skills.test.ts src/commands/onboard-helpers.test.ts` - 59/59 tests passed.
  - `pnpm check:changed -- src/commands/onboard-helpers.ts src/commands/onboard-skills.test.ts` - passed.
- Fresh `gpt-5.6-sol` medium review: no findings, confidence 0.98.
