### PR TITLE
refactor(agents): extract attempt prompt submission

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
@@ -1,0 +1,135 @@
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ImageContent } from "../../../llm/types.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import {
+  clearEmbeddedSessionPromptStates,
+  getEmbeddedSessionPromptState,
+} from "../session-prompt-state.js";
+import { submitEmbeddedAttemptPrompt } from "./attempt-prompt-submit.js";
+import type { RuntimeContextCustomMessage } from "./runtime-context-prompt.js";
+
+const sessionId = "attempt-prompt-submit-test";
+
+function createSession() {
+  const state = {
+    messages: [{ role: "user", content: "transcript prompt", timestamp: 1 }] as AgentMessage[],
+  };
+  const baseStreamFn: StreamFn = () => {
+    throw new Error("stream function should not be called directly");
+  };
+  const originalTransformContext = async (messages: AgentMessage[]) => messages;
+  const agent = {
+    state,
+    streamFn: baseStreamFn,
+    transformContext: originalTransformContext,
+  };
+  const activeSession = {
+    get messages() {
+      return state.messages;
+    },
+    agent,
+  };
+  return { activeSession, baseStreamFn, originalTransformContext };
+}
+
+function createBaseInput() {
+  const sessionPromptState = getEmbeddedSessionPromptState(sessionId);
+  return {
+    attempt: { sessionId },
+    appendContext: "append context",
+    contextTokenBudget: 8_000,
+    images: [] as ImageContent[],
+    modelPrompt: "model prompt",
+    onFinalPromptText: vi.fn(),
+    onSteeringAcknowledged: vi.fn(),
+    prependContext: "prepend context",
+    runtimeOnly: false,
+    sessionPromptState,
+    systemPrompt: "system prompt",
+    toolResultAggregateMaxChars: 8_000,
+    toolResultMaxChars: 4_000,
+    toolResultPromptProjectionState: sessionPromptState.toolResults,
+    trajectoryRecorder: null,
+    transcriptLeafId: null,
+    transcriptPrompt: "transcript prompt",
+  };
+}
+
+afterEach(() => {
+  clearEmbeddedSessionPromptStates([sessionId]);
+});
+
+describe("submitEmbeddedAttemptPrompt", () => {
+  it("submits runtime-only prompts without images and acknowledges steering", async () => {
+    const { activeSession, baseStreamFn, originalTransformContext } = createSession();
+    const input = createBaseInput();
+    const promptActiveSession = vi.fn(
+      async (
+        prompt: string,
+        options?: { images?: ImageContent[]; preflightResult?: (submitted: boolean) => void },
+      ) => {
+        expect(prompt).toBe("transcript prompt");
+        expect(options).not.toHaveProperty("images");
+        expect(input.onFinalPromptText).toHaveBeenCalledWith("transcript prompt");
+        expect(activeSession.agent.streamFn).not.toBe(baseStreamFn);
+        expect(activeSession.agent.transformContext).not.toBe(originalTransformContext);
+        options?.preflightResult?.(true);
+      },
+    );
+
+    await submitEmbeddedAttemptPrompt({
+      ...input,
+      activeSession,
+      images: [{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }],
+      leasedSteering: { leaseId: "lease-1", runIds: ["missing-run"] },
+      promptActiveSession,
+      runtimeOnly: true,
+    });
+
+    expect(input.onSteeringAcknowledged).toHaveBeenCalledOnce();
+    expect(activeSession.agent.streamFn).toBe(baseStreamFn);
+    expect(activeSession.agent.transformContext).toBe(originalTransformContext);
+  });
+
+  it("cleans up runtime context and transforms when normal submission fails", async () => {
+    const { activeSession, baseStreamFn, originalTransformContext } = createSession();
+    const input = createBaseInput();
+    const image: ImageContent = { type: "image", data: "aW1hZ2U=", mimeType: "image/png" };
+    const runtimeContextMessage: RuntimeContextCustomMessage = {
+      role: "custom",
+      customType: "openclaw.runtime-context",
+      content: "runtime context",
+      display: false,
+      details: { source: "openclaw-runtime-context", runtimeContextCarrier: true },
+      timestamp: 2,
+    };
+    const promptActiveSession = vi.fn(
+      async (
+        _prompt: string,
+        options?: { images?: ImageContent[]; preflightResult?: (submitted: boolean) => void },
+      ) => {
+        expect(activeSession.messages).toContain(runtimeContextMessage);
+        expect(options?.images).toEqual([image]);
+        options?.preflightResult?.(true);
+        throw new Error("provider failed");
+      },
+    );
+
+    await expect(
+      submitEmbeddedAttemptPrompt({
+        ...input,
+        activeSession,
+        images: [image],
+        promptActiveSession,
+        runtimeContextMessage,
+      }),
+    ).rejects.toThrow("provider failed");
+
+    expect(input.onFinalPromptText).toHaveBeenCalledWith("transcript prompt");
+    expect(input.onSteeringAcknowledged).not.toHaveBeenCalled();
+    expect(activeSession.messages).not.toContain(runtimeContextMessage);
+    expect(activeSession.agent.streamFn).toBe(baseStreamFn);
+    expect(activeSession.agent.transformContext).toBe(originalTransformContext);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
@@ -1,0 +1,169 @@
+/**
+ * Submits one prepared prompt while owning provider transforms and cleanup.
+ */
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import type { ImageContent } from "../../../llm/types.js";
+import type { createTrajectoryRuntimeRecorder } from "../../../trajectory/runtime.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import { ackPendingAgentSteeringItems } from "../../subagent-registry.js";
+import { normalizeAssistantReplayContent } from "../replay-history.js";
+import { updateActiveEmbeddedRunSnapshot } from "../runs.js";
+import type {
+  getEmbeddedSessionPromptState,
+  ToolResultPromptProjectionState,
+} from "../session-prompt-state.js";
+import { hasSessionUserTurnBeenSent, markSessionUserTurnsSent } from "../session-prompt-state.js";
+import { truncateOversizedToolResultsInMessages } from "../tool-result-truncation.js";
+import { snapshotRecentMessages } from "./attempt-context-summary.js";
+import {
+  installModelPromptTransform,
+  installRuntimeContextMessageForPrompt,
+} from "./attempt.llm-boundary.js";
+import { wrapStreamFnWithMessageTransform } from "./message-transform-stream-wrapper.js";
+import type { RuntimeContextCustomMessage } from "./runtime-context-prompt.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type PromptSubmissionSession = {
+  messages: AgentMessage[];
+  agent: {
+    state: { messages: AgentMessage[] };
+    streamFn: StreamFn;
+    transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
+    continue?: () => Promise<void>;
+  };
+};
+
+type PromptActiveSession = (
+  prompt: string,
+  options?: {
+    images?: ImageContent[];
+    preflightResult?: (submitted: boolean) => void;
+  },
+) => Promise<void>;
+
+type SteeringLease = {
+  leaseId: string;
+  runIds: readonly string[];
+};
+
+type TrajectoryRecorder = ReturnType<typeof createTrajectoryRuntimeRecorder>;
+
+export async function submitEmbeddedAttemptPrompt(input: {
+  attempt: Pick<EmbeddedRunAttemptParams, "sessionId" | "userTurnTranscriptRecorder">;
+  activeSession: PromptSubmissionSession;
+  appendContext?: string;
+  contextTokenBudget: number;
+  images: ImageContent[];
+  leasedSteering?: SteeringLease;
+  modelPrompt: string;
+  onFinalPromptText: (prompt: string) => void;
+  onSteeringAcknowledged: () => void;
+  prependContext?: string;
+  promptActiveSession: PromptActiveSession;
+  runtimeContextMessage?: RuntimeContextCustomMessage;
+  runtimeOnly: boolean;
+  sessionPromptState: ReturnType<typeof getEmbeddedSessionPromptState>;
+  systemPrompt: string;
+  toolResultAggregateMaxChars: number;
+  toolResultMaxChars: number;
+  toolResultPromptProjectionState: ToolResultPromptProjectionState;
+  trajectoryRecorder: TrajectoryRecorder | null;
+  transcriptLeafId: string | null;
+  transcriptPrompt: string;
+}): Promise<void> {
+  const { activeSession, attempt } = input;
+  const normalizedReplayMessages = normalizeAssistantReplayContent(activeSession.messages);
+  if (normalizedReplayMessages !== activeSession.messages) {
+    activeSession.agent.state.messages = normalizedReplayMessages;
+  }
+
+  const installProviderPromptHistoryTransform = (): (() => void) => {
+    const baseStreamFn = activeSession.agent.streamFn;
+    const providerPromptStreamFn = wrapStreamFnWithMessageTransform(baseStreamFn, (messages) => {
+      const providerPromptHistoryTruncation = truncateOversizedToolResultsInMessages(
+        messages,
+        input.contextTokenBudget,
+        input.toolResultMaxChars,
+        input.toolResultAggregateMaxChars,
+        input.toolResultPromptProjectionState,
+      );
+      const providerMessages =
+        providerPromptHistoryTruncation.messages !== messages
+          ? providerPromptHistoryTruncation.messages
+          : messages;
+      // Mark the current turn sent at provider dispatch so late media appends
+      // instead of rewriting its prompt-cache slot (#99495).
+      markSessionUserTurnsSent(input.sessionPromptState, providerMessages);
+      const recorder = attempt.userTurnTranscriptRecorder;
+      if (
+        recorder &&
+        hasSessionUserTurnBeenSent(input.sessionPromptState, recorder.message) !== false
+      ) {
+        recorder.markSentToProvider?.();
+      }
+      return providerMessages;
+    });
+    activeSession.agent.streamFn = providerPromptStreamFn;
+    return () => {
+      if (activeSession.agent.streamFn === providerPromptStreamFn) {
+        activeSession.agent.streamFn = baseStreamFn;
+      }
+    };
+  };
+
+  input.onFinalPromptText(input.transcriptPrompt);
+  input.trajectoryRecorder?.recordEvent("prompt.submitted", {
+    prompt: input.modelPrompt,
+    systemPrompt: input.systemPrompt,
+    messages: activeSession.messages,
+    imagesCount: input.images.length,
+  });
+  updateActiveEmbeddedRunSnapshot(attempt.sessionId, {
+    transcriptLeafId: input.transcriptLeafId,
+    messages: snapshotRecentMessages(normalizedReplayMessages),
+    inFlightPrompt: input.transcriptPrompt,
+  });
+
+  let captureCurrentPromptForModel = false;
+  const cleanupModelPromptTransform = installModelPromptTransform({
+    session: activeSession,
+    transcriptPrompt: input.transcriptPrompt,
+    modelPrompt: input.modelPrompt,
+    prependContext: input.prependContext,
+    appendContext: input.appendContext,
+    shouldCapturePrompt: () => captureCurrentPromptForModel,
+  });
+  const armModelPromptTransform = (submitted: boolean) => {
+    if (submitted) {
+      captureCurrentPromptForModel = true;
+    }
+  };
+  const cleanupProviderPromptHistoryTransform = installProviderPromptHistoryTransform();
+  try {
+    if (input.runtimeOnly) {
+      await input.promptActiveSession(input.transcriptPrompt, {
+        preflightResult: armModelPromptTransform,
+      });
+    } else {
+      const cleanupRuntimeContextMessage = installRuntimeContextMessageForPrompt({
+        session: activeSession,
+        message: input.runtimeContextMessage,
+      });
+      try {
+        await input.promptActiveSession(input.transcriptPrompt, {
+          ...(input.images.length > 0 ? { images: input.images } : {}),
+          preflightResult: armModelPromptTransform,
+        });
+      } finally {
+        cleanupRuntimeContextMessage();
+      }
+    }
+    if (input.leasedSteering) {
+      ackPendingAgentSteeringItems(input.leasedSteering);
+      input.onSteeringAcknowledged();
+    }
+  } finally {
+    cleanupProviderPromptHistoryTransform();
+    cleanupModelPromptTransform();
+  }
+}

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -62,10 +62,7 @@ import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js"
 import { acquireSessionWriteLock } from "../../session-write-lock.js";
 import { createAgentSession, SessionManager } from "../../sessions/index.js";
 import { wrapToolDefinition } from "../../sessions/tools/tool-definition-wrapper.js";
-import {
-  ackPendingAgentSteeringItems,
-  releasePendingAgentSteeringItems,
-} from "../../subagent-registry.js";
+import { releasePendingAgentSteeringItems } from "../../subagent-registry.js";
 import {
   clearToolSearchCatalog,
   resolveToolSearchCatalogTool,
@@ -81,21 +78,17 @@ import { buildEmbeddedExtensionFactories } from "../extensions.js";
 import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
 import { log } from "../logger.js";
 import type { PromptCacheBreak, PromptCacheChange } from "../prompt-cache-observability.js";
-import { normalizeAssistantReplayContent } from "../replay-history.js";
 import { createEmbeddedAgentResourceLoader } from "../resource-loader.js";
 import {
   clearActiveEmbeddedRun,
   type EmbeddedAgentQueueHandle,
   markActiveEmbeddedRunAbandoned,
-  updateActiveEmbeddedRunSnapshot,
 } from "../runs.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "../session-manager-cache.js";
 import { prepareSessionManagerForRun } from "../session-manager-init.js";
 import {
   cloneToolResultPromptProjectionState,
   getEmbeddedSessionPromptState,
-  hasSessionUserTurnBeenSent,
-  markSessionUserTurnsSent,
 } from "../session-prompt-state.js";
 import { resolveEmbeddedAgentApiKey } from "../stream-resolution.js";
 import { applySystemPromptToSession } from "../system-prompt.js";
@@ -115,7 +108,7 @@ import { completeEmbeddedAttemptAfterTurn } from "./attempt-after-turn.js";
 import { prepareEmbeddedAttemptBootstrap } from "./attempt-bootstrap-prepare.js";
 import { prepareEmbeddedAttemptBundleTools } from "./attempt-bundle-tools.js";
 import { prepareEmbeddedAttemptClientTools } from "./attempt-client-tools.js";
-import { snapshotRecentMessages, summarizeSessionContext } from "./attempt-context-summary.js";
+import { summarizeSessionContext } from "./attempt-context-summary.js";
 import { prepareEmbeddedAttemptHistory } from "./attempt-history-prepare.js";
 import {
   replayTrailingEntriesForOrphanRepair,
@@ -126,6 +119,7 @@ import {
   handleEmbeddedAttemptMidTurnPrecheck,
   prepareEmbeddedAttemptPromptPreflight,
 } from "./attempt-prompt-preflight.js";
+import { submitEmbeddedAttemptPrompt } from "./attempt-prompt-submit.js";
 import { completeEmbeddedAttemptResult } from "./attempt-result.js";
 import { createEmbeddedAgentSessionWithResourceLoader } from "./attempt-session.js";
 import { prepareEmbeddedAttemptSetup } from "./attempt-setup.js";
@@ -157,8 +151,6 @@ import {
   runAttemptContextEngineBootstrap,
 } from "./attempt.context-engine-helpers.js";
 import {
-  installModelPromptTransform,
-  installRuntimeContextMessageForPrompt,
   normalizeCurrentPromptTextForLlmBoundary,
   normalizeMessagesForCurrentPromptBoundary,
   normalizeMessagesForLlmBoundary,
@@ -190,7 +182,6 @@ import { shouldFlagCompactionTimeout } from "./compaction-timeout.js";
 import { installHistoryImagePruneContextTransform } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
 import { installMessageToolOnlyTerminalHook } from "./message-tool-terminal.js";
-import { wrapStreamFnWithMessageTransform } from "./message-transform-stream-wrapper.js";
 import { isMidTurnPrecheckSignal, type MidTurnPrecheckRequest } from "./midturn-precheck.js";
 import {
   detachPrePersistedCurrentUserTurn,
@@ -2046,114 +2037,35 @@ export async function runEmbeddedAttempt(
           } = promptPreflight);
 
           if (!skipPromptSubmission) {
-            const normalizedReplayMessages = normalizeAssistantReplayContent(
-              activeSession.messages,
-            );
-            if (normalizedReplayMessages !== activeSession.messages) {
-              activeSession.agent.state.messages = normalizedReplayMessages;
-            }
-            const installProviderPromptHistoryTransform = (): (() => void) => {
-              const baseStreamFn = activeSession.agent.streamFn;
-              const providerPromptStreamFn = wrapStreamFnWithMessageTransform(
-                baseStreamFn,
-                (messages) => {
-                  const providerPromptHistoryTruncation = truncateOversizedToolResultsInMessages(
-                    messages,
-                    contextTokenBudget,
-                    promptToolResultMaxChars,
-                    promptToolResultAggregateMaxChars,
-                    toolResultPromptProjectionState,
-                  );
-                  const providerMessages =
-                    providerPromptHistoryTruncation.messages !== messages
-                      ? providerPromptHistoryTruncation.messages
-                      : messages;
-                  // This provider-dispatch transform marks the current turn sent so late
-                  // media appends instead of rewriting its prompt-cache slot (#99495).
-                  markSessionUserTurnsSent(sessionPromptState, providerMessages);
-                  const recorder = params.userTurnTranscriptRecorder;
-                  if (
-                    recorder &&
-                    hasSessionUserTurnBeenSent(sessionPromptState, recorder.message) !== false
-                  ) {
-                    recorder.markSentToProvider?.();
-                  }
-                  return providerMessages;
-                },
-              );
-              activeSession.agent.streamFn = providerPromptStreamFn;
-              return () => {
-                if (activeSession.agent.streamFn === providerPromptStreamFn) {
-                  activeSession.agent.streamFn = baseStreamFn;
-                }
-              };
-            };
-            finalPromptText = promptForSession;
-            trajectoryRecorder?.recordEvent("prompt.submitted", {
-              prompt: promptForModel,
-              systemPrompt: systemPromptForHook,
-              messages: activeSession.messages,
-              imagesCount: imageResult.images.length,
-            });
-            const btwSnapshotMessages = snapshotRecentMessages(normalizedReplayMessages);
-            updateActiveEmbeddedRunSnapshot(params.sessionId, {
-              transcriptLeafId,
-              messages: btwSnapshotMessages,
-              inFlightPrompt: promptForSession,
-            });
-            let captureCurrentPromptForModel = false;
-            const cleanupModelPromptTransform = installModelPromptTransform({
-              session: activeSession,
-              transcriptPrompt: promptForSession,
+            await submitEmbeddedAttemptPrompt({
+              attempt: params,
+              activeSession,
+              ...(promptBuildAppendContext ? { appendContext: promptBuildAppendContext } : {}),
+              contextTokenBudget,
+              images: imageResult.images,
+              ...(leasedSteering ? { leasedSteering } : {}),
               modelPrompt: promptForModel,
-              prependContext: promptBuildPrependContext,
-              appendContext: promptBuildAppendContext,
-              shouldCapturePrompt: () => captureCurrentPromptForModel,
-            });
-            const armModelPromptTransform = (submitted: boolean) => {
-              if (submitted) {
-                captureCurrentPromptForModel = true;
-              }
-            };
-            const cleanupProviderPromptHistoryTransform = installProviderPromptHistoryTransform();
-            try {
-              if (promptSubmission.runtimeOnly) {
-                await promptActiveSession(promptForSession, {
-                  preflightResult: armModelPromptTransform,
-                });
-              } else {
-                const cleanupRuntimeContextMessage = installRuntimeContextMessageForPrompt({
-                  session: activeSession,
-                  message: runtimeContextMessageForCurrentTurn,
-                });
-                try {
-                  // Only pass images option if there are actually images to pass
-                  // This avoids potential issues with models that don't expect the images parameter
-                  if (imageResult.images.length > 0) {
-                    await promptActiveSession(promptForSession, {
-                      images: imageResult.images,
-                      preflightResult: armModelPromptTransform,
-                    });
-                  } else {
-                    await promptActiveSession(promptForSession, {
-                      preflightResult: armModelPromptTransform,
-                    });
-                  }
-                } finally {
-                  cleanupRuntimeContextMessage();
-                }
-              }
-              if (leasedSteering) {
-                ackPendingAgentSteeringItems({
-                  runIds: leasedSteering.runIds,
-                  leaseId: leasedSteering.leaseId,
-                });
+              onFinalPromptText: (prompt) => {
+                finalPromptText = prompt;
+              },
+              onSteeringAcknowledged: () => {
                 leasedSteering = undefined;
-              }
-            } finally {
-              cleanupProviderPromptHistoryTransform();
-              cleanupModelPromptTransform();
-            }
+              },
+              ...(promptBuildPrependContext ? { prependContext: promptBuildPrependContext } : {}),
+              promptActiveSession,
+              ...(runtimeContextMessageForCurrentTurn
+                ? { runtimeContextMessage: runtimeContextMessageForCurrentTurn }
+                : {}),
+              runtimeOnly: promptSubmission.runtimeOnly === true,
+              sessionPromptState,
+              systemPrompt: systemPromptForHook,
+              toolResultAggregateMaxChars: promptToolResultAggregateMaxChars,
+              toolResultMaxChars: promptToolResultMaxChars,
+              toolResultPromptProjectionState,
+              trajectoryRecorder,
+              transcriptLeafId,
+              transcriptPrompt: promptForSession,
+            });
           } else {
             releaseLeasedSteering(promptError ?? "prompt submission skipped");
           }


### PR DESCRIPTION
## What Problem This Solves

`runEmbeddedAttempt` still directly owned provider-dispatch transforms, model-prompt rewriting, runtime-context injection, prompt submission, steering acknowledgement, and cleanup. That submission lifecycle is a distinct phase with failure-ordering contracts of its own.

Related: #72072

## Why This Change Was Made

- Extract prompt submission into `attempt-prompt-submit.ts`.
- Preserve pre-await `finalPromptText` capture, trajectory/snapshot order, provider history projection, runtime-only image behavior, runtime-context cleanup, model-transform arming, and steering lease semantics.
- Keep failure cleanup order explicit and cover both success and provider-failure paths.

## User Impact

No intended behavior change. `attempt.ts` drops from 2,529 to 2,441 lines; prompt submission is independently testable.

## Evidence

- Blacksmith Testbox `tbx_01kxerra8eb2cvt9jknjr59jzz`: 142 focused tests passed across attempt, prompt-submit, cache-stability, and queue-message suites.
- Same Testbox: scoped `check:changed` passed, including core/core-test types, format, lint, LOC ratchet, import-cycle scan, and repository guards.
- Fresh autoreview: no accepted/actionable findings.
- Final rebase was conflict-free over unrelated auto-reply, memory, SDK, gateway, and UI paths; `git diff --check` remained clean.

Hosted CI and another remote proof loop intentionally not awaited per maintainer instruction.
