### PR TITLE
refactor(googlechat): privatize monitor access helpers

### DIFF
--- a/extensions/googlechat/src/monitor-access.ts
+++ b/extensions/googlechat/src/monitor-access.ts
@@ -49,7 +49,7 @@ function normalizeGoogleChatStableEntry(entry: string): string | null {
   return withoutProvider.startsWith("users/") ? normalizeUserId(withoutProvider) : withoutProvider;
 }
 
-export function normalizeGoogleChatEmailEntry(entry: string): string | null {
+function normalizeGoogleChatEmailEntry(entry: string): string | null {
   const withoutProvider = normalizeEntryValue(entry).replace(
     /^(googlechat|google-chat|gchat):/i,
     "",
@@ -89,7 +89,7 @@ type GoogleChatGroupEntry = {
   systemPrompt?: string;
 };
 
-export function resolveGoogleChatGroupConfig(params: {
+function resolveGoogleChatGroupConfig(params: {
   groupId: string;
   groupName?: string | null;
   groups?: Record<string, GoogleChatGroupEntry>;

--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -124,8 +124,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "extensions/googlechat/src/auth.ts: testing",
   "extensions/googlechat/src/google-auth.runtime.ts: __testing",
   "extensions/googlechat/src/google-auth.runtime.ts: createGoogleAuthFetch",
-  "extensions/googlechat/src/monitor-access.ts: normalizeGoogleChatEmailEntry",
-  "extensions/googlechat/src/monitor-access.ts: resolveGoogleChatGroupConfig",
   "extensions/googlechat/src/monitor-routing.ts: handleGoogleChatWebhookRequest",
   "extensions/googlechat/src/monitor.ts: testing",
   "extensions/googlechat/src/targets.ts: resolveGoogleChatSpaceChatType",


### PR DESCRIPTION
## What Problem This Solves

The Google Chat monitor access module exported two helpers that are only used inside that same file. Those unsupported internals remained as permanent exceptions in the unused-export baseline despite not being part of the plugin's public API.

## Why This Change Was Made

Make the email normalization and group-config resolution helpers module-private and remove their two dead-export baseline entries. Their implementations and runtime call sites remain unchanged.

## User Impact

No user-visible behavior changes. The Google Chat plugin exposes a smaller internal surface and the dead-export baseline drops two entries.

## Evidence

- Full codebase-memory graph: 312,755 nodes and 1,297,011 edges; each helper has one definition in `monitor-access.ts`.
- Exhaustive tracked-repo search found only each declaration and its same-file use.
- Neither helper appears in Google Chat public/private barrels, entrypoints, package metadata, Plugin SDK surfaces, or docs.
- Patch-identical Blacksmith Testbox `tbx_01kxeswckmgx35xst6tek2cqgy`, Actions run `29290323639`: all 21 Google Chat test files passed, 204 tests total.
- Same Testbox: changed-file gate passed for the extension source and dead-export baseline.
- Same Testbox: dead-export validation passed with 1,263 baseline entries.
- Fresh post-rebase `gpt-5.6-sol` medium autoreview: no findings, patch correct, confidence 0.95.
