### PR TITLE
refactor(discord): privatize voice context helper

### DIFF
--- a/extensions/discord/src/voice/participant-context.ts
+++ b/extensions/discord/src/voice/participant-context.ts
@@ -23,7 +23,7 @@ function memberLabel(state: APIVoiceState): string | undefined {
   );
 }
 
-export async function appendDiscordVoiceParticipantContext(params: {
+async function appendDiscordVoiceParticipantContext(params: {
   context: DiscordVoiceIngressContext | null;
   client: Client;
   entry: VoiceSessionEntry;


### PR DESCRIPTION
## What Problem This Solves

Production-mode Knip reports `appendDiscordVoiceParticipantContext` as a dead export. The export would otherwise grow the enforced shrink-only ratchet.

## Why This Change Was Made

The helper is called only inside its owning module. Make it module-private while retaining the production entry point and behavior.

## User Impact

None. Internal TypeScript surface cleanup only.

## Evidence

- Exact repository search found only the same-module call.
- Fresh autoreview clean at 0.99.
- Exact production-mode regeneration identified this current-main drift.
