### PR TITLE
refactor(gateway): extract command reply folding

### DIFF
--- a/src/gateway/server-methods/chat-send-command-replies.test.ts
+++ b/src/gateway/server-methods/chat-send-command-replies.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { selectChatSendFinalReplyPayloads } from "./chat-send-command-replies.js";
+
+describe("selectChatSendFinalReplyPayloads", () => {
+  it("keeps final replies and suppresses already-persisted media replies", () => {
+    const deliveredReplies = [
+      { kind: "block" as const, payload: { text: "progress" } },
+      { kind: "final" as const, payload: { text: "done" } },
+    ];
+
+    expect(
+      selectChatSendFinalReplyPayloads({
+        deliveredReplies,
+        foldCommandBlocks: false,
+        suppressReplies: false,
+      }),
+    ).toEqual([{ text: "done" }]);
+    expect(
+      selectChatSendFinalReplyPayloads({
+        deliveredReplies,
+        foldCommandBlocks: true,
+        suppressReplies: true,
+      }),
+    ).toEqual([]);
+  });
+
+  it("folds duplicate command media and semantics into the block reply", () => {
+    expect(
+      selectChatSendFinalReplyPayloads({
+        deliveredReplies: [
+          {
+            kind: "block",
+            payload: {
+              text: "done",
+              mediaUrl: "file:///tmp/result.png",
+              trustedLocalMedia: true,
+            },
+          },
+          {
+            kind: "final",
+            payload: {
+              text: "done",
+              mediaUrls: ["/tmp/result.png"],
+              sensitiveMedia: true,
+              replyToId: "message-1",
+            },
+          },
+        ],
+        foldCommandBlocks: true,
+        suppressReplies: false,
+      }),
+    ).toEqual([
+      {
+        text: "done",
+        mediaUrl: undefined,
+        mediaUrls: ["file:///tmp/result.png"],
+        trustedLocalMedia: true,
+        sensitiveMedia: true,
+        replyToId: "message-1",
+      },
+    ]);
+  });
+
+  it("keeps unmatched final text while deduplicating its media", () => {
+    expect(
+      selectChatSendFinalReplyPayloads({
+        deliveredReplies: [
+          {
+            kind: "block",
+            payload: { text: "progress", mediaUrl: "/tmp/result.png" },
+          },
+          {
+            kind: "final",
+            payload: {
+              text: "done",
+              mediaUrl: "file:///tmp/result.png",
+              audioAsVoice: true,
+            },
+          },
+        ],
+        foldCommandBlocks: true,
+        suppressReplies: false,
+      }),
+    ).toEqual([
+      {
+        text: "progress",
+        mediaUrl: undefined,
+        mediaUrls: ["/tmp/result.png"],
+        audioAsVoice: true,
+      },
+      {
+        text: "done",
+        mediaUrl: undefined,
+        mediaUrls: undefined,
+        audioAsVoice: true,
+      },
+    ]);
+  });
+});

