### PR TITLE
test(telegram): satisfy promise executor lint

### DIFF
--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -423,7 +423,9 @@ describe("bot-native-command-menu", () => {
       accountId,
       botIdentity: "bot-a",
     });
-    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
     expect(deleteMyCommands).toHaveBeenCalledTimes(2);
     expect(setMyCommands).toHaveBeenCalledTimes(2);
   });


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails the extension lint lane because a Telegram test returns the `setTimeout` expression from a Promise executor.

## Why This Change Was Made

Use a block-bodied executor so the test keeps the same event-loop yield without returning a value. This fixes the `no-promise-executor-return` violation reported by CI.

## User Impact

No runtime behavior change. CI can validate and land unrelated work again.

## Evidence

- Failing hosted check: https://github.com/openclaw/openclaw/actions/runs/29293046356/job/86960676426
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29293281458
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram/src/bot-native-command-menu.test.ts`
- `pnpm test extensions/telegram/src/bot-native-command-menu.test.ts` — 25 passed
