### PR TITLE
fix(ci): restore Telegram extension lint

### DIFF
--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -423,7 +423,9 @@ describe("bot-native-command-menu", () => {
       accountId,
       botIdentity: "bot-a",
     });
-    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
     expect(deleteMyCommands).toHaveBeenCalledTimes(2);
     expect(setMyCommands).toHaveBeenCalledTimes(2);
   });


### PR DESCRIPTION
## What Problem This Solves

Restores the Telegram extension lint lane after the command-menu ordering test began implicitly returning the `setTimeout` handle from a Promise executor.

## Why This Change Was Made

The Promise executor now uses a block body, preserving the same one-tick wait while satisfying `no-promise-executor-return`.

## User Impact

No user-visible behavior changes. Maintainers regain a green lint gate on current `main`.

## Evidence

- Exact failure: https://github.com/openclaw/openclaw/actions/runs/29292903715/job/86960252428
- Blacksmith Testbox `tbx_01kxexa6yjrt7hna5xw35a6t99`: `pnpm check:changed -- extensions/telegram/src/bot-native-command-menu.test.ts` passed.
- Blacksmith Testbox `tbx_01kxexa6yjrt7hna5xw35a6t99`: targeted Telegram test passed, 25/25.
- Targeted `oxlint` and `oxfmt --check` passed.
- Fresh `gpt-5.6-sol` medium review: no findings, 0.99 confidence.
