### PR TITLE
refactor(gateway): extract chat reply dispatch

### DIFF
--- a/src/gateway/server-methods/chat-send-reply-dispatch.test.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { setReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
+import {
+  buildTranscriptReplyText,
+  createChatSendReplyDispatch,
+} from "./chat-send-reply-dispatch.js";
+
+describe("buildTranscriptReplyText", () => {
+  it("keeps reply directives and safe media while suppressing reasoning", () => {
+    expect(
+      buildTranscriptReplyText([
+        { text: "hidden", isReasoning: true },
+        {
+          text: "Hello",
+          replyToId: "message-1",
+          mediaUrls: ["https://example.test/photo.png"],
+        },
+        {
+          text: "Listen",
+          audioAsVoice: true,
+          mediaUrl: "https://example.test/clip.mp3",
+        },
+        {
+          text: "private",
+          sensitiveMedia: true,
+          mediaUrl: "https://example.test/private.png",
+        },
+      ]),
+    ).toBe(
+      [
+        "[[reply_to:message-1]]\nHello\nAttachment: https://example.test/photo.png",
+        "Listen\nAttachment: https://example.test/clip.mp3\n[[audio_as_voice]]",
+        "private",
+      ].join("\n\n"),
+    );
+  });
+});
+
+describe("createChatSendReplyDispatch", () => {
+  it("captures visible replies, promotes tool media, and marks blocked turns", async () => {
+    const markBlocked = vi.fn();
+    const dispatch = createChatSendReplyDispatch({
+      accountId: undefined,
+      isAgentRunStarted: () => false,
+      logGateway: { warn: vi.fn() } as never,
+      session: {
+        agentId: "main",
+        backingSessionId: undefined,
+        cfg: {},
+        clientRunId: "run-1",
+        sessionKey: "agent:main:main",
+        sessionLoadOptions: undefined,
+      },
+      userTurnRecorder: { markBlocked },
+    });
+    const blockedPayload = setReplyPayloadMetadata(
+      { text: "blocked" },
+      { beforeAgentRunBlocked: true },
+    );
+
+    dispatch.dispatcher.sendBlockReply(blockedPayload);
+    dispatch.dispatcher.sendToolResult({
+      text: "tool summary",
+      mediaUrl: "https://example.test/audio.mp3",
+    });
+    dispatch.dispatcher.sendFinalReply({ text: "done" });
+    await dispatch.dispatcher.waitForIdle();
+
+    expect(markBlocked).toHaveBeenCalledOnce();
+    expect(dispatch.deliveredReplies).toEqual([
+      { payload: blockedPayload, kind: "block" },
+      {
+        payload: {
+          text: undefined,
+          mediaUrl: "https://example.test/audio.mp3",
+        },
+        kind: "final",
+      },
+      { payload: { text: "done" }, kind: "final" },
+    ]);
+  });
+});

--- a/src/gateway/server-methods/chat-send-reply-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.ts
@@ -1,0 +1,228 @@
+import { isAudioFileName } from "@openclaw/media-core/mime";
+import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import { getReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
+import {
+  appendLocalMediaParentRoots,
+  getAgentScopedMediaLocalRoots,
+} from "../../media/local-roots.js";
+import { createChannelMessageReplyPipeline } from "../../plugin-sdk/channel-outbound.js";
+import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
+import {
+  parseInlineDirectives,
+  stripInlineDirectiveTagsForDelivery,
+  sanitizeReplyDirectiveId,
+} from "../../utils/directive-tags.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
+import { isSuppressedControlReplyText } from "../control-reply-text.js";
+import { attachManagedOutgoingImagesToMessage } from "../managed-image-attachments.js";
+import { loadSessionEntry } from "../session-utils.js";
+import { formatForLog } from "../ws-log.js";
+import {
+  buildAssistantDisplayContentFromReplyPayloads,
+  extractAssistantDisplayTextFromContent,
+  hasAssistantDisplayMediaContent,
+  isMediaBearingPayload,
+  replaceAssistantContentTextBlocks,
+} from "./chat-assistant-content.js";
+import { isSourceReplyTranscriptMirrorPayload } from "./chat-broadcast.js";
+import { normalizeWebchatReplyMediaPathsForDisplay } from "./chat-reply-media.js";
+import type { PreparedChatSendSession } from "./chat-send-session.js";
+import { appendAssistantTranscriptMessage } from "./chat-transcript-persistence.js";
+import {
+  buildTtsSupplementTranscriptMarker,
+  stripVisibleTextFromTtsSupplement,
+} from "./chat-tts-markers.js";
+import { buildWebchatAssistantMessageFromReplyPayloads } from "./chat-webchat-media.js";
+import type { GatewayRequestContext } from "./types.js";
+
+type DeliveredChatSendReply = {
+  payload: ReplyPayload;
+  kind: "block" | "final";
+};
+
+export function buildTranscriptReplyText(payloads: ReplyPayload[]): string {
+  const chunks = payloads
+    .map((payload) => {
+      if (payload.isReasoning === true) {
+        return "";
+      }
+      const parts = resolveSendableOutboundReplyParts(payload);
+      const lines: string[] = [];
+      const parsedText = payload.text?.includes("[[")
+        ? parseInlineDirectives(payload.text)
+        : undefined;
+      const replyToId =
+        sanitizeReplyDirectiveId(payload.replyToId) ??
+        sanitizeReplyDirectiveId(parsedText?.replyToExplicitId);
+      if (replyToId) {
+        lines.push(`[[reply_to:${replyToId}]]`);
+      } else if (payload.replyToCurrent || parsedText?.replyToCurrent) {
+        lines.push("[[reply_to_current]]");
+      }
+      const text = payload.text
+        ? stripInlineDirectiveTagsForDelivery(payload.text).text.trim()
+        : "";
+      if (text && !isSuppressedControlReplyText(text)) {
+        lines.push(text);
+      }
+      for (const mediaUrl of parts.mediaUrls) {
+        if (payload.sensitiveMedia === true) {
+          continue;
+        }
+        const trimmed = mediaUrl.trim();
+        if (trimmed) {
+          lines.push(`Attachment: ${trimmed}`);
+        }
+      }
+      if (
+        (payload.audioAsVoice || parsedText?.audioAsVoice) &&
+        parts.mediaUrls.some((mediaUrl) => isAudioFileName(mediaUrl))
+      ) {
+        lines.push("[[audio_as_voice]]");
+      }
+      return lines.join("\n").trim();
+    })
+    .filter(Boolean);
+  return chunks.join("\n\n").trim();
+}
+
+/** Build the live reply dispatcher and capture payloads for post-dispatch projection. */
+export function createChatSendReplyDispatch(params: {
+  accountId: string | undefined;
+  isAgentRunStarted: () => boolean;
+  logGateway: GatewayRequestContext["logGateway"];
+  session: Pick<
+    PreparedChatSendSession,
+    "agentId" | "backingSessionId" | "cfg" | "clientRunId" | "sessionKey" | "sessionLoadOptions"
+  >;
+  userTurnRecorder: Pick<UserTurnTranscriptRecorder, "markBlocked">;
+}) {
+  const { accountId, isAgentRunStarted, logGateway, session, userTurnRecorder } = params;
+  const { agentId, backingSessionId, cfg, clientRunId, sessionKey, sessionLoadOptions } = session;
+  const { onModelSelected, ...replyPipeline } = createChannelMessageReplyPipeline({
+    cfg,
+    agentId,
+    channel: INTERNAL_MESSAGE_CHANNEL,
+  });
+  const deliveredReplies: DeliveredChatSendReply[] = [];
+  let appendedWebchatAgentMedia = false;
+  const appendWebchatAgentMediaTranscriptIfNeeded = async (payload: ReplyPayload) => {
+    if (!isAgentRunStarted() || appendedWebchatAgentMedia || !isMediaBearingPayload(payload)) {
+      return;
+    }
+    if (isSourceReplyTranscriptMirrorPayload(payload)) {
+      return;
+    }
+    const ttsSupplementMarker = buildTtsSupplementTranscriptMarker(payload);
+    const [transcriptPayload] = await normalizeWebchatReplyMediaPathsForDisplay({
+      cfg,
+      sessionKey,
+      agentId,
+      accountId,
+      payloads: [stripVisibleTextFromTtsSupplement(payload)],
+    });
+    if (!transcriptPayload) {
+      return;
+    }
+    const { storePath: latestStorePath, entry: latestEntry } = loadSessionEntry(
+      sessionKey,
+      sessionLoadOptions,
+    );
+    const sessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
+    const mediaLocalRoots = appendLocalMediaParentRoots(
+      getAgentScopedMediaLocalRoots(cfg, agentId),
+      latestStorePath ? [latestStorePath] : undefined,
+    );
+    const assistantContent = await buildAssistantDisplayContentFromReplyPayloads({
+      sessionKey,
+      agentId,
+      payloads: [transcriptPayload],
+      managedImageLocalRoots: mediaLocalRoots,
+      includeSensitiveMedia: transcriptPayload.sensitiveMedia !== true,
+      onLocalAudioAccessDenied: (message) => {
+        logGateway.warn(`webchat audio embedding denied local path: ${message}`);
+      },
+      onManagedImagePrepareError: (message) => {
+        logGateway.warn(`webchat image embedding skipped attachment: ${message}`);
+      },
+    });
+    const mediaMessage = await buildWebchatAssistantMessageFromReplyPayloads([transcriptPayload], {
+      localRoots: mediaLocalRoots,
+      onLocalAudioAccessDenied: (err) => {
+        logGateway.warn(`webchat audio embedding denied local path: ${formatForLog(err)}`);
+      },
+    });
+    const persistedAssistantContent = replaceAssistantContentTextBlocks(
+      assistantContent,
+      mediaMessage,
+    );
+    const persistedContentForAppend = hasAssistantDisplayMediaContent(persistedAssistantContent)
+      ? persistedAssistantContent
+      : undefined;
+    if (!persistedContentForAppend?.length) {
+      return;
+    }
+    const transcriptReply =
+      mediaMessage?.transcriptText ??
+      extractAssistantDisplayTextFromContent(assistantContent) ??
+      buildTranscriptReplyText([transcriptPayload]);
+    if (!transcriptReply && !persistedAssistantContent?.length && !assistantContent?.length) {
+      return;
+    }
+    const appended = await appendAssistantTranscriptMessage({
+      sessionKey,
+      message: transcriptReply,
+      ...(persistedContentForAppend.length ? { content: persistedContentForAppend } : {}),
+      sessionId,
+      storePath: latestStorePath,
+      sessionFile: latestEntry?.sessionFile,
+      agentId,
+      createIfMissing: true,
+      idempotencyKey: `${clientRunId}:assistant-media`,
+      ttsSupplement: ttsSupplementMarker,
+      cfg,
+    });
+    if (appended.ok) {
+      if (appended.messageId && assistantContent?.length) {
+        await attachManagedOutgoingImagesToMessage({
+          messageId: appended.messageId,
+          blocks: assistantContent,
+        });
+      }
+      appendedWebchatAgentMedia = true;
+      return;
+    }
+    logGateway.warn(
+      `webchat transcript append failed for media reply: ${appended.error ?? "unknown error"}`,
+    );
+  };
+  const dispatcher = createReplyDispatcher({
+    ...replyPipeline,
+    onError: (err) => {
+      logGateway.warn(`webchat dispatch failed: ${formatForLog(err)}`);
+    },
+    deliver: async (payload, info) => {
+      if (getReplyPayloadMetadata(payload)?.beforeAgentRunBlocked === true) {
+        userTurnRecorder.markBlocked();
+      }
+      switch (info.kind) {
+        case "block":
+        case "final":
+          deliveredReplies.push({ payload, kind: info.kind });
+          await appendWebchatAgentMediaTranscriptIfNeeded(payload);
+          break;
+        case "tool":
+          // TTS tool media becomes a final payload so downstream audio extraction sees it.
+          if (isMediaBearingPayload(payload)) {
+            deliveredReplies.push({
+              payload: { ...payload, text: undefined },
+              kind: "final",
+            });
+          }
+          break;
+      }
+    },
+  });
+  return { deliveredReplies, dispatcher, onModelSelected };
+}

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -4,7 +4,6 @@ import { createHash } from "node:crypto";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
-import { isAudioFileName } from "@openclaw/media-core/mime";
 import { expectDefined } from "@openclaw/normalization-core";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import {
@@ -36,7 +35,6 @@ import {
   isReplyPayloadStatusNotice,
   type ReplyPayload,
 } from "../../auto-reply/reply-payload.js";
-import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import { resolveSessionWorkStartError } from "../../config/sessions.js";
 import { resolveTranscriptSessionKeyBySessionId } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -54,7 +52,6 @@ import {
   appendLocalMediaParentRoots,
   getAgentScopedMediaLocalRoots,
 } from "../../media/local-roots.js";
-import { createChannelMessageReplyPipeline } from "../../plugin-sdk/channel-outbound.js";
 import {
   retainGatewayRootWorkAdmissionContinuation,
   runWithGatewayIndependentRootWorkContinuation,
@@ -63,7 +60,6 @@ import { normalizeAgentId, scopeLegacySessionKeyToAgent } from "../../routing/se
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
 import {
   parseInlineDirectives,
-  stripInlineDirectiveTagsForDelivery,
   stripInlineDirectiveTagsForDisplay,
   sanitizeReplyDirectiveId,
 } from "../../utils/directive-tags.js";
@@ -85,7 +81,6 @@ import {
   registerQueuedChatTurn,
   retireQueuedChatTurnCancellation,
 } from "../chat-queued-turns.js";
-import { isSuppressedControlReplyText } from "../control-reply-text.js";
 import {
   isDashboardSessionTitleCandidate,
   maybeGenerateDashboardSessionTitle,
@@ -119,7 +114,6 @@ import {
   hasManagedOutgoingAssistantContent,
   hasSensitiveMediaPayload,
   hasVisibleAssistantFinalMessage,
-  isMediaBearingPayload,
   replaceAssistantContentTextBlocks,
   sanitizeAssistantDisplayText,
   scheduleChatHistoryManagedImageCleanup,
@@ -159,6 +153,10 @@ import {
   respondChatSessionRoutingChanged,
   runChatSendPreAdmission,
 } from "./chat-send-pre-admission.js";
+import {
+  buildTranscriptReplyText,
+  createChatSendReplyDispatch,
+} from "./chat-send-reply-dispatch.js";
 import { normalizeChatSendRequest } from "./chat-send-request.js";
 import { prepareChatSendSession } from "./chat-send-session.js";
 import { applyChatSendManagedMediaFields, prepareChatSendUserTurn } from "./chat-send-user-turn.js";
@@ -179,11 +177,7 @@ import {
   type SourceReplyContentState,
   type SourceReplyTranscriptMirrorMetadata,
 } from "./chat-transcript-persistence.js";
-import {
-  buildMediaOnlyTtsSupplementTranscriptMarker,
-  buildTtsSupplementTranscriptMarker,
-  stripVisibleTextFromTtsSupplement,
-} from "./chat-tts-markers.js";
+import { buildMediaOnlyTtsSupplementTranscriptMarker } from "./chat-tts-markers.js";
 import { createGatewayChatUserTurnController } from "./chat-user-turn-recorder.js";
 import { buildWebchatAssistantMessageFromReplyPayloads } from "./chat-webchat-media.js";
 import {
@@ -429,52 +423,6 @@ export {
 } from "./chat-history-budget.js";
 
 const CHAT_STARTUP_OPTIONAL_MODEL_CATALOG_TIMEOUT_MS = 25;
-function buildTranscriptReplyText(payloads: ReplyPayload[]): string {
-  const chunks = payloads
-    .map((payload) => {
-      if (payload.isReasoning === true) {
-        return "";
-      }
-      const parts = resolveSendableOutboundReplyParts(payload);
-      const lines: string[] = [];
-      const parsedText = payload.text?.includes("[[")
-        ? parseInlineDirectives(payload.text)
-        : undefined;
-      const replyToId =
-        sanitizeReplyDirectiveId(payload.replyToId) ??
-        sanitizeReplyDirectiveId(parsedText?.replyToExplicitId);
-      if (replyToId) {
-        lines.push(`[[reply_to:${replyToId}]]`);
-      } else if (payload.replyToCurrent || parsedText?.replyToCurrent) {
-        lines.push("[[reply_to_current]]");
-      }
-      const text = payload.text
-        ? stripInlineDirectiveTagsForDelivery(payload.text).text.trim()
-        : "";
-      if (text && !isSuppressedControlReplyText(text)) {
-        lines.push(text);
-      }
-      for (const mediaUrl of parts.mediaUrls) {
-        if (payload.sensitiveMedia === true) {
-          continue;
-        }
-        const trimmed = mediaUrl.trim();
-        if (trimmed) {
-          lines.push(`Attachment: ${trimmed}`);
-        }
-      }
-      if (
-        (payload.audioAsVoice || parsedText?.audioAsVoice) &&
-        parts.mediaUrls.some((mediaUrl) => isAudioFileName(mediaUrl))
-      ) {
-        lines.push("[[audio_as_voice]]");
-      }
-      return lines.join("\n").trim();
-    })
-    .filter(Boolean);
-  return chunks.join("\n\n").trim();
-}
-
 function resolveChatHistoryNextOffset(params: {
   messages: unknown[];
   totalMessages: number;
@@ -1297,14 +1245,14 @@ export const chatHandlers: GatewayRequestHandlers = {
         userTurn,
       });
 
-      const { onModelSelected, ...replyPipeline } = createChannelMessageReplyPipeline({
-        cfg,
-        agentId,
-        channel: INTERNAL_MESSAGE_CHANNEL,
-      });
-      const deliveredReplies: Array<{ payload: ReplyPayload; kind: "block" | "final" }> = [];
-      let appendedWebchatAgentMedia = false;
       let agentRunStarted = false;
+      const { deliveredReplies, dispatcher, onModelSelected } = createChatSendReplyDispatch({
+        accountId,
+        isAgentRunStarted: () => agentRunStarted,
+        logGateway: context.logGateway,
+        session: preparedSession.value,
+        userTurnRecorder,
+      });
       let queuedFollowupEnqueued = false;
       let pendingDispatchLifecycleError:
         | {
@@ -1315,126 +1263,6 @@ export const chatHandlers: GatewayRequestHandlers = {
           }
         | undefined;
       let persistDispatchErrorUserTurn: (() => Promise<void>) | undefined;
-      const appendWebchatAgentMediaTranscriptIfNeeded = async (payload: ReplyPayload) => {
-        if (!agentRunStarted || appendedWebchatAgentMedia || !isMediaBearingPayload(payload)) {
-          return;
-        }
-        if (isSourceReplyTranscriptMirrorPayload(payload)) {
-          return;
-        }
-        const ttsSupplementMarker = buildTtsSupplementTranscriptMarker(payload);
-        const [transcriptPayload] = await normalizeWebchatReplyMediaPathsForDisplay({
-          cfg,
-          sessionKey,
-          agentId,
-          accountId,
-          payloads: [stripVisibleTextFromTtsSupplement(payload)],
-        });
-        if (!transcriptPayload) {
-          return;
-        }
-        const { storePath: latestStorePath, entry: latestEntry } = loadSessionEntry(
-          sessionKey,
-          sessionLoadOptions,
-        );
-        const sessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
-        const mediaLocalRoots = appendLocalMediaParentRoots(
-          getAgentScopedMediaLocalRoots(cfg, agentId),
-          latestStorePath ? [latestStorePath] : undefined,
-        );
-        const assistantContent = await buildAssistantDisplayContentFromReplyPayloads({
-          sessionKey,
-          agentId,
-          payloads: [transcriptPayload],
-          managedImageLocalRoots: mediaLocalRoots,
-          includeSensitiveMedia: transcriptPayload.sensitiveMedia !== true,
-          onLocalAudioAccessDenied: (message) => {
-            context.logGateway.warn(`webchat audio embedding denied local path: ${message}`);
-          },
-          onManagedImagePrepareError: (message) => {
-            context.logGateway.warn(`webchat image embedding skipped attachment: ${message}`);
-          },
-        });
-        const mediaMessage = await buildWebchatAssistantMediaMessage([transcriptPayload], {
-          localRoots: mediaLocalRoots,
-          onLocalAudioAccessDenied: (message) => {
-            context.logGateway.warn(`webchat audio embedding denied local path: ${message}`);
-          },
-        });
-        const persistedAssistantContent = replaceAssistantContentTextBlocks(
-          assistantContent,
-          mediaMessage,
-        );
-        const persistedContentForAppend = hasAssistantDisplayMediaContent(persistedAssistantContent)
-          ? persistedAssistantContent
-          : undefined;
-        if (!persistedContentForAppend?.length) {
-          return;
-        }
-        const transcriptReply =
-          mediaMessage?.transcriptText ??
-          extractAssistantDisplayTextFromContent(assistantContent) ??
-          buildTranscriptReplyText([transcriptPayload]);
-        if (!transcriptReply && !persistedAssistantContent?.length && !assistantContent?.length) {
-          return;
-        }
-        const appended = await appendAssistantTranscriptMessage({
-          sessionKey,
-          message: transcriptReply,
-          ...(persistedContentForAppend?.length ? { content: persistedContentForAppend } : {}),
-          sessionId,
-          storePath: latestStorePath,
-          sessionFile: latestEntry?.sessionFile,
-          agentId,
-          createIfMissing: true,
-          idempotencyKey: `${clientRunId}:assistant-media`,
-          ttsSupplement: ttsSupplementMarker,
-          cfg,
-        });
-        if (appended.ok) {
-          if (appended.messageId && assistantContent?.length) {
-            await attachManagedOutgoingImagesToMessage({
-              messageId: appended.messageId,
-              blocks: assistantContent,
-            });
-          }
-          appendedWebchatAgentMedia = true;
-          return;
-        }
-        context.logGateway.warn(
-          `webchat transcript append failed for media reply: ${appended.error ?? "unknown error"}`,
-        );
-      };
-      const dispatcher = createReplyDispatcher({
-        ...replyPipeline,
-        onError: (err) => {
-          context.logGateway.warn(`webchat dispatch failed: ${formatForLog(err)}`);
-        },
-        deliver: async (payload, info) => {
-          if (getReplyPayloadMetadata(payload)?.beforeAgentRunBlocked === true) {
-            userTurnRecorder.markBlocked();
-          }
-          switch (info.kind) {
-            case "block":
-            case "final":
-              deliveredReplies.push({ payload, kind: info.kind });
-              await appendWebchatAgentMediaTranscriptIfNeeded(payload);
-              break;
-            case "tool":
-              // Tool results that carry audio (e.g. the TTS tool) must be promoted
-              // to "final" so the downstream audio extraction path can pick them up.
-              // Strip text to avoid leaking tool summary into the combined reply.
-              if (isMediaBearingPayload(payload)) {
-                deliveredReplies.push({
-                  payload: { ...payload, text: undefined },
-                  kind: "final",
-                });
-              }
-              break;
-          }
-        },
-      });
-
       const emitServerTiming = (
         phase: ChatSendServerTimingPhase,
         extra?: Record<string, string | number>,


### PR DESCRIPTION
## What Problem This Solves

`chat.ts` still owned the full live reply-dispatch pipeline: blocked-turn tracking, reply capture, tool-media promotion, and media transcript persistence. That made the gateway handler harder to change and review as one lifecycle.

Closes another phase of #106555.

## Why This Change Was Made

- Move live reply dispatch into `chat-send-reply-dispatch.ts`.
- Keep payload capture, media transcript append, and TTS/tool-media promotion together under one owner.
- Move transcript reply-text assembly beside the dispatcher that consumes it.
- Leave admission, queued-turn lifecycle, agent dispatch, and finalization orchestration in `chat.ts`.

This reduces `chat.ts` from 2,806 to 2,634 lines. The extracted production module is 228 lines.

## User Impact

No intended behavior change. Webchat replies retain reply directives, media transcript persistence, blocked-turn markers, and tool audio promotion.

## Evidence

- Testbox `tbx_01kxeahs1200h8e66jd8fm54hb`: `corepack pnpm test src/gateway/server-methods/chat-send-reply-dispatch.test.ts` — 1 file, 2 tests passed.
- Fresh autoreview: clean, no accepted/actionable findings; correctness 0.97.
- `git diff --check origin/main...HEAD` passed after rebasing onto current `origin/main`.
- Hosted CI intentionally not awaited per maintainer direction.
