### PR TITLE
refactor(gateway): extract chat attachment phase

### DIFF
--- a/src/gateway/server-methods/chat-send-admission.ts
+++ b/src/gateway/server-methods/chat-send-admission.ts
@@ -384,3 +384,8 @@ export async function admitChatSend(params: {
     },
   };
 }
+
+export type AdmittedChatSend = Extract<
+  Awaited<ReturnType<typeof admitChatSend>>,
+  { ok: true }
+>["value"];

--- a/src/gateway/server-methods/chat-send-attachments.ts
+++ b/src/gateway/server-methods/chat-send-attachments.ts
@@ -1,0 +1,333 @@
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { expectDefined } from "@openclaw/normalization-core";
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
+import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
+import {
+  stageSandboxMedia,
+  type StageSandboxMediaResult,
+} from "../../auto-reply/reply/stage-sandbox-media.js";
+import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { clearAgentRunContext } from "../../infra/agent-events.js";
+import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
+import { formatErrorMessage, formatUncaughtError } from "../../infra/errors.js";
+import { parseInboundMediaUri } from "../../media/media-reference.js";
+import { deleteMediaBuffer, MEDIA_MAX_BYTES } from "../../media/store.js";
+import {
+  MediaOffloadError,
+  type OffloadedRef,
+  parseMessageWithAttachments,
+  resolveChatAttachmentMaxBytes,
+  UnsupportedAttachmentError,
+} from "../chat-attachments.js";
+import { resolveGatewayModelSupportsImages } from "../session-utils.js";
+import { formatForLog } from "../ws-log.js";
+import {
+  explicitOriginTargetsAcpSession,
+  explicitOriginTargetsPluginBinding,
+} from "./chat-origin-routing.js";
+import type { AdmittedChatSend } from "./chat-send-admission.js";
+import type { NormalizedChatSendRequest } from "./chat-send-request.js";
+import type { PreparedChatSendSession } from "./chat-send-session.js";
+import { roundedChatSendTimingMs } from "./chat-server-timing.js";
+import type { GatewayRequestHandlerOptions } from "./types.js";
+
+function formatAttachmentFailureForLog(err: unknown): string {
+  const primary = formatUncaughtError(err);
+  const cause = err instanceof Error ? err.cause : undefined;
+  if (cause === undefined) {
+    return primary;
+  }
+  const causeText = formatUncaughtError(cause);
+  if (!causeText || causeText === primary) {
+    return primary;
+  }
+  return `${primary}\nCaused by: ${causeText}`;
+}
+
+function logAttachmentFailure(
+  logGateway: Pick<GatewayRequestHandlerOptions["context"]["logGateway"], "error">,
+  label: string,
+  err: unknown,
+): void {
+  logGateway.error(label, {
+    error: formatAttachmentFailureForLog(err),
+    consoleMessage: `${label}: ${formatForLog(err)}`,
+  });
+}
+
+function stripTrailingOffloadedMediaMarkers(message: string, refs: OffloadedRef[]): string {
+  if (refs.length === 0) {
+    return message;
+  }
+  const removableRefs = new Set(refs.map((ref) => ref.mediaRef));
+  const lines = message.split(/\r?\n/);
+  while (lines.length > 0) {
+    const last = lines[lines.length - 1]?.trim() ?? "";
+    const match = /^\[media attached:\s*(media:\/\/inbound\/[^\]\s]+)\]$/.exec(last);
+    if (!match?.[1] || !removableRefs.delete(match[1])) {
+      break;
+    }
+    lines.pop();
+  }
+  return lines.join("\n").trimEnd();
+}
+
+function isPdfOffloadedRef(ref: OffloadedRef): boolean {
+  const mime = ref.mimeType.trim().toLowerCase();
+  if (mime === "application/pdf" || mime.endsWith("+pdf")) {
+    return true;
+  }
+  return path.extname(ref.path.split(/[?#]/u)[0] ?? "").toLowerCase() === ".pdf";
+}
+
+// Managed inbound PDFs can be read host-side from the media-store root, even
+// for locked-down agents, so sandbox staging may safely fall back to that path.
+function isManagedInboundPdfOffloadRef(ref: OffloadedRef): boolean {
+  if (!isPdfOffloadedRef(ref)) {
+    return false;
+  }
+  try {
+    return parseInboundMediaUri(ref.mediaRef) !== null;
+  } catch {
+    return false;
+  }
+}
+
+function shouldPassThroughManagedInboundPdfOffloadRef(ref: OffloadedRef): boolean {
+  // Oversized managed PDFs remain host-readable. A sandbox copy only hits the
+  // 5 MB staging cap without making the attachment more available.
+  return ref.sizeBytes > MEDIA_MAX_BYTES && isManagedInboundPdfOffloadRef(ref);
+}
+
+// Stage media before ACK so permanent client errors stay 4xx and retryable
+// staging failures stay 5xx. Managed PDFs retain their host-readable fallback.
+async function prestageMediaPathOffloads(params: {
+  offloadedRefs: OffloadedRef[];
+  includeImageRefs?: boolean;
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  agentId: string;
+}): Promise<{ paths: string[]; types: string[]; workspaceDir?: string }> {
+  const mediaPathRefs = params.offloadedRefs.filter(
+    (ref) => params.includeImageRefs || !ref.mimeType.startsWith("image/"),
+  );
+  if (mediaPathRefs.length === 0) {
+    return { paths: [], types: [] };
+  }
+  const refsByManagedPath = (refs: OffloadedRef[]) => ({
+    paths: refs.map((ref) => ref.path),
+    types: refs.map((ref) => ref.mimeType),
+  });
+  const passThroughRefs: OffloadedRef[] = [];
+  const refsToStage: OffloadedRef[] = [];
+  for (const ref of mediaPathRefs) {
+    (shouldPassThroughManagedInboundPdfOffloadRef(ref) ? passThroughRefs : refsToStage).push(ref);
+  }
+  if (refsToStage.length === 0) {
+    return refsByManagedPath(mediaPathRefs);
+  }
+
+  try {
+    const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
+    const sandbox = await ensureSandboxWorkspaceForSession({
+      config: params.cfg,
+      sessionKey: params.sessionKey,
+      workspaceDir,
+    });
+    if (!sandbox) {
+      return refsByManagedPath(mediaPathRefs);
+    }
+
+    // The parser admits more than the sandbox can stage. Reject non-PDF files
+    // in that gap as permanent 4xx instead of a retryable staging failure.
+    const oversizedForSandbox = refsToStage.filter((ref) => ref.sizeBytes > MEDIA_MAX_BYTES);
+    if (oversizedForSandbox.length > 0) {
+      const details = oversizedForSandbox
+        .map((ref) => `${ref.label} (${ref.sizeBytes} bytes)`)
+        .join(", ");
+      throw new UnsupportedAttachmentError(
+        "non-image-too-large-for-sandbox",
+        `attachments exceed sandbox staging limit (${MEDIA_MAX_BYTES} bytes): ${details}`,
+      );
+    }
+
+    const stagingCtx: MsgContext = {
+      MediaPath: expectDefined(refsToStage[0], "refs to stage entry at 0").path,
+      MediaPaths: refsToStage.map((ref) => ref.path),
+      MediaType: expectDefined(refsToStage[0], "refs to stage entry at 0").mimeType,
+      MediaTypes: refsToStage.map((ref) => ref.mimeType),
+    };
+    let stageResult: StageSandboxMediaResult;
+    try {
+      stageResult = await stageSandboxMedia({
+        ctx: stagingCtx,
+        sessionCtx: stagingCtx as TemplateContext,
+        cfg: params.cfg,
+        sessionKey: params.sessionKey,
+        workspaceDir,
+      });
+    } catch (stageErr) {
+      // Only managed inbound PDFs have a host-readable fallback. Other files
+      // must fail before ACK or the agent silently loses the attachment.
+      if (refsToStage.some((ref) => !isManagedInboundPdfOffloadRef(ref))) {
+        throw stageErr;
+      }
+      return refsByManagedPath(mediaPathRefs);
+    }
+
+    // stageSandboxMedia preserves an absolute source path when no copy lands;
+    // the staged map is the authoritative success signal.
+    const stagedSources = stageResult.staged;
+    const missing = refsToStage.filter((ref) => !stagedSources.has(ref.path));
+    const unstageable = missing.filter((ref) => !isManagedInboundPdfOffloadRef(ref));
+    if (unstageable.length > 0) {
+      throw new Error(
+        `attachment staging incomplete: ${stagedSources.size}/${refsToStage.length} paths staged into sandbox workspace (missing: ${unstageable.map((ref) => ref.path).join(", ")})`,
+      );
+    }
+    const stagedPaths = stagingCtx.MediaPaths ?? [];
+    const stagedTypes = stagingCtx.MediaTypes ?? refsToStage.map((ref) => ref.mimeType);
+    // Preserve request order while mixing sandbox-relative paths with managed
+    // host paths used by pass-through or fallback PDFs.
+    const resolvedByRef = new Map<OffloadedRef, { path: string; mimeType: string }>();
+    refsToStage.forEach((ref, index) => {
+      resolvedByRef.set(ref, {
+        path: stagedPaths[index] ?? ref.path,
+        mimeType: stagedTypes[index] ?? ref.mimeType,
+      });
+    });
+    for (const ref of passThroughRefs) {
+      resolvedByRef.set(ref, { path: ref.path, mimeType: ref.mimeType });
+    }
+    const ordered = mediaPathRefs.map(
+      (ref) => resolvedByRef.get(ref) ?? { path: ref.path, mimeType: ref.mimeType },
+    );
+    return {
+      paths: ordered.map((entry) => entry.path),
+      types: ordered.map((entry) => entry.mimeType),
+      workspaceDir: sandbox.workspaceDir,
+    };
+  } catch (err) {
+    await Promise.allSettled(
+      params.offloadedRefs.map((ref) => deleteMediaBuffer(ref.id, "inbound")),
+    );
+    if (err instanceof MediaOffloadError || err instanceof UnsupportedAttachmentError) {
+      throw err;
+    }
+    throw new MediaOffloadError(
+      `[Gateway Error] Failed to stage attachments into agent workspace: ${formatErrorMessage(err)}`,
+      { cause: err },
+    );
+  }
+}
+
+/** Parse and pre-stage attachments before the caller's synchronous pre-ACK checks. */
+export async function prepareChatSendAttachments(params: {
+  request: NormalizedChatSendRequest;
+  session: PreparedChatSendSession;
+  admission: AdmittedChatSend;
+  respond: GatewayRequestHandlerOptions["respond"];
+  context: GatewayRequestHandlerOptions["context"];
+}) {
+  const { request, session, admission, respond, context } = params;
+  const { inboundMessage, normalizedAttachments, explicitOrigin } = request;
+  const { cfg, sessionKey, agentId, resolvedSessionModel, clientRunId } = session;
+  const { chatSendTraceAttributes, cleanupAdmittedRun, lifecycleGeneration } = admission;
+  let parsedMessage = inboundMessage;
+  let parsedImages: Awaited<ReturnType<typeof parseMessageWithAttachments>>["images"] = [];
+  let imageOrder: Awaited<ReturnType<typeof parseMessageWithAttachments>>["imageOrder"] = [];
+  let offloadedRefs: OffloadedRef[] = [];
+  let mediaPathOffloadPaths: string[] = [];
+  let mediaPathOffloadTypes: string[] = [];
+  let mediaPathOffloadWorkspaceDir: string | undefined;
+  const explicitOriginTargetsPlugin = explicitOriginTargetsPluginBinding(explicitOrigin);
+  let prepareAttachmentsMs: number | undefined;
+
+  if (normalizedAttachments.length > 0) {
+    const prepareAttachmentsStartedAtMs = performance.now();
+    try {
+      await measureDiagnosticsTimelineSpan(
+        "gateway.chat_send.prepare_attachments",
+        async () => {
+          const supportsSessionModelImages = await resolveGatewayModelSupportsImages({
+            loadGatewayModelCatalog: context.loadGatewayModelCatalog,
+            provider: resolvedSessionModel.provider,
+            model: resolvedSessionModel.model,
+          });
+          const supportsImages =
+            supportsSessionModelImages ||
+            explicitOriginTargetsAcpSession(explicitOrigin) ||
+            explicitOriginTargetsPlugin;
+          const routeImageOffloadsAsMediaPaths = !supportsImages;
+          const parsed = await parseMessageWithAttachments(inboundMessage, normalizedAttachments, {
+            maxBytes: resolveChatAttachmentMaxBytes(cfg),
+            log: context.logGateway,
+            supportsImages,
+            acceptNonImage: true,
+          });
+          parsedMessage = stripTrailingOffloadedMediaMarkers(
+            parsed.message,
+            routeImageOffloadsAsMediaPaths
+              ? parsed.offloadedRefs.filter((ref) => ref.mimeType.startsWith("image/"))
+              : [],
+          );
+          parsedImages = parsed.images;
+          imageOrder = routeImageOffloadsAsMediaPaths ? [] : parsed.imageOrder;
+          offloadedRefs = parsed.offloadedRefs;
+          ({
+            paths: mediaPathOffloadPaths,
+            types: mediaPathOffloadTypes,
+            workspaceDir: mediaPathOffloadWorkspaceDir,
+          } = await prestageMediaPathOffloads({
+            offloadedRefs,
+            includeImageRefs: routeImageOffloadsAsMediaPaths,
+            cfg,
+            sessionKey,
+            agentId,
+          }));
+        },
+        {
+          phase: "agent-turn",
+          config: cfg,
+          attributes: {
+            ...chatSendTraceAttributes,
+            attachmentCount: normalizedAttachments.length,
+          },
+        },
+      );
+      prepareAttachmentsMs = roundedChatSendTimingMs(
+        performance.now() - prepareAttachmentsStartedAtMs,
+      );
+    } catch (err) {
+      cleanupAdmittedRun({ force: true });
+      clearAgentRunContext(clientRunId, lifecycleGeneration);
+      logAttachmentFailure(context.logGateway, "chat.send attachment parse/stage failed", err);
+      respond(
+        false,
+        undefined,
+        errorShape(
+          err instanceof MediaOffloadError ? ErrorCodes.UNAVAILABLE : ErrorCodes.INVALID_REQUEST,
+          String(err),
+        ),
+      );
+      return { ok: false as const };
+    }
+  }
+  return {
+    ok: true as const,
+    value: {
+      explicitOriginTargetsPlugin,
+      imageOrder,
+      mediaPathOffloadPaths,
+      mediaPathOffloadTypes,
+      mediaPathOffloadWorkspaceDir,
+      offloadedRefs,
+      parsedImages,
+      parsedMessage,
+      prepareAttachmentsMs,
+    },
+  };
+}

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -24,14 +24,12 @@ import {
 import {
   listAgentIds,
   resolveDefaultAgentId,
-  resolveAgentWorkspaceDir,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
 import { modelCatalogBrowseRequiresFullDiscovery } from "../../agents/model-catalog-browse.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
-import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import {
   getReplyPayloadMetadata,
@@ -39,11 +37,7 @@ import {
   type ReplyPayload,
 } from "../../auto-reply/reply-payload.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
-import {
-  stageSandboxMedia,
-  type StageSandboxMediaResult,
-} from "../../auto-reply/reply/stage-sandbox-media.js";
-import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
+import type { MsgContext } from "../../auto-reply/templating.js";
 import { resolveSessionWorkStartError } from "../../config/sessions.js";
 import { resolveTranscriptSessionKeyBySessionId } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -55,15 +49,14 @@ import {
   emitDiagnosticsTimelineEvent,
   measureDiagnosticsTimelineSpan,
 } from "../../infra/diagnostics-timeline.js";
-import { formatErrorMessage, formatUncaughtError } from "../../infra/errors.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import {
   appendLocalMediaParentRoots,
   getAgentScopedMediaLocalRoots,
 } from "../../media/local-roots.js";
-import { parseInboundMediaUri } from "../../media/media-reference.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
-import { deleteMediaBuffer, MEDIA_MAX_BYTES, type SavedMedia } from "../../media/store.js";
+import type { SavedMedia } from "../../media/store.js";
 import { createChannelMessageReplyPipeline } from "../../plugin-sdk/channel-outbound.js";
 import {
   retainGatewayRootWorkAdmissionContinuation,
@@ -87,12 +80,8 @@ import {
 } from "../chat-abort.js";
 import {
   type ChatImageContent,
-  MediaOffloadError,
   type OffloadedRef,
-  parseMessageWithAttachments,
   persistInboundImagesForTranscript,
-  resolveChatAttachmentMaxBytes,
-  UnsupportedAttachmentError,
 } from "../chat-attachments.js";
 import {
   augmentChatHistoryWithCanvasBlocks,
@@ -124,7 +113,6 @@ import {
   getSessionDefaults,
   loadSessionEntry,
   listAgentsForGateway,
-  resolveGatewayModelSupportsImages,
   resolveSessionModelRef,
   resolveSessionStoreKey,
 } from "../session-utils.js";
@@ -168,8 +156,6 @@ import {
   readChatHistoryPage,
 } from "./chat-history-pages.js";
 import {
-  explicitOriginTargetsAcpSession,
-  explicitOriginTargetsPluginBinding,
   hasGatewayAdminScope,
   isAcpBridgeClient,
   resolveRequestedChatAgentId,
@@ -178,6 +164,7 @@ import {
 import { normalizeWebchatReplyMediaPathsForDisplay } from "./chat-reply-media.js";
 import { terminalizeRestartSafeChatAdmission } from "./chat-restart-recovery.js";
 import { admitChatSend } from "./chat-send-admission.js";
+import { prepareChatSendAttachments } from "./chat-send-attachments.js";
 import {
   respondChatSessionRoutingChanged,
   runChatSendPreAdmission,
@@ -451,30 +438,6 @@ export {
 } from "./chat-history-budget.js";
 
 const CHAT_STARTUP_OPTIONAL_MODEL_CATALOG_TIMEOUT_MS = 25;
-function formatAttachmentFailureForLog(err: unknown): string {
-  const primary = formatUncaughtError(err);
-  const cause = err instanceof Error ? err.cause : undefined;
-  if (cause === undefined) {
-    return primary;
-  }
-  const causeText = formatUncaughtError(cause);
-  if (!causeText || causeText === primary) {
-    return primary;
-  }
-  return `${primary}\nCaused by: ${causeText}`;
-}
-
-function logAttachmentFailure(
-  logGateway: Pick<GatewayRequestContext["logGateway"], "error">,
-  label: string,
-  err: unknown,
-): void {
-  logGateway.error(label, {
-    error: formatAttachmentFailureForLog(err),
-    consoleMessage: `${label}: ${formatForLog(err)}`,
-  });
-}
-
 function buildTranscriptReplyText(payloads: ReplyPayload[]): string {
   const chunks = payloads
     .map((payload) => {
@@ -541,218 +504,6 @@ async function persistChatSendImages(params: {
     log: params.logGateway,
     logContext: "chat.send",
   });
-}
-
-function stripTrailingOffloadedMediaMarkers(message: string, refs: OffloadedRef[]): string {
-  if (refs.length === 0) {
-    return message;
-  }
-  const removableRefs = new Set(refs.map((ref) => ref.mediaRef));
-  const lines = message.split(/\r?\n/);
-  while (lines.length > 0) {
-    const last = lines[lines.length - 1]?.trim() ?? "";
-    const match = /^\[media attached:\s*(media:\/\/inbound\/[^\]\s]+)\]$/.exec(last);
-    if (!match?.[1] || !removableRefs.delete(match[1])) {
-      break;
-    }
-    lines.pop();
-  }
-  return lines.join("\n").trimEnd();
-}
-
-function isPdfOffloadedRef(ref: OffloadedRef): boolean {
-  const mime = ref.mimeType.trim().toLowerCase();
-  if (mime === "application/pdf" || mime.endsWith("+pdf")) {
-    return true;
-  }
-  return path.extname(ref.path.split(/[?#]/u)[0] ?? "").toLowerCase() === ".pdf";
-}
-
-// A managed inbound PDF saved to the media store is safe to hand the agent as its
-// media path without sandbox staging: host-side media-understanding extracts its
-// text (see resolveFileExtractionLimits) by reading the media-store root, so even
-// locked-down agents receive the document. This gates both the up-front bypass for
-// oversized PDFs and the fallback to the managed path when sandbox staging fails
-// for an already-managed PDF. #90097
-function isManagedInboundPdfOffloadRef(ref: OffloadedRef): boolean {
-  if (!isPdfOffloadedRef(ref)) {
-    return false;
-  }
-  try {
-    return parseInboundMediaUri(ref.mediaRef) !== null;
-  } catch {
-    return false;
-  }
-}
-
-// Oversized managed PDFs skip sandbox staging up front: copying a large PDF into
-// every sandbox is wasteful, and files above the 5MB staging cap would otherwise
-// be rejected as a 4xx (see prestageMediaPathOffloads).
-function shouldPassThroughManagedInboundPdfOffloadRef(ref: OffloadedRef): boolean {
-  return ref.sizeBytes > MEDIA_MAX_BYTES && isManagedInboundPdfOffloadRef(ref);
-}
-
-// Stages media-path offloads into the agent sandbox synchronously so chat.send
-// can surface 5xx before respond(). Throws MediaOffloadError when staging fails
-// for a ref that cannot fall back (ENOSPC / EPERM / partial-stage of a non-PDF or
-// unmanaged ref) so the outer chat.send handler maps it to UNAVAILABLE (5xx);
-// plain Error would be misclassified as 4xx. Already-managed inbound PDFs instead
-// fall back to their managed media path on staging failure (#90097), since
-// host-side media-understanding reads them from the media-store root. Offloaded
-// refs are cleaned up from the media store before rethrow.
-// Callers MUST set ctx.MediaStaged=true when this runs so the dispatch
-// pipeline skips its own stageSandboxMedia pass.
-//
-// Returned paths are absolute media-store paths when no sandbox is active, for
-// oversized managed PDFs that bypass staging, or for already-managed PDFs that
-// fall back when staging fails (#90097); files staged into the sandbox use
-// sandbox-relative paths plus `workspaceDir`. Host-side media-understanding
-// resolves both via MediaWorkspaceDir and the media-store root.
-async function prestageMediaPathOffloads(params: {
-  offloadedRefs: OffloadedRef[];
-  includeImageRefs?: boolean;
-  cfg: OpenClawConfig;
-  sessionKey: string;
-  agentId: string;
-}): Promise<{ paths: string[]; types: string[]; workspaceDir?: string }> {
-  const mediaPathRefs = params.offloadedRefs.filter(
-    (ref) => params.includeImageRefs || !ref.mimeType.startsWith("image/"),
-  );
-  if (mediaPathRefs.length === 0) {
-    return { paths: [], types: [] };
-  }
-  const refsByManagedPath = (refs: OffloadedRef[]) => ({
-    paths: refs.map((ref) => ref.path),
-    types: refs.map((ref) => ref.mimeType),
-  });
-
-  // Oversized managed PDFs bypass sandbox staging and are read host-side, so they
-  // do not need a workspace copy or the staging-cap check below.
-  const passThroughRefs: OffloadedRef[] = [];
-  const refsToStage: OffloadedRef[] = [];
-  for (const ref of mediaPathRefs) {
-    (shouldPassThroughManagedInboundPdfOffloadRef(ref) ? passThroughRefs : refsToStage).push(ref);
-  }
-  if (refsToStage.length === 0) {
-    return refsByManagedPath(mediaPathRefs);
-  }
-
-  try {
-    const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
-    const sandbox = await ensureSandboxWorkspaceForSession({
-      config: params.cfg,
-      sessionKey: params.sessionKey,
-      workspaceDir,
-    });
-    if (!sandbox) {
-      return refsByManagedPath(mediaPathRefs);
-    }
-
-    // stageSandboxMedia caps each file at STAGED_MEDIA_MAX_BYTES (=
-    // MEDIA_MAX_BYTES, 5MB) and silently skips oversized files. The parse cap
-    // (resolveChatAttachmentMaxBytes, default 20MB) is higher, so a sandboxed
-    // session receiving a non-PDF file between the two caps would otherwise
-    // pass parse, fail staging, and surface as a retryable 5xx even though
-    // retry cannot succeed. Reject here as a client-side 4xx instead. Managed
-    // PDFs in that range pass through above instead of being rejected.
-    const oversizedForSandbox = refsToStage.filter((ref) => ref.sizeBytes > MEDIA_MAX_BYTES);
-    if (oversizedForSandbox.length > 0) {
-      const details = oversizedForSandbox
-        .map((ref) => `${ref.label} (${ref.sizeBytes} bytes)`)
-        .join(", ");
-      throw new UnsupportedAttachmentError(
-        "non-image-too-large-for-sandbox",
-        `attachments exceed sandbox staging limit (${MEDIA_MAX_BYTES} bytes): ${details}`,
-      );
-    }
-
-    const stagingCtx: MsgContext = {
-      MediaPath: expectDefined(refsToStage[0], "refs to stage entry at 0").path,
-      MediaPaths: refsToStage.map((ref) => ref.path),
-      MediaType: expectDefined(refsToStage[0], "refs to stage entry at 0").mimeType,
-      MediaTypes: refsToStage.map((ref) => ref.mimeType),
-    };
-    let stageResult: StageSandboxMediaResult;
-    try {
-      stageResult = await stageSandboxMedia({
-        ctx: stagingCtx,
-        sessionCtx: stagingCtx as TemplateContext,
-        cfg: params.cfg,
-        sessionKey: params.sessionKey,
-        workspaceDir,
-      });
-    } catch (stageErr) {
-      // stageSandboxMedia threw before copying anything (e.g. workspace mkdir
-      // ENOSPC/EPERM), so nothing reached the sandbox. Already-managed inbound
-      // PDFs still reach the agent via their managed media path (host-side
-      // media-understanding reads the media-store root); fail the send only when a
-      // ref cannot fall back. #90097
-      if (refsToStage.some((ref) => !isManagedInboundPdfOffloadRef(ref))) {
-        throw stageErr;
-      }
-      return refsByManagedPath(mediaPathRefs);
-    }
-
-    // stageSandboxMedia silently keeps unstaged entries as their original
-    // absolute path, so length parity does not prove every file landed in the
-    // sandbox. The RPC max (20MB via resolveChatAttachmentMaxBytes) admits files
-    // above the staging cap (STAGED_MEDIA_MAX_BYTES = 5MB); check the returned
-    // `staged` map for missing sources. Already-managed inbound PDFs fall back to
-    // their absolute managed path (host-side media-understanding reads the
-    // media-store root); any other missing source is a 5xx MediaOffloadError the
-    // client can retry. #90097
-    const stagedSources = stageResult.staged;
-    const missing = refsToStage.filter((ref) => !stagedSources.has(ref.path));
-    const unstageable = missing.filter((ref) => !isManagedInboundPdfOffloadRef(ref));
-    if (unstageable.length > 0) {
-      throw new Error(
-        `attachment staging incomplete: ${stagedSources.size}/${refsToStage.length} paths staged into sandbox workspace (missing: ${unstageable.map((ref) => ref.path).join(", ")})`,
-      );
-    }
-    const stagedPaths = stagingCtx.MediaPaths ?? [];
-    const stagedTypes = stagingCtx.MediaTypes ?? refsToStage.map((ref) => ref.mimeType);
-
-    // Map each ref to its post-staging path. Staged files become sandbox-relative
-    // (e.g. `media/inbound/foo.pdf`) so the agent inside the container can read
-    // them; pass-through PDFs and managed PDFs that fell back from staging keep
-    // their absolute managed path (stagedPaths preserves the absolute path for any
-    // unstaged entry). Host-side media-understanding resolves both via
-    // ctx.MediaWorkspaceDir plus the media-store root. Preserve attachment order.
-    const resolvedByRef = new Map<OffloadedRef, { path: string; mimeType: string }>();
-    refsToStage.forEach((ref, index) => {
-      resolvedByRef.set(ref, {
-        path: stagedPaths[index] ?? ref.path,
-        mimeType: stagedTypes[index] ?? ref.mimeType,
-      });
-    });
-    for (const ref of passThroughRefs) {
-      resolvedByRef.set(ref, { path: ref.path, mimeType: ref.mimeType });
-    }
-    const ordered = mediaPathRefs.map(
-      (ref) => resolvedByRef.get(ref) ?? { path: ref.path, mimeType: ref.mimeType },
-    );
-    return {
-      paths: ordered.map((entry) => entry.path),
-      types: ordered.map((entry) => entry.mimeType),
-      workspaceDir: sandbox.workspaceDir,
-    };
-  } catch (err) {
-    await Promise.allSettled(
-      params.offloadedRefs.map((ref) => deleteMediaBuffer(ref.id, "inbound")),
-    );
-    if (err instanceof MediaOffloadError) {
-      throw err;
-    }
-    // Sandbox-oversize rejections are client-side 4xx (see check above). Wrapping
-    // them as MediaOffloadError would misclassify them as retryable 5xx.
-    if (err instanceof UnsupportedAttachmentError) {
-      throw err;
-    }
-    throw new MediaOffloadError(
-      `[Gateway Error] Failed to stage attachments into agent workspace: ${formatErrorMessage(err)}`,
-      { cause: err },
-    );
-  }
 }
 
 type ChatSendManagedMediaFields = Partial<
@@ -1367,8 +1118,6 @@ export const chatHandlers: GatewayRequestHandlers = {
       clientInfo,
       supportsTaskSuggestions,
       p,
-      explicitOrigin,
-      inboundMessage,
       systemInputProvenance,
       systemProvenanceReceipt,
       suppressCommandInterpretation,
@@ -1435,108 +1184,40 @@ export const chatHandlers: GatewayRequestHandlers = {
       restartSafeAdmission,
       setReleaseGatewayRootContinuation,
     } = admitted.value;
-    let parsedMessage = inboundMessage;
-    let parsedImages: ChatImageContent[] = [];
-    let imageOrder: PromptImageOrderEntry[] = [];
-    let offloadedRefs: OffloadedRef[] = [];
-    let mediaPathOffloadPaths: string[] = [];
-    let mediaPathOffloadTypes: string[] = [];
-    let mediaPathOffloadWorkspaceDir: string | undefined;
-    const explicitOriginTargetsPlugin = explicitOriginTargetsPluginBinding(explicitOrigin);
-    let prepareAttachmentsMs: number | undefined;
-    if (normalizedAttachments.length > 0) {
-      const prepareAttachmentsStartedAtMs = performance.now();
-      try {
-        await measureDiagnosticsTimelineSpan(
-          "gateway.chat_send.prepare_attachments",
-          async () => {
-            const supportsSessionModelImages = await resolveGatewayModelSupportsImages({
-              loadGatewayModelCatalog: context.loadGatewayModelCatalog,
-              provider: resolvedSessionModel.provider,
-              model: resolvedSessionModel.model,
-            });
-            const explicitOriginSupportsInlineImages =
-              explicitOriginTargetsAcpSession(explicitOrigin) || explicitOriginTargetsPlugin;
-            // Bound plugin sessions own the real recipient model, so keep image
-            // attachments even when the parent OpenClaw session model is text-only.
-            const supportsImages = supportsSessionModelImages || explicitOriginSupportsInlineImages;
-            const routeImageOffloadsAsMediaPaths = !supportsImages;
-            const parsed = await parseMessageWithAttachments(
-              inboundMessage,
-              normalizedAttachments,
-              {
-                maxBytes: resolveChatAttachmentMaxBytes(cfg),
-                log: context.logGateway,
-                supportsImages,
-                // chat.send routes selected offloadedRefs into ctx.MediaPaths below
-                // so the auto-reply stage pipeline can surface them to the agent.
-                acceptNonImage: true,
-              },
-            );
-            parsedMessage = stripTrailingOffloadedMediaMarkers(
-              parsed.message,
-              routeImageOffloadsAsMediaPaths
-                ? parsed.offloadedRefs.filter((ref) => ref.mimeType.startsWith("image/"))
-                : [],
-            );
-            parsedImages = parsed.images;
-            imageOrder = routeImageOffloadsAsMediaPaths ? [] : parsed.imageOrder;
-            offloadedRefs = parsed.offloadedRefs;
-            ({
-              paths: mediaPathOffloadPaths,
-              types: mediaPathOffloadTypes,
-              workspaceDir: mediaPathOffloadWorkspaceDir,
-            } = await prestageMediaPathOffloads({
-              offloadedRefs,
-              // Text-only image offloads need ctx.MediaPaths so media-understanding
-              // can describe them via agents.defaults.imageModel. Vision-capable
-              // image offloads stay as prompt refs for native image loading.
-              includeImageRefs: routeImageOffloadsAsMediaPaths,
-              cfg,
-              sessionKey,
-              agentId,
-            }));
-          },
-          {
-            phase: "agent-turn",
-            config: cfg,
-            attributes: {
-              ...chatSendTraceAttributes,
-              attachmentCount: normalizedAttachments.length,
-            },
-          },
-        );
-        prepareAttachmentsMs = roundedChatSendTimingMs(
-          performance.now() - prepareAttachmentsStartedAtMs,
-        );
-      } catch (err) {
-        cleanupAdmittedRun({ force: true });
-        clearAgentRunContext(clientRunId, lifecycleGeneration);
-        logAttachmentFailure(context.logGateway, "chat.send attachment parse/stage failed", err);
-        respond(
-          false,
-          undefined,
-          errorShape(
-            err instanceof MediaOffloadError ? ErrorCodes.UNAVAILABLE : ErrorCodes.INVALID_REQUEST,
-            String(err),
-          ),
-        );
-        return;
-      }
+    const preparedAttachments = await prepareChatSendAttachments({
+      request: normalizedRequest.value,
+      session: preparedSession.value,
+      admission: admitted.value,
+      respond,
+      context,
+    });
+    if (!preparedAttachments.ok) {
+      return;
     }
     if (activeRunAbort.controller.signal.aborted) {
       finishAbortedChatSend();
       return;
     }
 
-    // Attachment preparation and admission can suspend. Recheck immediately
-    // before ACK/dispatch so hot config reload cannot cross the send boundary.
+    // Attachment preparation can suspend. Recheck immediately before the
+    // synchronous ACK path so aborts and hot routing reloads cannot cross it.
     if (sessionRoutingChanged(context.getRuntimeConfig())) {
       cleanupAdmittedRun({ force: true });
       clearAgentRunContext(clientRunId, lifecycleGeneration);
       respondChatSessionRoutingChanged(respond);
       return;
     }
+    const {
+      explicitOriginTargetsPlugin,
+      imageOrder,
+      mediaPathOffloadPaths,
+      mediaPathOffloadTypes,
+      mediaPathOffloadWorkspaceDir,
+      offloadedRefs,
+      parsedImages,
+      parsedMessage,
+      prepareAttachmentsMs,
+    } = preparedAttachments.value;
 
     const admissionStartedAt = Date.now();
     const terminalizeRestartSafeAdmission = async (terminalState: {


### PR DESCRIPTION
Related: #106555

## What Problem This Solves

The hot `chat.send` handler still owned attachment capability routing, parsing, media-store cleanup, sandbox staging, error mapping, and timing. That kept a separable pre-ack phase inside the main gateway method and made concurrency-sensitive send changes difficult to review.

## Why This Change Was Made

Extract attachment preparation into a typed `prepareChatSendAttachments` phase while preserving the existing staging and cleanup branches. Abort and routing validation remain in the caller immediately after the awaited phase so the check-to-ack segment stays synchronous.

## User Impact

No user-visible behavior change. Maintainers get a smaller `chat.send` handler and an independently reviewable attachment phase; `chat.ts` drops from 3,328 to 3,009 lines.

## Evidence

- Blacksmith Testbox `tbx_01kxe6ewrzjq0asctkyz4hhc06`: 351 focused gateway/chat tests passed across 9 files.
- Same Testbox: `pnpm check:changed` passed, including the TypeScript LOC ratchet, core and core-test typechecks, lint, import cycles, and repository guards.
- Fresh autoreview after the concurrency fix: clean, no accepted/actionable findings; correctness confidence 0.98.
- `git diff --check` passed.
