### PR TITLE
fix(gateway): preserve chat media dispatch state

### DIFF
--- a/src/gateway/server-methods/chat-send-reply-dispatch.test.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.test.ts
@@ -53,6 +53,7 @@ describe("createChatSendReplyDispatch", () => {
       },
       userTurnRecorder: { markBlocked },
     });
+    expect(dispatch.hasAppendedWebchatAgentMedia()).toBe(false);
     const blockedPayload = setReplyPayloadMetadata(
       { text: "blocked" },
       { beforeAgentRunBlocked: true },

--- a/src/gateway/server-methods/chat-send-reply-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.ts
@@ -224,5 +224,10 @@ export function createChatSendReplyDispatch(params: {
       }
     },
   });
-  return { deliveredReplies, dispatcher, onModelSelected };
+  return {
+    deliveredReplies,
+    dispatcher,
+    hasAppendedWebchatAgentMedia: () => appendedWebchatAgentMedia,
+    onModelSelected,
+  };
 }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -63,7 +63,7 @@ import {
   stripInlineDirectiveTagsForDisplay,
   sanitizeReplyDirectiveId,
 } from "../../utils/directive-tags.js";
-import { INTERNAL_MESSAGE_CHANNEL, isOperatorUiClient } from "../../utils/message-channel.js";
+import { isOperatorUiClient } from "../../utils/message-channel.js";
 import { listGatewayAgentsBasic } from "../agent-list.js";
 import {
   boundInFlightRunSnapshotForChatHistory,
@@ -1246,13 +1246,14 @@ export const chatHandlers: GatewayRequestHandlers = {
       });
 
       let agentRunStarted = false;
-      const { deliveredReplies, dispatcher, onModelSelected } = createChatSendReplyDispatch({
-        accountId,
-        isAgentRunStarted: () => agentRunStarted,
-        logGateway: context.logGateway,
-        session: preparedSession.value,
-        userTurnRecorder,
-      });
+      const { deliveredReplies, dispatcher, hasAppendedWebchatAgentMedia, onModelSelected } =
+        createChatSendReplyDispatch({
+          accountId,
+          isAgentRunStarted: () => agentRunStarted,
+          logGateway: context.logGateway,
+          session: preparedSession.value,
+          userTurnRecorder,
+        });
       let queuedFollowupEnqueued = false;
       let pendingDispatchLifecycleError:
         | {
@@ -1789,7 +1790,7 @@ export const chatHandlers: GatewayRequestHandlers = {
                     : finalPayloadEntries;
                   // Non-agent command paths can enqueue only block replies. If no visible final
                   // supersedes them, fold those blocks into the final WebChat message.
-                  const rawFinalPayloads = appendedWebchatAgentMedia
+                  const rawFinalPayloads = hasAppendedWebchatAgentMedia()
                     ? []
                     : [
                         ...commandBlockPayloadEntriesForDelivery,


### PR DESCRIPTION
## What Problem This Solves

#106697 moved the webchat media-append state into `chat-send-reply-dispatch.ts`, but post-dispatch finalization still referenced the deleted handler-local variable. Current `main` therefore failed core TypeScript compilation with the stale state reference and also retained an unused import from the extraction.

## Why This Change Was Made

- Expose the dispatcher's live media-append state through a closure-backed getter.
- Query that owner state during non-agent reply finalization.
- Remove the stale `INTERNAL_MESSAGE_CHANNEL` import.
- Add focused coverage for the exposed initial state.

## User Impact

Restores compiler-clean gateway code and preserves suppression of duplicate final payloads after dispatcher-owned media transcript persistence.

## Evidence

- Testbox `tbx_01kxeb7fqwcerksnjmabt7e84z`: focused reply-dispatch test passed, 1 file and 2 tests.
- Same Testbox: `corepack pnpm tsgo:core` passed after reproducing and fixing the stale import/state compile failures.
- Fresh autoreview clean, no accepted/actionable findings; correctness 0.93.
- `git diff --check origin/main...HEAD` passed after rebasing onto current `origin/main`.
- Hosted CI intentionally not awaited per maintainer direction.
