### PR TITLE
fix(ci): bind release target context

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -764,6 +764,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_REF: ${{ inputs.ref }}
+          TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
           TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
           CHILD_WORKFLOW_REF: ${{ github.ref_name }}
           PARENT_WORKFLOW_SHA: ${{ github.sha }}

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -279,9 +279,10 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
     const pluginPrereleaseScript = releaseWorkflow.jobs.plugin_prerelease.steps.find(
       (step: WorkflowStep) => step.name === "Dispatch and monitor plugin prerelease",
     ).run;
-    const releaseChecksScript = releaseWorkflow.jobs.release_checks.steps.find(
+    const releaseChecksStep = releaseWorkflow.jobs.release_checks.steps.find(
       (step: WorkflowStep) => step.name === "Dispatch and monitor release checks",
-    ).run;
+    );
+    const releaseChecksScript = releaseChecksStep.run;
     const buildDistStep = workflow.jobs["build-artifacts"].steps.find(
       (step: WorkflowStep) => step.name === "Build dist",
     );
@@ -425,6 +426,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
     expect(releaseChecksScript).toContain(
       'release_checks_target_ref="${TARGET_CONTEXT_REF:-$TARGET_REF}"',
     );
+    expect(releaseChecksStep.env?.TARGET_CONTEXT_REF).toBe("${{ inputs.target_context_ref }}");
     expect(releaseChecksScript).toContain('-f ref="$release_checks_target_ref"');
     expect(releaseWorkflowSource).toContain('--arg targetContextRef "$TARGET_CONTEXT_REF"');
     expect(releaseWorkflowSource).toContain("targetContextRef: $targetContextRef");


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation now computes the canonical release-check ref, but the
release-check job did not bind `inputs.target_context_ref` into its shell
environment. The safe fallback therefore still dispatched the exact SHA as
`ref`, and Telegram QA could not verify the canonical LTS branch provenance.

Exact evidence:

- Parent: https://github.com/openclaw/openclaw/actions/runs/29286860834
- Release Checks child: https://github.com/openclaw/openclaw/actions/runs/29286878601
- Telegram QA grandchild: https://github.com/openclaw/openclaw/actions/runs/29287015902

## Why This Change Was Made

Bind `TARGET_CONTEXT_REF` on the owning release-check dispatch step. Keep the
existing `${TARGET_CONTEXT_REF:-$TARGET_REF}` fallback and immutable
`expected_sha` validation. Add a regression assertion on the parsed step env so
the workflow cannot silently lose the binding again.

## User Impact

Frozen release branches and tags retain their canonical provenance through the
full parent/child/grandchild validation chain. No product runtime change.

## Evidence

- Blacksmith Testbox `tbx_01kxepwyeyxxc5xzj6mk58w03b`: focused workflow test
  11/11 passed; targeted formatting passed.
- Fresh autoreview: no accepted/actionable findings, confidence 0.98.
- `git diff --check` passed.
- Post-merge proof will rerun focused exact LTS Telegram validation at
  `de63d91e4bb95aba8827a94e3c8419e13da3017f` with
  `extended-stable/2026.6.33` context, then full LTS validation.

