### PR TITLE
refactor(agents): extract agent session preparation

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-session.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session.test.ts
@@ -91,14 +91,15 @@ function createInput(options?: { activationError?: Error }) {
       events.push("resource-reload");
     }),
   };
+  const setActiveToolsByName = vi.fn(() => {
+    events.push("activate-tools");
+    if (options?.activationError) {
+      throw options.activationError;
+    }
+  });
   const activeSession = {
     agent: { id: "agent" },
-    setActiveToolsByName: vi.fn(() => {
-      events.push("activate-tools");
-      if (options?.activationError) {
-        throw options.activationError;
-      }
-    }),
+    setActiveToolsByName,
   } as unknown as AgentSession;
   const sessionManager = { id: "session-manager" };
   const sessionLockController = {
@@ -172,6 +173,7 @@ function createInput(options?: { activationError?: Error }) {
     },
     onDeliveredSourceReply: () => onDeliveredSourceReply?.(),
     resourceLoader,
+    setActiveToolsByName,
     sessionToolAllowlist,
     settingsManager,
   };
@@ -200,9 +202,7 @@ describe("prepareEmbeddedAttemptAgentSession", () => {
     ]);
     expect(hoisted.applyAgentAutoCompactionGuard).toHaveBeenCalledTimes(2);
     expect(hoisted.applyAgentCompactionSettingsFromConfig).toHaveBeenCalledOnce();
