### PR TITLE
fix: redact sensitive migration terminal output

### DIFF
--- a/src/commands/migrate/output.test.ts
+++ b/src/commands/migrate/output.test.ts
@@ -39,6 +39,10 @@ function configItem(): MigrationItem {
   };
 }
 
+function fakeSecret(label: string): string {
+  return ["sk", label, "secret", "12345678"].join("-");
+}
+
 function plan(items: MigrationItem[]): MigrationPlan {
   return {
     providerId: "codex",
@@ -117,6 +121,25 @@ describe("formatMigrationPreview", () => {
       "⚠️  Some Codex plugins could not be migrated. Run `openclaw migrate codex` after onboarding.",
     );
   });
+
+  it("redacts secrets from item text and warnings", () => {
+    const secret = fakeSecret("preview");
+    const output = formatMigrationPreview({
+      ...plan([
+        {
+          ...pluginItem("google-calendar"),
+          status: "error",
+          reason: `Provider rejected ${secret}`,
+        },
+      ]),
+      warnings: [`Retry with Bearer ${secret}`],
+    })
+      .map(stripAnsi)
+      .join("\n");
+
+    expect(output).not.toContain(secret);
+    expect(output).toContain("[redacted]");
+  });
 });
 
 describe("formatMigrationResult", () => {
@@ -185,5 +208,24 @@ describe("formatMigrationResult", () => {
       .join("\n");
 
     expect(output).toContain("(Skipped)");
+  });
+
+  it("redacts secrets from item text and next steps", () => {
+    const secret = fakeSecret("result");
+    const output = formatMigrationResult({
+      ...plan([
+        {
+          ...pluginItem("google-calendar"),
+          status: "warning",
+          message: `Provider returned Bearer ${secret}`,
+        },
+      ]),
+      nextSteps: [`Save ${secret} for retry`],
+    })
+      .map(stripAnsi)
+      .join("\n");
+
+    expect(output).not.toContain(secret);
+    expect(output).toContain("[redacted]");
   });
 });

--- a/src/commands/migrate/output.ts
+++ b/src/commands/migrate/output.ts
@@ -97,21 +97,26 @@ function formatPlanWarnings(plan: MigrationPlan): string[] {
 
 /** Formats a redaction-safe migration preview for terminal output. */
 export function formatMigrationPreview(plan: MigrationPlan): string[] {
+  const safePlan = redactMigrationPlan(plan);
   return [
-    ...formatPlanHeader(plan, "Migration preview:"),
-    ...formatPlanItems(plan, "preview"),
-    ...formatPlanWarnings(plan),
+    ...formatPlanHeader(safePlan, "Migration preview:"),
+    ...formatPlanItems(safePlan, "preview"),
+    ...formatPlanWarnings(safePlan),
   ];
 }
 
-/** Formats migration apply results for terminal output. */
+/** Formats redaction-safe migration apply results for terminal output. */
 export function formatMigrationResult(plan: MigrationPlan): string[] {
-  const lines = [...formatPlanHeader(plan, "Migration plan:"), ...formatPlanItems(plan, "result")];
-  if (plan.nextSteps && plan.nextSteps.length > 0) {
+  const safePlan = redactMigrationPlan(plan);
+  const lines = [
+    ...formatPlanHeader(safePlan, "Migration plan:"),
+    ...formatPlanItems(safePlan, "result"),
+  ];
+  if (safePlan.nextSteps && safePlan.nextSteps.length > 0) {
     lines.push("");
     lines.push(theme.heading("Next:"));
-    for (const step of plan.nextSteps) {
-      const prefix = plan.warnings?.includes(step) ? "⚠️ " : "•";
+    for (const step of safePlan.nextSteps) {
+      const prefix = safePlan.warnings?.includes(step) ? "⚠️ " : "•";
       lines.push(`${prefix} ${step}`);
     }
   }


### PR DESCRIPTION
Closes #103056

## What Problem This Solves

Fixes an issue where users previewing or applying a migration in the CLI or onboarding wizard could see credential-shaped provider text that JSON and report output already redacted.

## Why This Change Was Made

Human-readable preview and result formatters now redact the complete migration plan at their shared boundary. This covers item messages and reasons, warnings, next steps, source, target, and every CLI or wizard caller without duplicating policy.

## User Impact

Migration terminal and wizard output now matches the existing redaction guarantee for JSON and saved reports. Non-sensitive status and guidance remain visible.

## Evidence

- Blacksmith Testbox through Crabbox: `tbx_01kxekn2e8b90ed6vcxq414fx6`; [Actions run 29283681380](https://github.com/openclaw/openclaw/actions/runs/29283681380).
- `corepack pnpm test src/commands/migrate/output.test.ts`: 11 tests passed.
- `corepack pnpm build`: passed.
- Real CLI proof from an isolated Hermes source: `openclaw migrate plan hermes` and `openclaw migrate apply hermes --yes` both printed `[redacted]`; distinct credential-shaped fixtures were absent.
- `pnpm check:changed`: formatting, production typecheck, SDK baseline, and remaining scoped gates passed; core-test typecheck hit two unrelated existing errors in `src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.test.ts`.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings.

AI-assisted implementation; maintainer reviewed the full diff and behavior proof.
