### PR TITLE
fix: active-memory recall fails with billing rejections on subscription-only Claude CLI setups

### DIFF
--- a/docs/plugins/cli-backend-plugins.md
+++ b/docs/plugins/cli-backend-plugins.md
@@ -219,6 +219,7 @@ only for behavior that really belongs to the backend.
 | `sideQuestionToolMode`             | Declare disabled native tools for `/btw` side questions                     |
 | `bundleMcp` / `bundleMcpMode`      | Opt into OpenClaw's loopback MCP tool bridge                                |
 | `ownsNativeCompaction`             | Backend owns its own compaction - OpenClaw defers                           |
+| `subscriptionAuthDispatch`         | Opted-in embedded runs on subscription credentials execute via this backend |
 | `runtimeArtifact`                  | Bound a script launcher to its complete bundled package tree                |
 
 Keep these hooks provider-owned. Do not add CLI-specific branches to core when

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -143,6 +143,8 @@ two-party event loops that do not go through the shared inbound reply runner.
 
     `runEmbeddedPiAgent(...)` remains as a deprecated compatibility alias for existing plugins. New code should use `runEmbeddedAgent(...)`.
 
+    `resolveCliBackendDispatchEligibility({ provider, model, agentId, authProfileId, config, agentDir, workspaceDir })` shares the embedded runner's CLI-backend dispatch decision (route, the backend's declared `subscriptionAuthDispatch` capability, stored credential mode — honoring an explicitly pinned `authProfileId`) with callers that opt embedded runs into `cliBackendDispatch: "subscription-auth"`. It returns `{ provider }` when the run would execute through the CLI backend and `undefined` when it stays on the direct passthrough, so callers can budget timeouts for the run that will actually execute.
+
     `resolveThinkingPolicy(...)` returns the provider/model's supported thinking levels and optional default. Provider plugins own the model-specific profile through their thinking hooks, so tool plugins should call this runtime helper instead of importing or duplicating provider lists.
 
     `normalizeThinkingLevel(...)` converts user text such as `on`, `x-high`, or `extra high` to the canonical stored level before checking it against the resolved policy.

--- a/extensions/active-memory/config.ts
+++ b/extensions/active-memory/config.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_ACTIVE_MEMORY_TOOLS_ALLOW,
   DEFAULT_CACHE_TTL_MS,
   DEFAULT_CIRCUIT_BREAKER_COOLDOWN_MS,
+  DEFAULT_CLI_RUNTIME_RECALL_TIMEOUT_MS,
   DEFAULT_CIRCUIT_BREAKER_MAX_TIMEOUTS,
   DEFAULT_MAX_SUMMARY_CHARS,
   DEFAULT_MIN_TIMEOUT_MS,
@@ -251,6 +252,7 @@ function normalizePluginConfig(
       minimumTimeoutMs,
       MAX_TIMEOUT_MS,
     ),
