### PR TITLE
fix(onepassword): validate audit limit strictly

### DIFF
--- a/extensions/onepassword/src/cli.test.ts
+++ b/extensions/onepassword/src/cli.test.ts
@@ -161,11 +161,26 @@ describe("1Password CLI output", () => {
     ]);
   });
 
-  it.each(["0x10", "1e3"])("rejects non-decimal audit limits: %s", async (limit) => {
-    const { onepassword } = setupCommands();
+  it.each(["", "0", "-1", "1.5", "0x10", "1e3", "1001"])(
+    "rejects invalid audit limits: %j",
+    async (limit) => {
+      const store = new MemoryKeyedStore<AuditRow>();
+      const entries = vi.spyOn(store, "entries");
+      const { onepassword, write } = setupCommands(store);
 
-    await expect(onepassword.child("audit").run({ limit })).rejects.toThrow(
-      "--limit must be an integer from 1 to 1000",
-    );
+      await expect(onepassword.child("audit").run({ limit })).rejects.toThrow(
+        "--limit must be an integer from 1 to 1000",
+      );
+      expect(entries).not.toHaveBeenCalled();
+      expect(write).not.toHaveBeenCalled();
+    },
+  );
+
+  it("accepts the maximum decimal audit limit", async () => {
+    const { onepassword, write } = setupCommands();
+
+    await onepassword.child("audit").run({ limit: "1000" });
+
+    expect(JSON.parse(String(write.mock.calls[0]?.[0]))).toEqual([]);
   });
 });

--- a/extensions/onepassword/src/cli.test.ts
+++ b/extensions/onepassword/src/cli.test.ts
@@ -160,4 +160,12 @@ describe("1Password CLI output", () => {
       `${"x".repeat(76)}...`,
     ]);
   });
+
+  it.each(["0x10", "1e3"])("rejects non-decimal audit limits: %s", async (limit) => {
+    const { onepassword } = setupCommands();
+
+    await expect(onepassword.child("audit").run({ limit })).rejects.toThrow(
+      "--limit must be an integer from 1 to 1000",
+    );
+  });
 });

