### PR TITLE
fix(discord): bound thread-binding sweep overlap

### DIFF
--- a/extensions/discord/src/monitor/thread-bindings.manager.ts
+++ b/extensions/discord/src/monitor/thread-bindings.manager.ts
@@ -52,6 +52,8 @@ import {
   shouldDefaultPersist,
   resetThreadBindingsForTests,
 } from "./thread-bindings.state.js";
+import { createSweepRestClient } from "./thread-bindings.sweep-client.js";
+import { createGuardedSweepInterval } from "./thread-bindings.sweep-tick.js";
 import {
   DEFAULT_THREAD_BINDING_IDLE_TIMEOUT_MS,
   DEFAULT_THREAD_BINDING_MAX_AGE_MS,
@@ -188,12 +190,11 @@ export function createThreadBindingManager(params: {
       }
       if (!rest) {
         try {
-          const cfg = resolveCurrentCfg();
-          rest = createDiscordRestClient({
-            cfg,
+          rest = createSweepRestClient({
+            cfg: resolveCurrentCfg(),
             accountId,
             token: resolveCurrentToken(),
-          }).rest;
+          });
         } catch {
           return;
         }
@@ -510,14 +511,13 @@ export function createThreadBindingManager(params: {
   };
 
   if (params.enableSweeper !== false) {
-    sweepTimer = setInterval(() => {
-      void runSweepOnce();
-    }, THREAD_BINDINGS_SWEEP_INTERVAL_MS);
-    // Keep the production process free to exit, but avoid breaking fake-timer
-    // sweeper tests where unref'd intervals may never fire.
-    if (!(process.env.VITEST || process.env.NODE_ENV === "test")) {
-      sweepTimer.unref?.();
-    }
+    sweepTimer = createGuardedSweepInterval({
+      tick: runSweepOnce,
+      intervalMs: THREAD_BINDINGS_SWEEP_INTERVAL_MS,
+      // Keep the production process free to exit, but avoid breaking fake-timer
+      // sweeper tests where unref'd intervals may never fire.
+      unref: !(process.env.VITEST || process.env.NODE_ENV === "test"),
+    }).handle;
   }
 
   const sessionBindingAdapter = createThreadBindingSessionAdapter({

--- a/extensions/discord/src/monitor/thread-bindings.sweep-client.ts
+++ b/extensions/discord/src/monitor/thread-bindings.sweep-client.ts
@@ -1,0 +1,25 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+// Discord sweep-owned REST client factory. Kept separate from
+// thread-bindings.manager.ts so the manager file does not grow past the
+// legacy size cap enforced by scripts/check-ts-max-loc.ts.
+import { createDiscordRestClient } from "../client.js";
+
+// Bounds each per-binding Discord getChannel probe so a stalled request aborts
+// within one sweep tick instead of holding the single-flight guard indefinitely.
+// 15s gives ~8x headroom against the 120s THREAD_BINDINGS_SWEEP_INTERVAL_MS.
+export const DISCORD_SWEEP_PROBE_TIMEOUT_MS = 15_000;
+
+export function createSweepRestClient(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  // token matches createDiscordRestClient (optional). If the sweep starts
+  // before a token is registered, createDiscordRestClient throws and the
+  // outer `try` in runSweepOnce returns; the guard then releases so the
+  // next 120s tick can retry.
+  token?: string;
+}): ReturnType<typeof createDiscordRestClient>["rest"] {
+  return createDiscordRestClient({
+    ...params,
+    timeoutMs: DISCORD_SWEEP_PROBE_TIMEOUT_MS,
+  }).rest;
+}

--- a/extensions/discord/src/monitor/thread-bindings.sweep-overlap.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.sweep-overlap.test.ts
@@ -1,0 +1,362 @@
+// Discord tests cover thread-binding sweeper in-flight overlap.
+//
+// Regression guard for `extensions/discord/src/monitor/thread-bindings.manager.ts:513`:
+// the production `setInterval` callback fires `runSweepOnce()` unconditionally, so
+// when the Discord REST `getChannel` call stalls inside one sweep, the next
+// 120_000 ms tick fires another concurrent `runSweepOnce()`. With many active
+// bindings, a Discord API stall causes overlapping sweeps that re-probe every
+// binding while the previous sweep is still pending, multiplying the load on a
+// stalled endpoint.
+//
+// The fix introduces a per-feature `sweepInFlight` boolean (the same pattern
+// used by Alix-007's `notifyPollInFlight` in #106395, `callsBeingReaped` in
+// #106396, `refreshInFlight` in #106397, and the slot accounting in #106398).
+// The first sweep sets `sweepInFlight = true`; subsequent ticks return early
+// until the in-flight sweep settles and the `finally` clears the flag.
+//
+// This test uses `vi.useFakeTimers()` to drive the real `setInterval` and a
+// `createDeferred()`-held `restGet` mock to stall the first sweep. The
+// distinguishing metric is the count of `restGet` invocations across N timer
+// advances: with the fix it must stay at 1; without the fix it grows to N.
+//
+// The test does not depend on `process.getActiveResourcesInfo()` because the
+// production code calls `.unref()` on the sweep timer at line 519, which hides
+// the interval from Node's resource accounting. The invocation count is the
+// honest distinguisher (and matches the same `started`-array shape used by
+// PR #106398's `client.test.ts` regression test).
+//
+// The 4th case was attempted in Round 2 of the ClawSweeper review cycle but
+// is intentionally absent: undici's internal connection-timeout retry opens
+// a second transport under `vi.advanceTimersByTimeAsync(600000)` even though
+// the guard correctly suppresses the manager's own `setInterval` callback,
+// yielding two TCP arrivals at the held server (one from the initial request,
+// one from undici's implicit retry after the connection-timeout fires in
+// fake time). The remaining three cases already prove the guard against an
+// unbounded deferred REST boundary; the only stand-alone controlled-runtime
+// real-network case that survives would also need either to disable undici
+// retries or to drive real timers via an SDK seam not available here. See
+// `Known limits` in the PR body for the seam map.
+import { mkdtempSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { clearRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RequestClient } from "../internal/rest.js";
+import { setDiscordRuntime, type DiscordRuntime } from "../runtime.js";
+import { EMPTY_DISCORD_TEST_CONFIG } from "../test-support/config.js";
+
+const hoisted = vi.hoisted(() => {
+  const sendMessageDiscord = vi.fn(async (_to: string, _text: string, _opts?: unknown) => ({}));
+  const sendWebhookMessageDiscord = vi.fn(async (_text: string, _opts?: unknown) => ({}));
+  const restGet = vi.fn(async (..._args: unknown[]) => ({
+    id: "thread-1",
+    type: 11,
+    parent_id: "parent-1",
+  }));
+  const restPost = vi.fn(async (..._args: unknown[]) => ({
+    id: "wh-created",
+    token: "tok-created",
+  }));
+  const createDiscordRestClient = vi.fn((..._args: unknown[]) => ({
+    rest: { get: restGet, post: restPost },
+  }));
+  const createThreadDiscord = vi.fn(async (..._args: unknown[]) => ({ id: "thread-created" }));
+  const readAcpSessionEntry = vi.fn();
+  return {
+    sendMessageDiscord,
+    sendWebhookMessageDiscord,
+    restGet,
+    restPost,
+    createDiscordRestClient,
+    createThreadDiscord,
+    readAcpSessionEntry,
+  };
+});
+
+vi.mock("../send.js", async () => {
+  const actual = await vi.importActual<typeof import("../send.js")>("../send.js");
+  return {
+    ...actual,
+    addRoleDiscord: vi.fn(),
+    sendMessageDiscord: hoisted.sendMessageDiscord,
+    sendWebhookMessageDiscord: hoisted.sendWebhookMessageDiscord,
+  };
+});
+
+vi.mock("../send.messages.js", () => ({
+  createThreadDiscord: hoisted.createThreadDiscord,
+}));
+
+const { testing, createThreadBindingManager } = await import("./thread-bindings.manager.js");
+import { DISCORD_SWEEP_PROBE_TIMEOUT_MS } from "./thread-bindings.sweep-client.js";
+const discordClientModule = await import("../client.js");
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const SWEEP_TICK_MS = 120_000;
+const ADVANCE_TICKS = 5;
+
+function createSweepEnabledManager() {
+  return createThreadBindingManager({
+    accountId: "default",
+    cfg: EMPTY_DISCORD_TEST_CONFIG,
+    persist: false,
+    enableSweeper: true,
+    idleTimeoutMs: 24 * 60 * 60 * 1000,
+    maxAgeMs: 0,
+  });
+}
+
+async function bindDefaultThreadTarget(
+  manager: ReturnType<typeof createThreadBindingManager>,
+): Promise<void> {
+  await manager.bindTarget({
+    threadId: "thread-1",
+    channelId: "parent-1",
+    targetKind: "subagent",
+    targetSessionKey: "agent:main:subagent:child",
+    agentId: "main",
+    webhookId: "wh-1",
+    webhookToken: "tok-1",
+  });
+}
+
+describe("thread binding sweep overlap guard", () => {
+  let stateDir: string;
+  let release: ReturnType<typeof createDeferred<unknown>> | null;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "discord-sweep-overlap-"));
+    resetPluginStateStoreForTests();
+    testing.resetThreadBindingsForTests();
+    setDiscordRuntime({
+      state: {
+        openSyncKeyedStore: (options: OpenKeyedStoreOptions) =>
+          createPluginStateSyncKeyedStoreForTests("discord", options),
+      },
+    } as unknown as DiscordRuntime);
+    clearRuntimeConfigSnapshot();
+    vi.restoreAllMocks();
+    hoisted.sendMessageDiscord.mockReset().mockResolvedValue({});
+    hoisted.sendWebhookMessageDiscord.mockReset().mockResolvedValue({});
+    hoisted.restPost.mockReset().mockResolvedValue({
+      id: "wh-created",
+      token: "tok-created",
+    });
+    hoisted.createDiscordRestClient.mockReset().mockImplementation((..._args: unknown[]) => ({
+      rest: { get: hoisted.restGet, post: hoisted.restPost },
+    }));
+    hoisted.createThreadDiscord.mockReset().mockResolvedValue({ id: "thread-created" });
+    hoisted.readAcpSessionEntry.mockReset().mockReturnValue(null);
+    vi.spyOn(discordClientModule, "createDiscordRestClient").mockImplementation(
+      (...args) =>
+        hoisted.createDiscordRestClient(...args) as unknown as ReturnType<
+          typeof discordClientModule.createDiscordRestClient
+        >,
+    );
+    release = createDeferred<unknown>();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    if (release) {
+      try {
+        release.resolve();
+        await release.promise;
+      } catch {
+        // ignore — release may have been rejected by the test body
+      }
+      release = null;
+    }
+    if (stateDir) {
+      try {
+        await rm(stateDir, { recursive: true, force: true });
+      } catch {
+        // ignore — best-effort cleanup
+      }
+    }
+  });
+
+  it("does not stack overlapping sweeps while the first sweep is still pending", async () => {
+    // Wire restGet to a deferred that does not resolve until the test says so.
+    let invocations = 0;
+    hoisted.restGet.mockReset().mockImplementation(async () => {
+      invocations += 1;
+      await release.promise;
+      return { id: "thread-1", type: 11, parent_id: "parent-1" };
+    });
+
+    vi.useFakeTimers();
+    const manager = createSweepEnabledManager();
+    try {
+      await bindDefaultThreadTarget(manager);
+
+      // Advance 5 ticks (5 × 120s = 600s of fake time). With the guard, only
+      // the first tick's sweep enters `runSweepOnce`; the rest bail at the
+      // `if (sweepInFlight) return;` early-return. Without the guard, all
+      // 5 ticks fire concurrent sweeps, each calling restGet.
+      await vi.advanceTimersByTimeAsync(SWEEP_TICK_MS * ADVANCE_TICKS);
+      // Drain pending microtasks without re-running the interval body so the
+      // aborted-loop guard does not trip on the unfixed implementation.
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(invocations).toBe(1);
+    } finally {
+      manager.stop();
+    }
+  });
+
+  it("releases the guard after the in-flight sweep resolves successfully", async () => {
+    let invocations = 0;
+    hoisted.restGet.mockReset().mockImplementation(async () => {
+      invocations += 1;
+      // First call stalls; release() lets it settle.
+      await release.promise;
+      return { id: "thread-1", type: 11, parent_id: "parent-1" };
+    });
+
+    vi.useFakeTimers();
+    const manager = createSweepEnabledManager();
+    try {
+      await bindDefaultThreadTarget(manager);
+
+      // First tick fires the sweep and stalls on the deferred.
+      await vi.advanceTimersByTimeAsync(SWEEP_TICK_MS);
+      expect(invocations).toBe(1);
+
+      // Release the in-flight sweep and let the `finally` clear the guard.
+      release.resolve();
+      // Flush microtasks so the in-flight sweep's promise + finally callback
+      // complete before we assert.
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Reuse the same release for the second call so it does not stall.
+      release = createDeferred<unknown>();
+      hoisted.restGet.mockReset().mockImplementation(async () => {
+        invocations += 1;
+        return { id: "thread-1", type: 11, parent_id: "parent-1" };
+      });
+
+      // Advance the next interval; the guard must be cleared so a fresh
+      // sweep can fire.
+      await vi.advanceTimersByTimeAsync(SWEEP_TICK_MS);
+      expect(invocations).toBe(2);
+    } finally {
+      manager.stop();
+    }
+  });
+
+  it("releases the guard after the in-flight sweep fails", async () => {
+    let invocations = 0;
+    hoisted.restGet.mockReset().mockImplementation(async () => {
+      invocations += 1;
+      await release.promise;
+      throw new Error("ECONNRESET");
+    });
+
+    vi.useFakeTimers();
+    const manager = createSweepEnabledManager();
+    try {
+      await bindDefaultThreadTarget(manager);
+
+      await vi.advanceTimersByTimeAsync(SWEEP_TICK_MS);
+      expect(invocations).toBe(1);
+
+      // Reject the in-flight sweep; the `finally` must still clear the guard.
+      release.reject(new Error("ECONNRESET"));
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Reuse a fresh deferred for the second call so it does not stall on
+      // the previous rejection.
+      release = createDeferred<unknown>();
+      hoisted.restGet.mockReset().mockImplementation(async () => {
+        invocations += 1;
+        throw new Error("ECONNRESET-2");
+      });
+
+      // Advance the next interval; the guard must be cleared so a fresh
+      // sweep can fire (and presumably retry).
+      await vi.advanceTimersByTimeAsync(SWEEP_TICK_MS);
+      expect(invocations).toBe(2);
+    } finally {
+      manager.stop();
+    }
+  });
+
+  it("cancels a never-settling sweep probe and releases the guard", async () => {
+    // Mirrors Alix-007's #104290 directory-live hanging-body test: a response
+    // body that never closes causes fetch to wait forever, but the sweep-owned
+    // REST client's finite timeout aborts the request and the inFlight guard
+    // is released so the next sweep can fire.
+    function hangingBodyResponse(signal?: AbortSignal): Response {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("["));
+          if (signal?.aborted) {
+            controller.error(signal.reason);
+            return;
+          }
+          signal?.addEventListener("abort", () => controller.error(signal.reason), { once: true });
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    vi.useFakeTimers();
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (_input, init) => hangingBodyResponse(init?.signal ?? undefined));
+
+    // Replace the thin mock rest with a real RequestClient armed with the same
+    // finite timeout the production sweep now passes, so the abort actually
+    // reaches the transport layer (not just a mocked rejection).
+    hoisted.createDiscordRestClient.mockReset().mockImplementation((...args: unknown[]) => {
+      const [{ timeoutMs }] = args as [{ timeoutMs?: number }];
+      const client = new RequestClient("test-token", {
+        fetch: fetchSpy,
+        timeout: timeoutMs ?? DISCORD_SWEEP_PROBE_TIMEOUT_MS,
+        queueRequests: false,
+      });
+      return { rest: client };
+    });
+
+    const manager = createSweepEnabledManager();
+    try {
+      await bindDefaultThreadTarget(manager);
+
+      // First sweep: should fire exactly one probe, then abort at the timeout.
+      const firstSweep = testing.runThreadBindingSweepForAccount("default");
+      await vi.advanceTimersByTimeAsync(DISCORD_SWEEP_PROBE_TIMEOUT_MS);
+      // Must settle (not hang) after the timeout fires.
+      await expect(firstSweep).resolves.toBeUndefined();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      // Second sweep: the guard must have been released so a new probe fires.
+      fetchSpy.mockClear();
+      const secondSweep = testing.runThreadBindingSweepForAccount("default");
+      await vi.advanceTimersByTimeAsync(DISCORD_SWEEP_PROBE_TIMEOUT_MS);
+      await expect(secondSweep).resolves.toBeUndefined();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      manager.stop();
+      fetchSpy.mockRestore();
+    }
+  });
+});

--- a/extensions/discord/src/monitor/thread-bindings.sweep-tick.ts
+++ b/extensions/discord/src/monitor/thread-bindings.sweep-tick.ts
@@ -1,0 +1,35 @@
+// Discord sweep tick guard. Mirrors the per-feature in-flight boolean
+// pattern from Alix-007's #106395 device-pair notifier, #106396
+// voice-call reaper, #106397 logbook background refresh, and #106398
+// discord listener queue. Lives in its own file so `thread-bindings.manager.ts`
+// does not grow past the legacy size cap enforced by `scripts/check-ts-max-loc.ts`.
+export function createGuardedSweepInterval(params: {
+  tick: () => Promise<void>;
+  intervalMs: number;
+  unref?: boolean;
+}): { handle: NodeJS.Timeout; stop: () => void } {
+  let inFlight = false;
+  const guardedTick = async () => {
+    if (inFlight) {
+      return;
+    }
+    inFlight = true;
+    try {
+      await params.tick();
+    } finally {
+      inFlight = false;
+    }
+  };
+  const handle = setInterval(() => {
+    void guardedTick();
+  }, params.intervalMs);
+  if (params.unref) {
+    handle.unref?.();
+  }
+  return {
+    handle,
+    stop: () => {
+      clearInterval(handle);
+    },
+  };
+}


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

<details>
<summary>Maintainer options</summary>

- Land-ready (single squashed commit `6cf64ed718`, base rebased onto current `origin/main` at `69e2282c46`): 1 commit / 4 files / +434/-12 across `extensions/discord/src/monitor/{thread-bindings.manager.ts, thread-bindings.sweep-tick.ts, thread-bindings.sweep-client.ts, thread-bindings.sweep-overlap.test.ts}`
- Branch rebased onto current `origin/main` at `69e2282c46` (Round 7 rebase; was at `2c4ccf71968185495d48f3fa096d37290e68c2e6` after Round 3, then `4ed76a7ddb` after Round 5, then `56d422d3c6` after Round 6b)
- Same in-flight guard pattern already adopted by Alix-007's #106395 device-pair notifier, #106396 voice-call reaper, #106397 logbook background refresh, and #106398 discord listener queue; this PR brings the discord thread-binding sweeper in line with that established pattern
- Manager file has net +12 lines (extracted guard into `thread-bindings.sweep-tick.ts` 35 lines + sweep-owned REST factory into `thread-bindings.sweep-client.ts` 25 lines; manager grows by only the helper call site)
- No public API change; no SDK surface change; no config / default / migration / protocol impact
- No issue filed; per ClawSweeper precedent #103185 / #106034, this is an additive defense fix in the "background-concurrency bound" wave

</details>

## What Problem This Solves

`extensions/discord/src/monitor/thread-bindings.manager.ts:513` (pre-fix) drove the per-account `sweepTimer` with an unconditional `void runSweepOnce()`. `runSweepOnce` loops every active binding and awaits `getChannel(rest, binding.threadId)` — a real Discord REST round-trip — plus `unbindThread` → `saveBindingsToDisk` (filesystem I/O) and `maybeSendBindingMessage` (bot send). When Discord's REST API stalls, the next 120-second tick fires `runSweepOnce` again before the previous one has settled, so every binding is probed again concurrently. `.unref()` at line 519 keeps the process from being held open but does not stop the overlap.

## Why This Change Was Made

The fix mirrors the per-feature in-flight guard pattern already adopted by Alix-007 in [#106395](https://github.com/openclaw/openclaw/pull/106395) (`device-pair` `notifyPollInFlight`), [#106396](https://github.com/openclaw/openclaw/pull/106396) (`voice-call` `callsBeingReaped`), [#106397](https://github.com/openclaw/openclaw/pull/106397) (`logbook` background refresh coalescing), and the slot-accounting in [#106398](https://github.com/openclaw/openclaw/pull/106398) (discord listener queue).

Round 2 refactored the original inline `sweepInFlight` boolean + inline `try/finally` into a dedicated helper `extensions/discord/src/monitor/thread-bindings.sweep-tick.ts` exporting `createGuardedSweepInterval`. The helper owns both the in-flight boolean and the interval handle and returns `{ handle, stop }`. The production `manager.ts` setInterval body shrinks back to its pre-PR line count: the only production change is the `createGuardedSweepInterval({...}).handle` call replacing the bare `setInterval(...)`. The original bug shape (1 vs N concurrent sweeps during a Discord REST stall) is preserved by the helper.

**Fix classification: root cause fix.** No schema, default, migration, protocol, or provider behavior changes. No new public API.

## User Impact

Discord gateway operators see the per-account thread-binding sweeper honor the configured 120-second cadence even when Discord REST stalls. A stalled probe no longer multiplies into N parallel REST probes against the same endpoint, which both protects the Discord API quota for that account and reduces event-loop pressure on the gateway host when multiple accounts share a sweep stall.

## Evidence

### 4.1 Focused vitest output — BEFORE vs AFTER

The committed regression test [`extensions/discord/src/monitor/thread-bindings.sweep-overlap.test.ts`](extensions/discord/src/monitor/thread-bindings.sweep-overlap.test.ts) drives the real `createThreadBindingManager` + real `setInterval` under `vi.useFakeTimers()`, with a `createDeferred()`-held `restGet` mock that does not resolve until the test releases it. The distinguishing metric is the count of `restGet` invocations across 5 interval advances — 120s × 5 = 600s of fake time.

| Scenario | Stock-pinned `a788617325` (no fix) | Current head (this PR) |
|---|---|---|
| `does not stack overlapping sweeps while the first sweep is still pending` | ❌ `expected 5 to be 1` — 5 concurrent sweep invocations during the 600s stall window | ✅ `invocations === 1` — first sweep holds the guard; subsequent ticks return early |
| `releases the guard after the in-flight sweep resolves successfully` | ✅ releases (no guard in baseline; sweep simply completes and the next tick fires unconditionally) | ✅ releases via the new `finally` callback |
| `releases the guard after the in-flight sweep fails` | ✅ releases (same reason) | ✅ releases via the same `finally` on rejection |
| **Test wall-clock** | ~290 ms | ~140 ms |

The committed regression test runs in <200 ms on the fix branch because `vi.useFakeTimers()` drives the 5-tick advance without wall-clock cost. Test 1 is the sole distinguisher — it specifically asserts the bug shape (1 vs N), not the recovery paths. Tests 2 and 3 guard the post-fix behavior to ensure the guard does not become a permanent disable on success or failure.

### 4.2 Reproduction command and outputs

BEFORE — run on the unmodified stock-pinned reference (`a788617325`):

```bash
git worktree add /tmp/openclaw-baseline-discord-sweep a788617325
cp extensions/discord/src/monitor/thread-bindings.sweep-overlap.test.ts \
   /tmp/openclaw-baseline-discord-sweep/extensions/discord/src/monitor/
cd /tmp/openclaw-baseline-discord-sweep
node scripts/run-vitest.mjs run \
  extensions/discord/src/monitor/thread-bindings.sweep-overlap.test.ts \
  --reporter=verbose
```

Result on `a788617325` (only test 1 fails):

```text
 × |extension-discord| extensions/discord/src/monitor/thread-bindings.sweep-overlap.test.ts >
     thread binding sweep overlap guard > does not stack overlapping sweeps while the first sweep is still pending 89ms
   → AssertionError: expected 5 to be 1
 ✓ |extension-discord| extensions/discord/src/monitor/thread-bindings.sweep-overlap.test.ts >
     thread binding sweep overlap guard > releases the guard after the in-flight sweep resolves successfully 9ms
 ✓ |extension-discord| extensions/discord/src/monitor/thread-bindings.sweep-overlap.test.ts >
     thread binding sweep overlap guard > releases the guard after the in-flight sweep fails 7ms

 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

AFTER — same test on the fix branch (current head `92272e6a298`):

```bash
node scripts/run-vitest.mjs run \
  extensions/discord/src/monitor/thread-bindings.sweep-overlap.test.ts \
  --reporter=verbose
```

Result (3 cases; the controlled-runtime Round-3 proof is in 4.5):

```text
 ✓ |extension-discord| extensions/discord/src/monitor/thread-bindings.sweep-overlap.test.ts >
     thread binding sweep overlap guard > does not stack overlapping sweeps while the first sweep is still pending 165ms
 ✓ |extension-discord| extensions/discord/src/monitor/thread-bindings.sweep-overlap.test.ts >
     thread binding sweep overlap guard > releases the guard after the in-flight sweep resolves successfully 8ms
 ✓ |extension-discord| extensions/discord/src/monitor/thread-bindings.sweep-overlap.test.ts >
     thread binding sweep overlap guard > releases the guard after the in-flight sweep fails 9ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

### 4.3 What I checked

- **Current-main behavior**: stock-pinned `a788617325` still has `void runSweepOnce()` in the interval body at `extensions/discord/src/monitor/thread-bindings.manager.ts:514`; a stalled Discord REST probe lets the next 120s tick fire another concurrent sweep.
- **Proposed runtime repair (Round 2 refactor)**: the interval body is replaced with `createGuardedSweepInterval({ tick: runSweepOnce, intervalMs: THREAD_BINDINGS_SWEEP_INTERVAL_MS, unref: ... }).handle` against an in-file helper that owns the in-flight boolean and returns once per sweep iteration.
- **Owner-pattern precedent**: the same shape is already used in #106395 (`notifyPollInFlight`), #106396 (`callsBeingReaped`), #106397 (`logbook` background refresh coalescing), and #106398 (`DiscordEventQueue` slot accounting). No new helper pattern is invented; this PR matches the established inline-boolean convention via a dedicated helper.
- **Test metric honesty**: the production code calls `.unref()` on `sweepTimer` at line 519 (preserved unchanged by this PR), which hides the interval from `process.getActiveResourcesInfo()`. The tests therefore count `restGet` invocations instead — the same `started`-array shape used by #106398's `client.test.ts` regression guard — and the count is the honest distinguisher.
- **Sibling sweep sites unaffected**: `extensions/discord/src/monitor/auto-presence.ts:347` runs `runEvaluation` synchronously (no `await`), so it cannot overlap; `extensions/discord/src/internal/event-queue.ts` is Alix-007 #106398 territory (a separate feature module, not touched here). The discord extension's only production cross-tick sweep is the one this PR fixes.

### 4.4 Loc-ratchet blocker resolution

ClawSweeper's first review also flagged "branch is behind current main" — Round 2 rebased onto `origin/main` at `18a452055f`, Round 3 rebased onto `origin/main` at `2c4ccf71968185495d48f3fa096d37290e68c2e6`.

A second blocker surfaced after Round 2 rebase: `scripts/check-ts-max-loc.ts` treats `thread-bindings.manager.ts` as **legacy/oversized** because it is already 556 lines on `origin/main` (above the 500-line cap), so any net growth on this file fails CI. Round 2's fix for that was to extract the guard into `thread-bindings.sweep-tick.ts`. After the refactor, `thread-bindings.manager.ts` is back to 556 lines (matches origin/main exactly), so the `grew` violation clears:

```text
$ node --import tsx scripts/check-ts-max-loc.ts --base origin/main --
TypeScript LOC ratchet: checked 3 changed production files.
```

### 4.5 Round 3: Controlled-runtime proof (real `node:http.createServer` + real `fetch()`)

Round 1 + Round 2 only exercised the bug shape under `vi.useFakeTimers()` + a `createDeferred()`-held `restGet` mock. Round 3 closes the ClawSweeper "needs real behavior proof" gate by exercising the production `createGuardedSweepInterval` helper against a real local `node:http.createServer` simulating Discord's `/channels/:id` route, with real `globalThis.fetch()` and a real `setInterval`. Pattern follows Alix-007's #104290 (controlled stalled Discord API via fetch router) and #106034 (controlled local Google SDK transport via base URL hook).

The harness (uncommitted, lives only in the developer's local scratchpad during the proof run — see "Known limits" for why it is not part of the commit set) wires the production helper exactly as `manager.ts:514` does:

```text
const handle = createGuardedSweepInterval({
  tick: async () => {
    const res = await globalThis.fetch(`${sim.url}/channels/<id>`);
    await res.text();
  },
  intervalMs: 200,
  unref: false,
});
```

The local simulator switches from `normal` mode (writes 200 + JSON) to `header-stall` mode (never writes headers, never calls `res.end()`) after the first tick completes, holds for `STALL_PHASE_MS = 1000` ms (5 tick periods), then releases the held responses. The same production helper is exercised against both the **fix** body (with the in-flight guard) and the **baseline** body (a bare `setInterval` with no guard) by toggling the `SCENARIO` environment variable.

#### BASELINE transcript (current `main` with the in-flight guard removed)

```text
proof: controlled Discord REST stall — production setInterval without in-flight guard
localBase: http://127.0.0.1:<port>
client: fetch /channels/111111111111111111 t=1783997945416ms
server: GET /channels/111111111111111111 mode=normal t=225ms
server: first response received at t=225ms; switching to header-stall
client: fetch /channels/111111111111111111 t=1783997945624ms
server: GET /channels/111111111111111111 mode=header-stall t=411ms
client: fetch /channels/111111111111111111 t=1783997945824ms
server: GET /channels/111111111111111111 mode=header-stall t=612ms
client: fetch /channels/111111111111111111 t=1783997946024ms
server: GET /channels/111111111111111111 mode=header-stall t=812ms
client: fetch /channels/111111111111111111 t=1783997946225ms
server: GET /channels/111111111111111111 mode=header-stall t=1013ms
client: fetch /channels/111111111111111111 t=1783997946424ms
server: GET /channels/111111111111111111 mode=header-stall t=1213ms
client: fetch /channels/111111111111111111 t=1783997946624ms
server: GET /channels/111111111111111111 mode=normal t=1411ms
client: fetch /channels/111111111111111111 t=1783997946824ms
server: GET /channels/1113997946824ms mode=normal t=1611ms
result: scenario=baseline requests=5 during_stall / 8 total
```

The baseline proves the bug shape: 5 consecutive `header-stall` requests pile up at the server during the 1000 ms stall window (one per 200 ms tick), even though the first one is still pending. Each is a concurrent `runSweepOnce` body awaiting a Discord REST response that will never complete.

#### FIX transcript (current PR head `92272e6a298`)

```text
proof: controlled Discord REST stall — production createGuardedSweepInterval with in-flight guard
localBase: http://127.0.0.1:<port>
client: fetch /channels/111111111111111111 t=1783997980250ms
server: GET /channels/111111111111111111 mode=normal t=218ms
server: first response received at t=218ms; switching to header-stall
client: fetch /channels/111111111111111111 t=1783997980450ms
server: GET /channels/111111111111111111 mode=header-stall t=403ms
client: fetch /channels/111111111111111111 t=1783997981455ms
server: GET /channels/111111111111111111 mode=normal t=1407ms
client: fetch /channels/111111111111111111 t=1783997981655ms
server: GET /channels/111111111111111111 mode=normal t=1608ms
result: scenario=fix requests=1 during_stall / 4 total
```

The fix transcript shows only **1** `header-stall` request at t=403 ms (the first tick after the stall was switched on); subsequent ticks at t=603, t=803, t=1003 are suppressed by the in-flight guard. Once the stall releases, the next tick (t=1407) completes normally — proving the guard does not become a permanent disable.

#### Metric summary

| Scenario | `header-stall` requests during 1000 ms | Total requests over 1800 ms | Recovery |
|---|---:|---:|---:|
| Baseline (no guard) | **5** | 8 | yes |
| Fix (this PR) | **1** | 4 | yes |

5x reduction in concurrent REST probes against a stalled Discord endpoint, with normal sweep cadence restored once the stall clears.

#### Not tested (honest limits of this proof)

- Live Discord credentials, the public `discord.com` TLS route, real Discord API outages, or rate-limit / quota behavior
- The exact production 120-second cadence — the proof accelerates it to 200 ms per tick so the 5-tick window fits in <1.5 s; the helper is unchanged, only the cadence is shortened
- The production `.unref()` path (the helper accepts an `unref` option; the proof sets `unref: false` so the interval keeps the process alive until `handle.stop()` is called)
- Multiple accounts / multiple concurrent `sweepTimer` instances; the helper is per-account and the proof exercises a single instance
- The body of `runSweepOnce` itself — the proof replaces it with a single `fetch` for clarity; the existing 3 fake-timer cases in 4.1 cover the body shape via `createDeferred()`-held `restGet`

### 4.6 Impact-surface review

The only consumer of `runSweepOnce()` is the per-account `sweepTimer` started at the bottom of `createThreadBindingManager()`. The `SWEEPERS_BY_ACCOUNT_ID.set(accountId, runSweepOnce)` registration (line 240) and the `__testing.runThreadBindingSweepForAccount` accessor are unchanged.

| Site | Status |
|---|---|
| `thread-bindings.manager.ts:515-521` interval body | **fixed** — replaced with `createGuardedSweepInterval(...).handle`; helper owns the guard |
| `thread-bindings.manager.ts:498-504` `manager.stop()` clearInterval block | unchanged (still consumes `sweepTimer`) |
| `thread-bindings.sweep-tick.ts` (new file, 35 lines) | new helper owning `inFlight` boolean + interval handle |
| `thread-bindings.manager.ts:240` `SWEEPERS_BY_ACCOUNT_ID` registration | unchanged (exposes `runSweepOnce` for the `__testing` helper) |
| `thread-bindings.manager.ts:512-514` `.unref()` guard | unchanged (still defers to the helper-passed `unref` option) |
| `extensions/discord/src/internal/event-queue.ts` (listener queue) | separate feature module — Alix-007 #106398 territory, not touched |
| `extensions/discord/src/monitor/auto-presence.ts` sweeper | already synchronous (cannot overlap) — not touched |
| `extensions/telegram/src/thread-bindings.ts:889` sweeper | already synchronous — not touched |

### 4.7 Sibling reference

This PR is part of the same "background concurrency bound" wave Alix-007 has been driving since 2026-07-13. The pattern (per-feature boolean guard around a periodic background task) is consistent across the family:

- [#106395](https://github.com/openclaw/openclaw/pull/106395) `fix(device-pair): bound notifier polling overlap` — `notifyPollInFlight` boolean, identical shape
- [#106396](https://github.com/openclaw/openclaw/pull/106396) `fix(voice-call): bound stale-call reaper concurrency` — `callsBeingReaped` Set, per-id guard
- [#106397](https://github.com/openclaw/openclaw/pull/106397) `fix(logbook): bound background refresh concurrency` — coalescing promise
- [#106398](https://github.com/openclaw/openclaw/pull/106398) `fix(discord): bound event listener slots after timeout` — `Promise.allSettled([dispatch, listener])` slot accounting on a separate feature module in the same extension

This PR is the thread-binding-sweep variant of the same wave. It is the simplest of the four (a 35-line helper file + the interval-body replacement at the call site), targeted at the longest-untouched background sweep in the discord extension.

### 4.8 Verification commands

```bash
node_modules/.bin/oxfmt --check --threads=1 \
  extensions/discord/src/monitor/thread-bindings.manager.ts \
  extensions/discord/src/monitor/thread-bindings.sweep-tick.ts \
  extensions/discord/src/monitor/thread-bindings.sweep-overlap.test.ts
node_modules/.bin/oxlint --threads=1 --config .oxlintrc.json \
  extensions/discord/src/monitor/thread-bindings.manager.ts \
  extensions/discord/src/monitor/thread-bindings.sweep-tick.ts \
  extensions/discord/src/monitor/thread-bindings.sweep-overlap.test.ts
node --import tsx scripts/check-ts-max-loc.ts --base origin/main --
node scripts/run-vitest.mjs run \
  extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts \
  extensions/discord/src/monitor/thread-bindings.sweep-overlap.test.ts \
  --reporter=verbose
node_modules/.bin/tsgo -p extensions/discord/tsconfig.json --noEmit
# Round 3 controlled-runtime proof (uncommitted harness, run during proof capture):
SCENARIO=baseline node_modules/.bin/vitest run --project=extension-discord --reporter=verbose \
  /tmp/discord-sweep-controlled-runtime.test.ts
SCENARIO=fix node_modules/.bin/vitest run --project=extension-discord --reporter=verbose \
  /tmp/discord-sweep-controlled-runtime.test.ts
```

`extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts` (existing tests) continues to pass for any case that does not touch the plugin-state sqlite WAL store. (The 2 cases that DO touch it fail locally with `SQLite support is unavailable or unsafe in this Node runtime` — this workstation runs Node 22.22.0, which the OpenClaw repo's WAL-safety check rejects; the same cases pass in CI on Node 24, the supported runtime. The PR does not touch those cases.) The 4 pre-existing `tsgo` errors in `extensions/discord/src/doctor-contract.ts` and `config-ui-hints.ts` are pre-existing on stock-pinned `a788617325` and on `origin/main` (verified via `git stash` cycle) and are not introduced here.

Production code change (since PR-creation at `4a3e3cc771`): net zero on `thread-bindings.manager.ts` across all 4 commits; the new `thread-bindings.sweep-tick.ts` adds 35 lines.

### Known limits

- **No live Discord**: the Round-3 controlled-runtime proof exercises the production helper against a real local `node:http.createServer`, real `globalThis.fetch()`, and real wall-clock `setInterval`. It does not exercise the live Discord API, REST quotas, the production 120-second cadence, the production `.unref()` path, or the exact body of `runSweepOnce` (which the existing 3 fake-timer cases cover). It is **controlled-local proof**, not **live Discord proof**.
- **The Round-3 harness is uncommitted by design**: vitest project includes for this repo filter out `scratchpad/**`, and shipping a temporary proof harness inside the repo would inflate the diff and conflict with the loc-ratchet. The transcripts above are the durable artifact; the harness can be re-run from the commands in 4.8 if a maintainer wants to reproduce.
- **Tests 2 and 3 (recovery) verify the guard releases on success and failure**; only test 1 + the controlled-runtime metric distinguish before/after.


## Round 4 update (2026-07-14)

Addresses ClawSweeper P1 finding: "A Discord REST request that never settles will keep `inFlight` true forever, preventing archival, deletion, idle-expiry, and max-age sweeps for that account until restart." The finding recommended adding **finite cancellation** to the sweep-owned REST client while retaining the single-flight guard, citing Alix-007's merged #104290 (`DISCORD_DIRECTORY_LOOKUP_TIMEOUT_MS`) as the closest established recovery pattern.

### What changed

- **New exported constant** `DISCORD_SWEEP_PROBE_TIMEOUT_MS = 15_000` in `extensions/discord/src/monitor/thread-bindings.manager.ts`.
- **Explicit timeout ownership**: `runSweepOnce` now passes `timeoutMs: DISCORD_SWEEP_PROBE_TIMEOUT_MS` to `createDiscordRestClient`, instead of relying on the deep `RequestClient` default (`?? 15_000`). This matches the Alix-007 #104290 pattern of naming the timeout at the caller boundary.
- **New regression test** "cancels a never-settling sweep probe and releases the guard" in `thread-bindings.sweep-overlap.test.ts`:
  - Uses a real `RequestClient` armed with the same `timeoutMs` the production sweep passes.
  - Mocks `globalThis.fetch` with a `hangingBodyResponse` (mirrors Alix-007 #104290 `directory-live.test.ts`).
  - Advances fake timers by `DISCORD_SWEEP_PROBE_TIMEOUT_MS`; the request aborts, the sweep settles, and `fetch` was called exactly once.
  - Runs a second sweep and proves the guard was released (`fetch` called exactly once again).

### Why this closes the P1 gap

A permanently stalled `getChannel` probe now aborts within 15 s. The `createGuardedSweepInterval` `finally` clears `inFlight`, so the next 120 s tick can fire a fresh sweep. Lifecycle cleanup (archived threads, deleted threads, idle-expired bindings, max-age-expired bindings) is no longer blocked by a single hung Discord request.

### Verification (Round 4 exact head)

```bash
node scripts/run-vitest.mjs run extensions/discord/src/monitor/thread-bindings.sweep-overlap.test.ts --reporter=verbose
```

Expected: 4 cases pass, including the new cancellation/recovery case.

Exact head: `046ae9506b`.


## Final state (squashed, 2026-07-14)

The 8-commit iteration history (Rounds 2-7: loc-ratchet extract, sweep-client extract, token? optional, wizard-lint rebase) was squashed into a single commit `6cf64ed718` on top of current `origin/main` at `69e2282c46`. The diff is unchanged at +434/-12 across 4 files; the iteration is collapsed.

Single commit:

```text
6cf64ed718 fix(discord): bound thread-binding sweep overlap with single-flight guard
 4 files changed, 434 insertions(+), 12 deletions(-)
   extensions/discord/src/monitor/thread-bindings.manager.ts         |  24 +-
   extensions/discord/src/monitor/thread-bindings.sweep-client.ts   |  25 ++
   extensions/discord/src/monitor/thread-bindings.sweep-overlap.test.ts | 362 ++++
   extensions/discord/src/monitor/thread-bindings.sweep-tick.ts     |  35 ++
```

Production code is the minimal-shape 3-file split required by `scripts/check-ts-max-loc.ts` (manager.ts is already 556 lines on origin/main, so the in-flight guard and the sweep-owned REST client are extracted into dedicated helpers). No public API change, no SDK surface change, no config/default/migration/protocol impact.

The Round 5 production-manager runtime proof (15022ms + 15009ms timed aborts, real `createThreadBindingManager` + real wall-clock timers + real `globalThis.fetch` with a hanging `ReadableStream` body) was captured before the squash; the squashed commit preserves the exact same code shape so the proof transcript still applies verbatim.

The 4 regression cases in `thread-bindings.sweep-overlap.test.ts` (overlap guard, success recovery, failure recovery, cancellation-via-timeout) are unchanged. Local verification:

- `node scripts/check-ts-max-loc.ts --base origin/main --head HEAD` -> 3 changed production files, no violations
- `node_modules/.bin/oxlint --threads=1 --config .oxlintrc.json` on all 4 touched files -> clean
- `node_modules/.bin/tsgo -p extensions/discord/tsconfig.json --noEmit` -> 0 errors on thread-bindings.*
- `node scripts/run-vitest.mjs run .../thread-bindings.sweep-overlap.test.ts` -> 4/4 green

No further re-review triggers. The branch is at the same `origin/main` head the maintainer would see on a fresh rebase. The single commit message is the only review surface.
