### PR TITLE
refactor(agents): extract attempt timeout phase

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-timeout-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-timeout-prepare.test.ts
@@ -1,0 +1,119 @@
+// Coverage for attempt timeout ownership and cleanup.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { prepareEmbeddedAttemptTimeout } from "./attempt-timeout-prepare.js";
+
+function createTimeoutHarness(options?: {
+  activeCompaction?: boolean;
+  pendingCompaction?: boolean;
+  timeoutMs?: number;
+}) {
+  const state = {
+    activeCompaction: options?.activeCompaction ?? false,
+    pendingCompaction: options?.pendingCompaction ?? false,
+    streaming: false,
+  };
+  const abortController = new AbortController();
+  const abortRun = vi.fn();
+  const markExternalAbort = vi.fn();
+  const markTimedOutDuringCompaction = vi.fn();
+  const markTimedOutByRunBudget = vi.fn();
+  const onAttemptTimeoutArmed = vi.fn();
+  const timeout = prepareEmbeddedAttemptTimeout({
+    attempt: {
+      runId: "run-1",
+      sessionId: "session-1",
+      timeoutMs: options?.timeoutMs ?? 100,
+      abortSignal: abortController.signal,
+      onAttemptTimeoutArmed,
+    },
+    activeSession: {
+      get isCompacting() {
+        return state.activeCompaction;
+      },
+      get isStreaming() {
+        return state.streaming;
+      },
+    },
+    compactionState: {
+      isCompacting: () => state.pendingCompaction,
+    },
+    compactionTimeoutMs: 50,
+    isProbeSession: true,
+    abortRun,
+    markExternalAbort,
+    markTimedOutDuringCompaction,
+    markTimedOutByRunBudget,
+  });
+  return {
+    abortController,
+    abortRun,
+    markExternalAbort,
+    markTimedOutDuringCompaction,
+    markTimedOutByRunBudget,
+    onAttemptTimeoutArmed,
+    state,
+    timeout,
+  };
+}
+
+describe("prepareEmbeddedAttemptTimeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("arms and fires the run budget timeout", async () => {
+    const harness = createTimeoutHarness();
+
+    expect(harness.onAttemptTimeoutArmed).toHaveBeenCalledOnce();
+    expect(harness.timeout.getRunAbortDeadlineAtMs()).toBe(100);
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(harness.markTimedOutByRunBudget).toHaveBeenCalledOnce();
+    expect(harness.abortRun).toHaveBeenCalledWith(true);
+    harness.timeout.clearTimers();
+  });
+
+  it("grants one compaction grace window before aborting", async () => {
+    const harness = createTimeoutHarness({ pendingCompaction: true });
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(harness.abortRun).not.toHaveBeenCalled();
+    expect(harness.timeout.getRunAbortDeadlineAtMs()).toBe(150);
+
+    harness.state.pendingCompaction = false;
+    await vi.advanceTimersByTimeAsync(50);
+    expect(harness.abortRun).toHaveBeenCalledWith(true);
+    harness.timeout.clearTimers();
+  });
+
+  it("classifies an external timeout during compaction", () => {
+    const harness = createTimeoutHarness({ activeCompaction: true });
+    const reason = new Error("request timed out");
+    reason.name = "TimeoutError";
+
+    harness.abortController.abort(reason);
+
+    expect(harness.markExternalAbort).toHaveBeenCalledOnce();
+    expect(harness.markTimedOutDuringCompaction).toHaveBeenCalledOnce();
+    expect(harness.abortRun).toHaveBeenCalledWith(true, reason);
+    harness.timeout.clearTimers();
+  });
+
+  it("cleans up both the timer and external abort listener", async () => {
+    const harness = createTimeoutHarness();
+
+    harness.timeout.clearTimers();
+    harness.timeout.removeAbortSignalListener();
+    harness.abortController.abort(new Error("late abort"));
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(harness.markExternalAbort).not.toHaveBeenCalled();
+    expect(harness.markTimedOutByRunBudget).not.toHaveBeenCalled();
+    expect(harness.abortRun).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-timeout-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-timeout-prepare.ts
@@ -1,0 +1,139 @@
+/**
+ * Owns the run deadline, compaction grace, and external abort listener.
+ */
+import { isSignalTimeoutReason } from "../../failover-error.js";
+import type { AgentSession } from "../../sessions/index.js";
+import { log } from "../logger.js";
+import {
+  resolveRunTimeoutDuringCompaction,
+  shouldFlagCompactionTimeout,
+} from "./compaction-timeout.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type AttemptCompactionState = {
+  isCompacting(): boolean;
+};
+
+type EmbeddedAttemptTimeoutParams = Pick<
+  EmbeddedRunAttemptParams,
+  "abortSignal" | "onAttemptTimeoutArmed" | "runId" | "sessionId" | "timeoutMs"
+>;
+
+function getAbortReason(signal: AbortSignal): unknown {
+  return "reason" in signal ? (signal as { reason?: unknown }).reason : undefined;
+}
+
+export function prepareEmbeddedAttemptTimeout(input: {
+  attempt: EmbeddedAttemptTimeoutParams;
+  activeSession: Pick<AgentSession, "isCompacting" | "isStreaming">;
+  compactionState: AttemptCompactionState;
+  compactionTimeoutMs: number;
+  isProbeSession: boolean;
+  abortRun: (isTimeout?: boolean, reason?: unknown) => void;
+  markExternalAbort: () => void;
+  markTimedOutDuringCompaction: () => void;
+  markTimedOutByRunBudget: () => void;
+}) {
+  const { activeSession, attempt } = input;
+  let abortWarnTimer: NodeJS.Timeout | undefined;
+  let abortTimer: NodeJS.Timeout | undefined;
+  let runAbortDeadlineAtMs = Date.now() + attempt.timeoutMs;
+  let compactionGraceUsed = false;
+
+  const scheduleAbortTimer = (delayMs: number, reason: "initial" | "compaction-grace") => {
+    runAbortDeadlineAtMs = Date.now() + Math.max(1, delayMs);
+    abortTimer = setTimeout(
+      () => {
+        const timeoutAction = resolveRunTimeoutDuringCompaction({
+          isCompactionPendingOrRetrying: input.compactionState.isCompacting(),
+          isCompactionInFlight: activeSession.isCompacting,
+          graceAlreadyUsed: compactionGraceUsed,
+        });
+        if (timeoutAction === "extend") {
+          compactionGraceUsed = true;
+          if (!input.isProbeSession) {
+            log.warn(
+              `embedded run timeout reached during compaction; extending deadline: ` +
+                `runId=${attempt.runId} sessionId=${attempt.sessionId} extraMs=${input.compactionTimeoutMs}`,
+            );
+          }
+          scheduleAbortTimer(input.compactionTimeoutMs, "compaction-grace");
+          return;
+        }
+
+        if (!input.isProbeSession) {
+          log.warn(
+            reason === "compaction-grace"
+              ? `embedded run timeout after compaction grace: runId=${attempt.runId} sessionId=${attempt.sessionId} timeoutMs=${attempt.timeoutMs} compactionGraceMs=${input.compactionTimeoutMs}`
+              : `embedded run timeout: runId=${attempt.runId} sessionId=${attempt.sessionId} timeoutMs=${attempt.timeoutMs}`,
+          );
+        }
+        if (
+          shouldFlagCompactionTimeout({
+            isTimeout: true,
+            isCompactionPendingOrRetrying: input.compactionState.isCompacting(),
+            isCompactionInFlight: activeSession.isCompacting,
+          })
+        ) {
+          input.markTimedOutDuringCompaction();
+        }
+        input.markTimedOutByRunBudget();
+        input.abortRun(true);
+        if (!abortWarnTimer) {
+          abortWarnTimer = setTimeout(() => {
+            if (!activeSession.isStreaming) {
+              return;
+            }
+            if (!input.isProbeSession) {
+              log.warn(
+                `embedded run abort still streaming: runId=${attempt.runId} sessionId=${attempt.sessionId}`,
+              );
+            }
+          }, 10_000);
+        }
+      },
+      Math.max(1, delayMs),
+    );
+  };
+
+  scheduleAbortTimer(attempt.timeoutMs, "initial");
+  attempt.onAttemptTimeoutArmed?.();
+
+  const onAbort = () => {
+    input.markExternalAbort();
+    const reason = attempt.abortSignal ? getAbortReason(attempt.abortSignal) : undefined;
+    const timeout = reason ? isSignalTimeoutReason(reason) : false;
+    if (
+      shouldFlagCompactionTimeout({
+        isTimeout: timeout,
+        isCompactionPendingOrRetrying: input.compactionState.isCompacting(),
+        isCompactionInFlight: activeSession.isCompacting,
+      })
+    ) {
+      input.markTimedOutDuringCompaction();
+    }
+    input.abortRun(timeout, reason);
+  };
+  if (attempt.abortSignal) {
+    if (attempt.abortSignal.aborted) {
+      onAbort();
+    } else {
+      attempt.abortSignal.addEventListener("abort", onAbort, { once: true });
+    }
+  }
+
+  return {
+    getRunAbortDeadlineAtMs: () => runAbortDeadlineAtMs,
+    clearTimers: () => {
+      if (abortTimer) {
+        clearTimeout(abortTimer);
+      }
+      if (abortWarnTimer) {
+        clearTimeout(abortWarnTimer);
+      }
+    },
+    removeAbortSignalListener: () => {
+      attempt.abortSignal?.removeEventListener("abort", onAbort);
+    },
+  };
+}

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -137,6 +137,7 @@ import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
 import { prepareEmbeddedAttemptTransport } from "./attempt-stream-transport.js";
 import { installEmbeddedAttemptStreamGuards } from "./attempt-stream.js";
 import { prepareEmbeddedAttemptSystemPrompt } from "./attempt-system-prompt-prepare.js";
+import { prepareEmbeddedAttemptTimeout } from "./attempt-timeout-prepare.js";
 import { prepareEmbeddedAttemptToolBase } from "./attempt-tool-base-prepare.js";
 import { prepareEmbeddedAttemptToolCatalog } from "./attempt-tool-catalog.js";
 import { flushEmbeddedAttemptTrajectoryRecorder } from "./attempt-trajectory-flush-cleanup.js";
@@ -182,10 +183,7 @@ import {
 import { cleanupEmbeddedAttemptResources } from "./attempt.subscription-cleanup.js";
 import { composeSystemPromptWithHookContext } from "./attempt.thread-helpers.js";
 import { resolveAttemptTranscriptPolicy } from "./attempt.transcript-policy.js";
-import {
-  resolveRunTimeoutDuringCompaction,
-  shouldFlagCompactionTimeout,
-} from "./compaction-timeout.js";
+import { shouldFlagCompactionTimeout } from "./compaction-timeout.js";
 import { installHistoryImagePruneContextTransform } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
 import { installMessageToolOnlyTerminalHook } from "./message-tool-terminal.js";
@@ -1320,6 +1318,7 @@ export async function runEmbeddedAttempt(
       } = preparedHistory;
 
       let yieldAborted = false;
+      const isProbeSession = params.sessionId?.startsWith("probe-") ?? false;
       const abortCompaction = () => {
         if (!activeSession.isCompacting) {
           return;
@@ -1439,96 +1438,31 @@ export async function runEmbeddedAttempt(
       let finalPromptText: string | undefined;
       const queueHandleForAbandonment: EmbeddedAgentQueueHandle | undefined = queueHandle;
 
-      let abortWarnTimer: NodeJS.Timeout | undefined;
-      const isProbeSession = params.sessionId?.startsWith("probe-") ?? false;
-      let abortTimer: NodeJS.Timeout | undefined;
-      let runAbortDeadlineAtMs = Date.now() + params.timeoutMs;
-      let compactionGraceUsed = false;
-      const scheduleAbortTimer = (delayMs: number, reason: "initial" | "compaction-grace") => {
-        runAbortDeadlineAtMs = Date.now() + Math.max(1, delayMs);
-        abortTimer = setTimeout(
-          () => {
-            const timeoutAction = resolveRunTimeoutDuringCompaction({
-              isCompactionPendingOrRetrying: subscription.isCompacting(),
-              isCompactionInFlight: activeSession.isCompacting,
-              graceAlreadyUsed: compactionGraceUsed,
-            });
-            if (timeoutAction === "extend") {
-              compactionGraceUsed = true;
-              if (!isProbeSession) {
-                log.warn(
-                  `embedded run timeout reached during compaction; extending deadline: ` +
-                    `runId=${params.runId} sessionId=${params.sessionId} extraMs=${compactionTimeoutMs}`,
-                );
-              }
-              scheduleAbortTimer(compactionTimeoutMs, "compaction-grace");
-              return;
-            }
-
-            if (!isProbeSession) {
-              log.warn(
-                reason === "compaction-grace"
-                  ? `embedded run timeout after compaction grace: runId=${params.runId} sessionId=${params.sessionId} timeoutMs=${params.timeoutMs} compactionGraceMs=${compactionTimeoutMs}`
-                  : `embedded run timeout: runId=${params.runId} sessionId=${params.sessionId} timeoutMs=${params.timeoutMs}`,
-              );
-            }
-            if (
-              shouldFlagCompactionTimeout({
-                isTimeout: true,
-                isCompactionPendingOrRetrying: subscription.isCompacting(),
-                isCompactionInFlight: activeSession.isCompacting,
-              })
-            ) {
-              timedOutDuringCompaction = true;
-            }
-            timedOutByRunBudget = true;
-            abortRun(true);
-            if (!abortWarnTimer) {
-              abortWarnTimer = setTimeout(() => {
-                if (!activeSession.isStreaming) {
-                  return;
-                }
-                if (!isProbeSession) {
-                  log.warn(
-                    `embedded run abort still streaming: runId=${params.runId} sessionId=${params.sessionId}`,
-                  );
-                }
-              }, 10_000);
-            }
-          },
-          Math.max(1, delayMs),
-        );
-      };
-      scheduleAbortTimer(params.timeoutMs, "initial");
-      params.onAttemptTimeoutArmed?.();
-
+      const attemptTimeout = prepareEmbeddedAttemptTimeout({
+        attempt: params,
+        activeSession,
+        compactionState: subscription,
+        compactionTimeoutMs,
+        isProbeSession,
+        abortRun,
+        markExternalAbort: () => {
+          externalAbort = true;
+        },
+        markTimedOutDuringCompaction: () => {
+          timedOutDuringCompaction = true;
+        },
+        markTimedOutByRunBudget: () => {
+          timedOutByRunBudget = true;
+        },
+      });
+      const {
+        getRunAbortDeadlineAtMs,
+        clearTimers: clearAttemptTimeoutTimers,
+        removeAbortSignalListener: removeAttemptAbortSignalListener,
+      } = attemptTimeout;
       let messagesSnapshot: AgentMessage[] = [];
       let sessionIdUsed = activeSession.sessionId;
       let sessionFileUsed: string | undefined = params.sessionFile;
-      const onAbort = () => {
-        externalAbort = true;
-        const reason = params.abortSignal ? getAbortReason(params.abortSignal) : undefined;
-        const timeout = reason ? isSignalTimeoutReason(reason) : false;
-        if (
-          shouldFlagCompactionTimeout({
-            isTimeout: timeout,
-            isCompactionPendingOrRetrying: subscription.isCompacting(),
-            isCompactionInFlight: activeSession.isCompacting,
-          })
-        ) {
-          timedOutDuringCompaction = true;
-        }
-        abortRun(timeout, reason);
-      };
-      if (params.abortSignal) {
-        if (params.abortSignal.aborted) {
-          onAbort();
-        } else {
-          params.abortSignal.addEventListener("abort", onAbort, {
-            once: true,
-          });
-        }
-      }
 
       const activeSessionManager = sessionManager;
       let preflightRecovery: EmbeddedRunAttemptResult["preflightRecovery"];
@@ -2502,7 +2436,7 @@ export async function runEmbeddedAttempt(
           markTimedOutDuringCompaction: () => {
             timedOutDuringCompaction = true;
           },
-          runAbortDeadlineAtMs,
+          runAbortDeadlineAtMs: getRunAbortDeadlineAtMs(),
           runAbortSignal: runAbortController.signal,
           isProbeSession,
           onBlockReplyFlush,
@@ -2584,10 +2518,7 @@ export async function runEmbeddedAttempt(
         sessionIdUsed = afterTurn.sessionIdUsed;
         sessionFileUsed = afterTurn.sessionFileUsed;
       } finally {
-        clearTimeout(abortTimer);
-        if (abortWarnTimer) {
-          clearTimeout(abortWarnTimer);
-        }
+        clearAttemptTimeoutTimers();
         if (!isProbeSession && (aborted || timedOut) && !timedOutDuringCompaction) {
           log.debug(
             `run cleanup: runId=${params.runId} sessionId=${params.sessionId} aborted=${aborted} timedOut=${timedOut}`,
@@ -2612,7 +2543,7 @@ export async function runEmbeddedAttempt(
           params.sessionKey,
           params.sessionFile,
         );
-        params.abortSignal?.removeEventListener?.("abort", onAbort);
+        removeAttemptAbortSignalListener();
       }
 
       const beforeAgentFinalizeRevisionReason = getBeforeAgentFinalizeRevisionReason();


### PR DESCRIPTION
## What Problem This Solves

`runEmbeddedAttempt` still owned the full timeout lifecycle: run-budget deadlines, compaction grace, external abort classification, delayed streaming warnings, and split cleanup. That lifecycle was separable from attempt orchestration and kept the hotspot difficult to review.

Related: #72072

## Why This Change Was Made

- Extract timeout ownership into `prepareEmbeddedAttemptTimeout` with a narrow input contract.
- Preserve the existing single compaction grace window, timeout classification, callback order, and delayed streaming warning.
- Keep timer cleanup and abort-listener removal as separate operations so the existing `finally` ordering remains unchanged.
- Add focused fake-timer coverage for budget expiry, grace extension, external timeout classification, and cleanup.

## User Impact

No intended behavior change. `attempt.ts` drops from 2,796 to 2,727 lines, while timeout behavior becomes independently testable and easier to change safely.

## Evidence

- Blacksmith Testbox `tbx_01kxenb63r1rvgeaw658zbe8bq`: 141 focused tests passed (121 attempt, 16 compaction-timeout, 4 timeout-owner).
- Same exact-head Testbox: scoped `check:changed` passed, including core and core-test types, formatting, lint, LOC ratchet, import-cycle scan, and repository guards.
- Fresh autoreview: no accepted/actionable findings.
- `git diff --check` passed.

Hosted CI intentionally not awaited per maintainer instruction.
