### PR TITLE
refactor(google): use genai session type

### DIFF
--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -13,6 +13,7 @@ import type {
   LiveServerToolCall,
   Modality,
   RealtimeInputConfig,
+  Session,
   StartSensitivity,
   ThinkingConfig,
   TurnCoverage,
@@ -123,20 +124,6 @@ type GoogleRealtimeLiveConfig = {
 
 type GoogleRealtimeVoiceBridgeConfig = RealtimeVoiceBridgeCreateRequest & GoogleRealtimeLiveConfig;
 type GoogleLiveTranscription = NonNullable<LiveServerContent["inputTranscription"]>;
-
-type GoogleLiveSession = {
-  sendClientContent: (params: {
-    turns?: Array<{ role: string; parts: Array<{ text: string }> }>;
-    turnComplete?: boolean;
-  }) => void;
-  sendRealtimeInput: (params: {
-    audio?: { data: string; mimeType: string };
-    audioStreamEnd?: boolean;
-    text?: string;
-  }) => void;
-  sendToolResponse: (params: { functionResponses: FunctionResponse[] | FunctionResponse }) => void;
-  close: () => void;
-};
 
 function trimToUndefined(value: unknown): string | undefined {
   return normalizeOptionalString(value);
@@ -496,7 +483,7 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
   readonly supportsToolResultContinuation: boolean;
   readonly supportsToolResultSuppression = false;
 
-  private session: GoogleLiveSession | null = null;
+  private session: Session | null = null;
   private connected = false;
   private sessionConfigured = false;
   private intentionallyClosed = false;
@@ -543,7 +530,7 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
       },
     });
 
-    this.session = (await ai.live.connect({
+    this.session = await ai.live.connect({
       model: this.model,
       config: {
         ...buildGoogleLiveConnectConfig(this.config, this.model),
@@ -594,7 +581,7 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
           this.config.onClose?.("error");
         },
       },
-    })) as GoogleLiveSession;
+    });
     this.hasConnectedSession = true;
   }
 


### PR DESCRIPTION
Closes #106785

## What Problem This Solves

The Google realtime voice bridge duplicated the public four-method `@google/genai` `Session` contract, then asserted the SDK connect result back to that local mirror.

## Why This Change Was Made

Use the exact `Session` type returned by the pinned SDK's `Live.connect()` method. This removes 13 lines of duplicate type surface and lets dependency updates check the real contract directly.

## User Impact

No runtime, configuration, or documentation behavior changes. This is type-only maintenance.

## Evidence

- Exact head `e32fd14342d08797a4a34e8a5c72f27082690bdd`.
- Blacksmith Testbox `tbx_01kxej9zmcq1mh716tv1t6xjq2`: [run 29282105796](https://github.com/openclaw/openclaw/actions/runs/29282105796).
- `pnpm test extensions/google/realtime-voice-provider.test.ts`: 43/43 passed.
- `pnpm tsgo:extensions` passed.
- `pnpm tsgo:extensions:test` passed.
- `git diff --check` passed.
- Fresh autoreview: clean.
