### PR TITLE
refactor(google): use genai thinking levels

### DIFF
--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -11,6 +11,7 @@ import {
   type GenerateContentResponse,
   type Part,
   type ThinkingConfig,
+  ThinkingLevel,
 } from "@google/genai";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
 import type {
@@ -37,16 +38,7 @@ import { transformMessages } from "./transform-messages.js";
 
 type GoogleApiType = "google-generative-ai" | "google-vertex";
 
-/**
- * Thinking level for Gemini 3 models.
- * Mirrors Google's ThinkingLevel enum values.
- */
-export type GoogleThinkingLevel =
-  | "THINKING_LEVEL_UNSPECIFIED"
-  | "MINIMAL"
-  | "LOW"
-  | "MEDIUM"
-  | "HIGH";
+export type GoogleThinkingLevel = `${ThinkingLevel}`;
 
 type GoogleToolChoice = "auto" | "none" | "any";
 
@@ -485,7 +477,6 @@ export function buildGoogleGenerateContentParams<T extends GoogleApiType>(
   context: Context,
   options: GoogleProviderOptions = {},
   configHooks?: {
-    mapThinkingLevel?: (level: GoogleThinkingLevel) => ThinkingConfig["thinkingLevel"];
     getDisabledThinkingConfig?: (model: Model<T>) => ThinkingConfig;
   },
 ): GenerateContentParameters {
@@ -523,9 +514,7 @@ export function buildGoogleGenerateContentParams<T extends GoogleApiType>(
   if (options.thinking?.enabled && model.reasoning) {
     const thinkingConfig: ThinkingConfig = { includeThoughts: true };
     if (options.thinking.level !== undefined) {
-      thinkingConfig.thinkingLevel = configHooks?.mapThinkingLevel
-        ? configHooks.mapThinkingLevel(options.thinking.level)
-        : (options.thinking.level as ThinkingConfig["thinkingLevel"]);
+      thinkingConfig.thinkingLevel = ThinkingLevel[options.thinking.level];
     } else if (options.thinking.budgetTokens !== undefined) {
       thinkingConfig.thinkingBudget = options.thinking.budgetTokens;
     }
@@ -595,25 +584,19 @@ export function getDisabledGoogleThinkingConfig<T extends GoogleApiType>(
   model: Model<T>,
   config?: {
     includeGemma4?: boolean;
-    mapThinkingLevel?: (level: GoogleThinkingLevel) => ThinkingConfig["thinkingLevel"];
   },
 ): ThinkingConfig {
-  const mapThinkingLevel = (level: GoogleThinkingLevel): ThinkingConfig["thinkingLevel"] =>
-    config?.mapThinkingLevel
-      ? config.mapThinkingLevel(level)
-      : (level as ThinkingConfig["thinkingLevel"]);
-
   // Google docs: Gemini 3.1 Pro cannot disable thinking, and Gemini 3 Flash / Flash-Lite
   // do not support full thinking-off either. For Gemini 3 models, use the lowest supported
   // thinkingLevel without includeThoughts so hidden thinking remains invisible to OpenClaw.
   if (isGemini3ProModel(model)) {
-    return { thinkingLevel: mapThinkingLevel("LOW") };
+    return { thinkingLevel: ThinkingLevel.LOW };
   }
   if (isGemini3FlashModel(model)) {
-    return { thinkingLevel: mapThinkingLevel("MINIMAL") };
+    return { thinkingLevel: ThinkingLevel.MINIMAL };
   }
   if (config?.includeGemma4 && isGemma4Model(model)) {
-    return { thinkingLevel: mapThinkingLevel("MINIMAL") };
+    return { thinkingLevel: ThinkingLevel.MINIMAL };
   }
 
   // Gemini 2.x supports disabling via thinkingBudget = 0.
@@ -637,38 +620,38 @@ function getGoogleThinkingLevel<T extends GoogleApiType>(
   effort: ClampedGoogleThinkingLevel,
   model: Model<T>,
   config?: { includeGemma4?: boolean },
-): GoogleThinkingLevel {
+): ThinkingLevel {
   if (isGemini3ProModel(model)) {
     switch (effort) {
       case "minimal":
       case "low":
-        return "LOW";
+        return ThinkingLevel.LOW;
       case "medium":
       case "high":
-        return "HIGH";
+        return ThinkingLevel.HIGH;
     }
   }
   if (config?.includeGemma4 && isGemma4Model(model)) {
     switch (effort) {
       case "minimal":
       case "low":
-        return "MINIMAL";
+        return ThinkingLevel.MINIMAL;
       case "medium":
       case "high":
-        return "HIGH";
+        return ThinkingLevel.HIGH;
     }
   }
   switch (effort) {
     case "minimal":
-      return "MINIMAL";
+      return ThinkingLevel.MINIMAL;
     case "low":
-      return "LOW";
+      return ThinkingLevel.LOW;
     case "medium":
-      return "MEDIUM";
+      return ThinkingLevel.MEDIUM;
     case "high":
-      return "HIGH";
+      return ThinkingLevel.HIGH;
   }
-  return "HIGH";
+  return ThinkingLevel.HIGH;
 }
 
 function getGoogleBudget<T extends GoogleApiType>(

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -4,17 +4,14 @@ import {
   GoogleGenAI,
   type HttpOptions,
   ResourceScope,
-  ThinkingLevel as VertexThinkingLevel,
 } from "@google/genai";
 import { getAiTransportHost, resolveAiTransportHeaderSentinels } from "../host.js";
 import type { Context, Model, SimpleStreamOptions, StreamFunction } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
-import type { GoogleThinkingLevel } from "./google-shared.js";
 import {
   buildGoogleGenerateContentParams,
   buildGoogleSimpleThinking,
   createGoogleAssistantOutput,
-  getDisabledGoogleThinkingConfig,
   type GoogleProviderOptions,
   runGoogleGenerateContentLifecycle,
 } from "./google-shared.js";
@@ -27,14 +24,6 @@ interface GoogleVertexOptions extends GoogleProviderOptions {
 
 const API_VERSION = "v1";
 const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
-
-const THINKING_LEVEL_MAP: Record<GoogleThinkingLevel, VertexThinkingLevel> = {
-  THINKING_LEVEL_UNSPECIFIED: VertexThinkingLevel.THINKING_LEVEL_UNSPECIFIED,
-  MINIMAL: VertexThinkingLevel.MINIMAL,
-  LOW: VertexThinkingLevel.LOW,
-  MEDIUM: VertexThinkingLevel.MEDIUM,
-  HIGH: VertexThinkingLevel.HIGH,
-};
 
 // Counter for generating unique tool call IDs
 let toolCallCounter = 0;
@@ -187,13 +176,5 @@ function buildParams(
   context: Context,
   options: GoogleVertexOptions = {},
 ): GenerateContentParameters {
-  return buildGoogleGenerateContentParams(model, context, options, {
-    mapThinkingLevel: mapVertexThinkingLevel,
-    getDisabledThinkingConfig: (modelLocal) =>
-      getDisabledGoogleThinkingConfig(modelLocal, { mapThinkingLevel: mapVertexThinkingLevel }),
-  });
-}
-
-function mapVertexThinkingLevel(level: GoogleThinkingLevel): VertexThinkingLevel {
-  return THINKING_LEVEL_MAP[level];
+  return buildGoogleGenerateContentParams(model, context, options);
 }


### PR DESCRIPTION
## What Problem This Solves

Google provider code duplicated `@google/genai`'s public `ThinkingLevel` enum with a local union and a Vertex identity map.

Closes #106795.

## Why This Change Was Made

Derive the existing public raw-string type from the SDK enum, convert it through the enum object at the request boundary, and use SDK enum members for generated defaults. Vertex now uses the shared request builder directly.

## User Impact

No behavior or public option break. Existing raw string values remain accepted. Request payload values remain unchanged. Net change: 36 fewer lines.

## Evidence

- `pnpm test packages/ai/src/providers/google-shared.test.ts packages/ai/src/providers/google-client-auth.test.ts` — 10/10 passed
- `pnpm tsgo:core` — passed
- `pnpm tsgo:test:packages` — passed
- `pnpm build` — passed
- Fresh autoreview — clean
- Blacksmith Testbox: `tbx_01kxekbe3v4hrhw44b9a84x64p`
- Delegated run: https://github.com/openclaw/openclaw/actions/runs/29283323497
- Rebased onto current `main`; stable patch ID remained `c3367d7c8162bd0abe126bd3e722a020134c3f26`
