### PR TITLE
fix(android): providers back button lacks outline

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
@@ -85,7 +85,7 @@ internal fun ProvidersModelsScreen(
               verticalAlignment = Alignment.CenterVertically,
               horizontalArrangement = Arrangement.SpaceBetween,
             ) {
-              ProviderHeaderIconButton(icon = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = nativeString("Back"), onClick = onBack)
+              ProviderHeaderIconButton(icon = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = nativeString("Back"), outlined = true, onClick = onBack)
             }
             Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
               Text(text = nativeString("Providers & Models"), style = ClawTheme.type.display.copy(fontSize = 14.8.sp, lineHeight = 18.sp), color = ClawTheme.colors.text, maxLines = 1)


### PR DESCRIPTION
[AI-assisted]

## What Problem This Solves

Fixes an issue where the Android Providers & Models screen showed its back button without the circular outline used to distinguish the header action.

## Why This Change Was Made

The screen now enables the existing outlined variant at its only back-button call site. The shared button component, navigation behavior, and other screens remain unchanged.

## User Impact

The Providers & Models back action is visually consistent and easier to recognize without changing its touch target or behavior.

## Evidence

### Real behavior proof

- Pinned Base source: 343334951d9e2a3f2f4f1c0463c3e720e84cd968.
- Exact Base APK SHA-256: dd1f141f339d3982039ccdc810dae5208a146c2a24da28845dd5c0a5d5f5ac75.
- Exact After APK SHA-256: ee36ae0d423a9310b6a0acdbb208ad124498149066776e2b3bc09ae7f04118a4.
- Installed package digests matched the corresponding Base and After APKs exactly.
- Both Base and After pnpm android:assemble builds completed successfully.
- The isolated After Gateway reached ready state and the Android node approval completed successfully.
- The media operator supplied and approved the Before and After screenshots/videos for public use.

### Validation

- The patch changes one call site in one file with one insertion and one deletion.
- git diff --check passed.
- The existing screen-local outlined variant is reused; the shared component remains unchanged.
- Fresh duplicate searches found no overlapping open PR.
- Current main has no overlap in ProvidersModelsScreen.kt or the Android build scope.

### Visual comparison

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="260" alt="Before: Providers and Models back button without an outline" src="https://github.com/user-attachments/assets/95064dcc-4019-4284-912a-88ed359dc997" /></td>
    <td><img width="260" alt="After: Providers and Models back button with a circular outline" src="https://github.com/user-attachments/assets/15fc7b44-2b12-4152-b7ec-84b24c5948b1" /></td>
  </tr>
</table>

Before video - the Providers & Models header before the outline is enabled:

https://github.com/user-attachments/assets/0ca3a69a-2e44-42e7-815f-e05b9c228cac

After video - the same header with the outlined back button:

https://github.com/user-attachments/assets/01547b41-412b-4989-a721-3963a55f29f4