### PR TITLE
refactor(auto-reply): privatize finalization timeout

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -939,7 +939,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/auto-reply/reply/queue/cleanup.ts: testing",
   "src/auto-reply/reply/queue/drain.ts: resolveFollowupAuthorizationKey",
   "src/auto-reply/reply/queue/enqueue.ts: resetRecentQueuedMessageIdDedupe",
-  "src/auto-reply/reply/reply-run-finalization-lease.ts: REPLY_RUN_FINALIZATION_SETTLE_TIMEOUT_MS (replyRunSettle)",
   "src/auto-reply/reply/reply-run-registry.ts: testing",
   "src/auto-reply/reply/stage-sandbox-media.ts: appendScpStderrTail",
   "src/auto-reply/reply/stage-sandbox-media.ts: SCP_STDERR_TAIL_CHARS",

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -32,7 +32,8 @@ let createReplyOperation: typeof import("./reply-run-registry.js").createReplyOp
 let replyRunRegistry: typeof import("./reply-run-registry.js").replyRunRegistry;
 let runAfterReplyOperationClear: typeof import("./reply-run-registry.js").runAfterReplyOperationClear;
 let resetReplyRunRegistry: typeof import("./reply-run-registry.js").testing.resetReplyRunRegistry;
-let replyRunFinalizationSettleTimeoutMs: number;
+
+const REPLY_RUN_FINALIZATION_SETTLE_TIMEOUT_MS = 60_000;
 
 function firstRuntimeLoadCall() {
   return runtimePluginMocks.ensureRuntimePluginsLoaded.mock.calls[0]?.[0] as
@@ -69,13 +70,10 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     ({ dispatchReplyFromConfig } = await import("./dispatch-from-config.js"));
     ({ resetInboundDedupe } = await import("./inbound-dedupe.js"));
     const replyRunRegistryModule = await import("./reply-run-registry.js");
-    const finalizationLeaseModule = await import("./reply-run-finalization-lease.js");
     createReplyOperation = replyRunRegistryModule.createReplyOperation;
     replyRunRegistry = replyRunRegistryModule.replyRunRegistry;
     runAfterReplyOperationClear = replyRunRegistryModule.runAfterReplyOperationClear;
     resetReplyRunRegistry = () => replyRunRegistryModule.testing.resetReplyRunRegistry();
-    replyRunFinalizationSettleTimeoutMs =
-      finalizationLeaseModule.REPLY_RUN_FINALIZATION_SETTLE_TIMEOUT_MS;
   });
 
   beforeEach(() => {
@@ -827,7 +825,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       });
 
       await ownerStarted.promise;
-      await vi.advanceTimersByTimeAsync(replyRunFinalizationSettleTimeoutMs);
+      await vi.advanceTimersByTimeAsync(REPLY_RUN_FINALIZATION_SETTLE_TIMEOUT_MS);
       await expect(dispatchPromise).resolves.toMatchObject({ queuedFinal: false });
 
       expect(replyRunRegistry.get("agent:test:session")).toBeUndefined();
@@ -878,7 +876,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       });
 
       await ttsStarted.promise;
-      await vi.advanceTimersByTimeAsync(replyRunFinalizationSettleTimeoutMs);
+      await vi.advanceTimersByTimeAsync(REPLY_RUN_FINALIZATION_SETTLE_TIMEOUT_MS);
 
       const active = replyRunRegistry.get("agent:test:session");
       expect(active).toBeDefined();

--- a/src/auto-reply/reply/reply-run-finalization-lease.ts
+++ b/src/auto-reply/reply/reply-run-finalization-lease.ts
@@ -1,6 +1,6 @@
 import { resolveTimerTimeoutMs } from "../../shared/number-coercion.js";
 
-export const REPLY_RUN_FINALIZATION_SETTLE_TIMEOUT_MS = 60_000;
+const REPLY_RUN_FINALIZATION_SETTLE_TIMEOUT_MS = 60_000;
 export type ReplyOperationStaleReason =
   | "terminal_unreleased"
   | "finalization_stalled"

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -8,10 +8,7 @@ import {
 } from "../../logging/diagnostic-run-activity.js";
 import { diagnosticLogger } from "../../logging/diagnostic-runtime.js";
 import { MAX_TIMER_TIMEOUT_MS } from "../../shared/number-coercion.js";
-import {
-  beginReplyOperationFinalizationWork,
-  REPLY_RUN_FINALIZATION_SETTLE_TIMEOUT_MS,
-} from "./reply-run-finalization-lease.js";
+import { beginReplyOperationFinalizationWork } from "./reply-run-finalization-lease.js";
 import {
   testing,
   abortActiveReplyRuns,
@@ -33,6 +30,8 @@ import {
   waitForReplyRunEndBySessionId,
 } from "./reply-run-registry.js";
 import { admitReplyTurn } from "./reply-turn-admission.js";
+
+const REPLY_RUN_FINALIZATION_SETTLE_TIMEOUT_MS = 60_000;
 
 describe("reply run registry", () => {
   afterEach(() => {


### PR DESCRIPTION
## What Problem This Solves

The reply-finalization settle timeout was exported only for tests, leaving a same-file production constant in the dead-export baseline.

## Why This Change Was Made

Makes the 60-second timeout module-private. Behavior tests retain the same timing assertions with a local expected duration and continue exercising the production reply-operation paths.

Baseline delta: 1,281 → 1,280 (`+0/-1`).

## User Impact

No user-visible behavior change. Reply finalization still expires, renews, and honors bounded work with the same 60-second default.

## Evidence

- Blacksmith Testbox `tbx_01kxerfrtp3mzmxdz4tm8xt2wt`, run [29288975536](https://github.com/openclaw/openclaw/actions/runs/29288975536): exact regeneration byte-stable at 1,280; dead-export checker green
- Same Testbox: formatting and touched-path type-aware lint green; focused auto-reply tests 68/68; core types green
- Fresh autoreview: no accepted/actionable findings, patch correct at 0.98
- Latest main movement is plugin-SDK migration hardening only; no touched-path or baseline overlap
