### PR TITLE
fix: stop model fallback on sandbox provisioning failures

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -20,6 +20,7 @@ import {
   resolveModelFallbackError,
 } from "./failover-error.js";
 import { AgentHarnessSessionSupersededError } from "./harness/errors.js";
+import { SandboxProvisioningError } from "./sandbox/errors.js";
 import { SessionWriteLockTimeoutError } from "./session-write-lock-error.js";
 
 // OpenAI 429 example shape: https://help.openai.com/en/articles/5955604-how-can-i-solve-429-too-many-requests-errors
@@ -1397,6 +1398,33 @@ describe("failover-error", () => {
       expect(isNonProviderRuntimeCoordinationError(wrappedTakeover)).toBe(true);
     });
 
+    it("returns true for sandbox provisioning errors without parsing their messages", () => {
+      const provisioningError = new SandboxProvisioningError(
+        "docker",
+        new Error("Sandbox image not found"),
+      );
+      expect(isNonProviderRuntimeCoordinationError(provisioningError)).toBe(true);
+      expect(isNonProviderRuntimeCoordinationError(new Error("wrapper", { cause: provisioningError }))).toBe(
+        true,
+      );
+      expect(resolveFailoverReasonFromError(provisioningError)).toBeNull();
+    });
+
+    it("preserves explicit provider classification over a nested provisioning error", () => {
+      const providerError = Object.assign(
+        new Error("upstream quota pressure", {
+          cause: new SandboxProvisioningError("docker", new Error("image missing")),
+        }),
+        { status: 429, code: "RESOURCE_EXHAUSTED" },
+      );
+
+      expect(isNonProviderRuntimeCoordinationError(providerError)).toBe(false);
+      expect(resolveModelFallbackError(providerError)).toMatchObject({
+        kind: "failover",
+        error: { reason: "rate_limit" },
+      });
+    });
+
     it("returns true for Codex missing tool-result local execution failures", () => {
       const missingToolResultMessage =
         "OpenClaw recorded a native Codex tool.call without a matching tool.result before the turn completed.";
@@ -1414,9 +1442,7 @@ describe("failover-error", () => {
     it("returns false for plain timeouts and provider errors", () => {
       const timeoutErr = Object.assign(new Error("operation timed out"), { name: "TimeoutError" });
       expect(isNonProviderRuntimeCoordinationError(timeoutErr)).toBe(false);
-      expect(isNonProviderRuntimeCoordinationError({ status: 429, message: "rate limit" })).toBe(
-        false,
-      );
+      expect(isNonProviderRuntimeCoordinationError({ status: 429, message: "rate limit" })).toBe(false);
       expect(
         isNonProviderRuntimeCoordinationError({
           status: 429,

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -1404,9 +1404,9 @@ describe("failover-error", () => {
         new Error("Sandbox image not found"),
       );
       expect(isNonProviderRuntimeCoordinationError(provisioningError)).toBe(true);
-      expect(isNonProviderRuntimeCoordinationError(new Error("wrapper", { cause: provisioningError }))).toBe(
-        true,
-      );
+      expect(
+        isNonProviderRuntimeCoordinationError(new Error("wrapper", { cause: provisioningError })),
+      ).toBe(true);
       expect(resolveFailoverReasonFromError(provisioningError)).toBeNull();
     });
 
@@ -1442,7 +1442,9 @@ describe("failover-error", () => {
     it("returns false for plain timeouts and provider errors", () => {
       const timeoutErr = Object.assign(new Error("operation timed out"), { name: "TimeoutError" });
       expect(isNonProviderRuntimeCoordinationError(timeoutErr)).toBe(false);
-      expect(isNonProviderRuntimeCoordinationError({ status: 429, message: "rate limit" })).toBe(false);
+      expect(isNonProviderRuntimeCoordinationError({ status: 429, message: "rate limit" })).toBe(
+        false,
+      );
       expect(
         isNonProviderRuntimeCoordinationError({
           status: 429,

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -17,6 +17,7 @@ import {
 import { isTimeoutErrorMessage } from "./embedded-agent-helpers/errors.js";
 import type { FailoverReason } from "./embedded-agent-helpers/types.js";
 import { AgentHarnessSessionSupersededError } from "./harness/errors.js";
+import { isSandboxProvisioningError } from "./sandbox/errors.js";
 import { isSessionWriteLockAcquireError } from "./session-write-lock-error.js";
 
 const ABORT_TIMEOUT_RE = /request was aborted|request aborted/i;
@@ -494,14 +495,9 @@ function hasMissingToolResultFailure(err: unknown): boolean {
   return findErrorProperty(err, readMissingToolResultMarker) === true;
 }
 
-/**
- * True when the error is a local runtime coordination/tool-execution error
- * rather than a provider/model failure. The model fallback chain must abort on
- * these instead of consuming candidate slots — retrying any model would hit the
- * same local condition. See #83510 and #95474.
- */
-export function isNonProviderRuntimeCoordinationError(err: unknown): boolean {
-  return resolveModelFallbackError(err).kind === "coordination";
+/** True for local runtime failures shared by every model candidate. See #83510, #95474, #106516. */
+export function isNonProviderRuntimeError(err: unknown): boolean {
+  return resolveModelFallbackError(err).kind === "non_provider";
 }
 
 function hasTimeoutHint(err: unknown): boolean {
@@ -625,7 +621,8 @@ function resolveFailoverClassificationFromErrorInternal(
   depth: number,
   providerHint?: string,
 ): FailoverClassification | null {
-  if (depth > MAX_FAILOVER_CAUSE_DEPTH) {
+  // Provisioning text can resemble provider errors; keep it out of signal parsing. See #106516.
+  if (depth > MAX_FAILOVER_CAUSE_DEPTH || isSandboxProvisioningError(err)) {
     return null;
   }
   if (err && typeof err === "object") {
@@ -828,7 +825,7 @@ type FailoverErrorContext = {
 
 type ModelFallbackErrorResolution =
   | { kind: "failover"; error: FailoverError }
-  | { kind: "coordination"; error: unknown }
+  | { kind: "non_provider"; error: unknown }
   | { kind: "unknown"; error: unknown };
 
 /** Convert a classified raw error into a FailoverError with optional request context. */
@@ -901,18 +898,19 @@ export function resolveModelFallbackError(
   // cleanup wrapper owns a preserved prompt error. Its message alone must not
   // reclassify session-state loss as a provider failure.
   if (isEmbeddedAttemptSessionTakeover(err) && !hasPreservedTakeoverPromptError(err)) {
-    return { kind: "coordination", error: err };
+    return { kind: "non_provider", error: err };
   }
   const failoverError = coerceToFailoverError(err, context);
   if (failoverError) {
     return { kind: "failover", error: failoverError };
   }
   if (
+    findErrorProperty(err, (candidate) => isSandboxProvisioningError(candidate) || undefined) ||
     hasSessionWriteLockContention(err) ||
     hasEmbeddedAttemptSessionTakeover(err) ||
     hasMissingToolResultFailure(err)
   ) {
-    return { kind: "coordination", error: err };
+    return { kind: "non_provider", error: err };
   }
   return { kind: "unknown", error: err };
 }

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -495,9 +495,15 @@ function hasMissingToolResultFailure(err: unknown): boolean {
   return findErrorProperty(err, readMissingToolResultMarker) === true;
 }
 
-/** True for local runtime failures shared by every model candidate. See #83510, #95474, #106516. */
-export function isNonProviderRuntimeError(err: unknown): boolean {
-  return resolveModelFallbackError(err).kind === "non_provider";
+/**
+ * True when the error is a local runtime coordination/tool-execution error
+ * rather than a provider/model failure. The model fallback chain must abort on
+ * these instead of consuming candidate slots — retrying any model would hit the
+ * same local condition. Sandbox provisioning failures join this class because
+ * every candidate shares the same sandbox. See #83510, #95474 and #106516.
+ */
+export function isNonProviderRuntimeCoordinationError(err: unknown): boolean {
+  return resolveModelFallbackError(err).kind === "coordination";
 }
 
 function hasTimeoutHint(err: unknown): boolean {
@@ -825,7 +831,7 @@ type FailoverErrorContext = {
 
 type ModelFallbackErrorResolution =
   | { kind: "failover"; error: FailoverError }
-  | { kind: "non_provider"; error: unknown }
+  | { kind: "coordination"; error: unknown }
   | { kind: "unknown"; error: unknown };
 
 /** Convert a classified raw error into a FailoverError with optional request context. */
@@ -898,7 +904,7 @@ export function resolveModelFallbackError(
   // cleanup wrapper owns a preserved prompt error. Its message alone must not
   // reclassify session-state loss as a provider failure.
   if (isEmbeddedAttemptSessionTakeover(err) && !hasPreservedTakeoverPromptError(err)) {
-    return { kind: "non_provider", error: err };
+    return { kind: "coordination", error: err };
   }
   const failoverError = coerceToFailoverError(err, context);
   if (failoverError) {
@@ -910,7 +916,7 @@ export function resolveModelFallbackError(
     hasEmbeddedAttemptSessionTakeover(err) ||
     hasMissingToolResultFailure(err)
   ) {
-    return { kind: "non_provider", error: err };
+    return { kind: "coordination", error: err };
   }
   return { kind: "unknown", error: err };
 }

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -643,6 +643,22 @@ function resolveFailoverClassificationFromErrorInternal(
       reason: err.reason,
     };
   }
+  const hasProvisioningCause =
+    findErrorProperty(err, (candidate) => isSandboxProvisioningError(candidate) || undefined) !==
+    undefined;
+  const directSignal = normalizeDirectErrorSignal(err);
+  const directCodeReason = directSignal.code
+    ? failoverReasonFromClassification(classifyFailoverSignal({ code: directSignal.code }))
+    : null;
+  const hasDirectFailoverMetadata =
+    directSignal.status !== undefined ||
+    (directCodeReason !== null && directCodeReason !== "timeout");
+  // Wrapper prose is not stronger evidence than a typed local provisioning
+  // cause. Keep explicit provider status/code precedence, but do not let copied
+  // timeout or rate-limit wording consume model fallbacks. See #106516.
+  if (hasProvisioningCause && !hasDirectFailoverMetadata) {
+    return null;
+  }
   const signal = normalizeErrorSignal(err, providerHint);
   const codeReason = signal.code
     ? failoverReasonFromClassification(classifyFailoverSignal({ code: signal.code }))

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -41,6 +41,7 @@ import {
   createAgentRunRestartAbortError,
   resolveAgentRunErrorLifecycleFields,
 } from "./run-termination.js";
+import { SandboxProvisioningError } from "./sandbox/errors.js";
 import { resolveSessionSuspensionReason } from "./session-suspension.js";
 import { SessionWriteLockTimeoutError } from "./session-write-lock-error.js";
 import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
@@ -912,6 +913,33 @@ describe("runWithModelFallback", () => {
     expect(expectDefined(result.attempts[0], "result.attempts[0] test invariant").reason).toBe(
       "unknown",
     );
+  });
+
+  it("does not consume model fallbacks for sandbox provisioning failures", async () => {
+    const cfg = makeCfg();
+    const diagnostics = captureModelFailoverDiagnostics();
+    const provisioningError = new SandboxProvisioningError(
+      "docker",
+      new Error("Sandbox image not found"),
+    );
+    const run = vi.fn().mockRejectedValue(provisioningError);
+
+    try {
+      await expect(
+        runWithModelFallback({
+          cfg,
+          provider: "openai",
+          model: "gpt-4.1-mini",
+          sessionId: "session:sandbox-provisioning",
+          sessionKey: "agent:test:sandbox-provisioning",
+          run,
+        }),
+      ).rejects.toBe(provisioningError);
+    } finally {
+      diagnostics.stop();
+    }
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(diagnostics.events).toEqual([]);
   });
 
   it("does not treat Codex missing tool-result failures as model fallback candidates", async () => {

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -915,14 +915,15 @@ describe("runWithModelFallback", () => {
     );
   });
 
-  it("does not consume model fallbacks for sandbox provisioning failures", async () => {
+  it("does not consume model fallbacks for wrapped sandbox provisioning failures", async () => {
     const cfg = makeCfg();
     const diagnostics = captureModelFailoverDiagnostics();
     const provisioningError = new SandboxProvisioningError(
       "docker",
       new Error("Sandbox image not found"),
     );
-    const run = vi.fn().mockRejectedValue(provisioningError);
+    const wrappedError = new Error("sandbox startup timed out", { cause: provisioningError });
+    const run = vi.fn().mockRejectedValue(wrappedError);
 
     try {
       await expect(
@@ -934,7 +935,7 @@ describe("runWithModelFallback", () => {
           sessionKey: "agent:test:sandbox-provisioning",
           run,
         }),
-      ).rejects.toBe(provisioningError);
+      ).rejects.toBe(wrappedError);
     } finally {
       diagnostics.stop();
     }

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -42,7 +42,7 @@ import {
   describeFailoverError,
   findCliMaxTurnsError,
   isFailoverError,
-  isNonProviderRuntimeError,
+  isNonProviderRuntimeCoordinationError,
   resolveModelFallbackError,
 } from "./failover-error.js";
 import {
@@ -420,7 +420,7 @@ async function runFallbackCandidate<T>(params: {
       sessionId: params.attribution?.sessionId,
       lane: params.attribution?.lane,
     });
-    if (fallbackError.kind === "non_provider") {
+    if (fallbackError.kind === "coordination") {
       throw err;
     }
     if (isTerminalAbort(params.abortSignal) || isCallerAbortSignal(params.abortSignal)) {
@@ -1398,7 +1398,7 @@ function shouldDiscardDeferredSessionSuspension(params: {
     isAgentRunRestartAbortReason(params.error) ||
     isTerminalAbortFromError(params.error) ||
     isCommandLaneTaskTimeoutError(params.error) ||
-    isNonProviderRuntimeError(params.error) ||
+    isNonProviderRuntimeCoordinationError(params.error) ||
     isTranscriptNotContinuableError(params.error) ||
     isLikelyContextOverflowError(formatErrorMessage(params.error))
   );
@@ -1842,7 +1842,7 @@ async function runWithModelFallbackInternal<T>(
       // timeout, embedded attempt takeover) are not provider/model failures.
       // Aborting prevents retries of the same condition and a misleading
       // "All models failed" summary. See #83510 and #106516.
-      if (isNonProviderRuntimeError(err)) {
+      if (isNonProviderRuntimeCoordinationError(err)) {
         throw err;
       }
       if (isTranscriptNotContinuableError(err)) {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -42,7 +42,7 @@ import {
   describeFailoverError,
   findCliMaxTurnsError,
   isFailoverError,
-  isNonProviderRuntimeCoordinationError,
+  isNonProviderRuntimeError,
   resolveModelFallbackError,
 } from "./failover-error.js";
 import {
@@ -420,7 +420,7 @@ async function runFallbackCandidate<T>(params: {
       sessionId: params.attribution?.sessionId,
       lane: params.attribution?.lane,
     });
-    if (fallbackError.kind === "coordination") {
+    if (fallbackError.kind === "non_provider") {
       throw err;
     }
     if (isTerminalAbort(params.abortSignal) || isCallerAbortSignal(params.abortSignal)) {
@@ -1398,7 +1398,7 @@ function shouldDiscardDeferredSessionSuspension(params: {
     isAgentRunRestartAbortReason(params.error) ||
     isTerminalAbortFromError(params.error) ||
     isCommandLaneTaskTimeoutError(params.error) ||
-    isNonProviderRuntimeCoordinationError(params.error) ||
+    isNonProviderRuntimeError(params.error) ||
     isTranscriptNotContinuableError(params.error) ||
     isLikelyContextOverflowError(formatErrorMessage(params.error))
   );
@@ -1838,12 +1838,11 @@ async function runWithModelFallbackInternal<T>(
       exhaustionResult = attemptRun.exhaustionResult;
     }
     {
-      // Local runtime coordination errors (session write-lock timeout, embedded
-      // attempt session takeover) are not provider/model failures. Aborting
-      // here prevents the fallback chain from consuming candidates retrying
-      // the same local condition and surfacing a misleading "All models
-      // failed" summary. See #83510.
-      if (isNonProviderRuntimeCoordinationError(err)) {
+      // Local runtime failures (sandbox provisioning, session write-lock
+      // timeout, embedded attempt takeover) are not provider/model failures.
+      // Aborting prevents retries of the same condition and a misleading
+      // "All models failed" summary. See #83510 and #106516.
+      if (isNonProviderRuntimeError(err)) {
         throw err;
       }
       if (isTranscriptNotContinuableError(err)) {

--- a/src/agents/sandbox.resolveSandboxContext.test.ts
+++ b/src/agents/sandbox.resolveSandboxContext.test.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { SkillUsagePath } from "../skills/types.js";
 import { registerSandboxBackend } from "./sandbox/backend.js";
 import { ensureSandboxWorkspaceForSession, resolveSandboxContext } from "./sandbox/context.js";
+import { SandboxProvisioningError } from "./sandbox/errors.js";
 
 const updateRegistryMock = vi.hoisted(() => vi.fn());
 const syncSkillsToWorkspaceMock = vi.hoisted(() =>
@@ -263,6 +264,43 @@ describe("resolveSandboxContext", () => {
         workspaceDir: "/tmp/openclaw-test",
       });
       expect(workspace?.containerWorkdir).toBe("/runtime/workspace");
+    } finally {
+      restore();
+    }
+  }, 15_000);
+
+  it("types backend startup failures as sandbox provisioning errors", async () => {
+    const startupError = new Error("runtime image is missing");
+    const restore = registerSandboxBackend("broken-backend", async () => {
+      throw startupError;
+    });
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            sandbox: {
+              mode: "all",
+              backend: "broken-backend",
+              scope: "session",
+              workspaceAccess: "rw",
+              prune: { idleHours: 0, maxAgeDays: 0 },
+            },
+          },
+        },
+      };
+
+      const promise = resolveSandboxContext({
+        config: cfg,
+        sessionKey: "agent:worker:broken",
+        workspaceDir: "/tmp/openclaw-test",
+      });
+
+      await expect(promise).rejects.toMatchObject({
+        name: "SandboxProvisioningError",
+        message: 'Sandbox backend "broken-backend" failed to start: runtime image is missing',
+        backendId: "broken-backend",
+        cause: startupError,
+      } satisfies Partial<SandboxProvisioningError>);
     } finally {
       restore();
     }

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -16,10 +16,15 @@ import {
 import { defaultRuntime } from "../../runtime.js";
 import type { SkillEligibilityContext, SkillUsagePath } from "../../skills/types.js";
 import type { ExecPolicyOverrides } from "../exec-defaults.js";
-import { getSandboxBackendWorkdirResolver, requireSandboxBackendFactory } from "./backend.js";
+import {
+  getSandboxBackendWorkdirResolver,
+  requireSandboxBackendFactory,
+  type SandboxBackendHandle,
+} from "./backend.js";
 import { ensureSandboxBrowser } from "./browser.js";
 import { resolveSandboxConfigForAgent } from "./config.js";
 import { resolveSandboxDockerUser } from "./docker-user.js";
+import { isSandboxProvisioningError, SandboxProvisioningError } from "./errors.js";
 import { createSandboxFsBridge } from "./fs-bridge.js";
 import { updateRegistry } from "./registry.js";
 import { resolveSandboxRuntimeStatus } from "./runtime-status.js";
@@ -227,17 +232,27 @@ export async function resolveSandboxContext(params: {
   const resolvedCfg = docker === cfg.docker ? cfg : { ...cfg, docker };
 
   const backendFactory = requireSandboxBackendFactory(resolvedCfg.backend);
-  const backend = await backendFactory({
-    sessionKey: rawSessionKey,
-    scopeKey,
-    workspaceDir,
-    agentWorkspaceDir,
-    skillsWorkspaceDir,
-    cfg: resolvedCfg,
-    ...(params.requireCurrentConfig !== undefined
-      ? { requireCurrentConfig: params.requireCurrentConfig }
-      : {}),
-  });
+  let backend: SandboxBackendHandle;
+  try {
+    backend = await backendFactory({
+      sessionKey: rawSessionKey,
+      scopeKey,
+      workspaceDir,
+      agentWorkspaceDir,
+      skillsWorkspaceDir,
+      cfg: resolvedCfg,
+      ...(params.requireCurrentConfig !== undefined
+        ? { requireCurrentConfig: params.requireCurrentConfig }
+        : {}),
+    });
+  } catch (error) {
+    if (isSandboxProvisioningError(error)) {
+      throw error;
+    }
+    // Backend creation is local provisioning, not a model attempt. Preserve
+    // that distinction so model fallback cannot retry the same broken runtime.
+    throw new SandboxProvisioningError(resolvedCfg.backend, error);
+  }
   await updateRegistry({
     containerName: backend.runtimeId,
     backendId: backend.id,

--- a/src/agents/sandbox/errors.ts
+++ b/src/agents/sandbox/errors.ts
@@ -1,0 +1,15 @@
+/** A local sandbox backend failed before an agent model attempt could start. */
+export class SandboxProvisioningError extends Error {
+  readonly backendId: string;
+
+  constructor(backendId: string, cause: unknown) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    super(`Sandbox backend "${backendId}" failed to start: ${detail}`, { cause });
+    this.name = "SandboxProvisioningError";
+    this.backendId = backendId;
+  }
+}
+
+export function isSandboxProvisioningError(error: unknown): error is SandboxProvisioningError {
+  return error instanceof SandboxProvisioningError;
+}

--- a/src/agents/subagent-announce-output.test.ts
+++ b/src/agents/subagent-announce-output.test.ts
@@ -389,6 +389,39 @@ describe("buildChildCompletionFindings", () => {
 });
 
 describe("applySubagentWaitOutcome", () => {
+  it("preserves sandbox provisioning failures for parent completion findings", () => {
+    const error =
+      'Sandbox backend "docker" failed to start: Sandbox image not found: openclaw-sandbox:analyst';
+    const applied = applySubagentWaitOutcome({
+      wait: {
+        status: "error",
+        startedAt: 100,
+        endedAt: 150,
+        error,
+      },
+      outcome: undefined,
+    });
+
+    expect(applied.outcome).toEqual({
+      status: "error",
+      error,
+      startedAt: 100,
+      endedAt: 150,
+      elapsedMs: 50,
+    });
+    expect(
+      buildChildCompletionFindings([
+        {
+          childSessionKey: "agent:main:subagent:sandbox-failure",
+          task: "sandboxed child",
+          createdAt: 100,
+          endedAt: 150,
+          outcome: applied.outcome,
+        },
+      ]),
+    ).toContain(`status: error: ${error}`);
+  });
+
   it("treats blocked ok wait snapshots as errors", () => {
     const applied = applySubagentWaitOutcome({
       wait: {


### PR DESCRIPTION
Closes #106516

AI-assisted: implemented with Codex and independently reviewed with the repository autoreview workflow (Claude fallback after both Codex reviewer models failed before returning a verdict).

## What Problem This Solves

Fixes an issue where users running sandboxed agents would consume every configured model fallback when the sandbox backend could not start, such as when a Docker sandbox image was missing. The same local provisioning failure was repeated as model fallback activity instead of surfacing once as the actionable runtime error.

## Why This Change Was Made

Sandbox backend creation now wraps startup failures in a typed `SandboxProvisioningError`. The existing non-provider runtime classification handles that type before fallback candidate accounting, without matching Docker error text, while explicit provider status/code errors retain provider-fallback precedence.

## User Impact

Sandbox provisioning failures now stop after the first attempt, emit no model-fallback transition diagnostics, and preserve a clear backend startup message for the child run and parent completion path. Legitimate provider/model failures continue to use configured fallbacks.

## Evidence

- Before the fix, the focused regression run failed because the same provisioning error invoked two model candidates and backend creation exposed only a plain `Error`.
- On the final prepared head, the focused suite passed remotely on Cloudflare Containers:
  - `node scripts/run-vitest.mjs src/agents/model-fallback.test.ts src/agents/failover-error.test.ts src/agents/sandbox.resolveSandboxContext.test.ts src/agents/subagent-announce-output.test.ts`
  - 4 files, 270 tests passed across 2 Vitest shards.
- Regression coverage verifies:
  - one model attempt and zero `model.failover` diagnostics;
  - typed backend startup failure with the original cause and actionable message;
  - explicit provider classification still wins over a nested provisioning error;
  - failed child wait state preserves the actionable provisioning error in parent completion findings.
- `git diff --check origin/main...HEAD` passed.
- `pnpm check:loc --base origin/main --head HEAD` passed after CI caught the initial legacy-file LOC growth; `src/agents/failover-error.ts` is now two lines smaller than `main`.
- Mandatory autoreview was clean against the full production diff and the final parent-visibility test; no actionable findings remain. The Codex reviewer runtime failed before a verdict after three identical retries, while the supported Claude fallback returned clean results.

### Real behavior proof

A real missing-image path was exercised on Cloudflare Containers via Crabbox
using an isolated Docker 20.10.24 daemon (`vfs` storage, bridge and iptables
disabled). The reviewed production and test bytes were verified by SHA-256
before execution. Only `CI` was forwarded; no model or provider credentials
were present.

The missing image `openclaw-proof-missing:pr-106657` produced:

```json
{
  "proof": "sandbox-provisioning-real-docker",
  "missingImage": "openclaw-proof-missing:pr-106657",
  "attempts": 1,
  "modelFailoverEvents": 0,
  "childErrorPreserved": true,
  "parentErrorPreserved": true
}
```

The real-Docker run exercised the prepared provisioning implementation before
the follow-up wrapper-precedence hardening in `5f8d3b2`. That follow-up changes
only how misleading wrapper prose competes with a nested typed provisioning
cause. On the final exact head, 270 focused tests passed remotely alongside
touched-file formatting, the `src/agents` lint shard, production typechecking,
and 81 hosted checks. Final autoreview reported no actionable findings.

### Ownership note

This PR modifies `src/agents/sandbox/context.ts` and adds `src/agents/sandbox/errors.ts`. `.github/CODEOWNERS` assigns `/src/agents/sandbox/` to `@openclaw/openclaw-secops`, so this needs code-owner review from that team before it can land. #106516 has no secops involvement yet, so flagging it here rather than leaving it to be noticed at merge time.

The fix has to live at that boundary — `isSandboxProvisioningError` belongs next to the sandbox error types it classifies, and relocating it purely to avoid the ownership path would be a worse seam. Happy to restructure or drop this if the owning team would rather approach it differently.


### Current-base merge verification

The maintainer preparation workflow refreshed the merge result against the then-current `origin/main` snapshot `e2790760102aee5d99504bce640a5b3160df5331`. `scripts/pr merge-verify 106657` passed with the required `openclaw/ci-gate` check green, and a synthetic merge completed without conflicts (tree `f22d00011209e3c641521119ddbe5e323c973377`). Per repository policy, the workflow preserved the hosted contributor ancestry rather than force-rebasing or creating a no-op synchronization commit; merge verification owns relevant mainline drift and runs again immediately before landing.
