### PR TITLE
refactor(msteams): use exact Teams SDK types

### DIFF
--- a/extensions/msteams/src/sdk-proactive.ts
+++ b/extensions/msteams/src/sdk-proactive.ts
@@ -56,24 +56,12 @@ type MSTeamsApiClient = {
   };
 };
 
-type MSTeamsApiClientCtor = new (
-  serviceUrl: string,
-  options?: unknown,
-  apiClientSettings?: unknown,
-) => unknown;
-
-type MSTeamsApiModule = {
-  Client: MSTeamsApiClientCtor;
-};
-
 type MSTeamsProactiveOptions = {
   threadActivityId?: string;
   serviceUrlBoundary?: MSTeamsSdkCloudOptions;
 };
 
-const loadMSTeamsApiModule = createLazyRuntimeModule(
-  () => import("@microsoft/teams.api") as unknown as Promise<MSTeamsApiModule>,
-);
+const loadMSTeamsApiModule = createLazyRuntimeModule(() => import("@microsoft/teams.api"));
 
 function resolveThreadedConversationId(conversationId: string, threadActivityId?: string): string {
   if (!threadActivityId) {
@@ -180,8 +168,8 @@ async function getApiClientForReference(
   }
 
   const appInternals = app as unknown as {
-    client?: unknown;
-    api?: { http?: unknown };
+    client?: ConstructorParameters<typeof import("@microsoft/teams.api").Client>[1];
+    api?: { http?: ConstructorParameters<typeof import("@microsoft/teams.api").Client>[1] };
   };
   const httpClient = appInternals.api?.http ?? appInternals.client;
 
@@ -190,7 +178,7 @@ async function getApiClientForReference(
   }
 
   const { Client } = await loadMSTeamsApiModule();
-  return new Client(ref.serviceUrl, httpClient) as MSTeamsApiClient;
+  return new Client(ref.serviceUrl, httpClient) as unknown as MSTeamsApiClient;
 }
 
 function mergeReferenceIntoActivity(

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -7,36 +7,8 @@ import { MSTEAMS_REQUEST_TIMEOUT_MS } from "./request-timeout.js";
 import type { MSTeamsCredentials, MSTeamsFederatedCredentials } from "./token.js";
 import { buildOpenClawUserAgentFragment } from "./user-agent.js";
 
-/**
- * Structural shape of the SDK's HTTP server adapter (e.g. `ExpressAdapter`).
- * Modeled here rather than imported from `@microsoft/teams.apps` because the
- * SDK's barrel re-exports `ExpressAdapter` / `IHttpServerAdapter` through a
- * folder-with-index.d.ts chain (`export * from "./http"`) that NodeNext
- * resolution doesn't follow through every tsconfig setup in this repo.
- * This keeps the Teams SDK type-import surface to just `App`.
- */
-type MSTeamsHttpServerAdapter = {
-  registerRoute(method: string, path: string, handler: unknown): void;
-  start?(port: number | string): Promise<void>;
-  stop?(): Promise<void>;
-};
-
-type MSTeamsExpressAdapterCtor = new (
-  serverOrApp?: unknown,
-  options?: { logger?: unknown; onError?: (err: Error) => void },
-) => MSTeamsHttpServerAdapter;
-
-/**
- * Resolved Teams SDK modules loaded lazily to avoid importing when the
- * provider is disabled. `ExpressAdapter` is held as a constructor type
- * because the SDK's chained `export *` barrel doesn't expose its class type
- * through every tsconfig in this repo (see `MSTeamsHttpServerAdapter`).
- */
-type TeamsSdkModules = {
-  App: typeof import("@microsoft/teams.apps").App;
-  ExpressAdapter: MSTeamsExpressAdapterCtor;
-  cloudFromName: (name: string) => unknown;
-};
+type MSTeamsHttpServerAdapter =
+  import("@microsoft/teams.apps/dist/http/adapter.js").IHttpServerAdapter;
 
 /**
  * Borrow the SDK's `IRoutes` map so `app.on("<route-name>", (ctx) => …)`
@@ -209,17 +181,22 @@ const loadAzureIdentity = createLazyRuntimeModule(
   () => import(AZURE_IDENTITY_MODULE) as Promise<AzureIdentityModule>,
 );
 
+// tsgo misses these chained root-barrel types, so pair the public root runtime
+// exports with their exact published deep declarations.
 const loadSdkModules = createLazyRuntimeModule(() =>
   Promise.all([import("@microsoft/teams.apps"), import("@microsoft/teams.api")]).then(
     ([apps, api]) => ({
       App: apps.App,
-      // ExpressAdapter is in the runtime barrel but its type is hidden behind
-      // the SDK's chained `export *` (see MSTeamsHttpServerAdapter comment).
-      // Cast to the structural constructor we model locally so the seam stays
-      // typed without depending on the SDK's namespace shape.
-      ExpressAdapter: (apps as unknown as { ExpressAdapter: MSTeamsExpressAdapterCtor })
-        .ExpressAdapter,
-      cloudFromName: (api as unknown as { cloudFromName: (name: string) => unknown }).cloudFromName,
+      ExpressAdapter: (
+        apps as unknown as {
+          ExpressAdapter: typeof import("@microsoft/teams.apps/dist/http/express-adapter.js").ExpressAdapter;
+        }
+      ).ExpressAdapter,
+      cloudFromName: (
+        api as unknown as {
+          cloudFromName: typeof import("@microsoft/teams.api/dist/auth/cloud-environment.js").cloudFromName;
+        }
+      ).cloudFromName,
     }),
   ),
 );
@@ -231,7 +208,9 @@ const loadSdkModules = createLazyRuntimeModule(() =>
  * `loadMSTeamsSdkWithAuth` accepts as its `httpServerAdapter` option.
  */
 export async function createMSTeamsExpressAdapter(
-  serverOrApp: unknown,
+  serverOrApp: ConstructorParameters<
+    typeof import("@microsoft/teams.apps/dist/http/express-adapter.js").ExpressAdapter
+  >[0],
 ): Promise<MSTeamsHttpServerAdapter> {
   const { ExpressAdapter } = await loadSdkModules();
   return new ExpressAdapter(serverOrApp);
@@ -318,7 +297,7 @@ export async function createMSTeamsApp(
 
 function createFederatedApp(
   creds: MSTeamsFederatedCredentials,
-  App: TeamsSdkModules["App"],
+  App: typeof import("@microsoft/teams.apps").App,
   appOptions: Record<string, unknown>,
 ): MSTeamsApp {
   if (creds.useManagedIdentity) {
@@ -354,7 +333,7 @@ function createFederatedApp(
 function createCertificateApp(
   creds: MSTeamsFederatedCredentials,
   privateKey: string,
-  App: TeamsSdkModules["App"],
+  App: typeof import("@microsoft/teams.apps").App,
   appOptions: Record<string, unknown>,
 ): MSTeamsApp {
   let credentialPromise: Promise<AzureTokenCredential> | null = null;


### PR DESCRIPTION
Closes #106757

## What Problem This Solves

The Microsoft Teams plugin duplicated public adapter, client, and cloud contracts from its SDK dependencies. Those local facades and casts could drift from the pinned packages and added 33 lines of maintenance overhead.

## Why This Change Was Made

Use exact published Microsoft Teams declarations while keeping the documented root runtime imports and existing lazy-loading boundary. Deep declaration paths are used only where tsgo cannot resolve the SDK's chained root-barrel types; the permissive activity-client cast remains because the upstream generated declaration is incomplete under tsgo.

## User Impact

No user-visible behavior or configuration change. Maintainers now get dependency-checked SDK seams with less duplicate code.

## Evidence

- Blacksmith Testbox `tbx_01kxegfwek4w225y3g3c2fd111` on the rebased head (`57bd36e7828`).
- 36 focused Microsoft Teams SDK, proactive-send, and monitor lifecycle tests passed.
- `pnpm tsgo:extensions` passed.
- `pnpm tsgo:extensions:test` passed.
- Root runtime-export probe passed for `ExpressAdapter` and `cloudFromName`.
- Full build completed plugin assets, tsdown, CLI bootstrap, plugin SDK export checks, and runtime postbuild; the unrelated Control UI startup-request budget on current main remains 25 versus 24.
- Fresh autoreview: clean.
