### PR TITLE
feat(control-ui): show compaction savings and run time

### DIFF
--- a/src/gateway/server-methods/chat-history-pages.test.ts
+++ b/src/gateway/server-methods/chat-history-pages.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+import { enrichChatHistoryCompactionMarkers } from "./chat-history-pages.js";
+
+describe("enrichChatHistoryCompactionMarkers", () => {
+  it("joins checkpoint token metrics to the matching transcript marker", () => {
+    const marker = {
+      role: "system",
+      __openclaw: { kind: "compaction", id: "compact-entry-1", seq: 4 },
+    };
+    const entry = {
+      compactionCheckpoints: [
+        {
+          checkpointId: "checkpoint-1",
+          sessionKey: "main",
+          sessionId: "session-1",
+          createdAt: 1_000,
+          reason: "auto-threshold",
+          tokensBefore: 900_000,
+          tokensAfter: 24_700,
+          preCompaction: { sessionId: "session-1" },
+          postCompaction: { sessionId: "session-1", entryId: "compact-entry-1" },
+        },
+      ],
+    } as SessionEntry;
+
+    const result = enrichChatHistoryCompactionMarkers([marker], entry);
+
+    expect(result[0]).toEqual({
+      ...marker,
+      __openclaw: {
+        ...marker["__openclaw"],
+        tokensBefore: 900_000,
+        tokensAfter: 24_700,
+      },
+    });
+    expect(marker["__openclaw"]).not.toHaveProperty("tokensBefore");
+  });
+
+  it("preserves message identity without a matching checkpoint", () => {
+    const marker = {
+      role: "system",
+      __openclaw: { kind: "compaction", id: "compact-entry-1" },
+    };
+
+    const result = enrichChatHistoryCompactionMarkers([marker], undefined);
+
+    expect(result[0]).toBe(marker);
+  });
+});

--- a/src/gateway/server-methods/chat-history-pages.ts
+++ b/src/gateway/server-methods/chat-history-pages.ts
@@ -428,11 +428,3 @@ export async function readChatHistoryPage(params: {
     },
   };
 }
-
-export async function readEnrichedChatHistoryPage(
-  params: Parameters<typeof readChatHistoryPage>[0],
-): Promise<ChatHistoryPage> {
-  const page = await readChatHistoryPage(params);
-  const messages = enrichChatHistoryCompactionMarkers(page.messages, params.entry);
-  return messages === page.messages ? page : { ...page, messages };
-}

--- a/src/gateway/server-methods/chat-history-pages.ts
+++ b/src/gateway/server-methods/chat-history-pages.ts
@@ -44,6 +44,55 @@ type ChatHistoryPage = {
   };
 };
 