-    expect(fixture.activeSession.setActiveToolsByName).toHaveBeenCalledWith(
-      fixture.sessionToolAllowlist,
-    );
+    expect(fixture.setActiveToolsByName).toHaveBeenCalledWith(fixture.sessionToolAllowlist);
     expect(result).toEqual(
       expect.objectContaining({
         activeSession: fixture.activeSession,

--- a/src/agents/embedded-agent-runner/run/attempt-session.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentSession } from "../../sessions/index.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+const hoisted = vi.hoisted(() => ({
+  applyAgentAutoCompactionGuard: vi.fn(),
+  applyAgentCompactionSettingsFromConfig: vi.fn(),
+  applySystemPromptToSession: vi.fn(),
+  buildEmbeddedExtensionFactories: vi.fn(),
+  createAgentSession: vi.fn(),
+  createEmbeddedAgentResourceLoader: vi.fn(),
+  createPreparedEmbeddedAgentSettingsManager: vi.fn(),
+  getGlobalHookRunner: vi.fn(),
+  installMessageToolOnlyTerminalHook: vi.fn(),
+  prepareEmbeddedAttemptClientTools: vi.fn(),
+  resolveEffectiveCompactionMode: vi.fn(),
+  isSilentOverflowProneModel: vi.fn(),
+  resolveToolSearchCatalogTool: vi.fn(),
+  toToolDefinitions: vi.fn(),
+  wrapToolDefinition: vi.fn(),
+  notifyToolActivity: vi.fn(),
+}));
+
+vi.mock("../../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: hoisted.getGlobalHookRunner,
+}));
+vi.mock("../../agent-project-settings.js", () => ({
+  createPreparedEmbeddedAgentSettingsManager: hoisted.createPreparedEmbeddedAgentSettingsManager,
+}));
+vi.mock("../../agent-settings.js", () => ({
+  applyAgentAutoCompactionGuard: hoisted.applyAgentAutoCompactionGuard,
+  applyAgentCompactionSettingsFromConfig: hoisted.applyAgentCompactionSettingsFromConfig,
+  isSilentOverflowProneModel: hoisted.isSilentOverflowProneModel,
+  resolveEffectiveCompactionMode: hoisted.resolveEffectiveCompactionMode,
+}));
+vi.mock("../../agent-tool-definition-adapter.js", () => ({
+  toToolDefinitions: hoisted.toToolDefinitions,
+}));
+vi.mock("../../sessions/index.js", () => ({
+  createAgentSession: hoisted.createAgentSession,
+}));
+vi.mock("../../sessions/tools/tool-definition-wrapper.js", () => ({
+  wrapToolDefinition: hoisted.wrapToolDefinition,
+}));
+vi.mock("../../tool-search.js", () => ({
+  resolveToolSearchCatalogTool: hoisted.resolveToolSearchCatalogTool,
+}));
+vi.mock("../extensions.js", () => ({
+  buildEmbeddedExtensionFactories: hoisted.buildEmbeddedExtensionFactories,
+}));
+vi.mock("../logger.js", () => ({ log: { info: vi.fn() } }));
+vi.mock("../resource-loader.js", () => ({
+  createEmbeddedAgentResourceLoader: hoisted.createEmbeddedAgentResourceLoader,
+}));
+vi.mock("../system-prompt.js", () => ({
+  applySystemPromptToSession: hoisted.applySystemPromptToSession,
+}));
+vi.mock("./attempt-client-tools.js", () => ({
+  prepareEmbeddedAttemptClientTools: hoisted.prepareEmbeddedAttemptClientTools,
+}));
+vi.mock("./message-tool-terminal.js", () => ({
+  installMessageToolOnlyTerminalHook: hoisted.installMessageToolOnlyTerminalHook,
+}));
+vi.mock("./tool-activity-heartbeat.js", () => ({
+  notifyToolActivity: hoisted.notifyToolActivity,
+}));
+
+import { prepareEmbeddedAttemptAgentSession } from "./attempt-session.js";
+
+const attempt = {
+  authStorage: { id: "auth" },
+  config: {},
+  contextTokenBudget: 32_000,
+  model: { id: "model-1", api: "anthropic-messages" },
+  modelId: "model-1",
+  modelRegistry: { id: "registry" },
+  provider: "anthropic",
+  prompt: "prompt",
+  runId: "run-1",
+  sessionId: "session-1",
+  sourceReplyDeliveryMode: "message_tool_only",
+  timeoutMs: 30_000,
+  workspaceDir: "/workspace",
+} as unknown as EmbeddedRunAttemptParams;
+
+function createInput(options?: { activationError?: Error }) {
+  const events: string[] = [];
+  const settingsManager = { id: "settings" };
+  const resourceLoader = {
+    reload: vi.fn(async () => {
+      events.push("resource-reload");
+    }),
+  };
+  const activeSession = {
+    agent: { id: "agent" },
+    setActiveToolsByName: vi.fn(() => {
+      events.push("activate-tools");
+      if (options?.activationError) {
+        throw options.activationError;
+      }
+    }),
+  } as unknown as AgentSession;
+  const sessionManager = { id: "session-manager" };
+  const sessionLockController = {
+    withSessionWriteLock: vi.fn(async (operation: () => unknown) => await operation()),
+  };
+  const hookRunner = { id: "hooks" };
+  const sessionToolAllowlist = [{ name: "read" }];
+  const allCustomTools = [{ name: "custom" }];
+  const clientToolRuntime = {
+    builtinToolNames: new Set(["read"]),
+    clientToolCallSlots: [],
+    clientToolDefs: [],
+    clientToolLoopDetection: { enabled: true },
+    replaySafeToolNames: new Set(["read"]),
+    replaySafeTools: new Set(allCustomTools),
+  };
+  let onDeliveredSourceReply: (() => void) | undefined;
+
+  hoisted.createPreparedEmbeddedAgentSettingsManager.mockReturnValue(settingsManager);
+  hoisted.resolveEffectiveCompactionMode.mockReturnValue("safeguard");
+  hoisted.isSilentOverflowProneModel.mockReturnValue(false);
+  hoisted.buildEmbeddedExtensionFactories.mockReturnValue([{ id: "extension" }]);
+  hoisted.createEmbeddedAgentResourceLoader.mockReturnValue(resourceLoader);
+  hoisted.getGlobalHookRunner.mockReturnValue(hookRunner);
+  hoisted.prepareEmbeddedAttemptClientTools.mockReturnValue({
+    allCustomTools,
+    sessionToolAllowlist,
+    ...clientToolRuntime,
+  });
+  hoisted.createAgentSession.mockImplementation(async () => {
+    events.push("create-session");
+    return { session: activeSession };
+  });
+  hoisted.applySystemPromptToSession.mockImplementation(() => {
+    events.push("apply-system-prompt");
+  });
+  hoisted.installMessageToolOnlyTerminalHook.mockImplementation(
+    (input: { onDeliveredSourceReply?: () => void }) => {
+      events.push("install-terminal-hook");
+      onDeliveredSourceReply = input.onDeliveredSourceReply;
+    },
+  );
+
+  return {
+    activeSession,
+    allCustomTools,
+    clientToolRuntime,
+    events,
+    hookRunner,
+    input: {
+      attempt,
+      agentCoreThinkingLevel: "high" as const,
+      agentDir: "/agent",
+      clientToolPreparation: { deferredDirectoryToolsCallable: false } as never,
+      effectiveCwd: "/workspace",
+      getCurrentAttemptPluginMetadataSnapshot: () => undefined,
+      initialSystemPrompt: "system prompt",
+      markStage: (stage: string) => events.push(`stage:${stage}`),
+      onSessionCreated: (session: AgentSession) => {
+        expect(session).toBe(activeSession);
+        events.push("publish-session");
+      },
+      onSystemPromptChanged: (systemPrompt: string) => {
+        expect(systemPrompt).toBe("system prompt");
+        events.push("publish-system-prompt");
+      },
+      runAbortSignal: new AbortController().signal,
+      sessionAgentId: "agent-1",
+      sessionLockController: sessionLockController as never,
+      sessionManager: sessionManager as never,
+    },
+    onDeliveredSourceReply: () => onDeliveredSourceReply?.(),
+    resourceLoader,
+    sessionToolAllowlist,
+    settingsManager,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("prepareEmbeddedAttemptAgentSession", () => {
+  it("prepares resources and publishes the activated session runtime", async () => {
+    const fixture = createInput();
+
+    const result = await prepareEmbeddedAttemptAgentSession(fixture.input);
+
+    expect(fixture.events).toEqual([
+      "resource-reload",
+      "stage:session-resource-loader",
+      "create-session",
+      "publish-session",
+      "activate-tools",
+      "publish-system-prompt",
+      "apply-system-prompt",
+      "install-terminal-hook",
+      "stage:agent-session",
+    ]);
+    expect(hoisted.applyAgentAutoCompactionGuard).toHaveBeenCalledTimes(2);
+    expect(hoisted.applyAgentCompactionSettingsFromConfig).toHaveBeenCalledOnce();
+    expect(fixture.activeSession.setActiveToolsByName).toHaveBeenCalledWith(
+      fixture.sessionToolAllowlist,
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        activeSession: fixture.activeSession,
+        allCustomTools: fixture.allCustomTools,
+        hookRunner: fixture.hookRunner,
+        settingsManager: fixture.settingsManager,
+        ...fixture.clientToolRuntime,
+      }),
+    );
+    expect(result.hasDeliveredSourceReply()).toBe(false);
+    fixture.onDeliveredSourceReply();
+    expect(result.hasDeliveredSourceReply()).toBe(true);
+  });
+
+  it("publishes session ownership before activation can fail", async () => {
+    const fixture = createInput({ activationError: new Error("activation failed") });
+
+    await expect(prepareEmbeddedAttemptAgentSession(fixture.input)).rejects.toThrow(
+      "activation failed",
+    );
+
+    expect(fixture.events).toEqual([
+      "resource-reload",
+      "stage:session-resource-loader",
+      "create-session",
+      "publish-session",
+      "activate-tools",
+    ]);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-session.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session.ts
@@ -1,7 +1,34 @@
 /**
- * Creates embedded-agent sessions with the runner resource loader installed.
+ * Prepares embedded-agent resources, tools, and active sessions.
  */
-import type { CreateAgentSessionOptions } from "../../sessions/index.js";
+import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
+import type { PluginMetadataSnapshot } from "../../../plugins/plugin-metadata-snapshot.types.js";
+import { createPreparedEmbeddedAgentSettingsManager } from "../../agent-project-settings.js";
+import {
+  applyAgentAutoCompactionGuard,
+  applyAgentCompactionSettingsFromConfig,
+  isSilentOverflowProneModel,
+  resolveEffectiveCompactionMode,
+} from "../../agent-settings.js";
+import { toToolDefinitions } from "../../agent-tool-definition-adapter.js";
+import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
+import {
+  createAgentSession,
+  type AgentSession,
+  type CreateAgentSessionOptions,
+} from "../../sessions/index.js";
+import { wrapToolDefinition } from "../../sessions/tools/tool-definition-wrapper.js";
+import { resolveToolSearchCatalogTool } from "../../tool-search.js";
+import { buildEmbeddedExtensionFactories } from "../extensions.js";
+import { log } from "../logger.js";
+import { createEmbeddedAgentResourceLoader } from "../resource-loader.js";
+import { applySystemPromptToSession } from "../system-prompt.js";
+import { prepareEmbeddedAttemptClientTools } from "./attempt-client-tools.js";
+import type { AttemptContextEngine } from "./attempt.context-engine-helpers.js";
+import type { EmbeddedAttemptSessionLockController } from "./attempt.session-lock.js";
+import { installMessageToolOnlyTerminalHook } from "./message-tool-terminal.js";
+import { notifyToolActivity } from "./tool-activity-heartbeat.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
 
 /**
  * Session construction bridge for embedded-attempt runs.
@@ -21,6 +48,178 @@ type EmbeddedAgentSessionOptions = {
   resolveDeferredTool?: CreateAgentSessionOptions["resolveDeferredTool"];
   withSessionWriteLock?: CreateAgentSessionOptions["withSessionWriteLock"];
 };
+
+type ClientToolPreparation = Omit<
+  Parameters<typeof prepareEmbeddedAttemptClientTools>[0],
+  "attempt"
+>;
+
+type AttemptSessionManager = ReturnType<typeof guardSessionManager>;
+
+/** Prepares resource loading, client tools, and the active agent session. */
+export async function prepareEmbeddedAttemptAgentSession(input: {
+  attempt: EmbeddedRunAttemptParams;
+  activeContextEngineInfo?: AttemptContextEngine["info"];
+  agentCoreThinkingLevel: CreateAgentSessionOptions["thinkingLevel"];
+  agentDir: string;
+  clientToolPreparation: ClientToolPreparation;
+  effectiveCwd: string;
+  getCurrentAttemptPluginMetadataSnapshot: () => PluginMetadataSnapshot | undefined;
+  initialSystemPrompt: string;
+  markStage: (stage: string) => void;
+  onSessionCreated: (session: AgentSession) => void;
+  onSystemPromptChanged: (systemPrompt: string) => void;
+  runAbortSignal: AbortSignal;
+  sessionAgentId: string;
+  sessionLockController: EmbeddedAttemptSessionLockController;
+  sessionManager: AttemptSessionManager;
+}) {
+  const { attempt } = input;
+  const settingsManager = createPreparedEmbeddedAgentSettingsManager({
+    cwd: input.effectiveCwd,
+    agentDir: input.agentDir,
+    cfg: attempt.config,
+    pluginMetadataSnapshot: input.getCurrentAttemptPluginMetadataSnapshot(),
+    contextTokenBudget: attempt.contextTokenBudget,
+  });
+  const autoCompactionGuardArgs = {
+    settingsManager,
+    contextEngineInfo: input.activeContextEngineInfo,
+    compactionMode: resolveEffectiveCompactionMode(attempt.config),
+    silentOverflowProneProvider: isSilentOverflowProneModel({
+      provider: attempt.provider,
+      modelId: attempt.modelId,
+      baseUrl: attempt.model.baseUrl ?? undefined,
+    }),
+  };
+  applyAgentAutoCompactionGuard(autoCompactionGuardArgs);
+
+  // These factories carry compaction/pruning runtime state into the resource loader.
+  const extensionFactories = buildEmbeddedExtensionFactories({
+    cfg: attempt.config,
+    sessionManager: input.sessionManager,
+    provider: attempt.provider,
+    modelId: attempt.modelId,
+    model: attempt.model,
+    runId: attempt.runId,
+  });
+  const resourceLoader = createEmbeddedAgentResourceLoader({
+    cwd: input.effectiveCwd,
+    agentDir: input.agentDir,
+    settingsManager,
+    extensionFactories,
+  });
+  await resourceLoader.reload();
+  // reload() rehydrates disk settings. Reapply OpenClaw's context budget and
+  // auto-compaction guards before the session can submit a prompt (#75799).
+  applyAgentCompactionSettingsFromConfig({
+    settingsManager,
+    cfg: attempt.config,
+    contextTokenBudget: attempt.contextTokenBudget,
+  });
+  applyAgentAutoCompactionGuard(autoCompactionGuardArgs);
+  input.markStage("session-resource-loader");
+
+  // Tool creation needs the same runner later used by lifecycle hooks.
+  const hookRunner = getGlobalHookRunner();
+  const preparedClientTools = prepareEmbeddedAttemptClientTools({
+    attempt,
+    ...input.clientToolPreparation,
+  });
+  const { allCustomTools, sessionToolAllowlist, ...clientToolRuntime } = preparedClientTools;
+
+  const createdSession = await createEmbeddedAgentSessionWithResourceLoader({
+    createAgentSession: async (options) =>
+      await createAgentSession(options as unknown as Parameters<typeof createAgentSession>[0]),
+    options: {
+      cwd: input.effectiveCwd,
+      agentDir: input.agentDir,
+      authStorage: attempt.authStorage,
+      modelRegistry: attempt.modelRegistry,
+      model: attempt.model,
+      thinkingLevel: input.agentCoreThinkingLevel,
+      tools: sessionToolAllowlist,
+      customTools: allCustomTools,
+      sessionManager: input.sessionManager,
+      settingsManager,
+      resourceLoader,
+      resolveDeferredTool: input.clientToolPreparation.deferredDirectoryToolsCallable
+        ? ({ toolCall }) => {
+            const tool = resolveToolSearchCatalogTool(
+              {
+                config: attempt.config,
+                runtimeConfig: attempt.config,
+                agentId: input.sessionAgentId,
+                sessionKey: input.clientToolPreparation.sandboxSessionKey,
+                sessionId: attempt.sessionId,
+                runId: attempt.runId,
+                catalogRef: input.clientToolPreparation.toolSearchCatalogRef,
+                abortSignal: input.runAbortSignal,
+              },
+              toolCall.name,
+            );
+            // Catalog entries already own before_tool_call wrapping.
+            const definition = tool
+              ? toToolDefinitions([tool], input.clientToolPreparation.catalogToolHookContext)[0]
+              : undefined;
+            const hydratedTool = definition ? wrapToolDefinition(definition) : undefined;
+            if (hydratedTool) {
+              log.info(`tool-search: hydrated deferred directory tool ${toolCall.name}`);
+              const originalExecute = hydratedTool.execute;
+              hydratedTool.execute = (async (...args: Parameters<typeof originalExecute>) => {
+                const interval = setInterval(() => notifyToolActivity(attempt.runId), 60_000);
+                interval.unref?.();
+                try {
+                  notifyToolActivity(attempt.runId);
+                  return await originalExecute(...args);
+                } finally {
+                  clearInterval(interval);
+                  notifyToolActivity(attempt.runId);
+                }
+              }) as typeof originalExecute;
+            }
+            return hydratedTool;
+          }
+        : undefined,
+      withSessionWriteLock: (operation) =>
+        input.sessionLockController.withSessionWriteLock(operation),
+    },
+  });
+  const activeSession = createdSession.session;
+  if (!activeSession) {
+    throw new Error("Embedded agent session missing");
+  }
+  // Publish ownership before post-construction hooks. Outer cleanup must dispose
+  // the session if tool activation or terminal-hook installation fails.
+  input.onSessionCreated(activeSession);
+  activeSession.setActiveToolsByName(sessionToolAllowlist);
+  const setActiveSessionSystemPrompt = (nextSystemPrompt: string) => {
+    input.onSystemPromptChanged(nextSystemPrompt);
+    applySystemPromptToSession(activeSession, nextSystemPrompt);
+  };
+  setActiveSessionSystemPrompt(input.initialSystemPrompt);
+  let didDeliverSourceReplyViaMessageTool = false;
+  const markSourceReplyDelivered = () => {
+    didDeliverSourceReplyViaMessageTool = true;
+  };
+  installMessageToolOnlyTerminalHook({
+    agent: activeSession.agent,
+    sourceReplyDeliveryMode: attempt.sourceReplyDeliveryMode,
+    onDeliveredSourceReply: markSourceReplyDelivered,
+  });
+  input.markStage("agent-session");
+
+  return {
+    activeSession,
+    allCustomTools,
+    ...clientToolRuntime,
+    hasDeliveredSourceReply: () => didDeliverSourceReplyViaMessageTool,
+    hookRunner,
+    markSourceReplyDelivered,
+    setActiveSessionSystemPrompt,
+    settingsManager,
+  };
+}
 
 /** Invokes the supplied session factory with the prepared embedded-agent session options. */
 export async function createEmbeddedAgentSessionWithResourceLoader<Result>(params: {

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -26,7 +26,6 @@ import {
   buildAgentHookContextChannelFields,
   buildAgentHookContextIdentityFields,
 } from "../../../plugins/hook-agent-context.js";
-import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import { buildTrajectoryRunMetadata } from "../../../trajectory/metadata.js";
 import {
   createTrajectoryRuntimeRecorder,
@@ -34,15 +33,7 @@ import {
 } from "../../../trajectory/runtime.js";
 import { createBundleLspToolRuntime } from "../../agent-bundle-lsp-runtime.js";
 import { materializeBundleMcpToolsForRun } from "../../agent-bundle-mcp-tools.js";
-import { createPreparedEmbeddedAgentSettingsManager } from "../../agent-project-settings.js";
 import { resolveAgentDir, resolveSessionAgentIds } from "../../agent-scope.js";
-import {
-  applyAgentAutoCompactionGuard,
-  applyAgentCompactionSettingsFromConfig,
-  isSilentOverflowProneModel,
-  resolveEffectiveCompactionMode,
-} from "../../agent-settings.js";
-import { toToolDefinitions } from "../../agent-tool-definition-adapter.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
 import { isHeartbeatLifecycleRunKind } from "../../bootstrap-mode.js";
 import { createCacheTrace } from "../../cache-trace.js";
@@ -55,12 +46,10 @@ import { relocateCurrentRuntimeContextCarrierToTail } from "../../internal-runti
 import type { AgentMessage } from "../../runtime/index.js";
 import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import { acquireSessionWriteLock } from "../../session-write-lock.js";
-import { createAgentSession } from "../../sessions/index.js";
-import { wrapToolDefinition } from "../../sessions/tools/tool-definition-wrapper.js";
+import type { AgentSession } from "../../sessions/index.js";
 import { releasePendingAgentSteeringItems } from "../../subagent-registry.js";
 import {
   clearToolSearchCatalog,
-  resolveToolSearchCatalogTool,
   type ToolSearchCatalogRef,
   type ToolSearchCatalogToolExecutor,
 } from "../../tool-search.js";
@@ -68,11 +57,9 @@ import { invalidateComputerFrameIfMissing } from "../../tools/computer-tool.js";
 import type { NormalizedUsage } from "../../usage.js";
 import { readLastCacheTtlTimestamp } from "../cache-ttl.js";
 import { resolveCompactionTimeoutMs } from "../compaction-safety-timeout.js";
-import { buildEmbeddedExtensionFactories } from "../extensions.js";
 import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
 import { log } from "../logger.js";
 import type { PromptCacheBreak, PromptCacheChange } from "../prompt-cache-observability.js";
-import { createEmbeddedAgentResourceLoader } from "../resource-loader.js";
 import {
   clearActiveEmbeddedRun,
   type EmbeddedAgentQueueHandle,
@@ -83,7 +70,6 @@ import {
   getEmbeddedSessionPromptState,
 } from "../session-prompt-state.js";
 import { resolveEmbeddedAgentApiKey } from "../stream-resolution.js";
-import { applySystemPromptToSession } from "../system-prompt.js";
 import {
   installContextEngineLoopHook,
   installToolResultContextGuard,
@@ -100,7 +86,6 @@ import { completeEmbeddedAttemptAfterTurn } from "./attempt-after-turn.js";
 import { runEmbeddedAttemptBeforeAgentRun } from "./attempt-before-agent-run.js";
 import { prepareEmbeddedAttemptBootstrap } from "./attempt-bootstrap-prepare.js";
 import { prepareEmbeddedAttemptBundleTools } from "./attempt-bundle-tools.js";
-import { prepareEmbeddedAttemptClientTools } from "./attempt-client-tools.js";
 import { summarizeSessionContext } from "./attempt-context-summary.js";
 import { prepareEmbeddedAttemptHistory } from "./attempt-history-prepare.js";
 import {
@@ -115,7 +100,7 @@ import {
 import { submitEmbeddedAttemptPrompt } from "./attempt-prompt-submit.js";
 import { completeEmbeddedAttemptResult } from "./attempt-result.js";
 import { prepareEmbeddedAttemptSessionManager } from "./attempt-session-manager-prepare.js";
-import { createEmbeddedAgentSessionWithResourceLoader } from "./attempt-session.js";
+import { prepareEmbeddedAttemptAgentSession } from "./attempt-session.js";
 import { prepareEmbeddedAttemptSetup } from "./attempt-setup.js";
 import { createEmbeddedRunStageTracker } from "./attempt-stage-timing.js";
 import {
@@ -169,7 +154,6 @@ import { composeSystemPromptWithHookContext } from "./attempt.thread-helpers.js"
 import { shouldFlagCompactionTimeout } from "./compaction-timeout.js";
 import { installHistoryImagePruneContextTransform } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
-import { installMessageToolOnlyTerminalHook } from "./message-tool-terminal.js";
 import { isMidTurnPrecheckSignal, type MidTurnPrecheckRequest } from "./midturn-precheck.js";
 import { detachPrePersistedCurrentUserTurn } from "./pre-persisted-user-turn.js";
 import { PREEMPTIVE_OVERFLOW_ERROR_TEXT } from "./preemptive-compaction.js";
@@ -178,7 +162,7 @@ import {
   buildRuntimeContextCustomMessage,
   resolveRuntimeContextPromptParts,
 } from "./runtime-context-prompt.js";
-import { clearToolActivityRun, notifyToolActivity } from "./tool-activity-heartbeat.js";
+import { clearToolActivityRun } from "./tool-activity-heartbeat.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
 const aggregateToolResultPressureWarnings = new Set<string>();
@@ -571,7 +555,7 @@ export async function runEmbeddedAttempt(
     // Recheck after arming so a stopped run never reaches session creation or provider prompt.
     await throwIfAttemptAbortSignalFiredAfterPrepCleanup();
 
-    let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
+    let session: AgentSession | undefined;
     let removeToolResultContextGuard: (() => void) | undefined;
     let trajectoryRecorder: ReturnType<typeof createTrajectoryRuntimeRecorder> | null = null;
     let trajectoryEndRecorded = false;
@@ -598,161 +582,54 @@ export async function runEmbeddedAttempt(
         preparedSessionManager;
       sessionManager = preparedSessionManager.sessionManager;
 
-      const settingsManager = createPreparedEmbeddedAgentSettingsManager({
-        cwd: effectiveCwd,
-        agentDir,
-        cfg: params.config,
-        pluginMetadataSnapshot: getCurrentAttemptPluginMetadataSnapshot(),
-        contextTokenBudget: params.contextTokenBudget,
-      });
-      const autoCompactionGuardArgs = {
-        settingsManager,
-        contextEngineInfo: activeContextEngine?.info,
-        compactionMode: resolveEffectiveCompactionMode(params.config),
-        silentOverflowProneProvider: isSilentOverflowProneModel({
-          provider: params.provider,
-          modelId: params.modelId,
-          baseUrl: params.model.baseUrl ?? undefined,
-        }),
-      };
-      applyAgentAutoCompactionGuard(autoCompactionGuardArgs);
-
-      // Sets compaction/pruning runtime state and returns extension factories
-      // that must be passed to the resource loader for the safeguard to be active.
-      const extensionFactories = buildEmbeddedExtensionFactories({
-        cfg: params.config,
-        sessionManager,
-        provider: params.provider,
-        modelId: params.modelId,
-        model: params.model,
-        runId: params.runId,
-      });
-      const resourceLoader = createEmbeddedAgentResourceLoader({
-        cwd: effectiveCwd,
-        agentDir,
-        settingsManager,
-        extensionFactories,
-      });
-      await resourceLoader.reload();
-      // DefaultResourceLoader.reload() rehydrates settings from disk and can drop OpenClaw
-      // compaction overrides applied in createPreparedEmbeddedAgentSettingsManager — same
-      // rehydration also restores OpenClaw runtime's auto-compaction (openclaw#75799), so re-apply
-      // both guards.
-      applyAgentCompactionSettingsFromConfig({
-        settingsManager,
-        cfg: params.config,
-        contextTokenBudget: params.contextTokenBudget,
-      });
-      applyAgentAutoCompactionGuard(autoCompactionGuardArgs);
-      prepStages.mark("session-resource-loader");
-
-      // Get hook runner early so it's available when creating tools
-      const hookRunner = getGlobalHookRunner();
-
       const {
+        activeSession,
         allCustomTools,
         builtinToolNames,
         clientToolCallSlots,
         clientToolDefs,
         clientToolLoopDetection,
+        hasDeliveredSourceReply,
+        hookRunner,
+        markSourceReplyDelivered,
         replaySafeToolNames,
         replaySafeTools,
-        sessionToolAllowlist,
-      } = prepareEmbeddedAttemptClientTools({
+        setActiveSessionSystemPrompt,
+        settingsManager,
+      } = await prepareEmbeddedAttemptAgentSession({
         attempt: params,
-        catalogToolHookContext,
-        clientTools,
-        codeModeControlsEnabledForRun,
-        deferredDirectoryToolsCallable,
-        effectiveTools,
-        replaySafetyOptions,
-        sandboxEnabled: Boolean(sandbox?.enabled),
-        sandboxSessionKey,
-        sessionAgentId,
-        toolSearchCatalogRef,
-        toolSearchRuntimeConfig,
-        uncompactedEffectiveTools,
-      });
-
-      const createdSession = await createEmbeddedAgentSessionWithResourceLoader<
-        Awaited<ReturnType<typeof createAgentSession>>
-      >({
-        createAgentSession: async (options) =>
-          await createAgentSession(options as unknown as Parameters<typeof createAgentSession>[0]),
-        options: {
-          cwd: effectiveCwd,
-          agentDir,
-          authStorage: params.authStorage,
-          modelRegistry: params.modelRegistry,
-          model: params.model,
-          thinkingLevel: agentCoreThinkingLevel,
-          tools: sessionToolAllowlist,
-          customTools: allCustomTools,
-          sessionManager,
-          settingsManager,
-          resourceLoader,
-          resolveDeferredTool: deferredDirectoryToolsCallable
-            ? ({ toolCall }) => {
-                const tool = resolveToolSearchCatalogTool(
-                  {
-                    config: params.config,
-                    runtimeConfig: params.config,
-                    agentId: sessionAgentId,
-                    sessionKey: sandboxSessionKey,
-                    sessionId: params.sessionId,
-                    runId: params.runId,
-                    catalogRef: toolSearchCatalogRef,
-                    abortSignal: runAbortController.signal,
-                  },
-                  toolCall.name,
-                );
-                // Catalog entries already own before_tool_call wrapping.
-                const definition = tool
-                  ? toToolDefinitions([tool], catalogToolHookContext)[0]
-                  : undefined;
-                const hydratedTool = definition ? wrapToolDefinition(definition) : undefined;
-                if (hydratedTool) {
-                  log.info(`tool-search: hydrated deferred directory tool ${toolCall.name}`);
-                  const originalExecute = hydratedTool.execute;
-                  hydratedTool.execute = (async (...args: Parameters<typeof originalExecute>) => {
-                    const interval = setInterval(() => notifyToolActivity(params.runId), 60_000);
-                    interval.unref?.();
-                    try {
-                      notifyToolActivity(params.runId);
-                      const result = await originalExecute(...args);
-                      return result;
-                    } finally {
-                      clearInterval(interval);
-                      notifyToolActivity(params.runId);
-                    }
-                  }) as typeof originalExecute;
-                }
-                return hydratedTool;
-              }
-            : undefined,
-          withSessionWriteLock: (operation) =>
-            sessionLockController.withSessionWriteLock(operation),
+        activeContextEngineInfo: activeContextEngine?.info,
+        agentCoreThinkingLevel,
+        agentDir,
+        clientToolPreparation: {
+          catalogToolHookContext,
+          clientTools,
+          codeModeControlsEnabledForRun,
+          deferredDirectoryToolsCallable,
+          effectiveTools,
+          replaySafetyOptions,
+          sandboxEnabled: Boolean(sandbox?.enabled),
+          sandboxSessionKey,
+          sessionAgentId,
+          toolSearchCatalogRef,
+          toolSearchRuntimeConfig,
+          uncompactedEffectiveTools,
         },
+        effectiveCwd,
+        getCurrentAttemptPluginMetadataSnapshot,
+        initialSystemPrompt: systemPromptText,
+        markStage: (stage) => prepStages.mark(stage),
+        onSessionCreated: (createdSession) => {
+          session = createdSession;
+        },
+        onSystemPromptChanged: (nextSystemPrompt) => {
+          systemPromptText = nextSystemPrompt;
+        },
+        runAbortSignal: runAbortController.signal,
+        sessionAgentId,
+        sessionLockController,
+        sessionManager,
       });
-      session = createdSession.session;
-      if (!session) {
-        throw new Error("Embedded agent session missing");
-      }
-      session.setActiveToolsByName(sessionToolAllowlist);
-      const activeSession = session;
-      const setActiveSessionSystemPrompt = (nextSystemPrompt: string) => {
-        systemPromptText = nextSystemPrompt;
-        applySystemPromptToSession(activeSession, nextSystemPrompt);
-      };
-      setActiveSessionSystemPrompt(systemPromptText);
-      let didDeliverSourceReplyViaMessageTool = false;
-      const markSourceReplyDelivered = () => (didDeliverSourceReplyViaMessageTool = true);
-      installMessageToolOnlyTerminalHook({
-        agent: activeSession.agent,
-        sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-        onDeliveredSourceReply: markSourceReplyDelivered,
-      });
-      prepStages.mark("agent-session");
       if (isRawModelRun) {
         // Raw model probes should measure exactly the requested prompt against
         // the selected provider/model. Reset clears restored transcript state
@@ -1254,7 +1131,7 @@ export async function runEmbeddedAttempt(
           timedOut,
           yieldDetected,
         }),
-        hasDeliveredSourceReply: () => didDeliverSourceReplyViaMessageTool,
+        hasDeliveredSourceReply,
         markSourceReplyDelivered,
         onBlockReply,
         onBlockReplyFlush,
@@ -2082,7 +1959,7 @@ export async function runEmbeddedAttempt(
           promptCache,
           contextBudgetStatus,
           yieldDetected,
-          didDeliverSourceReplyViaMessageTool,
+          didDeliverSourceReplyViaMessageTool: hasDeliveredSourceReply(),
         },
         clientToolCallSlots,
         hookRunner,


### PR DESCRIPTION
## What Problem This Solves

`runEmbeddedAttempt` still owned settings setup, resource loading, client-tool preparation, session construction, activation, prompt installation, and delivery tracking in one function.

## Why This Change Was Made

Extract `prepareEmbeddedAttemptAgentSession` as the setup-phase owner. The helper returns the prepared runtime facts needed by the stream/finalize path and preserves the cleanup-critical rule that session ownership is published before tool activation can fail.

Related #72072.

## User Impact

No intended behavior change. `attempt.ts` drops from 2,235 to 2,112 lines while session preparation becomes directly testable.

## Evidence

- Blacksmith Testbox `tbx_01kxewj1jcphwt8g6b0gvdy04x`: 309 focused runner, session-lock, resource-loader, context-engine, and terminal-hook tests passed.
- `pnpm tsgo:core` passed.
- `pnpm tsgo:core:test` passed.
- Changed gate passed conflict-marker, TypeScript LOC ratchet, attribution, export, dependency, and formatting checks; it then stopped on unrelated Plugin SDK baseline hash drift. This branch changes only three agent-runner files.
- Fresh branch autoreview: no accepted or actionable findings; correctness 0.95.
- Hosted CI intentionally not awaited per maintainer instruction.
