### PR TITLE
fix: keep unresolved API-key providers visible

### DIFF
--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -11,6 +11,8 @@ import { MAX_DATE_TIMESTAMP_MS } from "../../shared/number-coercion.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
+type BuildAuthHealthSummary = typeof import("../../agents/auth-health.js").buildAuthHealthSummary;
+
 const emptyUsageSummary = (): UsageSummary => ({ updatedAt: 0, providers: [] });
 
 const mocks = vi.hoisted(() => ({
@@ -39,7 +41,7 @@ const mocks = vi.hoisted(() => ({
   refreshActiveProviderAuthRuntimeSnapshot: vi.fn(async () => false),
   clearCurrentProviderAuthState: vi.fn(),
   warmCurrentProviderAuthStateOffMainThread: vi.fn(async (_cfg: unknown) => {}),
-  buildAuthHealthSummary: vi.fn(
+  buildAuthHealthSummary: vi.fn<BuildAuthHealthSummary>(
     (): AuthHealthSummary => ({ now: 0, warnAfterMs: 0, profiles: [], providers: [] }),
   ),
   loadProviderUsageSummary: vi.fn(async (): Promise<UsageSummary> => emptyUsageSummary()),

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -211,7 +211,8 @@ function firstBuildAuthHealthSummaryCall() {
 async function firstAuthStatusProvider() {
   const opts = createOptions();
   await handler(opts);
-  const [, payload] = firstRespondCall(opts) ?? [];
+  const [ok, payload, error] = firstRespondCall(opts) ?? [];
+  expect(ok, JSON.stringify(error)).toBe(true);
   return (payload as ModelAuthStatusResult).providers[0];
 }
 
@@ -529,6 +530,23 @@ describe("models.authStatus", () => {
       models: {
         providers: {
           ollama: Object.fromEntries([["apiKey", "ollama-local"]]),
+        },
+      },
+    });
+    mocks.buildAuthHealthSummary.mockImplementationOnce(actualAuthHealth.buildAuthHealthSummary);
+
+    const provider = await firstAuthStatusProvider();
+    expect(provider).toBeUndefined();
+  });
+
+  it("does not report an AWS SDK marker as a configured API key", async () => {
+    const actualAuthHealth = await vi.importActual<typeof import("../../agents/auth-health.js")>(
+      "../../agents/auth-health.js",
+    );
+    mocks.getRuntimeConfig.mockReturnValue({
+      models: {
+        providers: {
+          "amazon-bedrock": { ...Object.fromEntries([["apiKey", "AWS_PROFILE"]]) },
         },
       },
     });

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -502,9 +502,9 @@ describe("models.authStatus", () => {
 
   it("does not report unresolved persisted markers as API keys", async () => {
     await withEnvAsync(Object.fromEntries([["ANTHROPIC_API_KEY", undefined]]), async () => {
-      const actualAuthHealth = await vi.importActual<
-        typeof import("../../agents/auth-health.js")
-      >("../../agents/auth-health.js");
+      const actualAuthHealth = await vi.importActual<typeof import("../../agents/auth-health.js")>(
+        "../../agents/auth-health.js",
+      );
       mocks.getRuntimeConfig.mockReturnValue({
         models: {
           providers: {

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -548,7 +548,7 @@ describe("models.authStatus", () => {
     mocks.getRuntimeConfig.mockReturnValue({
       models: {
         providers: {
-          "amazon-bedrock": { ...Object.fromEntries([["apiKey", "AWS_PROFILE"]]) },
+          "amazon-bedrock": Object.fromEntries([["apiKey", "AWS_PROFILE"]]),
         },
       },
     });
@@ -565,7 +565,7 @@ describe("models.authStatus", () => {
     mocks.getRuntimeConfig.mockReturnValue({
       models: {
         providers: {
-          openai: { ...Object.fromEntries([["apiKey", NON_ENV_SECRETREF_MARKER]]) },
+          openai: Object.fromEntries([["apiKey", NON_ENV_SECRETREF_MARKER]]),
         },
       },
     });

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -5,6 +5,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthHealthSummary } from "../../agents/auth-health.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles.js";
+import { NON_ENV_SECRETREF_MARKER } from "../../agents/model-auth-markers.js";
 import type { UsageSummary } from "../../infra/provider-usage.types.js";
 import { MAX_DATE_TIMESTAMP_MS } from "../../shared/number-coercion.js";
 import { withEnvAsync } from "../../test-utils/env.js";
@@ -501,6 +502,9 @@ describe("models.authStatus", () => {
 
   it("does not report unresolved persisted markers as API keys", async () => {
     await withEnvAsync(Object.fromEntries([["ANTHROPIC_API_KEY", undefined]]), async () => {
+      const actualAuthHealth = await vi.importActual<
+        typeof import("../../agents/auth-health.js")
+      >("../../agents/auth-health.js");
       mocks.getRuntimeConfig.mockReturnValue({
         models: {
           providers: {
@@ -508,20 +512,19 @@ describe("models.authStatus", () => {
           },
         },
       });
-      mocks.buildAuthHealthSummary.mockReturnValue({
-        now: 0,
-        warnAfterMs: 0,
-        profiles: [],
-        providers: [{ provider: "anthropic", status: "missing", profiles: [] }],
-      });
+      mocks.buildAuthHealthSummary.mockImplementationOnce(actualAuthHealth.buildAuthHealthSummary);
 
       const provider = await firstAuthStatusProvider();
+      expect(provider?.provider).toBe("anthropic");
       expect(provider?.apiKey).toBeUndefined();
       expect(provider?.status).toBe("missing");
     });
   });
 
   it("does not report a local no-auth marker as a configured API key", async () => {
+    const actualAuthHealth = await vi.importActual<typeof import("../../agents/auth-health.js")>(
+      "../../agents/auth-health.js",
+    );
     mocks.getRuntimeConfig.mockReturnValue({
       models: {
         providers: {
@@ -529,15 +532,29 @@ describe("models.authStatus", () => {
         },
       },
     });
-    mocks.buildAuthHealthSummary.mockReturnValue({
-      now: 0,
-      warnAfterMs: 0,
-      profiles: [],
-      providers: [{ provider: "ollama", status: "missing", profiles: [] }],
-    });
+    mocks.buildAuthHealthSummary.mockImplementationOnce(actualAuthHealth.buildAuthHealthSummary);
 
     const provider = await firstAuthStatusProvider();
+    expect(provider).toBeUndefined();
+  });
+
+  it("keeps unresolved managed SecretRef markers visible as missing", async () => {
+    const actualAuthHealth = await vi.importActual<typeof import("../../agents/auth-health.js")>(
+      "../../agents/auth-health.js",
+    );
+    mocks.getRuntimeConfig.mockReturnValue({
+      models: {
+        providers: {
+          openai: { ...Object.fromEntries([["apiKey", NON_ENV_SECRETREF_MARKER]]) },
+        },
+      },
+    });
+    mocks.buildAuthHealthSummary.mockImplementationOnce(actualAuthHealth.buildAuthHealthSummary);
+
+    const provider = await firstAuthStatusProvider();
+    expect(provider?.provider).toBe("openai");
     expect(provider?.apiKey).toBeUndefined();
+    expect(provider?.status).toBe("missing");
   });
 
   it("does not duplicate profile references as config API keys", async () => {

--- a/src/gateway/server-methods/models-auth-status.ts
+++ b/src/gateway/server-methods/models-auth-status.ts
@@ -502,11 +502,7 @@ function resolveConfiguredApiKeyProviders(cfg: OpenClawConfig): Set<string> {
     const rawKey = typeof provider?.apiKey === "string" ? provider.apiKey.trim() : "";
     // Unresolved credentials still need a missing status row. Local no-auth
     // markers do not: they intentionally represent providers without secrets.
-    if (
-      rawKey &&
-      rawKey !== NON_ENV_SECRETREF_MARKER &&
-      nonSecretMarkers.has(rawKey)
-    ) {
+    if (rawKey && rawKey !== NON_ENV_SECRETREF_MARKER && nonSecretMarkers.has(rawKey)) {
       continue;
     }
     providers.add(normalized);

--- a/src/gateway/server-methods/models-auth-status.ts
+++ b/src/gateway/server-methods/models-auth-status.ts
@@ -34,6 +34,7 @@ import { resolveProviderEnvAuthEvidence } from "../../agents/model-auth-env.js";
 import {
   isKnownEnvApiKeyMarker,
   listKnownNonSecretApiKeyMarkers,
+  NON_ENV_SECRETREF_MARKER,
 } from "../../agents/model-auth-markers.js";
 import {
   resolveProviderEntryApiKeyProfileReference,
@@ -490,6 +491,29 @@ function resolveConfigBoundProfileIds(cfg: OpenClawConfig, store: AuthProfileSto
   return profileIds;
 }
 
+function resolveConfiguredApiKeyProviders(cfg: OpenClawConfig): Set<string> {
+  const providers = new Set<string>();
+  const nonSecretMarkers = new Set(listKnownNonSecretApiKeyMarkers());
+  for (const [id, provider] of Object.entries(cfg.models?.providers ?? {})) {
+    const normalized = normalizeProviderId(id);
+    if (!normalized || !hasConfiguredSecretInput(provider?.apiKey, cfg.secrets?.defaults)) {
+      continue;
+    }
+    const rawKey = typeof provider?.apiKey === "string" ? provider.apiKey.trim() : "";
+    // Unresolved credentials still need a missing status row. Local no-auth
+    // markers do not: they intentionally represent providers without secrets.
+    if (
+      rawKey &&
+      rawKey !== NON_ENV_SECRETREF_MARKER &&
+      nonSecretMarkers.has(rawKey)
+    ) {
+      continue;
+    }
+    providers.add(normalized);
+  }
+  return providers;
+}
+
 function resolveConfiguredProviders(
   cfg: OpenClawConfig,
   apiKeys: ReadonlyMap<string, ModelAuthStatusProvider["apiKey"]>,
@@ -665,6 +689,9 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
       const apiKeys = resolveProviderApiKeys(cfg, store);
       const configured = resolveConfiguredProviders(cfg, apiKeys);
       const statusProviderIds = new Set(configured.providers);
+      for (const provider of resolveConfiguredApiKeyProviders(cfg)) {
+        statusProviderIds.add(provider);
+      }
       for (const provider of apiKeys.keys()) {
         statusProviderIds.add(provider);
       }

--- a/src/gateway/server-methods/models-auth-status.ts
+++ b/src/gateway/server-methods/models-auth-status.ts
@@ -33,7 +33,7 @@ import {
 import { resolveProviderEnvAuthEvidence } from "../../agents/model-auth-env.js";
 import {
   isKnownEnvApiKeyMarker,
-  listKnownNonSecretApiKeyMarkers,
+  isNonSecretApiKeyMarker,
   NON_ENV_SECRETREF_MARKER,
 } from "../../agents/model-auth-markers.js";
 import {
@@ -452,7 +452,7 @@ function resolveProviderApiKeys(
           // Local no-auth placeholders (e.g. the ollama-local marker) resolve to
           // a usable value but represent no credential; do not advertise them as
           // a configured API key or the provider would render as static.
-          if (rawKey && listKnownNonSecretApiKeyMarkers().includes(rawKey)) {
+          if (rawKey && isNonSecretApiKeyMarker(rawKey, { includeEnvVarName: false })) {
             continue;
           }
           const envVar =
@@ -491,25 +491,6 @@ function resolveConfigBoundProfileIds(cfg: OpenClawConfig, store: AuthProfileSto
   return profileIds;
 }
 
-function resolveConfiguredApiKeyProviders(cfg: OpenClawConfig): Set<string> {
-  const providers = new Set<string>();
-  const nonSecretMarkers = new Set(listKnownNonSecretApiKeyMarkers());
-  for (const [id, provider] of Object.entries(cfg.models?.providers ?? {})) {
-    const normalized = normalizeProviderId(id);
-    if (!normalized || !hasConfiguredSecretInput(provider?.apiKey, cfg.secrets?.defaults)) {
-      continue;
-    }
-    const rawKey = typeof provider?.apiKey === "string" ? provider.apiKey.trim() : "";
-    // Unresolved credentials still need a missing status row. Local no-auth
-    // markers do not: they intentionally represent providers without secrets.
-    if (rawKey && rawKey !== NON_ENV_SECRETREF_MARKER && nonSecretMarkers.has(rawKey)) {
-      continue;
-    }
-    providers.add(normalized);
-  }
-  return providers;
-}
-
 function resolveConfiguredProviders(
   cfg: OpenClawConfig,
   apiKeys: ReadonlyMap<string, ModelAuthStatusProvider["apiKey"]>,
@@ -520,17 +501,17 @@ function resolveConfiguredProviders(
   const out = new Set<string>();
   const expectsOAuth = new Set<string>();
   for (const [id, provider] of Object.entries(cfg.models?.providers ?? {})) {
-    if (!id) {
-      continue;
-    }
     const normalized = normalizeProviderId(id);
     if (!normalized) {
       continue;
     }
-    // Only include providers whose configured auth mode is refreshable.
-    // `undefined` / "api-key" / "aws-sdk" are deliberately skipped.
+    const rawKey = typeof provider?.apiKey === "string" ? provider.apiKey.trim() : "";
+    const hasApiKey =
+      hasConfiguredSecretInput(provider?.apiKey, cfg.secrets?.defaults) &&
+      (rawKey === NON_ENV_SECRETREF_MARKER ||
+        !isNonSecretApiKeyMarker(rawKey, { includeEnvVarName: false }));
     const mode = provider?.auth;
-    if (mode !== "oauth" && mode !== "token") {
+    if (mode !== "oauth" && mode !== "token" && !hasApiKey) {
       continue;
     }
     if (apiKeys.has(normalized)) {
@@ -541,8 +522,7 @@ function resolveConfiguredProviders(
       expectsOAuth.add(normalized);
     }
   }
-  // auth.profiles entries explicitly opt into the refreshable set via
-  // `mode: oauth | token`. api_key profiles are excluded (no lifecycle).
+  // auth.profiles opt in via `mode: oauth | token`; API-key profiles have no lifecycle.
   for (const profile of Object.values(cfg.auth?.profiles ?? {})) {
     const provider = profile?.provider;
     const mode = profile?.mode;
@@ -685,9 +665,6 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
       const apiKeys = resolveProviderApiKeys(cfg, store);
       const configured = resolveConfiguredProviders(cfg, apiKeys);
       const statusProviderIds = new Set(configured.providers);
-      for (const provider of resolveConfiguredApiKeyProviders(cfg)) {
-        statusProviderIds.add(provider);
-      }
       for (const provider of apiKeys.keys()) {
         statusProviderIds.add(provider);
       }


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #106490. A provider configured with an API-key secret input disappeared from `models.authStatus` when the credential could not currently resolve and no stored auth profile existed. The Models settings page therefore omitted the provider instead of showing its intended `missing` state.

## Why This Change Was Made

Seed auth-health provider synthesis from configured API-key inputs as well as resolved keys and OAuth/token modes. Keep non-secret auth markers out of that set, including local no-auth markers and AWS SDK ambient-auth markers, while retaining unresolved environment and managed SecretRef inputs.

This is the narrow owner-boundary fix: the gateway status assembler owns which providers enter `buildAuthHealthSummary`. Changing the generic health builder or synthesizing rows in the UI would leave the RPC contract incomplete.

## User Impact

Configured providers with temporarily unresolved API-key inputs remain visible in Model Providers with status `missing`. Local providers such as Ollama and ambient AWS SDK auth markers do not gain false missing rows.

Release note: Fix configured model providers disappearing from auth status when their API-key secret is unresolved.

## Evidence

- Final-head Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/29285687731
- `corepack pnpm test src/gateway/server-methods/models-auth-status.test.ts` — 62 passed
- Final-head changed gate — formatting, typecheck, lint, and runtime guards passed
- Gateway RPC validation: unset `ANTHROPIC_API_KEY` returned Anthropic as `missing` and omitted the Ollama local marker; a fixture environment value returned Anthropic as `static` with env provenance
- Fresh whole-branch autoreview — no accepted/actionable findings (0.88 confidence)
