### PR TITLE
refactor(shared): narrow entry status API

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -1203,8 +1203,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/shared/config-eval.ts: resolveConfigPath",
   "src/shared/config-eval.ts: resolveRuntimePlatform",
   "src/shared/device-auth-store.ts: DeviceAuthStoreAdapter",
-  "src/shared/entry-status.ts: evaluateEntryMetadataRequirements",
-  "src/shared/entry-status.ts: evaluateEntryMetadataRequirementsForCurrentPlatform",
   "src/shared/node-match.ts: normalizeNodeKey",
   "src/shared/runtime-import.ts: resolveRuntimeImportSpecifier",
   "src/shared/silent-reply-policy.ts: DEFAULT_SILENT_REPLY_POLICY",

--- a/src/shared/entry-status.test.ts
+++ b/src/shared/entry-status.test.ts
@@ -1,11 +1,7 @@
-// Entry status tests cover normalized status labels and terminal-state behavior.
+// Entry status tests cover shared presentation metadata and requirement evaluation.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mockProcessPlatform } from "../test-utils/vitest-spies.js";
-import {
-  evaluateEntryMetadataRequirements,
-  evaluateEntryMetadataRequirementsForCurrentPlatform,
-  evaluateEntryRequirementsForCurrentPlatform,
-} from "./entry-status.js";
+import { evaluateEntryRequirementsForCurrentPlatform } from "./entry-status.js";
 
 function setPlatform(platform: NodeJS.Platform): void {
   mockProcessPlatform(platform);
@@ -17,25 +13,28 @@ afterEach(() => {
 
 describe("shared/entry-status", () => {
   it("combines metadata presentation fields with evaluated requirements", () => {
-    const result = evaluateEntryMetadataRequirements({
+    setPlatform("linux");
+
+    const result = evaluateEntryRequirementsForCurrentPlatform({
       always: false,
-      metadata: {
-        emoji: "🦀",
-        homepage: "https://openclaw.ai",
-        requires: {
-          bins: ["bun"],
-          anyBins: ["ffmpeg", "sox"],
-          env: ["OPENCLAW_TOKEN"],
-          config: ["gateway.bind"],
+      entry: {
+        metadata: {
+          emoji: "🦀",
+          homepage: "https://openclaw.ai",
+          requires: {
+            bins: ["bun"],
+            anyBins: ["ffmpeg", "sox"],
+            env: ["OPENCLAW_TOKEN"],
+            config: ["gateway.bind"],
+          },
+          os: ["darwin"],
         },
-        os: ["darwin"],
-      },
-      frontmatter: {
-        emoji: "🙂",
-        homepage: "https://docs.openclaw.ai",
+        frontmatter: {
+          emoji: "🙂",
+          homepage: "https://docs.openclaw.ai",
+        },
       },
       hasLocalBin: (bin) => bin === "bun",
-      localPlatform: "linux",
       remote: {
         hasAnyBin: (bins) => bins.includes("sox"),
       },
@@ -68,10 +67,12 @@ describe("shared/entry-status", () => {
   it("uses process.platform in the current-platform wrapper", () => {
     setPlatform("darwin");
 
-    const result = evaluateEntryMetadataRequirementsForCurrentPlatform({
+    const result = evaluateEntryRequirementsForCurrentPlatform({
       always: false,
-      metadata: {
-        os: ["darwin"],
+      entry: {
+        metadata: {
+          os: ["darwin"],
+        },
       },
       hasLocalBin: () => false,
       isEnvSatisfied: () => true,
@@ -126,10 +127,12 @@ describe("shared/entry-status", () => {
   });
 
   it("returns empty requirements when metadata and frontmatter are missing", () => {
-    const result = evaluateEntryMetadataRequirements({
+    setPlatform("linux");
+
+    const result = evaluateEntryRequirementsForCurrentPlatform({
       always: false,
+      entry: {},
       hasLocalBin: () => false,
-      localPlatform: "linux",
       isEnvSatisfied: () => false,
       isConfigSatisfied: () => false,
     });

--- a/src/shared/entry-status.ts
+++ b/src/shared/entry-status.ts
@@ -8,10 +8,8 @@ import {
   type RequirementsMetadata,
 } from "./requirements.js";
 
-type EntryMetadataRequirementsParams = Parameters<typeof evaluateEntryMetadataRequirements>[0];
-
 /** Resolves entry presentation metadata and requirement eligibility in one shared shape. */
-export function evaluateEntryMetadataRequirements(params: {
+function evaluateEntryMetadataRequirements(params: {
   always: boolean;
   metadata?: (RequirementsMetadata & { emoji?: string; homepage?: string }) | null;
   frontmatter?: {
@@ -56,16 +54,6 @@ export function evaluateEntryMetadataRequirements(params: {
   };
 }
 
-/** Evaluates entry metadata requirements against the current Node platform. */
-export function evaluateEntryMetadataRequirementsForCurrentPlatform(
-  params: Omit<EntryMetadataRequirementsParams, "localPlatform">,
-): ReturnType<typeof evaluateEntryMetadataRequirements> {
-  return evaluateEntryMetadataRequirements({
-    ...params,
-    localPlatform: process.platform,
-  });
-}
-
 /** Evaluates an entry object's metadata/frontmatter requirements on the current platform. */
 export function evaluateEntryRequirementsForCurrentPlatform(params: {
   always: boolean;
@@ -83,11 +71,12 @@ export function evaluateEntryRequirementsForCurrentPlatform(params: {
   isEnvSatisfied: (envName: string) => boolean;
   isConfigSatisfied: (pathStr: string) => boolean;
 }): ReturnType<typeof evaluateEntryMetadataRequirements> {
-  return evaluateEntryMetadataRequirementsForCurrentPlatform({
+  return evaluateEntryMetadataRequirements({
     always: params.always,
     metadata: params.entry.metadata,
     frontmatter: params.entry.frontmatter,
     hasLocalBin: params.hasLocalBin,
+    localPlatform: process.platform,
     remote: params.remote,
     isEnvSatisfied: params.isEnvSatisfied,
     isConfigSatisfied: params.isConfigSatisfied,


### PR DESCRIPTION
## What Problem This Solves

The shared entry-status module exposed two lower-level requirement evaluators that had no production consumers. Tests called those internals directly, leaving an unsupported API surface and two permanent exceptions in the unused-export baseline.

## Why This Change Was Made

Keep `evaluateEntryRequirementsForCurrentPlatform` as the single production boundary, privatize its evaluator, and remove the redundant current-platform wrapper. Route the existing behavior tests through that same entry-shaped API.

## User Impact

No user-visible behavior changes. The internal API is smaller, tests now exercise the production path, and the dead-export baseline drops two entries.

## Evidence

- Full codebase-memory graph: 312,655 nodes and 1,296,645 edges; the removed wrapper is absent and the canonical API calls the private evaluator directly.
- Exhaustive tracked-repo search found only two production callers of the remaining API: hook status and skill discovery status.
- Blacksmith Testbox `tbx_01kxertnq0n6587twq6c8b17yh`: 24 focused tests passed across entry status and both skill-status suites.
- Same Testbox: `pnpm check:changed -- src/shared/entry-status.ts src/shared/entry-status.test.ts scripts/deadcode-exports.baseline.mjs` passed.
- Same Testbox: `pnpm deadcode:exports` passed with 1,279 baseline entries.
- Fresh `gpt-5.6-sol` medium autoreview: no findings, patch correct, confidence 0.97.
