### PR TITLE
fix(ci): restore prompt context dependency checks

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-e511874a61fa05dc67613e171fb9617102525db3efbe4c7240da0d3e84c270d8  plugin-sdk-api-baseline.json
-575271760452cbd7da8fb57eef8ffce527254ccb876aaefd850c13b9522dd744  plugin-sdk-api-baseline.jsonl
+d8b28c82d7fd1407cd453fda96998861302d89c67f1c2af6d1df4aa5c25e437d  plugin-sdk-api-baseline.json
+13e2773bfc7476eadd6e7f7e5cc66677824aab2992dc04d04e0a6ebf443595ba  plugin-sdk-api-baseline.jsonl

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-context.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-context.ts
@@ -56,13 +56,13 @@ type PromptAssemblyContext = {
   heartbeatSummary?: Pick<HeartbeatSummary, "ackMaxChars" | "prompt">;
 };
 
-export type CurrentUserTimestampOverride = {
+type CurrentUserTimestampOverride = {
   timestamp: number;
   text: string;
   alternateText?: string;
 };
 
-export type EmbeddedAttemptPromptContext = {
+type EmbeddedAttemptPromptContext = {
   aggregatePressureEngaged: boolean;
   contextTokenBudget: number;
   currentUserTimestampOverride?: CurrentUserTimestampOverride;


### PR DESCRIPTION
## What Problem This Solves

Current dependency checks report two unused exports introduced by the prompt-context extraction:

- `CurrentUserTimestampOverride`
- `EmbeddedAttemptPromptContext`

The Plugin SDK API hash is also stale after `WorktreeRunLease` became module-private in #106925.

## Why This Change Was Made

Both prompt-context types remain useful inside their owner module, but no external caller imports them. This change makes them module-private instead of deleting useful domain shapes or adding dead exports to the baseline.

The SDK hash refresh is mechanical: two existing testing declarations now render the private lease as its structural `{ id, token, release }` shape. The public export set and runtime behavior are unchanged.

## User Impact

No user-visible behavior change. Core dependency checks are restored without preserving unnecessary public surface.

## Evidence

- Testbox `tbx_01kxf04rdnc8zvssr1ajfkqqsk`
- `pnpm test:serial src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts` (3/3)
- `pnpm deadcode:exports` (1,191-entry baseline matched)
- `pnpm check:changed -- docs/.generated/plugin-sdk-api-baseline.sha256 src/agents/embedded-agent-runner/run/attempt-prompt-context.ts`
- `git diff --check`
- fresh `gpt-5.6-sol` medium autoreview: clean (0.93)
