### PR TITLE
fix: Windows installer fails after winget installs Node.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 - **Browser auto-routing:** fall back to the Gateway host when an implicitly selected browser node reports that its control host is unreachable, while preserving explicit node pins and ambiguous action failures.
 - **Discord voice participant context:** maintain the live Gateway voice-state roster and include current channel participants in authorized voice agent turns so agents can answer who is present.
 - **OC Path JSONC insertion:** patch object and array insertions through `jsonc-parser` so comments, trailing commas, and CRLF formatting survive. (#106847)
+- **Windows winget installs:** continue in the current PowerShell session when winget installs Node.js before the machine PATH update becomes visible, avoiding a false `Node.js not found` failure. (#106862)
 - **Control UI realtime Talk feedback:** request browser echo cancellation, noise suppression, and automatic gain control for every microphone transport, and keep PCM capture processors connected through zero-gain sinks so microphone input cannot play locally.
 - **Agent source-reply recovery:** preserve current-chat delivery evidence for message sends executed through Code Mode, preventing successful replies from triggering a redundant retry and misleading delivery-failure diagnostic.
 - **Gateway in-process restarts:** clear stale SIGUSR1 restart state and resume prepared host suspensions before rebuilding runtime admission, preventing restart cooldowns or paused scheduling from leaking into the next lifecycle.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -392,6 +392,7 @@ function Install-Node {
 
         # Refresh PATH
         Refresh-ProcessPath
+        Add-InstalledNodeToProcessPath | Out-Null
         if (Check-Node) {
             Write-Host "[OK] Node.js installed via winget" -ForegroundColor Green
             return $true
@@ -487,6 +488,20 @@ function Add-ToProcessPath {
     }
 
     $env:Path = "$PathEntry;$env:Path"
+}
+
+function Add-InstalledNodeToProcessPath {
+    foreach ($programFilesRoot in @($env:ProgramW6432, $env:ProgramFiles, ${env:ProgramFiles(x86)})) {
+        if ([string]::IsNullOrWhiteSpace($programFilesRoot)) {
+            continue
+        }
+        $nodeDir = Join-Path $programFilesRoot "nodejs"
+        if (Test-Path (Join-Path $nodeDir "node.exe")) {
+            Add-ToProcessPath $nodeDir
+            return $true
+        }
+    }
+    return $false
 }
 
 function Refresh-ProcessPath {

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -213,6 +213,42 @@ describe("install.ps1 failure handling", () => {
         ].join("\n"),
       },
       {
+        name: "winget-node-delayed-path",
+        source: [
+          scriptWithoutEntryPoint,
+          "",
+          "function Get-Command {",
+          "  [CmdletBinding()]",
+          "  param([string]$Name)",
+          "  if ($Name -eq 'winget') { return $true }",
+          "  return $null",
+          "}",
+          "function Join-Path {",
+          "  param([string]$Path, [string]$ChildPath)",
+          "  return \"$($Path.TrimEnd('\\'))\\$ChildPath\"",
+          "}",
+          "function Test-Path {",
+          "  param([string]$Path)",
+          "  return ($Path -eq 'C:\\Program Files\\nodejs\\node.exe')",
+          "}",
+          "filter Out-Host { }",
+          "$env:ProgramW6432 = 'C:\\Program Files'",
+          "$env:ProgramFiles = 'C:\\Program Files (x86)'",
+          "$env:Path = 'C:\\Windows\\System32'",
+          "function winget {",
+          "  $global:LASTEXITCODE = 0",
+          "  Write-Output 'winget output'",
+          "}",
+          "function Check-Node {",
+          "  return (($env:Path -split ';') -contains 'C:\\Program Files\\nodejs')",
+          "}",
+          "$result = @(Install-Node)",
+          'if ($result.Count -ne 1 -or $result[0] -ne $true) { throw "Install-Node returned $result" }',
+          "if (($env:Path -split ';')[0] -ne 'C:\\Program Files\\nodejs') { throw \"Path=$env:Path\" }",
+          "",
+        ].join("\n"),
+      },
+      {
         name: "chocolatey-node-upgrade",
         source: [
           scriptWithoutEntryPoint,
@@ -459,9 +495,20 @@ describe("install.ps1 failure handling", () => {
   });
 
   runIfPowerShell("upgrades and validates Node installed by Windows package managers", () => {
+    expectBatchedPowerShellCase("winget-node-delayed-path");
     expectBatchedPowerShellCase("chocolatey-node-upgrade");
     expectBatchedPowerShellCase("scoop-node-update");
     expectBatchedPowerShellCase("package-manager-node-validation-failure");
+  });
+
+  it("discovers a winget Node install before the machine PATH refreshes", () => {
+    const installNodeBody = extractFunctionBody(source, "Install-Node");
+    const addInstalledNodeBody = extractFunctionBody(source, "Add-InstalledNodeToProcessPath");
+    expect(installNodeBody).toContain("Add-InstalledNodeToProcessPath | Out-Null");
+    expect(addInstalledNodeBody).toContain("$env:ProgramW6432");
+    expect(addInstalledNodeBody).toContain("$env:ProgramFiles");
+    expect(addInstalledNodeBody).toContain('Join-Path $nodeDir "node.exe"');
+    expect(addInstalledNodeBody).toContain("Add-ToProcessPath $nodeDir");
   });
 
   it("runs npm install through the resolved command with quiet CI defaults", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Windows installer stopped after winget successfully installed Node.js because the current PowerShell process could not yet see the updated machine PATH.

## Why This Change Was Made

After refreshing environment PATH values, the installer now probes Node.js under the standard Program Files roots and adds the discovered directory to the current process PATH. Existing Node version and SQLite validation remain authoritative.

## User Impact

Fresh Windows installs can continue in the same PowerShell session after winget installs Node.js; no manual terminal restart is required.

## Evidence

- Failure: https://github.com/openclaw/openclaw/actions/runs/29288945243/job/86949374045
- Blacksmith Testbox through Crabbox: tbx_01kxes9grpetx6xrxxfwx4cm7s
- Focused proof: 27/27 tests passed in test/scripts/install-ps1.test.ts, including the delayed machine-PATH scenario
- Autoreview: clean, no accepted/actionable findings
