### PR TITLE
fix(acpx): stop creating empty stderr logs

### DIFF
--- a/extensions/acpx/src/codex-auth-bridge.test.ts
+++ b/extensions/acpx/src/codex-auth-bridge.test.ts
@@ -763,11 +763,13 @@ describe("prepareAcpxCodexAuthConfig", () => {
     await expectPathMissing(path.join(stateDir, "acpx", "codex-acp-wrapper.stderr.log"));
   });
 
-  it("does not create a per-lease stderr log when the adapter writes no stderr", async () => {
+  it("removes a previous per-lease stderr log when the adapter writes no stderr", async () => {
     const root = await makeTempDir();
     const stateDir = path.join(root, "state");
     const generated = generatedCodexPaths(stateDir);
+    const noisyScript = path.join(root, "noisy-adapter.mjs");
     const quietScript = path.join(root, "quiet-adapter.mjs");
+    await fs.writeFile(noisyScript, 'process.stderr.write("previous diagnostics\\n");\n', "utf8");
     await fs.writeFile(quietScript, "process.exit(0);\n", "utf8");
     const pluginConfig = resolveAcpxPluginConfig({
       rawConfig: {
@@ -786,20 +788,31 @@ describe("prepareAcpxCodexAuthConfig", () => {
       resolveInstalledCodexAcpBinPath: async () => path.join(root, "codex-acp.js"),
     });
 
+    const wrapperArgs = [
+      OPENCLAW_ACPX_LEASE_ID_ARG,
+      "quiet-lease",
+      OPENCLAW_GATEWAY_INSTANCE_ID_ARG,
+      "gateway-test",
+    ];
+    await execFileAsync(process.execPath, [
+      generated.wrapperPath,
+      "--openclaw-run-configured",
+      process.execPath,
+      noisyScript,
+      ...wrapperArgs,
+    ]);
+    const stderrLogPath = path.join(stateDir, "acpx", "codex-acp-wrapper.stderr.quiet-lease.log");
+    await expect(fs.readFile(stderrLogPath, "utf8")).resolves.toBe("previous diagnostics\n");
+
     await execFileAsync(process.execPath, [
       generated.wrapperPath,
       "--openclaw-run-configured",
       process.execPath,
       quietScript,
-      OPENCLAW_ACPX_LEASE_ID_ARG,
-      "quiet-lease",
-      OPENCLAW_GATEWAY_INSTANCE_ID_ARG,
-      "gateway-test",
+      ...wrapperArgs,
     ]);
 
-    await expectPathMissing(
-      path.join(stateDir, "acpx", "codex-acp-wrapper.stderr.quiet-lease.log"),
-    );
+    await expectPathMissing(stderrLogPath);
   });
 
   it("keeps the persisted stderr line tail UTF-16 safe at the 256 KiB boundary", async () => {

--- a/extensions/acpx/src/codex-auth-bridge.test.ts
+++ b/extensions/acpx/src/codex-auth-bridge.test.ts
@@ -815,6 +815,37 @@ describe("prepareAcpxCodexAuthConfig", () => {
     await expectPathMissing(stderrLogPath);
   });
 
+  it("starts the adapter when a previous stderr log cannot be removed", async () => {
+    const root = await makeTempDir();
+    const stateDir = path.join(root, "state");
+    const generated = generatedCodexPaths(stateDir);
+    const quietScript = path.join(root, "quiet-adapter.mjs");
+    await fs.writeFile(quietScript, "process.exit(0);\n", "utf8");
+    const pluginConfig = resolveAcpxPluginConfig({ rawConfig: {}, workspaceDir: root });
+
+    await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+      resolveInstalledCodexAcpBinPath: async () => path.join(root, "codex-acp.js"),
+    });
+
+    const stderrLogPath = path.join(stateDir, "acpx", "codex-acp-wrapper.stderr.blocked-lease.log");
+    await fs.mkdir(stderrLogPath);
+
+    await expect(
+      execFileAsync(process.execPath, [
+        generated.wrapperPath,
+        "--openclaw-run-configured",
+        process.execPath,
+        quietScript,
+        OPENCLAW_ACPX_LEASE_ID_ARG,
+        "blocked-lease",
+        OPENCLAW_GATEWAY_INSTANCE_ID_ARG,
+        "gateway-test",
+      ]),
+    ).resolves.toMatchObject({ stderr: "" });
+  });
+
   it("keeps the persisted stderr line tail UTF-16 safe at the 256 KiB boundary", async () => {
     const { log } = await captureGeneratedCodexWrapperStderr(`
       const maxChars = 256 * 1024;

--- a/extensions/acpx/src/codex-auth-bridge.test.ts
+++ b/extensions/acpx/src/codex-auth-bridge.test.ts
@@ -763,6 +763,45 @@ describe("prepareAcpxCodexAuthConfig", () => {
     await expectPathMissing(path.join(stateDir, "acpx", "codex-acp-wrapper.stderr.log"));
   });
 
+  it("does not create a per-lease stderr log when the adapter writes no stderr", async () => {
+    const root = await makeTempDir();
+    const stateDir = path.join(root, "state");
+    const generated = generatedCodexPaths(stateDir);
+    const quietScript = path.join(root, "quiet-adapter.mjs");
+    await fs.writeFile(quietScript, "process.exit(0);\n", "utf8");
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {
+        agents: {
+          codex: {
+            command: `${process.execPath} ${quietScript}`,
+          },
+        },
+      },
+      workspaceDir: root,
+    });
+
+    await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+      resolveInstalledCodexAcpBinPath: async () => path.join(root, "codex-acp.js"),
+    });
+
+    await execFileAsync(process.execPath, [
+      generated.wrapperPath,
+      "--openclaw-run-configured",
+      process.execPath,
+      quietScript,
+      OPENCLAW_ACPX_LEASE_ID_ARG,
+      "quiet-lease",
+      OPENCLAW_GATEWAY_INSTANCE_ID_ARG,
+      "gateway-test",
+    ]);
+
+    await expectPathMissing(
+      path.join(stateDir, "acpx", "codex-acp-wrapper.stderr.quiet-lease.log"),
+    );
+  });
+
   it("keeps the persisted stderr line tail UTF-16 safe at the 256 KiB boundary", async () => {
     const { log } = await captureGeneratedCodexWrapperStderr(`
       const maxChars = 256 * 1024;

--- a/extensions/acpx/src/codex-auth-bridge.ts
+++ b/extensions/acpx/src/codex-auth-bridge.ts
@@ -232,7 +232,7 @@ function buildAdapterWrapperScript(params: {
   stderrLogFileNamePrefix?: string;
 }): string {
   return `#!/usr/bin/env node
-import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { StringDecoder } from "node:string_decoder";
@@ -401,6 +401,9 @@ function stripOpenClawWrapperArgs(args) {
 
 const rawConfiguredArgs = process.argv.slice(2);
 const stderrLogPath = resolveStderrLogPath(rawConfiguredArgs);
+if (stderrLogPath) {
+  rmSync(stderrLogPath, { force: true });
+}
 
 const configuredArgs = stripOpenClawWrapperArgs(rawConfiguredArgs);
 

--- a/extensions/acpx/src/codex-auth-bridge.ts
+++ b/extensions/acpx/src/codex-auth-bridge.ts
@@ -402,7 +402,11 @@ function stripOpenClawWrapperArgs(args) {
 const rawConfiguredArgs = process.argv.slice(2);
 const stderrLogPath = resolveStderrLogPath(rawConfiguredArgs);
 if (stderrLogPath) {
-  rmSync(stderrLogPath, { force: true });
+  try {
+    rmSync(stderrLogPath, { force: true });
+  } catch {
+    // Diagnostic cleanup must never prevent the adapter from starting.
+  }
 }
 
 const configuredArgs = stripOpenClawWrapperArgs(rawConfiguredArgs);

--- a/extensions/acpx/src/codex-auth-bridge.ts
+++ b/extensions/acpx/src/codex-auth-bridge.ts
@@ -402,14 +402,6 @@ function stripOpenClawWrapperArgs(args) {
 const rawConfiguredArgs = process.argv.slice(2);
 const stderrLogPath = resolveStderrLogPath(rawConfiguredArgs);
 
-try {
-  if (stderrLogPath) {
-    writeFileSync(stderrLogPath, "", "utf8");
-  }
-} catch {
-  // Stderr capture is diagnostic-only; never break the ACP adapter.
-}
-
 const configuredArgs = stripOpenClawWrapperArgs(rawConfiguredArgs);
 
 function resolveNpmCliPath() {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ACP operators accumulated an empty stderr log file for every quiet Codex ACP process lease. On a busy long-running gateway this produced tens of thousands of zero-byte files without adding diagnostic value.

## Why This Change Was Made

The Codex auth bridge now creates the stderr log lazily on the first stderr write. Startup also removes a stale log for a reused diagnostic path, while cleanup failures remain non-fatal. Non-empty stderr keeps the existing redaction and bounded-tail behavior.

## User Impact

Operators can keep ACP stderr diagnostics enabled without unbounded zero-byte file churn or stale diagnostics. Actual stderr remains available for failures, and diagnostic cleanup cannot block adapter startup.

## Evidence

- Exact focused wrapper suite: 24 passed.
- Full ACPX extension suite before the bounded maintainer cleanup: 167 passed.
- Exact improved content passed the Blacksmith path-scoped changed gate: formatting, production and test typechecks, lint, plugin boundaries, storage guards, and import-cycle checks ([run 29489658499](https://github.com/openclaw/openclaw/actions/runs/29489658499)).
- Mandatory Autoreview accepted and repaired stale-log and cleanup-failure edge cases; final branch review clean at 0.98 confidence.
- Direct upstream contract inspection confirmed Codex app-server and exec-server stderr are diagnostic streams; quiet processes may emit none.

## Real behavior proof

- **Behavior or issue addressed:** Quiet ACP process leases created empty stderr log files even though there was no diagnostic output.
- **Real environment tested:** A Linux system running a long-lived OpenClaw gateway from a local build with the bundled ACPX plugin and Codex ACP enabled.
- **Exact steps run:** Removed the existing empty lease logs, restarted the patched gateway, ran multiple quiet ACP turns, then triggered a run that emitted stderr and inspected the configured stderr log directory.
- **Evidence after fix:** Before the patch, the diagnostic directory contained approximately 29,590 zero-byte per-lease log files. After patched quiet runs, zero new empty log files appeared. The stderr-producing run created a non-empty retained log.
- **Automated edge coverage added by maintainer review:** A noisy invocation followed by a quiet invocation on the same lease removes stale diagnostics; an unremovable diagnostic path does not stop the adapter.
- **What was not tested live:** Windows and macOS process wrappers; they share this generated implementation and are covered by automated tests.

## AI-assisted disclosure

This PR is AI-assisted. The original author ran the real behavior validation and automated tests, reviewed the diff, and confirmed the lazy stderr-log behavior. Maintainer review added bounded cleanup and regression coverage before landing.
