### PR TITLE
fix(test): extension planner fails after repository inventory exceeds child buffer

### DIFF
--- a/scripts/lib/extension-test-plan.mjs
+++ b/scripts/lib/extension-test-plan.mjs
@@ -31,6 +31,10 @@ import { listAvailableExtensionIds } from "./changed-extensions.mjs";
 import { parsePositiveInt } from "./numeric-options.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+const TRACKED_EXTENSION_TEST_PATHSPECS = [
+  `:(glob)${BUNDLED_PLUGIN_ROOT_DIR}/**/*.test.ts`,
+  `:(glob)${BUNDLED_PLUGIN_ROOT_DIR}/**/*.test.tsx`,
+];
 /** Default number of shards for broad bundled extension test batches. */
 export const DEFAULT_EXTENSION_TEST_SHARD_COUNT = 8;
 const EXTENSION_TEST_COST_MULTIPLIERS = {
@@ -110,12 +114,14 @@ function loadTrackedRepoTestFiles() {
     return trackedRepoTestFiles;
   }
 
-  const result = spawnSync("git", ["ls-files"], {
+  // Query only the planner-owned tree: a full-repo inventory can overflow
+  // spawnSync's buffer and either truncate the plan or force directory walks.
+  const result = spawnSync("git", ["ls-files", "--", ...TRACKED_EXTENSION_TEST_PATHSPECS], {
     cwd: repoRoot,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "ignore"],
   });
-  if (result.status !== 0) {
+  if (result.status !== 0 || result.error) {
     trackedRepoTestFiles = null;
     return trackedRepoTestFiles;
   }


### PR DESCRIPTION
Closes #106602

## What Problem This Solves

Fixes an issue where extension test planning could fail CI or consume an incomplete tracked-test inventory after the repository's `git ls-files` output exceeded Node's default synchronous child-process buffer.

## Why This Change Was Made

The planner still reuses one Git inventory, but the query is now limited to `.test.ts` and `.test.tsx` files under the bundled extension tree. Git spawn errors are treated as failures so a truncated buffer can never be accepted as complete; non-Git source trees retain the existing filesystem fallback.

## User Impact

Maintainers and contributors get reliable extension batch plans and a green compact tooling shard as the repository grows. The change does not alter runtime OpenClaw behavior.

## Evidence

- Before: CI run 29268559826 failed the same assertion on both attempts: expected zero directory reads, observed 54. The shard otherwise passed 2,446 tests.
- Root-cause probe on current source: full `git ls-files` output is 1,051,363 bytes and Node reports `spawnSync git ENOBUFS`; the bounded extension-test inventory is 120,356 bytes across 2,379 files with no spawn error.
- Blacksmith Testbox `tbx_01kxe7k40jbe9791va27w37pvc`: `corepack pnpm test test/scripts/test-extension.test.ts -t 'counts tracked extension tests without walking extension directories'` passed 1/1.
- Same Testbox: `corepack pnpm test test/scripts/test-extension.test.ts` passed 138/138.
- Same Testbox: `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` passed the tooling lane, including format, guards, and lint.
- Fresh autoreview with a real OpenAI account (`gpt-5.6-sol`, `xhigh`) reported no accepted/actionable findings and rated the patch correct at 0.97.

AI-assisted change. I reviewed the implementation and validation evidence.
