### PR TITLE
refactor(agents): extract before-agent-run gate

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-before-agent-run.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-before-agent-run.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GlobalHookRunnerRegistry } from "../../../plugins/hook-registry.types.js";
+import type {
+  PluginHookAgentContext,
+  PluginHookBeforeAgentRunEvent,
+  PluginHookRegistration,
+} from "../../../plugins/hook-types.js";
+import { createHookRunner } from "../../../plugins/hooks.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
+import { SessionManager } from "../../sessions/index.js";
+import { runEmbeddedAttemptBeforeAgentRun } from "./attempt-before-agent-run.js";
+
+function createRegistry(hooks: PluginHookRegistration[] = []): GlobalHookRunnerRegistry {
+  return { hooks: [], typedHooks: hooks, plugins: [] };
+}
+
+const hookContext: PluginHookAgentContext = {
+  runId: "run-1",
+  agentId: "agent-1",
+  sessionKey: "session-1",
+  sessionId: "sid-1",
+};
+
+function createInput(hooks: PluginHookRegistration[] = []) {
+  const sessionManager = guardSessionManager(SessionManager.inMemory());
+  const state = {
+    messages: [
+      {
+        role: "user",
+        content: [{ type: "text", text: "original prompt" }],
+        timestamp: 1,
+      },
+    ] as AgentMessage[],
+  };
+  const activeSession = {
+    get messages() {
+      return state.messages;
+    },
+    agent: { state },
+  };
+  const lock = { acquisitions: 0 };
+  const withOwnedSessionWriteLock = async <T>(operation: () => Promise<T> | T): Promise<T> => {
+    lock.acquisitions += 1;
+    return await operation();
+  };
+  return {
+    input: {
+      attempt: {
+        runId: "run-1",
+        agentAccountId: "account-1",
+        senderId: "sender-1",
+        senderIsOwner: true,
+      },
+      activeSession,
+      hookContext,
+      hookMessages: state.messages,
+      hookRunner: createHookRunner(createRegistry(hooks)),
+      modelPrompt: "model prompt",
+      sessionManager,
+      systemPrompt: "system prompt",
+      withOwnedSessionWriteLock,
+    },
+    lock,
+    sessionManager,
+    state,
+  };
+}
+
+describe("runEmbeddedAttemptBeforeAgentRun", () => {
+  it("does nothing when no gate is registered", async () => {
+    const { input, lock, sessionManager } = createInput();
+
+    await expect(runEmbeddedAttemptBeforeAgentRun(input)).resolves.toBeUndefined();
+
+    expect(lock.acquisitions).toBe(0);
+    expect(sessionManager.buildSessionContext().messages).toEqual([]);
+  });
+
+  it("passes cloned prompt context and leaves passing turns unchanged", async () => {
+    const handler = vi.fn(async (event: PluginHookBeforeAgentRunEvent) => {
+      const first = event.messages[0] as Extract<AgentMessage, { role: "user" }>;
+      first.content = "mutated by hook";
+      return { outcome: "pass" as const };
+    });
+    const { input, lock, state } = createInput([
+      { pluginId: "policy", hookName: "before_agent_run", handler, source: "test" },
+    ]);
+
+    await expect(runEmbeddedAttemptBeforeAgentRun(input)).resolves.toBeUndefined();
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: "model prompt",
+        systemPrompt: "system prompt",
+        channelId: undefined,
+        accountId: "account-1",
+        senderId: "sender-1",
+        senderIsOwner: true,
+      }),
+      hookContext,
+    );
+    expect(state.messages[0]).toEqual(
+      expect.objectContaining({ content: [{ type: "text", text: "original prompt" }] }),
+    );
+    expect(lock.acquisitions).toBe(0);
+  });
+
+  it("persists one redacted blocked turn across retries", async () => {
+    const handler = vi.fn(async () => ({
+      outcome: "block" as const,
+      reason: "unsafe input",
+      message: "Request blocked.",
+    }));
+    const { input, lock, sessionManager, state } = createInput([
+      { pluginId: "policy", hookName: "before_agent_run", handler, source: "test" },
+    ]);
+
+    const first = await runEmbeddedAttemptBeforeAgentRun(input);
+    const second = await runEmbeddedAttemptBeforeAgentRun(input);
+
+    expect(first).toEqual({ blockedBy: "policy", promptError: expect.any(Error) });
+    expect(first?.promptError.message).toBe(
+      "Your message could not be sent: Request blocked. (blocked by policy)",
+    );
+    expect(second?.blockedBy).toBe("policy");
+    expect(lock.acquisitions).toBe(1);
+    expect(handler).toHaveBeenCalledTimes(2);
+    const persistedMessages = sessionManager.buildSessionContext().messages;
+    expect(persistedMessages).toHaveLength(1);
+    expect(persistedMessages[0]).toEqual(
+      expect.objectContaining({
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Your message could not be sent: Request blocked. (blocked by policy)",
+          },
+        ],
+        idempotencyKey: "hook-block:before_agent_run:user:run-1",
+        __openclaw: {
+          beforeAgentRunBlocked: {
+            blockedBy: "policy",
+            blockedAt: expect.any(Number),
+          },
+        },
+      }),
+    );
+    expect(state.messages).toEqual(persistedMessages);
+  });
+
+  it("fails closed and persists a safe turn when the hook runner throws", async () => {
+    const handler = vi.fn(async () => {
+      throw new Error("policy unavailable");
+    });
+    const { input, lock, sessionManager } = createInput([
+      { pluginId: "policy", hookName: "before_agent_run", handler, source: "test" },
+    ]);
+
+    const outcome = await runEmbeddedAttemptBeforeAgentRun(input);
+
+    expect(outcome?.blockedBy).toBe("before_agent_run");
+    expect(outcome?.promptError.message).toBe(
+      "Your message could not be sent: blocked by before_agent_run",
+    );
+    expect(lock.acquisitions).toBe(1);
+    expect(sessionManager.buildSessionContext().messages).toEqual([
+      expect.objectContaining({
+        role: "user",
+        idempotencyKey: "hook-block:before_agent_run:user:run-1",
+      }),
+    ]);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-before-agent-run.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-before-agent-run.ts
@@ -1,0 +1,121 @@
+/**
+ * Runs the fail-closed before_agent_run gate and persists blocked turns.
+ */
+import { resolveBlockMessage } from "../../../plugins/hook-decision-types.js";
+import type { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import { log } from "../logger.js";
+import { cloneHookMessages, flushSessionManagerTranscript } from "./attempt-transcript-helpers.js";
+import { sessionMessagesContainIdempotencyKey } from "./pre-persisted-user-turn.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type HookRunner = NonNullable<ReturnType<typeof getGlobalHookRunner>>;
+type BeforeAgentRunHookRunner = Pick<HookRunner, "hasHooks" | "runBeforeAgentRun">;
+type HookContext = Parameters<HookRunner["runBeforeAgentRun"]>[1];
+type AttemptSessionManager = Parameters<typeof flushSessionManagerTranscript>[0];
+type WithOwnedSessionWriteLock = <T>(operation: () => Promise<T> | T) => Promise<T>;
+
+type BeforeAgentRunSession = {
+  messages: AgentMessage[];
+  agent: { state: { messages: AgentMessage[] } };
+};
+
+export type BeforeAgentRunBlockOutcome = {
+  blockedBy: string;
+  promptError: Error;
+};
+
+export async function runEmbeddedAttemptBeforeAgentRun(input: {
+  attempt: Pick<
+    EmbeddedRunAttemptParams,
+    "agentAccountId" | "runId" | "senderId" | "senderIsOwner"
+  >;
+  activeSession: BeforeAgentRunSession;
+  hookContext: HookContext;
+  hookMessages: AgentMessage[];
+  hookRunner: BeforeAgentRunHookRunner | null;
+  modelPrompt: string;
+  sessionManager: AttemptSessionManager;
+  systemPrompt: string;
+  withOwnedSessionWriteLock: WithOwnedSessionWriteLock;
+}): Promise<BeforeAgentRunBlockOutcome | undefined> {
+  if (!input.hookRunner?.hasHooks("before_agent_run")) {
+    return undefined;
+  }
+
+  const persistBlockedBeforeAgentRun = async (block: {
+    message: string;
+    pluginId: string;
+  }): Promise<boolean> => {
+    const idempotencyKey = `hook-block:before_agent_run:user:${input.attempt.runId}`;
+    if (sessionMessagesContainIdempotencyKey(input.activeSession.messages, idempotencyKey)) {
+      return true;
+    }
+    const nowMs = Date.now();
+    const redactedUserMessage = {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: block.message }],
+      timestamp: nowMs,
+      idempotencyKey,
+      __openclaw: {
+        beforeAgentRunBlocked: {
+          blockedBy: block.pluginId,
+          blockedAt: nowMs,
+        },
+      },
+    };
+    try {
+      await input.withOwnedSessionWriteLock(() => {
+        input.sessionManager.appendMessage(
+          redactedUserMessage as Parameters<typeof input.sessionManager.appendMessage>[0],
+        );
+        flushSessionManagerTranscript(input.sessionManager);
+      });
+      input.activeSession.agent.state.messages =
+        input.sessionManager.buildSessionContext().messages;
+      return true;
+    } catch (err) {
+      log.warn(
+        `before_agent_run block: failed to persist redacted user message: ${
+          (err as Error)?.message ?? String(err)
+        }`,
+      );
+      return false;
+    }
+  };
+
+  let beforeRunResult: Awaited<ReturnType<HookRunner["runBeforeAgentRun"]>> | undefined;
+  try {
+    beforeRunResult = await input.hookRunner.runBeforeAgentRun(
+      {
+        prompt: input.modelPrompt,
+        systemPrompt: input.systemPrompt,
+        messages: cloneHookMessages(input.hookMessages),
+        channelId: input.hookContext.channelId,
+        accountId: input.attempt.agentAccountId ?? undefined,
+        senderId: input.attempt.senderId ?? undefined,
+        senderIsOwner: input.attempt.senderIsOwner ?? undefined,
+      },
+      input.hookContext,
+    );
+  } catch {
+    log.warn("before_agent_run hook failed; blocking request");
+    const blockedBy = "before_agent_run";
+    const message = resolveBlockMessage(
+      { outcome: "block", reason: "before_agent_run hook failed" },
+      { blockedBy },
+    );
+    await persistBlockedBeforeAgentRun({ message, pluginId: blockedBy });
+    return { blockedBy, promptError: new Error(message) };
+  }
+
+  const beforeRunDecision = beforeRunResult?.decision;
+  if (beforeRunDecision?.outcome !== "block") {
+    return undefined;
+  }
+  const blockedBy = beforeRunResult?.pluginId ?? "unknown";
+  const message = resolveBlockMessage(beforeRunDecision, { blockedBy });
+  log.warn(`before_agent_run hook blocked by ${blockedBy}`);
+  await persistBlockedBeforeAgentRun({ message, pluginId: blockedBy });
+  return { blockedBy, promptError: new Error(message) };
+}

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -26,7 +26,6 @@ import {
   buildAgentHookContextChannelFields,
   buildAgentHookContextIdentityFields,
 } from "../../../plugins/hook-agent-context.js";
-import { resolveBlockMessage } from "../../../plugins/hook-decision-types.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import { buildTrajectoryRunMetadata } from "../../../trajectory/metadata.js";
 import {
@@ -105,6 +104,7 @@ import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.
 import { abortable as abortableWithSignal } from "./abortable.js";
 import { releaseEmbeddedAttemptSessionLockForAbort } from "./attempt-abort.js";
 import { completeEmbeddedAttemptAfterTurn } from "./attempt-after-turn.js";
+import { runEmbeddedAttemptBeforeAgentRun } from "./attempt-before-agent-run.js";
 import { prepareEmbeddedAttemptBootstrap } from "./attempt-bootstrap-prepare.js";
 import { prepareEmbeddedAttemptBundleTools } from "./attempt-bundle-tools.js";
 import { prepareEmbeddedAttemptClientTools } from "./attempt-client-tools.js";
@@ -140,7 +140,6 @@ import { prepareEmbeddedAttemptToolCatalog } from "./attempt-tool-catalog.js";
 import { flushEmbeddedAttemptTrajectoryRecorder } from "./attempt-trajectory-flush-cleanup.js";
 import {
   cloneHookMessages,
-  flushSessionManagerTranscript,
   removeTrailingMidTurnPrecheckAssistantError,
   repairAttemptToolUseResultPairing,
   resolveAttemptTrajectorySessionFile,
@@ -183,10 +182,7 @@ import { installHistoryImagePruneContextTransform } from "./history-image-prune.
 import { detectAndLoadPromptImages } from "./images.js";
 import { installMessageToolOnlyTerminalHook } from "./message-tool-terminal.js";
 import { isMidTurnPrecheckSignal, type MidTurnPrecheckRequest } from "./midturn-precheck.js";
-import {
-  detachPrePersistedCurrentUserTurn,
-  sessionMessagesContainIdempotencyKey,
-} from "./pre-persisted-user-turn.js";
+import { detachPrePersistedCurrentUserTurn } from "./pre-persisted-user-turn.js";
 import { PREEMPTIVE_OVERFLOW_ERROR_TEXT } from "./preemptive-compaction.js";
 import {
   buildCurrentInboundPrompt,
@@ -1688,102 +1684,23 @@ export async function runEmbeddedAttempt(
           }
           const systemPromptForHook = systemPromptText;
 
-          const persistBlockedBeforeAgentRun = async (block: {
-            message: string;
-            pluginId: string;
-          }): Promise<boolean> => {
-            const idempotencyKey = `hook-block:before_agent_run:user:${params.runId}`;
-            if (sessionMessagesContainIdempotencyKey(activeSession.messages, idempotencyKey)) {
-              return true;
-            }
-            const nowMs = Date.now();
-            const redactedUserMessage = {
-              role: "user" as const,
-              content: [{ type: "text" as const, text: block.message }],
-              timestamp: nowMs,
-              idempotencyKey,
-              __openclaw: {
-                beforeAgentRunBlocked: {
-                  blockedBy: block.pluginId,
-                  blockedAt: nowMs,
-                },
-              },
-            };
-            try {
-              await withOwnedSessionWriteLock(() => {
-                activeSessionManager.appendMessage(
-                  redactedUserMessage as Parameters<typeof activeSessionManager.appendMessage>[0],
-                );
-                flushSessionManagerTranscript(activeSessionManager);
-              });
-              activeSession.agent.state.messages =
-                activeSessionManager.buildSessionContext().messages;
-              return true;
-            } catch (err) {
-              log.warn(
-                `before_agent_run block: failed to persist redacted user message: ${
-                  (err as Error)?.message ?? String(err)
-                }`,
-              );
-              return false;
-            }
-          };
-
-          if (hookRunner?.hasHooks("before_agent_run")) {
-            const beforeRunMessages = cloneHookMessages(hookMessagesForCurrentPrompt);
-            let beforeRunResult:
-              | Awaited<ReturnType<NonNullable<typeof hookRunner>["runBeforeAgentRun"]>>
-              | undefined;
-            try {
-              beforeRunResult = await hookRunner.runBeforeAgentRun(
-                {
-                  prompt: promptForModel,
-                  systemPrompt: systemPromptForHook,
-                  messages: beforeRunMessages,
-                  channelId: hookCtx.channelId,
-                  accountId: params.agentAccountId ?? undefined,
-                  senderId: params.senderId ?? undefined,
-                  senderIsOwner: params.senderIsOwner ?? undefined,
-                },
-                hookCtx,
-              );
-            } catch {
-              log.warn("before_agent_run hook failed; blocking request");
-              beforeAgentRunBlocked = true;
-              beforeAgentRunBlockedBy = "before_agent_run";
-              await persistBlockedBeforeAgentRun({
-                message: resolveBlockMessage(
-                  { outcome: "block", reason: "before_agent_run hook failed" },
-                  { blockedBy: "before_agent_run" },
-                ),
-                pluginId: "before_agent_run",
-              });
-              promptError = new Error(
-                resolveBlockMessage(
-                  { outcome: "block", reason: "before_agent_run hook failed" },
-                  { blockedBy: "before_agent_run" },
-                ),
-              );
-              promptErrorSource = "hook:before_agent_run";
-              skipPromptSubmission = true;
-            }
-            const beforeRunDecision = beforeRunResult?.decision;
-            const beforeRunPluginId = beforeRunResult?.pluginId ?? "unknown";
-            if (beforeRunDecision?.outcome === "block") {
-              beforeAgentRunBlocked = true;
-              beforeAgentRunBlockedBy = beforeRunPluginId;
-              const blockReplacementMsg = resolveBlockMessage(beforeRunDecision, {
-                blockedBy: beforeRunPluginId,
-              });
-              log.warn(`before_agent_run hook blocked by ${beforeRunPluginId}`);
-              await persistBlockedBeforeAgentRun({
-                message: blockReplacementMsg,
-                pluginId: beforeRunPluginId,
-              });
-              promptError = new Error(blockReplacementMsg);
-              promptErrorSource = "hook:before_agent_run";
-              skipPromptSubmission = true;
-            }
+          const beforeAgentRunOutcome = await runEmbeddedAttemptBeforeAgentRun({
+            attempt: params,
+            activeSession,
+            hookContext: hookCtx,
+            hookMessages: hookMessagesForCurrentPrompt,
+            hookRunner,
+            modelPrompt: promptForModel,
+            sessionManager: activeSessionManager,
+            systemPrompt: systemPromptForHook,
+            withOwnedSessionWriteLock,
+          });
+          if (beforeAgentRunOutcome) {
+            beforeAgentRunBlocked = true;
+            beforeAgentRunBlockedBy = beforeAgentRunOutcome.blockedBy;
+            promptError = beforeAgentRunOutcome.promptError;
+            promptErrorSource = "hook:before_agent_run";
+            skipPromptSubmission = true;
           }
 
           if (!skipPromptSubmission) {


### PR DESCRIPTION
## What Problem This Solves

`runEmbeddedAttempt` still owned the complete `before_agent_run` fail-closed gate: hook dispatch, cloned input assembly, blocked-turn persistence, retry idempotency, and caller state projection. This kept another separable lifecycle phase inside the hot orchestration function.

Related: #72072

## Why This Change Was Made

The gate now lives in `attempt-before-agent-run.ts`. The extracted helper preserves cloned hook messages, fail-closed hook errors, explicit block attribution, redacted transcript persistence, the owned session write lock, and idempotent retry behavior. `attempt.ts` now only applies the returned block outcome to orchestration state.

Focused tests cover no-hook, passing-hook clone isolation, explicit block persistence across retries, and thrown-hook fail-closed behavior.

## User Impact

No intended behavior change. The refactor removes 83 lines from `attempt.ts` (2,441 to 2,358 LOC) and makes the security-sensitive gate independently testable.

## Evidence

- Blacksmith Testbox `tbx_01kxesb7sj1t81j7wfhtzft72k`: 219 focused tests passed across the new helper, attempt runner, context-engine attempt path, and hook lifecycle gates.
- Blacksmith Testbox: `pnpm tsgo:core` passed.
- Blacksmith Testbox: `pnpm check:test-types` passed.
- Blacksmith Testbox: scoped `pnpm check:changed` passed, including the TypeScript LOC ratchet, formatting, core/test types, lint, and runtime guards.
- Fresh autoreview: clean, no accepted/actionable findings; correctness 0.97.
- `git diff --check` passed.
- Final conflict-free rebase covered only unrelated paths; hosted CI was not awaited per maintainer instruction.
