### PR TITLE
fix: stabilize detached agent terminal assertions

### DIFF
--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -1709,18 +1709,20 @@ describe("gateway agent handler", () => {
         "task",
         "background cli seam task",
       );
-      expect(finalizeTaskRunByRunIdSpy).toHaveBeenCalledTimes(1);
-      expectRecordFields(mockCallArg(finalizeTaskRunByRunIdSpy), {
-        runtime: "cli",
-        runId: "task-registry-agent-seam",
-        status: "succeeded",
-        terminalSummary: "completed",
-      });
-      expectRecordFields(findTaskByRunId("task-registry-agent-seam"), {
-        runtime: "cli",
-        childSessionKey: "agent:main:main",
-        status: "succeeded",
-        terminalSummary: "completed",
+      await waitForAssertion(() => {
+        expect(finalizeTaskRunByRunIdSpy).toHaveBeenCalledTimes(1);
+        expectRecordFields(mockCallArg(finalizeTaskRunByRunIdSpy), {
+          runtime: "cli",
+          runId: "task-registry-agent-seam",
+          status: "succeeded",
+          terminalSummary: "completed",
+        });
+        expectRecordFields(findTaskByRunId("task-registry-agent-seam"), {
+          runtime: "cli",
+          childSessionKey: "agent:main:main",
+          status: "succeeded",
+          terminalSummary: "completed",
+        });
       });
     });
   });
@@ -2024,23 +2026,27 @@ describe("gateway agent handler", () => {
         { context, respond, reqId: "task-registry-finalize-throw" },
       );
 
-      // Finalize threw, but the run must still complete (second res frame with ok status).
-      expect(finalizeTaskRunByRunIdSpy).toHaveBeenCalledTimes(1);
-      const completed = respond.mock.calls.some(([ok, payload]) => {
-        return ok === true && (payload as { status?: string } | undefined)?.status === "ok";
-      });
-      expect(completed).toBe(true);
-
-      // The swallowed finalize error stays observable via a warn log.
       const warnMock = context.logGateway.warn as ReturnType<typeof vi.fn>;
-      const loggedFinalizeError = warnMock.mock.calls.some(([message]) => {
-        return (
-          typeof message === "string" &&
-          message.includes("failed to finalize tracked agent task") &&
-          message.includes("finalize boom")
-        );
+      await waitForAssertion(() => {
+        // Finalize threw, but the run must still complete (second res frame with ok status).
+        expect(finalizeTaskRunByRunIdSpy).toHaveBeenCalledTimes(1);
+        expect(
+          respond.mock.calls.some(([ok, payload]) => {
+            return ok === true && (payload as { status?: string } | undefined)?.status === "ok";
+          }),
+        ).toBe(true);
+
+        // The swallowed finalize error stays observable via a warn log.
+        expect(
+          warnMock.mock.calls.some(([message]) => {
+            return (
+              typeof message === "string" &&
+              message.includes("failed to finalize tracked agent task") &&
+              message.includes("finalize boom")
+            );
+          }),
+        ).toBe(true);
       });
-      expect(loggedFinalizeError).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI race where detached agent terminal assertions could run before background finalization completed. Under load, the test waited almost two seconds, failed with zero finalize calls, and required a rerun even though runtime behavior was correct.

## Why This Change Was Made

The two affected tests now use the existing condition-based assertion helper for terminal-only state. Task creation assertions remain immediate, and no fixed sleep or production behavior change is introduced.

AI-assisted change; behavior and diff reviewed before submission.

## User Impact

No user-visible behavior change. Maintainer CI gets fewer false failures and wasted reruns.

## Evidence

- Before: hosted CI run 29289505601 attempt 1 failed after 1,999 ms because `finalizeTaskRunByRunIdSpy` had zero calls; attempt 2 passed unchanged.
- Blacksmith Testbox lease `tbx_01kxexsv7swrz1y0g5z11gm9hx`: both focused tests passed 20 consecutive runs (40 assertions total), with each pair taking about 198-212 ms.
- `pnpm check:changed`: passed remotely on the same lease in 2m51s, including format, TSGo core/test types, lint, cycle, and repository guards.
- Fresh autoreview: no findings; patch correct at 0.98 confidence.
