### PR TITLE
fix(android): stop killing long chat runs with hardcoded timeouts (#106863)

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -1731,7 +1731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2140,
+      "line": 2142,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not stage an attachment for sending.",
       "surface": "android",
@@ -1739,7 +1739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2160,
+      "line": 2162,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not queue message for later delivery.",
       "surface": "android",
@@ -1747,7 +1747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2170,
+      "line": 2172,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Offline queue is full ($OUTBOX_MAX_QUEUED messages); delete queued items first.",
       "surface": "android",
@@ -1755,7 +1755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2174,
+      "line": 2176,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Attachments are too large to queue for one message; remove some and try again.",
       "surface": "android",
@@ -1763,7 +1763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2178,
+      "line": 2180,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Offline attachment storage is full; delete queued items first.",
       "surface": "android",
@@ -1771,7 +1771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2182,
+      "line": 2184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Gateway health not OK; cannot send",
       "surface": "android",
@@ -1779,7 +1779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2813,
+      "line": 2815,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Chat failed",
       "surface": "android",
@@ -1787,7 +1787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2916,
+      "line": 2918,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Event stream interrupted; try refreshing.",
       "surface": "android",
@@ -1795,7 +1795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2996,
+      "line": 3004,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Timed out waiting for a reply; try again or refresh.",
       "surface": "android",
@@ -1803,7 +1803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3188,
+      "line": 3196,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Timed out confirming the sent message; refresh to check delivery.",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -1699,7 +1699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 763,
+      "line": 769,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Wait for the current response to finish before starting a new chat.",
       "surface": "android",
@@ -1707,7 +1707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 894,
+      "line": 900,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not update model.",
       "surface": "android",
@@ -1715,7 +1715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 958,
+      "line": 964,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not update thinking level.",
       "surface": "android",
@@ -1723,7 +1723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1337,
+      "line": 1343,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Chat failed before the run started; try again.",
       "surface": "android",
@@ -1731,7 +1731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2142,
+      "line": 2148,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not stage an attachment for sending.",
       "surface": "android",
@@ -1739,7 +1739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2162,
+      "line": 2168,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not queue message for later delivery.",
       "surface": "android",
@@ -1747,7 +1747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2172,
+      "line": 2178,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Offline queue is full ($OUTBOX_MAX_QUEUED messages); delete queued items first.",
       "surface": "android",
@@ -1755,7 +1755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2176,
+      "line": 2182,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Attachments are too large to queue for one message; remove some and try again.",
       "surface": "android",
@@ -1763,7 +1763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2180,
+      "line": 2186,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Offline attachment storage is full; delete queued items first.",
       "surface": "android",
@@ -1771,7 +1771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2184,
+      "line": 2190,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Gateway health not OK; cannot send",
       "surface": "android",
@@ -1779,7 +1779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2815,
+      "line": 2821,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Chat failed",
       "surface": "android",
@@ -1787,7 +1787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2918,
+      "line": 2924,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Event stream interrupted; try refreshing.",
       "surface": "android",
@@ -1795,7 +1795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3004,
+      "line": 3024,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Timed out waiting for a reply; try again or refresh.",
       "surface": "android",
@@ -1803,7 +1803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3196,
+      "line": 3216,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Timed out confirming the sent message; refresh to check delivery.",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -1442,7 +1442,9 @@ class ChatController internal constructor(
       put("sessionKey", JsonPrimitive(sessionKey))
       put("message", JsonPrimitive(text))
       put("thinking", JsonPrimitive(thinking))
-      put("timeoutMs", JsonPrimitive(30_000))
+      // No timeoutMs override: it becomes the server-side run expiry, and agent
+      // turns can legitimately run for many minutes. Omitting it applies the
+      // gateway's configured default, same as other channels.
       put("idempotencyKey", JsonPrimitive(idempotencyKey))
       if (attachments.isNotEmpty()) {
         put(
@@ -2977,11 +2979,17 @@ class ChatController internal constructor(
         )
         val runStillInFlight = synchronized(gatewayScopeApplyLock) { latestAppliedInFlightRunId == runId }
         val replyStillUnresolved = unresolvedRepliesByRunId.containsKey(runId)
-        if (!runStillInFlight) {
-          clearPendingRun(runId)
-          clearTransientRunUiIfIdle()
-          if (!replyStillUnresolved) return@launch
+        if (runStillInFlight) {
+          // The refreshed snapshot confirms the run is still executing; long agent
+          // turns can outlast one timeout window, so keep waiting instead of
+          // surfacing a false timeout and dropping the optimistic bubble. Terminal
+          // events and the server-side expiry remain the liveness backstop.
+          armPendingRunTimeout(runId)
+          return@launch
         }
+        clearPendingRun(runId)
+        clearTransientRunUiIfIdle()
+        if (!replyStillUnresolved) return@launch
         val stillPending =
           synchronized(pendingRuns) {
             pendingRuns.contains(runId)

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -164,6 +164,12 @@ class ChatController internal constructor(
     val generation: Long,
   )
 
+  private enum class HistoryRefreshResult {
+    Applied,
+    Superseded,
+    Failed,
+  }
+
   @Volatile
   private var liveHistoryMarker: LiveHistoryMarker? = null
 
@@ -1675,14 +1681,14 @@ class ChatController internal constructor(
     // live chat.history response always replaces cached rows wholesale.
     primeFromCache(sessionKey, generation)
     try {
-      val historyApplied =
+      val historyResult =
         fetchAndApplyHistory(
           sessionKey,
           generation,
           updateSessionInfo = true,
           runIdsToReconcile = runIdsToReconcile,
         )
-      if (!historyApplied) return
+      if (historyResult != HistoryRefreshResult.Applied) return
 
       if (!ownsReconnectRecovery) {
         pollHealthIfNeeded(force = forceHealth)
@@ -1707,14 +1713,14 @@ class ChatController internal constructor(
 
   /**
    * Requests live history and applies it to controller state, replacing any cached transcript.
-   * Returns false when a newer load superseded this request (stale responses are dropped).
+   * Reports when a newer load superseded this request (stale responses are dropped).
    */
   private suspend fun fetchAndApplyHistory(
     sessionKey: String,
     generation: Long,
     updateSessionInfo: Boolean,
     runIdsToReconcile: Set<String> = emptySet(),
-  ): Boolean {
+  ): HistoryRefreshResult {
     val requestSequence = historyRequestSequence.incrementAndGet()
     val requestModelSelectionGeneration = modelSelectionGeneration.get()
     val requestCacheScope = currentCacheScope()
@@ -1723,7 +1729,7 @@ class ChatController internal constructor(
       !isCurrentHistoryLoad(sessionKey, _sessionKey.value, generation, historyLoadGeneration.get()) ||
       requestCacheScope != currentCacheScope()
     ) {
-      return false
+      return HistoryRefreshResult.Superseded
     }
     val history =
       try {
@@ -1743,7 +1749,7 @@ class ChatController internal constructor(
               requestCacheScope != currentCacheScope() ||
               requestSequence < latestAppliedHistoryRequest
           }
-        if (superseded) return false
+        if (superseded) return HistoryRefreshResult.Superseded
         throw err
       }
     val applied =
@@ -1814,11 +1820,11 @@ class ChatController internal constructor(
           ?.let { _thinkingLevel.value = it }
         true
       }
-    if (!applied) return false
+    if (!applied) return HistoryRefreshResult.Superseded
     completeReconnectRecoveryIfOwned(sessionKey, generation)
     persistTranscript(requestCacheScope, sessionKey, history.messages)
     confirmDurableSendsFromHistory(requestCacheScope, history)
-    return true
+    return HistoryRefreshResult.Applied
   }
 
   private suspend fun awaitMainSessionReadiness(
@@ -2972,14 +2978,28 @@ class ChatController internal constructor(
     pendingRunTimeoutJobs[runId] =
       scope.launch {
         delay(pendingRunTimeoutMs)
-        refreshHistorySnapshotBestEffort(
-          sessionKey = _sessionKey.value,
-          generation = historyLoadGeneration.get(),
-          runIdsToReconcile = emptySet(),
-        )
-        val runStillInFlight = synchronized(gatewayScopeApplyLock) { latestAppliedInFlightRunId == runId }
-        val replyStillUnresolved = unresolvedRepliesByRunId.containsKey(runId)
-        if (runStillInFlight) {
+        val watchdogSessionKey = _sessionKey.value
+        val latestAppliedBeforeRefresh =
+          synchronized(gatewayScopeApplyLock) {
+            latestAppliedHistoryRequest
+          }
+        val historyResult =
+          refreshHistorySnapshotBestEffort(
+            sessionKey = watchdogSessionKey,
+            generation = historyLoadGeneration.get(),
+            runIdsToReconcile = emptySet(),
+          )
+        val refreshState =
+          synchronized(gatewayScopeApplyLock) {
+            // A concurrent recovery load can supersede this request. Its newer
+            // current-session snapshot is equally authoritative confirmation.
+            val currentSession = watchdogSessionKey == _sessionKey.value
+            val freshSnapshotApplied =
+              historyResult == HistoryRefreshResult.Applied || latestAppliedHistoryRequest > latestAppliedBeforeRefresh
+            Triple(currentSession, freshSnapshotApplied, latestAppliedInFlightRunId == runId)
+          }
+        val (currentSession, freshSnapshotApplied, latestRunMatches) = refreshState
+        if (currentSession && freshSnapshotApplied && latestRunMatches) {
           // The refreshed snapshot confirms the run is still executing; long agent
           // turns can outlast one timeout window, so keep waiting instead of
           // surfacing a false timeout and dropping the optimistic bubble. Terminal
@@ -2987,16 +3007,16 @@ class ChatController internal constructor(
           armPendingRunTimeout(runId)
           return@launch
         }
+        if (currentSession && !freshSnapshotApplied && historyResult == HistoryRefreshResult.Superseded) {
+          // The newer current-session load owns reconciliation but has not applied
+          // yet. Defer expiry; its snapshot or the next watchdog decides the run.
+          armPendingRunTimeout(runId)
+          return@launch
+        }
+        val replyStillUnresolved = unresolvedRepliesByRunId.containsKey(runId)
         clearPendingRun(runId)
         clearTransientRunUiIfIdle()
         if (!replyStillUnresolved) return@launch
-        val stillPending =
-          synchronized(pendingRuns) {
-            pendingRuns.contains(runId)
-          }
-        if (!stillPending && !replyStillUnresolved) return@launch
-        clearPendingRun(runId)
-        clearTransientRunUiIfIdle()
         removeOptimisticMessage(runId)
         unresolvedRepliesByRunId.remove(runId)
         terminalWithoutReplyRunIds.remove(runId)
@@ -3205,7 +3225,7 @@ class ChatController internal constructor(
     sessionKey: String,
     generation: Long,
     runIdsToReconcile: Set<String>,
-  ) {
+  ): HistoryRefreshResult =
     try {
       fetchAndApplyHistory(
         sessionKey,
@@ -3217,8 +3237,8 @@ class ChatController internal constructor(
       throw err
     } catch (_: Throwable) {
       // The bounded expiry below remains the final reconciliation path.
+      HistoryRefreshResult.Failed
     }
-  }
 
   private fun refreshCurrentHistoryBestEffort(
     runIdsToReconcile: Set<String> = emptySet(),

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
@@ -25,11 +25,14 @@ import org.junit.Test
 class ChatControllerReconnectRestoreTest {
   private val json = Json { ignoreUnknownKeys = true }
 
-  private fun TestScope.newController(gateway: ScriptedGateway): ChatController = ChatController(scope = this, json = json, requestGateway = gateway::request)
+  // The controller runs on backgroundScope: while a restored run stays in flight the
+  // pending-run watchdog keeps re-arming, so its timer must be cancelled by runTest
+  // instead of counting as an uncompleted test coroutine.
+  private fun TestScope.newController(gateway: ScriptedGateway): ChatController = ChatController(scope = backgroundScope, json = json, requestGateway = gateway::request)
 
   private fun TestScope.newScopedController(gateway: ScriptedGateway): ChatController =
     ChatController(
-      scope = this,
+      scope = backgroundScope,
       json = json,
       requestGateway = gateway::request,
       requestGatewayForGateway = { _, method, paramsJson -> gateway.request(method, paramsJson) },

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
@@ -554,6 +554,88 @@ class ChatControllerReconnectRestoreTest {
 
   @Test
   @OptIn(ExperimentalCoroutinesApi::class)
+  fun recoveredPendingRunStopsWatchdogWhenRefreshFails() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith(
+        "chat.history",
+        historyResponse("session-1", listOf(userTurn), inFlightRun = "run-active" to "working"),
+      )
+      val controller = newController(gateway)
+      controller.load("main")
+      runCurrent()
+      assertEquals(1, controller.pendingRunCount.value)
+
+      gateway.respond("chat.history") { error("history unavailable") }
+      advanceTimeBy(120_000)
+      runCurrent()
+
+      assertEquals(2, gateway.callCount("chat.history"))
+      assertEquals(0, controller.pendingRunCount.value)
+      assertNull(controller.streamingAssistantText.value)
+
+      advanceTimeBy(120_000)
+      runCurrent()
+      assertEquals(2, gateway.callCount("chat.history"))
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun newerRecoverySnapshotCanSupersedePendingRunWatchdogRefresh() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith(
+        "chat.history",
+        historyResponse("session-1", listOf(userTurn), inFlightRun = "run-active" to "working"),
+      )
+      val controller = newController(gateway)
+      controller.load("main")
+      runCurrent()
+
+      val watchdogRefreshStarted = CompletableDeferred<Unit>()
+      val releaseWatchdogRefresh = CompletableDeferred<String>()
+      val newerRefreshStarted = CompletableDeferred<Unit>()
+      val releaseNewerRefresh = CompletableDeferred<String>()
+      var refreshCalls = 0
+      gateway.respond("chat.history") {
+        refreshCalls += 1
+        if (refreshCalls == 1) {
+          watchdogRefreshStarted.complete(Unit)
+          releaseWatchdogRefresh.await()
+        } else {
+          newerRefreshStarted.complete(Unit)
+          releaseNewerRefresh.await()
+        }
+      }
+
+      advanceTimeBy(120_000)
+      runCurrent()
+      watchdogRefreshStarted.await()
+      controller.refresh()
+      runCurrent()
+      newerRefreshStarted.await()
+      releaseWatchdogRefresh.complete(
+        historyResponse("session-1", listOf(userTurn), inFlightRun = "run-active" to "stale working"),
+      )
+      runCurrent()
+
+      assertEquals(1, controller.pendingRunCount.value)
+      assertEquals("working", controller.streamingAssistantText.value)
+      assertNull(controller.errorText.value)
+
+      releaseNewerRefresh.complete(
+        historyResponse("session-1", listOf(userTurn), inFlightRun = "run-active" to "still working"),
+      )
+      runCurrent()
+
+      assertEquals(3, gateway.callCount("chat.history"))
+      assertEquals(1, controller.pendingRunCount.value)
+      assertEquals("still working", controller.streamingAssistantText.value)
+      assertNull(controller.errorText.value)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
   fun explicitRefreshClearsPriorHistoryError() =
     runTest {
       val gateway = ScriptedGateway(json)


### PR DESCRIPTION
## What Problem This Solves

Any agent turn longer than ~2 minutes started from the Android app ends in an error, while the identical turn over Telegram completes fine. Full analysis in #106863. Two independent causes, both in `ChatController.kt`:

1. `buildChatSendParams` hardcodes `timeoutMs: 30_000` into every `chat.send`. The gateway uses that as the server-side run expiry (`resolveAgentTimeoutMs({ cfg, overrideMs: p.timeoutMs })` in `chat-send-session.ts`), so the maintenance sweep aborts app-initiated runs that outlive ~30 s + grace ("CLI run aborted" / "Embedded agent failed before reply"). Other channels get the config default (48 h). Queued sends burn their expiry budget before their turn even starts.
2. `armPendingRunTimeout` fires after a hard 120 s, refreshes the history snapshot, computes `runStillInFlight` — and then declares a timeout **even when the run is confirmed in flight**: spurious "Timed out waiting for a reply" banner, optimistic bubble removed, outbox row parked as Failed/delivery-unconfirmed. Streaming deltas never re-arm the timer, so this hits actively streaming turns too.

## Fix

- Omit `timeoutMs` from `chat.send` so app runs get the gateway's configured default expiry, same as other channels.
- In `armPendingRunTimeout`, when the post-delay snapshot confirms the run is still in flight, re-arm the timer and keep waiting instead of timing out. The not-in-flight path is unchanged; terminal events and the server-side expiry remain the liveness backstop, so a genuinely dead run still resolves (and `wasTimedOut` recovery is untouched).

## Evidence

Before/after screen recordings on a real device (Pixel 5, same gateway, same long-running prompt — an agent turn deliberately longer than 2 minutes):

- **Before** (current app): ["Timed out waiting for a reply" at ~120 s, optimistic bubble lost](https://github.com/LeC-D/openclaw/releases/download/pr106864-evidence/before-test.mp4)
- **After** (debug APK built from this PR's head, d50a26f7, via CI `assembleDebug`): [same prompt, no timeout — the run keeps streaming and the reply lands normally](https://github.com/LeC-D/openclaw/releases/download/pr106864-evidence/after-test.mp4)

Both files are hosted as release assets on the fork: <https://github.com/LeC-D/openclaw/releases/tag/pr106864-evidence>

Additional verification:

- Verified the equivalent server-side behavior on a live gateway (Android/Termux host where turns of 2–11+ min are routine): with the 30 s override neutralized, app-initiated long turns complete exactly like Telegram ones instead of ~50% dying to run expiry.
- `ChatControllerReconnectRestoreTest` updated for the re-armed timer (perpetual-job pattern on `backgroundScope`); `android-test-play` and `android-test-third-party` are green on the current head.

Fixes #106863

🤖 Generated with [Claude Code](https://claude.com/claude-code)
