### PR TITLE
fix(gateway): recover when suppressed channel secrets are unavailable

### DIFF
--- a/src/gateway/server-startup-config.breaker-secrets.integration.test.ts
+++ b/src/gateway/server-startup-config.breaker-secrets.integration.test.ts
@@ -1,0 +1,152 @@
+/** Integration coverage for breaker-suppressed startup SecretRef projection. */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "../secrets/runtime-telegram.test-support.ts";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.js";
+import {
+  asConfig,
+  beginSecretsRuntimeIsolationForTest,
+  EMPTY_LOADABLE_PLUGIN_ORIGINS,
+  endSecretsRuntimeIsolationForTest,
+  loadAuthStoreWithProfiles,
+  SECRETS_RUNTIME_INTEGRATION_TIMEOUT_MS,
+  type SecretsRuntimeEnvSnapshot,
+} from "../secrets/runtime.integration.test-helpers.js";
+import {
+  activateSecretsRuntimeSnapshot,
+  getActiveSecretsRuntimeSnapshot,
+  prepareSecretsRuntimeSnapshot,
+} from "../secrets/runtime.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import {
+  createRuntimeSecretsActivator,
+  prepareGatewayStartupConfig,
+} from "./server-startup-config.js";
+import { buildTestConfigSnapshot } from "./test-helpers.config-snapshots.js";
+
+const GATEWAY_TOKEN_ENV = "BREAKER_GATEWAY_AUTH_TOKEN";
+const CHANNEL_TOKEN_ENV = "BREAKER_TELEGRAM_BOT_TOKEN";
+
+function buildSnapshot(config: OpenClawConfig): ConfigFileSnapshot {
+  const raw = `${JSON.stringify(config, null, 2)}\n`;
+  return buildTestConfigSnapshot({
+    path: "/tmp/openclaw-breaker-secrets-integration.json",
+    exists: true,
+    raw,
+    parsed: config,
+    valid: true,
+    config,
+    issues: [],
+    legacyIssues: [],
+  });
+}
+
+describe("gateway breaker SecretRef integration", () => {
+  let envSnapshot: SecretsRuntimeEnvSnapshot;
+
+  beforeEach(() => {
+    envSnapshot = beginSecretsRuntimeIsolationForTest();
+  });
+
+  afterEach(() => {
+    endSecretsRuntimeIsolationForTest(envSnapshot);
+  });
+
+  it(
+    "preserves suppressed channel source for full reload projection",
+    async () => {
+      await withEnvAsync(
+        {
+          [GATEWAY_TOKEN_ENV]: "resolved-gateway-token",
+          [CHANNEL_TOKEN_ENV]: undefined,
+          OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+          OPENCLAW_SKIP_CHANNELS: undefined,
+          OPENCLAW_SKIP_PROVIDERS: undefined,
+          OPENCLAW_VERSION: undefined,
+        },
+        async () => {
+          const gatewayTokenRef = {
+            source: "env",
+            provider: "default",
+            id: GATEWAY_TOKEN_ENV,
+          } as const;
+          const channelTokenRef = {
+            source: "env",
+            provider: "default",
+            id: CHANNEL_TOKEN_ENV,
+          } as const;
+          const config = asConfig({
+            secrets: {
+              providers: {
+                default: { source: "env" },
+              },
+            },
+            gateway: {
+              auth: {
+                mode: "token",
+                token: gatewayTokenRef,
+              },
+            },
+            channels: {
+              telegram: {
+                enabled: true,
+                botToken: channelTokenRef,
+              },
+            },
+          });
+          const prepareRuntimeSecretsSnapshot: typeof prepareSecretsRuntimeSnapshot = async (
+            params,
+          ) =>
+            await prepareSecretsRuntimeSnapshot({
+              ...params,
+              agentDirs: ["/tmp/openclaw-agent-main"],
+              loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+              loadAuthStore: () => loadAuthStoreWithProfiles({}),
+            });
+          const activateRuntimeSecrets = createRuntimeSecretsActivator({
+            logSecrets: {
+              info: vi.fn(),
+              warn: vi.fn(),
+              error: vi.fn(),
+            },
+            emitStateEvent: vi.fn(),
+            prepareRuntimeSecretsSnapshot,
+            activateRuntimeSecretsSnapshot: activateSecretsRuntimeSnapshot,
+            channelAutostartSuppression: {
+              reason: "crash-loop-breaker",
+              message: "breaker tripped: 20 unclean boots",
+            },
+          });
+
+          const startup = await prepareGatewayStartupConfig({
+            configSnapshot: buildSnapshot(config),
+            activateRuntimeSecrets,
+          });
+
+          expect(startup.cfg.gateway?.auth?.token).toBe("resolved-gateway-token");
+          expect(startup.cfg.channels).toBeUndefined();
+          const activeStartup = getActiveSecretsRuntimeSnapshot();
+          if (!activeStartup) {
+            throw new Error("Expected an active startup secrets snapshot");
+          }
+          expect(activeStartup.sourceConfig.gateway?.auth?.token).toEqual(gatewayTokenRef);
+          expect(activeStartup.sourceConfig.channels?.telegram?.botToken).toEqual(channelTokenRef);
+          expect(activeStartup.config.channels).toBeUndefined();
+
+          process.env[CHANNEL_TOKEN_ENV] = "restored-channel-token";
+          const reloaded = await activateRuntimeSecrets(activeStartup.sourceConfig, {
+            reason: "reload",
+            activate: true,
+          });
+
+          expect(reloaded.sourceConfig.channels?.telegram?.botToken).toEqual(channelTokenRef);
+          expect(reloaded.config.gateway?.auth?.token).toBe("resolved-gateway-token");
+          expect(reloaded.config.channels?.telegram?.botToken).toBe("restored-channel-token");
+          expect(getActiveSecretsRuntimeSnapshot()?.config.channels?.telegram?.botToken).toBe(
+            "restored-channel-token",
+          );
+        },
+      );
+    },
+    SECRETS_RUNTIME_INTEGRATION_TIMEOUT_MS,
+  );
+});

