### PR TITLE
fix(ui): keep the chat scrollbar flush with the review-sidebar divider

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -114,8 +114,12 @@ openclaw-chat-page {
   /* The tall top inset is a titlebar band: it keeps the floating rail
      openers (.chat-floating-toggles, 28px at top 10px) clear of the first
      message and gives the native macOS app an empty strip that starts a
-     window drag (see the thread mousedown handler in chat-thread.ts). */
-  padding: clamp(44px, 5vh, 52px) clamp(6px, 1vw, 12px) 6px;
+     window drag (see the thread mousedown handler in chat-thread.ts).
+     No horizontal padding: macOS overlay scrollbars render inside the
+     scroll container's padding, which floats the thumb away from the pane
+     edge (visible next to the sidebar divider). The side inset lives on
+     .chat-thread-inner instead so the scrollbar hugs the edge. */
+  padding: clamp(44px, 5vh, 52px) 0 6px;
   margin: 0 0 0 0;
   min-height: 0;
   /* Allow shrinking for flex scroll behavior */
@@ -145,7 +149,10 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 
 .chat-thread-inner {
   box-sizing: border-box;
-  width: calc(100% - 36px);
+  /* 36px shared gutter plus the responsive side inset that used to be
+     .chat-thread's horizontal padding (moved off the scroll container so
+     overlay scrollbars sit flush at the pane edge). */
+  width: calc(100% - 36px - 2 * clamp(6px, 1vw, 12px));
   max-width: var(--chat-thread-max-width);
   margin-inline: auto;
 }

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -550,7 +550,13 @@
 
   .chat-thread {
     margin-top: 0;
-    padding: 0 8px 12px;
+    /* Horizontal inset lives on .chat-thread-inner (see layout.css): padding
+       on the scroll container floats macOS overlay scrollbars off the edge. */
+    padding: 0 0 12px;
+  }
+
+  .chat-thread-inner {
+    width: calc(100% - 36px - 16px);
   }
 
   .chat-msg {


### PR DESCRIPTION
## What Problem This Solves

On macOS, when the session Changes ("review") sidebar is open, the chat thread's scrollbar appears dynamically but floats inset to the left instead of sitting flush against the divider that separates the chat from the sidebar.

The chat thread (`.chat-thread`) carried its horizontal content inset as `padding` on the scroll container itself (`padding-right: clamp(6px, 1vw, 12px)` desktop, `8px` mobile). macOS native overlay scrollbars (Safari/WKWebView, and Chromium's native overlay path that `.chat-thread` opts into via `scrollbar-color`) render inside the scroll container's padding box, so the thumb ends up floating up to 12px away from the pane edge instead of hugging the separation border.

## Why This Change Was Made

Scrollbars should sit at the edge of their pane, immediately next to the divider. Moving the horizontal inset off the scroll container removes the engine-dependent padding offset entirely instead of chasing per-engine quirks: with zero horizontal padding on the scroller, every engine (custom `::-webkit-scrollbar`, native overlay, classic) places the bar flush at the pane edge.

The inset now lives on `.chat-thread-inner`, which already centers the transcript:
- Desktop: `width: calc(100% - 36px - 2 * clamp(6px, 1vw, 12px))` replaces the old `36px` calc plus scroll-container padding — identical content bounds.
- Mobile: `.chat-thread` keeps only its bottom padding; `.chat-thread-inner` gets `width: calc(100% - 36px - 16px)` to preserve the previous 8px-per-side inset.

## User Impact

The chat scrollbar hugs the pane edge (right next to the review-sidebar divider when it is open) on macOS overlay-scrollbar environments. Message layout is unchanged: the effective side insets are byte-identical on desktop and mobile.

## Evidence

- Measured content bounds before/after in the mock harness (`pnpm dev:ui:mock`, Chromium): `.chat-thread-inner` width and position unchanged (side inset 30px at 1600px viewport, same as before); thread padding is now `45px 0 6px`.
- Playwright WebKit screenshot of the Changes panel + scrolled thread: thumb sits at the pane edge, 2px from the divider hairline (the divider's own centered-gutter), no regression vs before.
- Minimal WebKit/Chromium fixture confirming custom `::-webkit-scrollbar` bars are unaffected by the change (already edge-flush), so only the native-overlay inset behavior changes.
- Autoreview (codex, gpt-5.6-sol, xhigh): clean, "patch is correct (0.97)".
