### PR TITLE
refactor(gateway): extract chat user-turn assembly

### DIFF
--- a/src/gateway/server-methods/chat-send-user-turn.test.ts
+++ b/src/gateway/server-methods/chat-send-user-turn.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  GATEWAY_CLIENT_IDS,
+  GATEWAY_CLIENT_MODES,
+  type GatewayClientInfo,
+} from "../../../packages/gateway-protocol/src/client-info.js";
+import type { MsgContext } from "../../auto-reply/templating.js";
+import type { UserTurnInput } from "../../sessions/user-turn-transcript.js";
+import { applyChatSendManagedMediaFields, prepareChatSendUserTurn } from "./chat-send-user-turn.js";
+
+function createUserTurnInputController() {
+  const baseInput: UserTurnInput = {
+    text: "raw message",
+    timestamp: 1,
+    idempotencyKey: "run-1:user",
+  };
+  let inputPromise = Promise.resolve(baseInput);
+  return {
+    controller: {
+      baseInput,
+      setInputPromise: (input: Promise<UserTurnInput>) => {
+        inputPromise = input;
+      },
+    },
+    readInput: () => inputPromise,
+  };
+}
+
+function createClientInfo(overrides: Partial<GatewayClientInfo> = {}): GatewayClientInfo {
+  return {
+    id: GATEWAY_CLIENT_IDS.CLI,
+    version: "test",
+    platform: "test",
+    mode: GATEWAY_CLIENT_MODES.CLI,
+    ...overrides,
+  };
+}
+
+function createAttachments(
+  overrides: Partial<{
+    explicitOriginTargetsPlugin: boolean;
+    mediaPathOffloadPaths: string[];
+    mediaPathOffloadTypes: string[];
+    mediaPathOffloadWorkspaceDir: string | undefined;
+    parsedMessage: string;
+  }> = {},
+) {
+  return {
+    explicitOriginTargetsPlugin: false,
+    imageOrder: [],
+    mediaPathOffloadPaths: [],
+    mediaPathOffloadTypes: [],
+    mediaPathOffloadWorkspaceDir: undefined,
+    offloadedRefs: [],
+    parsedImages: [],
+    parsedMessage: "hello",
+    prepareAttachmentsMs: undefined,
+    ...overrides,
+  };
+}
+
+describe("prepareChatSendUserTurn", () => {
+  it("assembles command, provenance, sender, and origin facts", async () => {
+    const { controller, readInput } = createUserTurnInputController();
+    const prepared = prepareChatSendUserTurn({
+      request: {
+        clientInfo: createClientInfo({ displayName: "Gateway CLI" }),
+        normalizedAttachments: [],
+        suppressCommandInterpretation: false,
+        systemInputProvenance: { kind: "internal_system", sourceTool: "test" },
+        systemProvenanceReceipt: "[System receipt]",
+      },
+      session: {
+        agentId: "main",
+        clientRunId: "run-1",
+        sessionKey: "agent:main:main",
+      },
+      admission: {
+        originatingRoute: {
+          originatingChannel: "discord",
+          originatingTo: "channel:1",
+          accountId: "account-1",
+          messageThreadId: "thread-1",
+          explicitDeliverRoute: true,
+        },
+      },
+      attachments: createAttachments({ parsedMessage: "/status" }),
+      client: null,
+      logGateway: { warn: vi.fn() } as never,
+      userTurn: controller,
+    });
+
+    expect(prepared.ctx).toMatchObject({
+      Body: "[System receipt]\n\n/status",
+      BodyForAgent: "[System receipt]\n\n/status",
+      BodyForCommands: "/status",
+      RawBody: "/status",
+      CommandSource: "text",
+      CommandAuthorized: true,
+      CommandTurn: {
+        kind: "text-slash",
+        source: "text",
+        authorized: true,
+        body: "/status",
+      },
+      InputProvenance: { kind: "internal_system", sourceTool: "test" },
+      OriginatingChannel: "discord",
+      OriginatingTo: "channel:1",
+      AccountId: "account-1",
+      MessageThreadId: "thread-1",
+      ExplicitDeliverRoute: true,
+      SenderId: GATEWAY_CLIENT_IDS.CLI,
+      SenderName: "Gateway CLI",
+      SenderUsername: "Gateway CLI",
+    });
+    expect(prepared.accountId).toBe("account-1");
+    expect(prepared.isInternalTextSlashCommandTurn).toBe(true);
+    expect(prepared.queuedFollowupOwnerKey).toBeUndefined();
+    expect(prepared.replyOptionImages).toBeUndefined();
+    await expect(prepared.pluginBoundMediaFieldsPromise).resolves.toEqual({});
+    await expect(readInput()).resolves.toEqual(controller.baseInput);
+  });
+
+  it("carries pre-staged media and device ownership without UI sender decoration", async () => {
+    const { controller, readInput } = createUserTurnInputController();
+    const prepared = prepareChatSendUserTurn({
+      request: {
+        clientInfo: createClientInfo({
+          id: GATEWAY_CLIENT_IDS.CONTROL_UI,
+          mode: GATEWAY_CLIENT_MODES.UI,
+        }),
+        normalizedAttachments: [{}],
+        suppressCommandInterpretation: true,
+        systemInputProvenance: undefined,
+        systemProvenanceReceipt: undefined,
+      },
+      session: {
+        agentId: "main",
+        clientRunId: "run-1",
+        sessionKey: "agent:main:main",
+      },
+      admission: {
+        originatingRoute: {
+          originatingChannel: "webchat",
+          explicitDeliverRoute: false,
+        },
+      },
+      attachments: createAttachments({
+        mediaPathOffloadPaths: ["uploads/report.pdf"],
+        mediaPathOffloadTypes: ["application/pdf"],
+        mediaPathOffloadWorkspaceDir: "/workspace",
+      }),
+      client: {
+        connId: "conn-1",
+        connect: {
+          device: { id: "device-1" },
+          scopes: ["operator.admin"],
+          caps: ["tool-events"],
+        },
+      } as never,
+      logGateway: { warn: vi.fn() } as never,
+      userTurn: controller,
+    });
+
+    expect(prepared.ctx).toMatchObject({
+      CommandAuthorized: false,
+      CommandTurn: {
+        kind: "normal",
+        source: "message",
+        authorized: false,
+        body: "hello",
+      },
+      ApprovalReviewerDeviceId: "device-1",
+      MediaPath: "uploads/report.pdf",
+      MediaPaths: ["uploads/report.pdf"],
+      MediaType: "application/pdf",
+      MediaTypes: ["application/pdf"],
+      MediaWorkspaceDir: "/workspace",
+      MediaStaged: true,
+      GatewayClientScopes: ["operator.admin"],
+      GatewayClientCaps: ["tool-events"],
+    });
+    expect(prepared.ctx).not.toHaveProperty("SenderId");
+    expect(prepared.queuedFollowupOwnerKey).toBe("device:device-1");
+    await expect(readInput()).resolves.toEqual(controller.baseInput);
+  });
+});
+
+describe("applyChatSendManagedMediaFields", () => {
+  it("fills missing staged fields without replacing pre-staged paths", () => {
+    const ctx = {
+      MediaStaged: true,
+      MediaPath: "uploads/report.pdf",
+    } as MsgContext;
+
+    applyChatSendManagedMediaFields(ctx, {
+      MediaPath: "managed/image.png",
+      MediaPaths: ["managed/image.png"],
+      MediaType: "image/png",
+      MediaTypes: ["image/png"],
+    });
+
+    expect(ctx).toMatchObject({
+      MediaPath: "uploads/report.pdf",
+      MediaPaths: ["managed/image.png"],
+      MediaType: "image/png",
+      MediaTypes: ["image/png"],
+    });
+  });
+});

