### PR TITLE
feat(linux): ship deb/AppImage bundles on stable main-based releases

### DIFF
--- a/.github/workflows/linux-app-release.yml
+++ b/.github/workflows/linux-app-release.yml
@@ -87,17 +87,29 @@ jobs:
         env:
           # appimagetool strips fail on CI runners; Tauri documents NO_STRIP for Actions.
           NO_STRIP: "true"
-        run: pnpm dlx @tauri-apps/cli@2.11.4 build --bundles deb,appimage
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          # Stamp the release version into the bundles; the committed manifests
+          # keep a placeholder 0.1.0 so releases stay tag-driven.
+          pnpm dlx @tauri-apps/cli@2.11.4 build --bundles deb,appimage \
+            --config "{\"version\":\"${version}\"}"
 
-      - name: Rename bundles for the release tag
+      - name: Verify and rename bundles for the release tag
         env:
           RELEASE_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
           version="${RELEASE_TAG#v}"
+          deb=$(ls apps/linux/src-tauri/target/release/bundle/deb/*.deb)
+          deb_version=$(dpkg-deb -f "${deb}" Version)
+          if [[ "${deb_version}" != "${version}"* ]]; then
+            echo "Debian package version '${deb_version}' does not match release version '${version}'"
+            exit 1
+          fi
           mkdir -p dist/linux-app
-          cp apps/linux/src-tauri/target/release/bundle/deb/*.deb \
-            "dist/linux-app/OpenClaw-${version}-amd64.deb"
+          cp "${deb}" "dist/linux-app/OpenClaw-${version}-amd64.deb"
           cp apps/linux/src-tauri/target/release/bundle/appimage/*.AppImage \
             "dist/linux-app/OpenClaw-${version}-amd64.AppImage"
           (cd dist/linux-app && sha256sum ./* > SHA256SUMS.linux-app.txt)

--- a/.github/workflows/linux-app-release.yml
+++ b/.github/workflows/linux-app-release.yml
@@ -1,0 +1,115 @@
+name: Linux App Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing OpenClaw release tag to receive Linux companion bundles, for example v2026.7.1
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: linux-app-release-${{ inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  build_and_attach:
+    name: Build and attach Linux companion bundles
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Validate tag input format
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*((-(alpha|beta)\.[1-9][0-9]*)|(-[1-9][0-9]*))?$ ]]; then
+            echo "Invalid release tag format: ${RELEASE_TAG}"
+            exit 1
+          fi
+
+      - name: Checkout selected tag
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Ensure tag commit is reachable from main
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin main
+          tag_sha=$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")
+          if ! git merge-base --is-ancestor "${tag_sha}" origin/main; then
+            echo "Tag ${RELEASE_TAG} (${tag_sha}) is not reachable from main; Linux bundles ship for main-based releases only."
+            exit 1
+          fi
+
+      - name: Ensure matching GitHub release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --json tagName --jq .tagName
+
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            curl \
+            file \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            wget
+
+      - name: Install Rust
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+          install-deps: "false"
+
+      - name: Build Linux companion bundles
+        working-directory: apps/linux/src-tauri
+        env:
+          # appimagetool strips fail on CI runners; Tauri documents NO_STRIP for Actions.
+          NO_STRIP: "true"
+        run: pnpm dlx @tauri-apps/cli@2.11.4 build --bundles deb,appimage
+
+      - name: Rename bundles for the release tag
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          mkdir -p dist/linux-app
+          cp apps/linux/src-tauri/target/release/bundle/deb/*.deb \
+            "dist/linux-app/OpenClaw-${version}-amd64.deb"
+          cp apps/linux/src-tauri/target/release/bundle/appimage/*.AppImage \
+            "dist/linux-app/OpenClaw-${version}-amd64.AppImage"
+          (cd dist/linux-app && sha256sum ./* > SHA256SUMS.linux-app.txt)
+          cat dist/linux-app/SHA256SUMS.linux-app.txt
+
+      - name: Attach bundles to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release upload "${RELEASE_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --clobber \
+            dist/linux-app/*

--- a/.github/workflows/linux-app-release.yml
+++ b/.github/workflows/linux-app-release.yml
@@ -31,11 +31,11 @@ jobs:
           RELEASE_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ ]]; then
-            # Prerelease semver (-alpha.N/-beta.N) maps to a Debian revision that
-            # sorts AFTER the plain stable version, breaking beta-to-stable
-            # upgrades; Linux bundles ship for stable tags only.
-            echo "Linux bundles ship for stable release tags only (vYYYY.M.PATCH); got: ${RELEASE_TAG}"
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-[1-9][0-9]*)?$ ]]; then
+            # Alpha/beta semver suffixes map to a Debian revision that sorts
+            # AFTER the plain stable version, breaking beta-to-stable upgrades;
+            # numeric stable revisions (-N) order correctly and stay allowed.
+            echo "Linux bundles ship for stable release tags only (vYYYY.M.PATCH or vYYYY.M.PATCH-N); got: ${RELEASE_TAG}"
             exit 1
           fi
 

--- a/.github/workflows/linux-app-release.yml
+++ b/.github/workflows/linux-app-release.yml
@@ -21,7 +21,9 @@ env:
 jobs:
   build_and_attach:
     name: Build and attach Linux companion bundles
-    runs-on: ubuntu-latest
+    # Oldest supported build base: bundles link against this glibc, so newer
+    # runners would silently drop Ubuntu 22.04/Debian 12 users.
+    runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
       - name: Validate tag input format
@@ -29,8 +31,11 @@ jobs:
           RELEASE_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*((-(alpha|beta)\.[1-9][0-9]*)|(-[1-9][0-9]*))?$ ]]; then
-            echo "Invalid release tag format: ${RELEASE_TAG}"
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ ]]; then
+            # Prerelease semver (-alpha.N/-beta.N) maps to a Debian revision that
+            # sorts AFTER the plain stable version, breaking beta-to-stable
+            # upgrades; Linux bundles ship for stable tags only.
+            echo "Linux bundles ship for stable release tags only (vYYYY.M.PATCH); got: ${RELEASE_TAG}"
             exit 1
           fi
 

--- a/.github/workflows/linux-app.yml
+++ b/.github/workflows/linux-app.yml
@@ -20,7 +20,8 @@ permissions:
 jobs:
   build:
     name: Build Linux companion
-    runs-on: ubuntu-latest
+    # Match the release build base so PR artifacts have the same glibc floor.
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/apps/linux/README.md
+++ b/apps/linux/README.md
@@ -58,3 +58,11 @@ pnpm dlx @tauri-apps/cli@2.11.4 build --bundles deb,appimage
 Bundles land in `target/release/bundle/{deb,appimage}/`. The `Linux App` CI
 workflow uploads them as the `openclaw-linux-companion` artifact on pull
 requests touching `apps/linux/**` and on manual dispatch.
+
+## Releases
+
+The `Linux App Release` workflow (manual dispatch, release operators) builds
+the bundles from an existing release tag and attaches them to that tag's
+GitHub release with a `SHA256SUMS.linux-app.txt` checksum file. It refuses
+tags whose commit is not reachable from `main`: Linux bundles ship for
+main-based releases only.

--- a/apps/linux/README.md
+++ b/apps/linux/README.md
@@ -62,7 +62,8 @@ requests touching `apps/linux/**` and on manual dispatch.
 ## Releases
 
 The `Linux App Release` workflow (manual dispatch, release operators) builds
-the bundles from an existing release tag and attaches them to that tag's
+the bundles from an existing stable release tag (prerelease tags are
+rejected: their semver suffix breaks Debian upgrade ordering) and attaches them to that tag's
 GitHub release with a `SHA256SUMS.linux-app.txt` checksum file. It refuses
 tags whose commit is not reachable from `main`: Linux bundles ship for
 main-based releases only.

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -21,14 +21,24 @@ The OpenClaw Linux companion is a Tauri desktop app for a local Gateway. It:
 - opens the Gateway-served Control UI with its resolved authentication URL
 - remains available from the system tray when its window is closed
 
-Hosted releases are not published yet. Build a `.deb` and AppImage from a source checkout:
+Releases built from `main` ship `.deb` and AppImage bundles as assets on the
+[GitHub release](https://github.com/openclaw/openclaw/releases) for the tag,
+named `OpenClaw-<version>-amd64.deb` and `OpenClaw-<version>-amd64.AppImage`,
+with a `SHA256SUMS.linux-app.txt` checksum file next to them. Download the
+`.deb` and install it with `sudo apt install ./OpenClaw-<version>-amd64.deb`,
+or mark the AppImage executable and run it directly.
+
+You can also build the same bundles from a source checkout:
 
 ```bash
 cd apps/linux/src-tauri
 pnpm dlx @tauri-apps/cli@2.11.4 build --bundles deb,appimage
 ```
 
-The `Linux App` CI workflow also uploads the same bundles as the `openclaw-linux-companion` artifact for pull requests touching the app and for manual runs. See `apps/linux/README.md` in the repository for Linux build dependencies and development commands.
+The `Linux App` CI workflow uploads the same bundles as the
+`openclaw-linux-companion` artifact for pull requests touching the app and for
+manual runs. See `apps/linux/README.md` in the repository for Linux build
+dependencies and development commands.
 
 ## CLI and SSH alternative
 

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -21,7 +21,7 @@ The OpenClaw Linux companion is a Tauri desktop app for a local Gateway. It:
 - opens the Gateway-served Control UI with its resolved authentication URL
 - remains available from the system tray when its window is closed
 
-Releases built from `main` ship `.deb` and AppImage bundles as assets on the
+Stable releases built from `main` ship `.deb` and AppImage bundles as assets on the
 [GitHub release](https://github.com/openclaw/openclaw/releases) for the tag,
 named `OpenClaw-<version>-amd64.deb` and `OpenClaw-<version>-amd64.AppImage`,
 with a `SHA256SUMS.linux-app.txt` checksum file next to them. Download the

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -26,7 +26,9 @@ Stable releases built from `main` ship `.deb` and AppImage bundles as assets on 
 named `OpenClaw-<version>-amd64.deb` and `OpenClaw-<version>-amd64.AppImage`,
 with a `SHA256SUMS.linux-app.txt` checksum file next to them. Download the
 `.deb` and install it with `sudo apt install ./OpenClaw-<version>-amd64.deb`,
-or mark the AppImage executable and run it directly.
+or mark the AppImage executable and run it directly. The AppImage runtime
+needs FUSE 2 (`sudo apt install libfuse2`, or `libfuse2t64` on Ubuntu 24.04+);
+without it, run the AppImage with `APPIMAGE_EXTRACT_AND_RUN=1`.
 
 You can also build the same bundles from a source checkout:
 


### PR DESCRIPTION
Related: #106337

## What Problem This Solves

Linux companion bundles (deb/AppImage, added in #106352/#106533) exist only as CI artifacts; nothing ships them to users. Releases need a wired, repeatable path that attaches installable Linux packages to the GitHub release for a tag.

## Why This Change Was Made

New operator-dispatched `Linux App Release` workflow, mirroring the Windows installer promotion pattern:

- takes an existing release tag, validates the format, and **rejects prerelease (alpha/beta) tags** — their semver suffix maps to a Debian revision that sorts after the plain stable version, breaking beta-to-stable upgrades; numeric stable revisions (`vYYYY.M.PATCH-N`) order correctly and are allowed
- **requires the tag commit to be reachable from `main`** (Linux bundles ship for main-based releases only)
- builds on **ubuntu-22.04** as the glibc floor so bundles run on Ubuntu 22.04/Debian 12 (PR CI build pinned to match)
- **stamps the release version into the bundles** via a Tauri config override (committed manifests keep a placeholder 0.1.0), and verifies the resulting `.deb` Version field before upload
- attaches `OpenClaw-<version>-amd64.{deb,AppImage}` plus `SHA256SUMS.linux-app.txt` to the GitHub release with `gh release upload --clobber`

Docs updated: `docs/platforms/linux.md` documents the release assets, install commands, and the AppImage FUSE 2 prerequisite (`libfuse2`/`libfuse2t64`, or `APPIMAGE_EXTRACT_AND_RUN=1`); `apps/linux/README.md` documents the release workflow and its stable-only gate.

## User Impact

Linux users can install OpenClaw's desktop companion from GitHub release assets instead of building from source. Operators get a one-dispatch workflow per stable release. No runtime or CLI behavior changes.

## Evidence

- `actionlint` clean on both workflows; `docs:map:check` clean.
- The exact build command and bundle output were live-verified in #106533 (deb built, apt-installed, and run end-to-end on Ubuntu 26.04; AppImage launch smoke) and on fresh Wayland (labwc) boxes via Crabbox where the packaged deb app rendered the full Control UI dashboard end-to-end (CLI discovery, gateway bring-up, dashboard --json auth, WebKitGTK rendering) with only cosmetic warnings.
- Autoreview (Codex gpt-5.6-sol, xhigh): clean after five accepted findings were fixed across rounds — version stamping + deb metadata verification, glibc build floor, prerelease-tag rejection, numeric-revision tags allowed, FUSE prerequisite documented.
- Workflow is dispatch-only; nothing runs until a release operator invokes it, so there is no CI-behavior change on PRs beyond the runner pin.
