### PR TITLE
refactor(agents): extract attempt stream phase

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -1,0 +1,379 @@
+/**
+ * Prepares stream subscription, tool execution, and the active run queue.
+ */
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
+import {
+  freezeDiagnosticTraceContext,
+  type DiagnosticTraceContext,
+} from "../../../infra/diagnostic-trace-context.js";
+import { formatErrorMessage } from "../../../infra/errors.js";
+import type { AssistantMessage } from "../../../llm/types.js";
+import {
+  buildAgentHookContextChannelFields,
+  buildAgentHookContextIdentityFields,
+} from "../../../plugins/hook-agent-context.js";
+import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
+import { recordStructuredReplayTrustForToolCall } from "../../agent-tools.before-tool-call.js";
+import { subscribeEmbeddedAgentSession } from "../../embedded-agent-subscribe.js";
+import { runAgentHarnessBeforeAgentFinalizeHook } from "../../harness/lifecycle-hook-helpers.js";
+import {
+  AGENT_RUN_RESTART_ABORT_STOP_REASON,
+  createAgentRunRestartAbortError,
+  isAgentRunRestartAbortReason,
+} from "../../run-termination.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import type { AgentSession } from "../../sessions/index.js";
+import {
+  projectToolSearchTargetTranscriptMessages,
+  type ToolSearchCatalogToolExecutor,
+  type ToolSearchTargetTranscriptProjection,
+} from "../../tool-search.js";
+import { log } from "../logger.js";
+import {
+  clearActiveEmbeddedRun,
+  type EmbeddedAgentQueueHandle,
+  setActiveEmbeddedRun,
+} from "../runs.js";
+import type { EmbeddedAttemptClientToolCallSlot } from "./attempt-result.js";
+import {
+  requiresCompletionRequiredAsyncTaskWait,
+  type AsyncStartedToolMeta,
+} from "./attempt.async-tasks.js";
+import { steerActiveSessionWithOptionalDeliveryWait } from "./attempt.queue-message.js";
+import { buildEmbeddedSubscriptionParams } from "./attempt.subscription-cleanup.js";
+import {
+  resolveFinalAssistantRawText,
+  resolveFinalAssistantVisibleText,
+  resolveReportedModelRef,
+} from "./helpers.js";
+import { notifyToolActivity } from "./tool-activity-heartbeat.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type HookRunner = ReturnType<typeof getGlobalHookRunner>;
+type StreamRunState = {
+  aborted: boolean;
+  promptError: unknown;
+  timedOut: boolean;
+  yieldDetected: boolean;
+};
+
+type AttemptStreamQueueHandle = EmbeddedAgentQueueHandle & {
+  kind: "embedded";
+  cancel: (reason?: "user_abort" | "restart" | "superseded") => void;
+};
+
+export function prepareEmbeddedAttemptStream(input: {
+  attempt: EmbeddedRunAttemptParams;
+  activeSession: AgentSession;
+  runtimeChannel?: string;
+  hookRunner: HookRunner;
+  hookAgentId: string;
+  diagnosticTrace: DiagnosticTraceContext;
+  clientToolCallSlots: readonly EmbeddedAttemptClientToolCallSlot[];
+  toolSearchTargetTranscriptProjections: ToolSearchTargetTranscriptProjection[];
+  isReplaySafeTool: (tool: Parameters<ToolSearchCatalogToolExecutor>[0]["tool"]) => boolean;
+  runAbortController: AbortController;
+  abortRun: (isTimeout?: boolean, reason?: unknown) => void;
+  markExternalAbort: () => void;
+  getRunState: () => StreamRunState;
+  hasDeliveredSourceReply: () => boolean;
+  markSourceReplyDelivered: () => void;
+  onBlockReply: EmbeddedRunAttemptParams["onBlockReply"];
+  onBlockReplyFlush: EmbeddedRunAttemptParams["onBlockReplyFlush"];
+  sandboxSessionKey: string;
+  builtinToolNames: ReadonlySet<string>;
+  replaySafeToolNames: ReadonlySet<string>;
+}) {
+  const attempt = input.attempt;
+  const hookRunner = input.hookRunner;
+  let beforeAgentFinalizeRevisionReason: string | undefined;
+  const onBeforeTerminalDelivery = hookRunner?.hasHooks("before_agent_finalize")
+    ? async (event: {
+        messages: AgentMessage[];
+        willRetry: boolean;
+        lastAssistant?: AgentMessage;
+        assistantTexts: readonly string[];
+        hasAssistantVisibleText: boolean;
+        isError: boolean;
+        incompleteTerminalAssistant: boolean;
+        hadDeterministicSideEffect: boolean;
+      }): Promise<void | { suppressTerminalDelivery: true }> => {
+        if (
+          beforeAgentFinalizeRevisionReason ||
+          event.willRetry ||
+          event.isError ||
+          event.incompleteTerminalAssistant ||
+          !event.hasAssistantVisibleText
+        ) {
+          return;
+        }
+        const lastAssistant = event.lastAssistant as AssistantMessage | undefined;
+        const lastAssistantMessage =
+          normalizeOptionalString(resolveFinalAssistantVisibleText(lastAssistant)) ??
+          normalizeOptionalString(resolveFinalAssistantRawText(lastAssistant)) ??
+          normalizeOptionalString(event.assistantTexts.join("\n\n"));
+        if (!lastAssistantMessage) {
+          return;
+        }
+        const state = input.getRunState();
+        const hasCompletedClientToolCall = input.clientToolCallSlots.some((slot) => slot.completed);
+        const silentFinalReply =
+          attempt.silentExpected && isSilentReplyText(lastAssistantMessage, SILENT_REPLY_TOKEN);
+        if (
+          state.aborted ||
+          state.promptError ||
+          state.timedOut ||
+          hasCompletedClientToolCall ||
+          state.yieldDetected ||
+          silentFinalReply
+        ) {
+          return;
+        }
+        const hookMessages = projectToolSearchTargetTranscriptMessages(
+          input.activeSession.messages.slice(),
+          input.toolSearchTargetTranscriptProjections,
+        );
+        const reportedModelRef = resolveReportedModelRef({
+          provider: attempt.provider,
+          model: attempt.modelId,
+          assistant: lastAssistant,
+        });
+        const maxRevisionAttempts = attempt.maxBeforeAgentFinalizeRevisions ?? 0;
+        if (
+          maxRevisionAttempts > 0 &&
+          (attempt.beforeAgentFinalizeRevisionAttempts ?? 0) >= maxRevisionAttempts
+        ) {
+          log.warn(
+            `before_agent_finalize revision limit reached; finalizing ` +
+              `runId=${attempt.runId} sessionId=${attempt.sessionId} ` +
+              `attempts=${attempt.beforeAgentFinalizeRevisionAttempts ?? 0}/${maxRevisionAttempts}`,
+          );
+          return;
+        }
+        const outcome = await runAgentHarnessBeforeAgentFinalizeHook({
+          event: {
+            runId: attempt.runId,
+            sessionId: attempt.sessionId,
+            ...(attempt.sessionKey ? { sessionKey: attempt.sessionKey } : {}),
+            provider: reportedModelRef.provider,
+            model: reportedModelRef.model,
+            ...((attempt.cwd ?? attempt.workspaceDir)
+              ? { cwd: attempt.cwd ?? attempt.workspaceDir }
+              : {}),
+            ...(attempt.sessionFile ? { transcriptPath: attempt.sessionFile } : {}),
+            stopHookActive: false,
+            lastAssistantMessage,
+            messages: hookMessages,
+          },
+          ctx: {
+            runId: attempt.runId,
+            trace: freezeDiagnosticTraceContext(input.diagnosticTrace),
+            agentId: input.hookAgentId,
+            sessionKey: attempt.sessionKey,
+            sessionId: attempt.sessionId,
+            workspaceDir: attempt.workspaceDir,
+            modelProviderId: reportedModelRef.provider,
+            modelId: reportedModelRef.model,
+            trigger: attempt.trigger,
+            ...buildAgentHookContextChannelFields(attempt),
+            ...buildAgentHookContextIdentityFields({
+              trigger: attempt.trigger,
+              senderId: attempt.senderId,
+              chatId: attempt.chatId,
+              channelContext: attempt.channelContext,
+            }),
+          },
+          hookRunner,
+        });
+        if (outcome.action !== "revise") {
+          return;
+        }
+        if (event.hadDeterministicSideEffect) {
+          log.warn(
+            `before_agent_finalize requested revision after potential side effects; finalizing ` +
+              `runId=${attempt.runId} sessionId=${attempt.sessionId}`,
+          );
+          return;
+        }
+        beforeAgentFinalizeRevisionReason = outcome.reason;
+        return { suppressTerminalDelivery: true };
+      }
+    : undefined;
+
+  let toolMetasForTerminal: readonly AsyncStartedToolMeta[] = [];
+  // Terminal callbacks run after queue construction; keep the queue in this
+  // phase so active-run clearing and subscription teardown share one owner.
+  const getQueueHandle = (): AttemptStreamQueueHandle => queueHandle;
+  const subscription = subscribeEmbeddedAgentSession(
+    buildEmbeddedSubscriptionParams({
+      session: input.activeSession,
+      runId: attempt.runId,
+      lifecycleGeneration: attempt.lifecycleGeneration,
+      messageChannel: input.runtimeChannel,
+      initialReplayState: attempt.initialReplayState,
+      hookRunner: getGlobalHookRunner() ?? undefined,
+      verboseLevel: attempt.verboseLevel,
+      reasoningMode: attempt.reasoningLevel ?? "off",
+      thinkingLevel: attempt.thinkLevel,
+      toolResultFormat: attempt.toolResultFormat,
+      shouldEmitToolResult: attempt.shouldEmitToolResult,
+      shouldEmitToolOutput: attempt.shouldEmitToolOutput,
+      sourceReplyDeliveryMode: attempt.sourceReplyDeliveryMode,
+      hasDeliveredMessageToolOnlySourceReply: input.hasDeliveredSourceReply,
+      onDeliveredMessageToolOnlySourceReply: input.markSourceReplyDelivered,
+      onAgentToolResult: attempt.onAgentToolResult,
+      onToolResult: attempt.onToolResult,
+      onReasoningStream: attempt.onReasoningStream,
+      streamReasoningInNonStreamModes: attempt.streamReasoningInNonStreamModes,
+      onReasoningEnd: attempt.onReasoningEnd,
+      onBlockReply: input.onBlockReply,
+      onBlockReplyFlush: input.onBlockReplyFlush,
+      onBeforeTerminalDelivery,
+      blockReplyBreak: attempt.blockReplyBreak,
+      blockReplyChunking: attempt.blockReplyChunking,
+      onPartialReply: attempt.onPartialReply,
+      onAssistantMessageStart: attempt.onAssistantMessageStart,
+      onExecutionPhase: attempt.onExecutionPhase,
+      onAgentEvent: attempt.onAgentEvent,
+      terminalLifecyclePhase:
+        (attempt.deferTerminalLifecycle ?? attempt.deferTerminalLifecycleEnd) ? "finishing" : "end",
+      onToolStreamBoundary: attempt.onToolStreamBoundary,
+      isTerminalAborted: () => input.getRunState().aborted,
+      resolveTerminalStopReason: () =>
+        isAgentRunRestartAbortReason(input.runAbortController.signal.reason)
+          ? AGENT_RUN_RESTART_ABORT_STOP_REASON
+          : undefined,
+      onBeforeLifecycleTerminal: () => {
+        if (
+          requiresCompletionRequiredAsyncTaskWait({
+            sessionKey: attempt.sessionKey,
+            toolMetas: toolMetasForTerminal,
+          })
+        ) {
+          return;
+        }
+        // Clear embedded-run activity before emitting terminal lifecycle events so
+        // post-completion cleanup does not observe a logically finished run as active.
+        clearActiveEmbeddedRun(
+          attempt.sessionId,
+          getQueueHandle(),
+          attempt.sessionKey,
+          attempt.sessionFile,
+        );
+      },
+      enforceFinalTag: attempt.enforceFinalTag,
+      silentExpected: attempt.silentExpected,
+      suppressLiveStreamOutput: attempt.suppressLiveStreamOutput,
+      config: attempt.config,
+      sessionKey: input.sandboxSessionKey,
+      currentChannelId: attempt.currentChannelId,
+      currentMessagingTarget: attempt.currentMessagingTarget,
+      currentThreadId: attempt.currentThreadTs,
+      currentMessageId: attempt.currentMessageId,
+      replyToMode: attempt.replyToMode,
+      hasRepliedRef: attempt.hasRepliedRef,
+      sessionId: attempt.sessionId,
+      agentId: input.hookAgentId,
+      builtinToolNames: input.builtinToolNames,
+      replaySafeToolNames: input.replaySafeToolNames,
+      internalEvents: attempt.internalEvents,
+    }),
+  );
+  toolMetasForTerminal = subscription.toolMetas;
+
+  const toolSearchCatalogExecutor: ToolSearchCatalogToolExecutor = async (toolParams) => {
+    try {
+      if (toolParams.source === "openclaw" && toolParams.sourceName === "core") {
+        recordStructuredReplayTrustForToolCall(
+          toolParams.toolCallId,
+          toolParams.tool as never,
+          attempt.runId,
+        );
+      }
+      const result = await subscription.runToolLifecycle({
+        toolName: toolParams.toolName,
+        toolCallId: toolParams.toolCallId,
+        args: toolParams.input,
+        replaySafe: input.isReplaySafeTool(toolParams.tool),
+        hideFromChannelProgress:
+          "hideFromChannelProgress" in toolParams.tool &&
+          toolParams.tool.hideFromChannelProgress === true,
+        execute: async () =>
+          await toolParams.tool.execute(
+            toolParams.toolCallId,
+            toolParams.input,
+            toolParams.signal ?? input.runAbortController.signal,
+            toolParams.onUpdate,
+            undefined as never,
+          ),
+      });
+      input.toolSearchTargetTranscriptProjections.push({
+        parentToolCallId: toolParams.parentToolCallId,
+        toolCallId: toolParams.toolCallId,
+        toolName: toolParams.toolName,
+        input: toolParams.input,
+        result,
+        timestamp: Date.now(),
+      });
+      notifyToolActivity(attempt.runId);
+      return result;
+    } catch (error) {
+      const message = formatErrorMessage(error);
+      input.toolSearchTargetTranscriptProjections.push({
+        parentToolCallId: toolParams.parentToolCallId,
+        toolCallId: toolParams.toolCallId,
+        toolName: toolParams.toolName,
+        input: toolParams.input,
+        result: {
+          content: [{ type: "text", text: message }],
+          details: { status: "error", error: message },
+        },
+        isError: true,
+        timestamp: Date.now(),
+      });
+      notifyToolActivity(attempt.runId);
+      throw error;
+    }
+  };
+
+  const abortActiveRunExternally = (reason?: "user_abort" | "restart" | "superseded") => {
+    input.markExternalAbort();
+    attempt.onAttemptAbort?.();
+    input.abortRun(false, reason === "restart" ? createAgentRunRestartAbortError() : undefined);
+  };
+  let acceptingSteerMessages = true;
+  const queueHandle: AttemptStreamQueueHandle = {
+    kind: "embedded",
+    runId: attempt.runId,
+    queueMessage: async (text: string, options) => {
+      if (options?.steeringMode) {
+        input.activeSession.agent.steeringMode = options.steeringMode;
+      }
+      await steerActiveSessionWithOptionalDeliveryWait(input.activeSession, text, options);
+    },
+    isStreaming: () => input.activeSession.isStreaming,
+    isStopped: () =>
+      !acceptingSteerMessages ||
+      input.getRunState().aborted ||
+      input.runAbortController.signal.aborted,
+    isCompacting: () => subscription.isCompacting(),
+    supportsTranscriptCommitWait: true,
+    sourceReplyDeliveryMode: attempt.sourceReplyDeliveryMode,
+    taskSuggestionDeliveryMode: attempt.taskSuggestionDeliveryMode,
+    cancel: abortActiveRunExternally,
+    abort: (reason) => abortActiveRunExternally(reason),
+  };
+  attempt.replyOperation?.attachBackend(queueHandle);
+  setActiveEmbeddedRun(attempt.sessionId, queueHandle, attempt.sessionKey, attempt.sessionFile);
+
+  return {
+    subscription,
+    queueHandle,
+    toolSearchCatalogExecutor,
+    getBeforeAgentFinalizeRevisionReason: () => beforeAgentFinalizeRevisionReason,
+    stopAcceptingSteerMessages: () => {
+      acceptingSteerMessages = false;
+    },
+  };
+}

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2,9 +2,7 @@
  * Orchestrates one embedded-agent attempt from prompt setup through stream result.
  */
 import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { filterHeartbeatTranscriptArtifacts } from "../../../auto-reply/heartbeat-filter.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import {
   bindOwnedSessionTranscriptWrites,
   type OwnedSessionTranscriptCacheSnapshot,
