### PR TITLE
fix(oc-path): preserve JSONC formatting during insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **OC Path JSONC insertion:** patch object and array insertions through `jsonc-parser` so comments, trailing commas, and CRLF formatting survive. (#106847)
 - **Control UI realtime Talk feedback:** request browser echo cancellation, noise suppression, and automatic gain control for every microphone transport, and keep PCM capture processors connected through zero-gain sinks so microphone input cannot play locally.
 - **Agent source-reply recovery:** preserve current-chat delivery evidence for message sends executed through Code Mode, preventing successful replies from triggering a redundant retry and misleading delivery-failure diagnostic.
 - **Gateway in-process restarts:** clear stale SIGUSR1 restart state and resume prepared host suspensions before rebuilding runtime admission, preventing restart cooldowns or paused scheduling from leaking into the next lifecycle.

--- a/extensions/oc-path/src/oc-path/jsonc/edit.ts
+++ b/extensions/oc-path/src/oc-path/jsonc/edit.ts
@@ -14,6 +14,7 @@ import type { JsoncAst, JsoncValue } from "./ast.js";
 import { parseJsonc } from "./parse.js";
 
 type JsoncEditPath = Array<string | number>;
+type JsoncEditTarget = { readonly path: JsoncEditPath; readonly value: JsoncValue };
 
 type JsoncEditResult =
   | { readonly ok: true; readonly ast: JsoncAst }
@@ -24,15 +25,54 @@ export function setJsoncOcPath(ast: JsoncAst, path: OcPath, newValue: JsoncValue
     return { ok: false, reason: "no-root" };
   }
 
-  const segments = resolveEditSegments(ast.root, pathSegments(path));
-  if (segments === null) {
+  const target = resolveEditTarget(ast.root, pathSegments(path));
+  if (target === null) {
     return { ok: false, reason: "unresolved" };
   }
-  guardSentinel(newValue, `oc://${path.file}/${segments.join("/")}`);
+  guardSentinel(newValue, `oc://${path.file}/${target.path.join("/")}`);
+  return applyJsoncEdit(ast, target.path, newValue, false);
+}
 
-  const edits = modify(ast.raw, segments, jsoncValueToJson(newValue), {
+export function insertJsoncOcPath(
+  ast: JsoncAst,
+  parentPath: OcPath,
+  indexOrKey: number | string,
+  newValue: JsoncValue,
+): JsoncEditResult {
+  if (ast.root === null) {
+    return { ok: false, reason: "no-root" };
+  }
+
+  const target = resolveEditTarget(ast.root, pathSegments(parentPath));
+  if (target === null) {
+    return { ok: false, reason: "unresolved" };
+  }
+  if (typeof indexOrKey === "string") {
+    if (
+      target.value.kind !== "object" ||
+      target.value.entries.some((entry) => entry.key === indexOrKey)
+    ) {
+      return { ok: false, reason: "unresolved" };
+    }
+  } else if (target.value.kind !== "array") {
+    return { ok: false, reason: "unresolved" };
+  }
+
+  const segment = typeof indexOrKey === "number" && indexOrKey < 0 ? -1 : indexOrKey;
+  const editPath = [...target.path, segment];
+  guardSentinel(newValue, `oc://${parentPath.file}/${editPath.join("/")}`);
+  return applyJsoncEdit(ast, editPath, newValue, typeof segment === "number");
+}
+
+function applyJsoncEdit(
+  ast: JsoncAst,
+  path: JsoncEditPath,
+  newValue: JsoncValue,
+  isArrayInsertion: boolean,
+): JsoncEditResult {
+  const edits = modify(ast.raw, path, jsoncValueToJson(newValue), {
     formattingOptions: { insertSpaces: true, tabSize: 2 },
-    isArrayInsertion: false,
+    isArrayInsertion,
   });
   if (edits.length === 0) {
     return { ok: false, reason: "unresolved" };
@@ -78,7 +118,7 @@ function pathSegments(path: OcPath): string[] {
   return out;
 }
 
-function resolveEditSegments(root: JsoncValue, segments: readonly string[]): JsoncEditPath | null {
+function resolveEditTarget(root: JsoncValue, segments: readonly string[]): JsoncEditTarget | null {
   const out: JsoncEditPath = [];
   let current: JsoncValue = root;
   for (let segment of segments) {
@@ -111,7 +151,7 @@ function resolveEditSegments(root: JsoncValue, segments: readonly string[]): Jso
     }
     return null;
   }
-  return out;
+  return { path: out, value: current };
 }
 
 function positionalForJsonc(node: JsoncValue, segment: string): string | null {

--- a/extensions/oc-path/src/oc-path/tests/scenarios/sentinel-cross-kind.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/scenarios/sentinel-cross-kind.test.ts
@@ -1,7 +1,7 @@
 // OC Path tests cover sentinel cross kind plugin behavior.
 import { describe, expect, it } from "vitest";
 import { emitMd } from "../../emit.js";
-import { setJsoncOcPath } from "../../jsonc/edit.js";
+import { insertJsoncOcPath, setJsoncOcPath } from "../../jsonc/edit.js";
 import { emitJsonc } from "../../jsonc/emit.js";
 import { parseJsonc } from "../../jsonc/parse.js";
 import { emitJsonl } from "../../jsonl/emit.js";
@@ -80,14 +80,16 @@ describe("sentinel guard cross-kind", () => {
     expect(() => emitJsonl(tampered, { mode: "render" })).toThrow(OcEmitSentinelError);
   });
 
-  it("setJsoncOcPath itself throws when the new value contains the sentinel", () => {
-    // The substrate guard fires at write-time: setJsoncOcPath rebuilds
-    // raw via render mode emit, which scans every leaf. Defense-in-depth
-    // — even if a caller forgets to call emit afterward, the sentinel
-    // can't make it into an in-memory AST that pretends to be valid.
+  it("jsonc edits reject caller-injected sentinels before mutation", () => {
     const ast = parseJsonc('{ "x": "ok" }').ast;
     expect(() =>
       setJsoncOcPath(ast, parseOcPath("oc://config/x"), {
+        kind: "string",
+        value: REDACTED_SENTINEL,
+      }),
+    ).toThrow(OcEmitSentinelError);
+    expect(() =>
+      insertJsoncOcPath(ast, parseOcPath("oc://config"), "y", {
         kind: "string",
         value: REDACTED_SENTINEL,
       }),

--- a/extensions/oc-path/src/oc-path/tests/universal.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/universal.test.ts
@@ -485,6 +485,23 @@ describe("setOcPath — jsonc insertion", () => {
       });
     }
   });
+
+  it("preserves comments, trailing commas, and CRLF", () => {
+    const ast = parseJsonc(
+      '{\r\n  // keep\r\n  "plugins": {\r\n    "github": "tok",\r\n  },\r\n}\r\n',
+    ).ast;
+    const r = setOcPath(ast, parseOcPath("oc://config/plugins/+gitlab"), '"new-tok"');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(emitJsonc(r.ast as Parameters<typeof emitJsonc>[0])).toBe(
+        '{\r\n  // keep\r\n  "plugins": {\r\n    "github": "tok",\r\n    "gitlab": "new-tok",\r\n  },\r\n}\r\n',
+      );
+      expectLeaf(resolveOcPath(r.ast, parseOcPath("oc://config/plugins/gitlab")), {
+        leafType: "string",
+        valueText: "new-tok",
+      });
+    }
+  });
 });
 
 describe("setOcPath — jsonl insertion (session append)", () => {

--- a/extensions/oc-path/src/oc-path/universal.ts
+++ b/extensions/oc-path/src/oc-path/universal.ts
@@ -20,23 +20,14 @@ import { isMap, isScalar, isSeq, type Pair } from "yaml";
 import type { MdAst } from "./ast.js";
 import { setMdOcPath } from "./edit.js";
 import type { JsoncAst, JsoncEntry, JsoncValue } from "./jsonc/ast.js";
-import { setJsoncOcPath } from "./jsonc/edit.js";
-import { emitJsonc } from "./jsonc/emit.js";
+import { insertJsoncOcPath, setJsoncOcPath } from "./jsonc/edit.js";
 import { resolveJsoncOcPath } from "./jsonc/resolve.js";
 import type { JsonlAst } from "./jsonl/ast.js";
 import { appendJsonlOcPath as appendJsonlLine, setJsonlOcPath } from "./jsonl/edit.js";
 import { emitJsonl } from "./jsonl/emit.js";
 import { resolveJsonlOcPath } from "./jsonl/resolve.js";
 import type { OcPath } from "./oc-path.js";
-import {
-  formatOcPath,
-  hasWildcard,
-  isQuotedSeg,
-  OcPathError,
-  parseArrayIndexSegment,
-  splitRespectingBrackets,
-  unquoteSeg,
-} from "./oc-path.js";
+import { formatOcPath, hasWildcard, OcPathError, parseArrayIndexSegment } from "./oc-path.js";
 import { resolveMdOcPath } from "./resolve.js";
 import type { YamlAst } from "./yaml/ast.js";
 import { insertYamlOcPath, setYamlOcPath } from "./yaml/edit.js";
@@ -676,43 +667,17 @@ function setJsoncInsertion(ast: JsoncAst, info: InsertionInfo, value: string): S
     if (typeof info.marker === "object" && info.marker.kind === "keyed") {
       return { ok: false, reason: "type-mismatch", detail: "cannot insert by key into array" };
     }
-    return mutateJsoncContainer(ast, info.parentPath, (container) => {
-      if (container.kind !== "array") {
-        return null;
-      }
-      const items = container.items.slice();
-      if (info.marker === "+") {
-        items.push(newJsoncValue);
-      } else if (typeof info.marker === "object" && info.marker.kind === "indexed") {
-        const idx = Math.min(info.marker.index, items.length);
-        items.splice(idx, 0, newJsoncValue);
-      }
-      return {
-        kind: "array",
-        items,
-        ...(container.line !== undefined ? { line: container.line } : {}),
-      };
-    });
+    const index = info.marker === "+" ? -1 : info.marker.index;
+    const r = insertJsoncOcPath(ast, info.parentPath, index, newJsoncValue);
+    return r.ok ? { ok: true, ast: r.ast } : { ok: false, reason: r.reason };
   }
 
   if (typeof info.marker !== "object" || info.marker.kind !== "keyed") {
     return { ok: false, reason: "type-mismatch", detail: "jsonc object insertion requires +key" };
   }
   const key = info.marker.key;
-  return mutateJsoncContainer(ast, info.parentPath, (container) => {
-    if (container.kind !== "object") {
-      return null;
-    }
-    if (container.entries.some((e) => e.key === key)) {
-      return null;
-    } // duplicate
-    const newEntry: JsoncEntry = { key, value: newJsoncValue, line: 0 };
-    return {
-      kind: "object",
-      entries: [...container.entries, newEntry],
-      ...(container.line !== undefined ? { line: container.line } : {}),
-    };
-  });
+  const r = insertJsoncOcPath(ast, info.parentPath, key, newJsoncValue);
+  return r.ok ? { ok: true, ast: r.ast } : { ok: false, reason: r.reason };
 }
 
 function setJsonlInsertion(ast: JsonlAst, info: InsertionInfo, value: string): SetResult {
@@ -878,92 +843,6 @@ function jsonToJsoncValue(v: unknown): JsoncValue | null {
   }
   // JSON.parse never produces undefined / function / symbol.
   throw new Error(`unsupported JSON value type: ${typeof v}`);
-}
-
-function mutateJsoncContainer(
-  ast: JsoncAst,
-  parentPath: OcPath,
-  mutate: (container: JsoncValue) => JsoncValue | null,
-): SetResult {
-  if (ast.root === null) {
-    return { ok: false, reason: "no-root" };
-  }
-
-  // Quote-aware split so insertion under a key with `/`/`.`/etc. works.
-  const segments: string[] = [];
-  if (parentPath.section !== undefined) {
-    segments.push(...splitRespectingBrackets(parentPath.section, "."));
-  }
-  if (parentPath.item !== undefined) {
-    segments.push(...splitRespectingBrackets(parentPath.item, "."));
-  }
-  if (parentPath.field !== undefined) {
-    segments.push(...splitRespectingBrackets(parentPath.field, "."));
-  }
-
-  const newRoot =
-    segments.length === 0 ? mutate(ast.root) : mutateAt(ast.root, segments, 0, mutate);
-  if (newRoot === null) {
-    return { ok: false, reason: "unresolved" };
-  }
-
-  const next: JsoncAst = { kind: "jsonc", raw: "", root: newRoot };
-  return { ok: true, ast: { ...next, raw: emitJsonc(next, { mode: "render" }) } };
-}
-
-function mutateAt(
-  current: JsoncValue,
-  segments: readonly string[],
-  i: number,
-  mutate: (container: JsoncValue) => JsoncValue | null,
-): JsoncValue | null {
-  const seg = segments[i];
-  if (seg === undefined) {
-    return mutate(current);
-  }
-  if (seg.length === 0) {
-    return null;
-  }
-
-  if (current.kind === "object") {
-    // AST keys are unquoted; strip quotes from the path segment.
-    const lookupKey = isQuotedSeg(seg) ? unquoteSeg(seg) : seg;
-    const idx = current.entries.findIndex((e) => e.key === lookupKey);
-    if (idx === -1) {
-      return null;
-    }
-    const child = expectDefined(current.entries[idx], "located JSONC object entry index");
-    const replaced = mutateAt(child.value, segments, i + 1, mutate);
-    if (replaced === null) {
-      return null;
-    }
-    const newEntries = current.entries.slice();
-    newEntries[idx] = { ...child, value: replaced };
-    return {
-      kind: "object",
-      entries: newEntries,
-      ...(current.line !== undefined ? { line: current.line } : {}),
-    };
-  }
-  if (current.kind === "array") {
-    const idx = parseArrayIndexSegment(seg, current.items.length);
-    if (idx === null) {
-      return null;
-    }
-    const child = expectDefined(current.items[idx], "parsed JSONC array index is in bounds");
-    const replaced = mutateAt(child, segments, i + 1, mutate);
-    if (replaced === null) {
-      return null;
-    }
-    const newItems = current.items.slice();
-    newItems[idx] = replaced;
-    return {
-      kind: "array",
-      items: newItems,
-      ...(current.line !== undefined ? { line: current.line } : {}),
-    };
-  }
-  return null;
 }
 
 function rebuildMdRaw(ast: MdAst): MdAst {


### PR DESCRIPTION
Closes #106847

## What Problem This Solves

Fixes an issue where OC Path insertions into JSONC documents would discard comments, trailing commas, and CRLF formatting.

## Why This Change Was Made

Object and array insertions now use the installed `jsonc-parser` edit API, matching the existing set operation. The custom recursive serializer and path parser are removed, reducing the implementation by 61 net lines while retaining duplicate-key and sentinel protections.

## User Impact

Users can insert OC Path values without unrelated JSONC formatting and comments being rewritten.

## Evidence

- Blacksmith Testbox `tbx_01kxer8eqxy4vewajkm89457fm`: full OC Path suite, 40 files and 707 tests passed.
- Exact follow-up: insertion-formatting and sentinel suites, 2 files and 71 tests passed.
- `pnpm tsgo:extensions`
- `pnpm tsgo:test:extensions`
- `pnpm build`
- Fresh autoreview: no accepted/actionable findings.
- Stable patch ID preserved across the final rebase onto current `main`.
- Hosted CI intentionally not awaited per maintainer instruction.