--- a/src/gateway/server-startup-config.breaker-secrets.integration.test.ts
+++ b/src/gateway/server-startup-config.breaker-secrets.integration.test.ts
@@ -83,13 +83,13 @@ describe("gateway breaker SecretRef integration", () => {
             gateway: {
               auth: {
                 mode: "token",
-                token: gatewayTokenRef,
+                token: { ...gatewayTokenRef },
               },
             },
             channels: {
               telegram: {
                 enabled: true,
-                botToken: channelTokenRef,
+                botToken: { ...channelTokenRef },
               },
             },
           });

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -18,7 +18,6 @@ import { applyConfigOverrides } from "../config/runtime-overrides.js";
 import type { GatewayAuthConfig, GatewayTailscaleConfig } from "../config/types.gateway.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import { measureDiagnosticsTimelineSpan } from "../infra/diagnostics-timeline.js";
-import { isTruthyEnvValue } from "../infra/env.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { prepareSecretsRuntimeFastPathSnapshot } from "../secrets/runtime-fast-path.js";
@@ -35,6 +34,11 @@ import {
 import { createLazyPromise } from "../shared/lazy-runtime.js";
 import { resolveGatewayAuth } from "./auth.js";
 import { assertGatewayAuthNotKnownWeak } from "./known-weak-gateway-secrets.js";
+import type { ChannelAutostartSuppression } from "./server-channels.js";
+import {
+  resolveGatewayStartupSecretProjection,
+  resolveGatewayStartupSourceConfig,
+} from "./server-startup-secret-surfaces.js";
 import {
   ensureGatewayStartupAuth,
   mergeGatewayAuthConfig,
@@ -189,6 +193,7 @@ export function createRuntimeSecretsActivator(params: {
   activateRuntimeSecretsSnapshot?: ActivateRuntimeSecretsSnapshot;
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
   pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins" | "manifestRegistry">;
+  channelAutostartSuppression?: ChannelAutostartSuppression | null;
 }): ActivateRuntimeSecrets {
   let secretsDegraded = false;
   let secretsActivationTail: Promise<void> = Promise.resolve();
@@ -279,16 +284,23 @@ export function createRuntimeSecretsActivator(params: {
   const activateRuntimeSecrets = (async (config, activationParams) =>
     await runWithSecretsActivationLock(async () => {
       try {
+        const { sourceConfig, assignmentConfig } = resolveGatewayStartupSecretProjection({
+          config,
+          reason: activationParams.reason,
+          channelAutostartSuppression: params.channelAutostartSuppression,
+          ...(activationParams.env ? { env: activationParams.env } : {}),
+        });
         const startupPreflight =
           activationParams.reason === "startup" || activationParams.reason === "restart-check";
         if (
           activationParams.reason === "startup" &&
           activationParams.activate &&
           !params.prepareRuntimeSecretsSnapshot &&
-          !params.activateRuntimeSecretsSnapshot
+          !params.activateRuntimeSecretsSnapshot &&
+          assignmentConfig === sourceConfig
         ) {
           const fastPath = prepareSecretsRuntimeFastPathSnapshot({
-            config: pruneSkippedStartupSecretSurfaces(config),
+            config: sourceConfig,
             ...(startupManifestRegistry ? { manifestRegistry: startupManifestRegistry } : {}),
           });
           if (fastPath) {
@@ -326,7 +338,8 @@ export function createRuntimeSecretsActivator(params: {
           "secrets.prepare",
           () =>
             prepareRuntimeSecretsSnapshot({
-              config: pruneSkippedStartupSecretSurfaces(config),
+              config: sourceConfig,
+              ...(assignmentConfig !== sourceConfig ? { assignmentConfig } : {}),
               ...(activationParams.env ? { env: activationParams.env } : {}),
               includeAuthStoreRefs: activationParams.includeAuthStoreRefs,
               ...(startupManifestRegistry ? { manifestRegistry: startupManifestRegistry } : {}),
@@ -478,7 +491,10 @@ export async function prepareGatewayStartupConfig(params: {
     Boolean(
       preflightPrepared &&
       params.activateRuntimeSecrets.activatePreparedSnapshot &&
-      isDeepStrictEqual(pruneSkippedStartupSecretSurfaces(config), preflightPrepared.sourceConfig),
+      isDeepStrictEqual(
+        resolveGatewayStartupSourceConfig(config, process.env),
+        preflightPrepared.sourceConfig,
+      ),
     );
   const activateStartupSecrets = async (config: OpenClawConfig) => {
     // Reuse the preflight snapshot only if generated startup auth did not
@@ -549,19 +565,6 @@ function hasActiveGatewayAuthSecretRef(config: OpenClawConfig): boolean {
     const state = states[path];
     return state.hasSecretRef && state.active;
   });
-}
-
-function pruneSkippedStartupSecretSurfaces(config: OpenClawConfig): OpenClawConfig {
-  const skipChannels =
-    isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
-    isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS);
-  if (!skipChannels || !config.channels) {
-    return config;
-  }
-  return {
-    ...config,
-    channels: undefined,
-  };
 }
 
 function assertRuntimeGatewayAuthNotKnownWeak(config: OpenClawConfig): void {

--- a/src/gateway/server-startup-secret-surfaces.test.ts
+++ b/src/gateway/server-startup-secret-surfaces.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveGatewayStartupSecretProjection } from "./server-startup-secret-surfaces.js";
+
+function channelConfig(): OpenClawConfig {
+  return {
+    channels: {
+      telegram: {
+        botToken: "test-token",
+      },
+    },
+  };
+}
+
+describe("gateway startup secret surfaces", () => {
+  it("preserves source while pruning breaker-suppressed startup assignments", () => {
+    const config = channelConfig();
+    const projection = resolveGatewayStartupSecretProjection({
+      config,
+      reason: "startup",
+      channelAutostartSuppression: {
+        reason: "crash-loop-breaker",
+        message: "safe mode",
+      },
+      env: {},
+    });
+
+    expect(projection.sourceConfig).toBe(config);
+    expect(projection.sourceConfig.channels).toBeDefined();
+    expect(projection.assignmentConfig.channels).toBeUndefined();
+  });
+
+  it.each(["reload", "restart-check"] as const)(
+    "keeps full assignments during %s while startup suppression is active",
+    (reason) => {
+      const config = channelConfig();
+      const projection = resolveGatewayStartupSecretProjection({
+        config,
+        reason,
+        channelAutostartSuppression: {
+          reason: "crash-loop-breaker",
+          message: "safe mode",
+        },
+        env: {},
+      });
+
+      expect(projection.sourceConfig).toBe(config);
+      expect(projection.assignmentConfig).toBe(config);
+    },
+  );
+
+  it("keeps full startup assignments without breaker suppression", () => {
+    const config = channelConfig();
+    const projection = resolveGatewayStartupSecretProjection({
+      config,
+      reason: "startup",
+      channelAutostartSuppression: null,
+      env: {},
+    });
+
+    expect(projection.sourceConfig).toBe(config);
+    expect(projection.assignmentConfig).toBe(config);
+  });
+
+  it("preserves explicit skip behavior", () => {
+    const projection = resolveGatewayStartupSecretProjection({
+      config: channelConfig(),
+      reason: "startup",
+      env: { OPENCLAW_SKIP_CHANNELS: "1" },
+    });
+
+    expect(projection.sourceConfig.channels).toBeUndefined();
+    expect(projection.assignmentConfig).toBe(projection.sourceConfig);
+  });
+});

--- a/src/gateway/server-startup-secret-surfaces.test.ts
+++ b/src/gateway/server-startup-secret-surfaces.test.ts
@@ -6,7 +6,7 @@ function channelConfig(): OpenClawConfig {
   return {
     channels: {
       telegram: {
-        botToken: "test-token",
+        botToken: "example",
       },
     },
   };

--- a/src/gateway/server-startup-secret-surfaces.ts
+++ b/src/gateway/server-startup-secret-surfaces.ts
@@ -1,0 +1,47 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isTruthyEnvValue } from "../infra/env.js";
+import type { ChannelAutostartSuppression } from "./server-channels.js";
+
+type GatewaySecretsActivationReason = "startup" | "reload" | "restart-check";
+
+/**
+ * Keeps the recoverable source config separate from the SecretRef assignment
+ * surface that is safe to resolve during crash-loop recovery.
+ */
+export function resolveGatewayStartupSecretProjection(params: {
+  config: OpenClawConfig;
+  reason: GatewaySecretsActivationReason;
+  channelAutostartSuppression?: ChannelAutostartSuppression | null;
+  env?: NodeJS.ProcessEnv;
+}): { sourceConfig: OpenClawConfig; assignmentConfig: OpenClawConfig } {
+  const sourceConfig = resolveGatewayStartupSourceConfig(params.config, params.env ?? process.env);
+  if (
+    params.reason !== "startup" ||
+    params.channelAutostartSuppression == null ||
+    !sourceConfig.channels
+  ) {
+    return { sourceConfig, assignmentConfig: sourceConfig };
+  }
+  return {
+    sourceConfig,
+    assignmentConfig: {
+      ...sourceConfig,
+      channels: undefined,
+    },
+  };
+}
+
+export function resolveGatewayStartupSourceConfig(
+  config: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+): OpenClawConfig {
+  const skipChannels =
+    isTruthyEnvValue(env.OPENCLAW_SKIP_CHANNELS) || isTruthyEnvValue(env.OPENCLAW_SKIP_PROVIDERS);
+  if (!skipChannels || !config.channels) {
+    return config;
+  }
+  return {
+    ...config,
+    channels: undefined,
+  };
+}

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -653,11 +653,11 @@ export async function startGatewayServer(
   const activateRuntimeSecrets = createRuntimeSecretsActivator({
     logSecrets,
     emitStateEvent: emitSecretsStateEvent,
+    channelAutostartSuppression: opts.channelAutostartSuppression,
     ...(startupConfigLoad.pluginMetadataSnapshot
       ? { pluginMetadataSnapshot: startupConfigLoad.pluginMetadataSnapshot }
       : {}),
   });
-
   let startupInternalWriteHash: string | null = null;
   let startupLastGoodSnapshot = configSnapshot;
   const startupActivationSourceConfig = configSnapshot.sourceConfig;


### PR DESCRIPTION
<!-- submission-timestamps:start -->
First submission time: July 13, 2026, 5:23 PM EDT/21:23 UTC. 
Last edit time of the main text: July 14, 2026, 11:45 PM EDT/03:45 UTC.
Latest head submission time: July 14, 2026, 11:30 PM EDT/03:30 UTC.
<!-- submission-timestamps:end -->

Closes #106379.

Supersedes #106405, which was closed after this PR became the covering implementation.

AI-assisted: yes. The runtime path, source/assignment snapshot contract, competing implementation, focused tests, official CI, and generated-systemd proof were reviewed for the current head.

## What Problem This Solves

Fixes an issue where operators running a supervised Gateway could lose the control plane when the persisted crash-loop breaker suppressed channel autostart but an enabled channel SecretRef was unavailable.

## Why This Change Was Made

The fix separates the complete recovery source config from the startup assignment projection. Only breaker-suppressed startup omits channel assignments; reload, restart-check, Gateway authentication, and non-channel secret behavior remain unchanged.

## User Impact

Safe mode can now reach an authenticated control plane. Operators can restore the missing channel secret and reload without weakening normal startup or Gateway-auth failure handling.

## Evidence

- [Generated-systemd before/after and Gateway-auth proof](https://github.com/snowzlmbot/openclaw/actions/runs/29386734158) passed on production-equivalent head `485c2110869b4b02fe67614c4dd4d69b1f1cc807`.
- [Blacksmith Testbox changed-surface proof](https://github.com/openclaw/openclaw/actions/runs/29387049437) passed 28 focused/adjacent tests and `pnpm check:changed`.
- Exact current head `0b2c96a2cb2f0b3e17783b808b904b5238a14e92` passed the two test-only maintainer cleanup suites locally: 1/1 integration and 5/5 projection tests.

## Summary

When the persisted crash-loop breaker has already suppressed channel autostart, unavailable channel SecretRefs no longer prevent the Gateway control plane from starting.

The patch preserves the complete secrets `sourceConfig` for recovery while applying breaker suppression only to the startup `assignmentConfig`. Normal startup, reload, restart-check, Gateway authentication, and non-channel required secrets retain their existing behavior.

## Breaking Changes

None. There are no config, protocol, dependency, schema, storage, or migration changes.

## Why / User Impact

Before this change, the breaker reported safe mode but eager SecretRef activation still resolved enabled channel credentials. One unavailable channel SecretRef therefore kept the supervised Gateway in a restart loop and left the control plane unavailable.

After this change:

- breaker-suppressed startup can reach a stable, authenticated control plane;
- channel assignments remain absent during that startup;
- the canonical channel-bearing source config remains available for a later reload;
- normal startup remains fail-loud; and
- missing Gateway-auth or other required non-channel secrets still prevent startup.

## Implementation

- Added `src/gateway/server-startup-secret-surfaces.ts` as the bounded owner for startup source/assignment projection.
- Passed the existing `ChannelAutostartSuppression` decision into the Gateway secrets activator.
- Preserved explicit `OPENCLAW_SKIP_CHANNELS` / `OPENCLAW_SKIP_PROVIDERS` semantics by pruning the source config for those operator-selected modes.
- For crash-loop suppression only, and only for `reason: "startup"`, retained the full source config while removing channels from the assignment projection.
- Kept reload and restart-check assignment projections complete.
- Bypassed the startup secrets fast path only when the source and assignment projections differ, so the existing full preparer owns the split contract.

## Code-Path Analysis

- Breaker entry and lifecycle owner: `src/cli/gateway-cli/run.ts` computes channel autostart suppression before each Gateway boot.
- Startup caller: `src/gateway/server.impl.ts` passes that suppression into secrets activation before channel-manager startup.
- Projection owner: `src/gateway/server-startup-config.ts` delegates source/assignment selection to `src/gateway/server-startup-secret-surfaces.ts`.
- Callee and data contract: `src/secrets/runtime.ts` accepts canonical `config` plus an optional `assignmentConfig`, stores the former as `sourceConfig`, and projects the latter into the active runtime snapshot.
- Sibling behavior: explicit skip environment variables still prune the source itself; reload and restart-check retain full assignments.
- Adjacent coverage: `src/gateway/server-startup-secret-surfaces.test.ts`, `src/gateway/server-startup-config.breaker-secrets.integration.test.ts`, `src/gateway/server-startup-config.secrets.test.ts`, and `src/infra/gateway-boot-lifecycle.test.ts`.

## Mainline Comparison

- Rebased implementation base: `OpenClaw/OpenClaw:main@a3f06fb119bb0817d5b7b66ddded55c80125e8b8`.
- Latest upstream observed while preparing this body: `ce078367e40d04b938271afbfab341952f12936e`.
- The single intervening upstream commit is documentation-only and does not modify this PR's Gateway startup, secrets runtime, channel lifecycle, or test surfaces.
- The two unrelated CI regressions encountered on earlier moving baselines were fixed upstream before this final rebase.

## Branch / Base Provenance

- Base repository/ref: `OpenClaw/OpenClaw:main`.
- Rebased base SHA: `a3f06fb119bb0817d5b7b66ddded55c80125e8b8`.
- Head repository/ref: `snowzlmbot/OpenClaw:fix/106379-preserve-suppressed-channel-config`.
- Current head SHA: `0b2c96a2cb2f0b3e17783b808b904b5238a14e92`.
- The implementation is isolated to this dedicated PR branch.
- The fork default branch has pre-existing divergence and was not modified by this work.
- Proof branch: `snowzlmbot/OpenClaw:evidence/pr-106826-systemd-proof`; it is not part of the PR diff.

## Dependency / Contract Verification

- No dependency or lockfile changes.
- No protocol, schema, permission, or persistent data-model changes.
- The patch uses the existing `prepareSecretsRuntimeSnapshot({ config, assignmentConfig })` contract.
- The integration test verifies that suppressed startup retains the unresolved channel SecretRef in `sourceConfig`, omits channels from the active startup snapshot, and restores the channel assignment after the credential becomes available and reload runs.

## Labels Considered

- `gateway`: the owner boundary is Gateway startup and secrets activation.
- `P0` / `impact:crash-loop`: the defect can keep the entire supervised Gateway unavailable.
- `merge-risk: security-boundary`: the patch changes which secret surfaces are resolved in breaker-selected safe mode while preserving fail-closed Gateway auth.
- `proof: sufficient`: exact-head focused tests and generated-systemd before/after evidence are available below.

## Validation

Local work was limited to static inspection and the two test-only maintainer cleanup suites; no local build result is claimed.

### Production-patch downstream proof

[Production-patch proof run](https://github.com/snowzlmbot/openclaw/actions/runs/29386734158) completed successfully on the dedicated evidence branch at `485c2110869b4b02fe67614c4dd4d69b1f1cc807`. The current head adds only scanner-safe test fixture cleanup.

- [Focused and adjacent regression tests](https://github.com/snowzlmbot/openclaw/actions/runs/29386734158/job/87261484704): success.
- [Before-fix generated-systemd reproduction](https://github.com/snowzlmbot/openclaw/actions/runs/29386734158/job/87261484819): success; official base `a3f06fb119bb0817d5b7b66ddded55c80125e8b8` continues restarting after the breaker.
- [After-fix generated-systemd convergence](https://github.com/snowzlmbot/openclaw/actions/runs/29386734158/job/87261484747): success; the production patch stabilizes with a reachable control plane.
- [After-fix Gateway-auth fail-closed proof](https://github.com/snowzlmbot/openclaw/actions/runs/29386734158/job/87261484730): success; an unavailable Gateway-auth SecretRef still prevents control-plane startup.

### Upstream PR CI

[Predecessor-head upstream CI](https://github.com/openclaw/openclaw/actions/runs/29386697097) passed build artifacts, lint, production/test types, dependency and security guards, LOC ratchet, QA smoke profiles, channel/plugin contracts, and all selected Node shards except one unrelated process-timing test.

`checks-node-compact-small-whole-2` timed out in `src/cli/hooks-cli.process.test.ts` while waiting for `hooks relay pre_tool_use` to exit after output. This file and lifecycle are outside the five-file PR diff. The aggregate `openclaw/ci-gate` was red only because of that shard. Exact-current-head CI was retriggered after the test-only maintainer commits.

## Evidence Source Map

- Before-fix availability failure: generated systemd user service on the official base, missing channel SecretRef, breaker event, continued post-breaker secret failures, and increasing restart count.
- After-fix availability: same generated-service scenario on the PR production patch, active/running service, stable restart count, health/readiness success, and authenticated Gateway RPC success.
- Security boundary: same production patch with a missing Gateway-auth SecretRef remains unavailable after the breaker.
- Source preservation: focused unit and integration tests verify full `sourceConfig`, startup-only channel assignment omission, complete reload/restart-check projections, and explicit skip compatibility.
- Artifacts: sanitized `journal.txt` and `summary.txt` files are retained by the proof run.

## Sanitized Logs

Before fix (`a3f06fb119bb0817d5b7b66ddded55c80125e8b8`):

```text
breaker_events=1
post_breaker_missing_secret_failures=2
restarts_before_stability_window=3
restarts_after_stability_window=5
```

After fix (`485c2110869b4b02fe67614c4dd4d69b1f1cc807`):

```text
active_state=active
sub_state=running
breaker_events=1
post_breaker_missing_secret_failures=0
restarts_before_stability_window=3
restarts_after_stability_window=3
safe_mode_control_plane_convergence=success
suppressed_channel_secret_no_longer_fatal=success
```

Gateway-auth fail-closed (`485c2110869b4b02fe67614c4dd4d69b1f1cc807`):

```text
post_breaker_missing_secret_failures=2
restarts_before_stability_window=4
restarts_after_stability_window=5
```

The workflow redacts workspace, runner-temp, home, authentication tokens, and channel token values from uploaded journals.

## Media Evidence

This is a service/process lifecycle defect rather than a visual UI workflow. The proof therefore uses generated-systemd state, restart counters, health/readiness probes, authenticated RPC output, focused tests, and retained sanitized artifacts. No screenshot or video is presented as stronger evidence than those machine-verifiable signals.

## Review Context Addressed

- The competing implementation is closed as superseded by this focused branch.
- The source/assignment split is a runtime recovery requirement: reload uses the active snapshot's preserved `sourceConfig`.
- The implementation does not mutate process-wide skip state and does not weaken normal startup or Gateway authentication.
- The current branch was rebased after upstream repaired unrelated CI regressions, and production-patch evidence was regenerated.

## Risk

- Regression scope is limited to Gateway startup SecretRef projection while crash-loop suppression is active.
- A mistaken projection could suppress too much or too little; focused tests cover startup, reload, restart-check, normal startup, explicit skip behavior, and Gateway-auth fail-closed behavior.
- No automatic channel start behavior is changed.
- No dependency, performance-critical loop, persistent data, or permission surface changes.

## Rollback

Revert the implementation and test-fixture commits. No config, schema, database, secret-store, or irreversible data rollback is required.

## Docs Updated

No documentation change is required. The patch makes startup match the existing documented crash-loop safe-mode contract; it does not add a new operator command or configuration surface.

## Related

- Canonical issue: #106379
- Superseded implementation: #106405

## Not Tested / Limitations

- Generated-service proof covers the reported Linux systemd environment; launchd and Windows Scheduled Task supervisors were not run.
- No real external channel API credential was used; the defect occurs before channel traffic and is proven through SecretRef resolution, service convergence, and focused runtime tests.
- Exact-current-head upstream CI is still running after the two test-only maintainer commits.
