### PR TITLE
fix(ui): uniform control heights across settings clusters

### DIFF
--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -555,6 +555,7 @@ function renderJobsFilterPopover(props: CronProps, active: boolean) {
         <label class="field">
           <span>${t("cron.jobs.schedule")}</span>
           <select
+            class="settings-select"
             data-test-id="cron-jobs-schedule-filter"
             .value=${props.jobsScheduleKindFilter}
             @change=${(e: Event) =>
@@ -572,6 +573,7 @@ function renderJobsFilterPopover(props: CronProps, active: boolean) {
         <label class="field">
           <span>${t("cron.jobs.lastRun")}</span>
           <select
+            class="settings-select"
             data-test-id="cron-jobs-last-status-filter"
             .value=${props.jobsLastStatusFilter}
             @change=${(e: Event) =>
@@ -590,6 +592,7 @@ function renderJobsFilterPopover(props: CronProps, active: boolean) {
         <label class="field">
           <span>${t("cron.jobs.sort")}</span>
           <select
+            class="settings-select"
             .value=${props.jobsSortBy}
             @change=${(e: Event) =>
               props.onJobsFiltersChange({
@@ -604,6 +607,7 @@ function renderJobsFilterPopover(props: CronProps, active: boolean) {
         <label class="field">
           <span>${t("cron.jobs.direction")}</span>
           <select
+            class="settings-select"
             .value=${props.jobsSortDir}
             @change=${(e: Event) =>
               props.onJobsFiltersChange({

--- a/ui/src/pages/model-providers/default-models-view.ts
+++ b/ui/src/pages/model-providers/default-models-view.ts
@@ -83,6 +83,7 @@ export function renderDefaultModels(props: DefaultModelsViewProps) {
         <label class="field">
           <span>${t("modelProviders.defaults.primary")}</span>
           <select
+            class="settings-select"
             .value=${props.selection.primary}
             ?disabled=${disabled || saving}
             title=${title}
@@ -98,6 +99,7 @@ export function renderDefaultModels(props: DefaultModelsViewProps) {
         <label class="field">
           <span>${t("modelProviders.defaults.utility")}</span>
           <select
+            class="settings-select"
             .value=${props.selection.utilityModel ?? AUTOMATIC_UTILITY_VALUE}
             ?disabled=${disabled || saving}
             title=${title}
@@ -139,6 +141,7 @@ export function renderDefaultModels(props: DefaultModelsViewProps) {
         <label class="field model-providers__fallback-add">
           <span>${t("modelProviders.defaults.addFallback")}</span>
           <select
+            class="settings-select"
             .value=${""}
             ?disabled=${disabled || saving || !props.selection.primary}
             title=${title}

--- a/ui/src/pages/model-providers/view.ts
+++ b/ui/src/pages/model-providers/view.ts
@@ -399,6 +399,7 @@ function renderAddProvider(props: ModelProvidersViewProps) {
               <label class="field">
                 <span>${t("modelProviders.add.provider")}</span>
                 <select
+                  class="settings-select"
                   .value=${props.addProviderId}
                   @change=${(event: Event) =>
                     props.onAddProviderIdChange((event.target as HTMLSelectElement).value)}

--- a/ui/src/pages/usage/view-overview.ts
+++ b/ui/src/pages/usage/view-overview.ts
@@ -1053,6 +1053,7 @@ function renderSessionsCard(
           <label class="sessions-sort">
             <span>${t("usage.sessions.sort")}</span>
             <select
+              class="settings-select"
               @change=${(e: Event) =>
                 onSessionSortChange((e.target as HTMLSelectElement).value as typeof sessionSort)}
             >

--- a/ui/src/styles/cron.css
+++ b/ui/src/styles/cron.css
@@ -124,6 +124,14 @@
   flex-wrap: wrap;
 }
 
+/* Toolbar buttons share the settings control height with the adjacent
+   segmented switches, search input, and filter selects. */
+.cron-toolbar .btn {
+  height: var(--settings-control-height);
+  padding-block: 0;
+  box-sizing: border-box;
+}
+
 .cron-search-box {
   position: relative;
   flex: 1 1 220px;

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -1,3 +1,7 @@
+:root {
+  --settings-control-height: 32px;
+}
+
 /* ── Settings design language ──────────────────────────────────────────────
  *
  * One structural pattern for every settings surface:
@@ -180,11 +184,13 @@
 
 .settings-row__control {
   display: flex;
-  flex-wrap: wrap;
+  /* No wrap here: Chromium sizes a wrappable shrink-to-fit flex container to
+     its widest item, collapsing multi-control clusters. The <=640px block
+     gives the cluster a definite width and enables wrapping there. */
   align-items: center;
   justify-content: flex-end;
   gap: var(--space-2);
-  flex: 0 1 auto;
+  flex: 0 0 auto;
   min-width: 0;
   max-width: 60%;
 }
@@ -274,6 +280,40 @@
 }
 
 /* ── Controls ── */
+
+/* One control height inside settings clusters. Buttons, inputs, selects, and
+   segmented controls share 32px so mixed rows never show ragged heights.
+   Multi-select list boxes and textareas keep their natural height. */
+.settings-row__control .btn,
+.settings-section__actions .btn,
+.settings-group .data-table-search input,
+input.settings-input,
+select.settings-select:not([multiple]) {
+  height: var(--settings-control-height);
+  padding-block: 0;
+  box-sizing: border-box;
+}
+
+/* Segmented keeps its 2px track inset; the buttons fill the inner height.
+   min-height (not height) so many-option enums can still wrap to two lines. */
+.settings-segmented {
+  min-height: var(--settings-control-height);
+  box-sizing: border-box;
+  align-items: stretch;
+}
+
+.settings-segmented > .settings-segmented__btn {
+  display: inline-flex;
+  align-items: center;
+  padding-block: 0;
+}
+
+.settings-row__control .btn--icon,
+.settings-section__actions .btn--icon {
+  width: var(--settings-control-height);
+  min-width: var(--settings-control-height);
+  padding-inline: 0;
+}
 
 .settings-toggle {
   display: inline-flex;
@@ -526,6 +566,9 @@ textarea.settings-input {
   }
 
   .settings-row__control {
+    /* Definite width makes flex-wrap size lines correctly (see desktop note). */
+    width: 100%;
     max-width: 100%;
+    flex-wrap: wrap;
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Second polish pass on the settings design language (#106470): controls sitting in the same row or toolbar had mixed heights — text inputs rendered 41px, default buttons 38px, small buttons 33px, icon buttons 30–36px, segmented switches 33px — and eight selects (cron filter popover, model-provider default/fallback pickers, usage session sort) still rendered with the generic `.field` baseline instead of the design-language control style.

## Why This Change Was Made

A DOM audit script measured every control cluster across all 22 settings routes and flagged each cluster whose controls differed by >2px, plus every native-styled form control. Fixes, all at the design-language layer:

- New `--settings-control-height: 32px` token; buttons, inputs, selects, and segmented switches inside `.settings-row__control`, `.settings-section__actions`, and the cron toolbar all share it. Icon buttons become 32px squares.
- Segmented switches keep their 2px track inset with buttons filling the inner height (`min-height` so many-option enums can still wrap).
- The eight remaining native selects adopt `.settings-select`.
- Row control clusters wrap only at mobile widths where they have a definite width — Chromium sizes wrappable shrink-to-fit flex containers to their widest item, which would collapse multi-control clusters on desktop (documented in the stylesheet).

## User Impact

Every settings row and toolbar now shows one flush control height; the cron filter popover, model-provider pickers, and usage sort match the rest of the design language. CSS + class-only changes, no behavior changes.

## Evidence

| Surface | Before | After |
| --- | --- | --- |
| Connection (input + reveal button) | ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-settings-design-language/polish-connection-before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-settings-design-language/polish-connection-after.png) |
| Automations toolbar | ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-settings-design-language/polish-cron-before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-settings-design-language/polish-cron-after.png) |
| Model provider pickers | ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-settings-design-language/polish-modelproviders-before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-settings-design-language/polish-modelproviders-after.png) |

- Audit script re-run post-fix: zero height mismatches across all 22 routes (remaining flags are descendant-styled false positives).
- `node scripts/run-vitest.mjs` on touched pages (cron, model-providers, usage): 13 files / 129 tests green.
- Codex autoreview (`gpt-5.6-sol`, xhigh) on the branch diff: clean, no findings.
- Visually verified on Connection, Automations, Plugins, Devices, Model Providers, General, Sessions against the mock gateway.
