### PR TITLE
fix(sandbox): stream large command stdin buffers

### DIFF
--- a/src/agents/sandbox/command-stdin.test.ts
+++ b/src/agents/sandbox/command-stdin.test.ts
@@ -1,0 +1,30 @@
+import { Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { describe, expect, it } from "vitest";
+import { createChunkedCommandInput } from "../../process/exec.js";
+
+describe("createChunkedCommandInput", () => {
+  it("streams large buffers in bounded chunks without changing their bytes", async () => {
+    const input = Buffer.alloc(2 * 64 * 1024 + 17);
+    input.forEach((_, index) => {
+      input[index] = index % 251;
+    });
+    const chunks: Buffer[] = [];
+    const stdin = new Writable({
+      highWaterMark: 1,
+      write(chunk: Buffer, _encoding, callback) {
+        chunks.push(Buffer.from(chunk));
+        setImmediate(callback);
+      },
+    });
+
+    const commandInput = createChunkedCommandInput(input);
+    if (!(commandInput instanceof Readable)) {
+      throw new Error("expected a stream for large command input");
+    }
+    await pipeline(commandInput, stdin);
+
+    expect(chunks.map((chunk) => chunk.length)).toEqual([64 * 1024, 64 * 1024, 17]);
+    expect(Buffer.concat(chunks)).toEqual(input);
+  });
+});

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -6,7 +6,7 @@
 import { createAbortError } from "../../infra/abort-signal.js";
 import { toErrorObject } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { isPlainCommandExitFailure, spawnCommand } from "../../process/exec.js";
+import * as commandExec from "../../process/exec.js";
 import {
   sanitizeEnvVars,
   sanitizeExplicitSandboxEnvVars,
@@ -37,10 +37,10 @@ export async function execDockerRaw(
 ): Promise<ExecDockerRawResult> {
   let result;
   try {
-    result = await spawnCommand(["docker", ...args], {
+    result = await commandExec.spawnCommand(["docker", ...args], {
       cancelSignal: opts?.signal,
       encoding: "buffer",
-      input: opts?.input ?? Buffer.alloc(0),
+      input: commandExec.createChunkedCommandInput(opts?.input),
       maxBuffer: SANDBOX_COMMAND_MAX_BUFFER_BYTES,
       reject: false,
       stripFinalNewline: false,
@@ -62,7 +62,7 @@ export async function execDockerRaw(
   if (opts?.signal?.aborted || result.isCanceled) {
     throw createAbortError("Aborted");
   }
-  if (result.failed && !isPlainCommandExitFailure(result)) {
+  if (result.failed && !commandExec.isPlainCommandExitFailure(result)) {
     if (result.code === "ENOENT") {
       throw Object.assign(
         new Error(

--- a/src/agents/sandbox/ssh.ts
+++ b/src/agents/sandbox/ssh.ts
@@ -12,7 +12,7 @@ import { resolveRootPath } from "../../infra/boundary-path.js";
 import { toErrorObject } from "../../infra/errors.js";
 import { parseSshTarget } from "../../infra/ssh-tunnel.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
-import { isPlainCommandExitFailure, spawnCommand } from "../../process/exec.js";
+import * as commandExec from "../../process/exec.js";
 import { resolveUserPath } from "../../utils.js";
 import type { SandboxBackendCommandResult } from "./backend-handle.types.js";
 import { SANDBOX_COMMAND_MAX_BUFFER_BYTES } from "./constants.js";
@@ -684,11 +684,11 @@ export async function runSshSandboxCommand(
     throw new Error("SSH command argv is empty");
   }
   const sshEnv = sanitizeEnvVars(process.env).allowed;
-  const result = await spawnCommand([executable, ...args], {
+  const result = await commandExec.spawnCommand([executable, ...args], {
     baseEnv: sshEnv,
     cancelSignal: params.signal,
     encoding: "buffer",
-    input: params.stdin ?? Buffer.alloc(0),
+    input: commandExec.createChunkedCommandInput(params.stdin),
     maxBuffer: SANDBOX_COMMAND_MAX_BUFFER_BYTES,
     reject: false,
     stripFinalNewline: false,
@@ -696,7 +696,7 @@ export async function runSshSandboxCommand(
   if (params.signal?.aborted || result.isCanceled) {
     throw createAbortError("Aborted");
   }
-  if (result.failed && !isPlainCommandExitFailure(result)) {
+  if (result.failed && !commandExec.isPlainCommandExitFailure(result)) {
     throw toErrorObject(result, "SSH command execution failed");
   }
   const stdout = Buffer.from(result.stdout);

--- a/src/process/exec-spawn.ts
+++ b/src/process/exec-spawn.ts
@@ -1,10 +1,29 @@
 import path from "node:path";
 import process from "node:process";
+import { Readable } from "node:stream";
 import { execa, type Options as ExecaOptions, type ResultPromise } from "execa";
 import { markOpenClawExecEnv } from "../infra/openclaw-exec-env.js";
 import { resolveSafeChildProcessInvocation } from "./windows-command.js";
 
 export const COMMAND_PROCESS_TREE_KILL_GRACE_MS = 300;
+const COMMAND_INPUT_CHUNK_BYTES = 64 * 1024;
+
+/** Convert large binary command input into bounded, backpressure-aware writes. */
+export function createChunkedCommandInput(
+  input?: string | Uint8Array,
+): string | Uint8Array | Readable {
+  const resolvedInput = input ?? new Uint8Array();
+  if (typeof resolvedInput === "string" || resolvedInput.byteLength <= COMMAND_INPUT_CHUNK_BYTES) {
+    return resolvedInput;
+  }
+  return Readable.from(chunkCommandInput(resolvedInput));
+}
+
+function* chunkCommandInput(input: Uint8Array): Generator<Uint8Array> {
+  for (let offset = 0; offset < input.byteLength; offset += COMMAND_INPUT_CHUNK_BYTES) {
+    yield input.subarray(offset, offset + COMMAND_INPUT_CHUNK_BYTES);
+  }
+}
 
 function assignChildEnvValue(params: {
   env: NodeJS.ProcessEnv;

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -15,7 +15,12 @@ export { runCommandWithTimeout } from "./exec-runner.js";
 export type { CommandOptions } from "./exec-runner.js";
 export { isPlainCommandExitFailure, resolveProcessExitCode } from "./exec-result.js";
 export type { SpawnResult } from "./exec-result.js";
-export { resolveCommandEnv, shouldSpawnWithShell, spawnCommand } from "./exec-spawn.js";
+export {
+  createChunkedCommandInput,
+  resolveCommandEnv,
+  shouldSpawnWithShell,
+  spawnCommand,
+} from "./exec-spawn.js";
 export type { SpawnCommandOptions } from "./exec-spawn.js";
 
 const DEFAULT_EXEC_MAX_BUFFER_BYTES = 1024 * 1024;


### PR DESCRIPTION
## What Problem This Solves

Sandbox filesystem writes convert their payload to a `Buffer`, then pass it through the backend command contract. Both Docker and SSH transports previously supplied that entire buffer to `child.stdin.end()` as a single write, so a large file payload could be queued at once instead of respecting the child process stream's backpressure. This could increase memory pressure and destabilize the host during large sandbox writes.

## Summary

- stream large sandbox command stdin buffers in 64 KiB zero-copy slices
- use Node's stream pipeline to honor child-process backpressure for both Docker and SSH backends
- retain the existing direct `stdin.end()` fast path for small buffers and string inputs

## Impact

Large sandbox file writes now keep the in-flight stdin payload bounded while preserving the existing write API, atomic mutation helper, and exact bytes. The shared transport fix covers both local Docker sandboxes and remote SSH sandboxes.

Fixes #106583.

## Evidence

- Focused regression and transport tests: 27 passed
  - `node scripts/run-vitest.mjs src/agents/sandbox/command-stdin.test.ts src/agents/sandbox/docker.test.ts src/agents/sandbox/ssh.spawn-env.test.ts src/agents/sandbox/ssh.stream-errors.test.ts -t 'streams large|filters blocked|rejects and terminates'`
- Core TypeScript validation passed:
  - `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- Formatting passed on all four changed files:
  - `oxfmt --check --threads=1`
- The regression test forces backpressure with a one-byte writable high-water mark and verifies a 131,089-byte payload is emitted as 64 KiB, 64 KiB, and 17-byte chunks with exact byte preservation.
