### PR TITLE
fix: recognize provider-wrapped HTTP status for session retry

### DIFF
--- a/src/llm/utils/retry.test.ts
+++ b/src/llm/utils/retry.test.ts
@@ -112,4 +112,21 @@ describe("isRetryableAssistantError", () => {
       ),
     ).toBe(true);
   });
+
+  it.each([
+    "OpenAI API error (500): 500 The server had an error while processing your request. Sorry about that!",
+    "Azure OpenAI API error (502): Bad gateway from upstream",
+    "Mistral API error (503): service temporarily unavailable",
+    "Provider API error (504): gateway timeout",
+  ])("retries built-in provider-wrapped transient 5xx: %s", (text) => {
+    expect(isRetryableAssistantError(errorMessage(text))).toBe(true);
+  });
+
+  it("does not treat permanent provider-wrapped 4xx as retryable", () => {
+    expect(
+      isRetryableAssistantError(
+        errorMessage("OpenAI API error (400): 400 Model Id [gpt-5.4-nano] not found"),
+      ),
+    ).toBe(false);
+  });
 });

--- a/src/llm/utils/retry.ts
+++ b/src/llm/utils/retry.ts
@@ -1,4 +1,7 @@
-import { extractLeadingHttpStatus } from "../../shared/assistant-error-format.js";
+import {
+  extractLeadingHttpStatus,
+  extractProviderWrappedHttpStatus,
+} from "../../shared/assistant-error-format.js";
 import type { AssistantMessage } from "../types.js";
 import { classifyRateLimitWindow } from "./rate-limit-window.js";
 
@@ -67,7 +70,9 @@ export function isRetryableAssistantError(message: AssistantMessage): boolean {
   if (NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN.test(errorMessage)) {
     return false;
   }
-  const status = extractLeadingHttpStatus(errorMessage)?.code;
+  const status =
+    extractLeadingHttpStatus(errorMessage)?.code ??
+    extractProviderWrappedHttpStatus(errorMessage)?.code;
   if (status && status !== 429 && RETRYABLE_HTTP_STATUS_CODES.has(status)) {
     return true;
   }

--- a/src/shared/assistant-error-format.ts
+++ b/src/shared/assistant-error-format.ts
@@ -12,6 +12,11 @@ const HTTP_STATUS_CODE_PREFIX_RE = new RegExp(
   `^(?:http\\s*)?(\\d{3})(?:${HTTP_STATUS_DELIMITER_RE.source}([\\s\\S]+))?$`,
   "i",
 );
+// Built-in provider adapters format status as `OpenAI API error (500): ...` (also
+// Azure OpenAI / Mistral / Provider). Keep this anchored so mid-string numbers
+// like model ids or image dimensions never become fake HTTP statuses.
+const PROVIDER_WRAPPED_HTTP_STATUS_RE =
+  /^(?:[a-z][\w-]*(?:\s+[a-z][\w-]*){0,3}\s+)?api\s*error\s*\((\d{3})\)(?:\s*:\s*([\s\S]*))?$/i;
 const HTML_ERROR_PREFIX_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
 const HTML_CLOSE_RE = /<\/html>/i;
 const CLOUDFLARE_HTML_ERROR_CODES = new Set([521, 522, 523, 524, 525, 526, 530]);
@@ -96,7 +101,7 @@ export function parseApiErrorPayload(raw?: string): ErrorPayload | null {
 }
 
 export function extractLeadingHttpStatus(raw: string): { code: number; rest: string } | null {
-  const match = raw.match(HTTP_STATUS_CODE_PREFIX_RE);
+  const match = raw.match(HTTP_STATUS_CODE_PREFIX_RE) ?? raw.match(PROVIDER_WRAPPED_HTTP_STATUS_RE);
   if (!match) {
     return null;
   }

--- a/src/shared/assistant-error-format.ts
+++ b/src/shared/assistant-error-format.ts
@@ -100,8 +100,9 @@ export function parseApiErrorPayload(raw?: string): ErrorPayload | null {
   return null;
 }
 
-export function extractLeadingHttpStatus(raw: string): { code: number; rest: string } | null {
-  const match = raw.match(HTTP_STATUS_CODE_PREFIX_RE) ?? raw.match(PROVIDER_WRAPPED_HTTP_STATUS_RE);
+function extractHttpStatusMatch(
+  match: RegExpMatchArray | null,
+): { code: number; rest: string } | null {
   if (!match) {
     return null;
   }
@@ -110,6 +111,16 @@ export function extractLeadingHttpStatus(raw: string): { code: number; rest: str
     return null;
   }
   return { code, rest: (match[2] ?? "").trim() };
+}
+
+export function extractLeadingHttpStatus(raw: string): { code: number; rest: string } | null {
+  return extractHttpStatusMatch(raw.match(HTTP_STATUS_CODE_PREFIX_RE));
+}
+
+export function extractProviderWrappedHttpStatus(
+  raw: string,
+): { code: number; rest: string } | null {
+  return extractHttpStatusMatch(raw.match(PROVIDER_WRAPPED_HTTP_STATUS_RE));
 }
 
 export function isCloudflareOrHtmlErrorPage(raw: string): boolean {


### PR DESCRIPTION
Fixes #106824

## What Problem This Solves

Session auto-retry did not recognize transient 5xx failures emitted in the built-in OpenAI Responses, Azure OpenAI Responses, and Mistral adapter format: `Provider API error (NNN): ...`. Those errors became terminal even though their HTTP status was retryable.

## Why This Change Was Made

The retry classifier only parsed an HTTP status at the start of a message. This change adds a separately named parser for the repository's anchored provider-wrapper format and lets retry classification opt into it. The existing leading-status parser remains strict for rate-window detection, display formatting, sanitization, and slug generation.

This scope matters: broadening the shared leading parser changed the sibling short-window 429 contract. Keeping provider-wrapper recognition local to retry restores the missing behavior without changing those callers.

## User Impact

Transient 500/502/503/504 responses from the built-in adapters can schedule the normal same-model session retry again. Wrapped permanent 4xx responses remain non-retryable, and arbitrary mid-message status substrings remain ignored.

## Evidence

- Original contributor head `d27ec56bc74d65fe88010553bc2aaa52c9cecc51`: sanitized public AWS, exact-head retry tests, 26/26 passed.
- Maintainer-improved head `dfae309c9014bbbfc1b79b931fda94928da8ed59`: Blacksmith Testbox, retry plus sibling assistant-failover tests, 58/58 passed.
- Tests cover OpenAI, Azure OpenAI, Mistral, generic provider wrappers, transient 5xx, permanent 400, and the unchanged leading-status behavior.
- Fresh exact-head hosted CI required before merge.

No billed provider request was needed: the changed contract is local error formatting and classification, and the emitting adapter implementations plus consuming classifier were inspected directly.

## AI disclosure

The contributor used AI assistance. Maintainer review narrowed the implementation after a sibling-contract regression surfaced in exact-head CI.
