### PR TITLE
refactor(canvas): use chokidar watch directly

### DIFF
--- a/extensions/canvas/src/host/server.ts
+++ b/extensions/canvas/src/host/server.ts
@@ -3,7 +3,6 @@
  */
 import fs from "node:fs/promises";
 import http, { type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import { createRequire } from "node:module";
 import type { Socket } from "node:net";
 import path from "node:path";
 import type { Duplex } from "node:stream";
@@ -30,8 +29,6 @@ import {
 import { normalizeUrlPath, resolveFileWithinRoot } from "./file-resolver.js";
 
 export const CANVAS_LIVE_RELOAD_MAX_INBOUND_MESSAGE_BYTES = 64 * 1024;
-
-type ChokidarWatch = typeof import("chokidar").watch;
 
 /** Options for Canvas host creation. */
 type CanvasHostOpts = {
@@ -248,25 +245,6 @@ function resolveDefaultCanvasRoot(): string {
   return path.join(resolveStateDir(), "canvas");
 }
 
-function resolveDefaultWatchFactory(): ChokidarWatch {
-  const importedWatch = (chokidar as { watch?: ChokidarWatch } | undefined)?.watch;
-  if (typeof importedWatch === "function") {
-    return importedWatch.bind(chokidar);
-  }
-
-  const require = createRequire(import.meta.url);
-  const runtime = require("chokidar") as
-    | { watch?: ChokidarWatch; default?: { watch?: ChokidarWatch } }
-    | undefined;
-  if (runtime && typeof runtime.watch === "function") {
-    return runtime.watch.bind(runtime);
-  }
-  if (runtime?.default && typeof runtime.default.watch === "function") {
-    return runtime.default.watch.bind(runtime.default);
-  }
-  throw new Error("chokidar.watch unavailable");
-}
-
 function shouldIgnoreCanvasWatchPath(rootReal: string, candidatePath: string): boolean {
   const relative = path.relative(rootReal, candidatePath);
   if (!relative || relative === ".." || relative.startsWith(`..${path.sep}`)) {
@@ -350,9 +328,8 @@ export async function createCanvasHostHandler(
   };
 
   let watcherClosed = false;
-  const watchFactory = opts.watchFactory ?? resolveDefaultWatchFactory();
   const watcher = liveReload
-    ? watchFactory(rootReal, {
+    ? (opts.watchFactory ?? chokidar.watch)(rootReal, {
         ignoreInitial: true,
         awaitWriteFinish: {
           stabilityThreshold: writeStabilityThresholdMs,


### PR DESCRIPTION
## What Problem This Solves

Canvas retained a CommonJS/default-export fallback resolver for Chokidar despite pinning ESM-only Chokidar v5 with an exact default `watch` API.

Closes #106809.

## Why This Change Was Made

Call `chokidar.watch` directly while preserving the injectable `watchFactory` used by tests.

## User Impact

No watcher option or lifecycle change. The obsolete module-shape compatibility path is gone, reducing the implementation by 23 lines.

## Evidence

- `pnpm test extensions/canvas/src/host/server.test.ts extensions/canvas/src/host/server.state-dir.test.ts` — 19/19 passed
- `pnpm tsgo:extensions` — passed
- `pnpm build` — passed
- Built `dist/extensions/canvas/runtime-api.js` handler created a live Chokidar watcher and closed cleanly
- Fresh autoreview — clean
- Blacksmith Testbox: `tbx_01kxeme5y4h4tadqzjqmmztb84`
- Delegated run: https://github.com/openclaw/openclaw/actions/runs/29284595069
- Stable patch ID: `26c47ce1852572bc94fe49dec1c370d521451e7a`
