### PR TITLE
refactor(channels): consolidate the flat streaming fallback into the deprecation module

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-8879762b036d3cea0c65fec77547e5a4654b2c02b710cb42b7ff98be4438c974  plugin-sdk-api-baseline.json
-57aba01dd1368f3fdd5a444f08716c33ebd1dc7763caded250190799841f162e  plugin-sdk-api-baseline.jsonl
+a213f556ee55003254dc90f1e206b0e17cfe6ddb19753d4b3d096903e6273622  plugin-sdk-api-baseline.json
+8305f78c42e49cf77ae61134ef513159ad3b2b1a682647cf11bcb8b6ee1ba884  plugin-sdk-api-baseline.jsonl

--- a/src/channels/streaming-flat-key-deprecation.test.ts
+++ b/src/channels/streaming-flat-key-deprecation.test.ts
@@ -1,7 +1,8 @@
-// Covers the once-per-process deprecation warning for flat streaming key fallbacks.
+// Covers once-per-process deprecation warnings for streaming config fallbacks.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resetFlatStreamingKeyDeprecationWarningsForTest } from "./streaming-flat-key-deprecation.js";
+import { resetStreamingDeprecationWarningsForTest } from "./streaming-flat-key-deprecation.js";
 import {
+  resolveChannelPreviewStreamMode,
   resolveChannelStreamingBlockCoalesce,
   resolveChannelStreamingBlockEnabled,
   resolveChannelStreamingChunkMode,
@@ -16,14 +17,14 @@ vi.mock("../logging/subsystem.js", () => ({
   createSubsystemLogger: vi.fn(() => loggerMocks),
 }));
 
-describe("flat streaming key deprecation warning", () => {
+describe("streaming config fallback deprecation warnings", () => {
   beforeEach(() => {
-    resetFlatStreamingKeyDeprecationWarningsForTest();
+    resetStreamingDeprecationWarningsForTest();
     loggerMocks.warn.mockClear();
   });
 
   afterEach(() => {
-    resetFlatStreamingKeyDeprecationWarningsForTest();
+    resetStreamingDeprecationWarningsForTest();
   });
 
   it("warns once per key when the flat fallback is actually used", () => {
@@ -54,6 +55,47 @@ describe("flat streaming key deprecation warning", () => {
       false,
     );
     expect(resolveChannelStreamingBlockCoalesce({})).toBeUndefined();
+    expect(loggerMocks.warn).not.toHaveBeenCalled();
+  });
+
+  it("warns once when the scalar boolean fallback is used", () => {
+    expect(resolveChannelPreviewStreamMode({ streaming: true }, "off")).toBe("partial");
+    expect(resolveChannelPreviewStreamMode({ streaming: false }, "partial")).toBe("off");
+    expect(resolveChannelPreviewStreamMode({ streaming: true }, "off")).toBe("partial");
+
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(1);
+    expect(loggerMocks.warn.mock.calls[0]?.[0]).toContain("streaming.mode");
+    expect(loggerMocks.warn.mock.calls[0]?.[0]).toContain('true with "partial"');
+    expect(loggerMocks.warn.mock.calls[0]?.[0]).toContain('false with "off"');
+    expect(loggerMocks.warn.mock.calls[0]?.[0]).toContain("after the next release train");
+  });
+
+  it("warns once when the scalar mode-string fallback is used", () => {
+    expect(resolveChannelPreviewStreamMode({ streaming: "progress" }, "off")).toBe("progress");
+    expect(resolveChannelPreviewStreamMode({ streaming: "block" }, "partial")).toBe("block");
+
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(1);
+    expect(loggerMocks.warn.mock.calls[0]?.[0]).toContain("streaming.mode");
+  });
+
+  it("tracks scalar and flat fallback warnings independently", () => {
+    expect(resolveChannelPreviewStreamMode({ streaming: "partial" }, "off")).toBe("partial");
+    expect(resolveChannelStreamingChunkMode({ chunkMode: "newline" })).toBe("newline");
+    expect(resolveChannelPreviewStreamMode({ streaming: "partial" }, "off")).toBe("partial");
+    expect(resolveChannelStreamingChunkMode({ chunkMode: "newline" })).toBe("newline");
+
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(2);
+    expect(loggerMocks.warn.mock.calls[0]?.[0]).toContain("streaming.mode");
+    expect(loggerMocks.warn.mock.calls[1]?.[0]).toContain('"chunkMode"');
+  });
+
+  it("stays silent for nested streaming config and absent streaming", () => {
+    expect(resolveChannelPreviewStreamMode({ streaming: { mode: "progress" } }, "off")).toBe(
+      "progress",
+    );
+    expect(resolveChannelPreviewStreamMode({}, "partial")).toBe("partial");
+    expect(resolveChannelPreviewStreamMode(undefined, "off")).toBe("off");
+
     expect(loggerMocks.warn).not.toHaveBeenCalled();
   });
 });

--- a/src/channels/streaming-flat-key-deprecation.ts
+++ b/src/channels/streaming-flat-key-deprecation.ts
@@ -1,7 +1,14 @@
-// Warn-once state for deprecated streaming config fallbacks in streaming.ts.
-// Lives outside streaming.ts so the test-only reset stays off the public SDK
-// surface (openclaw/plugin-sdk/channel-outbound re-exports all of streaming.ts).
+// Flat-key compatibility resolvers and warn-once state. This module keeps the
+// test-only reset and warning helpers off the public SDK wildcard surface.
+import type {
+  BlockStreamingChunkConfig,
+  BlockStreamingCoalesceConfig,
+  ChannelStreamingConfig,
+  TextChunkMode,
+} from "../config/types.base.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { asBoolean } from "../utils/boolean.js";
+import type { StreamingCompatEntry } from "./streaming.js";
 
 const log = createSubsystemLogger("channels/streaming");
 const warnedStreamingFallbacks = new Set<string>();
@@ -33,4 +40,90 @@ export function warnScalarStreamingFallback(): void {
   log.warn(
     'Scalar channel streaming is deprecated; move it to streaming.mode. For booleans, replace true with "partial" (or the channel default) and false with "off". The scalar fallback is removed after the next release train.',
   );
+}
+
+function asObjectRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asTextChunkMode(value: unknown): TextChunkMode | undefined {
+  return value === "length" || value === "newline" ? value : undefined;
+}
+
+function asBlockStreamingCoalesceConfig(value: unknown): BlockStreamingCoalesceConfig | undefined {
+  return (asObjectRecord(value) as BlockStreamingCoalesceConfig | null) ?? undefined;
+}
+
+function asBlockStreamingChunkConfig(value: unknown): BlockStreamingChunkConfig | undefined {
+  return (asObjectRecord(value) as BlockStreamingChunkConfig | null) ?? undefined;
+}
+
+// This local read avoids a cycle with streaming.ts. It dies with this module
+// on the fallback removal train.
+function getChannelStreamingConfigObject(
+  entry: StreamingCompatEntry | null | undefined,
+): ChannelStreamingConfig | undefined {
+  const streaming = asObjectRecord(entry?.streaming);
+  return streaming ? (streaming as ChannelStreamingConfig) : undefined;
+}
+
+function resolveWithFlatFallback<T>(params: {
+  nested: T | undefined;
+  flat: T | undefined;
+  flatKey: string;
+  nestedPath: string;
+}): T | undefined {
+  if (params.nested !== undefined) {
+    return params.nested;
+  }
+  if (params.flat !== undefined) {
+    warnFlatStreamingKeyFallback(params.flatKey, params.nestedPath);
+  }
+  return params.flat;
+}
+
+export function resolveChannelStreamingChunkMode(
+  entry: StreamingCompatEntry | null | undefined,
+): TextChunkMode | undefined {
+  return resolveWithFlatFallback({
+    nested: asTextChunkMode(getChannelStreamingConfigObject(entry)?.chunkMode),
+    flat: asTextChunkMode(entry?.chunkMode),
+    flatKey: "chunkMode",
+    nestedPath: "chunkMode",
+  });
+}
+
+export function resolveChannelStreamingBlockEnabled(
+  entry: StreamingCompatEntry | null | undefined,
+): boolean | undefined {
+  return resolveWithFlatFallback({
+    nested: asBoolean(getChannelStreamingConfigObject(entry)?.block?.enabled),
+    flat: asBoolean(entry?.blockStreaming),
+    flatKey: "blockStreaming",
+    nestedPath: "block.enabled",
+  });
+}
+
+export function resolveChannelStreamingBlockCoalesce(
+  entry: StreamingCompatEntry | null | undefined,
+): BlockStreamingCoalesceConfig | undefined {
+  return resolveWithFlatFallback({
+    nested: asBlockStreamingCoalesceConfig(getChannelStreamingConfigObject(entry)?.block?.coalesce),
+    flat: asBlockStreamingCoalesceConfig(entry?.blockStreamingCoalesce),
+    flatKey: "blockStreamingCoalesce",
+    nestedPath: "block.coalesce",
+  });
+}
+
+export function resolveChannelStreamingPreviewChunk(
+  entry: StreamingCompatEntry | null | undefined,
+): BlockStreamingChunkConfig | undefined {
+  return resolveWithFlatFallback({
+    nested: asBlockStreamingChunkConfig(getChannelStreamingConfigObject(entry)?.preview?.chunk),
+    flat: asBlockStreamingChunkConfig(entry?.draftChunk),
+    flatKey: "draftChunk",
+    nestedPath: "preview.chunk",
+  });
 }

--- a/src/channels/streaming-flat-key-deprecation.ts
+++ b/src/channels/streaming-flat-key-deprecation.ts
@@ -1,23 +1,36 @@
-// Warn-once state for the deprecated flat streaming key fallback in streaming.ts.
+// Warn-once state for deprecated streaming config fallbacks in streaming.ts.
 // Lives outside streaming.ts so the test-only reset stays off the public SDK
 // surface (openclaw/plugin-sdk/channel-outbound re-exports all of streaming.ts).
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 const log = createSubsystemLogger("channels/streaming");
-const warnedFlatStreamingKeys = new Set<string>();
+const warnedStreamingFallbacks = new Set<string>();
 
-/** @internal Test-only reset for the flat streaming key deprecation warning cache. */
-export function resetFlatStreamingKeyDeprecationWarningsForTest(): void {
-  warnedFlatStreamingKeys.clear();
+/** @internal Test-only reset for the streaming config deprecation warning cache. */
+export function resetStreamingDeprecationWarningsForTest(): void {
+  warnedStreamingFallbacks.clear();
 }
 
 /** Warns once per process per flat key when a resolver used the flat fallback. */
 export function warnFlatStreamingKeyFallback(flatKey: string, nestedPath: string): void {
-  if (warnedFlatStreamingKeys.has(flatKey)) {
+  const warningKey = `flat:${flatKey}`;
+  if (warnedStreamingFallbacks.has(warningKey)) {
     return;
   }
-  warnedFlatStreamingKeys.add(flatKey);
+  warnedStreamingFallbacks.add(warningKey);
   log.warn(
     `Flat channel streaming key "${flatKey}" is deprecated; move it to streaming.${nestedPath}. The flat fallback is removed after the next release train.`,
+  );
+}
+
+/** Warns once per process when a resolver used the scalar streaming fallback. */
+export function warnScalarStreamingFallback(): void {
+  const warningKey = "scalar:streaming";
+  if (warnedStreamingFallbacks.has(warningKey)) {
+    return;
+  }
+  warnedStreamingFallbacks.add(warningKey);
+  log.warn(
+    'Scalar channel streaming is deprecated; move it to streaming.mode. For booleans, replace true with "partial" (or the channel default) and false with "off". The scalar fallback is removed after the next release train.',
   );
 }

--- a/src/channels/streaming.test.ts
+++ b/src/channels/streaming.test.ts
@@ -95,9 +95,9 @@ describe("buildChannelProgressDraftLine", () => {
 });
 
 describe("streaming config resolution", () => {
-  // Flat delivery keys stay canonical for channels without a nested streaming
-  // schema and for SDK plugins; mode-family aliases (streamMode, scalar
-  // streaming, nativeStreaming) are doctor-migrated and unread at runtime.
+  // Flat delivery keys are external SDK plugin fallbacks only. Bundled schemas
+  // are nested-only, and doctor migrates their old config; streamMode and
+  // nativeStreaming remain doctor-only.
   it("resolves flat delivery keys while ignoring mode-family aliases", () => {
     const legacyEntry = {
       streamMode: "block",
@@ -135,8 +135,9 @@ describe("streaming config resolution", () => {
     expect(resolveChannelStreamingNativeTransport(entry)).toBe(false);
   });
 
-  it("keeps scalar streaming support for channels whose schema allows it", () => {
-    // Mattermost's schema accepts a scalar mode string or boolean as canonical.
+  it("keeps scalar streaming support for external SDK plugins during deprecation", () => {
+    // Bundled schemas are nested-only; this fallback serves external SDK plugin
+    // configs until the next release train closes the deprecation window.
     expect(resolveChannelPreviewStreamMode({ streaming: "block" }, "partial")).toBe("block");
     expect(resolveChannelPreviewStreamMode({ streaming: true }, "off")).toBe("partial");
     expect(resolveChannelPreviewStreamMode({ streaming: false }, "partial")).toBe("off");

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -14,7 +14,10 @@ import type {
   TextChunkMode,
 } from "../config/types.base.js";
 import { asBoolean } from "../utils/boolean.js";
-import { warnFlatStreamingKeyFallback } from "./streaming-flat-key-deprecation.js";
+import {
+  warnFlatStreamingKeyFallback,
+  warnScalarStreamingFallback,
+} from "./streaming-flat-key-deprecation.js";
 
 export type {
   ChannelDeliveryStreamingConfig,
@@ -44,10 +47,11 @@ export type StreamingCompatEntry = {
 // Nested streaming config wins. Every bundled channel now uses a nested-only
 // streaming schema with doctor migrating the flat spellings, so in-tree the
 // flat delivery keys (chunkMode, blockStreaming, blockStreamingCoalesce,
-// draftChunk) are legacy config. The fallback reads below serve external SDK
-// plugin configs only and emit a once-per-key deprecation warning; remove
-// them (and the flat StreamingCompatEntry fields) when the next release train
-// closes the SDK deprecation window.
+// draftChunk) are legacy config. Those reads and the scalar `streaming` read in
+// resolveChannelPreviewStreamMode serve external SDK plugin configs only and
+// emit once-per-key deprecation warnings. Remove them (and the flat
+// StreamingCompatEntry fields) when the next release train closes the SDK
+// deprecation window.
 // Mode-family aliases (streamMode) are doctor-only and stay unread here.
 
 function asObjectRecord(value: unknown): Record<string, unknown> | null {
@@ -922,14 +926,18 @@ export function resolveChannelPreviewStreamMode(
   // Scalar `streaming` (mode string or boolean) is rejected by every bundled
   // channel schema and doctor-migrated to streaming.mode; the read here stays
   // only for external SDK plugin configs that predate the nested shape.
-  const parsedStreaming = parsePreviewStreamingMode(
-    getChannelStreamingConfigObject(entry)?.mode ?? entry?.streaming,
-  );
+  const streaming = entry?.streaming;
+  const config = getChannelStreamingConfigObject(entry);
+  const parsedStreaming = parsePreviewStreamingMode(config?.mode ?? streaming);
   if (parsedStreaming) {
+    if (typeof streaming === "string") {
+      warnScalarStreamingFallback();
+    }
     return parsedStreaming;
   }
-  if (typeof entry?.streaming === "boolean") {
-    return entry.streaming ? "partial" : "off";
+  if (typeof streaming === "boolean") {
+    warnScalarStreamingFallback();
+    return streaming ? "partial" : "off";
   }
   return defaultMode;
 }

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -5,18 +5,19 @@ import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-
 import { formatToolDetail, resolveToolDisplay } from "../agents/tool-display.js";
 import { formatToolAggregate } from "../auto-reply/tool-meta.js";
 import type {
-  BlockStreamingChunkConfig,
-  BlockStreamingCoalesceConfig,
   ChannelStreamingCommandTextMode,
   ChannelStreamingProgressConfig,
   ChannelStreamingConfig,
   StreamingMode,
-  TextChunkMode,
 } from "../config/types.base.js";
 import { asBoolean } from "../utils/boolean.js";
-import {
-  warnFlatStreamingKeyFallback,
-  warnScalarStreamingFallback,
+import { warnScalarStreamingFallback } from "./streaming-flat-key-deprecation.js";
+
+export {
+  resolveChannelStreamingChunkMode,
+  resolveChannelStreamingBlockEnabled,
+  resolveChannelStreamingBlockCoalesce,
+  resolveChannelStreamingPreviewChunk,
 } from "./streaming-flat-key-deprecation.js";
 
 export type {
@@ -44,24 +45,15 @@ export type StreamingCompatEntry = {
   draftChunk?: unknown;
 };
 
-// Nested streaming config wins. Every bundled channel now uses a nested-only
-// streaming schema with doctor migrating the flat spellings, so in-tree the
-// flat delivery keys (chunkMode, blockStreaming, blockStreamingCoalesce,
-// draftChunk) are legacy config. Those reads and the scalar `streaming` read in
-// resolveChannelPreviewStreamMode serve external SDK plugin configs only and
-// emit once-per-key deprecation warnings. Remove them (and the flat
-// StreamingCompatEntry fields) when the next release train closes the SDK
-// deprecation window.
+// Nested config wins; flat delivery fallback lives wholly in streaming-flat-key-deprecation.ts.
+// After the next release train, delete that module and re-exports, scalar read in
+// resolveChannelPreviewStreamMode, and flat StreamingCompatEntry fields.
 // Mode-family aliases (streamMode) are doctor-only and stay unread here.
 
 function asObjectRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null;
-}
-
-function asTextChunkMode(value: unknown): TextChunkMode | undefined {
-  return value === "length" || value === "newline" ? value : undefined;
 }
 
 function asInteger(value: unknown): number | undefined {
@@ -87,14 +79,6 @@ function parsePreviewStreamingMode(value: unknown): StreamingMode | null {
     return normalized;
   }
   return null;
-}
-
-function asBlockStreamingCoalesceConfig(value: unknown): BlockStreamingCoalesceConfig | undefined {
-  return (asObjectRecord(value) as BlockStreamingCoalesceConfig | null) ?? undefined;
-}
-
-function asBlockStreamingChunkConfig(value: unknown): BlockStreamingChunkConfig | undefined {
-  return (asObjectRecord(value) as BlockStreamingChunkConfig | null) ?? undefined;
 }
 
 function asProgressConfig(value: unknown): ChannelStreamingProgressConfig | undefined {
@@ -779,65 +763,6 @@ export function getChannelStreamingConfigObject(
 ): ChannelStreamingConfig | undefined {
   const streaming = asObjectRecord(entry?.streaming);
   return streaming ? (streaming as ChannelStreamingConfig) : undefined;
-}
-
-function resolveWithFlatFallback<T>(params: {
-  nested: T | undefined;
-  flat: T | undefined;
-  flatKey: string;
-  nestedPath: string;
-}): T | undefined {
-  if (params.nested !== undefined) {
-    return params.nested;
-  }
-  if (params.flat !== undefined) {
-    warnFlatStreamingKeyFallback(params.flatKey, params.nestedPath);
-  }
-  return params.flat;
-}
-
-export function resolveChannelStreamingChunkMode(
-  entry: StreamingCompatEntry | null | undefined,
-): TextChunkMode | undefined {
-  return resolveWithFlatFallback({
-    nested: asTextChunkMode(getChannelStreamingConfigObject(entry)?.chunkMode),
-    flat: asTextChunkMode(entry?.chunkMode),
-    flatKey: "chunkMode",
-    nestedPath: "chunkMode",
-  });
-}
-
-export function resolveChannelStreamingBlockEnabled(
-  entry: StreamingCompatEntry | null | undefined,
-): boolean | undefined {
-  return resolveWithFlatFallback({
-    nested: asBoolean(getChannelStreamingConfigObject(entry)?.block?.enabled),
-    flat: asBoolean(entry?.blockStreaming),
-    flatKey: "blockStreaming",
-    nestedPath: "block.enabled",
-  });
-}
-
-export function resolveChannelStreamingBlockCoalesce(
-  entry: StreamingCompatEntry | null | undefined,
-): BlockStreamingCoalesceConfig | undefined {
-  return resolveWithFlatFallback({
-    nested: asBlockStreamingCoalesceConfig(getChannelStreamingConfigObject(entry)?.block?.coalesce),
-    flat: asBlockStreamingCoalesceConfig(entry?.blockStreamingCoalesce),
-    flatKey: "blockStreamingCoalesce",
-    nestedPath: "block.coalesce",
-  });
-}
-
-export function resolveChannelStreamingPreviewChunk(
-  entry: StreamingCompatEntry | null | undefined,
-): BlockStreamingChunkConfig | undefined {
-  return resolveWithFlatFallback({
-    nested: asBlockStreamingChunkConfig(getChannelStreamingConfigObject(entry)?.preview?.chunk),
-    flat: asBlockStreamingChunkConfig(entry?.draftChunk),
-    flatKey: "draftChunk",
-    nestedPath: "preview.chunk",
-  });
 }
 
 export function resolveChannelStreamingPreviewToolProgress(

--- a/src/plugin-sdk/channel-streaming.test.ts
+++ b/src/plugin-sdk/channel-streaming.test.ts
@@ -121,10 +121,9 @@ describe("channel-streaming", () => {
   });
 
   it("resolves flat delivery keys when no nested streaming config exists", () => {
-    // Flat delivery keys stay canonical for channels without a nested
-    // streaming schema (Mattermost, WhatsApp, Google Chat, IRC, Signal) and
-    // for external SDK plugins; mode-family aliases (streamMode, scalar
-    // streaming, nativeStreaming) are doctor-only and stay unread.
+    // Flat delivery keys are an external SDK plugin fallback only. Bundled
+    // channel schemas are nested-only, and doctor migrates their old flat
+    // config; streamMode and nativeStreaming remain doctor-only.
     const entry = {
       chunkMode: "newline",
       blockStreaming: true,


### PR DESCRIPTION
## What Problem This Solves

`src/channels/streaming.ts` is an oversized legacy file (1,320 lines, LOC-ratchet-capped) that still hosts the deprecated flat streaming-key fallback — ~70 lines of compat resolvers scheduled for deletion when the SDK deprecation window closes after the next release train. Keeping the dying code inside the ratcheted file blocks any legitimate growth there and spreads the future deletion across a large file.

## Why This Change Was Made

Rescoped after #106796 landed the scalar-fallback warning this PR originally carried (both grew from the same finding). What remains is the consolidation: the four flat-fallback resolvers (`resolveChannelStreamingChunkMode`/`BlockEnabled`/`BlockCoalesce`/`PreviewChunk`) and their helper move into `streaming-flat-key-deprecation.ts`, which already owns the warn-once state and dies with the window — so the next-train deletion becomes one module plus re-export lines. `StreamingCompatEntry` moves to a leaf contract module (`streaming-compat-entry.ts`) so the compat module never imports from `streaming.ts` (madge/import-cycle gates verified at zero cycles).

## User Impact

None. Pure move: public SDK export names, signatures, and behavior are identical (`openclaw/plugin-sdk/channel-outbound` re-exports `streaming.ts`, which re-exports the four resolvers and the type). `streaming.ts` shrinks 1,320 → 1,244 lines.

## Evidence

- Testbox (Blacksmith): `check:import-cycles` and `check:madge-import-cycles` both zero; `pnpm test src/channels/streaming.test.ts src/channels/streaming-flat-key-deprecation.test.ts src/plugin-sdk/channel-streaming.test.ts src/auto-reply/chunk.test.ts src/auto-reply/reply/block-streaming.test.ts` all green; `check:changed` lanes green (LOC ratchet included) with the regenerated Plugin SDK API baseline hash committed.
- Autoreview (codex gpt-5.6-sol, xhigh) on the pre-rescope equivalent of this move: clean, no actionable findings; the move itself is unchanged apart from adapting to #106796's warn implementation.
