### PR TITLE
refactor(channels): consolidate the flat streaming fallback into the deprecation module

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-5be50abd8a5549977d5e78bdb5cd4cd69929967ee4f41ca103a8b2ac042cdeb6  plugin-sdk-api-baseline.json
-b214693bf7c2f5ab189b71a25286ca82a15415b64e3d55507adbb32f203b16fd  plugin-sdk-api-baseline.jsonl
+511e28906e94a606742bb9adf2ba216bfb81611dac0629e7da151811fa057d3b  plugin-sdk-api-baseline.json
+8624d46170622ca9b136c5a1021117b782460f72f94b7d6ac5dbe8e62af5ed42  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-45054152e19f42e55bdbfd59b2628b058053285add967278fb9feb254fbb3f19  plugin-sdk-api-baseline.json
-9a76d83e694e003b6bec91aa43378060245aa0124f13bbe3485ab6848136d215  plugin-sdk-api-baseline.jsonl
+d43b631bf84fdef65d44514e34f77dc97de14a3e5016d728e59585a1c47d1b2b  plugin-sdk-api-baseline.json
+5c272b15c12c2f7ff0756c57f33706662702564882b5c9fbdd46c58cf8dcf314  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-511e28906e94a606742bb9adf2ba216bfb81611dac0629e7da151811fa057d3b  plugin-sdk-api-baseline.json
-8624d46170622ca9b136c5a1021117b782460f72f94b7d6ac5dbe8e62af5ed42  plugin-sdk-api-baseline.jsonl
+45054152e19f42e55bdbfd59b2628b058053285add967278fb9feb254fbb3f19  plugin-sdk-api-baseline.json
+9a76d83e694e003b6bec91aa43378060245aa0124f13bbe3485ab6848136d215  plugin-sdk-api-baseline.jsonl

--- a/src/channels/streaming-compat-entry.ts
+++ b/src/channels/streaming-compat-entry.ts
@@ -1,0 +1,14 @@
+// Leaf contract shared by streaming.ts and streaming-flat-key-deprecation.ts;
+// living here keeps the compat module off streaming.ts and out of madge cycles.
+// The flat fields die with the fallback window after the next release train.
+export type StreamingCompatEntry = {
+  /**
+   * Canonical nested streaming config. External SDK plugin configs may still
+   * carry a scalar mode string or boolean here; bundled schemas reject those.
+   */
+  streaming?: unknown;
+  chunkMode?: unknown;
+  blockStreaming?: unknown;
+  blockStreamingCoalesce?: unknown;
+  draftChunk?: unknown;
+};

--- a/src/channels/streaming-flat-key-deprecation.ts
+++ b/src/channels/streaming-flat-key-deprecation.ts
@@ -1,7 +1,16 @@
-// Warn-once state for the deprecated flat streaming key fallback in streaming.ts.
-// Lives outside streaming.ts so the test-only reset stays off the public SDK
-// surface (openclaw/plugin-sdk/channel-outbound re-exports all of streaming.ts).
+// Flat-key compatibility resolvers and warn-once state. This module keeps the
+// test-only reset and warning helpers off the public SDK wildcard surface
+// (openclaw/plugin-sdk/channel-outbound re-exports all of streaming.ts) and
+// bounds the deletion scope when the fallback window closes next release train.
+import type {
+  BlockStreamingChunkConfig,
+  BlockStreamingCoalesceConfig,
+  ChannelStreamingConfig,
+  TextChunkMode,
+} from "../config/types.base.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { asBoolean } from "../utils/boolean.js";
+import type { StreamingCompatEntry } from "./streaming-compat-entry.js";
 
 const log = createSubsystemLogger("channels/streaming");
 const warnedFlatStreamingKeys = new Set<string>();
