### PR TITLE
fix(release): keep frozen package inventory self-contained

### DIFF
--- a/scripts/package-openclaw-for-docker.d.mts
+++ b/scripts/package-openclaw-for-docker.d.mts
@@ -28,6 +28,15 @@ export function packOpenClawPackageForDocker(
   outputDir: unknown,
   options?: Record<string, unknown>,
 ): Promise<string>;
+export function writePackageInventoryForDocker(
+  sourceDir: string,
+  runImpl?: (
+    command: string,
+    args: string[],
+    cwd: string,
+    options?: Record<string, unknown>,
+  ) => Promise<unknown>,
+): Promise<void>;
 export function runCommandForTest(
   command: unknown,
   args: unknown,

--- a/scripts/package-openclaw-for-docker.mjs
+++ b/scripts/package-openclaw-for-docker.mjs
@@ -721,6 +721,22 @@ export async function packOpenClawPackageForDocker(sourceDir, outputDir, options
   return tarball;
 }
 
+export async function writePackageInventoryForDocker(sourceDir, runImpl = run) {
+  // Frozen release refs own their inventory shape; run their writer instead of importing current-main helpers.
+  const tsxModuleUrl = import.meta.resolve("tsx");
+  await runImpl(
+    "node",
+    ["--import", tsxModuleUrl, path.join(sourceDir, "scripts/write-package-dist-inventory.ts")],
+    sourceDir,
+    {
+      timeoutMs: resolveTimeoutMs(
+        "OPENCLAW_DOCKER_PACKAGE_INVENTORY_TIMEOUT_MS",
+        DEFAULT_PACKAGE_INVENTORY_TIMEOUT_MS,
+      ),
+    },
+  );
+}
+
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const sourceDir = path.resolve(ROOT_DIR, options.sourceDir || ROOT_DIR);
@@ -735,23 +751,7 @@ async function main() {
   }
 
   console.error("==> Writing OpenClaw package inventory");
-  await run(
-    "node",
-    [
-      "--import",
-      "tsx",
-      "--input-type=module",
-      "-e",
-      "const { writePackageDistInventory } = await import('./scripts/lib/package-dist-inventory.ts'); await writePackageDistInventory(process.cwd());",
-    ],
-    sourceDir,
-    {
-      timeoutMs: resolveTimeoutMs(
-        "OPENCLAW_DOCKER_PACKAGE_INVENTORY_TIMEOUT_MS",
-        DEFAULT_PACKAGE_INVENTORY_TIMEOUT_MS,
-      ),
-    },
-  );
+  await writePackageInventoryForDocker(sourceDir);
 
   const tarball = await packOpenClawPackageForDocker(sourceDir, outputDir, {
     allowUnreleasedChangelog: options.allowUnreleasedChangelog,

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -13,6 +13,7 @@ import {
   parseArgs,
   prepareBundledAiRuntimePackage,
   runCommandForTest,
+  writePackageInventoryForDocker,
 } from "../../../../scripts/package-openclaw-for-docker.mjs";
 import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
 
@@ -173,6 +174,32 @@ describe("package-openclaw-for-docker", () => {
     } finally {
       fs.rmSync(tempRoot, { force: true, recursive: true });
     }
+  });
+
+  it("writes inventory for a frozen source checkout without the trusted helper", async () => {
+    const sourceDir = tempDirs.make("openclaw-package-frozen-source-");
+    fs.mkdirSync(path.join(sourceDir, "dist"), { recursive: true });
+    fs.mkdirSync(path.join(sourceDir, "scripts"), { recursive: true });
+    fs.writeFileSync(path.join(sourceDir, "package.json"), '{"name":"openclaw"}\n');
+    fs.writeFileSync(path.join(sourceDir, "dist", "entry.js"), "export {};\n");
+    fs.writeFileSync(
+      path.join(sourceDir, "scripts", "write-package-dist-inventory.ts"),
+      [
+        'import fs from "node:fs";',
+        'fs.writeFileSync("dist/postinstall-inventory.json", JSON.stringify(["dist/entry.js"]));',
+      ].join("\n"),
+    );
+
+    await writePackageInventoryForDocker(sourceDir);
+
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(sourceDir, "dist", "postinstall-inventory.json"), "utf8"),
+      ),
+    ).toEqual(["dist/entry.js"]);
+    expect(fs.existsSync(path.join(sourceDir, "scripts", "lib", "package-dist-inventory.ts"))).toBe(
+      false,
+    );
   });
 
   it("rejects pnpm pack with npm metadata output", () => {


### PR DESCRIPTION
## What Problem This Solves

Trusted-main release recovery failed while packaging a frozen stable target because the current packer imported a current-main inventory helper that does not exist in the frozen checkout.

## Why This Change Was Made

Run the frozen source checkout's own inventory writer while loading `tsx` from trusted main. This keeps the target's inventory schema and dependencies self-contained without requiring new helper files to exist on older refs.

## User Impact

Release validation can package older trusted refs again. Normal package output is unchanged.

## Evidence

- Failing recovery child: https://github.com/openclaw/openclaw/actions/runs/29291003028
- Focused Testbox: https://github.com/openclaw/openclaw/actions/runs/29291864481 (27/27 passed)
- Exact frozen-target package proof: https://github.com/openclaw/openclaw/actions/runs/29291971304
- Autoreview: clean, no actionable findings