--- a/src/gateway/server-methods/chat-send-command-replies.ts
+++ b/src/gateway/server-methods/chat-send-command-replies.ts
@@ -1,0 +1,253 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { parseInlineDirectives, sanitizeReplyDirectiveId } from "../../utils/directive-tags.js";
+import { sanitizeAssistantDisplayText } from "./chat-assistant-content.js";
+
+type DeliveredReply = {
+  payload: ReplyPayload;
+  kind: "block" | "final";
+};
+
+function parseReplyInlineDirectives(payload: ReplyPayload) {
+  return typeof payload.text === "string" && payload.text.includes("[[")
+    ? parseInlineDirectives(payload.text)
+    : undefined;
+}
+
+function replyMediaUrls(payload: ReplyPayload): string[] {
+  return resolveSendableOutboundReplyParts(payload).mediaUrls;
+}
+
+function normalizeCommandMediaDedupeKey(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (!trimmed.toLowerCase().startsWith("file://")) {
+    return path.isAbsolute(trimmed) ? path.normalize(trimmed) : trimmed;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol === "file:") {
+      return path.normalize(fileURLToPath(parsed));
+    }
+  } catch {
+    // Keep malformed file URL-like values comparable with the fallback below.
+  }
+  return trimmed.replace(/^file:\/\//iu, "");
+}
+
+function replyMediaDedupeKeys(payload: ReplyPayload): string[] {
+  return replyMediaUrls(payload).map((mediaUrl) => normalizeCommandMediaDedupeKey(mediaUrl));
+}
+
+function canonicalizeReplyMedia(payload: ReplyPayload): ReplyPayload {
+  const mediaUrls = replyMediaUrls(payload);
+  return {
+    ...payload,
+    mediaUrl: undefined,
+    mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
+  };
+}
+
+function mergeDefinedReplySemantics(target: ReplyPayload, source: ReplyPayload): ReplyPayload {
+  const sourceInlineDirectives = parseReplyInlineDirectives(source);
+  const sourceReplyToId =
+    sanitizeReplyDirectiveId(source.replyToId) ??
+    sanitizeReplyDirectiveId(sourceInlineDirectives?.replyToExplicitId);
+  return {
+    ...target,
+    ...(source.trustedLocalMedia === true || target.trustedLocalMedia === true
+      ? { trustedLocalMedia: true }
+      : {}),
+    ...(source.sensitiveMedia === true || target.sensitiveMedia === true
+      ? { sensitiveMedia: true }
+      : {}),
+    ...(source.presentation !== undefined ? { presentation: source.presentation } : {}),
+    ...(source.delivery !== undefined ? { delivery: source.delivery } : {}),
+    ...(source.interactive !== undefined ? { interactive: source.interactive } : {}),
+    ...(sourceReplyToId !== undefined ? { replyToId: sourceReplyToId } : {}),
+    ...(source.replyToTag === true || target.replyToTag === true ? { replyToTag: true } : {}),
+    ...(source.replyToCurrent === true ||
+    sourceInlineDirectives?.replyToCurrent === true ||
+    target.replyToCurrent === true
+      ? { replyToCurrent: true }
+      : {}),
+    ...(source.audioAsVoice === true ||
+    sourceInlineDirectives?.audioAsVoice === true ||
+    target.audioAsVoice === true
+      ? { audioAsVoice: true }
+      : {}),
+    ...(source.spokenText !== undefined ? { spokenText: source.spokenText } : {}),
+    ...(source.ttsSupplement !== undefined ? { ttsSupplement: source.ttsSupplement } : {}),
+    ...(source.isError === true || target.isError === true ? { isError: true } : {}),
+    ...(source.channelData !== undefined ? { channelData: source.channelData } : {}),
+  };
+}
+
+function mergeMediaReplySemantics(target: ReplyPayload, source: ReplyPayload): ReplyPayload {
+  const sourceInlineDirectives = parseReplyInlineDirectives(source);
+  return {
+    ...target,
+    ...(source.trustedLocalMedia === true || target.trustedLocalMedia === true
+      ? { trustedLocalMedia: true }
+      : {}),
+    ...(source.sensitiveMedia === true || target.sensitiveMedia === true
+      ? { sensitiveMedia: true }
+      : {}),
+    ...(source.audioAsVoice === true ||
+    sourceInlineDirectives?.audioAsVoice === true ||
+    target.audioAsVoice === true
+      ? { audioAsVoice: true }
+      : {}),
+  };
+}
+
+function hasMergeableReplySemantics(payload: ReplyPayload): boolean {
+  const inlineDirectives = parseReplyInlineDirectives(payload);
+  return Boolean(
+    payload.trustedLocalMedia !== undefined ||
+    payload.sensitiveMedia !== undefined ||
+    payload.presentation ||
+    payload.delivery ||
+    payload.interactive ||
+    payload.replyToId ||
+    payload.replyToTag !== undefined ||
+    payload.replyToCurrent !== undefined ||
+    payload.audioAsVoice !== undefined ||
+    inlineDirectives?.hasReplyTag ||
+    inlineDirectives?.hasAudioTag ||
+    payload.spokenText ||
+    payload.ttsSupplement ||
+    payload.isError !== undefined ||
+    payload.channelData,
+  );
+}
+
+function hasUnmergedReplySemantics(payload: ReplyPayload): boolean {
+  return Boolean(
+    payload.isReasoning ||
+    payload.isReasoningSnapshot ||
+    payload.isCompactionNotice ||
+    payload.isFallbackNotice ||
+    payload.isStatusNotice ||
+    payload.btw,
+  );
+}
+
+function hasReplySemantics(payload: ReplyPayload): boolean {
+  return hasMergeableReplySemantics(payload) || hasUnmergedReplySemantics(payload);
+}
+
+function mediaSetsMatch(leftMediaUrls: readonly string[], rightMediaUrls: readonly string[]) {
+  if (leftMediaUrls.length !== rightMediaUrls.length) {
+    return false;
+  }
+  return leftMediaUrls.every((mediaUrl, index) => mediaUrl === rightMediaUrls[index]);
+}
+
+function replyDisplayText(payload: ReplyPayload): string {
+  return sanitizeAssistantDisplayText(payload.text) ?? "";
+}
+
+/** Fold command block replies into the final payload list without duplicating text or media. */
+export function selectChatSendFinalReplyPayloads(params: {
+  deliveredReplies: readonly DeliveredReply[];
+  foldCommandBlocks: boolean;
+  suppressReplies: boolean;
+}): ReplyPayload[] {
+  const { deliveredReplies, foldCommandBlocks, suppressReplies } = params;
+  const finalPayloadEntries = deliveredReplies.filter((entry) => entry.kind === "final");
+  const commandBlockPayloadEntries = foldCommandBlocks
+    ? deliveredReplies.filter((entry) => entry.kind === "block")
+    : [];
+  const commandBlockPayloadEntriesForDelivery = commandBlockPayloadEntries.map((entry) => ({
+    kind: entry.kind,
+    payload: canonicalizeReplyMedia(entry.payload),
+  }));
+  const sensitiveMediaDedupeKeys = new Set(
+    finalPayloadEntries.flatMap((entry) =>
+      entry.payload.sensitiveMedia === true
+        ? replyMediaDedupeKeys(entry.payload).filter(Boolean)
+        : [],
+    ),
+  );
+  if (sensitiveMediaDedupeKeys.size > 0) {
+    for (const entry of commandBlockPayloadEntriesForDelivery) {
+      if (replyMediaDedupeKeys(entry.payload).some((key) => sensitiveMediaDedupeKeys.has(key))) {
+        entry.payload = { ...entry.payload, sensitiveMedia: true };
+      }
+    }
+  }
+  const finalPayloadEntriesForDelivery = foldCommandBlocks
+    ? finalPayloadEntries.flatMap((entry) => {
+        const finalMediaUrls = replyMediaUrls(entry.payload);
+        const finalMediaKeys = replyMediaDedupeKeys(entry.payload);
+        const finalDisplayText = replyDisplayText(entry.payload);
+        const matchingMediaBlockEntry =
+          finalMediaUrls.length > 0
+            ? commandBlockPayloadEntriesForDelivery.find((candidate) =>
+                mediaSetsMatch(replyMediaDedupeKeys(candidate.payload), finalMediaKeys),
+              )
+            : undefined;
+        const matchingTextBlockEntry = finalDisplayText
+          ? commandBlockPayloadEntriesForDelivery.find(
+              (candidate) => replyDisplayText(candidate.payload) === finalDisplayText,
+            )
+          : undefined;
+        const matchingMediaAndTextBlockEntry =
+          finalMediaUrls.length > 0 && finalDisplayText
+            ? commandBlockPayloadEntriesForDelivery.find(
+                (candidate) =>
+                  replyDisplayText(candidate.payload) === finalDisplayText &&
+                  mediaSetsMatch(replyMediaDedupeKeys(candidate.payload), finalMediaKeys),
+              )
+            : undefined;
+        const duplicateBlockEntry =
+          finalMediaUrls.length > 0
+            ? finalDisplayText
+              ? matchingMediaAndTextBlockEntry
+              : matchingMediaBlockEntry
+            : finalMediaUrls.length === 0
+              ? matchingTextBlockEntry
+              : undefined;
+        if (duplicateBlockEntry) {
+          duplicateBlockEntry.payload = mergeDefinedReplySemantics(
+            duplicateBlockEntry.payload,
+            entry.payload,
+          );
+        } else if (matchingMediaBlockEntry) {
+          matchingMediaBlockEntry.payload = mergeMediaReplySemantics(
+            matchingMediaBlockEntry.payload,
+            entry.payload,
+          );
+        }
+        const remainingFinalMediaUrls = matchingMediaBlockEntry ? [] : finalMediaUrls;
+        if (
+          remainingFinalMediaUrls.length === 0 &&
+          ((duplicateBlockEntry && !hasUnmergedReplySemantics(entry.payload)) ||
+            (!duplicateBlockEntry && !finalDisplayText && !hasReplySemantics(entry.payload)))
+        ) {
+          return [];
+        }
+        return [
+          {
+            ...entry,
+            payload: {
+              ...entry.payload,
+              mediaUrl: undefined,
+              mediaUrls: remainingFinalMediaUrls.length > 0 ? remainingFinalMediaUrls : undefined,
+            },
+          },
+        ];
+      })
+    : finalPayloadEntries;
+  if (suppressReplies) {
+    return [];
+  }
+  return [...commandBlockPayloadEntriesForDelivery, ...finalPayloadEntriesForDelivery].map(
+    (entry) => entry.payload,
+  );
+}

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1,11 +1,8 @@
 // Chat gateway methods implement chat.send/history/abort/inject/metadata and
 // bridge UI RPCs to agent dispatch, transcripts, media, and streaming state.
 import { createHash } from "node:crypto";
