### PR TITLE
refactor(bonjour): use ciao runtime contract

### DIFF
--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -6,7 +6,7 @@ import type { ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
-import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import type { CiaoService } from "@homebridge/ciao";
 import type { PluginLogger } from "openclaw/plugin-sdk/plugin-entry";
 import { isTruthyEnvValue } from "openclaw/plugin-sdk/runtime-env";
 import { classifyCiaoProcessError, type CiaoProcessErrorClassification } from "./ciao.js";
@@ -36,38 +36,7 @@ type GatewayBonjourAdvertiseOpts = {
   minimal?: boolean;
 };
 
-type BonjourService = {
-  serviceState?: unknown;
-  advertise: () => Promise<void>;
-  destroy: () => Promise<void>;
-  getFQDN: () => string;
-  getHostname: () => string;
-  getPort: () => number;
-  on: (event: "name-change" | "hostname-change", listener: (value: unknown) => void) => unknown;
-};
-
-type BonjourResponder = {
-  createService: (options: {
-    name: string;
-    type: string;
-    protocol: unknown;
-    port: number;
-    domain: string;
-    hostname: string;
-    txt: Record<string, string>;
-  }) => BonjourService;
-  shutdown: () => Promise<void>;
-};
-
-type CiaoModule = {
-  getResponder: () => BonjourResponder;
-  Protocol: { TCP: unknown };
-};
-
-type BonjourCycle = {
-  responder: BonjourResponder;
-  services: Array<{ label: string; svc: BonjourService }>;
-};
+type BonjourCycle = Array<{ label: string; svc: CiaoService }>;
 
 type ServiceStateTracker = {
   state: string;
@@ -102,7 +71,6 @@ const MAX_CONSECUTIVE_STUCK_STATE_RESTARTS = 1;
 // failures, which resets the consecutive counter. Bound total restarts too.
 const RESTART_WINDOW_MS = 30 * 60_000;
 const MAX_RESTARTS_IN_WINDOW = 5;
-const BONJOUR_ANNOUNCED_STATE = "announced";
 const CIAO_SELF_PROBE_RETRY_FRAGMENT =
   "failed probing with reason: Error: Can't probe for a service which is announced already.";
 
@@ -112,12 +80,9 @@ const defaultLogger = {
   debug: (_msg: string) => {},
 };
 
-const CIAO_MODULE_ID = "@homebridge/ciao";
 const CIAO_WINDOWS_SHELL_COMMANDS = new Set(['arp -a | findstr /C:"---"']);
 let ciaoExecHidePatchDepth = 0;
 let restoreCiaoExecHidePatchOnce: (() => void) | null = null;
-
-const loadCiaoModule = createLazyRuntimeModule(() => import(CIAO_MODULE_ID) as Promise<CiaoModule>);
 
 function readBonjourDisableOverride(): boolean | null {
   const raw = process.env.OPENCLAW_DISABLE_BONJOUR;
@@ -232,35 +197,8 @@ function prettifyInstanceName(name: string) {
   return normalized.replace(/\s+\(OpenClaw\)\s*$/i, "").trim() || normalized;
 }
 
-function serviceSummary(label: string, svc: BonjourService): string {
-  let fqdn = "unknown";
-  let hostname = "unknown";
-  let port = -1;
-  try {
-    fqdn = svc.getFQDN();
-  } catch {
-    // ignore
-  }
-  try {
-    hostname = svc.getHostname();
-  } catch {
-    // ignore
-  }
-  try {
-    port = svc.getPort();
-  } catch {
-    // ignore
-  }
-  const state = typeof svc.serviceState === "string" ? svc.serviceState : "unknown";
-  return `${label} fqdn=${fqdn} host=${hostname} port=${port} state=${state}`;
-}
-
-function isAnnouncedState(state: string) {
-  return state === BONJOUR_ANNOUNCED_STATE;
-}
-
-function isAdvertisingInProgressState(state: string) {
-  return state === "probing" || state === "announcing";
+function serviceSummary(label: string, svc: CiaoService): string {
+  return `${label} fqdn=${svc.getFQDN()} host=${svc.getHostname()} port=${svc.getPort()} state=${svc.serviceState}`;
 }
 
 function shouldSuppressCiaoConsoleLog(args: unknown[]): boolean {
@@ -395,7 +333,7 @@ export async function startGatewayBonjourAdvertiser(
   }
 
   try {
-    const { getResponder, Protocol } = await loadCiaoModule();
+    const { getResponder } = await import("@homebridge/ciao");
     restoreConsoleLog = installCiaoConsoleNoiseFilter();
     const handleCiaoProcessError = (reason: unknown): boolean => {
       const classification = classifyCiaoProcessError(reason);
@@ -478,12 +416,11 @@ export async function startGatewayBonjourAdvertiser(
     const responder = getResponder();
 
     function createCycle(): BonjourCycle {
-      const services: Array<{ label: string; svc: BonjourService }> = [];
+      const services: BonjourCycle = [];
 
       const gateway = responder.createService({
         name: safeServiceName(instanceName),
         type: "openclaw-gw",
-        protocol: Protocol.TCP,
         port: opts.gatewayPort,
         domain: "local",
         hostname,
@@ -491,10 +428,10 @@ export async function startGatewayBonjourAdvertiser(
       });
       services.push({
         label: "gateway",
-        svc: gateway as unknown as BonjourService,
+        svc: gateway,
       });
 
-      return { responder, services };
+      return services;
     }
 
     async function stopCycle(
@@ -504,7 +441,7 @@ export async function startGatewayBonjourAdvertiser(
       if (!cycle) {
         return;
       }
-      for (const { svc } of cycle.services) {
+      for (const { svc } of cycle) {
         try {
           await svc.destroy();
         } catch {
@@ -513,28 +450,26 @@ export async function startGatewayBonjourAdvertiser(
       }
       try {
         if (optsValue?.shutdownResponder) {
-          await cycle.responder.shutdown();
+          await responder.shutdown();
         }
       } catch {
         /* ignore */
       }
     }
 
-    function attachConflictListeners(services: Array<{ label: string; svc: BonjourService }>) {
+    function attachConflictListeners(services: BonjourCycle) {
       for (const { label, svc } of services) {
         try {
-          svc.on("name-change", (name: unknown) => {
+          svc.on("name-change", (name) => {
             markConflictObserved(label, svc);
-            const next = typeof name === "string" ? name : String(name);
             logger.warn(
-              `bonjour: ${label} name conflict resolved; newName=${JSON.stringify(next)}`,
+              `bonjour: ${label} name conflict resolved; newName=${JSON.stringify(name)}`,
             );
           });
-          svc.on("hostname-change", (nextHostname: unknown) => {
+          svc.on("hostname-change", (hostname) => {
             markConflictObserved(label, svc);
-            const next = typeof nextHostname === "string" ? nextHostname : String(nextHostname);
             logger.warn(
-              `bonjour: ${label} hostname conflict resolved; newHostname=${JSON.stringify(next)}`,
+              `bonjour: ${label} hostname conflict resolved; newHostname=${JSON.stringify(hostname)}`,
             );
           });
         } catch (err) {
@@ -545,7 +480,7 @@ export async function startGatewayBonjourAdvertiser(
 
     function handleAdvertiseFailure(
       label: string,
-      svc: BonjourService,
+      svc: CiaoService,
       err: unknown,
       action: "failed" | "threw",
     ) {
@@ -565,7 +500,7 @@ export async function startGatewayBonjourAdvertiser(
       );
     }
 
-    function startAdvertising(services: Array<{ label: string; svc: BonjourService }>) {
+    function startAdvertising(services: BonjourCycle) {
       for (const { label, svc } of services) {
         try {
           void svc
@@ -598,20 +533,19 @@ export async function startGatewayBonjourAdvertiser(
     const stateTracker = new Map<string, ServiceStateTracker>();
     const conflictTracker = new Map<string, number>();
 
-    const markConflictObserved = (label: string, svc: BonjourService) => {
+    const markConflictObserved = (label: string, svc: CiaoService) => {
       const now = Date.now();
       conflictTracker.set(label, now);
-      const nextState = typeof svc.serviceState === "string" ? svc.serviceState : "unknown";
-      stateTracker.set(label, { state: nextState, sinceMs: now });
+      stateTracker.set(label, { state: svc.serviceState, sinceMs: now });
     };
 
-    const updateStateTrackers = (services: Array<{ label: string; svc: BonjourService }>) => {
+    const updateStateTrackers = (services: BonjourCycle) => {
       const now = Date.now();
       for (const { label, svc } of services) {
-        const nextState = typeof svc.serviceState === "string" ? svc.serviceState : "unknown";
+        const nextState = svc.serviceState;
         const current = stateTracker.get(label);
         const nextEnteredAt =
-          current && !isAnnouncedState(current.state) && !isAnnouncedState(nextState)
+          current && current.state !== "announced" && nextState !== "announced"
             ? current.sinceMs
             : now;
         if (!current || current.state !== nextState || current.sinceMs !== nextEnteredAt) {
@@ -671,8 +605,8 @@ export async function startGatewayBonjourAdvertiser(
         cycle = createCycle();
         stateTracker.clear();
         conflictTracker.clear();
-        attachConflictListeners(cycle.services);
-        startAdvertising(cycle.services);
+        attachConflictListeners(cycle);
+        startAdvertising(cycle);
       })().finally(() => {
         recreatePromise = null;
       });
@@ -681,8 +615,8 @@ export async function startGatewayBonjourAdvertiser(
     requestCiaoRecovery = (classification) => {
       void recreateAdvertiser(`ciao ${classification.kind}: ${classification.formatted}`);
     };
-    attachConflictListeners(cycle.services);
-    startAdvertising(cycle.services);
+    attachConflictListeners(cycle);
+    startAdvertising(cycle);
 
     const lastRepairAttempt = new Map<string, number>();
     const watchdog = setInterval(() => {
@@ -692,14 +626,11 @@ export async function startGatewayBonjourAdvertiser(
       if (disabled || !cycle) {
         return;
       }
-      updateStateTrackers(cycle.services);
-      for (const { label, svc } of cycle.services) {
+      updateStateTrackers(cycle);
+      for (const { label, svc } of cycle) {
         const now = Date.now();
-        const stateUnknown = (svc as { serviceState?: unknown }).serviceState;
-        if (typeof stateUnknown !== "string") {
-          continue;
-        }
-        if (stateUnknown === "announced") {
+        const state = svc.serviceState;
+        if (state === "announced") {
           consecutiveRestarts = 0;
           consecutiveStuckStateRestarts = 0;
           conflictTracker.delete(label);
@@ -712,13 +643,9 @@ export async function startGatewayBonjourAdvertiser(
           continue;
         }
         const tracked = stateTracker.get(label);
-        if (
-          stateUnknown !== "announced" &&
-          tracked &&
-          now - tracked.sinceMs >= STUCK_ANNOUNCING_MS
-        ) {
+        if (state !== "announced" && tracked && now - tracked.sinceMs >= STUCK_ANNOUNCING_MS) {
           void recreateAdvertiser(
-            `service stuck in ${stateUnknown} for ${now - tracked.sinceMs}ms (${serviceSummary(
+            `service stuck in ${state} for ${now - tracked.sinceMs}ms (${serviceSummary(
               label,
               svc,
             )})`,
@@ -726,7 +653,7 @@ export async function startGatewayBonjourAdvertiser(
           );
           return;
         }
-        if (stateUnknown === "announced" || isAdvertisingInProgressState(stateUnknown)) {
+        if (state === "announced" || state === "probing" || state === "announcing") {
           continue;
         }
 


### PR DESCRIPTION
Closes #106699

## What Problem This Solves

The bundled Bonjour advertiser duplicated the pinned ciao service and responder contract in local structural types, then cast the real dependency into that facade. A second lazy-module cache also sat behind the plugin entry's existing lazy runtime boundary.

## Why This Change Was Made

Use the published `CiaoService` type and a native dynamic import, rely on ciao's documented TCP default and typed lifecycle state/events, and delete the redundant mirrors, casts, guards, and cache. The plugin entry remains the outer lazy boundary; recovery, watchdog, Windows, and shutdown behavior stay unchanged.

## User Impact

No user-visible or configuration change. The Bonjour adapter is 73 lines smaller, and future ciao upgrades are checked against the dependency's real TypeScript contract.

## Evidence

- Blacksmith Testbox `tbx_01kxebyzsbs29qmyf4y0753z2y` (`golden-barnacle-dcc8`)
- `pnpm test:extension bonjour`: 50 tests passed
- `pnpm test test/scripts/root-dependency-ownership-audit.test.ts`: 13 tests passed
- `pnpm tsgo:extensions`: passed
- `pnpm check:import-cycles`: 0 runtime value cycles
- `pnpm build`: bundling, runtime postbuild, plugin SDK declarations, and sidecar checks passed; current `main` then failed its unrelated Control UI request budget (25 > 24) after #106490. The same patch's full build passed before that base change.
- Fresh autoreview of signed head: no accepted/actionable findings
- Direct Node runtime probe confirmed named CJS exports and native import caching for `@homebridge/ciao@1.3.9`

AI-assisted: yes. Maintainer-directed dependency/LOC audit; dependency source, types, runtime exports, callers, and tests inspected directly.
