### PR TITLE
feat(config): add canonical group-policy scope-tree resolver

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-9bc00d1b67cf1902b3deb36a79553684cccd0cf5d405e9bf0373065ec1e1005f  plugin-sdk-api-baseline.json
-517cab00f614e15bf68b68468b0398c9faae6a8035dbfd7512e6527d815046c5  plugin-sdk-api-baseline.jsonl
+a79050188f3f8c3706b63718f710a0359e24a3882bf14fc1dcee6a078a72cf30  plugin-sdk-api-baseline.json
+92e7af85e5eb68cccf5bd757ba6272a57ebff6652fbce01577d39c3a49ebe506  plugin-sdk-api-baseline.jsonl

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -135,7 +135,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   types: 6,
   "agent-config-primitives": 2,
   "command-auth": 81,
-  compat: 152,
+  compat: 158,
   "direct-dm": 9,
   "direct-dm-access": 5,
   discord: 48,
@@ -159,7 +159,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "channel-pairing": 1,
   "conversation-runtime": 4,
   "channel-send-result": 1,
-  "channel-policy": 8,
+  "channel-policy": 14,
   "channel-route": 5,
   "session-store-runtime": 4,
   "session-transcript-runtime": 2,
@@ -202,19 +202,20 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       327,
       env,
     ),
