### PR TITLE
perf(ui): defer model-provider data from startup

### DIFF
--- a/ui/src/pages/model-providers/route.ts
+++ b/ui/src/pages/model-providers/route.ts
@@ -1,12 +1,12 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
 import type { ApplicationContext } from "../../app/context.ts";
-import { EMPTY_MODEL_PROVIDERS_DATA, loadModelProvidersData } from "./load.ts";
 import type { ModelProvidersRouteData } from "./model-providers-page.ts";
 
 async function loadModelProvidersRouteData(
   context: ApplicationContext,
 ): Promise<ModelProvidersRouteData> {
+  const { EMPTY_MODEL_PROVIDERS_DATA, loadModelProvidersData } = await import("./load.ts");
   const gatewaySnapshot = context.gateway.snapshot;
   const client = gatewaySnapshot.connected ? gatewaySnapshot.client : null;
   if (!client) {


### PR DESCRIPTION
## What Problem This Solves

The eagerly registered Model Providers route statically imported its data loader, pulling route-only configuration and model helpers into the Control UI startup graph. Current `main` uses all 25 allowed startup JavaScript requests, leaving no request-budget headroom.

## Why This Change Was Made

Load the fixed `./load.ts` module inside the existing async route loader. The route registry stays cheap at startup, while navigation and preload still fetch data through the same loader contract. The component already follows the same lazy route boundary.

## User Impact

No behavior change. Control UI startup uses one fewer JavaScript request and regains budget headroom; Model Providers data loads when that route is requested.

## Evidence

- Exact head `48e256ea3af814283bce96aa739297713195673b`.
- Blacksmith Testbox run: https://github.com/openclaw/openclaw/actions/runs/29289583155
- `corepack pnpm ui:build`: passed; startup JavaScript is `24 requests`, `303.6 KiB gzip`, `277.7 KiB br` against limits of `25 requests` and `320.0 KiB gzip`.
- `corepack pnpm check:changed -- ui/src/pages/model-providers/route.ts`: passed.
- Fresh branch autoreview: clean; no accepted or actionable findings.
- Verified `@openclaw/uirouter@0.1.0` invokes route loaders only during route loading and accepts async loader results.
- AI-assisted change; code and proof reviewed and understood.