@@ -46,23 +44,15 @@ import {
   resolveEffectiveCompactionMode,
 } from "../../agent-settings.js";
 import { toToolDefinitions } from "../../agent-tool-definition-adapter.js";
-import { recordStructuredReplayTrustForToolCall } from "../../agent-tools.before-tool-call.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
 import { isHeartbeatLifecycleRunKind } from "../../bootstrap-mode.js";
 import { createCacheTrace } from "../../cache-trace.js";
 import { resolveUserTimezone } from "../../date-time.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { countActiveToolExecutions } from "../../embedded-agent-subscribe.handlers.tools.js";
-import { subscribeEmbeddedAgentSession } from "../../embedded-agent-subscribe.js";
 import { isSignalTimeoutReason } from "../../failover-error.js";
-import { runAgentHarnessBeforeAgentFinalizeHook } from "../../harness/lifecycle-hook-helpers.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import { relocateCurrentRuntimeContextCarrierToTail } from "../../internal-runtime-context.js";
-import {
-  AGENT_RUN_RESTART_ABORT_STOP_REASON,
-  createAgentRunRestartAbortError,
-  isAgentRunRestartAbortReason,
-} from "../../run-termination.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import {
   invalidateSessionFileRepairCache,
@@ -78,7 +68,6 @@ import {
 } from "../../subagent-registry.js";
 import {
   clearToolSearchCatalog,
-  projectToolSearchTargetTranscriptMessages,
   resolveToolSearchCatalogTool,
   type ToolSearchCatalogRef,
   type ToolSearchCatalogToolExecutor,
@@ -98,7 +87,6 @@ import {
   clearActiveEmbeddedRun,
   type EmbeddedAgentQueueHandle,
   markActiveEmbeddedRunAbandoned,
-  setActiveEmbeddedRun,
   updateActiveEmbeddedRunSnapshot,
 } from "../runs.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "../session-manager-cache.js";
@@ -144,6 +132,7 @@ import {
   startEmbeddedAttemptDiagnostics,
   type EmitDiagnosticRunCompleted,
 } from "./attempt-startup.js";
+import { prepareEmbeddedAttemptStream } from "./attempt-stream-prepare.js";
 import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
 import { prepareEmbeddedAttemptTransport } from "./attempt-stream-transport.js";
 import { installEmbeddedAttemptStreamGuards } from "./attempt-stream.js";
@@ -160,10 +149,6 @@ import {
   resolveExistingAttemptTranscriptState,
 } from "./attempt-transcript-helpers.js";
 import {
-  requiresCompletionRequiredAsyncTaskWait,
-  type AsyncStartedToolMeta,
-} from "./attempt.async-tasks.js";
-import {
   buildLoopPromptCacheInfo,
   runAttemptContextEngineBootstrap,
 } from "./attempt.context-engine-helpers.js";
@@ -178,7 +163,6 @@ import {
   buildAfterTurnRuntimeContext,
   resolvePromptSubmissionSkipReason,
 } from "./attempt.prompt-helpers.js";
-import { steerActiveSessionWithOptionalDeliveryWait } from "./attempt.queue-message.js";
 import { resolveEmbeddedAttemptSessionWriteLockOptions } from "./attempt.run-decisions.js";
 import {
   acquireEmbeddedAttemptSessionFileOwner,
@@ -195,21 +179,13 @@ import {
   stripSessionsYieldArtifacts,
   waitForSessionsYieldAbortSettle,
 } from "./attempt.sessions-yield.js";
-import {
-  buildEmbeddedSubscriptionParams,
-  cleanupEmbeddedAttemptResources,
-} from "./attempt.subscription-cleanup.js";
+import { cleanupEmbeddedAttemptResources } from "./attempt.subscription-cleanup.js";
 import { composeSystemPromptWithHookContext } from "./attempt.thread-helpers.js";
 import { resolveAttemptTranscriptPolicy } from "./attempt.transcript-policy.js";
 import {
   resolveRunTimeoutDuringCompaction,
   shouldFlagCompactionTimeout,
 } from "./compaction-timeout.js";
-import {
-  resolveFinalAssistantRawText,
-  resolveFinalAssistantVisibleText,
-  resolveReportedModelRef,
-} from "./helpers.js";
 import { installHistoryImagePruneContextTransform } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
 import { installMessageToolOnlyTerminalHook } from "./message-tool-terminal.js";
@@ -1407,290 +1383,51 @@ export async function runEmbeddedAttempt(
         );
       // Hook runner was already obtained earlier before tool creation.
       const hookAgentId = sessionAgentId;
-      let beforeAgentFinalizeRevisionReason: string | undefined;
       const onBlockReply = params.onBlockReply
         ? bindOwnedSessionTranscriptWrites(ownedTranscriptWriteContext, params.onBlockReply)
         : undefined;
       const onBlockReplyFlush = params.onBlockReplyFlush
         ? bindOwnedSessionTranscriptWrites(ownedTranscriptWriteContext, params.onBlockReplyFlush)
         : undefined;
-      const onBeforeTerminalDelivery = hookRunner?.hasHooks("before_agent_finalize")
-        ? async (event: {
-            messages: AgentMessage[];
-            willRetry: boolean;
-            lastAssistant?: AgentMessage;
-            assistantTexts: readonly string[];
-            hasAssistantVisibleText: boolean;
-            isError: boolean;
-            incompleteTerminalAssistant: boolean;
-            hadDeterministicSideEffect: boolean;
-          }): Promise<void | { suppressTerminalDelivery: true }> => {
-            if (
-              beforeAgentFinalizeRevisionReason ||
-              event.willRetry ||
-              event.isError ||
-              event.incompleteTerminalAssistant ||
-              !event.hasAssistantVisibleText
-            ) {
-              return;
-            }
-            const lastAssistant = event.lastAssistant as AssistantMessage | undefined;
-            const lastAssistantMessage =
-              normalizeOptionalString(resolveFinalAssistantVisibleText(lastAssistant)) ??
-              normalizeOptionalString(resolveFinalAssistantRawText(lastAssistant)) ??
-              normalizeOptionalString(event.assistantTexts.join("\n\n"));
-            if (!lastAssistantMessage) {
-              return;
-            }
-            const hasCompletedClientToolCall = clientToolCallSlots.some((slot) => slot.completed);
-            const silentFinalReply =
-              params.silentExpected && isSilentReplyText(lastAssistantMessage, SILENT_REPLY_TOKEN);
-            if (
-              aborted ||
-              promptError ||
-              timedOut ||
-              hasCompletedClientToolCall ||
-              yieldDetected ||
-              silentFinalReply
-            ) {
-              return;
-            }
-            const hookMessages = projectToolSearchTargetTranscriptMessages(
-              activeSession.messages.slice(),
-              toolSearchTargetTranscriptProjections,
-            );
-            const reportedModelRef = resolveReportedModelRef({
-              provider: params.provider,
-              model: params.modelId,
-              assistant: lastAssistant,
-            });
-            const maxRevisionAttempts = params.maxBeforeAgentFinalizeRevisions ?? 0;
-            if (
-              maxRevisionAttempts > 0 &&
-              (params.beforeAgentFinalizeRevisionAttempts ?? 0) >= maxRevisionAttempts
-            ) {
-              log.warn(
-                `before_agent_finalize revision limit reached; finalizing ` +
-                  `runId=${params.runId} sessionId=${params.sessionId} ` +
-                  `attempts=${params.beforeAgentFinalizeRevisionAttempts ?? 0}/${maxRevisionAttempts}`,
-              );
-              return;
-            }
-            const outcome = await runAgentHarnessBeforeAgentFinalizeHook({
-              event: {
-                runId: params.runId,
-                sessionId: params.sessionId,
-                ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-                provider: reportedModelRef.provider,
-                model: reportedModelRef.model,
-                ...((params.cwd ?? params.workspaceDir)
-                  ? { cwd: params.cwd ?? params.workspaceDir }
-                  : {}),
-                ...(params.sessionFile ? { transcriptPath: params.sessionFile } : {}),
-                stopHookActive: false,
-                lastAssistantMessage,
-                messages: hookMessages,
-              },
-              ctx: {
-                runId: params.runId,
-                trace: freezeDiagnosticTraceContext(diagnosticTrace),
-                agentId: hookAgentId,
-                sessionKey: params.sessionKey,
-                sessionId: params.sessionId,
-                workspaceDir: params.workspaceDir,
-                modelProviderId: reportedModelRef.provider,
-                modelId: reportedModelRef.model,
-                trigger: params.trigger,
-                ...buildAgentHookContextChannelFields(params),
-                ...buildAgentHookContextIdentityFields({
-                  trigger: params.trigger,
-                  senderId: params.senderId,
-                  chatId: params.chatId,
-                  channelContext: params.channelContext,
-                }),
-              },
-              hookRunner,
-            });
-            if (outcome.action !== "revise") {
-              return;
-            }
-            if (event.hadDeterministicSideEffect) {
-              log.warn(
-                `before_agent_finalize requested revision after potential side effects; finalizing ` +
-                  `runId=${params.runId} sessionId=${params.sessionId}`,
-              );
-              return;
-            }
-            beforeAgentFinalizeRevisionReason = outcome.reason;
-            return { suppressTerminalDelivery: true };
-          }
-        : undefined;
-
-      let toolMetasForTerminal: readonly AsyncStartedToolMeta[] = [];
-      const subscription = subscribeEmbeddedAgentSession(
-        buildEmbeddedSubscriptionParams({
-          session: activeSession,
-          runId: params.runId,
-          lifecycleGeneration: params.lifecycleGeneration,
-          messageChannel: runtimeChannel,
-          initialReplayState: params.initialReplayState,
-          hookRunner: getGlobalHookRunner() ?? undefined,
-          verboseLevel: params.verboseLevel,
-          reasoningMode: params.reasoningLevel ?? "off",
-          thinkingLevel: params.thinkLevel,
-          toolResultFormat: params.toolResultFormat,
-          shouldEmitToolResult: params.shouldEmitToolResult,
-          shouldEmitToolOutput: params.shouldEmitToolOutput,
-          sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-          hasDeliveredMessageToolOnlySourceReply: () => didDeliverSourceReplyViaMessageTool,
-          onDeliveredMessageToolOnlySourceReply: markSourceReplyDelivered,
-          onAgentToolResult: params.onAgentToolResult,
-          onToolResult: params.onToolResult,
-          onReasoningStream: params.onReasoningStream,
-          streamReasoningInNonStreamModes: params.streamReasoningInNonStreamModes,
-          onReasoningEnd: params.onReasoningEnd,
-          onBlockReply,
-          onBlockReplyFlush,
-          onBeforeTerminalDelivery,
-          blockReplyBreak: params.blockReplyBreak,
-          blockReplyChunking: params.blockReplyChunking,
-          onPartialReply: params.onPartialReply,
-          onAssistantMessageStart: params.onAssistantMessageStart,
-          onExecutionPhase: params.onExecutionPhase,
-          onAgentEvent: params.onAgentEvent,
-          terminalLifecyclePhase:
-            (params.deferTerminalLifecycle ?? params.deferTerminalLifecycleEnd)
-              ? "finishing"
-              : "end",
-          onToolStreamBoundary: params.onToolStreamBoundary,
-          isTerminalAborted: () => aborted,
-          resolveTerminalStopReason: () =>
-            isAgentRunRestartAbortReason(runAbortController.signal.reason)
-              ? AGENT_RUN_RESTART_ABORT_STOP_REASON
-              : undefined,
-          onBeforeLifecycleTerminal: () => {
-            if (
-              requiresCompletionRequiredAsyncTaskWait({
-                sessionKey: params.sessionKey,
-                toolMetas: toolMetasForTerminal,
-              })
-            ) {
-              return;
-            }
-            // Clear embedded-run activity before emitting terminal lifecycle events so
-            // post-completion cleanup does not observe a logically finished run as active.
-            clearActiveEmbeddedRun(
-              params.sessionId,
-              queueHandle,
-              params.sessionKey,
-              params.sessionFile,
-            );
-          },
-          enforceFinalTag: params.enforceFinalTag,
-          silentExpected: params.silentExpected,
-          suppressLiveStreamOutput: params.suppressLiveStreamOutput,
-          config: params.config,
-          sessionKey: sandboxSessionKey,
-          currentChannelId: params.currentChannelId,
-          currentMessagingTarget: params.currentMessagingTarget,
-          currentThreadId: params.currentThreadTs,
-          currentMessageId: params.currentMessageId,
-          replyToMode: params.replyToMode,
-          hasRepliedRef: params.hasRepliedRef,
-          sessionId: params.sessionId,
-          agentId: sessionAgentId,
-          builtinToolNames,
-          replaySafeToolNames,
-          internalEvents: params.internalEvents,
+      const preparedStream = prepareEmbeddedAttemptStream({
+        attempt: params,
+        activeSession,
+        runtimeChannel,
+        hookRunner,
+        hookAgentId,
+        diagnosticTrace,
+        clientToolCallSlots,
+        toolSearchTargetTranscriptProjections,
+        isReplaySafeTool: (tool) => replaySafeTools.has(tool as never),
+        runAbortController,
+        abortRun,
+        markExternalAbort: () => {
+          externalAbort = true;
+        },
+        getRunState: () => ({
+          aborted,
+          promptError,
+          timedOut,
+          yieldDetected,
         }),
-      );
-
-      const { toolMetas, runToolLifecycle, unsubscribe, waitForPendingEvents } = subscription;
-      toolMetasForTerminal = toolMetas;
+        hasDeliveredSourceReply: () => didDeliverSourceReplyViaMessageTool,
+        markSourceReplyDelivered,
+        onBlockReply,
+        onBlockReplyFlush,
+        sandboxSessionKey,
+        builtinToolNames,
+        replaySafeToolNames,
+      });
+      const {
+        subscription,
+        queueHandle,
+        stopAcceptingSteerMessages,
+        getBeforeAgentFinalizeRevisionReason,
+      } = preparedStream;
+      const { unsubscribe, waitForPendingEvents } = subscription;
+      toolSearchCatalogExecutor = preparedStream.toolSearchCatalogExecutor;
       isCompactionPendingForExternalSignal = subscription.isCompacting;
       isCompactionInFlightForExternalSignal = () => activeSession.isCompacting;
-      toolSearchCatalogExecutor = async (toolParams) => {
-        try {
-          if (toolParams.source === "openclaw" && toolParams.sourceName === "core") {
-            recordStructuredReplayTrustForToolCall(
-              toolParams.toolCallId,
-              toolParams.tool as never,
-              params.runId,
-            );
-          }
-          const result = await runToolLifecycle({
-            toolName: toolParams.toolName,
-            toolCallId: toolParams.toolCallId,
-            args: toolParams.input,
-            replaySafe: replaySafeTools.has(toolParams.tool as never),
-            hideFromChannelProgress:
-              "hideFromChannelProgress" in toolParams.tool &&
-              toolParams.tool.hideFromChannelProgress === true,
-            execute: async () =>
-              await toolParams.tool.execute(
-                toolParams.toolCallId,
-                toolParams.input,
-                toolParams.signal ?? runAbortController.signal,
-                toolParams.onUpdate,
-                undefined as never,
-              ),
-          });
-          toolSearchTargetTranscriptProjections.push({
-            parentToolCallId: toolParams.parentToolCallId,
-            toolCallId: toolParams.toolCallId,
-            toolName: toolParams.toolName,
-            input: toolParams.input,
-            result,
-            timestamp: Date.now(),
-          });
-          notifyToolActivity(params.runId);
-          return result;
-        } catch (error) {
-          const message = formatErrorMessage(error);
-          toolSearchTargetTranscriptProjections.push({
-            parentToolCallId: toolParams.parentToolCallId,
-            toolCallId: toolParams.toolCallId,
-            toolName: toolParams.toolName,
-            input: toolParams.input,
-            result: {
-              content: [{ type: "text", text: message }],
-              details: { status: "error", error: message },
-            },
-            isError: true,
-            timestamp: Date.now(),
-          });
-          notifyToolActivity(params.runId);
-          throw error;
-        }
-      };
-
-      const abortActiveRunExternally = (reason?: "user_abort" | "restart" | "superseded") => {
-        externalAbort = true;
-        params.onAttemptAbort?.();
-        abortRun(false, reason === "restart" ? createAgentRunRestartAbortError() : undefined);
-      };
-      let acceptingSteerMessages = true;
-      const queueHandle: EmbeddedAgentQueueHandle & {
-        kind: "embedded";
-        cancel: (reason?: "user_abort" | "restart" | "superseded") => void;
-      } = {
-        kind: "embedded",
-        runId: params.runId,
-        queueMessage: async (text: string, options) => {
-          if (options?.steeringMode) {
-            activeSession.agent.steeringMode = options.steeringMode;
-          }
-          await steerActiveSessionWithOptionalDeliveryWait(activeSession, text, options);
-        },
-        isStreaming: () => activeSession.isStreaming,
-        isStopped: () => !acceptingSteerMessages || aborted || runAbortController.signal.aborted,
-        isCompacting: () => subscription.isCompacting(),
-        supportsTranscriptCommitWait: true,
-        sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-        taskSuggestionDeliveryMode: params.taskSuggestionDeliveryMode,
-        cancel: abortActiveRunExternally,
-        abort: (reason) => abortActiveRunExternally(reason),
-      };
       let lastAssistant: AssistantMessage | undefined;
       let currentAttemptAssistant: EmbeddedRunAttemptResult["currentAttemptAssistant"];
       let attemptUsage: NormalizedUsage | undefined;
@@ -1700,11 +1437,7 @@ export async function runEmbeddedAttempt(
       let contextBudgetStatus: EmbeddedRunAttemptResult["contextBudgetStatus"];
       let compactionOccurredThisAttempt = false;
       let finalPromptText: string | undefined;
-      if (params.replyOperation) {
-        params.replyOperation.attachBackend(queueHandle);
-      }
       const queueHandleForAbandonment: EmbeddedAgentQueueHandle | undefined = queueHandle;
-      setActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey, params.sessionFile);
 
       let abortWarnTimer: NodeJS.Timeout | undefined;
       const isProbeSession = params.sessionId?.startsWith("probe-") ?? false;
@@ -2717,7 +2450,7 @@ export async function runEmbeddedAttempt(
             promptErrorSource = "prompt";
           }
         } finally {
-          acceptingSteerMessages = false;
+          stopAcceptingSteerMessages();
           log.debug(
             `embedded run prompt end: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - promptStartedAt}`,
           );
@@ -2782,7 +2515,7 @@ export async function runEmbeddedAttempt(
             retention: effectivePromptCacheRetention,
           },
           shouldFlushForContextEngine: Boolean(
-            activeContextEngine && !beforeAgentFinalizeRevisionReason,
+            activeContextEngine && !getBeforeAgentFinalizeRevisionReason(),
           ),
         }).catch((err: unknown) => {
           // Preserve the outer lifecycle flags when settlement fails after
@@ -2804,6 +2537,7 @@ export async function runEmbeddedAttempt(
         lastCallUsage = settledStream.lastCallUsage;
         promptCache = settledStream.promptCache;
 
+        const beforeAgentFinalizeRevisionReason = getBeforeAgentFinalizeRevisionReason();
         const afterTurn = await completeEmbeddedAttemptAfterTurn({
           attempt: params,
           activeContextEngine,
@@ -2881,6 +2615,7 @@ export async function runEmbeddedAttempt(
         params.abortSignal?.removeEventListener?.("abort", onAbort);
       }
 
+      const beforeAgentFinalizeRevisionReason = getBeforeAgentFinalizeRevisionReason();
       const finalizedResult = completeEmbeddedAttemptResult({
         attempt: params,
         subscription,


### PR DESCRIPTION
Related: #72072

## What Problem This Solves

`runEmbeddedAttempt` still owned stream subscription construction, final-answer revision hooks, Tool Search lifecycle execution, and the active steering queue inline.

## Why This Change Was Made

Extract that complete stream phase behind `prepareEmbeddedAttemptStream`. The orchestrator now consumes the subscription, queue, executor, and lifecycle state accessors while retaining timeout, prompt, settlement, and finalization ownership.

## User Impact

No intended behavior change. `attempt.ts` is smaller and stream lifecycle ownership now has one focused module.

## Evidence

- `attempt.ts`: 3,061 -> 2,795 lines.
- Exact final rebased head, Blacksmith Testbox `tbx_01kxekprm0bqxzepfakq9ypanb`: 202 focused attempt, queue, subscription, source-delivery, and final-revision tests passed.
- Same exact head: production types, targeted lint, formatting, and LOC ratchet passed. Earlier import-cycle check also passed.
- Full scoped `check:changed` reached core test types, then found an unrelated unchanged current-main mock typing regression in `auth-choice.plugin-providers.test.ts`; this PR does not touch that surface.
- Fresh autoreview found one pending-event state race; fixed. Post-rebase follow-up review clean with no accepted or actionable findings.
