### PR TITLE
refactor(agents): extract attempt history assembly

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-history-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-history-prepare.ts
@@ -1,0 +1,274 @@
+/**
+ * Prepares restored transcript history and applies context-engine assembly.
+ */
+import { buildHierarchyReinforcementMessage } from "../../../auto-reply/handoff-summarizer.js";
+import { filterHeartbeatTranscriptArtifacts } from "../../../auto-reply/heartbeat-filter.js";
+import { resolveStorePath } from "../../../config/sessions/paths.js";
+import {
+  listSessionEntries,
+  updateSessionEntry,
+} from "../../../config/sessions/session-accessor.js";
+import { OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST } from "../../../context-engine/host-compat.js";
+import type { AssembleResult } from "../../../context-engine/types.js";
+import { resolveHeartbeatSummaryForAgent } from "../../../infra/heartbeat-summary.js";
+import type { createPreparedEmbeddedAgentSettingsManager } from "../../agent-project-settings.js";
+import type { createCacheTrace } from "../../cache-trace.js";
+import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import type { AgentSession, SessionManager } from "../../sessions/index.js";
+import { buildActiveSubagentSystemPromptAddition } from "../../subagent-active-context.js";
+import type { TranscriptPolicy } from "../../transcript-policy.js";
+import { getHistoryLimitFromSessionKey, limitHistoryTurns } from "../history.js";
+import { log } from "../logger.js";
+import { sanitizeSessionHistory, validateReplayTurns } from "../replay-history.js";
+import type { resolveOrphanRepairPlan } from "./attempt-orphan-repair.js";
+import {
+  loadAttemptSessionEntryAfterQuotaMaintenance,
+  repairAttemptToolUseResultPairing,
+} from "./attempt-transcript-helpers.js";
+import {
+  assembleAttemptContextEngine,
+  type AttemptContextEngine,
+} from "./attempt.context-engine-helpers.js";
+import { prependSystemPromptAddition } from "./attempt.prompt-helpers.js";
+import { estimateRenderedLlmBoundaryTokenPressure } from "./preemptive-compaction.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type CacheTrace = ReturnType<typeof createCacheTrace>;
+type OrphanRepairPlan = ReturnType<typeof resolveOrphanRepairPlan>;
+type SettingsManager = Pick<
+  ReturnType<typeof createPreparedEmbeddedAgentSettingsManager>,
+  "getCompactionReserveTokens"
+>;
+
+type PreparedEmbeddedAttemptHistory = {
+  contextEnginePromptAuthority: NonNullable<AssembleResult["promptAuthority"]>;
+  contextEngineAssemblySucceeded: boolean;
+  unwindowedContextEngineMessagesForPrecheck?: AgentMessage[];
+};
+
+export async function prepareEmbeddedAttemptHistory(input: {
+  attempt: EmbeddedRunAttemptParams;
+  activeSession: AgentSession;
+  sessionManager: SessionManager;
+  activeContextEngine?: AttemptContextEngine;
+  cacheTrace: CacheTrace;
+  capabilityToolNames: ReadonlySet<string>;
+  effectiveWorkspace: string;
+  isOpenAIResponsesApi: boolean;
+  isRawModelRun: boolean;
+  orphanRepair?: OrphanRepairPlan;
+  replayAllowedToolNames: Set<string>;
+  sessionAgentId: string;
+  settingsManager: SettingsManager;
+  systemPromptText: string;
+  transcriptPolicy: TranscriptPolicy;
+  setActiveSessionSystemPrompt: (systemPrompt: string) => void;
+}): Promise<PreparedEmbeddedAttemptHistory> {
+  const { activeSession, attempt } = input;
+  let systemPromptText = input.systemPromptText;
+  const setSystemPrompt = (nextSystemPrompt: string) => {
+    systemPromptText = nextSystemPrompt;
+    input.setActiveSessionSystemPrompt(nextSystemPrompt);
+  };
+
+  if (input.isRawModelRun) {
+    activeSession.agent.reset();
+    setSystemPrompt("");
+    input.cacheTrace?.recordStage("session:raw-model-run", {
+      messages: activeSession.messages,
+      system: systemPromptText,
+    });
+  } else {
+    const prior = await sanitizeSessionHistory({
+      messages: activeSession.messages,
+      modelApi: attempt.model.api,
+      modelId: attempt.modelId,
+      provider: attempt.provider,
+      allowedToolNames: input.replayAllowedToolNames,
+      config: attempt.config,
+      workspaceDir: input.effectiveWorkspace,
+      env: process.env,
+      model: attempt.model,
+      sessionManager: input.sessionManager,
+      sessionId: attempt.sessionId,
+      policy: input.transcriptPolicy,
+    });
+    input.cacheTrace?.recordStage("session:sanitized", { messages: prior });
+    const validated = await validateReplayTurns({
+      messages: prior,
+      modelApi: attempt.model.api,
+      modelId: attempt.modelId,
+      provider: attempt.provider,
+      config: attempt.config,
+      workspaceDir: input.effectiveWorkspace,
+      env: process.env,
+      model: attempt.model,
+      sessionId: attempt.sessionId,
+      policy: input.transcriptPolicy,
+    });
+
+    if (attempt.sessionKey) {
+      const storePath = resolveStorePath(attempt.config?.session?.store, {
+        agentId: input.sessionAgentId,
+      });
+      const sessionEntry = await loadAttemptSessionEntryAfterQuotaMaintenance({
+        storePath,
+        sessionKey: attempt.sessionKey,
+      });
+      const suspension = sessionEntry?.quotaSuspension;
+      if (sessionEntry && suspension?.state === "resuming") {
+        const subagents = listSessionEntries({ storePath, clone: false })
+          .map(({ entry }) => entry)
+          .filter((entry) => entry.spawnedBy === sessionEntry.sessionId)
+          .map((entry) => ({
+            sessionId: entry.sessionId,
+            role: entry.subagentRole,
+            lastStatus: entry.status,
+          }));
+        validated.push(
+          buildHierarchyReinforcementMessage({
+            summary: suspension.summary ?? "No recovery briefing was captured.",
+            activeSubagents: subagents,
+          }),
+        );
+        await updateSessionEntry(
+          { storePath, sessionKey: attempt.sessionKey },
+          async (entry) => {
+            if (entry.quotaSuspension?.state !== "resuming") {
+              return null;
+            }
+            return {
+              quotaSuspension: { ...entry.quotaSuspension, state: "active" },
+            };
+          },
+          { skipMaintenance: true, takeCacheOwnership: true },
+        );
+      }
+    }
+
+    if (attempt.sessionKey && attempt.config) {
+      // Capability guidance must include deferred OpenClaw tools without
+      // interpreting arbitrary client tool names as native capabilities.
+      const activeSubagentPromptAddition = buildActiveSubagentSystemPromptAddition({
+        cfg: attempt.config,
+        controllerSessionKey: attempt.sessionKey,
+        hasSessionsYield: input.capabilityToolNames.has("sessions_yield"),
+      });
+      if (activeSubagentPromptAddition) {
+        setSystemPrompt(
+          prependSystemPromptAddition({
+            systemPrompt: systemPromptText,
+            systemPromptAddition: activeSubagentPromptAddition,
+          }),
+        );
+      }
+    }
+
+    const heartbeatSummary =
+      attempt.config && input.sessionAgentId
+        ? resolveHeartbeatSummaryForAgent(attempt.config, input.sessionAgentId)
+        : undefined;
+    const heartbeatFiltered = filterHeartbeatTranscriptArtifacts(
+      validated,
+      heartbeatSummary?.ackMaxChars,
+      heartbeatSummary?.prompt,
+    );
+    const truncated = limitHistoryTurns(
+      heartbeatFiltered,
+      getHistoryLimitFromSessionKey(attempt.sessionKey, attempt.config),
+    );
+    // Truncation can orphan tool_result blocks by removing the assistant message
+    // that contained the matching tool_use, so repair the pairs once more.
+    const limited = input.transcriptPolicy.repairToolUseResultPairing
+      ? repairAttemptToolUseResultPairing(truncated, input.isOpenAIResponsesApi)
+      : truncated;
+    input.cacheTrace?.recordStage("session:limited", { messages: limited });
+    if (limited.length > 0 || prior.length > 0) {
+      activeSession.agent.state.messages = limited;
+    }
+  }
+
+  let contextEnginePromptAuthority: NonNullable<AssembleResult["promptAuthority"]> = "assembled";
+  let contextEngineAssemblySucceeded = false;
+  let unwindowedContextEngineMessagesForPrecheck: AgentMessage[] | undefined;
+  if (input.activeContextEngine) {
+    try {
+      // Assemble may window the input in place. Preserve the original history for
+      // the overflow precheck when the engine says preassembly can still overflow.
+      const preassemblyMessages = activeSession.messages.slice();
+      const reserveTokens = Math.max(
+        0,
+        Math.floor(input.settingsManager.getCompactionReserveTokens()),
+      );
+      const contextTokenBudget = Math.max(
+        1,
+        Math.floor(
+          attempt.contextTokenBudget ??
+            attempt.model.contextWindow ??
+            attempt.model.maxTokens ??
+            DEFAULT_CONTEXT_TOKENS,
+        ),
+      );
+      const promptBudget = Math.max(1, contextTokenBudget - reserveTokens);
+      const prompt = input.orphanRepair?.contextEnginePrompt ?? attempt.prompt ?? "";
+      const renderedPromptTokens = estimateRenderedLlmBoundaryTokenPressure({
+        systemPrompt: systemPromptText,
+        prompt,
+      });
+      const messageBudget = Math.max(1, promptBudget - renderedPromptTokens);
+      const assembled = await assembleAttemptContextEngine({
+        contextEngine: input.activeContextEngine,
+        sessionId: attempt.sessionId,
+        sessionKey: attempt.sessionKey,
+        messages: activeSession.messages,
+        tokenBudget: messageBudget,
+        availableTools: new Set(input.capabilityToolNames),
+        citationsMode: attempt.config?.memory?.citations,
+        modelId: attempt.modelId,
+        maxOutputTokens: reserveTokens,
+        contextEngineHostSupport: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
+        providerId: attempt.provider,
+        requestedModelId: attempt.requestedModelId,
+        fallbackReason: attempt.fallbackReason,
+        degradedReason: attempt.degradedReason,
+        ...(attempt.prompt !== undefined ? { prompt } : {}),
+      });
+      if (!assembled) {
+        throw new Error("context engine assemble returned no result");
+      }
+      const assembledMessages = input.transcriptPolicy.repairToolUseResultPairing
+        ? repairAttemptToolUseResultPairing(assembled.messages, input.isOpenAIResponsesApi)
+        : assembled.messages;
+      if (assembledMessages !== activeSession.messages) {
+        activeSession.agent.state.messages = assembledMessages;
+      }
+      contextEnginePromptAuthority = assembled.promptAuthority ?? "assembled";
+      contextEngineAssemblySucceeded = true;
+      if (contextEnginePromptAuthority === "preassembly_may_overflow") {
+        unwindowedContextEngineMessagesForPrecheck = preassemblyMessages;
+      }
+      if (assembled.systemPromptAddition) {
+        setSystemPrompt(
+          prependSystemPromptAddition({
+            systemPrompt: systemPromptText,
+            systemPromptAddition: assembled.systemPromptAddition,
+          }),
+        );
+        log.debug(
+          `context engine: prepended system prompt addition (${assembled.systemPromptAddition.length} chars)`,
+        );
+      }
+    } catch (error) {
+      log.warn(`context engine assemble failed, using pipeline messages: ${String(error)}`);
+    }
+  }
+
+  return {
+    contextEnginePromptAuthority,
+    contextEngineAssemblySucceeded,
+    ...(unwindowedContextEngineMessagesForPrecheck
+      ? { unwindowedContextEngineMessagesForPrecheck }
+      : {}),
+  };
+}

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3,14 +3,8 @@
  */
 import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { buildHierarchyReinforcementMessage } from "../../../auto-reply/handoff-summarizer.js";
 import { filterHeartbeatTranscriptArtifacts } from "../../../auto-reply/heartbeat-filter.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