@@ -20,4 +29,90 @@ export function warnFlatStreamingKeyFallback(flatKey: string, nestedPath: string
   log.warn(
     `Flat channel streaming key "${flatKey}" is deprecated; move it to streaming.${nestedPath}. The flat fallback is removed after the next release train.`,
   );
+}
+
+function asObjectRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asTextChunkMode(value: unknown): TextChunkMode | undefined {
+  return value === "length" || value === "newline" ? value : undefined;
+}
+
+function asBlockStreamingCoalesceConfig(value: unknown): BlockStreamingCoalesceConfig | undefined {
+  return (asObjectRecord(value) as BlockStreamingCoalesceConfig | null) ?? undefined;
+}
+
+function asBlockStreamingChunkConfig(value: unknown): BlockStreamingChunkConfig | undefined {
+  return (asObjectRecord(value) as BlockStreamingChunkConfig | null) ?? undefined;
+}
+
+// Local nested read avoids a cycle with streaming.ts. It dies with this module
+// on the fallback removal train.
+function getNestedStreamingConfig(
+  entry: StreamingCompatEntry | null | undefined,
+): ChannelStreamingConfig | undefined {
+  const streaming = asObjectRecord(entry?.streaming);
+  return streaming ? (streaming as ChannelStreamingConfig) : undefined;
+}
+
+function resolveWithFlatFallback<T>(params: {
+  nested: T | undefined;
+  flat: T | undefined;
+  flatKey: string;
+  nestedPath: string;
+}): T | undefined {
+  if (params.nested !== undefined) {
+    return params.nested;
+  }
+  if (params.flat !== undefined) {
+    warnFlatStreamingKeyFallback(params.flatKey, params.nestedPath);
+  }
+  return params.flat;
+}
+
+export function resolveChannelStreamingChunkMode(
+  entry: StreamingCompatEntry | null | undefined,
+): TextChunkMode | undefined {
+  return resolveWithFlatFallback({
+    nested: asTextChunkMode(getNestedStreamingConfig(entry)?.chunkMode),
+    flat: asTextChunkMode(entry?.chunkMode),
+    flatKey: "chunkMode",
+    nestedPath: "chunkMode",
+  });
+}
+
+export function resolveChannelStreamingBlockEnabled(
+  entry: StreamingCompatEntry | null | undefined,
+): boolean | undefined {
+  return resolveWithFlatFallback({
+    nested: asBoolean(getNestedStreamingConfig(entry)?.block?.enabled),
+    flat: asBoolean(entry?.blockStreaming),
+    flatKey: "blockStreaming",
+    nestedPath: "block.enabled",
+  });
+}
+
+export function resolveChannelStreamingBlockCoalesce(
+  entry: StreamingCompatEntry | null | undefined,
+): BlockStreamingCoalesceConfig | undefined {
+  return resolveWithFlatFallback({
+    nested: asBlockStreamingCoalesceConfig(getNestedStreamingConfig(entry)?.block?.coalesce),
+    flat: asBlockStreamingCoalesceConfig(entry?.blockStreamingCoalesce),
+    flatKey: "blockStreamingCoalesce",
+    nestedPath: "block.coalesce",
+  });
+}
+
+export function resolveChannelStreamingPreviewChunk(
+  entry: StreamingCompatEntry | null | undefined,
+): BlockStreamingChunkConfig | undefined {
+  return resolveWithFlatFallback({
+    nested: asBlockStreamingChunkConfig(getNestedStreamingConfig(entry)?.preview?.chunk),
+    flat: asBlockStreamingChunkConfig(entry?.draftChunk),
+    flatKey: "draftChunk",
+    nestedPath: "preview.chunk",
+  });
 }

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -5,16 +5,22 @@ import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-
 import { formatToolDetail, resolveToolDisplay } from "../agents/tool-display.js";
 import { formatToolAggregate } from "../auto-reply/tool-meta.js";
 import type {
-  BlockStreamingChunkConfig,
-  BlockStreamingCoalesceConfig,
   ChannelStreamingCommandTextMode,
   ChannelStreamingProgressConfig,
   ChannelStreamingConfig,
   StreamingMode,
-  TextChunkMode,
 } from "../config/types.base.js";
 import { asBoolean } from "../utils/boolean.js";
