### PR TITLE
test(ui): deduplicate MCP security coverage

### DIFF
--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -62,6 +62,7 @@ const rawSqliteAllowPathGroups = {
     "src/commands/doctor-session-sqlite-readers.ts",
     "src/commands/doctor-session-sqlite-recover-report.ts",
     "src/commands/doctor-state-sqlite-compact.ts",
+    "src/infra/state-migrations.task-sidecar-rows.ts",
     "src/infra/state-migrations.storage.ts",
     "src/infra/state-migrations.cron-run-logs.ts",
     "src/infra/state-migrations.debug-proxy.ts",

--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -62,7 +62,6 @@ const rawSqliteAllowPathGroups = {
     "src/commands/doctor-session-sqlite-readers.ts",
     "src/commands/doctor-session-sqlite-recover-report.ts",
     "src/commands/doctor-state-sqlite-compact.ts",
-    "src/infra/state-migrations.task-sidecar-rows.ts",
     "src/infra/state-migrations.storage.ts",
     "src/infra/state-migrations.cron-run-logs.ts",
     "src/infra/state-migrations.debug-proxy.ts",

--- a/ui/src/components/mcp-app-view.test.ts
+++ b/ui/src/components/mcp-app-view.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "../i18n/index.ts";
-import { buildMcpAppHostCapabilities, resolveMcpAppSandboxUrl } from "./mcp-app-security.ts";
 import { McpAppView } from "./mcp-app-view.ts";
 
 const MCP_APP_VIEW_ELEMENT_NAME = `test-mcp-app-view-${crypto.randomUUID()}`;
@@ -10,74 +9,6 @@ const MCP_APP_VIEW_ELEMENT_NAME = `test-mcp-app-view-${crypto.randomUUID()}`;
 class TestMcpAppView extends McpAppView {}
 
 customElements.define(MCP_APP_VIEW_ELEMENT_NAME, TestMcpAppView);
-
-describe("mcp-app-view security contract", () => {
-  it("advertises the CSP actually applied to MCP Apps", () => {
-    expect(
-      buildMcpAppHostCapabilities({ connectDomains: ["https://api.example.com"] }),
-    ).toMatchObject({
-      sandbox: { csp: { connectDomains: ["https://api.example.com"] } },
-    });
-    expect(buildMcpAppHostCapabilities()).toMatchObject({ sandbox: { csp: {} } });
-  });
-
-  it("accepts only the dedicated-origin MCP App sandbox endpoint", () => {
-    expect(
-      resolveMcpAppSandboxUrl(
-        "/mcp-app-sandbox?csp=abc",
-        8444,
-        undefined,
-        "wss://gateway.example:8443/openclaw",
-        "https://gateway.example:8443",
-      ),
-    ).toBe("https://gateway.example:8444/mcp-app-sandbox?csp=abc");
-    expect(
-      resolveMcpAppSandboxUrl(
-        "/mcp-app-sandbox",
-        18790,
-        "https://apps.example.com",
-        "wss://gateway.example",
-        "https://gateway.example",
-      ),
-    ).toBe("https://apps.example.com/mcp-app-sandbox");
-    expect(() =>
-      resolveMcpAppSandboxUrl(
-        "https://attacker.example/mcp-app-sandbox",
-        8444,
-        undefined,
-        "wss://gateway.example:8443/openclaw",
-        "https://gateway.example:8443",
-      ),
-    ).toThrow("MCP App sandbox URL is invalid");
-    expect(() =>
-      resolveMcpAppSandboxUrl(
-        "data:text/html;base64,cHJveHk=",
-        8444,
-        undefined,
-        "wss://gateway.example:8443/openclaw",
-        "https://gateway.example:8443",
-      ),
-    ).toThrow("MCP App sandbox URL is invalid");
-    expect(() =>
-      resolveMcpAppSandboxUrl(
-        "/mcp-app-sandbox",
-        8443,
-        undefined,
-        "wss://gateway.example:8443/openclaw",
-        "https://gateway.example:8443",
-      ),
-    ).toThrow("MCP App sandbox URL is invalid");
-    expect(() =>
-      resolveMcpAppSandboxUrl(
-        "/mcp-app-sandbox",
-        8444,
-        "https://gateway.example:8443",
-        "wss://gateway.example:8443/openclaw",
-        "https://control.example",
-      ),
-    ).toThrow("MCP App sandbox URL is invalid");
-  });
-});
 
 describe("mcp-app-view localization", () => {
   afterEach(async () => {


### PR DESCRIPTION
Related: #106019

## What Problem This Solves

The UI suite runs the same MCP App CSP and sandbox-origin security contract in both `mcp-app-view.test.ts` and the canonical focused `mcp-app-security.test.ts`.

## Why This Change Was Made

Remove only the duplicate direct-helper assertions from the view suite. `mcp-app-security.test.ts` still covers the CSP capability, both accepted dedicated-origin cases, and all four rejected attacker/data/same-port/host-origin cases. `mcp-app-view.test.ts` still proves those rejections through the mounted view and verifies no iframe is created.

## User Impact

No runtime or security behavior change. CI executes 69 fewer duplicate test lines while retaining direct and integration coverage at their owning boundaries.

## Evidence

- Exact head `5def2ba0c458d40c011d7b833da061f55b751e34`.
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29284869524
- Focused MCP security and mounted-view suites: 7 tests passed.
- Kysely guard, architecture gate, explicit changed gate, and full repository lint: passed.
- Fresh branch autoreview with canonical-suite evidence: clean, no accepted or actionable findings.
- AI-assisted change; code and tests reviewed and understood.
