### PR TITLE
refactor(ui): privatize chat settings patch tracker

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -1290,7 +1290,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/wizard/setup.migration-import.ts: inspectSetupMigrationFreshness",
   "src/wizard/setup.official-plugins.ts: resolveOfficialPluginOnboardingInstallEntries",
   "src/wizard/setup.official-plugins.ts: testing",
-  "ui/src/pages/chat/chat-settings-patches.ts: trackPendingChatSettingsPatch",
 ];
 
 // Platform-variant findings. Allowed when present; never required.

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -21,7 +21,7 @@ import {
   switchChatFastMode,
   switchChatThinkingLevel,
 } from "./chat-session.ts";
-import { trackPendingChatSettingsPatch } from "./chat-settings-patches.ts";
+import { patchChatSessionSettings } from "./chat-settings-patches.ts";
 import type { ChatPageHost } from "./chat-state.ts";
 import {
   admitStoredChatComposerQueueItem,
@@ -230,6 +230,31 @@ function fetchUrl(source: MockCallSource, callIndex: number) {
   throw new Error(`expected fetch input ${callIndex}`);
 }
 
+function createPendingSettingsSessionCapability(
+  sessions: ChatHost["sessions"],
+  pendingSettingsPatches: Record<string, Promise<boolean>>,
+): ChatHost["sessions"] {
+  const pendingBySession = new Map(Object.entries(pendingSettingsPatches));
+  const wrapped = Object.create(sessions) as ChatHost["sessions"];
+  wrapped.patch = async (sessionKey, patch, options) => {
+    const pendingPatch = pendingBySession.get(sessionKey);
+    if (!pendingPatch) {
+      return sessions.patch(sessionKey, patch, options);
+    }
+    pendingBySession.delete(sessionKey);
+    if (!(await pendingPatch)) {
+      return null;
+    }
+    return {
+      ok: true,
+      path: "",
+      key: sessionKey,
+      entry: { sessionId: "pending-settings-test" },
+    };
+  };
+  return wrapped;
+}
+
 function makeHost(overrides?: Partial<TestChatHost>): TestChatHost {
   const settings = { lastActiveSessionKey: "", ...overrides?.settings };
   const renderLifecycle: RenderLifecycle = {
@@ -332,11 +357,13 @@ function makeHost(overrides?: Partial<TestChatHost>): TestChatHost {
       showArchived: host.sessionsShowArchived,
     });
   }
-  const resolvedHost = { ...host, sessions } as TestChatHost;
-  for (const [sessionKey, patchPromise] of Object.entries(
-    overrides?.pendingSettingsPatches ?? {},
-  )) {
-    trackPendingChatSettingsPatch(resolvedHost, sessionKey, patchPromise);
+  const pendingSettingsPatches = overrides?.pendingSettingsPatches;
+  const resolvedSessions = pendingSettingsPatches
+    ? createPendingSettingsSessionCapability(sessions, pendingSettingsPatches)
+    : sessions;
+  const resolvedHost = { ...host, sessions: resolvedSessions } as TestChatHost;
+  for (const sessionKey of Object.keys(pendingSettingsPatches ?? {})) {
+    void patchChatSessionSettings(resolvedHost, sessionKey, {}).catch(() => undefined);
   }
   return resolvedHost;
 }

--- a/ui/src/pages/chat/chat-settings-patches.ts
+++ b/ui/src/pages/chat/chat-settings-patches.ts
@@ -100,7 +100,7 @@ export function getPendingChatPickerPatch(
   return getPendingPatch(pendingChatPickerPatches, host, sessionKey, agentId);
 }
 
-export function trackPendingChatSettingsPatch(
+function trackPendingChatSettingsPatch(
   host: ChatPickerPatchHost,
   sessionKey: string,
   patchPromise: Promise<boolean>,


### PR DESCRIPTION
## What Problem This Solves

The Control UI chat settings tracker was exported only so tests could seed pending operations, leaving an internal helper in the production dead-export baseline.

## Why This Change Was Made

Makes the tracker module-private and routes the existing full chat-send fixture through the retained `patchChatSessionSettings` production entry point. The fixture wraps the real session capability, consumes each seeded pending result once, then delegates later patches to the real capability.

Baseline delta: 1,289 → 1,288 (`+0/-1`).

## User Impact

No user-visible behavior change. Pending model, reasoning, and fast-mode patches keep gating sends and retries through the same production path.

## Evidence

- Blacksmith Testbox `tbx_01kxepn3g77wzbetbc9sdkbfz1`, run [29287071543](https://github.com/openclaw/openclaw/actions/runs/29287071543): full `chat-send.test.ts` 201/201, UI prod/test types, formatting, and type-aware lint green
- Exact rebased deadcode: Testbox `tbx_01kxeqmqpx843jg2b3yc8ep0ph`, run [29288118066](https://github.com/openclaw/openclaw/actions/runs/29288118066), generator and checker matched 1,288; final harness status only reflected the expected committed baseline diff
- Rebase preserved patch identity (`413d3bed065` = `408e52f59ce`)
- Autoreview identified one repeat-interception defect; fixed with one-shot Map consumption. Fresh retry clean at 0.96.
