### PR TITLE
improve: speed up type suppression inventory

### DIFF
--- a/scripts/type-suppression-inventory.ts
+++ b/scripts/type-suppression-inventory.ts
@@ -30,6 +30,7 @@ export type TypeSuppressionReport = {
 };
 
 const DEFAULT_SCAN_ROOTS = ["src", "test", "extensions", "packages", "ui", "scripts"];
+const TYPE_SUPPRESSION_CANDIDATE_PATTERN = /\bany\b|@ts-expect-error/u;
 const DEFAULT_SKIPPED_DIR_NAMES = new Set([
   ".artifacts",
   ".generated",
@@ -160,11 +161,16 @@ export function collectTypeSuppressionReport(params: {
       continue;
     }
     const source = fs.readFileSync(absolutePath, "utf8");
+    // Full AST parsing dominates the repository ratchet. Every reported construct
+    // contains one of these literal markers, so marker-free files are safe to skip.
+    if (!TYPE_SUPPRESSION_CANDIDATE_PATTERN.test(source)) {
+      continue;
+    }
     const sourceFile = ts.createSourceFile(
       file,
       source,
       ts.ScriptTarget.Latest,
-      true,
+      false,
       sourceKindForFile(file),
     );
     addAnyCastFindings(sourceFile, file, findings);

--- a/test/scripts/type-suppression-inventory.test.ts
+++ b/test/scripts/type-suppression-inventory.test.ts
@@ -35,10 +35,11 @@ describe("type suppression inventory", () => {
         // @ts-expect-error invalid contract fixture
         consume({ invalid: true });
       `,
+      "src/plain.ts": "export const value = 1;",
     });
 
     const report = collectTypeSuppressionReport({
-      files: ["src/example.ts"],
+      files: ["src/example.ts", "src/plain.ts"],
       repoRoot: fixtureRoot,
     });
 
@@ -49,6 +50,7 @@ describe("type suppression inventory", () => {
         "expect-error": 1,
         "type-assertion-any": 1,
       },
+      scannedFileCount: 2,
       touchedFileCount: 1,
     });
   });


### PR DESCRIPTION
## What Problem This Solves

Resolves an operational slowdown where the type-suppression inventory test parsed every TypeScript file into a full AST. In current CI this single ratchet assertion took 22-28 seconds and was the largest individual tooling test.

## Why This Change Was Made

The inventory now skips AST creation for files without the literal tokens required by any reported suppression kind, while preserving total scanned-file accounting. Candidate files use parent-free TypeScript ASTs because this traversal only reads nodes and positions.

AI-assisted change; implementation, syntax boundaries, and measured output reviewed before submission.

## User Impact

No runtime behavior change. Maintainer and contributor test runs spend about 23 fewer seconds in this repository ratchet.

## Evidence

- Blacksmith Testbox baseline: the two-test file took 28.32s; the repository-ratchet assertion took 28.31s.
- Rebased exact head: the two-test file took 5.18s; the repository-ratchet assertion took 4.75s, about 83% faster.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29296387103 (`tbx_01kxf0vtbeb2dfc5927pdcng59`).
- Exact-head `pnpm check:changed`: passed in 1m36.56s, including LOC, formatting, TSGo script/test types, lint, and repository guards.
- Fresh exact-head autoreview: no findings; patch correct at 0.89 confidence.
