### PR TITLE
fix(retry): recognize provider-wrapped transient 5xx for session retry

### DIFF
--- a/src/llm/utils/retry.test.ts
+++ b/src/llm/utils/retry.test.ts
@@ -112,4 +112,50 @@ describe("isRetryableAssistantError", () => {
       ),
     ).toBe(true);
   });
+
+  it.each([
+    "OpenAI API error (500): 500 The server had an error while processing your request. Sorry about that!",
+    "OpenAI API error (502): Bad Gateway",
+    "OpenAI API error (503): Service Unavailable upstream",
+    "OpenAI API error (504): Gateway Timeout",
+    "Azure OpenAI API error (503): Service Unavailable",
+    "Mistral API error (502): upstream error",
+    'Mistral API error (500): {"object":"error","message":"internal error"}',
+    "API error (500): plain wrapper without provider prefix",
+  ])("retries transient provider-wrapped 5xx: %s", (text) => {
+    expect(isRetryableAssistantError(errorMessage(text))).toBe(true);
+  });
+
+  it.each([
+    "OpenAI API error (400): Bad Request",
+    "OpenAI API error (401): Unauthorized",
+    "OpenAI API error (403): Forbidden",
+    "Azure OpenAI API error (404): Not Found",
+  ])("does not retry provider-wrapped non-transient 4xx: %s", (text) => {
+    expect(isRetryableAssistantError(errorMessage(text))).toBe(false);
+  });
+
+  it("retries provider-wrapped 429 with short window", () => {
+    expect(
+      isRetryableAssistantError(
+        errorMessage(
+          "OpenAI API error (429): RESOURCE_EXHAUSTED: Quota exceeded for requests per minute; please retry your request",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not retry provider-wrapped 429 with embedded quota failure", () => {
+    expect(
+      isRetryableAssistantError(errorMessage("OpenAI API error (429): insufficient_quota")),
+    ).toBe(false);
+  });
+
+  it("does not retry API error text embedded after unrelated leading prose", () => {
+    expect(
+      isRetryableAssistantError(
+        errorMessage("some earlier error: API error (503) was returned upstream"),
+      ),
+    ).toBe(false);
+  });
 });

--- a/src/llm/utils/retry.ts
+++ b/src/llm/utils/retry.ts
@@ -27,6 +27,8 @@ const RATE_LIMIT_CONTEXT_PATTERN = buildProviderErrorPattern([
   "quota exceeded",
 ]);
 
+const BUILTIN_PROVIDER_ERROR_STATUS_RE = /^(?:\w[\w ]* )?API error \((\d{3})\): /i;
+
 const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "overloaded",
   "rate.?limit",
@@ -68,14 +70,21 @@ export function isRetryableAssistantError(message: AssistantMessage): boolean {
     return false;
   }
   const status = extractLeadingHttpStatus(errorMessage)?.code;
-  if (status && status !== 429 && RETRYABLE_HTTP_STATUS_CODES.has(status)) {
+  const effectiveStatus =
+    status ?? (Number(BUILTIN_PROVIDER_ERROR_STATUS_RE.exec(errorMessage)?.[1] ?? 0) || undefined);
+  if (
+    effectiveStatus &&
+    effectiveStatus !== 429 &&
+    RETRYABLE_HTTP_STATUS_CODES.has(effectiveStatus)
+  ) {
     return true;
   }
-  const hasRateLimitContext = status === 429 || RATE_LIMIT_CONTEXT_PATTERN.test(errorMessage);
+  const hasRateLimitContext =
+    effectiveStatus === 429 || RATE_LIMIT_CONTEXT_PATTERN.test(errorMessage);
   if (hasRateLimitContext && classifyRateLimitWindow(errorMessage).kind === "long") {
     return false;
   }
-  if (status === 429) {
+  if (effectiveStatus === 429) {
     return true;
   }
   return RETRYABLE_PROVIDER_ERROR_PATTERN.test(errorMessage);


### PR DESCRIPTION

Closes #106824

## What Problem This Solves

Fixes an issue where users with OpenAI Responses, Azure OpenAI Responses, or Mistral providers would not get session auto-retry for transient 5xx errors (500/502/503/504). The built-in provider adapters format these errors as `OpenAI API error (500): ...`, but the retry classifier only recognized HTTP status codes at the very beginning of the message — so a transient provider failure would terminate the turn immediately instead of scheduling the normal same-model retry.

## Why This Change Was Made

The status extractor `extractLeadingHttpStatus` intentionally reads status only from the start of the error string, a hardening introduced in #105258 to prevent arbitrary numeric substrings (model IDs like `model-x-500-preview`, image dimensions) from accidentally triggering retries. However, the repository's own provider adapters — OpenAI Responses (`openai-responses.ts:56`), Azure OpenAI Responses (`azure-openai-responses.ts:47`), and Mistral (`mistral.ts:287`) — all produce a parenthesized wrapper format `Provider API error (status): message` that the extractor does not recognize, and the fallback keyword patterns also do not match the typical OpenAI/Mistral error body text.

The fix adds an anchored regex fallback at the call site in `isRetryableAssistantError` that recognizes the structured `API error (NNN):` envelope from the start of the message. It does not change `extractLeadingHttpStatus` or any shared helper module — the recognition scopes to the retry classifier alone, preserving the no-arbitrary-substring invariant from #105258. The regex is provider-agnostic (`/^(?:\w[\w ]* )?API error \((\d{3})\): /i`), so any adapter using the same parenthesized envelope — including the common `Provider API error (status):` convention used in `web-search-provider-common.ts:179` — is automatically covered without manual allowlist updates.

## User Impact

Transient 500/502/503/504 responses from all three built-in adapters can schedule the normal session retry path again instead of failing the turn immediately. Permanent errors (4xx, quota exhaustion, model-not-found) remain correctly classified as non-retryable. Users with Azure OpenAI or Mistral providers also benefit from the fix, not just the primary OpenAI Responses surface. The fix is provider-agnostic and does not require updates when new adapters join the existing `Provider API error (status)` convention.

## Evidence

**Unit tests** — 36/36 passing (21 existing + 15 new), no existing test modified:

```
✓ |unit| retry.test.ts > retries transient provider-wrapped 5xx: OpenAI API error (500): ...
✓ |unit| retry.test.ts > retries transient provider-wrapped 5xx: Azure OpenAI API error (503): ...
✓ |unit| retry.test.ts > retries transient provider-wrapped 5xx: Mistral API error (502): ...
✓ |unit| retry.test.ts > retries transient provider-wrapped 5xx: API error (500): plain ...
✓ |unit| retry.test.ts > does not retry provider-wrapped non-transient 4xx: OpenAI API error (400): ...
✓ |unit| retry.test.ts > retries provider-wrapped 429 with short window
✓ |unit| retry.test.ts > does not retry provider-wrapped 429 with embedded quota failure
✓ |unit| retry.test.ts > does not retry API error text embedded after unrelated leading prose
```

**Static checks** — oxlint: 0 warnings, 0 errors. tsgo: clean (typecheck passed).

**Real-behavior proof — AgentSession retry scheduling**:

Created a real `AgentSession` via production `createAgentSession`, subscribed to its event system (`agent-session.ts:818`), and drove a full prompt cycle where the mock LLM first returns the adapter-wrapped 5xx, triggering `AgentSession.willRetryAfterAgentEnd() → isRetryableAssistantError → true → prepareRetry() → emit("auto_retry_start")`, followed by a second LLM call completing successfully. The only mocked component is `streamSimple` (replaces real HTTP round-trip). Every other layer is production code:

```
=== session.prompt() start ===
[mock streamSimple] Call #1: returning error
[AgentSession] message_end role=assistant stopReason=error errorMessage=OpenAI API error (503): Service Unavailable contentText=none
[AgentSession] auto_retry_start attempt=1 maxAttempts=1 delayMs=0 error="OpenAI API error (503): Service Unavailable"
[mock streamSimple] Call #2: returning stop
[AgentSession] message_end role=assistant stopReason=stop errorMessage=none contentText=retry succeeded
[AgentSession] auto_retry_end attempt=1 success=true finalError="none"
=== session.prompt() end ===

Event trace: agent_start → turn_start → message_start → message_end → message_start → message_end → turn_end → agent_end → auto_retry_start → agent_start → turn_start → message_start → message_end → auto_retry_end → turn_end → agent_end

Retry occurred: YES ✓
```

This proves the full retry cycle:
1. LLM returns adapter-wrapped `OpenAI API error (503): ...`
2. `isRetryableAssistantError` returns `true`
3. `AgentSession.prepareRetry()` schedules retry and emits `auto_retry_start`
4. Retry issues a second LLM call (proving the scheduler dispatched it)
5. Second call succeeds — retry completes with `auto_retry_end`

**Diff** — +58/-3 across 2 files (product code +12/-3, tests +46/-0).

---

This PR is AI-assisted. Analysis, implementation, and testing were performed using AI tools (opencode) with review by the author.
