### PR TITLE
fix(ui): make mock task transcript navigation work

### DIFF
--- a/scripts/control-ui-mock-background-tasks.ts
+++ b/scripts/control-ui-mock-background-tasks.ts
@@ -1,0 +1,52 @@
+function historyMessage(role: "assistant" | "user", text: string, timestamp: number) {
+  return { content: [{ type: "text", text }], role, timestamp };
+}
+
+export function buildBackgroundTasksMock(baseTime: number) {
+  const now = Date.now();
+  const taskSessionKey = "agent:openclaw-mock:subagent:mock-task-1";
+  return {
+    "chat.history": {
+      cases: [
+        {
+          match: { sessionKey: taskSessionKey },
+          response: {
+            messages: [
+              historyMessage(
+                "user",
+                "Map the run-status indicator code and report the active execution path.",
+                baseTime + 40 * 60_000,
+              ),
+              historyMessage(
+                "assistant",
+                "Tracing task events from the gateway through the chat background-tasks rail.",
+                baseTime + 40 * 60_000 + 8_000,
+              ),
+            ],
+            sessionId: "control-ui-mock-task-session",
+            thinkingLevel: null,
+          },
+        },
+      ],
+    },
+    // One live subagent task exercises the rail, collapsed badge, and running-task status row.
+    "tasks.list": {
+      tasks: [
+        {
+          id: "task-mock-running",
+          taskId: "task-mock-running",
+          status: "running",
+          runtime: "subagent",
+          agentId: "openclaw-mock",
+          title: "Map run-status indicator code",
+          createdAt: now - 25_000,
+          startedAt: now - 25_000,
+          updatedAt: now,
+          toolUseCount: 7,
+          lastToolName: "read",
+          childSessionKey: taskSessionKey,
+        },
+      ],
+    },
+  };
+}

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -16,6 +16,7 @@ import {
   resolveSourcePackageAliasesForVite,
   resolveTsconfigPathAliasesForVite,
 } from "../ui/vite.config.ts";
+import { buildBackgroundTasksMock } from "./control-ui-mock-background-tasks.ts";
 import { buildChannelsStatusMock, buildChannelWizardMocks } from "./control-ui-mock-channels.ts";
 import { buildPluginCatalogMock } from "./control-ui-mock-plugins.ts";
 
@@ -946,27 +947,8 @@ async function createChatPickerScenario(): Promise<ControlUiMockGatewayScenario>
     featureMethods: ["chat.metadata", "chat.startup", "sessions.diff", "sessions.files.set"],
     historyMessages: buildScrollableChatHistory(baseTime),
     methodResponses: {
+      ...buildBackgroundTasksMock(baseTime),
       "sessions.diff": buildSessionDiffMock(),
-      // One live subagent task: exercises the tasks rail, the collapsed-rail
-      // toggle badge, and the post-turn running-tasks status row in the thread.
-      "tasks.list": {
-        tasks: [
-          {
-            id: "task-mock-running",
-            taskId: "task-mock-running",
-            status: "running",
-            runtime: "subagent",
-            agentId: "openclaw-mock",
-            title: "Map run-status indicator code",
-            createdAt: Date.now() - 25_000,
-            startedAt: Date.now() - 25_000,
-            updatedAt: Date.now(),
-            toolUseCount: 7,
-            lastToolName: "read",
-            childSessionKey: "agent:openclaw-mock:subagent:mock-task-1",
-          },
-        ],
-      },
       "plugins.list": buildPluginCatalogMock(),
       "channels.status": buildChannelsStatusMock(baseTime),
       "wizard.start": channelWizard.start,

--- a/ui/src/pages/chat/background-tasks.e2e.test.ts
+++ b/ui/src/pages/chat/background-tasks.e2e.test.ts
@@ -99,6 +99,24 @@ describeControlUiE2e("Control UI chat background-tasks rail mocked Gateway E2E",
           },
         ],
         methodResponses: {
+          "chat.history": {
+            cases: [
+              {
+                match: { sessionKey: runningSubagent.childSessionKey },
+                response: {
+                  messages: [
+                    {
+                      content: [{ type: "text", text: "Subagent transcript proof." }],
+                      role: "assistant",
+                      timestamp: Date.now(),
+                    },
+                  ],
+                  sessionId: "subagent-transcript",
+                  thinkingLevel: null,
+                },
+              },
+            ],
+          },
           "tasks.list": { tasks: [runningSubagent, queuedCron, finishedCli] },
           "tasks.cancel": {
             found: true,
@@ -170,6 +188,21 @@ describeControlUiE2e("Control UI chat background-tasks rail mocked Gateway E2E",
       await expect
         .poll(() => new URL(page.url()).searchParams.get("session"))
         .toBe("agent:main:subagent:routing");
+      await page.getByText("Subagent transcript proof.").waitFor({ state: "visible" });
+      await page.getByText("Background tasks rail proof.").waitFor({ state: "detached" });
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("chat.history")).some(
+            (request) =>
+              (request.params as { sessionKey?: string }).sessionKey ===
+              runningSubagent.childSessionKey,
+          ),
+        )
+        .toBe(true);
+      await page.screenshot({
+        path: path.join(artifactDir, "03-transcript-open.png"),
+        fullPage: true,
+      });
     } finally {
       await context.close();
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers using the Control UI mock would click **View transcript** in the Background tasks rail but continue seeing the parent chat, making the button appear unresponsive.

## Why This Change Was Made

The mock Gateway now serves a task-session-specific chat history from a small background-task fixture module. The focused browser E2E now proves the child session is requested, its transcript becomes visible, and stale parent-session content disappears.

## User Impact

The Control UI mock now demonstrates task transcript navigation accurately, so the Background tasks rail can be reviewed and tested end to end.

## Evidence

- Exact head `475fa5b4cde70734762d06def1ab63a3e0d0b647`, Blacksmith Testbox `tbx_01kxep8gqgpkjevbj0jepb76hj`: `corepack pnpm test ui/src/pages/chat/background-tasks.e2e.test.ts` — 1 test passed; post-click screenshot captured.
- Same exact-head Testbox: full `corepack pnpm check:changed` passed, including typechecks, lint, format, boundary, dependency, and package gates.
- Fresh branch autoreview against `origin/main`: no actionable findings; correctness confidence 0.93.