+/** Add checkpoint token metrics to the synthetic transcript compaction marker. */
+export function enrichChatHistoryCompactionMarkers(
+  messages: unknown[],
+  entry: ReturnType<typeof loadSessionEntry>["entry"],
+): unknown[] {
+  const checkpoints = entry?.compactionCheckpoints;
+  if (!Array.isArray(checkpoints) || checkpoints.length === 0) {
+    return messages;
+  }
+  const checkpointByEntryId = new Map(
+    checkpoints.flatMap((checkpoint) => {
+      const entryId = checkpoint.postCompaction?.entryId;
+      return typeof entryId === "string" && entryId ? [[entryId, checkpoint] as const] : [];
+    }),
+  );
+  let changed = false;
+  const enriched = messages.map((message) => {
+    const record = asOptionalRecord(message);
+    const metadata = asOptionalRecord(record?.["__openclaw"]);
+    if (metadata?.kind !== "compaction" || typeof metadata.id !== "string") {
+      return message;
+    }
+    const checkpoint = checkpointByEntryId.get(metadata.id);
+    if (!checkpoint) {
+      return message;
+    }
+    const tokensBefore = checkpoint.tokensBefore;
+    const tokensAfter = checkpoint.tokensAfter;
+    if (
+      (typeof tokensBefore !== "number" || !Number.isFinite(tokensBefore)) &&
+      (typeof tokensAfter !== "number" || !Number.isFinite(tokensAfter))
+    ) {
+      return message;
+    }
+    changed = true;
+    return {
+      ...record,
+      __openclaw: {
+        ...metadata,
+        ...(typeof tokensBefore === "number" && Number.isFinite(tokensBefore)
+          ? { tokensBefore }
+          : {}),
+        ...(typeof tokensAfter === "number" && Number.isFinite(tokensAfter) ? { tokensAfter } : {}),
+      },
+    };
+  });
+  return changed ? enriched : messages;
+}
+
 function capOffsetChatHistoryProjectedMessages(messages: unknown[], max: number): unknown[] {
   if (messages.length <= max) {
     return messages;
@@ -378,4 +427,12 @@ export async function readChatHistoryPage(params: {
       ),
     },
   };
+}
+
+export async function readEnrichedChatHistoryPage(
+  params: Parameters<typeof readChatHistoryPage>[0],
+): Promise<ChatHistoryPage> {
+  const page = await readChatHistoryPage(params);
+  const messages = enrichChatHistoryCompactionMarkers(page.messages, params.entry);
+  return messages === page.messages ? page : { ...page, messages };
 }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -563,10 +563,8 @@ async function handleChatHistoryRequest({
   const historyEntry =
     requestedSessionId && requestedSessionId !== entry?.sessionId ? undefined : entry;
   const resolvedSessionModel = resolveSessionModelRef(cfg, entry, sessionAgentId);
-  const hardMax = 1000;
-  const defaultLimit = 200;
-  const requested = typeof limit === "number" ? limit : defaultLimit;
-  const max = Math.min(hardMax, requested);
+  const requested = typeof limit === "number" ? limit : 200;
+  const max = Math.min(1000, requested);
   const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
   const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(cfg, maxChars);
   const historyPage = await readChatHistoryPage({

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -103,7 +103,7 @@ import {
   capChatHistoryAroundMessage,
   readChatHistoryMessageId,
   readChatHistoryMessageSeq,
-  readChatHistoryPage,
+  readEnrichedChatHistoryPage,
 } from "./chat-history-pages.js";
 import {
   hasGatewayAdminScope,
@@ -568,7 +568,7 @@ async function handleChatHistoryRequest({
   const max = Math.min(hardMax, requested);
   const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
   const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(cfg, maxChars);
-  const historyPage = await readChatHistoryPage({
+  const historyPage = await readEnrichedChatHistoryPage({
     entry: historyEntry,
     provider: resolvedSessionModel.provider,
     sessionId,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -101,9 +101,10 @@ import {
 } from "./chat-history-budget.js";
 import {
   capChatHistoryAroundMessage,
+  enrichChatHistoryCompactionMarkers,
+  readChatHistoryPage,
   readChatHistoryMessageId,
   readChatHistoryMessageSeq,
-  readEnrichedChatHistoryPage,
 } from "./chat-history-pages.js";
 import {
   hasGatewayAdminScope,
@@ -568,7 +569,7 @@ async function handleChatHistoryRequest({
   const max = Math.min(hardMax, requested);
   const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
   const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(cfg, maxChars);
-  const historyPage = await readEnrichedChatHistoryPage({
+  const historyPage = await readChatHistoryPage({
     entry: historyEntry,
     provider: resolvedSessionModel.provider,
     sessionId,
@@ -581,7 +582,7 @@ async function handleChatHistoryRequest({
     offset,
     messageId,
   });
-  const normalized = historyPage.messages;
+  const normalized = enrichChatHistoryCompactionMarkers(historyPage.messages, historyEntry);
   const perMessageHardCap = Math.min(CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES, maxHistoryBytes);
   const replaced = replaceOversizedChatHistoryMessages({
     messages: normalized,

--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -38,6 +38,42 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
     await server?.close();
   });
 
+  it("shows compaction savings and live working time", async () => {
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const currentPage = await context.newPage();
+    page = currentPage;
+    await currentPage.clock.install();
+    const gateway = await installMockGateway(currentPage, {
+      historyMessages: [
+        {
+          role: "system",
+          timestamp: Date.now() - 1_000,
+          __openclaw: {
+            kind: "compaction",
+            id: "compact-entry-1",
+            tokensBefore: 900_000,
+            tokensAfter: 24_700,
+          },
+        },
+      ],
+    });
+
+    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.getByText("saved 875.3k tokens", { exact: true }).waitFor();
+    await currentPage.locator(".agent-chat__input textarea").fill("keep working");
+    await currentPage.getByRole("button", { name: "Send message" }).click();
+    await gateway.waitForRequest("chat.send");
+    await currentPage.locator(".chat-working-indicator").waitFor();
+
+    await currentPage.clock.runFor(177_000);
+
+    await expect
+      .poll(() => currentPage.locator(".chat-working-indicator__elapsed").textContent())
+      .toBe("2m 57s");
+    await currentPage.getByText("Working…", { exact: true }).waitFor();
+  });
+
   it("clears shared session activity when chat final arrives first", async () => {
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });

--- a/ui/src/e2e/mantis-chat-proof.e2e.test.ts
+++ b/ui/src/e2e/mantis-chat-proof.e2e.test.ts
@@ -68,8 +68,19 @@ describeMantisWebUiChat("Mantis Control UI web chat proof", () => {
       viewport: { height: 900, width: 1280 },
     });
     const page = await context.newPage();
+    await page.clock.install();
     const gateway = await installMockGateway(page, {
       historyMessages: [
+        {
+          role: "system",
+          timestamp: Date.now() - 1_000,
+          __openclaw: {
+            kind: "compaction",
+            id: "mantis-compaction-entry",
+            tokensBefore: 900_000,
+            tokensAfter: 24_700,
+          },
+        },
         {
           content: [{ text: "Mantis web UI proof is ready.", type: "text" }],
           role: "assistant",
@@ -96,9 +107,16 @@ describeMantisWebUiChat("Mantis Control UI web chat proof", () => {
       const params = sendRequest.params as { idempotencyKey?: string };
       expect(params.idempotencyKey).toEqual(expect.any(String));
 
+      await page.getByText("saved 875.3k tokens", { exact: true }).waitFor();
+      await page.locator(".chat-working-indicator").waitFor();
+      await page.clock.runFor(177_000);
+      await expect
+        .poll(() => page.locator(".chat-working-indicator__elapsed").textContent())
+        .toBe("2m 57s");
+      await page.screenshot({ fullPage: true, path: path.join(artifactDir, "web-ui-chat.png") });
+
       await gateway.emitChatFinal({ runId: params.idempotencyKey ?? "", text: reply });
       await page.getByText(reply).waitFor({ timeout: 10_000 });
-      await page.screenshot({ fullPage: true, path: path.join(artifactDir, "web-ui-chat.png") });
       await writeFile(
         path.join(artifactDir, "web-ui-chat-proof.json"),
         `${JSON.stringify(

--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:40:06.891Z",
+  "generatedAt": "2026-07-14T00:51:15.745Z",
   "locale": "ar",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:39:09.687Z",
+  "generatedAt": "2026-07-14T00:51:10.089Z",
   "locale": "de",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:39:10.173Z",
+  "generatedAt": "2026-07-14T00:51:11.202Z",
   "locale": "es",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:40:43.127Z",
+  "generatedAt": "2026-07-14T00:51:23.506Z",
   "locale": "fa",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:39:11.628Z",
+  "generatedAt": "2026-07-14T00:51:13.851Z",
   "locale": "fr",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/hi.meta.json
+++ b/ui/src/i18n/.i18n/hi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:40:06.342Z",
+  "generatedAt": "2026-07-14T00:51:14.667Z",
   "locale": "hi",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:40:09.134Z",
+  "generatedAt": "2026-07-14T00:51:18.742Z",
   "locale": "id",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:40:07.505Z",
+  "generatedAt": "2026-07-14T00:51:16.550Z",
   "locale": "it",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:39:10.640Z",
+  "generatedAt": "2026-07-14T00:51:11.973Z",
   "locale": "ja-JP",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:39:11.155Z",
+  "generatedAt": "2026-07-14T00:51:12.764Z",
   "locale": "ko",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:40:10.872Z",
+  "generatedAt": "2026-07-14T00:51:22.172Z",
   "locale": "nl",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:40:09.624Z",
+  "generatedAt": "2026-07-14T00:51:19.381Z",
   "locale": "pl",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:39:09.296Z",
+  "generatedAt": "2026-07-14T00:51:09.131Z",
   "locale": "pt-BR",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ru.meta.json
+++ b/ui/src/i18n/.i18n/ru.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:40:43.591Z",
+  "generatedAt": "2026-07-14T00:51:24.731Z",
   "locale": "ru",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:40:10.071Z",
+  "generatedAt": "2026-07-14T00:51:20.134Z",
   "locale": "th",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:40:08.125Z",
+  "generatedAt": "2026-07-14T00:51:17.168Z",
   "locale": "tr",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:40:08.583Z",
+  "generatedAt": "2026-07-14T00:51:18.084Z",
   "locale": "uk",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:40:10.508Z",
+  "generatedAt": "2026-07-14T00:51:20.983Z",
   "locale": "vi",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:39:08.100Z",
+  "generatedAt": "2026-07-14T00:51:06.914Z",
   "locale": "zh-CN",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-13T22:39:08.780Z",
+  "generatedAt": "2026-07-14T00:51:08.115Z",
   "locale": "zh-TW",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "c00a7a9b9d3aaf3f3d56bd471b30185b26aca6e0ff8dcde5f287ce439de5da5b",
-  "totalKeys": 3299,
-  "translatedKeys": 3299,
+  "sourceHash": "abbaf15fe6ffffba696f7a398b6be58e52144fa1660eb9715bfe1f8bb115d9ca",
+  "totalKeys": 3300,
+  "translatedKeys": 3300,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -3336,6 +3336,7 @@ export const ar: TranslationMap = {
     },
     compaction: {
       label: "السجل المضغوط",
+      savedTokens: "saved {count} tokens",
       description:
         "يُحتفظ بالنص المضغوط كنقطة تحقق. افتح نقاط تحقق الجلسة لإنشاء تفرع أو الاستعادة من ذلك العرض المضغوط.",
       openCheckpoints: "فتح نقاط التحقق",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -3406,6 +3406,7 @@ export const de: TranslationMap = {
     },
     compaction: {
       label: "Komprimierter Verlauf",
+      savedTokens: "saved {count} tokens",
       description:
         "Das komprimierte Transkript wird als Checkpoint gespeichert. Öffnen Sie die Sitzungs-Checkpoints, um von dieser komprimierten Ansicht zu verzweigen oder wiederherzustellen.",
       openCheckpoints: "Checkpoints öffnen",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3315,6 +3315,7 @@ export const en: TranslationMap = {
     },
     compaction: {
       label: "Compacted history",
+      savedTokens: "saved {count} tokens",
       description:
         "The compacted transcript is preserved as a checkpoint. Open session checkpoints to branch or restore from that compacted view.",
       openCheckpoints: "Open checkpoints",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -3402,6 +3402,7 @@ export const es: TranslationMap = {
     },
     compaction: {
       label: "Historial compactado",
+      savedTokens: "saved {count} tokens",
       description:
         "La transcripción compactada se conserva como punto de control. Abre los puntos de control de la sesión para ramificar o restaurar desde esa vista compactada.",
       openCheckpoints: "Abrir puntos de control",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -3364,6 +3364,7 @@ export const fa: TranslationMap = {
     },
     compaction: {
       label: "تاریخچه فشرده‌شده",
+      savedTokens: "saved {count} tokens",
       description:
         "رونوشت فشرده‌شده به‌عنوان یک نقطه‌بازرسی حفظ می‌شود. نقاط‌بازرسی نشست را باز کنید تا از آن نمای فشرده‌شده شاخه بزنید یا بازیابی کنید.",
       openCheckpoints: "باز کردن نقاط‌بازرسی",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -3430,6 +3430,7 @@ export const fr: TranslationMap = {
     },
     compaction: {
       label: "Historique compacté",
+      savedTokens: "saved {count} tokens",
       description:
         "La transcription compactée est conservée comme point de contrôle. Ouvrez les points de contrôle de la session pour créer une branche ou restaurer à partir de cette vue compactée.",
       openCheckpoints: "Ouvrir les points de contrôle",

--- a/ui/src/i18n/locales/hi.ts
+++ b/ui/src/i18n/locales/hi.ts
@@ -3332,6 +3332,7 @@ export const hi: TranslationMap = {
     },
     compaction: {
       label: "संक्षिप्त इतिहास",
+      savedTokens: "saved {count} tokens",
       description:
         "संक्षिप्त ट्रांसक्रिप्ट एक चेकपॉइंट के रूप में सुरक्षित रहता है। उस संक्षिप्त दृश्य से ब्रांच करने या पुनर्स्थापित करने के लिए सत्र चेकपॉइंट खोलें।",
       openCheckpoints: "चेकपॉइंट खोलें",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -3368,6 +3368,7 @@ export const id: TranslationMap = {
     },
     compaction: {
       label: "Riwayat yang dipadatkan",
+      savedTokens: "saved {count} tokens",
       description:
         "Transkrip yang dipadatkan disimpan sebagai checkpoint. Buka checkpoint sesi untuk membuat cabang atau memulihkan dari tampilan yang dipadatkan tersebut.",
       openCheckpoints: "Buka checkpoint",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -3405,6 +3405,7 @@ export const it: TranslationMap = {
     },
     compaction: {
       label: "Cronologia compattata",
+      savedTokens: "saved {count} tokens",
       description:
         "La trascrizione compattata viene conservata come checkpoint. Apri i checkpoint della sessione per creare un ramo o ripristinare da quella vista compattata.",
       openCheckpoints: "Apri checkpoint",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -3380,6 +3380,7 @@ export const ja_JP: TranslationMap = {
     },
     compaction: {
       label: "圧縮された履歴",
+      savedTokens: "saved {count} tokens",
       description:
         "圧縮されたトランスクリプトはチェックポイントとして保存されます。セッションのチェックポイントを開いて、その圧縮ビューから分岐または復元できます。",
       openCheckpoints: "チェックポイントを開く",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -3348,6 +3348,7 @@ export const ko: TranslationMap = {
     },
     compaction: {
       label: "압축된 기록",
+      savedTokens: "saved {count} tokens",
       description:
         "압축된 대화 기록은 체크포인트로 보존됩니다. 세션 체크포인트를 열어 해당 압축 보기에서 분기하거나 복원하세요.",
       openCheckpoints: "체크포인트 열기",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -3382,6 +3382,7 @@ export const nl: TranslationMap = {
     },
     compaction: {
       label: "Gecomprimeerde geschiedenis",
+      savedTokens: "saved {count} tokens",
       description:
         "Het gecomprimeerde transcript wordt bewaard als checkpoint. Open sessiecheckpoints om te vertakken of te herstellen vanuit die gecomprimeerde weergave.",
       openCheckpoints: "Checkpoints openen",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -3391,6 +3391,7 @@ export const pl: TranslationMap = {
     },
     compaction: {
       label: "Skompaktowana historia",
+      savedTokens: "saved {count} tokens",
       description:
         "Skompaktowany zapis jest zachowany jako punkt kontrolny. Otwórz punkty kontrolne sesji, aby rozgałęzić lub przywrócić z tego skompaktowanego widoku.",
       openCheckpoints: "Otwórz punkty kontrolne",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -3378,6 +3378,7 @@ export const pt_BR: TranslationMap = {
     },
     compaction: {
       label: "Histórico compactado",
+      savedTokens: "saved {count} tokens",
       description:
         "A transcrição compactada é preservada como ponto de verificação. Abra os pontos de verificação da sessão para ramificar ou restaurar a partir dessa visualização compactada.",
       openCheckpoints: "Abrir pontos de verificação",

--- a/ui/src/i18n/locales/ru.ts
+++ b/ui/src/i18n/locales/ru.ts
@@ -3394,6 +3394,7 @@ export const ru: TranslationMap = {
     },
     compaction: {
       label: "Сжатая история",
+      savedTokens: "saved {count} tokens",
       description:
         "Сжатая расшифровка сохраняется как контрольная точка. Откройте контрольные точки сессии, чтобы создать ветку или восстановить из этого сжатого представления.",
       openCheckpoints: "Открыть контрольные точки",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -3309,6 +3309,7 @@ export const th: TranslationMap = {
     },
     compaction: {
       label: "ประวัติที่ย่อแล้ว",
+      savedTokens: "saved {count} tokens",
       description:
         "ทรานสคริปต์ที่ย่อจะถูกเก็บไว้เป็นจุดตรวจสอบ เปิดจุดตรวจสอบเซสชันเพื่อแตกสาขาหรือกู้คืนจากมุมมองที่ย่อนั้น",
       openCheckpoints: "เปิดจุดตรวจสอบ",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -3388,6 +3388,7 @@ export const tr: TranslationMap = {
     },
     compaction: {
       label: "Sıkıştırılmış geçmiş",
+      savedTokens: "saved {count} tokens",
       description:
         "Sıkıştırılmış döküm bir kontrol noktası olarak saklanır. O sıkıştırılmış görünümden dallanmak veya geri yüklemek için oturum kontrol noktalarını açın.",
       openCheckpoints: "Kontrol noktalarını aç",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -3375,6 +3375,7 @@ export const uk: TranslationMap = {
     },
     compaction: {
       label: "Ущільнена історія",
+      savedTokens: "saved {count} tokens",
       description:
         "Ущільнений транскрипт зберігається як контрольна точка. Відкрийте контрольні точки сеансу, щоб створити гілку або відновити з цього ущільненого вигляду.",
       openCheckpoints: "Відкрити контрольні точки",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -3363,6 +3363,7 @@ export const vi: TranslationMap = {
     },
     compaction: {
       label: "Lịch sử đã nén",
+      savedTokens: "saved {count} tokens",
       description:
         "Bản ghi đã nén được giữ lại làm điểm kiểm tra. Mở điểm kiểm tra phiên để phân nhánh hoặc khôi phục từ chế độ xem đã nén đó.",
       openCheckpoints: "Mở điểm kiểm tra",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -3291,6 +3291,7 @@ export const zh_CN: TranslationMap = {
     },
     compaction: {
       label: "已压缩的历史记录",
+      savedTokens: "saved {count} tokens",
       description: "压缩后的会话记录会作为检查点保留。打开会话检查点即可从该压缩视图分支或恢复。",
       openCheckpoints: "打开检查点",
     },

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -3296,6 +3296,7 @@ export const zh_TW: TranslationMap = {
     },
     compaction: {
       label: "已壓縮的歷史記錄",
+      savedTokens: "saved {count} tokens",
       description:
         "壓縮後的對話記錄會保留為檢查點。開啟工作階段檢查點，即可從該壓縮檢視進行分支或還原。",
       openCheckpoints: "開啟檢查點",

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -49,12 +49,13 @@ export type ChatItem =
       kind: "divider";
       key: string;
       label: string;
+      metric?: string;
       description?: string;
       action?: { kind: "session-checkpoints"; label: string };
       timestamp: number;
     }
   | { kind: "stream"; key: string; text: string; startedAt: number; isStreaming: boolean }
-  | { kind: "reading-indicator"; key: string };
+  | { kind: "reading-indicator"; key: string; startedAt: number };
 
 export const CHAT_HISTORY_RENDER_LIMIT = 100;
 export const CHAT_HISTORY_RENDER_CHAR_BUDGET = 240_000;

--- a/ui/src/pages/chat/chat-progress.ts
+++ b/ui/src/pages/chat/chat-progress.ts
@@ -1,0 +1,103 @@
+import { t } from "../../i18n/index.ts";
+import type { ChatItem, ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import { formatCompactTokenCount } from "../../lib/format.ts";
+
+const workingStartBySession = new Map<string, { runId: string | null; startedAt: number }>();
+
+export function buildCompactionDividerItem(
+  marker: Record<string, unknown>,
+  timestamp: number,
+  index: number,
+): Extract<ChatItem, { kind: "divider" }> {
+  const tokensBefore = marker.tokensBefore;
+  const tokensAfter = marker.tokensAfter;
+  const tokensSaved =
+    typeof tokensBefore === "number" &&
+    Number.isFinite(tokensBefore) &&
+    typeof tokensAfter === "number" &&
+    Number.isFinite(tokensAfter) &&
+    tokensBefore > tokensAfter
+      ? Math.floor(tokensBefore - tokensAfter)
+      : null;
+  return {
+    kind: "divider",
+    key:
+      typeof marker.id === "string"
+        ? `divider:compaction:${marker.id}`
+        : `divider:compaction:${timestamp}:${index}`,
+    label: t("chat.compaction.label"),
+    ...(tokensSaved === null
+      ? {}
+      : {
+          metric: t("chat.compaction.savedTokens", {
+            count: formatCompactTokenCount(tokensSaved),
+          }),
+        }),
+    description: t("chat.compaction.description"),
+    action: { kind: "session-checkpoints", label: t("chat.compaction.openCheckpoints") },
+    timestamp,
+  };
+}
+
+export function shouldRenderQueuedSendInThread(item: ChatQueueItem): boolean {
+  // Page-local submit timing is not persisted; durable attempts keep restored prompts visible.
+  const sendStarted = typeof item.sendSubmittedAtMs === "number" || (item.sendAttempts ?? 0) > 0;
+  return (
+    sendStarted &&
+    (item.sendState === "waiting-model" ||
+      item.sendState === "sending" ||
+      item.sendState === "waiting-reconnect")
+  );
+}
+
+export function resolveWorkingStartedAt(
+  sessionKey: string,
+  runId: string | null,
+  streamStartedAt: number | null,
+  queue: ChatQueueItem[],
+  streamSegments: Array<{ ts: number }>,
+  toolMessages: unknown[],
+): number {
+  const queuedRunId =
+    queue.find((item) => item.sendState === "sending" && shouldRenderQueuedSendInThread(item))
+      ?.sendRunId ?? queue.find(shouldRenderQueuedSendInThread)?.sendRunId;
+  const toolRunId = toolMessages
+    .map((message) => (message as Record<string, unknown> | null)?.runId)
+    .find(
+      (candidate): candidate is string => typeof candidate === "string" && candidate.length > 0,
+    );
+  const explicitRunId = queuedRunId ?? runId ?? toolRunId;
+  const cached = workingStartBySession.get(sessionKey);
+  const cachedStartedAt =
+    cached && (!explicitRunId || !cached.runId || cached.runId === explicitRunId)
+      ? cached.startedAt
+      : null;
+  const candidates = [
+    cachedStartedAt,
+    streamStartedAt,
+    ...queue
+      .filter(shouldRenderQueuedSendInThread)
+      .map((item) => item.sendRequestStartedAtMs ?? item.sendSubmittedAtMs ?? item.createdAt),
+    ...streamSegments.map((segment) => segment.ts),
+    ...toolMessages.map((message) => {
+      const receivedAt = (message as Record<string, unknown> | null)?.[
+        "__openclawToolStreamReceivedAt"
+      ];
+      return typeof receivedAt === "number" ? receivedAt : null;
+    }),
+  ].filter((value): value is number => typeof value === "number" && Number.isFinite(value));
+  const startedAt = candidates.length > 0 ? Math.min(...candidates) : Date.now();
+  workingStartBySession.set(sessionKey, {
+    runId: explicitRunId ?? cached?.runId ?? null,
+    startedAt,
+  });
+  return startedAt;
+}
+
+export function clearWorkingStartedAt(sessionKey: string): void {
+  workingStartBySession.delete(sessionKey);
+}
+
+export function resetWorkingStartedAt(): void {
+  workingStartBySession.clear();
+}

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -24,6 +24,7 @@ const SENDER_METADATA_BLOCK =
 function createProps(overrides: Partial<CachedChatItemsProps> = {}): CachedChatItemsProps {
   return {
     sessionKey: "main",
+    runId: null,
     messages: [],
     toolMessages: [],
     streamSegments: [],
@@ -263,15 +264,98 @@ describe("buildCachedChatItems working spark", () => {
     buildCachedChatItems(createProps(props)).some((item) => item.kind === "reading-indicator");
   const liveTool = (resultReceived: boolean) => ({
     role: "assistant",
+    runId: "engine-run-1",
     toolCallId: "tool-1",
     content: [{ type: "toolcall", name: "exec", arguments: {} }],
     timestamp: 1_000,
     __openclawToolStreamLive: true,
     __openclawToolStreamResultReceived: resultReceived,
+    __openclawToolStreamReceivedAt: 1_000,
   });
 
   it("shows the spark while a run works with nothing streaming", () => {
     expect(hasReadingIndicator({ runWorking: true })).toBe(true);
+  });
+
+  it("keeps the run start time on the working indicator", () => {
+    const indicator = buildCachedChatItems(
+      createProps({ runWorking: true, streamStartedAt: 42_000 }),
+    ).find((item) => item.kind === "reading-indicator");
+
+    expect(indicator).toMatchObject({ kind: "reading-indicator", startedAt: 42_000 });
+  });
+
+  it("keeps the elapsed start and trailing position after a tool flush", () => {
+    const items = buildCachedChatItems(
+      createProps({
+        runWorking: true,
+        streamStartedAt: null,
+        streamSegments: [{ text: "progress", ts: 2_000 }],
+        toolMessages: [liveTool(true)],
+      }),
+    );
+
+    expect(items.at(-1)).toMatchObject({ kind: "reading-indicator", startedAt: 1_000 });
+  });
+
+  it("keeps the earliest browser-local start across run phases", () => {
+    const sessionKey = "agent:main:elapsed-cache";
+    buildCachedChatItems(
+      createProps({ sessionKey, runId: "run-1", runWorking: true, streamStartedAt: 1_000 }),
+    );
+    const indicator = buildCachedChatItems(
+      createProps({
+        sessionKey,
+        runId: "run-1",
+        runWorking: true,
+        streamStartedAt: null,
+        streamSegments: [{ text: "later", ts: 2_000 }],
+      }),
+    ).find((item) => item.kind === "reading-indicator");
+
+    expect(indicator).toMatchObject({ kind: "reading-indicator", startedAt: 1_000 });
+  });
+
+  it("keeps client and engine run identities separate", () => {
+    const sessionKey = "agent:main:elapsed-run-namespaces";
+    buildCachedChatItems(
+      createProps({ sessionKey, runId: "client-run-1", runWorking: true, streamStartedAt: 500 }),
+    );
+    const indicator = buildCachedChatItems(
+      createProps({
+        sessionKey,
+        runId: "client-run-1",
+        runWorking: true,
+        streamStartedAt: null,
+        toolMessages: [liveTool(true)],
+      }),
+    ).find((item) => item.kind === "reading-indicator");
+
+    expect(indicator).toMatchObject({ kind: "reading-indicator", startedAt: 500 });
+  });
+
+  it("starts fresh when a session advances to another run", () => {
+    const sessionKey = "agent:main:elapsed-next-run";
+    buildCachedChatItems(
+      createProps({ sessionKey, runId: "run-1", runWorking: true, streamStartedAt: 1_000 }),
+    );
+    const indicator = buildCachedChatItems(
+      createProps({ sessionKey, runId: "run-2", runWorking: true, streamStartedAt: 2_000 }),
+    ).find((item) => item.kind === "reading-indicator");
+
+    expect(indicator).toMatchObject({ kind: "reading-indicator", startedAt: 2_000 });
+  });
+
+  it("ignores gateway clock skew in tool timestamps", () => {
+    const indicator = buildCachedChatItems(
+      createProps({
+        sessionKey: "agent:main:elapsed-clock",
+        runWorking: true,
+        toolMessages: [{ ...liveTool(true), timestamp: -60_000 }],
+      }),
+    ).find((item) => item.kind === "reading-indicator");
+
+    expect(indicator).toMatchObject({ kind: "reading-indicator", startedAt: 1_000 });
   });
 
   it("keeps the spark during a background reload with visible content", () => {
@@ -2198,6 +2282,31 @@ describe("buildCachedChatItems", () => {
     const action = requireRecord(divider.action);
     expect(action.kind).toBe("session-checkpoints");
     expect(action.label).toBe("Open checkpoints");
+  });
+
+  it("shows the token savings recorded on a compaction boundary", () => {
+    const items = buildCachedChatItems(
+      createProps({
+        messages: [
+          {
+            role: "system",
+            timestamp: 2_000,
+            __openclaw: {
+              kind: "compaction",
+              id: "checkpoint-with-metrics",
+              tokensBefore: 900_000,
+              tokensAfter: 24_700,
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(items[0]).toMatchObject({
+      kind: "divider",
+      label: "Compacted history",
+      metric: "saved 875.3k tokens",
+    });
   });
 });
 

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -5,7 +5,6 @@ import {
   isToolResultContentType,
   resolveToolUseId,
 } from "../../../../src/chat/tool-content.js";
-import { t } from "../../i18n/index.ts";
 import type {
   ChatItem,
   MessageGroup,
@@ -40,11 +39,19 @@ import {
   isToolCardError,
 } from "../../lib/chat/tool-cards.ts";
 import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
+import {
+  buildCompactionDividerItem,
+  clearWorkingStartedAt,
+  resetWorkingStartedAt,
+  resolveWorkingStartedAt,
+  shouldRenderQueuedSendInThread,
+} from "./chat-progress.ts";
 import { getOrCreateSessionCacheValue } from "./session-cache.ts";
 import { buildUserChatMessageContentBlocks } from "./user-message-content.ts";
 
 type BuildChatItemsProps = {
   sessionKey: string;
+  runId?: string | null;
   /** Invalidates cached display copy when the active UI language changes. */
   locale?: string;
   messages: unknown[];
@@ -83,6 +90,7 @@ const lastAutoExpandPrefBySession = new Map<string, boolean>();
 
 export function resetChatThreadState(): void {
   chatItemsBySession.clear();
+  resetWorkingStartedAt();
   expandedToolCardsBySession.clear();
   initializedToolCardsBySession.clear();
   lastAutoExpandPrefBySession.clear();
@@ -978,17 +986,6 @@ function sanitizeStreamText(text: string): string {
   return stripped.trim().length > 0 ? stripped : "";
 }
 
-function shouldRenderQueuedSendInThread(item: ChatQueueItem): boolean {
-  // Page-local submit timing is not persisted; durable attempts keep restored prompts visible.
-  const sendStarted = typeof item.sendSubmittedAtMs === "number" || (item.sendAttempts ?? 0) > 0;
-  return (
-    sendStarted &&
-    (item.sendState === "waiting-model" ||
-      item.sendState === "sending" ||
-      item.sendState === "waiting-reconnect")
-  );
-}
-
 function queuedSendThreadMessage(item: ChatQueueItem): Record<string, unknown> | null {
   const content = buildUserChatMessageContentBlocks(item.text, item.attachments);
   if (content.length === 0) {
@@ -1311,20 +1308,7 @@ function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | MessageGro
     const raw = asRecord(msg) ?? {};
     const marker = raw["__openclaw"] as Record<string, unknown> | undefined;
     if (marker && marker.kind === "compaction") {
-      items.push({
-        kind: "divider",
-        key:
-          typeof marker.id === "string"
-            ? `divider:compaction:${marker.id}`
-            : `divider:compaction:${normalized.timestamp}:${i}`,
-        label: t("chat.compaction.label"),
-        description: t("chat.compaction.description"),
-        action: {
-          kind: "session-checkpoints",
-          label: t("chat.compaction.openCheckpoints"),
-        },
-        timestamp: normalized.timestamp ?? Date.now(),
-      });
+      items.push(buildCompactionDividerItem(marker, normalized.timestamp ?? Date.now(), i));
       continue;
     }
 
@@ -1556,10 +1540,21 @@ function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | MessageGro
       queuedSends.some(
         (item) => item.sendState === "sending" && shouldRenderQueuedSendInThread(item),
       ));
+  if (props.runWorking !== true && props.stream === null && !hasPendingResponse) {
+    clearWorkingStartedAt(props.sessionKey);
+  }
   if (hasPendingResponse) {
     items.push({
       kind: "reading-indicator",
       key: `stream:${props.sessionKey}:pending`,
+      startedAt: resolveWorkingStartedAt(
+        props.sessionKey,
+        props.runId ?? null,
+        props.streamStartedAt,
+        queuedSends,
+        segments,
+        tools,
+      ),
     });
   } else if (props.stream !== null) {
     const key = `stream:${props.sessionKey}:${props.streamStartedAt ?? "live"}`;
@@ -1577,7 +1572,7 @@ function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | MessageGro
         });
       }
     } else if (props.stream.trim().length === 0) {
-      items.push({ kind: "reading-indicator", key });
+      items.push({ kind: "reading-indicator", key, startedAt });
     }
   }
 
@@ -1628,6 +1623,7 @@ function sameChatItem(previous: RenderChatItem, next: RenderChatItem): boolean {
       return (
         previous.kind === "divider" &&
         previous.label === next.label &&
+        previous.metric === next.metric &&
         previous.description === next.description &&
         previous.timestamp === next.timestamp &&
         previous.action?.kind === next.action?.kind &&
@@ -1641,7 +1637,7 @@ function sameChatItem(previous: RenderChatItem, next: RenderChatItem): boolean {
         previous.isStreaming === next.isStreaming
       );
     case "reading-indicator":
-      return previous.kind === "reading-indicator";
+      return previous.kind === "reading-indicator" && previous.startedAt === next.startedAt;
   }
   return false;
 }
@@ -1667,6 +1663,7 @@ function stabilizeChatItems(
 function sameChatItemsInput(previous: BuildChatItemsProps, next: BuildChatItemsProps): boolean {
   return (
     previous.sessionKey === next.sessionKey &&
+    previous.runId === next.runId &&
     previous.locale === next.locale &&
     previous.messages === next.messages &&
     previous.toolMessages === next.toolMessages &&

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -124,13 +124,21 @@ const buildChatItemsMock = vi.hoisted(() =>
                 startedAt: props.streamStartedAt ?? 1,
                 isStreaming: true,
               }
-            : { kind: "reading-indicator", key: "reading:test" },
+            : {
+                kind: "reading-indicator",
+                key: "reading:test",
+                startedAt: props.streamStartedAt ?? 1,
+              },
         );
       } else if (
         props.runWorking === true &&
         !(props.loading === true && props.messages.length === 0)
       ) {
-        items.push({ kind: "reading-indicator", key: "reading:test" });
+        items.push({
+          kind: "reading-indicator",
+          key: "reading:test",
+          startedAt: props.streamStartedAt ?? 1,
+        });
       }
       return items;
     },
@@ -654,7 +662,9 @@ describe("chat compaction divider", () => {
       onOpenSessionCheckpoints,
     });
 
-    expect(container.querySelector(".chat-divider__label")?.textContent).toBe("Compacted history");
+    expect(container.querySelector(".chat-divider__label > span")?.textContent).toBe(
+      "Compacted history",
+    );
     expect(container.querySelector(".chat-divider__description")?.textContent?.trim()).toBe(
       "The compacted transcript is preserved as a checkpoint. Open session checkpoints to branch or restore from that compacted view.",
     );

--- a/ui/src/pages/chat/components/chat-divider.ts
+++ b/ui/src/pages/chat/components/chat-divider.ts
@@ -1,0 +1,49 @@
+import { html, nothing } from "lit";
+import type { ChatItem } from "../../../lib/chat/chat-types.ts";
+
+export function renderChatDivider(
+  item: Extract<ChatItem, { kind: "divider" }>,
+  onOpenSessionCheckpoints?: () => void | Promise<void>,
+) {
+  return html`
+    <div class="chat-divider" data-ts=${String(item.timestamp)}>
+      <div
+        class="chat-divider__rule"
+        role="separator"
+        aria-label=${item.metric ? `${item.label}, ${item.metric}` : item.label}
+      >
+        <span class="chat-divider__line"></span>
+        <span class="chat-divider__label">
+          <span>${item.label}</span>
+          ${item.metric
+            ? html`
+                <span class="chat-divider__separator" aria-hidden="true">·</span>
+                <span class="chat-divider__metric">${item.metric}</span>
+              `
+            : nothing}
+        </span>
+        <span class="chat-divider__line"></span>
+      </div>
+      ${item.description || item.action
+        ? html`
+            <div class="chat-divider__details">
+              ${item.description
+                ? html`<span class="chat-divider__description">${item.description}</span>`
+                : nothing}
+              ${item.action?.kind === "session-checkpoints" && onOpenSessionCheckpoints
+                ? html`
+                    <button
+                      type="button"
+                      class="btn btn--subtle btn--sm chat-divider__action"
+                      @click=${() => onOpenSessionCheckpoints()}
+                    >
+                      ${item.action.label}
+                    </button>
+                  `
+                : nothing}
+            </div>
+          `
+        : nothing}
+    </div>
+  `;
+}

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1034,7 +1034,10 @@ describe("grouped chat rendering", () => {
   it("renders a reading-indicator-only run without avatar or footer", () => {
     const container = document.createElement("div");
 
-    render(renderStreamGroup([{ kind: "reading-indicator", key: "reading" }]), container);
+    render(
+      renderStreamGroup([{ kind: "reading-indicator", key: "reading", startedAt: 1_000 }]),
+      container,
+    );
 
     const group = container.querySelector(".chat-group.assistant");
     expect(group).not.toBeNull();
@@ -1042,6 +1045,10 @@ describe("grouped chat rendering", () => {
     // Working runs are pure claw: the avatar only arrives with stream text.
     expect(container.querySelectorAll(".chat-avatar.assistant")).toHaveLength(0);
     expect(container.querySelector(".chat-reading-indicator")).not.toBeNull();
+    expect(container.querySelector(".chat-working-indicator__elapsed")).not.toBeNull();
+    expect(container.querySelector(".chat-working-indicator__status")?.textContent).toContain(
+      "Working…",
+    );
     expect(container.querySelector(".chat-group-footer")).toBeNull();
   });
 
@@ -1051,7 +1058,7 @@ describe("grouped chat rendering", () => {
     render(
       renderStreamGroup([
         { kind: "stream", key: "stream:s:live", text: "reply", startedAt: 10, isStreaming: true },
-        { kind: "reading-indicator", key: "reading" },
+        { kind: "reading-indicator", key: "reading", startedAt: 10 },
       ]),
       container,
     );
@@ -1065,7 +1072,7 @@ describe("grouped chat rendering", () => {
   it("seeds a stable punch stance per reading-indicator key", () => {
     const stanceFor = (key: string) => {
       const container = document.createElement("div");
-      render(renderStreamGroup([{ kind: "reading-indicator", key }]), container);
+      render(renderStreamGroup([{ kind: "reading-indicator", key, startedAt: 1 }]), container);
       const bubble = container.querySelector(".chat-reading-indicator");
       return [...(bubble?.classList ?? [])].filter((cls) =>
         cls.startsWith("chat-reading-indicator--"),

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -62,6 +62,7 @@ import {
   resolveToolRowText,
   shouldToggleSelectableDisclosure,
 } from "./chat-tool-cards.ts";
+import { renderChatWorkingIndicator } from "./chat-working-indicator.ts";
 
 function renderChatIcon(name: string) {
   return icons[name as IconName] ?? icons.zap;
@@ -564,50 +565,6 @@ type StreamGroupOptions = {
   authToken?: string | null;
 };
 
-// One salt per page load so each run's fighter rerolls between visits while
-// re-renders within a load stay stable for a given item key (same trick as
-// the lobster pet's LOAD_SALT).
-const PUNCH_SALT = Math.trunc(Math.random() * 0xffffffff);
-
-// Weighted fighting styles for the working claw; class suffixes map to the
-// stance variants in styles/chat/tool-cards.css. Orthodox is the unmarked
-// default; southpaw mirrors, flurry speeds the combo up, haymaker is the
-// rare slow heavyweight with the big pow.
-const PUNCH_STANCES: Array<[stance: string, weight: number]> = [
-  ["", 47],
-  ["chat-reading-indicator--southpaw", 35],
-  ["chat-reading-indicator--flurry", 12],
-  ["chat-reading-indicator--haymaker", 6],
-];
-
-function punchStanceClass(key: string): string {
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < key.length; i++) {
-    hash ^= key.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  const total = PUNCH_STANCES.reduce((sum, [, weight]) => sum + weight, 0);
-  let roll = ((((hash ^ PUNCH_SALT) >>> 0) % 1000) / 1000) * total;
-  for (const [stance, weight] of PUNCH_STANCES) {
-    roll -= weight;
-    if (roll <= 0) {
-      return stance;
-    }
-  }
-  return "";
-}
-
-function renderReadingIndicatorBubble(key: string) {
-  // Working claw: the brand pincer shadowboxes where the reply will
-  // materialize - jab, jab, cross with a pow on impact. The stance is seeded
-  // per item key so each run fights its own style but re-renders never
-  // flicker. aria-hidden; the composer sr-only run-status announces.
-  const stance = punchStanceClass(key);
-  return html`
-    <div class="chat-bubble chat-reading-indicator ${stance}" aria-hidden="true">${icons.claw}</div>
-  `;
-}
-
 // One assistant group per contiguous run of streaming items: a reply that
 // arrives as several stream segments renders under a single avatar/footer
 // instead of flashing a separate avatar+bubble per segment (#63956).
@@ -632,7 +589,7 @@ export function renderStreamGroup(parts: StreamGroupPart[], opts: StreamGroupOpt
       <div class="chat-group-messages">
         ${parts.map((part) =>
           part.kind === "reading-indicator"
-            ? renderReadingIndicatorBubble(part.key)
+            ? renderChatWorkingIndicator(part)
             : renderGroupedMessage(
                 {
                   role: "assistant",

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -53,6 +53,7 @@ import {
   renderBackgroundTasksStatusRow,
   type BackgroundTasksProps,
 } from "./chat-background-tasks.ts";
+import { renderChatDivider } from "./chat-divider.ts";
 import {
   getAssistantAttachmentAvailabilityRenderVersion,
   renderMessageGroup,
@@ -791,6 +792,9 @@ export function renderChatThread(props: ChatThreadProps) {
   const locale = i18n.getLocale();
   const chatItems = buildCachedChatItems({
     sessionKey: props.sessionKey,
+    runId:
+      props.sessions?.sessions.find((row) => areUiSessionKeysEquivalent(row.key, props.sessionKey))
+        ?.activeRunIds?.[0] ?? null,
     locale,
     messages: props.messages,
     toolMessages: props.toolMessages,
@@ -976,38 +980,7 @@ export function renderChatThread(props: ChatThreadProps) {
               (item) => item.key,
               guardChatRenderItems(state, (item) => {
                 if (item.kind === "divider") {
-                  return html`
-                    <div class="chat-divider" data-ts=${String(item.timestamp)}>
-                      <div class="chat-divider__rule" role="separator" aria-label=${item.label}>
-                        <span class="chat-divider__line"></span>
-                        <span class="chat-divider__label">${item.label}</span>
-                        <span class="chat-divider__line"></span>
-                      </div>
-                      ${item.description || item.action
-                        ? html`
-                            <div class="chat-divider__details">
-                              ${item.description
-                                ? html`<span class="chat-divider__description">
-                                    ${item.description}
-                                  </span>`
-                                : nothing}
-                              ${item.action?.kind === "session-checkpoints" &&
-                              props.onOpenSessionCheckpoints
-                                ? html`
-                                    <button
-                                      type="button"
-                                      class="btn btn--subtle btn--sm chat-divider__action"
-                                      @click=${() => props.onOpenSessionCheckpoints?.()}
-                                    >
-                                      ${item.action.label}
-                                    </button>
-                                  `
-                                : nothing}
-                            </div>
-                          `
-                        : nothing}
-                    </div>
-                  `;
+                  return renderChatDivider(item, props.onOpenSessionCheckpoints);
                 }
                 if (item.kind === "stream-run") {
                   return renderStreamGroup(item.parts, {

--- a/ui/src/pages/chat/components/chat-working-indicator.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.ts
@@ -1,0 +1,54 @@
+import { html } from "lit";
+import "../../../components/elapsed-time.ts";
+import { icons } from "../../../components/icons.ts";
+import { t } from "../../../i18n/index.ts";
+import type { ChatItem } from "../../../lib/chat/chat-types.ts";
+
+// One salt per page load keeps each run stable while varying the animation between visits.
+const PUNCH_SALT = Math.trunc(Math.random() * 0xffffffff);
+const PUNCH_STANCES: Array<[stance: string, weight: number]> = [
+  ["", 47],
+  ["chat-reading-indicator--southpaw", 35],
+  ["chat-reading-indicator--flurry", 12],
+  ["chat-reading-indicator--haymaker", 6],
+];
+
+function punchStanceClass(key: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < key.length; i++) {
+    hash ^= key.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  const total = PUNCH_STANCES.reduce((sum, [, weight]) => sum + weight, 0);
+  let roll = ((((hash ^ PUNCH_SALT) >>> 0) % 1000) / 1000) * total;
+  for (const [stance, weight] of PUNCH_STANCES) {
+    roll -= weight;
+    if (roll <= 0) {
+      return stance;
+    }
+  }
+  return "";
+}
+
+export function renderChatWorkingIndicator(part: Extract<ChatItem, { kind: "reading-indicator" }>) {
+  // The animated claw stays decorative; the text status exposes progress without
+  // announcing every elapsed-time tick to screen readers.
+  return html`
+    <div class="chat-working-indicator" role="status" aria-live="off">
+      <div
+        class="chat-bubble chat-reading-indicator ${punchStanceClass(part.key)}"
+        aria-hidden="true"
+      >
+        ${icons.claw}
+      </div>
+      <span class="chat-working-indicator__status">
+        <openclaw-elapsed-time
+          class="chat-working-indicator__elapsed"
+          .startMs=${part.startedAt}
+        ></openclaw-elapsed-time>
+        <span aria-hidden="true">·</span>
+        <span>${t("common.working")}</span>
+      </span>
+    </div>
+  `;
+}

--- a/ui/src/pages/chat/tool-stream.node.test.ts
+++ b/ui/src/pages/chat/tool-stream.node.test.ts
@@ -818,6 +818,7 @@ describe("app-tool-stream fallback lifecycle handling", () => {
 
 describe("app-tool-stream result blocks", () => {
   it("emits a result block for completed tools with empty output", () => {
+    useToolStreamFakeTimers();
     const host = createHost();
 
     handleAgentEvent(host, {
@@ -839,6 +840,8 @@ describe("app-tool-stream result blocks", () => {
 
     const entry = host.toolStreamById.get("call-1") as ToolStreamEntry;
     expect(entry.resultReceived).toBe(true);
+    expect(entry.receivedAt).toBe(TOOL_STREAM_TEST_NOW);
+    expect(entry.message["__openclawToolStreamReceivedAt"]).toBe(TOOL_STREAM_TEST_NOW);
     const content = entry.message.content as Array<Record<string, unknown>>;
     // The empty-output result block marks the call as finished so the UI does
     // not keep it in a running state for the rest of the run.

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -44,7 +44,7 @@ export type ToolStreamEntry = {
   /** True once a result event landed, even when the output text is empty. */
   resultReceived?: boolean;
   startedAt: number;
-  updatedAt: number;
+  receivedAt: number;
   message: Record<string, unknown>;
 };
 
@@ -276,6 +276,7 @@ function buildToolStreamMessage(entry: ToolStreamEntry): Record<string, unknown>
     // so historical output-less calls (aborted runs) stay inert.
     __openclawToolStreamLive: true,
     __openclawToolStreamResultReceived: entry.resultReceived === true,
+    __openclawToolStreamReceivedAt: entry.receivedAt,
   };
 }
 
@@ -761,7 +762,7 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
       ...(resultIsError !== undefined ? { isError: resultIsError } : {}),
       ...(phase === "result" ? { resultReceived: true } : {}),
       startedAt: typeof payload.ts === "number" ? payload.ts : now,
-      updatedAt: now,
+      receivedAt: now,
       message: {},
     };
     host.toolStreamById.set(toolCallId, entry);
@@ -783,7 +784,6 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
     if (phase === "result") {
       entry.resultReceived = true;
     }
-    entry.updatedAt = now;
   }
 
   entry.message = buildToolStreamMessage(entry);

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -203,12 +203,22 @@
 }
 
 .chat-divider__label {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
   padding: 2px 10px;
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
   background: rgba(255, 255, 255, 0.02);
   font-weight: 600;
   text-transform: uppercase;
+}
+
+.chat-divider__separator,
+.chat-divider__metric {
+  color: var(--muted);
+  font-weight: 500;
+  text-transform: none;
 }
 
 .chat-divider__details {

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -1043,6 +1043,26 @@
   color: var(--accent);
 }
 
+.chat-working-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 22px;
+  min-height: 28px;
+}
+
+.chat-working-indicator__status {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  color: var(--muted);
+  font-size: var(--control-ui-text-sm);
+  font-variant-numeric: tabular-nums;
+}
+
+.chat-working-indicator__elapsed {
+  color: var(--muted);
+}
+
 .chat-reading-indicator svg {
   width: 18px;
   height: 18px;


### PR DESCRIPTION
Closes #106876

## What Problem This Solves

The Control UI did not show when conversation compaction occurred, how many tokens it saved, or how long the current agent run had been working. Long-running chats therefore hid both context-management events and basic progress timing.

## Why This Change Was Made

Compaction history markers are enriched with their persisted before/after token counts at the gateway boundary, then rendered as an inline conversation divider. The working indicator now uses a browser-local, run-scoped start time so its live elapsed timer remains stable across stream updates, tool transitions, reconnects, and differing gateway clocks.

## User Impact

Users now see messages such as `Compacted conversation · saved 875.3k tokens` in chat history and a live `2m 57s · Working…` indicator during an active run.

## Evidence

- Blacksmith Testbox `tbx_01kxexsjq5ag99xjcsemsdb0bc`: 398 focused gateway/UI tests passed.
- Same Testbox: 3 Chromium E2E tests passed, including deterministic `875.3k` compaction savings and `2m 57s` elapsed-time assertions plus a Mantis screenshot capture.
- Same Testbox: full changed gate passed (format, core/core-test/UI typechecks, all lint shards, storage/import/auth guards). Current `main` has a stale tracked Plugin SDK baseline hash; the gate passed after regenerating that hash only inside the disposable Testbox. Generated API JSON/JSONL was identical between this branch and `main`.
- Same Testbox: `pnpm build` passed, including the Control UI production bundle, precompressed-asset verification, and performance budgets.
- Visual Mantis artifact will be attached by the dedicated PR workflow.

AI-assisted implementation; maintainer-reviewed and validated with focused, browser, full changed-gate, and production-build proof.
