### PR TITLE
refactor(code-mode): use quickjs-wasi defaults

### DIFF
--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -7,7 +7,7 @@ import { createRequire } from "node:module";
 import { parentPort, workerData } from "node:worker_threads";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { Result } from "@openclaw/normalization-core/result";
-import { EvalFlags, Intrinsics, JSException, QuickJS, type JSValueHandle } from "quickjs-wasi";
+import { EvalFlags, JSException, QuickJS, type JSValueHandle } from "quickjs-wasi";
 import type { CodeModeApiVirtualFile } from "./code-mode-namespaces.js";
 const require = createRequire(import.meta.url);
 const QUICKJS_WASM_PATH = require.resolve("quickjs-wasi/quickjs.wasm");
@@ -431,7 +431,6 @@ async function createVm(params: {
   const vm = await QuickJS.create({
     wasm: await getQuickJsWasmModule(),
     memoryLimit: params.config.memoryLimitBytes,
-    intrinsics: Intrinsics.ALL,
     timezoneOffset: 0,
     interruptHandler: () => {
       timedOut = deadlineReached();
@@ -485,7 +484,6 @@ async function restoreVm(params: {
   const vm = await QuickJS.restore(snapshot, {
     wasm: await getQuickJsWasmModule(),
     memoryLimit: params.config.memoryLimitBytes,
-    intrinsics: Intrinsics.ALL,
     timezoneOffset: 0,
     interruptHandler: () => {
       timedOut = deadlineReached();
@@ -561,19 +559,6 @@ function throwWorkerFailureWithOutput(params: {
   throw params.error;
 }
 
-function drainPendingJobs(vm: QuickJS): void {
-  for (let index = 0; index < 1000; index += 1) {
-    if (vm.executePendingJobs() === 0) {
-      return;
-    }
-  }
-  throw new Error("code mode pending job limit exceeded");
-}
-
-function getResultHandle(vm: QuickJS): JSValueHandle {
-  return vm.global.getProp("__openclawResult");
-}
-
 async function readCompletedResult(vm: QuickJS, resultHandle: JSValueHandle): Promise<unknown> {
   if (!resultHandle.isPromise) {
     return toJsonSafe(vm.dump(resultHandle));
@@ -629,9 +614,9 @@ async function runVmExecution(params: {
   let output: unknown[] = [];
   try {
     params.prepare();
-    drainPendingJobs(params.vm);
+    params.vm.executePendingJobs();
     output = takeOutput(params.vm);
-    const resultHandle = getResultHandle(params.vm);
+    const resultHandle = params.vm.global.getProp("__openclawResult");
     try {
       if (params.pendingRequests.length > 0) {
         // Pending host work suspends the VM instead of blocking in-worker; the


### PR DESCRIPTION
## What Problem This Solves

Code Mode duplicated behavior already guaranteed by pinned `quickjs-wasi` v3.0.2: all-intrinsics defaults, pending-job draining, and a trivial result-handle getter.

Closes #106812.

## Why This Change Was Made

Use the dependency defaults and direct VM methods. `QuickJS.restore` does not consume an intrinsics option, and one `executePendingJobs()` call drains the complete queue.

## User Impact

No guest API, timeout, snapshot, or execution-policy change. The worker is 15 lines smaller.

## Evidence

- `pnpm test src/agents/code-mode.test.ts src/agents/code-mode-headless.test.ts` — 77/77 passed
- `pnpm build` — passed
- Fresh autoreview — clean
- Blacksmith Testbox: `tbx_01kxems8byjcvc6g06q73t13cy`
- Delegated run: https://github.com/openclaw/openclaw/actions/runs/29284995570
- Rebased onto current `main`; stable patch ID remained `eec69d8595b7f712de5e881458d25c6514f4a0b2`
