### PR TITLE
fix: model probes find credentials stored under auth aliases

### DIFF
--- a/src/commands/models/list.probe.models.ts
+++ b/src/commands/models/list.probe.models.ts
@@ -1,0 +1,70 @@
+/** Model candidate normalization and catalog selection for auth probes. */
+import { expectDefined } from "@openclaw/normalization-core";
+import { normalizeProviderId, parseModelRef } from "../../agents/model-selection.js";
+import { DEFAULT_PROVIDER } from "./shared.js";
+
+/** Groups configured model candidates by their requested provider identity. */
+export function buildProbeCandidateMap(modelCandidates: string[]): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  for (const raw of modelCandidates) {
+    const parsed = parseModelRef(raw ?? "", DEFAULT_PROVIDER);
+    if (!parsed) {
+      continue;
+    }
+    const list = map.get(parsed.provider) ?? [];
+    if (!list.includes(parsed.model)) {
+      list.push(parsed.model);
+    }
+    map.set(parsed.provider, list);
+  }
+  return map;
+}
+
+function catalogProbePriority(provider: string, modelId: string): number {
+  const id = modelId.trim().toLowerCase();
+  if (provider !== "anthropic") {
+    return 50;
+  }
+  if (/^claude-haiku-4-5-\d{8}$/.test(id)) {
+    return 0;
+  }
+  if (id === "claude-haiku-4-5") {
+    return 1;
+  }
+  if (id === "claude-sonnet-5" || id.startsWith("claude-sonnet-5-")) {
+    return 2;
+  }
+  if (id === "claude-sonnet-4-6" || id.startsWith("claude-sonnet-4-6-")) {
+    return 3;
+  }
+  if (id.startsWith("claude-sonnet-4-")) {
+    return 4;
+  }
+  if (id.startsWith("claude-3-")) {
+    return 100;
+  }
+  return 50;
+}
+
+/** Selects a requested-provider candidate before falling back to its catalog rows. */
+export function selectProbeModel(params: {
+  provider: string;
+  candidates: Map<string, string[]>;
+  catalog: Array<{ provider: string; id: string }>;
+}): { provider: string; model: string } | null {
+  const { provider, candidates, catalog } = params;
+  const direct = candidates.get(provider);
+  if (direct && direct.length > 0) {
+    return { provider, model: expectDefined(direct[0], "direct entry at 0") };
+  }
+  const fromCatalog = catalog
+    .map((entry, index) => ({ entry, index }))
+    .filter(({ entry }) => normalizeProviderId(entry.provider) === provider)
+    .toSorted((left, right) => {
+      const priority =
+        catalogProbePriority(provider, left.entry.id) -
+        catalogProbePriority(provider, right.entry.id);
+      return priority || left.index - right.index;
+    })[0]?.entry;
+  return fromCatalog ? { provider, model: fromCatalog.id } : null;
+}

--- a/src/commands/models/list.probe.targets.test.ts
+++ b/src/commands/models/list.probe.targets.test.ts
@@ -740,6 +740,42 @@ describe("buildProbeTargets reason codes", () => {
     ]);
   });
 