-import { resolveStorePath } from "../../../config/sessions/paths.js";
-import {
-  listSessionEntries,
-  updateSessionEntry,
-} from "../../../config/sessions/session-accessor.js";
 import {
   bindOwnedSessionTranscriptWrites,
   type OwnedSessionTranscriptCacheSnapshot,
@@ -23,14 +17,12 @@ import {
 } from "../../../context-engine/host-compat.js";
 import { resolveContextEngineOwnerPluginId } from "../../../context-engine/registry.js";
 import { buildContextEngineRuntimeSettings } from "../../../context-engine/runtime-settings.js";
-import type { AssembleResult } from "../../../context-engine/types.js";
 import { emitTrustedDiagnosticEvent } from "../../../infra/diagnostic-events.js";
 import {
   createChildDiagnosticTraceContext,
   freezeDiagnosticTraceContext,
 } from "../../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage, toErrorObject } from "../../../infra/errors.js";
-import { resolveHeartbeatSummaryForAgent } from "../../../infra/heartbeat-summary.js";
 import type { AssistantMessage } from "../../../llm/types.js";
 import {
   buildAgentHookContextChannelFields,
@@ -80,7 +72,6 @@ import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js"
 import { acquireSessionWriteLock } from "../../session-write-lock.js";
 import { createAgentSession, SessionManager } from "../../sessions/index.js";
 import { wrapToolDefinition } from "../../sessions/tools/tool-definition-wrapper.js";
-import { buildActiveSubagentSystemPromptAddition } from "../../subagent-active-context.js";
 import {
   ackPendingAgentSteeringItems,
   releasePendingAgentSteeringItems,
@@ -99,14 +90,9 @@ import { resolveCompactionTimeoutMs } from "../compaction-safety-timeout.js";
 import { runContextEngineMaintenance } from "../context-engine-maintenance.js";
 import { buildEmbeddedExtensionFactories } from "../extensions.js";
 import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
-import { getHistoryLimitFromSessionKey, limitHistoryTurns } from "../history.js";
 import { log } from "../logger.js";
 import type { PromptCacheBreak, PromptCacheChange } from "../prompt-cache-observability.js";
-import {
-  normalizeAssistantReplayContent,
-  sanitizeSessionHistory,
-  validateReplayTurns,
-} from "../replay-history.js";
+import { normalizeAssistantReplayContent } from "../replay-history.js";
 import { createEmbeddedAgentResourceLoader } from "../resource-loader.js";
 import {
   clearActiveEmbeddedRun,
@@ -143,6 +129,7 @@ import { prepareEmbeddedAttemptBootstrap } from "./attempt-bootstrap-prepare.js"
 import { prepareEmbeddedAttemptBundleTools } from "./attempt-bundle-tools.js";
 import { prepareEmbeddedAttemptClientTools } from "./attempt-client-tools.js";
 import { snapshotRecentMessages, summarizeSessionContext } from "./attempt-context-summary.js";
+import { prepareEmbeddedAttemptHistory } from "./attempt-history-prepare.js";
 import {
   replayTrailingEntriesForOrphanRepair,
   resolveOrphanRepairPlan,
@@ -167,7 +154,6 @@ import { flushEmbeddedAttemptTrajectoryRecorder } from "./attempt-trajectory-flu
 import {
   cloneHookMessages,
   flushSessionManagerTranscript,
-  loadAttemptSessionEntryAfterQuotaMaintenance,
   removeTrailingMidTurnPrecheckAssistantError,
   repairAttemptToolUseResultPairing,
   resolveAttemptTrajectorySessionFile,
@@ -178,7 +164,6 @@ import {
   type AsyncStartedToolMeta,
 } from "./attempt.async-tasks.js";
 import {
-  assembleAttemptContextEngine,
   buildLoopPromptCacheInfo,
   runAttemptContextEngineBootstrap,
 } from "./attempt.context-engine-helpers.js";
@@ -191,7 +176,6 @@ import {
 } from "./attempt.llm-boundary.js";
 import {
   buildAfterTurnRuntimeContext,
-  prependSystemPromptAddition,
   resolvePromptSubmissionSkipReason,
 } from "./attempt.prompt-helpers.js";
 import { steerActiveSessionWithOptionalDeliveryWait } from "./attempt.queue-message.js";
@@ -239,7 +223,6 @@ import {
   PREEMPTIVE_OVERFLOW_ERROR_TEXT,
   buildPrePromptContextBudgetStatus,
   estimateLlmBoundaryTokenPressure,
-  estimateRenderedLlmBoundaryTokenPressure,
   formatPrePromptPrecheckLog,
   shouldPreemptivelyCompactBeforePrompt,
 } from "./preemptive-compaction.js";
@@ -1027,10 +1010,6 @@ export async function runEmbeddedAttempt(
       const sessionPromptState = getEmbeddedSessionPromptState(params.sessionId);
       const toolResultPromptProjectionState = sessionPromptState.toolResults;
       let contextEngineAfterTurnCheckpoint: number | null = null;
-      let unwindowedContextEngineMessagesForPrecheck: AgentMessage[] | undefined;
-      let contextEnginePromptAuthority: NonNullable<AssembleResult["promptAuthority"]> =
-        "assembled";
-      let contextEngineAssemblySucceeded = false;
       const inFlightPromptSettlePromises = new Set<Promise<void>>();
       const inFlightAbortSettlePromises = new Set<Promise<void>>();
       const trackSettlePromise = (
@@ -1326,214 +1305,26 @@ export async function runEmbeddedAttempt(
       emitPrepStageSummary("stream-ready");
       let promptCacheChangesForTurn: PromptCacheChange[] | null = null;
 
+      let preparedHistory: Awaited<ReturnType<typeof prepareEmbeddedAttemptHistory>>;
       try {
-        if (isRawModelRun) {
-          activeSession.agent.reset();
-          setActiveSessionSystemPrompt("");
-          cacheTrace?.recordStage("session:raw-model-run", {
-            messages: activeSession.messages,
-            system: systemPromptText,
-          });
-        } else {
-          const prior = await sanitizeSessionHistory({
-            messages: activeSession.messages,
-            modelApi: params.model.api,
-            modelId: params.modelId,
-            provider: params.provider,
-            allowedToolNames: replayAllowedToolNames,
-            config: params.config,
-            workspaceDir: effectiveWorkspace,
-            env: process.env,
-            model: params.model,
-            sessionManager,
-            sessionId: params.sessionId,
-            policy: transcriptPolicy,
-          });
-          cacheTrace?.recordStage("session:sanitized", { messages: prior });
-          const validated = await validateReplayTurns({
-            messages: prior,
-            modelApi: params.model.api,
-            modelId: params.modelId,
-            provider: params.provider,
-            config: params.config,
-            workspaceDir: effectiveWorkspace,
-            env: process.env,
-            model: params.model,
-            sessionId: params.sessionId,
-            policy: transcriptPolicy,
-          });
-
-          if (params.sessionKey && !isRawModelRun) {
-            const storePath = resolveStorePath(params.config?.session?.store, {
-              agentId: sessionAgentId,
-            });
-            const sessionEntry = await loadAttemptSessionEntryAfterQuotaMaintenance({
-              storePath,
-              sessionKey: params.sessionKey,
-            });
-            const suspension = sessionEntry?.quotaSuspension;
-            if (sessionEntry && suspension?.state === "resuming") {
-              const subagents = listSessionEntries({ storePath, clone: false })
-                .map(({ entry }) => entry)
-                .filter((s) => s.spawnedBy === sessionEntry.sessionId)
-                .map((s) => ({
-                  sessionId: s.sessionId,
-                  role: s.subagentRole,
-                  lastStatus: s.status,
-                }));
-              const handoffMsg = buildHierarchyReinforcementMessage({
-                summary: suspension.summary ?? "No recovery briefing was captured.",
-                activeSubagents: subagents,
-              });
-              validated.push(handoffMsg);
-              await updateSessionEntry(
-                {
-                  storePath,
-                  sessionKey: params.sessionKey,
-                },
-                async (entry) => {
-                  if (entry.quotaSuspension?.state !== "resuming") {
-                    return null;
-                  }
-                  return {
-                    quotaSuspension: { ...entry.quotaSuspension, state: "active" },
-                  };
-                },
-                {
-                  skipMaintenance: true,
-                  takeCacheOwnership: true,
-                },
-              );
-            }
-          }
-
-          if (params.sessionKey && params.config && !isRawModelRun) {
-            // Capability guidance must include deferred OpenClaw tools without
-            // interpreting arbitrary client tool names as native capabilities.
-            const activeSubagentPromptAddition = buildActiveSubagentSystemPromptAddition({
-              cfg: params.config,
-              controllerSessionKey: params.sessionKey,
-              hasSessionsYield: capabilityToolNames.has("sessions_yield"),
-            });
-            if (activeSubagentPromptAddition) {
-              setActiveSessionSystemPrompt(
-                prependSystemPromptAddition({
-                  systemPrompt: systemPromptText,
-                  systemPromptAddition: activeSubagentPromptAddition,
-                }),
-              );
-            }
-          }
-
-          const heartbeatSummary =
-            params.config && sessionAgentId
-              ? resolveHeartbeatSummaryForAgent(params.config, sessionAgentId)
-              : undefined;
-          const heartbeatFiltered = filterHeartbeatTranscriptArtifacts(
-            validated,
-            heartbeatSummary?.ackMaxChars,
-            heartbeatSummary?.prompt,
-          );
-          const truncated = limitHistoryTurns(
-            heartbeatFiltered,
-            getHistoryLimitFromSessionKey(params.sessionKey, params.config),
-          );
-          // Re-run tool_use/tool_result pairing repair after truncation, since
-          // limitHistoryTurns can orphan tool_result blocks by removing the
-          // assistant message that contained the matching tool_use.
-          const limited = transcriptPolicy.repairToolUseResultPairing
-            ? repairAttemptToolUseResultPairing(truncated, isOpenAIResponsesApi)
-            : truncated;
-          cacheTrace?.recordStage("session:limited", { messages: limited });
-          if (limited.length > 0 || prior.length > 0) {
-            activeSession.agent.state.messages = limited;
-          }
-        }
-
-        if (activeContextEngine) {
-          try {
-            // Snapshot before assemble: the assemble contract does not require
-            // the input array to be treated immutably, so an engine that windows
-            // history in place would otherwise leave the precheck reading
-            // already-windowed messages instead of the true pre-assembly state.
-            const preassemblyContextEngineMessagesForPrecheck = activeSession.messages.slice();
-            const contextEngineAssembleReserveTokens = Math.max(
-              0,
-              Math.floor(settingsManager.getCompactionReserveTokens()),
-            );
-            const contextEngineAssembleContextTokenBudget = Math.max(
-              1,
-              Math.floor(
-                params.contextTokenBudget ??
-                  params.model.contextWindow ??
-                  params.model.maxTokens ??
-                  DEFAULT_CONTEXT_TOKENS,
-              ),
-            );
-            const contextEngineAssemblePromptBudget = Math.max(
-              1,
-              contextEngineAssembleContextTokenBudget - contextEngineAssembleReserveTokens,
-            );
-            const contextEngineAssemblePrompt =
-              orphanRepair?.contextEnginePrompt ?? params.prompt ?? "";
-            const contextEngineAssembleRenderedPromptTokens =
-              estimateRenderedLlmBoundaryTokenPressure({
-                systemPrompt: systemPromptText,
-                prompt: contextEngineAssemblePrompt,
-              });
-            const contextEngineAssembleMessageBudget = Math.max(
-              1,
-              contextEngineAssemblePromptBudget - contextEngineAssembleRenderedPromptTokens,
-            );
-            const assembled = await assembleAttemptContextEngine({
-              contextEngine: activeContextEngine,
-              sessionId: params.sessionId,
-              sessionKey: params.sessionKey,
-              messages: activeSession.messages,
-              tokenBudget: contextEngineAssembleMessageBudget,
-              availableTools: new Set(capabilityToolNames),
-              citationsMode: params.config?.memory?.citations,
-              modelId: params.modelId,
-              maxOutputTokens: contextEngineAssembleReserveTokens,
-              contextEngineHostSupport: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
-              providerId: params.provider,
-              requestedModelId: params.requestedModelId,
-              fallbackReason: params.fallbackReason,
-              degradedReason: params.degradedReason,
-              ...(params.prompt !== undefined ? { prompt: contextEngineAssemblePrompt } : {}),
-            });
-            if (!assembled) {
-              throw new Error("context engine assemble returned no result");
-            }
-            const assembledMessages = transcriptPolicy.repairToolUseResultPairing
-              ? repairAttemptToolUseResultPairing(assembled.messages, isOpenAIResponsesApi)
-              : assembled.messages;
-            if (assembledMessages !== activeSession.messages) {
-              activeSession.agent.state.messages = assembledMessages;
-            }
-            contextEnginePromptAuthority = assembled.promptAuthority ?? "assembled";
-            contextEngineAssemblySucceeded = true;
-            if (contextEnginePromptAuthority === "preassembly_may_overflow") {
-              unwindowedContextEngineMessagesForPrecheck =
-                preassemblyContextEngineMessagesForPrecheck;
-            }
-            if (assembled.systemPromptAddition) {
-              setActiveSessionSystemPrompt(
-                prependSystemPromptAddition({
-                  systemPrompt: systemPromptText,
-                  systemPromptAddition: assembled.systemPromptAddition,
-                }),
-              );
-              log.debug(
-                `context engine: prepended system prompt addition (${assembled.systemPromptAddition.length} chars)`,
-              );
-            }
-          } catch (assembleErr) {
-            log.warn(
-              `context engine assemble failed, using pipeline messages: ${String(assembleErr)}`,
-            );
-          }
-        }
+        preparedHistory = await prepareEmbeddedAttemptHistory({
+          attempt: params,
+          activeSession,
+          sessionManager,
+          ...(activeContextEngine ? { activeContextEngine } : {}),
+          cacheTrace,
+          capabilityToolNames,
+          effectiveWorkspace,
+          isOpenAIResponsesApi,
+          isRawModelRun,
+          ...(orphanRepair ? { orphanRepair } : {}),
+          replayAllowedToolNames,
+          sessionAgentId,
+          settingsManager,
+          systemPromptText,
+          transcriptPolicy,
+          setActiveSessionSystemPrompt,
+        });
       } catch (err) {
         await flushPendingToolResultsAfterIdle({
           agent: activeSession?.agent,
@@ -1546,6 +1337,11 @@ export async function runEmbeddedAttempt(
         activeSession.dispose();
         throw err;
       }
+      const {
+        contextEnginePromptAuthority,
+        contextEngineAssemblySucceeded,
+        unwindowedContextEngineMessagesForPrecheck,
+      } = preparedHistory;
 
       let yieldAborted = false;
       const abortCompaction = () => {


### PR DESCRIPTION
Related: #72072

## What Problem This Solves

`runEmbeddedAttempt` still contains transcript restoration and context-engine assembly inline, obscuring the phase boundary between session setup and prompt execution.

## Why This Change Was Made

Extract one complete history-preparation phase: replay sanitation, quota-resume reinforcement, heartbeat/history filtering, pairing repair, and context-engine assembly. The handler now consumes the prepared assembly state and retains setup-error cleanup ownership.

## User Impact

No intended behavior change. Maintainers get a smaller attempt handler and one focused owner for restored history plus context-engine assembly.

## Evidence

- `attempt.ts`: 3,265 -> 3,061 lines.
- Blacksmith Testbox `tbx_01kxegpe1qrfxt1093crbkx8wn`: 245 history/context-engine regression tests plus full scoped `check:changed` passed.
- Exact rebased head, Testbox `tbx_01kxej059mtame0ajmgt69vjhm`: 246 regression tests, core types, and LOC ratchet passed.
- Fresh post-rebase independent autoreview: clean, no accepted or actionable findings.
