### PR TITLE
fix(sandbox): pin LC_ALL=C for sandbox stat on localized hosts

### DIFF
--- a/src/agents/sandbox/fs-bridge-shell-command-plans.ts
+++ b/src/agents/sandbox/fs-bridge-shell-command-plans.ts
@@ -22,7 +22,9 @@ export function buildStatPlan(
 ): SandboxFsCommandPlan {
   return {
     checks: [{ target, options: { action: "stat files" } }],
-    script: 'set -eu\ncd -- "$1"\nstat -c "%F|%s|%y" -- "$2"',
+    // Pin LC_ALL=C so the `%F` type word and the ENOENT stderr stay English on
+    // localized hosts; the caller matches both against fixed English strings.
+    script: 'set -eu\ncd -- "$1"\nLC_ALL=C stat -c "%F|%s|%y" -- "$2"',
     args: [anchoredTarget.canonicalParentPath, anchoredTarget.basename],
     allowFailure: true,
   };

--- a/src/agents/sandbox/fs-bridge.shell.test.ts
+++ b/src/agents/sandbox/fs-bridge.shell.test.ts
@@ -67,6 +67,15 @@ describe("sandbox fs bridge shell compatibility", () => {
     });
   });
 
+  it("pins LC_ALL=C on stat so localized hosts still parse the type word and absence", async () => {
+    const bridge = createSandboxFsBridge({ sandbox: createSandbox() });
+
+    await bridge.stat({ filePath: "c.txt" });
+
+    const scripts = getScriptsFromCalls();
+    expectSomeScriptContaining(scripts, "LC_ALL=C stat -c");
+  });
+
   it("path canonicalization recheck script is valid POSIX sh", async () => {
     const bridge = createSandboxFsBridge({ sandbox: createSandbox() });
 


### PR DESCRIPTION
## What Problem This Solves

`SandboxFsBridge.stat()` decides whether a path is missing by matching the sandbox `stat` command's stderr against the English string `"No such file or directory"` (`src/agents/sandbox/fs-bridge.ts`). On a host whose shell/libc runs in a non-English locale, `stat` emits a translated ENOENT message, so an absent file falls through to `throw` instead of returning `null`. The same locale sensitivity hits the success path: `%F` prints a translated type word (e.g. `répertoire`), and `coerceStatType()` only recognizes the English `"directory"`, so a directory is misclassified as `"other"`. (Reported in #106576.)

## Why This Change Was Made

The fix is at the root: `buildStatPlan()` now runs the probe as `LC_ALL=C stat -c "%F|%s|%y" …`. Pinning `LC_ALL=C` for that one command forces both the ENOENT stderr and the `%F` type word to their fixed English forms that the caller already matches, instead of adding locale-specific string tables or a second `test -e` round-trip. It also stabilizes the `%y` mtime formatting the caller parses. `LC_ALL=C` is a plain per-command env assignment: corrective on glibc hosts and a harmless no-op on BusyBox/Alpine, so no backend regresses.

## User Impact

Sandbox filesystem `stat` (existence checks, type detection) now behaves identically regardless of the host locale. Missing files return `null` rather than throwing, and directories are typed correctly, on localized hosts.

## Evidence

- New focused regression in `src/agents/sandbox/fs-bridge.shell.test.ts` asserts the stat plan emits `LC_ALL=C stat -c`; full file green (9 passed) via `node scripts/run-vitest.mjs src/agents/sandbox/fs-bridge.shell.test.ts`. Without the fix the assertion fails (script was `stat -c` with no locale pin).
- `git diff --check` clean; change is 2 files, +12/−1; no `CHANGELOG.md` edit.
- Source-reproducible: the behavior is a fixed English-string match against locale-dependent `stat` output; a live localized host is not required to demonstrate the defect or the fix.

Fixes #106576
