### PR TITLE
fix(msteams): keep delegated auth healthy when an expired token can auto-refresh

### DIFF
--- a/extensions/msteams/src/probe.test.ts
+++ b/extensions/msteams/src/probe.test.ts
@@ -103,7 +103,9 @@ describe("msteams probe", () => {
     });
   });
 
-  it("reports delegated tokens expired when the process clock is invalid", async () => {
+  it("treats an expired delegated access token as healthy when a refresh token is present", async () => {
+    // NaN clock forces the expiry check to fail; a stored refresh token means
+    // the client auto-refreshes, so the probe must not report a health failure.
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(Number.NaN);
     hostMockState.delegatedTokens = {
       accessToken: "delegated-token",
@@ -126,10 +128,43 @@ describe("msteams probe", () => {
         appId: "app",
         graph: { ok: true, roles: undefined, scopes: undefined },
         delegatedAuth: {
+          ok: true,
+          scopes: ["ChatMessage.Send"],
+          userPrincipalName: "user@example.com",
+        },
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("reports delegated auth unhealthy when the token is expired and no refresh token is stored", async () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(Number.NaN);
+    hostMockState.delegatedTokens = {
+      accessToken: "delegated-token",
+      refreshToken: "",
+      expiresAt: Date.parse("2030-01-01T00:00:00.000Z"),
+      scopes: ["ChatMessage.Send"],
+      userPrincipalName: "user@example.com",
+    };
+    const cfg = {
+      enabled: true,
+      appId: "app",
+      appPassword: "pw",
+      tenantId: "tenant",
+      delegatedAuth: { enabled: true },
+    } as unknown as MSTeamsConfig;
+
+    try {
+      await expect(probeMSTeams(cfg)).resolves.toEqual({
+        ok: true,
+        appId: "app",
+        graph: { ok: true, roles: undefined, scopes: undefined },
+        delegatedAuth: {
           ok: false,
           scopes: ["ChatMessage.Send"],
           userPrincipalName: "user@example.com",
-          error: "token expired (will auto-refresh on next use)",
+          error: "token expired and no refresh token available (re-run setup wizard)",
         },
       });
     } finally {

--- a/extensions/msteams/src/probe.ts
+++ b/extensions/msteams/src/probe.ts
@@ -103,11 +103,17 @@ export async function probeMSTeams(cfg?: MSTeamsConfig): Promise<ProbeMSTeamsRes
         const tokens = loadDelegatedTokens();
         if (tokens) {
           const isExpired = !isFutureDateTimestampMs(tokens.expiresAt);
+          // An expired access token is not a health failure while a refresh
+          // token is stored: the client refreshes it on the next API call. Only
+          // an expired token with no refresh token needs operator re-auth.
+          const canAutoRefresh = Boolean(tokens.refreshToken);
           delegatedAuth = {
-            ok: !isExpired,
+            ok: !isExpired || canAutoRefresh,
             scopes: tokens.scopes,
             userPrincipalName: tokens.userPrincipalName,
-            ...(isExpired ? { error: "token expired (will auto-refresh on next use)" } : {}),
+            ...(isExpired && !canAutoRefresh
+              ? { error: "token expired and no refresh token available (re-run setup wizard)" }
+              : {}),
           };
         } else {
           delegatedAuth = { ok: false, error: "no delegated tokens found (run setup wizard)" };


### PR DESCRIPTION
## What Problem This Solves

`probeMSTeams` marks the MS Teams channel unhealthy (`delegatedAuth.ok: false`) whenever the cached delegated **access** token is expired (`extensions/msteams/src/probe.ts`). But an expired access token is not a broken connection: the delegated-token path (`token.ts`) refreshes it from the stored refresh token on the next API call. The result is false-positive health failures — alert spam and channel restarts — for a connector that is actually fine. The existing code even labels it "will auto-refresh on next use" while still reporting a failure. (Reported in #106566.)

## Why This Change Was Made

`loadDelegatedTokens()` returns a `refreshToken` alongside the access-token `expiresAt`, and `getDelegatedAccessToken()` already auto-refreshes an expired access token using it. So the probe now treats an expired access token as healthy **when a refresh token is stored** (`ok: !isExpired || canAutoRefresh`), matching real runtime behavior. The genuine-failure signal is preserved: an expired token with **no** refresh token still reports `ok: false` with a clearer "re-run setup wizard" message, because that state genuinely needs operator re-auth. The probe intentionally does not attempt a network refresh to verify the refresh token server-side — that would change a cheap local health check into an API call; presence is the intended, issue-specified proxy.

## User Impact

MS Teams channel health checks stop firing false alarms (and stop triggering needless restarts) for connectors whose access token has simply aged out but can auto-refresh. Operators are still alerted when delegated auth is truly unrecoverable (expired with no refresh token).

## Evidence

- `extensions/msteams/src/probe.test.ts`: the prior test that asserted `ok: false` for an expired-but-refreshable token is corrected to expect `ok: true` with no error; a new test covers expired + no refresh token → `ok: false` with the re-auth message. Full file green (5 passed) via `node scripts/run-vitest.mjs extensions/msteams/src/probe.test.ts`.
- `git diff --check` clean; 2 files, +45/−4; no `CHANGELOG.md` edit.
- Source-reproducible: the false positive is a local health computation over stored token fields; no live MS Teams tenant is required to demonstrate it.

Fixes #106566
