### PR TITLE
fix(ci): remove dead Google thinking type export

### DIFF
--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -38,7 +38,7 @@ import { transformMessages } from "./transform-messages.js";
 
 type GoogleApiType = "google-generative-ai" | "google-vertex";
 
-export type GoogleThinkingLevel = `${ThinkingLevel}`;
+type GoogleThinkingLevel = `${ThinkingLevel}`;
 
 type GoogleToolChoice = "auto" | "none" | "any";
 


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails the `check-dependencies` CI shard because Knip reports `GoogleThinkingLevel` as an unexpected unused export.

## Why This Change Was Made

`google-shared.ts` uses the type only within its module. `@openclaw/ai` does not expose that module in its package export map, and the public providers barrel does not re-export the type. Keeping the type module-private matches the real contract and clears the dead-export gate.

## User Impact

None. Runtime behavior and supported package exports stay unchanged. This restores the current-main quality gate and unblocks queued fixes.

## Evidence

- Blacksmith Testbox `tbx_01kxemsct2wz109jf93shaj2kj`: `pnpm deadcode:exports` passed.
- Same Testbox: `pnpm tsgo:prod` passed.
- Same Testbox: full `pnpm build` passed.
- Fresh autoreview: clean; verified the package export map and providers barrel.

AI assistance: implementation and review used AI tooling; maintainer-directed and fully validated.
