### PR TITLE
refactor(cli): share Clack select styling

### DIFF
--- a/packages/terminal-core/src/prompt-select-styled.test.ts
+++ b/packages/terminal-core/src/prompt-select-styled.test.ts
@@ -3,36 +3,12 @@ import { describe, expect, it } from "vitest";
 import { styleSelectParams } from "./prompt-select-styled-params.js";
 
 describe("styleSelectParams", () => {
-  it("styles message and option hints before select receives params", () => {
-    expect(
-      styleSelectParams(
-        {
-          message: "Pick channel",
-          options: [
-            { value: "stable", label: "Stable", hint: "Tagged releases" },
-            { value: "dev", label: "Dev" },
-          ],
-        },
-        {
-          message: (value) => `msg:${value}`,
-          hint: (value) => `hint:${value}`,
-        },
-      ),
-    ).toEqual({
-      message: "msg:Pick channel",
-      options: [
-        { value: "stable", label: "Stable", hint: "hint:Tagged releases" },
-        { value: "dev", label: "Dev" },
-      ],
-    });
-  });
-
-  it("keeps unhinted options unchanged", () => {
+  it("styles messages and hints without replacing unhinted options", () => {
     const option = { value: "dev", label: "Dev" };
     const params = styleSelectParams(
       {
         message: "Pick channel",
-        options: [option],
+        options: [{ value: "stable", label: "Stable", hint: "Tagged releases" }, option],
       },
       {
         message: (value) => `msg:${value}`,
@@ -42,8 +18,11 @@ describe("styleSelectParams", () => {
 
     expect(params).toEqual({
       message: "msg:Pick channel",
-      options: [{ value: "dev", label: "Dev" }],
+      options: [
+        { value: "stable", label: "Stable", hint: "hint:Tagged releases" },
+        { value: "dev", label: "Dev" },
+      ],
     });
-    expect(params.options[0]).toBe(option);
+    expect(params.options[1]).toBe(option);
   });
 });

--- a/src/commands/configure.shared.ts
+++ b/src/commands/configure.shared.ts
@@ -8,8 +8,8 @@ import {
   text as clackText,
 } from "@clack/prompts";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { styleSelectParams } from "../../packages/terminal-core/src/prompt-select-styled-params.js";
 import {
-  stylePromptHint,
   stylePromptMessage,
   stylePromptTitle,
 } from "../../packages/terminal-core/src/prompt-style.js";
@@ -104,10 +104,4 @@ export const confirm = (params: Parameters<typeof clackConfirm>[0]) =>
   });
 /** Styled select prompt wrapper that also normalizes option hints. */
 export const select = <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
-  clackSelect({
-    ...params,
-    message: stylePromptMessage(params.message),
-    options: params.options.map((opt) =>
-      opt.hint === undefined ? opt : { ...opt, hint: stylePromptHint(opt.hint) },
-    ),
-  });
+  clackSelect(styleSelectParams(params));

--- a/src/commands/doctor-prompter.ts
+++ b/src/commands/doctor-prompter.ts
@@ -1,9 +1,7 @@
 /** Doctor prompt adapter that centralizes repair, force, update, and noninteractive behavior. */
 import { confirm, select } from "@clack/prompts";
-import {
-  stylePromptHint,
-  stylePromptMessage,
-} from "../../packages/terminal-core/src/prompt-style.js";
+import { styleSelectParams } from "../../packages/terminal-core/src/prompt-select-styled-params.js";
+import { stylePromptMessage } from "../../packages/terminal-core/src/prompt-style.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   resolveDoctorRepairMode,
@@ -114,17 +112,7 @@ export function createDoctorPrompter(params: {
       if (!repairMode.canPrompt || repairMode.shouldRepair) {
         return fallback;
       }
-      return guardCancel(
-        await select({
-          ...p,
-          message: stylePromptMessage(p.message),
-          options: p.options.map((opt) =>
-            opt.hint === undefined ? opt : { ...opt, hint: stylePromptHint(opt.hint) },
-          ),
-        }),
-        params.runtime,
-        130,
-      ) as T;
+      return guardCancel(await select(styleSelectParams(p)), params.runtime, 130) as T;
     },
     shouldRepair: repairMode.shouldRepair,
     shouldForce: repairMode.shouldForce,

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -13,10 +13,8 @@ import {
   normalizeOptionalString,
   normalizeStringifiedOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import {
-  stylePromptHint,
-  stylePromptMessage,
-} from "../../../packages/terminal-core/src/prompt-style.js";
+import { styleSelectParams } from "../../../packages/terminal-core/src/prompt-select-styled-params.js";
+import { stylePromptMessage } from "../../../packages/terminal-core/src/prompt-style.js";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
@@ -130,15 +128,7 @@ const password = async (params: Parameters<typeof clackPassword>[0]) =>
     }),
   );
 const select = async <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
-  guardCancel(
-    await clackSelect({
-      ...params,
-      message: stylePromptMessage(params.message),
-      options: params.options.map((opt) =>
-        opt.hint === undefined ? opt : { ...opt, hint: stylePromptHint(opt.hint) },
-      ),
-    }),
-  );
+  guardCancel(await clackSelect(styleSelectParams(params)));
 
 async function readPipedStdin(): Promise<string> {
   process.stdin.setEncoding("utf8");

--- a/src/commands/models/scan.ts
+++ b/src/commands/models/scan.ts
@@ -1,11 +1,8 @@
 /** OpenRouter free-model scanner and fallback updater for model commands. */
 import { cancel, multiselect as clackMultiselect, isCancel } from "@clack/prompts";
 import { getEnvApiKey } from "@openclaw/ai/internal/runtime";
-import {
-  stylePromptHint,
-  stylePromptMessage,
-  stylePromptTitle,
-} from "../../../packages/terminal-core/src/prompt-style.js";
+import { styleSelectParams } from "../../../packages/terminal-core/src/prompt-select-styled-params.js";
+import { stylePromptTitle } from "../../../packages/terminal-core/src/prompt-style.js";
 import { resolveApiKeyForProvider } from "../../agents/model-auth.js";
 import { type ModelScanResult, scanOpenRouterModels } from "../../agents/model-scan.js";
 import { formatCliCommand } from "../../cli/command-format.js";
@@ -25,13 +22,7 @@ const MODEL_PAD = 42;
 const CTX_PAD = 8;
 
 const multiselect = <T>(params: Parameters<typeof clackMultiselect<T>>[0]) =>
-  clackMultiselect({
-    ...params,
-    message: stylePromptMessage(params.message),
-    options: params.options.map((opt) =>
-      opt.hint === undefined ? opt : { ...opt, hint: stylePromptHint(opt.hint) },
-    ),
-  });
+  clackMultiselect(styleSelectParams(params));
 
 function guardPromptCancel<T>(value: T | symbol, runtime: RuntimeEnv): T {
   if (isCancel(value)) {

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -3,8 +3,8 @@
 
 import path from "node:path";
 import { cancel, confirm, isCancel, multiselect } from "@clack/prompts";
+import { styleSelectParams } from "../../packages/terminal-core/src/prompt-select-styled-params.js";
 import {
-  stylePromptHint,
   stylePromptMessage,
   stylePromptTitle,
 } from "../../packages/terminal-core/src/prompt-style.js";
@@ -36,13 +36,7 @@ type UninstallOptions = {
 };
 
 const multiselectStyled = <T>(params: Parameters<typeof multiselect<T>>[0]) =>
-  multiselect({
-    ...params,
-    message: stylePromptMessage(params.message),
-    options: params.options.map((opt) =>
-      opt.hint === undefined ? opt : { ...opt, hint: stylePromptHint(opt.hint) },
-    ),
-  });
+  multiselect(styleSelectParams(params));
 
 function buildScopeSelection(opts: UninstallOptions): {
   scopes: Set<UninstallScope>;

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -18,8 +18,8 @@ import {
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { note as emitNote } from "../../packages/terminal-core/src/note.js";
+import { styleSelectParams } from "../../packages/terminal-core/src/prompt-select-styled-params.js";
 import {
-  stylePromptHint,
   stylePromptMessage,
   stylePromptTitle,
 } from "../../packages/terminal-core/src/prompt-style.js";
@@ -169,10 +169,8 @@ export function createClackPrompter(): WizardPrompter {
       process.stdout.write(message.endsWith("\n") ? message : `${message}\n`);
     },
     select: async (params) => {
-      const options = params.options.map((opt) => {
-        const base = { value: opt.value, label: opt.label };
-        return opt.hint === undefined ? base : { ...base, hint: stylePromptHint(opt.hint) };
-      }) as Option<(typeof params.options)[number]["value"]>[];
+      const { message, options: styledOptions } = styleSelectParams(params);
+      const options = styledOptions as Option<(typeof params.options)[number]["value"]>[];
 
       if (params.searchable) {
         return await withHorizontalCursorActionsDisabled(
@@ -181,7 +179,7 @@ export function createClackPrompter(): WizardPrompter {
             await runPromptWithNavigation(params.navigation, async (signal) =>
               params.navigation
                 ? await autocompleteWithNavigationFooter({
-                    message: stylePromptMessage(params.message),
+                    message,
                     options,
                     initialValue: params.initialValue,
                     filter: tokenizedOptionFilter,
@@ -189,7 +187,7 @@ export function createClackPrompter(): WizardPrompter {
                     navigation: params.navigation,
                   })
                 : await autocomplete({
-                    message: stylePromptMessage(params.message),
+                    message,
                     options,
                     initialValue: params.initialValue,
                     filter: tokenizedOptionFilter,
@@ -205,14 +203,14 @@ export function createClackPrompter(): WizardPrompter {
           await runPromptWithNavigation(params.navigation, async (signal) =>
             params.navigation
               ? await selectWithNavigationFooter({
-                  message: stylePromptMessage(params.message),
+                  message,
                   options,
                   initialValue: params.initialValue,
                   signal,
                   navigation: params.navigation,
                 })
               : await select({
-                  message: stylePromptMessage(params.message),
+                  message,
                   options,
                   initialValue: params.initialValue,
                   signal,
@@ -221,10 +219,8 @@ export function createClackPrompter(): WizardPrompter {
       );
     },
     multiselect: async (params) => {
-      const options = params.options.map((opt) => {
-        const base = { value: opt.value, label: opt.label };
-        return opt.hint === undefined ? base : { ...base, hint: stylePromptHint(opt.hint) };
-      }) as Option<(typeof params.options)[number]["value"]>[];
+      const { message, options: styledOptions } = styleSelectParams(params);
+      const options = styledOptions as Option<(typeof params.options)[number]["value"]>[];
 
       if (params.searchable) {
         return await withHorizontalCursorActionsDisabled(
@@ -233,7 +229,7 @@ export function createClackPrompter(): WizardPrompter {
             await runPromptWithNavigation(params.navigation, async (signal) =>
               params.navigation
                 ? await autocompleteMultiselectWithNavigationFooter({
-                    message: stylePromptMessage(params.message),
+                    message,
                     options,
                     initialValues: params.initialValues,
                     filter: tokenizedOptionFilter,
@@ -241,7 +237,7 @@ export function createClackPrompter(): WizardPrompter {
                     navigation: params.navigation,
                   })
                 : await autocompleteMultiselect({
-                    message: stylePromptMessage(params.message),
+                    message,
                     options,
                     initialValues: params.initialValues,
                     filter: tokenizedOptionFilter,
@@ -257,14 +253,14 @@ export function createClackPrompter(): WizardPrompter {
           await runPromptWithNavigation(params.navigation, async (signal) =>
             params.navigation
               ? await multiselectWithNavigationFooter({
-                  message: stylePromptMessage(params.message),
+                  message,
                   options,
                   initialValues: params.initialValues,
                   signal,
                   navigation: params.navigation,
                 })
               : await multiselect({
-                  message: stylePromptMessage(params.message),
+                  message,
                   options,
                   initialValues: params.initialValues,
                   signal,


### PR DESCRIPTION
## What Problem This Solves

Six Clack adapters independently styled select messages and option hints even though Terminal Core already owns that behavior in `styleSelectParams`. The copies added drift risk and redundant tests.

Closes #106834.

## Why This Change Was Made

Route select and multiselect parameters through the existing shared helper in configure, doctor, model auth, model scan, uninstall, and wizard adapters. Keep the shipped helper API and subpath broad; consolidate its two overlapping tests without reducing coverage.

## User Impact

No prompt or selection behavior changes. Messages, hints, option identity, search, navigation, initial values, and cancellation handling stay intact. Net change: 68 fewer lines.

## Evidence

- Blacksmith Testbox `tbx_01kxepyw09dh4teg6cfth35t94`
- Six focused test files — 72/72 tests passed
- `pnpm tsgo:core` — passed
- `pnpm tsgo:test:src` — passed
- `pnpm tsgo:test:packages` — passed
- `pnpm build` — passed
- Fresh autoreview — clean, no actionable findings
- Rebased onto current `origin/main`; stable patch identity preserved
- Hosted CI intentionally not awaited per maintainer instruction
