### PR TITLE
refactor(browser): privatize proxy request type

### DIFF
--- a/extensions/browser/src/browser-node-proxy.ts
+++ b/extensions/browser/src/browser-node-proxy.ts
@@ -26,7 +26,7 @@ class BrowserNodeControlHostUnavailableError extends Error {
   }
 }
 
-export type BrowserProxyRequest = ((params: {
+type BrowserProxyRequest = ((params: {
   method: string;
   path: string;
   query?: Record<string, string | number | boolean | undefined>;


### PR DESCRIPTION
## What Problem This Solves

Production-mode Knip reports `BrowserProxyRequest` as a dead export. Keeping it exported would force the dead-export ratchet to grow.

## Why This Change Was Made

The type is consumed only inside its owning module. Make it module-private without changing the function shape or runtime behavior.

## User Impact

None. Internal TypeScript surface cleanup only.

## Evidence

- Exact one-line diff reviewed clean by autoreview at 0.97.
- Dead-export regeneration previously confirmed this as a current-main ratchet repair.
- No external imports or dynamic consumers found.