+  it("keeps profiles stored under the requested provider alias", async () => {
+    mockStore = {
+      version: 1,
+      profiles: {
+        "byteplus-plan:saved": {
+          type: "api_key",
+          provider: "byteplus-plan",
+          key: "byteplus-plan-key",
+        },
+      },
+      order: { "byteplus-plan": ["byteplus-plan:saved"] },
+    };
+    mockAllowedProfiles = ["byteplus-plan:saved"];
+    resolveAuthProfileEligibilityMock.mockReturnValue({ eligible: true, reasonCode: "ok" });
+
+    const plan = await buildProbeTargets({
+      cfg: {} as OpenClawConfig,
+      providers: ["byteplus-plan"],
+      modelCandidates: ["byteplus-plan/ark-code-latest"],
+      options: {
+        timeoutMs: 5_000,
+        concurrency: 1,
+        maxTokens: 16,
+      },
+    });
+
+    expect(plan.results).toStrictEqual([]);
+    expect(plan.targets).toContainEqual(
+      expect.objectContaining({
+        provider: "byteplus-plan",
+        profileId: "byteplus-plan:saved",
+        source: "profile",
+      }),
+    );
+  });
+
   it("matches canonical providers against alias-valued catalog probe models", async () => {
     await withClearedZaiEnv(async () => {
       mockStore = {

--- a/src/commands/models/list.probe.targets.test.ts
+++ b/src/commands/models/list.probe.targets.test.ts
@@ -90,6 +90,10 @@ vi.mock("../../agents/model-auth.js", () => ({
       : null;
   },
 }));
+vi.mock("../../agents/provider-auth-aliases.js", () => ({
+  resolveProviderIdForAuth: (provider: string) =>
+    provider === "byteplus-plan" ? "byteplus" : provider,
+}));
 vi.mock("../../agents/model-selection.js", () => {
   const normalizeProviderId = (value: string) =>
     value.trim().toLowerCase() === "z.ai" || value.trim().toLowerCase() === "z-ai"
@@ -680,6 +684,60 @@ describe("buildProbeTargets reason codes", () => {
         );
       },
     );
+  });
+
+  it("keeps alias model selection while resolving profiles from the auth provider", async () => {
+    mockStore = {
+      version: 1,
+      profiles: {
+        "byteplus:plan": {
+          type: "api_key",
+          provider: "byteplus",
+          key: "byteplus-plan-key",
+        },
+      },
+      order: { byteplus: ["byteplus:plan"] },
+    };
+    mockAllowedProfiles = ["byteplus:plan"];
+    resolveAuthProfileEligibilityMock.mockReturnValue({ eligible: true, reasonCode: "ok" });
+    loadModelCatalogMock.mockResolvedValueOnce([
+      { provider: "byteplus", id: "seed-2-0-mini", name: "BytePlus Standard" },
+      { provider: "byteplus-plan", id: "ark-code-latest", name: "BytePlus Plan" },
+    ]);
+
+    const plan = await buildProbeTargets({
+      cfg: {
+        models: {
+          providers: {
+            "byteplus-plan": {
+              baseUrl: "https://ark.ap-southeast.bytepluses.com/api/coding/v3",
+              api: "openai-completions",
+              models: [],
+            },
+          },
+        },
+        auth: { order: { byteplus: ["byteplus:plan"] } },
+      } as OpenClawConfig,
+      providers: ["byteplus-plan"],
+      modelCandidates: [],
+      options: {
+        timeoutMs: 5_000,
+        concurrency: 1,
+        maxTokens: 16,
+      },
+    });
+
+    expect(plan.results).toStrictEqual([]);
+    expect(plan.targets).toStrictEqual([
+      {
+        label: "byteplus:plan",
+        mode: "api_key",
+        model: { provider: "byteplus-plan", model: "ark-code-latest" },
+        profileId: "byteplus:plan",
+        provider: "byteplus-plan",
+        source: "profile",
+      },
+    ]);
   });
 
   it("matches canonical providers against alias-valued catalog probe models", async () => {

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -3,7 +3,6 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
 import pMap from "p-map";
 import {
@@ -33,11 +32,8 @@ import {
   resolveUsableCustomProviderApiKey,
 } from "../../agents/model-auth.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
-import {
-  findNormalizedProviderValue,
-  normalizeProviderId,
-  parseModelRef,
-} from "../../agents/model-selection.js";
+import { findNormalizedProviderValue, normalizeProviderId } from "../../agents/model-selection.js";
+import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import {
   resolveSessionTranscriptPath,
@@ -53,7 +49,8 @@ import { type SecretRefResolveCache, resolveSecretRefString } from "../../secret
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { disposeOpenClawAgentDatabaseByPath } from "../../state/openclaw-agent-db.js";
 import { redactSecrets } from "../status-all/format.js";
-import { DEFAULT_PROVIDER, formatMs } from "./shared.js";
+import { buildProbeCandidateMap, selectProbeModel } from "./list.probe.models.js";
+import { formatMs } from "./shared.js";
 
 const PROBE_PROMPT = "Reply with OK. Do not use tools.";
 
@@ -168,73 +165,6 @@ export function mapFailoverReasonToProbeStatus(reason?: string | null): AuthProb
     return "format";
   }
   return "unknown";
-}
-
-function buildCandidateMap(modelCandidates: string[]): Map<string, string[]> {
-  const map = new Map<string, string[]>();
-  for (const raw of modelCandidates) {
-    const parsed = parseModelRef(raw ?? "", DEFAULT_PROVIDER);
-    if (!parsed) {
-      continue;
-    }
-    const list = map.get(parsed.provider) ?? [];
-    if (!list.includes(parsed.model)) {
-      list.push(parsed.model);
-    }
-    map.set(parsed.provider, list);
-  }
-  return map;
-}
-
-function catalogProbePriority(provider: string, modelId: string): number {
-  const id = modelId.trim().toLowerCase();
-  if (provider !== "anthropic") {
-    return 50;
-  }
-  if (/^claude-haiku-4-5-\d{8}$/.test(id)) {
-    return 0;
-  }
-  if (id === "claude-haiku-4-5") {
-    return 1;
-  }
-  if (id === "claude-sonnet-5" || id.startsWith("claude-sonnet-5-")) {
-    return 2;
-  }
-  if (id === "claude-sonnet-4-6" || id.startsWith("claude-sonnet-4-6-")) {
-    return 3;
-  }
-  if (id.startsWith("claude-sonnet-4-")) {
-    return 4;
-  }
-  if (id.startsWith("claude-3-")) {
-    return 100;
-  }
-  return 50;
-}
-
-function selectProbeModel(params: {
-  provider: string;
-  candidates: Map<string, string[]>;
-  catalog: Array<{ provider: string; id: string }>;
-}): { provider: string; model: string } | null {
-  const { provider, candidates, catalog } = params;
-  const direct = candidates.get(provider);
-  if (direct && direct.length > 0) {
-    return { provider, model: expectDefined(direct[0], "direct entry at 0") };
-  }
-  const fromCatalog = catalog
-    .map((entry, index) => ({ entry, index }))
-    .filter(({ entry }) => normalizeProviderId(entry.provider) === provider)
-    .toSorted((left, right) => {
-      const priority =
-        catalogProbePriority(provider, left.entry.id) -
-        catalogProbePriority(provider, right.entry.id);
-      return priority || left.index - right.index;
-    })[0]?.entry;
-  if (fromCatalog) {
-    return { provider, model: fromCatalog.id };
-  }
-  return null;
 }
 
 function mapEligibilityReasonToProbeReasonCode(
@@ -405,11 +335,14 @@ export async function buildProbeTargets(params: {
   options: AuthProbeOptions;
 }): Promise<{ targets: AuthProbeTarget[]; results: AuthProbeResult[] }> {
   const { cfg, agentDir, providers, modelCandidates, options, workspaceDir } = params;
+  const authAliasLookupParams = { config: cfg, workspaceDir };
   const store = ensureAuthProfileStore(agentDir, {
     externalCli: externalCliDiscoveryScoped({
       config: cfg,
       allowKeychainPrompt: false,
-      providerIds: providers,
+      providerIds: providers.map((provider) =>
+        resolveProviderIdForAuth(provider, authAliasLookupParams),
+      ),
       profileIds: options.profileIds,
     }),
   });
@@ -418,12 +351,13 @@ export async function buildProbeTargets(params: {
   const profileFilter = new Set(normalizeUniqueStringEntries(options.profileIds));
   const refResolveCache: SecretRefResolveCache = {};
   const catalog = await loadModelCatalog({ config: cfg });
-  const candidates = buildCandidateMap(modelCandidates);
+  const candidates = buildProbeCandidateMap(modelCandidates);
   const targets: AuthProbeTarget[] = [];
   const results: AuthProbeResult[] = [];
 
   for (const provider of providers) {
     const providerKey = normalizeProviderId(provider);
+    const authProviderKey = resolveProviderIdForAuth(providerKey, authAliasLookupParams);
     if (providerFilterKey && providerKey !== providerFilterKey) {
       continue;
     }
@@ -439,9 +373,13 @@ export async function buildProbeTargets(params: {
       includeDirectKeys &&
       profileFilter.size === 0 &&
       hasConfiguredSecretInput(configuredProvider?.apiKey, cfg.secrets?.defaults);
-    const profileIds = listProfilesForProvider(store, providerKey);
+    const profileIds = listProfilesForProvider(store, authProviderKey);
     const configuredReference = includeConfigKey
-      ? resolveProviderEntryApiKeyProfileReference({ cfg, provider: providerKey, store })
+      ? resolveProviderEntryApiKeyProfileReference({
+          cfg,
+          provider: providerKey,
+          store,
+        })
       : ({ kind: "none" } as const);
     const configuredBinding =
       configuredReference.kind === "profile" && !profileIds.includes(configuredReference.profileId)
@@ -473,7 +411,7 @@ export async function buildProbeTargets(params: {
         ? configuredProvider.auth
         : "api_key";
     const resolvedEnvironmentValue = includeDirectKeys
-      ? resolveEnvApiKey(providerKey, process.env, {
+      ? resolveEnvApiKey(authProviderKey, process.env, {
           config: cfg,
           workspaceDir,
         })
@@ -596,12 +534,11 @@ export async function buildProbeTargets(params: {
         }
       }
     };
-    const explicitOrder = (() => {
-      return (
-        findNormalizedProviderValue(store.order, providerKey) ??
-        findNormalizedProviderValue(cfg?.auth?.order, providerKey)
-      );
-    })();
+    const explicitOrder =
+      findNormalizedProviderValue(store.order, authProviderKey) ??
+      findNormalizedProviderValue(store.order, providerKey) ??
+      findNormalizedProviderValue(cfg?.auth?.order, authProviderKey) ??
+      findNormalizedProviderValue(cfg?.auth?.order, providerKey);
     const orderResolution = resolveAuthProfileOrderWithMetadata({
       cfg,
       store,
@@ -725,7 +662,7 @@ export async function buildProbeTargets(params: {
 
     const envKey = orderResolution.hasExplicitOrder
       ? null
-      : resolveEnvApiKey(providerKey, process.env, {
+      : resolveEnvApiKey(authProviderKey, process.env, {
           config: cfg,
           workspaceDir,
         });

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -373,7 +373,14 @@ export async function buildProbeTargets(params: {
       includeDirectKeys &&
       profileFilter.size === 0 &&
       hasConfiguredSecretInput(configuredProvider?.apiKey, cfg.secrets?.defaults);
-    const profileIds = listProfilesForProvider(store, authProviderKey);
+    // Keep profiles saved under either surface. The production profile helper
+    // is alias-aware, but scoped plugin metadata can differ between lookups.
+    const profileIds = [
+      ...new Set([
+        ...listProfilesForProvider(store, authProviderKey),
+        ...(authProviderKey === providerKey ? [] : listProfilesForProvider(store, providerKey)),
+      ]),
+    ];
     const configuredReference = includeConfigKey
       ? resolveProviderEntryApiKeyProfileReference({
           cfg,

--- a/src/gateway/server-methods/models-probe.test.ts
+++ b/src/gateway/server-methods/models-probe.test.ts
@@ -95,11 +95,31 @@ describe("models.probe", () => {
   });
 
   it("probes the requested provider so overrides and model selection resolve", async () => {
-    const { options, respond } = createOptions({ provider: "byteplus-plan" });
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "byteplus-plan": {
+            baseUrl: "https://ark.ap-southeast.bytepluses.com/api/coding/v3",
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      },
+      auth: {
+        profiles: {
+          "byteplus:plan": { provider: "byteplus", mode: "api_key" },
+        },
+        order: { byteplus: ["byteplus:plan"] },
+      },
+      agents: { defaults: { model: { primary: "byteplus-plan/ark-code-latest" } } },
+    };
+    const { options, respond } = createOptions({ provider: "byteplus-plan" }, cfg);
     await handler(options);
     expect(mocks.runAuthProbes).toHaveBeenCalledWith(
       expect.objectContaining({
+        cfg,
         providers: ["byteplus-plan"],
+        modelCandidates: ["byteplus-plan/ark-code-latest"],
         options: expect.objectContaining({ provider: "byteplus-plan" }),
       }),
     );

--- a/src/gateway/server-methods/models-probe.ts
+++ b/src/gateway/server-methods/models-probe.ts
@@ -121,10 +121,8 @@ export const modelsProbeHandlers: GatewayRequestHandlers = {
       const cfg = context.getRuntimeConfig();
       // Probe under the requested provider so model selection, catalog rows, and
       // a models.providers.<id> override resolve against the surface the client
-      // asked about. Auth-alias split surfaces (e.g. a coding-plan-only
-      // credential stored under a canonical provider) are a known gap tracked
-      // as follow-up; canonicalizing here instead would probe the wrong
-      // endpoint for override providers.
+      // asked about. The probe planner resolves credentials separately through
+      // the provider's auth alias, matching normal agent runtime planning.
       const summary = await runAuthProbes({
         cfg,
         providers: [provider],


### PR DESCRIPTION
Related: #106490

## What Problem This Solves

Fixes an issue where users probing an auth-aliased model provider could see a valid credential reported as unavailable when the model and provider override lived under the requested alias but the credential lived under the canonical auth provider.

## Why This Change Was Made

The probe planner now preserves the requested provider for model selection, catalog rows, and `models.providers.<id>` overrides while resolving credential discovery, profiles, environment keys, and auth order through `resolveProviderIdForAuth`. This mirrors normal agent runtime planning, which keeps the requested model route and resolves authentication through the canonical provider.

The model-candidate selection helpers moved to a small sibling module to keep the existing probe planner under the TypeScript LOC limit; behavior is unchanged.

AI-assisted: yes. The implementation was reviewed with the repository autoreview workflow; both local-diff and branch reviews returned no actionable findings.

## User Impact

Coding-plan and similar split-provider credentials stored under a canonical provider can now be probed through their alias without losing the alias-specific model, endpoint, or provider override.

## Evidence

- Before fix: the new `byteplus-plan` / `byteplus` planner regression test failed because `buildProbeTargets` returned no targets.
- After fix, Blacksmith Testbox `tbx_01kxecsegkqhgr2d0msnrkfdja` passed 187 focused tests across probe planning, gateway RPC, runtime auth, model auth, provider aliases, and the BytePlus plugin.
- `pnpm check:changed` passed conflict, LOC, attribution, boundary, dependency, formatting, type/lint stages reached; it stopped on the Plugin SDK API baseline hash already drifting on current `main`. This patch changes no Plugin SDK entrypoint or export.
- GitHub Testbox hydration/proof run: https://github.com/openclaw/openclaw/actions/runs/29275777657
