### PR TITLE
fix(fleet): harden logs and restore recovery

### DIFF
--- a/docs/cli/fleet.md
+++ b/docs/cli/fleet.md
@@ -166,7 +166,7 @@ openclaw fleet logs acme --tail 200
 openclaw fleet logs acme --since 10m
 ```
 
-Fleet verifies the registered container's ownership labels before reading any logs, so it refuses a foreign container using the expected cell name. Press Ctrl-C to end `--follow` without treating the operator stop as a command failure. Log output is piped through a redaction filter that replaces the cell's current Gateway token with `<redacted>` before anything reaches the terminal.
+Fleet verifies the registered container's ownership labels before reading any logs, so it refuses a foreign container using the expected cell name. The stream is pinned to that inspected container ID, so a concurrent replacement cannot redirect it to a newer generation. Press Ctrl-C to end `--follow` without treating the operator stop as a command failure. Log output is piped through a redaction filter that replaces the cell's current Gateway token with `<redacted>` before anything reaches the terminal.
 
 `fleet logs` has no `--json` mode because container logs are a raw stdout/stderr stream. For scripts, bound the output with `--tail` and use ordinary shell redirection or pipelines.
 
@@ -218,6 +218,8 @@ openclaw fleet restore acme --from ./acme.tgz
 ```
 
 These are host-operator-privileged commands. Archives contain tenant state and auth secrets, are created with mode `0600`, and must be stored like credentials. Backup refuses a running cell so SQLite state is captured consistently. Restore refuses a running cell unless `--force` is supplied, replaces only that tenant's state, rotates the Gateway token, and prints the new token once. Fleet backs up one tenant at a time; all-tenant backup is a separate operator action.
+
+Restore needs an existing stopped container because its inspected runtime profile supplies the replacement limits, user mapping, environment provenance, and image. If the registered container was removed out of band, first run `fleet rm <tenant> --force` without `--purge-data`, recreate the cell with the intended image and `--no-start`, then retry restore. The first removal keeps both tenant data directories intact.
 
 Both commands accept `--max-bytes <bytes>` to bound archived or extracted file data, and both apply the same fixed one-million budget of archive path segments so metadata-only archive bombs cannot exhaust host inodes and every accepted backup stays restorable. Backup accepts `--out <path>` and both commands support `--json`.
 

--- a/src/fleet/backup.runtime.test.ts
+++ b/src/fleet/backup.runtime.test.ts
@@ -44,7 +44,7 @@ function inspection(running = false): Extract<FleetContainerInspectResult, { kin
   };
 }
 
