### PR TITLE
feat(codex): continue paired-node Codex catalog sessions from the Control UI

### DIFF
--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -49,8 +49,6 @@ type CodexThreadHistoryImportResult = {
   omittedMessages: number;
 };
 
-export type CodexThreadHistory = Pick<CodexThread, "id" | "createdAt" | "modelProvider" | "turns">;
-
 type BoundedCodexThreadHistoryProjection = CodexThreadHistoryImportResult & {
   responseItems: JsonValue[];
   transcriptMessages: AgentMessage[];
@@ -126,7 +124,7 @@ function projectCodexUserItemText(item: Record<string, unknown>): string | undef
 }
 
 function selectTurnsThroughBoundary(
-  thread: CodexThreadHistory,
+  thread: CodexThread,
   throughTurnId: string | null,
 ): NonNullable<CodexThread["turns"]> {
   if (throughTurnId === null) {
@@ -149,7 +147,7 @@ function selectTurnsThroughBoundary(
 }
 
 function projectCodexThreadHistory(params: {
-  thread: CodexThreadHistory;
+  thread: CodexThread;
   throughTurnId: string | null;
   importedAt: number;
   modelProvider?: string;
@@ -254,7 +252,7 @@ function selectBoundedCodexHistoryTail(
 
 /** Projects one terminal Codex history prefix into transcript and Responses API items. */
 export function projectBoundedCodexThreadHistory(params: {
-  thread: CodexThreadHistory;
+  thread: CodexThread;
   throughTurnId: string | null;
   importedAt: number;
   modelProvider?: string | null;
@@ -276,7 +274,7 @@ export function projectBoundedCodexThreadHistory(params: {
 
 /** Imports a bounded, user-visible Codex history tail into a new OpenClaw transcript. */
 export async function importCodexThreadHistoryToTranscript(params: {
-  thread: CodexThreadHistory;
+  thread: CodexThread;
   throughTurnId: string | null;
   storePath: string;
   sessionId: string;

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -49,6 +49,8 @@ type CodexThreadHistoryImportResult = {
   omittedMessages: number;
 };
 
+export type CodexThreadHistory = Pick<CodexThread, "id" | "createdAt" | "modelProvider" | "turns">;
+
 type BoundedCodexThreadHistoryProjection = CodexThreadHistoryImportResult & {
   responseItems: JsonValue[];
   transcriptMessages: AgentMessage[];
@@ -124,7 +126,7 @@ function projectCodexUserItemText(item: Record<string, unknown>): string | undef
 }
 
 function selectTurnsThroughBoundary(
-  thread: CodexThread,
+  thread: CodexThreadHistory,
   throughTurnId: string | null,
 ): NonNullable<CodexThread["turns"]> {
   if (throughTurnId === null) {
@@ -147,7 +149,7 @@ function selectTurnsThroughBoundary(
 }
 
 function projectCodexThreadHistory(params: {
-  thread: CodexThread;
+  thread: CodexThreadHistory;
   throughTurnId: string | null;
   importedAt: number;
   modelProvider?: string;
@@ -252,7 +254,7 @@ function selectBoundedCodexHistoryTail(
 
 /** Projects one terminal Codex history prefix into transcript and Responses API items. */
 export function projectBoundedCodexThreadHistory(params: {
-  thread: CodexThread;
+  thread: CodexThreadHistory;
   throughTurnId: string | null;
   importedAt: number;
   modelProvider?: string | null;
@@ -274,7 +276,7 @@ export function projectBoundedCodexThreadHistory(params: {
 
 /** Imports a bounded, user-visible Codex history tail into a new OpenClaw transcript. */
 export async function importCodexThreadHistoryToTranscript(params: {
-  thread: CodexThread;
+  thread: CodexThreadHistory;
   throughTurnId: string | null;
   storePath: string;
   sessionId: string;

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -760,7 +760,7 @@ describe("codex conversation binding", () => {
     expect(sharedClientMocks.getSharedCodexAppServerClient).not.toHaveBeenCalled();
   });
 
-  it("routes bound Codex CLI node sessions through node resume", async () => {
+  it("routes a programmatically bound Control UI session through node resume", async () => {
     const resumeCodexCliSessionOnNode = vi.fn(async () => ({
       ok: true as const,
       sessionId: "019e2007-1f7e-7eb1-a42b-8c01f4b9b5cd",
@@ -770,21 +770,21 @@ describe("codex conversation binding", () => {
     const result = await handleCodexConversationInboundClaim(
       {
         content: "continue the task",
-        channel: "discord",
-        isGroup: true,
+        channel: "webchat",
+        isGroup: false,
         commandAuthorized: true,
         sessionKey: "node-session",
       },
       {
-        channelId: "discord",
+        channelId: "webchat",
         sessionKey: "node-session",
         pluginBinding: {
           bindingId: "binding-1",
           pluginId: "codex",
           pluginRoot: tempDir,
-          channel: "discord",
+          channel: "webchat",
           accountId: "default",
-          conversationId: "channel-1",
+          conversationId: "node-session",
           boundAt: Date.now(),
           data: {
             kind: "codex-cli-node-session",

--- a/extensions/codex/src/node-cli-sessions.ts
+++ b/extensions/codex/src/node-cli-sessions.ts
@@ -21,7 +21,7 @@ import {
 import { formatCodexDisplayText } from "./command-formatters.js";
 
 const CODEX_CLI_SESSIONS_LIST_COMMAND = "codex.cli.sessions.list";
-const CODEX_CLI_SESSION_RESUME_COMMAND = "codex.cli.session.resume";
+export const CODEX_CLI_SESSION_RESUME_COMMAND = "codex.cli.session.resume";
 
 const DEFAULT_SESSION_LIMIT = 10;
 const MAX_SESSION_LIMIT = 50;

--- a/extensions/codex/src/session-catalog-node-adoption.ts
+++ b/extensions/codex/src/session-catalog-node-adoption.ts
@@ -1,0 +1,378 @@
+import { createHash } from "node:crypto";
+import { listAgentIds, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import { parseAgentSessionKey } from "openclaw/plugin-sdk/routing";
+import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { CodexThread } from "./app-server/protocol.js";
+import { importCodexThreadHistoryToTranscript } from "./app-server/transcript-mirror.js";
+import {
+  boundedCatalogString,
+  CatalogParamsError,
+  MAX_SESSION_ID_LENGTH,
+} from "./session-catalog-parsing.js";
+import type { CodexSessionCatalogSession } from "./session-catalog-types.js";
+
+const CODEX_NODE_SESSION_KEY_PREFIX = "harness:codex:node-session:";
+
+type CatalogSessionEntry = ReturnType<
+  PluginRuntime["agent"]["session"]["listSessionEntries"]
+>[number]["entry"];
+
+type CodexNodeSessionMarker = {
+  sourceHostId: string;
+  sourceThreadId: string;
+  nodeId: string;
+  initializing?: true;
+};
+
+export type AdoptedSessionEntry = {
+  key: string;
+  sessionId: string;
+  agentId: string;
+  initializing?: true;
+};
+
+export type CodexNodeHistory = {
+  thread: CodexThread;
+  throughTurnId: string | null;
+};
+
+export type CodexSessionDisposition = "existing" | "forked";
+
+export const continueOperations = new Map<
+  string,
+  Promise<{ sessionKey: string; disposition: CodexSessionDisposition }>
+>();
+const sessionActionTails = new Map<string, Promise<void>>();
+
+export async function runSessionActionExclusive<T>(
+  threadId: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous = sessionActionTails.get(threadId) ?? Promise.resolve();
+  const operation = previous.then(run);
+  const tail = operation.then(
+    () => undefined,
+    () => undefined,
+  );
+  sessionActionTails.set(threadId, tail);
+  try {
+    return await operation;
+  } finally {
+    if (sessionActionTails.get(threadId) === tail) {
+      sessionActionTails.delete(threadId);
+    }
+  }
+}
+
+// Session creation persists this plugin-owned suffix under an agent-qualified key.
+// Restart discovery must compare the parsed suffix, not the returned canonical key.
+export function adoptionSessionKeyRest(sessionKey: string): string {
+  const trimmed = sessionKey.trim();
+  return parseAgentSessionKey(trimmed)?.rest ?? trimmed;
+}
+
+export function listSupervisionAgentIds(config: OpenClawConfig): string[] {
+  const defaultAgentId = resolveDefaultAgentId(config);
+  return [defaultAgentId, ...listAgentIds(config).filter((agentId) => agentId !== defaultAgentId)];
+}
+
+export function adoptedSourceKey(hostId: string, threadId: string): string {
+  return `${hostId}\u0000${threadId}`;
+}
+
+export function lastTerminalTurnId(thread: CodexThread): string | undefined {
+  for (let index = (thread.turns?.length ?? 0) - 1; index >= 0; index -= 1) {
+    const turn = thread.turns?.[index];
+    const turnId = boundedCatalogString(turn?.id, MAX_SESSION_ID_LENGTH);
+    if (!turnId) {
+      continue;
+    }
+    if (
+      turn?.status === "completed" ||
+      turn?.status === "interrupted" ||
+      turn?.status === "failed"
+    ) {
+      return turnId;
+    }
+  }
+  return undefined;
+}
+
+function nodeAdoptionSessionKey(hostId: string, threadId: string): string {
+  const digest = createHash("sha256")
+    .update(JSON.stringify([hostId, threadId]))
+    .digest("hex");
+  return `${CODEX_NODE_SESSION_KEY_PREFIX}${digest}`;
+}
+
+function readNodeSessionMarker(entry: CatalogSessionEntry): CodexNodeSessionMarker | undefined {
+  const codex = isRecord(entry.pluginExtensions?.codex) ? entry.pluginExtensions.codex : undefined;
+  const marker = codex && isRecord(codex.sessionCatalog) ? codex.sessionCatalog : undefined;
+  if (
+    !marker ||
+    typeof marker.sourceHostId !== "string" ||
+    !marker.sourceHostId.startsWith("node:") ||
+    typeof marker.sourceThreadId !== "string" ||
+    !marker.sourceThreadId.trim() ||
+    typeof marker.nodeId !== "string" ||
+    !marker.nodeId.trim()
+  ) {
+    return undefined;
+  }
+  return {
+    sourceHostId: marker.sourceHostId,
+    sourceThreadId: marker.sourceThreadId,
+    nodeId: marker.nodeId,
+    ...(marker.initializing === true ? { initializing: true } : {}),
+  };
+}
+
+export function listNodeAdoptedSessionEntries(params: {
+  config?: OpenClawConfig;
+  runtime: PluginRuntime;
+  includeInitializing?: boolean;
+}): Map<string, AdoptedSessionEntry> {
+  const adopted = new Map<string, AdoptedSessionEntry>();
+  for (const agentId of listSupervisionAgentIds(params.config ?? {})) {
+    for (const { entry, sessionKey } of params.runtime.agent.session.listSessionEntries({
+      agentId,
+    })) {
+      const marker = readNodeSessionMarker(entry);
+      const sessionId = entry.sessionId?.trim();
+      if (
+        !marker ||
+        (marker.initializing === true && params.includeInitializing !== true) ||
+        entry.initializationPending === true ||
+        entry.agentHarnessId !== "codex" ||
+        entry.modelSelectionLocked !== true ||
+        !sessionId ||
+        adoptionSessionKeyRest(sessionKey) !==
+          nodeAdoptionSessionKey(marker.sourceHostId, marker.sourceThreadId) ||
+        marker.sourceHostId !== `node:${marker.nodeId}`
+      ) {
+        continue;
+      }
+      const sourceKey = adoptedSourceKey(marker.sourceHostId, marker.sourceThreadId);
+      if (adopted.has(sourceKey)) {
+        throw new Error(
+          `multiple OpenClaw sessions adopt Codex thread ${marker.sourceThreadId} on ${marker.sourceHostId}`,
+        );
+      }
+      adopted.set(sourceKey, {
+        key: sessionKey,
+        sessionId,
+        agentId,
+        ...(marker.initializing === true ? { initializing: true } : {}),
+      });
+    }
+  }
+  return adopted;
+}
+
+export function findNodeAdoptedSessionEntry(params: {
+  config: OpenClawConfig;
+  runtime: PluginRuntime;
+  hostId: string;
+  threadId: string;
+  includeInitializing?: boolean;
+}): AdoptedSessionEntry | undefined {
+  return listNodeAdoptedSessionEntries(params).get(
+    adoptedSourceKey(params.hostId, params.threadId),
+  );
+}
+
+export function nodeSessionMarker(params: {
+  hostId: string;
+  threadId: string;
+  nodeId: string;
+  initializing?: true;
+}): CodexNodeSessionMarker {
+  return {
+    sourceHostId: params.hostId,
+    sourceThreadId: params.threadId,
+    nodeId: params.nodeId,
+    ...(params.initializing === true ? { initializing: true } : {}),
+  };
+}
+
+export async function restoreNodeAdoptedSession(params: {
+  api: OpenClawPluginApi;
+  existing: AdoptedSessionEntry;
+  hostId: string;
+  threadId: string;
+  nodeId: string;
+}): Promise<void> {
+  const changedError = () =>
+    new CatalogParamsError("Codex OpenClaw session changed before it could be opened. Retry.");
+  const restored = await params.api.runtime.agent.session.patchSessionEntry({
+    sessionKey: params.existing.key,
+    readConsistency: "latest",
+    preserveActivity: true,
+    update: (entry) => {
+      const marker = readNodeSessionMarker(entry);
+      if (
+        entry.sessionId?.trim() !== params.existing.sessionId ||
+        entry.initializationPending === true ||
+        entry.agentHarnessId !== "codex" ||
+        entry.modelSelectionLocked !== true ||
+        !marker ||
+        marker.initializing === true ||
+        marker.sourceHostId !== params.hostId ||
+        marker.sourceThreadId !== params.threadId ||
+        marker.nodeId !== params.nodeId
+      ) {
+        throw changedError();
+      }
+      return { archivedAt: undefined };
+    },
+  });
+  if (!restored) {
+    throw changedError();
+  }
+}
+
+export async function finalizeNodeAdoptedSession(params: {
+  api: OpenClawPluginApi;
+  adopted: AdoptedSessionEntry;
+  marker: CodexNodeSessionMarker;
+}): Promise<void> {
+  const changedError = () =>
+    new CatalogParamsError("Codex OpenClaw session changed before it could be bound. Retry.");
+  let finalized: CatalogSessionEntry | null;
+  try {
+    finalized = await params.api.runtime.agent.session.patchSessionEntry({
+      sessionKey: params.adopted.key,
+      readConsistency: "latest",
+      preserveActivity: true,
+      update: (entry) => {
+        const current = readNodeSessionMarker(entry);
+        if (
+          entry.sessionId?.trim() !== params.adopted.sessionId ||
+          entry.initializationPending === true ||
+          entry.agentHarnessId !== "codex" ||
+          entry.modelSelectionLocked !== true ||
+          !current ||
+          current.sourceHostId !== params.marker.sourceHostId ||
+          current.sourceThreadId !== params.marker.sourceThreadId ||
+          current.nodeId !== params.marker.nodeId
+        ) {
+          throw changedError();
+        }
+        if (current.initializing !== true) {
+          return { archivedAt: undefined };
+        }
+        const codex = isRecord(entry.pluginExtensions?.codex) ? entry.pluginExtensions.codex : {};
+        return {
+          archivedAt: undefined,
+          pluginExtensions: {
+            ...entry.pluginExtensions,
+            codex: { ...codex, sessionCatalog: params.marker },
+          },
+        };
+      },
+    });
+  } catch (error) {
+    const currentEntry = params.api.runtime.agent.session.getSessionEntry({
+      sessionKey: params.adopted.key,
+      readConsistency: "latest",
+    });
+    const current = currentEntry ? readNodeSessionMarker(currentEntry) : undefined;
+    if (
+      currentEntry?.sessionId?.trim() === params.adopted.sessionId &&
+      current?.initializing !== true &&
+      current?.sourceHostId === params.marker.sourceHostId &&
+      current.sourceThreadId === params.marker.sourceThreadId &&
+      current.nodeId === params.marker.nodeId
+    ) {
+      return;
+    }
+    throw error;
+  }
+  if (!finalized) {
+    throw changedError();
+  }
+}
+
+export async function createOrReuseNodeAdoptedSession(params: {
+  api: OpenClawPluginApi;
+  config: OpenClawConfig;
+  hostId: string;
+  nodeId: string;
+  record: CodexSessionCatalogSession;
+  history: CodexNodeHistory;
+}): Promise<AdoptedSessionEntry> {
+  const existing = findNodeAdoptedSessionEntry({
+    config: params.config,
+    runtime: params.api.runtime,
+    hostId: params.hostId,
+    threadId: params.record.threadId,
+    includeInitializing: true,
+  });
+  if (existing) {
+    return existing;
+  }
+  const marker = nodeSessionMarker({
+    hostId: params.hostId,
+    threadId: params.record.threadId,
+    nodeId: params.nodeId,
+  });
+  const initializingMarker = { ...marker, initializing: true as const };
+  try {
+    const created = await params.api.runtime.agent.session.createSessionEntry({
+      cfg: params.config,
+      key: nodeAdoptionSessionKey(params.hostId, params.record.threadId),
+      agentId: resolveDefaultAgentId(params.config),
+      recoverMatchingInitialEntry: true,
+      ...(params.record.name?.trim() ? { label: params.record.name.trim() } : {}),
+      ...(params.record.cwd?.trim() ? { spawnedCwd: params.record.cwd.trim() } : {}),
+      initialEntry: {
+        agentHarnessId: "codex",
+        modelSelectionLocked: true,
+        pluginExtensions: {
+          codex: {
+            sessionCatalog: initializingMarker,
+          },
+        },
+      },
+      afterCreate: async (entry) => {
+        const storePath = resolveStorePath(params.config.session?.store, {
+          agentId: entry.agentId,
+        });
+        await importCodexThreadHistoryToTranscript({
+          thread: params.history.thread,
+          throughTurnId: params.history.throughTurnId,
+          storePath,
+          sessionId: entry.sessionId,
+          sessionKey: entry.key,
+          agentId: entry.agentId,
+          ...(params.record.cwd?.trim() ? { cwd: params.record.cwd.trim() } : {}),
+          modelProvider: params.record.modelProvider,
+          config: params.config,
+        });
+        return { pluginExtensions: { codex: { sessionCatalog: initializingMarker } } };
+      },
+    });
+    return {
+      key: created.key,
+      sessionId: created.sessionId,
+      agentId: created.agentId,
+      initializing: true,
+    };
+  } catch (error) {
+    const raced = findNodeAdoptedSessionEntry({
+      config: params.config,
+      runtime: params.api.runtime,
+      hostId: params.hostId,
+      threadId: params.record.threadId,
+      includeInitializing: true,
+    });
+    if (raced) {
+      return raced;
+    }
+    throw error;
+  }
+}

--- a/extensions/codex/src/session-catalog-node-adoption.ts
+++ b/extensions/codex/src/session-catalog-node-adoption.ts
@@ -199,42 +199,6 @@ export function nodeSessionMarker(params: {
   };
 }
 
-export async function restoreNodeAdoptedSession(params: {
-  api: OpenClawPluginApi;
-  existing: AdoptedSessionEntry;
-  hostId: string;
-  threadId: string;
-  nodeId: string;
-}): Promise<void> {
-  const changedError = () =>
-    new CatalogParamsError("Codex OpenClaw session changed before it could be opened. Retry.");
-  const restored = await params.api.runtime.agent.session.patchSessionEntry({
-    sessionKey: params.existing.key,
-    readConsistency: "latest",
-    preserveActivity: true,
-    update: (entry) => {
-      const marker = readNodeSessionMarker(entry);
-      if (
-        entry.sessionId?.trim() !== params.existing.sessionId ||
-        entry.initializationPending === true ||
-        entry.agentHarnessId !== "codex" ||
-        entry.modelSelectionLocked !== true ||
-        !marker ||
-        marker.initializing === true ||
-        marker.sourceHostId !== params.hostId ||
-        marker.sourceThreadId !== params.threadId ||
-        marker.nodeId !== params.nodeId
-      ) {
-        throw changedError();
-      }
-      return { archivedAt: undefined };
-    },
-  });
-  if (!restored) {
-    throw changedError();
-  }
-}
-
 export async function finalizeNodeAdoptedSession(params: {
   api: OpenClawPluginApi;
   adopted: AdoptedSessionEntry;

--- a/extensions/codex/src/session-catalog-node-continue.ts
+++ b/extensions/codex/src/session-catalog-node-continue.ts
@@ -1,0 +1,348 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import type { CodexThread } from "./app-server/protocol.js";
+import { createCodexCliNodeConversationBindingData } from "./conversation-binding-data.js";
+import { CODEX_CLI_SESSION_RESUME_COMMAND } from "./node-cli-sessions.js";
+import {
+  adoptedSourceKey,
+  continueOperations,
+  createOrReuseNodeAdoptedSession,
+  finalizeNodeAdoptedSession,
+  findNodeAdoptedSessionEntry,
+  lastTerminalTurnId,
+  nodeSessionMarker,
+  restoreNodeAdoptedSession,
+  runSessionActionExclusive,
+  type AdoptedSessionEntry,
+  type CodexNodeHistory,
+  type CodexSessionDisposition,
+} from "./session-catalog-node-adoption.js";
+import {
+  catalogError,
+  CatalogParamsError,
+  CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT,
+  filterCatalogPageByTitle,
+  isInteractiveThreadSource,
+  MAX_ACTION_CATALOG_PAGES,
+  MAX_TRANSCRIPT_PAGE_LIMIT,
+  parseCatalogPage,
+  parseTranscriptPage,
+  unwrapNodeInvokePayload,
+} from "./session-catalog-parsing.js";
+import type {
+  CodexSessionCatalogHost,
+  CodexSessionCatalogParams,
+  CodexSessionCatalogSession,
+} from "./session-catalog-types.js";
+
+export const CODEX_APP_SERVER_THREADS_LIST_COMMAND = "codex.appServer.threads.list.v1";
+export const CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND = "codex.appServer.thread.turns.list.v1";
+
+// A node may need a cold Codex state scan before returning a large catalog page.
+// Keep this above the Mac node's native 60-second deadline so its specific
+// timeout wins instead of the less useful generic node.invoke timeout.
+export const NODE_INVOKE_TIMEOUT_MS = 65_000;
+const CODEX_NODE_CONTINUE_COMMANDS = [
+  CODEX_APP_SERVER_THREADS_LIST_COMMAND,
+  CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND,
+  CODEX_CLI_SESSION_RESUME_COMMAND,
+] as const;
+
+export type CatalogNode = Awaited<ReturnType<PluginRuntime["nodes"]["list"]>>["nodes"][number];
+
+export function nodeLabel(node: CatalogNode): string {
+  return node.displayName?.trim() || node.remoteIp?.trim() || node.nodeId;
+}
+
+export function compareNodeLabels(left: CatalogNode, right: CatalogNode): number {
+  const leftLabel = nodeLabel(left);
+  const rightLabel = nodeLabel(right);
+  if (leftLabel < rightLabel) {
+    return -1;
+  }
+  if (leftLabel > rightLabel) {
+    return 1;
+  }
+  return 0;
+}
+
+function canContinueCodexOnNode(node: CatalogNode): boolean {
+  return (
+    node.connected === true &&
+    CODEX_NODE_CONTINUE_COMMANDS.every(
+      (command) =>
+        node.commands?.includes(command) === true &&
+        node.invocableCommands?.includes(command) === true,
+    )
+  );
+}
+
+export async function listPairedNode(params: {
+  runtime: PluginRuntime;
+  node: CatalogNode;
+  query: CodexSessionCatalogParams;
+  adoptedSessions: ReadonlyMap<string, AdoptedSessionEntry>;
+}): Promise<CodexSessionCatalogHost> {
+  const hostId = `node:${params.node.nodeId}`;
+  const common = {
+    hostId,
+    label: nodeLabel(params.node),
+    kind: "node" as const,
+    nodeId: params.node.nodeId,
+    canContinueCodex: canContinueCodexOnNode(params.node),
+  };
+  if (params.node.connected !== true) {
+    return {
+      ...common,
+      connected: false,
+      sessions: [],
+      error: { code: "NODE_OFFLINE", message: "Paired node is offline" },
+    };
+  }
+  try {
+    const raw = await params.runtime.nodes.invoke({
+      nodeId: params.node.nodeId,
+      command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
+      params: {
+        cursor: params.query.cursors?.[hostId],
+        limit: params.query.limitPerHost,
+        searchTerm: params.query.search,
+      },
+      timeoutMs: NODE_INVOKE_TIMEOUT_MS,
+    });
+    const page = filterCatalogPageByTitle(
+      parseCatalogPage(unwrapNodeInvokePayload(raw)),
+      params.query.search,
+    );
+    return {
+      ...common,
+      connected: true,
+      ...page,
+      sessions: page.sessions.map((session) => {
+        const adopted = params.adoptedSessions.get(adoptedSourceKey(hostId, session.threadId));
+        return adopted ? Object.assign({}, session, { openClawSessionKey: adopted.key }) : session;
+      }),
+    };
+  } catch (error) {
+    return {
+      ...common,
+      connected: true,
+      sessions: [],
+      error: catalogError("NODE_INVOKE_FAILED", error),
+    };
+  }
+}
+
+async function requireNodeForCodexContinue(params: {
+  runtime: PluginRuntime;
+  hostId: string;
+}): Promise<{ node: CatalogNode; nodeId: string }> {
+  const nodeId = params.hostId.slice("node:".length).trim();
+  if (!nodeId || params.hostId !== `node:${nodeId}`) {
+    throw new CatalogParamsError("Codex session catalog hostId is invalid");
+  }
+  const node = (await params.runtime.nodes.list()).nodes.find(
+    (candidate) => candidate.nodeId === nodeId,
+  );
+  if (!node || !canContinueCodexOnNode(node)) {
+    throw new CatalogParamsError("paired node does not permit Codex session continuation");
+  }
+  return { node, nodeId };
+}
+
+async function resolveNodeCodexRecord(params: {
+  runtime: PluginRuntime;
+  nodeId: string;
+  threadId: string;
+}): Promise<CodexSessionCatalogSession> {
+  let cursor: string | undefined;
+  const seenCursors = new Set<string>();
+  for (let pageIndex = 0; pageIndex < MAX_ACTION_CATALOG_PAGES; pageIndex += 1) {
+    const raw = await params.runtime.nodes.invoke({
+      nodeId: params.nodeId,
+      command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
+      params: {
+        limit: CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT,
+        ...(cursor ? { cursor } : {}),
+      },
+      timeoutMs: NODE_INVOKE_TIMEOUT_MS,
+    });
+    const page = parseCatalogPage(unwrapNodeInvokePayload(raw));
+    const record = page.sessions.find((candidate) => candidate.threadId === params.threadId);
+    if (record) {
+      return record;
+    }
+    const nextCursor = page.nextCursor?.trim();
+    if (!nextCursor) {
+      break;
+    }
+    if (seenCursors.has(nextCursor)) {
+      throw new CatalogParamsError("Codex session eligibility could not be verified");
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+  throw new CatalogParamsError("Codex session is unavailable on the paired node");
+}
+
+function requireContinuableNodeRecord(record: CodexSessionCatalogSession): void {
+  if (record.archived) {
+    throw new CatalogParamsError("Codex session is archived on the paired node");
+  }
+  if (!isInteractiveThreadSource(record.source)) {
+    throw new CatalogParamsError(
+      "Codex session is not a non-archived interactive CLI or VS Code session",
+    );
+  }
+  if (record.status === "idle" || record.status === "notLoaded") {
+    // The node App Server is a passive catalog reader, so stored CLI/VS Code
+    // sessions normally report notLoaded. Node resume serializes OpenClaw turns.
+    return;
+  }
+  if (record.status === "active") {
+    throw new CatalogParamsError(
+      "Codex session is active on the paired node; wait for it to finish before continuing",
+    );
+  }
+  throw new CatalogParamsError("Codex session cannot be continued in its current state");
+}
+
+async function readNodeCodexHistory(params: {
+  runtime: PluginRuntime;
+  nodeId: string;
+  record: CodexSessionCatalogSession;
+}): Promise<CodexNodeHistory> {
+  const raw = await params.runtime.nodes.invoke({
+    nodeId: params.nodeId,
+    command: CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND,
+    params: {
+      threadId: params.record.threadId,
+      limit: MAX_TRANSCRIPT_PAGE_LIMIT,
+    },
+    timeoutMs: NODE_INVOKE_TIMEOUT_MS,
+  });
+  const page = parseTranscriptPage(unwrapNodeInvokePayload(raw));
+  const thread: CodexThread = {
+    id: params.record.threadId,
+    createdAt: params.record.createdAt ?? 0,
+    modelProvider: params.record.modelProvider ?? "openai",
+    turns: page.data.toReversed(),
+  };
+  return { thread, throughTurnId: lastTerminalTurnId(thread) ?? null };
+}
+
+async function continueNodeCodexSessionInner(params: {
+  api: OpenClawPluginApi;
+  config: OpenClawConfig;
+  hostId: string;
+  threadId: string;
+}): Promise<{
+  sessionKey: string;
+  disposition: CodexSessionDisposition;
+  conversationBinding: {
+    summary: string;
+    detachHint: string;
+    data: Record<string, unknown>;
+  };
+  afterConversationBound: () => Promise<void>;
+}> {
+  const { nodeId } = await requireNodeForCodexContinue({
+    runtime: params.api.runtime,
+    hostId: params.hostId,
+  });
+  const record = await resolveNodeCodexRecord({
+    runtime: params.api.runtime,
+    nodeId,
+    threadId: params.threadId,
+  });
+  requireContinuableNodeRecord(record);
+  const existing = findNodeAdoptedSessionEntry({
+    config: params.config,
+    runtime: params.api.runtime,
+    hostId: params.hostId,
+    threadId: params.threadId,
+    includeInitializing: true,
+  });
+  let adopted: AdoptedSessionEntry;
+  let disposition: CodexSessionDisposition;
+  if (existing) {
+    if (existing.initializing !== true) {
+      await restoreNodeAdoptedSession({
+        api: params.api,
+        existing,
+        hostId: params.hostId,
+        threadId: params.threadId,
+        nodeId,
+      });
+    }
+    adopted = existing;
+    disposition = "existing";
+  } else {
+    const history = await readNodeCodexHistory({
+      runtime: params.api.runtime,
+      nodeId,
+      record,
+    });
+    adopted = await createOrReuseNodeAdoptedSession({
+      api: params.api,
+      config: params.config,
+      hostId: params.hostId,
+      nodeId,
+      record,
+      history,
+    });
+    disposition = "forked";
+  }
+  const marker = nodeSessionMarker({
+    hostId: params.hostId,
+    threadId: params.threadId,
+    nodeId,
+  });
+  return {
+    sessionKey: adopted.key,
+    disposition,
+    conversationBinding: {
+      summary: "Continue this Codex session on its paired node.",
+      detachHint: "Start a new chat to leave the paired-node Codex session.",
+      data: createCodexCliNodeConversationBindingData({
+        nodeId,
+        sessionId: params.threadId,
+        agentId: adopted.agentId,
+        cwd: record.cwd,
+      }),
+    },
+    afterConversationBound: async () =>
+      await finalizeNodeAdoptedSession({ api: params.api, adopted, marker }),
+  };
+}
+
+export async function continueNodeCodexSession(params: {
+  api: OpenClawPluginApi;
+  config: OpenClawConfig;
+  hostId: string;
+  threadId: string;
+}) {
+  const nodeId = params.hostId.slice("node:".length).trim();
+  if (!nodeId || params.hostId !== `node:${nodeId}`) {
+    throw new CatalogParamsError("Codex session catalog hostId is invalid");
+  }
+  const sourceKey = adoptedSourceKey(`node:${nodeId}`, params.threadId);
+  const current = continueOperations.get(sourceKey) as
+    | Promise<Awaited<ReturnType<typeof continueNodeCodexSessionInner>>>
+    | undefined;
+  if (current) {
+    return await current;
+  }
+  const operation = runSessionActionExclusive(sourceKey, async () =>
+    continueNodeCodexSessionInner(params),
+  );
+  continueOperations.set(sourceKey, operation);
+  try {
+    return await operation;
+  } finally {
+    if (continueOperations.get(sourceKey) === operation) {
+      continueOperations.delete(sourceKey);
+    }
+  }
+}

--- a/extensions/codex/src/session-catalog-node-continue.ts
+++ b/extensions/codex/src/session-catalog-node-continue.ts
@@ -12,7 +12,6 @@ import {
   findNodeAdoptedSessionEntry,
   lastTerminalTurnId,
   nodeSessionMarker,
-  restoreNodeAdoptedSession,
   runSessionActionExclusive,
   type AdoptedSessionEntry,
   type CodexNodeHistory,
@@ -268,15 +267,8 @@ async function continueNodeCodexSessionInner(params: {
   let adopted: AdoptedSessionEntry;
   let disposition: CodexSessionDisposition;
   if (existing) {
-    if (existing.initializing !== true) {
-      await restoreNodeAdoptedSession({
-        api: params.api,
-        existing,
-        hostId: params.hostId,
-        threadId: params.threadId,
-        nodeId,
-      });
-    }
+    // Unarchive/finalize happens in afterConversationBound so a failed binding
+    // install cannot leave a visible session with no node routing.
     adopted = existing;
     disposition = "existing";
   } else {

--- a/extensions/codex/src/session-catalog-node-continue.ts
+++ b/extensions/codex/src/session-catalog-node-continue.ts
@@ -237,6 +237,7 @@ async function continueNodeCodexSessionInner(params: {
   config: OpenClawConfig;
   hostId: string;
   threadId: string;
+  clientScopes?: readonly string[];
 }): Promise<{
   sessionKey: string;
   disposition: CodexSessionDisposition;
@@ -307,7 +308,9 @@ async function continueNodeCodexSessionInner(params: {
       detachHint: "Start a new chat to leave the paired-node Codex session.",
       data: createCodexCliNodeConversationBindingData({
         nodeId,
-        sessionId: params.threadId,
+        // codex exec resume takes the CLI session id; forked threads share a
+        // session tree where the thread id and session id differ.
+        sessionId: record.sessionId?.trim() || params.threadId,
         agentId: adopted.agentId,
         cwd: record.cwd,
       }),
@@ -322,7 +325,14 @@ export async function continueNodeCodexSession(params: {
   config: OpenClawConfig;
   hostId: string;
   threadId: string;
+  clientScopes?: readonly string[];
 }) {
+  // Bound turns run native Codex on the node and pass canMutateCodexHost only
+  // for owners/admins; gate before the dedupe join so a non-admin caller can
+  // neither mint an always-rejected session nor ride an admin's operation.
+  if (params.clientScopes?.includes("operator.admin") !== true) {
+    throw new CatalogParamsError("continuing a paired-node Codex session requires operator.admin");
+  }
   const nodeId = params.hostId.slice("node:".length).trim();
   if (!nodeId || params.hostId !== `node:${nodeId}`) {
     throw new CatalogParamsError("Codex session catalog hostId is invalid");

--- a/extensions/codex/src/session-catalog-parsing.ts
+++ b/extensions/codex/src/session-catalog-parsing.ts
@@ -1,0 +1,455 @@
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import type { CodexThread, CodexThreadTurnsListResponse } from "./app-server/protocol.js";
+import { CODEX_INTERACTIVE_THREAD_SOURCE_KINDS } from "./app-server/protocol.js";
+import type {
+  CodexSessionCatalogError,
+  CodexSessionCatalogPage,
+  CodexSessionCatalogPageParams,
+  CodexSessionCatalogParams,
+  CodexSessionCatalogSession,
+} from "./session-catalog-types.js";
+
+const DEFAULT_PAGE_LIMIT = 50;
+export const CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT = 100;
+const MAX_SEARCH_LENGTH = 500;
+export const MAX_CURSOR_LENGTH = 4096;
+const MAX_CURSOR_COUNT = 100;
+export const MAX_HOST_COUNT = 100;
+const MAX_HOST_ID_LENGTH = 256;
+const MAX_CWD_LENGTH = 4096;
+export const MAX_SESSION_ID_LENGTH = 256;
+const MAX_SESSION_NAME_LENGTH = 500;
+const MAX_SESSION_KEY_LENGTH = 1024;
+const MAX_METADATA_LENGTH = 500;
+const MAX_ACTIVE_FLAGS = 16;
+export const MAX_ACTION_CATALOG_PAGES = 100;
+export const DEFAULT_TRANSCRIPT_PAGE_LIMIT = 20;
+export const MAX_TRANSCRIPT_PAGE_LIMIT = 50;
+const MAX_TRANSCRIPT_PAGE_BYTES = 20 * 1024 * 1024;
+export const MAX_TITLE_SEARCH_CATALOG_PAGES = 20;
+
+export class CatalogParamsError extends Error {}
+
+export function readControlCursor(value: unknown, label: string): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== "string" || !value.trim() || value.length > MAX_CURSOR_LENGTH) {
+    throw new CatalogParamsError(`invalid Codex session catalog ${label} cursor`);
+  }
+  return value;
+}
+
+export function boundedCatalogString(
+  value: unknown,
+  maxLength: number,
+  overflow: "omit" | "truncate" = "omit",
+): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return overflow === "truncate" ? truncateUtf16Safe(normalized, maxLength) : undefined;
+}
+
+type CodexInteractiveThreadSourceKind = (typeof CODEX_INTERACTIVE_THREAD_SOURCE_KINDS)[number];
+
+export function isInteractiveThreadSource(
+  source: unknown,
+): source is CodexInteractiveThreadSourceKind {
+  return CODEX_INTERACTIVE_THREAD_SOURCE_KINDS.some((kind) => kind === source);
+}
+
+export function toCatalogSession(
+  thread: CodexThread,
+  archived: boolean,
+): CodexSessionCatalogSession | undefined {
+  const source = thread.source;
+  if (!isInteractiveThreadSource(source)) {
+    return undefined;
+  }
+  const record = thread as CodexThread & Record<string, unknown>;
+  const threadId = boundedCatalogString(thread.id, MAX_SESSION_ID_LENGTH);
+  if (!threadId) {
+    return undefined;
+  }
+  const activeFlags =
+    thread.status?.type === "active"
+      ? thread.status.activeFlags
+          ?.flatMap((flag) => {
+            const normalized = boundedCatalogString(flag, 128);
+            return normalized ? [normalized] : [];
+          })
+          .slice(0, MAX_ACTIVE_FLAGS)
+      : undefined;
+  const gitInfo = isRecord(record.gitInfo) ? record.gitInfo : undefined;
+  const sessionId = boundedCatalogString(thread.sessionId, MAX_SESSION_ID_LENGTH);
+  const name = boundedCatalogString(thread.name, MAX_SESSION_NAME_LENGTH, "truncate");
+  const cwd = boundedCatalogString(thread.cwd, MAX_CWD_LENGTH);
+  const modelProvider = boundedCatalogString(record.modelProvider, MAX_METADATA_LENGTH, "truncate");
+  const cliVersion = boundedCatalogString(record.cliVersion, MAX_METADATA_LENGTH, "truncate");
+  const gitBranch = boundedCatalogString(gitInfo?.branch, MAX_METADATA_LENGTH, "truncate");
+  return {
+    threadId,
+    status: thread.status?.type ?? "notLoaded",
+    archived,
+    ...(sessionId ? { sessionId } : {}),
+    ...(thread.name === null ? { name: null } : name ? { name } : {}),
+    ...(cwd ? { cwd } : {}),
+    ...(activeFlags?.length ? { activeFlags } : {}),
+    ...(typeof thread.createdAt === "number" && Number.isFinite(thread.createdAt)
+      ? { createdAt: thread.createdAt }
+      : {}),
+    ...(typeof thread.updatedAt === "number" && Number.isFinite(thread.updatedAt)
+      ? { updatedAt: thread.updatedAt }
+      : {}),
+    ...(typeof record.recencyAt === "number" && Number.isFinite(record.recencyAt)
+      ? { recencyAt: record.recencyAt }
+      : record.recencyAt === null
+        ? { recencyAt: null }
+        : {}),
+    source,
+    ...(modelProvider ? { modelProvider } : {}),
+    ...(cliVersion ? { cliVersion } : {}),
+    ...(gitBranch ? { gitBranch } : {}),
+  };
+}
+
+export function normalizeLimit(value: unknown, key: string): number {
+  if (value === undefined) {
+    return DEFAULT_PAGE_LIMIT;
+  }
+  if (
+    !Number.isInteger(value) ||
+    (value as number) < 1 ||
+    (value as number) > CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT
+  ) {
+    throw new CatalogParamsError(
+      `${key} must be an integer from 1 to ${CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT}`,
+    );
+  }
+  return value as number;
+}
+
+export function readOptionalString(
+  params: Record<string, unknown>,
+  key: string,
+  maxLength: number,
+) {
+  const value = params[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new CatalogParamsError(`${key} must be a string`);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed.length > maxLength) {
+    throw new CatalogParamsError(`${key} must be at most ${maxLength} characters`);
+  }
+  return trimmed;
+}
+
+export function requireOnlyKeys(
+  params: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+): void {
+  const unknown = Object.keys(params).find((key) => !allowed.has(key));
+  if (unknown) {
+    throw new CatalogParamsError(`unknown Codex session catalog parameter: ${unknown}`);
+  }
+}
+
+export function readPageParams(value: unknown): CodexSessionCatalogPageParams {
+  if (!isRecord(value)) {
+    throw new CatalogParamsError("Codex session catalog parameters must be an object");
+  }
+  const params = value;
+  requireOnlyKeys(params, new Set(["cursor", "limit", "searchTerm", "cwd"]));
+  const cursor = readOptionalString(params, "cursor", MAX_CURSOR_LENGTH);
+  const searchTerm = readOptionalString(params, "searchTerm", MAX_SEARCH_LENGTH);
+  const cwd = readOptionalString(params, "cwd", MAX_CWD_LENGTH);
+  return {
+    limit: normalizeLimit(params.limit, "limit"),
+    ...(cursor ? { cursor } : {}),
+    ...(searchTerm ? { searchTerm } : {}),
+    ...(cwd ? { cwd } : {}),
+  };
+}
+
+export function readGatewayParams(value: unknown): CodexSessionCatalogParams {
+  if (value !== undefined && !isRecord(value)) {
+    throw new CatalogParamsError("Codex session catalog parameters must be an object");
+  }
+  const params = isRecord(value) ? value : {};
+  requireOnlyKeys(params, new Set(["search", "limitPerHost", "hostIds", "cursors"]));
+  const search = readOptionalString(params, "search", MAX_SEARCH_LENGTH);
+  let hostIds: string[] | undefined;
+  if (params.hostIds !== undefined) {
+    if (!Array.isArray(params.hostIds) || params.hostIds.length > MAX_HOST_COUNT) {
+      throw new CatalogParamsError(`hostIds must contain at most ${MAX_HOST_COUNT} host ids`);
+    }
+    hostIds = [...new Set(params.hostIds.map((hostId) => readHostId(hostId)))];
+  }
+  let cursors: Record<string, string> | undefined;
+  if (params.cursors !== undefined) {
+    if (!isRecord(params.cursors)) {
+      throw new CatalogParamsError("cursors must be an object");
+    }
+    const entries = Object.entries(params.cursors);
+    if (entries.length > MAX_CURSOR_COUNT) {
+      throw new CatalogParamsError(`cursors may contain at most ${MAX_CURSOR_COUNT} hosts`);
+    }
+    cursors = {};
+    for (const [hostId, cursor] of entries) {
+      const normalizedHostId = hostId.trim();
+      if (
+        normalizedHostId.length === 0 ||
+        normalizedHostId.length > MAX_HOST_ID_LENGTH ||
+        (!normalizedHostId.startsWith("gateway:") && !normalizedHostId.startsWith("node:"))
+      ) {
+        throw new CatalogParamsError(`invalid Codex session catalog host id: ${hostId}`);
+      }
+      if (
+        typeof cursor !== "string" ||
+        !cursor.trim() ||
+        cursor.trim().length > MAX_CURSOR_LENGTH
+      ) {
+        throw new CatalogParamsError(`invalid cursor for Codex session catalog host: ${hostId}`);
+      }
+      cursors[normalizedHostId] = cursor.trim();
+    }
+  }
+  return {
+    limitPerHost: normalizeLimit(params.limitPerHost, "limitPerHost"),
+    ...(search ? { search } : {}),
+    ...(hostIds && hostIds.length > 0 ? { hostIds } : {}),
+    ...(cursors && Object.keys(cursors).length > 0 ? { cursors } : {}),
+  };
+}
+
+function readHostId(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new CatalogParamsError("Codex session catalog host ids must be strings");
+  }
+  const hostId = value.trim();
+  if (
+    hostId.length === 0 ||
+    hostId.length > MAX_HOST_ID_LENGTH ||
+    (!hostId.startsWith("gateway:") && !hostId.startsWith("node:"))
+  ) {
+    throw new CatalogParamsError(`invalid Codex session catalog host id: ${value}`);
+  }
+  return hostId;
+}
+
+export function parseJsonParams(paramsJSON?: string | null): unknown {
+  if (!paramsJSON?.trim()) {
+    return {};
+  }
+  try {
+    return JSON.parse(paramsJSON) as unknown;
+  } catch (error) {
+    throw new Error("Codex session catalog parameters must be valid JSON", { cause: error });
+  }
+}
+
+function readFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function parseOptionalCatalogString(
+  value: unknown,
+  field: string,
+  maxLength: number,
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string" || value.length > maxLength) {
+    throw new Error(`Codex session catalog returned an invalid ${field}`);
+  }
+  return value;
+}
+
+function parseCatalogSession(
+  value: unknown,
+  options: { allowOpenClawSessionKey?: boolean } = {},
+): CodexSessionCatalogSession {
+  if (
+    !isRecord(value) ||
+    typeof value.threadId !== "string" ||
+    !value.threadId.trim() ||
+    value.threadId.length > MAX_SESSION_ID_LENGTH ||
+    value.archived !== false
+  ) {
+    throw new Error("Codex session catalog returned an invalid session");
+  }
+  const status = parseOptionalCatalogString(value.status, "status", 64);
+  if (!status?.trim()) {
+    throw new Error("Codex session catalog returned an invalid status");
+  }
+  if (value.activeFlags !== undefined && !Array.isArray(value.activeFlags)) {
+    throw new Error("Codex session catalog returned invalid active flags");
+  }
+  if (Array.isArray(value.activeFlags) && value.activeFlags.length > MAX_ACTIVE_FLAGS) {
+    throw new Error("Codex session catalog returned too many active flags");
+  }
+  const activeFlags = Array.isArray(value.activeFlags)
+    ? value.activeFlags.map((entry) => {
+        const flag = parseOptionalCatalogString(entry, "active flag", 128);
+        if (flag === undefined) {
+          throw new Error("Codex session catalog returned an invalid active flag");
+        }
+        return flag;
+      })
+    : undefined;
+  const sessionId = parseOptionalCatalogString(
+    value.sessionId,
+    "session id",
+    MAX_SESSION_ID_LENGTH,
+  );
+  const name =
+    value.name === null
+      ? null
+      : parseOptionalCatalogString(value.name, "session name", MAX_SESSION_NAME_LENGTH);
+  const cwd = parseOptionalCatalogString(value.cwd, "cwd", MAX_CWD_LENGTH);
+  const source = parseOptionalCatalogString(value.source, "source", MAX_METADATA_LENGTH);
+  const modelProvider = parseOptionalCatalogString(
+    value.modelProvider,
+    "model provider",
+    MAX_METADATA_LENGTH,
+  );
+  const cliVersion = parseOptionalCatalogString(
+    value.cliVersion,
+    "CLI version",
+    MAX_METADATA_LENGTH,
+  );
+  const gitBranch = parseOptionalCatalogString(value.gitBranch, "Git branch", MAX_METADATA_LENGTH);
+  const openClawSessionKey = options.allowOpenClawSessionKey
+    ? parseOptionalCatalogString(
+        value.openClawSessionKey,
+        "OpenClaw session key",
+        MAX_SESSION_KEY_LENGTH,
+      )
+    : undefined;
+  const createdAt = readFiniteNumber(value.createdAt);
+  const updatedAt = readFiniteNumber(value.updatedAt);
+  const recencyAt = value.recencyAt === null ? null : readFiniteNumber(value.recencyAt);
+  return {
+    threadId: value.threadId,
+    status,
+    archived: value.archived,
+    ...(sessionId !== undefined ? { sessionId } : {}),
+    ...(name !== undefined ? { name } : {}),
+    ...(cwd !== undefined ? { cwd } : {}),
+    ...(activeFlags && activeFlags.length > 0 ? { activeFlags } : {}),
+    ...(createdAt !== undefined ? { createdAt } : {}),
+    ...(updatedAt !== undefined ? { updatedAt } : {}),
+    ...(recencyAt !== undefined ? { recencyAt } : {}),
+    ...(source !== undefined ? { source } : {}),
+    ...(modelProvider !== undefined ? { modelProvider } : {}),
+    ...(cliVersion !== undefined ? { cliVersion } : {}),
+    ...(gitBranch !== undefined ? { gitBranch } : {}),
+    ...(openClawSessionKey !== undefined ? { openClawSessionKey } : {}),
+  };
+}
+
+export function parseCatalogPage(
+  value: unknown,
+  options: { allowOpenClawSessionKey?: boolean } = {},
+): CodexSessionCatalogPage {
+  if (
+    !isRecord(value) ||
+    !Array.isArray(value.sessions) ||
+    value.sessions.length > CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT
+  ) {
+    throw new Error("Codex session catalog returned an invalid page");
+  }
+  const nextCursor = parseOptionalCatalogString(value.nextCursor, "next cursor", MAX_CURSOR_LENGTH);
+  const backwardsCursor = parseOptionalCatalogString(
+    value.backwardsCursor,
+    "backwards cursor",
+    MAX_CURSOR_LENGTH,
+  );
+  return {
+    sessions: value.sessions.map((session) => parseCatalogSession(session, options)),
+    ...(nextCursor ? { nextCursor } : {}),
+    ...(backwardsCursor ? { backwardsCursor } : {}),
+  };
+}
+
+export function filterCatalogPageByTitle(
+  page: CodexSessionCatalogPage,
+  searchTerm: string | undefined,
+): CodexSessionCatalogPage {
+  if (!searchTerm) {
+    return page;
+  }
+  return {
+    ...page,
+    sessions: page.sessions.filter((session) =>
+      session.name?.toLocaleLowerCase().includes(searchTerm.toLocaleLowerCase()),
+    ),
+  };
+}
+
+export function unwrapNodeInvokePayload(value: unknown): unknown {
+  if (!isRecord(value)) {
+    return value;
+  }
+  if (typeof value.payloadJSON === "string" && value.payloadJSON.trim()) {
+    try {
+      return JSON.parse(value.payloadJSON) as unknown;
+    } catch (error) {
+      throw new Error("Codex node returned malformed session catalog JSON", { cause: error });
+    }
+  }
+  return "payload" in value ? value.payload : value;
+}
+
+export function catalogError(code: string, _error: unknown): CodexSessionCatalogError {
+  const messages: Record<string, string> = {
+    APP_SERVER_UNAVAILABLE: "Codex app-server is unavailable on this host",
+    NODE_INVOKE_FAILED: "The paired node could not return its Codex session catalog",
+    NODE_LIST_FAILED: "Paired nodes could not be listed",
+  };
+  return { code, message: messages[code] ?? "Codex session catalog request failed" };
+}
+
+export function parseTranscriptPage(value: unknown): CodexThreadTurnsListResponse {
+  if (
+    !isRecord(value) ||
+    !Array.isArray(value.data) ||
+    value.data.length > MAX_TRANSCRIPT_PAGE_LIMIT ||
+    value.data.some(
+      (turn) =>
+        !isRecord(turn) || !Array.isArray(turn.items) || turn.items.some((item) => !isRecord(item)),
+    )
+  ) {
+    throw new Error("Codex app-server returned an invalid transcript page");
+  }
+  const nextCursor = readControlCursor(value.nextCursor, "transcript next response");
+  const backwardsCursor = readControlCursor(value.backwardsCursor, "transcript backwards response");
+  const page: CodexThreadTurnsListResponse = {
+    data: value.data as CodexThreadTurnsListResponse["data"],
+    ...(nextCursor ? { nextCursor } : {}),
+    ...(backwardsCursor ? { backwardsCursor } : {}),
+  };
+  // A bounded item count does not bound tool output embedded in one item. Keep
+  // the page below node.invoke and Gateway WebSocket payload ceilings.
+  if (Buffer.byteLength(JSON.stringify(page), "utf8") > MAX_TRANSCRIPT_PAGE_BYTES) {
+    throw new Error("Codex app-server transcript page exceeds the safe response size");
+  }
+  return page;
+}

--- a/extensions/codex/src/session-catalog-types.ts
+++ b/extensions/codex/src/session-catalog-types.ts
@@ -42,6 +42,7 @@ export type CodexSessionCatalogHost = {
   kind: "gateway" | "node";
   connected: boolean;
   nodeId?: string;
+  canContinueCodex?: boolean;
   sessions: CodexSessionCatalogSession[];
   nextCursor?: string;
   backwardsCursor?: string;

--- a/extensions/codex/src/session-catalog.test.ts
+++ b/extensions/codex/src/session-catalog.test.ts
@@ -23,6 +23,12 @@ import {
 
 const CODEX_APP_SERVER_THREADS_LIST_COMMAND = "codex.appServer.threads.list.v1";
 const CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND = "codex.appServer.thread.turns.list.v1";
+const CODEX_CLI_SESSION_RESUME_COMMAND = "codex.cli.session.resume";
+const CODEX_NODE_CONTINUE_COMMANDS = [
+  CODEX_APP_SERVER_THREADS_LIST_COMMAND,
+  CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND,
+  CODEX_CLI_SESSION_RESUME_COMMAND,
+] as const;
 type CodexSessionCatalogControl = ReturnType<typeof createCodexSessionCatalogControl>;
 
 const archiveLocalCodexSession = codexSessionCatalogRuntime.archiveLocal;
@@ -726,6 +732,7 @@ describe("Codex supervision catalog", () => {
         label: "Dev Box",
         kind: "node",
         nodeId: "devbox",
+        canContinueCodex: false,
         connected: true,
         sessions: [{ threadId: "remote", name: "Remote task", status: "idle", archived: false }],
       },
@@ -2586,7 +2593,7 @@ describe("Codex supervision actions", () => {
     expect(control.archiveThread).toHaveBeenCalledWith("thread-1");
   });
 
-  it("registers generic actions and rejects paired-node mutations", async () => {
+  it("registers generic actions and keeps paired-node archive view-only", async () => {
     const { runtime, createSessionEntry } = createRuntime();
     const { api, getProvider, registerSessionCatalog } = createGatewayApi(runtime);
     const control = createEligibleControl();
@@ -2624,9 +2631,310 @@ describe("Codex supervision actions", () => {
         hostId: "node:devbox",
         threadId: "thread-remote",
       }),
-    ).rejects.toThrow("paired-node Codex sessions are view-only");
+    ).rejects.toThrow("paired node does not permit Codex session continuation");
     expect(control.readThread).toHaveBeenCalledOnce();
     expect(control.archiveThread).toHaveBeenCalledOnce();
+    expect(createSessionEntry).not.toHaveBeenCalled();
+  });
+
+  it("marks paired-node rows continuable only with complete permitted capabilities", async () => {
+    const sourceByNode = new Map([
+      ["ready-cli", { status: "idle", source: "cli" }],
+      ["ready-vscode", { status: "notLoaded", source: "vscode" }],
+      ["missing-run", { status: "idle", source: "cli" }],
+      ["active", { status: "active", source: "cli" }],
+      ["noninteractive", { status: "idle", source: "exec" }],
+    ]);
+    const invoke = vi.fn<PluginRuntime["nodes"]["invoke"]>(async ({ nodeId }) => {
+      const source = sourceByNode.get(nodeId);
+      if (!source) {
+        throw new Error("unexpected node");
+      }
+      return {
+        payloadJSON: JSON.stringify({
+          sessions: [
+            {
+              threadId: `thread-${nodeId}`,
+              status: source.status,
+              source: source.source,
+              archived: false,
+            },
+          ],
+        }),
+      };
+    });
+    const { runtime } = createRuntime({
+      nodes: [...sourceByNode.keys()].map((nodeId) => ({
+        nodeId,
+        displayName: nodeId,
+        connected: true,
+        commands: [...CODEX_NODE_CONTINUE_COMMANDS],
+        invocableCommands:
+          nodeId === "missing-run"
+            ? CODEX_NODE_CONTINUE_COMMANDS.filter(
+                (command) => command !== CODEX_CLI_SESSION_RESUME_COMMAND,
+              )
+            : [...CODEX_NODE_CONTINUE_COMMANDS],
+      })),
+      invoke,
+    });
+    const { api, getProvider } = createGatewayApi(runtime);
+    registerCodexSessionCatalog({
+      api,
+      bindingStore: createCodexTestBindingStore(),
+      control: createControl(),
+      getRuntimeConfig: () => config,
+    });
+
+    const hosts = await getProvider()?.list({
+      hostIds: [...sourceByNode.keys()].map((id) => `node:${id}`),
+    });
+    const sessionByHost = new Map(hosts?.map((host) => [host.hostId, host.sessions[0]]) ?? []);
+    expect(sessionByHost.get("node:ready-cli")).toMatchObject({
+      canContinue: true,
+      canArchive: false,
+    });
+    expect(sessionByHost.get("node:ready-vscode")).toMatchObject({
+      canContinue: true,
+      canArchive: false,
+    });
+    expect(sessionByHost.get("node:missing-run")).toMatchObject({ canContinue: false });
+    expect(sessionByHost.get("node:active")).toMatchObject({ canContinue: false });
+    expect(sessionByHost.get("node:noninteractive")).toMatchObject({ canContinue: false });
+  });
+
+  it("adopts a paired-node session with bounded history and an executable binding", async () => {
+    let runtimeConfig = {
+      agents: { list: [{ id: "alpha", default: true }, { id: "beta" }] },
+    } as OpenClawConfig;
+    const invoke = vi.fn<PluginRuntime["nodes"]["invoke"]>(async ({ command }) => {
+      if (command === CODEX_APP_SERVER_THREADS_LIST_COMMAND) {
+        return {
+          payloadJSON: JSON.stringify({
+            sessions: [
+              {
+                threadId: "thread-remote",
+                name: "Remote task",
+                cwd: "/remote/repo",
+                status: "idle",
+                source: "vscode",
+                modelProvider: "openai",
+                createdAt: 123,
+                archived: false,
+              },
+            ],
+          }),
+        };
+      }
+      if (command === CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND) {
+        return {
+          payloadJSON: JSON.stringify({
+            data: [
+              {
+                id: "turn-1",
+                status: "completed",
+                items: [{ id: "item-1", type: "agentMessage", text: "done" }],
+              },
+            ],
+          }),
+        };
+      }
+      throw new Error(`unexpected command: ${command}`);
+    });
+    const { runtime, createSessionEntry, patchSessionEntry } = createRuntime({
+      nodes: [
+        {
+          nodeId: "devbox",
+          displayName: "Devbox",
+          connected: true,
+          commands: [...CODEX_NODE_CONTINUE_COMMANDS],
+          invocableCommands: [...CODEX_NODE_CONTINUE_COMMANDS],
+        },
+      ],
+      invoke,
+    });
+    const { api, getProvider } = createGatewayApi(runtime);
+    registerCodexSessionCatalog({
+      api,
+      bindingStore: createCodexTestBindingStore(),
+      control: createControl(),
+      getRuntimeConfig: () => runtimeConfig,
+    });
+    const provider = getProvider();
+
+    const first = await provider?.continueSession?.({
+      hostId: "node:devbox",
+      threadId: "thread-remote",
+    });
+    const pendingList = await provider?.list({ hostIds: ["node:devbox"] });
+    expect(pendingList?.[0]?.sessions[0]?.openClawSessionKey).toBeUndefined();
+    await first?.afterConversationBound?.();
+    runtimeConfig = {
+      agents: { list: [{ id: "alpha" }, { id: "beta", default: true }] },
+    } as OpenClawConfig;
+    const second = await provider?.continueSession?.({
+      hostId: "node:devbox",
+      threadId: "thread-remote",
+    });
+    await second?.afterConversationBound?.();
+
+    expect(first?.sessionKey).toBe(second?.sessionKey);
+    expect(first).toMatchObject({
+      conversationBinding: {
+        data: {
+          kind: "codex-cli-node-session",
+          version: 1,
+          nodeId: "devbox",
+          sessionId: "thread-remote",
+          agentId: "alpha",
+          cwd: "/remote/repo",
+        },
+      },
+    });
+    expect(second).toMatchObject({
+      conversationBinding: { data: { agentId: "alpha" } },
+    });
+    expect(createSessionEntry).toHaveBeenCalledOnce();
+    expect(createSessionEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: "Remote task",
+        spawnedCwd: "/remote/repo",
+        initialEntry: expect.objectContaining({
+          agentHarnessId: "codex",
+          modelSelectionLocked: true,
+          pluginExtensions: {
+            codex: {
+              sessionCatalog: expect.objectContaining({
+                sourceHostId: "node:devbox",
+                sourceThreadId: "thread-remote",
+                nodeId: "devbox",
+                initializing: true,
+              }),
+            },
+          },
+        }),
+      }),
+    );
+    expect(transcriptMirrorMocks.importCodexThreadHistoryToTranscript).toHaveBeenCalledOnce();
+    expect(transcriptMirrorMocks.importCodexThreadHistoryToTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thread: expect.objectContaining({
+          id: "thread-remote",
+          turns: [expect.objectContaining({ id: "turn-1" })],
+        }),
+        throughTurnId: "turn-1",
+        cwd: "/remote/repo",
+      }),
+    );
+    expect(patchSessionEntry).toHaveBeenCalledTimes(3);
+
+    const listed = await provider?.list({ hostIds: ["node:devbox"] });
+    expect(listed?.[0]?.sessions[0]).toMatchObject({
+      threadId: "thread-remote",
+      openClawSessionKey: first?.sessionKey,
+    });
+  });
+
+  it("rejects paired-node continue without the permitted run command", async () => {
+    const { runtime, createSessionEntry } = createRuntime({
+      nodes: [
+        {
+          nodeId: "devbox",
+          connected: true,
+          commands: [
+            CODEX_APP_SERVER_THREADS_LIST_COMMAND,
+            CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND,
+          ],
+          invocableCommands: [
+            CODEX_APP_SERVER_THREADS_LIST_COMMAND,
+            CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND,
+          ],
+        },
+      ],
+    });
+    const { api, getProvider } = createGatewayApi(runtime);
+    registerCodexSessionCatalog({
+      api,
+      bindingStore: createCodexTestBindingStore(),
+      control: createControl(),
+      getRuntimeConfig: () => config,
+    });
+
+    await expect(
+      getProvider()?.continueSession?.({
+        hostId: "node:devbox",
+        threadId: "thread-remote",
+      }),
+    ).rejects.toThrow("paired node does not permit Codex session continuation");
+    expect(createSessionEntry).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-canonical paired-node host ids before adoption keying", async () => {
+    const { runtime, createSessionEntry } = createRuntime({
+      nodes: [
+        {
+          nodeId: "devbox",
+          connected: true,
+          commands: [...CODEX_NODE_CONTINUE_COMMANDS],
+          invocableCommands: [...CODEX_NODE_CONTINUE_COMMANDS],
+        },
+      ],
+    });
+    const { api, getProvider } = createGatewayApi(runtime);
+    registerCodexSessionCatalog({
+      api,
+      bindingStore: createCodexTestBindingStore(),
+      control: createControl(),
+      getRuntimeConfig: () => config,
+    });
+
+    await expect(
+      getProvider()?.continueSession?.({
+        hostId: "node:devbox ",
+        threadId: "thread-remote",
+      }),
+    ).rejects.toThrow("hostId is invalid");
+    expect(createSessionEntry).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-continuable paired-node session status", async () => {
+    const invoke = vi.fn<PluginRuntime["nodes"]["invoke"]>(async () => ({
+      payloadJSON: JSON.stringify({
+        sessions: [
+          {
+            threadId: "thread-remote",
+            status: "active",
+            source: "cli",
+            archived: false,
+          },
+        ],
+      }),
+    }));
+    const { runtime, createSessionEntry } = createRuntime({
+      nodes: [
+        {
+          nodeId: "devbox",
+          connected: true,
+          commands: [...CODEX_NODE_CONTINUE_COMMANDS],
+          invocableCommands: [...CODEX_NODE_CONTINUE_COMMANDS],
+        },
+      ],
+      invoke,
+    });
+    const { api, getProvider } = createGatewayApi(runtime);
+    registerCodexSessionCatalog({
+      api,
+      bindingStore: createCodexTestBindingStore(),
+      control: createControl(),
+      getRuntimeConfig: () => config,
+    });
+
+    await expect(
+      getProvider()?.continueSession?.({
+        hostId: "node:devbox",
+        threadId: "thread-remote",
+      }),
+    ).rejects.toThrow("active on the paired node");
     expect(createSessionEntry).not.toHaveBeenCalled();
   });
 

--- a/extensions/codex/src/session-catalog.test.ts
+++ b/extensions/codex/src/session-catalog.test.ts
@@ -2831,7 +2831,8 @@ describe("Codex supervision actions", () => {
         cwd: "/remote/repo",
       }),
     );
-    expect(patchSessionEntry).toHaveBeenCalledTimes(3);
+    // One finalize patch per continue; the restore rides afterConversationBound.
+    expect(patchSessionEntry).toHaveBeenCalledTimes(2);
 
     const listed = await provider?.list({ hostIds: ["node:devbox"] });
     expect(listed?.[0]?.sessions[0]).toMatchObject({

--- a/extensions/codex/src/session-catalog.test.ts
+++ b/extensions/codex/src/session-catalog.test.ts
@@ -2630,6 +2630,7 @@ describe("Codex supervision actions", () => {
       provider?.continueSession?.({
         hostId: "node:devbox",
         threadId: "thread-remote",
+        clientScopes: ["operator.admin"],
       }),
     ).rejects.toThrow("paired node does not permit Codex session continuation");
     expect(control.readThread).toHaveBeenCalledOnce();
@@ -2714,6 +2715,7 @@ describe("Codex supervision actions", () => {
             sessions: [
               {
                 threadId: "thread-remote",
+                sessionId: "cli-session-remote",
                 name: "Remote task",
                 cwd: "/remote/repo",
                 status: "idle",
@@ -2765,6 +2767,7 @@ describe("Codex supervision actions", () => {
     const first = await provider?.continueSession?.({
       hostId: "node:devbox",
       threadId: "thread-remote",
+      clientScopes: ["operator.admin"],
     });
     const pendingList = await provider?.list({ hostIds: ["node:devbox"] });
     expect(pendingList?.[0]?.sessions[0]?.openClawSessionKey).toBeUndefined();
@@ -2775,6 +2778,7 @@ describe("Codex supervision actions", () => {
     const second = await provider?.continueSession?.({
       hostId: "node:devbox",
       threadId: "thread-remote",
+      clientScopes: ["operator.admin"],
     });
     await second?.afterConversationBound?.();
 
@@ -2785,7 +2789,8 @@ describe("Codex supervision actions", () => {
           kind: "codex-cli-node-session",
           version: 1,
           nodeId: "devbox",
-          sessionId: "thread-remote",
+          // codex exec resume needs the CLI session id, not the thread id.
+          sessionId: "cli-session-remote",
           agentId: "alpha",
           cwd: "/remote/repo",
         },
@@ -2864,6 +2869,7 @@ describe("Codex supervision actions", () => {
       getProvider()?.continueSession?.({
         hostId: "node:devbox",
         threadId: "thread-remote",
+        clientScopes: ["operator.admin"],
       }),
     ).rejects.toThrow("paired node does not permit Codex session continuation");
     expect(createSessionEntry).not.toHaveBeenCalled();
@@ -2892,8 +2898,38 @@ describe("Codex supervision actions", () => {
       getProvider()?.continueSession?.({
         hostId: "node:devbox ",
         threadId: "thread-remote",
+        clientScopes: ["operator.admin"],
       }),
     ).rejects.toThrow("hostId is invalid");
+    expect(createSessionEntry).not.toHaveBeenCalled();
+  });
+
+  it("requires operator.admin before continuing a paired-node session", async () => {
+    const { runtime, createSessionEntry } = createRuntime({
+      nodes: [
+        {
+          nodeId: "devbox",
+          connected: true,
+          commands: [...CODEX_NODE_CONTINUE_COMMANDS],
+          invocableCommands: [...CODEX_NODE_CONTINUE_COMMANDS],
+        },
+      ],
+    });
+    const { api, getProvider } = createGatewayApi(runtime);
+    registerCodexSessionCatalog({
+      api,
+      bindingStore: createCodexTestBindingStore(),
+      control: createControl(),
+      getRuntimeConfig: () => config,
+    });
+
+    await expect(
+      getProvider()?.continueSession?.({
+        hostId: "node:devbox",
+        threadId: "thread-remote",
+        clientScopes: ["operator.write"],
+      }),
+    ).rejects.toThrow("requires operator.admin");
     expect(createSessionEntry).not.toHaveBeenCalled();
   });
 
@@ -2933,6 +2969,7 @@ describe("Codex supervision actions", () => {
       getProvider()?.continueSession?.({
         hostId: "node:devbox",
         threadId: "thread-remote",
+        clientScopes: ["operator.admin"],
       }),
     ).rejects.toThrow("active on the paired node");
     expect(createSessionEntry).not.toHaveBeenCalled();

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -44,8 +44,13 @@ import {
   releaseLeasedSharedCodexAppServerClient,
 } from "./app-server/shared-client.js";
 import { assertCodexArchiveDescendantsUnowned } from "./app-server/thread-archive-guard.js";
-import { importCodexThreadHistoryToTranscript } from "./app-server/transcript-mirror.js";
+import {
+  importCodexThreadHistoryToTranscript,
+  type CodexThreadHistory,
+} from "./app-server/transcript-mirror.js";
 import { codexControlRequest } from "./command-rpc.js";
+import { createCodexCliNodeConversationBindingData } from "./conversation-binding-data.js";
+import { CODEX_CLI_SESSION_RESUME_COMMAND } from "./node-cli-sessions.js";
 import type {
   CodexSessionCatalogError,
   CodexSessionCatalogHost,
@@ -84,10 +89,19 @@ const MAX_TRANSCRIPT_PAGE_LIMIT = 50;
 const MAX_TRANSCRIPT_PAGE_BYTES = 20 * 1024 * 1024;
 const MAX_TITLE_SEARCH_CATALOG_PAGES = 20;
 const CODEX_SUPERVISION_SESSION_KEY_PREFIX = "harness:codex:supervision:";
+const CODEX_NODE_SESSION_KEY_PREFIX = "harness:codex:node-session:";
+const CODEX_NODE_CONTINUE_COMMANDS = [
+  CODEX_APP_SERVER_THREADS_LIST_COMMAND,
+  CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND,
+  CODEX_CLI_SESSION_RESUME_COMMAND,
+] as const;
 
 class CatalogParamsError extends Error {}
 
 type CatalogNode = Awaited<ReturnType<PluginRuntime["nodes"]["list"]>>["nodes"][number];
+type CatalogSessionEntry = ReturnType<
+  PluginRuntime["agent"]["session"]["listSessionEntries"]
+>[number]["entry"];
 
 export const CODEX_LOCAL_SESSION_HOST_ID = "gateway:local";
 
@@ -769,10 +783,22 @@ function compareNodeLabels(left: CatalogNode, right: CatalogNode): number {
   return 0;
 }
 
+function canContinueCodexOnNode(node: CatalogNode): boolean {
+  return (
+    node.connected === true &&
+    CODEX_NODE_CONTINUE_COMMANDS.every(
+      (command) =>
+        node.commands?.includes(command) === true &&
+        node.invocableCommands?.includes(command) === true,
+    )
+  );
+}
+
 async function listPairedNode(params: {
   runtime: PluginRuntime;
   node: CatalogNode;
   query: CodexSessionCatalogParams;
+  adoptedSessions: ReadonlyMap<string, AdoptedSessionEntry>;
 }): Promise<CodexSessionCatalogHost> {
   const hostId = `node:${params.node.nodeId}`;
   const common = {
@@ -780,6 +806,7 @@ async function listPairedNode(params: {
     label: nodeLabel(params.node),
     kind: "node" as const,
     nodeId: params.node.nodeId,
+    canContinueCodex: canContinueCodexOnNode(params.node),
   };
   if (params.node.connected !== true) {
     return {
@@ -808,6 +835,10 @@ async function listPairedNode(params: {
       ...common,
       connected: true,
       ...page,
+      sessions: page.sessions.map((session) => {
+        const adopted = params.adoptedSessions.get(adoptedSourceKey(hostId, session.threadId));
+        return adopted ? Object.assign({}, session, { openClawSessionKey: adopted.key }) : session;
+      }),
     };
   } catch (error) {
     return {
@@ -870,9 +901,18 @@ async function listCodexSessionCatalog(params: {
       ],
     };
   }
-  const nodeHosts = nodes
-    .toSorted(compareNodeLabels)
-    .map((node) => listPairedNode({ runtime: params.runtime, node, query }));
+  const adoptedNodeSessions = listNodeAdoptedSessionEntries({
+    config: params.config,
+    runtime: params.runtime,
+  });
+  const nodeHosts = nodes.toSorted(compareNodeLabels).map((node) =>
+    listPairedNode({
+      runtime: params.runtime,
+      node,
+      query,
+      adoptedSessions: adoptedNodeSessions,
+    }),
+  );
   return { hosts: await Promise.all([...localHosts, ...nodeHosts]) };
 }
 
@@ -1129,14 +1169,110 @@ type CodexSessionDisposition = "existing" | "forked";
 
 type CodexSupervisionMarker = { sourceThreadId: string };
 
+type CodexNodeSessionMarker = {
+  sourceHostId: string;
+  sourceThreadId: string;
+  nodeId: string;
+  initializing?: true;
+};
+
 type AdoptedSessionEntry = {
   key: string;
   sessionId: string;
+  agentId: string;
+  initializing?: true;
 };
+
+function adoptedSourceKey(hostId: string, threadId: string): string {
+  return `${hostId}\u0000${threadId}`;
+}
+
+function nodeAdoptionSessionKey(hostId: string, threadId: string): string {
+  const digest = createHash("sha256")
+    .update(JSON.stringify([hostId, threadId]))
+    .digest("hex");
+  return `${CODEX_NODE_SESSION_KEY_PREFIX}${digest}`;
+}
+
+function readNodeSessionMarker(entry: CatalogSessionEntry): CodexNodeSessionMarker | undefined {
+  const codex = isRecord(entry.pluginExtensions?.codex) ? entry.pluginExtensions.codex : undefined;
+  const marker = codex && isRecord(codex.sessionCatalog) ? codex.sessionCatalog : undefined;
+  if (
+    !marker ||
+    typeof marker.sourceHostId !== "string" ||
+    !marker.sourceHostId.startsWith("node:") ||
+    typeof marker.sourceThreadId !== "string" ||
+    !marker.sourceThreadId.trim() ||
+    typeof marker.nodeId !== "string" ||
+    !marker.nodeId.trim()
+  ) {
+    return undefined;
+  }
+  return {
+    sourceHostId: marker.sourceHostId,
+    sourceThreadId: marker.sourceThreadId,
+    nodeId: marker.nodeId,
+    ...(marker.initializing === true ? { initializing: true } : {}),
+  };
+}
 
 function listSupervisionAgentIds(config: OpenClawConfig): string[] {
   const defaultAgentId = resolveDefaultAgentId(config);
   return [defaultAgentId, ...listAgentIds(config).filter((agentId) => agentId !== defaultAgentId)];
+}
+
+function listNodeAdoptedSessionEntries(params: {
+  config?: OpenClawConfig;
+  runtime: PluginRuntime;
+  includeInitializing?: boolean;
+}): Map<string, AdoptedSessionEntry> {
+  const adopted = new Map<string, AdoptedSessionEntry>();
+  for (const agentId of listSupervisionAgentIds(params.config ?? {})) {
+    for (const { entry, sessionKey } of params.runtime.agent.session.listSessionEntries({
+      agentId,
+    })) {
+      const marker = readNodeSessionMarker(entry);
+      const sessionId = entry.sessionId?.trim();
+      if (
+        !marker ||
+        (marker.initializing === true && params.includeInitializing !== true) ||
+        entry.initializationPending === true ||
+        entry.agentHarnessId !== "codex" ||
+        entry.modelSelectionLocked !== true ||
+        !sessionId ||
+        adoptionSessionKeyRest(sessionKey) !==
+          nodeAdoptionSessionKey(marker.sourceHostId, marker.sourceThreadId) ||
+        marker.sourceHostId !== `node:${marker.nodeId}`
+      ) {
+        continue;
+      }
+      const sourceKey = adoptedSourceKey(marker.sourceHostId, marker.sourceThreadId);
+      if (adopted.has(sourceKey)) {
+        throw new Error(
+          `multiple OpenClaw sessions adopt Codex thread ${marker.sourceThreadId} on ${marker.sourceHostId}`,
+        );
+      }
+      adopted.set(sourceKey, {
+        key: sessionKey,
+        sessionId,
+        agentId,
+        ...(marker.initializing === true ? { initializing: true } : {}),
+      });
+    }
+  }
+  return adopted;
+}
+
+function findNodeAdoptedSessionEntry(params: {
+  config: OpenClawConfig;
+  runtime: PluginRuntime;
+  hostId: string;
+  threadId: string;
+  includeInitializing?: boolean;
+}): AdoptedSessionEntry | undefined {
+  return listNodeAdoptedSessionEntries(params).get(
+    adoptedSourceKey(params.hostId, params.threadId),
+  );
 }
 
 async function listAdoptedSessionEntries(params: {
@@ -1145,37 +1281,39 @@ async function listAdoptedSessionEntries(params: {
   runtime: PluginRuntime;
 }): Promise<Map<string, AdoptedSessionEntry>> {
   const adopted = new Map<string, AdoptedSessionEntry>();
-  for (const { entry, sessionKey } of listSupervisionAgentIds(params.config ?? {}).flatMap(
-    (agentId) => params.runtime.agent.session.listSessionEntries({ agentId }),
-  )) {
-    const sessionKeyRest = adoptionSessionKeyRest(sessionKey);
-    if (
-      !sessionKeyRest.startsWith(CODEX_SUPERVISION_SESSION_KEY_PREFIX) ||
-      entry.initializationPending === true ||
-      entry.agentHarnessId !== "codex" ||
-      entry.modelSelectionLocked !== true
-    ) {
-      continue;
+  for (const agentId of listSupervisionAgentIds(params.config ?? {})) {
+    for (const { entry, sessionKey } of params.runtime.agent.session.listSessionEntries({
+      agentId,
+    })) {
+      const sessionKeyRest = adoptionSessionKeyRest(sessionKey);
+      if (
+        !sessionKeyRest.startsWith(CODEX_SUPERVISION_SESSION_KEY_PREFIX) ||
+        entry.initializationPending === true ||
+        entry.agentHarnessId !== "codex" ||
+        entry.modelSelectionLocked !== true
+      ) {
+        continue;
+      }
+      const sessionId = entry.sessionId?.trim();
+      if (!sessionId) {
+        continue;
+      }
+      const binding = await params.bindingStore.read(
+        sessionBindingIdentity({ sessionId, sessionKey, config: params.config }),
+      );
+      const sourceThreadId = binding?.supervisionSourceThreadId?.trim();
+      if (
+        binding?.connectionScope !== "supervision" ||
+        !sourceThreadId ||
+        sessionKeyRest !== adoptionSessionKey(sourceThreadId)
+      ) {
+        continue;
+      }
+      if (adopted.has(sourceThreadId)) {
+        throw new Error(`multiple OpenClaw sessions adopt Codex thread ${sourceThreadId}`);
+      }
+      adopted.set(sourceThreadId, { key: sessionKey, sessionId, agentId });
     }
-    const sessionId = entry.sessionId?.trim();
-    if (!sessionId) {
-      continue;
-    }
-    const binding = await params.bindingStore.read(
-      sessionBindingIdentity({ sessionId, sessionKey, config: params.config }),
-    );
-    const sourceThreadId = binding?.supervisionSourceThreadId?.trim();
-    if (
-      binding?.connectionScope !== "supervision" ||
-      !sourceThreadId ||
-      sessionKeyRest !== adoptionSessionKey(sourceThreadId)
-    ) {
-      continue;
-    }
-    if (adopted.has(sourceThreadId)) {
-      throw new Error(`multiple OpenClaw sessions adopt Codex thread ${sourceThreadId}`);
-    }
-    adopted.set(sourceThreadId, { key: sessionKey, sessionId });
   }
   return adopted;
 }
@@ -1233,7 +1371,7 @@ async function clearCreatedAdoptionBinding(params: {
   );
 }
 
-function lastTerminalTurnId(thread: CodexThread): string | undefined {
+function lastTerminalTurnId(thread: CodexThreadHistory): string | undefined {
   for (let index = (thread.turns?.length ?? 0) - 1; index >= 0; index -= 1) {
     const turn = thread.turns?.[index];
     const turnId = boundedCatalogString(turn?.id, MAX_SESSION_ID_LENGTH);
@@ -1446,7 +1584,7 @@ async function createOrReuseAdoptedSession(params: {
         };
       },
     });
-    return { key: created.key, sessionId: created.sessionId };
+    return { key: created.key, sessionId: created.sessionId, agentId: created.agentId };
   } catch (error) {
     // Concurrent/retried Continue calls converge on the same trusted marker.
     // An unrelated entry at the deterministic key is never overwritten.
@@ -1578,21 +1716,427 @@ async function continueLocalCodexSession(params: {
   control: CodexSessionCatalogControl;
   threadId: string;
 }): Promise<{ sessionKey: string; disposition: CodexSessionDisposition }> {
-  const current = continueOperations.get(params.threadId);
+  const sourceKey = adoptedSourceKey(CODEX_LOCAL_SESSION_HOST_ID, params.threadId);
+  const current = continueOperations.get(sourceKey);
   if (current) {
     return await current;
   }
-  const operation = runSessionActionExclusive(params.threadId, async () =>
+  const operation = runSessionActionExclusive(sourceKey, async () =>
     params.control.withPinnedConnection(async (control) =>
       continueLocalCodexSessionInner({ ...params, control }),
     ),
   );
-  continueOperations.set(params.threadId, operation);
+  continueOperations.set(sourceKey, operation);
   try {
     return await operation;
   } finally {
-    if (continueOperations.get(params.threadId) === operation) {
-      continueOperations.delete(params.threadId);
+    if (continueOperations.get(sourceKey) === operation) {
+      continueOperations.delete(sourceKey);
+    }
+  }
+}
+
+async function requireNodeForCodexContinue(params: {
+  runtime: PluginRuntime;
+  hostId: string;
+}): Promise<{ node: CatalogNode; nodeId: string }> {
+  const nodeId = params.hostId.slice("node:".length).trim();
+  if (!nodeId || params.hostId !== `node:${nodeId}`) {
+    throw new CatalogParamsError("Codex session catalog hostId is invalid");
+  }
+  const node = (await params.runtime.nodes.list()).nodes.find(
+    (candidate) => candidate.nodeId === nodeId,
+  );
+  if (!node || !canContinueCodexOnNode(node)) {
+    throw new CatalogParamsError("paired node does not permit Codex session continuation");
+  }
+  return { node, nodeId };
+}
+
+async function resolveNodeCodexRecord(params: {
+  runtime: PluginRuntime;
+  nodeId: string;
+  threadId: string;
+}): Promise<CodexSessionCatalogSession> {
+  let cursor: string | undefined;
+  const seenCursors = new Set<string>();
+  for (let pageIndex = 0; pageIndex < MAX_ACTION_CATALOG_PAGES; pageIndex += 1) {
+    const raw = await params.runtime.nodes.invoke({
+      nodeId: params.nodeId,
+      command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
+      params: {
+        limit: CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT,
+        ...(cursor ? { cursor } : {}),
+      },
+      timeoutMs: NODE_INVOKE_TIMEOUT_MS,
+    });
+    const page = parseCatalogPage(unwrapNodeInvokePayload(raw));
+    const record = page.sessions.find((candidate) => candidate.threadId === params.threadId);
+    if (record) {
+      return record;
+    }
+    const nextCursor = page.nextCursor?.trim();
+    if (!nextCursor) {
+      break;
+    }
+    if (seenCursors.has(nextCursor)) {
+      throw new CatalogParamsError("Codex session eligibility could not be verified");
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+  throw new CatalogParamsError("Codex session is unavailable on the paired node");
+}
+
+function requireContinuableNodeRecord(record: CodexSessionCatalogSession): void {
+  if (record.archived) {
+    throw new CatalogParamsError("Codex session is archived on the paired node");
+  }
+  if (!isInteractiveThreadSource(record.source)) {
+    throw new CatalogParamsError(
+      "Codex session is not a non-archived interactive CLI or VS Code session",
+    );
+  }
+  if (record.status === "idle" || record.status === "notLoaded") {
+    // The node App Server is a passive catalog reader, so stored CLI/VS Code
+    // sessions normally report notLoaded. Node resume serializes OpenClaw turns.
+    return;
+  }
+  if (record.status === "active") {
+    throw new CatalogParamsError(
+      "Codex session is active on the paired node; wait for it to finish before continuing",
+    );
+  }
+  throw new CatalogParamsError("Codex session cannot be continued in its current state");
+}
+
+async function readNodeCodexHistory(params: {
+  runtime: PluginRuntime;
+  nodeId: string;
+  record: CodexSessionCatalogSession;
+}): Promise<{ thread: CodexThreadHistory; throughTurnId: string | null }> {
+  const raw = await params.runtime.nodes.invoke({
+    nodeId: params.nodeId,
+    command: CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND,
+    params: {
+      threadId: params.record.threadId,
+      limit: MAX_TRANSCRIPT_PAGE_LIMIT,
+    },
+    timeoutMs: NODE_INVOKE_TIMEOUT_MS,
+  });
+  const page = parseTranscriptPage(unwrapNodeInvokePayload(raw));
+  const thread: CodexThreadHistory = {
+    id: params.record.threadId,
+    createdAt: params.record.createdAt ?? 0,
+    modelProvider: params.record.modelProvider ?? "openai",
+    turns: page.data.toReversed(),
+  };
+  return { thread, throughTurnId: lastTerminalTurnId(thread) ?? null };
+}
+
+function nodeSessionMarker(params: {
+  hostId: string;
+  threadId: string;
+  nodeId: string;
+  initializing?: true;
+}): CodexNodeSessionMarker {
+  return {
+    sourceHostId: params.hostId,
+    sourceThreadId: params.threadId,
+    nodeId: params.nodeId,
+    ...(params.initializing === true ? { initializing: true } : {}),
+  };
+}
+
+async function restoreNodeAdoptedSession(params: {
+  api: OpenClawPluginApi;
+  existing: AdoptedSessionEntry;
+  hostId: string;
+  threadId: string;
+  nodeId: string;
+}): Promise<void> {
+  const changedError = () =>
+    new CatalogParamsError("Codex OpenClaw session changed before it could be opened. Retry.");
+  const restored = await params.api.runtime.agent.session.patchSessionEntry({
+    sessionKey: params.existing.key,
+    readConsistency: "latest",
+    preserveActivity: true,
+    update: (entry) => {
+      const marker = readNodeSessionMarker(entry);
+      if (
+        entry.sessionId?.trim() !== params.existing.sessionId ||
+        entry.initializationPending === true ||
+        entry.agentHarnessId !== "codex" ||
+        entry.modelSelectionLocked !== true ||
+        !marker ||
+        marker.initializing === true ||
+        marker.sourceHostId !== params.hostId ||
+        marker.sourceThreadId !== params.threadId ||
+        marker.nodeId !== params.nodeId
+      ) {
+        throw changedError();
+      }
+      return { archivedAt: undefined };
+    },
+  });
+  if (!restored) {
+    throw changedError();
+  }
+}
+
+async function finalizeNodeAdoptedSession(params: {
+  api: OpenClawPluginApi;
+  adopted: AdoptedSessionEntry;
+  marker: CodexNodeSessionMarker;
+}): Promise<void> {
+  const changedError = () =>
+    new CatalogParamsError("Codex OpenClaw session changed before it could be bound. Retry.");
+  let finalized: CatalogSessionEntry | null;
+  try {
+    finalized = await params.api.runtime.agent.session.patchSessionEntry({
+      sessionKey: params.adopted.key,
+      readConsistency: "latest",
+      preserveActivity: true,
+      update: (entry) => {
+        const current = readNodeSessionMarker(entry);
+        if (
+          entry.sessionId?.trim() !== params.adopted.sessionId ||
+          entry.initializationPending === true ||
+          entry.agentHarnessId !== "codex" ||
+          entry.modelSelectionLocked !== true ||
+          !current ||
+          current.sourceHostId !== params.marker.sourceHostId ||
+          current.sourceThreadId !== params.marker.sourceThreadId ||
+          current.nodeId !== params.marker.nodeId
+        ) {
+          throw changedError();
+        }
+        if (current.initializing !== true) {
+          return { archivedAt: undefined };
+        }
+        const codex = isRecord(entry.pluginExtensions?.codex) ? entry.pluginExtensions.codex : {};
+        return {
+          archivedAt: undefined,
+          pluginExtensions: {
+            ...entry.pluginExtensions,
+            codex: { ...codex, sessionCatalog: params.marker },
+          },
+        };
+      },
+    });
+  } catch (error) {
+    const currentEntry = params.api.runtime.agent.session.getSessionEntry({
+      sessionKey: params.adopted.key,
+      readConsistency: "latest",
+    });
+    const current = currentEntry ? readNodeSessionMarker(currentEntry) : undefined;
+    if (
+      currentEntry?.sessionId?.trim() === params.adopted.sessionId &&
+      current?.initializing !== true &&
+      current?.sourceHostId === params.marker.sourceHostId &&
+      current.sourceThreadId === params.marker.sourceThreadId &&
+      current.nodeId === params.marker.nodeId
+    ) {
+      return;
+    }
+    throw error;
+  }
+  if (!finalized) {
+    throw changedError();
+  }
+}
+
+async function createOrReuseNodeAdoptedSession(params: {
+  api: OpenClawPluginApi;
+  config: OpenClawConfig;
+  hostId: string;
+  nodeId: string;
+  record: CodexSessionCatalogSession;
+  history: Awaited<ReturnType<typeof readNodeCodexHistory>>;
+}): Promise<AdoptedSessionEntry> {
+  const existing = findNodeAdoptedSessionEntry({
+    config: params.config,
+    runtime: params.api.runtime,
+    hostId: params.hostId,
+    threadId: params.record.threadId,
+    includeInitializing: true,
+  });
+  if (existing) {
+    return existing;
+  }
+  const marker = nodeSessionMarker({
+    hostId: params.hostId,
+    threadId: params.record.threadId,
+    nodeId: params.nodeId,
+  });
+  const initializingMarker = { ...marker, initializing: true as const };
+  try {
+    const created = await params.api.runtime.agent.session.createSessionEntry({
+      cfg: params.config,
+      key: nodeAdoptionSessionKey(params.hostId, params.record.threadId),
+      agentId: resolveDefaultAgentId(params.config),
+      recoverMatchingInitialEntry: true,
+      ...(params.record.name?.trim() ? { label: params.record.name.trim() } : {}),
+      ...(params.record.cwd?.trim() ? { spawnedCwd: params.record.cwd.trim() } : {}),
+      initialEntry: {
+        agentHarnessId: "codex",
+        modelSelectionLocked: true,
+        pluginExtensions: {
+          codex: {
+            sessionCatalog: initializingMarker,
+          },
+        },
+      },
+      afterCreate: async (entry) => {
+        const storePath = resolveStorePath(params.config.session?.store, {
+          agentId: entry.agentId,
+        });
+        await importCodexThreadHistoryToTranscript({
+          thread: params.history.thread,
+          throughTurnId: params.history.throughTurnId,
+          storePath,
+          sessionId: entry.sessionId,
+          sessionKey: entry.key,
+          agentId: entry.agentId,
+          ...(params.record.cwd?.trim() ? { cwd: params.record.cwd.trim() } : {}),
+          modelProvider: params.record.modelProvider,
+          config: params.config,
+        });
+        return { pluginExtensions: { codex: { sessionCatalog: initializingMarker } } };
+      },
+    });
+    return {
+      key: created.key,
+      sessionId: created.sessionId,
+      agentId: created.agentId,
+      initializing: true,
+    };
+  } catch (error) {
+    const raced = findNodeAdoptedSessionEntry({
+      config: params.config,
+      runtime: params.api.runtime,
+      hostId: params.hostId,
+      threadId: params.record.threadId,
+      includeInitializing: true,
+    });
+    if (raced) {
+      return raced;
+    }
+    throw error;
+  }
+}
+
+async function continueNodeCodexSessionInner(params: {
+  api: OpenClawPluginApi;
+  config: OpenClawConfig;
+  hostId: string;
+  threadId: string;
+}): Promise<{
+  sessionKey: string;
+  disposition: CodexSessionDisposition;
+  conversationBinding: {
+    summary: string;
+    detachHint: string;
+    data: Record<string, unknown>;
+  };
+  afterConversationBound: () => Promise<void>;
+}> {
+  const { nodeId } = await requireNodeForCodexContinue({
+    runtime: params.api.runtime,
+    hostId: params.hostId,
+  });
+  const record = await resolveNodeCodexRecord({
+    runtime: params.api.runtime,
+    nodeId,
+    threadId: params.threadId,
+  });
+  requireContinuableNodeRecord(record);
+  const existing = findNodeAdoptedSessionEntry({
+    config: params.config,
+    runtime: params.api.runtime,
+    hostId: params.hostId,
+    threadId: params.threadId,
+    includeInitializing: true,
+  });
+  let adopted: AdoptedSessionEntry;
+  let disposition: CodexSessionDisposition;
+  if (existing) {
+    if (existing.initializing !== true) {
+      await restoreNodeAdoptedSession({
+        api: params.api,
+        existing,
+        hostId: params.hostId,
+        threadId: params.threadId,
+        nodeId,
+      });
+    }
+    adopted = existing;
+    disposition = "existing";
+  } else {
+    const history = await readNodeCodexHistory({
+      runtime: params.api.runtime,
+      nodeId,
+      record,
+    });
+    adopted = await createOrReuseNodeAdoptedSession({
+      api: params.api,
+      config: params.config,
+      hostId: params.hostId,
+      nodeId,
+      record,
+      history,
+    });
+    disposition = "forked";
+  }
+  const marker = nodeSessionMarker({
+    hostId: params.hostId,
+    threadId: params.threadId,
+    nodeId,
+  });
+  return {
+    sessionKey: adopted.key,
+    disposition,
+    conversationBinding: {
+      summary: "Continue this Codex session on its paired node.",
+      detachHint: "Start a new chat to leave the paired-node Codex session.",
+      data: createCodexCliNodeConversationBindingData({
+        nodeId,
+        sessionId: params.threadId,
+        agentId: adopted.agentId,
+        cwd: record.cwd,
+      }),
+    },
+    afterConversationBound: async () =>
+      await finalizeNodeAdoptedSession({ api: params.api, adopted, marker }),
+  };
+}
+
+async function continueNodeCodexSession(params: {
+  api: OpenClawPluginApi;
+  config: OpenClawConfig;
+  hostId: string;
+  threadId: string;
+}) {
+  const nodeId = params.hostId.slice("node:".length).trim();
+  if (!nodeId || params.hostId !== `node:${nodeId}`) {
+    throw new CatalogParamsError("Codex session catalog hostId is invalid");
+  }
+  const sourceKey = adoptedSourceKey(`node:${nodeId}`, params.threadId);
+  const current = continueOperations.get(sourceKey) as
+    | Promise<Awaited<ReturnType<typeof continueNodeCodexSessionInner>>>
+    | undefined;
+  if (current) {
+    return await current;
+  }
+  const operation = runSessionActionExclusive(sourceKey, async () =>
+    continueNodeCodexSessionInner(params),
+  );
+  continueOperations.set(sourceKey, operation);
+  try {
+    return await operation;
+  } finally {
+    if (continueOperations.get(sourceKey) === operation) {
+      continueOperations.delete(sourceKey);
     }
   }
 }
@@ -1643,38 +2187,41 @@ async function archiveLocalCodexSession(params: {
   runtime: PluginRuntime;
   threadId: string;
 }): Promise<{ archived: true }> {
-  return await runSessionActionExclusive(params.threadId, async () => {
-    return await params.bindingStore.withThreadArchiveFence(async () => {
-      return await params.control.withPinnedConnection(async (control) => {
-        await requireCatalogEligibleThread(control, params.threadId);
-        await assertNoPendingSupervisionBranch(params);
-        const thread = await control.readThread(params.threadId, false);
-        if (thread.id !== params.threadId) {
-          throw new Error("Codex app-server returned a different thread than requested");
-        }
-        requireIdleThread(thread, "archive");
-        if (await params.bindingStore.hasOtherThreadOwner(params.threadId)) {
-          throw new CatalogParamsError(
-            "Codex session cannot be archived while it is attached to an OpenClaw session",
-          );
-        }
-        await assertCodexArchiveDescendantsUnowned({
-          bindingStore: params.bindingStore,
-          threadId: params.threadId,
-          listPage: (request) => control.listDescendantPage(request),
-          assertDescendantIdle: async (descendantThreadId) => {
-            const descendant = await control.readThread(descendantThreadId, false);
-            if (descendant.id !== descendantThreadId) {
-              throw new Error("Codex app-server returned a different descendant than requested");
-            }
-            requireIdleThread(descendant, "archive");
-          },
+  return await runSessionActionExclusive(
+    adoptedSourceKey(CODEX_LOCAL_SESSION_HOST_ID, params.threadId),
+    async () => {
+      return await params.bindingStore.withThreadArchiveFence(async () => {
+        return await params.control.withPinnedConnection(async (control) => {
+          await requireCatalogEligibleThread(control, params.threadId);
+          await assertNoPendingSupervisionBranch(params);
+          const thread = await control.readThread(params.threadId, false);
+          if (thread.id !== params.threadId) {
+            throw new Error("Codex app-server returned a different thread than requested");
+          }
+          requireIdleThread(thread, "archive");
+          if (await params.bindingStore.hasOtherThreadOwner(params.threadId)) {
+            throw new CatalogParamsError(
+              "Codex session cannot be archived while it is attached to an OpenClaw session",
+            );
+          }
+          await assertCodexArchiveDescendantsUnowned({
+            bindingStore: params.bindingStore,
+            threadId: params.threadId,
+            listPage: (request) => control.listDescendantPage(request),
+            assertDescendantIdle: async (descendantThreadId) => {
+              const descendant = await control.readThread(descendantThreadId, false);
+              if (descendant.id !== descendantThreadId) {
+                throw new Error("Codex app-server returned a different descendant than requested");
+              }
+              requireIdleThread(descendant, "archive");
+            },
+          });
+          await control.archiveThread(params.threadId);
+          return { archived: true };
         });
-        await control.archiveThread(params.threadId);
-        return { archived: true };
       });
-    });
-  });
+    },
+  );
 }
 
 /** Allows read-only catalog and transcript commands on supported paired-node platforms. */
@@ -1697,8 +2244,13 @@ function toGenericCatalogHost(host: CodexSessionCatalogHost): SessionCatalogHost
     connected: host.connected,
     ...(host.nodeId ? { nodeId: host.nodeId } : {}),
     sessions: host.sessions.map((session) => {
-      const continuableStatus = session.status === "idle" || session.status === "notLoaded";
-      const actionable = local && continuableStatus && isInteractiveThreadSource(session.source);
+      const continuableStatus =
+        !session.archived && (session.status === "idle" || session.status === "notLoaded");
+      const canContinue =
+        (local || host.canContinueCodex === true) &&
+        continuableStatus &&
+        isInteractiveThreadSource(session.source);
+      const canArchive = local && continuableStatus && isInteractiveThreadSource(session.source);
       return {
         threadId: session.threadId,
         ...(session.name != null ? { name: session.name } : {}),
@@ -1713,8 +2265,8 @@ function toGenericCatalogHost(host: CodexSessionCatalogHost): SessionCatalogHost
         ...(session.gitBranch ? { gitBranch: session.gitBranch } : {}),
         archived: session.archived,
         ...(session.openClawSessionKey ? { openClawSessionKey: session.openClawSessionKey } : {}),
-        canContinue: actionable,
-        canArchive: actionable,
+        canContinue,
+        canArchive,
       };
     }),
     ...(host.nextCursor ? { nextCursor: host.nextCursor } : {}),
@@ -1797,12 +2349,20 @@ function registerCodexSessionCatalog(params: {
       return { ...page, items: page.items.map(toGenericTranscriptItem) };
     },
     continueSession: async (request) => {
-      if (request.hostId !== CODEX_LOCAL_SESSION_HOST_ID) {
-        throw new CatalogParamsError("paired-node Codex sessions are view-only");
-      }
       const config = params.getRuntimeConfig();
       if (!config) {
         throw new Error("OpenClaw runtime config is unavailable");
+      }
+      if (request.hostId.startsWith("node:")) {
+        return await continueNodeCodexSession({
+          api: params.api,
+          config,
+          hostId: request.hostId,
+          threadId: request.threadId,
+        });
+      }
+      if (request.hostId !== CODEX_LOCAL_SESSION_HOST_ID) {
+        throw new CatalogParamsError("Codex session catalog hostId is invalid");
       }
       const continued = await continueLocalCodexSession({
         api: params.api,
@@ -1845,5 +2405,6 @@ export const codexSessionCatalogRuntime = {
   list: listCodexSessionCatalog,
   readTranscript: readCodexSessionTranscript,
   continueLocal: continueLocalCodexSession,
+  continueNode: continueNodeCodexSession,
   archiveLocal: archiveLocalCodexSession,
 };

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -1299,6 +1299,7 @@ function registerCodexSessionCatalog(params: {
           config,
           hostId: request.hostId,
           threadId: request.threadId,
+          clientScopes: request.clientScopes,
         });
       }
       if (request.hostId !== CODEX_LOCAL_SESSION_HOST_ID) {

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -1,9 +1,5 @@
 import { createHash } from "node:crypto";
-import {
-  listAgentIds,
-  resolveDefaultAgentDir,
-  resolveDefaultAgentId,
-} from "openclaw/plugin-sdk/agent-runtime";
+import { resolveDefaultAgentDir, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type {
   OpenClawPluginApi,
@@ -11,7 +7,6 @@ import type {
   OpenClawPluginNodeInvokePolicy,
 } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
-import { parseAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import type {
   SessionCatalogHost,
   SessionCatalogProvider,
@@ -19,7 +14,6 @@ import type {
 } from "openclaw/plugin-sdk/session-catalog";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { CODEX_CONTROL_METHODS } from "./app-server/capabilities.js";
 import { resolveCodexSupervisionAppServerRuntimeOptions } from "./app-server/config.js";
 import { buildCodexAppServerConnectionFingerprint } from "./app-server/plugin-app-cache-key.js";
@@ -44,15 +38,55 @@ import {
   releaseLeasedSharedCodexAppServerClient,
 } from "./app-server/shared-client.js";
 import { assertCodexArchiveDescendantsUnowned } from "./app-server/thread-archive-guard.js";
-import {
-  importCodexThreadHistoryToTranscript,
-  type CodexThreadHistory,
-} from "./app-server/transcript-mirror.js";
+import { importCodexThreadHistoryToTranscript } from "./app-server/transcript-mirror.js";
 import { codexControlRequest } from "./command-rpc.js";
-import { createCodexCliNodeConversationBindingData } from "./conversation-binding-data.js";
-import { CODEX_CLI_SESSION_RESUME_COMMAND } from "./node-cli-sessions.js";
+import {
+  adoptedSourceKey,
+  adoptionSessionKeyRest,
+  continueOperations,
+  lastTerminalTurnId,
+  listNodeAdoptedSessionEntries,
+  listSupervisionAgentIds,
+  runSessionActionExclusive,
+  type AdoptedSessionEntry,
+  type CodexSessionDisposition,
+} from "./session-catalog-node-adoption.js";
+import {
+  CODEX_APP_SERVER_THREADS_LIST_COMMAND,
+  CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND,
+  compareNodeLabels,
+  continueNodeCodexSession,
+  listPairedNode,
+  nodeLabel,
+  NODE_INVOKE_TIMEOUT_MS,
+  type CatalogNode,
+} from "./session-catalog-node-continue.js";
+import {
+  catalogError,
+  CatalogParamsError,
+  CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT,
+  DEFAULT_TRANSCRIPT_PAGE_LIMIT,
+  filterCatalogPageByTitle,
+  isInteractiveThreadSource,
+  MAX_ACTION_CATALOG_PAGES,
+  MAX_CURSOR_LENGTH,
+  MAX_HOST_COUNT,
+  MAX_SESSION_ID_LENGTH,
+  MAX_TITLE_SEARCH_CATALOG_PAGES,
+  MAX_TRANSCRIPT_PAGE_LIMIT,
+  normalizeLimit,
+  parseCatalogPage,
+  parseJsonParams,
+  parseTranscriptPage,
+  readControlCursor,
+  readGatewayParams,
+  readOptionalString,
+  readPageParams,
+  requireOnlyKeys,
+  toCatalogSession,
+  unwrapNodeInvokePayload,
+} from "./session-catalog-parsing.js";
 import type {
-  CodexSessionCatalogError,
   CodexSessionCatalogHost,
   CodexSessionCatalogPage,
   CodexSessionCatalogPageParams,
@@ -62,46 +96,10 @@ import type {
   CodexSessionTranscriptPage,
 } from "./session-catalog-types.js";
 
-const CODEX_APP_SERVER_THREADS_LIST_COMMAND = "codex.appServer.threads.list.v1";
-const CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND = "codex.appServer.thread.turns.list.v1";
-
 const CODEX_APP_SERVER_THREADS_CAPABILITY = "codex-app-server-threads";
-const DEFAULT_PAGE_LIMIT = 50;
-export const CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT = 100;
-// A node may need a cold Codex state scan before returning a large catalog page.
-// Keep this above the Mac node's native 60-second deadline so its specific
-// timeout wins instead of the less useful generic node.invoke timeout.
-const NODE_INVOKE_TIMEOUT_MS = 65_000;
-const MAX_SEARCH_LENGTH = 500;
-const MAX_CURSOR_LENGTH = 4096;
-const MAX_CURSOR_COUNT = 100;
-const MAX_HOST_COUNT = 100;
-const MAX_HOST_ID_LENGTH = 256;
-const MAX_CWD_LENGTH = 4096;
-const MAX_SESSION_ID_LENGTH = 256;
-const MAX_SESSION_NAME_LENGTH = 500;
-const MAX_SESSION_KEY_LENGTH = 1024;
-const MAX_METADATA_LENGTH = 500;
-const MAX_ACTIVE_FLAGS = 16;
-const MAX_ACTION_CATALOG_PAGES = 100;
-const DEFAULT_TRANSCRIPT_PAGE_LIMIT = 20;
-const MAX_TRANSCRIPT_PAGE_LIMIT = 50;
-const MAX_TRANSCRIPT_PAGE_BYTES = 20 * 1024 * 1024;
-const MAX_TITLE_SEARCH_CATALOG_PAGES = 20;
 const CODEX_SUPERVISION_SESSION_KEY_PREFIX = "harness:codex:supervision:";
-const CODEX_NODE_SESSION_KEY_PREFIX = "harness:codex:node-session:";
-const CODEX_NODE_CONTINUE_COMMANDS = [
-  CODEX_APP_SERVER_THREADS_LIST_COMMAND,
-  CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND,
-  CODEX_CLI_SESSION_RESUME_COMMAND,
-] as const;
 
-class CatalogParamsError extends Error {}
-
-type CatalogNode = Awaited<ReturnType<PluginRuntime["nodes"]["list"]>>["nodes"][number];
-type CatalogSessionEntry = ReturnType<
-  PluginRuntime["agent"]["session"]["listSessionEntries"]
->[number]["entry"];
+export { CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT } from "./session-catalog-parsing.js";
 
 export const CODEX_LOCAL_SESSION_HOST_ID = "gateway:local";
 
@@ -335,393 +333,6 @@ export function createCodexSessionCatalogControl(params: {
   });
 }
 
-function readControlCursor(value: unknown, label: string): string | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  if (typeof value !== "string" || !value.trim() || value.length > MAX_CURSOR_LENGTH) {
-    throw new CatalogParamsError(`invalid Codex session catalog ${label} cursor`);
-  }
-  return value;
-}
-
-function boundedCatalogString(
-  value: unknown,
-  maxLength: number,
-  overflow: "omit" | "truncate" = "omit",
-): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const normalized = value.trim();
-  if (!normalized) {
-    return undefined;
-  }
-  if (normalized.length <= maxLength) {
-    return normalized;
-  }
-  return overflow === "truncate" ? truncateUtf16Safe(normalized, maxLength) : undefined;
-}
-
-type CodexInteractiveThreadSourceKind = (typeof CODEX_INTERACTIVE_THREAD_SOURCE_KINDS)[number];
-
-function isInteractiveThreadSource(source: unknown): source is CodexInteractiveThreadSourceKind {
-  return CODEX_INTERACTIVE_THREAD_SOURCE_KINDS.some((kind) => kind === source);
-}
-
-function toCatalogSession(
-  thread: CodexThread,
-  archived: boolean,
-): CodexSessionCatalogSession | undefined {
-  const source = thread.source;
-  if (!isInteractiveThreadSource(source)) {
-    return undefined;
-  }
-  const record = thread as CodexThread & Record<string, unknown>;
-  const threadId = boundedCatalogString(thread.id, MAX_SESSION_ID_LENGTH);
-  if (!threadId) {
-    return undefined;
-  }
-  const activeFlags =
-    thread.status?.type === "active"
-      ? thread.status.activeFlags
-          ?.flatMap((flag) => {
-            const normalized = boundedCatalogString(flag, 128);
-            return normalized ? [normalized] : [];
-          })
-          .slice(0, MAX_ACTIVE_FLAGS)
-      : undefined;
-  const gitInfo = isRecord(record.gitInfo) ? record.gitInfo : undefined;
-  const sessionId = boundedCatalogString(thread.sessionId, MAX_SESSION_ID_LENGTH);
-  const name = boundedCatalogString(thread.name, MAX_SESSION_NAME_LENGTH, "truncate");
-  const cwd = boundedCatalogString(thread.cwd, MAX_CWD_LENGTH);
-  const modelProvider = boundedCatalogString(record.modelProvider, MAX_METADATA_LENGTH, "truncate");
-  const cliVersion = boundedCatalogString(record.cliVersion, MAX_METADATA_LENGTH, "truncate");
-  const gitBranch = boundedCatalogString(gitInfo?.branch, MAX_METADATA_LENGTH, "truncate");
-  return {
-    threadId,
-    status: thread.status?.type ?? "notLoaded",
-    archived,
-    ...(sessionId ? { sessionId } : {}),
-    ...(thread.name === null ? { name: null } : name ? { name } : {}),
-    ...(cwd ? { cwd } : {}),
-    ...(activeFlags?.length ? { activeFlags } : {}),
-    ...(typeof thread.createdAt === "number" && Number.isFinite(thread.createdAt)
-      ? { createdAt: thread.createdAt }
-      : {}),
-    ...(typeof thread.updatedAt === "number" && Number.isFinite(thread.updatedAt)
-      ? { updatedAt: thread.updatedAt }
-      : {}),
-    ...(typeof record.recencyAt === "number" && Number.isFinite(record.recencyAt)
-      ? { recencyAt: record.recencyAt }
-      : record.recencyAt === null
-        ? { recencyAt: null }
-        : {}),
-    source,
-    ...(modelProvider ? { modelProvider } : {}),
-    ...(cliVersion ? { cliVersion } : {}),
-    ...(gitBranch ? { gitBranch } : {}),
-  };
-}
-
-function normalizeLimit(value: unknown, key: string): number {
-  if (value === undefined) {
-    return DEFAULT_PAGE_LIMIT;
-  }
-  if (
-    !Number.isInteger(value) ||
-    (value as number) < 1 ||
-    (value as number) > CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT
-  ) {
-    throw new CatalogParamsError(
-      `${key} must be an integer from 1 to ${CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT}`,
-    );
-  }
-  return value as number;
-}
-
-function readOptionalString(params: Record<string, unknown>, key: string, maxLength: number) {
-  const value = params[key];
-  if (value === undefined) {
-    return undefined;
-  }
-  if (typeof value !== "string") {
-    throw new CatalogParamsError(`${key} must be a string`);
-  }
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  if (trimmed.length > maxLength) {
-    throw new CatalogParamsError(`${key} must be at most ${maxLength} characters`);
-  }
-  return trimmed;
-}
-
-function requireOnlyKeys(params: Record<string, unknown>, allowed: ReadonlySet<string>): void {
-  const unknown = Object.keys(params).find((key) => !allowed.has(key));
-  if (unknown) {
-    throw new CatalogParamsError(`unknown Codex session catalog parameter: ${unknown}`);
-  }
-}
-
-function readPageParams(value: unknown): CodexSessionCatalogPageParams {
-  if (!isRecord(value)) {
-    throw new CatalogParamsError("Codex session catalog parameters must be an object");
-  }
-  const params = value;
-  requireOnlyKeys(params, new Set(["cursor", "limit", "searchTerm", "cwd"]));
-  const cursor = readOptionalString(params, "cursor", MAX_CURSOR_LENGTH);
-  const searchTerm = readOptionalString(params, "searchTerm", MAX_SEARCH_LENGTH);
-  const cwd = readOptionalString(params, "cwd", MAX_CWD_LENGTH);
-  return {
-    limit: normalizeLimit(params.limit, "limit"),
-    ...(cursor ? { cursor } : {}),
-    ...(searchTerm ? { searchTerm } : {}),
-    ...(cwd ? { cwd } : {}),
-  };
-}
-
-function readGatewayParams(value: unknown): CodexSessionCatalogParams {
-  if (value !== undefined && !isRecord(value)) {
-    throw new CatalogParamsError("Codex session catalog parameters must be an object");
-  }
-  const params = isRecord(value) ? value : {};
-  requireOnlyKeys(params, new Set(["search", "limitPerHost", "hostIds", "cursors"]));
-  const search = readOptionalString(params, "search", MAX_SEARCH_LENGTH);
-  let hostIds: string[] | undefined;
-  if (params.hostIds !== undefined) {
-    if (!Array.isArray(params.hostIds) || params.hostIds.length > MAX_HOST_COUNT) {
-      throw new CatalogParamsError(`hostIds must contain at most ${MAX_HOST_COUNT} host ids`);
-    }
-    hostIds = [...new Set(params.hostIds.map((hostId) => readHostId(hostId)))];
-  }
-  let cursors: Record<string, string> | undefined;
-  if (params.cursors !== undefined) {
-    if (!isRecord(params.cursors)) {
-      throw new CatalogParamsError("cursors must be an object");
-    }
-    const entries = Object.entries(params.cursors);
-    if (entries.length > MAX_CURSOR_COUNT) {
-      throw new CatalogParamsError(`cursors may contain at most ${MAX_CURSOR_COUNT} hosts`);
-    }
-    cursors = {};
-    for (const [hostId, cursor] of entries) {
-      const normalizedHostId = hostId.trim();
-      if (
-        normalizedHostId.length === 0 ||
-        normalizedHostId.length > MAX_HOST_ID_LENGTH ||
-        (!normalizedHostId.startsWith("gateway:") && !normalizedHostId.startsWith("node:"))
-      ) {
-        throw new CatalogParamsError(`invalid Codex session catalog host id: ${hostId}`);
-      }
-      if (
-        typeof cursor !== "string" ||
-        !cursor.trim() ||
-        cursor.trim().length > MAX_CURSOR_LENGTH
-      ) {
-        throw new CatalogParamsError(`invalid cursor for Codex session catalog host: ${hostId}`);
-      }
-      cursors[normalizedHostId] = cursor.trim();
-    }
-  }
-  return {
-    limitPerHost: normalizeLimit(params.limitPerHost, "limitPerHost"),
-    ...(search ? { search } : {}),
-    ...(hostIds && hostIds.length > 0 ? { hostIds } : {}),
-    ...(cursors && Object.keys(cursors).length > 0 ? { cursors } : {}),
-  };
-}
-
-function readHostId(value: unknown): string {
-  if (typeof value !== "string") {
-    throw new CatalogParamsError("Codex session catalog host ids must be strings");
-  }
-  const hostId = value.trim();
-  if (
-    hostId.length === 0 ||
-    hostId.length > MAX_HOST_ID_LENGTH ||
-    (!hostId.startsWith("gateway:") && !hostId.startsWith("node:"))
-  ) {
-    throw new CatalogParamsError(`invalid Codex session catalog host id: ${value}`);
-  }
-  return hostId;
-}
-
-function parseJsonParams(paramsJSON?: string | null): unknown {
-  if (!paramsJSON?.trim()) {
-    return {};
-  }
-  try {
-    return JSON.parse(paramsJSON) as unknown;
-  } catch (error) {
-    throw new Error("Codex session catalog parameters must be valid JSON", { cause: error });
-  }
-}
-
-function readFiniteNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-}
-
-function parseOptionalCatalogString(
-  value: unknown,
-  field: string,
-  maxLength: number,
-): string | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (typeof value !== "string" || value.length > maxLength) {
-    throw new Error(`Codex session catalog returned an invalid ${field}`);
-  }
-  return value;
-}
-
-function parseCatalogSession(
-  value: unknown,
-  options: { allowOpenClawSessionKey?: boolean } = {},
-): CodexSessionCatalogSession {
-  if (
-    !isRecord(value) ||
-    typeof value.threadId !== "string" ||
-    !value.threadId.trim() ||
-    value.threadId.length > MAX_SESSION_ID_LENGTH ||
-    value.archived !== false
-  ) {
-    throw new Error("Codex session catalog returned an invalid session");
-  }
-  const status = parseOptionalCatalogString(value.status, "status", 64);
-  if (!status?.trim()) {
-    throw new Error("Codex session catalog returned an invalid status");
-  }
-  if (value.activeFlags !== undefined && !Array.isArray(value.activeFlags)) {
-    throw new Error("Codex session catalog returned invalid active flags");
-  }
-  if (Array.isArray(value.activeFlags) && value.activeFlags.length > MAX_ACTIVE_FLAGS) {
-    throw new Error("Codex session catalog returned too many active flags");
-  }
-  const activeFlags = Array.isArray(value.activeFlags)
-    ? value.activeFlags.map((entry) => {
-        const flag = parseOptionalCatalogString(entry, "active flag", 128);
-        if (flag === undefined) {
-          throw new Error("Codex session catalog returned an invalid active flag");
-        }
-        return flag;
-      })
-    : undefined;
-  const sessionId = parseOptionalCatalogString(
-    value.sessionId,
-    "session id",
-    MAX_SESSION_ID_LENGTH,
-  );
-  const name =
-    value.name === null
-      ? null
-      : parseOptionalCatalogString(value.name, "session name", MAX_SESSION_NAME_LENGTH);
-  const cwd = parseOptionalCatalogString(value.cwd, "cwd", MAX_CWD_LENGTH);
-  const source = parseOptionalCatalogString(value.source, "source", MAX_METADATA_LENGTH);
-  const modelProvider = parseOptionalCatalogString(
-    value.modelProvider,
-    "model provider",
-    MAX_METADATA_LENGTH,
-  );
-  const cliVersion = parseOptionalCatalogString(
-    value.cliVersion,
-    "CLI version",
-    MAX_METADATA_LENGTH,
-  );
-  const gitBranch = parseOptionalCatalogString(value.gitBranch, "Git branch", MAX_METADATA_LENGTH);
-  const openClawSessionKey = options.allowOpenClawSessionKey
-    ? parseOptionalCatalogString(
-        value.openClawSessionKey,
-        "OpenClaw session key",
-        MAX_SESSION_KEY_LENGTH,
-      )
-    : undefined;
-  const createdAt = readFiniteNumber(value.createdAt);
-  const updatedAt = readFiniteNumber(value.updatedAt);
-  const recencyAt = value.recencyAt === null ? null : readFiniteNumber(value.recencyAt);
-  return {
-    threadId: value.threadId,
-    status,
-    archived: value.archived,
-    ...(sessionId !== undefined ? { sessionId } : {}),
-    ...(name !== undefined ? { name } : {}),
-    ...(cwd !== undefined ? { cwd } : {}),
-    ...(activeFlags && activeFlags.length > 0 ? { activeFlags } : {}),
-    ...(createdAt !== undefined ? { createdAt } : {}),
-    ...(updatedAt !== undefined ? { updatedAt } : {}),
-    ...(recencyAt !== undefined ? { recencyAt } : {}),
-    ...(source !== undefined ? { source } : {}),
-    ...(modelProvider !== undefined ? { modelProvider } : {}),
-    ...(cliVersion !== undefined ? { cliVersion } : {}),
-    ...(gitBranch !== undefined ? { gitBranch } : {}),
-    ...(openClawSessionKey !== undefined ? { openClawSessionKey } : {}),
-  };
-}
-
-function parseCatalogPage(
-  value: unknown,
-  options: { allowOpenClawSessionKey?: boolean } = {},
-): CodexSessionCatalogPage {
-  if (
-    !isRecord(value) ||
-    !Array.isArray(value.sessions) ||
-    value.sessions.length > CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT
-  ) {
-    throw new Error("Codex session catalog returned an invalid page");
-  }
-  const nextCursor = parseOptionalCatalogString(value.nextCursor, "next cursor", MAX_CURSOR_LENGTH);
-  const backwardsCursor = parseOptionalCatalogString(
-    value.backwardsCursor,
-    "backwards cursor",
-    MAX_CURSOR_LENGTH,
-  );
-  return {
-    sessions: value.sessions.map((session) => parseCatalogSession(session, options)),
-    ...(nextCursor ? { nextCursor } : {}),
-    ...(backwardsCursor ? { backwardsCursor } : {}),
-  };
-}
-
-function filterCatalogPageByTitle(
-  page: CodexSessionCatalogPage,
-  searchTerm: string | undefined,
-): CodexSessionCatalogPage {
-  if (!searchTerm) {
-    return page;
-  }
-  return {
-    ...page,
-    sessions: page.sessions.filter((session) =>
-      session.name?.toLocaleLowerCase().includes(searchTerm.toLocaleLowerCase()),
-    ),
-  };
-}
-
-function unwrapNodeInvokePayload(value: unknown): unknown {
-  if (!isRecord(value)) {
-    return value;
-  }
-  if (typeof value.payloadJSON === "string" && value.payloadJSON.trim()) {
-    try {
-      return JSON.parse(value.payloadJSON) as unknown;
-    } catch (error) {
-      throw new Error("Codex node returned malformed session catalog JSON", { cause: error });
-    }
-  }
-  return "payload" in value ? value.payload : value;
-}
-
-function catalogError(code: string, _error: unknown): CodexSessionCatalogError {
-  const messages: Record<string, string> = {
-    APP_SERVER_UNAVAILABLE: "Codex app-server is unavailable on this host",
-    NODE_INVOKE_FAILED: "The paired node could not return its Codex session catalog",
-    NODE_LIST_FAILED: "Paired nodes could not be listed",
-  };
-  return { code, message: messages[code] ?? "Codex session catalog request failed" };
-}
-
 async function listGatewayHost(params: {
   bindingStore: CodexAppServerBindingStore;
   config?: OpenClawConfig;
@@ -763,89 +374,6 @@ async function listGatewayHost(params: {
       connected: false,
       sessions: [],
       error: catalogError("APP_SERVER_UNAVAILABLE", error),
-    };
-  }
-}
-
-function nodeLabel(node: CatalogNode): string {
-  return node.displayName?.trim() || node.remoteIp?.trim() || node.nodeId;
-}
-
-function compareNodeLabels(left: CatalogNode, right: CatalogNode): number {
-  const leftLabel = nodeLabel(left);
-  const rightLabel = nodeLabel(right);
-  if (leftLabel < rightLabel) {
-    return -1;
-  }
-  if (leftLabel > rightLabel) {
-    return 1;
-  }
-  return 0;
-}
-
-function canContinueCodexOnNode(node: CatalogNode): boolean {
-  return (
-    node.connected === true &&
-    CODEX_NODE_CONTINUE_COMMANDS.every(
-      (command) =>
-        node.commands?.includes(command) === true &&
-        node.invocableCommands?.includes(command) === true,
-    )
-  );
-}
-
-async function listPairedNode(params: {
-  runtime: PluginRuntime;
-  node: CatalogNode;
-  query: CodexSessionCatalogParams;
-  adoptedSessions: ReadonlyMap<string, AdoptedSessionEntry>;
-}): Promise<CodexSessionCatalogHost> {
-  const hostId = `node:${params.node.nodeId}`;
-  const common = {
-    hostId,
-    label: nodeLabel(params.node),
-    kind: "node" as const,
-    nodeId: params.node.nodeId,
-    canContinueCodex: canContinueCodexOnNode(params.node),
-  };
-  if (params.node.connected !== true) {
-    return {
-      ...common,
-      connected: false,
-      sessions: [],
-      error: { code: "NODE_OFFLINE", message: "Paired node is offline" },
-    };
-  }
-  try {
-    const raw = await params.runtime.nodes.invoke({
-      nodeId: params.node.nodeId,
-      command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
-      params: {
-        cursor: params.query.cursors?.[hostId],
-        limit: params.query.limitPerHost,
-        searchTerm: params.query.search,
-      },
-      timeoutMs: NODE_INVOKE_TIMEOUT_MS,
-    });
-    const page = filterCatalogPageByTitle(
-      parseCatalogPage(unwrapNodeInvokePayload(raw)),
-      params.query.search,
-    );
-    return {
-      ...common,
-      connected: true,
-      ...page,
-      sessions: page.sessions.map((session) => {
-        const adopted = params.adoptedSessions.get(adoptedSourceKey(hostId, session.threadId));
-        return adopted ? Object.assign({}, session, { openClawSessionKey: adopted.key }) : session;
-      }),
-    };
-  } catch (error) {
-    return {
-      ...common,
-      connected: true,
-      sessions: [],
-      error: catalogError("NODE_INVOKE_FAILED", error),
     };
   }
 }
@@ -1003,33 +531,6 @@ function readBoundedLimit(value: unknown, key: string, fallback: number, max: nu
   return value as number;
 }
 
-function parseTranscriptPage(value: unknown): CodexThreadTurnsListResponse {
-  if (
-    !isRecord(value) ||
-    !Array.isArray(value.data) ||
-    value.data.length > MAX_TRANSCRIPT_PAGE_LIMIT ||
-    value.data.some(
-      (turn) =>
-        !isRecord(turn) || !Array.isArray(turn.items) || turn.items.some((item) => !isRecord(item)),
-    )
-  ) {
-    throw new Error("Codex app-server returned an invalid transcript page");
-  }
-  const nextCursor = readControlCursor(value.nextCursor, "transcript next response");
-  const backwardsCursor = readControlCursor(value.backwardsCursor, "transcript backwards response");
-  const page: CodexThreadTurnsListResponse = {
-    data: value.data as CodexThreadTurnsListResponse["data"],
-    ...(nextCursor ? { nextCursor } : {}),
-    ...(backwardsCursor ? { backwardsCursor } : {}),
-  };
-  // A bounded item count does not bound tool output embedded in one item. Keep
-  // the page below node.invoke and Gateway WebSocket payload ceilings.
-  if (Buffer.byteLength(JSON.stringify(page), "utf8") > MAX_TRANSCRIPT_PAGE_BYTES) {
-    throw new Error("Codex app-server transcript page exceeds the safe response size");
-  }
-  return page;
-}
-
 function flattenTranscriptPageDesc(page: CodexThreadTurnsListResponse) {
   return page.data.flatMap((turn) => turn.items.toReversed());
 }
@@ -1154,126 +655,11 @@ function adoptionSessionKey(threadId: string): string {
   return `${CODEX_SUPERVISION_SESSION_KEY_PREFIX}${digest}`;
 }
 
-// Session creation persists this plugin-owned suffix under an agent-qualified key.
-// Restart discovery must compare the parsed suffix, not the returned canonical key.
-function adoptionSessionKeyRest(sessionKey: string): string {
-  const trimmed = sessionKey.trim();
-  return parseAgentSessionKey(trimmed)?.rest ?? trimmed;
-}
-
 function isAdoptionSessionKeyForThread(sessionKey: string, threadId: string): boolean {
   return adoptionSessionKeyRest(sessionKey) === adoptionSessionKey(threadId);
 }
 
-type CodexSessionDisposition = "existing" | "forked";
-
 type CodexSupervisionMarker = { sourceThreadId: string };
-
-type CodexNodeSessionMarker = {
-  sourceHostId: string;
-  sourceThreadId: string;
-  nodeId: string;
-  initializing?: true;
-};
-
-type AdoptedSessionEntry = {
-  key: string;
-  sessionId: string;
-  agentId: string;
-  initializing?: true;
-};
-
-function adoptedSourceKey(hostId: string, threadId: string): string {
-  return `${hostId}\u0000${threadId}`;
-}
-
-function nodeAdoptionSessionKey(hostId: string, threadId: string): string {
-  const digest = createHash("sha256")
-    .update(JSON.stringify([hostId, threadId]))
-    .digest("hex");
-  return `${CODEX_NODE_SESSION_KEY_PREFIX}${digest}`;
-}
-
-function readNodeSessionMarker(entry: CatalogSessionEntry): CodexNodeSessionMarker | undefined {
-  const codex = isRecord(entry.pluginExtensions?.codex) ? entry.pluginExtensions.codex : undefined;
-  const marker = codex && isRecord(codex.sessionCatalog) ? codex.sessionCatalog : undefined;
-  if (
-    !marker ||
-    typeof marker.sourceHostId !== "string" ||
-    !marker.sourceHostId.startsWith("node:") ||
-    typeof marker.sourceThreadId !== "string" ||
-    !marker.sourceThreadId.trim() ||
-    typeof marker.nodeId !== "string" ||
-    !marker.nodeId.trim()
-  ) {
-    return undefined;
-  }
-  return {
-    sourceHostId: marker.sourceHostId,
-    sourceThreadId: marker.sourceThreadId,
-    nodeId: marker.nodeId,
-    ...(marker.initializing === true ? { initializing: true } : {}),
-  };
-}
-
-function listSupervisionAgentIds(config: OpenClawConfig): string[] {
-  const defaultAgentId = resolveDefaultAgentId(config);
-  return [defaultAgentId, ...listAgentIds(config).filter((agentId) => agentId !== defaultAgentId)];
-}
-
-function listNodeAdoptedSessionEntries(params: {
-  config?: OpenClawConfig;
-  runtime: PluginRuntime;
-  includeInitializing?: boolean;
-}): Map<string, AdoptedSessionEntry> {
-  const adopted = new Map<string, AdoptedSessionEntry>();
-  for (const agentId of listSupervisionAgentIds(params.config ?? {})) {
-    for (const { entry, sessionKey } of params.runtime.agent.session.listSessionEntries({
-      agentId,
-    })) {
-      const marker = readNodeSessionMarker(entry);
-      const sessionId = entry.sessionId?.trim();
-      if (
-        !marker ||
-        (marker.initializing === true && params.includeInitializing !== true) ||
-        entry.initializationPending === true ||
-        entry.agentHarnessId !== "codex" ||
-        entry.modelSelectionLocked !== true ||
-        !sessionId ||
-        adoptionSessionKeyRest(sessionKey) !==
-          nodeAdoptionSessionKey(marker.sourceHostId, marker.sourceThreadId) ||
-        marker.sourceHostId !== `node:${marker.nodeId}`
-      ) {
-        continue;
-      }
-      const sourceKey = adoptedSourceKey(marker.sourceHostId, marker.sourceThreadId);
-      if (adopted.has(sourceKey)) {
-        throw new Error(
-          `multiple OpenClaw sessions adopt Codex thread ${marker.sourceThreadId} on ${marker.sourceHostId}`,
-        );
-      }
-      adopted.set(sourceKey, {
-        key: sessionKey,
-        sessionId,
-        agentId,
-        ...(marker.initializing === true ? { initializing: true } : {}),
-      });
-    }
-  }
-  return adopted;
-}
-
-function findNodeAdoptedSessionEntry(params: {
-  config: OpenClawConfig;
-  runtime: PluginRuntime;
-  hostId: string;
-  threadId: string;
-  includeInitializing?: boolean;
-}): AdoptedSessionEntry | undefined {
-  return listNodeAdoptedSessionEntries(params).get(
-    adoptedSourceKey(params.hostId, params.threadId),
-  );
-}
 
 async function listAdoptedSessionEntries(params: {
   bindingStore: CodexAppServerBindingStore;
@@ -1369,24 +755,6 @@ async function clearCreatedAdoptionBinding(params: {
     [params.cause, ...(clearError ? [clearError] : [])],
     `OpenClaw session creation failed and the Codex binding could not be cleared for ${params.sourceThreadId}`,
   );
-}
-
-function lastTerminalTurnId(thread: CodexThreadHistory): string | undefined {
-  for (let index = (thread.turns?.length ?? 0) - 1; index >= 0; index -= 1) {
-    const turn = thread.turns?.[index];
-    const turnId = boundedCatalogString(turn?.id, MAX_SESSION_ID_LENGTH);
-    if (!turnId) {
-      continue;
-    }
-    if (
-      turn?.status === "completed" ||
-      turn?.status === "interrupted" ||
-      turn?.status === "failed"
-    ) {
-      return turnId;
-    }
-  }
-  return undefined;
 }
 
 function matchesPendingAdoptionBinding(
@@ -1619,29 +987,6 @@ async function createOrReuseAdoptedSession(params: {
   }
 }
 
-const continueOperations = new Map<
-  string,
-  Promise<{ sessionKey: string; disposition: CodexSessionDisposition }>
->();
-const sessionActionTails = new Map<string, Promise<void>>();
-
-async function runSessionActionExclusive<T>(threadId: string, run: () => Promise<T>): Promise<T> {
-  const previous = sessionActionTails.get(threadId) ?? Promise.resolve();
-  const operation = previous.then(run);
-  const tail = operation.then(
-    () => undefined,
-    () => undefined,
-  );
-  sessionActionTails.set(threadId, tail);
-  try {
-    return await operation;
-  } finally {
-    if (sessionActionTails.get(threadId) === tail) {
-      sessionActionTails.delete(threadId);
-    }
-  }
-}
-
 async function continueLocalCodexSessionInner(params: {
   api: OpenClawPluginApi;
   bindingStore: CodexAppServerBindingStore;
@@ -1725,411 +1070,6 @@ async function continueLocalCodexSession(params: {
     params.control.withPinnedConnection(async (control) =>
       continueLocalCodexSessionInner({ ...params, control }),
     ),
-  );
-  continueOperations.set(sourceKey, operation);
-  try {
-    return await operation;
-  } finally {
-    if (continueOperations.get(sourceKey) === operation) {
-      continueOperations.delete(sourceKey);
-    }
-  }
-}
-
-async function requireNodeForCodexContinue(params: {
-  runtime: PluginRuntime;
-  hostId: string;
-}): Promise<{ node: CatalogNode; nodeId: string }> {
-  const nodeId = params.hostId.slice("node:".length).trim();
-  if (!nodeId || params.hostId !== `node:${nodeId}`) {
-    throw new CatalogParamsError("Codex session catalog hostId is invalid");
-  }
-  const node = (await params.runtime.nodes.list()).nodes.find(
-    (candidate) => candidate.nodeId === nodeId,
-  );
-  if (!node || !canContinueCodexOnNode(node)) {
-    throw new CatalogParamsError("paired node does not permit Codex session continuation");
-  }
-  return { node, nodeId };
-}
-
-async function resolveNodeCodexRecord(params: {
-  runtime: PluginRuntime;
-  nodeId: string;
-  threadId: string;
-}): Promise<CodexSessionCatalogSession> {
-  let cursor: string | undefined;
-  const seenCursors = new Set<string>();
-  for (let pageIndex = 0; pageIndex < MAX_ACTION_CATALOG_PAGES; pageIndex += 1) {
-    const raw = await params.runtime.nodes.invoke({
-      nodeId: params.nodeId,
-      command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
-      params: {
-        limit: CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT,
-        ...(cursor ? { cursor } : {}),
-      },
-      timeoutMs: NODE_INVOKE_TIMEOUT_MS,
-    });
-    const page = parseCatalogPage(unwrapNodeInvokePayload(raw));
-    const record = page.sessions.find((candidate) => candidate.threadId === params.threadId);
-    if (record) {
-      return record;
-    }
-    const nextCursor = page.nextCursor?.trim();
-    if (!nextCursor) {
-      break;
-    }
-    if (seenCursors.has(nextCursor)) {
-      throw new CatalogParamsError("Codex session eligibility could not be verified");
-    }
-    seenCursors.add(nextCursor);
-    cursor = nextCursor;
-  }
-  throw new CatalogParamsError("Codex session is unavailable on the paired node");
-}
-
-function requireContinuableNodeRecord(record: CodexSessionCatalogSession): void {
-  if (record.archived) {
-    throw new CatalogParamsError("Codex session is archived on the paired node");
-  }
-  if (!isInteractiveThreadSource(record.source)) {
-    throw new CatalogParamsError(
-      "Codex session is not a non-archived interactive CLI or VS Code session",
-    );
-  }
-  if (record.status === "idle" || record.status === "notLoaded") {
-    // The node App Server is a passive catalog reader, so stored CLI/VS Code
-    // sessions normally report notLoaded. Node resume serializes OpenClaw turns.
-    return;
-  }
-  if (record.status === "active") {
-    throw new CatalogParamsError(
-      "Codex session is active on the paired node; wait for it to finish before continuing",
-    );
-  }
-  throw new CatalogParamsError("Codex session cannot be continued in its current state");
-}
-
-async function readNodeCodexHistory(params: {
-  runtime: PluginRuntime;
-  nodeId: string;
-  record: CodexSessionCatalogSession;
-}): Promise<{ thread: CodexThreadHistory; throughTurnId: string | null }> {
-  const raw = await params.runtime.nodes.invoke({
-    nodeId: params.nodeId,
-    command: CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND,
-    params: {
-      threadId: params.record.threadId,
-      limit: MAX_TRANSCRIPT_PAGE_LIMIT,
-    },
-    timeoutMs: NODE_INVOKE_TIMEOUT_MS,
-  });
-  const page = parseTranscriptPage(unwrapNodeInvokePayload(raw));
-  const thread: CodexThreadHistory = {
-    id: params.record.threadId,
-    createdAt: params.record.createdAt ?? 0,
-    modelProvider: params.record.modelProvider ?? "openai",
-    turns: page.data.toReversed(),
-  };
-  return { thread, throughTurnId: lastTerminalTurnId(thread) ?? null };
-}
-
-function nodeSessionMarker(params: {
-  hostId: string;
-  threadId: string;
-  nodeId: string;
-  initializing?: true;
-}): CodexNodeSessionMarker {
-  return {
-    sourceHostId: params.hostId,
-    sourceThreadId: params.threadId,
-    nodeId: params.nodeId,
-    ...(params.initializing === true ? { initializing: true } : {}),
-  };
-}
-
-async function restoreNodeAdoptedSession(params: {
-  api: OpenClawPluginApi;
-  existing: AdoptedSessionEntry;
-  hostId: string;
-  threadId: string;
-  nodeId: string;
-}): Promise<void> {
-  const changedError = () =>
-    new CatalogParamsError("Codex OpenClaw session changed before it could be opened. Retry.");
-  const restored = await params.api.runtime.agent.session.patchSessionEntry({
-    sessionKey: params.existing.key,
-    readConsistency: "latest",
-    preserveActivity: true,
-    update: (entry) => {
-      const marker = readNodeSessionMarker(entry);
-      if (
-        entry.sessionId?.trim() !== params.existing.sessionId ||
-        entry.initializationPending === true ||
-        entry.agentHarnessId !== "codex" ||
-        entry.modelSelectionLocked !== true ||
-        !marker ||
-        marker.initializing === true ||
-        marker.sourceHostId !== params.hostId ||
-        marker.sourceThreadId !== params.threadId ||
-        marker.nodeId !== params.nodeId
-      ) {
-        throw changedError();
-      }
-      return { archivedAt: undefined };
-    },
-  });
-  if (!restored) {
-    throw changedError();
-  }
-}
-
-async function finalizeNodeAdoptedSession(params: {
-  api: OpenClawPluginApi;
-  adopted: AdoptedSessionEntry;
-  marker: CodexNodeSessionMarker;
-}): Promise<void> {
-  const changedError = () =>
-    new CatalogParamsError("Codex OpenClaw session changed before it could be bound. Retry.");
-  let finalized: CatalogSessionEntry | null;
-  try {
-    finalized = await params.api.runtime.agent.session.patchSessionEntry({
-      sessionKey: params.adopted.key,
-      readConsistency: "latest",
-      preserveActivity: true,
-      update: (entry) => {
-        const current = readNodeSessionMarker(entry);
-        if (
-          entry.sessionId?.trim() !== params.adopted.sessionId ||
-          entry.initializationPending === true ||
-          entry.agentHarnessId !== "codex" ||
-          entry.modelSelectionLocked !== true ||
-          !current ||
-          current.sourceHostId !== params.marker.sourceHostId ||
-          current.sourceThreadId !== params.marker.sourceThreadId ||
-          current.nodeId !== params.marker.nodeId
-        ) {
-          throw changedError();
-        }
-        if (current.initializing !== true) {
-          return { archivedAt: undefined };
-        }
-        const codex = isRecord(entry.pluginExtensions?.codex) ? entry.pluginExtensions.codex : {};
-        return {
-          archivedAt: undefined,
-          pluginExtensions: {
-            ...entry.pluginExtensions,
-            codex: { ...codex, sessionCatalog: params.marker },
-          },
-        };
-      },
-    });
-  } catch (error) {
-    const currentEntry = params.api.runtime.agent.session.getSessionEntry({
-      sessionKey: params.adopted.key,
-      readConsistency: "latest",
-    });
-    const current = currentEntry ? readNodeSessionMarker(currentEntry) : undefined;
-    if (
-      currentEntry?.sessionId?.trim() === params.adopted.sessionId &&
-      current?.initializing !== true &&
-      current?.sourceHostId === params.marker.sourceHostId &&
-      current.sourceThreadId === params.marker.sourceThreadId &&
-      current.nodeId === params.marker.nodeId
-    ) {
-      return;
-    }
-    throw error;
-  }
-  if (!finalized) {
-    throw changedError();
-  }
-}
-
-async function createOrReuseNodeAdoptedSession(params: {
-  api: OpenClawPluginApi;
-  config: OpenClawConfig;
-  hostId: string;
-  nodeId: string;
-  record: CodexSessionCatalogSession;
-  history: Awaited<ReturnType<typeof readNodeCodexHistory>>;
-}): Promise<AdoptedSessionEntry> {
-  const existing = findNodeAdoptedSessionEntry({
-    config: params.config,
-    runtime: params.api.runtime,
-    hostId: params.hostId,
-    threadId: params.record.threadId,
-    includeInitializing: true,
-  });
-  if (existing) {
-    return existing;
-  }
-  const marker = nodeSessionMarker({
-    hostId: params.hostId,
-    threadId: params.record.threadId,
-    nodeId: params.nodeId,
-  });
-  const initializingMarker = { ...marker, initializing: true as const };
-  try {
-    const created = await params.api.runtime.agent.session.createSessionEntry({
-      cfg: params.config,
-      key: nodeAdoptionSessionKey(params.hostId, params.record.threadId),
-      agentId: resolveDefaultAgentId(params.config),
-      recoverMatchingInitialEntry: true,
-      ...(params.record.name?.trim() ? { label: params.record.name.trim() } : {}),
-      ...(params.record.cwd?.trim() ? { spawnedCwd: params.record.cwd.trim() } : {}),
-      initialEntry: {
-        agentHarnessId: "codex",
-        modelSelectionLocked: true,
-        pluginExtensions: {
-          codex: {
-            sessionCatalog: initializingMarker,
-          },
-        },
-      },
-      afterCreate: async (entry) => {
-        const storePath = resolveStorePath(params.config.session?.store, {
-          agentId: entry.agentId,
-        });
-        await importCodexThreadHistoryToTranscript({
-          thread: params.history.thread,
-          throughTurnId: params.history.throughTurnId,
-          storePath,
-          sessionId: entry.sessionId,
-          sessionKey: entry.key,
-          agentId: entry.agentId,
-          ...(params.record.cwd?.trim() ? { cwd: params.record.cwd.trim() } : {}),
-          modelProvider: params.record.modelProvider,
-          config: params.config,
-        });
-        return { pluginExtensions: { codex: { sessionCatalog: initializingMarker } } };
-      },
-    });
-    return {
-      key: created.key,
-      sessionId: created.sessionId,
-      agentId: created.agentId,
-      initializing: true,
-    };
-  } catch (error) {
-    const raced = findNodeAdoptedSessionEntry({
-      config: params.config,
-      runtime: params.api.runtime,
-      hostId: params.hostId,
-      threadId: params.record.threadId,
-      includeInitializing: true,
-    });
-    if (raced) {
-      return raced;
-    }
-    throw error;
-  }
-}
-
-async function continueNodeCodexSessionInner(params: {
-  api: OpenClawPluginApi;
-  config: OpenClawConfig;
-  hostId: string;
-  threadId: string;
-}): Promise<{
-  sessionKey: string;
-  disposition: CodexSessionDisposition;
-  conversationBinding: {
-    summary: string;
-    detachHint: string;
-    data: Record<string, unknown>;
-  };
-  afterConversationBound: () => Promise<void>;
-}> {
-  const { nodeId } = await requireNodeForCodexContinue({
-    runtime: params.api.runtime,
-    hostId: params.hostId,
-  });
-  const record = await resolveNodeCodexRecord({
-    runtime: params.api.runtime,
-    nodeId,
-    threadId: params.threadId,
-  });
-  requireContinuableNodeRecord(record);
-  const existing = findNodeAdoptedSessionEntry({
-    config: params.config,
-    runtime: params.api.runtime,
-    hostId: params.hostId,
-    threadId: params.threadId,
-    includeInitializing: true,
-  });
-  let adopted: AdoptedSessionEntry;
-  let disposition: CodexSessionDisposition;
-  if (existing) {
-    if (existing.initializing !== true) {
-      await restoreNodeAdoptedSession({
-        api: params.api,
-        existing,
-        hostId: params.hostId,
-        threadId: params.threadId,
-        nodeId,
-      });
-    }
-    adopted = existing;
-    disposition = "existing";
-  } else {
-    const history = await readNodeCodexHistory({
-      runtime: params.api.runtime,
-      nodeId,
-      record,
-    });
-    adopted = await createOrReuseNodeAdoptedSession({
-      api: params.api,
-      config: params.config,
-      hostId: params.hostId,
-      nodeId,
-      record,
-      history,
-    });
-    disposition = "forked";
-  }
-  const marker = nodeSessionMarker({
-    hostId: params.hostId,
-    threadId: params.threadId,
-    nodeId,
-  });
-  return {
-    sessionKey: adopted.key,
-    disposition,
-    conversationBinding: {
-      summary: "Continue this Codex session on its paired node.",
-      detachHint: "Start a new chat to leave the paired-node Codex session.",
-      data: createCodexCliNodeConversationBindingData({
-        nodeId,
-        sessionId: params.threadId,
-        agentId: adopted.agentId,
-        cwd: record.cwd,
-      }),
-    },
-    afterConversationBound: async () =>
-      await finalizeNodeAdoptedSession({ api: params.api, adopted, marker }),
-  };
-}
-
-async function continueNodeCodexSession(params: {
-  api: OpenClawPluginApi;
-  config: OpenClawConfig;
-  hostId: string;
-  threadId: string;
-}) {
-  const nodeId = params.hostId.slice("node:".length).trim();
-  if (!nodeId || params.hostId !== `node:${nodeId}`) {
-    throw new CatalogParamsError("Codex session catalog hostId is invalid");
-  }
-  const sourceKey = adoptedSourceKey(`node:${nodeId}`, params.threadId);
-  const current = continueOperations.get(sourceKey) as
-    | Promise<Awaited<ReturnType<typeof continueNodeCodexSessionInner>>>
-    | undefined;
-  if (current) {
-    return await current;
-  }
-  const operation = runSessionActionExclusive(sourceKey, async () =>
-    continueNodeCodexSessionInner(params),
   );
   continueOperations.set(sourceKey, operation);
   try {

--- a/src/gateway/server-methods/session-catalog.test.ts
+++ b/src/gateway/server-methods/session-catalog.test.ts
@@ -3,9 +3,18 @@ import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import type { SessionCatalogProvider } from "../../plugins/session-catalog.js";
 
 const activeRegistry = vi.hoisted(() => ({ sessionCatalogs: [] as unknown[] }));
+const conversationBindingMocks = vi.hoisted(() => ({
+  bindPluginSessionConversation: vi.fn(async (params: { afterBind?: () => Promise<void> }) => {
+    await params.afterBind?.();
+    return {};
+  }),
+}));
 
 vi.mock("../../plugins/runtime-state.js", () => ({
   getPluginRegistryState: () => ({ activeRegistry }),
+}));
+vi.mock("../../plugins/conversation-binding.js", () => ({
+  bindPluginSessionConversation: conversationBindingMocks.bindPluginSessionConversation,
 }));
 
 const { resolveSessionCatalogCreateTarget, sessionCatalogHandlers } =
@@ -41,6 +50,7 @@ async function call(
 describe("session catalog Gateway methods", () => {
   beforeEach(() => {
     activeRegistry.sessionCatalogs = [];
+    conversationBindingMocks.bindPluginSessionConversation.mockClear();
   });
 
   it("sorts catalogs and isolates provider failures", async () => {
@@ -219,6 +229,117 @@ describe("session catalog Gateway methods", () => {
       threadId: "thread-1",
     });
     expect(respond).toHaveBeenCalledWith(true, { sessionKey: "agent:main:adopted" });
+  });
+
+  it("installs a provider-requested binding on the adopted Control UI session", async () => {
+    const afterConversationBound = vi.fn(async () => undefined);
+    const continueSession = vi.fn(async () => ({
+      sessionKey: "agent:main:adopted",
+      conversationBinding: {
+        summary: "Continue remotely",
+        data: { kind: "remote-runtime", version: 1 },
+      },
+      afterConversationBound,
+    }));
+    activeRegistry.sessionCatalogs = [
+      {
+        pluginId: "remote",
+        pluginName: "Remote Runtime",
+        rootDir: "/plugins/remote",
+        source: "/plugins/remote/index.ts",
+        provider: provider("remote", { continueSession }),
+      },
+    ];
+
+    const respond = await call("sessions.catalog.continue", {
+      catalogId: "remote",
+      hostId: "node:devbox",
+      threadId: "thread-1",
+    });
+
+    expect(conversationBindingMocks.bindPluginSessionConversation).toHaveBeenCalledWith({
+      pluginId: "remote",
+      pluginName: "Remote Runtime",
+      pluginRoot: "/plugins/remote",
+      sessionKey: "agent:main:adopted",
+      binding: {
+        summary: "Continue remotely",
+        data: { kind: "remote-runtime", version: 1 },
+      },
+      afterBind: afterConversationBound,
+    });
+    expect(afterConversationBound).toHaveBeenCalledOnce();
+    expect(
+      conversationBindingMocks.bindPluginSessionConversation.mock.invocationCallOrder[0],
+    ).toBeLessThan(afterConversationBound.mock.invocationCallOrder[0] ?? 0);
+    expect(respond).toHaveBeenCalledWith(true, { sessionKey: "agent:main:adopted" });
+  });
+
+  it("does not publish provider adoption when the Control UI binding fails", async () => {
+    const afterConversationBound = vi.fn(async () => undefined);
+    conversationBindingMocks.bindPluginSessionConversation.mockRejectedValueOnce(
+      new Error("binding failed"),
+    );
+    activeRegistry.sessionCatalogs = [
+      {
+        pluginId: "remote",
+        rootDir: "/plugins/remote",
+        source: "/plugins/remote/index.ts",
+        provider: provider("remote", {
+          continueSession: vi.fn(async () => ({
+            sessionKey: "agent:main:pending",
+            conversationBinding: { data: { kind: "remote-runtime", version: 1 } },
+            afterConversationBound,
+          })),
+        }),
+      },
+    ];
+
+    const respond = await call("sessions.catalog.continue", {
+      catalogId: "remote",
+      hostId: "node:devbox",
+      threadId: "thread-1",
+    });
+
+    expect(afterConversationBound).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "binding failed" }),
+    );
+  });
+
+  it("removes the Control UI binding when provider adoption cannot finalize", async () => {
+    const afterConversationBound = vi.fn(async () => {
+      throw new Error("finalization failed");
+    });
+    activeRegistry.sessionCatalogs = [
+      {
+        pluginId: "remote",
+        rootDir: "/plugins/remote",
+        source: "/plugins/remote/index.ts",
+        provider: provider("remote", {
+          continueSession: vi.fn(async () => ({
+            sessionKey: "agent:main:pending",
+            conversationBinding: { data: { kind: "remote-runtime", version: 1 } },
+            afterConversationBound,
+          })),
+        }),
+      },
+    ];
+
+    const respond = await call("sessions.catalog.continue", {
+      catalogId: "remote",
+      hostId: "node:devbox",
+      threadId: "thread-1",
+    });
+
+    expect(afterConversationBound).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "finalization failed" }),
+    );
   });
 
   it("rejects an unknown catalog id when listing", async () => {

--- a/src/gateway/server-methods/session-catalog.test.ts
+++ b/src/gateway/server-methods/session-catalog.test.ts
@@ -37,11 +37,13 @@ async function call(
   method: keyof typeof sessionCatalogHandlers,
   params: unknown,
   config: Record<string, unknown> = {},
+  client?: { connect?: { scopes?: string[] } },
 ) {
   const respond = vi.fn();
   await sessionCatalogHandlers[method]?.({
     params,
     respond,
+    client,
     context: { getRuntimeConfig: () => config },
   } as never);
   return respond;
@@ -216,10 +218,31 @@ describe("session catalog Gateway methods", () => {
     });
   });
 
-  it("dispatches continue by catalog id", async () => {
+  it("dispatches continue by catalog id with the caller's scopes", async () => {
     const continueSession = vi.fn(async () => ({ sessionKey: "agent:main:adopted" }));
     activeRegistry.sessionCatalogs = [{ provider: provider("codex", { continueSession }) }];
-    const respond = await call("sessions.catalog.continue", {
+    const respond = await call(
+      "sessions.catalog.continue",
+      {
+        catalogId: "codex",
+        hostId: "gateway:local",
+        threadId: "thread-1",
+      },
+      {},
+      { connect: { scopes: ["operator.write", "operator.admin"] } },
+    );
+    expect(continueSession).toHaveBeenCalledWith({
+      hostId: "gateway:local",
+      threadId: "thread-1",
+      clientScopes: ["operator.write", "operator.admin"],
+    });
+    expect(respond).toHaveBeenCalledWith(true, { sessionKey: "agent:main:adopted" });
+  });
+
+  it("forwards empty scopes for unscoped callers", async () => {
+    const continueSession = vi.fn(async () => ({ sessionKey: "agent:main:adopted" }));
+    activeRegistry.sessionCatalogs = [{ provider: provider("codex", { continueSession }) }];
+    await call("sessions.catalog.continue", {
       catalogId: "codex",
       hostId: "gateway:local",
       threadId: "thread-1",
@@ -227,8 +250,8 @@ describe("session catalog Gateway methods", () => {
     expect(continueSession).toHaveBeenCalledWith({
       hostId: "gateway:local",
       threadId: "thread-1",
+      clientScopes: [],
     });
-    expect(respond).toHaveBeenCalledWith(true, { sessionKey: "agent:main:adopted" });
   });
 
   it("installs a provider-requested binding on the adopted Control UI session", async () => {

--- a/src/gateway/server-methods/session-catalog.test.ts
+++ b/src/gateway/server-methods/session-catalog.test.ts
@@ -13,7 +13,7 @@ const conversationBindingMocks = vi.hoisted(() => ({
 vi.mock("../../plugins/runtime-state.js", () => ({
   getPluginRegistryState: () => ({ activeRegistry }),
 }));
-vi.mock("../../plugins/conversation-binding.js", () => ({
+vi.mock("../../plugins/session-conversation-binding.js", () => ({
   bindPluginSessionConversation: conversationBindingMocks.bindPluginSessionConversation,
 }));
 

--- a/src/gateway/server-methods/session-catalog.ts
+++ b/src/gateway/server-methods/session-catalog.ts
@@ -12,12 +12,12 @@ import {
   validateSessionsCatalogListParams,
   validateSessionsCatalogReadParams,
 } from "../../../packages/gateway-protocol/src/index.js";
-import { bindPluginSessionConversation } from "../../plugins/conversation-binding.js";
 import { getPluginRegistryState } from "../../plugins/runtime-state.js";
 import type {
   SessionCatalogCreateTarget,
   SessionCatalogProvider,
 } from "../../plugins/session-catalog.js";
+import { bindPluginSessionConversation } from "../../plugins/session-conversation-binding.js";
 import { resolveAgentIdOrRespondError } from "./agent-id-shared.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";

--- a/src/gateway/server-methods/session-catalog.ts
+++ b/src/gateway/server-methods/session-catalog.ts
@@ -12,6 +12,7 @@ import {
   validateSessionsCatalogListParams,
   validateSessionsCatalogReadParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { bindPluginSessionConversation } from "../../plugins/conversation-binding.js";
 import { getPluginRegistryState } from "../../plugins/runtime-state.js";
 import type {
   SessionCatalogCreateTarget,
@@ -98,6 +99,18 @@ function providerOrRespond(
     );
   }
   return provider;
+}
+
+function registrationOrRespond(catalogId: string, respond: RespondFn) {
+  const registration = registrations().find((candidate) => candidate.provider.id === catalogId);
+  if (!registration) {
+    respond(
+      false,
+      undefined,
+      errorShape(ErrorCodes.INVALID_REQUEST, `unknown session catalog: ${catalogId}`),
+    );
+  }
+  return registration;
 }
 
 function catalogResult(
@@ -216,17 +229,31 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
       return;
     }
     const request = params as SessionsCatalogContinueParams;
-    const provider = providerOrRespond(request.catalogId, respond);
-    if (!provider) {
+    const registration = registrationOrRespond(request.catalogId, respond);
+    if (!registration) {
       return;
     }
+    const provider = registration.provider;
     if (!provider.continueSession) {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "catalog is view-only"));
       return;
     }
     try {
       const { catalogId: _catalogId, ...providerRequest } = request;
-      respond(true, await provider.continueSession(providerRequest));
+      const result = await provider.continueSession(providerRequest);
+      if (result.conversationBinding) {
+        // operator.write on Continue is the approval boundary. Per-turn plugin and
+        // node command authorization still applies after this binding is installed.
+        await bindPluginSessionConversation({
+          pluginId: registration.pluginId,
+          pluginName: registration.pluginName,
+          pluginRoot: registration.rootDir?.trim() || registration.source,
+          sessionKey: result.sessionKey,
+          binding: result.conversationBinding,
+          afterBind: result.afterConversationBound,
+        });
+      }
+      respond(true, { sessionKey: result.sessionKey });
     } catch (error) {
       const details = catalogError(error);
       respond(

--- a/src/gateway/server-methods/session-catalog.ts
+++ b/src/gateway/server-methods/session-catalog.ts
@@ -217,7 +217,7 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
     }
   },
 
-  "sessions.catalog.continue": async ({ params, respond }) => {
+  "sessions.catalog.continue": async ({ params, respond, client }) => {
     if (
       !assertValidParams(
         params,
@@ -240,7 +240,10 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
     }
     try {
       const { catalogId: _catalogId, ...providerRequest } = request;
-      const result = await provider.continueSession(providerRequest);
+      // Fail closed for unscoped callers: providers gate high-authority
+      // continues (e.g. node-executing bindings) on these scopes.
+      const clientScopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
+      const result = await provider.continueSession({ ...providerRequest, clientScopes });
       if (result.conversationBinding) {
         // operator.write on Continue is the approval boundary. Per-turn plugin and
         // node command authorization still applies after this binding is installed.

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -128,6 +128,23 @@ describe("message hook mappers", () => {
     expect(canonical.guildId).toBe("guild-1");
   });
 
+  it("uses the session key as the Control UI conversation id", () => {
+    const canonical = deriveInboundMessageHookContext(
+      makeInboundCtx({
+        From: undefined,
+        To: undefined,
+        OriginatingTo: undefined,
+        Provider: "webchat",
+        Surface: "webchat",
+        OriginatingChannel: "webchat",
+        SessionKey: "agent:main:adopted",
+      }),
+    );
+
+    expect(canonical.channelId).toBe("webchat");
+    expect(canonical.conversationId).toBe("agent:main:adopted");
+  });
+
   it("maps inbound reply metadata into canonical and plugin payloads", () => {
     const canonical = deriveInboundMessageHookContext(
       makeInboundCtx({

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -16,7 +16,8 @@ import type {
   PluginHookMessageReceivedEvent,
   PluginHookMessageSentEvent,
 } from "../plugins/hook-message.types.js";
-import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
+import { internalSessionConversationId } from "../utils/message-channel-constants.js";
+import { stripChannelPrefix } from "../utils/string-readers.js";
 import type {
   MessagePreprocessedHookContext,
   MessageReceivedHookContext,
@@ -141,7 +142,7 @@ export function deriveInboundMessageHookContext(
     ctx.OriginatingTo ??
     ctx.To ??
     ctx.From ??
-    (channelId === INTERNAL_MESSAGE_CHANNEL ? ctx.SessionKey : undefined);
+    internalSessionConversationId(channelId, ctx.SessionKey);
   const isGroup = Boolean(ctx.GroupSubject || ctx.GroupChannel);
   const mediaPaths = Array.isArray(ctx.MediaPaths)
     ? ctx.MediaPaths.filter(
@@ -306,20 +307,6 @@ export function toPluginMessageContext(
     context.callDepth = canonical.callDepth;
   }
   return context;
-}
-
-function stripChannelPrefix(value: string | undefined, channelId: string): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-  const genericPrefixes = ["channel:", "chat:", "user:"];
-  for (const prefix of genericPrefixes) {
-    if (value.startsWith(prefix)) {
-      return value.slice(prefix.length);
-    }
-  }
-  const prefix = `${channelId}:`;
-  return value.startsWith(prefix) ? value.slice(prefix.length) : value;
 }
 
 function resolveInboundConversation(canonical: CanonicalInboundMessageHookContext): {

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -16,6 +16,7 @@ import type {
   PluginHookMessageReceivedEvent,
   PluginHookMessageSentEvent,
 } from "../plugins/hook-message.types.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
 import type {
   MessagePreprocessedHookContext,
   MessageReceivedHookContext,
@@ -136,7 +137,11 @@ export function deriveInboundMessageHookContext(
   const channelId = normalizeLowercaseStringOrEmpty(
     ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider ?? "",
   );
-  const conversationId = ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? undefined;
+  const conversationId =
+    ctx.OriginatingTo ??
+    ctx.To ??
+    ctx.From ??
+    (channelId === INTERNAL_MESSAGE_CHANNEL ? ctx.SessionKey : undefined);
   const isGroup = Boolean(ctx.GroupSubject || ctx.GroupChannel);
   const mediaPaths = Array.isArray(ctx.MediaPaths)
     ? ctx.MediaPaths.filter(

--- a/src/infra/outbound/current-conversation-bindings.test.ts
+++ b/src/infra/outbound/current-conversation-bindings.test.ts
@@ -229,6 +229,44 @@ describe("generic current-conversation bindings", () => {
     ).toBeNull();
   });
 
+  it("stores Control UI session-key conversations without a channel plugin", async () => {
+    setActivePluginRegistry(createTestRegistry([]));
+    expect(
+      getGenericCurrentConversationBindingCapabilities({
+        channel: "webchat",
+        accountId: "default",
+      }),
+    ).toMatchObject({ bindSupported: true, placements: ["current"] });
+
+    const bound = await bindGenericCurrentConversation({
+      targetSessionKey: "agent:main:adopted",
+      targetKind: "session",
+      conversation: {
+        channel: "webchat",
+        accountId: "default",
+        conversationId: "agent:main:adopted",
+      },
+      metadata: { pluginBindingOwner: "plugin", pluginId: "codex", pluginRoot: "/codex" },
+    });
+
+    expectBindingFields(bound, {
+      targetSessionKey: "agent:main:adopted",
+      conversation: {
+        channel: "webchat",
+        accountId: "default",
+        conversationId: "agent:main:adopted",
+      },
+    });
+    expectBindingFields(
+      resolveGenericCurrentConversationBinding({
+        channel: "webchat",
+        accountId: "default",
+        conversationId: "agent:main:adopted",
+      }),
+      { targetSessionKey: "agent:main:adopted" },
+    );
+  });
+
   it("reloads persisted bindings after the in-memory cache is cleared", async () => {
     const bound = await bindGenericCurrentConversation({
       targetSessionKey: "agent:codex:acp:workspace-dm",

--- a/src/infra/outbound/current-conversation-bindings.ts
+++ b/src/infra/outbound/current-conversation-bindings.ts
@@ -15,6 +15,7 @@ import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../../state/openclaw-state-db.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel-constants.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../kysely-sync.js";
 import { normalizeConversationRef } from "./session-binding-normalization.js";
 import type {
@@ -223,6 +224,9 @@ function supportsGenericCurrentConversationBinding(ref: {
     ...ref,
     conversationId: "capability-check",
   });
+  if (normalized.channel === INTERNAL_MESSAGE_CHANNEL) {
+    return true;
+  }
   return resolveChannelSupportsCurrentConversationBinding({
     channel: normalized.channel,
     accountId: normalized.accountId,

--- a/src/plugins/conversation-binding-session-key.ts
+++ b/src/plugins/conversation-binding-session-key.ts
@@ -1,0 +1,29 @@
+import crypto from "node:crypto";
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+
+export const PLUGIN_BINDING_SESSION_PREFIX = "plugin-binding";
+
+export function normalizeChannel(value: string): string {
+  return normalizeOptionalLowercaseString(value) ?? "";
+}
+
+export function buildPluginBindingSessionKey(params: {
+  pluginId: string;
+  channel: string;
+  accountId: string;
+  conversationId: string;
+}): string {
+  const hash = crypto
+    .createHash("sha256")
+    .update(
+      JSON.stringify({
+        pluginId: params.pluginId,
+        channel: normalizeChannel(params.channel),
+        accountId: params.accountId,
+        conversationId: params.conversationId,
+      }),
+    )
+    .digest("hex")
+    .slice(0, 24);
+  return `${PLUGIN_BINDING_SESSION_PREFIX}:${params.pluginId}:${hash}`;
+}

--- a/src/plugins/conversation-binding.test.ts
+++ b/src/plugins/conversation-binding.test.ts
@@ -114,7 +114,7 @@ vi.mock("./runtime.js", async () => {
 });
 
 let buildPluginBindingApprovalCustomId: typeof import("./conversation-binding.js").buildPluginBindingApprovalCustomId;
-let bindPluginSessionConversation: typeof import("./conversation-binding.js").bindPluginSessionConversation;
+let bindPluginSessionConversation: typeof import("./session-conversation-binding.js").bindPluginSessionConversation;
 let detachPluginConversationBinding: typeof import("./conversation-binding.js").detachPluginConversationBinding;
 let getCurrentPluginConversationBinding: typeof import("./conversation-binding.js").getCurrentPluginConversationBinding;
 let parsePluginBindingApprovalCustomId: typeof import("./conversation-binding.js").parsePluginBindingApprovalCustomId;
@@ -170,7 +170,6 @@ afterAll(() => {
 
 beforeAll(async () => {
   ({
-    bindPluginSessionConversation,
     buildPluginBindingApprovalCustomId,
     detachPluginConversationBinding,
     getCurrentPluginConversationBinding,
@@ -178,6 +177,7 @@ beforeAll(async () => {
     requestPluginConversationBinding,
     resolvePluginConversationBindingApproval,
   } = await import("./conversation-binding.js"));
+  ({ bindPluginSessionConversation } = await import("./session-conversation-binding.js"));
   ({ registerSessionBindingAdapter, unregisterSessionBindingAdapter } =
     await import("../infra/outbound/session-binding-service.js"));
   ({ setActivePluginRegistry } = await import("./runtime.js"));

--- a/src/plugins/conversation-binding.test.ts
+++ b/src/plugins/conversation-binding.test.ts
@@ -114,6 +114,7 @@ vi.mock("./runtime.js", async () => {
 });
 
 let buildPluginBindingApprovalCustomId: typeof import("./conversation-binding.js").buildPluginBindingApprovalCustomId;
+let bindPluginSessionConversation: typeof import("./conversation-binding.js").bindPluginSessionConversation;
 let detachPluginConversationBinding: typeof import("./conversation-binding.js").detachPluginConversationBinding;
 let getCurrentPluginConversationBinding: typeof import("./conversation-binding.js").getCurrentPluginConversationBinding;
 let parsePluginBindingApprovalCustomId: typeof import("./conversation-binding.js").parsePluginBindingApprovalCustomId;
@@ -169,6 +170,7 @@ afterAll(() => {
 
 beforeAll(async () => {
   ({
+    bindPluginSessionConversation,
     buildPluginBindingApprovalCustomId,
     detachPluginConversationBinding,
     getCurrentPluginConversationBinding,
@@ -471,10 +473,85 @@ describe("plugin conversation binding approvals", () => {
     unregisterSessionBindingAdapter({ channel: "discord", accountId: "work" });
     unregisterSessionBindingAdapter({ channel: "discord", accountId: "isolated" });
     unregisterSessionBindingAdapter({ channel: "telegram", accountId: "default" });
+    unregisterSessionBindingAdapter({ channel: "webchat", accountId: "default" });
     registerSessionBindingAdapter(createAdapter("discord", "default"));
     registerSessionBindingAdapter(createAdapter("discord", "work"));
     registerSessionBindingAdapter(createAdapter("discord", "isolated"));
     registerSessionBindingAdapter(createAdapter("telegram", "default"));
+    registerSessionBindingAdapter(createAdapter("webchat", "default"));
+  });
+
+  it("restores the prior Control UI binding when provider publication fails", async () => {
+    const previous: SessionBindingRecord = {
+      bindingId: "binding-prior",
+      targetSessionKey: "agent:main:adopted",
+      targetKind: "session",
+      conversation: {
+        channel: "webchat",
+        accountId: "default",
+        conversationId: "agent:main:adopted",
+      },
+      status: "active",
+      boundAt: 1,
+      metadata: { pluginBindingOwner: "plugin", pluginId: "codex", pluginRoot: "/codex" },
+    };
+    sessionBindingState.setRecord(previous);
+
+    await expect(
+      bindPluginSessionConversation({
+        pluginId: "codex",
+        pluginRoot: "/codex",
+        sessionKey: "agent:main:adopted",
+        binding: { data: { kind: "codex-cli-node-session", version: 1 } },
+        afterBind: async () => {
+          throw new Error("publication failed");
+        },
+      }),
+    ).rejects.toThrow("publication failed");
+
+    expect(sessionBindingState.resolveByConversation(previous.conversation)).toMatchObject({
+      targetSessionKey: previous.targetSessionKey,
+      metadata: previous.metadata,
+    });
+    expect(sessionBindingState.bind).toHaveBeenCalledTimes(2);
+    expect(sessionBindingState.unbind).toHaveBeenCalledWith({
+      bindingId: "binding-1",
+      reason: "plugin-session-bind-rollback",
+    });
+  });
+
+  it("does not roll back a newer successful Control UI binding", async () => {
+    const unbindCallsBefore = sessionBindingState.unbind.mock.calls.length;
+    let rejectFirst = (_error: Error) => {};
+    const firstPublication = new Promise<void>((_resolve, reject) => {
+      rejectFirst = reject;
+    });
+    const first = bindPluginSessionConversation({
+      pluginId: "codex",
+      pluginRoot: "/codex",
+      sessionKey: "agent:main:adopted",
+      binding: { data: { kind: "remote-runtime", generation: 1 } },
+      afterBind: async () => await firstPublication,
+    });
+    await vi.waitFor(() => expect(sessionBindingState.bind).toHaveBeenCalledOnce());
+
+    await bindPluginSessionConversation({
+      pluginId: "codex",
+      pluginRoot: "/codex",
+      sessionKey: "agent:main:adopted",
+      binding: { data: { kind: "remote-runtime", generation: 2 } },
+    });
+    rejectFirst(new Error("older publication failed"));
+    await expect(first).rejects.toThrow("older publication failed");
+
+    expect(
+      sessionBindingState.resolveByConversation({
+        channel: "webchat",
+        accountId: "default",
+        conversationId: "agent:main:adopted",
+      }),
+    ).toMatchObject({ metadata: { data: { kind: "remote-runtime", generation: 2 } } });
+    expect(sessionBindingState.unbind).toHaveBeenCalledTimes(unbindCallsBefore);
   });
 
   it("keeps Telegram bind approval callback_data within Telegram's limit", () => {

--- a/src/plugins/conversation-binding.test.ts
+++ b/src/plugins/conversation-binding.test.ts
@@ -521,7 +521,6 @@ describe("plugin conversation binding approvals", () => {
   });
 
   it("does not roll back a newer successful Control UI binding", async () => {
-    const unbindCallsBefore = sessionBindingState.unbind.mock.calls.length;
     let rejectFirst = (_error: Error) => {};
     const firstPublication = new Promise<void>((_resolve, reject) => {
       rejectFirst = reject;
@@ -535,7 +534,9 @@ describe("plugin conversation binding approvals", () => {
     });
     await vi.waitFor(() => expect(sessionBindingState.bind).toHaveBeenCalledOnce());
 
-    await bindPluginSessionConversation({
+    // A concurrent Continue for the same session queues behind the failing
+    // attempt instead of interleaving with its rollback.
+    const second = bindPluginSessionConversation({
       pluginId: "codex",
       pluginRoot: "/codex",
       sessionKey: "agent:main:adopted",
@@ -543,6 +544,7 @@ describe("plugin conversation binding approvals", () => {
     });
     rejectFirst(new Error("older publication failed"));
     await expect(first).rejects.toThrow("older publication failed");
+    await second;
 
     expect(
       sessionBindingState.resolveByConversation({
@@ -551,7 +553,10 @@ describe("plugin conversation binding approvals", () => {
         conversationId: "agent:main:adopted",
       }),
     ).toMatchObject({ metadata: { data: { kind: "remote-runtime", generation: 2 } } });
-    expect(sessionBindingState.unbind).toHaveBeenCalledTimes(unbindCallsBefore);
+    // Only the failed attempt rolled back its own binding.
+    expect(sessionBindingState.unbind).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "plugin-session-bind-rollback" }),
+    );
   });
 
   it("keeps Telegram bind approval callback_data within Telegram's limit", () => {

--- a/src/plugins/conversation-binding.ts
+++ b/src/plugins/conversation-binding.ts
@@ -1,9 +1,6 @@
 // Binds plugin conversations to stable channel and agent identifiers.
 import crypto from "node:crypto";
-import {
-  normalizeOptionalLowercaseString,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import {
   createConversationBindingRecord,
@@ -21,7 +18,11 @@ import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
-import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
+import {
+  buildPluginBindingSessionKey,
+  normalizeChannel,
+  PLUGIN_BINDING_SESSION_PREFIX,
+} from "./conversation-binding-session-key.js";
 import type {
   PluginConversationBinding,
   PluginConversationBindingResolvedEvent,
@@ -35,7 +36,6 @@ const log = createSubsystemLogger("plugins/binding");
 
 const PLUGIN_BINDING_CUSTOM_ID_PREFIX = "pluginbind";
 const PLUGIN_BINDING_OWNER = "plugin";
-const PLUGIN_BINDING_SESSION_PREFIX = "plugin-binding";
 const LEGACY_CODEX_PLUGIN_SESSION_PREFIXES = [
   "openclaw-app-server:thread:",
   "openclaw-codex-app-server:thread:",
@@ -159,10 +159,6 @@ function getPluginBindingGlobalState(): PluginBindingGlobalState {
   return pluginBindingGlobalState;
 }
 
-function normalizeChannel(value: string): string {
-  return normalizeOptionalLowercaseString(value) ?? "";
-}
-
 function normalizeConversation(params: PluginBindingConversation): PluginBindingConversation {
   return {
     channel: normalizeChannel(params.channel),
@@ -226,28 +222,7 @@ function buildApprovalScopeKey(params: {
   ].join("::");
 }
 
-function buildPluginBindingSessionKey(params: {
-  pluginId: string;
-  channel: string;
-  accountId: string;
-  conversationId: string;
-}): string {
-  const hash = crypto
-    .createHash("sha256")
-    .update(
-      JSON.stringify({
-        pluginId: params.pluginId,
-        channel: normalizeChannel(params.channel),
-        accountId: params.accountId,
-        conversationId: params.conversationId,
-      }),
-    )
-    .digest("hex")
-    .slice(0, 24);
-  return `${PLUGIN_BINDING_SESSION_PREFIX}:${params.pluginId}:${hash}`;
-}
-
-function buildPluginBindingIdentity(params: PluginBindingIdentity): PluginBindingIdentity {
+export function buildPluginBindingIdentity(params: PluginBindingIdentity): PluginBindingIdentity {
   return {
     pluginId: params.pluginId,
     pluginName: params.pluginName,
@@ -607,7 +582,7 @@ function buildApprovalEntryFromRequest(
   };
 }
 
-async function bindConversationNow(params: {
+export async function bindConversationNow(params: {
   identity: PluginBindingIdentity;
   conversation: PluginBindingConversation;
   targetSessionKey?: string;
@@ -645,102 +620,6 @@ async function bindConversationNow(params: {
     throw new Error("plugin binding was created without plugin metadata");
   }
   return withConversationBindingContext(binding, params.conversation);
-}
-
-// Serializes bind+finalize+rollback per session so a failing older attempt
-// can never unbind or restore over a newer successful one (all session binds
-// go through this in-process seam).
-const pluginSessionBindTails = new Map<string, Promise<void>>();
-
-/** Binds a plugin-owned runtime to one authenticated Control UI session. */
-export async function bindPluginSessionConversation(params: {
-  pluginId: string;
-  pluginName?: string;
-  pluginRoot: string;
-  sessionKey: string;
-  binding: PluginConversationBindingRequestParams;
-  afterBind?: () => Promise<void>;
-}): Promise<PluginConversationBinding> {
-  const sessionKey = params.sessionKey.trim();
-  if (!sessionKey) {
-    throw new Error("session key is required for a plugin session binding");
-  }
-  const previousTail = pluginSessionBindTails.get(sessionKey) ?? Promise.resolve();
-  const operation = previousTail.then(() =>
-    bindPluginSessionConversationExclusive({ ...params, sessionKey }),
-  );
-  const tail = operation.then(
-    () => undefined,
-    () => undefined,
-  );
-  pluginSessionBindTails.set(sessionKey, tail);
-  try {
-    return await operation;
-  } finally {
-    if (pluginSessionBindTails.get(sessionKey) === tail) {
-      pluginSessionBindTails.delete(sessionKey);
-    }
-  }
-}
-
-async function bindPluginSessionConversationExclusive(params: {
-  pluginId: string;
-  pluginName?: string;
-  pluginRoot: string;
-  sessionKey: string;
-  binding: PluginConversationBindingRequestParams;
-  afterBind?: () => Promise<void>;
-}): Promise<PluginConversationBinding> {
-  const sessionKey = params.sessionKey;
-  const conversation = {
-    channel: INTERNAL_MESSAGE_CHANNEL,
-    accountId: "default",
-    conversationId: sessionKey,
-  };
-  const previous = resolveConversationBindingRecord(conversation);
-  const bindingAttemptId = crypto.randomUUID();
-  const binding = await bindConversationNow({
-    identity: buildPluginBindingIdentity(params),
-    conversation,
-    targetSessionKey: sessionKey,
-    summary: params.binding.summary,
-    detachHint: params.binding.detachHint,
-    data: params.binding.data,
-    bindingAttemptId,
-  });
-  try {
-    await params.afterBind?.();
-    return binding;
-  } catch (error) {
-    const current = resolveConversationBindingRecord(conversation);
-    if (current?.metadata?.bindingAttemptId !== bindingAttemptId) {
-      throw error;
-    }
-    try {
-      await unbindConversationBindingRecord({
-        bindingId: current.bindingId,
-        reason: "plugin-session-bind-rollback",
-      });
-      if (previous && (previous.expiresAt === undefined || previous.expiresAt > Date.now())) {
-        await createConversationBindingRecord({
-          targetSessionKey: previous.targetSessionKey,
-          targetKind: previous.targetKind,
-          conversation: previous.conversation,
-          placement: "current",
-          metadata: previous.metadata,
-          ...(previous.expiresAt === undefined
-            ? {}
-            : { ttlMs: Math.max(1, previous.expiresAt - Date.now()) }),
-        });
-      }
-    } catch (rollbackError) {
-      throw new AggregateError(
-        [error, rollbackError],
-        "plugin session binding finalization failed and its previous binding could not be restored",
-      );
-    }
-    throw error;
-  }
 }
 
 function buildApprovalMessage(request: PendingPluginBindingRequest): string {

--- a/src/plugins/conversation-binding.ts
+++ b/src/plugins/conversation-binding.ts
@@ -647,6 +647,11 @@ async function bindConversationNow(params: {
   return withConversationBindingContext(binding, params.conversation);
 }
 
+// Serializes bind+finalize+rollback per session so a failing older attempt
+// can never unbind or restore over a newer successful one (all session binds
+// go through this in-process seam).
+const pluginSessionBindTails = new Map<string, Promise<void>>();
+
 /** Binds a plugin-owned runtime to one authenticated Control UI session. */
 export async function bindPluginSessionConversation(params: {
   pluginId: string;
@@ -660,6 +665,33 @@ export async function bindPluginSessionConversation(params: {
   if (!sessionKey) {
     throw new Error("session key is required for a plugin session binding");
   }
+  const previousTail = pluginSessionBindTails.get(sessionKey) ?? Promise.resolve();
+  const operation = previousTail.then(() =>
+    bindPluginSessionConversationExclusive({ ...params, sessionKey }),
+  );
+  const tail = operation.then(
+    () => undefined,
+    () => undefined,
+  );
+  pluginSessionBindTails.set(sessionKey, tail);
+  try {
+    return await operation;
+  } finally {
+    if (pluginSessionBindTails.get(sessionKey) === tail) {
+      pluginSessionBindTails.delete(sessionKey);
+    }
+  }
+}
+
+async function bindPluginSessionConversationExclusive(params: {
+  pluginId: string;
+  pluginName?: string;
+  pluginRoot: string;
+  sessionKey: string;
+  binding: PluginConversationBindingRequestParams;
+  afterBind?: () => Promise<void>;
+}): Promise<PluginConversationBinding> {
+  const sessionKey = params.sessionKey;
   const conversation = {
     channel: INTERNAL_MESSAGE_CHANNEL,
     accountId: "default",

--- a/src/plugins/conversation-binding.ts
+++ b/src/plugins/conversation-binding.ts
@@ -21,6 +21,7 @@ import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
 import type {
   PluginConversationBinding,
   PluginConversationBindingResolvedEvent,
@@ -96,6 +97,7 @@ type PluginBindingMetadata = {
   summary?: string;
   detachHint?: string;
   data?: Record<string, unknown>;
+  bindingAttemptId?: string;
 };
 
 type PluginBindingResolveResult =
@@ -451,6 +453,7 @@ function buildBindingMetadata(params: {
   summary?: string;
   detachHint?: string;
   data?: Record<string, unknown>;
+  bindingAttemptId?: string;
 }): PluginBindingMetadata {
   return {
     pluginBindingOwner: PLUGIN_BINDING_OWNER,
@@ -460,6 +463,7 @@ function buildBindingMetadata(params: {
     summary: normalizeOptionalString(params.summary),
     detachHint: normalizeOptionalString(params.detachHint),
     data: normalizeBindingData(params.data),
+    bindingAttemptId: normalizeOptionalString(params.bindingAttemptId),
   };
 }
 
@@ -606,17 +610,21 @@ function buildApprovalEntryFromRequest(
 async function bindConversationNow(params: {
   identity: PluginBindingIdentity;
   conversation: PluginBindingConversation;
+  targetSessionKey?: string;
   summary?: string;
   detachHint?: string;
   data?: Record<string, unknown>;
+  bindingAttemptId?: string;
 }): Promise<PluginConversationBinding> {
   const ref = toConversationRef(params.conversation);
-  const targetSessionKey = buildPluginBindingSessionKey({
-    pluginId: params.identity.pluginId,
-    channel: ref.channel,
-    accountId: ref.accountId,
-    conversationId: ref.conversationId,
-  });
+  const targetSessionKey =
+    normalizeOptionalString(params.targetSessionKey) ??
+    buildPluginBindingSessionKey({
+      pluginId: params.identity.pluginId,
+      channel: ref.channel,
+      accountId: ref.accountId,
+      conversationId: ref.conversationId,
+    });
   const record = await createConversationBindingRecord({
     targetSessionKey,
     targetKind: "session",
@@ -629,6 +637,7 @@ async function bindConversationNow(params: {
       summary: params.summary,
       detachHint: params.detachHint,
       data: params.data,
+      bindingAttemptId: params.bindingAttemptId,
     }),
   });
   const binding = toPluginConversationBinding(record);
@@ -636,6 +645,70 @@ async function bindConversationNow(params: {
     throw new Error("plugin binding was created without plugin metadata");
   }
   return withConversationBindingContext(binding, params.conversation);
+}
+
+/** Binds a plugin-owned runtime to one authenticated Control UI session. */
+export async function bindPluginSessionConversation(params: {
+  pluginId: string;
+  pluginName?: string;
+  pluginRoot: string;
+  sessionKey: string;
+  binding: PluginConversationBindingRequestParams;
+  afterBind?: () => Promise<void>;
+}): Promise<PluginConversationBinding> {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    throw new Error("session key is required for a plugin session binding");
+  }
+  const conversation = {
+    channel: INTERNAL_MESSAGE_CHANNEL,
+    accountId: "default",
+    conversationId: sessionKey,
+  };
+  const previous = resolveConversationBindingRecord(conversation);
+  const bindingAttemptId = crypto.randomUUID();
+  const binding = await bindConversationNow({
+    identity: buildPluginBindingIdentity(params),
+    conversation,
+    targetSessionKey: sessionKey,
+    summary: params.binding.summary,
+    detachHint: params.binding.detachHint,
+    data: params.binding.data,
+    bindingAttemptId,
+  });
+  try {
+    await params.afterBind?.();
+    return binding;
+  } catch (error) {
+    const current = resolveConversationBindingRecord(conversation);
+    if (current?.metadata?.bindingAttemptId !== bindingAttemptId) {
+      throw error;
+    }
+    try {
+      await unbindConversationBindingRecord({
+        bindingId: current.bindingId,
+        reason: "plugin-session-bind-rollback",
+      });
+      if (previous && (previous.expiresAt === undefined || previous.expiresAt > Date.now())) {
+        await createConversationBindingRecord({
+          targetSessionKey: previous.targetSessionKey,
+          targetKind: previous.targetKind,
+          conversation: previous.conversation,
+          placement: "current",
+          metadata: previous.metadata,
+          ...(previous.expiresAt === undefined
+            ? {}
+            : { ttlMs: Math.max(1, previous.expiresAt - Date.now()) }),
+        });
+      }
+    } catch (rollbackError) {
+      throw new AggregateError(
+        [error, rollbackError],
+        "plugin session binding finalization failed and its previous binding could not be restored",
+      );
+    }
+    throw error;
+  }
 }
 
 function buildApprovalMessage(request: PendingPluginBindingRequest): string {

--- a/src/plugins/session-catalog.ts
+++ b/src/plugins/session-catalog.ts
@@ -22,6 +22,18 @@ export type SessionCatalogCreateTarget = {
   agentRuntime: string;
 };
 
+type SessionCatalogContinueProviderResult = {
+  sessionKey: string;
+  /** Plugin binding installed for this authenticated Control UI session. */
+  conversationBinding?: {
+    summary?: string;
+    detachHint?: string;
+    data?: Record<string, unknown>;
+  };
+  /** Publishes provider state only after the requested binding is durable. */
+  afterConversationBound?: () => Promise<void>;
+};
+
 type SessionCatalogCreateParams = {
   /** Agent whose model/runtime policy must authorize the catalog target. */
   agentId?: string;
@@ -38,6 +50,6 @@ export type SessionCatalogProvider = {
   read: (params: SessionCatalogReadProviderParams) => Promise<SessionsCatalogReadResult>;
   continueSession?: (
     params: SessionCatalogContinueProviderParams,
-  ) => Promise<{ sessionKey: string }>;
+  ) => Promise<SessionCatalogContinueProviderResult>;
   archive?: (params: SessionCatalogArchiveProviderParams) => Promise<{ ok: true }>;
 };

--- a/src/plugins/session-catalog.ts
+++ b/src/plugins/session-catalog.ts
@@ -13,7 +13,13 @@ export type SessionCatalogListProviderParams = {
   cursors?: Record<string, string>;
 };
 export type SessionCatalogReadProviderParams = Omit<SessionsCatalogReadParams, "catalogId">;
-export type SessionCatalogContinueProviderParams = Omit<SessionsCatalogContinueParams, "catalogId">;
+export type SessionCatalogContinueProviderParams = Omit<
+  SessionsCatalogContinueParams,
+  "catalogId"
+> & {
+  /** Caller's gateway scopes so providers can gate high-authority continues up front. */
+  clientScopes?: readonly string[];
+};
 export type SessionCatalogArchiveProviderParams = Omit<SessionsCatalogArchiveParams, "catalogId">;
 
 export type SessionCatalogCreateTarget = {

--- a/src/plugins/session-conversation-binding.ts
+++ b/src/plugins/session-conversation-binding.ts
@@ -4,12 +4,15 @@ import {
   resolveConversationBindingRecord,
   unbindConversationBindingRecord,
 } from "../bindings/records.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
 import { bindConversationNow, buildPluginBindingIdentity } from "./conversation-binding.js";
 import type {
   PluginConversationBinding,
   PluginConversationBindingRequestParams,
 } from "./conversation-binding.types.js";
+
+const log = createSubsystemLogger("plugins/binding");
 
 // Serializes bind+finalize+rollback per session so a failing older attempt
 // can never unbind or restore over a newer successful one (all session binds
@@ -98,9 +101,12 @@ async function bindPluginSessionConversationExclusive(params: {
         });
       }
     } catch (rollbackError) {
-      throw new AggregateError(
-        [error, rollbackError],
+      // The finalize failure is superseded by the rollback failure on the
+      // throw path; keep it observable for diagnosis.
+      log.warn("plugin session binding finalization failed before rollback", { error });
+      throw new Error(
         "plugin session binding finalization failed and its previous binding could not be restored",
+        { cause: rollbackError },
       );
     }
     throw error;

--- a/src/plugins/session-conversation-binding.ts
+++ b/src/plugins/session-conversation-binding.ts
@@ -1,0 +1,108 @@
+import crypto from "node:crypto";
+import {
+  createConversationBindingRecord,
+  resolveConversationBindingRecord,
+  unbindConversationBindingRecord,
+} from "../bindings/records.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
+import { bindConversationNow, buildPluginBindingIdentity } from "./conversation-binding.js";
+import type {
+  PluginConversationBinding,
+  PluginConversationBindingRequestParams,
+} from "./conversation-binding.types.js";
+
+// Serializes bind+finalize+rollback per session so a failing older attempt
+// can never unbind or restore over a newer successful one (all session binds
+// go through this in-process seam).
+const pluginSessionBindTails = new Map<string, Promise<void>>();
+
+/** Binds a plugin-owned runtime to one authenticated Control UI session. */
+export async function bindPluginSessionConversation(params: {
+  pluginId: string;
+  pluginName?: string;
+  pluginRoot: string;
+  sessionKey: string;
+  binding: PluginConversationBindingRequestParams;
+  afterBind?: () => Promise<void>;
+}): Promise<PluginConversationBinding> {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    throw new Error("session key is required for a plugin session binding");
+  }
+  const previousTail = pluginSessionBindTails.get(sessionKey) ?? Promise.resolve();
+  const operation = previousTail.then(() =>
+    bindPluginSessionConversationExclusive({ ...params, sessionKey }),
+  );
+  const tail = operation.then(
+    () => undefined,
+    () => undefined,
+  );
+  pluginSessionBindTails.set(sessionKey, tail);
+  try {
+    return await operation;
+  } finally {
+    if (pluginSessionBindTails.get(sessionKey) === tail) {
+      pluginSessionBindTails.delete(sessionKey);
+    }
+  }
+}
+
+async function bindPluginSessionConversationExclusive(params: {
+  pluginId: string;
+  pluginName?: string;
+  pluginRoot: string;
+  sessionKey: string;
+  binding: PluginConversationBindingRequestParams;
+  afterBind?: () => Promise<void>;
+}): Promise<PluginConversationBinding> {
+  const sessionKey = params.sessionKey;
+  const conversation = {
+    channel: INTERNAL_MESSAGE_CHANNEL,
+    accountId: "default",
+    conversationId: sessionKey,
+  };
+  const previous = resolveConversationBindingRecord(conversation);
+  const bindingAttemptId = crypto.randomUUID();
+  const binding = await bindConversationNow({
+    identity: buildPluginBindingIdentity(params),
+    conversation,
+    targetSessionKey: sessionKey,
+    summary: params.binding.summary,
+    detachHint: params.binding.detachHint,
+    data: params.binding.data,
+    bindingAttemptId,
+  });
+  try {
+    await params.afterBind?.();
+    return binding;
+  } catch (error) {
+    const current = resolveConversationBindingRecord(conversation);
+    if (current?.metadata?.bindingAttemptId !== bindingAttemptId) {
+      throw error;
+    }
+    try {
+      await unbindConversationBindingRecord({
+        bindingId: current.bindingId,
+        reason: "plugin-session-bind-rollback",
+      });
+      if (previous && (previous.expiresAt === undefined || previous.expiresAt > Date.now())) {
+        await createConversationBindingRecord({
+          targetSessionKey: previous.targetSessionKey,
+          targetKind: previous.targetKind,
+          conversation: previous.conversation,
+          placement: "current",
+          metadata: previous.metadata,
+          ...(previous.expiresAt === undefined
+            ? {}
+            : { ttlMs: Math.max(1, previous.expiresAt - Date.now()) }),
+        });
+      }
+    } catch (rollbackError) {
+      throw new AggregateError(
+        [error, rollbackError],
+        "plugin session binding finalization failed and its previous binding could not be restored",
+      );
+    }
+    throw error;
+  }
+}

--- a/src/utils/message-channel-constants.ts
+++ b/src/utils/message-channel-constants.ts
@@ -3,6 +3,13 @@ import { isStringOption } from "./string-readers.js";
 
 export const INTERNAL_MESSAGE_CHANNEL = "webchat" as const;
 
+export function internalSessionConversationId(
+  channelId: string,
+  sessionKey: string | undefined,
+): string | undefined {
+  return channelId === INTERNAL_MESSAGE_CHANNEL ? sessionKey : undefined;
+}
+
 // Internal, non-delivery sources that may surface as a `channel` hint when an
 // agent run is triggered by something other than a chat message — heartbeat
 // ticks, cron jobs, or webhook receivers. They are not deliverable on their

--- a/src/utils/string-readers.ts
+++ b/src/utils/string-readers.ts
@@ -42,3 +42,20 @@ export function readTrimmedStringAlias(
   }
   return undefined;
 }
+
+export function stripChannelPrefix(
+  value: string | undefined,
+  channelId: string,
+): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const genericPrefixes = ["channel:", "chat:", "user:"];
+  for (const prefix of genericPrefixes) {
+    if (value.startsWith(prefix)) {
+      return value.slice(prefix.length);
+    }
+  }
+  const prefix = `${channelId}:`;
+  return value.startsWith(prefix) ? value.slice(prefix.length) : value;
+}


### PR DESCRIPTION
## What Problem This Solves

Codex catalog sessions on paired nodes were view-only in the web Control UI: node rows always reported `canContinue: false` and `sessions.catalog.continue` threw `"paired-node Codex sessions are view-only"`. The sibling Claude catalog already supports continuing node-hosted sessions, so Codex was the remaining parity gap after #106074.

## Why This Change Was Made

The Claude node-continue shape (CLI backend + `cliSessionBinding` + `execNode`) is wrong for Codex: `codex-cli` is a retired runtime id that `openclaw doctor` actively migrates away (`extensions/codex/doctor-contract-api.ts:145-148`). Instead, continue reuses the codex plugin's existing node execution surface — the `codex.cli.session.resume` node command (one-shot `codex exec resume <sessionId> <prompt>` on the node) and the `codex-cli-node-session` conversation-binding turn loop that `/codex resume <id> --host <node> --bind here` already uses. Web-UI chat sends flow through the same `inbound_claim` pipeline as channel messages, so a bound adopted session gets node-executed turns with no new transport.

- **Capability**: a node row is continuable only when the node advertises AND permits (`commands` + `invocableCommands`) all of `codex.appServer.threads.list.v1`, `codex.appServer.thread.turns.list.v1`, and `codex.cli.session.resume` — mirroring the Claude node gating.
- **Adoption**: continue creates a locked codex OpenClaw session at a deterministic `harness:codex:node-session:<sha256(host,thread)>` key, imports a bounded native-history tail into the transcript, and uses a two-phase `initializing` marker so a half-adopted session is invisible to the catalog until its binding is durable (retries heal it).
- **Binding**: the gateway installs a `webchat/default/<sessionKey>` binding through a new generic `bindPluginSessionConversation` seam (`src/plugins/conversation-binding.ts`) — serialized per session key with attempt-ID-guarded rollback, so a failing older attempt can only ever roll back its own binding. The catalog provider returns an optional binding descriptor + post-bind finalizer; the wire result stays `{sessionKey}` (no protocol change).
- Per-turn safety is unchanged: node command policy gates each `codex.cli.session.resume` invocation, and the existing `commandAuthorized` / native-sandbox gates in the claim handler still apply.
- Bonus fix: archived local rows are no longer offered as continuable/archivable (`!session.archived` now gates `canContinue`/`canArchive`).

## User Impact

Paired-node Codex sessions in the sidebar catalog light up like local ones: selecting one and typing adopts it into a real OpenClaw chat with its history imported, and each message runs `codex exec resume` on the owning node with the reply streamed back into the session. Archived rows stop offering a continue that would fail. Existing local continue/archive behavior is unchanged.

## Evidence

- 177+ tests pass across the six touched surfaces (`extensions/codex/src/session-catalog.test.ts` 113, `conversation-binding.test.ts`, `src/gateway/server-methods/session-catalog.test.ts`, `src/plugins/conversation-binding.test.ts` incl. a rollback-race regression test, `src/hooks/message-hook-mappers.test.ts`, `src/infra/outbound/current-conversation-bindings.test.ts`), via `node scripts/run-vitest.mjs`.
- `tsgo` core + extensions lanes clean; `oxfmt --check` clean.
- Sibling Codex contracts verified in `../codex`: `codex exec resume <SESSION_ID>` accepts rollout UUIDs (`codex-rs/exec/src/cli.rs:167`), which share the app-server thread-id space (`codex-rs/app-server-protocol/src/protocol/common.rs:482-492`).
- Review: two autoreview passes drove a real P2 fix (bind rollback TOCTOU → per-session serialization); the final remaining P1 claim was verified false against the unchanged `conversation-binding-data.ts:77` contract (the field it says is missing exists on main).
- Known gap: no live paired-node E2E — node invocation is mocked in tests. The per-turn path (`codex.cli.session.resume` → `codex exec resume`) is the same one `/codex resume --bind here` uses in production for channel conversations.
