### PR TITLE
fix: preserve discovered context limits over static metadata

### DIFF
--- a/src/agents/context.fallback.test.ts
+++ b/src/agents/context.fallback.test.ts
@@ -1,0 +1,40 @@
+// Covers fallback-only context-cache precedence independently of runtime warmup.
+import { describe, expect, it } from "vitest";
+import { providerContextTokenCacheKey } from "./context-cache.js";
+import { applyDiscoveredContextWindows } from "./context.js";
+
+describe("applyDiscoveredContextWindows fallback mode", () => {
+  it("keeps discovered keys while collapsing duplicate static-only rows conservatively", () => {
+    const cache = new Map<string, number>();
+    applyDiscoveredContextWindows({
+      cache,
+      models: [
+        { id: "model-a", provider: "provider-a", contextTokens: 900_000 },
+        {
+          id: "provider-a/model-b",
+          provider: "provider-a",
+          contextTokens: 800_000,
+        },
+      ],
+    });
+    applyDiscoveredContextWindows({
+      cache,
+      mode: "fallback",
+      models: [
+        { id: "model-a", provider: "provider-a", contextWindow: 64_000 },
+        { id: "model-a", provider: "provider-a", contextWindow: 32_000 },
+        { id: "provider-a/model-b", provider: "provider-a", contextWindow: 64_000 },
+        { id: "offline", provider: "provider-a", contextWindow: 128_000 },
+        { id: "offline", provider: "provider-a", contextWindow: 64_000 },
+      ],
+    });
+
+    expect(cache.get("model-a")).toBe(900_000);
+    expect(cache.get(providerContextTokenCacheKey("provider-a", "model-a"))).toBe(900_000);
+    expect(cache.get("provider-a/model-b")).toBe(800_000);
+    expect(cache.get("model-b")).toBeUndefined();
+    expect(cache.get(providerContextTokenCacheKey("provider-a", "model-b"))).toBe(800_000);
+    expect(cache.get("offline")).toBe(64_000);
+    expect(cache.get(providerContextTokenCacheKey("provider-a", "offline"))).toBe(64_000);
+  });
+});

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -22,8 +22,9 @@ const contextTestState = vi.hoisted(() => {
     runtimeConfigSourceSnapshot: null as OpenClawConfig | null,
     loadModelCatalogOwnerSnapshot: vi.fn(async (_params: unknown) => ({
       modelCatalog: {
-        entries: state.discoveredModels,
+        entries: [...state.discoveredModels, ...state.staticCatalogModels],
         routeVariants: [],
+        discoveredEntries: state.discoveredModels,
         staticEntries: state.staticCatalogModels,
       },
     })),
@@ -135,8 +136,9 @@ describe("lookupContextTokens", () => {
     contextTestState.loadModelCatalogOwnerSnapshot.mockClear();
     contextTestState.loadModelCatalogOwnerSnapshot.mockImplementation(async () => ({
       modelCatalog: {
-        entries: contextTestState.discoveredModels,
+        entries: [...contextTestState.discoveredModels, ...contextTestState.staticCatalogModels],
         routeVariants: [],
+        discoveredEntries: contextTestState.discoveredModels,
         staticEntries: contextTestState.staticCatalogModels,
       },
     }));
@@ -439,6 +441,57 @@ describe("lookupContextTokens", () => {
     await flushAsyncWarmup();
 
     expect(lookupContextTokens("gemini-3.1-pro-preview")).toBe(1_048_576);
+  });
+
+  it("keeps provider-discovered budgets ahead of prepared static fallbacks", async () => {
+    mockContextDeps({
+      getRuntimeConfig: () => ({}),
+      discoveredModels: [
+        { id: "gpt-5.6-sol", provider: "github-copilot", contextTokens: 922_000 },
+        { id: "gpt-5.6-sol", provider: "other-provider", contextTokens: 64_000 },
+        {
+          id: "github-copilot/claude-opus-4.8",
+          provider: "github-copilot",
+          contextTokens: 936_000,
+        },
+        {
+          id: "mai-code-1-flash-picker",
+          provider: "github-copilot",
+          contextTokens: 128_000,
+        },
+      ],
+    });
+    contextTestState.staticCatalogModels = [
+      { id: "gpt-5.6-sol", provider: "github-copilot", contextWindow: 128_000 },
+      { id: "claude-opus-4.8", provider: "github-copilot", contextWindow: 128_000 },
+      {
+        id: "github-copilot/mai-code-1-flash-picker",
+        provider: "github-copilot",
+        contextWindow: 64_000,
+      },
+      { id: "offline-model", provider: "github-copilot", contextWindow: 64_000 },
+    ];
+
+    const { lookupContextTokens, resolveContextTokensForModel } = await importContextModule();
+    lookupContextTokens("gpt-5.6-sol");
+    await flushAsyncWarmup();
+
+    expect(contextTestState.loadModelCatalogOwnerSnapshot).toHaveBeenCalledOnce();
+    expect(resolveContextTokensForModel({ provider: "github-copilot", model: "gpt-5.6-sol" })).toBe(
+      922_000,
+    );
+    expect(
+      resolveContextTokensForModel({ provider: "github-copilot", model: "claude-opus-4.8" }),
+    ).toBe(936_000);
+    expect(
+      resolveContextTokensForModel({
+        provider: "github-copilot",
+        model: "mai-code-1-flash-picker",
+      }),
+    ).toBe(128_000);
+    expect(
+      resolveContextTokensForModel({ provider: "github-copilot", model: "offline-model" }),
+    ).toBe(64_000);
   });
 
   it("keeps discovered context metadata when no static rows exist", async () => {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -54,9 +54,21 @@ const loadPreparedModelCatalogRuntime = () => import("./prepared-model-catalog.j
 export function applyDiscoveredContextWindows(params: {
   cache: Map<string, number>;
   models: ModelEntry[];
+  mode?: "minimum" | "fallback";
 }) {
+  const mode = params.mode ?? "minimum";
+  const fallbackProtectedKeys = mode === "fallback" ? new Set(params.cache.keys()) : undefined;
   const cacheMinimum = (key: string, contextTokens: number) => {
     const existing = params.cache.get(key);
+    if (mode === "fallback") {
+      if (fallbackProtectedKeys?.has(key)) {
+        return;
+      }
+      if (existing === undefined || contextTokens < existing) {
+        params.cache.set(key, contextTokens);
+      }
+      return;
+    }
     if (existing === undefined || contextTokens < existing) {
       params.cache.set(key, contextTokens);
     }
@@ -222,15 +234,20 @@ export function ensureContextWindowCacheLoaded(cfgOverride?: OpenClawConfig): Pr
         if (CONTEXT_WINDOW_RUNTIME_STATE.generation !== generation) {
           return;
         }
-        const models =
-          catalogResult.status === "fulfilled" ? catalogResult.value.modelCatalog.entries : [];
-        const providerStaticModels =
-          catalogResult.status === "fulfilled"
-            ? (catalogResult.value.modelCatalog.staticEntries ?? [])
-            : [];
+        const catalog =
+          catalogResult.status === "fulfilled" ? catalogResult.value.modelCatalog : undefined;
         applyDiscoveredContextWindows({
           cache: stagedTokenCache,
-          models: [...models, ...providerStaticModels],
+          models: catalog?.discoveredEntries ?? catalog?.entries ?? [],
+        });
+        // The final catalog includes manifest/config overlays, while staticEntries
+        // contains bundled provider fallbacks. Both may fill missing aliases and
+        // models, but neither may lower provider-discovered limits captured from
+        // this same prepared lifecycle generation.
+        applyDiscoveredContextWindows({
+          cache: stagedTokenCache,
+          models: [...(catalog?.entries ?? []), ...(catalog?.staticEntries ?? [])],
+          mode: "fallback",
         });
       } catch {
         // Static and discovered rows belong to one atomic generation. If its owner fails, keep

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -75,6 +75,7 @@ describe("prepared model catalog builder", () => {
       "alpha/a",
       "beta/z",
     ]);
+    expect(snapshot.discoveredEntries).toEqual(snapshot.entries);
     expect(snapshot.routeVariants).toEqual(snapshot.entries);
   });
 
@@ -108,6 +109,7 @@ describe("prepared model catalog builder", () => {
           id: "demo",
           name: "Discovered Demo",
           provider: "custom",
+          contextWindow: 96_000,
           input: ["text"],
         },
       ],
@@ -122,6 +124,15 @@ describe("prepared model catalog builder", () => {
       reasoning: true,
       input: ["text", "image"],
     });
+    expect(snapshot.discoveredEntries).toEqual([
+      expect.objectContaining({
+        provider: "custom",
+        id: "demo",
+        name: "Discovered Demo",
+        contextWindow: 96_000,
+        input: ["text"],
+      }),
+    ]);
     expect(snapshot.routeVariants).toHaveLength(2);
   });
 
@@ -288,6 +299,152 @@ describe("prepared model catalog builder", () => {
     expect(resolvedOAuth).toBe(resolveOAuthApiKeyMarker("subscription"));
     expect(mocks.augmentModelCatalogWithProviderPlugins).toHaveBeenCalledWith(
       expect.objectContaining({ metadataSnapshot }),
+    );
+  });
+
+  it("does not let hook-cloned overlays replace registry-discovered context", async () => {
+    mocks.augmentModelCatalogWithProviderPlugins.mockImplementationOnce(async ({ context }) => {
+      const entry = context.entries.find(
+        (candidate) => candidate.provider === "custom" && candidate.id === "demo",
+      );
+      return entry ? [structuredClone(entry)] : [];
+    });
+
+    const snapshot = await buildPreparedModelCatalogSnapshot({
+      agentDir: "/tmp/model-catalog-test",
+      authCredentials: {},
+      config: {
+        plugins: { enabled: false },
+        models: {
+          providers: {
+            custom: {
+              baseUrl: "https://example.test/v1",
+              api: "openai-completions",
+              models: [
+                {
+                  id: "demo",
+                  name: "Configured demo",
+                  contextWindow: 32_000,
+                  maxTokens: 4_096,
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                },
+              ],
+            },
+          },
+        },
+      },
+      metadataSnapshot,
+      modelRegistry: registry([
+        {
+          provider: "custom",
+          id: "demo",
+          name: "Discovered demo",
+          contextWindow: 900_000,
+        },
+      ]),
+    });
+
+    expect(snapshot.entries).toContainEqual(
+      expect.objectContaining({ provider: "custom", id: "demo", contextWindow: 32_000 }),
+    );
+    expect(snapshot.discoveredEntries).toContainEqual(
+      expect.objectContaining({ provider: "custom", id: "demo", contextWindow: 900_000 }),
+    );
+  });
+
+  it("keeps live hook context when discovery changes the physical route", async () => {
+    mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValueOnce([
+      {
+        provider: "custom",
+        id: "demo",
+        name: "Live route B",
+        api: "openai-completions",
+        baseUrl: "https://route-b.example.test/v1",
+        contextWindow: 800_000,
+      },
+    ]);
+
+    const snapshot = await buildPreparedModelCatalogSnapshot({
+      agentDir: "/tmp/model-catalog-test",
+      authCredentials: {},
+      config: {
+        plugins: { enabled: false },
+        models: {
+          providers: {
+            custom: {
+              api: "openai-completions",
+              baseUrl: "https://route-b.example.test/v1",
+              models: [
+                {
+                  id: "demo",
+                  name: "Configured route B",
+                  contextWindow: 32_000,
+                  maxTokens: 4_096,
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                },
+              ],
+            },
+          },
+        },
+      },
+      metadataSnapshot,
+      modelRegistry: registry([
+        {
+          provider: "custom",
+          id: "demo",
+          name: "Registry route A",
+          api: "openai-responses",
+          baseUrl: "https://route-a.example.test/v1",
+          contextWindow: 900_000,
+        },
+      ]),
+    });
+
+    expect(snapshot.entries).toContainEqual(
+      expect.objectContaining({
+        provider: "custom",
+        id: "demo",
+        baseUrl: "https://route-b.example.test/v1",
+        contextWindow: 32_000,
+      }),
+    );
+    expect(snapshot.discoveredEntries).toContainEqual(
+      expect.objectContaining({
+        provider: "custom",
+        id: "demo",
+        baseUrl: "https://route-b.example.test/v1",
+        contextWindow: 800_000,
+      }),
+    );
+  });
+
+  it("keeps provider-hook discovery separate from manifest overlays", async () => {
+    mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValueOnce([
+      {
+        provider: "dynamic",
+        id: "live-model",
+        name: "Live model",
+        contextWindow: 900_000,
+      },
+    ]);
+
+    const snapshot = await buildPreparedModelCatalogSnapshot({
+      agentDir: "/tmp/model-catalog-test",
+      authCredentials: {},
+      config: { plugins: { enabled: false } },
+      metadataSnapshot,
+      modelRegistry: registry([]),
+    });
+
+    expect(snapshot.entries).toContainEqual(
+      expect.objectContaining({ provider: "dynamic", id: "live-model", contextWindow: 900_000 }),
+    );
+    expect(snapshot.discoveredEntries).toContainEqual(
+      expect.objectContaining({ provider: "dynamic", id: "live-model", contextWindow: 900_000 }),
     );
   });
 

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -195,6 +195,7 @@ function overlayCatalogMetadata(
   options?: {
     catalogCompatRoute?: ModelCatalogEntry;
     preserveBaseCompat?: boolean;
+    preserveBaseContext?: boolean;
     preserveBaseName?: boolean;
   },
 ): ModelCatalogEntry {
@@ -209,8 +210,12 @@ function overlayCatalogMetadata(
     ...(routeChanged && !options?.preserveBaseName ? { name: overlay.name } : {}),
     ...(overlay.api !== undefined ? { api: overlay.api } : {}),
     ...(overlay.baseUrl !== undefined ? { baseUrl: overlay.baseUrl } : {}),
-    ...(overlay.contextWindow !== undefined ? { contextWindow: overlay.contextWindow } : {}),
-    ...(overlay.contextTokens !== undefined ? { contextTokens: overlay.contextTokens } : {}),
+    ...((!options?.preserveBaseContext || routeChanged) && overlay.contextWindow !== undefined
+      ? { contextWindow: overlay.contextWindow }
+      : {}),
+    ...((!options?.preserveBaseContext || routeChanged) && overlay.contextTokens !== undefined
+      ? { contextTokens: overlay.contextTokens }
+      : {}),
     ...(overlay.reasoning !== undefined ? { reasoning: overlay.reasoning } : {}),
     ...(overlay.input !== undefined ? { input: overlay.input } : {}),
     ...(params ? { params } : {}),
@@ -245,6 +250,7 @@ function mergeCatalogEntries(
   options?: {
     catalogCompatRoutes?: readonly ModelCatalogEntry[];
     preserveBaseCompat?: boolean;
+    preserveBaseContext?: boolean;
     preserveBaseName?: boolean;
   },
 ): void {
@@ -439,6 +445,7 @@ export async function buildPreparedModelCatalogSnapshot(
 
     const shouldSuppressBuiltInModel = buildShouldSuppressBuiltInModel({ config: cfg });
     logStage("suppress-resolver-ready");
+    const discoveredEntries: ModelCatalogEntry[] = [];
 
     for (const entry of entries) {
       const rawId = normalizeOptionalString(entry?.id) ?? "";
@@ -485,6 +492,7 @@ export async function buildPreparedModelCatalogSnapshot(
         compat,
       } satisfies ModelCatalogEntry;
       models.push(model);
+      discoveredEntries.push(model);
       mergeCatalogRouteVariants(routeVariants, [model]);
     }
     const manifestModels = loadManifestModelCatalog({
@@ -549,6 +557,13 @@ export async function buildPreparedModelCatalogSnapshot(
         }
         mergeCatalogRouteVariants(routeVariants, normalizedSupplemental);
         mergeCatalogEntries(models, normalizedSupplemental);
+        // Provider hooks may add genuinely live rows, but some compatibility
+        // hooks clone their already manifest/config-overlaid input. Preserve
+        // registry-owned context metadata when the same provider/model exists,
+        // while still accepting new hook-discovered models.
+        mergeCatalogEntries(discoveredEntries, normalizedSupplemental, {
+          preserveBaseContext: true,
+        });
       }
     }
     logStage("plugin-models-merged", `entries=${models.length}`);
@@ -563,7 +578,10 @@ export async function buildPreparedModelCatalogSnapshot(
     }
     logStage("configured-models-finalized", `entries=${models.length}`);
 
-    const snapshot = createModelCatalogSnapshot(models, routeVariants);
+    const snapshot = {
+      ...createModelCatalogSnapshot(models, routeVariants),
+      discoveredEntries: sortModelCatalogEntries(discoveredEntries),
+    } satisfies ModelCatalogSnapshot;
     logStage("complete", `entries=${snapshot.entries.length}`);
     return snapshot;
   } catch (error) {

--- a/src/agents/model-catalog.types.ts
+++ b/src/agents/model-catalog.types.ts
@@ -30,6 +30,8 @@ export type ModelCatalogEntry = {
 export type ModelCatalogSnapshot = {
   entries: ModelCatalogEntry[];
   routeVariants: ModelCatalogEntry[];
+  /** Provider-discovered rows captured before manifest/config/static overlays. */
+  discoveredEntries?: ModelCatalogEntry[];
   /** Static provider-hook rows captured alongside the full lifecycle generation. */
   staticEntries?: ModelCatalogEntry[];
   /**


### PR DESCRIPTION
Related: #97844

## What Problem This Solves

Provider discovery can report a larger account-specific context limit than bundled, manifest, or configured catalog metadata for the same model. The prepared catalog previously flattened those sources before the context cache consumed them, allowing a lower static value to cause premature compaction.

## Design

The prepared model-catalog snapshot now retains explicit provenance:

- `discoveredEntries` contains registry-discovered rows before manifest/config/static overlays;
- provider hooks may add genuinely discovered models; same-route cloned overlay rows cannot replace registry-owned context metadata, while a genuine route-changing hook retains its own live context limit;
- discovered rows populate the context cache first using existing conservative minimum semantics;
- final catalog and `staticEntries` then run in fallback mode, filling missing model/alias keys without lowering keys supplied by the discovered generation;
- bare, provider-qualified, and self-prefixed IDs retain their existing cache behavior;
- duplicate static-only rows still collapse to a conservative minimum;
- legacy/hand-built snapshots without `discoveredEntries` remain compatible by falling back to `entries`;
- explicit configured context limits remain authoritative through the separate configured-context cache.

No request-time discovery or public API change is introduced.

## Rebase and Squash

Rebuilt as **one commit on current `main`**, replacing the previous seven-commit merge-heavy head. The surviving patch remains limited to six context/catalog source and regression-test files.

## Evidence

Existing live GitHub Copilot evidence remains applicable: fresh explicit sessions used the provider-reported context budgets without premature compaction or `compactionTokens=128001` diagnostics.

Exact-head validation:

- focused context/catalog suites: **13 files / 387 tests passed**;
- production TypeScript: passed;
- test TypeScript: passed;
- focused type-aware lint: **0 warnings / 0 errors**;
- focused formatting: passed;
- full build: passed, including Control UI budgets;
- `git diff --check`: passed.

Regression coverage proves that provider-discovered values beat lower prepared final/static rows, aliases retain provider-scoped authority, duplicate static-only rows remain conservative, same-route hook-cloned overlays cannot contaminate discovery provenance, route-changing live hook context is retained, genuine hook-discovered models are retained, and offline-only models still receive static fallback limits.
