### PR TITLE
fix(ai): safely format circular rejections in stream catch paths

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -32,6 +32,7 @@ import type {
 } from "../types.js";
 import { createDeferredEventBuffer } from "../utils/deferred-event-buffer.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { formatUnknownError } from "../utils/format-unknown-error.js";
 import { headersToRecord } from "../utils/headers.js";
 import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.js";
 import { notifyLlmRequestActivity } from "../utils/llm-request-activity.js";
@@ -934,7 +935,8 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
         output.content = [];
       }
       output.stopReason = requestOptions?.signal?.aborted ? "aborted" : "error";
-      output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+      // Same terminal-stream invariant as OpenAI/Google: never throw while formatting.
+      output.errorMessage = formatUnknownError(error);
       stream.push({ type: "error", reason: output.stopReason, error: output });
       stream.end();
     }

--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -8,6 +8,8 @@ import {
   buildGoogleGenerateContentParams,
   buildGoogleSimpleThinking,
   consumeGoogleGenerateContentStream,
+  createGoogleAssistantOutput,
+  runGoogleGenerateContentLifecycle,
 } from "./google-shared.js";
 
 const model: Model<"google-generative-ai"> = {
@@ -89,6 +91,40 @@ describe("buildGoogleSimpleThinking", () => {
 async function* chunks(items: GenerateContentResponse[]) {
   yield* items;
 }
+
+describe("runGoogleGenerateContentLifecycle", () => {
+  it("emits a terminal error for circular non-Error rejections without rethrowing (#106568)", async () => {
+    const circular: Record<string, unknown> = { kind: "google-provider-reject" };
+    circular.self = circular;
+    expect(() => JSON.stringify(circular)).toThrow();
+
+    const output = createGoogleAssistantOutput(model);
+    const stream = new AssistantMessageEventStream();
+    const events: Array<{ type: string; reason?: string }> = [];
+    const collect = (async () => {
+      for await (const event of stream) {
+        events.push({ type: event.type, reason: "reason" in event ? event.reason : undefined });
+      }
+    })();
+
+    await runGoogleGenerateContentLifecycle({
+      stream,
+      model,
+      output,
+      createClient: () => {
+        throw circular;
+      },
+      buildParams: () => ({ model: model.id, contents: [] }),
+      nextToolCallId: (name) => `generated-${name}`,
+    });
+    await collect;
+
+    expect(events.some((event) => event.type === "error")).toBe(true);
+    expect(output.stopReason).toBe("error");
+    expect(output.errorMessage).toBeTruthy();
+    expect(output.errorMessage).toContain("Object");
+  });
+});
 
 describe("consumeGoogleGenerateContentStream", () => {
   it("projects text, thinking, tool calls, response id, and usage into one stream", async () => {

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -30,6 +30,7 @@ import type {
   StreamOptions,
 } from "../types.js";
 import type { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { formatUnknownError } from "../utils/format-unknown-error.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
 import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
@@ -474,7 +475,8 @@ export async function runGoogleGenerateContentLifecycle<T extends GoogleApiType>
       }
     }
     output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-    output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+    // Circular non-Error rejections must not throw inside this catch (#106568).
+    output.errorMessage = formatUnknownError(error);
     stream.push({ type: "error", reason: output.stopReason, error: output });
     stream.end();
   }

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -511,6 +511,29 @@ describe("OpenAI-compatible completions params", () => {
     expect(capturedPayload?.tools).toEqual([]);
   });
 
+  it("emits a terminal error for circular non-Error rejections without rethrowing (#106570)", async () => {
+    const circular: Record<string, unknown> = { kind: "provider-reject" };
+    circular.self = circular;
+    expect(() => JSON.stringify(circular)).toThrow();
+
+    mockChunksRef.stream = {
+      [Symbol.asyncIterator]() {
+        return {
+          next() {
+            return Promise.reject(circular);
+          },
+        };
+      },
+    };
+
+    const stream = streamOpenAICompletions(model, context, { apiKey: "sk-test" });
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBeTruthy();
+    expect(result.errorMessage).toContain("Object");
+  });
+
   it("replays update_plan-style empty non-image tool results as no output", async () => {
     let capturedMessages:
       | Array<{ role?: string; content?: unknown; tool_call_id?: string }>

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -35,6 +35,7 @@ import type {
   ToolCall,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { formatUnknownError } from "../utils/format-unknown-error.js";
 import { headersToRecord } from "../utils/headers.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { createReasoningTagTextPartitioner } from "../utils/reasoning-tag-text-partitioner.js";
@@ -563,7 +564,8 @@ export const streamOpenAICompletions: StreamFunction<
         delete (block as { streamIndex?: number }).streamIndex;
       }
       output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-      output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+      // Circular non-Error rejections must not throw inside this catch (#106570).
+      output.errorMessage = formatUnknownError(error);
       // Some providers via OpenRouter give additional information in this field.
       const rawMetadata = (error as { error?: { metadata?: { raw?: string } } })?.error?.metadata
         ?.raw;

--- a/packages/ai/src/utils/format-unknown-error.test.ts
+++ b/packages/ai/src/utils/format-unknown-error.test.ts
@@ -1,0 +1,25 @@
+// Covers safe formatting of circular non-Error rejections for stream catch paths.
+import { describe, expect, it } from "vitest";
+import { formatUnknownError } from "./format-unknown-error.js";
+
+describe("formatUnknownError", () => {
+  it("prefers Error.message", () => {
+    expect(formatUnknownError(new Error("boom"))).toBe("boom");
+  });
+
+  it("JSON-stringifies ordinary non-Error values", () => {
+    expect(formatUnknownError({ code: "ECONNRESET" })).toBe('{"code":"ECONNRESET"}');
+    expect(formatUnknownError("plain")).toBe('"plain"');
+    expect(formatUnknownError(42)).toBe("42");
+  });
+
+  it("falls back to String for circular structures without throwing", () => {
+    const circular: Record<string, unknown> = { kind: "provider-reject" };
+    circular.self = circular;
+    expect(() => JSON.stringify(circular)).toThrow();
+    const formatted = formatUnknownError(circular);
+    expect(typeof formatted).toBe("string");
+    expect(formatted.length).toBeGreaterThan(0);
+    expect(formatted).toContain("Object");
+  });
+});

--- a/packages/ai/src/utils/format-unknown-error.test.ts
+++ b/packages/ai/src/utils/format-unknown-error.test.ts
@@ -22,4 +22,33 @@ describe("formatUnknownError", () => {
     expect(formatted.length).toBeGreaterThan(0);
     expect(formatted).toContain("Object");
   });
+
+  it("returns a stable literal when String conversion throws", () => {
+    // Reach the String fallback with a circular null-prototype object:
+    // JSON.stringify throws on the cycle, and String() throws without Object.prototype.
+    const nullProto = Object.create(null) as Record<string, unknown>;
+    nullProto.kind = "null-proto-reject";
+    nullProto.self = nullProto;
+    expect(() => JSON.stringify(nullProto)).toThrow();
+    expect(() => String(nullProto)).toThrow();
+    expect(formatUnknownError(nullProto)).toBe("Unknown error");
+
+    // Hostile conversion hooks with a cycle force the same final fallback.
+    const hostile: {
+      self?: unknown;
+      toString: () => string;
+      valueOf: () => number;
+    } = {
+      toString() {
+        throw new Error("toString blocked");
+      },
+      valueOf() {
+        throw new Error("valueOf blocked");
+      },
+    };
+    hostile.self = hostile;
+    expect(() => JSON.stringify(hostile)).toThrow();
+    expect(() => String(hostile)).toThrow();
+    expect(formatUnknownError(hostile)).toBe("Unknown error");
+  });
 });

--- a/packages/ai/src/utils/format-unknown-error.ts
+++ b/packages/ai/src/utils/format-unknown-error.ts
@@ -1,0 +1,17 @@
+/**
+ * Formats an unknown rejection/throw value for provider stream terminal errors.
+ *
+ * Prefer Error.message; fall back to safe JSON, then String(). Never throw —
+ * stream catch paths must still emit a terminal error event and end the stream.
+ */
+export function formatUnknownError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  try {
+    const serialized = JSON.stringify(error);
+    return serialized === undefined ? String(error) : serialized;
+  } catch {
+    return String(error);
+  }
+}

--- a/packages/ai/src/utils/format-unknown-error.ts
+++ b/packages/ai/src/utils/format-unknown-error.ts
@@ -3,6 +3,8 @@
  *
  * Prefer Error.message; fall back to safe JSON, then String(). Never throw —
  * stream catch paths must still emit a terminal error event and end the stream.
+ * Final conversion uses a constant literal if String() itself throws (for
+ * example Object.create(null) or a throwing @@toPrimitive / valueOf / toString).
  */
 export function formatUnknownError(error: unknown): string {
   if (error instanceof Error) {
@@ -10,8 +12,16 @@ export function formatUnknownError(error: unknown): string {
   }
   try {
     const serialized = JSON.stringify(error);
-    return serialized === undefined ? String(error) : serialized;
+    if (serialized !== undefined) {
+      return serialized;
+    }
   } catch {
+    // Circular structures and other non-JSON values fall through to String().
+  }
+  try {
     return String(error);
+  } catch {
+    // String() is not guaranteed for null-prototype or hostile conversion hooks.
+    return "Unknown error";
   }
 }


### PR DESCRIPTION
Closes #106570
Related: #106568

## What Problem This Solves

Fixes an issue where provider stream failure handling could throw a second exception when formatting a non-Error rejection that contains circular references. That second throw prevented a clean terminal error event and stream end on OpenAI Completions (and the sibling Google shared stream path), so agent runs could hang or fail without a structured provider error.

## Why This Change Was Made

Introduces a shared `formatUnknownError` helper that prefers `Error.message`, safely JSON-stringifies ordinary values, falls back to `String(error)` when `JSON.stringify` throws, and returns the constant `"Unknown error"` if `String()` itself throws (null-prototype or hostile conversion hooks). The OpenAI Completions, Google shared, and Anthropic stream catch paths use it so terminal stream termination cannot be broken by circular or hostile rejection payloads. OpenAI Responses/Azure already guarded stringify; this keeps the unsafe catch sites consistent without new config or fallback policy.

Fix quality: compatibility — no API/config shape change, same errorMessage field; performance — O(1) catch-path only; usability — still delivers a terminal error message; security — no secret logging or trust-boundary changes.

## User Impact

When a provider transport rejects with an unusual non-Error object (including circular structures or values whose String conversion throws), the agent stream fails closed with a normal error stop reason and message instead of throwing inside the recovery path.

## Evidence

Verification host: local macOS (Node v24.17.0)

```text
node scripts/run-vitest.mjs packages/ai/src/utils/format-unknown-error.test.ts
# 4 passed (Error.message, JSON path, circular String fallback, non-throwing final literal)

node scripts/run-vitest.mjs \
  packages/ai/src/providers/openai-completions.test.ts \
  packages/ai/src/providers/google-shared.test.ts \
  -t "circular"
# 2 passed (OpenAI #106570 + Google #106568 lifecycle: stopReason=error + non-empty errorMessage)

node scripts/run-vitest.mjs packages/ai/src/providers/openai-completions.test.ts -t "circular" --reporter=verbose
# ✓ emits a terminal error for circular non-Error rejections without rethrowing (#106570)

pnpm exec oxfmt --check packages/ai/src/utils/format-unknown-error.ts \
  packages/ai/src/utils/format-unknown-error.test.ts  # pass
git diff --check  # pass
```

## Real behavior proof

- Behavior addressed: Stream catch paths must emit a terminal error event when the transport rejects with a circular non-Error value (or a value whose String conversion throws), without a second exception in the recovery path.
- Environment: local macOS openclaw checkout; focused Vitest via `node scripts/run-vitest.mjs`; Node v24.17.0 runtime transcript for the formatter + stream-shaped terminal events. No live provider credentials required (SDK circular non-Error shapes are not guaranteed from supported providers; proof exercises the catch-path contract the providers call).
- Current-main contrast: On main, `error instanceof Error ? error.message : JSON.stringify(error)` throws `TypeError: Converting circular structure to JSON` for self-referential objects, so the catch path never reaches `stream.push({ type: "error" })` / `stream.end()`. Reproduced with: `const c={k:1}; c.self=c; JSON.stringify(c)` → throws.
- Exact steps after this patch:
  1. `node scripts/run-vitest.mjs packages/ai/src/utils/format-unknown-error.test.ts`
  2. `node scripts/run-vitest.mjs packages/ai/src/providers/openai-completions.test.ts -t "circular"`
  3. `node scripts/run-vitest.mjs packages/ai/src/providers/google-shared.test.ts -t "circular"`
  4. Runtime transcript (formatter + stream-shaped terminal emission; redacted, no secrets):
```text
=== formatUnknownError runtime proof (redacted) ===
host: darwin v24.17.0
before: JSON.stringify(circular) throws: true
format(circular): threw=false value="[object Object]"
format(null-proto-circular): threw=false value="Unknown error"
format(hostile-circular): threw=false value="Unknown error"
format(Error): threw=false value="upstream boom"
format(plain-object): threw=false value="{\"code\":\"ECONNRESET\"}"

=== stream catch-path terminal emission (synthetic runtime, OpenAI Completions shape) ===
case=circular-non-Error
  output.stopReason= error
  output.errorMessage= [object Object]
  events= [{"type":"error","reason":"error","errorMessage":"[object Object]"},{"type":"end"}]
  stream_closed= true
case=null-proto-circular
  output.stopReason= error
  output.errorMessage= Unknown error
  events= [{"type":"error","reason":"error","errorMessage":"Unknown error"},{"type":"end"}]
  stream_closed= true
case=hostile-circular
  output.stopReason= error
  output.errorMessage= Unknown error
  events= [{"type":"error","reason":"error","errorMessage":"Unknown error"},{"type":"end"}]
  stream_closed= true
proof_ok=true
```
- Evidence after fix: Focused OpenAI/Google lifecycle cases pass with `stopReason === "error"` and a non-empty `errorMessage`. Helper never throws: circular → `[object Object]`; null-prototype/hostile circular → `"Unknown error"`. Runtime events show `{type:"error"}` then stream end for each case.
- Control check: Ordinary Error rejections still use `error.message`; ordinary plain objects still JSON-stringify; only circular non-Errors take the String fallback; only values that break both JSON and String take the constant literal.
- Observed result after fix: Circular and hostile non-Error rejections produce a terminal stream error instead of a secondary serialization/conversion crash.
- What was not tested: Live OpenAI/Google network failures that happen to reject with circular non-Error SDK payloads; Anthropic live path (same helper wired for sibling invariant only).

---

AI-assisted contribution: implementation and tests authored with AI assistance (Grok). Proof commands and results above were run on this host.
