### PR TITLE
refactor(agents): extract prompt context and cleanup phases

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionSystemPromptReport } from "../../../config/sessions/types.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import type { ToolResultPromptProjectionState } from "../session-prompt-state.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+const hoisted = vi.hoisted(() => ({
+  info: vi.fn(),
+  resolveLiveToolResultAggregateMaxChars: vi.fn(() => 200),
+  resolveLiveToolResultMaxChars: vi.fn(() => 100),
+  truncateOversizedToolResultsInMessages: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock("../logger.js", () => ({
+  log: { info: hoisted.info, warn: hoisted.warn },
+}));
+vi.mock("../tool-result-truncation.js", () => ({
+  resolveLiveToolResultAggregateMaxChars: hoisted.resolveLiveToolResultAggregateMaxChars,
+  resolveLiveToolResultMaxChars: hoisted.resolveLiveToolResultMaxChars,
+  truncateOversizedToolResultsInMessages: hoisted.truncateOversizedToolResultsInMessages,
+}));
+
+import { prepareEmbeddedAttemptPromptContext } from "./attempt-prompt-context.js";
+
+const messages = [
+  {
+    role: "user",
+    content: [{ type: "text", text: "Previous request" }],
+    timestamp: 100,
+  },
+] as AgentMessage[];
+
+const projectionState: ToolResultPromptProjectionState = {
+  replacements: new Map(),
+  frozen: new Set(),
+  ambiguousBaseKeys: new Set(),
+  sourceTextByKey: new Map(),
+};
+
+function createAttempt(overrides?: Partial<EmbeddedRunAttemptParams>) {
+  return {
+    config: {},
+    contextTokenBudget: 32_000,
+    currentInboundContext: {
+      text: "Conversation info (untrusted metadata): channel=telegram",
+    },
+    currentInboundEventKind: "user_request",
+    sessionId: "session-1",
+    sessionKey: "agent:main:session-1",
+    suppressNextUserMessagePersistence: false,
+    ...overrides,
+  } as EmbeddedRunAttemptParams;
+}
+
+function createPrompt(overrides?: Record<string, unknown>) {
+  return {
+    effectivePrompt: "Visible request",
+    promptBeforePromptBuildHooks: "Visible request",
+    hasPromptBuildContext: false,
+    effectiveTranscriptPrompt: "Visible request",
+    transcriptPromptForRuntimeSplit: "Visible request",
+    promptForRuntimeContextSplit: "Visible request",
+    promptForModelBeforeRuntimeContextSplit: "Visible request",
+    promptForRuntimeContextBeforeAnnotation: "Visible request",
+    ...overrides,
+  };
+}
+
+function createInput(options?: {
+  attempt?: EmbeddedRunAttemptParams;
+  prompt?: ReturnType<typeof createPrompt>;
+  report?: SessionSystemPromptReport;
+}) {
+  const replaceSessionMessages = vi.fn();
+  const setActiveSessionSystemPrompt = vi.fn();
+  const report = options?.report ?? ({} as SessionSystemPromptReport);
+  return {
+    input: {
+      attempt: options?.attempt ?? createAttempt(),
+      includeBoundaryTimestamp: false,
+      isRawModelRun: false,
+      messages,
+      preparedUserTurnTimestamp: 123,
+      prompt: options?.prompt ?? createPrompt(),
+      replaceSessionMessages,
+      sessionAgentId: "agent-1",
+      setActiveSessionSystemPrompt,
+      systemPromptReport: report,
+      systemPromptText: "Base system prompt",
+      toolResultPromptProjectionState: projectionState,
+    },
+    replaceSessionMessages,
+    report,
+    setActiveSessionSystemPrompt,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hoisted.truncateOversizedToolResultsInMessages.mockImplementation((inputMessages) => ({
+    messages: inputMessages,
+    truncatedCount: 0,
+    aggregateTruncatedCount: 0,
+    aggregatePressureEngaged: false,
+    aggregateBudgetChars: 200,
+  }));
+});
+
+describe("prepareEmbeddedAttemptPromptContext", () => {
+  it("keeps the transcript prompt bare while carrying inbound context to hooks", () => {
+    const fixture = createInput();
+
+    const result = prepareEmbeddedAttemptPromptContext(fixture.input);
+
+    expect(result.promptForSession).toBe("Visible request");
+    expect(result.promptForModel).toBe("Visible request");
+    expect(result.currentUserTimestampOverride).toEqual({
+      timestamp: 123,
+      text: "Visible request",
+    });
+    expect(result.runtimeContextMessageForCurrentTurn?.content).toContain(
+      "Conversation info (untrusted metadata)",
+    );
+    expect(result.hookMessagesForCurrentPrompt.some((message) => message.role === "custom")).toBe(
+      true,
+    );
+    expect(result.prePromptMessageCount).toBe(1);
+    expect(result.contextTokenBudget).toBe(32_000);
+    expect(result.promptToolResultMaxChars).toBe(100);
+    expect(result.promptToolResultAggregateMaxChars).toBe(200);
+    expect(fixture.report.currentTurn).toEqual({
+      kind: "user_request",
+      promptChars: "Visible request".length,
+      runtimeContextChars: "Conversation info (untrusted metadata): channel=telegram".length,
+      modelOnlyPromptChars: 0,
+    });
+    expect(fixture.replaceSessionMessages).not.toHaveBeenCalled();
+    expect(fixture.setActiveSessionSystemPrompt).not.toHaveBeenCalled();
+    const clonedProjectionState = hoisted.truncateOversizedToolResultsInMessages.mock.calls[0]?.[4];
+    expect(clonedProjectionState).not.toBe(projectionState);
+  });
+
+  it("reports aggregate tool-result pressure for compact-then-truncate routing", () => {
+    hoisted.truncateOversizedToolResultsInMessages.mockImplementation((inputMessages) => ({
+      messages: [...inputMessages],
+      truncatedCount: 2,
+      aggregateTruncatedCount: 1,
+      aggregatePressureEngaged: true,
+      aggregateBudgetChars: 200,
+    }));
+    const fixture = createInput({
+      attempt: createAttempt({ sessionId: "pressure-session", sessionKey: "pressure-session" }),
+    });
+
+    const result = prepareEmbeddedAttemptPromptContext(fixture.input);
+
+    expect(result.aggregatePressureEngaged).toBe(true);
+    expect(hoisted.warn).toHaveBeenCalledWith(
+      expect.stringContaining("aggregate tool-result pressure"),
+    );
+  });
+
+  it("moves runtime-only context into the active system prompt", () => {
+    const fixture = createInput({
+      attempt: createAttempt({
+        currentInboundContext: { text: "Room event metadata" },
+        currentInboundEventKind: "room_event",
+      }),
+      prompt: createPrompt({
+        effectivePrompt: "Runtime room event",
+        effectiveTranscriptPrompt: "",
+        transcriptPromptForRuntimeSplit: "",
+        promptForRuntimeContextSplit: "Runtime room event",
+        promptForModelBeforeRuntimeContextSplit: "Runtime room event",
+      }),
+    });
+
+    const result = prepareEmbeddedAttemptPromptContext(fixture.input);
+
+    expect(result.promptSubmission.runtimeOnly).toBe(true);
+    expect(result.promptForSession).toContain("Room event metadata");
+    expect(result.runtimeContextMessageForCurrentTurn).toBeUndefined();
+    expect(result.systemPromptForHook).toContain("Runtime room event");
+    expect(fixture.setActiveSessionSystemPrompt).toHaveBeenCalledWith(
+      expect.stringContaining("Runtime room event"),
+    );
+    expect(fixture.report.currentTurn?.kind).toBe("room_event");
+    expect(fixture.report.currentTurn?.runtimeContextChars).toBeGreaterThan(0);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-context.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-context.ts
@@ -1,0 +1,265 @@
+/**
+ * Compiles current-turn prompt text, hidden runtime context, and hook messages.
+ */
+import { filterHeartbeatTranscriptArtifacts } from "../../../auto-reply/heartbeat-filter.js";
+import type { SessionSystemPromptReport } from "../../../config/sessions/types.js";
+import type { HeartbeatSummary } from "../../../infra/heartbeat-summary.js";
+import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import { log } from "../logger.js";
+import {
+  cloneToolResultPromptProjectionState,
+  type ToolResultPromptProjectionState,
+} from "../session-prompt-state.js";
+import {
+  resolveLiveToolResultAggregateMaxChars,
+  resolveLiveToolResultMaxChars,
+  truncateOversizedToolResultsInMessages,
+} from "../tool-result-truncation.js";
+import {
+  normalizeCurrentPromptTextForLlmBoundary,
+  normalizeMessagesForCurrentPromptBoundary,
+} from "./attempt.llm-boundary.js";
+import { composeSystemPromptWithHookContext } from "./attempt.thread-helpers.js";
+import {
+  buildCurrentInboundPrompt,
+  buildRuntimeContextCustomMessage,
+  resolveRuntimeContextPromptParts,
+  type RuntimeContextCustomMessage,
+} from "./runtime-context-prompt.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+const aggregateToolResultPressureWarnings = new Set<string>();
+
+type PromptContextAttempt = Pick<
+  EmbeddedRunAttemptParams,
+  | "config"
+  | "contextTokenBudget"
+  | "currentInboundContext"
+  | "currentInboundEventKind"
+  | "sessionId"
+  | "sessionKey"
+  | "suppressNextUserMessagePersistence"
+>;
+
+type PromptAssemblyContext = {
+  effectivePrompt: string;
+  promptBeforePromptBuildHooks: string;
+  promptBuildPrependContext?: string;
+  promptBuildAppendContext?: string;
+  hasPromptBuildContext: boolean;
+  effectiveTranscriptPrompt?: string;
+  transcriptPromptForRuntimeSplit?: string;
+  promptForRuntimeContextSplit: string;
+  promptForModelBeforeRuntimeContextSplit: string;
+  promptForRuntimeContextBeforeAnnotation: string;
+  heartbeatSummary?: Pick<HeartbeatSummary, "ackMaxChars" | "prompt">;
+};
+
+export type CurrentUserTimestampOverride = {
+  timestamp: number;
+  text: string;
+  alternateText?: string;
+};
+
+export type EmbeddedAttemptPromptContext = {
+  aggregatePressureEngaged: boolean;
+  contextTokenBudget: number;
+  currentUserTimestampOverride?: CurrentUserTimestampOverride;
+  effectivePrompt: string;
+  hookMessagesForCurrentPrompt: AgentMessage[];
+  llmBoundaryPromptForPrecheck: string;
+  prePromptMessageCount: number;
+  promptForModel: string;
+  promptForSession: string;
+  promptSubmission: ReturnType<typeof resolveRuntimeContextPromptParts>;
+  promptToolResultAggregateMaxChars: number;
+  promptToolResultMaxChars: number;
+  runtimeContextMessageForCurrentTurn?: RuntimeContextCustomMessage;
+  systemPromptForHook: string;
+};
+
+export function prepareEmbeddedAttemptPromptContext(input: {
+  attempt: PromptContextAttempt;
+  boundaryTimezone?: string;
+  includeBoundaryTimestamp: boolean;
+  isRawModelRun: boolean;
+  messages: AgentMessage[];
+  preparedUserTurnTimestamp?: number;
+  prompt: PromptAssemblyContext;
+  replaceSessionMessages: (messages: AgentMessage[]) => void;
+  sessionAgentId: string;
+  setActiveSessionSystemPrompt: (systemPrompt: string) => void;
+  systemPromptReport?: SessionSystemPromptReport;
+  systemPromptText: string;
+  toolResultPromptProjectionState: ToolResultPromptProjectionState;
+}): EmbeddedAttemptPromptContext {
+  const { attempt } = input;
+  let sessionMessages = filterHeartbeatTranscriptArtifacts(
+    input.messages,
+    input.prompt.heartbeatSummary?.ackMaxChars,
+    input.prompt.heartbeatSummary?.prompt,
+  );
+  if (sessionMessages.length < input.messages.length) {
+    input.replaceSessionMessages(sessionMessages);
+  }
+  const prePromptMessageCount = sessionMessages.length;
+  const contextTokenBudget = attempt.contextTokenBudget ?? DEFAULT_CONTEXT_TOKENS;
+  const promptToolResultMaxChars = resolveLiveToolResultMaxChars({
+    contextWindowTokens: contextTokenBudget,
+    cfg: attempt.config,
+    agentId: input.sessionAgentId,
+  });
+  const promptToolResultAggregateMaxChars = resolveLiveToolResultAggregateMaxChars({
+    contextWindowTokens: contextTokenBudget,
+    perResultMaxChars: promptToolResultMaxChars,
+  });
+  const promptToolResultTruncation = truncateOversizedToolResultsInMessages(
+    sessionMessages,
+    contextTokenBudget,
+    promptToolResultMaxChars,
+    promptToolResultAggregateMaxChars,
+    cloneToolResultPromptProjectionState(input.toolResultPromptProjectionState),
+  );
+  const promptHistoryChanged = promptToolResultTruncation.messages !== sessionMessages;
+  const { aggregatePressureEngaged } = promptToolResultTruncation;
+  if (promptHistoryChanged) {
+    sessionMessages = promptToolResultTruncation.messages;
+  }
+  if (promptHistoryChanged || aggregatePressureEngaged) {
+    const sessionLogKey = attempt.sessionKey ?? attempt.sessionId ?? "unknown";
+    const truncationLog =
+      `[tool-result-truncation] Truncated ${promptToolResultTruncation.truncatedCount} ` +
+      `tool result(s) for prompt history ` +
+      `(maxChars=${promptToolResultMaxChars} ` +
+      `aggregateBudgetChars=${promptToolResultAggregateMaxChars} ` +
+      `aggregate=${promptToolResultTruncation.aggregateTruncatedCount}) ` +
+      `sessionKey=${sessionLogKey}`;
+    if (aggregatePressureEngaged) {
+      if (!aggregateToolResultPressureWarnings.has(sessionLogKey)) {
+        aggregateToolResultPressureWarnings.add(sessionLogKey);
+        log.warn(
+          `${truncationLog}; aggregate tool-result pressure detected, compaction has been requested; consider /compact or /new if pressure persists`,
+        );
+      }
+    } else {
+      log.info(truncationLog);
+    }
+  }
+
+  const promptSubmission = resolveRuntimeContextPromptParts({
+    effectivePrompt: input.prompt.promptForRuntimeContextSplit,
+    transcriptPrompt: input.prompt.transcriptPromptForRuntimeSplit,
+    modelPrompt: input.prompt.hasPromptBuildContext
+      ? input.prompt.promptForModelBeforeRuntimeContextSplit
+      : undefined,
+    modelPromptBuildContext:
+      input.prompt.hasPromptBuildContext && input.prompt.effectiveTranscriptPrompt !== undefined
+        ? {
+            promptBeforeHooks: input.prompt.promptBeforePromptBuildHooks,
+            transcriptPromptBeforeTransforms: input.prompt.effectiveTranscriptPrompt,
+            promptBeforeAnnotation: input.prompt.promptForRuntimeContextBeforeAnnotation,
+            prependContext: input.prompt.promptBuildPrependContext ?? "",
+            appendContext: input.prompt.promptBuildAppendContext ?? "",
+          }
+        : undefined,
+    emptyTranscriptMode: attempt.suppressNextUserMessagePersistence
+      ? "model-prompt"
+      : "runtime-event",
+  });
+  const isRuntimeOnlyTurn = promptSubmission.runtimeOnly === true;
+  const currentInboundContextText = isRuntimeOnlyTurn
+    ? undefined
+    : attempt.currentInboundContext?.text?.trim() || undefined;
+  // Normal user turns persist the bare prompt and carry current inbound metadata
+  // in a hidden runtime-context message. Runtime-only turns have no bare user turn,
+  // so their inbound context remains inline and byte-stable across replay.
+  const promptForSession = isRuntimeOnlyTurn
+    ? buildCurrentInboundPrompt({
+        context: attempt.currentInboundContext,
+        prompt: promptSubmission.prompt,
+      })
+    : promptSubmission.prompt;
+  const promptForModel = isRuntimeOnlyTurn
+    ? buildCurrentInboundPrompt({
+        context: attempt.currentInboundContext,
+        prompt: promptSubmission.modelPrompt ?? promptSubmission.prompt,
+      })
+    : (promptSubmission.modelPrompt ?? promptSubmission.prompt);
+  const currentUserTimestampOverride =
+    !input.isRawModelRun && typeof input.preparedUserTurnTimestamp === "number"
+      ? {
+          timestamp: input.preparedUserTurnTimestamp,
+          text: promptForSession,
+          ...(promptForModel !== promptForSession ? { alternateText: promptForModel } : {}),
+        }
+      : undefined;
+  const runtimeSystemContext = promptSubmission.runtimeSystemContext?.trim();
+  let systemPromptForHook = input.systemPromptText;
+  if (promptSubmission.runtimeOnly && runtimeSystemContext) {
+    const runtimeSystemPrompt = composeSystemPromptWithHookContext({
+      baseSystemPrompt: input.systemPromptText,
+      appendSystemContext: runtimeSystemContext,
+    });
+    if (runtimeSystemPrompt) {
+      systemPromptForHook = runtimeSystemPrompt;
+      input.setActiveSessionSystemPrompt(runtimeSystemPrompt);
+    }
+  }
+  const runtimeContextForHook = isRuntimeOnlyTurn
+    ? undefined
+    : [currentInboundContextText, promptSubmission.runtimeContext?.trim()]
+        .filter((value): value is string => Boolean(value))
+        .join("\n\n") || undefined;
+  const runtimeContextMessageForCurrentTurn =
+    buildRuntimeContextCustomMessage(runtimeContextForHook);
+  const messagesForCurrentPrompt = runtimeContextMessageForCurrentTurn
+    ? [...sessionMessages, runtimeContextMessageForCurrentTurn]
+    : sessionMessages;
+  const hookMessagesForCurrentPrompt = normalizeMessagesForCurrentPromptBoundary({
+    messages: messagesForCurrentPrompt,
+    prompt: promptForModel,
+    ...(input.boundaryTimezone ? { timezone: input.boundaryTimezone } : {}),
+    ...(input.includeBoundaryTimestamp ? {} : { includeTimestamp: false }),
+    ...(typeof input.preparedUserTurnTimestamp === "number"
+      ? { currentUserTimestamp: input.preparedUserTurnTimestamp }
+      : {}),
+  });
+  if (input.systemPromptReport) {
+    input.systemPromptReport.currentTurn = {
+      ...(attempt.currentInboundEventKind ? { kind: attempt.currentInboundEventKind } : {}),
+      promptChars: promptForModel.length,
+      runtimeContextChars: promptSubmission.runtimeOnly
+        ? (runtimeSystemContext?.length ?? 0)
+        : (runtimeContextForHook?.length ?? 0),
+      // Hook context reaches only the model, so count the delta beyond the
+      // transcript prompt or downstream context accounting undercounts it.
+      modelOnlyPromptChars: Math.max(0, promptForModel.length - promptForSession.length),
+    };
+  }
+  const llmBoundaryPromptForPrecheck = normalizeCurrentPromptTextForLlmBoundary({
+    prompt: promptForModel,
+    ...(input.boundaryTimezone ? { timezone: input.boundaryTimezone } : {}),
+    ...(input.includeBoundaryTimestamp ? {} : { includeTimestamp: false }),
+    ...(typeof input.preparedUserTurnTimestamp === "number"
+      ? { currentUserTimestamp: input.preparedUserTurnTimestamp }
+      : {}),
+  });
+
+  return {
+    aggregatePressureEngaged,
+    contextTokenBudget,
+    ...(currentUserTimestampOverride ? { currentUserTimestampOverride } : {}),
+    effectivePrompt: input.prompt.effectivePrompt,
+    hookMessagesForCurrentPrompt,
+    llmBoundaryPromptForPrecheck,
+    prePromptMessageCount,
+    promptForModel,
+    promptForSession,
+    promptSubmission,
+    promptToolResultAggregateMaxChars,
+    promptToolResultMaxChars,
+    ...(runtimeContextMessageForCurrentTurn ? { runtimeContextMessageForCurrentTurn } : {}),
+    systemPromptForHook,
+  };
+}

--- a/src/agents/embedded-agent-runner/run/attempt-session-cleanup.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-cleanup.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  cleanupEmbeddedAttemptResources: vi.fn(),
+  clearToolSearchCatalog: vi.fn(),
+  flushEmbeddedAttemptTrajectoryRecorder: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock("../../tool-search.js", () => ({
+  clearToolSearchCatalog: hoisted.clearToolSearchCatalog,
+}));
+vi.mock("../logger.js", () => ({
+  log: { warn: hoisted.warn },
+}));
+vi.mock("./attempt-trajectory-flush-cleanup.js", () => ({
+  flushEmbeddedAttemptTrajectoryRecorder: hoisted.flushEmbeddedAttemptTrajectoryRecorder,
+}));
+vi.mock("./attempt.subscription-cleanup.js", () => ({
+  cleanupEmbeddedAttemptResources: hoisted.cleanupEmbeddedAttemptResources,
+}));
+
+import { cleanupEmbeddedAttemptSessionPhase } from "./attempt-session-cleanup.js";
+
+const attempt = {
+  runId: "run-1",
+  sessionId: "session-1",
+  sessionFile: "/tmp/session.jsonl",
+} as never;
+
+function createInput(overrides: Record<string, unknown> = {}) {
+  const sessionLockController = {
+    acquireForCleanup: vi.fn(async () => ({ release: vi.fn() })),
+    hasSessionTakeover: vi.fn(() => false),
+  };
+  const emitDiagnosticRunCompleted = vi.fn();
+  const trajectoryRecorder = {
+    recordEvent: vi.fn(),
+    describeFlushState: vi.fn(),
+    flush: vi.fn(),
+  };
+  const state = {
+    aborted: false,
+    externalAbort: false,
+    timedOut: false,
+    idleTimedOut: false,
+    timedOutDuringCompaction: false,
+    timedOutDuringToolExecution: false,
+    timedOutByRunBudget: false,
+    promptError: null,
+    beforeAgentRunBlocked: false,
+  };
+  return {
+    attempt,
+    sessionLockController,
+    sessionAgentId: "main",
+    buildAbortSettlePromise: () => null,
+    trajectoryRecorder,
+    trajectoryEndRecorded: false,
+    cleanupYieldAborted: false,
+    emitDiagnosticRunCompleted,
+    readState: () => state,
+    ...overrides,
+  };
+}
+
+describe("cleanupEmbeddedAttemptSessionPhase", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.cleanupEmbeddedAttemptResources.mockResolvedValue(undefined);
+    hoisted.flushEmbeddedAttemptTrajectoryRecorder.mockResolvedValue(undefined);
+  });
+
+  it("records the terminal event before lock-safe resource cleanup", async () => {
+    const input = createInput();
+
+    await cleanupEmbeddedAttemptSessionPhase(input as never);
+
+    expect(input.trajectoryRecorder.recordEvent).toHaveBeenCalledWith(
+      "session.ended",
+      expect.objectContaining({ status: "cleanup", aborted: false }),
+    );
+    expect(hoisted.flushEmbeddedAttemptTrajectoryRecorder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        sessionId: "session-1",
+        trajectoryRecorder: input.trajectoryRecorder,
+      }),
+    );
+    expect(hoisted.clearToolSearchCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: "run-1", sessionId: "session-1", agentId: "main" }),
+    );
+    expect(hoisted.cleanupEmbeddedAttemptResources).toHaveBeenCalledWith(
+      expect.objectContaining({ aborted: false, skipSessionFlush: false }),
+    );
+    expect(input.emitDiagnosticRunCompleted).toHaveBeenCalledWith("completed", null, undefined);
+  });
+
+  it("re-reads abort state after trajectory flushing", async () => {
+    let aborted = false;
+    hoisted.flushEmbeddedAttemptTrajectoryRecorder.mockImplementation(async () => {
+      aborted = true;
+    });
+    const input = createInput({
+      readState: () => ({
+        aborted,
+        externalAbort: aborted,
+        timedOut: aborted,
+        idleTimedOut: false,
+        timedOutDuringCompaction: false,
+        timedOutDuringToolExecution: false,
+        timedOutByRunBudget: false,
+        promptError: aborted ? new Error("request aborted") : null,
+        beforeAgentRunBlocked: false,
+      }),
+    });
+
+    await cleanupEmbeddedAttemptSessionPhase(input as never);
+
+    expect(hoisted.cleanupEmbeddedAttemptResources).toHaveBeenCalledWith(
+      expect.objectContaining({ aborted: true }),
+    );
+    expect(input.emitDiagnosticRunCompleted).toHaveBeenCalledWith(
+      "error",
+      expect.objectContaining({ message: "request aborted" }),
+      undefined,
+    );
+  });
+
+  it("preserves the prompt error when cleanup detects session takeover", async () => {
+    const promptError = new Error("prompt failed");
+    const sessionLockController = {
+      acquireForCleanup: vi.fn(async () => ({ release: vi.fn() })),
+      hasSessionTakeover: vi.fn(() => true),
+    };
+    const emitDiagnosticRunCompleted = vi.fn();
+    const input = createInput({
+      sessionLockController,
+      emitDiagnosticRunCompleted,
+      trajectoryRecorder: null,
+      readState: () => ({
+        aborted: false,
+        externalAbort: false,
+        timedOut: false,
+        idleTimedOut: false,
+        timedOutDuringCompaction: false,
+        timedOutDuringToolExecution: false,
+        timedOutByRunBudget: false,
+        promptError,
+        beforeAgentRunBlocked: false,
+      }),
+    });
+
+    await expect(cleanupEmbeddedAttemptSessionPhase(input as never)).rejects.toMatchObject({
+      name: "EmbeddedAttemptSessionTakeoverError",
+      promptError,
+    });
+    expect(hoisted.cleanupEmbeddedAttemptResources).toHaveBeenCalledWith(
+      expect.objectContaining({ skipSessionFlush: true }),
+    );
+    expect(emitDiagnosticRunCompleted).toHaveBeenCalledWith("error", promptError, undefined);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-session-cleanup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-cleanup.ts
@@ -1,0 +1,199 @@
+/**
+ * Finalizes trajectory and session-owned resources for one embedded attempt.
+ */
+import { formatErrorMessage, toErrorObject } from "../../../infra/errors.js";
+import type { createTrajectoryRuntimeRecorder } from "../../../trajectory/runtime.js";
+import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
+import type { AgentSession } from "../../sessions/index.js";
+import { clearToolSearchCatalog, type ToolSearchCatalogRef } from "../../tool-search.js";
+import { log } from "../logger.js";
+import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
+import type { EmitDiagnosticRunCompleted } from "./attempt-startup.js";
+import { flushEmbeddedAttemptTrajectoryRecorder } from "./attempt-trajectory-flush-cleanup.js";
+import {
+  type createEmbeddedAttemptSessionLockController,
+  EmbeddedAttemptSessionTakeoverError,
+} from "./attempt.session-lock.js";
+import { cleanupEmbeddedAttemptResources } from "./attempt.subscription-cleanup.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type AttemptSessionLockController = Awaited<
+  ReturnType<typeof createEmbeddedAttemptSessionLockController>
+>;
+type TrajectoryRecorder = ReturnType<typeof createTrajectoryRuntimeRecorder>;
+type DisposableRuntime = { dispose(): Promise<void> | void };
+
+type CleanupEmbeddedAttemptSessionInput = {
+  attempt: EmbeddedRunAttemptParams;
+  session?: AgentSession;
+  sessionManager?: ReturnType<typeof guardSessionManager>;
+  sessionLockController: AttemptSessionLockController;
+  bundleMcpRuntime?: DisposableRuntime;
+  bundleLspRuntime?: DisposableRuntime;
+  removeToolResultContextGuard?: () => void;
+  toolSearchCatalogRef?: ToolSearchCatalogRef;
+  sandboxSessionKey?: string;
+  sessionAgentId: string;
+  buildAbortSettlePromise: () => Promise<void> | null;
+  trajectoryRecorder: TrajectoryRecorder | null;
+  trajectoryEndRecorded: boolean;
+  cleanupYieldAborted: boolean;
+  emitDiagnosticRunCompleted?: EmitDiagnosticRunCompleted;
+  readState: () => {
+    aborted: boolean;
+    externalAbort: boolean;
+    timedOut: boolean;
+    idleTimedOut: boolean;
+    timedOutDuringCompaction: boolean;
+    timedOutDuringToolExecution: boolean;
+    timedOutByRunBudget: boolean;
+    promptError: unknown;
+    beforeAgentRunBlocked: boolean;
+    beforeAgentRunBlockedBy?: string;
+  };
+};
+
+class EmbeddedAttemptPromptErrorWithCleanupTakeoverError extends Error {
+  readonly promptError: unknown;
+  readonly cleanupError: EmbeddedAttemptSessionTakeoverError;
+
+  constructor(params: { promptError: unknown; cleanupError: EmbeddedAttemptSessionTakeoverError }) {
+    super(formatErrorMessage(params.promptError), { cause: params.cleanupError });
+    this.name = "EmbeddedAttemptSessionTakeoverError";
+    this.promptError = params.promptError;
+    this.cleanupError = params.cleanupError;
+  }
+}
+
+function shouldPreservePromptErrorAfterCleanupError(params: {
+  promptError: unknown;
+  cleanupError: unknown;
+}): boolean {
+  return (
+    Boolean(params.promptError) &&
+    params.cleanupError instanceof EmbeddedAttemptSessionTakeoverError
+  );
+}
+
+export async function cleanupEmbeddedAttemptSessionPhase(
+  input: CleanupEmbeddedAttemptSessionInput,
+): Promise<void> {
+  const { attempt } = input;
+  const initialState = input.readState();
+  if (input.trajectoryRecorder && !input.trajectoryEndRecorded) {
+    input.trajectoryRecorder.recordEvent("session.ended", {
+      status: initialState.promptError
+        ? "error"
+        : initialState.aborted || initialState.timedOut
+          ? "interrupted"
+          : "cleanup",
+      aborted: initialState.aborted,
+      externalAbort: initialState.externalAbort,
+      timedOut: initialState.timedOut,
+      idleTimedOut: initialState.idleTimedOut,
+      timedOutDuringCompaction: initialState.timedOutDuringCompaction,
+      timedOutDuringToolExecution: initialState.timedOutDuringToolExecution,
+      timedOutByRunBudget: initialState.timedOutByRunBudget,
+      promptError: initialState.promptError
+        ? formatErrorMessage(initialState.promptError)
+        : undefined,
+    });
+  }
+  await flushEmbeddedAttemptTrajectoryRecorder({
+    runId: attempt.runId,
+    sessionId: attempt.sessionId,
+    log,
+    trajectoryRecorder: input.trajectoryRecorder,
+  });
+
+  // Agent retries can report idle before retried tools finish; waiting before
+  // the flush prevents synthetic missing-tool results (#8643). Teardown keeps
+  // lock release ahead of runtime disposal so the next attempt can recover.
+  let cleanupError: unknown;
+  try {
+    clearToolSearchCatalog({
+      sessionId: attempt.sessionId,
+      sessionKey: input.sandboxSessionKey,
+      agentId: input.sessionAgentId,
+      runId: attempt.runId,
+      catalogRef: input.toolSearchCatalogRef,
+    });
+    // Abort handling remains armed during cleanup, so reread after trajectory
+    // flushing instead of using the state captured at helper entry.
+    const cleanupState = input.readState();
+    const cleanupAborted =
+      Boolean(attempt.abortSignal?.aborted) ||
+      cleanupState.aborted ||
+      cleanupState.timedOut ||
+      cleanupState.idleTimedOut ||
+      cleanupState.timedOutDuringCompaction;
+    const cleanupAbortLike = cleanupAborted || input.cleanupYieldAborted;
+    const cleanupSessionLock = await input.sessionLockController.acquireForCleanup({
+      session: input.session,
+    });
+    await cleanupEmbeddedAttemptResources({
+      removeToolResultContextGuard: input.removeToolResultContextGuard,
+      flushPendingToolResultsAfterIdle,
+      session: input.session,
+      sessionManager: input.sessionManager,
+      bundleMcpRuntime: input.bundleMcpRuntime,
+      bundleLspRuntime: input.bundleLspRuntime,
+      sessionLock: cleanupSessionLock,
+      // Aborted runs skip the idle wait so teardown cannot strand the lock.
+      aborted: cleanupAbortLike,
+      abortSettlePromise: cleanupAborted ? input.buildAbortSettlePromise() : null,
+      skipSessionFlush: input.sessionLockController.hasSessionTakeover(),
+      runId: attempt.runId,
+      sessionId: attempt.sessionId,
+    });
+  } catch (err) {
+    cleanupError = err;
+  }
+
+  const finalState = input.readState();
+  const synthesizedCleanupTakeoverError =
+    !cleanupError && finalState.promptError && input.sessionLockController.hasSessionTakeover()
+      ? new EmbeddedAttemptSessionTakeoverError(attempt.sessionFile)
+      : undefined;
+  const cleanupFailure = cleanupError ?? synthesizedCleanupTakeoverError;
+  const shouldPreservePromptError = shouldPreservePromptErrorAfterCleanupError({
+    promptError: finalState.promptError,
+    cleanupError: cleanupFailure,
+  });
+  input.emitDiagnosticRunCompleted?.(
+    cleanupFailure
+      ? "error"
+      : finalState.beforeAgentRunBlocked
+        ? "blocked"
+        : finalState.promptError
+          ? "error"
+          : finalState.aborted ||
+              finalState.timedOut ||
+              finalState.idleTimedOut ||
+              finalState.timedOutDuringCompaction
+            ? "aborted"
+            : "completed",
+    shouldPreservePromptError ? finalState.promptError : (cleanupFailure ?? finalState.promptError),
+    finalState.beforeAgentRunBlocked
+      ? { blockedBy: finalState.beforeAgentRunBlockedBy ?? "before_agent_run" }
+      : undefined,
+  );
+
+  if (!cleanupFailure) {
+    return;
+  }
+  if (shouldPreservePromptError) {
+    log.warn(
+      `embedded attempt cleanup detected session takeover after prompt failure; preserving prompt error: ` +
+        `runId=${attempt.runId} sessionId=${attempt.sessionId} ` +
+        `promptError=${formatErrorMessage(finalState.promptError)} cleanupError=${formatErrorMessage(cleanupFailure)}`,
+    );
+    await Promise.reject(
+      new EmbeddedAttemptPromptErrorWithCleanupTakeoverError({
+        promptError: finalState.promptError,
+        cleanupError: cleanupFailure as EmbeddedAttemptSessionTakeoverError,
+      }),
+    );
+  }
+  await Promise.reject(toErrorObject(cleanupFailure, "Non-Error rejection"));
+}

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2,7 +2,6 @@
  * Orchestrates one embedded-agent attempt from prompt setup through stream result.
  */
 import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
-import { filterHeartbeatTranscriptArtifacts } from "../../../auto-reply/heartbeat-filter.js";
 import {
   bindOwnedSessionTranscriptWrites,
   type OwnedSessionTranscriptCacheSnapshot,
@@ -20,7 +19,7 @@ import {
   createChildDiagnosticTraceContext,
   freezeDiagnosticTraceContext,
 } from "../../../infra/diagnostic-trace-context.js";
-import { formatErrorMessage, toErrorObject } from "../../../infra/errors.js";
+import { formatErrorMessage } from "../../../infra/errors.js";
 import type { AssistantMessage } from "../../../llm/types.js";
 import {
   buildAgentHookContextChannelFields,
@@ -65,20 +64,13 @@ import {
   type EmbeddedAgentQueueHandle,
   markActiveEmbeddedRunAbandoned,
 } from "../runs.js";
-import {
-  cloneToolResultPromptProjectionState,
-  getEmbeddedSessionPromptState,
-} from "../session-prompt-state.js";
+import { getEmbeddedSessionPromptState } from "../session-prompt-state.js";
 import { resolveEmbeddedAgentApiKey } from "../stream-resolution.js";
 import {
   installContextEngineLoopHook,
   installToolResultContextGuard,
 } from "../tool-result-context-guard.js";
-import {
-  resolveLiveToolResultMaxChars,
-  resolveLiveToolResultAggregateMaxChars,
-  truncateOversizedToolResultsInMessages,
-} from "../tool-result-truncation.js";
+import { resolveLiveToolResultMaxChars } from "../tool-result-truncation.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
 import { abortable as abortableWithSignal } from "./abortable.js";
 import { releaseEmbeddedAttemptSessionLockForAbort } from "./attempt-abort.js";
@@ -93,12 +85,14 @@ import {
   resolveOrphanRepairPlan,
 } from "./attempt-orphan-repair.js";
 import { prepareEmbeddedAttemptPromptAssembly } from "./attempt-prompt-assembly.js";
+import { prepareEmbeddedAttemptPromptContext } from "./attempt-prompt-context.js";
 import {
   handleEmbeddedAttemptMidTurnPrecheck,
   prepareEmbeddedAttemptPromptPreflight,
 } from "./attempt-prompt-preflight.js";
 import { submitEmbeddedAttemptPrompt } from "./attempt-prompt-submit.js";
 import { completeEmbeddedAttemptResult } from "./attempt-result.js";
+import { cleanupEmbeddedAttemptSessionPhase } from "./attempt-session-cleanup.js";
 import { prepareEmbeddedAttemptSessionManager } from "./attempt-session-manager-prepare.js";
 import { prepareEmbeddedAttemptAgentSession } from "./attempt-session.js";
 import { prepareEmbeddedAttemptSetup } from "./attempt-setup.js";
@@ -116,7 +110,6 @@ import { prepareEmbeddedAttemptSystemPrompt } from "./attempt-system-prompt-prep
 import { prepareEmbeddedAttemptTimeout } from "./attempt-timeout-prepare.js";
 import { prepareEmbeddedAttemptToolBase } from "./attempt-tool-base-prepare.js";
 import { prepareEmbeddedAttemptToolCatalog } from "./attempt-tool-catalog.js";
-import { flushEmbeddedAttemptTrajectoryRecorder } from "./attempt-trajectory-flush-cleanup.js";
 import {
   cloneHookMessages,
   removeTrailingMidTurnPrecheckAssistantError,
@@ -124,11 +117,7 @@ import {
   resolveAttemptTrajectorySessionFile,
 } from "./attempt-transcript-helpers.js";
 import { buildLoopPromptCacheInfo } from "./attempt.context-engine-helpers.js";
-import {
-  normalizeCurrentPromptTextForLlmBoundary,
-  normalizeMessagesForCurrentPromptBoundary,
-  normalizeMessagesForLlmBoundary,
-} from "./attempt.llm-boundary.js";
+import { normalizeMessagesForLlmBoundary } from "./attempt.llm-boundary.js";
 import {
   buildAfterTurnRuntimeContext,
   resolvePromptSubmissionSkipReason,
@@ -136,7 +125,6 @@ import {
 import { resolveEmbeddedAttemptSessionWriteLockOptions } from "./attempt.run-decisions.js";
 import {
   acquireEmbeddedAttemptSessionFileOwner,
-  EmbeddedAttemptSessionTakeoverError,
   type EmbeddedAttemptSessionFileOwner,
   createEmbeddedAttemptSessionLockController,
   installPromptSubmissionLockRelease,
@@ -149,45 +137,14 @@ import {
   stripSessionsYieldArtifacts,
   waitForSessionsYieldAbortSettle,
 } from "./attempt.sessions-yield.js";
-import { cleanupEmbeddedAttemptResources } from "./attempt.subscription-cleanup.js";
-import { composeSystemPromptWithHookContext } from "./attempt.thread-helpers.js";
 import { shouldFlagCompactionTimeout } from "./compaction-timeout.js";
 import { installHistoryImagePruneContextTransform } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
 import { isMidTurnPrecheckSignal, type MidTurnPrecheckRequest } from "./midturn-precheck.js";
 import { detachPrePersistedCurrentUserTurn } from "./pre-persisted-user-turn.js";
 import { PREEMPTIVE_OVERFLOW_ERROR_TEXT } from "./preemptive-compaction.js";
-import {
-  buildCurrentInboundPrompt,
-  buildRuntimeContextCustomMessage,
-  resolveRuntimeContextPromptParts,
-} from "./runtime-context-prompt.js";
 import { clearToolActivityRun } from "./tool-activity-heartbeat.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
-
-const aggregateToolResultPressureWarnings = new Set<string>();
-
-function shouldPreservePromptErrorAfterCleanupError(params: {
-  promptError: unknown;
-  cleanupError: unknown;
-}): boolean {
-  return (
-    Boolean(params.promptError) &&
-    params.cleanupError instanceof EmbeddedAttemptSessionTakeoverError
-  );
-}
-
-class EmbeddedAttemptPromptErrorWithCleanupTakeoverError extends Error {
-  readonly promptError: unknown;
-  readonly cleanupError: EmbeddedAttemptSessionTakeoverError;
-
-  constructor(params: { promptError: unknown; cleanupError: EmbeddedAttemptSessionTakeoverError }) {
-    super(formatErrorMessage(params.promptError), { cause: params.cleanupError });
-    this.name = "EmbeddedAttemptSessionTakeoverError";
-    this.promptError = params.promptError;
-    this.cleanupError = params.cleanupError;
-  }
-}
 
 export async function runEmbeddedAttempt(
   params: EmbeddedRunAttemptParams,
@@ -1258,185 +1215,55 @@ export async function runEmbeddedAttempt(
             trace: cacheTrace,
           },
         });
-        const {
-          hookCtx,
-          effectivePrompt,
-          promptBeforePromptBuildHooks,
-          promptBuildPrependContext,
-          promptBuildAppendContext,
-          hasPromptBuildContext,
-          effectiveTranscriptPrompt,
-          transcriptPromptForRuntimeSplit,
-          promptForRuntimeContextSplit,
-          promptForModelBeforeRuntimeContextSplit,
-          promptForRuntimeContextBeforeAnnotation,
-          transcriptLeafId,
-          heartbeatSummary,
-        } = promptAssembly;
+        const { hookCtx, promptBuildPrependContext, promptBuildAppendContext, transcriptLeafId } =
+          promptAssembly;
         leasedSteering = promptAssembly.leasedSteering ?? leasedSteering;
         promptCacheChangesForTurn = promptAssembly.promptCacheChangesForTurn;
 
         try {
-          const filteredMessages = filterHeartbeatTranscriptArtifacts(
-            activeSession.messages,
-            heartbeatSummary?.ackMaxChars,
-            heartbeatSummary?.prompt,
-          );
-          if (filteredMessages.length < activeSession.messages.length) {
-            activeSession.agent.state.messages = filteredMessages;
-          }
-          prePromptMessageCount = activeSession.messages.length;
-          const contextTokenBudget = params.contextTokenBudget ?? DEFAULT_CONTEXT_TOKENS;
-          const promptToolResultMaxChars = resolveLiveToolResultMaxChars({
-            contextWindowTokens: contextTokenBudget,
-            cfg: params.config,
-            agentId: sessionAgentId,
-          });
-          const promptToolResultAggregateMaxChars = resolveLiveToolResultAggregateMaxChars({
-            contextWindowTokens: contextTokenBudget,
-            perResultMaxChars: promptToolResultMaxChars,
-          });
-          let promptHistoryMessages = activeSession.messages;
-          const promptToolResultTruncation = truncateOversizedToolResultsInMessages(
-            activeSession.messages,
-            contextTokenBudget,
-            promptToolResultMaxChars,
-            promptToolResultAggregateMaxChars,
-            cloneToolResultPromptProjectionState(toolResultPromptProjectionState),
-          );
-          const promptHistoryChanged =
-            promptToolResultTruncation.messages !== activeSession.messages;
-          const { aggregatePressureEngaged } = promptToolResultTruncation;
-          if (promptHistoryChanged) {
-            promptHistoryMessages = promptToolResultTruncation.messages;
-          }
-          if (promptHistoryChanged || aggregatePressureEngaged) {
-            const sessionLogKey = params.sessionKey ?? params.sessionId ?? "unknown";
-            const truncationLog =
-              `[tool-result-truncation] Truncated ${promptToolResultTruncation.truncatedCount} ` +
-              `tool result(s) for prompt history ` +
-              `(maxChars=${promptToolResultMaxChars} ` +
-              `aggregateBudgetChars=${promptToolResultAggregateMaxChars} ` +
-              `aggregate=${promptToolResultTruncation.aggregateTruncatedCount}) ` +
-              `sessionKey=${sessionLogKey}`;
-            if (aggregatePressureEngaged) {
-              if (!aggregateToolResultPressureWarnings.has(sessionLogKey)) {
-                aggregateToolResultPressureWarnings.add(sessionLogKey);
-                log.warn(
-                  `${truncationLog}; aggregate tool-result pressure detected, compaction has been requested; consider /compact or /new if pressure persists`,
-                );
-              }
-              // Compaction and aggregate truncation both target about half the window;
-              // compact-then-truncate prevents re-hitting the same cap on the next turn.
-              preflightRecovery = { route: "compact_then_truncate" };
-              promptError = new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
-              promptErrorSource = "precheck";
-              skipPromptSubmission = true;
-            } else {
-              log.info(truncationLog);
-            }
-          }
-
-          const promptSubmission = resolveRuntimeContextPromptParts({
-            effectivePrompt: promptForRuntimeContextSplit,
-            transcriptPrompt: transcriptPromptForRuntimeSplit,
-            modelPrompt: hasPromptBuildContext
-              ? promptForModelBeforeRuntimeContextSplit
-              : undefined,
-            modelPromptBuildContext:
-              hasPromptBuildContext && effectiveTranscriptPrompt !== undefined
-                ? {
-                    promptBeforeHooks: promptBeforePromptBuildHooks,
-                    transcriptPromptBeforeTransforms: effectiveTranscriptPrompt,
-                    promptBeforeAnnotation: promptForRuntimeContextBeforeAnnotation,
-                    prependContext: promptBuildPrependContext ?? "",
-                    appendContext: promptBuildAppendContext ?? "",
-                  }
-                : undefined,
-            emptyTranscriptMode: params.suppressNextUserMessagePersistence
-              ? "model-prompt"
-              : "runtime-event",
-          });
-          const isRuntimeOnlyTurn = promptSubmission.runtimeOnly === true;
-          const currentInboundContextText = isRuntimeOnlyTurn
-            ? undefined
-            : params.currentInboundContext?.text?.trim() || undefined;
-          // Normal user turns keep the user prompt BARE and route current-turn
-          // inbound metadata into the runtime-context carrier (relocated after the
-          // active user turn on the wire), so the persisted/replayed user message
-          // is byte-identical whether active or historical — the cache-stability
-          // fix. Runtime-only turns (room events, etc.) have no bare user turn to
-          // protect, so their inbound context stays inline exactly as before. That
-          // inline path stays byte-stable because a runtime-only turn only ever
-          // carries room-event/system context, which is NOT strip-eligible: the
-          // historical strip only removes the `buildInboundUserContextPrefix`
-          // blocks (Conversation info / Reply target / Sender / …), and those are
-          // produced only for non-room turns — which always have a non-empty body
-          // and so are never runtime-only. So inline-active and inline-historical
-          // serialize identically (verified in the cache-stability tests).
-          const promptForSession = isRuntimeOnlyTurn
-            ? buildCurrentInboundPrompt({
-                context: params.currentInboundContext,
-                prompt: promptSubmission.prompt,
-              })
-            : promptSubmission.prompt;
-          const promptForModel = isRuntimeOnlyTurn
-            ? buildCurrentInboundPrompt({
-                context: params.currentInboundContext,
-                prompt: promptSubmission.modelPrompt ?? promptSubmission.prompt,
-              })
-            : (promptSubmission.modelPrompt ?? promptSubmission.prompt);
-          currentUserTimestampOverride =
-            !isRawModelRun && typeof preparedUserTurnMessage?.timestamp === "number"
-              ? {
-                  timestamp: preparedUserTurnMessage.timestamp,
-                  text: promptForSession,
-                  ...(promptForModel !== promptForSession ? { alternateText: promptForModel } : {}),
-                }
-              : undefined;
-          const runtimeSystemContext = promptSubmission.runtimeSystemContext?.trim();
-          if (promptSubmission.runtimeOnly && runtimeSystemContext) {
-            const runtimeSystemPrompt = composeSystemPromptWithHookContext({
-              baseSystemPrompt: systemPromptText,
-              appendSystemContext: runtimeSystemContext,
-            });
-            if (runtimeSystemPrompt) {
-              setActiveSessionSystemPrompt(runtimeSystemPrompt);
-            }
-          }
-          const runtimeContextForHook = isRuntimeOnlyTurn
-            ? undefined
-            : [currentInboundContextText, promptSubmission.runtimeContext?.trim()]
-                .filter((value): value is string => Boolean(value))
-                .join("\n\n") || undefined;
-          const runtimeContextMessageForCurrentTurn =
-            buildRuntimeContextCustomMessage(runtimeContextForHook);
-          const messagesForCurrentPrompt = runtimeContextMessageForCurrentTurn
-            ? [...promptHistoryMessages, runtimeContextMessageForCurrentTurn]
-            : promptHistoryMessages;
-          const hookMessagesForCurrentPrompt = normalizeMessagesForCurrentPromptBoundary({
-            messages: messagesForCurrentPrompt,
-            prompt: promptForModel,
-            ...(boundaryTimezone ? { timezone: boundaryTimezone } : {}),
-            ...(includeBoundaryTimestamp ? {} : { includeTimestamp: false }),
+          const promptContext = prepareEmbeddedAttemptPromptContext({
+            attempt: params,
+            ...(boundaryTimezone ? { boundaryTimezone } : {}),
+            includeBoundaryTimestamp,
+            isRawModelRun,
+            messages: activeSession.messages,
             ...(typeof preparedUserTurnMessage?.timestamp === "number"
-              ? { currentUserTimestamp: preparedUserTurnMessage.timestamp }
+              ? { preparedUserTurnTimestamp: preparedUserTurnMessage.timestamp }
               : {}),
+            prompt: promptAssembly,
+            replaceSessionMessages: (messages) => {
+              activeSession.agent.state.messages = messages;
+            },
+            sessionAgentId,
+            setActiveSessionSystemPrompt,
+            ...(systemPromptReport ? { systemPromptReport } : {}),
+            systemPromptText,
+            toolResultPromptProjectionState,
           });
-          if (systemPromptReport) {
-            systemPromptReport.currentTurn = {
-              ...(params.currentInboundEventKind ? { kind: params.currentInboundEventKind } : {}),
-              promptChars: promptForModel.length,
-              runtimeContextChars: promptSubmission.runtimeOnly
-                ? (runtimeSystemContext?.length ?? 0)
-                : (runtimeContextForHook?.length ?? 0),
-              // promptForSession is what persists to the transcript; hook
-              // prepend/append context reaches only the model, so record the
-              // delta or transcript-based context accounting undercounts it.
-              modelOnlyPromptChars: Math.max(0, promptForModel.length - promptForSession.length),
-            };
+          const {
+            aggregatePressureEngaged,
+            contextTokenBudget,
+            effectivePrompt,
+            hookMessagesForCurrentPrompt,
+            llmBoundaryPromptForPrecheck,
+            promptForModel,
+            promptForSession,
+            promptSubmission,
+            promptToolResultAggregateMaxChars,
+            promptToolResultMaxChars,
+            runtimeContextMessageForCurrentTurn,
+            systemPromptForHook,
+          } = promptContext;
+          prePromptMessageCount = promptContext.prePromptMessageCount;
+          currentUserTimestampOverride = promptContext.currentUserTimestampOverride;
+          if (aggregatePressureEngaged) {
+            // Compaction and aggregate truncation both target about half the window;
+            // compact-then-truncate prevents re-hitting the same cap on the next turn.
+            preflightRecovery = { route: "compact_then_truncate" };
+            promptError = new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
+            promptErrorSource = "precheck";
+            skipPromptSubmission = true;
           }
-          const systemPromptForHook = systemPromptText;
 
           const beforeAgentRunOutcome = await runEmbeddedAttemptBeforeAgentRun({
             attempt: params,
@@ -1625,15 +1452,6 @@ export async function runEmbeddedAttempt(
                 `provider=${params.provider}/${params.modelId} sessionFile=${params.sessionFile}`,
             );
           }
-
-          const llmBoundaryPromptForPrecheck = normalizeCurrentPromptTextForLlmBoundary({
-            prompt: promptForModel,
-            ...(boundaryTimezone ? { timezone: boundaryTimezone } : {}),
-            ...(includeBoundaryTimestamp ? {} : { includeTimestamp: false }),
-            ...(typeof preparedUserTurnMessage?.timestamp === "number"
-              ? { currentUserTimestamp: preparedUserTurnMessage.timestamp }
-              : {}),
-          });
 
           if (!skipPromptSubmission && !isRawModelRun && hookRunner?.hasHooks("llm_input")) {
             hookRunner
@@ -1977,9 +1795,23 @@ export async function runEmbeddedAttempt(
       trajectoryEndRecorded = true;
       return finalizedResult;
     } finally {
-      if (trajectoryRecorder && !trajectoryEndRecorded) {
-        trajectoryRecorder.recordEvent("session.ended", {
-          status: promptError ? "error" : aborted || timedOut ? "interrupted" : "cleanup",
+      await cleanupEmbeddedAttemptSessionPhase({
+        attempt: params,
+        session,
+        sessionManager,
+        sessionLockController,
+        bundleMcpRuntime,
+        bundleLspRuntime,
+        removeToolResultContextGuard,
+        toolSearchCatalogRef,
+        sandboxSessionKey,
+        sessionAgentId,
+        buildAbortSettlePromise,
+        trajectoryRecorder,
+        trajectoryEndRecorded,
+        cleanupYieldAborted,
+        emitDiagnosticRunCompleted,
+        readState: () => ({
           aborted,
           externalAbort,
           timedOut,
@@ -1987,101 +1819,11 @@ export async function runEmbeddedAttempt(
           timedOutDuringCompaction,
           timedOutDuringToolExecution,
           timedOutByRunBudget,
-          promptError: promptError ? formatErrorMessage(promptError) : undefined,
-        });
-      }
-      await flushEmbeddedAttemptTrajectoryRecorder({
-        runId: params.runId,
-        sessionId: params.sessionId,
-        log,
-        trajectoryRecorder,
+          promptError,
+          beforeAgentRunBlocked,
+          beforeAgentRunBlockedBy,
+        }),
       });
-      // Always tear down the session (and release the lock) before we leave this attempt.
-      //
-      // BUGFIX: Wait for the agent to be truly idle before flushing pending tool results.
-      // agent runtime's auto-retry resolves waitForRetry() on assistant message receipt,
-      // *before* tool execution completes in the retried agent loop. Without this wait,
-      // flushPendingToolResults() fires while tools are still executing, inserting
-      // synthetic "missing tool result" errors and causing silent agent failures.
-      // See: https://github.com/openclaw/openclaw/issues/8643
-      let cleanupError: unknown;
-      try {
-        clearToolSearchCatalog({
-          sessionId: params.sessionId,
-          sessionKey: sandboxSessionKey,
-          agentId: sessionAgentId,
-          runId: params.runId,
-          catalogRef: toolSearchCatalogRef,
-        });
-        const cleanupAborted =
-          Boolean(params.abortSignal?.aborted) ||
-          aborted ||
-          timedOut ||
-          idleTimedOut ||
-          timedOutDuringCompaction;
-        const cleanupAbortLike = cleanupAborted || cleanupYieldAborted;
-        const cleanupSessionLock = await sessionLockController.acquireForCleanup({ session });
-        await cleanupEmbeddedAttemptResources({
-          removeToolResultContextGuard,
-          flushPendingToolResultsAfterIdle,
-          session,
-          sessionManager,
-          bundleMcpRuntime,
-          bundleLspRuntime,
-          sessionLock: cleanupSessionLock,
-          // PERF: If the run was aborted (user stop, timeout, sessions_yield, etc.),
-          // skip the idle wait and flush pending results synchronously so we can
-          // release the session lock ASAP.
-          aborted: cleanupAbortLike,
-          abortSettlePromise: cleanupAborted ? buildAbortSettlePromise() : null,
-          skipSessionFlush: sessionLockController.hasSessionTakeover(),
-          runId: params.runId,
-          sessionId: params.sessionId,
-        });
-      } catch (err) {
-        cleanupError = err;
-      }
-      const synthesizedCleanupTakeoverError =
-        !cleanupError && promptError && sessionLockController.hasSessionTakeover()
-          ? new EmbeddedAttemptSessionTakeoverError(params.sessionFile)
-          : undefined;
-      const cleanupFailure = cleanupError ?? synthesizedCleanupTakeoverError;
-      const shouldPreservePromptError = shouldPreservePromptErrorAfterCleanupError({
-        promptError,
-        cleanupError: cleanupFailure,
-      });
-      emitDiagnosticRunCompleted?.(
-        cleanupFailure
-          ? "error"
-          : beforeAgentRunBlocked
-            ? "blocked"
-            : promptError
-              ? "error"
-              : aborted || timedOut || idleTimedOut || timedOutDuringCompaction
-                ? "aborted"
-                : "completed",
-        shouldPreservePromptError ? promptError : (cleanupFailure ?? promptError),
-        beforeAgentRunBlocked
-          ? { blockedBy: beforeAgentRunBlockedBy ?? "before_agent_run" }
-          : undefined,
-      );
-      if (cleanupFailure) {
-        if (shouldPreservePromptError) {
-          log.warn(
-            `embedded attempt cleanup detected session takeover after prompt failure; preserving prompt error: ` +
-              `runId=${params.runId} sessionId=${params.sessionId} ` +
-              `promptError=${formatErrorMessage(promptError)} cleanupError=${formatErrorMessage(cleanupFailure)}`,
-          );
-          await Promise.reject(
-            new EmbeddedAttemptPromptErrorWithCleanupTakeoverError({
-              promptError,
-              cleanupError: cleanupFailure as EmbeddedAttemptSessionTakeoverError,
-            }),
-          );
-        } else {
-          await Promise.reject(toErrorObject(cleanupFailure, "Non-Error rejection"));
-        }
-      }
     }
   } finally {
     removeExternalAbortSignalListener?.();


### PR DESCRIPTION
## What Problem This Solves

`runEmbeddedAttempt` still directly compiled current-turn runtime context and owned final trajectory/session teardown. Those two phases mixed prompt-cache-sensitive transformation rules and cleanup/error precedence into the orchestration function.

## Why This Change Was Made

Extract `prepareEmbeddedAttemptPromptContext` for heartbeat filtering, tool-result projection, runtime-context carriers, boundary messages, and prompt reporting. Extract `cleanupEmbeddedAttemptSessionPhase` for trajectory flush, live lifecycle-state rereads, lock-safe resource cleanup, takeover error precedence, and terminal diagnostics.

Related #72072.

## User Impact

No intended behavior change. `attempt.ts` drops from 2,112 to 1,854 lines. Both extracted phases now have direct unit coverage.

## Evidence

- Blacksmith Testbox `tbx_01kxez0gtb2er8jbjzz36vfc1h`: 314 focused prompt-context, cleanup, runner, session-lock, context-engine, and terminal-hook tests passed.
- `pnpm tsgo:core` passed.
- `pnpm tsgo:core:test` passed.
- Changed gate passed conflict-marker, TypeScript LOC ratchet, attribution, export, dependency, and formatting checks; it then stopped on unrelated Plugin SDK baseline hash drift already present on current `main`.
- Fresh exact-head autoreview: no accepted or actionable findings; correctness 0.94.
- Hosted CI intentionally not awaited per maintainer instruction.
