### PR TITLE
refactor(commands): remove duplicate session target export

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -1312,7 +1312,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/commands/onboard-skills.ts: testing",
   "src/commands/onboarding-plugin-install.ts: testing",
   "src/commands/runtime-plugin-install.ts: RuntimePluginInstallResult",
-  "src/commands/session-store-targets.ts: resolveSessionStoreTargets",
   "src/commands/sessions-tail.ts: setSessionsTailFollowIntervalMsForTests",
   "src/commands/sessions.ts: testing",
   "src/commands/status.command.ts: resolvePairingRecoveryContext",

--- a/src/commands/session-store-targets.test.ts
+++ b/src/commands/session-store-targets.test.ts
@@ -1,6 +1,7 @@
 // Session store target tests cover session-store path resolution for command surfaces.
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveSessionStoreTargets } from "./session-store-targets.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { resolveSessionStoreTargetsOrExit } from "./session-store-targets.js";
 
 const resolveSessionStoreTargetsMock = vi.hoisted(() => vi.fn());
 
@@ -8,19 +9,50 @@ vi.mock("../config/sessions.js", () => ({
   resolveSessionStoreTargets: resolveSessionStoreTargetsMock,
 }));
 
-describe("resolveSessionStoreTargets", () => {
+function createRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+}
+
+describe("resolveSessionStoreTargetsOrExit", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("delegates session store target resolution to the shared config helper", () => {
+  it("returns targets from the shared config helper", () => {
     resolveSessionStoreTargetsMock.mockReturnValue([
       { agentId: "main", storePath: "/tmp/main-sessions.json" },
     ]);
+    const runtime = createRuntime();
 
-    const targets = resolveSessionStoreTargets({}, {});
+    const targets = resolveSessionStoreTargetsOrExit({
+      cfg: {},
+      opts: {},
+      runtime,
+    });
 
     expect(targets).toEqual([{ agentId: "main", storePath: "/tmp/main-sessions.json" }]);
     expect(resolveSessionStoreTargetsMock).toHaveBeenCalledWith({}, {});
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("reports resolution errors and exits the command", () => {
+    resolveSessionStoreTargetsMock.mockImplementation(() => {
+      throw new Error("Unknown agent id: ghost");
+    });
+    const runtime = createRuntime();
+
+    const targets = resolveSessionStoreTargetsOrExit({
+      cfg: {},
+      opts: { agent: "ghost" },
+      runtime,
+    });
+
+    expect(targets).toBeNull();
+    expect(runtime.error).toHaveBeenCalledWith("Unknown agent id: ghost");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 });

--- a/src/commands/session-store-targets.ts
+++ b/src/commands/session-store-targets.ts
@@ -12,7 +12,6 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { RuntimeEnv } from "../runtime.js";
-export { resolveSessionStoreTargets };
 
 /** Resolves session store targets or exits the current command on validation errors. */
 export function resolveSessionStoreTargetsOrExit(params: {


### PR DESCRIPTION
## What Problem This Solves

The command-layer session target helper re-exported the canonical config resolver even though production callers use only the command error-handling wrapper. That left a redundant owner surface in the unused-export baseline and a test that only proved the re-export delegated back to config.

## Why This Change Was Made

Remove the duplicate command-layer export and its baseline entry. Retarget the existing test to cover the supported `resolveSessionStoreTargetsOrExit` success and error behavior while keeping `src/config/sessions/targets.ts` as the single resolver owner.

## User Impact

No user-visible behavior changes. Internal imports now have one canonical owner, and the command wrapper's error contract has direct coverage.

## Evidence

- `pnpm test:serial src/commands/session-store-targets.test.ts` (2 tests passed)
- `pnpm check:changed -- scripts/deadcode-exports.baseline.mjs src/commands/session-store-targets.ts src/commands/session-store-targets.test.ts`
- `pnpm deadcode:exports` (baseline matched 2,502 entries)
- Testbox: https://github.com/openclaw/openclaw/actions/runs/29269499676
- Fresh `gpt-5.6-sol` medium autoreview: no findings, patch correct (0.96 confidence)
