### PR TITLE
refactor(cli): privatize precomputed help parser

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -979,7 +979,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/cli/ports.ts: parseLsofOutput",
   "src/cli/ports.ts: PortProcess",
   "src/cli/ports.ts: probePortFree",
-  "src/cli/precomputed-help.ts: resolvePrecomputedSubcommandHelpCommand",
   "src/cli/startup-metadata.ts: testing",
   "src/cli/tagline.ts: DEFAULT_TAGLINE",
   "src/cli/update-cli/progress.ts: inferUpdateFailureHints",

--- a/src/cli/precomputed-help.ts
+++ b/src/cli/precomputed-help.ts
@@ -42,7 +42,7 @@ function isPrecomputedSubcommandHelpName(value: string): value is PrecomputedSub
   return PRECOMPUTED_SUBCOMMAND_HELP_COMMANDS.has(value as PrecomputedSubcommandHelpName);
 }
 
-export function resolvePrecomputedSubcommandHelpCommand(
+function resolvePrecomputedSubcommandHelpCommand(
   argv: string[],
 ): PrecomputedSubcommandHelpName | null {
   const args = argv.slice(2);

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -2,7 +2,6 @@
 import { describe, expect, it } from "vitest";
 import type { PluginManifestCommandAliasRegistry } from "../plugins/manifest-command-aliases.js";
 import { resolveGatewayRunPreBootstrapOptions } from "./gateway-run-argv.js";
-import { resolvePrecomputedSubcommandHelpCommand } from "./precomputed-help.js";
 import {
   rewriteUpdateFlagArgv,
   resolveMissingPluginCommandMessage,
@@ -283,70 +282,6 @@ describe("shouldUseSetupOnboardConfigureHelpFastPath", () => {
     expect(
       shouldUseSetupOnboardConfigureHelpFastPath(["node", "openclaw", "status", "--help"]),
     ).toBe(false);
-  });
-});
-
-describe("resolvePrecomputedSubcommandHelpCommand", () => {
-  it("matches only strict allowlisted parent command help", () => {
-    expect(resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "doctor", "--help"])).toBe(
-      "doctor",
-    );
-    expect(resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "gateway", "-h"])).toBe(
-      "gateway",
-    );
-    expect(
-      resolvePrecomputedSubcommandHelpCommand([
-        "node",
-        "openclaw",
-        "--profile",
-        "work",
-        "--no-color",
-        "models",
-        "-h",
-      ]),
-    ).toBe("models");
-    expect(resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "plugins", "--help"])).toBe(
-      "plugins",
-    );
-    expect(
-      resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "sessions", "--help"]),
-    ).toBe("sessions");
-    expect(resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "tasks", "-h"])).toBe(
-      "tasks",
-    );
-    expect(
-      resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "doctor", "--version"]),
-    ).toBeNull();
-    expect(
-      resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "gateway", "-V"]),
-    ).toBeNull();
-    expect(
-      resolvePrecomputedSubcommandHelpCommand([
-        "node",
-        "openclaw",
-        "doctor",
-        "--help",
-        "--version",
-      ]),
-    ).toBeNull();
-    expect(
-      resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "doctor", "--version", "-h"]),
-    ).toBeNull();
-    expect(
-      resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "--bogus", "doctor", "--help"]),
-    ).toBeNull();
-    expect(
-      resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "doctor", "--help", "--bogus"]),
-    ).toBeNull();
-    expect(
-      resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "doctor", "--help", "extra"]),
-    ).toBeNull();
-    expect(
-      resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "gateway", "status", "--help"]),
-    ).toBeNull();
-    expect(
-      resolvePrecomputedSubcommandHelpCommand(["node", "openclaw", "status", "--help"]),
-    ).toBeNull();
   });
 });
 

--- a/src/entry.test.ts
+++ b/src/entry.test.ts
@@ -155,7 +155,7 @@ describe("entry precomputed command help fast path", () => {
     expect(outputPrecomputedNodesHelpTextCalls).toBe(1);
   });
 
-  it.each(["doctor", "sessions", "tasks"])(
+  it.each(["doctor", "gateway", "plugins", "sessions", "tasks"])(
     "renders precomputed %s help from startup metadata without importing the full program",
     async (commandName) => {
       const outputPrecomputedSubcommandHelpTextCalls: string[] = [];
@@ -196,10 +196,15 @@ describe("entry precomputed command help fast path", () => {
 
   it("keeps subcommand help fast path strict for extra or mixed flags", async () => {
     const invocations = [
+      ["node", "openclaw", "doctor", "--version"],
+      ["node", "openclaw", "gateway", "-V"],
+      ["node", "openclaw", "doctor", "--help", "--version"],
       ["node", "openclaw", "doctor", "--help", "--bogus"],
       ["node", "openclaw", "doctor", "--help", "extra"],
       ["node", "openclaw", "doctor", "--version", "-h"],
       ["node", "openclaw", "--bogus", "doctor", "--help"],
+      ["node", "openclaw", "gateway", "status", "--help"],
+      ["node", "openclaw", "status", "--help"],
     ];
     let outputPrecomputedSubcommandHelpTextCalls = 0;
 


### PR DESCRIPTION
## What Problem This Solves

The precomputed CLI help parser was exposed as a production export only so tests could import its internal decision logic directly. That duplicated the public surface and kept a dead-export baseline exemption alive.

## Why This Change Was Made

Make the parser private to its owner module and move the positive and rejection cases through the public entry fast path. This preserves the existing help-selection behavior while testing the real dispatch boundary.

## User Impact

No user-visible behavior changes. The CLI keeps the same precomputed help behavior, with a smaller public surface and 61 fewer net lines.

## Evidence

- Final branch head: `8bef0b86fc3d61a06cfb0b2e51c0a8affc5f3a8e`.
- Codebase-memory graph reindexed at the final head: 312,535 nodes and 1,252,356 edges. The parser has one definition and no cross-module usage edges; repository search finds only its definition and same-module call.
- Open-PR overlap search finds only this PR for `src/cli/precomputed-help.ts`; no other open PR mentions the parser symbol.
- Exact-head Testbox run: https://github.com/openclaw/openclaw/actions/runs/29285801060
  - `pnpm test:serial src/entry.test.ts src/cli/run-main.test.ts`: 67 tests passed.
  - `pnpm deadcode:exports`: baseline matched at 1,312 entries after removing the obsolete row.
  - touched-path `pnpm check:changed`: passed, including production/test types, lint, generated API validation, import cycles, and repository guards.
- Fresh exact-head branch autoreview with `gpt-5.6-sol` at medium reasoning: clean, confidence 0.97.