+    // ScopeTree adds six channel-policy exports, mirrored by compat, including three functions.
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
-      10648,
+      10660,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS",
-      5360,
+      5366,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
-      3283,
+      3289,
       env,
     ),
     publicWildcardReexports: readPluginSdkSurfaceBudgetEnv(

--- a/src/config/group-scope-tree.test.ts
+++ b/src/config/group-scope-tree.test.ts
@@ -1,0 +1,296 @@
+// Verifies canonical group scope precedence and sender policy resolution.
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "./config.js";
+import { resolveChannelGroupRequireMention, resolveToolsBySender } from "./group-policy.js";
+import {
+  resolveScopeIntroHint,
+  resolveScopeRequireMention,
+  resolveScopeToolsPolicy,
+  type ScopeTree,
+} from "./group-scope-tree.js";
+
+describe("resolveScopeRequireMention", () => {
+  const scalarCases: Array<{
+    name: string;
+    tree: ScopeTree;
+    path: string[];
+    expected: boolean;
+  }> = [
+    {
+      name: "uses the most specific configured scope",
+      tree: {
+        defaults: { requireMention: false },
+        scopes: {
+          broad: { requireMention: false },
+          narrow: { requireMention: true },
+        },
+      },
+      path: ["broad", "narrow"],
+      expected: true,
+    },
+    {
+      name: "skips missing scope keys",
+      tree: { scopes: { broad: { requireMention: false } } },
+      path: ["broad", "missing"],
+      expected: false,
+    },
+    {
+      name: "uses defaults after path scopes",
+      tree: { defaults: { requireMention: false }, scopes: { room: {} } },
+      path: ["room"],
+      expected: false,
+    },
+    {
+      name: "defaults to requiring a mention",
+      tree: { scopes: {} },
+      path: ["missing"],
+      expected: true,
+    },
+  ];
+
+  it.each(scalarCases)("$name", ({ tree, path, expected }) => {
+    expect(resolveScopeRequireMention({ tree, path })).toBe(expected);
+  });
+
+  it("honors Telegram wildcard-topic precedence encoded by the path", () => {
+    const tree: ScopeTree = {
+      scopes: {
+        "*#topic:7": { requireMention: false },
+        "<chat>": { requireMention: true },
+      },
+    };
+
+    expect(
+      resolveScopeRequireMention({
+        tree,
+        path: ["*", "<chat>", "*#topic:7", "<chat>#topic:7"],
+      }),
+    ).toBe(false);
+  });
+
+  it.each([
+    {
+      name: "no override",
+      configured: false,
+      override: undefined,
+      overrideOrder: undefined,
+    },
+    {
+      name: "before-config override",
+      configured: false,
+      override: true,
+      overrideOrder: "before-config" as const,
+    },
+    {
+      name: "after-config override",
+      configured: false,
+      override: true,
+      overrideOrder: "after-config" as const,
+    },
+    {
+      name: "after-config fallback override",
+      configured: undefined,
+      override: false,
+      overrideOrder: "after-config" as const,
+    },
+  ])("matches flat group-policy behavior: $name", ({ configured, override, overrideOrder }) => {
+    const node = typeof configured === "boolean" ? { requireMention: configured } : {};
+    const tree: ScopeTree = { scopes: { room: node } };
+    const cfg = {
+      channels: { whatsapp: { groups: { room: node } } },
+    } as OpenClawConfig;
+
+    expect(
+      resolveScopeRequireMention({
+        tree,
+        path: ["room"],
+        requireMentionOverride: override,
+        overrideOrder,
+      }),
+    ).toBe(
+      resolveChannelGroupRequireMention({
+        cfg,
+        channel: "whatsapp",
+        groupId: "room",
+        requireMentionOverride: override,
+        overrideOrder,
+      }),
+    );
+  });
+
+  it("defaults configured-but-unset scopes to no mention only when requested", () => {
+    const tree: ScopeTree = { scopes: { configured: {} } };
+
+    expect(
+      resolveScopeRequireMention({
+        tree,
+        path: ["configured"],
+        configuredScopeDefaultsToNoMention: true,
+      }),
+    ).toBe(false);
+    expect(
+      resolveScopeRequireMention({
+        tree,
+        path: ["missing"],
+        configuredScopeDefaultsToNoMention: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("resolveScopeToolsPolicy", () => {
+  const cascadeCases: Array<{
+    name: string;
+    tree: ScopeTree;
+    senderId: string;
+    expected: { allow?: string[]; deny?: string[] };
+  }> = [
+    {
+      name: "channel sender policy",
+      tree: {
+        scopes: {
+          team: { tools: { deny: ["team"] } },
+          channel: {
+            toolsBySender: { "id:alice": { allow: ["channel-sender"] } },
+            tools: { allow: ["channel"] },
+          },
+        },
+      },
+      senderId: "alice",
+      expected: { allow: ["channel-sender"] },
+    },
+    {
+      name: "channel policy",
+      tree: {
+        scopes: {
+          team: { tools: { deny: ["team"] } },
+          channel: {
+            toolsBySender: { "id:alice": { allow: ["channel-sender"] } },
+            tools: { allow: ["channel"] },
+          },
+        },
+      },
+      senderId: "bob",
+      expected: { allow: ["channel"] },
+    },
+    {
+      name: "team sender policy",
+      tree: {
+        scopes: {
+          team: {
+            toolsBySender: { "id:bob": { allow: ["team-sender"] } },
+            tools: { deny: ["team"] },
+          },
+          channel: {},
+        },
+      },
+      senderId: "bob",
+      expected: { allow: ["team-sender"] },
+    },
+    {
+      name: "team policy",
+      tree: {
+        scopes: {
+          team: {
+            toolsBySender: { "id:bob": { allow: ["team-sender"] } },
+            tools: { deny: ["team"] },
+          },
+          channel: {},
+        },
+      },
+      senderId: "carol",
+      expected: { deny: ["team"] },
+    },
+  ];
+
+  it.each(cascadeCases)(
+    "resolves the MSTeams cascade through $name",
+    ({ tree, senderId, expected }) => {
+      expect(resolveScopeToolsPolicy({ tree, path: ["team", "channel"], senderId })).toEqual(
+        expected,
+      );
+    },
+  );
+
+  it.each([
+    { name: "id", sender: { senderId: "user:alice" }, expected: { allow: ["id"] } },
+    {
+      name: "username",
+      sender: { senderUsername: "@Alice" },
+      expected: { allow: ["username"] },
+    },
+    {
+      name: "channel",
+      sender: { senderId: "user:alice", messageProvider: "discord" },
+      expected: { allow: ["channel"] },
+    },
+    {
+      name: "channel without provider",
+      sender: { senderId: "user:alice" },
+      expected: { allow: ["id"] },
+    },
+  ])("matches resolveToolsBySender for typed $name keys", ({ sender, expected }) => {
+    const toolsBySender = {
+      "id:user:alice": { allow: ["id"] },
+      "username:alice": { allow: ["username"] },
+      "channel:discord:user:alice": { allow: ["channel"] },
+      "*": { deny: ["fallback"] },
+    };
+    const tree: ScopeTree = { scopes: { room: { toolsBySender } } };
+
+    const directPolicy = resolveToolsBySender({ toolsBySender, ...sender });
+    expect(resolveScopeToolsPolicy({ tree, path: ["room"], ...sender })).toEqual(directPolicy);
+    expect(directPolicy).toEqual(expected);
+  });
+
+  it("uses sender and plain policies from defaults after path scopes", () => {
+    const senderTree: ScopeTree = {
+      defaults: {
+        toolsBySender: { "id:alice": { allow: ["default-sender"] } },
+        tools: { deny: ["default"] },
+      },
+      scopes: { channel: {} },
+    };
+
+    expect(
+      resolveScopeToolsPolicy({ tree: senderTree, path: ["channel"], senderId: "alice" }),
+    ).toEqual({ allow: ["default-sender"] });
+    expect(
+      resolveScopeToolsPolicy({ tree: senderTree, path: ["channel"], senderId: "bob" }),
+    ).toEqual({ deny: ["default"] });
+    expect(resolveScopeToolsPolicy({ tree: { scopes: {} }, path: [] })).toBeUndefined();
+  });
+
+  it("keeps a narrower plain policy ahead of a broader sender match", () => {
+    const tree: ScopeTree = {
+      scopes: {
+        team: { toolsBySender: { "id:alice": { allow: ["team-sender"] } } },
+        channel: { tools: { deny: ["channel"] } },
+      },
+    };
+
+    expect(
+      resolveScopeToolsPolicy({
+        tree,
+        path: ["team", "channel"],
+        senderId: "alice",
+      }),
+    ).toEqual({ deny: ["channel"] });
+  });
+});
+
+describe("resolveScopeIntroHint", () => {
+  it("uses the first defined hint from narrowest scope through defaults", () => {
+    const tree: ScopeTree = {
+      defaults: { introHint: "default" },
+      scopes: {
+        team: { introHint: "team" },
+        channel: {},
+        thread: { introHint: "thread" },
+      },
+    };
+
+    expect(resolveScopeIntroHint({ tree, path: ["team", "channel", "thread"] })).toBe("thread");
+    expect(resolveScopeIntroHint({ tree, path: ["missing"] })).toBe("default");
+  });
+});

--- a/src/config/group-scope-tree.ts
+++ b/src/config/group-scope-tree.ts
@@ -1,0 +1,109 @@
+// Resolves canonical group policy scopes prepared by channel plugins.
+import { resolveToolsBySender } from "./group-policy.js";
+import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
+
+export type ScopeNode = {
+  requireMention?: boolean;
+  tools?: GroupToolPolicyConfig;
+  toolsBySender?: GroupToolPolicyBySenderConfig;
+  introHint?: string;
+};
+
+export type ScopeTree = {
+  defaults?: ScopeNode;
+  // Flat keys preserve channel-defined precedence: channels emit broad-to-narrow paths.
+  // Nested trees cannot model Telegram, where a wildcard-group topic outranks
+  // an exact-group scalar requireMention.
+  scopes: Record<string, ScopeNode>;
+};
+
+export type ScopePath = string[];
+
+type ScopeToolPolicySender = Omit<Parameters<typeof resolveToolsBySender>[0], "toolsBySender">;
+
+function resolveFromScopes<Value>(params: {
+  tree: ScopeTree;
+  path: ScopePath;
+  resolveNode: (node: ScopeNode) => Value | undefined;
+}): Value | undefined {
+  for (let index = params.path.length - 1; index >= 0; index -= 1) {
+    const key = params.path[index];
+    if (key === undefined || !Object.hasOwn(params.tree.scopes, key)) {
+      continue;
+    }
+    const node = params.tree.scopes[key];
+    if (!node) {
+      continue;
+    }
+    const value = params.resolveNode(node);
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  return params.tree.defaults ? params.resolveNode(params.tree.defaults) : undefined;
+}
+
+export function resolveScopeRequireMention(params: {
+  tree: ScopeTree;
+  path: ScopePath;
+  requireMentionOverride?: boolean;
+  overrideOrder?: "before-config" | "after-config";
+  configuredScopeDefaultsToNoMention?: boolean;
+}): boolean {
+  // Runtime overrides stay in resolver parameters because channels derive them per message.
+  const { requireMentionOverride, overrideOrder = "after-config" } = params;
+  const configuredMention = resolveFromScopes({
+    tree: params.tree,
+    path: params.path,
+    resolveNode: (node) => node.requireMention,
+  });
+
+  if (overrideOrder === "before-config" && typeof requireMentionOverride === "boolean") {
+    return requireMentionOverride;
+  }
+  if (typeof configuredMention === "boolean") {
+    return configuredMention;
+  }
+  if (overrideOrder !== "before-config" && typeof requireMentionOverride === "boolean") {
+    return requireMentionOverride;
+  }
+  if (
+    params.configuredScopeDefaultsToNoMention &&
+    params.path.some((key) => Object.hasOwn(params.tree.scopes, key))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export function resolveScopeToolsPolicy(
+  params: {
+    tree: ScopeTree;
+    path: ScopePath;
+  } & ScopeToolPolicySender,
+): GroupToolPolicyConfig | undefined {
+  return resolveFromScopes({
+    tree: params.tree,
+    path: params.path,
+    resolveNode: (node) =>
+      resolveToolsBySender({
+        toolsBySender: node.toolsBySender,
+        senderId: params.senderId,
+        senderName: params.senderName,
+        senderUsername: params.senderUsername,
+        senderE164: params.senderE164,
+        messageProvider: params.messageProvider,
+      }) ?? node.tools,
+  });
+}
+
+export function resolveScopeIntroHint(params: {
+  tree: ScopeTree;
+  path: ScopePath;
+}): string | undefined {
+  return resolveFromScopes({
+    tree: params.tree,
+    path: params.path,
+    resolveNode: (node) => node.introHint,
+  });
+}

--- a/src/plugin-sdk/channel-policy.ts
+++ b/src/plugin-sdk/channel-policy.ts
@@ -49,6 +49,14 @@ export {
   type ChannelGroupPolicy,
 } from "../config/group-policy.js";
 export {
+  resolveScopeIntroHint,
+  resolveScopeRequireMention,
+  resolveScopeToolsPolicy,
+  type ScopeNode,
+  type ScopePath,
+  type ScopeTree,
+} from "../config/group-scope-tree.js";
+export {
   DM_GROUP_ACCESS_REASON,
   readStoreAllowFromForDmPolicy,
   resolveDmGroupAccessWithCommandGate,


### PR DESCRIPTION
## What Problem This Solves

16 channel plugins register a `groups` adapter answering the same questions — effective `requireMention`, tool policy (including sender-scoped tools), group intro hints — but only 9 delegate to the shared resolver in `src/config/group-policy.ts`. The rest ship private walkers over channel-specific config nests (discord guild→channel, telegram group→topic, msteams team→channel with cross-team scan, slack/matrix/zalouser candidate matching): same decision, many implementations, measurable drift (e.g. adapter paths that can never match `channel:`-prefixed `toolsBySender` keys while the core fallback can).

## Why This Change Was Made

Stage 1 of the group-policy scope normalization design (load-time canonical model, zero user-visible config change): a `ScopeTree` of flat keyed scope nodes plus channel-ordered scope paths, with core-owned resolvers for requireMention (most-specific-wins, override-order semantics identical to `resolveChannelGroupRequireMention`), tool policy (per-level `toolsBySender` → `tools`, whole-object override, reusing `resolveToolsBySender` verbatim as the sender engine), and intro hints. Flat keys instead of a nested tree are deliberate: telegram's real precedence lets a wildcard-group topic node outrank an exact-group scalar, which a nested walk cannot express; channels encode precedence in the path they emit. Runtime overrides stay resolver parameters, never tree data. Follow-up PRs migrate channels in parity-tested batches and delete the per-channel walkers (~600 LOC across 11 files).

## User Impact

None yet — no callers are wired in this PR; behavior is unchanged. The new resolvers are exported via `openclaw/plugin-sdk/channel-policy` (surface budgets bumped by the exact delta with a citation comment) so channel migrations can adopt them.

## Evidence

- Testbox (Blacksmith): `pnpm test src/config/group-scope-tree.test.ts src/config/group-policy.test.ts src/plugin-sdk` green; `pnpm check:changed` green through all lanes with the regenerated Plugin SDK API baseline hash committed.
- Tests: table-driven precedence walks (skip-missing keys, defaults last, final default `true`), the telegram-shaped ordering case, msteams-shaped two-level cascade, typed-sender key integration incl. `messageProvider` gating, before-/after-config override parity with `group-policy.ts`, `configuredScopeDefaultsToNoMention`, and narrowest-first intro hints.
- Autoreview (codex gpt-5.6-sol, xhigh): clean, "patch is correct (0.88)", no actionable findings.
- Design + parity groundwork: semantics table extracted from all 16 adapter registrations (scope levels, per-field precedence, merge-vs-override, sender scoping, drift list) drives the batch order for the migration PRs.
