### PR TITLE
refactor(gateway): privatize chat media fields type

### DIFF
--- a/src/gateway/server-methods/chat-send-user-turn.ts
+++ b/src/gateway/server-methods/chat-send-user-turn.ts
@@ -28,7 +28,7 @@ type ChatSendUserTurnInputController = {
   setInputPromise: (input: Promise<UserTurnInput>) => void;
 };
 
-export type ChatSendManagedMediaFields = Partial<
+type ChatSendManagedMediaFields = Partial<
   Pick<MsgContext, "MediaPath" | "MediaPaths" | "MediaType" | "MediaTypes">
 >;
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a dead-export ratchet regression introduced when an internal chat-send media helper type became exported without an external production consumer.

## Why This Change Was Made

Keeps `ChatSendManagedMediaFields` module-private while preserving the exported production helper and all runtime behavior. This is a narrow current-main ratchet repair requested as part of the active dead-export burn-down.

## User Impact

No user-visible behavior change. The production dead-export baseline remains shrink-only and exact.

## Evidence

- Blacksmith Testbox `tbx_01kxeb3trc3w6yq7e97re6rh88`, run `29273810805`
- `pnpm deadcode:exports:update` produced no baseline diff
- `pnpm deadcode:exports`
- `pnpm test src/gateway/server-methods/chat-send-user-turn.test.ts` (3/3)
- `pnpm tsgo:core`
- touched-file type-aware oxlint and oxfmt checks
- Fresh autoreview: clean, confidence 0.98

AI-assisted; maintainer-reviewed and understood.
