### PR TITLE
refactor(ui): avoid model group map spreads

### DIFF
--- a/ui/src/pages/model-providers/default-models-view.ts
+++ b/ui/src/pages/model-providers/default-models-view.ts
@@ -48,12 +48,11 @@ function modelGroups(models: ModelPickerEntry[]): ModelOptionGroup[] {
     group.models.push({ ref, label: model.name || ref });
     groups.set(groupKey, group);
   }
-  return [...groups.values()]
-    .map((group) => ({
-      ...group,
-      models: group.models.toSorted((a, b) => a.label.localeCompare(b.label)),
-    }))
-    .toSorted((a, b) => a.label.localeCompare(b.label));
+  const sortedGroups = [...groups.values()];
+  for (const group of sortedGroups) {
+    group.models = group.models.toSorted((a, b) => a.label.localeCompare(b.label));
+  }
+  return sortedGroups.toSorted((a, b) => a.label.localeCompare(b.label));
 }
 
 function renderModelOptions(models: ModelPickerEntry[], selected = "") {


### PR DESCRIPTION
## What Problem This Solves

Resolves a current-main typed-lint failure in the Control UI model-provider defaults view, where cloning each group inside a `map` call violates the enforced no-map-spread rule.

## Why This Change Was Made

Sorts the locally created model arrays in a simple loop, then keeps the existing immutable group ordering. The rendered model and provider order is unchanged.

## User Impact

No user-visible behavior change. The model-provider settings view keeps the same deterministic ordering while passing the repository lint contract.

## Evidence

- Blacksmith Testbox `tbx_01kxecg5wc8kpr5x470ad8ymfn`, run `29275418783`
- production dead-export regeneration byte-stable; exact 2,125-entry guard green
- `pnpm tsgo:ui`
- touched-file type-aware oxlint and oxfmt
- fresh whole-diff autoreview clean at 0.99

AI-assisted; maintainer-reviewed and understood.
