### PR TITLE
fix: prevent ESRCH test cleanup flakes

### DIFF
--- a/src/test-utils/process-tree.test.ts
+++ b/src/test-utils/process-tree.test.ts
@@ -1,0 +1,34 @@
+// Tests race-safe process cleanup helpers.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { killPidIfAlive } from "./process-tree.js";
+
+describe("killPidIfAlive", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("ignores ESRCH when a live process exits before SIGKILL", () => {
+    const killError = Object.assign(new Error("kill ESRCH"), { code: "ESRCH" });
+    const kill = vi
+      .spyOn(process, "kill")
+      .mockReturnValueOnce(true)
+      .mockImplementationOnce(() => {
+        throw killError;
+      });
+
+    expect(() => killPidIfAlive(123)).not.toThrow();
+    expect(kill).toHaveBeenNthCalledWith(1, 123, 0);
+    expect(kill).toHaveBeenNthCalledWith(2, 123, "SIGKILL");
+  });
+
+  it("rethrows other SIGKILL failures", () => {
+    const killError = Object.assign(new Error("kill EPERM"), { code: "EPERM" });
+    vi.spyOn(process, "kill")
+      .mockReturnValueOnce(true)
+      .mockImplementationOnce(() => {
+        throw killError;
+      });
+
+    expect(() => killPidIfAlive(123)).toThrow(killError);
+  });
+});

--- a/src/test-utils/process-tree.ts
+++ b/src/test-utils/process-tree.ts
@@ -52,5 +52,12 @@ export function killPidIfAlive(pid: number | undefined): void {
   if (pid === undefined || !isPidAlive(pid)) {
     return;
   }
-  process.kill(pid, "SIGKILL");
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch (error) {
+    // The process can exit after the liveness probe; ESRCH already satisfies cleanup.
+    if ((error as NodeJS.ErrnoException | undefined)?.code !== "ESRCH") {
+      throw error;
+    }
+  }
 }

--- a/test/scripts/bundled-plugin-install-uninstall-probe.test.ts
+++ b/test/scripts/bundled-plugin-install-uninstall-probe.test.ts
@@ -215,7 +215,14 @@ function killPidIfAlive(pid: number | undefined): void {
   if (pid === undefined || !pidIsAlive(pid)) {
     return;
   }
-  process.kill(pid, "SIGKILL");
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch (error) {
+    // The process can exit after the liveness probe; ESRCH already satisfies cleanup.
+    if ((error as NodeJS.ErrnoException | undefined)?.code !== "ESRCH") {
+      throw error;
+    }
+  }
 }
 
 afterEach(() => {
@@ -247,6 +254,20 @@ describe("bundled plugin install/uninstall probe", () => {
     await expect(pendingPid).resolves.toBe(123);
     killPidIfAlive(0);
     expect(kill).not.toHaveBeenCalled();
+  });
+
+  it("ignores ESRCH when a probed process exits before cleanup", () => {
+    const killError = Object.assign(new Error("kill ESRCH"), { code: "ESRCH" });
+    const kill = vi
+      .spyOn(process, "kill")
+      .mockReturnValueOnce(true)
+      .mockImplementationOnce(() => {
+        throw killError;
+      });
+
+    expect(() => killPidIfAlive(123)).not.toThrow();
+    expect(kill).toHaveBeenNthCalledWith(1, 123, 0);
+    expect(kill).toHaveBeenNthCalledWith(2, 123, "SIGKILL");
   });
 
   it("keeps the sweep script compatible with macOS Bash 3", () => {


### PR DESCRIPTION
AI-assisted: Codex

## What Problem This Solves

Fixes an issue where process-cleanup tests could fail with `kill ESRCH` when a child exited between the helper's liveness probe and its SIGKILL call.

Observed in `src/agents/provider-local-service.test.ts` on `checks-node-compact-large-1`: https://github.com/openclaw/openclaw/actions/runs/29288374350/job/86946261059

## Why This Change Was Made

Treat ESRCH from the final SIGKILL as successful cleanup while continuing to rethrow every other kill error. The same race-prone helper in the bundled-plugin install/uninstall probe was fixed too.

Focused regression coverage simulates the liveness-check/SIGKILL race and verifies non-ESRCH errors still propagate.

## User Impact

No product behavior change. CI and local test cleanup no longer flakes when the target process exits at the desired moment.

## Evidence

- Before: failed run attempt 1 reported `Error: kill ESRCH` from `src/test-utils/process-tree.ts:55` in the failed one-shot host test.
- After: Testbox-through-Crabbox lease `tbx_01kxev0yg9ezny0qe133pyztg7`, Actions run https://github.com/openclaw/openclaw/actions/runs/29291394112. All 79 focused tests passed across:
  - `src/test-utils/process-tree.test.ts`
  - `src/agents/provider-local-service.test.ts`
  - `test/scripts/bundled-plugin-install-uninstall-probe.test.ts`
- Remote changed gate: `pnpm check:changed` passed on Testbox lease `tbx_01kxeth2xx6twaa5wx6vsav000`.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` returned no accepted/actionable findings; correctness confidence 0.98.
