### PR TITLE
fix(ui): retain settings route across queued patches

### DIFF
--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -645,6 +645,44 @@ describe("createSessionCapability", () => {
     sessions.dispose();
   });
 
+  it("does not dispatch a queued patch on a replacement connection", async () => {
+    const priorPatch = deferred<void>();
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.patch") {
+        return { ok: true, path: "", key: "agent:main:main", entry: {} };
+      }
+      if (method === "sessions.subscribe") {
+        return {};
+      }
+      if (method === "sessions.list") {
+        return sessionsResult([], 2);
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { gateway, publish } = createGatewayHarness(client);
+    const sessions = createSessionCapability(gateway);
+    const key = "agent:main:main";
+    sessions.setModelOverride(key, "openai/gpt-old");
+
+    const operation = sessions.patch(
+      key,
+      { model: "openai/gpt-new" },
+      { waitFor: priorPatch.promise },
+    );
+    expect(sessions.state.modelOverrides[key]).toBe("openai/gpt-new");
+    expect(request).not.toHaveBeenCalledWith("sessions.patch", expect.anything());
+
+    publish(false);
+    publish(true);
+    priorPatch.resolve();
+
+    await expect(operation).resolves.toBeNull();
+    expect(request).not.toHaveBeenCalledWith("sessions.patch", expect.anything());
+    expect(sessions.state.modelOverrides[key]).toBe("openai/gpt-old");
+    sessions.dispose();
+  });
+
   it("passes transcript fork parameters to sessions.create", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.create") {

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -90,7 +90,7 @@ export type SessionRunTerminal = {
   endedAt: number;
 };
 
-export type { SessionPatch, SessionPatchOptions } from "./patch.ts";
+export type { SessionPatch } from "./patch.ts";
 
 type SessionDeleteOptions = {
   agentId?: string;

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -5,7 +5,6 @@ import {
   type GatewayHelloOk,
 } from "../../api/gateway.ts";
 import type {
-  FastMode,
   GatewaySessionRow,
   SessionCompactionCheckpoint,
   SessionRunStatus,
@@ -29,6 +28,7 @@ import {
 } from "./create.ts";
 import { readSessionCustomGroupNames } from "./custom-groups.ts";
 import { scopedAgentListParamsForSession } from "./navigation.ts";
+import type { SessionPatch, SessionPatchOptions, SessionPatchRoute } from "./patch.ts";
 import {
   readSessionChangedEvent,
   reconcileSessionChanged,
@@ -90,18 +90,7 @@ export type SessionRunTerminal = {
   endedAt: number;
 };
 
-export type SessionPatch = {
-  label?: string | null;
-  category?: string | null;
-  model?: string | null;
-  thinkingLevel?: string | null;
-  fastMode?: FastMode | null;
-  verboseLevel?: string | null;
-  reasoningLevel?: string | null;
-  archived?: boolean;
-  pinned?: boolean;
-  unread?: boolean;
-};
+export type { SessionPatch, SessionPatchOptions } from "./patch.ts";
 
 type SessionDeleteOptions = {
   agentId?: string;
@@ -189,11 +178,7 @@ export type SessionCapability = {
   refresh: (options?: SessionRefreshOptions) => Promise<void>;
   createResult: (params?: SessionCreateParams) => Promise<SessionCreateOutcome | null>;
   create: (params?: SessionCreateParams) => Promise<string | null>;
-  patch: (
-    key: string,
-    patch: SessionPatch,
-    options?: { agentId?: string },
-  ) => Promise<SessionsPatchResult | null>;
+  patch: SessionPatchRoute;
   setModelOverride: (key: string, value: string | null | undefined) => void;
   delete: (key: string, options?: SessionDeleteOptions) => Promise<SessionDeleteOutcome>;
   deleteMany: (targets: readonly SessionDeleteTarget[]) => Promise<SessionDeleteBatchResult>;
@@ -1041,7 +1026,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
   const patch = async (
     key: string,
     patchParams: SessionPatch,
-    options: { agentId?: string } = {},
+    options: SessionPatchOptions = {},
   ): Promise<SessionsPatchResult | null> => {
     const scope = captureConnection();
     if (!scope) {
@@ -1069,6 +1054,13 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       setModelOverride(key, previousModelOverride);
     };
     try {
+      if (options.waitFor) {
+        await options.waitFor;
+        if (!isCurrentConnection(scope)) {
+          restoreModelOverride();
+          return null;
+        }
+      }
       const result = await requestSessionPatch(scope.client, key, patchParams, options);
       if (!isCurrentConnection(scope)) {
         restoreModelOverride();

--- a/ui/src/lib/sessions/patch.ts
+++ b/ui/src/lib/sessions/patch.ts
@@ -1,0 +1,26 @@
+import type { FastMode, SessionsPatchResult } from "../../api/types.ts";
+
+export type SessionPatch = {
+  label?: string | null;
+  category?: string | null;
+  model?: string | null;
+  thinkingLevel?: string | null;
+  fastMode?: FastMode | null;
+  verboseLevel?: string | null;
+  reasoningLevel?: string | null;
+  archived?: boolean;
+  pinned?: boolean;
+  unread?: boolean;
+};
+
+export type SessionPatchOptions = {
+  agentId?: string;
+  /** Capture the current connection now, but dispatch only after this tail settles. */
+  waitFor?: Promise<unknown>;
+};
+
+export type SessionPatchRoute = (
+  key: string,
+  patch: SessionPatch,
+  options?: SessionPatchOptions,
+) => Promise<SessionsPatchResult | null>;

--- a/ui/src/pages/chat/chat-settings-patches.ts
+++ b/ui/src/pages/chat/chat-settings-patches.ts
@@ -121,11 +121,12 @@ export function patchChatSessionSettings(
   const previous = getPendingChatPickerPatch(host, sessionKey, options.agentId);
   const operation = (async () => {
     // Model-dependent settings and sends share this canonical per-session tail.
-    // Later user intent still runs after a rejection and gets its own Gateway validation.
-    if (previous) {
-      await previous;
-    }
-    const result = await host.sessions.patch(sessionKey, patch, { agentId: options.agentId });
+    // The capability captures this route before waiting, so a reconnect cannot
+    // redirect queued intent to a replacement Gateway.
+    const result = await host.sessions.patch(sessionKey, patch, {
+      agentId: options.agentId,
+      waitFor: previous,
+    });
     if (result) {
       await options.reconcile?.(result);
     }

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -14,11 +14,8 @@ import type { UiSettings } from "../../app/settings.ts";
 import { i18n, t } from "../../i18n/index.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { SLASH_COMMANDS } from "../../lib/chat/commands.ts";
-import {
-  createSessionCapability,
-  type SessionCapability,
-  type SessionPatchOptions,
-} from "../../lib/sessions/index.ts";
+import { createSessionCapability, type SessionCapability } from "../../lib/sessions/index.ts";
+import type { SessionPatchOptions } from "../../lib/sessions/patch.ts";
 import {
   createModelCatalog,
   createSessionsListResult,

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -14,7 +14,11 @@ import type { UiSettings } from "../../app/settings.ts";
 import { i18n, t } from "../../i18n/index.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { SLASH_COMMANDS } from "../../lib/chat/commands.ts";
-import { createSessionCapability, type SessionCapability } from "../../lib/sessions/index.ts";
+import {
+  createSessionCapability,
+  type SessionCapability,
+  type SessionPatchOptions,
+} from "../../lib/sessions/index.ts";
 import {
   createModelCatalog,
   createSessionsListResult,
@@ -4759,16 +4763,21 @@ describe("chat model controls", () => {
     };
     const sessions = {
       state: { modelOverrides: {} },
-      patch: vi.fn((_key: string, patch: Record<string, unknown>) => {
-        patches.push(patch);
-        if (Object.hasOwn(patch, "model")) {
-          return modelPatch.promise;
-        }
-        if (Object.hasOwn(patch, "thinkingLevel")) {
-          return thinkingUpdate.promise;
-        }
-        return Promise.resolve(patchResult);
-      }),
+      patch: vi.fn(
+        async (_key: string, patch: Record<string, unknown>, options?: SessionPatchOptions) => {
+          if (options?.waitFor) {
+            await options.waitFor;
+          }
+          patches.push(patch);
+          if (Object.hasOwn(patch, "model")) {
+            return modelPatch.promise;
+          }
+          if (Object.hasOwn(patch, "thinkingLevel")) {
+            return thinkingUpdate.promise;
+          }
+          return patchResult;
+        },
+      ),
       refresh: async () => {},
       setModelOverride: vi.fn(),
     };
@@ -4829,10 +4838,15 @@ describe("chat model controls", () => {
     };
     const sessions = {
       state: { modelOverrides: {} },
-      patch: vi.fn((_key: string, patch: Record<string, unknown>) => {
-        patches.push(patch);
-        return Promise.resolve(patchResult);
-      }),
+      patch: vi.fn(
+        async (_key: string, patch: Record<string, unknown>, options?: SessionPatchOptions) => {
+          if (options?.waitFor) {
+            await options.waitFor;
+          }
+          patches.push(patch);
+          return patchResult;
+        },
+      ),
       refresh: async () => {},
       setModelOverride: vi.fn(),
     };
@@ -4876,10 +4890,15 @@ describe("chat model controls", () => {
     const patches: Array<Record<string, unknown>> = [];
     const sessions = {
       state: { modelOverrides: {} },
-      patch: vi.fn((_key: string, patch: Record<string, unknown>) => {
-        patches.push(patch);
-        return modelPatch.promise;
-      }),
+      patch: vi.fn(
+        async (_key: string, patch: Record<string, unknown>, options?: SessionPatchOptions) => {
+          if (options?.waitFor) {
+            await options.waitFor;
+          }
+          patches.push(patch);
+          return modelPatch.promise;
+        },
+      ),
       refresh: async () => {},
       setModelOverride: vi.fn(),
     };
@@ -4925,8 +4944,15 @@ describe("chat model controls", () => {
       chatThinkingLevel: null,
       sessionsResult: createSessionsResultFromRows([{ key: "main", kind: "direct", updatedAt: 1 }]),
       sessions: {
-        patch: () =>
-          new Promise((resolve, reject) => {
+        patch: async (
+          _key: string,
+          _patch: Record<string, unknown>,
+          options?: SessionPatchOptions,
+        ) => {
+          if (options?.waitFor) {
+            await options.waitFor;
+          }
+          return new Promise((resolve, reject) => {
             pendingPatches.push({
               resolve: () =>
                 resolve({
@@ -4937,7 +4963,8 @@ describe("chat model controls", () => {
                 }),
               reject,
             });
-          }),
+          });
+        },
         refresh: async () => {},
       },
     } as unknown as Parameters<typeof switchChatFastMode>[0];


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #106534. A queued Control UI settings patch waited before entering the session capability, so a reconnect during that wait could dispatch the old user intent on the replacement Gateway connection.

## Why This Change Was Made

The session capability now owns the optional queue tail. It captures the current connection synchronously, waits, then refuses dispatch if that connection was replaced. Patch types move to a small focused module so the shared capability stays under the TypeScript LOC ratchet.

## User Impact

Queued model, thinking, fast-mode, and related session-setting changes cannot leak across a reconnect to another Gateway route. Android receives the fix through the shared Control UI.

## Evidence

- Blacksmith Testbox `tbx_01kxexjfpvwdg81zzc25a17wys`: 232 focused UI tests passed.
- Same Testbox: `pnpm check:changed` passed format, LOC ratchet, typecheck, lint, and repository guards.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29293667899
- Fresh autoreview: no accepted/actionable findings.

No separate changelog entry: this repairs the unreleased implementation introduced by #106534, whose user-visible behavior is already documented.
