### PR TITLE
fix: prevent completed Codex hook relays from lingering

### DIFF
--- a/src/cli/hooks-cli.process.test.ts
+++ b/src/cli/hooks-cli.process.test.ts
@@ -2,16 +2,15 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { once } from "node:events";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 
-const tempDirs: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const activeChildren = new Set<ChildProcessWithoutNullStreams>();
 
 afterEach(async () => {
   await Promise.all(Array.from(activeChildren, terminateChild));
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
 });
 
 async function terminateChild(child: ChildProcessWithoutNullStreams): Promise<void> {
@@ -27,8 +26,7 @@ async function createLingeringPluginFixture(): Promise<{
   markerPath: string;
   stateDir: string;
 }> {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hooks-cli-"));
-  tempDirs.push(root);
+  const root = tempDirs.make("openclaw-hooks-cli-");
   const stateDir = path.join(root, "state");
   const pluginDir = path.join(root, "linger-plugin");
   const markerPath = path.join(root, "registered");
@@ -84,8 +82,7 @@ async function createLingeringPreloadFixture(): Promise<{
   preloadPath: string;
   stateDir: string;
 }> {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hooks-relay-"));
-  tempDirs.push(root);
+  const root = tempDirs.make("openclaw-hooks-relay-");
   const markerPath = path.join(root, "loaded");
   const preloadPath = path.join(root, "linger.mjs");
   const stateDir = path.join(root, "state");

--- a/src/cli/hooks-cli.process.test.ts
+++ b/src/cli/hooks-cli.process.test.ts
@@ -1,15 +1,26 @@
 // Hooks CLI process tests cover plugin-owned handles that outlive command output.
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 const tempDirs: string[] = [];
+const activeChildren = new Set<ChildProcessWithoutNullStreams>();
 
 afterEach(async () => {
+  await Promise.all(Array.from(activeChildren, terminateChild));
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
 });
+
+async function terminateChild(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  child.kill("SIGKILL");
+  await once(child, "close");
+}
 
 async function createLingeringPluginFixture(): Promise<{
   configPath: string;
@@ -68,24 +79,46 @@ async function createLingeringPluginFixture(): Promise<{
   return { configPath, markerPath, stateDir };
 }
 
-async function runHooksList(fixture: Awaited<ReturnType<typeof createLingeringPluginFixture>>) {
-  const child = spawn(
-    process.execPath,
-    ["--import", "tsx", "src/entry.ts", "hooks", "list", "--json"],
-    {
-      cwd: path.resolve("."),
-      env: {
-        ...process.env,
-        LINGER_MARKER: fixture.markerPath,
-        OPENCLAW_CONFIG_PATH: fixture.configPath,
-        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
-        OPENCLAW_STATE_DIR: fixture.stateDir,
-        NODE_ENV: undefined,
-        VITEST: undefined,
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-    },
+async function createLingeringPreloadFixture(): Promise<{
+  markerPath: string;
+  preloadPath: string;
+  stateDir: string;
+}> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hooks-relay-"));
+  tempDirs.push(root);
+  const markerPath = path.join(root, "loaded");
+  const preloadPath = path.join(root, "linger.mjs");
+  const stateDir = path.join(root, "state");
+  await fs.mkdir(stateDir, { recursive: true });
+  await fs.writeFile(
+    preloadPath,
+    [
+      'import fs from "node:fs";',
+      'fs.writeFileSync(process.env.LINGER_MARKER, "loaded\\n");',
+      "setInterval(() => {}, 60_000);",
+      "",
+    ].join("\n"),
   );
+  return { markerPath, preloadPath, stateDir };
+}
+
+async function runHooksCli(params: {
+  args: string[];
+  env?: NodeJS.ProcessEnv;
+  stdin?: string;
+  timeoutMessage: string;
+}) {
+  const child = spawn(process.execPath, ["--import", "tsx", "src/entry.ts", ...params.args], {
+    cwd: path.resolve("."),
+    env: {
+      ...process.env,
+      NODE_ENV: undefined,
+      VITEST: undefined,
+      ...params.env,
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  activeChildren.add(child);
   let stdout = "";
   let stderr = "";
   child.stdout.setEncoding("utf8");
@@ -96,6 +129,7 @@ async function runHooksList(fixture: Awaited<ReturnType<typeof createLingeringPl
   child.stderr.on("data", (chunk: string) => {
     stderr += chunk;
   });
+  child.stdin.end(params.stdin ?? "");
 
   return await new Promise<{
     code: number | null;
@@ -103,30 +137,102 @@ async function runHooksList(fixture: Awaited<ReturnType<typeof createLingeringPl
     stderr: string;
     stdout: string;
   }>((resolve, reject) => {
+    let timedOut = false;
     const timer = setTimeout(() => {
+      timedOut = true;
       child.kill("SIGKILL");
-      reject(new Error("hooks list did not exit after emitting output"));
     }, 15_000);
     child.once("error", (error) => {
       clearTimeout(timer);
+      activeChildren.delete(child);
       reject(error);
     });
     child.once("close", (code, signal) => {
       clearTimeout(timer);
+      activeChildren.delete(child);
+      if (timedOut) {
+        reject(new Error(`${params.timeoutMessage}\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+        return;
+      }
       resolve({ code, signal, stderr, stdout });
     });
   });
+}
+
+async function runHooksRelay(params: { event: "post_tool_use" | "pre_tool_use"; stdin: string }) {
+  const fixture = await createLingeringPreloadFixture();
+  const result = await runHooksCli({
+    args: [
+      "hooks",
+      "relay",
+      "--provider",
+      "codex",
+      "--relay-id",
+      "missing-relay",
+      "--event",
+      params.event,
+      "--timeout",
+      "50",
+    ],
+    env: {
+      LINGER_MARKER: fixture.markerPath,
+      NODE_OPTIONS: `--import=${fixture.preloadPath}`,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_NO_RESPAWN: "1",
+      OPENCLAW_STATE_DIR: fixture.stateDir,
+    },
+    stdin: params.stdin,
+    timeoutMessage: `hooks relay ${params.event} did not exit after emitting output`,
+  });
+  await expect(fs.readFile(fixture.markerPath, "utf8")).resolves.toBe("loaded\n");
+  return result;
 }
 
 describe("hooks CLI process lifecycle", () => {
   it("exits after JSON output when plugin registration leaves a ref'd handle", async () => {
     const fixture = await createLingeringPluginFixture();
 
-    const result = await runHooksList(fixture);
+    const result = await runHooksCli({
+      args: ["hooks", "list", "--json"],
+      env: {
+        LINGER_MARKER: fixture.markerPath,
+        OPENCLAW_CONFIG_PATH: fixture.configPath,
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        OPENCLAW_STATE_DIR: fixture.stateDir,
+      },
+      timeoutMessage: "hooks list did not exit after emitting output",
+    });
 
     expect(result, result.stderr).toMatchObject({ code: 0, signal: null });
     expect(result.stderr).not.toContain("Error:");
     expect(JSON.parse(result.stdout)).toMatchObject({ hooks: expect.any(Array) });
     await expect(fs.readFile(fixture.markerPath, "utf8")).resolves.toBe("registered\n");
+  }, 20_000);
+
+  it("exits successfully after an observational relay result with a ref'd handle", async () => {
+    const result = await runHooksRelay({ event: "post_tool_use", stdin: "{}" });
+
+    expect(result, result.stderr).toMatchObject({ code: 0, signal: null, stdout: "" });
+    expect(result.stderr).toMatch(/native hook relay (timed out|unavailable)/);
+  }, 20_000);
+
+  it("flushes fail-closed PreToolUse JSON before exiting with a ref'd handle", async () => {
+    const result = await runHooksRelay({ event: "pre_tool_use", stdin: "{}" });
+
+    expect(result, result.stderr).toMatchObject({ code: 0, signal: null });
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: expect.any(String),
+      },
+    });
+  }, 20_000);
+
+  it("preserves a malformed-input exit code with a ref'd handle", async () => {
+    const result = await runHooksRelay({ event: "post_tool_use", stdin: "{nope" });
+
+    expect(result).toMatchObject({ code: 1, signal: null, stdout: "" });
+    expect(result.stderr).toContain("failed to read native hook input");
   }, 20_000);
 });

--- a/src/cli/hooks-cli.process.test.ts
+++ b/src/cli/hooks-cli.process.test.ts
@@ -3,6 +3,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { once } from "node:events";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 
@@ -173,7 +174,7 @@ async function runHooksRelay(params: { event: "post_tool_use" | "pre_tool_use"; 
     ],
     env: {
       LINGER_MARKER: fixture.markerPath,
-      NODE_OPTIONS: `--import=${fixture.preloadPath}`,
+      NODE_OPTIONS: `--import=${pathToFileURL(fixture.preloadPath).href}`,
       OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
       OPENCLAW_NO_RESPAWN: "1",
       OPENCLAW_STATE_DIR: fixture.stateDir,

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -161,19 +161,20 @@ function writeHooksOutput(value: string, json: boolean | undefined): void {
   defaultRuntime.log(value);
 }
 
-async function runHooksCliAction(action: () => Promise<void> | void): Promise<void> {
+async function runHooksCliAction<T>(action: () => Promise<T> | T): Promise<T> {
   try {
-    await action();
+    return await action();
   } catch (err) {
-    exitHooksCliWithError(err);
+    return exitHooksCliWithError(err);
   }
 }
 
-async function runOneShotHooksCliAction(action: () => Promise<void> | void): Promise<void> {
-  await runHooksCliAction(action);
-  // Plugin registration can leave ref'd handles behind. Defer exit until runCli
-  // finishes shared teardown and drains both output streams.
-  requestExitAfterOneShotOutput();
+async function runOneShotHooksCliAction(action: () => Promise<number | void>): Promise<void> {
+  const result = await runHooksCliAction(action);
+  const exitCode = typeof result === "number" ? result : 0;
+  // CLI setup and handlers can leave ref'd handles behind. Defer exit until
+  // runCli finishes shared teardown and drains both output streams.
+  requestExitAfterOneShotOutput(defaultRuntime, exitCode);
 }
 
 /**
@@ -554,9 +555,7 @@ export function registerHooksCli(program: Command): void {
     )
     .option("--timeout <ms>", "Gateway timeout in ms", "5000")
     .action(async (opts: NativeHookRelayCliOptions) =>
-      runHooksCliAction(async () => {
-        process.exitCode = await runNativeHookRelayCli(opts);
-      }),
+      runOneShotHooksCliAction(() => runNativeHookRelayCli(opts)),
     );
 
   hooks


### PR DESCRIPTION
Closes #106838

## What Problem This Solves

Fixes an issue where users running native Codex hooks could leave completed OpenClaw relay CLI processes alive when CLI setup or a handler retained a referenced Node handle. Repeated parallel hook events could therefore accumulate process trees and memory after their relay work had finished.

## Why This Change Was Made

The hidden `hooks relay` command now uses the existing deferred one-shot shutdown path after its handler returns. The shared wrapper propagates the relay's numeric exit code, lets `runCli` complete normal harness, proxy, memory, and stdin teardown, and drains stdout and stderr before exiting. This does not change the native relay protocol, gateway behavior, configuration, or external timeout handling before a relay handler completes.

## User Impact

Completed native Codex hook relays now terminate even when a referenced Node handle would otherwise keep the CLI alive. This prevents completed relay processes from accumulating across parallel tool batches while preserving Codex-compatible output and exit statuses.

## Evidence

- Deterministic local process reproduction with a preload that creates a referenced `setInterval` and writes a marker proving it loaded:
  - Before, installed OpenClaw `2026.6.10` emitted complete fail-closed `PreToolUse` JSON but remained alive after 8 seconds and required `SIGKILL`.
  - After, the patched source CLI emitted the complete JSON and exited with code 0 in 2.6 seconds.
- Focused local suite: `node scripts/run-vitest.mjs src/cli/hooks-cli.process.test.ts src/cli/hooks-cli.test.ts src/cli/one-shot-exit.test.ts src/cli/native-hook-relay-cli.test.ts src/cli/run-main.exit.test.ts` — 5 files, 198 tests passed.
- Local core production and core-test typechecks passed.
- Type-aware lint passed for both changed files.
- Fresh local autoreview reported no accepted or actionable findings.
- `check:changed` passed its affected checks until the current-main Plugin SDK API baseline hash mismatch; the same mismatch reproduces with this patch fully stashed.

AI-assisted: Codex implemented and reviewed this change. I understand the lifecycle behavior and the regression coverage being submitted. Testing is complete for the touched CLI surface; the full repository suite was not run.
