### PR TITLE
refactor(agents): extract attempt prompt preflight

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentMessage } from "../../runtime/index.js";
+import { SessionManager } from "../../sessions/index.js";
+import {
+  handleEmbeddedAttemptMidTurnPrecheck,
+  prepareEmbeddedAttemptPromptPreflight,
+} from "./attempt-prompt-preflight.js";
+import {
+  PREEMPTIVE_OVERFLOW_ERROR_TEXT,
+  estimateLlmBoundaryTokenPressure,
+} from "./preemptive-compaction.js";
+
+const attempt = {
+  provider: "test-provider",
+  modelId: "test-model",
+  sessionFile: "/tmp/openclaw-attempt-preflight-test.jsonl",
+  sessionId: "session-1",
+  sessionKey: "agent:test:main",
+};
+
+const request = {
+  route: "compact_only" as const,
+  estimatedPromptTokens: 150,
+  promptBudgetBeforeReserve: 100,
+  overflowTokens: 50,
+  toolResultReducibleChars: 0,
+  effectiveReserveTokens: 20,
+};
+
+function makeToolResultMessage(text: string): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: "call-1",
+    toolName: "read",
+    content: [{ type: "text", text }],
+    isError: false,
+    timestamp: 1,
+  } as AgentMessage;
+}
+
+function createSessionManagerWithMessage(message: AgentMessage): SessionManager {
+  const sessionManager = SessionManager.inMemory();
+  sessionManager.appendMessage(message as Parameters<typeof sessionManager.appendMessage>[0]);
+  return sessionManager;
+}
+
+describe("attempt prompt preflight", () => {
+  it("routes a mid-turn compaction request with its measured budget", () => {
+    const outcome = handleEmbeddedAttemptMidTurnPrecheck({
+      attempt,
+      request,
+      sessionAgentId: "test",
+      sessionManager: SessionManager.inMemory(),
+      prePromptMessageCount: 4,
+      replaceSessionMessages: vi.fn(),
+    });
+
+    expect(outcome).toEqual({
+      preflightRecovery: {
+        route: "compact_only",
+        source: "mid-turn",
+        estimatedPromptTokens: 150,
+        promptBudgetBeforeReserve: 100,
+        overflowTokens: 50,
+      },
+      promptError: expect.objectContaining({ message: PREEMPTIVE_OVERFLOW_ERROR_TEXT }),
+    });
+  });
+
+  it("falls back to compaction when mid-turn tool-result truncation cannot help", () => {
+    const outcome = handleEmbeddedAttemptMidTurnPrecheck({
+      attempt,
+      request: { ...request, route: "truncate_tool_results_only" },
+      sessionAgentId: "test",
+      sessionManager: SessionManager.inMemory(),
+      prePromptMessageCount: 4,
+      replaceSessionMessages: vi.fn(),
+    });
+
+    expect(outcome.preflightRecovery.route).toBe("compact_only");
+    expect(outcome.promptError?.message).toBe(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
+  });
+
+  it("handles successful mid-turn tool-result truncation without a prompt error", () => {
+    const sessionManager = createSessionManagerWithMessage(
+      makeToolResultMessage("large tool output ".repeat(5_000)),
+    );
+    const replaceSessionMessages = vi.fn();
+    const outcome = handleEmbeddedAttemptMidTurnPrecheck({
+      attempt: { ...attempt, contextTokenBudget: 100 },
+      request: { ...request, route: "truncate_tool_results_only" },
+      sessionAgentId: "test",
+      sessionManager,
+      prePromptMessageCount: 4,
+      replaceSessionMessages,
+    });
+
+    expect(outcome.promptError).toBeUndefined();
+    expect(outcome.preflightRecovery).toEqual(
+      expect.objectContaining({
+        route: "truncate_tool_results_only",
+        source: "mid-turn",
+        handled: true,
+        truncatedCount: 1,
+      }),
+    );
+    expect(replaceSessionMessages).toHaveBeenCalledWith(
+      sessionManager.buildSessionContext().messages,
+    );
+  });
+
+  it("short-circuits an oversized prompt into precheck recovery", async () => {
+    const result = await prepareEmbeddedAttemptPromptPreflight({
+      attempt,
+      contextEngineAssemblySucceeded: false,
+      contextEnginePromptAuthority: "assembled",
+      contextTokenBudget: 100,
+      hookMessagesForCurrentPrompt: [],
+      includeBoundaryTimestamp: false,
+      promptForPrecheck: "x".repeat(4_000),
+      reserveTokens: 20,
+      sessionAgentId: "test",
+      sessionManager: SessionManager.inMemory(),
+      sessionMessageCount: 0,
+      state: {
+        contextBudgetStatus: undefined,
+        preflightRecovery: undefined,
+        promptError: null,
+        promptErrorSource: null,
+        skipPromptSubmission: false,
+      },
+      systemPrompt: "",
+      toolResultMaxChars: 1_000,
+      withOwnedSessionWriteLock: async (operation) => await operation(),
+    });
+
+    expect(result.skipPromptSubmission).toBe(true);
+    expect(result.promptErrorSource).toBe("precheck");
+    expect(result.preflightRecovery?.route).toBe("compact_only");
+    expect(result.contextBudgetStatus?.shouldCompact).toBe(true);
+    expect(result.contextBudgetStatus?.overflowTokens).toBeGreaterThan(0);
+  });
+
+  it("defers overflow admission to a context engine that owns compaction", async () => {
+    const state: Parameters<typeof prepareEmbeddedAttemptPromptPreflight>[0]["state"] = {
+      contextBudgetStatus: undefined,
+      preflightRecovery: undefined,
+      promptError: null,
+      promptErrorSource: null,
+      skipPromptSubmission: false,
+    };
+    const result = await prepareEmbeddedAttemptPromptPreflight({
+      attempt,
+      activeContextEngine: {
+        info: { id: "owner", name: "Owner", ownsCompaction: true },
+      },
+      contextEngineAssemblySucceeded: true,
+      contextEnginePromptAuthority: "assembled",
+      contextTokenBudget: 100,
+      hookMessagesForCurrentPrompt: [],
+      includeBoundaryTimestamp: false,
+      promptForPrecheck: "x".repeat(4_000),
+      reserveTokens: 20,
+      sessionAgentId: "test",
+      sessionManager: SessionManager.inMemory(),
+      sessionMessageCount: 0,
+      state,
+      systemPrompt: "",
+      toolResultMaxChars: 1_000,
+      withOwnedSessionWriteLock: async (operation) => await operation(),
+    });
+
+    expect(result).toEqual(state);
+  });
+
+  it("runs successful pre-prompt truncation under the owned write lock", async () => {
+    const toolResult = makeToolResultMessage("alpha beta gamma delta epsilon ".repeat(2_200));
+    const messages = [toolResult];
+    const reserveTokens = 2_000;
+    const estimatedPromptTokens = estimateLlmBoundaryTokenPressure({
+      messages,
+      systemPrompt: "sys",
+      prompt: "hello",
+    });
+    const contextTokenBudget = estimatedPromptTokens - 200 + reserveTokens;
+    const sessionManager = createSessionManagerWithMessage(toolResult);
+    let lockCalls = 0;
+    const withOwnedSessionWriteLock = async <T>(operation: () => Promise<T> | T): Promise<T> => {
+      lockCalls += 1;
+      return await operation();
+    };
+
+    const result = await prepareEmbeddedAttemptPromptPreflight({
+      attempt,
+      contextEngineAssemblySucceeded: false,
+      contextEnginePromptAuthority: "assembled",
+      contextTokenBudget,
+      hookMessagesForCurrentPrompt: messages,
+      includeBoundaryTimestamp: true,
+      promptForPrecheck: "hello",
+      reserveTokens,
+      sessionAgentId: "test",
+      sessionManager,
+      sessionMessageCount: messages.length,
+      state: {
+        contextBudgetStatus: undefined,
+        preflightRecovery: undefined,
+        promptError: null,
+        promptErrorSource: null,
+        skipPromptSubmission: false,
+      },
+      systemPrompt: "sys",
+      toolResultMaxChars: 1_000,
+      withOwnedSessionWriteLock,
+    });
+
+    expect(lockCalls).toBe(1);
+    expect(result.skipPromptSubmission).toBe(true);
+    expect(result.promptError).toBeNull();
+    expect(result.promptErrorSource).toBeNull();
+    expect(result.preflightRecovery).toEqual(
+      expect.objectContaining({
+        route: "truncate_tool_results_only",
+        handled: true,
+        truncatedCount: 1,
+      }),
+    );
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.ts
@@ -1,0 +1,340 @@
+/**
+ * Owns prompt overflow admission and mid-turn recovery routing.
+ */
+import type { AssembleResult } from "../../../context-engine/types.js";
+import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import type { SessionManager } from "../../sessions/index.js";
+import { log } from "../logger.js";
+import {
+  resolveLiveToolResultMaxChars,
+  truncateOversizedToolResultsInSessionManager,
+} from "../tool-result-truncation.js";
+import type { AttemptContextEngine } from "./attempt.context-engine-helpers.js";
+import { normalizeMessagesForLlmBoundary } from "./attempt.llm-boundary.js";
+import type { MidTurnPrecheckRequest } from "./midturn-precheck.js";
+import {
+  PREEMPTIVE_OVERFLOW_ERROR_TEXT,
+  buildPrePromptContextBudgetStatus,
+  estimateLlmBoundaryTokenPressure,
+  formatPrePromptPrecheckLog,
+  shouldPreemptivelyCompactBeforePrompt,
+} from "./preemptive-compaction.js";
+import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
+
+type AttemptPromptPreflightParams = Pick<
+  EmbeddedRunAttemptParams,
+  "config" | "modelId" | "provider" | "sessionFile" | "sessionId" | "sessionKey"
+>;
+
+type AttemptPromptPreflightState = {
+  contextBudgetStatus: EmbeddedRunAttemptResult["contextBudgetStatus"];
+  preflightRecovery: EmbeddedRunAttemptResult["preflightRecovery"];
+  promptError: unknown;
+  promptErrorSource: EmbeddedRunAttemptResult["promptErrorSource"];
+  skipPromptSubmission: boolean;
+};
+
+type PreflightRecoveryBudgetSnapshot = Pick<
+  MidTurnPrecheckRequest,
+  "estimatedPromptTokens" | "promptBudgetBeforeReserve" | "overflowTokens"
+>;
+
+type WithOwnedSessionWriteLock = <T>(operation: () => Promise<T> | T) => Promise<T>;
+
+// Carries the measured prompt budget into the outer recovery loop. The synthetic
+// precheck error is only a routing signal, so compaction engines need these
+// fields to compact against the prompt OpenClaw actually rendered.
+function buildPreflightRecoveryBudgetSnapshot(snapshot: PreflightRecoveryBudgetSnapshot) {
+  return {
+    estimatedPromptTokens: snapshot.estimatedPromptTokens,
+    promptBudgetBeforeReserve: snapshot.promptBudgetBeforeReserve,
+    overflowTokens: snapshot.overflowTokens,
+  };
+}
+
+export function handleEmbeddedAttemptMidTurnPrecheck(input: {
+  attempt: AttemptPromptPreflightParams & Pick<EmbeddedRunAttemptParams, "contextTokenBudget">;
+  request: MidTurnPrecheckRequest;
+  sessionAgentId: string;
+  sessionManager: SessionManager;
+  prePromptMessageCount: number;
+  replaceSessionMessages: (messages: AgentMessage[]) => void;
+}): {
+  preflightRecovery: NonNullable<EmbeddedRunAttemptResult["preflightRecovery"]>;
+  promptError?: Error;
+} {
+  const { attempt, request } = input;
+  const logMidTurnPrecheck = (route: string, extra?: string) => {
+    log.warn(
+      `[context-overflow-midturn-precheck] sessionKey=${attempt.sessionKey ?? attempt.sessionId} ` +
+        `provider=${attempt.provider}/${attempt.modelId} route=${route} ` +
+        `estimatedPromptTokens=${request.estimatedPromptTokens} ` +
+        `promptBudgetBeforeReserve=${request.promptBudgetBeforeReserve} ` +
+        `overflowTokens=${request.overflowTokens} ` +
+        `toolResultReducibleChars=${request.toolResultReducibleChars} ` +
+        `effectiveReserveTokens=${request.effectiveReserveTokens} ` +
+        `prePromptMessageCount=${input.prePromptMessageCount} ` +
+        (extra ? `${extra} ` : "") +
+        `sessionFile=${attempt.sessionFile}`,
+    );
+  };
+
+  if (request.route === "truncate_tool_results_only") {
+    const contextTokenBudget = attempt.contextTokenBudget ?? DEFAULT_CONTEXT_TOKENS;
+    const toolResultMaxChars = resolveLiveToolResultMaxChars({
+      contextWindowTokens: contextTokenBudget,
+      cfg: attempt.config,
+      agentId: input.sessionAgentId,
+    });
+    const truncationResult = truncateOversizedToolResultsInSessionManager({
+      sessionManager: input.sessionManager,
+      contextWindowTokens: contextTokenBudget,
+      maxCharsOverride: toolResultMaxChars,
+      sessionFile: attempt.sessionFile,
+      sessionId: attempt.sessionId,
+      sessionKey: attempt.sessionKey,
+      agentId: input.sessionAgentId,
+    });
+    if (truncationResult.truncated) {
+      const preflightRecovery = {
+        route: "truncate_tool_results_only" as const,
+        source: "mid-turn" as const,
+        ...buildPreflightRecoveryBudgetSnapshot(request),
+        handled: true as const,
+        truncatedCount: truncationResult.truncatedCount,
+      };
+      input.replaceSessionMessages(input.sessionManager.buildSessionContext().messages);
+      logMidTurnPrecheck(
+        request.route,
+        `handled=true truncatedCount=${truncationResult.truncatedCount}`,
+      );
+      return { preflightRecovery };
+    }
+
+    const preflightRecovery = {
+      route: "compact_only" as const,
+      source: "mid-turn" as const,
+      ...buildPreflightRecoveryBudgetSnapshot(request),
+    };
+    logMidTurnPrecheck(
+      "compact_only",
+      `truncateFallbackReason=${truncationResult.reason ?? "unknown"}`,
+    );
+    return {
+      preflightRecovery,
+      promptError: new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT),
+    };
+  }
+
+  const preflightRecovery = {
+    route: request.route,
+    source: "mid-turn" as const,
+    ...buildPreflightRecoveryBudgetSnapshot(request),
+  };
+  logMidTurnPrecheck(request.route);
+  return {
+    preflightRecovery,
+    promptError: new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT),
+  };
+}
+
+export async function prepareEmbeddedAttemptPromptPreflight(input: {
+  attempt: AttemptPromptPreflightParams;
+  activeContextEngine?: Pick<AttemptContextEngine, "info">;
+  contextEngineAssemblySucceeded: boolean;
+  contextEnginePromptAuthority: NonNullable<AssembleResult["promptAuthority"]>;
+  contextTokenBudget: number;
+  hookMessagesForCurrentPrompt: AgentMessage[];
+  includeBoundaryTimestamp: boolean;
+  promptForPrecheck: string;
+  reserveTokens: number;
+  sessionAgentId: string;
+  sessionManager: SessionManager;
+  sessionMessageCount: number;
+  state: AttemptPromptPreflightState;
+  systemPrompt: string;
+  timezone?: string;
+  toolResultMaxChars: number;
+  unwindowedContextEngineMessagesForPrecheck?: AgentMessage[];
+  withOwnedSessionWriteLock: WithOwnedSessionWriteLock;
+}): Promise<AttemptPromptPreflightState> {
+  const { attempt } = input;
+  let {
+    contextBudgetStatus,
+    preflightRecovery,
+    promptError,
+    promptErrorSource,
+    skipPromptSubmission,
+  } = input.state;
+  const boundaryOptions =
+    input.timezone || !input.includeBoundaryTimestamp
+      ? {
+          ...(input.timezone ? { timezone: input.timezone } : {}),
+          ...(input.includeBoundaryTimestamp ? {} : { includeTimestamp: false }),
+        }
+      : undefined;
+  const unwindowedLlmBoundaryMessagesForPrecheck =
+    input.contextEnginePromptAuthority === "preassembly_may_overflow" &&
+    input.unwindowedContextEngineMessagesForPrecheck
+      ? normalizeMessagesForLlmBoundary(
+          input.unwindowedContextEngineMessagesForPrecheck,
+          boundaryOptions,
+        )
+      : undefined;
+  const llmBoundaryTokenPressure = estimateLlmBoundaryTokenPressure({
+    messages: input.hookMessagesForCurrentPrompt,
+    systemPrompt: input.systemPrompt,
+    prompt: input.promptForPrecheck,
+  });
+  let preemptiveCompaction: ReturnType<typeof shouldPreemptivelyCompactBeforePrompt> | null = null;
+  const shouldSkipPrecheck =
+    skipPromptSubmission ||
+    (input.contextEngineAssemblySucceeded &&
+      input.activeContextEngine?.info.ownsCompaction &&
+      input.contextEnginePromptAuthority !== "preassembly_may_overflow");
+
+  if (shouldSkipPrecheck && !skipPromptSubmission) {
+    log.info(
+      `[context-overflow-precheck] skipped: context engine "${input.activeContextEngine!.info.id}" owns compaction`,
+    );
+  }
+
+  if (!shouldSkipPrecheck) {
+    preemptiveCompaction = shouldPreemptivelyCompactBeforePrompt({
+      messages: input.hookMessagesForCurrentPrompt,
+      ...(unwindowedLlmBoundaryMessagesForPrecheck
+        ? { unwindowedMessages: unwindowedLlmBoundaryMessagesForPrecheck }
+        : {}),
+      systemPrompt: input.systemPrompt,
+      prompt: input.promptForPrecheck,
+      contextTokenBudget: input.contextTokenBudget,
+      reserveTokens: input.reserveTokens,
+      toolResultMaxChars: input.toolResultMaxChars,
+      llmBoundaryTokenPressure: {
+        estimatedPromptTokens: llmBoundaryTokenPressure,
+        source: "llm_boundary_normalized_prompt",
+        renderedChars: input.promptForPrecheck.length,
+      },
+    });
+  }
+  if (preemptiveCompaction) {
+    contextBudgetStatus = buildPrePromptContextBudgetStatus({
+      result: preemptiveCompaction,
+      provider: attempt.provider,
+      modelId: attempt.modelId,
+      messageCount: input.sessionMessageCount,
+      contextTokenBudget: input.contextTokenBudget,
+      reserveTokens: input.reserveTokens,
+      ...(attempt.sessionId ? { sessionId: attempt.sessionId } : {}),
+      ...(input.contextEnginePromptAuthority === "preassembly_may_overflow" &&
+      input.unwindowedContextEngineMessagesForPrecheck
+        ? { unwindowedMessageCount: input.unwindowedContextEngineMessagesForPrecheck.length }
+        : {}),
+    });
+    log.debug(
+      formatPrePromptPrecheckLog({
+        result: preemptiveCompaction,
+        provider: attempt.provider,
+        modelId: attempt.modelId,
+        messageCount: input.sessionMessageCount,
+        contextTokenBudget: input.contextTokenBudget,
+        reserveTokens: input.reserveTokens,
+        ...(attempt.sessionKey ? { sessionKey: attempt.sessionKey } : {}),
+        ...(attempt.sessionId ? { sessionId: attempt.sessionId } : {}),
+        ...(input.contextEnginePromptAuthority === "preassembly_may_overflow" &&
+        input.unwindowedContextEngineMessagesForPrecheck
+          ? { unwindowedMessageCount: input.unwindowedContextEngineMessagesForPrecheck.length }
+          : {}),
+        ...(attempt.sessionFile ? { sessionFile: attempt.sessionFile } : {}),
+      }),
+    );
+  }
+  if (preemptiveCompaction?.route === "truncate_tool_results_only") {
+    const toolResultMaxChars = resolveLiveToolResultMaxChars({
+      contextWindowTokens: input.contextTokenBudget,
+      cfg: attempt.config,
+      agentId: input.sessionAgentId,
+    });
+    const truncationResult = await input.withOwnedSessionWriteLock(() =>
+      truncateOversizedToolResultsInSessionManager({
+        sessionManager: input.sessionManager,
+        contextWindowTokens: input.contextTokenBudget,
+        maxCharsOverride: toolResultMaxChars,
+        sessionFile: attempt.sessionFile,
+        sessionId: attempt.sessionId,
+        sessionKey: attempt.sessionKey,
+        agentId: input.sessionAgentId,
+      }),
+    );
+    if (truncationResult.truncated) {
+      preflightRecovery = {
+        route: "truncate_tool_results_only",
+        ...buildPreflightRecoveryBudgetSnapshot(preemptiveCompaction),
+        handled: true,
+        truncatedCount: truncationResult.truncatedCount,
+      };
+      log.info(
+        `[context-overflow-precheck] early tool-result truncation succeeded for ` +
+          `${attempt.provider}/${attempt.modelId} route=${preemptiveCompaction.route} ` +
+          `truncatedCount=${truncationResult.truncatedCount} ` +
+          `estimatedPromptTokens=${preemptiveCompaction.estimatedPromptTokens} ` +
+          `promptBudgetBeforeReserve=${preemptiveCompaction.promptBudgetBeforeReserve} ` +
+          `overflowTokens=${preemptiveCompaction.overflowTokens} ` +
+          `toolResultReducibleChars=${preemptiveCompaction.toolResultReducibleChars} ` +
+          `effectiveReserveTokens=${preemptiveCompaction.effectiveReserveTokens} ` +
+          `sessionFile=${attempt.sessionFile}`,
+      );
+      skipPromptSubmission = true;
+    }
+    if (!skipPromptSubmission) {
+      log.warn(
+        `[context-overflow-precheck] early tool-result truncation did not help for ` +
+          `${attempt.provider}/${attempt.modelId}; falling back to compaction ` +
+          `reason=${truncationResult.reason ?? "unknown"} sessionFile=${attempt.sessionFile}`,
+      );
+      preflightRecovery = {
+        route: "compact_only",
+        ...buildPreflightRecoveryBudgetSnapshot(preemptiveCompaction),
+      };
+      promptError = new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
+      promptErrorSource = "precheck";
+      skipPromptSubmission = true;
+    }
+  }
+  if (preemptiveCompaction?.shouldCompact) {
+    preflightRecovery =
+      preemptiveCompaction.route === "compact_then_truncate"
+        ? {
+            route: "compact_then_truncate",
+            ...buildPreflightRecoveryBudgetSnapshot(preemptiveCompaction),
+          }
+        : {
+            route: "compact_only",
+            ...buildPreflightRecoveryBudgetSnapshot(preemptiveCompaction),
+          };
+    promptError = new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
+    promptErrorSource = "precheck";
+    log.warn(
+      `[context-overflow-precheck] sessionKey=${attempt.sessionKey ?? attempt.sessionId} ` +
+        `provider=${attempt.provider}/${attempt.modelId} ` +
+        `route=${preemptiveCompaction.route} ` +
+        `estimatedPromptTokens=${preemptiveCompaction.estimatedPromptTokens} ` +
+        `promptBudgetBeforeReserve=${preemptiveCompaction.promptBudgetBeforeReserve} ` +
+        `overflowTokens=${preemptiveCompaction.overflowTokens} ` +
+        `toolResultReducibleChars=${preemptiveCompaction.toolResultReducibleChars} ` +
+        `reserveTokens=${input.reserveTokens} ` +
+        `effectiveReserveTokens=${preemptiveCompaction.effectiveReserveTokens} ` +
+        `sessionFile=${attempt.sessionFile}`,
+    );
+    skipPromptSubmission = true;
+  }
+
+  return {
+    contextBudgetStatus,
+    preflightRecovery,
+    promptError,
+    promptErrorSource,
+    skipPromptSubmission,
+  };
+}

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -107,7 +107,6 @@ import {
   resolveLiveToolResultMaxChars,
   resolveLiveToolResultAggregateMaxChars,
   truncateOversizedToolResultsInMessages,
-  truncateOversizedToolResultsInSessionManager,
 } from "../tool-result-truncation.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
 import { abortable as abortableWithSignal } from "./abortable.js";
@@ -123,6 +122,10 @@ import {
   resolveOrphanRepairPlan,
 } from "./attempt-orphan-repair.js";
 import { prepareEmbeddedAttemptPromptAssembly } from "./attempt-prompt-assembly.js";
+import {
+  handleEmbeddedAttemptMidTurnPrecheck,
+  prepareEmbeddedAttemptPromptPreflight,
+} from "./attempt-prompt-preflight.js";
 import { completeEmbeddedAttemptResult } from "./attempt-result.js";
 import { createEmbeddedAgentSessionWithResourceLoader } from "./attempt-session.js";
 import { prepareEmbeddedAttemptSetup } from "./attempt-setup.js";
@@ -193,13 +196,7 @@ import {
   detachPrePersistedCurrentUserTurn,
   sessionMessagesContainIdempotencyKey,
 } from "./pre-persisted-user-turn.js";
-import {
-  PREEMPTIVE_OVERFLOW_ERROR_TEXT,
-  buildPrePromptContextBudgetStatus,
-  estimateLlmBoundaryTokenPressure,
-  formatPrePromptPrecheckLog,
-  shouldPreemptivelyCompactBeforePrompt,
-} from "./preemptive-compaction.js";
+import { PREEMPTIVE_OVERFLOW_ERROR_TEXT } from "./preemptive-compaction.js";
 import {
   buildCurrentInboundPrompt,
   buildRuntimeContextCustomMessage,
@@ -207,22 +204,6 @@ import {
 } from "./runtime-context-prompt.js";
 import { clearToolActivityRun, notifyToolActivity } from "./tool-activity-heartbeat.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
-
-type PreflightRecoveryBudgetSnapshot = Pick<
-  MidTurnPrecheckRequest,
-  "estimatedPromptTokens" | "promptBudgetBeforeReserve" | "overflowTokens"
->;
-
-// Carries the measured prompt budget into the outer recovery loop. The synthetic
-// precheck error is only a routing signal, so compaction engines need these
-// fields to compact against the prompt OpenClaw actually rendered.
-function buildPreflightRecoveryBudgetSnapshot(snapshot: PreflightRecoveryBudgetSnapshot) {
-  return {
-    estimatedPromptTokens: snapshot.estimatedPromptTokens,
-    promptBudgetBeforeReserve: snapshot.promptBudgetBeforeReserve,
-    overflowTokens: snapshot.overflowTokens,
-  };
-}
 
 const aggregateToolResultPressureWarnings = new Set<string>();
 
@@ -1468,72 +1449,20 @@ export async function runEmbeddedAttempt(
       let preflightRecovery: EmbeddedRunAttemptResult["preflightRecovery"];
       let promptErrorSource: EmbeddedRunAttemptResult["promptErrorSource"] = null;
       const handleMidTurnPrecheckRequest = (request: MidTurnPrecheckRequest) => {
-        const logMidTurnPrecheck = (route: string, extra?: string) => {
-          log.warn(
-            `[context-overflow-midturn-precheck] sessionKey=${params.sessionKey ?? params.sessionId} ` +
-              `provider=${params.provider}/${params.modelId} route=${route} ` +
-              `estimatedPromptTokens=${request.estimatedPromptTokens} ` +
-              `promptBudgetBeforeReserve=${request.promptBudgetBeforeReserve} ` +
-              `overflowTokens=${request.overflowTokens} ` +
-              `toolResultReducibleChars=${request.toolResultReducibleChars} ` +
-              `effectiveReserveTokens=${request.effectiveReserveTokens} ` +
-              `prePromptMessageCount=${prePromptMessageCount} ` +
-              (extra ? `${extra} ` : "") +
-              `sessionFile=${params.sessionFile}`,
-          );
-        };
-        if (request.route === "truncate_tool_results_only") {
-          const contextTokenBudget = params.contextTokenBudget ?? DEFAULT_CONTEXT_TOKENS;
-          const toolResultMaxChars = resolveLiveToolResultMaxChars({
-            contextWindowTokens: contextTokenBudget,
-            cfg: params.config,
-            agentId: sessionAgentId,
-          });
-          const truncationResult = truncateOversizedToolResultsInSessionManager({
-            sessionManager: activeSessionManager,
-            contextWindowTokens: contextTokenBudget,
-            maxCharsOverride: toolResultMaxChars,
-            sessionFile: params.sessionFile,
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
-            agentId: sessionAgentId,
-          });
-          if (truncationResult.truncated) {
-            preflightRecovery = {
-              route: "truncate_tool_results_only",
-              source: "mid-turn",
-              ...buildPreflightRecoveryBudgetSnapshot(request),
-              handled: true,
-              truncatedCount: truncationResult.truncatedCount,
-            };
-            const sessionContext = activeSessionManager.buildSessionContext();
-            activeSession.agent.state.messages = sessionContext.messages;
-            logMidTurnPrecheck(
-              request.route,
-              `handled=true truncatedCount=${truncationResult.truncatedCount}`,
-            );
-          } else {
-            preflightRecovery = {
-              route: "compact_only",
-              source: "mid-turn",
-              ...buildPreflightRecoveryBudgetSnapshot(request),
-            };
-            promptError = new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
-            promptErrorSource = "precheck";
-            logMidTurnPrecheck(
-              "compact_only",
-              `truncateFallbackReason=${truncationResult.reason ?? "unknown"}`,
-            );
-          }
-        } else {
-          preflightRecovery = {
-            route: request.route,
-            source: "mid-turn",
-            ...buildPreflightRecoveryBudgetSnapshot(request),
-          };
-          promptError = new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
+        const outcome = handleEmbeddedAttemptMidTurnPrecheck({
+          attempt: params,
+          request,
+          sessionAgentId,
+          sessionManager: activeSessionManager,
+          prePromptMessageCount,
+          replaceSessionMessages: (messages) => {
+            activeSession.agent.state.messages = messages;
+          },
+        });
+        preflightRecovery = outcome.preflightRecovery;
+        if (outcome.promptError) {
+          promptError = outcome.promptError;
           promptErrorSource = "precheck";
-          logMidTurnPrecheck(request.route);
         }
       };
       let skipPromptSubmission = false;
@@ -2080,168 +2009,41 @@ export async function runEmbeddedAttempt(
               });
           }
 
-          const llmBoundaryOptionsForPrecheck =
-            boundaryTimezone || !includeBoundaryTimestamp
-              ? {
-                  ...(boundaryTimezone ? { timezone: boundaryTimezone } : {}),
-                  ...(includeBoundaryTimestamp ? {} : { includeTimestamp: false }),
-                }
-              : undefined;
-          const unwindowedLlmBoundaryMessagesForPrecheck =
-            contextEnginePromptAuthority === "preassembly_may_overflow" &&
-            unwindowedContextEngineMessagesForPrecheck
-              ? normalizeMessagesForLlmBoundary(
-                  unwindowedContextEngineMessagesForPrecheck,
-                  llmBoundaryOptionsForPrecheck,
-                )
-              : undefined;
-          const llmBoundaryTokenPressure = estimateLlmBoundaryTokenPressure({
-            messages: hookMessagesForCurrentPrompt,
+          const promptPreflight = await prepareEmbeddedAttemptPromptPreflight({
+            attempt: params,
+            ...(activeContextEngine ? { activeContextEngine } : {}),
+            contextEngineAssemblySucceeded,
+            contextEnginePromptAuthority,
+            contextTokenBudget,
+            hookMessagesForCurrentPrompt,
+            includeBoundaryTimestamp,
+            promptForPrecheck: llmBoundaryPromptForPrecheck,
+            reserveTokens,
+            sessionAgentId,
+            sessionManager: activeSessionManager,
+            sessionMessageCount: activeSession.messages.length,
+            state: {
+              contextBudgetStatus,
+              preflightRecovery,
+              promptError,
+              promptErrorSource,
+              skipPromptSubmission,
+            },
             systemPrompt: systemPromptForHook,
-            prompt: llmBoundaryPromptForPrecheck,
+            ...(boundaryTimezone ? { timezone: boundaryTimezone } : {}),
+            toolResultMaxChars: promptToolResultMaxChars,
+            ...(unwindowedContextEngineMessagesForPrecheck
+              ? { unwindowedContextEngineMessagesForPrecheck }
+              : {}),
+            withOwnedSessionWriteLock,
           });
-          let preemptiveCompaction = null;
-          const shouldSkipPrecheck =
-            skipPromptSubmission ||
-            (contextEngineAssemblySucceeded &&
-              activeContextEngine?.info.ownsCompaction &&
-              contextEnginePromptAuthority !== "preassembly_may_overflow");
-
-          if (shouldSkipPrecheck && !skipPromptSubmission) {
-            log.info(
-              `[context-overflow-precheck] skipped: context engine "${activeContextEngine!.info.id}" owns compaction`,
-            );
-          }
-
-          if (!shouldSkipPrecheck) {
-            preemptiveCompaction = shouldPreemptivelyCompactBeforePrompt({
-              messages: hookMessagesForCurrentPrompt,
-              ...(unwindowedLlmBoundaryMessagesForPrecheck
-                ? { unwindowedMessages: unwindowedLlmBoundaryMessagesForPrecheck }
-                : {}),
-              systemPrompt: systemPromptForHook,
-              prompt: llmBoundaryPromptForPrecheck,
-              contextTokenBudget,
-              reserveTokens,
-              toolResultMaxChars: promptToolResultMaxChars,
-              llmBoundaryTokenPressure: {
-                estimatedPromptTokens: llmBoundaryTokenPressure,
-                source: "llm_boundary_normalized_prompt",
-                renderedChars: llmBoundaryPromptForPrecheck.length,
-              },
-            });
-          }
-          if (preemptiveCompaction) {
-            contextBudgetStatus = buildPrePromptContextBudgetStatus({
-              result: preemptiveCompaction,
-              provider: params.provider,
-              modelId: params.modelId,
-              messageCount: activeSession.messages.length,
-              contextTokenBudget,
-              reserveTokens,
-              ...(params.sessionId ? { sessionId: params.sessionId } : {}),
-              ...(contextEnginePromptAuthority === "preassembly_may_overflow" &&
-              unwindowedContextEngineMessagesForPrecheck
-                ? { unwindowedMessageCount: unwindowedContextEngineMessagesForPrecheck.length }
-                : {}),
-            });
-            log.debug(
-              formatPrePromptPrecheckLog({
-                result: preemptiveCompaction,
-                provider: params.provider,
-                modelId: params.modelId,
-                messageCount: activeSession.messages.length,
-                contextTokenBudget,
-                reserveTokens,
-                ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-                ...(params.sessionId ? { sessionId: params.sessionId } : {}),
-                ...(contextEnginePromptAuthority === "preassembly_may_overflow" &&
-                unwindowedContextEngineMessagesForPrecheck
-                  ? { unwindowedMessageCount: unwindowedContextEngineMessagesForPrecheck.length }
-                  : {}),
-                ...(params.sessionFile ? { sessionFile: params.sessionFile } : {}),
-              }),
-            );
-          }
-          if (preemptiveCompaction?.route === "truncate_tool_results_only") {
-            const toolResultMaxChars = resolveLiveToolResultMaxChars({
-              contextWindowTokens: contextTokenBudget,
-              cfg: params.config,
-              agentId: sessionAgentId,
-            });
-            const truncationResult = await withOwnedSessionWriteLock(() =>
-              truncateOversizedToolResultsInSessionManager({
-                sessionManager: activeSessionManager,
-                contextWindowTokens: contextTokenBudget,
-                maxCharsOverride: toolResultMaxChars,
-                sessionFile: params.sessionFile,
-                sessionId: params.sessionId,
-                sessionKey: params.sessionKey,
-                agentId: sessionAgentId,
-              }),
-            );
-            if (truncationResult.truncated) {
-              preflightRecovery = {
-                route: "truncate_tool_results_only",
-                ...buildPreflightRecoveryBudgetSnapshot(preemptiveCompaction),
-                handled: true,
-                truncatedCount: truncationResult.truncatedCount,
-              };
-              log.info(
-                `[context-overflow-precheck] early tool-result truncation succeeded for ` +
-                  `${params.provider}/${params.modelId} route=${preemptiveCompaction.route} ` +
-                  `truncatedCount=${truncationResult.truncatedCount} ` +
-                  `estimatedPromptTokens=${preemptiveCompaction.estimatedPromptTokens} ` +
-                  `promptBudgetBeforeReserve=${preemptiveCompaction.promptBudgetBeforeReserve} ` +
-                  `overflowTokens=${preemptiveCompaction.overflowTokens} ` +
-                  `toolResultReducibleChars=${preemptiveCompaction.toolResultReducibleChars} ` +
-                  `effectiveReserveTokens=${preemptiveCompaction.effectiveReserveTokens} ` +
-                  `sessionFile=${params.sessionFile}`,
-              );
-              skipPromptSubmission = true;
-            }
-            if (!skipPromptSubmission) {
-              log.warn(
-                `[context-overflow-precheck] early tool-result truncation did not help for ` +
-                  `${params.provider}/${params.modelId}; falling back to compaction ` +
-                  `reason=${truncationResult.reason ?? "unknown"} sessionFile=${params.sessionFile}`,
-              );
-              preflightRecovery = {
-                route: "compact_only",
-                ...buildPreflightRecoveryBudgetSnapshot(preemptiveCompaction),
-              };
-              promptError = new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
-              promptErrorSource = "precheck";
-              skipPromptSubmission = true;
-            }
-          }
-          if (preemptiveCompaction?.shouldCompact) {
-            preflightRecovery =
-              preemptiveCompaction.route === "compact_then_truncate"
-                ? {
-                    route: "compact_then_truncate",
-                    ...buildPreflightRecoveryBudgetSnapshot(preemptiveCompaction),
-                  }
-                : {
-                    route: "compact_only",
-                    ...buildPreflightRecoveryBudgetSnapshot(preemptiveCompaction),
-                  };
-            promptError = new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
-            promptErrorSource = "precheck";
-            log.warn(
-              `[context-overflow-precheck] sessionKey=${params.sessionKey ?? params.sessionId} ` +
-                `provider=${params.provider}/${params.modelId} ` +
-                `route=${preemptiveCompaction.route} ` +
-                `estimatedPromptTokens=${preemptiveCompaction.estimatedPromptTokens} ` +
-                `promptBudgetBeforeReserve=${preemptiveCompaction.promptBudgetBeforeReserve} ` +
-                `overflowTokens=${preemptiveCompaction.overflowTokens} ` +
-                `toolResultReducibleChars=${preemptiveCompaction.toolResultReducibleChars} ` +
-                `reserveTokens=${reserveTokens} ` +
-                `effectiveReserveTokens=${preemptiveCompaction.effectiveReserveTokens} ` +
-                `sessionFile=${params.sessionFile}`,
-            );
-            skipPromptSubmission = true;
-          }
+          ({
+            contextBudgetStatus,
+            preflightRecovery,
+            promptError,
+            promptErrorSource,
+            skipPromptSubmission,
+          } = promptPreflight);
 
           if (!skipPromptSubmission) {
             const normalizedReplayMessages = normalizeAssistantReplayContent(


### PR DESCRIPTION
## What Problem This Solves

`runEmbeddedAttempt` still owned prompt overflow admission and mid-turn recovery: boundary token pressure, context-engine compaction ownership, tool-result truncation, recovery state, and error routing. Those concerns formed a separable phase but were embedded inside the orchestration function.

Related: #72072

## Why This Change Was Made

- Extract pre-prompt overflow admission and mid-turn precheck recovery into `attempt-prompt-preflight.ts`.
- Keep the five mutable preflight fields explicit at the phase boundary.
- Preserve context-engine skip rules, unwindowed boundary normalization, lock scope, budget snapshots, logs, and successful/fallback truncation semantics.
- Add focused coverage for direct recovery, fallback, successful truncation, owned-lock execution, and context-engine deferral.

## User Impact

No intended behavior change. `attempt.ts` drops from 2,727 to 2,529 lines, and prompt admission becomes independently testable.

## Evidence

- Blacksmith Testbox `tbx_01kxeqpgmny68p4e63r507wc7a`: 262 focused tests passed across attempt, preflight, preemptive compaction, context-engine, and overflow-loop suites.
- Same Testbox: scoped `check:changed` passed, including core/core-test types, format, lint, LOC ratchet, import-cycle scan, and repository guards.
- Final rebase was conflict-free over unrelated CLI, CI, UI, and plugin paths; `git diff --check` remained clean.
- Fresh autoreview: no accepted/actionable findings after successful-truncation coverage was added.
Hosted CI and another remote proof loop intentionally not awaited per maintainer instruction.
