### PR TITLE
test(telegram): cover sender-less channel post fragments

### DIFF
--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1562,6 +1562,47 @@ describe("createTelegramBot", () => {
     );
   });
 
+  it("normalizes sender-less channel posts before fragment classification", async () => {
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          groupPolicy: "open",
+          groups: { "*": { requireMention: false } },
+        },
+      },
+    });
+    createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
+    const handler = getOnHandler("channel_post") as (ctx: Record<string, unknown>) => Promise<void>;
+    const channelPostBase = {
+      chat: { id: -9_876_543_233, type: "channel", title: "Sender-less channel" },
+      date: 1_736_380_800,
+    };
+    const contextBase = {
+      me: { id: 7_654_321_000, username: "openclaw_bot" },
+      getFile: async () => null,
+    };
+
+    await handler({
+      ...contextBase,
+      channelPost: {
+        ...channelPostBase,
+        message_id: 1,
+        text: "channel-start".padEnd(4_000, "A"),
+      },
+    });
+    await handler({
+      ...contextBase,
+      channelPost: { ...channelPostBase, message_id: 2, text: "channel-tail" },
+    });
+
+    await vi.waitFor(() => expect(replySpy).toHaveBeenCalledTimes(1));
+    expect(replySpy.mock.calls[0]?.[0].BodyForAgent).toBe(
+      `${"channel-start".padEnd(4_000, "A")}channel-tail`,
+    );
+  });
+
   it("keeps peer-bot abort controls out of buffered text fragments", async () => {
     loadConfig.mockReturnValue({
       commands: { native: false },


### PR DESCRIPTION
## What Problem This Solves

The July LTS channel-post classification fix at `28e79cf2eaf68a3cc4edc02d834cc26f4541c23f` had no direct regression test for Telegram `channel_post` updates that omit both `from` and `sender_chat`. Without the normalization, adjacent near-limit fragments are classified as separate peer-bot turns.

## Why This Change Was Made

Add a handler-level regression that sends two sender-less channel posts through the real `channel_post` path and requires one combined agent turn. This covers the exact normalization invariant without changing runtime code.

## User Impact

Test-only. The LTS runtime fix remains unchanged; future regressions in sender-less channel-post classification now fail deterministically.

## Evidence

- Blacksmith Testbox through Crabbox `tbx_01kxerk56qm1wz6y483tgt6z0e`: 145/145 tests passed in `extensions/telegram/src/bot.create-telegram-bot.test.ts`.
- Same Testbox: targeted oxfmt check passed.
- Fresh Codex autoreview: clean, confidence 0.97.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29289082216