+import type { StreamingCompatEntry } from "./streaming-compat-entry.js";
 import { warnFlatStreamingKeyFallback } from "./streaming-flat-key-deprecation.js";
+
+export {
+  resolveChannelStreamingChunkMode,
+  resolveChannelStreamingBlockEnabled,
+  resolveChannelStreamingBlockCoalesce,
+  resolveChannelStreamingPreviewChunk,
+} from "./streaming-flat-key-deprecation.js";
+export type { StreamingCompatEntry } from "./streaming-compat-entry.js";
 
 export type {
   ChannelDeliveryStreamingConfig,
@@ -29,32 +35,17 @@ export type {
 } from "../config/types.base.js";
 export type { SlackChannelStreamingConfig } from "../config/types.slack.js";
 
-export type StreamingCompatEntry = {
-  /**
-   * Canonical nested streaming config. External SDK plugin configs may still
-   * carry a scalar mode string or boolean here; bundled schemas reject those.
-   */
-  streaming?: unknown;
-  chunkMode?: unknown;
-  blockStreaming?: unknown;
-  blockStreamingCoalesce?: unknown;
-  draftChunk?: unknown;
-};
-
-// Bundled schemas are nested-only; doctor migrates flat delivery keys
-// (chunkMode, blockStreaming, blockStreamingCoalesce, draftChunk) and scalar
-// `streaming`. External SDK fallbacks warn once; remove them, the flat
-// StreamingCompatEntry fields, and scalar support after the next release train.
+// Bundled schemas are nested-only; doctor migrates flat delivery keys and
+// scalar `streaming`. The flat delivery fallback lives wholly in
+// streaming-flat-key-deprecation.ts (re-exported above); after the next
+// release train delete that module, the re-exports, the scalar read in
+// resolveChannelPreviewStreamMode, and the flat StreamingCompatEntry fields.
 // Mode-family aliases (streamMode) are doctor-only and stay unread here.
 
 function asObjectRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null;
-}
-
-function asTextChunkMode(value: unknown): TextChunkMode | undefined {
-  return value === "length" || value === "newline" ? value : undefined;
 }
 
 function asInteger(value: unknown): number | undefined {
@@ -80,14 +71,6 @@ function parsePreviewStreamingMode(value: unknown): StreamingMode | null {
     return normalized;
   }
   return null;
-}
-
-function asBlockStreamingCoalesceConfig(value: unknown): BlockStreamingCoalesceConfig | undefined {
-  return (asObjectRecord(value) as BlockStreamingCoalesceConfig | null) ?? undefined;
-}
-
-function asBlockStreamingChunkConfig(value: unknown): BlockStreamingChunkConfig | undefined {
-  return (asObjectRecord(value) as BlockStreamingChunkConfig | null) ?? undefined;
 }
 
 function asProgressConfig(value: unknown): ChannelStreamingProgressConfig | undefined {
@@ -772,65 +755,6 @@ export function getChannelStreamingConfigObject(
 ): ChannelStreamingConfig | undefined {
   const streaming = asObjectRecord(entry?.streaming);
   return streaming ? (streaming as ChannelStreamingConfig) : undefined;
-}
-
-function resolveWithFlatFallback<T>(params: {
-  nested: T | undefined;
-  flat: T | undefined;
-  flatKey: string;
-  nestedPath: string;
-}): T | undefined {
-  if (params.nested !== undefined) {
-    return params.nested;
-  }
-  if (params.flat !== undefined) {
-    warnFlatStreamingKeyFallback(params.flatKey, params.nestedPath);
-  }
-  return params.flat;
-}
-
-export function resolveChannelStreamingChunkMode(
-  entry: StreamingCompatEntry | null | undefined,
-): TextChunkMode | undefined {
-  return resolveWithFlatFallback({
-    nested: asTextChunkMode(getChannelStreamingConfigObject(entry)?.chunkMode),
-    flat: asTextChunkMode(entry?.chunkMode),
-    flatKey: "chunkMode",
-    nestedPath: "chunkMode",
-  });
-}
-
-export function resolveChannelStreamingBlockEnabled(
-  entry: StreamingCompatEntry | null | undefined,
-): boolean | undefined {
-  return resolveWithFlatFallback({
-    nested: asBoolean(getChannelStreamingConfigObject(entry)?.block?.enabled),
-    flat: asBoolean(entry?.blockStreaming),
-    flatKey: "blockStreaming",
-    nestedPath: "block.enabled",
-  });
-}
-
-export function resolveChannelStreamingBlockCoalesce(
-  entry: StreamingCompatEntry | null | undefined,
-): BlockStreamingCoalesceConfig | undefined {
-  return resolveWithFlatFallback({
-    nested: asBlockStreamingCoalesceConfig(getChannelStreamingConfigObject(entry)?.block?.coalesce),
-    flat: asBlockStreamingCoalesceConfig(entry?.blockStreamingCoalesce),
-    flatKey: "blockStreamingCoalesce",
-    nestedPath: "block.coalesce",
-  });
-}
-
-export function resolveChannelStreamingPreviewChunk(
-  entry: StreamingCompatEntry | null | undefined,
-): BlockStreamingChunkConfig | undefined {
-  return resolveWithFlatFallback({
-    nested: asBlockStreamingChunkConfig(getChannelStreamingConfigObject(entry)?.preview?.chunk),
-    flat: asBlockStreamingChunkConfig(entry?.draftChunk),
-    flatKey: "draftChunk",
-    nestedPath: "preview.chunk",
-  });
 }
 
 export function resolveChannelStreamingPreviewToolProgress(


### PR DESCRIPTION
## What Problem This Solves

`src/channels/streaming.ts` is an oversized legacy file (1,320 lines, LOC-ratchet-capped) that still hosts the deprecated flat streaming-key fallback — ~70 lines of compat resolvers scheduled for deletion when the SDK deprecation window closes after the next release train. Keeping the dying code inside the ratcheted file blocks any legitimate growth there and spreads the future deletion across a large file.

## Why This Change Was Made

Rescoped after #106796 landed the scalar-fallback warning this PR originally carried (both grew from the same finding). What remains is the consolidation: the four flat-fallback resolvers (`resolveChannelStreamingChunkMode`/`BlockEnabled`/`BlockCoalesce`/`PreviewChunk`) and their helper move into `streaming-flat-key-deprecation.ts`, which already owns the warn-once state and dies with the window — so the next-train deletion becomes one module plus re-export lines. `StreamingCompatEntry` moves to a leaf contract module (`streaming-compat-entry.ts`) so the compat module never imports from `streaming.ts` (madge/import-cycle gates verified at zero cycles).

## User Impact

None. Pure move: public SDK export names, signatures, and behavior are identical (`openclaw/plugin-sdk/channel-outbound` re-exports `streaming.ts`, which re-exports the four resolvers and the type). `streaming.ts` shrinks 1,320 → 1,244 lines.

## Evidence

- Testbox (Blacksmith): `check:import-cycles` and `check:madge-import-cycles` both zero; `pnpm test src/channels/streaming.test.ts src/channels/streaming-flat-key-deprecation.test.ts src/plugin-sdk/channel-streaming.test.ts src/auto-reply/chunk.test.ts src/auto-reply/reply/block-streaming.test.ts` all green; `check:changed` lanes green (LOC ratchet included) with the regenerated Plugin SDK API baseline hash committed.
- Autoreview (codex gpt-5.6-sol, xhigh) on the pre-rescope equivalent of this move: clean, no actionable findings; the move itself is unchanged apart from adapting to #106796's warn implementation.
