### PR TITLE
refactor(gateway): extract source reply finalization

### DIFF
--- a/src/gateway/server-methods/chat-send-source-finalization.test.ts
+++ b/src/gateway/server-methods/chat-send-source-finalization.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { setReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
+import { selectChatSendAgentReplyPayloads } from "./chat-send-source-finalization.js";
+
+describe("selectChatSendAgentReplyPayloads", () => {
+  const sourceReply = setReplyPayloadMetadata(
+    { text: "source reply" },
+    {
+      sourceReplyTranscriptMirror: {
+        sessionKey: "agent:main:main",
+        text: "source reply",
+        idempotencyKey: "source-reply-1",
+      },
+    },
+  );
+  const deliveredReplies = [
+    { kind: "block" as const, payload: sourceReply },
+    { kind: "final" as const, payload: { text: "answer" } },
+    { kind: "final" as const, payload: { text: "status", isStatusNotice: true } },
+    { kind: "final" as const, payload: sourceReply },
+  ];
+
+  it("selects final status and source replies when the agent succeeded", () => {
+    expect(
+      selectChatSendAgentReplyPayloads({
+        deliveredReplies,
+        hasReturnedAgentErrorPayloads: false,
+      }),
+    ).toEqual([{ text: "status", isStatusNotice: true }, sourceReply]);
+  });
+
+  it("keeps source replies but suppresses status notices after an agent error", () => {
+    expect(
+      selectChatSendAgentReplyPayloads({
+        deliveredReplies,
+        hasReturnedAgentErrorPayloads: true,
+      }),
+    ).toEqual([sourceReply]);
+  });
+});

--- a/src/gateway/server-methods/chat-send-source-finalization.ts
+++ b/src/gateway/server-methods/chat-send-source-finalization.ts
@@ -1,0 +1,303 @@
+import {
+  getReplyPayloadMetadata,
+  isReplyPayloadStatusNotice,
+  type ReplyPayload,
+} from "../../auto-reply/reply-payload.js";
+import {
+  appendLocalMediaParentRoots,
+  getAgentScopedMediaLocalRoots,
+} from "../../media/local-roots.js";
+import { attachManagedOutgoingImagesToMessage } from "../managed-image-attachments.js";
+import { loadSessionEntry } from "../session-utils.js";
+import { formatForLog } from "../ws-log.js";
+import {
+  buildAssistantDisplayContentFromReplyPayloads,
+  extractAssistantDisplayTextFromContent,
+  hasAssistantDisplayMediaContent,
+  hasManagedOutgoingAssistantContent,
+  hasVisibleAssistantFinalMessage,
+  replaceAssistantContentTextBlocks,
+  stripManagedOutgoingAssistantContentBlocks,
+  type AssistantDisplayContentBlock,
+} from "./chat-assistant-content.js";
+import { broadcastChatFinal, isSourceReplyTranscriptMirrorPayload } from "./chat-broadcast.js";
+import { normalizeWebchatReplyMediaPathsForDisplay } from "./chat-reply-media.js";
+import { buildTranscriptReplyText } from "./chat-send-reply-dispatch.js";
+import type { PreparedChatSendSession } from "./chat-send-session.js";
+import {
+  assistantTranscriptScope,
+  publishAssistantTranscriptRewrite,
+  rewriteSourceReplyTranscriptMirrors,
+  type SourceReplyContentState,
+  type SourceReplyTranscriptMirrorMetadata,
+} from "./chat-transcript-persistence.js";
+import { buildWebchatAssistantMessageFromReplyPayloads } from "./chat-webchat-media.js";
+import type { GatewayRequestContext } from "./types.js";
+
+type DeliveredReply = {
+  payload: ReplyPayload;
+  kind: "block" | "final";
+};
+
+export function selectChatSendAgentReplyPayloads(params: {
+  deliveredReplies: readonly DeliveredReply[];
+  hasReturnedAgentErrorPayloads: boolean;
+}): ReplyPayload[] {
+  return params.deliveredReplies
+    .filter((entry) => entry.kind === "final")
+    .map((entry) => entry.payload)
+    .filter(
+      (payload) =>
+        isSourceReplyTranscriptMirrorPayload(payload) ||
+        (!params.hasReturnedAgentErrorPayloads && isReplyPayloadStatusNotice(payload)),
+    );
+}
+
+/** Persist and broadcast agent-run source/status replies that bypass the normal model turn. */
+export async function finalizeChatSendSourceReplies(params: {
+  accountId: string | undefined;
+  context: GatewayRequestContext;
+  deliveredReplies: readonly DeliveredReply[];
+  emitFirstAssistantServerTiming: () => void;
+  hasReturnedAgentErrorPayloads: boolean;
+  session: Pick<
+    PreparedChatSendSession,
+    "agentId" | "backingSessionId" | "cfg" | "clientRunId" | "sessionKey" | "sessionLoadOptions"
+  >;
+}): Promise<boolean> {
+  const {
+    accountId,
+    context,
+    deliveredReplies,
+    emitFirstAssistantServerTiming,
+    hasReturnedAgentErrorPayloads,
+    session,
+  } = params;
+  const { agentId, backingSessionId, cfg, clientRunId, sessionKey, sessionLoadOptions } = session;
+  const agentRunReplyPayloads = selectChatSendAgentReplyPayloads({
+    deliveredReplies,
+    hasReturnedAgentErrorPayloads,
+  });
+  if (agentRunReplyPayloads.length === 0) {
+    return false;
+  }
+
+  const hasSourceReplyTranscriptMirror = agentRunReplyPayloads.some(
+    isSourceReplyTranscriptMirrorPayload,
+  );
+  const finalPayloads = await normalizeWebchatReplyMediaPathsForDisplay({
+    cfg,
+    sessionKey,
+    agentId,
+    accountId,
+    payloads: agentRunReplyPayloads,
+  });
+  const { storePath: latestStorePath, entry: latestEntry } = loadSessionEntry(
+    sessionKey,
+    sessionLoadOptions,
+  );
+  const sessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
+  const mediaLocalRoots = appendLocalMediaParentRoots(
+    getAgentScopedMediaLocalRoots(cfg, agentId),
+    latestStorePath ? [latestStorePath] : undefined,
+  );
+  const buildReplyAssistantContent = async (
+    payloads: typeof finalPayloads,
+  ): Promise<AssistantDisplayContentBlock[] | undefined> =>
+    await buildAssistantDisplayContentFromReplyPayloads({
+      sessionKey,
+      agentId,
+      payloads,
+      managedImageLocalRoots: mediaLocalRoots,
+      includeSensitiveMedia: false,
+      onLocalAudioAccessDenied: (message) => {
+        context.logGateway.warn(`webchat audio embedding denied local path: ${message}`);
+      },
+      onManagedImagePrepareError: (message) => {
+        context.logGateway.warn(`webchat image embedding skipped attachment: ${message}`);
+      },
+    });
+  const buildReplyMediaMessage = async (payloads: typeof finalPayloads) =>
+    await buildWebchatAssistantMessageFromReplyPayloads(payloads, {
+      localRoots: mediaLocalRoots,
+      onLocalAudioAccessDenied: (err) => {
+        context.logGateway.warn(`webchat audio embedding denied local path: ${formatForLog(err)}`);
+      },
+    });
+  const combinedAssistantContent =
+    agentRunReplyPayloads.length === 1
+      ? await buildReplyAssistantContent(finalPayloads)
+      : undefined;
+  const combinedMediaMessage =
+    agentRunReplyPayloads.length === 1 ? await buildReplyMediaMessage(finalPayloads) : undefined;
+  const sourceReplyContentStates: SourceReplyContentState[] = [];
+  const sourceReplyBroadcastContent: AssistantDisplayContentBlock[] = [];
+  for (const [replyIndex] of agentRunReplyPayloads.entries()) {
+    const finalPayload = finalPayloads[replyIndex];
+    if (!finalPayload) {
+      continue;
+    }
+    const replyAssistantContent =
+      agentRunReplyPayloads.length === 1
+        ? combinedAssistantContent
+        : await buildReplyAssistantContent([finalPayload]);
+    const replyMediaMessage =
+      agentRunReplyPayloads.length === 1
+        ? combinedMediaMessage
+        : await buildReplyMediaMessage([finalPayload]);
+    const replyBroadcastContent = hasAssistantDisplayMediaContent(replyAssistantContent)
+      ? replyAssistantContent
+      : hasAssistantDisplayMediaContent(replyMediaMessage?.content)
+        ? replyMediaMessage?.content
+        : replyAssistantContent;
+    const persistedContent = replaceAssistantContentTextBlocks(
+      replyAssistantContent,
+      replyMediaMessage ?? null,
+    );
+    const state: SourceReplyContentState = {
+      broadcastContent: replyBroadcastContent ? [...replyBroadcastContent] : [],
+      persistedContent: persistedContent ? [...persistedContent] : [],
+      hasManagedOutgoingContent: hasManagedOutgoingAssistantContent(persistedContent),
+      backedManagedOutgoingContent: false,
+    };
+    sourceReplyContentStates[replyIndex] = state;
+    if (state.broadcastContent.length > 0) {
+      sourceReplyBroadcastContent.push(...state.broadcastContent);
+    }
+  }
+
+  const displayReply =
+    extractAssistantDisplayTextFromContent(sourceReplyBroadcastContent) ??
+    buildTranscriptReplyText(finalPayloads);
+  if (!sourceReplyBroadcastContent.length && !displayReply) {
+    return false;
+  }
+
+  const sourceReplyPersistenceRequests: Array<{
+    idempotencyKey: string;
+    metadata: SourceReplyTranscriptMirrorMetadata;
+    state: SourceReplyContentState;
+  }> = [];
+  for (const [replyIndex, sourceReplyPayload] of agentRunReplyPayloads.entries()) {
+    const state = sourceReplyContentStates[replyIndex];
+    if (!state || !hasAssistantDisplayMediaContent(state.persistedContent)) {
+      continue;
+    }
+    const mirrorMetadata = getReplyPayloadMetadata(sourceReplyPayload)?.sourceReplyTranscriptMirror;
+    const mirrorIdempotencyKey = mirrorMetadata?.idempotencyKey;
+    if (typeof mirrorIdempotencyKey !== "string" || mirrorIdempotencyKey.trim().length === 0) {
+      continue;
+    }
+    if (!state.hasManagedOutgoingContent) {
+      state.backedManagedOutgoingContent = true;
+    }
+    sourceReplyPersistenceRequests.push({
+      idempotencyKey: mirrorIdempotencyKey,
+      metadata: mirrorMetadata,
+      state,
+    });
+  }
+  const sourceReplyMirrorCandidates: Array<{
+    idempotencyKey: string;
+    metadata: SourceReplyTranscriptMirrorMetadata;
+  }> = [];
+  for (const [replyIndex, sourceReplyPayload] of agentRunReplyPayloads.entries()) {
+    if (!sourceReplyContentStates[replyIndex]) {
+      continue;
+    }
+    const mirrorMetadata = getReplyPayloadMetadata(sourceReplyPayload)?.sourceReplyTranscriptMirror;
+    const mirrorIdempotencyKey = mirrorMetadata?.idempotencyKey;
+    if (
+      typeof mirrorIdempotencyKey !== "string" ||
+      mirrorIdempotencyKey.trim().length === 0 ||
+      !mirrorMetadata
+    ) {
+      continue;
+    }
+    sourceReplyMirrorCandidates.push({
+      idempotencyKey: mirrorIdempotencyKey,
+      metadata: mirrorMetadata,
+    });
+  }
+
+  const attachSourceReplyManagedImages = async (attachParams: {
+    messageId?: string;
+    request: (typeof sourceReplyPersistenceRequests)[number];
+  }) => {
+    if (!attachParams.request.state.hasManagedOutgoingContent) {
+      attachParams.request.state.backedManagedOutgoingContent = true;
+      return;
+    }
+    if (!attachParams.messageId) {
+      return;
+    }
+    await attachManagedOutgoingImagesToMessage({
+      messageId: attachParams.messageId,
+      blocks: attachParams.request.state.persistedContent,
+    });
+    attachParams.request.state.backedManagedOutgoingContent = true;
+  };
+
+  const sourceReplyScope = assistantTranscriptScope({
+    sessionId,
+    sessionKey,
+    storePath: latestStorePath,
+    agentId,
+  });
+  if (sourceReplyScope && sourceReplyPersistenceRequests.length > 0) {
+    const rewritten = await rewriteSourceReplyTranscriptMirrors({
+      candidates: sourceReplyMirrorCandidates,
+      requests: sourceReplyPersistenceRequests,
+      scope: sourceReplyScope,
+    });
+    if (rewritten.length > 0) {
+      await publishAssistantTranscriptRewrite({
+        scope: sourceReplyScope,
+        rewritten,
+      });
+      for (const target of rewritten) {
+        await attachSourceReplyManagedImages({
+          messageId: target.messageId,
+          request: target.request,
+        });
+      }
+    }
+  }
+  const sourceReplyContent = sourceReplyContentStates
+    .flatMap((state) => {
+      if (state.hasManagedOutgoingContent && !state.backedManagedOutgoingContent) {
+        const stripped = stripManagedOutgoingAssistantContentBlocks(state.broadcastContent);
+        return stripped?.length
+          ? stripped
+          : [{ type: "text", text: "Media reply could not be displayed." }];
+      }
+      return state.broadcastContent;
+    })
+    .filter((block): block is AssistantDisplayContentBlock => Boolean(block));
+  const sourceReplyTextFromContent = extractAssistantDisplayTextFromContent(sourceReplyContent);
+  const sourceReplyText =
+    sourceReplyTextFromContent ?? (sourceReplyContent.length === 0 ? displayReply : undefined);
+  const message = {
+    role: "assistant",
+    ...(sourceReplyContent.length
+      ? { content: sourceReplyContent }
+      : sourceReplyText
+        ? { content: [{ type: "text", text: sourceReplyText }] }
+        : {}),
+    ...(sourceReplyText ? { text: sourceReplyText } : {}),
+    timestamp: Date.now(),
+    stopReason: "stop",
+    usage: { input: 0, output: 0, totalTokens: 0 },
+  };
+  if (hasVisibleAssistantFinalMessage(message)) {
+    emitFirstAssistantServerTiming();
+  }
+  broadcastChatFinal({
+    context,
+    runId: clientRunId,
+    sessionKey,
+    agentId,
+    message,
+  });
+  return hasSourceReplyTranscriptMirror;
+}

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -27,11 +27,7 @@ import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
-import {
-  getReplyPayloadMetadata,
-  isReplyPayloadStatusNotice,
-  type ReplyPayload,
-} from "../../auto-reply/reply-payload.js";
+import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { resolveSessionWorkStartError } from "../../config/sessions.js";
 import { resolveTranscriptSessionKeyBySessionId } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -104,20 +100,17 @@ import {
   extractAssistantDisplayText,
   extractAssistantDisplayTextFromContent,
   hasAssistantDisplayMediaContent,
-  hasManagedOutgoingAssistantContent,
   hasSensitiveMediaPayload,
   hasVisibleAssistantFinalMessage,
   replaceAssistantContentTextBlocks,
   scheduleChatHistoryManagedImageCleanup,
   stripManagedOutgoingAssistantContentBlocks,
-  type AssistantDisplayContentBlock,
 } from "./chat-assistant-content.js";
 import {
   broadcastChatError,
   broadcastChatFinal,
   broadcastSideResult,
   isBtwReplyPayload,
-  isSourceReplyTranscriptMirrorPayload,
   sendGlobalAwareNodeChatPayload,
 } from "./chat-broadcast.js";
 import {
@@ -152,6 +145,7 @@ import {
 } from "./chat-send-reply-dispatch.js";
 import { normalizeChatSendRequest } from "./chat-send-request.js";
 import { prepareChatSendSession } from "./chat-send-session.js";
+import { finalizeChatSendSourceReplies } from "./chat-send-source-finalization.js";
 import { applyChatSendManagedMediaFields, prepareChatSendUserTurn } from "./chat-send-user-turn.js";
 import {
   chatSendAckServerTimingAttributes,
@@ -162,14 +156,7 @@ import {
 } from "./chat-server-timing.js";
 import { normalizeOptionalChatText as normalizeOptionalText } from "./chat-text-normalization.js";
 import type { GatewayInjectedTtsSupplementMarker } from "./chat-transcript-inject.js";
-import {
-  assistantTranscriptScope,
-  appendAssistantTranscriptMessage,
-  publishAssistantTranscriptRewrite,
-  rewriteSourceReplyTranscriptMirrors,
-  type SourceReplyContentState,
-  type SourceReplyTranscriptMirrorMetadata,
-} from "./chat-transcript-persistence.js";
+import { appendAssistantTranscriptMessage } from "./chat-transcript-persistence.js";
 import { buildMediaOnlyTtsSupplementTranscriptMarker } from "./chat-tts-markers.js";
 import { createGatewayChatUserTurnController } from "./chat-user-turn-recorder.js";
 import { buildWebchatAssistantMessageFromReplyPayloads } from "./chat-webchat-media.js";
@@ -1711,263 +1698,14 @@ export const chatHandlers: GatewayRequestHandlers = {
                   });
                 }
               } else {
-                const hasReturnedAgentErrorPayloads = returnedAgentErrorPayloads.length > 0;
-                const agentRunReplyPayloads = deliveredReplies
-                  .filter((entryEntry) => entryEntry.kind === "final")
-                  .map((entryResult) => entryResult.payload)
-                  .filter(
-                    (payload) =>
-                      isSourceReplyTranscriptMirrorPayload(payload) ||
-                      (!hasReturnedAgentErrorPayloads && isReplyPayloadStatusNotice(payload)),
-                  );
-                if (agentRunReplyPayloads.length > 0) {
-                  const hasSourceReplyTranscriptMirror = agentRunReplyPayloads.some(
-                    isSourceReplyTranscriptMirrorPayload,
-                  );
-                  const finalPayloads = await normalizeWebchatReplyMediaPathsForDisplay({
-                    cfg,
-                    sessionKey,
-                    agentId,
-                    accountId,
-                    payloads: agentRunReplyPayloads,
-                  });
-                  const { storePath: latestStorePath, entry: latestEntry } = loadSessionEntry(
-                    sessionKey,
-                    sessionLoadOptions,
-                  );
-                  const sessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
-                  const mediaLocalRoots = appendLocalMediaParentRoots(
-                    getAgentScopedMediaLocalRoots(cfg, agentId),
-                    latestStorePath ? [latestStorePath] : undefined,
-                  );
-                  const buildReplyAssistantContent = async (
-                    payloads: typeof finalPayloads,
-                  ): Promise<AssistantDisplayContentBlock[] | undefined> =>
-                    await buildAssistantDisplayContentFromReplyPayloads({
-                      sessionKey,
-                      agentId,
-                      payloads,
-                      managedImageLocalRoots: mediaLocalRoots,
-                      includeSensitiveMedia: false,
-                      onLocalAudioAccessDenied: (message) => {
-                        context.logGateway.warn(
-                          `webchat audio embedding denied local path: ${message}`,
-                        );
-                      },
-                      onManagedImagePrepareError: (message) => {
-                        context.logGateway.warn(
-                          `webchat image embedding skipped attachment: ${message}`,
-                        );
-                      },
-                    });
-                  const buildReplyMediaMessage = async (payloads: typeof finalPayloads) =>
-                    await buildWebchatAssistantMediaMessage(payloads, {
-                      localRoots: mediaLocalRoots,
-                      onLocalAudioAccessDenied: (message) => {
-                        context.logGateway.warn(
-                          `webchat audio embedding denied local path: ${message}`,
-                        );
-                      },
-                    });
-                  const combinedAssistantContent =
-                    agentRunReplyPayloads.length === 1
-                      ? await buildReplyAssistantContent(finalPayloads)
-                      : undefined;
-                  const combinedMediaMessage =
-                    agentRunReplyPayloads.length === 1
-                      ? await buildReplyMediaMessage(finalPayloads)
-                      : undefined;
-                  const sourceReplyContentStates: SourceReplyContentState[] = [];
-                  const sourceReplyBroadcastContent: AssistantDisplayContentBlock[] = [];
-                  for (const [replyIndex] of agentRunReplyPayloads.entries()) {
-                    const finalPayload = finalPayloads[replyIndex];
-                    if (!finalPayload) {
-                      continue;
-                    }
-                    const replyAssistantContent =
-                      agentRunReplyPayloads.length === 1
-                        ? combinedAssistantContent
-                        : await buildReplyAssistantContent([finalPayload]);
-                    const replyMediaMessage =
-                      agentRunReplyPayloads.length === 1
-                        ? combinedMediaMessage
-                        : await buildReplyMediaMessage([finalPayload]);
-                    const replyBroadcastContent = hasAssistantDisplayMediaContent(
-                      replyAssistantContent,
-                    )
-                      ? replyAssistantContent
-                      : hasAssistantDisplayMediaContent(replyMediaMessage?.content)
-                        ? replyMediaMessage?.content
-                        : replyAssistantContent;
-                    const persistedContent = replaceAssistantContentTextBlocks(
-                      replyAssistantContent,
-                      replyMediaMessage ?? null,
-                    );
-                    const state: SourceReplyContentState = {
-                      broadcastContent: replyBroadcastContent ? [...replyBroadcastContent] : [],
-                      persistedContent: persistedContent ? [...persistedContent] : [],
-                      hasManagedOutgoingContent:
-                        hasManagedOutgoingAssistantContent(persistedContent),
-                      backedManagedOutgoingContent: false,
-                    };
-                    sourceReplyContentStates[replyIndex] = state;
-                    if (state.broadcastContent.length > 0) {
-                      sourceReplyBroadcastContent.push(...state.broadcastContent);
-                    }
-                  }
-
-                  const displayReply =
-                    extractAssistantDisplayTextFromContent(sourceReplyBroadcastContent) ??
-                    buildTranscriptReplyText(finalPayloads);
-                  if (sourceReplyBroadcastContent.length || displayReply) {
-                    const sourceReplyPersistenceRequests: Array<{
-                      idempotencyKey: string;
-                      metadata: SourceReplyTranscriptMirrorMetadata;
-                      state: SourceReplyContentState;
-                    }> = [];
-                    for (const [
-                      replyIndex,
-                      sourceReplyPayload,
-                    ] of agentRunReplyPayloads.entries()) {
-                      const state = sourceReplyContentStates[replyIndex];
-                      if (!state || !hasAssistantDisplayMediaContent(state.persistedContent)) {
-                        continue;
-                      }
-                      const mirrorMetadata =
-                        getReplyPayloadMetadata(sourceReplyPayload)?.sourceReplyTranscriptMirror;
-                      const mirrorIdempotencyKey = mirrorMetadata?.idempotencyKey;
-                      if (
-                        typeof mirrorIdempotencyKey !== "string" ||
-                        mirrorIdempotencyKey.trim().length === 0
-                      ) {
-                        continue;
-                      }
-                      if (!state.hasManagedOutgoingContent) {
-                        state.backedManagedOutgoingContent = true;
-                      }
-                      sourceReplyPersistenceRequests.push({
-                        idempotencyKey: mirrorIdempotencyKey,
-                        metadata: mirrorMetadata,
-                        state,
-                      });
-                    }
-                    const sourceReplyMirrorCandidates: Array<{
-                      idempotencyKey: string;
-                      metadata: SourceReplyTranscriptMirrorMetadata;
-                    }> = [];
-                    for (const [
-                      replyIndex,
-                      sourceReplyPayload,
-                    ] of agentRunReplyPayloads.entries()) {
-                      if (!sourceReplyContentStates[replyIndex]) {
-                        continue;
-                      }
-                      const mirrorMetadata =
-                        getReplyPayloadMetadata(sourceReplyPayload)?.sourceReplyTranscriptMirror;
-                      const mirrorIdempotencyKey = mirrorMetadata?.idempotencyKey;
-                      if (
-                        typeof mirrorIdempotencyKey !== "string" ||
-                        mirrorIdempotencyKey.trim().length === 0 ||
-                        !mirrorMetadata
-                      ) {
-                        continue;
-                      }
-                      sourceReplyMirrorCandidates.push({
-                        idempotencyKey: mirrorIdempotencyKey,
-                        metadata: mirrorMetadata,
-                      });
-                    }
-
-                    const attachSourceReplyManagedImages = async (paramsLocal: {
-                      messageId?: string;
-                      request: (typeof sourceReplyPersistenceRequests)[number];
-                    }) => {
-                      if (!paramsLocal.request.state.hasManagedOutgoingContent) {
-                        paramsLocal.request.state.backedManagedOutgoingContent = true;
-                        return;
-                      }
-                      if (!paramsLocal.messageId) {
-                        return;
-                      }
-                      await attachManagedOutgoingImagesToMessage({
-                        messageId: paramsLocal.messageId,
-                        blocks: paramsLocal.request.state.persistedContent,
-                      });
-                      paramsLocal.request.state.backedManagedOutgoingContent = true;
-                    };
-
-                    const sourceReplyScope = assistantTranscriptScope({
-                      sessionId,
-                      sessionKey,
-                      storePath: latestStorePath,
-                      agentId,
-                    });
-                    if (sourceReplyScope && sourceReplyPersistenceRequests.length > 0) {
-                      const rewritten = await rewriteSourceReplyTranscriptMirrors({
-                        candidates: sourceReplyMirrorCandidates,
-                        requests: sourceReplyPersistenceRequests,
-                        scope: sourceReplyScope,
-                      });
-                      if (rewritten.length > 0) {
-                        await publishAssistantTranscriptRewrite({
-                          scope: sourceReplyScope,
-                          rewritten,
-                        });
-                        for (const target of rewritten) {
-                          await attachSourceReplyManagedImages({
-                            messageId: target.messageId,
-                            request: target.request,
-                          });
-                        }
-                      }
-                    }
-                    const sourceReplyContent = sourceReplyContentStates
-                      .flatMap((state) => {
-                        if (
-                          state.hasManagedOutgoingContent &&
-                          !state.backedManagedOutgoingContent
-                        ) {
-                          const stripped = stripManagedOutgoingAssistantContentBlocks(
-                            state.broadcastContent,
-                          );
-                          return stripped?.length
-                            ? stripped
-                            : [{ type: "text", text: "Media reply could not be displayed." }];
-                        }
-                        return state.broadcastContent;
-                      })
-                      .filter((block): block is AssistantDisplayContentBlock => Boolean(block));
-                    const sourceReplyTextFromContent =
-                      extractAssistantDisplayTextFromContent(sourceReplyContent);
-                    const sourceReplyText =
-                      sourceReplyTextFromContent ??
-                      (sourceReplyContent.length === 0 ? displayReply : undefined);
-                    const nowLocal = Date.now();
-                    const message = {
-                      role: "assistant",
-                      ...(sourceReplyContent?.length
-                        ? { content: sourceReplyContent }
-                        : sourceReplyText
-                          ? { content: [{ type: "text", text: sourceReplyText }] }
-                          : {}),
-                      ...(sourceReplyText ? { text: sourceReplyText } : {}),
-                      timestamp: nowLocal,
-                      stopReason: "stop",
-                      usage: { input: 0, output: 0, totalTokens: 0 },
-                    };
-                    if (hasVisibleAssistantFinalMessage(message)) {
-                      emitFirstAssistantServerTiming();
-                    }
-                    broadcastChatFinal({
-                      context,
-                      runId: clientRunId,
-                      sessionKey,
-                      agentId,
-                      message,
-                    });
-                    broadcastedSourceReplyFinal = hasSourceReplyTranscriptMirror;
-                  }
-                }
+                broadcastedSourceReplyFinal = await finalizeChatSendSourceReplies({
+                  accountId,
+                  context,
+                  deliveredReplies,
+                  emitFirstAssistantServerTiming,
+                  hasReturnedAgentErrorPayloads: returnedAgentErrorPayloads.length > 0,
+                  session: preparedSession.value,
+                });
               }
               const shouldBroadcastAgentError =
                 returnedAgentErrorPayloads.length > 0 && !broadcastedSourceReplyFinal;


