### PR TITLE
fix(codex): stop warning when a non-Codex-native run has no mirrored history

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.test.ts
+++ b/extensions/codex/src/app-server/attempt-context.test.ts
@@ -45,6 +45,36 @@ describe("Codex app-server attempt context", () => {
     }
   });
 
+  it("does not warn when the mirror exists but is not a Codex-native session", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const debug = vi.spyOn(embeddedAgentLog, "debug").mockImplementation(() => undefined);
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-attempt-context-nonnative-"));
+    const sessionFile = path.join(dir, "session.jsonl");
+    // First entry is a message row, not a `session` header: the run is routed
+    // through the Codex harness but has no Codex-native mirror to read.
+    const nonSessionEntry = {
+      type: "message",
+      id: "m1",
+      parentId: null,
+      timestamp: "2026-06-15T00:00:00.000Z",
+      message: { role: "user", content: "hi", timestamp: 1 },
+    };
+    try {
+      await fs.writeFile(sessionFile, `${JSON.stringify(nonSessionEntry)}\n`);
+      await expect(
+        readMirroredSessionHistoryMessages({
+          sessionFile,
+          sessionId: "codex-session",
+          sessionKey: "codex-session",
+        }),
+      ).resolves.toBeUndefined();
+      expect(warn).not.toHaveBeenCalled();
+      expect(debug).toHaveBeenCalled();
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("returns a run context report without deferred Codex dynamic tool schemas", () => {
     const tools = [
       {

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -86,7 +86,11 @@ export async function readMirroredSessionHistoryMessages(params: {
 }): Promise<AgentMessage[] | undefined> {
   const messages = await readCodexMirroredSessionHistoryMessages(params);
   if (!messages) {
-    embeddedAgentLog.warn("failed to read mirrored session history for codex harness hooks", {
+    // A missing or non-Codex-native mirror (first turn, or a Claude/Haiku run
+    // routed through this harness) is expected, and every caller falls back to
+    // existing history. Keep it at debug so it does not surface to operators as
+    // a failed "Process".
+    embeddedAgentLog.debug("no mirrored session history for codex harness hooks", {
       sessionFile: params.sessionFile,
     });
   }


### PR DESCRIPTION
> Resubmit of #106912, which was auto-closed by the active-PR-limit bot. Same tested commit; unchanged.

## What Problem This Solves

The Codex app-server harness also runs non-OpenAI models (Claude/Haiku). On those runs — and on the first turn of any new session — there is no Codex-native mirrored session transcript to read, which is expected. `readMirroredSessionHistoryMessages()` nonetheless emitted a `warn` ("failed to read mirrored session history for codex harness hooks") on every such turn, and channels render that `agent/embedded` warn as `⚠️ 🧰 Process: <name> failed`, so operators see a routine, non-fatal condition as an error. (Reported in #106556.)

## Why This Change Was Made

`readCodexMirroredSessionHistoryMessages()` already distinguishes the cases: a missing file (ENOENT) returns `[]`, and a present-but-not-Codex-native mirror returns `undefined`. Every caller tolerates the miss and falls back to existing history (`?? []`, `?? historyState.messages`), so the `undefined` return is expected control flow, not a failure. The wrapper's warning also carried no error cause (only `sessionFile`), so it was low signal. This change downgrades it from `warn` to `debug` with clearer wording — the minimal, behavior-preserving fix (no control-flow or return-contract change) for a path under the Codex extension gate. The `undefined` return stays load-bearing for the two call sites that fall back to prior history.

Note: this is a log-severity change on OpenClaw's own mirrored-session reader (OpenClaw session-entry format), not Codex wire-protocol or runtime behavior.

## User Impact

Non-Codex-native and first-turn runs routed through the Codex harness no longer surface a spurious failed "Process" to operators. Genuine failures were already swallowed upstream and are unaffected; the run still completes via the existing fallback.

## Evidence

- New regression in `extensions/codex/src/app-server/attempt-context.test.ts`: a mirror whose first entry is not a `session` header returns `undefined`, emits **no** `warn`, and logs `debug` instead. Full file green (6 passed) via `node scripts/run-vitest.mjs extensions/codex/src/app-server/attempt-context.test.ts`. The prior "missing history → [] without warn" test still passes.
- `git diff --check` clean; 2 files, +35/−1; no `CHANGELOG.md` edit.
- Source-reproducible: the noise is a fixed `warn` on an expected `undefined` return; a live Codex run is not needed to demonstrate it.

Fixes #106556