--- a/src/gateway/server-methods/chat-send-user-turn.ts
+++ b/src/gateway/server-methods/chat-send-user-turn.ts
@@ -1,0 +1,275 @@
+import type { GatewayClientInfo } from "../../../packages/gateway-protocol/src/client-info.js";
+import type { MsgContext } from "../../auto-reply/templating.js";
+import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
+import type { SavedMedia } from "../../media/store.js";
+import type { InputProvenance } from "../../sessions/input-provenance.js";
+import type { UserTurnInput } from "../../sessions/user-turn-transcript.js";
+import { INTERNAL_MESSAGE_CHANNEL, isOperatorUiClient } from "../../utils/message-channel.js";
+import {
+  type ChatImageContent,
+  type OffloadedRef,
+  persistInboundImagesForTranscript,
+} from "../chat-attachments.js";
+import { isAcpBridgeClient } from "./chat-origin-routing.js";
+import type { AdmittedChatSend } from "./chat-send-admission.js";
+import type { prepareChatSendAttachments } from "./chat-send-attachments.js";
+import type { NormalizedChatSendRequest } from "./chat-send-request.js";
+import type { PreparedChatSendSession } from "./chat-send-session.js";
+import { normalizeOptionalChatText } from "./chat-text-normalization.js";
+import type { GatewayRequestContext, GatewayRequestHandlerOptions } from "./types.js";
+
+type PreparedChatSendAttachments = Extract<
+  Awaited<ReturnType<typeof prepareChatSendAttachments>>,
+  { ok: true }
+>["value"];
+
+type ChatSendUserTurnInputController = {
+  baseInput: UserTurnInput;
+  setInputPromise: (input: Promise<UserTurnInput>) => void;
+};
+
+export type ChatSendManagedMediaFields = Partial<
+  Pick<MsgContext, "MediaPath" | "MediaPaths" | "MediaType" | "MediaTypes">
+>;
+
+async function persistChatSendImages(params: {
+  images: ChatImageContent[];
+  imageOrder: PromptImageOrderEntry[];
+  offloadedRefs: OffloadedRef[];
+  client: GatewayRequestHandlerOptions["client"];
+  logGateway: GatewayRequestContext["logGateway"];
+}): Promise<SavedMedia[]> {
+  if (
+    (params.images.length === 0 && params.offloadedRefs.length === 0) ||
+    isAcpBridgeClient(params.client)
+  ) {
+    return [];
+  }
+  return await persistInboundImagesForTranscript({
+    images: params.images,
+    imageOrder: params.imageOrder,
+    offloadedRefs: params.offloadedRefs,
+    log: params.logGateway,
+    logContext: "chat.send",
+  });
+}
+
+function resolveChatSendManagedMediaFields(savedImages: SavedMedia[]): ChatSendManagedMediaFields {
+  const mediaPaths = savedImages.map((entry) => entry.path);
+  if (mediaPaths.length === 0) {
+    return {};
+  }
+  const mediaTypes = savedImages.map((entry) => entry.contentType ?? "application/octet-stream");
+  return {
+    MediaPath: mediaPaths[0],
+    MediaPaths: mediaPaths,
+    MediaType: mediaTypes[0],
+    MediaTypes: mediaTypes,
+  };
+}
+
+export function applyChatSendManagedMediaFields(
+  ctx: MsgContext,
+  fields: ChatSendManagedMediaFields,
+) {
+  if (!ctx.MediaStaged) {
+    Object.assign(ctx, fields);
+    return;
+  }
+
+  if (ctx.MediaPath === undefined && fields.MediaPath !== undefined) {
+    ctx.MediaPath = fields.MediaPath;
+  }
+  if (ctx.MediaPaths === undefined && fields.MediaPaths !== undefined) {
+    ctx.MediaPaths = fields.MediaPaths;
+  }
+  if (ctx.MediaType === undefined && fields.MediaType !== undefined) {
+    ctx.MediaType = fields.MediaType;
+  }
+  if (ctx.MediaTypes === undefined && fields.MediaTypes !== undefined) {
+    ctx.MediaTypes = fields.MediaTypes;
+  }
+}
+
+function buildChatSendUserTurnMedia(savedMedia: SavedMedia[]): NonNullable<UserTurnInput["media"]> {
+  return savedMedia.map((entry) => ({
+    path: entry.path,
+    contentType: entry.contentType,
+  }));
+}
+
+function buildChatSendMessageContext(params: {
+  agentId: string;
+  client: GatewayRequestHandlerOptions["client"];
+  clientInfo?: GatewayClientInfo;
+  clientRunId: string;
+  mediaPathOffloadPaths: string[];
+  mediaPathOffloadTypes: string[];
+  mediaPathOffloadWorkspaceDir?: string;
+  originatingRoute: AdmittedChatSend["originatingRoute"];
+  parsedMessage: string;
+  sessionKey: string;
+  suppressCommandInterpretation: boolean;
+  systemInputProvenance?: InputProvenance;
+  systemProvenanceReceipt?: string;
+}) {
+  const commandBody = params.parsedMessage;
+  const commandSource =
+    !params.suppressCommandInterpretation && params.parsedMessage.trim().startsWith("/")
+      ? "text"
+      : undefined;
+  const messageForAgent = params.systemProvenanceReceipt
+    ? [params.systemProvenanceReceipt, params.parsedMessage].filter(Boolean).join("\n\n")
+    : params.parsedMessage;
+  const queuedFollowupOwnerDeviceId = normalizeOptionalChatText(params.client?.connect?.device?.id);
+  const queuedFollowupOwnerConnId = normalizeOptionalChatText(params.client?.connId);
+  const queuedFollowupOwnerKey = queuedFollowupOwnerDeviceId
+    ? `device:${queuedFollowupOwnerDeviceId}`
+    : queuedFollowupOwnerConnId
+      ? `connection:${queuedFollowupOwnerConnId}`
+      : undefined;
+  const { originatingChannel, originatingTo, accountId, messageThreadId, explicitDeliverRoute } =
+    params.originatingRoute;
+  // Current and historical turns must reach the single LLM timestamp boundary
+  // with identical bare text. Stamping this live turn would bust the prompt cache.
+  const ctx: MsgContext = {
+    Body: messageForAgent,
+    BodyForAgent: messageForAgent,
+    BodyForCommands: commandBody,
+    RawBody: params.parsedMessage,
+    CommandBody: commandBody,
+    InputProvenance: params.systemInputProvenance,
+    SessionKey: params.sessionKey,
+    AgentId: params.agentId,
+    Provider: INTERNAL_MESSAGE_CHANNEL,
+    Surface: INTERNAL_MESSAGE_CHANNEL,
+    OriginatingChannel: originatingChannel,
+    OriginatingTo: originatingTo,
+    ExplicitDeliverRoute: explicitDeliverRoute,
+    AccountId: accountId,
+    MessageThreadId: messageThreadId,
+    ChatType: "direct",
+    ...(commandSource ? { CommandSource: commandSource } : {}),
+    CommandAuthorized: !params.suppressCommandInterpretation,
+    CommandTurn: commandSource
+      ? {
+          kind: "text-slash",
+          source: commandSource,
+          authorized: true,
+          body: commandBody,
+        }
+      : {
+          kind: "normal",
+          source: "message",
+          authorized: false,
+          body: commandBody,
+        },
+    MessageSid: params.clientRunId,
+    ApprovalReviewerDeviceId: queuedFollowupOwnerDeviceId,
+    ...(!isOperatorUiClient(params.clientInfo)
+      ? {
+          SenderId: params.clientInfo?.id,
+          SenderName: params.clientInfo?.displayName,
+          SenderUsername: params.clientInfo?.displayName,
+        }
+      : {}),
+    GatewayClientScopes: params.client?.connect?.scopes ?? [],
+    GatewayClientCaps: params.client?.connect?.caps ?? [],
+  };
+  if (params.mediaPathOffloadPaths.length > 0) {
+    // Pre-staged offloads must use the channel media fields and marker so the
+    // dispatch path renders their prompt note without staging them a second time.
+    ctx.MediaPath = params.mediaPathOffloadPaths[0];
+    ctx.MediaPaths = params.mediaPathOffloadPaths;
+    ctx.MediaType = params.mediaPathOffloadTypes[0];
+    ctx.MediaTypes = params.mediaPathOffloadTypes;
+    ctx.MediaWorkspaceDir = params.mediaPathOffloadWorkspaceDir;
+    ctx.MediaStaged = true;
+  }
+  return {
+    accountId,
+    ctx,
+    isInternalTextSlashCommandTurn: commandSource === "text",
+    queuedFollowupOwnerKey,
+  };
+}
+
+/** Assemble transcript media and the portable inbound context after chat.send ACK. */
+export function prepareChatSendUserTurn(params: {
+  request: Pick<
+    NormalizedChatSendRequest,
+    | "clientInfo"
+    | "normalizedAttachments"
+    | "suppressCommandInterpretation"
+    | "systemInputProvenance"
+    | "systemProvenanceReceipt"
+  >;
+  session: Pick<PreparedChatSendSession, "agentId" | "clientRunId" | "sessionKey">;
+  admission: Pick<AdmittedChatSend, "originatingRoute">;
+  attachments: PreparedChatSendAttachments;
+  client: GatewayRequestHandlerOptions["client"];
+  logGateway: GatewayRequestContext["logGateway"];
+  userTurn: ChatSendUserTurnInputController;
+}) {
+  const { request, session, admission, attachments, client, logGateway, userTurn } = params;
+  const persistedImagesPromise = persistChatSendImages({
+    images: attachments.parsedImages,
+    imageOrder: attachments.imageOrder,
+    offloadedRefs: attachments.offloadedRefs,
+    client,
+    logGateway,
+  });
+  let persistedMediaForTranscript: SavedMedia[] | undefined;
+  const getPersistedMediaForTranscript = async () => {
+    if (!persistedMediaForTranscript) {
+      persistedMediaForTranscript = await persistedImagesPromise;
+    }
+    return persistedMediaForTranscript;
+  };
+  const preparedUserTurnMediaPromise =
+    request.normalizedAttachments.length > 0
+      ? getPersistedMediaForTranscript()
+      : Promise.resolve([]);
+  userTurn.setInputPromise(
+    preparedUserTurnMediaPromise.then(buildChatSendUserTurnMedia).then((media) => ({
+      ...userTurn.baseInput,
+      ...(media.length > 0
+        ? {
+            media,
+            mediaOnlyText: "[User sent media without caption]",
+          }
+        : {}),
+    })),
+  );
+  const pluginBoundMediaFieldsPromise =
+    attachments.explicitOriginTargetsPlugin && attachments.parsedImages.length > 0
+      ? preparedUserTurnMediaPromise.then(resolveChatSendManagedMediaFields)
+      : Promise.resolve({});
+  const messageContext = buildChatSendMessageContext({
+    agentId: session.agentId,
+    client,
+    clientInfo: request.clientInfo,
+    clientRunId: session.clientRunId,
+    mediaPathOffloadPaths: attachments.mediaPathOffloadPaths,
+    mediaPathOffloadTypes: attachments.mediaPathOffloadTypes,
+    mediaPathOffloadWorkspaceDir: attachments.mediaPathOffloadWorkspaceDir,
+    originatingRoute: admission.originatingRoute,
+    parsedMessage: attachments.parsedMessage,
+    sessionKey: session.sessionKey,
+    suppressCommandInterpretation: request.suppressCommandInterpretation,
+    systemInputProvenance: request.systemInputProvenance,
+    systemProvenanceReceipt: request.systemProvenanceReceipt,
+  });
+  const mediaPathOffloadsIncludeImages = attachments.mediaPathOffloadTypes.some((type) =>
+    type.startsWith("image/"),
+  );
+  return {
+    ...messageContext,
+    pluginBoundMediaFieldsPromise,
+    replyOptionImages: mediaPathOffloadsIncludeImages
+      ? undefined
+      : attachments.parsedImages.length > 0
+        ? attachments.parsedImages
+        : undefined,
+  };
+}

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -37,7 +37,6 @@ import {
   type ReplyPayload,
 } from "../../auto-reply/reply-payload.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