--- a/extensions/onepassword/src/cli.ts
+++ b/extensions/onepassword/src/cli.ts
@@ -1,3 +1,4 @@
+import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { AuditRow } from "./broker.js";
@@ -23,8 +24,8 @@ function parseLimit(value: unknown): number {
   if (value === undefined) {
     return 50;
   }
-  const parsed = typeof value === "string" ? Number(value) : Number.NaN;
-  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 1000) {
+  const parsed = parseStrictPositiveInteger(value);
+  if (parsed === undefined || parsed > 1000) {
     throw new Error("--limit must be an integer from 1 to 1000");
   }
   return parsed;


### PR DESCRIPTION
## Summary

- reject hexadecimal and exponent notation for `onepassword audit --limit`
- reuse the shared strict positive-integer parser while preserving the existing `1..1000` bound
- add regression coverage for `0x10` and `1e3`

## What Problem This Solves

`onepassword audit --limit` used `Number(value)`, so JavaScript-specific forms such as `0x10` and `1e3` were accepted as 16 and 1000. That contradicted the command's documented integer contract and the stricter parsing used by sibling OpenClaw CLI surfaces.

## User Impact

Invalid limit syntax now fails immediately with the existing `--limit must be an integer from 1 to 1000` error instead of silently changing how many audit rows are returned. Ordinary decimal limits are unchanged.

## Origin / follow-up

- **Follows:** #106133, which introduced the optional 1Password broker and its status/audit CLI.
- **Gap this fills:** the original audit limit parser bounded the numeric result but did not enforce strict decimal integer syntax.
- **Consistency:** uses the existing `parseStrictPositiveInteger` plugin SDK helper already used by memory, wiki, workboard, canvas, and other CLI owners.

## Competition / linked PR analysis

Searches covered open PRs, issues, and recent merged PRs for `onepassword audit limit`, `1password audit limit`, `onepassword 0x10`, `onepassword parse limit`, the current error text, and the owner file. No competing strict-limit fix was found. Open PR #106424 touches the same two files but only fixes Unicode-safe audit reason truncation; it does not change `parseLimit`. Open PR #102293 is a separate broader 1Password proposal.

- **Related open PR scan:** no same-contract or canonical strict-limit PR was found; #106424 and #102293 are non-competing for the reasons above.

## Merge risk

- **Why it matters / User impact:** malformed numeric syntax currently succeeds and produces plausible JSON, so users receive no indication that the CLI interpreted a different value.
- **Risk labels considered:** compatibility.
- **Risk explanation:** the patch intentionally rejects non-decimal forms that were accepted only through JavaScript coercion; documented decimal values remain compatible.
- **Why acceptable:** the CLI already promises an integer range, sibling parsers are strict, and the existing error text is preserved.
- **Maintainer-ready confidence:** High; the owner is isolated, the shared parser is established, and real CLI before/after/control behavior was exercised.
- **Patch quality notes:** No fallback or downstream masking; validation is fixed at the single CLI source of truth.
- **Target test file:** `extensions/onepassword/src/cli.test.ts`
- **Root cause:** the root cause was permissive `Number(value)` coercion in the canonical `parseLimit` parser, which converted hexadecimal and exponent syntax into in-range integers before validation.
- **Why this is root-cause fix:** this fixes the source parser contract: strict decimal validation now occurs inside canonical `parseLimit` before the runtime audit-store slice, so malformed syntax cannot be normalized into a valid number downstream.
- **What did NOT change:** unchanged and out of scope are audit storage, row ordering, truncation, plugin configuration, defaults, and the existing `1..1000` range.
- **Architecture / source-of-truth check:** canonical source-of-truth is `extensions/onepassword/src/cli.ts`, the only owner of this option; no sibling onepassword parser requires a parallel change.
- **Scenario locked in:** `--limit 0x10` and `--limit 1e3` must fail; `--limit 16` must continue to succeed.
- **Why this is the smallest reliable guardrail:** one shared-helper import, one parser replacement, and one focused regression test.

## Real behavior proof

- **Behavior or issue addressed:** the shipped 1Password audit CLI must reject non-decimal limit syntax while retaining valid decimal behavior.
- **Canonical reachability path:** user CLI input (`openclaw onepassword audit --limit <value>`) → bundled plugin activation and Commander option ingestion → canonical `parseLimit` validation/parser → runtime audit-store slice → terminal JSON/error effect.
- **Boundary crossed:** local-runtime; both baseline and patched commands ran through the real built OpenClaw CLI with an isolated, credential-free state seed.
- **Shared helper / provider constraint check:** reused the repository's existing shared numeric parser, `parseStrictPositiveInteger` from `openclaw/plugin-sdk/number-runtime`; no provider contract applies.
- **Real environment tested:** Linux, Node 24.15.0, pinned main `668e5e8096ad21eedff4f9b31e7eeeb1f0123999`, CLI built with the repository `cliStartup` profile, isolated OpenClaw home with the bundled onepassword plugin enabled.
- **Exact steps or command run after this patch:** build the CLI, then run `openclaw.mjs onepassword audit --limit 0x10` and `openclaw.mjs onepassword audit --limit 16` through the state-aware daily-fix CLI adapter.
- **Evidence after fix:**

```text
BEFORE (pinned main)
$ openclaw.mjs onepassword audit --limit 0x10
[]
exit 0

AFTER (patched)
$ openclaw.mjs onepassword audit --limit 0x10
[openclaw] Reason: --limit must be an integer from 1 to 1000
exit 1

CONTROL (patched)
$ openclaw.mjs onepassword audit --limit 16
[]
exit 0
```

- **Observed result after fix:** hexadecimal input is rejected at the documented CLI validation boundary, while a normal decimal limit still reaches the local audit store and returns JSON.
- **What was not tested:** the full extension-tests tsgo project exited 1 without diagnostics on both the untouched pinned baseline and the initial patched worktree. After syncing the PR branch, the production extensions tsgo retry was terminated by SIGKILL without TypeScript diagnostics. On the final head, the focused CLI tests, formatting check, `cliStartup` build, diff check, and real CLI proof passed; remote CI remains responsible for the full typecheck lanes.
- **Fix classification:** Root cause fix

## Review findings addressed

- **RF-001:** documented the deliberate compatibility boundary: valid decimal limits and the existing range/default remain unchanged, while undocumented JavaScript coercion forms are rejected at the canonical parser.
- **RF-002:** rebased onto the main commit containing the Unicode-safe audit test, retained that test unchanged, and reran the combined focused CLI suite on the resulting exact head.
- **RF-003:** refreshed the branch through the approved `daily-fix sync-main` flow and regenerated the build, diff check, and real CLI BEFORE/AFTER/CONTROL proof for head `edc21fe2a353675f75edff285bdfa512302e66b5`.

## Regression Test Plan

- `pnpm exec vitest run extensions/onepassword/src/cli.test.ts`
- `pnpm exec oxfmt --check extensions/onepassword/src/cli.ts extensions/onepassword/src/cli.test.ts`
- `git diff --check`
- real built CLI before/after/control proof shown above

## Risk / Compatibility

Low. Valid decimal limits, the default of 50, and the maximum of 1000 are unchanged. Only undocumented JavaScript numeric notation is newly rejected.

## What was not changed

No changes to 1Password credential access, approval policy, audit persistence, reason truncation, plugin enablement, schemas, dependencies, or generated files.

## Root Cause

The range check ran after permissive JavaScript numeric coercion. `Number("0x10")` and `Number("1e3")` produce integers inside the accepted range, so malformed CLI syntax bypassed validation. Parsing through the shared strict integer helper closes that gap at the canonical owner.