### PR DESCRIPTION
## What Problem This Solves

`chat.send` still owned agent-run source/status reply finalization inline: payload selection, assistant display assembly, transcript-mirror rewrites, managed-image backing, fallback projection, and final broadcast. This lifecycle was difficult to review independently from normal agent completion and error handling.

Advances #106555.

## Why This Change Was Made

- Move source/status reply selection and finalization into `chat-send-source-finalization.ts`.
- Keep transcript-mirror rewrite and managed-media backing under one owner.
- Return the source-reply broadcast result to the handler for existing agent-error precedence.
- Add focused selection tests while retaining the existing full source-reply integration suite.

This reduces `chat.ts` from 2,368 to 2,106 lines. The extracted production module is 303 lines.

## User Impact

No intended behavior change. Agent-run source replies and internal status notices retain transcript rewrite, media fallback, final broadcast, and error-precedence behavior.

## Evidence

- Testbox `tbx_01kxecbxb9m99ncx6s3439yp7p`: 2 files, 145 tests passed, including the existing source-reply integration suite.
- Same Testbox: `corepack pnpm tsgo:core` passed.
- Fresh autoreview raised two stale-reference findings that were rejected: both named call sites already live in `chat-send-reply-dispatch.ts`; `rg` showed no references in `chat.ts`, and core `tsgo` passed. No accepted/actionable findings remain.
- `git diff --check origin/main...HEAD` passed after rebasing onto current `origin/main`.
- Hosted CI intentionally not awaited per maintainer direction.
