### PR TITLE
docs(changelog): keep release notes release-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Plugin config merging:** expose the canonical deep-merge policy through the plugin SDK, migrate Voice Call to it, and remove the duplicate merge engine and direct `defu` dependency.
 - **Skill Workshop history review:** add a manual, newest-first session scan that progressively searches older substantial work for conservative skill ideas, stores only SQLite cursor metadata, and leaves up to three results as pending proposals even when autonomous self-learning is disabled. (#106182)
 - **SQLite snapshots:** add `openclaw backup sqlite create|list|verify|restore` for compact, verified global and per-agent database artifacts with fresh-target-only restore. (#94805) Thanks @giodl73-repo.
 - **GPT-5.6 Ultra and runtime switching:** support Sol, Terra, and Luna across OpenClaw and Codex engines; keep model, runtime, and thinking selection atomic through `/model` and fallback; and add live matrix coverage for both harnesses. (#98021) Thanks @anyech.


### PR DESCRIPTION
Related: #106919

## What Problem This Solves

PR #106919 accidentally added a normal-PR entry to `CHANGELOG.md`, although repository policy reserves that file for release generation.

## Why This Change Was Made

Remove the single premature entry. The merged PR body already carries the release-note context that release generation consumes.

## User Impact

None. Runtime code, packages, configuration, and documentation remain unchanged.

## Evidence

- Exact diff: one line deleted from `CHANGELOG.md`.
- `git diff --check` passes for the cleanup commit.
- Fresh pre-commit autoreview reports no accepted or actionable findings.
- Hosted CI intentionally not awaited per maintainer direction.
