### PR TITLE
test(ui): cover workspace managed image ticket navigation

### DIFF
--- a/ui/src/e2e/chat-flow.media-files.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.media-files.e2e.test.ts
@@ -186,6 +186,82 @@ suite.define(() => {
     }
   });
 
+  it("opens a workspace managed image through an artifact-scoped ticket", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const attachmentId = crypto.randomUUID();
+    const artifactId = `artifact_managed_image_${attachmentId}`;
+    const imageUrl = `/api/chat/media/outgoing/agent%3Amain%3Amain/${attachmentId}/full`;
+    const ticketedUrl = `${imageUrl}?mediaTicket=ticket-workspace-e2e`;
+    const mediaRequests: Array<{ authorization?: string; url: URL }> = [];
+    await context.route("**/api/chat/media/outgoing/**", async (route) => {
+      mediaRequests.push({
+        authorization: route.request().headers().authorization,
+        url: new URL(route.request().url()),
+      });
+      await route.fulfill({
+        contentType: "image/png",
+        body: Buffer.from(
+          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Zl1sAAAAASUVORK5CYII=",
+          "base64",
+        ),
+      });
+    });
+    const artifact = {
+      download: { mode: "url" },
+      id: artifactId,
+      mimeType: "image/png",
+      sizeBytes: 68,
+      title: "Ticketed workspace image",
+      type: "image",
+    };
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "artifacts.list": { artifacts: [artifact] },
+        "artifacts.download": {
+          artifact,
+          url: ticketedUrl,
+          expiresAt: new Date(Date.now() + 5 * 60_000).toISOString(),
+        },
+        "sessions.files.list": {
+          browser: { entries: [], path: "" },
+          files: [],
+          root: "/workspace",
+          sessionKey: "main",
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.locator(".chat-workspace-toggle").click();
+      await page.locator(".chat-workspace-rail__file-name", { hasText: artifact.title }).click();
+
+      const openArtifact = page.getByRole("link", { name: "Open artifact" });
+      await openArtifact.waitFor({ state: "visible", timeout: 10_000 });
+      const [popup] = await Promise.all([page.waitForEvent("popup"), openArtifact.click()]);
+      await popup.waitForLoadState("load");
+
+      expect(new URL(popup.url()).searchParams.get("mediaTicket")).toBe("ticket-workspace-e2e");
+      expect(mediaRequests).toHaveLength(1);
+      expect(mediaRequests[0]?.url.pathname).toBe(imageUrl);
+      expect(mediaRequests[0]?.url.searchParams.get("mediaTicket")).toBe("ticket-workspace-e2e");
+      expect(mediaRequests[0]?.authorization).toBeUndefined();
+      const request = await gateway.waitForRequest("artifacts.download");
+      expect(request.params).toMatchObject({
+        sessionKey: "main",
+        artifactId,
+      });
+      await popup.close();
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("renders a canonical inbound image through the ticketed media route", async () => {
     const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
     const context = await suite.newBrowserContext({


### PR DESCRIPTION
Closes #106700

## What Problem This Solves

Current main resolves managed generated-image artifacts through artifacts.download, which returns a short-lived, exact-resource media ticket. That fix removed the need to forward a reusable Gateway bearer credential, but the session workspace click-through path did not have a focused browser regression.

This PR now contains only that missing regression. It verifies that selecting a managed image in the session workspace requests artifacts.download, renders the returned Open artifact link, and opens the ticketed media URL successfully in a new tab.

## Why This Change Was Made

The previous configurable bearer-forwarding implementation was superseded by the artifact-ticket design landed in #115042. The branch was rebuilt on current canonical main; all production, configuration, documentation, protocol, and bearer-forwarding changes were removed.

The regression asserts that:

- the workspace sends the pane session key and managed artifact id through the authenticated artifacts.download RPC;
- the returned URL contains the expected mediaTicket;
- browser navigation reaches the managed-media route exactly once;
- the media request does not include an Authorization header.

## User Impact

No runtime or configuration behavior changes. This protects the existing workspace generated-image flow from regressing back to unauthorized protected links or reusable credential forwarding.

## Evidence

- Exact head: 9c9df5d4070d86066f7a9512f12f55c333a9b469
- Canonical base: upstream/main 7a1aa4eb4f4
- Diff: one test file, +76/-0
- Focused Control UI browser proof:

      node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.media-files.e2e.test.ts

  Result: 1 file passed, 10 tests passed.

- Static proof: formatting, conflict-marker guard, dependency-pin guard, UI i18n verification, dead-export scans, targeted Oxlint, core-test typecheck, and git diff --check passed.
