### PR TITLE
chore(ui): align E2E assertions with current behavior

### DIFF
--- a/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
+++ b/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
@@ -38,6 +38,17 @@ async function captureToolActivityProof(page: import("playwright").Page, name: s
   await page.screenshot({ path: path.join(artifactDir, `${name}.png`), fullPage: true });
 }
 
+async function expandCompletedWorkGroups(page: import("playwright").Page) {
+  const workSummaries = page.locator(".chat-work-group > .chat-activity-group__summary");
+  await workSummaries.first().waitFor();
+  for (let index = 0; index < (await workSummaries.count()); index += 1) {
+    const summary = workSummaries.nth(index);
+    if ((await summary.getAttribute("aria-expanded")) !== "true") {
+      await summary.click();
+    }
+  }
+}
+
 describeControlUiE2e("Control UI autonomous tool-turn outcomes", () => {
   beforeAll(async () => {
     server = await startControlUiE2eServer();
@@ -73,6 +84,7 @@ describeControlUiE2e("Control UI autonomous tool-turn outcomes", () => {
 
     await page.goto(`${server.baseUrl}chat`);
     await page.getByText("Recovered on the next autonomous turn.", { exact: true }).waitFor();
+    await expandCompletedWorkGroups(page);
 
     expect(await page.locator(".chat-tool-msg-summary__label").allTextContents()).toEqual([
       "Tool error",
@@ -141,7 +153,8 @@ describeControlUiE2e("Control UI autonomous tool-turn outcomes", () => {
     });
 
     await page.goto(`${server.baseUrl}chat`);
-    const activity = page.locator(".chat-activity-group__summary");
+    await expandCompletedWorkGroups(page);
+    const activity = page.locator(".chat-group--activity .chat-activity-group__summary");
     await activity.waitFor();
     expect(await activity.textContent()).toContain("Read a file, edited 2 files");
     if ((await activity.getAttribute("aria-expanded")) !== "true") {

--- a/ui/src/e2e/profile-page.e2e.test.ts
+++ b/ui/src/e2e/profile-page.e2e.test.ts
@@ -164,7 +164,7 @@ describeControlUiE2e("Control UI profile page mocked Gateway E2E", () => {
       const statValues = await page.locator(".profile-stats__value").allTextContents();
       expect(statValues[0]?.trim()).toBe("2.8T");
       expect(statValues[1]?.trim()).toBe("82.1B");
-      expect(statValues[2]?.trim()).toBe("59h 4m");
+      expect(statValues[2]?.trim()).toBe("2d 11h");
       expect(statValues[3]?.trim()).toBe("3 days");
 
       const cellCount = await page.locator(".profile-heatmap__svg rect").count();


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where three Control UI E2E assertions failed after completed tool work began collapsing by default and long profile durations switched to compact day/hour formatting.

## Why This Change Was Made

The chat scenarios now open completed work before checking its nested tool rows and target the actual activity disclosure. The profile scenario now expects the current compact duration output.

## User Impact

No runtime behavior changes. Maintainers regain reliable regression coverage for autonomous tool outcomes and profile statistics.

## Evidence

- Exact head: `1d2c6ee71335276b6e0fa2e9a8b9363eaf9ed34b`
- Testbox `tbx_01kxecnf13qk6whkbcvx977d2d`: 2 files, 6 tests passed
- Actions proof: https://github.com/openclaw/openclaw/actions/runs/29275621757
- Fresh branch autoreview: no accepted or actionable findings
- `git diff --check`