-import type { MsgContext } from "../../auto-reply/templating.js";
 import { resolveSessionWorkStartError } from "../../config/sessions.js";
 import { resolveTranscriptSessionKeyBySessionId } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -55,8 +54,6 @@ import {
   appendLocalMediaParentRoots,
   getAgentScopedMediaLocalRoots,
 } from "../../media/local-roots.js";
-import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
-import type { SavedMedia } from "../../media/store.js";
 import { createChannelMessageReplyPipeline } from "../../plugin-sdk/channel-outbound.js";
 import {
   retainGatewayRootWorkAdmissionContinuation,
@@ -64,7 +61,6 @@ import {
 } from "../../process/gateway-work-admission.js";
 import { normalizeAgentId, scopeLegacySessionKeyToAgent } from "../../routing/session-key.js";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
-import type { UserTurnInput } from "../../sessions/user-turn-transcript.js";
 import {
   parseInlineDirectives,
   stripInlineDirectiveTagsForDelivery,
@@ -78,11 +74,6 @@ import {
   resolveInFlightRunSnapshot,
   updateChatRunProvider,
 } from "../chat-abort.js";
-import {
-  type ChatImageContent,
-  type OffloadedRef,
-  persistInboundImagesForTranscript,
-} from "../chat-attachments.js";
 import {
   augmentChatHistoryWithCanvasBlocks,
   dropPreSessionStartAnnouncePairs,
@@ -157,7 +148,6 @@ import {
 } from "./chat-history-pages.js";
 import {
   hasGatewayAdminScope,
-  isAcpBridgeClient,
   resolveRequestedChatAgentId,
   validateChatSelectedAgent,
 } from "./chat-origin-routing.js";
@@ -171,6 +161,7 @@ import {
 } from "./chat-send-pre-admission.js";
 import { normalizeChatSendRequest } from "./chat-send-request.js";
 import { prepareChatSendSession } from "./chat-send-session.js";
+import { applyChatSendManagedMediaFields, prepareChatSendUserTurn } from "./chat-send-user-turn.js";
 import {
   chatSendAckServerTimingAttributes,
   emitOperatorChatSendServerTiming,
@@ -482,73 +473,6 @@ function buildTranscriptReplyText(payloads: ReplyPayload[]): string {
     })
     .filter(Boolean);
   return chunks.join("\n\n").trim();
-}
-
-async function persistChatSendImages(params: {
-  images: ChatImageContent[];
-  imageOrder: PromptImageOrderEntry[];
-  offloadedRefs: OffloadedRef[];
-  client: GatewayRequestHandlerOptions["client"];
-  logGateway: GatewayRequestContext["logGateway"];
-}): Promise<SavedMedia[]> {
-  if (
-    (params.images.length === 0 && params.offloadedRefs.length === 0) ||
-    isAcpBridgeClient(params.client)
-  ) {
-    return [];
-  }
-  return await persistInboundImagesForTranscript({
-    images: params.images,
-    imageOrder: params.imageOrder,
-    offloadedRefs: params.offloadedRefs,
-    log: params.logGateway,
-    logContext: "chat.send",
-  });
-}
-
-type ChatSendManagedMediaFields = Partial<
-  Pick<MsgContext, "MediaPath" | "MediaPaths" | "MediaType" | "MediaTypes">
->;
-
-function resolveChatSendManagedMediaFields(savedImages: SavedMedia[]): ChatSendManagedMediaFields {
-  const mediaPaths = savedImages.map((entry) => entry.path);
-  if (mediaPaths.length === 0) {
-    return {};
-  }
-  const mediaTypes = savedImages.map((entry) => entry.contentType ?? "application/octet-stream");
-  return {
-    MediaPath: mediaPaths[0],
-    MediaPaths: mediaPaths,
-    MediaType: mediaTypes[0],
-    MediaTypes: mediaTypes,
-  };
-}
-
-function applyChatSendManagedMediaFields(ctx: MsgContext, fields: ChatSendManagedMediaFields) {
-  if (!ctx.MediaStaged) {
-    Object.assign(ctx, fields);
-    return;
-  }
-
-  if (ctx.MediaPath === undefined && fields.MediaPath !== undefined) {
-    ctx.MediaPath = fields.MediaPath;
-  }
-  if (ctx.MediaPaths === undefined && fields.MediaPaths !== undefined) {
-    ctx.MediaPaths = fields.MediaPaths;
-  }
-  if (ctx.MediaType === undefined && fields.MediaType !== undefined) {
-    ctx.MediaType = fields.MediaType;
-  }
-  if (ctx.MediaTypes === undefined && fields.MediaTypes !== undefined) {
-    ctx.MediaTypes = fields.MediaTypes;
-  }
-}
-
-function buildChatSendUserTurnMedia(savedMedia: SavedMedia[]): NonNullable<UserTurnInput["media"]> {
-  return savedMedia.map((entry) => ({
-    path: entry.path,
-    contentType: entry.contentType,
-  }));
 }
 
 function resolveChatHistoryNextOffset(params: {
@@ -1119,9 +1043,6 @@ export const chatHandlers: GatewayRequestHandlers = {
       supportsTaskSuggestions,
       p,
       systemInputProvenance,
-      systemProvenanceReceipt,
-      suppressCommandInterpretation,
-      normalizedAttachments,
       rawMessage,
       reconnectResumeRequested,
     } = normalizedRequest.value;
@@ -1180,7 +1101,6 @@ export const chatHandlers: GatewayRequestHandlers = {
       finishAbortedChatSend,
       gatewayWorkAdmission,
       lifecycleGeneration,
-      originatingRoute,
       restartSafeAdmission,
       setReleaseGatewayRootContinuation,
     } = admitted.value;
@@ -1207,17 +1127,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       respondChatSessionRoutingChanged(respond);
       return;
     }
-    const {
-      explicitOriginTargetsPlugin,
-      imageOrder,
-      mediaPathOffloadPaths,
-      mediaPathOffloadTypes,
-      mediaPathOffloadWorkspaceDir,
-      offloadedRefs,
-      parsedImages,
-      parsedMessage,
-      prepareAttachmentsMs,
-    } = preparedAttachments.value;
+    const { imageOrder, prepareAttachmentsMs } = preparedAttachments.value;
 
     const admissionStartedAt = Date.now();
     const terminalizeRestartSafeAdmission = async (terminalState: {
@@ -1251,7 +1161,6 @@ export const chatHandlers: GatewayRequestHandlers = {
         warn: (message) => context.logGateway.warn(message),
       });
       const {
-        baseInput: baseUserTurnInput,
         persist: persistGatewayUserTurnTranscript,
         persistBestEffort: persistGatewayUserTurnTranscriptBestEffort,
         recorder: userTurnRecorder,
@@ -1371,134 +1280,22 @@ export const chatHandlers: GatewayRequestHandlers = {
           );
         });
       }
-      const persistedImagesPromise = persistChatSendImages({
-        images: parsedImages,
-        imageOrder,
-        offloadedRefs,
+      const {
+        accountId,
+        ctx,
+        isInternalTextSlashCommandTurn,
+        pluginBoundMediaFieldsPromise,
+        queuedFollowupOwnerKey,
+        replyOptionImages,
+      } = prepareChatSendUserTurn({
+        request: normalizedRequest.value,
+        session: preparedSession.value,
+        admission: admitted.value,
+        attachments: preparedAttachments.value,
         client,
         logGateway: context.logGateway,
+        userTurn,
       });
-      let persistedMediaForTranscript: SavedMedia[] | undefined;
-      const getPersistedMediaForTranscript = async () => {
-        if (!persistedMediaForTranscript) {
-          persistedMediaForTranscript = await persistedImagesPromise;
-        }
-        return persistedMediaForTranscript;
-      };
-      const preparedUserTurnMediaPromise =
-        normalizedAttachments.length > 0 ? getPersistedMediaForTranscript() : Promise.resolve([]);
-      const userTurnMediaPromise = preparedUserTurnMediaPromise.then(buildChatSendUserTurnMedia);
-      userTurn.setInputPromise(
-        userTurnMediaPromise.then((media) => ({
-          ...baseUserTurnInput,
-          ...(media.length > 0
-            ? {
-                media,
-                mediaOnlyText: "[User sent media without caption]",
-              }
-            : {}),
-        })),
-      );
-      const pluginBoundMediaFieldsPromise =
-        explicitOriginTargetsPlugin && parsedImages.length > 0
-          ? preparedUserTurnMediaPromise.then(resolveChatSendManagedMediaFields)
-          : Promise.resolve({});
-
-      const trimmedMessage = parsedMessage.trim();
-      const commandBody = parsedMessage;
-      const commandSource =
-        !suppressCommandInterpretation && trimmedMessage.startsWith("/") ? "text" : undefined;
-      const messageForAgent = systemProvenanceReceipt
-        ? [systemProvenanceReceipt, parsedMessage].filter(Boolean).join("\n\n")
-        : parsedMessage;
-      const queuedFollowupOwnerDeviceId = normalizeOptionalText(client?.connect?.device?.id);
-      const queuedFollowupOwnerConnId = normalizeOptionalText(client?.connId);
-      const queuedFollowupOwnerKey = queuedFollowupOwnerDeviceId
-        ? `device:${queuedFollowupOwnerDeviceId}`
-        : queuedFollowupOwnerConnId
-          ? `connection:${queuedFollowupOwnerConnId}`
-          : undefined;
-      const {
-        originatingChannel,
-        originatingTo,
-        accountId,
-        messageThreadId,
-        explicitDeliverRoute,
-      } = originatingRoute;
-      // The per-message timestamp prefix is now applied at the single LLM
-      // boundary (normalizeMessagesForLlmBoundary), derived from each message's
-      // own timestamp, so the current turn and all historical turns carry
-      // identical bytes on the wire. BodyForAgent uses the same bare text as
-      // Body; the transient gateway stamp is removed (stamping the live turn
-      // here would diverge from bare stored history and bust the prompt cache).
-      // See: https://github.com/openclaw/openclaw/issues/3658
-      const ctx: MsgContext = {
-        Body: messageForAgent,
-        BodyForAgent: messageForAgent,
-        BodyForCommands: commandBody,
-        RawBody: parsedMessage,
-        CommandBody: commandBody,
-        InputProvenance: systemInputProvenance,
-        SessionKey: sessionKey,
-        AgentId: agentId,
-        Provider: INTERNAL_MESSAGE_CHANNEL,
-        Surface: INTERNAL_MESSAGE_CHANNEL,
-        OriginatingChannel: originatingChannel,
-        OriginatingTo: originatingTo,
-        ExplicitDeliverRoute: explicitDeliverRoute,
-        AccountId: accountId,
-        MessageThreadId: messageThreadId,
-        ChatType: "direct",
-        ...(commandSource ? { CommandSource: commandSource } : {}),
-        CommandAuthorized: !suppressCommandInterpretation,
-        CommandTurn: commandSource
-          ? {
-              kind: "text-slash",
-              source: commandSource,
-              authorized: true,
-              body: commandBody,
-            }
-          : {
-              kind: "normal",
-              source: "message",
-              authorized: false,
-              body: commandBody,
-            },
-        MessageSid: clientRunId,
-        ApprovalReviewerDeviceId: queuedFollowupOwnerDeviceId,
-        ...(!isOperatorUiClient(clientInfo)
-          ? {
-              SenderId: clientInfo?.id,
-              SenderName: clientInfo?.displayName,
-              SenderUsername: clientInfo?.displayName,
-            }
-          : {}),
-        GatewayClientScopes: client?.connect?.scopes ?? [],
-        GatewayClientCaps: client?.connect?.caps ?? [],
-      };
-      const isInternalTextSlashCommandTurn =
-        ctx.Provider === INTERNAL_MESSAGE_CHANNEL && ctx.CommandSource === "text";
-      if (mediaPathOffloadPaths.length > 0) {
-        // Inject offloads via the same MsgContext fields the channel
-        // path uses so buildInboundMediaNote renders a real `[media attached:
-        // <workspace-relative-path>]` line into the agent prompt. Marker
-        // blocks the dispatch pipeline from re-running stageSandboxMedia; see
-        // prestageMediaPathOffloads.
-        ctx.MediaPath = mediaPathOffloadPaths[0];
-        ctx.MediaPaths = mediaPathOffloadPaths;
-        ctx.MediaType = mediaPathOffloadTypes[0];
-        ctx.MediaTypes = mediaPathOffloadTypes;
-        ctx.MediaWorkspaceDir = mediaPathOffloadWorkspaceDir;
-        ctx.MediaStaged = true;
-      }
-      const mediaPathOffloadsIncludeImages = mediaPathOffloadTypes.some((type) =>
-        type.startsWith("image/"),
-      );
-      const replyOptionImages = mediaPathOffloadsIncludeImages
-        ? undefined
-        : parsedImages.length > 0
-          ? parsedImages
-          : undefined;
 
       const { onModelSelected, ...replyPipeline } = createChannelMessageReplyPipeline({
         cfg,


### PR DESCRIPTION
## What Problem This Solves

`chat.send` still assembled transcript media, command metadata, ownership, origin routing, and the inbound `MsgContext` inline. That kept a separable user-turn phase inside the gateway handler and made the hot path harder to test independently.

Refs #106555.

## Why This Change Was Made

Move user-turn media persistence and context assembly into `chat-send-user-turn.ts`. The handler keeps restart-safe admission and ACK ordering, then passes the already-prepared request/session/admission/attachment facts into the focused phase.

The module also owns the managed-media merge invariant: pre-staged offload paths win, while missing channel media fields may be filled from persisted managed media.

## User Impact

No intended behavior change. `chat.ts` drops from 3,009 to 2,806 lines, while the extracted production module stays at 275 lines and gains focused unit coverage.

## Evidence

- Blacksmith Testbox `tbx_01kxe9vx3f7emzdet0wrg5vk3p`: `corepack pnpm test src/gateway/server-methods/chat-send-user-turn.test.ts` — 3/3 passed.
- Fresh structured autoreview: clean, no accepted/actionable findings, patch-correct confidence 0.98.
- `git diff --check` passed.
- Hosted CI intentionally not awaited per maintainer direction for direct landing.
