### PR TITLE
chore(deadcode): baseline the unused embedded-agent session factory export

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -678,6 +678,7 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/agents/embedded-agent-runner/resource-loader.ts: EMBEDDED_AGENT_RESOURCE_LOADER_DISCOVERY_OPTIONS",
   "src/agents/embedded-agent-runner/run.ts: testing",
   "src/agents/embedded-agent-runner/run/abortable.ts: OPENCLAW_ABORTABLE_WRAPPER",
+  "src/agents/embedded-agent-runner/run/attempt-session.ts: createEmbeddedAgentSessionWithResourceLoader",
   "src/agents/embedded-agent-runner/run/attempt-trajectory-status.ts: NON_DELIVERABLE_TERMINAL_TURN_REASON",
   "src/agents/embedded-agent-runner/run/attempt-trajectory-status.ts: ResolveAttemptTrajectoryTerminalParams",
   "src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts: insertRuntimeContextMessageForPrompt",


### PR DESCRIPTION
## What Problem This Solves

`check-dependencies` fails on current main: `src/agents/embedded-agent-runner/run/attempt-session.ts` exports `createEmbeddedAgentSessionWithResourceLoader` with no callers and no baseline entry, so every open PR's merge-tree CI inherits a red check. Main's own CI hides this because rapid pushes cancel each run (last three main CI runs: cancelled).

## Why This Change Was Made

One-line ratchet absorb produced by `pnpm deadcode:exports:update` on current main (run on a Blacksmith Testbox; only this entry was emitted). Baselining rather than deleting because the export landed within the last hours as part of active embedded-agent-runner/skill-workshop work — deleting another stream's fresh surface is riskier than marking it; if a caller lands next, the entry prunes in the next update, and if not, the owner deletes the export and the entry together.

## User Impact

None — CI-only. Unblocks merge-tree CI for all open PRs.

## Evidence

- Failing check on any current merge tree: `check-dependencies` → "Unexpected unused exports: … attempt-session.ts: createEmbeddedAgentSessionWithResourceLoader" (e.g. run 29292215116).
- `pnpm deadcode:exports:update` on current main produces exactly this diff and nothing else.
