### PR TITLE
fix(plugins): clean scheduler jobs after failed registration

### DIFF
--- a/src/plugins/host-hook-cleanup-timeout.ts
+++ b/src/plugins/host-hook-cleanup-timeout.ts
@@ -16,15 +16,14 @@ export async function withPluginHostCleanupTimeout<T>(
 ): Promise<T> {
   let timeout: NodeJS.Timeout | undefined;
   try {
-    return await Promise.race([
-      Promise.resolve().then(cleanup),
-      new Promise<never>((_, reject) => {
-        timeout = setTimeout(() => {
-          reject(new PluginHostCleanupTimeoutError(hookId));
-        }, PLUGIN_HOST_CLEANUP_TIMEOUT_MS);
-        timeout.unref?.();
-      }),
-    ]);
+    const timedOut = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => {
+        reject(new PluginHostCleanupTimeoutError(hookId));
+      }, PLUGIN_HOST_CLEANUP_TIMEOUT_MS);
+      timeout.unref?.();
+    });
+    const cleanupResult = cleanup();
+    return await Promise.race([Promise.resolve(cleanupResult), timedOut]);
   } finally {
     if (timeout) {
       clearTimeout(timeout);

--- a/src/plugins/plugin-registry.test.ts
+++ b/src/plugins/plugin-registry.test.ts
@@ -3,12 +3,15 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
+import { createPluginRegistryFixture } from "openclaw/plugin-sdk/plugin-test-contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   closeOpenClawStateDatabaseForTest,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
 import type { PluginCandidate } from "./discovery.js";
+import { clearPluginHostRuntimeState } from "./host-hook-runtime.js";
+import { listPluginSessionSchedulerJobs } from "./host-hook-runtime.test-fixtures.js";
 import {
   readPersistedInstalledPluginIndex,
   writePersistedInstalledPluginIndex,
@@ -35,6 +38,7 @@ import {
   resolvePluginContributionOwners,
   resolveProviderOwners,
 } from "./plugin-registry.js";
+import { createPluginRecord } from "./status.test-helpers.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 
 const tempDirs: string[] = [];
@@ -47,6 +51,7 @@ function listPluginRecords(params: { index: InstalledPluginIndex }) {
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();
   clearPluginMetadataLifecycleCaches();
+  clearPluginHostRuntimeState();
   cleanupTrackedTempDirs(tempDirs);
 });
 
@@ -212,6 +217,52 @@ function expectSnapshotPluginIds(snapshot: InstalledPluginIndex, expectedPluginI
 }
 
 describe("plugin registry facade", () => {
+  it("cleans session scheduler jobs when plugin registration rolls back", async () => {
+    const cleanup = vi.fn();
+    const { config, registry } = createPluginRegistryFixture();
+    const api = registry.createApi(
+      createPluginRecord({
+        id: "rollback-scheduler",
+        name: "Rollback Scheduler",
+        description: "test plugin",
+        origin: "global",
+        source: "test-plugin",
+        rootDir: "/tmp/test-plugin",
+      }),
+      {
+        config,
+        pluginConfig: {},
+        registrationMode: "full",
+      },
+    );
+
+    api.registerSessionSchedulerJob({
+      id: "leaked-job",
+      sessionKey: "agent:main:main",
+      kind: "monitor",
+      cleanup,
+    });
+    expect(listPluginSessionSchedulerJobs("rollback-scheduler")).toEqual([
+      {
+        id: "leaked-job",
+        pluginId: "rollback-scheduler",
+        sessionKey: "agent:main:main",
+        kind: "monitor",
+      },
+    ]);
+
+    registry.rollbackPluginGlobalSideEffects("rollback-scheduler");
+
+    await vi.waitFor(() => {
+      expect(cleanup).toHaveBeenCalledWith({
+        reason: "disable",
+        sessionKey: "agent:main:main",
+        jobId: "leaked-job",
+      });
+      expect(listPluginSessionSchedulerJobs("rollback-scheduler")).toEqual([]);
+    });
+  });
+
   it("resolves cold plugin records and contribution owners without loading runtime", () => {
     const rootDir = makeTempDir();
     const candidate = createCandidate(rootDir);

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2,6 +2,7 @@
 import { clearCodeModeNamespacesForPlugin } from "../agents/code-mode-namespaces.js";
 import { clearContextEnginesForOwner } from "../context-engine/registry.js";
 import { clearPluginCommandsForPlugin } from "./command-registry-state.js";
+import { cleanupPluginSessionSchedulerJobs } from "./host-hook-runtime.js";
 import { clearPluginInteractiveHandlersForPlugin } from "./interactive-registry.js";
 import { createPluginApiFactory } from "./registry-api.js";
 import { createPluginRegistrars } from "./registry-registrars.js";
@@ -44,6 +45,30 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     clearCodeModeNamespacesForPlugin(pluginId);
     clearContextEnginesForOwner(`plugin:${pluginId}`);
     registrars.rollbackHooks(pluginId);
+    void cleanupPluginSessionSchedulerJobs({
+      pluginId,
+      reason: "disable",
+    })
+      .then((failures) => {
+        for (const failure of failures) {
+          state.pushDiagnostic({
+            level: "error",
+            pluginId: failure.pluginId,
+            source: pluginId,
+            message: `failed to clean session scheduler job during registration rollback: ${failure.hookId}`,
+          });
+        }
+      })
+      .catch((error: unknown) => {
+        state.pushDiagnostic({
+          level: "error",
+          pluginId,
+          source: pluginId,
+          message: `failed to clean session scheduler jobs during registration rollback: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        });
+      });
   };
 
   return {


### PR DESCRIPTION
Closes #106825

## What Problem This Solves

Fixes an issue where plugin registration failures could leave plugin-owned scheduled work active after the plugin was rolled back. Users or operators with a plugin that creates scheduler cleanup metadata and then fails during registration could end up with external scheduled work still running even though the plugin did not load.

## Why This Change Was Made

The registration rollback path now starts the existing owner-scoped session scheduler cleanup alongside the other plugin-global side effects. Cleanup callbacks are invoked immediately when cleanup begins, and cleanup failures are preserved as plugin diagnostics without masking the original registration failure.

## User Impact

Failed plugin registration no longer leaves session scheduler jobs behind on the live host runtime. Cleanup failures remain observable and retryable instead of silently losing the failed cleanup state.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/plugin-registry.test.ts` passed: 24 tests.
- `node scripts/run-vitest.mjs src/plugins/contracts/scheduled-turns.contract.test.ts` passed: 24 tests.
- `pnpm tsgo:core:test` passed.
- `node_modules/.bin/oxfmt --check --threads=1 src/plugins/registry.ts src/plugins/host-hook-cleanup-timeout.ts src/plugins/plugin-registry.test.ts` passed.
- `git diff --check` passed.
- Duplicate check before PR: searched open and closed PRs for `#106825`, `fix plugins registration rollback session scheduler cleanup`, `src/plugins/registry.ts cleanupPluginSessionSchedulerJobs`, and `host-hook-cleanup-timeout plugin-registry.test sessionSchedulerJobs rollback`; no overlapping PR was found.
