### PR TITLE
fix(gateway): reset state across in-process restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway in-process restarts:** clear stale SIGUSR1 restart state and resume prepared host suspensions before rebuilding runtime admission, preventing restart cooldowns or paused scheduling from leaking into the next lifecycle.
 - **macOS remote node readiness:** take the main-session key from the node hello snapshot instead of opening an operator connection during node admission, preventing remote tunnel recovery from leaving Computer Use and node exec stuck in lifecycle transition.
 - **Claude CLI context budgets:** honor Anthropic model and per-agent `contextTokens` limits by passing the effective limit to Claude Code's native auto-compactor and persisting the same prepared budget in OpenClaw session state. Fixes #80933. (#93198) Thanks @mushuiyu886.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.

--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -27,6 +27,7 @@ export {
   scheduleGatewaySigusr1Restart,
 } from "../../infra/restart.js";
 export { writeGatewayRestartHandoffSync } from "../../infra/restart-handoff.js";
+export { resetGatewaySuspendCoordinatorForLifecycleRestart } from "../../infra/gateway-suspend-coordinator.js";
 export { rotateAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 export { markUpdateRestartSentinelFailure } from "../../infra/restart-sentinel.js";
 export { detectRespawnSupervisor } from "../../infra/supervisor-markers.js";

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -19,6 +19,7 @@ const isGatewaySigusr1RestartExternallyAllowed = vi.fn(() => false);
 const markGatewaySigusr1RestartHandled = vi.fn();
 const peekGatewaySigusr1RestartReason = vi.fn<() => string | undefined>(() => undefined);
 const resetGatewayRestartStateForInProcessRestart = vi.fn();
+const resetGatewaySuspendCoordinatorForLifecycleRestart = vi.fn();
 const rollbackGatewayRestartSignalAdmission = vi.fn();
 const requestGatewayRestartWithSignalAdmission = vi.fn(() => ({ status: "emitted" as const }));
 const writeGatewayRestartHandoffSync = vi.fn((_opts: unknown) => ({
@@ -149,6 +150,11 @@ vi.mock("../../infra/restart.js", () => ({
   },
   scheduleGatewaySigusr1Restart: (opts?: { delayMs?: number; reason?: string }) =>
     scheduleGatewaySigusr1Restart(opts),
+}));
+
+vi.mock("../../infra/gateway-suspend-coordinator.js", () => ({
+  resetGatewaySuspendCoordinatorForLifecycleRestart: () =>
+    resetGatewaySuspendCoordinatorForLifecycleRestart(),
 }));
 
 vi.mock("../../infra/process-respawn.js", () => ({
@@ -966,6 +972,10 @@ describe("runGatewayLoop", () => {
       expect(retireActiveCronTaskRunTracking).toHaveBeenCalledTimes(1);
       expect(resetCronActiveJobs).toHaveBeenCalledTimes(1);
       expect(clearRuntimeConfigSnapshot).toHaveBeenCalledTimes(1);
+      expect(resetGatewaySuspendCoordinatorForLifecycleRestart).toHaveBeenCalledTimes(1);
+      expect(
+        resetGatewaySuspendCoordinatorForLifecycleRestart.mock.invocationCallOrder[0],
+      ).toBeLessThan(resetAllLanes.mock.invocationCallOrder[0] ?? 0);
       expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(1);
       expect(rotateAgentEventLifecycleGeneration).toHaveBeenCalledTimes(1);
       expect(reloadTaskRuntimeStateFromStore).toHaveBeenCalledTimes(1);
@@ -1005,6 +1015,7 @@ describe("runGatewayLoop", () => {
       expect(retireActiveCronTaskRunTracking).toHaveBeenCalledTimes(2);
       expect(resetCronActiveJobs).toHaveBeenCalledTimes(2);
       expect(clearRuntimeConfigSnapshot).toHaveBeenCalledTimes(2);
+      expect(resetGatewaySuspendCoordinatorForLifecycleRestart).toHaveBeenCalledTimes(2);
       expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(2);
       expect(rotateAgentEventLifecycleGeneration).toHaveBeenCalledTimes(2);
       expect(reloadTaskRuntimeStateFromStore).toHaveBeenCalledTimes(2);

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -907,6 +907,7 @@ export async function runGatewayLoop(params: {
         resetCronActiveJobs,
         resetAllLanes,
         resetGatewayRestartStateForInProcessRestart,
+        resetGatewaySuspendCoordinatorForLifecycleRestart,
         rotateAgentEventLifecycleGeneration,
         waitForActiveCronJobs,
         waitForActiveCronTaskRuns,
@@ -924,6 +925,9 @@ export async function runGatewayLoop(params: {
       }
       retireActiveCronTaskRunTracking();
       resetCronActiveJobs();
+      // Resume the retired scheduler before resetAllLanes invalidates its
+      // suspension admission callback and discards the coordinator entry.
+      resetGatewaySuspendCoordinatorForLifecycleRestart();
       resetAllLanes();
       clearRuntimeConfigSnapshot();
       resetGatewayRestartStateForInProcessRestart();

--- a/src/infra/gateway-suspend-coordinator.test.ts
+++ b/src/infra/gateway-suspend-coordinator.test.ts
@@ -20,6 +20,7 @@ import {
   GATEWAY_SUSPEND_TTL_MS,
   getGatewaySuspendStatus,
   prepareGatewaySuspend,
+  resetGatewaySuspendCoordinatorForLifecycleRestart,
   resetGatewaySuspendCoordinatorForTest,
   resumeGatewaySuspend,
 } from "./gateway-suspend-coordinator.js";
@@ -59,6 +60,30 @@ afterEach(() => {
 });
 
 describe("gateway suspend coordinator", () => {
+  it("lifecycle reset resumes a held scheduler before admission is cleared", () => {
+    const resumeScheduling = vi.fn(() => {
+      expect(isGatewayWorkAdmissionClosed()).toBe(true);
+    });
+    expect(
+      prepareGatewaySuspend({
+        requestId: "request-lifecycle-reset",
+        pauseScheduling: vi.fn(),
+        resumeScheduling,
+        inspect: inspectors(),
+      }),
+    ).toMatchObject({ status: "ready" });
+
+    markGatewayRestartDraining();
+    expect(resumeScheduling).not.toHaveBeenCalled();
+    expect(isGatewayWorkAdmissionClosed()).toBe(true);
+
+    resetGatewaySuspendCoordinatorForLifecycleRestart();
+
+    expect(resumeScheduling).toHaveBeenCalledOnce();
+    resetGatewayWorkAdmission();
+    expect(isGatewayWorkAdmissionClosed()).toBe(false);
+  });
+
   it("test reset resumes a held scheduler before admission is cleared", () => {
     const resumeScheduling = vi.fn(() => {
       expect(isGatewayWorkAdmissionClosed()).toBe(true);

--- a/src/infra/gateway-suspend-coordinator.ts
+++ b/src/infra/gateway-suspend-coordinator.ts
@@ -63,12 +63,14 @@ type GatewaySuspendCoordinatorEntry = HeldGatewaySuspension | GatewaySchedulerRe
 
 type GatewaySuspendCoordinatorState = {
   current: GatewaySuspendCoordinatorEntry | null;
+  retiredForLifecycleReset?: GatewaySuspendCoordinatorEntry | null;
 };
 
 const COORDINATOR_STATE = resolveGlobalSingleton(
   Symbol.for("openclaw.gatewaySuspendCoordinatorState"),
   (): GatewaySuspendCoordinatorState => ({
     current: null,
+    retiredForLifecycleReset: null,
   }),
 );
 
@@ -257,6 +259,9 @@ export function prepareGatewaySuspend(params: {
     }
     clearEntryTimer(activeEntry);
     COORDINATOR_STATE.current = null;
+    // Restart drain must not resume the old scheduler while shutdown is in
+    // flight. Keep its cleanup until the next in-process lifecycle begins.
+    COORDINATOR_STATE.retiredForLifecycleReset = activeEntry;
   });
   if (!admission) {
     const snapshot = createGatewayActiveWorkSnapshot(params.inspect);
@@ -400,16 +405,32 @@ export function resumeGatewaySuspend(suspensionId: string): GatewaySuspendResume
   };
 }
 
-export function resetGatewaySuspendCoordinatorForTest(): void {
+function resetGatewaySuspendCoordinator(reason: "lifecycle" | "test"): void {
   const current = COORDINATOR_STATE.current;
-  if (current) {
-    clearEntryTimer(current);
-    try {
-      current.resumeScheduling();
-    } catch (err) {
-      current.warn?.(`gateway scheduler resume failed during test reset: ${String(err)}`);
+  const retired = COORDINATOR_STATE.retiredForLifecycleReset;
+  COORDINATOR_STATE.current = null;
+  COORDINATOR_STATE.retiredForLifecycleReset = null;
+  const entries = current && current !== retired ? [current, retired] : [current ?? retired];
+  for (const entry of entries) {
+    if (!entry) {
+      continue;
     }
-    current.reopenAdmission();
-    COORDINATOR_STATE.current = null;
+    clearEntryTimer(entry);
+    try {
+      entry.resumeScheduling();
+    } catch (err) {
+      entry.warn?.(`gateway scheduler resume failed during ${reason} reset: ${String(err)}`);
+    }
+    entry.reopenAdmission();
   }
+}
+
+// An in-process restart rebuilds scheduler and admission ownership. Resume and
+// discard the old suspension first so paused work cannot leak across lifecycles.
+export function resetGatewaySuspendCoordinatorForLifecycleRestart(): void {
+  resetGatewaySuspendCoordinator("lifecycle");
+}
+
+export function resetGatewaySuspendCoordinatorForTest(): void {
+  resetGatewaySuspendCoordinator("test");
 }

--- a/src/infra/restart-suspension.test.ts
+++ b/src/infra/restart-suspension.test.ts
@@ -3,16 +3,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getActiveGatewayRootWorkCount,
   isGatewayWorkAdmissionClosed,
+  markGatewayRestartDraining,
   resetGatewayWorkAdmission,
 } from "../process/gateway-work-admission.js";
 import type { GatewayActiveWorkInspectors } from "./gateway-active-work.js";
 import {
+  getGatewaySuspendStatus,
   prepareGatewaySuspend,
+  resetGatewaySuspendCoordinatorForLifecycleRestart,
   resetGatewaySuspendCoordinatorForTest,
   resumeGatewaySuspend,
 } from "./gateway-suspend-coordinator.js";
 import {
   isGatewaySigusr1RestartExternallyAllowed,
+  resetGatewayRestartStateForInProcessRestart,
   scheduleGatewaySigusr1Restart,
   setGatewaySigusr1RestartPolicy,
   setPreRestartDeferralCheck,
@@ -136,7 +140,7 @@ describe("scheduled restart during gateway suspension", () => {
     });
   });
 
-  it("resets transient restart state without dropping live runtime bindings", async () => {
+  it("resets transient restart state and cooldown without dropping live bindings", async () => {
     const emitSpy = vi.spyOn(process, "emit");
     const preRestartCheck = vi.fn(() => 0);
     setPreRestartDeferralCheck(preRestartCheck);
@@ -148,11 +152,11 @@ describe("scheduled restart during gateway suspension", () => {
     expect(preRestartCheck).toHaveBeenCalledTimes(2);
     expect(isGatewayWorkAdmissionClosed()).toBe(true);
 
-    testing.resetSigusr1TransientState();
+    resetGatewayRestartStateForInProcessRestart();
     expect(isGatewayWorkAdmissionClosed()).toBe(false);
     expect(isGatewaySigusr1RestartExternallyAllowed()).toBe(true);
 
-    scheduleGatewaySigusr1Restart({ delayMs: 0, skipCooldown: true });
+    scheduleGatewaySigusr1Restart({ delayMs: 0 });
     await vi.advanceTimersByTimeAsync(0);
     expect(countSigusr1Emits(emitSpy.mock.calls)).toBe(2);
     expect(preRestartCheck).toHaveBeenCalledTimes(4);
@@ -162,7 +166,7 @@ describe("scheduled restart during gateway suspension", () => {
     const emitSpy = vi.spyOn(process, "emit");
     scheduleGatewaySigusr1Restart({ delayMs: 1_000, skipCooldown: true });
 
-    testing.resetSigusr1TransientState();
+    resetGatewayRestartStateForInProcessRestart();
     await vi.advanceTimersByTimeAsync(1_000);
 
     expect(countSigusr1Emits(emitSpy.mock.calls)).toBe(0);
@@ -183,9 +187,9 @@ describe("scheduled restart during gateway suspension", () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(countSigusr1Emits(emitSpy.mock.calls)).toBe(0);
 
-    resetGatewaySuspendCoordinatorForTest();
-    testing.resetSigusr1TransientState();
+    resetGatewaySuspendCoordinatorForLifecycleRestart();
     resetGatewayWorkAdmission();
+    resetGatewayRestartStateForInProcessRestart();
     await vi.advanceTimersByTimeAsync(0);
 
     expect(countSigusr1Emits(emitSpy.mock.calls)).toBe(0);
@@ -214,13 +218,36 @@ describe("scheduled restart during gateway suspension", () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(preparationStarted).toHaveBeenCalledOnce();
 
-    testing.resetSigusr1TransientState();
+    resetGatewayRestartStateForInProcessRestart();
     resetGatewayWorkAdmission();
     releasePreparation();
     await vi.advanceTimersByTimeAsync(0);
 
     expect(afterEmitRejected).toHaveBeenCalledOnce();
     expect(countSigusr1Emits(emitSpy.mock.calls)).toBe(0);
+    expect(isGatewayWorkAdmissionClosed()).toBe(false);
+  });
+
+  it("resumes and clears a prepared suspension during lifecycle reset", () => {
+    const resumeScheduling = vi.fn();
+    expect(
+      prepareGatewaySuspend({
+        requestId: "request-lifecycle-reset",
+        pauseScheduling: vi.fn(),
+        resumeScheduling,
+        inspect: inspectors(),
+        createSuspensionId: () => "suspension-lifecycle-reset",
+      }),
+    ).toMatchObject({ status: "ready" });
+
+    markGatewayRestartDraining();
+    expect(resumeScheduling).not.toHaveBeenCalled();
+    resetGatewaySuspendCoordinatorForLifecycleRestart();
+    resetGatewayWorkAdmission();
+    resetGatewayRestartStateForInProcessRestart();
+
+    expect(resumeScheduling).toHaveBeenCalledOnce();
+    expect(getGatewaySuspendStatus("suspension-lifecycle-reset")).toEqual({ status: "running" });
     expect(isGatewayWorkAdmissionClosed()).toBe(false);
   });
 });

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -139,10 +139,23 @@ function clearActiveDeferralPolls(): void {
   activeDeferralPolls.clear();
 }
 
-export function resetGatewayRestartStateForInProcessRestart(): void {
+function clearGatewayRestartTransientState(): void {
+  restartTransientGeneration += 1;
+  sigusr1AuthorizedCount = 0;
+  sigusr1AuthorizedUntil = 0;
+  restartCycleToken = 0;
+  emittedRestartToken = 0;
+  consumedRestartToken = 0;
+  emittedRestartReason = undefined;
+  emittedRestartIntent = undefined;
+  lastRestartEmittedAt = 0;
   clearActiveDeferralPolls();
   clearPendingScheduledRestart();
   clearPendingRestartSignalAdmission();
+}
+
+export function resetGatewayRestartStateForInProcessRestart(): void {
+  clearGatewayRestartTransientState();
   // Cancel any in-progress deferred channel reload so it doesn't race with
   // the restart to start the same channel (e.g. telegram double-spawn).
   void import("../gateway/server-reload-handlers.js")
@@ -1297,18 +1310,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
 }
 
 function resetSigusr1TransientStateForTest(): void {
-  restartTransientGeneration += 1;
-  sigusr1AuthorizedCount = 0;
-  sigusr1AuthorizedUntil = 0;
-  restartCycleToken = 0;
-  emittedRestartToken = 0;
-  consumedRestartToken = 0;
-  emittedRestartReason = undefined;
-  emittedRestartIntent = undefined;
-  lastRestartEmittedAt = 0;
-  clearActiveDeferralPolls();
-  clearPendingScheduledRestart();
-  clearPendingRestartSignalAdmission();
+  clearGatewayRestartTransientState();
 }
 
 export const testing = {


### PR DESCRIPTION
## What Problem This Solves

SIGUSR1 in-process Gateway restarts cleared pending timers but could retain authorization, token, intent, and cooldown state. Restart admission invalidation could also discard a prepared host-suspension coordinator entry before its paused scheduler was resumed.

## Why This Change Was Made

The runtime and test reset paths now share one transient-state reset. The suspension coordinator retains invalidated cleanup until the next lifecycle, and the run loop releases it before resetting admission state.

## User Impact

Repeated in-process restarts no longer inherit stale restart cooldown or signal state, and a host suspension cannot leave scheduling paused across the next Gateway lifecycle.

## Evidence

- Supported runtime: Node v24.16.0.
- `node scripts/run-vitest.mjs src/infra/restart-suspension.test.ts src/infra/gateway-suspend-coordinator.test.ts src/cli/gateway-cli/run-loop.test.ts src/infra/infra-runtime.test.ts src/process/gateway-work-admission.test.ts src/process/command-queue.test.ts src/gateway/server-cron-lazy.test.ts src/gateway/server-methods/suspend.test.ts --configLoader runner --experimental.fsModuleCachePath=/tmp/vitest-cache-lifecycle-prereq-rebase` — 9 files, 187 tests passed.
- Scoped `oxlint` over all changed TypeScript files — clean.
- `git diff --check` — clean.
- Dead-export baseline unchanged; no UI paths touched.
- Structured autoreview was attempted twice with `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`; both attempts failed before review because `chatgpt.com` DNS resolution was unavailable. Equivalent manual review covered the run-loop entry point, restart and suspension ownership, admission invalidation ordering, the full-process sibling path, and adjacent lifecycle tests.
- Per maintainer instruction, CI completion is not awaited for this direct landing.

Prerequisite for #106019.