### PR TITLE
fix(clawhub): honor standard plugin API comparators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **ClawHub plugin API ranges:** delegate each supported comparator to `semver` so tilde, partial-wildcard, and prerelease caret bounds are correct while preserving OpenClaw version normalization and the existing restricted range grammar. (#106877)
 - **Web Readability relative links:** seed parsed documents with the request URL so article links resolve correctly while removing the plugin's duplicate lazy-loader facade. (#106860)
 - **Browser auto-routing:** fall back to the Gateway host when an implicitly selected browser node reports that its control host is unreachable, while preserving explicit node pins and ambiguous action failures.
 - **Discord voice participant context:** maintain the live Gateway voice-state roster and include current channel participants in authorized voice agent turns so agents can answer who is present.

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -236,8 +236,12 @@ describe("clawhub helpers", () => {
 
   it("checks plugin api ranges with semver precedence", () => {
     expect(satisfiesPluginApiRange("1.2.3", "^1.2.0")).toBe(true);
+    expect(satisfiesPluginApiRange("1.2.3", "~1.2.0")).toBe(true);
+    expect(satisfiesPluginApiRange("1.2.3", "1.2.x")).toBe(true);
     expect(satisfiesPluginApiRange("1.9.0", ">=1.2.0 <2.0.0")).toBe(true);
+    expect(satisfiesPluginApiRange("1.3.0", "~1.2.0")).toBe(false);
     expect(satisfiesPluginApiRange("2.0.0", "^1.2.0")).toBe(false);
+    expect(satisfiesPluginApiRange("2.0.0-beta.1", "^1.2.0")).toBe(false);
     expect(satisfiesPluginApiRange("1.1.9", ">=1.2.0")).toBe(false);
     expect(satisfiesPluginApiRange("2026.3.22", ">=2026.3.22")).toBe(true);
     expect(satisfiesPluginApiRange("2026.3.21", ">=2026.3.22")).toBe(false);
@@ -266,6 +270,7 @@ describe("clawhub helpers", () => {
     expect(satisfiesPluginApiRange("2026.5.2", "2026.4")).toBe(true);
     expect(satisfiesPluginApiRange("2026.4.0", "2026.4")).toBe(true);
     expect(satisfiesPluginApiRange("2026.3.99", "2026.4")).toBe(false);
+    expect(satisfiesPluginApiRange("2026.4.1", "=2026.4")).toBe(false);
     expect(satisfiesPluginApiRange("2026.5.2", "=2026.4")).toBe(false);
     expect(satisfiesPluginApiRange("invalid", "2026.4")).toBe(false);
   });
@@ -288,6 +293,10 @@ describe("clawhub helpers", () => {
     expect(satisfiesPluginApiRange("invalid", "*")).toBe(false);
     expect(satisfiesPluginApiRange("2026.3.24", ">*")).toBe(false);
     expect(satisfiesPluginApiRange("2026.3.24", "<*")).toBe(false);
+    expect(satisfiesPluginApiRange("1.5.0", ">=1.0.0 || >=2.0.0")).toBe(false);
+    expect(satisfiesPluginApiRange("1.2.3", "1.2.3||2.0.0")).toBe(false);
+    expect(satisfiesPluginApiRange("1.5.0", "1.0.0 - 2.0.0")).toBe(false);
+    expect(satisfiesPluginApiRange("1.2.3", "~>1.2.3")).toBe(false);
   });
 
   it("checks min gateway versions with loose host labels", () => {

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -9,7 +9,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
-import { parse as parseSemverVersion, prerelease as parseSemverPrerelease } from "semver";
+import { prerelease as parseSemverPrerelease, satisfies as satisfiesSemver } from "semver";
 import { retryClawHubRead } from "./clawhub-retry.js";
 import { sha256Base64, sha256Hex as digestSha256Hex } from "./crypto-digest.js";
 import { readResponseTextSnippet, readResponseWithLimit } from "./http-body.js";
@@ -19,7 +19,6 @@ import {
   parseStrictPositiveInteger,
 } from "./parse-finite-number.js";
 import { isAtLeast, parseSemver } from "./runtime-guard.js";
-import { compareValidSemver } from "./semver.js";
 import { createTempDownloadTarget } from "./temp-download.js";
 export { parseClawHubPluginSpec } from "./clawhub-spec.js";
 
@@ -546,35 +545,6 @@ function normalizePartialComparableVersion(version: string): {
     : { version: trimmed, isPartial: false };
 }
 
-function compareSemver(left: string, right: string): number | null {
-  const normalizedLeft = normalizePartialComparableVersion(left).version;
-  const normalizedRight = normalizePartialComparableVersion(right).version;
-  return compareValidSemver(normalizedLeft, normalizedRight);
-}
-
-function upperBoundForCaret(version: string): string | null {
-  const parsed = parseSemverVersion(normalizePartialComparableVersion(version).version);
-  if (!parsed) {
-    return null;
-  }
-  if (parsed.major > 0) {
-    return `${parsed.major + 1}.0.0`;
-  }
-  if (parsed.minor > 0) {
-    return `0.${parsed.minor + 1}.0`;
-  }
-  return `0.0.${parsed.patch + 1}`;
-}
-
-function matchWildcardComparator(token: string): "any" | "none" | null {
-  const match = /^(>=|<=|>|<|=|\^|~)?\s*([*xX])$/.exec(token);
-  if (!match) {
-    return null;
-  }
-  const operator = match[1];
-  return operator === ">" || operator === "<" ? "none" : "any";
-}
-
 function shouldPreservePluginApiPrereleaseFloor(target: string): boolean {
   return Boolean(parseSemverPrerelease(normalizePartialComparableVersion(target).version));
 }
@@ -594,49 +564,28 @@ function satisfiesComparator(version: string, token: string): boolean {
   if (!trimmed) {
     return true;
   }
-  const wildcard = matchWildcardComparator(trimmed);
-  if (wildcard) {
-    return wildcard === "any" && parseSemverVersion(version) != null;
-  }
-  if (trimmed.startsWith("^")) {
-    const base = trimmed.slice(1).trim();
-    const upperBound = upperBoundForCaret(base);
-    const comparableVersion = normalizePluginApiVersionForComparator(version, base);
-    const lowerCmp = compareSemver(comparableVersion, base);
-    const upperCmp = upperBound ? compareSemver(comparableVersion, upperBound) : null;
-    return lowerCmp != null && upperCmp != null && lowerCmp >= 0 && upperCmp < 0;
-  }
-
-  const match = /^(>=|<=|>|<|=)?\s*(.+)$/.exec(trimmed);
+  const match = /^(>=|<=|>|<|=|\^|~)?\s*(.+)$/.exec(trimmed);
   if (!match) {
     return false;
   }
-  const operator = match[1];
+  const operator = match[1] ?? "";
   const target = match[2]?.trim();
-  if (!target) {
+  if (!target || /^[<>=^~]/.test(target)) {
     return false;
   }
   const comparableVersion = normalizePluginApiVersionForComparator(version, target);
   const normalizedTarget = normalizePartialComparableVersion(target);
-  const cmp = compareSemver(comparableVersion, normalizedTarget.version);
-  if (cmp == null) {
-    return false;
-  }
-  switch (operator) {
-    case ">=":
-      return cmp >= 0;
-    case "<=":
-      return cmp <= 0;
-    case ">":
-      return cmp > 0;
-    case "<":
-      return cmp < 0;
-    default:
-      return normalizedTarget.isPartial && !operator ? cmp >= 0 : cmp === 0;
-  }
+  const comparator =
+    normalizedTarget.isPartial && !operator
+      ? `>=${normalizedTarget.version}`
+      : `${operator}${normalizedTarget.version}`;
+  return satisfiesSemver(comparableVersion, comparator, { includePrerelease: true });
 }
 
 function satisfiesSemverRange(version: string, range: string): boolean {
+  if (range.includes("||")) {
+    return false;
+  }
   const tokens = normalizeStringEntries(range.trim().split(/\s+/));
   if (tokens.length === 0) {
     return false;


### PR DESCRIPTION
Closes #106877

## What Problem This Solves

Fixes an issue where ClawHub plugins using standard tilde or partial-wildcard API ranges could be rejected, while some prerelease versions could incorrectly satisfy caret ranges.

## Why This Change Was Made

Delegates each supported comparator to the existing `semver` dependency. OpenClaw correction-version normalization, the legacy bare `major.minor` lower-bound rule, and the intentionally restricted range grammar remain intact.

## User Impact

Plugin compatibility checks now honor standard tilde, wildcard, caret, and prerelease bounds without enabling OR or hyphen-range syntax.

## Evidence

- Blacksmith Testbox `tbx_01kxety9yqd6664yp9c1d011n6`: focused ClawHub suite, 69 passed and 2 skipped.
- Same Testbox: `pnpm tsgo:core` and `pnpm tsgo:test:src` passed.
- Source-blind runtime validation: 10/10 comparator and restricted-grammar probes passed after the fix.
- Broader ClawHub consumer run: 541 tests passed. Ten install-policy subprocess failures reproduced unchanged from an isolated archive of the exact base SHA, so they are unrelated baseline failures.
- Fresh local autoreview reported no accepted or actionable findings.
- Hosted CI was not awaited per maintainer direction.