-function containerMock(current = inspection()) {
+function containerMock(current: FleetContainerInspectResult = inspection()) {
   return {
     assertLocal: vi.fn(async () => undefined),
     inspect: vi.fn(async () => current),

--- a/src/fleet/backup.runtime.test.ts
+++ b/src/fleet/backup.runtime.test.ts
@@ -18,6 +18,7 @@ const tempRoot = createSuiteTempRootTracker({ prefix: "openclaw-fleet-backup-tes
 function inspection(running = false): Extract<FleetContainerInspectResult, { kind: "ok" }> {
   return {
     kind: "ok",
+    containerId: "container-id",
     state: running ? "running" : "exited",
     running,
     labels: {
@@ -305,6 +306,16 @@ describe("fleet restore runtime", () => {
     await expect(restoreFleetCell(restoreParams(running, archive))).rejects.toThrow(
       /pass --force/iu,
     );
+  });
+
+  it("gives a usable recovery sequence when the registered container is missing", async () => {
+    const archive = await createArchive();
+    const containers = containerMock({ kind: "missing", state: "missing" });
+
+    await expect(restoreFleetCell(restoreParams(containers, archive))).rejects.toThrow(
+      /fleet rm acme --force.*fleet create acme --no-start --image <image>.*retry fleet restore/iu,
+    );
+    expect(containers.remove).not.toHaveBeenCalled();
   });
 
   it("rejects archives inside cell state and foreign cell networks before mutation", async () => {

--- a/src/fleet/backup.runtime.ts
+++ b/src/fleet/backup.runtime.ts
@@ -499,7 +499,7 @@ export async function restoreFleetCell(params: {
   );
   if (inspectionResult.kind === "missing") {
     throw new Error(
-      `Fleet cell container is missing for ${params.record.tenantId}; create the cell (openclaw fleet create ${params.record.tenantId}) and then restore into it.`,
+      `Fleet cell container is missing for ${params.record.tenantId}; remove the stale registration without purging data (openclaw fleet rm ${params.record.tenantId} --force), recreate a stopped cell with the intended image (openclaw fleet create ${params.record.tenantId} --no-start --image <image>), then retry fleet restore.`,
     );
   }
   const inspection = assertManagedInspection(params.record, inspectionResult);

--- a/src/fleet/containers.runtime.test.ts
+++ b/src/fleet/containers.runtime.test.ts
@@ -154,10 +154,11 @@ describe("fleet container runtime", () => {
     const executor = vi.fn<FleetContainerCommandExecutor>(async () => ({
       stdout: JSON.stringify([
         {
+          Id: "container-id",
           Image: "sha256:old-image-id",
           State: { Status: "running", Running: true },
           Config: {
-            Env: ["OPENCLAW_GATEWAY_TOKEN=secret", "FEATURE=a=b"],
+            Env: ["OPENCLAW_GATEWAY_TOKEN=test-auth-token", "FEATURE=a=b"],
             Image: "ghcr.io/openclaw/openclaw:latest",
             Labels: { "openclaw.fleet.tenant": "acme" },
             User: "1000:1000",
@@ -178,10 +179,11 @@ describe("fleet container runtime", () => {
       createFleetContainerRuntime(executor).inspect("podman", "cell-acme"),
     ).resolves.toEqual({
       kind: "ok",
+      containerId: "container-id",
       state: "running",
       running: true,
       labels: { "openclaw.fleet.tenant": "acme" },
-      environment: { OPENCLAW_GATEWAY_TOKEN: "secret", FEATURE: "a=b" },
+      environment: { OPENCLAW_GATEWAY_TOKEN: "test-auth-token", FEATURE: "a=b" },
       imageId: "sha256:old-image-id",
       memory: "2147483648",
       cpus: "2",
@@ -544,6 +546,7 @@ describe("fleet container runtime", () => {
         : {
             stdout: JSON.stringify([
               {
+                Id: "container-id",
                 Image: "sha256:image",
                 State: { Status: "running", Running: true },
                 Config: { Env: [], Labels: {} },

--- a/src/fleet/containers.runtime.ts
+++ b/src/fleet/containers.runtime.ts
@@ -62,6 +62,7 @@ type FleetContainerLogsOptions = {
 export type FleetContainerInspectResult =
   | {
       kind: "ok";
+      containerId: string;
       state: string;
       running: boolean;
       labels: Record<string, string>;
@@ -293,6 +294,7 @@ function parseInspectOutput(stdout: string): Extract<FleetContainerInspectResult
 
   return {
     kind: "ok",
+    containerId: requireString(inspected.Id),
     state: requireString(state.Status),
     running: requireBoolean(state.Running),
     labels: readLabels(config.Labels),

--- a/src/fleet/containers.runtime.ts
+++ b/src/fleet/containers.runtime.ts
@@ -58,7 +58,6 @@ type FleetContainerLogsOptions = {
   since?: string;
   redactValues: readonly string[];
 };
-
 export type FleetContainerInspectResult =
   | {
       kind: "ok";
@@ -283,7 +282,6 @@ function parseInspectOutput(stdout: string): Extract<FleetContainerInspectResult
   if (!Array.isArray(parsed) || parsed.length !== 1) {
     throw new InvalidInspectOutputError();
   }
-
   const inspected = requireRecord(parsed[0]);
   const state = requireRecord(inspected.State);
   const config = requireRecord(inspected.Config);

--- a/src/fleet/doctor.runtime.test.ts
+++ b/src/fleet/doctor.runtime.test.ts
@@ -20,6 +20,7 @@ const tempRoot = createSuiteTempRootTracker({ prefix: "openclaw-fleet-doctor-" }
 function healthyInspection(): Extract<FleetContainerInspectResult, { kind: "ok" }> {
   return {
     kind: "ok",
+    containerId: "container-id",
     state: "running",
     running: true,
     labels: {

--- a/src/fleet/service-removal.runtime.test.ts
+++ b/src/fleet/service-removal.runtime.test.ts
@@ -36,6 +36,7 @@ function runningInspection(
 ): Extract<FleetContainerInspectResult, { kind: "ok" }> {
   return {
     kind: "ok",
+    containerId: "container-id",
     state: "running",
     running: true,
     labels: fleetLabels(),
@@ -91,6 +92,7 @@ function createContainerMock(
         running: start,
         labels: fleetLabels(profile.tenantId, profile.attemptId),
         environment: { ...profile.environment },
+        containerId: `container-${profile.attemptId}`,
         imageId: `sha256:${profile.attemptId}`,
         memory: profile.memory,
         cpus: profile.cpus,

--- a/src/fleet/service.runtime.test.ts
+++ b/src/fleet/service.runtime.test.ts
@@ -33,6 +33,7 @@ function runningInspection(
 ): Extract<FleetContainerInspectResult, { kind: "ok" }> {
   return {
     kind: "ok",
+    containerId: "container-id",
     state: "running",
     running: true,
     labels: fleetLabels(),
@@ -88,6 +89,7 @@ function createContainerMock(
         running: start,
         labels: fleetLabels(profile.tenantId, profile.attemptId),
         environment: { ...profile.environment },
+        containerId: `container-${profile.attemptId}`,
         imageId: `sha256:${profile.attemptId}`,
         memory: profile.memory,
         cpus: profile.cpus,
@@ -546,7 +548,7 @@ describe("fleet service", () => {
     expect(containers[action]).toHaveBeenCalledWith("docker", "openclaw-cell-acme");
   });
 
-  it("streams logs only after proving container ownership", async () => {
+  it("pins logs to the inspected container generation after proving ownership", async () => {
     const containers = createContainerMock();
     const service = createFleetService({ env, containers: containers.runtime, now: () => 1000 });
     await service.create({ tenant: "acme", gatewayToken: "token" });
@@ -556,7 +558,7 @@ describe("fleet service", () => {
       service.logs({ tenant: "acme", follow: true, tail: 100, since: "10m" }),
     ).resolves.toBeUndefined();
 
-    expect(containers.logs).toHaveBeenCalledWith("docker", "openclaw-cell-acme", {
+    expect(containers.logs).toHaveBeenCalledWith("docker", "container-id", {
       follow: true,
       tail: 100,
       since: "10m",

--- a/src/fleet/service.runtime.ts
+++ b/src/fleet/service.runtime.ts
@@ -538,7 +538,9 @@ export function createFleetService(options: FleetServiceOptions = {}) {
         await containers.inspect(record.runtime, record.containerName),
       );
       const gatewayCredential = inspection.environment.OPENCLAW_GATEWAY_TOKEN;
-      await containers.logs(record.runtime, record.containerName, {
+      // Pin the stream to the inspected generation. A concurrent restore can
+      // replace the named container after ownership inspection but before logs attach.
+      await containers.logs(record.runtime, inspection.containerId, {
         follow: logOptions.follow,
         tail: logOptions.tail,
         since: logOptions.since,

--- a/src/fleet/service.runtime.ts
+++ b/src/fleet/service.runtime.ts
@@ -528,7 +528,6 @@ export function createFleetService(options: FleetServiceOptions = {}) {
         },
       });
     },
-
     async logs(logOptions: FleetLogsOptions): Promise<void> {
       const record = requireCell(env, validateTenantId(logOptions.tenant));
       await containers.assertLocal(record.runtime);
@@ -538,8 +537,7 @@ export function createFleetService(options: FleetServiceOptions = {}) {
         await containers.inspect(record.runtime, record.containerName),
       );
       const gatewayCredential = inspection.environment.OPENCLAW_GATEWAY_TOKEN;
-      // Pin the stream to the inspected generation. A concurrent restore can
-      // replace the named container after ownership inspection but before logs attach.
+      // Pin the inspected generation so a concurrent restore cannot redirect the stream.
       await containers.logs(record.runtime, inspection.containerId, {
         follow: logOptions.follow,
         tail: logOptions.tail,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `fleet logs` could pass ownership checks for one container generation but attach by reusable name to a replacement created concurrently. Also fixes missing-container restore guidance that told operators to run `fleet create` while the stale registry row still made that command fail.

## Why This Change Was Made

Successful Docker and Podman inspection now carries the runtime's immutable container ID, and log streaming uses that inspected ID after ownership verification. Missing-container restore errors and Fleet docs now describe the working retained-data recovery sequence: remove the stale registration without purging, recreate a stopped cell with the intended image, then restore.

AI-assisted. The implementation, dependency contracts, and live Docker behavior were reviewed directly.

## User Impact

Fleet operators can trust a log stream to stay on the ownership-checked container generation during concurrent replacement. Operators whose registered cell container was removed out of band now receive recovery steps that work without deleting tenant data.

## Evidence

- Runtime head on Blacksmith Testbox `tbx_01kxeyrjcy11dzqr7aktzn05dh` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/29294665643)): `pnpm test src/fleet src/cli/fleet-cli` — 218 tests passed; `pnpm build` — passed.
- Exact rebased head `2011114e5cb9` on fresh Testbox `tbx_01kxf0srp669y4da9hag0wqah4` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/29296337204)): all 218 focused tests, `pnpm check:test-types`, `pnpm deadcode:exports`, and `pnpm build` passed.
- Blacksmith Testbox `tbx_01kxexygdhd28w9538c9ecxezc` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/29293996552)), real Docker lifecycle: create stopped cell, write marker, backup, remove container out of band, verify the new recovery error, execute its remove/recreate steps, restore archive, verify marker, and read logs — `FLEET_RECOVERY_STRESS_OK`.
- Pre-fix real Docker stress on Testbox `tbx_01kxex60ye8hntevtvvew7wsp3`: eight concurrent cells; create/list/start/health/status/doctor/log redaction/backup/restore/upgrade; same-tenant create race produced exactly one winner; parallel purge left an empty fleet.
- `pnpm check:changed`: conflict, LOC ratchet, attribution, wildcard export, duplicate coverage, dependency pin, and formatting checks passed. The later Plugin SDK baseline check also fails on exact `origin/main` with the same hash mismatch; this PR touches no Plugin SDK surface.
- Fresh local autoreview: no findings.
