### PR TITLE
refactor(cli): use Commander exit errors

### DIFF
--- a/src/cli/setup-onboard-configure-help-fast-path.ts
+++ b/src/cli/setup-onboard-configure-help-fast-path.ts
@@ -1,5 +1,5 @@
 // Fast help renderer for setup/onboard/configure without loading full CLI startup.
-import { Command } from "commander";
+import { Command, CommanderError } from "commander";
 import { VERSION } from "../version.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
 import type { ProgramContext } from "./program/context.js";
@@ -12,19 +12,6 @@ const SETUP_ONBOARD_CONFIGURE_HELP_COMMANDS = new Set<SetupOnboardConfigureHelpC
   "onboard",
   "configure",
 ]);
-
-function isCommanderParseExit(error: unknown): error is { exitCode: number } {
-  if (!error || typeof error !== "object") {
-    return false;
-  }
-  const candidate = error as { code?: unknown; exitCode?: unknown };
-  return (
-    typeof candidate.exitCode === "number" &&
-    Number.isInteger(candidate.exitCode) &&
-    typeof candidate.code === "string" &&
-    candidate.code.startsWith("commander.")
-  );
-}
 
 function resolveSetupOnboardConfigureHelpCommand(
   argv: string[],
@@ -75,17 +62,14 @@ export async function tryOutputSetupOnboardConfigureHelp(argv: string[]): Promis
 
   const program = new Command();
   program.enablePositionalOptions();
-  program.exitOverride((err) => {
-    process.exitCode = typeof err.exitCode === "number" ? err.exitCode : 1;
-    throw err;
-  });
+  program.exitOverride();
   configureProgramHelp(program, createHelpContext());
   await registerHelpCommand(program, command);
 
   try {
     await program.parseAsync(argv);
   } catch (error) {
-    if (!isCommanderParseExit(error)) {
+    if (!(error instanceof CommanderError)) {
       throw error;
     }
     process.exitCode = error.exitCode;


### PR DESCRIPTION
## What Problem This Solves

The setup/onboard/configure fast-help path duplicated Commander's exit callback and structurally reidentified errors that Commander already exposes as a public class.

## Why This Change Was Made

Use Commander's built-in `exitOverride()` and catch the documented `CommanderError` type from the same pinned module instance. This keeps the fast path on the dependency's supported API and removes the local error-shape shim.

## User Impact

No user-visible behavior changes. Fast help keeps the same output and exit codes while the implementation loses 16 net lines.

## Evidence

- Blacksmith Testbox `tbx_01kxezc7wz3v2wvd81a05vnjgy`: `src/cli/run-main.exit.test.ts` and `src/cli/help-cold-imports.test.ts` passed 173/173 tests.
- Blacksmith Testbox: `pnpm tsgo:core` passed.
- Blacksmith Testbox: real `openclaw setup --help`, `openclaw onboard --help`, and `openclaw configure --help` commands all produced non-empty help and exited successfully.
- Direct Commander 15.0.0 probe confirmed default override errors are `CommanderError` instances with help exit 0 and unknown-option exit 1.
- Targeted `oxfmt`, `git diff --check`, and fresh autoreview passed; autoreview reported no accepted or actionable findings.
- Rebase onto current `origin/main` touched no patch files; stable patch ID remained `15d7e119f5210fce7bba604db48bbc95cb7cfe60`.
- Hosted CI was not awaited per maintainer direction.