+    timeoutMsIsDefault: raw.timeoutMs === undefined || raw.timeoutMs === null,
     setupGraceTimeoutMs: clampInt(
       raw.setupGraceTimeoutMs,
       setupGraceTimeoutMs,
@@ -387,8 +389,28 @@ function setSetupGraceTimeoutMsForTests(value: number): void {
   setupGraceTimeoutMs = Math.max(0, Math.floor(value));
 }
 
+/**
+ * Recalls eligible for CLI-backend dispatch run a fresh CLI process, which
+ * measured runs place at 9-20s — over the plain 15s default. Eligibility is
+ * the runner's own dispatch decision (route, registered backend, stored
+ * credential mode), so API-key setups that keep the direct passthrough also
+ * keep the plain default. Explicit operator timeoutMs config always wins.
+ */
+function applyCliRuntimeRecallTimeoutDefault(
+  config: ResolvedActiveRecallPluginConfig,
+  cliDispatchEligible: boolean,
+): ResolvedActiveRecallPluginConfig {
+  if (!config.timeoutMsIsDefault || config.timeoutMs >= DEFAULT_CLI_RUNTIME_RECALL_TIMEOUT_MS) {
+    return config;
+  }
+  return cliDispatchEligible
+    ? { ...config, timeoutMs: DEFAULT_CLI_RUNTIME_RECALL_TIMEOUT_MS }
+    : config;
+}
+
 export {
   applyActiveMemoryRuntimeConfigSnapshot,
+  applyCliRuntimeRecallTimeoutDefault,
   clampInt,
   hasDeprecatedModelFallbackPolicy,
   isMissingRegisteredMemoryToolsError,

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -13,6 +13,7 @@ import { parseAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { parseSqliteSessionFileMarker } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { applyCliRuntimeRecallTimeoutDefault } from "./config.js";
 import plugin, { testing } from "./index.js";
 
 // Match only lone surrogates so valid supplementary-plane characters remain allowed.
@@ -131,6 +132,11 @@ describe("active-memory plugin", () => {
   const hookOptions: Record<string, Record<string, unknown> | undefined> = {};
   const registeredCommands: Record<string, any> = {};
   const runEmbeddedAgent = vi.fn();
+  // Default: recall routes are not CLI-dispatch-eligible; tests that prove the
+  // raised budget override this per-case.
+  const resolveCliBackendDispatchEligibility = vi.fn(
+    () => undefined as { provider: string } | undefined,
+  );
   const runtimeRunEmbeddedAgent = vi.fn(async (params: Record<string, unknown>) => {
     const sessionId =
       typeof params.sessionId === "string" && params.sessionId.length > 0
@@ -219,6 +225,7 @@ describe("active-memory plugin", () => {
     runtime: {
       agent: {
         runEmbeddedAgent: runtimeRunEmbeddedAgent,
+        resolveCliBackendDispatchEligibility,
         session: {
           resolveStorePath: vi.fn(() => path.join(stateDir, "sessions.json")),
           loadSessionStore: vi.fn(() => hoisted.sessionStore),
@@ -625,6 +632,9 @@ describe("active-memory plugin", () => {
     );
 
     expect(lastEmbeddedRunParams().authProfileFailurePolicy).toBe("local");
+    // Subscription-only claude-cli setups route recall through the CLI
+    // backend instead of the direct-API passthrough.
+    expect(lastEmbeddedRunParams().cliBackendDispatch).toBe("subscription-auth");
   });
 
   it("runs recall on a dedicated active-memory lane", async () => {
@@ -6497,6 +6507,67 @@ describe("active-memory plugin", () => {
     expect(testing.normalizePluginConfig({ fastMode: false }).fastMode).toBe(false);
     expect(testing.normalizePluginConfig({ fastMode: "auto" }).fastMode).toBe("auto");
     expect(testing.normalizePluginConfig({ fastMode: "on" }).fastMode).toBeUndefined();
+  });
+
+  it("raises the default recall budget only when CLI dispatch is eligible", () => {
+    const defaults = testing.normalizePluginConfig({});
+    expect(defaults.timeoutMs).toBe(15_000);
+    expect(defaults.timeoutMsIsDefault).toBe(true);
+    expect(applyCliRuntimeRecallTimeoutDefault(defaults, true).timeoutMs).toBe(45_000);
+    expect(applyCliRuntimeRecallTimeoutDefault(defaults, false).timeoutMs).toBe(15_000);
+    // Explicit operator config always wins.
+    const explicit = testing.normalizePluginConfig({ timeoutMs: 20_000 });
+    expect(explicit.timeoutMsIsDefault).toBe(false);
+    expect(applyCliRuntimeRecallTimeoutDefault(explicit, true).timeoutMs).toBe(20_000);
+  });
+
+  it("applies the CLI dispatch recall budget to the embedded run", async () => {
+    api.pluginConfig = { agents: ["main"], logging: true };
+    plugin.register(api as unknown as OpenClawPluginApi);
+    resolveCliBackendDispatchEligibility.mockReturnValueOnce({ provider: "claude-cli" });
+    runEmbeddedAgent.mockImplementationOnce(async () => ({
+      payloads: [{ text: "- lemon pepper wings" }],
+    }));
+    await requireHook("before_prompt_build")(
+      { prompt: "what wings should i order?", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:main",
+        messageProvider: "webchat",
+        modelProviderId: "claude-cli",
+        modelId: "claude-opus-4-8",
+      },
+    );
+    // 45s CLI-dispatch default + 0ms setup grace.
+    expect(lastEmbeddedRunParams().timeoutMs).toBe(45_000);
+    // Budgeting consults the runner's own eligibility decision.
+    expect(resolveCliBackendDispatchEligibility).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "claude-cli", model: "claude-opus-4-8" }),
+    );
+  });
+
+  it("keeps the plain recall budget when CLI dispatch is not eligible", async () => {
+    // API-key and missing-backend routes resolve to no eligibility: the run
+    // stays on the direct passthrough, so the plain 15s default applies.
+    api.pluginConfig = { agents: ["main"], logging: true };
+    plugin.register(api as unknown as OpenClawPluginApi);
+    resolveCliBackendDispatchEligibility.mockReturnValueOnce(undefined);
+    runEmbeddedAgent.mockImplementationOnce(async () => ({
+      payloads: [{ text: "- lemon pepper wings" }],
+    }));
+    await requireHook("before_prompt_build")(
+      { prompt: "what wings should i order?", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:main",
+        messageProvider: "webchat",
+        modelProviderId: "claude-cli",
+        modelId: "claude-opus-4-8",
+      },
+    );
+    expect(lastEmbeddedRunParams().timeoutMs).toBe(15_000);
   });
 
   it("normalizes setup grace config with a zero default and bounded opt-in", () => {

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -1,10 +1,12 @@
 /**
  * Active Memory plugin entry. Runtime behavior lives in focused sibling modules.
  */
+import { resolveAgentDir, resolveAgentWorkspaceDir } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveLivePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import {
+  applyCliRuntimeRecallTimeoutDefault,
   hasDeprecatedModelFallbackPolicy,
   isMissingRegisteredMemoryToolsError,
   normalizePluginConfig,
@@ -13,7 +15,7 @@ import {
   setSetupGraceTimeoutMsForTests,
 } from "./config.js";
 import { buildMetadata, buildPromptPrefix } from "./prompt.js";
-import { buildQuery, buildSearchQuery, extractRecentTurns } from "./query.js";
+import { buildQuery, buildSearchQuery, extractRecentTurns, getModelRef } from "./query.js";
 import {
   buildCacheKey,
   buildCircuitBreakerKey,
@@ -212,7 +214,37 @@ export default definePluginEntry({
       "before_prompt_build",
       async (event, ctx) => {
         refreshLiveConfigFromRuntime();
-        const invocationConfig = config;
+        // The hook deadline, watchdog, and embedded-run budget all flow from
+        // this config, so the CLI-runtime default raise must happen before
+        // any of them are armed. Budgeting shares the runner's own dispatch
+        // eligibility so API-key/missing-backend passthrough runs keep the
+        // plain default.
+        const timeoutAgentId = resolveStatusUpdateAgentId(ctx);
+        // getModelRef returns undefined when no recall model resolves; the
+        // eligibility check treats a missing provider as ineligible.
+        const timeoutModelRef =
+          (timeoutAgentId
+            ? getModelRef(api, timeoutAgentId, config, {
+                modelProviderId: ctx.modelProviderId,
+                modelId: ctx.modelId,
+              })
+            : { provider: ctx.modelProviderId, model: ctx.modelId }) ?? {};
+        const cliDispatchEligibility = api.runtime.agent.resolveCliBackendDispatchEligibility({
+          provider: timeoutModelRef.provider,
+          model: timeoutModelRef.model,
+          config: api.config,
+          ...(timeoutAgentId
+            ? {
+                agentId: timeoutAgentId,
+                agentDir: resolveAgentDir(api.config, timeoutAgentId),
+                workspaceDir: resolveAgentWorkspaceDir(api.config, timeoutAgentId),
+              }
+            : {}),
+        });
+        const invocationConfig = applyCliRuntimeRecallTimeoutDefault(
+          config,
+          cliDispatchEligibility !== undefined,
+        );
         const liveRecallTimeoutMs =
           invocationConfig.timeoutMs +
           invocationConfig.setupGraceTimeoutMs +

--- a/extensions/active-memory/openclaw.plugin.json
+++ b/extensions/active-memory/openclaw.plugin.json
@@ -130,7 +130,7 @@
     },
     "timeoutMs": {
       "label": "Timeout (ms)",
-      "help": "Recall work budget on the main lane. Before recall, the hook allows up to 1500 ms for session/config preflight. After recall starts, it reserves another fixed 1500 ms only for abort settlement and transcript recovery."
+      "help": "Recall work budget on the main lane. Defaults to 15000 ms, or 45000 ms when the recall is eligible for CLI-backend dispatch on subscription-only claude-cli auth (CLI-backed recalls include process startup); API-key routes keep 15000 ms. Explicit values always win. Before recall, the hook allows up to 1500 ms for session/config preflight. After recall starts, it reserves another fixed 1500 ms only for abort settlement and transcript recovery."
     },
     "setupGraceTimeoutMs": {
       "label": "Setup Grace Timeout (ms)",

--- a/extensions/active-memory/recall-run.ts
+++ b/extensions/active-memory/recall-run.ts
@@ -293,6 +293,11 @@ async function runRecallSubagent(params: {
       reasoningLevel: "off",
       silentExpected: true,
       authProfileFailurePolicy: "local",
+      // On subscription-only claude-cli setups, direct provider API calls
+      // either fail with a billing rejection or silently draw metered extra
+      // usage; route recall through the CLI backend so it runs on plan
+      // limits like the session's main turns.
+      cliBackendDispatch: "subscription-auth",
       cleanupBundleMcpOnRunEnd: true,
       abortSignal: params.abortSignal,
       onAgentToolResult: (event) => {

--- a/extensions/active-memory/types.ts
+++ b/extensions/active-memory/types.ts
@@ -1,6 +1,11 @@
 import type { SessionTranscriptTargetParams } from "openclaw/plugin-sdk/session-transcript-runtime";
 
 const DEFAULT_TIMEOUT_MS = 15_000;
+// CLI-runtime recalls dispatch through a fresh CLI process (spawn + MCP
+// handshake + tool roundtrips); measured runs take 14-20s, so the plain
+// default budget would time out most of them. Explicit timeoutMs config
+// always wins over this default.
+const DEFAULT_CLI_RUNTIME_RECALL_TIMEOUT_MS = 45_000;
 const DEFAULT_AGENT_ID = "main";
 const DEFAULT_MAX_SUMMARY_CHARS = 220;
 const DEFAULT_RECENT_USER_TURNS = 2;
@@ -186,6 +191,8 @@ type ResolvedActiveRecallPluginConfig = {
   promptOverride?: string;
   promptAppend?: string;
   timeoutMs: number;
+  /** True when timeoutMs is the built-in default rather than operator config. */
+  timeoutMsIsDefault: boolean;
   setupGraceTimeoutMs: number;
   queryMode: "message" | "recent" | "full";
   maxSummaryChars: number;
@@ -358,6 +365,7 @@ export {
   DEFAULT_RECENT_ASSISTANT_TURNS,
   DEFAULT_RECENT_USER_CHARS,
   DEFAULT_RECENT_USER_TURNS,
+  DEFAULT_CLI_RUNTIME_RECALL_TIMEOUT_MS,
   DEFAULT_SETUP_GRACE_TIMEOUT_MS,
   DEFAULT_TIMEOUT_MS,
   DEFAULT_TRANSCRIPT_DIR,

--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -45,6 +45,11 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
     nativeToolMode: "selectable",
     sideQuestionToolMode: "disabled",
     ownsNativeCompaction: true,
+    // Anthropic routes direct anthropic-messages calls on subscription OAuth
+    // tokens to metered extra-usage billing (or rejects them without balance);
+    // opted-in embedded runs on subscription credentials execute through this
+    // backend on plan limits instead.
+    subscriptionAuthDispatch: true,
     config: {
       command: "claude",
       args: [

--- a/src/agents/cli-runner/execute-messaging.ts
+++ b/src/agents/cli-runner/execute-messaging.ts
@@ -6,16 +6,15 @@ import {
   collectMessagingMediaUrlsFromToolResult,
   extractMessagingToolSend,
 } from "../embedded-agent-subscribe.tools.js";
+import { stripOpenClawMcpToolPrefix } from "./tool-policy.js";
 import type { PreparedCliRunContext } from "./types.js";
 
 export const CLI_MESSAGING_EVIDENCE_MAX_CALLS = 64;
-const OPENCLAW_MCP_TOOL_PREFIX = "mcp__openclaw__";
 
-export function normalizeCliMessagingToolName(toolName: string): string {
-  return toolName.startsWith(OPENCLAW_MCP_TOOL_PREFIX)
-    ? toolName.slice(OPENCLAW_MCP_TOOL_PREFIX.length)
-    : toolName;
-}
+// One canonical prefix-strip implementation: the loopback transport prefix is
+// a tool-policy concept shared with the embedded CLI-dispatch bridge, and
+// drifting copies would desync tool-name correlation across those surfaces.
+export const normalizeCliMessagingToolName = stripOpenClawMcpToolPrefix;
 
 export function extractCliMessagingTarget(
   context: PreparedCliRunContext,

--- a/src/agents/cli-runner/mcp-grant-context.ts
+++ b/src/agents/cli-runner/mcp-grant-context.ts
@@ -1,0 +1,160 @@
+import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { canonicalizeMainSessionAlias } from "../../config/sessions/main-session.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { McpLoopbackRequestContext } from "../../gateway/mcp-grant-store.js";
+import { normalizeMessageChannel } from "../../utils/message-channel.js";
+import type { RunCliAgentParams } from "./types.js";
+
+export function normalizeOptionalMcpContextValue(value: string | undefined): string | undefined {
+  return value?.trim() || undefined;
+}
+
+export function buildCliMcpExecSession(
+  sessionEntry: RunCliAgentParams["sessionEntry"],
+): McpLoopbackRequestContext["execSession"] {
+  const execSession = {
+    execHost: normalizeOptionalMcpContextValue(sessionEntry?.execHost),
+    execSecurity: normalizeOptionalMcpContextValue(sessionEntry?.execSecurity),
+    execAsk: normalizeOptionalMcpContextValue(sessionEntry?.execAsk),
+    execNode: normalizeOptionalMcpContextValue(sessionEntry?.execNode),
+  };
+  return Object.values(execSession).some(Boolean) ? execSession : undefined;
+}
+
+export function buildCliMcpExecOverrides(
+  execOverrides: RunCliAgentParams["execOverrides"],
+): McpLoopbackRequestContext["execOverrides"] {
+  if (!execOverrides) {
+    return undefined;
+  }
+  const scopedOverrides = {
+    ...(execOverrides.host !== undefined ? { host: execOverrides.host } : {}),
+    ...(execOverrides.security !== undefined ? { security: execOverrides.security } : {}),
+    ...(execOverrides.ask !== undefined ? { ask: execOverrides.ask } : {}),
+    ...(execOverrides.node !== undefined ? { node: execOverrides.node } : {}),
+  };
+  return Object.keys(scopedOverrides).length > 0 ? scopedOverrides : undefined;
+}
+
+export function buildCliMcpBashElevated(
+  bashElevated: RunCliAgentParams["bashElevated"],
+): McpLoopbackRequestContext["bashElevated"] {
+  if (!bashElevated) {
+    return undefined;
+  }
+  return {
+    enabled: bashElevated.enabled,
+    allowed: bashElevated.allowed,
+    defaultLevel: bashElevated.defaultLevel,
+    ...(bashElevated.fullAccessAvailable !== undefined
+      ? { fullAccessAvailable: bashElevated.fullAccessAvailable }
+      : {}),
+    ...(bashElevated.fullAccessBlockedReason !== undefined
+      ? { fullAccessBlockedReason: bashElevated.fullAccessBlockedReason }
+      : {}),
+  };
+}
+
+export function buildCliMcpChannelContext(
+  channelContext: RunCliAgentParams["channelContext"],
+  senderId?: string | null,
+): McpLoopbackRequestContext["channelContext"] {
+  const resolvedSenderId =
+    normalizeOptionalMcpContextValue(senderId ?? undefined) ??
+    normalizeOptionalMcpContextValue(channelContext?.sender?.id);
+  const chatId = normalizeOptionalMcpContextValue(channelContext?.chat?.id);
+  if (!resolvedSenderId && !chatId) {
+    return undefined;
+  }
+  return {
+    ...(resolvedSenderId ? { sender: { id: resolvedSenderId } } : {}),
+    ...(chatId ? { chat: { id: chatId } } : {}),
+  };
+}
+
+export function resolveCliMcpMessageProvider(
+  run: Pick<RunCliAgentParams, "messageProvider" | "messageChannel">,
+): string | undefined {
+  return normalizeMessageChannel(run.messageProvider ?? run.messageChannel) ?? undefined;
+}
+
+export function resolveCliMcpSessionKey(
+  run: Pick<RunCliAgentParams, "sessionKey">,
+  config: OpenClawConfig,
+  agentId: string,
+): string {
+  return canonicalizeMainSessionAlias({
+    cfg: config,
+    agentId,
+    sessionKey: run.sessionKey?.trim() || "main",
+  });
+}
+
+export function buildCliMcpGrantContext(params: {
+  run: RunCliAgentParams;
+  config: OpenClawConfig;
+  requireExplicitMessageTarget: boolean;
+  agentId: string;
+  modelProvider: string;
+  modelId: string;
+  toolsAllow?: string[];
+}): McpLoopbackRequestContext {
+  const sessionKey = resolveCliMcpSessionKey(params.run, params.config, params.agentId);
+  const clientCaps = uniqueStrings(
+    (params.run.clientCaps ?? []).map((cap) => cap.trim()).filter(Boolean),
+  );
+  const execSession = buildCliMcpExecSession(params.run.sessionEntry);
+  const execOverrides = buildCliMcpExecOverrides(params.run.execOverrides);
+  const bashElevated = buildCliMcpBashElevated(params.run.bashElevated);
+  const channelContext = buildCliMcpChannelContext(params.run.channelContext, params.run.senderId);
+  const senderName = normalizeOptionalMcpContextValue(params.run.senderName ?? undefined);
+  const senderUsername = normalizeOptionalMcpContextValue(params.run.senderUsername ?? undefined);
+  const senderE164 = normalizeOptionalMcpContextValue(params.run.senderE164 ?? undefined);
+  const groupId = normalizeOptionalMcpContextValue(params.run.groupId ?? undefined);
+  const groupChannel = normalizeOptionalMcpContextValue(params.run.groupChannel ?? undefined);
+  const groupSpace = normalizeOptionalMcpContextValue(params.run.groupSpace ?? undefined);
+  const spawnedBy = normalizeOptionalMcpContextValue(params.run.spawnedBy ?? undefined);
+  return {
+    sessionKey,
+    runtimePolicySessionKey: normalizeOptionalMcpContextValue(params.run.runtimePolicySessionKey),
+    agentId: params.agentId,
+    sessionId: normalizeOptionalMcpContextValue(params.run.sessionId),
+    runId: normalizeOptionalMcpContextValue(params.run.runId),
+    // Restricted runs get their allowlist stamped into the grant; the
+    // loopback server enforces it on tools/list and tools/call.
+    ...(params.toolsAllow ? { toolsAllow: params.toolsAllow } : {}),
+    modelProvider: params.modelProvider,
+    modelId: params.modelId,
+    messageProvider: resolveCliMcpMessageProvider(params.run),
+    clientCaps: clientCaps.length > 0 ? clientCaps : undefined,
+    currentChannelId: normalizeOptionalMcpContextValue(params.run.currentChannelId),
+    currentThreadTs: normalizeOptionalMcpContextValue(params.run.currentThreadTs),
+    currentMessageId:
+      params.run.currentMessageId == null
+        ? undefined
+        : normalizeOptionalMcpContextValue(String(params.run.currentMessageId)),
+    currentInboundAudio: params.run.currentInboundAudio === true ? true : undefined,
+    accountId: normalizeOptionalMcpContextValue(params.run.agentAccountId),
+    inboundEventKind: params.run.currentInboundEventKind,
+    sourceReplyDeliveryMode: params.run.sourceReplyDeliveryMode,
+    taskSuggestionDeliveryMode: params.run.taskSuggestionDeliveryMode,
+    requireExplicitMessageTarget: params.requireExplicitMessageTarget ? true : undefined,
+    senderIsOwner: params.run.senderIsOwner === true,
+    nodeExecAllowed: true,
+    ...(execSession ? { execSession } : {}),
+    ...(execOverrides ? { execOverrides } : {}),
+    ...(bashElevated ? { bashElevated } : {}),
+    ...(params.run.trigger ? { trigger: params.run.trigger } : {}),
+    ...(normalizeOptionalMcpContextValue(params.run.approvalReviewerDeviceId)
+      ? { approvalReviewerDeviceId: params.run.approvalReviewerDeviceId?.trim() }
+      : {}),
+    ...(channelContext ? { channelContext } : {}),
+    ...(senderName ? { senderName } : {}),
+    ...(senderUsername ? { senderUsername } : {}),
+    ...(senderE164 ? { senderE164 } : {}),
+    ...(groupId ? { groupId } : {}),
+    ...(groupChannel ? { groupChannel } : {}),
+    ...(groupSpace ? { groupSpace } : {}),
+    ...(spawnedBy ? { spawnedBy } : {}),
+  };
+}

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -3529,6 +3529,91 @@ describe("prepareCliRunContext", () => {
     }
   });
 
+  it("bounds the loopback grant to the selectable MCP tool allowlist", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    const resolveExecutionArgs = vi.fn((context: { baseArgs: readonly string[] }) => [
+      ...context.baseArgs,
+    ]);
+    const mintMcpLoopbackClientGrant = vi.fn(createTestMcpLoopbackClientGrant);
+    cliBackendsTesting.setDepsForTest({
+      resolvePluginSetupCliBackend: () => undefined,
+      resolveRuntimeCliBackends: () => [
+        {
+          id: "claude-cli",
+          pluginId: "anthropic",
+          bundleMcp: true,
+          bundleMcpMode: "claude-config-file",
+          nativeToolMode: "selectable",
+          resolveExecutionArgs,
+          config: {
+            command: "claude",
+            args: ["--print"],
+            output: "jsonl",
+            jsonlDialect: "claude-stream-json",
+            input: "stdin",
+            sessionMode: "existing",
+          },
+        },
+      ],
+    });
+    setCliRunnerPrepareTestDeps({
+      getActiveMcpLoopbackRuntime: vi.fn(() => ({
+        port: 31783,
+        ownerToken: "loopback-owner-token",
+        nonOwnerToken: "loopback-non-owner-token",
+      })),
+      ensureMcpLoopbackServer: vi.fn(createTestMcpLoopbackServer),
+      createMcpLoopbackServerConfig: vi.fn(createTestMcpLoopbackServerConfig),
+      mintMcpLoopbackClientGrant,
+      resolveMcpLoopbackScopedTools: vi.fn(() => ({ agentId: "main", tools: [] })),
+    });
+
+    let cleanup: (() => Promise<void>) | undefined;
+    try {
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:main",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "claude-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-loopback-tools-allow",
+        config: {
+          ...createCliBackendConfig(),
+          mcp: {
+            servers: {
+              userProbe: { command: "node", args: ["user-probe.mjs"] },
+            },
+          },
+        },
+        cliToolAvailability: {
+          native: [],
+          mcp: ["mcp__openclaw__memory_search", "mcp__openclaw__memory_get", "mcp__other__thing"],
+        },
+      });
+      cleanup = context.preparedBackend.cleanup;
+
+      // Foreign-server entries are not loopback-governed; the grant carries
+      // only the gateway tool names the run may reach.
+      const grantContext = mintMcpLoopbackClientGrant.mock.calls[0]?.[0]?.context;
+      expect(grantContext?.toolsAllow).toEqual(["memory_search", "memory_get"]);
+
+      // Restricted runs must not see user/plugin MCP servers: the generated
+      // bundle serves only the grant-scoped loopback server.
+      const args = context.preparedBackend.backend.args ?? [];
+      const mcpConfigPath = args[args.indexOf("--mcp-config") + 1];
+      const rawBundle = JSON.parse(fs.readFileSync(mcpConfigPath ?? "", "utf-8")) as {
+        mcpServers?: Record<string, unknown>;
+      };
+      expect(Object.keys(rawBundle.mcpServers ?? {})).toEqual(["openclaw"]);
+    } finally {
+      await cleanup?.();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("serves only the openclaw MCP server for ring-zero runs", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -5,9 +5,7 @@ import { ensureSystemPromptCacheBoundary } from "@openclaw/ai/internal/shared";
  */
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { getRuntimeConfig } from "../../config/config.js";
-import { canonicalizeMainSessionAlias } from "../../config/sessions/main-session.js";
 import type { CliBackendConfig } from "../../config/types.agent-defaults.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   assertContextEngineHostSupport,
   buildGenericCliContextEngineHostSupport,
@@ -19,7 +17,6 @@ import {
   deactivateMcpLoopbackClientGrantCapture,
   mintMcpLoopbackClientGrant,
   revokeMcpLoopbackClientGrant,
-  type McpLoopbackRequestContext,
 } from "../../gateway/mcp-grant-store.js";
 import { ensureMcpLoopbackServer } from "../../gateway/mcp-http.js";
 import {
@@ -106,6 +103,16 @@ import { getClaudeLiveSessionGenerationForOwner } from "./claude-live-session.js
 import { prepareClaudeCliSkillsPlugin } from "./claude-skills-plugin.js";
 import { buildCliAgentSystemPrompt, normalizeCliModel } from "./helpers.js";
 import { cliBackendLog } from "./log.js";
+import {
+  buildCliMcpBashElevated,
+  buildCliMcpChannelContext,
+  buildCliMcpExecOverrides,
+  buildCliMcpExecSession,
+  buildCliMcpGrantContext,
+  normalizeOptionalMcpContextValue,
+  resolveCliMcpMessageProvider,
+  resolveCliMcpSessionKey,
+} from "./mcp-grant-context.js";
 import { CLAUDE_CLI_CONTEXT_MODEL_ALIASES, resolveNodeClaudePlacement } from "./prepare-claude.js";
 import {
   buildCliSessionHistoryPrompt,
@@ -114,6 +121,7 @@ import {
   loadCliSessionReseedMessages,
   resolveAutoCliSessionReseedHistoryChars,
 } from "./session-history.js";
+import { resolveLoopbackToolsAllowFromMcpPermissions } from "./tool-policy.js";
 import type { CliReusableSession, PreparedCliRunContext, RunCliAgentParams } from "./types.js";
 
 function resolveClaudeCliContextModelId(modelId: string): string {
@@ -169,156 +177,6 @@ function canTransportSystemPrompt(backend: CliBackendConfig): boolean {
       backend.systemPromptArg || backend.systemPromptFileArg || backend.systemPromptFileConfigKey,
     )
   );
-}
-
-function normalizeOptionalMcpContextValue(value: string | undefined): string | undefined {
-  return value?.trim() || undefined;
-}
-
-function buildCliMcpExecSession(
-  sessionEntry: RunCliAgentParams["sessionEntry"],
-): McpLoopbackRequestContext["execSession"] {
-  const execSession = {
-    execHost: normalizeOptionalMcpContextValue(sessionEntry?.execHost),
-    execSecurity: normalizeOptionalMcpContextValue(sessionEntry?.execSecurity),
-    execAsk: normalizeOptionalMcpContextValue(sessionEntry?.execAsk),
-    execNode: normalizeOptionalMcpContextValue(sessionEntry?.execNode),
-  };
-  return Object.values(execSession).some(Boolean) ? execSession : undefined;
-}
-
-function buildCliMcpExecOverrides(
-  execOverrides: RunCliAgentParams["execOverrides"],
-): McpLoopbackRequestContext["execOverrides"] {
-  if (!execOverrides) {
-    return undefined;
-  }
-  const scopedOverrides = {
-    ...(execOverrides.host !== undefined ? { host: execOverrides.host } : {}),
-    ...(execOverrides.security !== undefined ? { security: execOverrides.security } : {}),
-    ...(execOverrides.ask !== undefined ? { ask: execOverrides.ask } : {}),
-    ...(execOverrides.node !== undefined ? { node: execOverrides.node } : {}),
-  };
-  return Object.keys(scopedOverrides).length > 0 ? scopedOverrides : undefined;
-}
-
-function buildCliMcpBashElevated(
-  bashElevated: RunCliAgentParams["bashElevated"],
-): McpLoopbackRequestContext["bashElevated"] {
-  if (!bashElevated) {
-    return undefined;
-  }
-  return {
-    enabled: bashElevated.enabled,
-    allowed: bashElevated.allowed,
-    defaultLevel: bashElevated.defaultLevel,
-    ...(bashElevated.fullAccessAvailable !== undefined
-      ? { fullAccessAvailable: bashElevated.fullAccessAvailable }
-      : {}),
-    ...(bashElevated.fullAccessBlockedReason !== undefined
-      ? { fullAccessBlockedReason: bashElevated.fullAccessBlockedReason }
-      : {}),
-  };
-}
-
-function buildCliMcpChannelContext(
-  channelContext: RunCliAgentParams["channelContext"],
-  senderId?: string | null,
-): McpLoopbackRequestContext["channelContext"] {
-  const resolvedSenderId =
-    normalizeOptionalMcpContextValue(senderId ?? undefined) ??
-    normalizeOptionalMcpContextValue(channelContext?.sender?.id);
-  const chatId = normalizeOptionalMcpContextValue(channelContext?.chat?.id);
-  if (!resolvedSenderId && !chatId) {
-    return undefined;
-  }
-  return {
-    ...(resolvedSenderId ? { sender: { id: resolvedSenderId } } : {}),
-    ...(chatId ? { chat: { id: chatId } } : {}),
-  };
-}
-
-function resolveCliMcpMessageProvider(
-  run: Pick<RunCliAgentParams, "messageProvider" | "messageChannel">,
-): string | undefined {
-  return normalizeMessageChannel(run.messageProvider ?? run.messageChannel) ?? undefined;
-}
-
-function resolveCliMcpSessionKey(
-  run: Pick<RunCliAgentParams, "sessionKey">,
-  config: OpenClawConfig,
-  agentId: string,
-): string {
-  return canonicalizeMainSessionAlias({
-    cfg: config,
-    agentId,
-    sessionKey: run.sessionKey?.trim() || "main",
-  });
-}
-
-function buildCliMcpGrantContext(params: {
-  run: RunCliAgentParams;
-  config: OpenClawConfig;
-  requireExplicitMessageTarget: boolean;
-  agentId: string;
-  modelProvider: string;
-  modelId: string;
-}): McpLoopbackRequestContext {
-  const sessionKey = resolveCliMcpSessionKey(params.run, params.config, params.agentId);
-  const clientCaps = uniqueStrings(
-    (params.run.clientCaps ?? []).map((cap) => cap.trim()).filter(Boolean),
-  );
-  const execSession = buildCliMcpExecSession(params.run.sessionEntry);
-  const execOverrides = buildCliMcpExecOverrides(params.run.execOverrides);
-  const bashElevated = buildCliMcpBashElevated(params.run.bashElevated);
-  const channelContext = buildCliMcpChannelContext(params.run.channelContext, params.run.senderId);
-  const senderName = normalizeOptionalMcpContextValue(params.run.senderName ?? undefined);
-  const senderUsername = normalizeOptionalMcpContextValue(params.run.senderUsername ?? undefined);
-  const senderE164 = normalizeOptionalMcpContextValue(params.run.senderE164 ?? undefined);
-  const groupId = normalizeOptionalMcpContextValue(params.run.groupId ?? undefined);
-  const groupChannel = normalizeOptionalMcpContextValue(params.run.groupChannel ?? undefined);
-  const groupSpace = normalizeOptionalMcpContextValue(params.run.groupSpace ?? undefined);
-  const spawnedBy = normalizeOptionalMcpContextValue(params.run.spawnedBy ?? undefined);
-  return {
-    sessionKey,
-    runtimePolicySessionKey: normalizeOptionalMcpContextValue(params.run.runtimePolicySessionKey),
-    agentId: params.agentId,
-    sessionId: normalizeOptionalMcpContextValue(params.run.sessionId),
-    runId: normalizeOptionalMcpContextValue(params.run.runId),
-    modelProvider: params.modelProvider,
-    modelId: params.modelId,
-    messageProvider: resolveCliMcpMessageProvider(params.run),
-    clientCaps: clientCaps.length > 0 ? clientCaps : undefined,
-    currentChannelId: normalizeOptionalMcpContextValue(params.run.currentChannelId),
-    currentThreadTs: normalizeOptionalMcpContextValue(params.run.currentThreadTs),
-    currentMessageId:
-      params.run.currentMessageId == null
-        ? undefined
-        : normalizeOptionalMcpContextValue(String(params.run.currentMessageId)),
-    currentInboundAudio: params.run.currentInboundAudio === true ? true : undefined,
-    accountId: normalizeOptionalMcpContextValue(params.run.agentAccountId),
-    inboundEventKind: params.run.currentInboundEventKind,
-    sourceReplyDeliveryMode: params.run.sourceReplyDeliveryMode,
-    taskSuggestionDeliveryMode: params.run.taskSuggestionDeliveryMode,
-    requireExplicitMessageTarget: params.requireExplicitMessageTarget ? true : undefined,
-    senderIsOwner: params.run.senderIsOwner === true,
-    nodeExecAllowed: true,
-    ...(execSession ? { execSession } : {}),
-    ...(execOverrides ? { execOverrides } : {}),
-    ...(bashElevated ? { bashElevated } : {}),
-    ...(params.run.trigger ? { trigger: params.run.trigger } : {}),
-    ...(normalizeOptionalMcpContextValue(params.run.approvalReviewerDeviceId)
-      ? { approvalReviewerDeviceId: params.run.approvalReviewerDeviceId?.trim() }
-      : {}),
-    ...(channelContext ? { channelContext } : {}),
-    ...(senderName ? { senderName } : {}),
-    ...(senderUsername ? { senderUsername } : {}),
-    ...(senderE164 ? { senderE164 } : {}),
-    ...(groupId ? { groupId } : {}),
-    ...(groupChannel ? { groupChannel } : {}),
-    ...(groupSpace ? { groupSpace } : {}),
-    ...(spawnedBy ? { spawnedBy } : {}),
-  };
 }
 
 function buildCliSessionDriftUserContext(
@@ -813,6 +671,14 @@ export async function prepareCliRunContext(
     );
   }
   const mcpDeliveryCaptureEnabled = bundleMcpEnabled && Boolean(mcpLoopbackRuntime);
+  // A restricted selectable tool surface must also bound the MCP bundle:
+  // CLI-side --allowedTools is advisory under bypass permission modes, so
+  // user/plugin MCP servers must not be merged into the run's config at all.
+  // The loopback server (scoped by the grant allowlist) becomes the complete
+  // tool universe for the run.
+  const restrictedLoopbackToolsAllow = resolveLoopbackToolsAllowFromMcpPermissions(
+    params.cliToolAvailability?.mcp,
+  );
   let cleanupPreparedResources: (() => Promise<void>) | undefined;
   let preparedExecution: Awaited<ReturnType<NonNullable<typeof backendResolved.prepareExecution>>> =
     undefined;
@@ -826,6 +692,7 @@ export async function prepareCliRunContext(
             agentId: sessionAgentId,
             modelProvider,
             modelId,
+            toolsAllow: restrictedLoopbackToolsAllow,
           }),
           runtimeOwnerToken: mcpLoopbackRuntime.ownerToken,
         })
@@ -863,6 +730,9 @@ export async function prepareCliRunContext(
         }
       : undefined;
     cleanupPreparedResources = cleanupMcpClientGrant;
+    const loopbackServerConfig = mcpLoopbackRuntime
+      ? prepareDeps.createMcpLoopbackServerConfig(mcpLoopbackRuntime.port)
+      : undefined;
     const preparedBackend = await prepareCliBundleMcpConfig({
       enabled: bundleMcpEnabled || systemAgentMcpConfig !== undefined,
       mode: backendResolved.bundleMcpMode,
@@ -870,10 +740,14 @@ export async function prepareCliRunContext(
       workspaceDir,
       config: params.config,
       agentDir,
-      ...(systemAgentMcpConfig ? { exclusiveConfig: systemAgentMcpConfig } : {}),
-      additionalConfig: mcpLoopbackRuntime
-        ? prepareDeps.createMcpLoopbackServerConfig(mcpLoopbackRuntime.port)
-        : undefined,
+      // Restricted runs serve only the loopback server; merging user/plugin
+      // MCP servers would let the run reach tools outside its allowlist.
+      ...(systemAgentMcpConfig
+        ? { exclusiveConfig: systemAgentMcpConfig }
+        : restrictedLoopbackToolsAllow && loopbackServerConfig
+          ? { exclusiveConfig: loopbackServerConfig }
+          : {}),
+      additionalConfig: restrictedLoopbackToolsAllow ? undefined : loopbackServerConfig,
       env:
         mcpLoopbackRuntime && mcpClientGrant
           ? {

--- a/src/agents/cli-runner/tool-policy.test.ts
+++ b/src/agents/cli-runner/tool-policy.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveCliRuntimeToolsAllow,
+  resolveLoopbackToolsAllowFromMcpPermissions,
+  stripOpenClawMcpToolPrefix,
+} from "./tool-policy.js";
+
+describe("resolveLoopbackToolsAllowFromMcpPermissions", () => {
+  it("returns undefined when no MCP permission list is set", () => {
+    expect(resolveLoopbackToolsAllowFromMcpPermissions(undefined)).toBeUndefined();
+  });
+
+  it("maps prefixed loopback names to gateway tool names", () => {
+    expect(
+      resolveLoopbackToolsAllowFromMcpPermissions([
+        "mcp__openclaw__memory_search",
+        "mcp__openclaw__memory_get",
+      ]),
+    ).toEqual(["memory_search", "memory_get"]);
+  });
+
+  it("keeps the full surface on wildcard entries", () => {
+    expect(resolveLoopbackToolsAllowFromMcpPermissions(["mcp__openclaw__*"])).toBeUndefined();
+    expect(
+      resolveLoopbackToolsAllowFromMcpPermissions(["mcp__openclaw__memory_search", "*"]),
+    ).toBeUndefined();
+  });
+
+  it("drops tools owned by other MCP servers and fails closed when none remain", () => {
+    expect(
+      resolveLoopbackToolsAllowFromMcpPermissions([
+        "mcp__other__thing",
+        "mcp__openclaw__memory_search",
+      ]),
+    ).toEqual(["memory_search"]);
+    // Only foreign-server entries: the loopback surface exposes nothing.
+    expect(resolveLoopbackToolsAllowFromMcpPermissions(["mcp__other__thing"])).toEqual([]);
+  });
+
+  it("normalizes and dedupes unprefixed entries", () => {
+    expect(
+      resolveLoopbackToolsAllowFromMcpPermissions([" Memory_Search ", "memory_search"]),
+    ).toEqual(["memory_search"]);
+  });
+});
+
+describe("stripOpenClawMcpToolPrefix", () => {
+  it("strips only the loopback transport prefix", () => {
+    expect(stripOpenClawMcpToolPrefix("mcp__openclaw__memory_search")).toBe("memory_search");
+    expect(stripOpenClawMcpToolPrefix("memory_search")).toBe("memory_search");
+    expect(stripOpenClawMcpToolPrefix("mcp__other__tool")).toBe("mcp__other__tool");
+  });
+});
+
+describe("resolveCliRuntimeToolsAllow", () => {
+  it("keeps only real restrictions", () => {
+    expect(resolveCliRuntimeToolsAllow(undefined)).toBeUndefined();
+    expect(resolveCliRuntimeToolsAllow(["memory_search"], true)).toBeUndefined();
+    expect(resolveCliRuntimeToolsAllow(["*"])).toBeUndefined();
+    expect(resolveCliRuntimeToolsAllow(["memory_search"])).toEqual(["memory_search"]);
+  });
+});

--- a/src/agents/cli-runner/tool-policy.ts
+++ b/src/agents/cli-runner/tool-policy.ts
@@ -1,5 +1,47 @@
 import { normalizeToolName } from "../tool-policy.js";
 
+/** Transport prefix CLI harnesses use for loopback OpenClaw MCP tool names. */
+export const OPENCLAW_MCP_TOOL_PREFIX = "mcp__openclaw__";
+
+/** Strips the loopback MCP transport prefix so observers see gateway tool names. */
+export function stripOpenClawMcpToolPrefix(toolName: string): string {
+  return toolName.startsWith(OPENCLAW_MCP_TOOL_PREFIX)
+    ? toolName.slice(OPENCLAW_MCP_TOOL_PREFIX.length)
+    : toolName;
+}
+
+/**
+ * Derives the loopback MCP grant allowlist from a selectable-backend MCP
+ * permission list. Wildcards keep the full session-scoped surface; entries for
+ * other MCP servers are not loopback-governed and drop out. A non-wildcard
+ * list that leaves no loopback names fails closed (empty allowlist).
+ */
+export function resolveLoopbackToolsAllowFromMcpPermissions(
+  mcp: readonly string[] | undefined,
+): string[] | undefined {
+  if (!mcp) {
+    return undefined;
+  }
+  const names = new Set<string>();
+  for (const entry of mcp) {
+    const trimmed = entry.trim();
+    if (!trimmed) {
+      continue;
+    }
+    if (trimmed === "*" || trimmed === `${OPENCLAW_MCP_TOOL_PREFIX}*`) {
+      return undefined;
+    }
+    if (trimmed.startsWith("mcp__") && !trimmed.startsWith(OPENCLAW_MCP_TOOL_PREFIX)) {
+      continue;
+    }
+    const name = normalizeToolName(stripOpenClawMcpToolPrefix(trimmed));
+    if (name) {
+      names.add(name);
+    }
+  }
+  return [...names];
+}
+
 /** CLI backends cannot enforce runtime caps; keep only real restrictions. */
 export function resolveCliRuntimeToolsAllow(
   toolsAllow?: string[],

--- a/src/agents/embedded-agent-runner/cli-backend-dispatch-eligibility.ts
+++ b/src/agents/embedded-agent-runner/cli-backend-dispatch-eligibility.ts
@@ -1,0 +1,121 @@
+/**
+ * Provider/backend/credential eligibility for CLI-backend dispatch of
+ * embedded runs. Shared by the dispatch itself and by callers that must
+ * budget for CLI latency before starting the run (active-memory recall's
+ * timeout default); both sides seeing one decision keeps timeouts and
+ * routing from drifting apart. Kept separate from the dispatch module so
+ * the plugin runtime surface does not eagerly load the run machinery.
+ */
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveRuntimeCliBackends } from "../../plugins/cli-backends.runtime.js";
+import {
+  ensureAuthProfileStore,
+  resolveAuthProfileOrder,
+  resolveModelAuthMode,
+} from "../model-auth.js";
+import { resolveCliRuntimeExecutionProvider } from "../model-runtime-aliases.js";
+
+type EmbeddedCliBackendDispatchEligibilityParams = {
+  provider?: string;
+  model?: string;
+  agentId?: string;
+  /** Explicitly pinned auth profile for the run; decisive when it resolves. */
+  authProfileId?: string;
+  config?: OpenClawConfig;
+  agentDir?: string;
+  workspaceDir?: string;
+};
+
+/**
+ * Decides whether an opted-in embedded run would execute through the CLI
+ * backend. Resolution stays on stored credential metadata — no credential
+ * materialization, refresh locks, or network calls on this per-turn path.
+ */
+export function resolveEmbeddedCliBackendDispatchEligibility(
+  params: EmbeddedCliBackendDispatchEligibilityParams,
+): { provider: string } | undefined {
+  // Canonical refs (anthropic/<model> routed to claude-cli via agentRuntime
+  // config) must dispatch the same as runs that arrive with the CLI runtime
+  // provider id directly, so resolve the configured execution runtime before
+  // gating.
+  const backends = new Map(
+    resolveRuntimeCliBackends().map((backend) => [normalizeProviderId(backend.id), backend]),
+  );
+  const requestedProvider = normalizeProviderId(params.provider ?? "");
+  const provider = backends.has(requestedProvider)
+    ? requestedProvider
+    : normalizeProviderId(
+        resolveCliRuntimeExecutionProvider({
+          provider: params.provider ?? "",
+          cfg: params.config,
+          agentId: params.agentId,
+          modelId: params.model,
+          // A pinned profile can be what maps a canonical ref onto its CLI
+          // runtime (e.g. multiple compatible profiles, no configured
+          // agentRuntime); omitting it here would strand the run on the
+          // passthrough before the credential-type check ever sees the pin.
+          authProfileId: params.authProfileId,
+        }) ?? "",
+      );
+  // The backend plugin owns the claim that its provider's direct-API
+  // passthrough cannot run on subscription credentials. Providers whose
+  // registered backend does not declare it — and config-only backends with
+  // no plugin descriptor — keep the passthrough unchanged.
+  if (!backends.get(provider)?.subscriptionAuthDispatch) {
+    return undefined;
+  }
+  const authMode = resolveAuthModeSafe(params, provider);
+  // An API key (also mixed/aws-sdk stores that include one) keeps the faster
+  // direct passthrough working; only subscription (oauth/token) or
+  // unresolvable credentials route through the CLI backend.
+  if (authMode === "api-key" || authMode === "mixed" || authMode === "aws-sdk") {
+    return undefined;
+  }
+  return { provider };
+}
+
+function resolveAuthModeSafe(
+  params: {
+    authProfileId?: string;
+    config?: OpenClawConfig;
+    agentDir?: string;
+    workspaceDir?: string;
+  },
+  provider: string,
+): ReturnType<typeof resolveModelAuthMode> {
+  try {
+    const store = ensureAuthProfileStore(params.agentDir, { config: params.config });
+    // A run pinned to an explicit profile executes on that credential, so its
+    // type decides regardless of the general order; an unresolvable pinned id
+    // falls back to ordered selection like the passthrough does.
+    const pinnedType = params.authProfileId
+      ? store.profiles[params.authProfileId.trim()]?.type
+      : undefined;
+    // Mixed stores must follow the same ordered selection the passthrough
+    // uses: the first ordered profile decides the mode. A store-wide
+    // aggregate would read oauth+api_key as "mixed" and keep the passthrough
+    // even when auth.order selects the subscription profile first.
+    const [selectedProfileId] = resolveAuthProfileOrder({
+      cfg: params.config,
+      store,
+      provider,
+    });
+    const selectedType =
+      pinnedType ?? (selectedProfileId ? store.profiles[selectedProfileId]?.type : undefined);
+    if (selectedType === "api_key") {
+      return "api-key";
+    }
+    if (selectedType === "oauth" || selectedType === "token") {
+      return selectedType;
+    }
+    return resolveModelAuthMode(provider, params.config, store, {
+      workspaceDir: params.workspaceDir,
+    });
+  } catch {
+    // Unreadable credential stores behave like missing credentials: the
+    // passthrough cannot work either, so the CLI backend is still the
+    // best-effort path.
+    return undefined;
+  }
+}

--- a/src/agents/embedded-agent-runner/cli-backend-dispatch-transcript.test.ts
+++ b/src/agents/embedded-agent-runner/cli-backend-dispatch-transcript.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createCliDispatchTranscriptRecorder } from "./cli-backend-dispatch-transcript.js";
+
+const appendTranscriptMessage = vi.hoisted(() => vi.fn());
+
+vi.mock("../../config/sessions/session-accessor.js", () => ({
+  appendTranscriptMessage,
+}));
+
+type AppendedRecord = {
+  scope: Record<string, unknown>;
+  message: Record<string, unknown>;
+};
+
+function appendedRecords(): AppendedRecord[] {
+  return appendTranscriptMessage.mock.calls.map((call) => ({
+    scope: call[0] as Record<string, unknown>,
+    message: (call[1] as { message: Record<string, unknown> }).message,
+  }));
+}
+
+function recorderParams() {
+  return {
+    sessionId: "recall-session",
+    sessionKey: "agent:main:recall",
+    agentId: "main",
+    sessionFile: "sqlite://agents/main/recall-session",
+    runId: "run-transcript-test",
+    prompt: "recall prompt",
+    provider: "claude-cli",
+    model: "claude-opus-4-8",
+  };
+}
+
+beforeEach(() => {
+  appendTranscriptMessage.mockReset();
+  appendTranscriptMessage.mockResolvedValue({ appended: true, message: {}, messageId: "m" });
+});
+
+describe("createCliDispatchTranscriptRecorder", () => {
+  it("appends the user turn to the run's session identity", async () => {
+    const recorder = createCliDispatchTranscriptRecorder(recorderParams());
+    await recorder.finalize();
+
+    const records = appendedRecords();
+    expect(records[0]?.scope).toMatchObject({
+      sessionId: "recall-session",
+      sessionKey: "agent:main:recall",
+      agentId: "main",
+      sessionFile: "sqlite://agents/main/recall-session",
+    });
+    expect(records[0]?.message).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: "recall prompt" }],
+    });
+  });
+
+  it("mirrors tool calls and results in the shapes the recall parsers accept", async () => {
+    const recorder = createCliDispatchTranscriptRecorder(recorderParams());
+    recorder.noteToolEvent({
+      phase: "start",
+      toolName: "memory_search",
+      toolCallId: "call-1",
+      args: { query: "wings" },
+    });
+    recorder.noteToolEvent({
+      phase: "result",
+      toolName: "memory_search",
+      toolCallId: "call-1",
+      result: {
+        content: [{ type: "text", text: '{"results":[{"id":"m1"}]}' }],
+        details: { results: [{ id: "m1" }], debug: { backend: "builtin", hits: 1 } },
+      },
+      isError: false,
+    });
+    await recorder.finalize("Lemon pepper.");
+
+    const messages = appendedRecords().map((record) => record.message);
+    expect(messages[1]).toMatchObject({
+      role: "assistant",
+      content: [
+        { type: "toolCall", id: "call-1", name: "memory_search", arguments: { query: "wings" } },
+      ],
+      stopReason: "toolUse",
+    });
+    // The toolResult shape is what active-memory's transcript readers parse:
+    // role/toolName gate the record; details/content decide usable-vs-unavailable.
+    expect(messages[2]).toMatchObject({
+      role: "toolResult",
+      toolCallId: "call-1",
+      toolName: "memory_search",
+      content: [{ type: "text", text: '{"results":[{"id":"m1"}]}' }],
+      details: { results: [{ id: "m1" }], debug: { backend: "builtin", hits: 1 } },
+      isError: false,
+    });
+    expect(messages[3]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Lemon pepper." }],
+      stopReason: "stop",
+    });
+  });
+
+  it("keeps bare-array tool_result content as claude stream-json echoes it", async () => {
+    // Live claude -p runs deliver MCP tool results as `block.content` — a bare
+    // content-block array with no {content} wrapper. Dropping it made every
+    // successful recall classify as no_relevant_memory.
+    const recorder = createCliDispatchTranscriptRecorder(recorderParams());
+    recorder.noteToolEvent({
+      phase: "start",
+      toolName: "memory_search",
+      toolCallId: "call-1",
+      args: { query: "copperfin" },
+    });
+    recorder.noteToolEvent({
+      phase: "result",
+      toolName: "memory_search",
+      toolCallId: "call-1",
+      result: [{ type: "text", text: '{"results":[{"path":"MEMORY.md"}]}' }],
+      isError: false,
+    });
+    await recorder.finalize("Port 4173.");
+
+    const messages = appendedRecords().map((record) => record.message);
+    expect(messages[2]).toMatchObject({
+      role: "toolResult",
+      toolCallId: "call-1",
+      toolName: "memory_search",
+      content: [{ type: "text", text: '{"results":[{"path":"MEMORY.md"}]}' }],
+      isError: false,
+    });
+  });
+
+  it("appends tool records incrementally for the live terminal-search watcher", async () => {
+    const recorder = createCliDispatchTranscriptRecorder(recorderParams());
+    recorder.noteToolEvent({
+      phase: "result",
+      toolName: "memory_search",
+      result: { content: [], details: { status: "unavailable", error: "backend offline" } },
+      isError: true,
+    });
+    // No finalize yet: the record must be written mid-run.
+    await vi.waitFor(() => {
+      expect(appendedRecords().some((record) => record.message.role === "toolResult")).toBe(true);
+    });
+    const toolResult = appendedRecords().find(
+      (record) => record.message.role === "toolResult",
+    )?.message;
+    expect(toolResult).toMatchObject({
+      toolName: "memory_search",
+      details: { status: "unavailable", error: "backend offline" },
+      isError: true,
+    });
+    await recorder.finalize();
+  });
+
+  it("flushes the last streamed assistant snapshot when no final text exists", async () => {
+    const recorder = createCliDispatchTranscriptRecorder(recorderParams());
+    recorder.noteAssistantText("partial an");
+    recorder.noteAssistantText("partial answer before timeout");
+    await recorder.finalize(undefined);
+
+    const assistant = appendedRecords().find(
+      (record) => record.message.role === "assistant",
+    )?.message;
+    expect(assistant).toMatchObject({
+      content: [{ type: "text", text: "partial answer before timeout" }],
+    });
+  });
+
+  it("flushes the latest snapshot on abort and does not duplicate it at finalize", async () => {
+    const recorder = createCliDispatchTranscriptRecorder(recorderParams());
+    recorder.noteAssistantText("partial before kill");
+    recorder.flushAssistantSnapshot();
+    await vi.waitFor(() => {
+      expect(
+        appendedRecords().filter((record) => record.message.role === "assistant"),
+      ).toHaveLength(1);
+    });
+    // The killed child settles later; finalize with the same text must not
+    // append a duplicate record.
+    await recorder.finalize(undefined);
+    const assistants = appendedRecords().filter((record) => record.message.role === "assistant");
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0]?.message).toMatchObject({
+      content: [{ type: "text", text: "partial before kill" }],
+      stopReason: "aborted",
+    });
+  });
+
+  it("writes a newer final text after an abort flush", async () => {
+    const recorder = createCliDispatchTranscriptRecorder(recorderParams());
+    recorder.noteAssistantText("partial");
+    recorder.flushAssistantSnapshot();
+    await recorder.finalize("full final answer");
+    const assistants = appendedRecords().filter((record) => record.message.role === "assistant");
+    expect(assistants).toHaveLength(2);
+    expect(assistants[1]?.message).toMatchObject({
+      content: [{ type: "text", text: "full final answer" }],
+      stopReason: "stop",
+    });
+  });
+
+  it("survives append failures without failing the run or later appends", async () => {
+    appendTranscriptMessage.mockRejectedValueOnce(new Error("store unavailable"));
+    const recorder = createCliDispatchTranscriptRecorder(recorderParams());
+    recorder.noteToolEvent({ phase: "result", toolName: "memory_search", isError: false });
+    await expect(recorder.finalize("text")).resolves.toBeUndefined();
+    // The user-turn append failed; the tool and assistant records still land.
+    expect(appendedRecords().some((record) => record.message.role === "toolResult")).toBe(true);
+    expect(appendedRecords().some((record) => record.message.role === "assistant")).toBe(true);
+  });
+});

--- a/src/agents/embedded-agent-runner/cli-backend-dispatch-transcript.ts
+++ b/src/agents/embedded-agent-runner/cli-backend-dispatch-transcript.ts
@@ -1,0 +1,227 @@
+/**
+ * Transcript recorder for CLI-dispatched embedded runs.
+ *
+ * The CLI backend runs its tool loop inside the external process and writes
+ * no OpenClaw transcript records, but one-shot callers (e.g. active-memory
+ * recall) read the run's transcript for timeout partial-text salvage,
+ * tool-result evidence, and a live terminal-search watcher that polls
+ * mid-run. Mirror the run into canonical transcript records through the
+ * session accessor: the user turn at start, tool calls/results as they
+ * stream, and the final assistant snapshot at run end.
+ */
+import { appendTranscriptMessage } from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { AgentMessage } from "../runtime/index.js";
+import { buildAssistantMessage, buildUsageWithNoCost } from "../stream-message-shared.js";
+
+const log = createSubsystemLogger("agents/embedded-cli-dispatch");
+
+type ToolResultContent =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string };
+
+type CliDispatchTranscriptToolEvent = {
+  phase: "start" | "result";
+  toolName: string;
+  toolCallId?: string;
+  args?: Record<string, unknown>;
+  result?: unknown;
+  isError?: boolean;
+};
+
+type CliDispatchTranscriptRecorder = {
+  noteToolEvent: (event: CliDispatchTranscriptToolEvent) => void;
+  noteAssistantText: (text: string) => void;
+  /**
+   * Writes the latest streamed assistant snapshot immediately. Called on
+   * abort: the killed CLI child can take seconds to settle, while timeout
+   * salvage reads the transcript within a short grace window.
+   */
+  flushAssistantSnapshot: () => void;
+  /** Appends the final assistant snapshot and drains pending writes. */
+  finalize: (finalText?: string) => Promise<void>;
+};
+
+/**
+ * Records a CLI-dispatched run into the run's session transcript by session
+ * identity. Tool records append as events arrive (the terminal-search
+ * watcher polls the transcript live); the assistant snapshot is held in
+ * memory and flushed once at finalize (or immediately on abort) so streamed
+ * text does not append a record per delta while timeout salvage still finds
+ * the last text the model produced.
+ */
+export function createCliDispatchTranscriptRecorder(params: {
+  sessionId: string;
+  sessionKey?: string;
+  agentId?: string;
+  sessionFile?: string;
+  runId: string;
+  prompt: string;
+  provider: string;
+  model?: string;
+  cwd?: string;
+  config?: OpenClawConfig;
+}): CliDispatchTranscriptRecorder {
+  let tail: Promise<void> = Promise.resolve();
+  let lastAssistantText = "";
+  let lastWrittenAssistantText = "";
+  let finalized = false;
+  let toolRecordSequence = 0;
+
+  const scope = {
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+    sessionFile: params.sessionFile,
+  };
+
+  const enqueue = (build: () => AgentMessage) => {
+    tail = tail.then(async () => {
+      await appendTranscriptMessage(scope, {
+        message: build(),
+        config: params.config,
+        cwd: params.cwd,
+      });
+    });
+    // Transcript mirroring is best-effort; a failed append must not fail the
+    // run or poison later appends in the chain.
+    tail = tail.catch((error: unknown) => {
+      log.warn(
+        `cli dispatch transcript append failed: runId=${params.runId} error=${String(error)}`,
+      );
+    });
+  };
+
+  const model = {
+    api: "cli",
+    provider: params.provider,
+    id: params.model ?? "",
+  };
+
+  type AssistantBuildParams = Parameters<typeof buildAssistantMessage>[0];
+  // Mirrored records carry zero usage: the CLI child's token accounting is
+  // not visible on this bridge, and cost fields must not invent values.
+  const buildZeroUsageAssistantMessage = (
+    content: AssistantBuildParams["content"],
+    stopReason: AssistantBuildParams["stopReason"],
+  ) => buildAssistantMessage({ model, content, stopReason, usage: buildUsageWithNoCost({}) });
+
+  enqueue(() => ({
+    role: "user",
+    content: [{ type: "text", text: params.prompt }],
+    timestamp: Date.now(),
+  }));
+
+  return {
+    noteToolEvent: (event) => {
+      if (finalized) {
+        return;
+      }
+      toolRecordSequence += 1;
+      const toolCallId =
+        event.toolCallId?.trim() || `${params.runId}-tool-${String(toolRecordSequence)}`;
+      if (event.phase === "start") {
+        enqueue(() =>
+          buildZeroUsageAssistantMessage(
+            [
+              {
+                type: "toolCall",
+                id: toolCallId,
+                name: event.toolName,
+                arguments: event.args ?? {},
+              },
+            ],
+            "toolUse",
+          ),
+        );
+        return;
+      }
+      enqueue(() => ({
+        role: "toolResult",
+        toolCallId,
+        toolName: event.toolName,
+        content: normalizeToolResultContent(event.result),
+        details: readToolResultDetails(event.result),
+        isError: event.isError === true,
+        timestamp: Date.now(),
+      }));
+    },
+    noteAssistantText: (text) => {
+      if (!finalized && text.trim()) {
+        lastAssistantText = text;
+      }
+    },
+    flushAssistantSnapshot: () => {
+      if (finalized) {
+        return;
+      }
+      const text = lastAssistantText.trim();
+      if (!text || text === lastWrittenAssistantText) {
+        return;
+      }
+      lastWrittenAssistantText = text;
+      enqueue(() => buildZeroUsageAssistantMessage([{ type: "text", text }], "aborted"));
+    },
+    finalize: async (finalText) => {
+      if (finalized) {
+        await tail;
+        return;
+      }
+      finalized = true;
+      const text = finalText?.trim() || lastAssistantText.trim();
+      if (text && text !== lastWrittenAssistantText) {
+        lastWrittenAssistantText = text;
+        enqueue(() => buildZeroUsageAssistantMessage([{ type: "text", text }], "stop"));
+      }
+      await tail;
+    },
+  };
+}
+
+/** Maps a sanitized CLI tool result onto transcript content blocks. */
+function normalizeToolResultContent(result: unknown): ToolResultContent[] {
+  if (typeof result === "string") {
+    return result ? [{ type: "text", text: result }] : [];
+  }
+  if (!result || typeof result !== "object") {
+    return [];
+  }
+  // Claude stream-json echoes MCP tool_result content as a bare block array;
+  // dropping it starves transcript consumers (active-memory reads these
+  // records to decide whether the recall summary is grounded in tool output).
+  const content = Array.isArray(result) ? result : (result as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  const blocks: ToolResultContent[] = [];
+  for (const block of content) {
+    if (typeof block === "string") {
+      blocks.push({ type: "text", text: block });
+      continue;
+    }
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const type = (block as { type?: unknown }).type;
+    const text = (block as { text?: unknown }).text;
+    if (type === "text" && typeof text === "string") {
+      blocks.push({ type: "text", text });
+      continue;
+    }
+    const data = (block as { data?: unknown }).data;
+    const mimeType = (block as { mimeType?: unknown }).mimeType;
+    if (type === "image" && typeof data === "string" && typeof mimeType === "string") {
+      blocks.push({ type: "image", data, mimeType });
+    }
+  }
+  return blocks;
+}
+
+function readToolResultDetails(result: unknown): unknown {
+  if (!result || typeof result !== "object") {
+    return undefined;
+  }
+  const details = (result as { details?: unknown }).details;
+  return details && typeof details === "object" ? details : undefined;
+}

--- a/src/agents/embedded-agent-runner/cli-backend-dispatch.test.ts
+++ b/src/agents/embedded-agent-runner/cli-backend-dispatch.test.ts
@@ -1,0 +1,548 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { emitAgentEvent } from "../../infra/agent-events.js";
+import { resolveEmbeddedCliBackendDispatchEligibility } from "./cli-backend-dispatch-eligibility.js";
+import { runEmbeddedAgentViaCliBackendIfEligible } from "./cli-backend-dispatch.js";
+import type { RunEmbeddedAgentParams } from "./run/params.js";
+import type { EmbeddedAgentRunResult } from "./types.js";
+
+const ensureAuthProfileStore = vi.hoisted(() => vi.fn());
+const resolveAuthProfileOrder = vi.hoisted(() => vi.fn());
+const resolveModelAuthMode = vi.hoisted(() => vi.fn());
+const resolveRuntimeCliBackends = vi.hoisted(() => vi.fn());
+const resolveCliRuntimeExecutionProvider = vi.hoisted(() => vi.fn());
+const runCliAgent = vi.hoisted(() => vi.fn());
+const retireSessionMcpRuntime = vi.hoisted(() => vi.fn());
+const retireSessionMcpRuntimeForSessionKey = vi.hoisted(() => vi.fn());
+
+vi.mock("../model-auth.js", () => ({
+  ensureAuthProfileStore,
+  resolveAuthProfileOrder,
+  resolveModelAuthMode,
+}));
+vi.mock("../model-runtime-aliases.js", () => ({
+  resolveCliRuntimeExecutionProvider,
+}));
+vi.mock("../../plugins/cli-backends.runtime.js", () => ({
+  resolveRuntimeCliBackends,
+}));
+vi.mock("../cli-runner.runtime.js", () => ({
+  runCliAgent,
+}));
+vi.mock("../agent-bundle-mcp-tools.js", () => ({
+  retireSessionMcpRuntime,
+  retireSessionMcpRuntimeForSessionKey,
+}));
+const transcriptRecorder = vi.hoisted(() => ({
+  noteToolEvent: vi.fn(),
+  noteAssistantText: vi.fn(),
+  flushAssistantSnapshot: vi.fn(),
+  finalize: vi.fn(async () => undefined),
+}));
+const createCliDispatchTranscriptRecorder = vi.hoisted(() => vi.fn(() => transcriptRecorder));
+vi.mock("./cli-backend-dispatch-transcript.js", () => ({
+  createCliDispatchTranscriptRecorder,
+}));
+
+function baseRunParams(overrides: Partial<RunEmbeddedAgentParams> = {}): RunEmbeddedAgentParams {
+  return {
+    sessionId: "recall-session",
+    sessionKey: "agent:main:recall",
+    sessionFile: "/tmp/recall/session.jsonl",
+    workspaceDir: "/tmp/recall/workspace",
+    prompt: "recall prompt",
+    provider: "claude-cli",
+    model: "claude-opus-4-8",
+    timeoutMs: 30_000,
+    runId: "run-cli-dispatch-test",
+    cliBackendDispatch: "subscription-auth" as const,
+    toolsAllow: ["memory_search"],
+    ...overrides,
+  };
+}
+
+function cliRunResult(meta: Partial<EmbeddedAgentRunResult["meta"]> = {}): EmbeddedAgentRunResult {
+  return {
+    payloads: [{ text: "recall summary" }],
+    meta: meta as EmbeddedAgentRunResult["meta"],
+  } as EmbeddedAgentRunResult;
+}
+
+beforeEach(() => {
+  ensureAuthProfileStore.mockReset();
+  resolveAuthProfileOrder.mockReset();
+  resolveModelAuthMode.mockReset();
+  resolveRuntimeCliBackends.mockReset();
+  runCliAgent.mockReset();
+  retireSessionMcpRuntime.mockReset();
+  retireSessionMcpRuntimeForSessionKey.mockReset();
+  resolveCliRuntimeExecutionProvider.mockReset();
+  ensureAuthProfileStore.mockReturnValue({ profiles: {} });
+  resolveAuthProfileOrder.mockReturnValue([]);
+  resolveModelAuthMode.mockReturnValue("oauth");
+  // Default registry: the claude-cli backend declares the capability, a
+  // gemini backend does not.
+  resolveRuntimeCliBackends.mockReturnValue([
+    { id: "claude-cli", subscriptionAuthDispatch: true },
+    { id: "google-gemini-cli" },
+  ]);
+  resolveCliRuntimeExecutionProvider.mockReturnValue(undefined);
+  retireSessionMcpRuntimeForSessionKey.mockResolvedValue(true);
+  retireSessionMcpRuntime.mockResolvedValue(true);
+  runCliAgent.mockResolvedValue(cliRunResult());
+  transcriptRecorder.noteToolEvent.mockReset();
+  transcriptRecorder.noteAssistantText.mockReset();
+  transcriptRecorder.flushAssistantSnapshot.mockReset();
+  transcriptRecorder.finalize.mockClear();
+  createCliDispatchTranscriptRecorder.mockClear();
+});
+
+describe("resolveEmbeddedCliBackendDispatchEligibility", () => {
+  // The recall timeout default consumes this decision directly; these cases
+  // pin that API-key and missing-backend setups stay ineligible so callers
+  // budgeting on it keep the passthrough default.
+  it("resolves the provider for subscription (oauth) credentials", () => {
+    expect(resolveEmbeddedCliBackendDispatchEligibility({ provider: "claude-cli" })).toEqual({
+      provider: "claude-cli",
+    });
+  });
+
+  it("returns undefined for API-key credentials", () => {
+    resolveModelAuthMode.mockReturnValue("api-key");
+    expect(
+      resolveEmbeddedCliBackendDispatchEligibility({ provider: "claude-cli" }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined without a registered claude-cli backend", () => {
+    resolveRuntimeCliBackends.mockReturnValue([]);
+    expect(
+      resolveEmbeddedCliBackendDispatchEligibility({ provider: "claude-cli" }),
+    ).toBeUndefined();
+  });
+
+  it("honors an explicitly pinned API-key profile over subscription-first order", () => {
+    // A pinned profile is the credential the run executes on; order must not
+    // override it in either direction.
+    ensureAuthProfileStore.mockReturnValue({
+      profiles: {
+        "anthropic:claude-cli": { type: "oauth", provider: "claude-cli" },
+        "anthropic:api": { type: "api_key", provider: "anthropic" },
+      },
+    });
+    resolveAuthProfileOrder.mockReturnValue(["anthropic:claude-cli", "anthropic:api"]);
+    expect(
+      resolveEmbeddedCliBackendDispatchEligibility({
+        provider: "claude-cli",
+        authProfileId: "anthropic:api",
+      }),
+    ).toBeUndefined();
+    expect(resolveModelAuthMode).not.toHaveBeenCalled();
+  });
+
+  it("honors an explicitly pinned OAuth profile over API-key-first order", () => {
+    ensureAuthProfileStore.mockReturnValue({
+      profiles: {
+        "anthropic:api": { type: "api_key", provider: "anthropic" },
+        "anthropic:claude-cli": { type: "oauth", provider: "claude-cli" },
+      },
+    });
+    resolveAuthProfileOrder.mockReturnValue(["anthropic:api", "anthropic:claude-cli"]);
+    expect(
+      resolveEmbeddedCliBackendDispatchEligibility({
+        provider: "claude-cli",
+        authProfileId: "anthropic:claude-cli",
+      }),
+    ).toEqual({ provider: "claude-cli" });
+  });
+
+  it("falls back to ordered selection when the pinned profile is unknown", () => {
+    ensureAuthProfileStore.mockReturnValue({
+      profiles: { "anthropic:api": { type: "api_key", provider: "anthropic" } },
+    });
+    resolveAuthProfileOrder.mockReturnValue(["anthropic:api"]);
+    expect(
+      resolveEmbeddedCliBackendDispatchEligibility({
+        provider: "claude-cli",
+        authProfileId: "anthropic:missing",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when the backend does not declare the capability", () => {
+    // The provider plugin owns the subscription-billing claim; a registered
+    // backend without it (e.g. gemini) keeps the passthrough.
+    expect(
+      resolveEmbeddedCliBackendDispatchEligibility({ provider: "google-gemini-cli" }),
+    ).toBeUndefined();
+    expect(resolveModelAuthMode).not.toHaveBeenCalled();
+  });
+
+  it("resolves canonical refs through the configured runtime", () => {
+    resolveCliRuntimeExecutionProvider.mockReturnValue("claude-cli");
+    expect(
+      resolveEmbeddedCliBackendDispatchEligibility({
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+        agentId: "main",
+      }),
+    ).toEqual({ provider: "claude-cli" });
+  });
+
+  it("forwards the pinned auth profile into runtime resolution", () => {
+    // The pin can be what maps a canonical ref onto its CLI runtime; the
+    // resolver must see it or dispatch strands the run on the passthrough.
+    resolveCliRuntimeExecutionProvider.mockReturnValue("claude-cli");
+    ensureAuthProfileStore.mockReturnValue({
+      profiles: { "anthropic:claude-cli": { type: "oauth", provider: "claude-cli" } },
+    });
+    expect(
+      resolveEmbeddedCliBackendDispatchEligibility({
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+        agentId: "main",
+        authProfileId: "anthropic:claude-cli",
+      }),
+    ).toEqual({ provider: "claude-cli" });
+    expect(resolveCliRuntimeExecutionProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ authProfileId: "anthropic:claude-cli" }),
+    );
+  });
+});
+
+describe("runEmbeddedAgentViaCliBackendIfEligible gate", () => {
+  const runGate = (overrides: Partial<RunEmbeddedAgentParams> = {}) =>
+    runEmbeddedAgentViaCliBackendIfEligible(baseRunParams(overrides));
+
+  it("returns undefined without the opt-in", async () => {
+    expect(await runGate({ cliBackendDispatch: undefined })).toBeUndefined();
+    expect(resolveModelAuthMode).not.toHaveBeenCalled();
+    expect(runCliAgent).not.toHaveBeenCalled();
+  });
+
+  it("dispatches claude-cli runs with subscription (oauth) credentials", async () => {
+    expect(await runGate({ agentDir: "/agents/main", workspaceDir: "/workspace" })).toBeDefined();
+    expect(ensureAuthProfileStore).toHaveBeenCalledWith("/agents/main", expect.anything());
+    expect(resolveModelAuthMode).toHaveBeenCalledWith(
+      "claude-cli",
+      undefined,
+      expect.anything(),
+      expect.objectContaining({ workspaceDir: "/workspace" }),
+    );
+    expect(runCliAgent.mock.calls[0]?.[0]).toMatchObject({ provider: "claude-cli" });
+  });
+
+  it("dispatches when no credential mode resolves for the passthrough", async () => {
+    resolveModelAuthMode.mockReturnValue(undefined);
+    expect(await runGate()).toBeDefined();
+    expect(runCliAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches when the credential store is unreadable", async () => {
+    ensureAuthProfileStore.mockImplementation(() => {
+      throw new Error("store unreadable");
+    });
+    expect(await runGate()).toBeDefined();
+    expect(runCliAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["api-key", "mixed", "aws-sdk"] as const)(
+    "keeps the passthrough when the auth mode is %s",
+    async (mode) => {
+      resolveModelAuthMode.mockReturnValue(mode);
+      expect(await runGate()).toBeUndefined();
+      expect(runCliAgent).not.toHaveBeenCalled();
+    },
+  );
+
+  it("dispatches when the ordered profile selection picks a subscription credential in a mixed store", async () => {
+    // The passthrough follows auth.order; a store-wide "mixed" aggregate must
+    // not suppress dispatch when the selected profile is oauth.
+    ensureAuthProfileStore.mockReturnValue({
+      profiles: {
+        "anthropic:claude-cli": { type: "oauth", provider: "claude-cli" },
+        "anthropic:api": { type: "api_key", provider: "anthropic" },
+      },
+    });
+    resolveAuthProfileOrder.mockReturnValue(["anthropic:claude-cli", "anthropic:api"]);
+    resolveModelAuthMode.mockReturnValue("mixed");
+    expect(await runGate()).toBeDefined();
+    expect(resolveModelAuthMode).not.toHaveBeenCalled();
+  });
+
+  it("keeps the passthrough when the ordered profile selection picks an API key", async () => {
+    ensureAuthProfileStore.mockReturnValue({
+      profiles: {
+        "anthropic:api": { type: "api_key", provider: "anthropic" },
+        "anthropic:claude-cli": { type: "oauth", provider: "claude-cli" },
+      },
+    });
+    resolveAuthProfileOrder.mockReturnValue(["anthropic:api", "anthropic:claude-cli"]);
+    expect(await runGate()).toBeUndefined();
+    expect(runCliAgent).not.toHaveBeenCalled();
+  });
+
+  it("dispatches canonical anthropic refs whose configured runtime is claude-cli", async () => {
+    resolveCliRuntimeExecutionProvider.mockReturnValue("claude-cli");
+    expect(
+      await runGate({ provider: "anthropic", model: "claude-opus-4-8", agentId: "main" }),
+    ).toBeDefined();
+    expect(resolveCliRuntimeExecutionProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "anthropic",
+        agentId: "main",
+        modelId: "claude-opus-4-8",
+      }),
+    );
+    // The dispatch runs on the resolved execution provider, not the canonical ref.
+    expect(runCliAgent.mock.calls[0]?.[0]).toMatchObject({ provider: "claude-cli" });
+  });
+
+  it("keeps the passthrough for canonical refs without a claude-cli runtime", async () => {
+    resolveCliRuntimeExecutionProvider.mockReturnValue(undefined);
+    expect(await runGate({ provider: "anthropic", model: "claude-opus-4-8" })).toBeUndefined();
+    resolveCliRuntimeExecutionProvider.mockReturnValue("google-gemini-cli");
+    expect(await runGate({ provider: "google", model: "gemini-3.1-pro-preview" })).toBeUndefined();
+    expect(runCliAgent).not.toHaveBeenCalled();
+  });
+
+  it("keeps the passthrough for other CLI runtimes until verified", async () => {
+    expect(await runGate({ provider: "google-gemini-cli" })).toBeUndefined();
+    expect(resolveModelAuthMode).not.toHaveBeenCalled();
+  });
+
+  it("keeps the passthrough without a caller-owned session file", async () => {
+    expect(await runGate({ sessionFile: undefined })).toBeUndefined();
+  });
+
+  it("keeps the passthrough when no claude-cli backend is registered", async () => {
+    resolveRuntimeCliBackends.mockReturnValue([]);
+    expect(await runGate()).toBeUndefined();
+  });
+});
+
+describe("runEmbeddedAgentViaCliBackendIfEligible execution", () => {
+  it("maps the embedded run onto a one-shot restricted CLI run", async () => {
+    runCliAgent.mockResolvedValue(cliRunResult());
+    const params = baseRunParams({
+      toolsAllow: ["memory_search", "memory_get", "notes_retrieve_context"],
+    });
+
+    const result = await runEmbeddedAgentViaCliBackendIfEligible(params);
+
+    expect(result?.payloads?.[0]?.text).toBe("recall summary");
+    expect(runCliAgent).toHaveBeenCalledTimes(1);
+    const cliParams = runCliAgent.mock.calls[0]?.[0];
+    expect(cliParams).toMatchObject({
+      provider: "claude-cli",
+      model: "claude-opus-4-8",
+      sessionFile: "/tmp/recall/session.jsonl",
+      timeoutMs: 30_000,
+      runTimeoutOverrideMs: 30_000,
+      disableCliLiveSession: true,
+      cleanupCliLiveSessionOnRunEnd: true,
+      requireExplicitMessageTarget: true,
+      cliToolAvailability: {
+        native: [],
+        mcp: [
+          "mcp__openclaw__memory_search",
+          "mcp__openclaw__memory_get",
+          "mcp__openclaw__notes_retrieve_context",
+        ],
+      },
+    });
+    // Embedded toolsAllow must never reach the CLI runner: it fails closed.
+    expect(cliParams).not.toHaveProperty("toolsAllow");
+  });
+
+  // Fail-closed tool policy: only a non-empty named allowlist is expressible
+  // on the CLI surface. Every other embedded tool state keeps the passthrough
+  // so no closed state silently widens.
+  it.each([
+    ["a wildcard allowlist", { toolsAllow: ["*"] }],
+    ["a mixed wildcard allowlist", { toolsAllow: ["memory_search", "*"] }],
+    ["a deny-all allowlist", { toolsAllow: [] }],
+    ["no allowlist", { toolsAllow: undefined }],
+    ["disableTools", { disableTools: true }],
+    ["a raw model run", { modelRun: true }],
+  ] as const)("refuses dispatch for %s", async (_label, overrides) => {
+    expect(
+      await runEmbeddedAgentViaCliBackendIfEligible(
+        baseRunParams(overrides as Partial<RunEmbeddedAgentParams>),
+      ),
+    ).toBeUndefined();
+    expect(runCliAgent).not.toHaveBeenCalled();
+  });
+
+  it("invokes onExecutionStarted once at the dispatch boundary", async () => {
+    runCliAgent.mockResolvedValue(cliRunResult());
+    const onExecutionStarted = vi.fn();
+    await runEmbeddedAgentViaCliBackendIfEligible(
+      baseRunParams({ onExecutionStarted, lifecycleGeneration: "gen-1" }),
+    );
+    expect(onExecutionStarted).toHaveBeenCalledTimes(1);
+    expect(onExecutionStarted).toHaveBeenCalledWith({ lifecycleGeneration: "gen-1" });
+  });
+
+  it("bridges CLI tool result events to onAgentToolResult without the MCP prefix", async () => {
+    const observed: Array<{ toolName: string; isError: boolean }> = [];
+    const params = baseRunParams({
+      toolsAllow: ["memory_search"],
+      onAgentToolResult: (event) => {
+        observed.push({ toolName: event.toolName, isError: event.isError });
+      },
+    });
+    runCliAgent.mockImplementation(async (cliParams: { runId: string }) => {
+      emitAgentEvent({
+        runId: cliParams.runId,
+        stream: "tool",
+        data: {
+          phase: "result",
+          name: "mcp__openclaw__memory_search",
+          result: { content: [] },
+          isError: false,
+        },
+      });
+      // Soft tool failures must surface as isError like the native path.
+      emitAgentEvent({
+        runId: cliParams.runId,
+        stream: "tool",
+        data: {
+          phase: "result",
+          name: "mcp__openclaw__memory_get",
+          result: { details: { status: "error" } },
+          isError: false,
+        },
+      });
+      emitAgentEvent({
+        runId: "other-run",
+        stream: "tool",
+        data: { phase: "result", name: "mcp__openclaw__memory_get", isError: true },
+      });
+      return cliRunResult();
+    });
+
+    await runEmbeddedAgentViaCliBackendIfEligible(params);
+
+    expect(observed).toEqual([
+      { toolName: "memory_search", isError: false },
+      { toolName: "memory_get", isError: true },
+    ]);
+
+    // The bridge must not outlive the run.
+    emitAgentEvent({
+      runId: params.runId,
+      stream: "tool",
+      data: { phase: "result", name: "mcp__openclaw__memory_search", isError: false },
+    });
+    expect(observed).toHaveLength(2);
+  });
+
+  it("retires only the run's session MCP runtime instead of the process-wide server", async () => {
+    runCliAgent.mockResolvedValue(cliRunResult());
+    const params = baseRunParams({ cleanupBundleMcpOnRunEnd: true });
+    await runEmbeddedAgentViaCliBackendIfEligible(params);
+    // The CLI runner's flag would close the shared loopback MCP server, which
+    // concurrent turns may still be using; it must never be forwarded.
+    expect(runCliAgent.mock.calls[0]?.[0]).not.toHaveProperty("cleanupBundleMcpOnRunEnd");
+    expect(retireSessionMcpRuntimeForSessionKey).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionKey: params.sessionKey }),
+    );
+    expect(retireSessionMcpRuntime).not.toHaveBeenCalled();
+  });
+
+  it("skips MCP runtime cleanup when the caller did not request it", async () => {
+    runCliAgent.mockResolvedValue(cliRunResult());
+    await runEmbeddedAgentViaCliBackendIfEligible(baseRunParams());
+    expect(retireSessionMcpRuntimeForSessionKey).not.toHaveBeenCalled();
+  });
+
+  it("mirrors the run into the transcript recorder", async () => {
+    runCliAgent.mockImplementation(async (cliParams: { runId: string }) => {
+      emitAgentEvent({
+        runId: cliParams.runId,
+        stream: "assistant",
+        data: { text: "partial answer" },
+      });
+      emitAgentEvent({
+        runId: cliParams.runId,
+        stream: "tool",
+        data: {
+          phase: "start",
+          name: "mcp__openclaw__memory_search",
+          toolCallId: "call-1",
+          args: { query: "wings" },
+        },
+      });
+      emitAgentEvent({
+        runId: cliParams.runId,
+        stream: "tool",
+        data: {
+          phase: "result",
+          name: "mcp__openclaw__memory_search",
+          toolCallId: "call-1",
+          result: { content: [] },
+          isError: false,
+        },
+      });
+      return cliRunResult();
+    });
+
+    await runEmbeddedAgentViaCliBackendIfEligible(baseRunParams({ toolsAllow: ["memory_search"] }));
+
+    expect(createCliDispatchTranscriptRecorder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionFile: "/tmp/recall/session.jsonl",
+        sessionId: "recall-session",
+        prompt: "recall prompt",
+        provider: "claude-cli",
+      }),
+    );
+    expect(transcriptRecorder.noteAssistantText).toHaveBeenCalledWith("partial answer");
+    expect(transcriptRecorder.noteToolEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: "start",
+        toolName: "memory_search",
+        toolCallId: "call-1",
+        args: { query: "wings" },
+      }),
+    );
+    expect(transcriptRecorder.noteToolEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ phase: "result", toolName: "memory_search" }),
+    );
+    expect(transcriptRecorder.finalize).toHaveBeenCalledWith("recall summary");
+  });
+
+  it("flushes the assistant snapshot the moment the run aborts", async () => {
+    const abortController = new AbortController();
+    runCliAgent.mockImplementation(async () => {
+      abortController.abort(new Error("recall timeout"));
+      expect(transcriptRecorder.flushAssistantSnapshot).toHaveBeenCalledTimes(1);
+      throw new Error("aborted");
+    });
+    await expect(
+      runEmbeddedAgentViaCliBackendIfEligible(
+        baseRunParams({ abortSignal: abortController.signal }),
+      ),
+    ).rejects.toThrow("aborted");
+    expect(transcriptRecorder.finalize).toHaveBeenCalledWith(undefined);
+  });
+
+  it("finalizes the transcript when the CLI run fails", async () => {
+    runCliAgent.mockRejectedValue(new Error("boom"));
+    await expect(runEmbeddedAgentViaCliBackendIfEligible(baseRunParams())).rejects.toThrow("boom");
+    expect(transcriptRecorder.finalize).toHaveBeenCalledWith(undefined);
+  });
+
+  it("drops CLI session bindings from the run result", async () => {
+    runCliAgent.mockResolvedValue(
+      cliRunResult({
+        agentMeta: {
+          sessionId: "native-session",
+          cliSessionBinding: { sessionId: "native-session" },
+        },
+      } as Partial<EmbeddedAgentRunResult["meta"]>),
+    );
+    const result = await runEmbeddedAgentViaCliBackendIfEligible(baseRunParams());
+    expect(result?.meta.agentMeta?.cliSessionBinding).toBeUndefined();
+  });
+});

--- a/src/agents/embedded-agent-runner/cli-backend-dispatch.ts
+++ b/src/agents/embedded-agent-runner/cli-backend-dispatch.ts
@@ -1,0 +1,292 @@
+/**
+ * Opt-in CLI-backend dispatch for one-shot embedded runs.
+ *
+ * Embedded runs targeting a CLI runtime provider normally fall through to the
+ * openclaw harness and call the provider API directly with that runtime's
+ * credentials (`cli_runtime_passthrough_openclaw`). Anthropic routes direct
+ * anthropic-messages calls on subscription OAuth tokens to metered "extra
+ * usage" billing: without extra-usage balance the passthrough fails closed
+ * with a billing error, and with it the run silently draws paid usage instead
+ * of the plan limits the CLI runtime was configured for. Callers that
+ * tolerate CLI latency opt in via `cliBackendDispatch: "subscription-auth"`
+ * to run through the CLI backend on plan limits instead.
+ */
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { onAgentEvent } from "../../infra/agent-events.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { OPENCLAW_MCP_TOOL_PREFIX, stripOpenClawMcpToolPrefix } from "../cli-runner/tool-policy.js";
+import { normalizeToolName } from "../tool-policy.js";
+import { isToolResultError } from "../tool-result-error.js";
+import { resolveEmbeddedCliBackendDispatchEligibility } from "./cli-backend-dispatch-eligibility.js";
+import { createCliDispatchTranscriptRecorder } from "./cli-backend-dispatch-transcript.js";
+import type { RunEmbeddedAgentParams } from "./run/params.js";
+import type { EmbeddedAgentRunResult } from "./types.js";
+
+const log = createSubsystemLogger("agents/embedded-cli-dispatch");
+
+type EmbeddedCliBackendDispatch = {
+  provider: string;
+  sessionFile: string;
+  /** Named loopback allowlist; the dispatch gate guarantees it is non-empty. */
+  toolsAllow: string[];
+};
+
+/**
+ * Runs the embedded turn through the CLI backend when the opt-in dispatch
+ * gate matches; returns undefined so the caller continues on the native path.
+ */
+export async function runEmbeddedAgentViaCliBackendIfEligible(
+  params: RunEmbeddedAgentParams,
+): Promise<EmbeddedAgentRunResult | undefined> {
+  const dispatch = resolveEmbeddedCliBackendDispatch(params);
+  return dispatch ? await runEmbeddedAgentViaCliBackend(params, dispatch) : undefined;
+}
+
+/** Applies the opt-in and transcript-path gates on top of shared eligibility. */
+function resolveEmbeddedCliBackendDispatch(
+  params: RunEmbeddedAgentParams,
+): EmbeddedCliBackendDispatch | undefined {
+  if (params.cliBackendDispatch !== "subscription-auth") {
+    return undefined;
+  }
+  // The CLI runner needs the caller-owned transcript path; runs without one
+  // stay on the passthrough where session targets are resolved internally.
+  const sessionFile = params.sessionFile?.trim();
+  if (!sessionFile) {
+    return undefined;
+  }
+  const toolsAllow = resolveDispatchableToolsAllow(params);
+  if (!toolsAllow) {
+    return undefined;
+  }
+  const eligibility = resolveEmbeddedCliBackendDispatchEligibility(params);
+  return eligibility ? { provider: eligibility.provider, sessionFile, toolsAllow } : undefined;
+}
+
+/**
+ * Fail closed on tool policy: dispatch only runs whose embedded tool state the
+ * CLI bridge can express faithfully — a non-empty named allowlist bounded by
+ * the loopback grant. Deny-all (`[]`), wildcards, absent allowlists, and
+ * flag-based restrictions (`disableTools`, `modelRun`) keep the embedded
+ * passthrough so no closed state silently widens on the CLI surface; full
+ * translation can arrive with the first caller that needs it (#57326).
+ */
+function resolveDispatchableToolsAllow(params: RunEmbeddedAgentParams): string[] | undefined {
+  if (params.disableTools || params.modelRun) {
+    return undefined;
+  }
+  if (!params.toolsAllow || params.toolsAllow.length === 0) {
+    return undefined;
+  }
+  const names = params.toolsAllow.map((name) => normalizeToolName(name));
+  if (names.some((name) => !name || name === "*" || name.includes("*"))) {
+    return undefined;
+  }
+  return [...new Set(names)];
+}
+
+/** Runs an opted-in embedded run through the CLI backend as a one-shot turn. */
+async function runEmbeddedAgentViaCliBackend(
+  params: RunEmbeddedAgentParams,
+  dispatch: EmbeddedCliBackendDispatch,
+): Promise<EmbeddedAgentRunResult> {
+  const { runCliAgent } = await import("../cli-runner.runtime.js");
+  // The dispatch gate guarantees a non-empty named allowlist; translate it to
+  // the selectable-backend surface: no native tools, only the listed loopback
+  // MCP tools. The MCP list also bounds the loopback grant server-side (tools
+  // outside it can be neither listed nor called) and makes prepare serve the
+  // loopback exclusively, so the message tool and user/plugin MCP servers stay
+  // unreachable, matching disableMessageTool intent.
+  const cliToolAvailability = {
+    native: [] as [],
+    mcp: dispatch.toolsAllow.map((name) => `${OPENCLAW_MCP_TOOL_PREFIX}${name}`),
+  };
+  const onAgentToolResult = params.onAgentToolResult;
+  // The CLI backend writes no OpenClaw session records; mirror the run into
+  // the caller-owned session file so transcript consumers (persistTranscripts,
+  // timeout partial-text salvage, the live terminal-search watcher) keep
+  // working at parity with embedded runs.
+  const transcript = createCliDispatchTranscriptRecorder({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+    sessionFile: dispatch.sessionFile,
+    runId: params.runId,
+    prompt: params.prompt,
+    provider: dispatch.provider,
+    model: params.model,
+    cwd: params.cwd ?? params.workspaceDir,
+    config: params.config,
+  });
+  // CLI tool results arrive as agent events with transport-prefixed MCP
+  // names; strip and normalize so observers and transcript records see the
+  // same tool names and soft-error signal the native embedded path reports.
+  const unsubscribe = onAgentEvent((evt) => {
+    if (evt.runId !== params.runId) {
+      return;
+    }
+    if (evt.stream === "assistant" && typeof evt.data.text === "string") {
+      transcript.noteAssistantText(evt.data.text);
+      return;
+    }
+    if (evt.stream !== "tool") {
+      return;
+    }
+    const phase = evt.data.phase;
+    if (phase !== "start" && phase !== "result") {
+      return;
+    }
+    const rawName = typeof evt.data.name === "string" ? evt.data.name : "";
+    if (!rawName) {
+      return;
+    }
+    const toolName = normalizeToolName(stripOpenClawMcpToolPrefix(rawName));
+    const toolCallId = typeof evt.data.toolCallId === "string" ? evt.data.toolCallId : undefined;
+    if (phase === "start") {
+      transcript.noteToolEvent({
+        phase,
+        toolName,
+        toolCallId,
+        args: isRecord(evt.data.args) ? evt.data.args : undefined,
+      });
+      return;
+    }
+    const isError = evt.data.isError === true || isToolResultError(evt.data.result);
+    transcript.noteToolEvent({
+      phase,
+      toolName,
+      toolCallId,
+      result: evt.data.result,
+      isError,
+    });
+    onAgentToolResult?.({
+      toolName,
+      result: evt.data.result,
+      isError,
+    });
+  });
+  // The killed CLI child can take seconds to settle after a timeout abort,
+  // while the caller's partial-text salvage reads the session file within a
+  // short grace window; flush the latest snapshot the moment abort fires.
+  const flushOnAbort = () => transcript.flushAssistantSnapshot();
+  params.abortSignal?.addEventListener("abort", flushOnAbort, { once: true });
+  // Reply/cron callers advance lifecycle state and arm execution-phase
+  // watchdogs on this signal; dispatched runs emit it at the same
+  // post-admission boundary where the native path does.
+  params.onExecutionStarted?.(
+    params.lifecycleGeneration !== undefined
+      ? { lifecycleGeneration: params.lifecycleGeneration }
+      : undefined,
+  );
+  log.info(
+    `dispatching embedded run through CLI backend: runId=${params.runId} provider=${dispatch.provider} model=${params.model ?? ""}`,
+  );
+  let finalAssistantText: string | undefined;
+  try {
+    const result = await runCliAgent({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+      trigger: params.trigger,
+      sessionFile: dispatch.sessionFile,
+      workspaceDir: params.workspaceDir,
+      agentDir: params.agentDir,
+      config: params.config,
+      prompt: params.prompt,
+      provider: dispatch.provider,
+      model: params.model,
+      thinkLevel: params.thinkLevel,
+      timeoutMs: params.timeoutMs,
+      runTimeoutOverrideMs: params.runTimeoutOverrideMs ?? params.timeoutMs,
+      runId: params.runId,
+      lifecycleGeneration: params.lifecycleGeneration,
+      lane: params.lane,
+      extraSystemPrompt: params.extraSystemPrompt,
+      messageChannel: params.messageChannel,
+      messageProvider: params.messageProvider,
+      bootstrapContextMode: params.bootstrapContextMode,
+      bootstrapContextRunKind: params.bootstrapContextRunKind,
+      abortSignal: params.abortSignal,
+      cliToolAvailability,
+      // One-shot helper run: fresh CLI process, no warm live session left
+      // behind, and no implicit message sends without an explicit target.
+      disableCliLiveSession: true,
+      cleanupCliLiveSessionOnRunEnd: true,
+      requireExplicitMessageTarget: true,
+      // Deliberately NOT forwarding cleanupBundleMcpOnRunEnd: on the CLI
+      // runner it closes the process-wide loopback MCP server, which a
+      // concurrent main turn or overlapping recall may still be using.
+      // Session-scoped MCP runtimes are retired below instead.
+    });
+    finalAssistantText = result.payloads?.find(
+      (payload) => payload.isReasoning !== true && typeof payload.text === "string",
+    )?.text;
+    return withoutCliSessionBinding(result);
+  } finally {
+    params.abortSignal?.removeEventListener("abort", flushOnAbort);
+    unsubscribe();
+    // Flush before the promise settles: timeout salvage reads the session
+    // file as soon as the caller observes the rejection.
+    await transcript.finalize(finalAssistantText);
+    if (params.cleanupBundleMcpOnRunEnd === true) {
+      await retireDispatchSessionMcpRuntime(params);
+    }
+  }
+}
+
+/**
+ * Mirrors the embedded runner's cleanupBundleMcpOnRunEnd semantics for the
+ * CLI dispatch path: retire only this run's session-scoped MCP runtimes so
+ * stdio children do not idle until the TTL reaper, without touching the
+ * process-wide loopback server shared with concurrent CLI turns.
+ */
+async function retireDispatchSessionMcpRuntime(params: {
+  sessionId: string;
+  sessionKey?: string;
+  runId: string;
+}): Promise<void> {
+  try {
+    const { retireSessionMcpRuntime, retireSessionMcpRuntimeForSessionKey } =
+      await import("../agent-bundle-mcp-tools.js");
+    const onError = (error: unknown, sessionId: string) => {
+      log.warn(
+        `bundle-mcp cleanup failed after CLI dispatch run: runId=${params.runId} sessionId=${sessionId} error=${String(error)}`,
+      );
+    };
+    const retiredBySessionKey = await retireSessionMcpRuntimeForSessionKey({
+      sessionKey: params.sessionKey,
+      reason: "embedded-cli-dispatch-run-end",
+      onError,
+    });
+    if (!retiredBySessionKey) {
+      await retireSessionMcpRuntime({
+        sessionId: params.sessionId,
+        reason: "embedded-cli-dispatch-run-end",
+        onError,
+      });
+    }
+  } catch (error) {
+    log.warn(
+      `bundle-mcp cleanup unavailable after CLI dispatch run: runId=${params.runId} error=${String(error)}`,
+    );
+  }
+}
+
+/** Dispatch runs own no session entry, so a returned CLI binding has no owner to persist it. */
+function withoutCliSessionBinding(result: EmbeddedAgentRunResult): EmbeddedAgentRunResult {
+  const agentMeta = result.meta.agentMeta;
+  if (!agentMeta?.cliSessionBinding && agentMeta?.clearCliSessionBinding !== true) {
+    return result;
+  }
+  return {
+    ...result,
+    meta: {
+      ...result.meta,
+      agentMeta: {
+        ...agentMeta,
+        cliSessionBinding: undefined,
+        clearCliSessionBinding: undefined,
+      },
+    },
+  };
+}

--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -26,14 +26,14 @@ import {
   type SessionSuspensionParams,
 } from "../session-suspension.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
+import { runEmbeddedAgentViaCliBackendIfEligible } from "./cli-backend-dispatch.js";
 import { waitForDeferredTurnMaintenanceForSession } from "./context-engine-maintenance.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
 import { executePreparedEmbeddedRun } from "./run-execution.js";
 import {
+  createEmbeddedRunStageSummaryEmitter,
   createEmbeddedRunStageTracker,
-  formatEmbeddedRunStageSummary,
-  shouldWarnEmbeddedRunStageSummary,
 } from "./run/attempt-stage-timing.js";
 import { hasEmbeddedRunConfiguredModelFallbacks } from "./run/fallbacks.js";
 import { buildHandledReplyPayloads } from "./run/handled-reply.js";
@@ -161,6 +161,13 @@ async function runEmbeddedAgentInternal(
     throwIfAborted();
     return enqueueGlobal(async () => {
       throwIfAborted();
+      // Subscription-scoped claude-cli auth executes via the CLI backend;
+      // resolved post-admission so dispatched runs obey the same lifecycle,
+      // placement, and concurrency gates as native embedded runs.
+      const cliDispatched = await runEmbeddedAgentViaCliBackendIfEligible(params);
+      if (cliDispatched) {
+        return cliDispatched;
+      }
       const started = Date.now();
       const startupStages = createEmbeddedRunStageTracker();
       const progressController = createEmbeddedRunProgressController({
@@ -169,22 +176,13 @@ async function runEmbeddedAgentInternal(
         startedAtMs: started,
       });
       const { notifyExecutionPhase } = progressController;
-      const emitStartupStageSummary = (phase: string) => {
-        const summary = startupStages.snapshot();
-        const shouldWarn = shouldWarnEmbeddedRunStageSummary(summary);
-        if (!shouldWarn && !log.isEnabled("trace")) {
-          return;
-        }
-        const message = formatEmbeddedRunStageSummary(
-          `[trace:embedded-run] startup stages: runId=${params.runId} sessionId=${params.sessionId} phase=${phase}`,
-          summary,
-        );
-        if (shouldWarn) {
-          log.warn(message);
-        } else {
-          log.trace(message);
-        }
-      };
+      const emitStartupStageSummary = createEmbeddedRunStageSummaryEmitter({
+        label: "startup stages",
+        log,
+        runId: params.runId,
+        sessionId: params.sessionId,
+        tracker: startupStages,
+      });
       params.onExecutionStarted?.({ lifecycleGeneration });
       notifyExecutionPhase("runner_entered");
       const workspaceResolution = resolveRunWorkspaceDir({

--- a/src/agents/embedded-agent-runner/run.cli-dispatch-lane.test.ts
+++ b/src/agents/embedded-agent-runner/run.cli-dispatch-lane.test.ts
@@ -1,0 +1,90 @@
+// Proves opted-in CLI-backend dispatch executes inside embedded lane
+// admission: the dispatch decision and the CLI run must happen within the
+// enqueued global-lane task, not before it, so dispatched runs obey the same
+// lifecycle, placement, and concurrency gates as native embedded runs.
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommandQueueEnqueueFn } from "../../process/command-queue.types.js";
+import type { EmbeddedAgentRunResult } from "./types.js";
+
+const runEmbeddedAgentViaCliBackendIfEligible = vi.hoisted(() => vi.fn());
+vi.mock("./cli-backend-dispatch.js", () => ({
+  runEmbeddedAgentViaCliBackendIfEligible,
+}));
+
+import { runEmbeddedAgent } from "./run.js";
+
+const tempRoot = mkdtempSync(join(tmpdir(), "cli-dispatch-lane-"));
+
+afterAll(() => {
+  rmSync(tempRoot, { recursive: true, force: true });
+});
+
+const dispatchResult: EmbeddedAgentRunResult = {
+  payloads: [{ text: "dispatched" }],
+  meta: {
+    durationMs: 1,
+    agentMeta: { usage: {} },
+  },
+} as unknown as EmbeddedAgentRunResult;
+
+function laneRunParams() {
+  return {
+    sessionId: "recall-lane-session",
+    sessionKey: "agent:main:recall-lane-test",
+    agentId: "main",
+    sessionTarget: {
+      agentId: "main",
+      sessionId: "recall-lane-session",
+      sessionKey: "agent:main:recall-lane-test",
+      storePath: join(tempRoot, "sessions.json"),
+    },
+    sessionFile: join(tempRoot, "session.jsonl"),
+    workspaceDir: join(tempRoot, "workspace"),
+    prompt: "recall prompt",
+    provider: "claude-cli",
+    model: "claude-opus-4-8",
+    timeoutMs: 5_000,
+    runId: "run-cli-dispatch-lane-test",
+    config: {},
+    cliBackendDispatch: "subscription-auth" as const,
+  };
+}
+
+describe("runEmbeddedAgent CLI dispatch lane admission", () => {
+  beforeEach(() => {
+    runEmbeddedAgentViaCliBackendIfEligible.mockReset();
+  });
+
+  it("resolves and executes CLI dispatch inside the global-lane task", async () => {
+    const order: string[] = [];
+    runEmbeddedAgentViaCliBackendIfEligible.mockImplementation(async () => {
+      order.push("dispatch-run");
+      return dispatchResult;
+    });
+    // The custom enqueue hook stands in for both the session and the global
+    // lane, so a compliant run enters it twice before dispatching.
+    const enqueue: CommandQueueEnqueueFn = async (task) => {
+      order.push("global-lane-enter");
+      const result = await task();
+      order.push("global-lane-exit");
+      return result;
+    };
+
+    const result = await runEmbeddedAgent({ ...laneRunParams(), enqueue });
+
+    expect(result.payloads?.[0]?.text).toBe("dispatched");
+    // Both lane admissions (session, then global) must fully wrap the
+    // dispatch decision and execution.
+    expect(order).toEqual([
+      "global-lane-enter",
+      "global-lane-enter",
+      "dispatch-run",
+      "global-lane-exit",
+      "global-lane-exit",
+    ]);
+    expect(runEmbeddedAgentViaCliBackendIfEligible).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-setup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.ts
@@ -16,6 +16,7 @@ import { log } from "../logger.js";
 import { mapThinkingLevel, mapThinkingLevelForProvider } from "../utils.js";
 import { configureEmbeddedAttemptHttpRuntime } from "./attempt-http-runtime.js";
 import {
+  createEmbeddedRunStageSummaryEmitter,
   createEmbeddedRunStageTracker,
   formatEmbeddedRunStageSummary,
   shouldWarnEmbeddedRunStageSummary,
@@ -61,22 +62,13 @@ export async function prepareEmbeddedAttemptSetup(params: EmbeddedRunAttemptPara
     `embedded run start: runId=${params.runId} sessionId=${params.sessionId} provider=${params.provider} model=${params.modelId} thinking=${params.thinkLevel} messageChannel=${params.messageChannel ?? params.messageProvider ?? "unknown"}`,
   );
   const prepStages = createEmbeddedRunStageTracker();
-  const emitPrepStageSummary = (phase: string) => {
-    const summary = prepStages.snapshot();
-    const shouldWarn = shouldWarnEmbeddedRunStageSummary(summary);
-    if (!shouldWarn && !log.isEnabled("trace")) {
-      return;
-    }
-    const message = formatEmbeddedRunStageSummary(
-      `[trace:embedded-run] prep stages: runId=${params.runId} sessionId=${params.sessionId} phase=${phase}`,
-      summary,
-    );
-    if (shouldWarn) {
-      log.warn(message);
-    } else {
-      log.trace(message);
-    }
-  };
+  const emitPrepStageSummary = createEmbeddedRunStageSummaryEmitter({
+    label: "prep stages",
+    log,
+    runId: params.runId,
+    sessionId: params.sessionId,
+    tracker: prepStages,
+  });
   const emitCorePluginToolStageSummary = (
     phase: string,
     summary: ReturnType<typeof prepStages.snapshot>,

--- a/src/agents/embedded-agent-runner/run/attempt-stage-timing.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stage-timing.ts
@@ -78,6 +78,40 @@ export function shouldWarnEmbeddedRunStageSummary(
   );
 }
 
+/**
+ * Builds the shared "emit stage summary" closure used by run startup and
+ * attempt prep: warn when thresholds trip, trace otherwise, stay silent when
+ * neither applies.
+ */
+export function createEmbeddedRunStageSummaryEmitter(options: {
+  label: string;
+  log: {
+    isEnabled: (level: "trace") => boolean;
+    warn: (message: string) => void;
+    trace: (message: string) => void;
+  };
+  runId: string;
+  sessionId?: string;
+  tracker: EmbeddedRunStageTracker;
+}): (phase: string) => void {
+  return (phase) => {
+    const summary = options.tracker.snapshot();
+    const shouldWarn = shouldWarnEmbeddedRunStageSummary(summary);
+    if (!shouldWarn && !options.log.isEnabled("trace")) {
+      return;
+    }
+    const message = formatEmbeddedRunStageSummary(
+      `[trace:embedded-run] ${options.label}: runId=${options.runId} sessionId=${options.sessionId} phase=${phase}`,
+      summary,
+    );
+    if (shouldWarn) {
+      options.log.warn(message);
+    } else {
+      options.log.trace(message);
+    }
+  };
+}
+
 /** Formats stage timing into compact log text for startup/attempt diagnostics. */
 export function formatEmbeddedRunStageSummary(
   prefix: string,

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -318,6 +318,22 @@ export type RunEmbeddedAgentParams = {
   allowEmptyAssistantReplyAsSilent?: boolean;
   authProfileFailurePolicy?: AuthProfileFailurePolicy;
   /**
+   * One-shot helper runs may opt in to executing through the provider's CLI
+   * backend instead of the direct-API passthrough when the run targets a CLI
+   * runtime provider whose passthrough credentials are subscription-scoped.
+   * Anthropic routes direct anthropic-messages calls on subscription OAuth to
+   * metered extra-usage billing: without extra-usage balance the passthrough
+   * fails closed with a billing error, and with it the run silently draws
+   * paid usage instead of plan limits. The CLI backend is the plan-limits
+   * path for those credentials. CLI dispatch translates `toolsAllow` into the
+   * selectable-backend surface (no native tools, allowlisted loopback MCP
+   * tools); the same list bounds the loopback MCP grant server-side, so tools
+   * outside it — including the message tool, matching `disableMessageTool`
+   * intent — can be neither listed nor called. Leave unset to keep the
+   * direct-API passthrough.
+   */
+  cliBackendDispatch?: "subscription-auth";
+  /**
    * Allow a single run attempt even when all auth profiles are in cooldown,
    * but only for inferred transient cooldowns like `rate_limit` or `overloaded`.
    *

--- a/src/gateway/mcp-grant-store.ts
+++ b/src/gateway/mcp-grant-store.ts
@@ -27,6 +27,14 @@ export type McpLoopbackRequestContext = {
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   taskSuggestionDeliveryMode?: TaskSuggestionDeliveryMode;
   requireExplicitMessageTarget?: boolean;
+  /**
+   * Per-run allowlist of gateway tool names for this grant. When set, the
+   * loopback surface lists and executes only these tools; CLI-side flags such
+   * as `--allowedTools` are advisory under bypass permission modes, so the
+   * grant is where restricted one-shot runs (e.g. active-memory recall) get
+   * hard enforcement. Unset keeps the full session-scoped surface.
+   */
+  toolsAllow?: string[];
   senderIsOwner: boolean;
   /** Capability minted only for Gateway-launched CLI backends. */
   nodeExecAllowed?: boolean;

--- a/src/gateway/mcp-http.runtime.test.ts
+++ b/src/gateway/mcp-http.runtime.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { McpLoopbackToolCache, resolveMcpLoopbackScopedTools } from "./mcp-http.runtime.js";
+
+const resolveGatewayScopedTools = vi.hoisted(() => vi.fn());
+
+vi.mock("./tool-resolution.js", () => ({
+  resolveGatewayScopedTools,
+}));
+
+function scopedToolFixture(names: string[]) {
+  return {
+    agentId: "main",
+    tools: names.map((name) => ({ name, description: `${name} tool` })),
+  };
+}
+
+function scopeParams(overrides: Record<string, unknown> = {}) {
+  return {
+    cfg: {} as OpenClawConfig,
+    sessionKey: "agent:main:recall",
+    messageProvider: undefined,
+    currentChannelId: undefined,
+    currentThreadTs: undefined,
+    currentMessageId: undefined,
+    currentInboundAudio: undefined,
+    accountId: undefined,
+    inboundEventKind: undefined,
+    sourceReplyDeliveryMode: undefined,
+    senderIsOwner: undefined,
+    ...overrides,
+  } as Parameters<typeof resolveMcpLoopbackScopedTools>[0];
+}
+
+beforeEach(() => {
+  resolveGatewayScopedTools.mockReset();
+  resolveGatewayScopedTools.mockReturnValue(
+    scopedToolFixture(["memory_search", "memory_get", "message", "cron"]),
+  );
+});
+
+describe("resolveMcpLoopbackScopedTools", () => {
+  it("keeps the full session scope without a grant allowlist", () => {
+    const scoped = resolveMcpLoopbackScopedTools(scopeParams());
+    expect(scoped.tools.map((tool) => (tool as { name: string }).name)).toEqual([
+      "memory_search",
+      "memory_get",
+      "message",
+      "cron",
+    ]);
+  });
+
+  it("hard-filters the surface to the grant allowlist", () => {
+    const scoped = resolveMcpLoopbackScopedTools(
+      scopeParams({ toolsAllow: ["memory_search", "memory_get"] }),
+    );
+    expect(scoped.tools.map((tool) => (tool as { name: string }).name)).toEqual([
+      "memory_search",
+      "memory_get",
+    ]);
+  });
+
+  it("fails closed on an empty grant allowlist", () => {
+    const scoped = resolveMcpLoopbackScopedTools(scopeParams({ toolsAllow: [] }));
+    expect(scoped.tools).toEqual([]);
+  });
+});
+
+describe("McpLoopbackToolCache", () => {
+  it("does not share cache rows across different grant allowlists", () => {
+    const cache = new McpLoopbackToolCache();
+    const cfg = {} as OpenClawConfig;
+
+    const unrestricted = cache.resolve(scopeParams({ cfg }));
+    const restricted = cache.resolve(scopeParams({ cfg, toolsAllow: ["memory_search"] }));
+    const denied = cache.resolve(scopeParams({ cfg, toolsAllow: [] }));
+
+    expect(unrestricted.tools).toHaveLength(4);
+    expect(restricted.tools).toHaveLength(1);
+    expect(denied.tools).toHaveLength(0);
+    expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(3);
+
+    // Same allowlist reuses the cached row.
+    cache.resolve(scopeParams({ cfg, toolsAllow: ["memory_search"] }));
+    expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -2,6 +2,7 @@
 // Resolves Gateway-visible tools for MCP clients with short-lived schema caching.
 import type { ExecElevatedDefaults } from "../agents/bash-tools.exec-types.js";
 import type { ExecPolicyOverrides, ExecSessionDefaults } from "../agents/exec-defaults.js";
+import { normalizeToolName } from "../agents/tool-policy.js";
 import type {
   SourceReplyDeliveryMode,
   TaskSuggestionDeliveryMode,
@@ -11,6 +12,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginHookChannelContext } from "../plugins/hook-types.js";
 import {
   buildMcpToolSchema,
+  readMcpLoopbackToolName,
   type McpLoopbackTool,
   type McpToolSchemaEntry,
 } from "./mcp-http.schema.js";
@@ -52,6 +54,8 @@ type McpLoopbackScopeParams = {
   sourceReplyDeliveryMode: SourceReplyDeliveryMode | undefined;
   taskSuggestionDeliveryMode?: TaskSuggestionDeliveryMode;
   requireExplicitMessageTarget?: boolean;
+  /** Per-run grant allowlist of gateway tool names; unset keeps full scope. */
+  toolsAllow?: string[];
   senderIsOwner: boolean | undefined;
   nodeExecAllowed?: boolean;
   execSession?: ExecSessionDefaults;
@@ -87,8 +91,28 @@ export function resolveMcpLoopbackScopedTools(params: McpLoopbackScopeParams): {
   });
   return {
     agentId: scoped.agentId,
-    tools: scoped.tools,
+    tools: applyGrantToolsAllow(scoped.tools, params.toolsAllow),
   };
+}
+
+/**
+ * Hard-enforces a per-run grant allowlist on the loopback surface. Both
+ * tools/list and tools/call consume this list, so a tool outside the
+ * allowlist can be neither discovered nor executed even when the CLI runs
+ * with a bypass permission mode. An empty allowlist fails closed.
+ */
+function applyGrantToolsAllow(
+  tools: McpLoopbackTool[],
+  toolsAllow: string[] | undefined,
+): McpLoopbackTool[] {
+  if (!toolsAllow) {
+    return tools;
+  }
+  const allowed = new Set(toolsAllow.map((name) => normalizeToolName(name)).filter(Boolean));
+  return tools.filter((tool) => {
+    const name = readMcpLoopbackToolName(tool);
+    return name !== undefined && allowed.has(normalizeToolName(name));
+  });
 }
 
 /** Short-lived cache for loopback tool lists keyed by session/channel context. */
@@ -117,6 +141,9 @@ export class McpLoopbackToolCache {
       params.sourceReplyDeliveryMode ?? "",
       params.taskSuggestionDeliveryMode ?? "",
       params.requireExplicitMessageTarget === true ? "explicit-message-target" : "",
+      // Unset (full scope) must never share a cache row with an empty
+      // allowlist (deny-all), so the marker distinguishes presence.
+      params.toolsAllow ? `allow:${[...new Set(params.toolsAllow)].toSorted().join(",")}` : "",
       params.nodeExecAllowed === true ? "node-exec" : "",
       params.execSession?.execHost ?? "",
       params.execSession?.execSecurity ?? "",

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -67,11 +67,7 @@ function createMcpJsonParseError(error: unknown): Error & { code: "mcp_json_pars
 }
 
 function isMcpJsonParseError(error: unknown): error is Error & { code: "mcp_json_parse_error" } {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    (error as { code?: unknown }).code === "mcp_json_parse_error"
-  );
+  return isRecord(error) && error.code === "mcp_json_parse_error";
 }
 
 function parseMcpJsonBody(body: string): unknown {
@@ -313,6 +309,7 @@ async function startMcpLoopbackServer(port = 0): Promise<{
           sourceReplyDeliveryMode: requestContext.sourceReplyDeliveryMode,
           taskSuggestionDeliveryMode: requestContext.taskSuggestionDeliveryMode,
           requireExplicitMessageTarget: requestContext.requireExplicitMessageTarget,
+          toolsAllow: requestContext.toolsAllow,
           senderIsOwner: requestContext.senderIsOwner,
           nodeExecAllowed: requestContext.nodeExecAllowed,
           execSession: requestContext.execSession,

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -414,6 +414,9 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       resolveThinkingDefault: vi.fn(
         () => "off",
       ) as unknown as PluginRuntime["agent"]["resolveThinkingDefault"],
+      resolveCliBackendDispatchEligibility: vi.fn(
+        () => undefined,
+      ) as unknown as PluginRuntime["agent"]["resolveCliBackendDispatchEligibility"],
       normalizeThinkingLevel: vi.fn(
         (raw?: string | null) => raw,
       ) as unknown as PluginRuntime["agent"]["normalizeThinkingLevel"],

--- a/src/plugins/cli-backend.types.ts
+++ b/src/plugins/cli-backend.types.ts
@@ -121,6 +121,16 @@ export type CliBackendPlugin = {
    */
   ownsNativeCompaction?: boolean;
   /**
+   * Whether embedded runs opted into `cliBackendDispatch: "subscription-auth"`
+   * execute through this backend when the selected credential is
+   * subscription-scoped (oauth/token) or unresolvable.
+   *
+   * Set only when this backend's model provider rejects or meters direct API
+   * calls on subscription tokens, so the passthrough would fail or silently
+   * bill outside plan limits. API-key credentials always keep the passthrough.
+   */
+  subscriptionAuthDispatch?: boolean;
+  /**
    * Optional live-smoke metadata owned by the backend plugin.
    *
    * Keep provider-specific test wiring here instead of scattering it across

--- a/src/plugins/runtime/runtime-agent.ts
+++ b/src/plugins/runtime/runtime-agent.ts
@@ -2,6 +2,7 @@
 import { isDeepStrictEqual } from "node:util";
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
+import { resolveEmbeddedCliBackendDispatchEligibility } from "../../agents/embedded-agent-runner/cli-backend-dispatch-eligibility.js";
 import { resolveAgentIdentity } from "../../agents/identity.js";
 import {
   buildConfiguredModelCatalog,
@@ -43,7 +44,6 @@ import type { PluginRuntime } from "./types.js";
 
 type RuntimeSessionStoreReadParams = {
   agentId?: string;
-
   env?: NodeJS.ProcessEnv;
   hydrateSkillPromptRefs?: boolean;
   sessionKey: string;
@@ -453,10 +453,7 @@ async function runWithSessionWorkAdmission<T>(
 /** Creates the plugin runtime agent facade with lazy embedded-agent/session helpers. */
 export function createRuntimeAgent(): PluginRuntime["agent"] {
   const agentRuntime = {
-    defaults: {
-      model: DEFAULT_MODEL,
-      provider: DEFAULT_PROVIDER,
-    },
+    defaults: { model: DEFAULT_MODEL, provider: DEFAULT_PROVIDER },
     resolveAgentDir,
     resolveAgentWorkspaceDir,
     resolveAgentIdentity,
@@ -489,6 +486,7 @@ export function createRuntimeAgent(): PluginRuntime["agent"] {
       return profile.defaultLevel ? { ...policy, defaultLevel: profile.defaultLevel } : policy;
     },
     resolveAgentTimeoutMs,
+    resolveCliBackendDispatchEligibility: resolveEmbeddedCliBackendDispatchEligibility,
     ensureAgentWorkspace,
   } satisfies Omit<PluginRuntime["agent"], "runEmbeddedAgent" | "runEmbeddedPiAgent" | "session"> &
     Partial<Pick<PluginRuntime["agent"], "runEmbeddedAgent" | "runEmbeddedPiAgent" | "session">>;

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -304,6 +304,12 @@ export type PluginRuntimeCore = {
     /** @deprecated Use runEmbeddedAgent. */
     runEmbeddedPiAgent: RuntimeRunEmbeddedAgent;
     resolveAgentTimeoutMs: typeof import("../../agents/timeout.js").resolveAgentTimeoutMs;
+    /**
+     * Shares the embedded runner's CLI-backend dispatch eligibility (route,
+     * registered backend, stored credential mode) so opted-in callers can
+     * budget timeouts for the run that will actually execute.
+     */
+    resolveCliBackendDispatchEligibility: typeof import("../../agents/embedded-agent-runner/cli-backend-dispatch-eligibility.js").resolveEmbeddedCliBackendDispatchEligibility;
     ensureAgentWorkspace: typeof import("../../agents/workspace.js").ensureAgentWorkspace;
     session: {
       resolveStorePath: typeof import("../../config/sessions/paths.js").resolveStorePath;


### PR DESCRIPTION
Closes #106839
Related: #86761

## What Problem This Solves

Fixes an issue where agents running on the Claude CLI runtime with subscription-only auth (Claude Code OAuth, no Anthropic API key) would have every active-memory recall either fail with a billing rejection (no extra-usage balance) or **silently draw paid metered extra usage** (extra usage enabled) — while main-session turns correctly ran on plan limits through the CLI backend. Anthropic routing direct anthropic-messages calls on subscription tokens to extra-usage billing is long-standing behavior; the embedded runner's direct-API passthrough (`cli_runtime_passthrough_openclaw`) was never a viable path for these credentials.

## Why This Change Was Made

Adds an opt-in `RunEmbeddedAgentParams.cliBackendDispatch: "subscription-auth"`: when the run's provider is `claude-cli` — directly or via a canonical `anthropic/<model>` ref whose configured `agentRuntime` is claude-cli — a backend is registered, and the ordered credential selection resolves to subscription (oauth/token) or nothing rather than an API key, the run executes through `runCliAgent` as a one-shot turn. Active-memory recall opts in. The dispatch preserves the embedded run's contracts:

- **Tool restriction is enforced server-side**: `toolsAllow` maps to the selectable-backend surface, bounds the loopback MCP grant (tools outside it can be neither listed nor called, even under bypass permission modes), and restricted runs get an exclusive loopback-only MCP bundle — user/plugin MCP servers are not merged in.
- **Transcript parity**: the run is mirrored into the caller-owned session file (user turn, live tool call/result records, assistant snapshot — flushed immediately on abort), so `persistTranscripts`, timeout partial-text salvage, and the live terminal-search watcher work identically to embedded runs.
- **Isolation**: fresh CLI process per run, no live-session reuse, session-scoped MCP cleanup (never the process-wide loopback server), CLI session bindings dropped from the result.
- **Scope**: claude-cli only; `google-gemini-cli` and custom backends keep the passthrough — their direct-API contracts were not verified and this PR makes no claims about them. An available API key keeps the existing fast passthrough. The core-side provider set could move to a `CliBackendConfig` capability flag if maintainers prefer that seam.

## User Impact

Subscription-only Claude CLI deployments get working active-memory recall on plan limits, consistent with their main turns — instead of failing every turn or silently consuming paid extra usage. Setups with an Anthropic API key see no behavior change. No config changes required; note that CLI-dispatched recalls measured 13.8–16.9s on a dev laptop, so the plugin's default 15s `timeoutMs` is tight — 30s is comfortable.

## Evidence

**Current-head success (read this first):** on PR head `aebb9ee1f7` (a code-identical rebase of proof head `92917da5ae`, whose dist produced the run below), a live subscription-only recall with the **default plugin config** (no `timeoutMs` override) completes end-to-end:

```
# Subscription-only auth store (the reported failure setup):
[plugins] active-memory: ... activeProvider=claude-cli activeModel=claude-opus-4-8 thinking=off fast=inherit start timeoutMs=45000 queryChars=70 searchQueryChars=70
[agents/embedded-cli-dispatch] dispatching embedded run through CLI backend: runId=active-memory-mrn4uh1l-3d620c7b provider=claude-cli model=claude-opus-4-8
[plugins] active-memory: ... done status=ok elapsedMs=11941 summaryChars=64

# Same head + build, auth store seeded with a claude-cli api_key profile:
[plugins] active-memory: ... activeProvider=claude-cli activeModel=claude-opus-4-8 start timeoutMs=15000 queryChars=170 searchQueryChars=169
[plugins] active-memory: ... done status=failed elapsedMs=1178 summaryChars=0
# 15000 ms plain default selected, no [agents/embedded-cli-dispatch] line: the API-key run
# stays on the direct passthrough (it fails here only because the fixture key is fake).
# timeoutMs above is selected by the runner's own dispatch eligibility, not a route-only check.
```

`timeoutMs=45000` is the new CLI-runtime default applied from unset config; `status=ok` with a grounded, cited summary is the successful default-config recall the review asked for. Details, the deny-path proof, and earlier rounds follow.

Before (subscription-only claude-cli setup): every recall fails in under a second, with the recall session recording the direct `anthropic-messages` route.

<details><summary>Before: per-turn billing rejection on the passthrough</summary>

```
# Gateway log excerpt: active-memory recall on a subscription-only claude-cli
# setup (Linux), before this change. Every eligible turn produced this failure.

[agent/embedded] embedded run agent end: runId=active-memory-... isError=true model=claude-opus-4-8 provider=claude-cli error=LLM request failed: provider rejected the request schema or tool payload. rawError={"type":"error","error":{"type":"invalid_request_error","message":"Third-party apps now draw from your extra usage, not your plan limits. Add more at claude.ai/settings/usage and keep going."}...
[agent/embedded] embedded run failover decision: ... stage=assistant decision=surface_error reason=billing from=claude-cli/claude-opus-4-8
[plugins] active-memory: memory sub-agent failed, skipping recall: LLM request rejected: ...
[plugins] active-memory: ... done status=failed elapsedMs=650 summaryChars=0

# The recall session transcript recorded the direct-API route:
#   "api":"anthropic-messages","provider":"claude-cli"
# with an empty assistant message, stopReason:"error", zero usage.
```
</details>

After (macOS, this branch, from source, no API key or synced credential profile): recall dispatches through the CLI backend as an independent one-shot process, the Claude child calls the memory tools through the grant-filtered loopback MCP bridge, and the run completes in 16.9s.

<details><summary>After: CLI-backend dispatch with grant-scoped MCP tool calls</summary>

```
2026-07-13T13:06:11.303-06:00 [plugins] active-memory: agent=main session=agent:main:direct:probe activeProvider=claude-cli activeModel=claude-opus-4-8 start timeoutMs=60000 queryChars=357 searchQueryChars=46
2026-07-13T13:06:11.529-06:00 [agents/embedded-cli-dispatch] dispatching embedded run through CLI backend: runId=active-memory-mrjlf6xz-8e7d1d14 provider=claude-cli model=claude-opus-4-8
2026-07-13T13:06:11.611-06:00 [agent/cli-backend] cli exec: provider=claude-cli model=claude-opus-4-8 promptChars=4384 trigger=manual useResume=false session=none resumeSession=none reuse=none historyPrompt=none
2026-07-13T13:06:28.240-06:00 [plugins] active-memory: agent=main session=agent:main:direct:probe activeProvider=claude-cli activeModel=claude-opus-4-8 done status=unavailable elapsedMs=16937 summaryChars=0
2026-07-13T13:06:28.320-06:00 [agent/cli-backend] claude live session start: provider=claude-cli model=claude-opus-4-8 activeSessions=1
2026-07-13T13:06:30.563-06:00 [agent/cli-backend] claude live session turn: provider=claude-cli model=claude-opus-4-8 durationMs=2241 rawLines=19 outBytes=18 outHash=6418a0305fab
2026-07-13T13:06:30.565-06:00 [agent/cli-backend] claude live session close: provider=claude-cli model=claude-opus-4-8 reason=restart
   2 "name":"mcp__openclaw__memory_get"
   2 "name":"mcp__openclaw__memory_search"
```
</details>

<details><summary>After: persistTranscripts announcing the persisted transcript</summary>

```
2026-07-13T13:46:16.067-06:00 [plugins] active-memory: agent=main session=agent:main:direct:probe activeProvider=claude-cli activeModel=claude-opus-4-8 start timeoutMs=30000 queryChars=223 searchQueryChars=52
2026-07-13T13:46:16.429-06:00 [agents/embedded-cli-dispatch] dispatching embedded run through CLI backend: runId=active-memory-mrjmuqgz-022c38a4 provider=claude-cli model=claude-opus-4-8
2026-07-13T13:46:35.408-06:00 [plugins] active-memory: agent=main session=agent:main:direct:probe activeProvider=claude-cli activeModel=claude-opus-4-8 transcript=~/.openclaw-recall-probe2/plugins/active-memory/transcripts/agents/main/active-memory/active-memory-mrjmuqgz-022c38a4.jsonl
2026-07-13T13:46:35.411-06:00 [plugins] active-memory: agent=main session=agent:main:direct:probe activeProvider=claude-cli activeModel=claude-opus-4-8 done status=unavailable elapsedMs=19343 summaryChars=0
```
</details>

<details><summary>After: the persisted OpenClaw transcript (full record chain)</summary>

```json
{"type":"session","version":3,"id":"active-memory-mrjmuqgz-022c38a4","timestamp":"2026-07-13T19:46:16.431Z","cwd":"~/.openclaw/workspace-recall-probe2"}
{"type":"message","id":"dfc7835d-0bd3-46a0-9993-243e8b34d2f3","parentId":null,"timestamp":"2026-07-13T19:46:16.431Z","message":{"role":"user","content":[{"type":"text","text":"You are a memory search agent.\nAnother model is preparing the final user-facing answer.\nYour job is to search memory and return only the most relevant memory context for that model.\nYou receive a bounded search query plus conversation context, including the user's latest message.\nUse only the available memory tools.\nUse the bounded search query with the configured memory tools.\nConfigured memory tools: memory_search, memory_get.\nDo not use channel metadata, provider metadata, debug output, or the full conversation context as the memory tool query.\nIf the available memory tools find nothing useful, reply with NONE.\nWhen searching for preference or habit recall, use permissive search limits or thresholds before deciding that no useful memory exists.\nDo not answer the user directly.\nPrompt style: balanced.\nTreat the latest user message as the primary query.\nUse recent conversation only to disambiguate what the latest user message means.\nDo not return memory just because it matched the broader recent topic; return memory only if it clearly helps with the latest user message itself.\nIf recent context and the latest user message point to different memory domains, prefer the domain that best matches the latest user message.\nIf the user is directly asking about favorites, preferences, habits, routines, or personal facts, treat that as a strong recall signal.\nQuestions like 'what is my favorite food', 'do you remember my flight preferences', or 'what do i usually get' should normally return memory when relevant results exist.\nIf the provided conversation context already contains recalled-memory summaries, debug output, or prior memory/tool traces, ignore that surfaced text unless the latest user message clearly requires re-checking it.\nReturn memory only when it would materially help the other model answer the user's latest message.\nMutable operational facts (cron/job health, automation status, deployments, incidents, service availability) go stale quickly: include the source timestamp when available, say when the memory may be stale, and tell the answering model to verify live before relying on it.\nDo not summarize mutable operational facts as simply current/running/healthy unless the memory result itself contains a current source timestamp and matching health state.\nIf the connection is weak, broad, or only vaguely related, reply with NONE.\nIf nothing clearly useful is found, reply with NONE.\nReturn exactly one of these two forms:\n1. NONE\n2. one compact plain-text summary\nIf something is useful, reply with one compact plain-text summary under 220 characters total.\nWrite the summary as a memory note about the user, not as a reply to the user.\nDo not explain your reasoning.\nDo not return bullets, numbering, labels, XML, JSON, or markdown list formatting.\nDo not prefix the summary with 'Memory:' or any other label.\n\nGood examples:\nUser message: What is my favorite food?\nReturn: User's favorite food is ramen; tacos also come up often.\nUser message: Do you remember my flight preferences?\nReturn: User prefers aisle seats and extra buffer over tight connections.\nRecent context: user was discussing flights and airport planning.\nLatest user message: I might see a movie while I wait for the flight.\nReturn: User's favorite movie snack is buttery popcorn with extra salt.\nUser message: Explain DNS over HTTPS.\nReturn: NONE\n\nBad examples:\nReturn: - Favorite food is ramen\nReturn: 1. Favorite food is ramen\nReturn: Memory: Favorite food is ramen\nReturn: {\"memory\":\"Favorite food is ramen\"}\nReturn: <memory>Favorite food is ramen</memory>\nReturn: Ramen seems to be your favorite food.\nReturn: You like aisle seats and extra buffer.\nReturn: I prefer aisle seats and extra buffer.\nRecent context: user was discussing flights and airport planning. Latest user message: I might see a movie while I wait for the flight. Return: User prefers aisle seats and extra buffer over tight connections.\n\nBounded memory search query:\nTranscript parity check: what are my favorite wings?\n\nConversation context:\nRecent conversation tail:\nuser: Quick memory check: favorite wings?\nuser: Final check: what are my favorite wings again?\nassistant: Lemon pepper. 🍋\n\nLatest user message:\nTranscript parity check: what are my favorite wings?"}],"timestamp":1783971976429}}
{"type":"message","id":"321b2cf2-f121-447c-944d-11706bac311a","parentId":"dfc7835d-0bd3-46a0-9993-243e8b34d2f3","timestamp":"2026-07-13T19:46:27.465Z","message":{"role":"assistant","content":[{"type":"toolCall","id":"toolu_01XBmeEUymFqWkprAMaRZLun","name":"memory_search","arguments":{"query":"favorite wings"}}],"stopReason":"toolUse","api":"cli","provider":"claude-cli","model":"claude-opus-4-8","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"timestamp":1783971987464}}
{"type":"message","id":"4b72573e-fcc8-4d18-ace2-2371104ccba7","parentId":"321b2cf2-f121-447c-944d-11706bac311a","timestamp":"2026-07-13T19:46:27.897Z","message":{"role":"toolResult","toolCallId":"toolu_01XBmeEUymFqWkprAMaRZLun","toolName":"memory_search","content":[],"isError":false,"timestamp":1783971987896}}
{"type":"message","id":"73114aef-2ca5-4954-af62-95b5f8bcff37","parentId":"4b72573e-fcc8-4d18-ace2-2371104ccba7","timestamp":"2026-07-13T19:46:32.683Z","message":{"role":"assistant","content":[{"type":"toolCall","id":"toolu_01RwHa7h5UodUnbYFTC2AsQk","name":"memory_get","arguments":{"path":"favorite-wings.md"}}],"stopReason":"toolUse","api":"cli","provider":"claude-cli","model":"claude-opus-4-8","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"timestamp":1783971992682}}
{"type":"message","id":"e01c5415-f452-41d4-ad26-662e9dd0942b","parentId":"73114aef-2ca5-4954-af62-95b5f8bcff37","timestamp":"2026-07-13T19:46:32.702Z","message":{"role":"toolResult","toolCallId":"toolu_01RwHa7h5UodUnbYFTC2AsQk","toolName":"memory_get","content":[{"type":"text","text":"{\n  \"path\": \"favorite-wings.md\",\n  \"text\": \"\",\n  \"disabled\": true,\n  \"error\": \"path required\"\n}"}],"isError":true,"timestamp":1783971992701}}
{"type":"message","id":"bdb84eb0-04c4-43f2-8510-66f0684ad020","parentId":"e01c5415-f452-41d4-ad26-662e9dd0942b","timestamp":"2026-07-13T19:46:35.392Z","message":{"role":"assistant","content":[{"type":"text","text":"User's favorite wings are lemon pepper."}],"stopReason":"stop","api":"cli","provider":"claude-cli","model":"claude-opus-4-8","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"timestamp":1783971995391}}
```
</details>


Round 3 (ClawSweeper review follow-up — successful default-config recall, deny-path proof, and a route-sensitive default budget):

- **Runtime-owner review round: fail-closed tool policy, pinned-profile resolution, lifecycle parity (round 9).** Addressing @Patrick-Erichsen's review: (1) the dispatch gate now fails closed on tool policy — only a non-empty named allowlist (the only state the CLI bridge expresses faithfully) dispatches; deny-all `[]`, wildcards, absent allowlists, and `disableTools`/`modelRun` keep the embedded passthrough, so no closed state widens and the wildcard-grant/merged-MCP-servers path is unreachable. (2) Eligibility forwards the pinned `authProfileId` into CLI runtime resolution, matching sibling routing callers. (3) Dispatched runs emit `onExecutionStarted` (with `lifecycleGeneration`) at the same post-admission boundary as the native path. Regression tests cover each closed-state refusal, the pin forwarding, and the lifecycle signal.
- **Dispatch eligibility is provider-owned (round 8 — the reviewer-recommended capability shape).** The core provider allowlist is deleted. The anthropic plugin's claude-cli backend now declares `CliBackendPlugin.subscriptionAuthDispatch: true` (documented in `docs/plugins/cli-backend-plugins.md`), and core eligibility reads the registered backend descriptor: no descriptor or no declared capability → the passthrough is untouched. Backends that never declare it (gemini, codex, config-only backends without a plugin descriptor) are structurally excluded, replacing the hardcoded claude-cli set. This implements the "Adopt a generic backend capability (recommended)" option from the ClawSweeper maintainer-decision block; the remaining owner ask shrinks to approving the new SDK capability field.
- **Eligibility honors an explicitly pinned auth profile (round 7).** Addressing the re-review P1: `RunEmbeddedAgentParams.authProfileId` now threads through the shared eligibility decision — a run pinned to an API-key profile keeps the passthrough (and the 15s default) even when the ordered selection would pick a subscription profile, and a pinned OAuth/token profile dispatches even when an API key sorts first; an unresolvable pinned id falls back to ordered selection like the passthrough. Profile-selection regression tests cover both explicit directions plus the fallback. Live proof of both routing directions on this head is in the lead block above (subscription → 45s dispatch `status=ok`; seeded claude-cli API-key store → 15s passthrough, no dispatch).
- **Timeout selection shares the full dispatch eligibility (round 6).** Addressing the re-review's remaining P2: the eligibility gate (route resolution, registered backend, stored credential mode) moved to `cli-backend-dispatch-eligibility.ts`, consumed by both the dispatch itself and a new plugin-runtime seam `api.runtime.agent.resolveCliBackendDispatchEligibility` (documented in `docs/plugins/sdk-runtime.md`). Active-memory's 45s default now applies exactly when the run will dispatch through the CLI backend — API-key and missing-backend routes that keep the direct passthrough keep the plain 15s default. Regression tests: core eligibility (oauth resolves, API-key undefined, missing backend undefined, canonical-ref resolution) plus plugin-level budget tests for the eligible and ineligible paths.
- **Default recall budget on CLI-runtime routes.** CLI-dispatched recalls measured 9–20s end-to-end, uncomfortably close to the plain 15s `timeoutMs` default. When the recall route resolves to the `claude-cli` runtime (direct provider ref or a canonical `provider/model` ref whose configured `agentRuntime.id` is `claude-cli`), the default budget is now 45s. This changes one default surface only for routes that could not work before this PR; an explicitly configured `timeoutMs` always wins, and no new config keys are added. Help text updated in `openclaw.plugin.json`.
- **Live success proof with default config.** Fixture memories were seeded in the scratch profile's workspace and `timeoutMs` was removed from the plugin config. The run below is the full success chain on a subscription-only claude-cli route: new default applied, CLI-backend dispatch, real `memory_search` hits, grounded cited summary, `status=ok`.
- **The success proof caught a real bridge defect.** The first fixed-deadline runs still classified `no_relevant_memory` with `summaryChars=0` despite the model returning the correct facts: claude stream-json echoes MCP `tool_result` content as a bare content-block array, and the transcript mirror only unwrapped `{content: [...]}` shapes, so every mirrored tool result was empty and active-memory's usable-result gate discarded the summary. Fixed in `cli-backend-dispatch-transcript.ts` with a regression test pinning the live stream shape. (This also explains the empty `"content":[]` tool results visible in the earlier transcript excerpt above.)
- **Repeated on the exact current head.** After rebasing onto current `main`, the dist was rebuilt from PR head `2b7b5bac7d` and the same default-config run repeated: `start timeoutMs=45000` → CLI-backend dispatch → two grounded `memory_search` hits → `done status=ok elapsedMs=13661 summaryChars=109` ("User prefers SQLite with Kysely for prototypes; Copperfin demo project's staging dashboard runs on port 4173.").
- **Lane admission (round 4).** Addressing the review finding at `run.ts`: the CLI-dispatch decision moved from the top of `runEmbeddedAgent` to inside the lane-admitted global-lane task, so dispatched runs now pass the same session/global lane queues, lifecycle-generation checks, harness admission, placement turn admission, and run-context claiming as native embedded runs. A new ordering test (`run.cli-dispatch-lane.test.ts`) pins that both lane admissions fully wrap dispatch resolution and execution. The live success run above executed on this shape.
- **Exact-head checks (round 5).** `check-dependencies` also required the dispatch internals (`resolveEmbeddedCliBackendDispatch`, `runEmbeddedAgentViaCliBackend`) to stop being test-only exports — knip's production scan does not count test imports. They are module-private now and the gate tests exercise the public `runEmbeddedAgentViaCliBackendIfEligible` wrapper.
- **Exact-head checks (round 5, continued).** The failing `check-dependencies` and `checks-fast-loc-ratchet` CI checks are repaired: the three unused type exports are no longer exported and the now-used `buildAssistantMessageWithZeroUsage` baseline entry is removed; the three grown legacy files were brought back under their ratchet baselines by moving the loopback grant-context builders into a new `cli-runner/mcp-grant-context.ts` module, deduplicating the run/prep stage-summary emitters into `attempt-stage-timing.ts` (they were verbatim copies), and simplifying an ad-hoc type guard with the existing `isRecord` helper. No behavior change; existing prepare/grant/lane tests cover the moved code.
- **Pre-existing `check-dependencies` failure on current `main`.** The two remaining knip findings on this PR's merge ref (`attempt-abort.ts: releaseEmbeddedAttemptSessionLockForAbort`, `attempt-prompt-skip.ts: PromptSubmissionSkipReason`) reproduce identically on a pristine `upstream/main` checkout (`4bff6b188e`) with the exact CI knip invocation — they were introduced by recent main-side refactors and are unrelated to this branch. All findings for files this PR touches are resolved.
- **Real deny-path proof under `bypassPermissions`.** While a recall run was live, the child's grant credentials (Bearer token + capture-key header, lifted from the child's process environment) were replayed from an independent MCP client: `tools/list` returned only `["memory_get","memory_search"]`, the allowed `memory_search` returned real indexed content, and the excluded `sessions_list` was rejected at the grant layer (`isError:true`, "Tool not available"). A token-only replay without the capture-key header was rejected `401 unauthorized`.

<details><summary>After (round 3): default-config success run — status=ok with grounded summary</summary>

```
# Plugin config: {enabled, logging, agents:[main], persistTranscripts} — no timeoutMs override.
# Route: agents.defaults.models["anthropic/claude-opus-4-8"].agentRuntime.id = claude-cli.
# Workspace memory seeded: MEMORY.md + memory/2026-07-12.md (fixture facts).

[plugins] active-memory: agent=main session=agent:main:main activeProvider=claude-cli activeModel=claude-opus-4-8 start timeoutMs=45000 queryChars=111 searchQueryChars=111
[agents/embedded-cli-dispatch] dispatching embedded run through CLI backend: runId=active-memory-mrjvtysh-ad8b9df9 provider=claude-cli model=claude-opus-4-8
[plugins] active-memory: ... transcript=~/.openclaw-recall-probe2/plugins/active-memory/transcripts/agents/main/active-memory/active-memory-mrjvtysh-ad8b9df9.jsonl
[plugins] active-memory: ... done status=ok elapsedMs=8987 summaryChars=161

# Repeated on a dist rebuilt from the exact PR head 2b7b5bac7dacc7a5d315af5376321df6f4e31dee:
[plugins] active-memory: ... start timeoutMs=45000 queryChars=122 searchQueryChars=122
[agents/embedded-cli-dispatch] dispatching embedded run through CLI backend: runId=active-memory-mrjy32s4-93f88d65 provider=claude-cli model=claude-opus-4-8
[plugins] active-memory: ... done status=ok elapsedMs=13661 summaryChars=109
# assistant: User prefers SQLite with Kysely for prototypes; Copperfin demo project's staging dashboard runs on port 4173.

# Persisted transcript (toolResult content now mirrored):
toolCall  memory_search {"query":"Copperfin staging dashboard port"}
toolCall  memory_search {"query":"beta feedback form deadline"}
toolResult memory_search blocks=1 {"type":"text","text":"{ \"results\": [ { \"path\": \"MEMORY.md\", \"startLine\": 1, \"endLine\": 5, \"score\": 0.5565..., \"snippet\": \"...codename is 'Copperfin'; its staging dashboard runs on port 4173...\" ...
toolResult memory_search blocks=1 {"type":"text","text":"{ \"results\": [ { \"path\": \"memory/2026-07-12.md\", \"startLine\": 1, \"endLine\": 5, \"score\": 0.5683... ...
assistant: Copperfin staging dashboard runs on port 4173; beta feedback form deadline is July 25 (recorded 2026-07-12). Source: MEMORY.md#L1-L5, memory/2026-07-12.md#L1-L5.
```
</details>

<details><summary>After (round 3): live deny-path replay against the loopback grant</summary>

```
# Child argv captured during a live recall run (env stripped):
claude -p --output-format stream-json ... --permission-mode bypassPermissions --strict-mcp-config \
  --mcp-config <tmp>/mcp.json --tools  --allowedTools mcp__openclaw__memory_search,mcp__openclaw__memory_get \
  --model claude-opus-4-8 ...

# Independent MCP client replaying the child grant's credentials:
tools/list (2): ["memory_get","memory_search"]
tools/call memory_search (allowed): {"content":[{"type":"text","text":"{ \"results\": [ { \"path\": \"MEMORY.md\", ... port 4173 ..." ...
tools/call sessions_list (excluded): {"content":[{"type":"text","text":"Tool not available: sessions_list"}],"isError":true}

# Bearer token alone (no x-openclaw-cli-capture-key header): 401 {"error":"unauthorized"}
```
</details>


Validation:

- Focused suites for the dispatch gate/adapter, transcript recorder (real-file record shapes incl. abort-flush dedup), loopback grant filtering + cache separation, and prepare-level grant/exclusive-bundle integration; `pnpm check` and `pnpm build` clean.
- Two rounds of `codex review --base upstream/main` run locally; all seven findings across both rounds fixed in-branch with tests.
- Round 3 (post-ClawSweeper): 181 active-memory + dispatch/recorder/grant tests plus the full `src/agents/embedded-agent-runner` suite (1909 tests) green after the deadline default and bare-array fixes; `tsgo` core and test-type lanes clean; branch rebased onto current `main`.
- Local full-suite runs on macOS were load-flaky; every failure was triaged as pass-on-idle-rerun or pre-existing on clean upstream/main (`packages/speech-core/src/tts.test.ts`). CI should be treated as the authoritative full gate.

<details><summary>AI session log (curated: prompts + review rounds)</summary>

# AI session log (curated)

This change was developed in a single interactive Claude Code (Claude Fable 5)
session, human-directed throughout. This is a curated log — author prompts
are quoted verbatim where they contain nothing private, and marked
`[redacted: …]` where they referenced the author's own infrastructure; agent
work is summarized. The raw transcript is withheld because it interleaves
private operator configuration; it can be shared with maintainers on request
after review.

## 1. Task briefing (author prompt, redacted paraphrase)

> Investigate and fix active-memory recall failing on `agentRuntime.id:
> "claude-cli"` sessions with subscription-only auth. Verified symptoms:
> main turns work through the CLI backend; recall goes through
> `runEmbeddedAgent`, harness selection returns
> `cli_runtime_passthrough_openclaw`, and the direct anthropic-messages call
> is rejected ("Third-party apps now draw from your extra usage…").
> [redacted: deployment details, version, log excerpts]
> Hard constraints: local branch only, nothing pushed or filed; scope code
> changes to claude-cli / the verified condition — a previous PR from this
> team overclaimed that a bug affected all CLI backends including Gemini and
> the maintainer had to correct it; deliver a verified-vs-assumed list.

## 2. Investigation (agent, with parallel research subagents)

Mapped both dispatch paths (embedded runner vs `runCliAgent`), confirmed no
CLI dispatch existed for embedded runs, and ran three parallel deep-dives:
CLI live-session concurrency (distinct session ids run as independent
processes), the selectable-backend tool surface (`toolsAllow` fails closed on
CLI runs; `cliToolAvailability` is the supported restriction), and credential
mode detection (claude-cli profiles are always subscription OAuth; mode is
resolvable from stored metadata without network).

## 3. Implementation and first review round

Implemented the opt-in `cliBackendDispatch: "subscription-auth"` dispatch,
then ran a multi-angle AI review (8 independent finder passes + verification)
which produced fixes: a cheap ordered-credential gate instead of credential
materialization on the per-turn path, native-path semantics for the bridged
tool results, wildcard-allowlist handling, and a shared MCP-prefix helper.

## 4. Author scope and framing direction (verbatim prompts)

> "I don't think we should include logic for tripping the recall circuit
> breaker on billing rejections. There could be quite a lot of debate around
> that and I feel like that is better left for a separate PR."

> "I want to challenge … how we are seemingly hedging by making this fix
> opt-in." — (After discussion of the adapter's supported parameter subset
> and unverified callers, the author kept the opt-in.)

> "Anthropic has rejected subscription-based calls to the API from
> third-party apps for a long time … This is a known issue and was not a
> recent regression." — (All regression framing removed from code, commit,
> and drafts.)

> "If a user has extra usage enabled … it will actually work but it will
> draw from the far more expensive extra usage bucket which they may not even
> realize." — (Silent-cost impact added to problem framing.)

## 5. Codex review rounds (per CONTRIBUTING)

`codex review --base upstream/main` was run locally twice. Round 1 (4
findings): grant-level tool enforcement on the loopback MCP surface, ordered
auth-profile selection for mixed stores, session-scoped MCP cleanup instead
of the process-wide server close, and transcript persistence. The author
directed full transcript parity:

> "It seems to me that if we are going to make active memory work with
> claude-cli subscription usage, we should strive for full parity. Otherwise,
> we are fixing one issue and introducing more that need to be addressed
> later."

Round 2 (3 findings, after the parity work): exclusive loopback-only MCP
bundle for restricted runs, canonical `anthropic/<model>` refs resolving
through the runtime policy before the dispatch gate, and abort-time flushing
of the streamed assistant snapshot. All seven findings across both rounds
were verified against source before fixing, fixed with tests, and re-validated.

## 6. Validation

Focused unit/integration suites for every touched surface; `pnpm check` and
`pnpm build` clean; end-to-end verification on macOS from source with a
scratch profile and subscription-only auth (dispatch, grant-filtered MCP tool
calls, persisted transcript chain, 13.8–16.9s latency measurements). Local
full-suite runs were load-flaky; every failure was triaged as pass-on-idle or
pre-existing on clean upstream/main.

## 7. Author understanding

Scope, semantics, naming, and framing decisions were made by the human
author; the final diff, commit message, and this evidence set were reviewed
by the author before submission.
</details>

---
**AI-assisted:** developed with Claude Code (Claude Fable 5); reviewed and understood by the author; two local Codex review rounds applied pre-submission (findings and disposition in the session log above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