-import path from "node:path";
 import { performance } from "node:perf_hooks";
-import { fileURLToPath } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
-import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import {
   GATEWAY_CLIENT_CAPS,
   hasGatewayClientCap,
@@ -58,11 +55,7 @@ import {
 } from "../../process/gateway-work-admission.js";
 import { normalizeAgentId, scopeLegacySessionKeyToAgent } from "../../routing/session-key.js";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
-import {
-  parseInlineDirectives,
-  stripInlineDirectiveTagsForDisplay,
-  sanitizeReplyDirectiveId,
-} from "../../utils/directive-tags.js";
+import { stripInlineDirectiveTagsForDisplay } from "../../utils/directive-tags.js";
 import { isOperatorUiClient } from "../../utils/message-channel.js";
 import { listGatewayAgentsBasic } from "../agent-list.js";
 import {
@@ -115,7 +108,6 @@ import {
   hasSensitiveMediaPayload,
   hasVisibleAssistantFinalMessage,
   replaceAssistantContentTextBlocks,
-  sanitizeAssistantDisplayText,
   scheduleChatHistoryManagedImageCleanup,
   stripManagedOutgoingAssistantContentBlocks,
   type AssistantDisplayContentBlock,
@@ -149,6 +141,7 @@ import { normalizeWebchatReplyMediaPathsForDisplay } from "./chat-reply-media.js
 import { terminalizeRestartSafeChatAdmission } from "./chat-restart-recovery.js";
 import { admitChatSend } from "./chat-send-admission.js";
 import { prepareChatSendAttachments } from "./chat-send-attachments.js";
+import { selectChatSendFinalReplyPayloads } from "./chat-send-command-replies.js";
 import {
   respondChatSessionRoutingChanged,
   runChatSendPreAdmission,
@@ -1531,271 +1524,11 @@ export const chatHandlers: GatewayRequestHandlers = {
                     agentId,
                   });
                 } else {
-                  const finalPayloadEntries = deliveredReplies.filter(
-                    (entryItem) => entryItem.kind === "final",
-                  );
-                  const parseReplyInlineDirectives = (payload: ReplyPayload) =>
-                    typeof payload.text === "string" && payload.text.includes("[[")
-                      ? parseInlineDirectives(payload.text)
-                      : undefined;
-                  const shouldFoldCommandBlocks = isInternalTextSlashCommandTurn;
-                  const commandBlockPayloadEntries = shouldFoldCommandBlocks
-                    ? deliveredReplies.filter((entryItem) => entryItem.kind === "block")
-                    : [];
-                  const replyMediaUrls = (payload: ReplyPayload) =>
-                    resolveSendableOutboundReplyParts(payload).mediaUrls;
-                  const normalizeCommandMediaDedupeKey = (value: string): string => {
-                    const trimmed = value.trim();
-                    if (!trimmed) {
-                      return "";
-                    }
-                    if (!trimmed.toLowerCase().startsWith("file://")) {
-                      return path.isAbsolute(trimmed) ? path.normalize(trimmed) : trimmed;
-                    }
-                    try {
-                      const parsed = new URL(trimmed);
-                      if (parsed.protocol === "file:") {
-                        return path.normalize(fileURLToPath(parsed));
-                      }
-                    } catch {
-                      // Keep malformed file URL-like values comparable with the fallback below.
-                    }
-                    return trimmed.replace(/^file:\/\//iu, "");
-                  };
-                  const replyMediaDedupeKeys = (payload: ReplyPayload) =>
-                    replyMediaUrls(payload).map((mediaUrl) =>
-                      normalizeCommandMediaDedupeKey(mediaUrl),
-                    );
-                  const canonicalizeReplyMedia = (payload: ReplyPayload): ReplyPayload => {
-                    const mediaUrls = replyMediaUrls(payload);
-                    return {
-                      ...payload,
-                      mediaUrl: undefined,
-                      mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
-                    };
-                  };
-                  const mergeDefinedReplySemantics = (
-                    target: ReplyPayload,
-                    source: ReplyPayload,
-                  ): ReplyPayload => {
-                    const sourceInlineDirectives = parseReplyInlineDirectives(source);
-                    const sourceReplyToId =
-                      sanitizeReplyDirectiveId(source.replyToId) ??
-                      sanitizeReplyDirectiveId(sourceInlineDirectives?.replyToExplicitId);
-                    return {
-                      ...target,
-                      ...(source.trustedLocalMedia === true || target.trustedLocalMedia === true
-                        ? { trustedLocalMedia: true }
-                        : {}),
-                      ...(source.sensitiveMedia === true || target.sensitiveMedia === true
-                        ? { sensitiveMedia: true }
-                        : {}),
-                      ...(source.presentation !== undefined
-                        ? { presentation: source.presentation }
-                        : {}),
-                      ...(source.delivery !== undefined ? { delivery: source.delivery } : {}),
-                      ...(source.interactive !== undefined
-                        ? { interactive: source.interactive }
-                        : {}),
-                      ...(sourceReplyToId !== undefined ? { replyToId: sourceReplyToId } : {}),
-                      ...(source.replyToTag === true || target.replyToTag === true
-                        ? { replyToTag: true }
-                        : {}),
-                      ...(source.replyToCurrent === true ||
-                      sourceInlineDirectives?.replyToCurrent === true ||
-                      target.replyToCurrent === true
-                        ? { replyToCurrent: true }
-                        : {}),
-                      ...(source.audioAsVoice === true ||
-                      sourceInlineDirectives?.audioAsVoice === true ||
-                      target.audioAsVoice === true
-                        ? { audioAsVoice: true }
-                        : {}),
-                      ...(source.spokenText !== undefined ? { spokenText: source.spokenText } : {}),
-                      ...(source.ttsSupplement !== undefined
-                        ? { ttsSupplement: source.ttsSupplement }
-                        : {}),
-                      ...(source.isError === true || target.isError === true
-                        ? { isError: true }
-                        : {}),
-                      ...(source.channelData !== undefined
-                        ? { channelData: source.channelData }
-                        : {}),
-                    };
-                  };
-                  const mergeMediaReplySemantics = (
-                    target: ReplyPayload,
-                    source: ReplyPayload,
-                  ): ReplyPayload => {
-                    const sourceInlineDirectives = parseReplyInlineDirectives(source);
-                    return {
-                      ...target,
-                      ...(source.trustedLocalMedia === true || target.trustedLocalMedia === true
-                        ? { trustedLocalMedia: true }
-                        : {}),
-                      ...(source.sensitiveMedia === true || target.sensitiveMedia === true
-                        ? { sensitiveMedia: true }
-                        : {}),
-                      ...(source.audioAsVoice === true ||
-                      sourceInlineDirectives?.audioAsVoice === true ||
-                      target.audioAsVoice === true
-                        ? { audioAsVoice: true }
-                        : {}),
-                    };
-                  };
-                  const hasMergeableReplySemantics = (payload: ReplyPayload): boolean => {
-                    const inlineDirectives = parseReplyInlineDirectives(payload);
-                    return Boolean(
-                      payload.trustedLocalMedia !== undefined ||
-                      payload.sensitiveMedia !== undefined ||
-                      payload.presentation ||
-                      payload.delivery ||
-                      payload.interactive ||
-                      payload.replyToId ||
-                      payload.replyToTag !== undefined ||
-                      payload.replyToCurrent !== undefined ||
-                      payload.audioAsVoice !== undefined ||
-                      inlineDirectives?.hasReplyTag ||
-                      inlineDirectives?.hasAudioTag ||
-                      payload.spokenText ||
-                      payload.ttsSupplement ||
-                      payload.isError !== undefined ||
-                      payload.channelData,
-                    );
-                  };
-                  const hasUnmergedReplySemantics = (payload: ReplyPayload): boolean =>
-                    Boolean(
-                      payload.isReasoning ||
-                      payload.isReasoningSnapshot ||
-                      payload.isCompactionNotice ||
-                      payload.isFallbackNotice ||
-                      payload.isStatusNotice ||
-                      payload.btw,
-                    );
-                  const hasReplySemantics = (payload: ReplyPayload): boolean =>
-                    hasMergeableReplySemantics(payload) || hasUnmergedReplySemantics(payload);
-                  const mediaSetsMatch = (
-                    leftMediaUrls: readonly string[],
-                    rightMediaUrls: readonly string[],
-                  ): boolean => {
-                    if (leftMediaUrls.length !== rightMediaUrls.length) {
-                      return false;
-                    }
-                    return leftMediaUrls.every(
-                      (mediaUrl, index) => mediaUrl === rightMediaUrls[index],
-                    );
-                  };
-                  const replyDisplayText = (payload: ReplyPayload): string =>
-                    sanitizeAssistantDisplayText(payload.text) ?? "";
-                  const commandBlockPayloadEntriesForDelivery = commandBlockPayloadEntries.map(
-                    (entryItem) => ({
-                      kind: entryItem.kind,
-                      payload: canonicalizeReplyMedia(entryItem.payload),
-                    }),
-                  );
-                  const sensitiveMediaDedupeKeys = new Set(
-                    finalPayloadEntries.flatMap((entryItem) =>
-                      entryItem.payload.sensitiveMedia === true
-                        ? replyMediaDedupeKeys(entryItem.payload).filter(Boolean)
-                        : [],
-                    ),
-                  );
-                  if (sensitiveMediaDedupeKeys.size > 0) {
-                    for (const entryItem of commandBlockPayloadEntriesForDelivery) {
-                      if (
-                        replyMediaDedupeKeys(entryItem.payload).some((key) =>
-                          sensitiveMediaDedupeKeys.has(key),
-                        )
-                      ) {
-                        entryItem.payload = { ...entryItem.payload, sensitiveMedia: true };
-                      }
-                    }
-                  }
-                  const finalPayloadEntriesForDelivery = shouldFoldCommandBlocks
-                    ? finalPayloadEntries.flatMap((entryItem) => {
-                        const finalMediaUrls = replyMediaUrls(entryItem.payload);
-                        const finalMediaKeys = replyMediaDedupeKeys(entryItem.payload);
-                        const finalDisplayText = replyDisplayText(entryItem.payload);
-                        const matchingMediaBlockEntry =
-                          finalMediaUrls.length > 0
-                            ? commandBlockPayloadEntriesForDelivery.find((candidate) =>
-                                mediaSetsMatch(
-                                  replyMediaDedupeKeys(candidate.payload),
-                                  finalMediaKeys,
-                                ),
-                              )
-                            : undefined;
-                        const matchingTextBlockEntry = finalDisplayText
-                          ? commandBlockPayloadEntriesForDelivery.find(
-                              (candidate) =>
-                                replyDisplayText(candidate.payload) === finalDisplayText,
-                            )
-                          : undefined;
-                        const matchingMediaAndTextBlockEntry =
-                          finalMediaUrls.length > 0 && finalDisplayText
-                            ? commandBlockPayloadEntriesForDelivery.find(
-                                (candidate) =>
-                                  replyDisplayText(candidate.payload) === finalDisplayText &&
-                                  mediaSetsMatch(
-                                    replyMediaDedupeKeys(candidate.payload),
-                                    finalMediaKeys,
-                                  ),
-                              )
-                            : undefined;
-                        const duplicateBlockEntry =
-                          finalMediaUrls.length > 0
-                            ? finalDisplayText
-                              ? matchingMediaAndTextBlockEntry
-                              : matchingMediaBlockEntry
-                            : finalMediaUrls.length === 0
-                              ? matchingTextBlockEntry
-                              : undefined;
-                        if (duplicateBlockEntry) {
-                          duplicateBlockEntry.payload = mergeDefinedReplySemantics(
-                            duplicateBlockEntry.payload,
-                            entryItem.payload,
-                          );
-                        } else if (matchingMediaBlockEntry) {
-                          matchingMediaBlockEntry.payload = mergeMediaReplySemantics(
-                            matchingMediaBlockEntry.payload,
-                            entryItem.payload,
-                          );
-                        }
-                        const remainingFinalMediaUrls = matchingMediaBlockEntry
-                          ? []
-                          : finalMediaUrls;
-                        if (
-                          remainingFinalMediaUrls.length === 0 &&
-                          ((duplicateBlockEntry && !hasUnmergedReplySemantics(entryItem.payload)) ||
-                            (!duplicateBlockEntry &&
-                              !finalDisplayText &&
-                              !hasReplySemantics(entryItem.payload)))
-                        ) {
-                          return [];
-                        }
-                        return [
-                          {
-                            ...entryItem,
-                            payload: {
-                              ...entryItem.payload,
-                              mediaUrl: undefined,
-                              mediaUrls:
-                                remainingFinalMediaUrls.length > 0
-                                  ? remainingFinalMediaUrls
-                                  : undefined,
-                            },
-                          },
-                        ];
-                      })
-                    : finalPayloadEntries;
-                  // Non-agent command paths can enqueue only block replies. If no visible final
-                  // supersedes them, fold those blocks into the final WebChat message.
-                  const rawFinalPayloads = hasAppendedWebchatAgentMedia()
-                    ? []
-                    : [
-                        ...commandBlockPayloadEntriesForDelivery,
-                        ...finalPayloadEntriesForDelivery,
-                      ].map((entryCandidate) => entryCandidate.payload);
+                  const rawFinalPayloads = selectChatSendFinalReplyPayloads({
+                    deliveredReplies,
+                    foldCommandBlocks: isInternalTextSlashCommandTurn,
+                    suppressReplies: hasAppendedWebchatAgentMedia(),
+                  });
                   const finalPayloads = await normalizeWebchatReplyMediaPathsForDisplay({
                     cfg,
                     sessionKey,


### PR DESCRIPTION
## What Problem This Solves

`chat.send` finalization still contained roughly 270 lines of pure command-reply selection: block/final folding, file-path media deduplication, sensitive-media propagation, and reply-directive semantic merging. This policy obscured the actual transcript and broadcast lifecycle.

Advances #106555.

## Why This Change Was Made

- Move deterministic command-reply selection into `chat-send-command-replies.ts`.
- Keep file URL/path canonicalization and media deduplication together.
- Preserve block/final ordering and semantic flag merging.
- Add focused coverage for normal finals, dispatcher-media suppression, duplicate media/semantics, and unmatched final text.

This reduces `chat.ts` from 2,635 to 2,368 lines. The extracted production module is 253 lines.

## User Impact

No intended behavior change. Internal text commands keep their existing final reply text, media, reply directives, sensitive-media handling, and duplicate suppression.

## Evidence

- Testbox `tbx_01kxebqtk1cm096f6q810vcffg`: 2 focused files, 5 tests passed.
- Same Testbox: `corepack pnpm tsgo:core` passed.
- Fresh autoreview clean, no accepted/actionable findings; correctness 0.96.
- `git diff --check origin/main...HEAD` passed after rebasing onto current `origin/main`.
- Hosted CI intentionally not awaited per maintainer direction.
