### PR TITLE
fix(cron): drop plain-text format from announce delivery footer

### DIFF
--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -1739,7 +1739,8 @@ describe("runCronIsolatedAgentTurn delivery instruction", () => {
     const prompt = expectEmbeddedRunPrompt();
     expect(prompt).not.toContain("Use the message tool");
     expect(prompt).not.toContain("Message delivery destination metadata");
-    expect(prompt).toContain("Return your response as plain text");
+    expect(prompt).toContain("Your response will be delivered automatically");
+    expect(prompt).not.toContain("as plain text");
   });
 
   it("does not prompt for the message tool when toolsAllow is explicitly empty", async () => {
@@ -1767,7 +1768,8 @@ describe("runCronIsolatedAgentTurn delivery instruction", () => {
     });
     const prompt = expectEmbeddedRunPrompt();
     expect(prompt).not.toContain("Use the message tool");
-    expect(prompt).toContain("Return your response as plain text");
+    expect(prompt).toContain("Your response will be delivered automatically");
+    expect(prompt).not.toContain("as plain text");
   });
 
   it("prompts for the message tool when toolsAllow uses wildcard access", async () => {
@@ -1848,6 +1850,7 @@ describe("runCronIsolatedAgentTurn delivery instruction", () => {
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const prompt = expectEmbeddedRunPrompt();
     expect(prompt).not.toContain("Return your response as plain text");
+    expect(prompt).not.toContain("Your response will be delivered automatically");
     expect(prompt).not.toContain("it will be delivered automatically");
   });
 

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -1736,6 +1736,7 @@ describe("runCronIsolatedAgentTurn delivery instruction", () => {
     });
 
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+    expectEmbeddedRunFields({ toolsAllow: ["read"] });
     const prompt = expectEmbeddedRunPrompt();
     expect(prompt).not.toContain("Use the message tool");
     expect(prompt).not.toContain("Message delivery destination metadata");

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -491,7 +491,7 @@ function appendCronDeliveryInstruction(params: {
         : "for the current chat";
     return `${params.commandBody}\n\nUse the message tool if you need to notify the user directly ${targetHint}. If you do not send directly, your final plain-text reply will be delivered automatically.`.trim();
   }
-  return `${params.commandBody}\n\nReturn your response as plain text; it will be delivered automatically. If the task explicitly calls for messaging a specific external recipient, note who/where it should go instead of sending it yourself.`.trim();
+  return `${params.commandBody}\n\nYour response will be delivered automatically. If the task explicitly calls for messaging a specific external recipient, note who/where it should go instead of sending it yourself.`.trim();
 }
 
 function resolvePositiveContextTokens(value: unknown): number | undefined {


### PR DESCRIPTION
Closes #106430

## What Problem This Solves

Fixes an issue where isolated cron jobs with `delivery: announce` (and no message tool) append a footer that says **Return your response as plain text**, which some models (notably Qwen) obey by writing tool-like tags as plain text instead of making API-level tool calls. Other models ignore the instruction, so the bug is easy to miss.

## Why This Change Was Made

Replace the format-constraining plain-text clause with neutral automatic-delivery guidance: **Your response will be delivered automatically.** This keeps the auto-delivery contract without telling models to suppress structured tool use.

Fix quality: compatibility — string-only prompt change on the non-message-tool announce path; no config/API/schema change. Performance — no hot-path cost. Usability — clearer delivery notice. Security — no trust-boundary change.

Note: open PR #106527 targets the same issue with a slightly different residual wording (`Return your response; …`). This PR follows ClawSweeper’s recommended neutral phrasing and drops the format instruction entirely.

## User Impact

Isolated announce cron runs can use non-message tools without a prompt footer that steers weaker models away from real tool calls. Automatic delivery of the final reply still works as before.

## Evidence

Verification host: local macOS (Crabbox bypass)

```text
node scripts/run-vitest.mjs src/cron/isolated-agent/run.message-tool-policy.test.ts
# Test Files  1 passed (1)
# Tests  56 passed (56)

pnpm exec oxfmt --check src/cron/isolated-agent/run.ts src/cron/isolated-agent/run.message-tool-policy.test.ts
# All matched files use the correct format.

git diff --check  # clean
node --import tsx scripts/check-ts-max-loc.ts --base origin/main -- src/cron/isolated-agent/run.ts
# TypeScript LOC ratchet: checked 1 changed production files. (flat)

pnpm check:changed  # partial: conflict markers, LOC, format, SDK baseline, package patches, typecheck core OK;
# typecheck core tests exceeded closeout budget (~47m still running) → stopped; focused surface proof above covers this string-only change.
```

## Real behavior proof

- Behavior addressed: Isolated announce delivery footer no longer instructs models to answer “as plain text,” which was suppressing API tool calls for some models.
- Environment: local macOS, OpenClaw checkout at `main` + this patch (`76d63df2f`), Node-driven focused Vitest via `node scripts/run-vitest.mjs`.
- Current-main contrast: `appendCronDeliveryInstruction` (non-message-tool path) still emits `Return your response as plain text; it will be delivered automatically. …` on `origin/main`. Focused tests on main require that exact substring when announce delivery is requested without the message tool.
- Exact steps or command run after this patch:
  1. Inspect `src/cron/isolated-agent/run.ts` non-message-tool branch of `appendCronDeliveryInstruction`.
  2. Run `node scripts/run-vitest.mjs src/cron/isolated-agent/run.message-tool-policy.test.ts`.
- Evidence after fix: Production string is `Your response will be delivered automatically. …`. Tests assert that substring is present, assert `as plain text` is absent on the non-message-tool announce path, and assert the delivery footer is still omitted when delivery is not requested. Suite result: **56/56 passed**.
- Control check: Message-tool announce path wording is unchanged (`Use the message tool… final plain-text reply will be delivered automatically`). Only the no-message-tool footer lost the format constraint. Delivery-not-requested case still has no auto-delivery footer.
- Observed result after fix: Prompt construction for announce + toolsAllow without `message` no longer contains format-constraining “as plain text” language while still stating automatic delivery.
- What was not tested: Live Qwen (or other model) tool-call turn against a real announce cron job. ClawSweeper accepted source-level repro for this issue; live model behavior was not independently re-run here.

## AI disclosure

This fix was authored with AI assistance (Grok). Human reviewer should still treat ClawSweeper guidance and the focused test output as the primary review anchors.
