### PR TITLE
fix(lobster): expose runtime dependency import

### DIFF
--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -274,8 +274,7 @@ async function withTimeout<T>(
 }
 
 async function loadEmbeddedToolRuntimeFromPackage(): Promise<EmbeddedToolRuntime> {
-  const coreSpecifier = ["@clawdbot", "lobster", "core"].join("/");
-  return (await import(coreSpecifier)) as EmbeddedToolRuntime;
+  return (await import("@clawdbot/lobster/core")) as EmbeddedToolRuntime;
 }
 
 export function createEmbeddedLobsterRunner(options?: {


### PR DESCRIPTION
## What Problem This Solves

Current main's plugin contract gate reports `@clawdbot/lobster` as an unused
direct dependency. The Lobster plugin still loads that package at runtime, but
commit `70ab6b324dd3` built the module specifier from string fragments, hiding
the dependency from contract analysis.

Exact failing PR CI job:
https://github.com/openclaw/openclaw/actions/runs/29287604524/job/86943842960

## Why This Change Was Made

Use the canonical literal dynamic import `@clawdbot/lobster/core`. This keeps
the same lazy runtime load while making the direct dependency visible to
TypeScript, bundlers, and the plugin dependency contract.

## User Impact

No behavior change. Restores main CI and keeps Lobster's runtime dependency
ownership explicit.

## Evidence

- Blacksmith Testbox `tbx_01kxeqcrhx9fqssmvmqkkn9kcj`:
  - plugin dependency contract: 431/431 passed;
  - Lobster runner: 24/24 passed;
  - targeted formatting passed.
- Fresh autoreview: no accepted/actionable findings, confidence 0.97.
- `git diff --check` passed.

