### PR TITLE
fix(agents): retry finalized subagent results after prompt failure

### DIFF
--- a/src/agents/agent-steering-queue.test.ts
+++ b/src/agents/agent-steering-queue.test.ts
@@ -144,6 +144,63 @@ describe("agent steering queue", () => {
     expect(runs.get("retry")?.cleanupHandled).toBe(false);
   });
 
+  it("releases finalized items for immediate steering retry", () => {
+    const runs = runMap([
+      makeRun({
+        runId: "finalized",
+        cleanup: "keep",
+        cleanupCompletedAt: 2_500,
+      }),
+    ]);
+
+    expect(
+      leasePendingAgentSteeringItemsFromSubagentRuns({
+        runs,
+        requesterSessionKey,
+        leaseId: "lease-1",
+        now: 3_000,
+      })?.runIds,
+    ).toEqual(["finalized"]);
+
+    expect(
+      releaseLeasedAgentSteeringItemsFromSubagentRuns({
+        runs,
+        runIds: ["finalized"],
+        leaseId: "stale-lease",
+      }),
+    ).toBe(0);
+    expect(runs.get("finalized")?.delivery).toMatchObject({
+      status: "in_progress",
+      steeringLeaseId: "lease-1",
+    });
+    expect(runs.get("finalized")?.cleanupHandled).toBe(true);
+
+    expect(
+      releaseLeasedAgentSteeringItemsFromSubagentRuns({
+        runs,
+        runIds: ["finalized"],
+        leaseId: "lease-1",
+        error: "prompt submission failed",
+      }),
+    ).toBe(1);
+    expect(runs.get("finalized")?.delivery).toMatchObject({
+      status: "pending",
+      steeringLeaseId: undefined,
+      steeringLeasedAt: undefined,
+      lastError: "prompt submission failed",
+    });
+    expect(runs.get("finalized")?.cleanupHandled).toBe(false);
+
+    expect(
+      leasePendingAgentSteeringItemsFromSubagentRuns({
+        runs,
+        requesterSessionKey,
+        leaseId: "lease-2",
+        now: 3_001,
+      })?.runIds,
+    ).toEqual(["finalized"]);
+  });
+
   it("preserves suspended payloads across prompt submission failures", () => {
     const runs = runMap([
       makeRun({

--- a/src/agents/agent-steering-queue.ts
+++ b/src/agents/agent-steering-queue.ts
@@ -248,8 +248,9 @@ export function releaseLeasedAgentSteeringItemsFromSubagentRuns(params: {
 }): number {
   let updated = 0;
   for (const runId of params.runIds) {
-    const delivery = params.runs.get(runId)?.delivery;
-    if (!delivery || delivery.steeringLeaseId !== params.leaseId) {
+    const entry = params.runs.get(runId);
+    const delivery = entry?.delivery;
+    if (!entry || !delivery || delivery.steeringLeaseId !== params.leaseId) {
       continue;
     }
     delivery.status = typeof delivery.suspendedAt === "number" ? "suspended" : "pending";
@@ -257,11 +258,9 @@ export function releaseLeasedAgentSteeringItemsFromSubagentRuns(params: {
     delivery.steeringLeasedAt = undefined;
     delivery.steeringInjectedAt = undefined;
     delivery.lastError = params.error ?? delivery.lastError ?? null;
-    const entry = params.runs.get(runId);
-    if (entry && typeof entry.cleanupCompletedAt !== "number") {
-      // Non-finalized runs can be retried by cleanup/delivery after release.
-      entry.cleanupHandled = false;
-    }
+    // The matching steering lease acquired this in-process cleanup lock.
+    // Release must relinquish it so the pending result can be leased again.
+    entry.cleanupHandled = false;
     updated += 1;
   }
   return updated;


### PR DESCRIPTION
Closes #106559

AI-assisted. I reviewed the queue lifecycle, ownership boundary, regression proof, and independent review findings and understand the change.

## What Problem This Solves

When prompt submission fails after leasing a finalized subagent result, the steering queue returns the delivery to `pending` or `suspended` but can leave the in-process `cleanupHandled` lock set. The collector then suppresses that result on every later parent turn.

The issue describes five-minute recovery, but release clears the lease timestamp used by stale-lease recovery. Without another state transition, the result can remain stranded indefinitely.

## Why This Change Was Made

A matching steering lease acquired the `cleanupHandled` lock, so releasing that lease now always relinquishes the lock. The existing lease-ID ownership check remains the mutation boundary: a stale or mismatched release cannot clear a newer owner's lock.

The collector's `cleanupHandled` guard remains intact because it prevents steering from racing an active direct announce/cleanup attempt. This is intentionally narrower than #106833, which removes that ownership fence and makes pending cleanup-owned payloads eligible for concurrent steering.

The regression test covers both sides of the ownership contract: a mismatched release is a no-op, while the matching release makes a finalized result immediately leasable again.

## User Impact

Finalized subagent results can be retried on the next parent turn after prompt submission fails, instead of disappearing from the steering queue. Active cleanup and direct announce work remain mutually exclusive with steering delivery.

## Evidence

### Full embedded-agent runtime: failed parent turn → next-turn delivery

A git-excluded proof harness imports the PR checkout's real `runEmbeddedAgent` and subagent registry, uses an isolated state/config/workspace, and drives two real parent turns. The first turn leases the finalized result and then fails the real prompt boundary through the runtime's unresolved explicit-tool allowlist guard. The second turn submits to a loopback OpenAI Responses endpoint, whose captured request must contain the subagent marker.

PR head `d2cbc2185589ab0d033c73c48eb94692f409471b`:

```text
PR #106849 full embedded-agent proof (.../openclaw-103540-base)
[PASS] BOUNDARY: real embedded parent turn failed after prompt assembly — modelRequests=0 error=Error: No callable tools remain after resolving explicit tool allowlist (...)
[PASS] RELEASE: runtime returned finalized result to pending without cleanup lock — status=pending cleanupHandled=false
[PASS] NEXT TURN: real model request contained finalized subagent result
[PASS] DELIVERY: successful parent turn acknowledged result exactly once — status=delivered successRequests=1
[PASS] PARENT: second embedded-agent turn completed
------------------------------------------------------------------------
RESULT: PASS — full runtime released and delivered the result on the next parent turn.
```

### Unfixed-main negative control

A smaller source-level lifecycle harness drives the same production queue helpers against unfixed main. It reproduces the stuck lock and missing next-turn delivery:

```text
[PASS] BOUNDARY: first parent prompt submission failed after leasing the finalized result
[FAIL] RELEASE: failed submission returned the result to pending without a cleanup lock — status=pending cleanupHandled=true
[FAIL] NEXT TURN: finalized subagent result was leased immediately (no five-minute wait)
[FAIL] NEXT TURN: accepted parent prompt contained the finalized subagent result
[FAIL] DELIVERY: successful parent submission acknowledged the result — status=pending
------------------------------------------------------------------------
RESULT: FAIL — BUG SIGNATURE: finalized result was not delivered on the next parent turn.
```

### Automated and review proof

- `node scripts/run-vitest.mjs src/agents/agent-steering-queue.test.ts` (Node 24)
  - 1 file passed, 8 tests passed.
- `node_modules/.bin/oxfmt --check src/agents/agent-steering-queue.ts src/agents/agent-steering-queue.test.ts`
  - Both files match repository formatting.
- `node_modules/.bin/oxlint src/agents/agent-steering-queue.ts src/agents/agent-steering-queue.test.ts`
  - Passed with no findings.
- `git diff --check origin/main...HEAD`
  - Passed.
- Independent exact-head lifecycle review
  - No actionable findings; judged this the best fix because it repairs the release transition while preserving the collector ownership fence.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine claude --model claude-fable-5 --thinking max`
  - No accepted/actionable findings; `patch is correct`.

The rebased exact-head [GitHub Actions matrix](https://github.com/openclaw/openclaw/actions/runs/29294605066) passed: 43 CI jobs succeeded and 12 were intentionally skipped. Across all PR checks, 68 succeeded, 38 were skipped, and CodeQL reported its expected neutral result. Pre-PR Blacksmith Testbox was unavailable because the local environment does not provide the `blacksmith` executable; the focused local checks were followed by the full GitHub matrix.
