### PR TITLE
fix(config): remove stale locked-session delete path

### DIFF
--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -75,7 +75,6 @@ const writerLockedSessionEntries = new WeakMap<
 >();
 
 type SessionStoreInvariantContext = {
-  allowedLockedEntryRemovals?: ReadonlyMap<string, SessionEntry>;
   lockedEntriesBefore?: ReadonlyMap<string, SessionEntry>;
 };
 
@@ -310,7 +309,6 @@ function snapshotLockedSessionEntries(
 }
 
 function assertLockedSessionEntriesPreserved(params: {
-  allowedRemovals?: ReadonlyMap<string, SessionEntry>;
   before?: ReadonlyMap<string, SessionEntry>;
   store: Record<string, SessionEntry>;
 }): void {
@@ -743,7 +741,6 @@ async function saveSessionStoreUnlocked(
   const lockedEntriesBefore =
     invariantContext?.lockedEntriesBefore ?? writerLockedSessionEntries.get(store);
   assertLockedSessionEntriesPreserved({
-    allowedRemovals: invariantContext?.allowedLockedEntryRemovals,
     before: lockedEntriesBefore,
     store,
   });
@@ -778,7 +775,6 @@ async function saveSessionStoreUnlocked(
   // Maintenance shares the mutable writer-owned object. Recheck after it runs so
   // no pruning or future cleanup path can bypass the durable lock invariant.
   assertLockedSessionEntriesPreserved({
-    allowedRemovals: invariantContext?.allowedLockedEntryRemovals,
     before: lockedEntriesBefore,
     store,
   });
@@ -1072,8 +1068,6 @@ type DeleteSessionEntryLifecycleParams = {
 
 async function deleteSessionEntryLifecycleInternal(
   params: DeleteSessionEntryLifecycleParams,
-  allowLockedEntryRemoval: boolean,
-  expectedPluginOwnerId?: string,
 ): Promise<DeleteSessionEntryLifecycleResult> {
   return await runExclusiveSessionStoreWrite(params.storePath, async () => {
     const store = loadMutableSessionStoreForWriter(params.storePath);
@@ -1117,32 +1111,6 @@ async function deleteSessionEntryLifecycleInternal(
         expectedEntryMismatch: true,
       };
     }
-    if (expectedPluginOwnerId) {
-      for (const sessionKey of params.target.storeKeys) {
-        const entry = store[sessionKey];
-        if (!entry) {
-          continue;
-        }
-        if (
-          isAgentHarnessSessionKey(sessionKey) ||
-          entry.agentHarnessId !== undefined ||
-          entry.modelSelectionLocked !== true ||
-          normalizeOptionalString(entry.pluginOwnerId) !== expectedPluginOwnerId
-        ) {
-          throw new Error(MODEL_SELECTION_LOCK_REMOVAL_MESSAGE);
-        }
-      }
-    }
-    const allowedLockedEntryRemovals = allowLockedEntryRemoval
-      ? new Map(
-          params.target.storeKeys.flatMap((sessionKey) => {
-            const entry = store[sessionKey];
-            return entry?.modelSelectionLocked === true
-              ? [[sessionKey, cloneSessionEntry(entry)] as const]
-              : [];
-          }),
-        )
-      : undefined;
     const removedEntries = params.target.storeKeys.flatMap((sessionKey) => {
       const entry = store[sessionKey];
       return entry ? [cloneSessionEntry(entry)] : [];
@@ -1151,16 +1119,9 @@ async function deleteSessionEntryLifecycleInternal(
     const deletedSessionId = deletedEntry.sessionId;
     const deletedSessionFile = deletedEntry.sessionFile;
     delete store[params.target.canonicalKey];
-    await saveSessionStoreUnlocked(
-      params.storePath,
-      store,
-      {
-        requireWriteSuccess: params.requireWriteSuccess,
-      },
-      allowedLockedEntryRemovals && allowedLockedEntryRemovals.size > 0
-        ? { allowedLockedEntryRemovals }
-        : undefined,
-    );
+    await saveSessionStoreUnlocked(params.storePath, store, {
+      requireWriteSuccess: params.requireWriteSuccess,
+    });
     const archivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
     if (params.archiveTranscript) {
       const { archiveSessionTranscriptPaths, resolveSessionTranscriptCandidates } =
@@ -1208,7 +1169,7 @@ async function deleteSessionEntryLifecycleInternal(
 export async function deleteSessionEntryLifecycle(
   params: DeleteSessionEntryLifecycleParams,
 ): Promise<DeleteSessionEntryLifecycleResult> {
-  return await deleteSessionEntryLifecycleInternal(params, false);
+  return await deleteSessionEntryLifecycleInternal(params);
 }
 
 function getErrorCode(error: unknown): string | null {


### PR DESCRIPTION
## What Problem This Solves

#106019 removed the only callers that could bypass the locked-session deletion invariant, but left the private override/plugin-owner branch behind. Its imports were correctly removed, so the orphaned branch no longer compiled.

## Why This Change Was Made

Delete the unreachable override parameters, plugin-owner validation branch, and allowed-removal context. The remaining public deletion path still runs through the ordinary locked-entry invariant with no bypass.

## User Impact

Fixes the current-main production typecheck. No supported runtime behavior changes; the removed path had no callers.

## Evidence

- Blacksmith Testbox `tbx_01kxee8edf2e9hrv61wxb6ya8g`, run `29277498311`: exact deadcode 1,575; 32/32 session lifecycle/invariant tests; core types green.
- One-file type-aware oxlint, oxfmt, and `git diff --check` green.
- Autoreview's only finding claimed three imports remained; exact source search proved all three were already absent, and typed lint passed. Finding rejected as factually inapplicable.
- Broad test types reached an unrelated existing `src/infra/npm-pack-install.test.ts:118` error; excluded from this focused correctness repair.

AI-assisted change.
