### PR TITLE
refactor(agents): extract attempt tool catalog phase

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
@@ -1,0 +1,276 @@
+/**
+ * Prepares the attempt-local tool catalog, schema projection, and diagnostics.
+ */
+import type { DiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
+import { copyPluginToolMeta } from "../../../plugins/tools.js";
+import { copyBeforeToolCallHookMarker } from "../../agent-tools.before-tool-call.js";
+import { resolveToolLoopDetectionConfig } from "../../agent-tools.js";
+import { copyChannelAgentToolMeta } from "../../channel-tools.js";
+import { copyCodeModeControlToolIdentity } from "../../code-mode-control-tools.js";
+import {
+  applyCodeModeCatalog,
+  CODE_MODE_EXEC_TOOL_NAME,
+  CODE_MODE_WAIT_TOOL_NAME,
+  createCodeModeTools,
+} from "../../code-mode.js";
+import {
+  filterLocalModelLeanTools,
+  shouldCatalogToolForLocalModelLean,
+} from "../../local-model-lean.js";
+import { logAgentRuntimeToolDiagnostics } from "../../runtime-plan/tools.js";
+import { buildEmptyExplicitToolAllowlistError } from "../../tool-allowlist-guard.js";
+import { filterRuntimeCompatibleTools } from "../../tool-schema-projection.js";
+import { logRuntimeToolSchemaQuarantine } from "../../tool-schema-quarantine.js";
+import {
+  applyToolSchemaDirectoryCatalog,
+  applyToolSearchCatalog,
+  estimateToolSchemaDirectoryToolNames,
+  TOOL_CALL_RAW_TOOL_NAME,
+  TOOL_DESCRIBE_RAW_TOOL_NAME,
+  TOOL_SEARCH_RAW_TOOL_NAME,
+  type ToolSearchCatalogToolExecutor,
+} from "../../tool-search.js";
+import { copyToolTerminalPresentation } from "../../tool-terminal-presentation.js";
+import type { AnyAgentTool } from "../../tools/common.js";
+import { log } from "../logger.js";
+import type { prepareEmbeddedAttemptBundleTools } from "./attempt-bundle-tools.js";
+import { collectAttemptExplicitToolAllowlistSources } from "./attempt-tool-allowlist.js";
+import type { prepareEmbeddedAttemptToolBase } from "./attempt-tool-base-prepare.js";
+import { buildToolSearchRunPlan } from "./attempt.tool-search-run-plan.js";
+import { notifyToolActivity } from "./tool-activity-heartbeat.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type PreparedToolBase = ReturnType<typeof prepareEmbeddedAttemptToolBase>;
+type PreparedBundleTools = Awaited<ReturnType<typeof prepareEmbeddedAttemptBundleTools>>;
+type ProviderRuntimeHandle = Parameters<typeof logAgentRuntimeToolDiagnostics>[0]["runtimeHandle"];
+
+export function wrapEmbeddedAttemptToolWithActivity<T extends AnyAgentTool>(
+  tool: T,
+  runId: string,
+): T {
+  const originalExecute = tool.execute;
+  const wrappedTool = {
+    ...tool,
+    execute: (async (...args: Parameters<typeof originalExecute>) => {
+      // Long-running tools keep the attempt's idle watchdog alive.
+      const interval = setInterval(() => notifyToolActivity(runId), 60_000);
+      interval.unref?.();
+      try {
+        notifyToolActivity(runId);
+        return await originalExecute(...args);
+      } finally {
+        clearInterval(interval);
+        notifyToolActivity(runId);
+      }
+    }) as typeof originalExecute,
+  } as T;
+  // Tool metadata lives in identity-keyed WeakMaps, so object spread is insufficient.
+  copyPluginToolMeta(tool, wrappedTool);
+  copyChannelAgentToolMeta(tool, wrappedTool);
+  copyBeforeToolCallHookMarker(tool, wrappedTool);
+  copyToolTerminalPresentation(tool, wrappedTool);
+  copyCodeModeControlToolIdentity(tool, wrappedTool);
+  return wrappedTool;
+}
+
+export function prepareEmbeddedAttemptToolCatalog(input: {
+  attempt: EmbeddedRunAttemptParams;
+  preparedToolBase: PreparedToolBase;
+  bundleTools: Pick<PreparedBundleTools, "clientTools" | "uncompactedEffectiveTools">;
+  effectiveCwd: string;
+  effectiveWorkspace: string;
+  sessionAgentId: string;
+  sandboxSessionKey: string;
+  runTrace: DiagnosticTraceContext;
+  abortSignal: AbortSignal;
+  executeCodeModeTool: ToolSearchCatalogToolExecutor;
+  getProviderRuntimeHandle: () => ProviderRuntimeHandle;
+  markStage: (name: string) => void;
+}) {
+  const { attempt, preparedToolBase } = input;
+  const {
+    codeModeControlsEnabledForRun,
+    localModelLeanEnabled,
+    localModelLeanPreserveToolNames,
+    runtimeCapabilityProfile,
+    toolSearchConfig,
+    toolSearchControlsEnabledForRun,
+    toolSearchRuntimeConfig,
+    toolsEnabled,
+  } = preparedToolBase;
+  const { clientTools, uncompactedEffectiveTools } = input.bundleTools;
+  let effectiveTools = uncompactedEffectiveTools;
+  const catalogToolHookContext = {
+    agentId: input.sessionAgentId,
+    config: attempt.config,
+    cwd: input.effectiveCwd,
+    sessionKey: input.sandboxSessionKey,
+    sessionId: attempt.sessionId,
+    runId: attempt.runId,
+    approvalReviewerDeviceId: attempt.approvalReviewerDeviceId,
+    channelId: attempt.currentChannelId,
+    trace: input.runTrace,
+    loopDetection: resolveToolLoopDetectionConfig({
+      cfg: attempt.config,
+      agentId: input.sessionAgentId,
+    }),
+    onToolOutcome: attempt.onToolOutcome,
+    allocateToolOutcomeOrdinal: attempt.allocateToolOutcomeOrdinal,
+  };
+  const codeModeTools = codeModeControlsEnabledForRun
+    ? createCodeModeTools({
+        config: attempt.config,
+        runtimeConfig: attempt.config,
+        agentId: input.sessionAgentId,
+        sessionKey: input.sandboxSessionKey,
+        sessionId: attempt.sessionId,
+        runId: attempt.runId,
+        catalogRef: preparedToolBase.toolSearchCatalogRef,
+        abortSignal: input.abortSignal,
+        forceRestartSafeTools: attempt.forceRestartSafeTools,
+        executeTool: input.executeCodeModeTool,
+      })
+    : [];
+  const directoryRequiredToolNames =
+    attempt.forceMessageTool === true || attempt.sourceReplyDeliveryMode === "message_tool_only"
+      ? ["message"]
+      : [];
+  const directoryHydratedToolNames =
+    toolSearchControlsEnabledForRun && toolSearchConfig.mode === "directory"
+      ? (() => {
+          try {
+            return estimateToolSchemaDirectoryToolNames({
+              tools: effectiveTools,
+              query: attempt.prompt,
+              maxTools: 4,
+              requiredToolNames: directoryRequiredToolNames,
+            });
+          } catch (err) {
+            log.warn(
+              `tool-search: directory schema estimation failed; continuing with deferred schemas only (${String(err)})`,
+            );
+            return directoryRequiredToolNames;
+          }
+        })()
+      : [];
+  const toolSearch = codeModeControlsEnabledForRun
+    ? applyCodeModeCatalog({
+        tools: [...codeModeTools, ...effectiveTools],
+        config: attempt.config,
+        sessionId: attempt.sessionId,
+        sessionKey: input.sandboxSessionKey,
+        agentId: input.sessionAgentId,
+        runId: attempt.runId,
+        catalogRef: preparedToolBase.toolSearchCatalogRef,
+        toolHookContext: catalogToolHookContext,
+      })
+    : toolSearchConfig.mode === "directory"
+      ? applyToolSchemaDirectoryCatalog({
+          tools: effectiveTools,
+          config: toolSearchRuntimeConfig,
+          sessionId: attempt.sessionId,
+          sessionKey: input.sandboxSessionKey,
+          agentId: input.sessionAgentId,
+          runId: attempt.runId,
+          catalogRef: preparedToolBase.toolSearchCatalogRef,
+          toolHookContext: catalogToolHookContext,
+          hydrateToolNames: directoryHydratedToolNames,
+        })
+      : applyToolSearchCatalog({
+          tools: effectiveTools,
+          config: toolSearchRuntimeConfig,
+          sessionId: attempt.sessionId,
+          sessionKey: input.sandboxSessionKey,
+          agentId: input.sessionAgentId,
+          runId: attempt.runId,
+          catalogRef: preparedToolBase.toolSearchCatalogRef,
+          toolHookContext: catalogToolHookContext,
+          shouldCatalogTool:
+            localModelLeanEnabled && toolSearchConfig.mode === "tools"
+              ? shouldCatalogToolForLocalModelLean
+              : undefined,
+        });
+  const projectedToolSearchTools = filterLocalModelLeanTools({
+    tools: toolSearch.tools,
+    config: attempt.config,
+    agentId: input.sessionAgentId,
+    preserveToolNames: localModelLeanPreserveToolNames,
+  });
+  const toolSearchSchemaProjection = filterRuntimeCompatibleTools(projectedToolSearchTools);
+  logRuntimeToolSchemaQuarantine({
+    diagnostics: toolSearchSchemaProjection.diagnostics,
+    tools: projectedToolSearchTools,
+    runId: attempt.runId,
+    agentId: input.sessionAgentId,
+    sessionKey: attempt.sessionKey,
+    sessionId: attempt.sessionId,
+  });
+  effectiveTools = toolSearchSchemaProjection.tools.map((tool) =>
+    wrapEmbeddedAttemptToolWithActivity(tool, attempt.runId),
+  );
+  if (toolSearch.compacted && !toolSearch.catalogReused) {
+    input.markStage(codeModeControlsEnabledForRun ? "code-mode" : "tool-search");
+    log.info(
+      codeModeControlsEnabledForRun
+        ? `code-mode: cataloged ${toolSearch.catalogToolCount} tools behind exec/wait`
+        : toolSearchConfig.mode === "directory"
+          ? `tool-search: cataloged ${toolSearch.catalogToolCount} tools behind compact directory surface`
+          : `tool-search: cataloged ${toolSearch.catalogToolCount} tools behind compact prompt surface`,
+    );
+  }
+  const deferredDirectoryToolsCallable =
+    toolSearchControlsEnabledForRun &&
+    toolSearchConfig.mode === "directory" &&
+    toolSearch.catalogRegistered;
+  input.markStage("bundle-tools");
+  const explicitToolAllowlistSources = collectAttemptExplicitToolAllowlistSources({
+    capabilityProfile: runtimeCapabilityProfile,
+    toolsAllow: attempt.toolsAllow,
+  });
+  const toolSearchRunPlan = buildToolSearchRunPlan({
+    visibleTools: effectiveTools,
+    uncompactedTools: uncompactedEffectiveTools,
+    clientTools,
+    clientToolsCataloged:
+      toolSearch.catalogRegistered &&
+      (codeModeControlsEnabledForRun || toolSearchConfig.mode !== "directory"),
+    catalogToolCount: toolSearch.catalogToolCount,
+    controlsEnabled: toolSearchControlsEnabledForRun || codeModeControlsEnabledForRun,
+    deferredToolsCallable: deferredDirectoryToolsCallable,
+    controlNames: codeModeControlsEnabledForRun
+      ? [CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME]
+      : toolSearchConfig.mode === "directory"
+        ? [TOOL_SEARCH_RAW_TOOL_NAME, TOOL_DESCRIBE_RAW_TOOL_NAME, TOOL_CALL_RAW_TOOL_NAME]
+        : undefined,
+    explicitAllowlistSources: explicitToolAllowlistSources,
+  });
+  const emptyExplicitToolAllowlistError = attempt.forceRestartSafeTools
+    ? null
+    : buildEmptyExplicitToolAllowlistError({
+        sources: explicitToolAllowlistSources,
+        callableToolNames: toolSearchRunPlan.emptyAllowlistCallableNames,
+        toolsEnabled,
+        disableTools: attempt.disableTools,
+      });
+  logAgentRuntimeToolDiagnostics({
+    runtimePlan: attempt.runtimePlan,
+    tools: effectiveTools,
+    provider: attempt.provider,
+    config: attempt.config,
+    workspaceDir: input.effectiveWorkspace,
+    env: process.env,
+    modelId: attempt.modelId,
+    modelApi: attempt.model.api,
+    model: attempt.model,
+    runtimeHandle: input.getProviderRuntimeHandle(),
+  });
+
+  return {
+    catalogToolHookContext,
+    deferredDirectoryToolsCallable,
+    effectiveTools,
+    emptyExplicitToolAllowlistError,
+    toolSearch,
+    toolSearchRunPlan,
+  };
+}

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -38,7 +38,6 @@ import {
 } from "../../../plugins/hook-agent-context.js";
 import { resolveBlockMessage } from "../../../plugins/hook-decision-types.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
-import { copyPluginToolMeta } from "../../../plugins/tools.js";
 import { buildTrajectoryRunMetadata } from "../../../trajectory/metadata.js";
 import {
   createTrajectoryRuntimeRecorder,
@@ -55,22 +54,10 @@ import {
   resolveEffectiveCompactionMode,
 } from "../../agent-settings.js";
 import { toToolDefinitions } from "../../agent-tool-definition-adapter.js";
-import {
-  copyBeforeToolCallHookMarker,
-  recordStructuredReplayTrustForToolCall,
-} from "../../agent-tools.before-tool-call.js";
-import { resolveToolLoopDetectionConfig } from "../../agent-tools.js";
+import { recordStructuredReplayTrustForToolCall } from "../../agent-tools.before-tool-call.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
 import { isHeartbeatLifecycleRunKind } from "../../bootstrap-mode.js";
 import { createCacheTrace } from "../../cache-trace.js";
-import { copyChannelAgentToolMeta } from "../../channel-tools.js";
-import { copyCodeModeControlToolIdentity } from "../../code-mode-control-tools.js";
-import {
-  applyCodeModeCatalog,
-  CODE_MODE_EXEC_TOOL_NAME,
-  CODE_MODE_WAIT_TOOL_NAME,
-  createCodeModeTools,
-} from "../../code-mode.js";
 import { resolveUserTimezone } from "../../date-time.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { countActiveToolExecutions } from "../../embedded-agent-subscribe.handlers.tools.js";
@@ -80,15 +67,10 @@ import { runAgentHarnessBeforeAgentFinalizeHook } from "../../harness/lifecycle-
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import { relocateCurrentRuntimeContextCarrierToTail } from "../../internal-runtime-context.js";
 import {
-  filterLocalModelLeanTools,
-  shouldCatalogToolForLocalModelLean,
-} from "../../local-model-lean.js";
-import {
   AGENT_RUN_RESTART_ABORT_STOP_REASON,
   createAgentRunRestartAbortError,
   isAgentRunRestartAbortReason,
 } from "../../run-termination.js";
-import { logAgentRuntimeToolDiagnostics } from "../../runtime-plan/tools.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import {
   invalidateSessionFileRepairCache,
@@ -103,23 +85,13 @@ import {
   ackPendingAgentSteeringItems,
   releasePendingAgentSteeringItems,
 } from "../../subagent-registry.js";
-import { buildEmptyExplicitToolAllowlistError } from "../../tool-allowlist-guard.js";
-import { filterRuntimeCompatibleTools } from "../../tool-schema-projection.js";
-import { logRuntimeToolSchemaQuarantine } from "../../tool-schema-quarantine.js";
 import {
-  applyToolSchemaDirectoryCatalog,
-  applyToolSearchCatalog,
   clearToolSearchCatalog,
-  estimateToolSchemaDirectoryToolNames,
   projectToolSearchTargetTranscriptMessages,
   resolveToolSearchCatalogTool,
-  TOOL_CALL_RAW_TOOL_NAME,
-  TOOL_DESCRIBE_RAW_TOOL_NAME,
-  TOOL_SEARCH_RAW_TOOL_NAME,
   type ToolSearchCatalogRef,
   type ToolSearchCatalogToolExecutor,
 } from "../../tool-search.js";
-import { copyToolTerminalPresentation } from "../../tool-terminal-presentation.js";
 import { invalidateComputerFrameIfMissing } from "../../tools/computer-tool.js";
 import type { NormalizedUsage } from "../../usage.js";
 import { readLastCacheTtlTimestamp } from "../cache-ttl.js";
@@ -189,8 +161,8 @@ import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
 import { prepareEmbeddedAttemptTransport } from "./attempt-stream-transport.js";
 import { installEmbeddedAttemptStreamGuards } from "./attempt-stream.js";
 import { prepareEmbeddedAttemptSystemPrompt } from "./attempt-system-prompt-prepare.js";
-import { collectAttemptExplicitToolAllowlistSources } from "./attempt-tool-allowlist.js";
 import { prepareEmbeddedAttemptToolBase } from "./attempt-tool-base-prepare.js";
+import { prepareEmbeddedAttemptToolCatalog } from "./attempt-tool-catalog.js";
 import { flushEmbeddedAttemptTrajectoryRecorder } from "./attempt-trajectory-flush-cleanup.js";
 import {
   cloneHookMessages,
@@ -244,7 +216,6 @@ import {
   cleanupEmbeddedAttemptResources,
 } from "./attempt.subscription-cleanup.js";
 import { composeSystemPromptWithHookContext } from "./attempt.thread-helpers.js";
-import { buildToolSearchRunPlan } from "./attempt.tool-search-run-plan.js";
 import { resolveAttemptTranscriptPolicy } from "./attempt.transcript-policy.js";
 import {
   resolveRunTimeoutDuringCompaction,
@@ -533,11 +504,7 @@ export async function runEmbeddedAttempt(
       codeModeControlsEnabledForRun,
       computerContextEpoch,
       localModelLeanEnabled,
-      localModelLeanPreserveToolNames,
       replaySafetyOptions,
-      runtimeCapabilityProfile,
-      toolSearchConfig,
-      toolSearchControlsEnabledForRun,
       toolSearchRuntimeConfig,
       toolSearchTargetTranscriptProjections,
       toolsEnabled,
@@ -587,206 +554,36 @@ export async function runEmbeddedAttempt(
     bundleMcpRuntime = preparedBundleTools.bundleMcpRuntime;
     bundleLspRuntime = preparedBundleTools.bundleLspRuntime;
     const { clientTools, tools, uncompactedEffectiveTools } = preparedBundleTools;
-    let effectiveTools = uncompactedEffectiveTools;
-    const catalogToolHookContext = {
-      agentId: sessionAgentId,
-      config: params.config,
-      cwd: effectiveCwd,
-      sessionKey: sandboxSessionKey,
-      sessionId: params.sessionId,
-      runId: params.runId,
-      approvalReviewerDeviceId: params.approvalReviewerDeviceId,
-      channelId: params.currentChannelId,
-      trace: runTrace,
-      loopDetection: resolveToolLoopDetectionConfig({
-        cfg: params.config,
-        agentId: sessionAgentId,
-      }),
-      onToolOutcome: params.onToolOutcome,
-      allocateToolOutcomeOrdinal: params.allocateToolOutcomeOrdinal,
-    };
-    const codeModeTools = codeModeControlsEnabledForRun
-      ? createCodeModeTools({
-          config: params.config,
-          runtimeConfig: params.config,
-          agentId: sessionAgentId,
-          sessionKey: sandboxSessionKey,
-          sessionId: params.sessionId,
-          runId: params.runId,
-          catalogRef: toolSearchCatalogRef,
-          abortSignal: runAbortController.signal,
-          forceRestartSafeTools: params.forceRestartSafeTools,
-          executeTool: (toolParams) => {
-            if (!toolSearchCatalogExecutor) {
-              throw new Error("Code Mode catalog executor is unavailable for this run.");
-            }
-            return toolSearchCatalogExecutor(toolParams);
-          },
-        })
-      : [];
-    const directoryRequiredToolNames =
-      params.forceMessageTool === true || params.sourceReplyDeliveryMode === "message_tool_only"
-        ? ["message"]
-        : [];
-    const directoryHydratedToolNames =
-      toolSearchControlsEnabledForRun && toolSearchConfig.mode === "directory"
-        ? (() => {
-            try {
-              return estimateToolSchemaDirectoryToolNames({
-                tools: effectiveTools,
-                query: params.prompt,
-                maxTools: 4,
-                requiredToolNames: directoryRequiredToolNames,
-              });
-            } catch (err) {
-              log.warn(
-                `tool-search: directory schema estimation failed; continuing with deferred schemas only (${String(err)})`,
-              );
-              return directoryRequiredToolNames;
-            }
-          })()
-        : [];
-    const toolSearch = codeModeControlsEnabledForRun
-      ? applyCodeModeCatalog({
-          tools: [...codeModeTools, ...effectiveTools],
-          config: params.config,
-          sessionId: params.sessionId,
-          sessionKey: sandboxSessionKey,
-          agentId: sessionAgentId,
-          runId: params.runId,
-          catalogRef: toolSearchCatalogRef,
-          toolHookContext: catalogToolHookContext,
-        })
-      : toolSearchConfig.mode === "directory"
-        ? applyToolSchemaDirectoryCatalog({
-            tools: effectiveTools,
-            config: toolSearchRuntimeConfig,
-            sessionId: params.sessionId,
-            sessionKey: sandboxSessionKey,
-            agentId: sessionAgentId,
-            runId: params.runId,
-            catalogRef: toolSearchCatalogRef,
-            toolHookContext: catalogToolHookContext,
-            hydrateToolNames: directoryHydratedToolNames,
-          })
-        : applyToolSearchCatalog({
-            tools: effectiveTools,
-            config: toolSearchRuntimeConfig,
-            sessionId: params.sessionId,
-            sessionKey: sandboxSessionKey,
-            agentId: sessionAgentId,
-            runId: params.runId,
-            catalogRef: toolSearchCatalogRef,
-            toolHookContext: catalogToolHookContext,
-            shouldCatalogTool:
-              localModelLeanEnabled && toolSearchConfig.mode === "tools"
-                ? shouldCatalogToolForLocalModelLean
-                : undefined,
-          });
-    const projectedToolSearchTools = filterLocalModelLeanTools({
-      tools: toolSearch.tools,
-      config: params.config,
-      agentId: sessionAgentId,
-      preserveToolNames: localModelLeanPreserveToolNames,
+    const preparedToolCatalog = prepareEmbeddedAttemptToolCatalog({
+      attempt: params,
+      preparedToolBase,
+      bundleTools: { clientTools, uncompactedEffectiveTools },
+      effectiveCwd,
+      effectiveWorkspace,
+      sessionAgentId,
+      sandboxSessionKey,
+      runTrace,
+      abortSignal: runAbortController.signal,
+      executeCodeModeTool: (toolParams) => {
+        if (!toolSearchCatalogExecutor) {
+          throw new Error("Code Mode catalog executor is unavailable for this run.");
+        }
+        return toolSearchCatalogExecutor(toolParams);
+      },
+      getProviderRuntimeHandle,
+      markStage: (name) => prepStages.mark(name),
     });
-    const toolSearchSchemaProjection = filterRuntimeCompatibleTools(projectedToolSearchTools);
-    logRuntimeToolSchemaQuarantine({
-      diagnostics: toolSearchSchemaProjection.diagnostics,
-      tools: projectedToolSearchTools,
-      runId: params.runId,
-      agentId: sessionAgentId,
-      sessionKey: params.sessionKey,
-      sessionId: params.sessionId,
-    });
-    effectiveTools = [...toolSearchSchemaProjection.tools];
-    effectiveTools = effectiveTools.map((tool) => {
-      const originalExecute = tool.execute;
-      const wrappedTool = {
-        ...tool,
-        execute: (async (...args: Parameters<typeof originalExecute>) => {
-          // Heartbeat every 60s during execution so the 120s idle watchdog
-          // never expires for long-running tools (web_fetch, exec, etc.).
-          const interval = setInterval(() => notifyToolActivity(params.runId), 60_000);
-          interval.unref?.();
-          try {
-            notifyToolActivity(params.runId);
-            const result = await originalExecute(...args);
-            return result;
-          } finally {
-            clearInterval(interval);
-            notifyToolActivity(params.runId);
-          }
-        }) as typeof originalExecute,
-      };
-      // Preserve plugin/channel/before-tool-call/terminal metadata that lives
-      // in WeakMaps keyed by tool object identity. The spread above copies own
-      // enumerable properties but loses these associations.
-      copyPluginToolMeta(tool, wrappedTool);
-      copyChannelAgentToolMeta(tool as never, wrappedTool as never);
-      copyBeforeToolCallHookMarker(tool, wrappedTool);
-      copyToolTerminalPresentation(tool, wrappedTool as never);
-      copyCodeModeControlToolIdentity(tool as never, wrappedTool as never);
-      return wrappedTool;
-    });
-    if (toolSearch.compacted && !toolSearch.catalogReused) {
-      prepStages.mark(codeModeControlsEnabledForRun ? "code-mode" : "tool-search");
-      log.info(
-        codeModeControlsEnabledForRun
-          ? `code-mode: cataloged ${toolSearch.catalogToolCount} tools behind exec/wait`
-          : toolSearchConfig.mode === "directory"
-            ? `tool-search: cataloged ${toolSearch.catalogToolCount} tools behind compact directory surface`
-            : `tool-search: cataloged ${toolSearch.catalogToolCount} tools behind compact prompt surface`,
-      );
-    }
-    const deferredDirectoryToolsCallable =
-      toolSearchControlsEnabledForRun &&
-      toolSearchConfig.mode === "directory" &&
-      toolSearch.catalogRegistered;
-    prepStages.mark("bundle-tools");
-    const explicitToolAllowlistSources = collectAttemptExplicitToolAllowlistSources({
-      capabilityProfile: runtimeCapabilityProfile,
-      toolsAllow: params.toolsAllow,
-    });
-    const toolSearchRunPlan = buildToolSearchRunPlan({
-      visibleTools: effectiveTools,
-      uncompactedTools: uncompactedEffectiveTools,
-      clientTools,
-      clientToolsCataloged:
-        toolSearch.catalogRegistered &&
-        (codeModeControlsEnabledForRun || toolSearchConfig.mode !== "directory"),
-      catalogToolCount: toolSearch.catalogToolCount,
-      controlsEnabled: toolSearchControlsEnabledForRun || codeModeControlsEnabledForRun,
-      deferredToolsCallable: deferredDirectoryToolsCallable,
-      controlNames: codeModeControlsEnabledForRun
-        ? [CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME]
-        : toolSearchConfig.mode === "directory"
-          ? [TOOL_SEARCH_RAW_TOOL_NAME, TOOL_DESCRIBE_RAW_TOOL_NAME, TOOL_CALL_RAW_TOOL_NAME]
-          : undefined,
-      explicitAllowlistSources: explicitToolAllowlistSources,
-    });
+    const {
+      catalogToolHookContext,
+      deferredDirectoryToolsCallable,
+      effectiveTools,
+      emptyExplicitToolAllowlistError,
+      toolSearch,
+      toolSearchRunPlan,
+    } = preparedToolCatalog;
     const replayAllowedToolNames = toolSearchRunPlan.replayAllowedToolNames;
     const liveAllowedToolNames = toolSearchRunPlan.liveAllowedToolNames;
     const capabilityToolNames = toolSearchRunPlan.capabilityToolNames;
-    const emptyExplicitToolAllowlistError = params.forceRestartSafeTools
-      ? null
-      : buildEmptyExplicitToolAllowlistError({
-          sources: explicitToolAllowlistSources,
-          callableToolNames: toolSearchRunPlan.emptyAllowlistCallableNames,
-          toolsEnabled,
-          disableTools: params.disableTools,
-        });
-    logAgentRuntimeToolDiagnostics({
-      runtimePlan: params.runtimePlan,
-      tools: effectiveTools,
-      provider: params.provider,
-      config: params.config,
-      workspaceDir: effectiveWorkspace,
-      env: process.env,
-      modelId: params.modelId,
-      modelApi: params.model.api,
-      model: params.model,
-      runtimeHandle: getProviderRuntimeHandle(),
-    });
 
     const preparedSystemPrompt = await prepareEmbeddedAttemptSystemPrompt({
       activeContextEngine,

--- a/src/agents/embedded-agent-runner/run/tool-activity-heartbeat.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-activity-heartbeat.test.ts
@@ -1,20 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { getPluginToolMeta, setPluginToolMeta } from "../../../plugins/tools.js";
+import { getChannelAgentToolMeta, setChannelAgentToolMeta } from "../../channel-tool-metadata.js";
+import { isCodeModeControlTool, markCodeModeControlTool } from "../../code-mode-control-tools.js";
 import {
-  copyPluginToolMeta,
-  getPluginToolMeta,
-  setPluginToolMeta,
-} from "../../../plugins/tools.js";
-import { copyBeforeToolCallHookMarker } from "../../agent-tools.before-tool-call.js";
-import {
-  copyChannelAgentToolMeta,
-  getChannelAgentToolMeta,
-  setChannelAgentToolMeta,
-} from "../../channel-tool-metadata.js";
-import {
-  copyToolTerminalPresentation,
-  setToolTerminalPresentation,
   getToolTerminalPresentation,
+  setToolTerminalPresentation,
 } from "../../tool-terminal-presentation.js";
+import { wrapEmbeddedAttemptToolWithActivity } from "./attempt-tool-catalog.js";
 import {
   clearToolActivityRun,
   getLastToolActivityMs,
@@ -110,23 +102,15 @@ describe("tool-activity-heartbeat", () => {
 });
 
 describe("heartbeat wrapper metadata preservation", () => {
-  // Regression: the heartbeat execute wrapper in attempt.ts replaces tool
-  // objects via spread ({ ...tool, execute: ... }), which copies own enumerable
-  // properties but loses WeakMap-keyed metadata. The copy calls below are the
-  // same pattern used in attempt.ts to preserve plugin, channel, before-tool-call,
-  // and terminal presentation metadata across the wrapper boundary.
+  // The attempt tool-catalog phase replaces tool objects to add heartbeats.
+  // These tests exercise the production wrapper so identity-keyed metadata
+  // cannot silently disappear across that boundary.
 
   it("preserves channel tool metadata on heartbeat-wrapped tools", () => {
     const source = { name: "test-tool", execute: vi.fn() as never };
     setChannelAgentToolMeta(source as never, { channelId: "telegram" });
 
-    // Same wrap pattern as attempt.ts effectiveTools.map()
-    const wrapped = {
-      ...source,
-      execute: ((...args: unknown[]) =>
-        (source.execute as (...a: unknown[]) => unknown)(...args)) as never,
-    };
-    copyChannelAgentToolMeta(source as never, wrapped as never);
+    const wrapped = wrapEmbeddedAttemptToolWithActivity(source as never, RUN) as typeof source;
 
     expect(getChannelAgentToolMeta(wrapped as never)).toEqual({ channelId: "telegram" });
   });
@@ -135,12 +119,7 @@ describe("heartbeat wrapper metadata preservation", () => {
     const source = { name: "test-tool", execute: vi.fn() as never };
     setPluginToolMeta(source as never, { pluginId: "test-plugin", optional: false });
 
-    const wrapped = {
-      ...source,
-      execute: ((...args: unknown[]) =>
-        (source.execute as (...a: unknown[]) => unknown)(...args)) as never,
-    };
-    copyPluginToolMeta(source as never, wrapped as never);
+    const wrapped = wrapEmbeddedAttemptToolWithActivity(source as never, RUN) as typeof source;
 
     const meta = getPluginToolMeta(wrapped as never);
     expect(meta?.pluginId).toBe("test-plugin");
@@ -158,12 +137,7 @@ describe("heartbeat wrapper metadata preservation", () => {
       enumerable: false,
     });
 
-    const wrapped = {
-      ...source,
-      execute: ((...args: unknown[]) =>
-        (source.execute as (...a: unknown[]) => unknown)(...args)) as never,
-    };
-    copyBeforeToolCallHookMarker(source as never, wrapped as never);
+    const wrapped = wrapEmbeddedAttemptToolWithActivity(source as never, RUN) as typeof source;
 
     expect((wrapped as Record<symbol, unknown>)[Symbol.for("openclaw:beforeToolCallWrapped")]).toBe(
       true,
@@ -175,15 +149,21 @@ describe("heartbeat wrapper metadata preservation", () => {
     const formatter = () => ({ text: "web_fetch: 3 pages" });
     setToolTerminalPresentation(source as never, formatter);
 
-    const wrapped = {
-      ...source,
-      execute: ((...args: unknown[]) =>
-        (source.execute as (...a: unknown[]) => unknown)(...args)) as never,
-    };
-    copyToolTerminalPresentation(source as never, wrapped as never);
+    const wrapped = wrapEmbeddedAttemptToolWithActivity(source as never, RUN) as typeof source;
 
     const copiedFormatter = getToolTerminalPresentation(wrapped as never);
     expect(copiedFormatter).toBe(formatter);
     expect(copiedFormatter?.(undefined, { content: [] } as never)?.text).toBe("web_fetch: 3 pages");
+  });
+
+  it("preserves code-mode control identity on heartbeat-wrapped tools", () => {
+    const source = markCodeModeControlTool({
+      name: "exec",
+      execute: vi.fn() as never,
+    } as never);
+
+    const wrapped = wrapEmbeddedAttemptToolWithActivity(source, RUN);
+
+    expect(isCodeModeControlTool(wrapped)).toBe(true);
   });
 });


### PR DESCRIPTION
Related: #72072

## What Problem This Solves

`runEmbeddedAttempt` still owns too many separable phases, which makes the hottest agent-runner path hard to review and risky to change.

## Why This Change Was Made

Extract the complete tool-catalog phase into one focused module: tool construction, code-mode selection, schema projection, allowlist diagnostics, tool-search planning, and heartbeat wrapping. The attempt handler now consumes the prepared catalog instead of rebuilding that policy inline.

## User Impact

No intended behavior change. Maintainers get a smaller `attempt.ts` and a directly testable boundary for tool preparation and activity wrapping.

## Evidence

- `attempt.ts`: 3,468 -> 3,265 lines.
- Blacksmith Testbox `tbx_01kxefebgdq568vvrj5n5haehj`: 145 focused tests passed.
- Same exact-head Testbox run: `pnpm tsgo:core` passed.
- TypeScript LOC ratchet passed for both changed production files.
- Scoped changed checks passed conflict-marker, LOC, attribution, export, duplicate, dependency-pin, and formatting gates. The repository-wide Plugin SDK baseline check reports an unrelated existing mismatch; this branch does not touch Plugin SDK surfaces.
- Fresh autoreview clean: no accepted or actionable findings.
