### PR TITLE
test: remove restart sleeps and finalization races

### DIFF
--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -1709,18 +1709,20 @@ describe("gateway agent handler", () => {
         "task",
         "background cli seam task",
       );
-      expect(finalizeTaskRunByRunIdSpy).toHaveBeenCalledTimes(1);
-      expectRecordFields(mockCallArg(finalizeTaskRunByRunIdSpy), {
-        runtime: "cli",
-        runId: "task-registry-agent-seam",
-        status: "succeeded",
-        terminalSummary: "completed",
-      });
-      expectRecordFields(findTaskByRunId("task-registry-agent-seam"), {
-        runtime: "cli",
-        childSessionKey: "agent:main:main",
-        status: "succeeded",
-        terminalSummary: "completed",
+      await waitForAssertion(() => {
+        expect(finalizeTaskRunByRunIdSpy).toHaveBeenCalledTimes(1);
+        expectRecordFields(mockCallArg(finalizeTaskRunByRunIdSpy), {
+          runtime: "cli",
+          runId: "task-registry-agent-seam",
+          status: "succeeded",
+          terminalSummary: "completed",
+        });
+        expectRecordFields(findTaskByRunId("task-registry-agent-seam"), {
+          runtime: "cli",
+          childSessionKey: "agent:main:main",
+          status: "succeeded",
+          terminalSummary: "completed",
+        });
       });
     });
   });
@@ -2024,23 +2026,25 @@ describe("gateway agent handler", () => {
         { context, respond, reqId: "task-registry-finalize-throw" },
       );
 
-      // Finalize threw, but the run must still complete (second res frame with ok status).
-      expect(finalizeTaskRunByRunIdSpy).toHaveBeenCalledTimes(1);
-      const completed = respond.mock.calls.some(([ok, payload]) => {
-        return ok === true && (payload as { status?: string } | undefined)?.status === "ok";
-      });
-      expect(completed).toBe(true);
+      await waitForAssertion(() => {
+        // Finalize threw, but the run must still complete (second res frame with ok status).
+        expect(finalizeTaskRunByRunIdSpy).toHaveBeenCalledTimes(1);
+        const completed = respond.mock.calls.some(([ok, payload]) => {
+          return ok === true && (payload as { status?: string } | undefined)?.status === "ok";
+        });
+        expect(completed).toBe(true);
 
-      // The swallowed finalize error stays observable via a warn log.
-      const warnMock = context.logGateway.warn as ReturnType<typeof vi.fn>;
-      const loggedFinalizeError = warnMock.mock.calls.some(([message]) => {
-        return (
-          typeof message === "string" &&
-          message.includes("failed to finalize tracked agent task") &&
-          message.includes("finalize boom")
-        );
+        // The swallowed finalize error stays observable via a warn log.
+        const warnMock = context.logGateway.warn as ReturnType<typeof vi.fn>;
+        const loggedFinalizeError = warnMock.mock.calls.some(([message]) => {
+          return (
+            typeof message === "string" &&
+            message.includes("failed to finalize tracked agent task") &&
+            message.includes("finalize boom")
+          );
+        });
+        expect(loggedFinalizeError).toBe(true);
       });
-      expect(loggedFinalizeError).toBe(true);
     });
   });
 });

--- a/src/infra/restart.test.ts
+++ b/src/infra/restart.test.ts
@@ -47,6 +47,7 @@ beforeEach(() => {
   resolveGatewayPortMock.mockReset();
   resolveLsofCommandSyncMock.mockReturnValue("/usr/sbin/lsof");
   resolveGatewayPortMock.mockReturnValue(18789);
+  vi.spyOn(Atomics, "wait").mockReturnValue("timed-out");
 });
 
 afterEach(() => {


### PR DESCRIPTION
## What Problem This Solves

Two restart unit tests paid the real 600 ms graceful-stop delay and 400 ms force-stop delay, adding about two seconds to every run even though the suite mocks process discovery and signals. Two detached agent-task tests also asserted background finalization immediately after the accepted response, causing a CI race and avoidable reruns.

## Why This Change Was Made

Stub `Atomics.wait` in the restart unit-test setup, matching the dedicated stale-PID suite while preserving all signal-order assertions. Use the existing microtask-aware `waitForAssertion` helper for terminal detached-task state, completion response, and warning-log assertions.

## User Impact

No runtime behavior changes. The restart test body drops from about 2.0 seconds to about 40 ms, and detached-task coverage waits for the event it owns instead of racing it.

## Evidence

- Hosted baseline [29293046356](https://github.com/openclaw/openclaw/actions/runs/29293046356): `src/infra/restart.test.ts` took 2018 ms; the two stale-PID cases took 1003 ms each.
- Exact-base Blacksmith Testbox [29293920280](https://github.com/openclaw/openclaw/actions/runs/29293920280): restart 7/7 passed with 41 ms test time; the stale-PID cases took 2 ms and 1 ms.
- Exact-base detached-task focused coverage passed 2/2 on Testbox `tbx_01kxexvtkt1cymq0376q49hj6g`.
- Exact-base changed gate passed core/core-test types, format, lint, and static guards on Testbox `tbx_01kxexvtkt1cymq0376q49hj6g`.
- Fresh autoreview reported no accepted/actionable findings; correctness confidence 0.96.

AI-assisted implementation; maintainer-directed and independently validated.
