### PR TITLE
refactor(media): inline CAF MIME fallback

### DIFF
--- a/packages/media-core/src/mime.ts
+++ b/packages/media-core/src/mime.ts
@@ -119,19 +119,8 @@ async function sniffMime(buffer?: Buffer): Promise<string | undefined> {
   } catch {
     // fall through to manual magic-byte sniffs
   }
-  return sniffKnownAudioMagic(buffer);
-}
-
-// Fallbacks for audio containers `file-type` doesn't recognize natively (e.g.
-// Apple's CAF, used by iMessage voice memos when produced by `afconvert`).
-// Without this the host-local-media validator drops these buffers as unknown
-// binary blobs because the sniff returns undefined, even though the file is
-// a valid audio container.
-function sniffKnownAudioMagic(buffer: Buffer): string | undefined {
-  if (buffer.byteLength >= 4 && buffer.toString("ascii", 0, 4) === "caff") {
-    return "audio/x-caf";
-  }
-  return undefined;
+  // Preserve iMessage CAF voice memos; file-type v22 does not detect them.
+  return buffer.toString("ascii", 0, 4) === "caff" ? "audio/x-caf" : undefined;
 }
 
 /** Extracts a lowercase extension from a local path or HTTP URL pathname. */


### PR DESCRIPTION
## What Problem This Solves

Media MIME sniffing wrapped its one pinned `file-type` v22 gap—CAF audio—in a separate helper and long fallback block.

Closes #106817.

## Why This Change Was Made

Keep the named CAF contract beside the dependency call and inline the four-byte check when `file-type` yields no result.

## User Impact

No MIME behavior change. iMessage CAF voice memos remain detected as `audio/x-caf`; the implementation is 11 lines smaller.

## Evidence

- `pnpm test packages/media-core/src/mime.test.ts src/plugins/contracts/session-attachments.contract.test.ts` — 135/135 passed
- `pnpm --filter @openclaw/media-core build` — passed
- Fresh autoreview — clean
- Blacksmith Testbox: `tbx_01kxen909sdb0qvhh68f3aaaks`
- Rebased onto current `main`; stable patch ID remained `14df06a659226b66796027568c0fe34f35fe40a5`
