### PR TITLE
fix(agents): retry released subagent results

### DIFF
--- a/src/agents/agent-steering-queue.test.ts
+++ b/src/agents/agent-steering-queue.test.ts
@@ -144,6 +144,42 @@ describe("agent steering queue", () => {
     expect(runs.get("retry")?.cleanupHandled).toBe(false);
   });
 
+  it("releases finalized cleanup leases back to pending steering", () => {
+    const runs = runMap([
+      makeRun({
+        runId: "finalized",
+        cleanupCompletedAt: 2_500,
+        cleanupHandled: false,
+      }),
+    ]);
+
+    expect(
+      leasePendingAgentSteeringItemsFromSubagentRuns({
+        runs,
+        requesterSessionKey,
+        leaseId: "lease-1",
+        now: 3_000,
+      })?.runIds,
+    ).toEqual(["finalized"]);
+    expect(
+      releaseLeasedAgentSteeringItemsFromSubagentRuns({
+        runs,
+        runIds: ["finalized"],
+        leaseId: "lease-1",
+      }),
+    ).toBe(1);
+    expect(runs.get("finalized")?.cleanupHandled).toBe(true);
+
+    expect(
+      leasePendingAgentSteeringItemsFromSubagentRuns({
+        runs,
+        requesterSessionKey,
+        leaseId: "lease-2",
+        now: 4_000,
+      })?.runIds,
+    ).toEqual(["finalized"]);
+  });
+
   it("preserves suspended payloads across prompt submission failures", () => {
     const runs = runMap([
       makeRun({
@@ -225,7 +261,7 @@ describe("agent steering queue", () => {
     }
   });
 
-  it("skips active cleanup, sanitizes metadata, and reclaims stale leases", () => {
+  it("uses delivery state for eligibility, sanitizes metadata, and reclaims stale leases", () => {
     const runs = runMap([
       makeRun({ runId: "handled", cleanupHandled: true }),
       makeRun({
@@ -249,8 +285,8 @@ describe("agent steering queue", () => {
         runs,
         requesterSessionKey,
         now: 3_000,
-      }),
-    ).toEqual([]);
+      }).map((item) => item.runId),
+    ).toEqual(["handled"]);
 
     const leased = leasePendingAgentSteeringItemsFromSubagentRuns({
       runs,
@@ -258,7 +294,7 @@ describe("agent steering queue", () => {
       leaseId: "new-lease",
       now: 1_000 + 6 * 60 * 1_000,
     });
-    expect(leased?.runIds).toEqual(["stale"]);
+    expect(leased?.runIds).toEqual(["stale", "handled"]);
     expect(runs.get("stale")?.delivery?.steeringLeaseId).toBe("new-lease");
     expect(leased?.prompt).toContain("labelmalicious");
     expect(leased?.prompt).toContain("boominject");

--- a/src/agents/agent-steering-queue.ts
+++ b/src/agents/agent-steering-queue.ts
@@ -99,9 +99,6 @@ export function listPendingAgentSteeringItemsFromSubagentRuns(params: {
       continue;
     }
     const staleLease = isStaleLease(delivery, now);
-    if (entry.cleanupHandled === true && !staleLease) {
-      continue;
-    }
     if (payload.requesterSessionKey !== requesterSessionKey) {
       continue;
     }


### PR DESCRIPTION
Closes #106559

AI-assisted. I reviewed the state transition, tests, and validation results and understand the change.

## What Problem This Solves

Fixes an issue where a parent agent session could permanently miss a finalized subagent result after prompt submission failed and released the result's steering lease.

## Why This Change Was Made

The steering queue now uses its dedicated delivery status and lease metadata as the authority for eligibility. The separate `cleanupHandled` field remains a lifecycle cleanup lock, but no longer suppresses a released delivery that has returned to `pending` or `suspended`.

## User Impact

Finalized subagent results whose requester prompt fails can be retried on a later parent turn instead of remaining stranded after the lease is released.

## Evidence

- Red/green regression proof: restoring the old `cleanupHandled` eligibility gate made the new finalized lease-release test fail (`expected ["finalized"], received undefined`); applying this change passed the same path.
- `node scripts/run-vitest.mjs src/agents/agent-steering-queue.test.ts src/agents/subagent-delivery-state.test.ts`
  - 2 files passed, 19 tests passed.
- `corepack pnpm exec oxfmt --check --threads=1 src/agents/agent-steering-queue.ts src/agents/agent-steering-queue.test.ts`
  - Both files matched repository formatting.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/agent-steering-queue.ts src/agents/agent-steering-queue.test.ts`
  - Passed with no findings.
- `git diff --check`
  - Passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --base origin/main`
  - No accepted/actionable findings; `patch is correct` (0.97 confidence) on the final-base diff.
- Exact-head GitHub Actions for `99532e6328b`: 64 checks passed and no checks remained pending.
  - One unrelated base failure remains in [`checks-fast-contracts-plugins-a`](https://github.com/openclaw/openclaw/actions/runs/29287336043/job/86942998191): `extensions/lobster` retains `@clawdbot/lobster` while its dependency-contract test sees no direct import. The failing surface came from current-main commit `70ab6b324dd` (`refactor(lobster): use canonical core export`) and is outside this PR's two `src/agents/agent-steering-queue*` files.

Pre-PR remote proof was attempted but unavailable in this environment: Blacksmith Testbox could not start because the `blacksmith` executable is absent, and the coordinator-backed AWS fallback requires a configured Crabbox broker login. The repository-approved narrow local fallback was used before push; exact-head GitHub Actions subsequently supplied remote CI proof. No live provider or channel behavior is involved.