### PR TITLE
fix(plugins): clean scheduler jobs after failed registration

### DIFF
--- a/src/plugins/plugin-registration-transaction.test.ts
+++ b/src/plugins/plugin-registration-transaction.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { registerPluginSessionSchedulerJob } from "./host-hook-runtime.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { clearPluginHostRuntimeState } from "./host-hook-runtime.js";
 import { listPluginSessionSchedulerJobs } from "./host-hook-runtime.test-fixtures.js";
 import { clearActivatedPluginRuntimeState } from "./loader-shared.js";
 import {
@@ -14,11 +15,13 @@ import {
 } from "./plugin-registration-transaction.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { createPluginRegistry } from "./registry.js";
+import type { PluginRuntime } from "./runtime/types.js";
 import {
   getSessionDiscussionProvider,
   registerSessionDiscussionProvider,
   type SessionDiscussionProvider,
 } from "./session-discussion-registry.js";
+import { createPluginRecord } from "./status.test-helpers.js";
 
 function discussionProvider(id: string): SessionDiscussionProvider {
   return {
@@ -26,6 +29,17 @@ function discussionProvider(id: string): SessionDiscussionProvider {
     info: vi.fn().mockResolvedValue({ state: "available" }),
     open: vi.fn().mockResolvedValue({ state: "open" }),
   };
+}
+
+function createSchedulerPlugin(pluginId: string) {
+  const pluginRegistry = createPluginRegistry({
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+    runtime: {} as PluginRuntime,
+  });
+  const api = pluginRegistry.createApi(createPluginRecord({ id: pluginId }), {
+    config: {} as OpenClawConfig,
+  });
+  return { api, pluginRegistry };
 }
 
 describe("plugin registration transaction", () => {
@@ -36,6 +50,7 @@ describe("plugin registration transaction", () => {
   });
 
   afterEach(() => {
+    clearPluginHostRuntimeState();
     restorePluginProcessGlobalState(initialProcessGlobalState);
   });
 
@@ -117,61 +132,51 @@ describe("plugin registration transaction", () => {
     expect(getSessionDiscussionProvider()).toBe(activeProvider);
   });
 
-  it("rolls back session scheduler jobs during plugin registration rollback", async () => {
-    const cleanup = vi.fn();
-    const registry = createPluginRegistry({
-      logger: { info() {}, warn() {}, error() {}, debug() {} },
-      runtime: {} as import("./runtime/types.js").PluginRuntime,
+  it("rolls back only scheduler jobs owned by the failed registry", async () => {
+    const pluginId = "scheduler-plugin";
+    const failedCleanup = vi.fn();
+    const activeCleanup = vi.fn();
+    const active = createSchedulerPlugin(pluginId);
+    const failed = createSchedulerPlugin(pluginId);
+
+    active.api.registerSessionSchedulerJob({
+      id: "active-job",
+      sessionKey: "agent:main:main",
+      kind: "monitor",
+      cleanup: activeCleanup,
     });
     const transaction = createPluginRegistrationTransaction({
-      registry: registry.registry,
-      rollbackGlobalSideEffects: () => registry.rollbackPluginGlobalSideEffects("scheduler-plugin"),
+      registry: failed.pluginRegistry.registry,
+      rollbackGlobalSideEffects: () =>
+        failed.pluginRegistry.rollbackPluginGlobalSideEffects(pluginId),
+    });
+    failed.api.registerSessionSchedulerJob({
+      id: "failed-job",
+      sessionKey: "agent:main:main",
+      kind: "monitor",
+      cleanup: failedCleanup,
     });
 
-    registry.registry.sessionSchedulerJobs.push({
-      pluginId: "scheduler-plugin",
-      pluginName: "Scheduler Plugin",
-      job: {
-        id: "test-job",
-        sessionKey: "agent:main:main",
-        kind: "monitor",
-        cleanup,
-      },
-      source: "scheduler-plugin",
-      rootDir: "/tmp",
+    transaction.rollback();
+    await vi.waitFor(() => {
+      expect(failedCleanup).toHaveBeenCalledOnce();
     });
 
-    registerPluginSessionSchedulerJob({
-      pluginId: "scheduler-plugin",
-      pluginName: "Scheduler Plugin",
-      job: {
-        id: "test-job",
-        sessionKey: "agent:main:main",
-        kind: "monitor",
-        cleanup,
-      },
+    expect(failedCleanup).toHaveBeenCalledWith({
+      reason: "disable",
+      sessionKey: "agent:main:main",
+      jobId: "failed-job",
     });
-
-    expect(listPluginSessionSchedulerJobs("scheduler-plugin")).toEqual([
+    expect(activeCleanup).not.toHaveBeenCalled();
+    expect(listPluginSessionSchedulerJobs(pluginId)).toStrictEqual([
       {
-        id: "test-job",
-        pluginId: "scheduler-plugin",
+        id: "active-job",
+        pluginId,
         sessionKey: "agent:main:main",
         kind: "monitor",
       },
     ]);
-
-    transaction.rollback();
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
-    });
-
-    expect(listPluginSessionSchedulerJobs("scheduler-plugin")).toStrictEqual([]);
-    expect(cleanup).toHaveBeenCalledOnce();
-    expect(cleanup).toHaveBeenCalledWith({
-      reason: "disable",
-      sessionKey: "agent:main:main",
-      jobId: "test-job",
-    });
+    expect(failed.pluginRegistry.registry.sessionSchedulerJobs).toStrictEqual([]);
+    expect(active.pluginRegistry.registry.sessionSchedulerJobs).toHaveLength(1);
   });
 });

--- a/src/plugins/plugin-registration-transaction.test.ts
+++ b/src/plugins/plugin-registration-transaction.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerPluginSessionSchedulerJob } from "./host-hook-runtime.js";
+import { listPluginSessionSchedulerJobs } from "./host-hook-runtime.test-fixtures.js";
 import { clearActivatedPluginRuntimeState } from "./loader-shared.js";
 import {
   getMemoryCapabilityRegistration,
@@ -11,6 +13,7 @@ import {
   snapshotPluginProcessGlobalState,
 } from "./plugin-registration-transaction.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
+import { createPluginRegistry } from "./registry.js";
 import {
   getSessionDiscussionProvider,
   registerSessionDiscussionProvider,
@@ -112,5 +115,63 @@ describe("plugin registration transaction", () => {
     transaction.rollback();
 
     expect(getSessionDiscussionProvider()).toBe(activeProvider);
+  });
+
+  it("rolls back session scheduler jobs during plugin registration rollback", async () => {
+    const cleanup = vi.fn();
+    const registry = createPluginRegistry({
+      logger: { info() {}, warn() {}, error() {}, debug() {} },
+      runtime: {} as import("./runtime/types.js").PluginRuntime,
+    });
+    const transaction = createPluginRegistrationTransaction({
+      registry: registry.registry,
+      rollbackGlobalSideEffects: () => registry.rollbackPluginGlobalSideEffects("scheduler-plugin"),
+    });
+
+    registry.registry.sessionSchedulerJobs.push({
+      pluginId: "scheduler-plugin",
+      pluginName: "Scheduler Plugin",
+      job: {
+        id: "test-job",
+        sessionKey: "agent:main:main",
+        kind: "monitor",
+        cleanup,
+      },
+      source: "scheduler-plugin",
+      rootDir: "/tmp",
+    });
+
+    registerPluginSessionSchedulerJob({
+      pluginId: "scheduler-plugin",
+      pluginName: "Scheduler Plugin",
+      job: {
+        id: "test-job",
+        sessionKey: "agent:main:main",
+        kind: "monitor",
+        cleanup,
+      },
+    });
+
+    expect(listPluginSessionSchedulerJobs("scheduler-plugin")).toEqual([
+      {
+        id: "test-job",
+        pluginId: "scheduler-plugin",
+        sessionKey: "agent:main:main",
+        kind: "monitor",
+      },
+    ]);
+
+    transaction.rollback();
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(listPluginSessionSchedulerJobs("scheduler-plugin")).toStrictEqual([]);
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(cleanup).toHaveBeenCalledWith({
+      reason: "disable",
+      sessionKey: "agent:main:main",
+      jobId: "test-job",
+    });
   });
 });

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -58,6 +58,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         pluginId,
         reason: "disable",
         records: schedulerRecords,
+        cleanupOwnerRegistry: state.registry,
       }).then((failures) => {
         for (const failure of failures) {
           state.pushDiagnostic({

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2,6 +2,7 @@
 import { clearCodeModeNamespacesForPlugin } from "../agents/code-mode-namespaces.js";
 import { clearContextEnginesForOwner } from "../context-engine/registry.js";
 import { clearPluginCommandsForPlugin } from "./command-registry-state.js";
+import { cleanupPluginSessionSchedulerJobs } from "./host-hook-runtime.js";
 import { clearPluginInteractiveHandlersForPlugin } from "./interactive-registry.js";
 import { createPluginApiFactory } from "./registry-api.js";
 import { createPluginRegistrars } from "./registry-registrars.js";
@@ -44,6 +45,29 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     clearCodeModeNamespacesForPlugin(pluginId);
     clearContextEnginesForOwner(`plugin:${pluginId}`);
     registrars.rollbackHooks(pluginId);
+
+    // Roll back live session-scheduler records created during a failed registration.
+    // registry.sessionSchedulerJobs metadata is restored by the snapshot above; this
+    // removes the module-global live records and invokes their cleanup callbacks so
+    // external plugin-owned work is cancelled at the rollback boundary.
+    const schedulerRecords = state.registry.sessionSchedulerJobs.filter(
+      (r) => r.pluginId === pluginId,
+    );
+    if (schedulerRecords.length > 0) {
+      void cleanupPluginSessionSchedulerJobs({
+        pluginId,
+        reason: "disable",
+        records: schedulerRecords,
+      }).then((failures) => {
+        for (const failure of failures) {
+          state.pushDiagnostic({
+            level: "warn",
+            pluginId: failure.pluginId,
+            message: `scheduler job cleanup failed during rollback: ${failure.hookId}`,
+          });
+        }
+      });
+    }
   };
 
   return {


### PR DESCRIPTION
Closes #106825

## What Problem This Solves

Fixes an issue where a plugin could register a session scheduler job and then throw later in the same `register` call. Registry metadata rolled back, but the process-global scheduler record and its external cleanup owner remained active.

## Why This Change Was Made

The existing registration rollback owner now passes the failed plugin's scheduler metadata to `cleanupPluginSessionSchedulerJobs` before restoring the registry snapshot. Cleanup is scoped with `cleanupOwnerRegistry: state.registry`, so a different live registry using the same plugin ID cannot have its dynamic jobs swept or its cleanup callbacks invoked.

The existing cleanup result remains fire-and-forget because registration rollback is synchronous while plugin cleanup may be asynchronous. Failures continue through the existing warning diagnostic path.

## User Impact

Plugin-owned external scheduler work is cancelled when registration fails instead of leaking after the plugin was rejected. Other active plugin registries remain intact, including registries that use the same plugin ID.

## Evidence

The regression uses two production plugin APIs with the same plugin ID:

1. Registry B registers `active-job`.
2. Registry A starts a registration transaction, registers `failed-job`, and rolls back.
3. Registry A's cleanup runs exactly once.
4. Registry B's cleanup never runs.
5. The process-global scheduler list retains only `active-job`.
6. Registry A metadata restores to its empty snapshot while registry B metadata remains present.

Focused proof on the final rebased branch:

```text
Blacksmith Testbox: tbx_01ky7ywfpscznbqyfwn1vt755f
Test Files  2 passed (2)
Tests       30 passed (30)
```

https://github.com/openclaw/openclaw/actions/runs/30027752189

Additional proof:

- Earlier Testbox `tbx_01ky7yp00adn2tz3hcw6f3yptm` passed the same 30 focused tests.
- Fresh Codex autoreview against `origin/main`: clean, no accepted/actionable findings.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/30028088721
- The broader scheduler-runtime refactor discovered during review was preserved on an unpushed local WIP branch and intentionally excluded from this focused fix.

AI-assisted: contributor patch repaired and verified by maintainers.
