### PR TITLE
refactor(ui): remove unused channel wizard getter

### DIFF
--- a/ui/src/pages/channels/wizard-controller.ts
+++ b/ui/src/pages/channels/wizard-controller.ts
@@ -103,10 +103,6 @@ export class ChannelWizardController {
     return this.currentState;
   }
 
-  get activeChannel(): string | null {
-    return this.channel;
-  }
-
   async start(channel: string | null): Promise<void> {
     const client = this.getClient();
     if (!client) {


### PR DESCRIPTION
## What Problem This Solves

Removes an unused Control UI controller accessor that exposed a second read surface for channel wizard state without any callers.

## Why This Change Was Made

Delete `ChannelWizardController.activeChannel`; the host and views already consume the canonical discriminated `ChannelWizardState.channel` value. The underlying state machine and channel adoption behavior are unchanged.

## User Impact

No user-visible behavior change. This narrows the internal controller API and removes dead maintenance surface.

## Evidence

- Exact-symbol repository search found the getter declaration and no reads.
- Full codebase-memory graph: 313,400 nodes / 1,300,038 edges; the getter had no incoming relationships.
- `pnpm test:serial ui/src/pages/channels/wizard-controller.test.ts`: 8 tests passed on Testbox `tbx_01kxev38t1bntxshvf2cnr9s3m`.
- `pnpm check:changed -- ui/src/pages/channels/wizard-controller.ts`: passed on the same exact-base Testbox.
- Fresh post-rebase `gpt-5.6-sol` medium branch review: no findings, patch correct (0.91 confidence).
