### PR TITLE
refactor(ui): privatize default model view props

### DIFF
--- a/ui/src/pages/model-providers/default-models-view.ts
+++ b/ui/src/pages/model-providers/default-models-view.ts
@@ -4,7 +4,7 @@ import { renderSettingsSection } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { modelCatalogRef, type DefaultModelSelection, type ModelPickerEntry } from "./data.ts";
 
-export type DefaultModelsViewProps = {
+type DefaultModelsViewProps = {
   models: ModelPickerEntry[];
   selection: DefaultModelSelection;
   canMutate: boolean;


### PR DESCRIPTION
## What Problem This Solves

Production Knip reports `DefaultModelsViewProps` as a new unused export on current `main`. Leaving it public would force the shrink-only dead-export ratchet to grow.

## Why This Change Was Made

The type is consumed only inside `default-models-view.ts`, so this removes only the unnecessary `export` modifier. Runtime behavior and the rendered model-provider settings UI are unchanged.

## User Impact

None. Internal TypeScript surface only.

## Evidence

- Exact base: `246cb488497d7f73952889bd9063347509b0f90a`.
- One-line declaration-only change; caller remains in the same module.
- Production Knip finding reproduced during exact baseline regeneration for #106019.
- Manual same-file caller review clean. Per maintainer instruction, hosted CI is not awaited.
