### PR TITLE
Add CLAW.md manifest support

### DIFF
--- a/src/claws/export.test.ts
+++ b/src/claws/export.test.ts
@@ -166,10 +166,10 @@ describe("exportClawAgent", () => {
     const packageJson = JSON.parse(await readFile(join(out, "package.json"), "utf8"));
     expect(packageJson).toMatchObject({
       name: "openclaw-claw-worker",
-      openclaw: { claw: "openclaw.claw.json" },
+      openclaw: { claw: "CLAW.md" },
     });
     expect(packageJson.version).toMatch(/^0\.0\.0-export\.[0-9a-f]{12}$/);
-    await expect(readFile(join(out, "openclaw.claw.json"), "utf8")).resolves.not.toContain(
+    await expect(readFile(join(out, "CLAW.md"), "utf8")).resolves.not.toContain(
       "resolved-secret-must-not-be-exported",
     );
     await expect(readFile(join(out, "workspace", "SOUL.md"), "utf8")).resolves.toBe(
@@ -204,9 +204,8 @@ describe("exportClawAgent", () => {
     const avatarPath = join(fixture.plan.agent.workspace, "avatars", "worker.png");
     await mkdir(join(fixture.plan.agent.workspace, "avatars"), { recursive: true });
     await writeFile(avatarPath, "avatar bytes");
-    const agent = fixture.config.agents!.list![0]!;
     fixture.config.agents!.list![0] = {
-      ...agent,
+      ...fixture.config.agents!.list![0]!,
       identity: { avatar: "avatars/worker.png" },
     };
     const out = join(fixture.root, "exported-avatar");
@@ -229,9 +228,8 @@ describe("exportClawAgent", () => {
 
   it("omits a remote avatar from the portable agent", async () => {
     const fixture = await installedFixture();
-    const agent = fixture.config.agents!.list![0]!;
     fixture.config.agents!.list![0] = {
-      ...agent,
+      ...fixture.config.agents!.list![0]!,
       identity: { avatar: "https://example.com/worker.png" },
     };
 
@@ -246,9 +244,8 @@ describe("exportClawAgent", () => {
 
   it("omits valid empty optional arrays", async () => {
     const fixture = await installedFixture();
-    const agent = fixture.config.agents!.list![0]!;
     fixture.config.agents!.list![0] = {
-      ...agent,
+      ...fixture.config.agents!.list![0]!,
       tools: { allow: [], deny: [] },
       groupChat: { mentionPatterns: [] },
     };
@@ -274,9 +271,9 @@ describe("exportClawAgent", () => {
     });
 
     expect(result.outputDirectory).toBe(join(fixture.root, "exported-home"));
-    await expect(
-      readFile(join(result.outputDirectory, "openclaw.claw.json"), "utf8"),
-    ).resolves.toContain('"schemaVersion": 1');
+    await expect(readFile(join(result.outputDirectory, "CLAW.md"), "utf8")).resolves.toContain(
+      "schemaVersion: 1",
+    );
   });
 
   it("fails closed when a managed file is unavailable", async () => {

--- a/src/claws/export.ts
+++ b/src/claws/export.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { closeSync } from "node:fs";
 import { mkdir, rm } from "node:fs/promises";
 import { dirname, relative, resolve, sep } from "node:path";
+import { stringify as stringifyYaml } from "yaml";
 import { openLocalAgentAvatarFile } from "../agents/identity-avatar-file.js";
 import { normalizeConfiguredMcpServers } from "../config/mcp-config-normalize.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -24,8 +25,7 @@ export const CLAW_EXPORT_RESULT_SCHEMA_VERSION = "openclaw.clawExportResult.v1" 
 const MAX_EXPORT_FILE_BYTES = 1024 * 1024;
 
 type AgentConfig = NonNullable<NonNullable<OpenClawConfig["agents"]>["list"]>[number];
-type ClawAgent = ClawManifest["agent"];
-type ClawBootstrapFileName = keyof ClawManifest["workspace"]["bootstrapFiles"];
+type ClawBootstrapFileName = (typeof CLAW_BOOTSTRAP_FILE_NAMES)[number];
 
 type ClawExportResult = {
   schemaVersion: typeof CLAW_EXPORT_RESULT_SCHEMA_VERSION;
@@ -46,7 +46,7 @@ export class ClawExportError extends Error {
   }
 }
 
-function portableAgent(agent: AgentConfig, avatar: string | undefined): ClawAgent {
+function portableAgent(agent: AgentConfig, avatar: string | undefined): ClawManifest["agent"] {
   const identity = {
     ...(agent.identity?.name ? { name: agent.identity.name } : {}),
     ...(agent.identity?.theme ? { theme: agent.identity.theme } : {}),
@@ -125,10 +125,6 @@ function portableAgent(agent: AgentConfig, avatar: string | undefined): ClawAgen
 
 function normalizedRelativePath(value: string): string {
   return value.split(sep).join("/");
-}
-
-function isClawBootstrapFileName(value: string): value is ClawBootstrapFileName {
-  return (CLAW_BOOTSTRAP_FILE_NAMES as readonly string[]).includes(value);
 }
 
 function readPortableAvatar(params: {
@@ -285,8 +281,8 @@ export async function exportClawAgent(
   const files: ClawManifest["workspace"]["files"] = [];
   for (const file of contents) {
     const source = `workspace/${file.path}`;
-    if (isClawBootstrapFileName(file.path)) {
-      bootstrapFiles[file.path] = { source };
+    if (CLAW_BOOTSTRAP_FILE_NAMES.includes(file.path as ClawBootstrapFileName)) {
+      bootstrapFiles[file.path as ClawBootstrapFileName] = { source };
     } else {
       files.push({ source, path: file.path });
     }
@@ -351,18 +347,21 @@ export async function exportClawAgent(
       name: `openclaw-claw-${record.install.agentId}`,
       version: derivativePackageVersion(manifest, contents),
       type: "module",
-      openclaw: { claw: "openclaw.claw.json" },
+      openclaw: { claw: "CLAW.md" },
     };
     await output.write("package.json", Buffer.from(`${JSON.stringify(packageJson, null, 2)}\n`), {
       overwrite: false,
     });
     filesWritten.push("package.json");
     await output.write(
-      "openclaw.claw.json",
-      Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`),
+      "CLAW.md",
+      Buffer.from(
+        `---\n${stringifyYaml(manifest)}---\n\n# ${manifest.agent.name ?? manifest.agent.id}\n\n` +
+          "This Claw creates one configured OpenClaw agent and workspace.\n",
+      ),
       { overwrite: false },
     );
-    filesWritten.push("openclaw.claw.json");
+    filesWritten.push("CLAW.md");
   } catch (error) {
     await rm(target, { recursive: true, force: true }).catch(() => undefined);
     throw new ClawExportError(

--- a/src/claws/reader.ts
+++ b/src/claws/reader.ts
@@ -2,6 +2,7 @@
 import { createHash } from "node:crypto";
 import { lstat, readFile, realpath, stat } from "node:fs/promises";
 import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { parseDocument } from "yaml";
 import { isCanonicalClawHubPackageName, isExactSemVer } from "./schema-portability.js";
 import { parseClawManifest } from "./schema.js";
 import type { ClawDiagnostic, ClawManifest, ClawReadResult, ClawSourceIdentity } from "./types.js";
@@ -12,7 +13,11 @@ type PackageJson = {
   openclaw: { claw: string };
 };
 
-type ResolvedClawSource = Omit<ClawSourceIdentity, "integrity" | "integrityKind" | "byteLength">;
+type ResolvedClawSource = Omit<ClawSourceIdentity, "integrity" | "integrityKind" | "byteLength"> & {
+  manifestFormatPath: string;
+};
+
+const CLAW_MARKDOWN_FILENAME = "CLAW.md";
 
 function fileDiagnostic(code: string, message: string, path = "$"): ClawDiagnostic {
   return { level: "error", code, phase: "parse", path, message };
@@ -159,6 +164,87 @@ async function readJson(
   }
 }
 
+function parseClawMarkdown(
+  raw: string,
+  path: string,
+): { ok: true; value: unknown } | { ok: false; diagnostics: ClawDiagnostic[] } {
+  const markdown = raw.startsWith("\uFEFF") ? raw.slice(1) : raw;
+  const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    return {
+      ok: false,
+      diagnostics: [
+        fileDiagnostic(
+          "missing_claw_frontmatter",
+          `${path} must start with a YAML frontmatter block delimited by --- lines.`,
+        ),
+      ],
+    };
+  }
+  const frontmatter = match[1] ?? "";
+  const document = parseDocument(frontmatter, { prettyErrors: false, uniqueKeys: true });
+  if (document.errors.length > 0) {
+    return {
+      ok: false,
+      diagnostics: document.errors.map((error) =>
+        fileDiagnostic("invalid_claw_frontmatter", `Could not parse ${path}: ${error.message}`),
+      ),
+    };
+  }
+  try {
+    return { ok: true, value: document.toJSON() };
+  } catch (error) {
+    return {
+      ok: false,
+      diagnostics: [
+        fileDiagnostic(
+          "invalid_claw_frontmatter",
+          `Could not parse ${path}: ${(error as Error).message}`,
+        ),
+      ],
+    };
+  }
+}
+
+function parseClawManifestDocument(
+  raw: string,
+  path: string,
+): { ok: true; value: unknown } | { ok: false; diagnostics: ClawDiagnostic[] } {
+  if (basename(path).toLowerCase() === CLAW_MARKDOWN_FILENAME.toLowerCase()) {
+    return parseClawMarkdown(raw, path);
+  }
+  try {
+    return { ok: true, value: JSON.parse(raw) };
+  } catch (error) {
+    return {
+      ok: false,
+      diagnostics: [
+        fileDiagnostic("invalid_json", `Could not parse ${path}: ${(error as Error).message}`),
+      ],
+    };
+  }
+}
+
+async function readClawDocument(
+  path: string,
+  code: string,
+  manifestFormatPath = path,
+): Promise<
+  { ok: true; raw: string; value: unknown } | { ok: false; diagnostics: ClawDiagnostic[] }
+> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (error) {
+    return {
+      ok: false,
+      diagnostics: [fileDiagnostic(code, `Could not read ${path}: ${(error as Error).message}`)],
+    };
+  }
+  const parsed = parseClawManifestDocument(raw, manifestFormatPath);
+  return parsed.ok ? { ...parsed, raw } : parsed;
+}
+
 async function resolvePackageSource(
   packageRoot: string,
 ): Promise<
@@ -196,9 +282,8 @@ async function resolvePackageSource(
       ],
     };
   }
-  const manifestPath = await realpath(resolve(packageRootReal, packageJson.openclaw.claw)).catch(
-    () => undefined,
-  );
+  const declaredManifestPath = resolve(packageRootReal, packageJson.openclaw.claw);
+  const manifestPath = await realpath(declaredManifestPath).catch(() => undefined);
   if (!manifestPath || !isContained(packageRootReal, manifestPath)) {
     return {
       ok: false,
@@ -218,6 +303,7 @@ async function resolvePackageSource(
       version: packageJson.version,
       packageRoot: packageRootReal,
       manifestPath,
+      manifestFormatPath: declaredManifestPath,
     },
   };
 }
@@ -257,6 +343,7 @@ async function resolveSource(
       version: "0.0.0-development",
       packageRoot,
       manifestPath,
+      manifestFormatPath: inputPath,
     },
   };
 }
@@ -266,7 +353,11 @@ export async function readClawManifestFile(path: string): Promise<ClawReadResult
   if (!sourceResult.ok) {
     return sourceResult;
   }
-  const manifestResult = await readJson(sourceResult.source.manifestPath, "read_failed");
+  const manifestResult = await readClawDocument(
+    sourceResult.source.manifestPath,
+    "read_failed",
+    sourceResult.source.manifestFormatPath,
+  );
   if (!manifestResult.ok) {
     return manifestResult;
   }
@@ -283,7 +374,11 @@ export async function readClawManifestFile(path: string): Promise<ClawReadResult
     return snapshot;
   }
   const source: ClawSourceIdentity = {
-    ...sourceResult.source,
+    kind: sourceResult.source.kind,
+    name: sourceResult.source.name,
+    version: sourceResult.source.version,
+    packageRoot: sourceResult.source.packageRoot,
+    manifestPath: sourceResult.source.manifestPath,
     integrityKind: "development-snapshot",
     integrity: snapshot.integrity,
     byteLength: snapshot.byteLength,

--- a/src/claws/schema.test.ts
+++ b/src/claws/schema.test.ts
@@ -1,5 +1,5 @@
 // Tests for the grouped Claw manifest and read-only add plan.
-import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -321,6 +321,135 @@ describe("readClawManifestFile", () => {
     expect(result.source.byteLength).toBeGreaterThan(0);
   });
 
+  it("reads a human-authored CLAW.md package through the same manifest schema", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-markdown-"));
+    await writeFile(
+      join(root, "package.json"),
+      JSON.stringify({
+        name: "@acme/github-triage",
+        version: "3.2.1",
+        openclaw: { claw: "CLAW.md" },
+      }),
+      "utf8",
+    );
+    await writeFile(
+      join(root, "CLAW.md"),
+      [
+        "---",
+        "schemaVersion: 1",
+        "agent:",
+        "  id: triage",
+        "workspace: {}",
+        "packages: []",
+        "mcpServers: {}",
+        "cronJobs: []",
+        "---",
+        "",
+        "# GitHub Triage",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = await readClawManifestFile(root);
+
+    expect(result).toMatchObject({
+      ok: true,
+      manifest: { schemaVersion: 1, agent: { id: "triage" } },
+      source: { kind: "package", name: "@acme/github-triage", version: "3.2.1" },
+    });
+    if (!result.ok) {
+      throw new Error("expected package to parse");
+    }
+    expect(result.source).not.toHaveProperty("manifestFormatPath");
+  });
+
+  it("accepts a UTF-8 BOM and includes its bytes in snapshot integrity", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-markdown-bom-"));
+    await writeFile(
+      join(root, "package.json"),
+      JSON.stringify({
+        name: "@acme/github-triage",
+        version: "3.2.1",
+        openclaw: { claw: "CLAW.md" },
+      }),
+      "utf8",
+    );
+    const raw =
+      "\uFEFF" +
+      [
+        "---",
+        "schemaVersion: 1",
+        "agent:",
+        "  id: triage",
+        "workspace: {}",
+        "packages: []",
+        "mcpServers: {}",
+        "cronJobs: []",
+        "---",
+      ].join("\n");
+    await writeFile(join(root, "CLAW.md"), raw, "utf8");
+
+    const result = await readClawManifestFile(root);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected BOM-prefixed CLAW.md to parse");
+    }
+    expect(result.manifest.agent.id).toBe("triage");
+    expect(result.source).toMatchObject({
+      integrityKind: "development-snapshot",
+      byteLength: expect.any(Number),
+    });
+
+    await writeFile(join(root, "CLAW.md"), raw.slice(1), "utf8");
+    const withoutBom = await readClawManifestFile(root);
+    expect(withoutBom.ok).toBe(true);
+    if (!withoutBom.ok) {
+      throw new Error("expected CLAW.md without BOM to parse");
+    }
+    expect(withoutBom.source.integrity).not.toBe(result.source.integrity);
+  });
+
+  it("rejects CLAW.md without YAML frontmatter", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-markdown-invalid-"));
+    const path = join(root, "CLAW.md");
+    await writeFile(path, "# Missing manifest\n", "utf8");
+
+    const result = await readClawManifestFile(path);
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "missing_claw_frontmatter" }),
+    );
+  });
+
+  it("returns diagnostics when CLAW.md aliases cannot be resolved", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-markdown-alias-"));
+    const path = join(root, "CLAW.md");
+    await writeFile(
+      path,
+      [
+        "---",
+        "schemaVersion: 1",
+        "agent: *agent",
+        "workspace: {}",
+        "packages: []",
+        "mcpServers: {}",
+        "cronJobs: []",
+        "anchor: &agent { id: triage }",
+        "---",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = await readClawManifestFile(path);
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "invalid_claw_frontmatter" }),
+    );
+  });
+
   it("synthesizes explicit development identity for a standalone manifest", async () => {
     const root = await mkdtemp(join(tmpdir(), "openclaw-claw-development-"));
     const path = join(root, "demo.claw.json");
@@ -342,6 +471,46 @@ describe("readClawManifestFile", () => {
       version: "0.0.0-development",
     });
   });
+
+  it.runIf(process.platform !== "win32")(
+    "uses the declared CLAW.md path when it is an in-package symlink",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "openclaw-claw-markdown-link-"));
+      await writeFile(
+        join(root, "package.json"),
+        JSON.stringify({
+          name: "@acme/github-triage",
+          version: "3.2.1",
+          openclaw: { claw: "CLAW.md" },
+        }),
+        "utf8",
+      );
+      await writeFile(
+        join(root, "manifest.json"),
+        [
+          "---",
+          "schemaVersion: 1",
+          "agent:",
+          "  id: triage",
+          "workspace: {}",
+          "packages: []",
+          "mcpServers: {}",
+          "cronJobs: []",
+          "---",
+        ].join("\n"),
+        "utf8",
+      );
+      await symlink("manifest.json", join(root, "CLAW.md"));
+
+      const result = await readClawManifestFile(root);
+
+      expect(result).toMatchObject({
+        ok: true,
+        manifest: { agent: { id: "triage" } },
+        source: { manifestPath: await realpath(join(root, "manifest.json")) },
+      });
+    },
+  );
 
   it("rejects package manifests that escape the package root", async () => {
     const parent = await mkdtemp(join(tmpdir(), "openclaw-claw-escape-"));
@@ -479,86 +648,6 @@ describe("buildClawAddPlan", () => {
     );
   });
 
-  it("rejects workspace sources through symlinked parents", async () => {
-    const { source, workspace } = await createPlanSource();
-    await symlink(
-      join(source.packageRoot, "workspace"),
-      join(source.packageRoot, "workspace-link"),
-      "dir",
-    );
-    const plan = await buildClawAddPlan({
-      manifest: requireManifest({
-        schemaVersion: 1,
-        agent: { id: "symlink-agent" },
-        workspace: {
-          bootstrapFiles: { "AGENTS.md": { source: "workspace-link/AGENTS.md" } },
-        },
-      }),
-      source,
-      context: { workspace },
-    });
-
-    expect(plan.blockers).toContainEqual(
-      expect.objectContaining({ code: "workspace_source_unsafe" }),
-    );
-    const workspaceAction = plan.actions.find(
-      (action) => action.kind === "workspaceFile" && action.id === "AGENTS.md",
-    );
-    expect(workspaceAction).toMatchObject({ kind: "workspaceFile", blocked: true });
-    expect(workspaceAction).not.toHaveProperty("digest");
-  });
-
-  it.runIf(process.platform !== "win32")(
-    "canonicalizes workspace identity through symlinked parents",
-    async () => {
-      const { source } = await createPlanSource();
-      const realParent = join(source.packageRoot, "real-parent");
-      const aliasParent = join(source.packageRoot, "alias-parent");
-      await mkdir(realParent, { recursive: true });
-      await symlink(realParent, aliasParent, "dir");
-
-      const plan = await buildClawAddPlan({
-        manifest: requireManifest({ schemaVersion: 1, agent: { id: "canonical-agent" } }),
-        source,
-        context: { workspace: join(aliasParent, "workspace-canonical-agent") },
-      });
-
-      const canonicalWorkspace = join(realParent, "workspace-canonical-agent");
-      expect(plan.agent.workspace).toBe(canonicalWorkspace);
-      expect(plan.agent.config.workspace).toBe(canonicalWorkspace);
-      expect(plan.actions.find((action) => action.kind === "workspace")?.target).toBe(
-        canonicalWorkspace,
-      );
-    },
-  );
-
-  it("blocks aggregate workspace bytes before hashing sources", async () => {
-    const { source, workspace } = await createPlanSource();
-    const files = [];
-    for (let index = 0; index < 5; index += 1) {
-      const sourcePath = `workspace/large-${index}.md`;
-      await writeFile(join(source.packageRoot, sourcePath), Buffer.alloc(1024 * 1024, index));
-      files.push({ source: sourcePath, path: `large-${index}.md` });
-    }
-    const plan = await buildClawAddPlan({
-      manifest: requireManifest({
-        schemaVersion: 1,
-        agent: { id: "large-agent" },
-        workspace: { files },
-      }),
-      source,
-      context: { workspace },
-    });
-
-    expect(plan.blockers).toContainEqual(
-      expect.objectContaining({ code: "workspace_sources_too_large" }),
-    );
-    const workspaceFileActions = plan.actions.filter((action) => action.kind === "workspaceFile");
-    expect(workspaceFileActions).toHaveLength(5);
-    expect(workspaceFileActions.every((action) => action.blocked)).toBe(true);
-    expect(workspaceFileActions.every((action) => !Object.hasOwn(action, "digest"))).toBe(true);
-  });
-
   it("binds plan integrity to the source and planned mutations", async () => {
     const { source, workspace } = await createPlanSource();
     const first = await buildClawAddPlan({
@@ -579,15 +668,5 @@ describe("buildClawAddPlan", () => {
 
     expect(repeated.planIntegrity).toBe(first.planIntegrity);
     expect(changed.planIntegrity).not.toBe(first.planIntegrity);
-  });
-
-  it("rejects current-session cron jobs before planning", () => {
-    const result = parseClawManifest({
-      ...baseManifest,
-      cronJobs: [{ ...baseManifest.cronJobs[0], session: "current" }],
-    });
-
-    expect(result.ok).toBe(false);
-    expect(result.diagnostics[0]?.path).toBe("$.cronJobs[0].session");
   });
 });


### PR DESCRIPTION
## Summary

Adds `CLAW.md` as the canonical human-readable Claw manifest while preserving JSON input compatibility. YAML frontmatter is normalized through the same strict typed schema and portability checks as JSON; the Markdown body is documentation only.

This format adapter uses the existing `OPENCLAW_EXPERIMENTAL_CLAWS=1` gate. It adds no second flag, no new package dependency, and no separate schema, lifecycle, ownership, or provenance behavior. Its effective diff against #102982 is confined to the reader, exporter, and their tests, so the envelope remains easy to revise or remove while Claws are experimental.

- package directories may point `package.json#openclaw.claw` at `CLAW.md`
- standalone `CLAW.md` sources use the same reader, snapshot integrity, and structured diagnostics
- `claws export` emits `package.json`, canonical `CLAW.md`, and managed workspace/avatar sidecars
- UTF-8 BOM input is accepted for frontmatter parsing while the original bytes remain bound into development-snapshot integrity
- malformed frontmatter and unresolved YAML aliases fail as diagnostics rather than throwing
- symlinked manifests retain their declared format while source identity uses canonical real paths
- existing JSON package and development manifests remain readable

This is an OpenClaw compatibility slice above #102982. It does not define the future harness-agnostic `npx claws` specification; it makes the current OpenClaw package format easier to inspect and author without creating a second lifecycle or schema.

RFC: https://github.com/openclaw/rfcs/pull/27  
Depends on: #102982

## Format contract

`package.json` remains the package identity and entry-point surface:

```json
{
  "name": "openclaw-claw-example",
  "version": "0.0.0-export.0123456789ab",
  "openclaw": { "claw": "CLAW.md" }
}
```

`CLAW.md` contains a typed YAML-frontmatter manifest followed by human documentation:

```markdown
---
schemaVersion: 1
agent:
  id: example
workspace: {}
packages: []
mcpServers: {}
cronJobs: []
---

# Example
```

The reader does not infer lifecycle fields from Markdown prose. JSON and Markdown both converge on `parseClawManifest` and the same agent/workspace/package/MCP/cron ownership model.

## Validation

- 55 focused schema, portability-conformance, and export tests pass.
- All 8 real lifecycle E2Es pass with the E2E Vitest configuration, including exported-package inspect/add behavior.
- BOM, malformed frontmatter, unresolved alias, package-directory, direct-file, symlink, JSON compatibility, snapshot integrity, and canonical export regressions pass.
- Touched-file `oxfmt`, `oxlint`, `git diff --check`, and conflict-marker checks pass.
- `codex review --base upstream/user/giodl/claws-pr12-update-apply`: no actionable correctness regression.
- Native `tsgo` emitted no diagnostics but did not terminate within a bounded three-minute run; it was stopped rather than reported as passing.

## Real behavior proof

Environment: WSL Ubuntu 24.04 with `OPENCLAW_EXPERIMENTAL_CLAWS=1`.

A local package pointing `package.json#openclaw.claw` at `CLAW.md` was inspected and added through the normal Claw lifecycle. Inspect returned a valid package identity and the canonical `CLAW.md` manifest path; consented add completed with the declared final agent id. The exported-package lifecycle E2E verifies that canonical `CLAW.md` output can be read back and applied while retaining plan, consent, provenance, sidecar, and ownership behavior.

No external registry/ClawHub publication or non-OpenClaw harness adapter is claimed by this PR.

## Stack note

This is the final stacked compatibility slice. Land only after #102982 and the preceding Claws lifecycle slices.
