### PR TITLE
fix(ui): preserve model provider route provenance

### DIFF
--- a/extensions/browser/src/browser-node-proxy.ts
+++ b/extensions/browser/src/browser-node-proxy.ts
@@ -26,7 +26,7 @@ class BrowserNodeControlHostUnavailableError extends Error {
   }
 }
 
-export type BrowserProxyRequest = ((params: {
+type BrowserProxyRequest = ((params: {
   method: string;
   path: string;
   query?: Record<string, string | number | boolean | undefined>;

--- a/extensions/discord/src/voice/participant-context.ts
+++ b/extensions/discord/src/voice/participant-context.ts
@@ -23,7 +23,7 @@ function memberLabel(state: APIVoiceState): string | undefined {
   );
 }
 
-export async function appendDiscordVoiceParticipantContext(params: {
+async function appendDiscordVoiceParticipantContext(params: {
   context: DiscordVoiceIngressContext | null;
   client: Client;
   entry: VoiceSessionEntry;

--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -66,7 +66,6 @@ const rawSqliteAllowPathGroups = {
     "src/infra/state-migrations.storage.ts",
     "src/infra/state-migrations.cron-run-logs.ts",
     "src/infra/state-migrations.debug-proxy.ts",
-    "src/infra/state-migrations.task-sidecar-rows.ts",
   ],
   "shared database stores with direct DatabaseSync access": ["src/proxy-capture/store.sqlite.ts"],
   "Kysely-backed stores that own a DatabaseSync boundary": [

--- a/src/agents/embedded-agent-runner/run/attempt-before-agent-run.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-before-agent-run.ts
@@ -20,7 +20,7 @@ type BeforeAgentRunSession = {
   agent: { state: { messages: AgentMessage[] } };
 };
 
-export type BeforeAgentRunBlockOutcome = {
+type BeforeAgentRunBlockOutcome = {
   blockedBy: string;
   promptError: Error;
 };

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -11,6 +11,7 @@ import { resetConfigRuntimeState } from "../config/config.js";
 import { loadCronStore, saveCronStore } from "../cron/store.js";
 import type { GuardedFetchOptions } from "../infra/net/fetch-guard.js";
 import { peekSystemEvents } from "../infra/system-events.js";
+import { getGatewayProcessInstanceId } from "./process-instance.js";
 import type { GatewayCronState } from "./server-cron.js";
 import {
   connectOk,
@@ -1540,7 +1541,12 @@ describe("gateway server cron", () => {
 
       const secondRunRes = await rpcReq(ws, "cron.run", { id: "busy-job", mode: "force" }, 1_000);
       expect(secondRunRes.ok).toBe(true);
-      expect(secondRunRes.payload).toEqual({ ok: true, ran: false, reason: "already-running" });
+      expect(secondRunRes.payload).toEqual({
+        ok: true,
+        ran: false,
+        reason: "already-running",
+        processInstanceId: getGatewayProcessInstanceId(),
+      });
       expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
 
       const finishedRun = waitForCronEvent(
@@ -1585,7 +1591,12 @@ describe("gateway server cron", () => {
     try {
       const runRes = await rpcReq(ws, "cron.run", { id: "future-job", mode: "due" }, 1_000);
       expect(runRes.ok).toBe(true);
-      expect(runRes.payload).toEqual({ ok: true, ran: false, reason: "not-due" });
+      expect(runRes.payload).toEqual({
+        ok: true,
+        ran: false,
+        reason: "not-due",
+        processInstanceId: getGatewayProcessInstanceId(),
+      });
       expect(cronIsolatedRun).not.toHaveBeenCalled();
     } finally {
       await cleanupCronTestRun({ ws, server, prevSkipCron });

--- a/ui/src/pages/model-providers/route.ts
+++ b/ui/src/pages/model-providers/route.ts
@@ -6,8 +6,8 @@ import type { ModelProvidersRouteData } from "./model-providers-page.ts";
 async function loadModelProvidersRouteData(
   context: ApplicationContext,
 ): Promise<ModelProvidersRouteData> {
-  const { EMPTY_MODEL_PROVIDERS_DATA, loadModelProvidersData } = await import("./load.ts");
   const gatewaySnapshot = context.gateway.snapshot;
+  const { EMPTY_MODEL_PROVIDERS_DATA, loadModelProvidersData } = await import("./load.ts");
   const client = gatewaySnapshot.connected ? gatewaySnapshot.client : null;
   if (!client) {
     return { data: EMPTY_MODEL_PROVIDERS_DATA, client: null };

--- a/ui/src/pages/route-provenance.test.ts
+++ b/ui/src/pages/route-provenance.test.ts
@@ -4,6 +4,8 @@ import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../app/context.ts";
 import type { AgentsRouteData } from "./agents/agents-page.ts";
 import { page as agentsPage } from "./agents/route.ts";
+import type { ModelProvidersRouteData } from "./model-providers/model-providers-page.ts";
+import { page as modelProvidersPage } from "./model-providers/route.ts";
 import type { NodesRouteData } from "./nodes/nodes-page.ts";
 import { page as nodesPage } from "./nodes/route.ts";
 import type { PluginsRouteData } from "./plugins/plugins-page.ts";
@@ -133,6 +135,26 @@ describe("route preload gateway provenance", () => {
 
     expect(data.gateway).toBe(gateway);
     expect(data.gatewaySnapshot).toBe(originalSnapshot);
+  });
+
+  it("keeps model providers provenance from before its lazy module load", async () => {
+    const originalRequest = vi.fn(async () => ({}));
+    const originalClient = { request: originalRequest } as unknown as GatewayBrowserClient;
+    const replacementRequest = vi.fn(async () => ({}));
+    const replacementClient = {
+      request: replacementRequest,
+    } as unknown as GatewayBrowserClient;
+    const mutable = mutableGateway(snapshot(originalClient, true));
+    const request = loadRoute<ModelProvidersRouteData>(modelProvidersPage, {
+      gateway: mutable.gateway,
+    } as unknown as ApplicationContext);
+
+    mutable.replaceSnapshot(snapshot(replacementClient, true));
+    const data = await request;
+
+    expect(data.client).toBe(originalClient);
+    expect(originalRequest).toHaveBeenCalled();
+    expect(replacementRequest).not.toHaveBeenCalled();
   });
 
   it("keeps skills provenance from before its async preload", async () => {


### PR DESCRIPTION
## What Problem This Solves

The lazy Model Providers route captured `context.gateway.snapshot` after awaiting its data-module import. A disconnect, reconnect, or client replacement during that import could make the loader use a different Gateway client from the navigation that started it.

Follow-up to #106633 and the review finding on #106726.

## Why This Change Was Made

Capture the Gateway snapshot before the first asynchronous boundary, matching the existing route-provenance invariant. Add a regression that swaps clients while the lazy module resolves and proves only the invocation-time client is used.

The first hosted run also exposed unrelated current-main gate failures. This branch repairs those directly: privatizes three unused internal exports, removes a duplicate Kysely allowlist entry, and updates cron response assertions for the new process provenance field.

## User Impact

Model Providers keeps the startup request-budget improvement while loading data from the Gateway connection associated with the initiating navigation. Current-main quality gates return green without relaxing their coverage.

## Evidence

- Exact head `f14e18ef3de2f239d2a608cecaeb9f17cc66813e`.
- Blacksmith Testbox [29291189343](https://github.com/openclaw/openclaw/actions/runs/29291189343): dead exports and architecture guards passed; cron 22/22 and route provenance 7/7 passed.
- Exact-head Blacksmith Testbox [29291479006](https://github.com/openclaw/openclaw/actions/runs/29291479006): `check:changed` passed all required core, UI, plugin, test, tooling, format, type, lint, and static guard lanes.
- Fresh autoreview: no accepted/actionable findings; correctness confidence 0.93.
- AI-assisted change; code and proof reviewed and understood.
