### PR TITLE
refactor(channels): migrate googlechat, imessage, and whatsapp group policy onto the scope tree

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-a79050188f3f8c3706b63718f710a0359e24a3882bf14fc1dcee6a078a72cf30  plugin-sdk-api-baseline.json
-92e7af85e5eb68cccf5bd757ba6272a57ebff6652fbce01577d39c3a49ebe506  plugin-sdk-api-baseline.jsonl
+3b50f444490a039391833942dea00febb0db15639eaf936400d5a960895df424  plugin-sdk-api-baseline.json
+772798b1d0a4063c2b610b69247723ce3bda42547f220d8ed39df192b709482b  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-9bc00d1b67cf1902b3deb36a79553684cccd0cf5d405e9bf0373065ec1e1005f  plugin-sdk-api-baseline.json
-517cab00f614e15bf68b68468b0398c9faae6a8035dbfd7512e6527d815046c5  plugin-sdk-api-baseline.jsonl
+a79050188f3f8c3706b63718f710a0359e24a3882bf14fc1dcee6a078a72cf30  plugin-sdk-api-baseline.json
+92e7af85e5eb68cccf5bd757ba6272a57ebff6652fbce01577d39c3a49ebe506  plugin-sdk-api-baseline.jsonl

--- a/extensions/googlechat/src/group-policy.test.ts
+++ b/extensions/googlechat/src/group-policy.test.ts
@@ -1,0 +1,55 @@
+// Googlechat tests cover group policy plugin behavior.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it } from "vitest";
+import { resolveGoogleChatGroupRequireMention } from "./group-policy.js";
+
+describe("googlechat group policy", () => {
+  it("resolves exact, wildcard, and unconfigured mention policies", () => {
+    const cfg = {
+      channels: {
+        googlechat: {
+          groups: {
+            "spaces/exact": { requireMention: false },
+            "*": { requireMention: true },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveGoogleChatGroupRequireMention({ cfg, groupId: "spaces/exact" })).toBe(false);
+    expect(resolveGoogleChatGroupRequireMention({ cfg, groupId: "spaces/other" })).toBe(true);
+    expect(resolveGoogleChatGroupRequireMention({ cfg: {}, groupId: "spaces/other" })).toBe(true);
+  });
+
+  it("uses account groups instead of root groups", () => {
+    const cfg = {
+      channels: {
+        googlechat: {
+          groups: { "spaces/exact": { requireMention: false } },
+          accounts: {
+            work: { groups: { "spaces/exact": { requireMention: true } } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGoogleChatGroupRequireMention({ cfg, accountId: "work", groupId: "spaces/exact" }),
+    ).toBe(true);
+  });
+
+  it("falls back to root groups for one account with an empty groups map", () => {
+    const cfg = {
+      channels: {
+        googlechat: {
+          groups: { "spaces/exact": { requireMention: false } },
+          accounts: { work: { groups: {} } },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGoogleChatGroupRequireMention({ cfg, accountId: "work", groupId: "spaces/exact" }),
+    ).toBe(false);
+  });
+});

--- a/extensions/googlechat/src/group-policy.ts
+++ b/extensions/googlechat/src/group-policy.ts
@@ -1,18 +1,17 @@
-// Googlechat plugin module implements group policy behavior.
-import { resolveChannelGroupRequireMention } from "openclaw/plugin-sdk/channel-policy";
+import {
+  buildChannelGroupsScopeTree,
+  resolveScopeRequireMention,
+} from "openclaw/plugin-sdk/channel-policy";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 
-type GoogleChatGroupContext = {
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  groupId?: string | null;
-};
+type GroupContext = { cfg: OpenClawConfig; accountId?: string | null; groupId?: string | null };
+function resolveScopePath(params: GroupContext) {
+  return params.groupId ? [params.groupId] : [];
+}
 
-export function resolveGoogleChatGroupRequireMention(params: GoogleChatGroupContext): boolean {
-  return resolveChannelGroupRequireMention({
-    cfg: params.cfg,
-    channel: "googlechat",
-    groupId: params.groupId,
-    accountId: params.accountId,
+export function resolveGoogleChatGroupRequireMention(params: GroupContext): boolean {
+  return resolveScopeRequireMention({
+    tree: buildChannelGroupsScopeTree(params.cfg, "googlechat", params.accountId),
+    path: resolveScopePath(params),
   });
 }

--- a/extensions/imessage/src/group-policy.test.ts
+++ b/extensions/imessage/src/group-policy.test.ts
@@ -1,0 +1,86 @@
+// Imessage tests cover group policy plugin behavior.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it } from "vitest";
+import {
+  resolveIMessageGroupRequireMention,
+  resolveIMessageGroupToolPolicy,
+} from "./group-policy.js";
+
+describe("imessage group policy", () => {
+  it("resolves exact, wildcard, and unconfigured policies", () => {
+    const cfg = {
+      channels: {
+        imessage: {
+          groups: {
+            exact: { requireMention: false, tools: { deny: ["exec"] } },
+            "*": { requireMention: true, tools: { allow: ["message.send"] } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveIMessageGroupRequireMention({ cfg, groupId: "exact" })).toBe(false);
+    expect(resolveIMessageGroupRequireMention({ cfg, groupId: "other" })).toBe(true);
+    expect(resolveIMessageGroupToolPolicy({ cfg, groupId: "exact" })).toEqual({
+      deny: ["exec"],
+    });
+    expect(resolveIMessageGroupToolPolicy({ cfg, groupId: "other" })).toEqual({
+      allow: ["message.send"],
+    });
+    expect(resolveIMessageGroupRequireMention({ cfg: {}, groupId: "other" })).toBe(true);
+    expect(resolveIMessageGroupToolPolicy({ cfg: {}, groupId: "other" })).toBeUndefined();
+  });
+
+  it("uses account groups and preserves the single-account empty fallback", () => {
+    const overrideCfg = {
+      channels: {
+        imessage: {
+          groups: { exact: { requireMention: false } },
+          accounts: { work: { groups: { exact: { requireMention: true } } } },
+        },
+      },
+    } as OpenClawConfig;
+    const fallbackCfg = {
+      channels: {
+        imessage: {
+          groups: { exact: { requireMention: false } },
+          accounts: { work: { groups: {} } },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveIMessageGroupRequireMention({
+        cfg: overrideCfg,
+        accountId: "work",
+        groupId: "exact",
+      }),
+    ).toBe(true);
+    expect(
+      resolveIMessageGroupRequireMention({
+        cfg: fallbackCfg,
+        accountId: "work",
+        groupId: "exact",
+      }),
+    ).toBe(false);
+  });
+
+  it("prefers sender-scoped tools", () => {
+    const cfg = {
+      channels: {
+        imessage: {
+          groups: {
+            exact: {
+              tools: { deny: ["exec"] },
+              toolsBySender: { "channel:imessage:alice": { allow: ["message.send"] } },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveIMessageGroupToolPolicy({ cfg, groupId: "exact", senderId: "alice" })).toEqual({
+      allow: ["message.send"],
+    });
+  });
+});

--- a/extensions/imessage/src/group-policy.ts
+++ b/extensions/imessage/src/group-policy.ts
@@ -1,7 +1,8 @@
 // Imessage plugin module implements group policy behavior.
 import {
-  resolveChannelGroupRequireMention,
-  resolveChannelGroupToolsPolicy,
+  buildChannelGroupsScopeTree,
+  resolveScopeRequireMention,
+  resolveScopeToolsPolicy,
   type GroupToolPolicyConfig,
 } from "openclaw/plugin-sdk/channel-policy";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
@@ -16,26 +17,24 @@ type IMessageGroupContext = {
   senderE164?: string | null;
 };
 
+function resolveScopePath(params: IMessageGroupContext) {
+  return params.groupId ? [params.groupId] : [];
+}
+
 export function resolveIMessageGroupRequireMention(params: IMessageGroupContext): boolean {
-  return resolveChannelGroupRequireMention({
-    cfg: params.cfg,
-    channel: "imessage",
-    groupId: params.groupId,
-    accountId: params.accountId,
+  return resolveScopeRequireMention({
+    tree: buildChannelGroupsScopeTree(params.cfg, "imessage", params.accountId),
+    path: resolveScopePath(params),
   });
 }
 
 export function resolveIMessageGroupToolPolicy(
   params: IMessageGroupContext,
 ): GroupToolPolicyConfig | undefined {
-  return resolveChannelGroupToolsPolicy({
-    cfg: params.cfg,
-    channel: "imessage",
-    groupId: params.groupId,
-    accountId: params.accountId,
-    senderId: params.senderId,
-    senderName: params.senderName,
-    senderUsername: params.senderUsername,
-    senderE164: params.senderE164,
+  return resolveScopeToolsPolicy({
+    ...params,
+    tree: buildChannelGroupsScopeTree(params.cfg, "imessage", params.accountId),
+    path: resolveScopePath(params),
+    messageProvider: "imessage",
   });
 }

--- a/extensions/whatsapp/src/group-policy.test.ts
+++ b/extensions/whatsapp/src/group-policy.test.ts
@@ -7,7 +7,7 @@ import {
 import type { OpenClawConfig } from "./runtime-api.js";
 
 describe("whatsapp group policy", () => {
-  it("uses generic channel group policy helpers", () => {
+  it("resolves exact, wildcard, and unconfigured policies", () => {
     const cfg = {
       channels: {
         whatsapp: {
@@ -33,5 +33,66 @@ describe("whatsapp group policy", () => {
     expect(resolveWhatsAppGroupToolPolicy({ cfg, groupId: "other@g.us" })).toEqual({
       allow: ["message.send"],
     });
+    expect(resolveWhatsAppGroupRequireMention({ cfg: {}, groupId: "other@g.us" })).toBe(true);
+    expect(resolveWhatsAppGroupToolPolicy({ cfg: {}, groupId: "other@g.us" })).toBeUndefined();
+  });
+
+  it("uses account groups and preserves the single-account empty fallback", () => {
+    const overrideCfg = {
+      channels: {
+        whatsapp: {
+          groups: { "1203630@g.us": { requireMention: false } },
+          accounts: {
+            work: { groups: { "1203630@g.us": { requireMention: true } } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const fallbackCfg = {
+      channels: {
+        whatsapp: {
+          groups: { "1203630@g.us": { requireMention: false } },
+          accounts: { work: { groups: {} } },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveWhatsAppGroupRequireMention({
+        cfg: overrideCfg,
+        accountId: "work",
+        groupId: "1203630@g.us",
+      }),
+    ).toBe(true);
+    expect(
+      resolveWhatsAppGroupRequireMention({
+        cfg: fallbackCfg,
+        accountId: "work",
+        groupId: "1203630@g.us",
+      }),
+    ).toBe(false);
+  });
+
+  it("prefers sender-scoped tools", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groups: {
+            "1203630@g.us": {
+              tools: { deny: ["exec"] },
+              toolsBySender: { "channel:whatsapp:alice": { allow: ["message.send"] } },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveWhatsAppGroupToolPolicy({
+        cfg,
+        groupId: "1203630@g.us",
+        senderId: "alice",
+      }),
+    ).toEqual({ allow: ["message.send"] });
   });
 });

--- a/extensions/whatsapp/src/group-policy.ts
+++ b/extensions/whatsapp/src/group-policy.ts
@@ -1,7 +1,8 @@
 // Whatsapp plugin module implements group policy behavior.
 import {
-  resolveChannelGroupRequireMention,
-  resolveChannelGroupToolsPolicy,
+  buildChannelGroupsScopeTree,
+  resolveScopeRequireMention,
+  resolveScopeToolsPolicy,
   type GroupToolPolicyConfig,
 } from "openclaw/plugin-sdk/channel-policy";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -16,26 +17,24 @@ type WhatsAppGroupContext = {
   senderE164?: string | null;
 };
 
+function resolveScopePath(params: WhatsAppGroupContext) {
+  return params.groupId ? [params.groupId] : [];
+}
+
 export function resolveWhatsAppGroupRequireMention(params: WhatsAppGroupContext): boolean {
-  return resolveChannelGroupRequireMention({
-    cfg: params.cfg,
-    channel: "whatsapp",
-    groupId: params.groupId,
-    accountId: params.accountId,
+  return resolveScopeRequireMention({
+    tree: buildChannelGroupsScopeTree(params.cfg, "whatsapp", params.accountId),
+    path: resolveScopePath(params),
   });
 }
 
 export function resolveWhatsAppGroupToolPolicy(
   params: WhatsAppGroupContext,
 ): GroupToolPolicyConfig | undefined {
-  return resolveChannelGroupToolsPolicy({
-    cfg: params.cfg,
-    channel: "whatsapp",
-    groupId: params.groupId,
-    accountId: params.accountId,
-    senderId: params.senderId,
-    senderName: params.senderName,
-    senderUsername: params.senderUsername,
-    senderE164: params.senderE164,
+  return resolveScopeToolsPolicy({
+    ...params,
+    tree: buildChannelGroupsScopeTree(params.cfg, "whatsapp", params.accountId),
+    path: resolveScopePath(params),
+    messageProvider: "whatsapp",
   });
 }

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -135,7 +135,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   types: 6,
   "agent-config-primitives": 2,
   "command-auth": 81,
-  compat: 158,
+  compat: 159,
   "direct-dm": 9,
   "direct-dm-access": 5,
   discord: 48,
@@ -159,7 +159,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "channel-pairing": 1,
   "conversation-runtime": 4,
   "channel-send-result": 1,
-  "channel-policy": 14,
+  "channel-policy": 15,
   "channel-route": 5,
   "session-store-runtime": 4,
   "session-transcript-runtime": 2,
@@ -203,19 +203,20 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       env,
     ),
     // ScopeTree adds six channel-policy exports, mirrored by compat, including three functions.
+    // Its flat channel-groups builder adds one function, also mirrored by compat.
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
-      10660,
+      10662,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS",
-      5366,
+      5368,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
-      3289,
+      3291,
       env,
     ),
     publicWildcardReexports: readPluginSdkSurfaceBudgetEnv(

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -135,7 +135,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   types: 6,
   "agent-config-primitives": 2,
   "command-auth": 81,
-  compat: 152,
+  compat: 158,
   "direct-dm": 9,
   "direct-dm-access": 5,
   discord: 48,
@@ -159,7 +159,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "channel-pairing": 1,
   "conversation-runtime": 4,
   "channel-send-result": 1,
-  "channel-policy": 8,
+  "channel-policy": 14,
   "channel-route": 5,
   "session-store-runtime": 4,
   "session-transcript-runtime": 2,
@@ -202,19 +202,20 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       327,
       env,
     ),
+    // ScopeTree adds six channel-policy exports, mirrored by compat, including three functions.
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
-      10648,
+      10660,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS",
-      5360,
+      5366,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
-      3283,
+      3289,
       env,
     ),
     publicWildcardReexports: readPluginSdkSurfaceBudgetEnv(

--- a/src/config/group-policy.ts
+++ b/src/config/group-policy.ts
@@ -330,7 +330,7 @@ export function resolveToolsBySender(
   return matchToolsBySenderPolicy(compiled, params);
 }
 
-function resolveChannelGroups(
+export function resolveChannelGroups(
   cfg: OpenClawConfig,
   channel: GroupPolicyChannel,
   accountId?: string | null,

--- a/src/config/group-scope-tree.test.ts
+++ b/src/config/group-scope-tree.test.ts
@@ -1,0 +1,296 @@
+// Verifies canonical group scope precedence and sender policy resolution.
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "./config.js";
+import { resolveChannelGroupRequireMention, resolveToolsBySender } from "./group-policy.js";
+import {
+  resolveScopeIntroHint,
+  resolveScopeRequireMention,
+  resolveScopeToolsPolicy,
+  type ScopeTree,
+} from "./group-scope-tree.js";
+
+describe("resolveScopeRequireMention", () => {
+  const scalarCases: Array<{
+    name: string;
+    tree: ScopeTree;
+    path: string[];
+    expected: boolean;
+  }> = [
+    {
+      name: "uses the most specific configured scope",
+      tree: {
+        defaults: { requireMention: false },
+        scopes: {
+          broad: { requireMention: false },
+          narrow: { requireMention: true },
+        },
+      },
+      path: ["broad", "narrow"],
+      expected: true,
+    },
+    {
+      name: "skips missing scope keys",
+      tree: { scopes: { broad: { requireMention: false } } },
+      path: ["broad", "missing"],
+      expected: false,
+    },
+    {
+      name: "uses defaults after path scopes",
+      tree: { defaults: { requireMention: false }, scopes: { room: {} } },
+      path: ["room"],
+      expected: false,
+    },
+    {
+      name: "defaults to requiring a mention",
+      tree: { scopes: {} },
+      path: ["missing"],
+      expected: true,
+    },
+  ];
+
+  it.each(scalarCases)("$name", ({ tree, path, expected }) => {
+    expect(resolveScopeRequireMention({ tree, path })).toBe(expected);
+  });
+
+  it("honors Telegram wildcard-topic precedence encoded by the path", () => {
+    const tree: ScopeTree = {
+      scopes: {
+        "*#topic:7": { requireMention: false },
+        "<chat>": { requireMention: true },
+      },
+    };
+
+    expect(
+      resolveScopeRequireMention({
+        tree,
+        path: ["*", "<chat>", "*#topic:7", "<chat>#topic:7"],
+      }),
+    ).toBe(false);
+  });
+
+  it.each([
+    {
+      name: "no override",
+      configured: false,
+      override: undefined,
+      overrideOrder: undefined,
+    },
+    {
+      name: "before-config override",
+      configured: false,
+      override: true,
+      overrideOrder: "before-config" as const,
+    },
+    {
+      name: "after-config override",
+      configured: false,
+      override: true,
+      overrideOrder: "after-config" as const,
+    },
+    {
+      name: "after-config fallback override",
+      configured: undefined,
+      override: false,
+      overrideOrder: "after-config" as const,
+    },
+  ])("matches flat group-policy behavior: $name", ({ configured, override, overrideOrder }) => {
+    const node = typeof configured === "boolean" ? { requireMention: configured } : {};
+    const tree: ScopeTree = { scopes: { room: node } };
+    const cfg = {
+      channels: { whatsapp: { groups: { room: node } } },
+    } as OpenClawConfig;
+
+    expect(
+      resolveScopeRequireMention({
+        tree,
+        path: ["room"],
+        requireMentionOverride: override,
+        overrideOrder,
+      }),
+    ).toBe(
+      resolveChannelGroupRequireMention({
+        cfg,
+        channel: "whatsapp",
+        groupId: "room",
+        requireMentionOverride: override,
+        overrideOrder,
+      }),
+    );
+  });
+
+  it("defaults configured-but-unset scopes to no mention only when requested", () => {
+    const tree: ScopeTree = { scopes: { configured: {} } };
+
+    expect(
+      resolveScopeRequireMention({
+        tree,
+        path: ["configured"],
+        configuredScopeDefaultsToNoMention: true,
+      }),
+    ).toBe(false);
+    expect(
+      resolveScopeRequireMention({
+        tree,
+        path: ["missing"],
+        configuredScopeDefaultsToNoMention: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("resolveScopeToolsPolicy", () => {
+  const cascadeCases: Array<{
+    name: string;
+    tree: ScopeTree;
+    senderId: string;
+    expected: { allow?: string[]; deny?: string[] };
+  }> = [
+    {
+      name: "channel sender policy",
+      tree: {
+        scopes: {
+          team: { tools: { deny: ["team"] } },
+          channel: {
+            toolsBySender: { "id:alice": { allow: ["channel-sender"] } },
+            tools: { allow: ["channel"] },
+          },
+        },
+      },
+      senderId: "alice",
+      expected: { allow: ["channel-sender"] },
+    },
+    {
+      name: "channel policy",
+      tree: {
+        scopes: {
+          team: { tools: { deny: ["team"] } },
+          channel: {
+            toolsBySender: { "id:alice": { allow: ["channel-sender"] } },
+            tools: { allow: ["channel"] },
+          },
+        },
+      },
+      senderId: "bob",
+      expected: { allow: ["channel"] },
+    },
+    {
+      name: "team sender policy",
+      tree: {
+        scopes: {
+          team: {
+            toolsBySender: { "id:bob": { allow: ["team-sender"] } },
+            tools: { deny: ["team"] },
+          },
+          channel: {},
+        },
+      },
+      senderId: "bob",
+      expected: { allow: ["team-sender"] },
+    },
+    {
+      name: "team policy",
+      tree: {
+        scopes: {
+          team: {
+            toolsBySender: { "id:bob": { allow: ["team-sender"] } },
+            tools: { deny: ["team"] },
+          },
+          channel: {},
+        },
+      },
+      senderId: "carol",
+      expected: { deny: ["team"] },
+    },
+  ];
+
+  it.each(cascadeCases)(
+    "resolves the MSTeams cascade through $name",
+    ({ tree, senderId, expected }) => {
+      expect(resolveScopeToolsPolicy({ tree, path: ["team", "channel"], senderId })).toEqual(
+        expected,
+      );
+    },
+  );
+
+  it.each([
+    { name: "id", sender: { senderId: "user:alice" }, expected: { allow: ["id"] } },
+    {
+      name: "username",
+      sender: { senderUsername: "@Alice" },
+      expected: { allow: ["username"] },
+    },
+    {
+      name: "channel",
+      sender: { senderId: "user:alice", messageProvider: "discord" },
+      expected: { allow: ["channel"] },
+    },
+    {
+      name: "channel without provider",
+      sender: { senderId: "user:alice" },
+      expected: { allow: ["id"] },
+    },
+  ])("matches resolveToolsBySender for typed $name keys", ({ sender, expected }) => {
+    const toolsBySender = {
+      "id:user:alice": { allow: ["id"] },
+      "username:alice": { allow: ["username"] },
+      "channel:discord:user:alice": { allow: ["channel"] },
+      "*": { deny: ["fallback"] },
+    };
+    const tree: ScopeTree = { scopes: { room: { toolsBySender } } };
+
+    const directPolicy = resolveToolsBySender({ toolsBySender, ...sender });
+    expect(resolveScopeToolsPolicy({ tree, path: ["room"], ...sender })).toEqual(directPolicy);
+    expect(directPolicy).toEqual(expected);
+  });
+
+  it("uses sender and plain policies from defaults after path scopes", () => {
+    const senderTree: ScopeTree = {
+      defaults: {
+        toolsBySender: { "id:alice": { allow: ["default-sender"] } },
+        tools: { deny: ["default"] },
+      },
+      scopes: { channel: {} },
+    };
+
+    expect(
+      resolveScopeToolsPolicy({ tree: senderTree, path: ["channel"], senderId: "alice" }),
+    ).toEqual({ allow: ["default-sender"] });
+    expect(
+      resolveScopeToolsPolicy({ tree: senderTree, path: ["channel"], senderId: "bob" }),
+    ).toEqual({ deny: ["default"] });
+    expect(resolveScopeToolsPolicy({ tree: { scopes: {} }, path: [] })).toBeUndefined();
+  });
+
+  it("keeps a narrower plain policy ahead of a broader sender match", () => {
+    const tree: ScopeTree = {
+      scopes: {
+        team: { toolsBySender: { "id:alice": { allow: ["team-sender"] } } },
+        channel: { tools: { deny: ["channel"] } },
+      },
+    };
+
+    expect(
+      resolveScopeToolsPolicy({
+        tree,
+        path: ["team", "channel"],
+        senderId: "alice",
+      }),
+    ).toEqual({ deny: ["channel"] });
+  });
+});
+
+describe("resolveScopeIntroHint", () => {
+  it("uses the first defined hint from narrowest scope through defaults", () => {
+    const tree: ScopeTree = {
+      defaults: { introHint: "default" },
+      scopes: {
+        team: { introHint: "team" },
+        channel: {},
+        thread: { introHint: "thread" },
+      },
+    };
+
+    expect(resolveScopeIntroHint({ tree, path: ["team", "channel", "thread"] })).toBe("thread");
+    expect(resolveScopeIntroHint({ tree, path: ["missing"] })).toBe("default");
+  });
+});

--- a/src/config/group-scope-tree.ts
+++ b/src/config/group-scope-tree.ts
@@ -1,5 +1,7 @@
 // Resolves canonical group policy scopes prepared by channel plugins.
-import { resolveToolsBySender } from "./group-policy.js";
+import type { ChannelId } from "../channels/plugins/channel-id.types.js";
+import { resolveChannelGroups, resolveToolsBySender } from "./group-policy.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
 import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
 
 export type ScopeNode = {
@@ -20,6 +22,19 @@ export type ScopeTree = {
 export type ScopePath = string[];
 
 type ScopeToolPolicySender = Omit<Parameters<typeof resolveToolsBySender>[0], "toolsBySender">;
+
+export function buildChannelGroupsScopeTree(
+  cfg: OpenClawConfig,
+  channel: ChannelId,
+  accountId?: string | null,
+): ScopeTree {
+  // 13+ channels share the flat `groups` config shape; richer channels such as
+  // Discord, Telegram, and Microsoft Teams ship their own builders.
+  const groups = resolveChannelGroups(cfg, channel, accountId) ?? {};
+  // The wildcard config is the fallback node, not a matchable exact scope.
+  const { "*": defaults, ...scopes } = groups;
+  return { defaults, scopes };
+}
 
 function resolveFromScopes<Value>(params: {
   tree: ScopeTree;

--- a/src/config/group-scope-tree.ts
+++ b/src/config/group-scope-tree.ts
@@ -1,0 +1,109 @@
+// Resolves canonical group policy scopes prepared by channel plugins.
+import { resolveToolsBySender } from "./group-policy.js";
+import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
+
+export type ScopeNode = {
+  requireMention?: boolean;
+  tools?: GroupToolPolicyConfig;
+  toolsBySender?: GroupToolPolicyBySenderConfig;
+  introHint?: string;
+};
+
+export type ScopeTree = {
+  defaults?: ScopeNode;
+  // Flat keys preserve channel-defined precedence: channels emit broad-to-narrow paths.
+  // Nested trees cannot model Telegram, where a wildcard-group topic outranks
+  // an exact-group scalar requireMention.
+  scopes: Record<string, ScopeNode>;
+};
+
+export type ScopePath = string[];
+
+type ScopeToolPolicySender = Omit<Parameters<typeof resolveToolsBySender>[0], "toolsBySender">;
+
+function resolveFromScopes<Value>(params: {
+  tree: ScopeTree;
+  path: ScopePath;
+  resolveNode: (node: ScopeNode) => Value | undefined;
+}): Value | undefined {
+  for (let index = params.path.length - 1; index >= 0; index -= 1) {
+    const key = params.path[index];
+    if (key === undefined || !Object.hasOwn(params.tree.scopes, key)) {
+      continue;
+    }
+    const node = params.tree.scopes[key];
+    if (!node) {
+      continue;
+    }
+    const value = params.resolveNode(node);
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  return params.tree.defaults ? params.resolveNode(params.tree.defaults) : undefined;
+}
+
+export function resolveScopeRequireMention(params: {
+  tree: ScopeTree;
+  path: ScopePath;
+  requireMentionOverride?: boolean;
+  overrideOrder?: "before-config" | "after-config";
+  configuredScopeDefaultsToNoMention?: boolean;
+}): boolean {
+  // Runtime overrides stay in resolver parameters because channels derive them per message.
+  const { requireMentionOverride, overrideOrder = "after-config" } = params;
+  const configuredMention = resolveFromScopes({
+    tree: params.tree,
+    path: params.path,
+    resolveNode: (node) => node.requireMention,
+  });
+
+  if (overrideOrder === "before-config" && typeof requireMentionOverride === "boolean") {
+    return requireMentionOverride;
+  }
+  if (typeof configuredMention === "boolean") {
+    return configuredMention;
+  }
+  if (overrideOrder !== "before-config" && typeof requireMentionOverride === "boolean") {
+    return requireMentionOverride;
+  }
+  if (
+    params.configuredScopeDefaultsToNoMention &&
+    params.path.some((key) => Object.hasOwn(params.tree.scopes, key))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export function resolveScopeToolsPolicy(
+  params: {
+    tree: ScopeTree;
+    path: ScopePath;
+  } & ScopeToolPolicySender,
+): GroupToolPolicyConfig | undefined {
+  return resolveFromScopes({
+    tree: params.tree,
+    path: params.path,
+    resolveNode: (node) =>
+      resolveToolsBySender({
+        toolsBySender: node.toolsBySender,
+        senderId: params.senderId,
+        senderName: params.senderName,
+        senderUsername: params.senderUsername,
+        senderE164: params.senderE164,
+        messageProvider: params.messageProvider,
+      }) ?? node.tools,
+  });
+}
+
+export function resolveScopeIntroHint(params: {
+  tree: ScopeTree;
+  path: ScopePath;
+}): string | undefined {
+  return resolveFromScopes({
+    tree: params.tree,
+    path: params.path,
+    resolveNode: (node) => node.introHint,
+  });
+}

--- a/src/plugin-sdk/channel-policy.ts
+++ b/src/plugin-sdk/channel-policy.ts
@@ -49,6 +49,14 @@ export {
   type ChannelGroupPolicy,
 } from "../config/group-policy.js";
 export {
+  resolveScopeIntroHint,
+  resolveScopeRequireMention,
+  resolveScopeToolsPolicy,
+  type ScopeNode,
+  type ScopePath,
+  type ScopeTree,
+} from "../config/group-scope-tree.js";
+export {
   DM_GROUP_ACCESS_REASON,
   readStoreAllowFromForDmPolicy,
   resolveDmGroupAccessWithCommandGate,

--- a/src/plugin-sdk/channel-policy.ts
+++ b/src/plugin-sdk/channel-policy.ts
@@ -49,6 +49,7 @@ export {
   type ChannelGroupPolicy,
 } from "../config/group-policy.js";
 export {
+  buildChannelGroupsScopeTree,
   resolveScopeIntroHint,
   resolveScopeRequireMention,
   resolveScopeToolsPolicy,


### PR DESCRIPTION
## What Problem This Solves

First channel batch of the group-policy scope normalization (stage 2). Google Chat, iMessage, and WhatsApp resolved group `requireMention`/tool policy through the older generic resolver with per-channel plumbing; this migrates them onto the canonical ScopeTree resolvers so every channel converges on one resolution model before the custom-walker channels (discord, telegram, msteams, …) migrate and their ~600 LOC of private walkers get deleted.

## Why This Change Was Made

Depends on #106819 (ScopeTree core resolver — this branch stacks on it). These three are pure delegates, so they prove the migration pattern at minimal risk. A shared `buildChannelGroupsScopeTree(cfg, channel, accountId)` builder was added to core because 13+ channels share the flat `groups` config shape (wildcard `"*"` → defaults node, exact keys → scopes); richer channels will ship their own builders. Account scoping stays core-owned via `resolveChannelGroups`, preserving the single-account empty-`groups:{}` fallback quirk.

## User Impact

None — behavior parity: exact-group hit, wildcard fallback, account-level groups overriding root, sender-scoped tool policy (explicit `messageProvider` matches the old resolver's default), and default `true`/`undefined` when nothing is configured. Each plugin's group-policy module ended smaller than before (17/40/40 lines vs 18/41/41).

## Evidence

- Testbox (Blacksmith): `pnpm test src/config/group-scope-tree.test.ts src/config/group-policy.test.ts extensions/googlechat extensions/imessage extensions/whatsapp` all green; `check:changed` lanes green with the regenerated Plugin SDK API baseline hash committed.
- New parity tests for googlechat and imessage (previously untested), extended whatsapp tests: exact/wildcard/absent, account override, single-account empty-groups fallback, toolsBySender sender scoping.
- Autoreview (codex gpt-5.6-sol, xhigh): clean, "patch is correct (0.86)", no actionable findings.
