### PR TITLE
fix(ci): refresh agent session API baseline

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-d8b28c82d7fd1407cd453fda96998861302d89c67f1c2af6d1df4aa5c25e437d  plugin-sdk-api-baseline.json
-13e2773bfc7476eadd6e7f7e5cc66677824aab2992dc04d04e0a6ebf443595ba  plugin-sdk-api-baseline.jsonl
+5be50abd8a5549977d5e78bdb5cd4cd69929967ee4f41ca103a8b2ac042cdeb6  plugin-sdk-api-baseline.json
+b214693bf7c2f5ab189b71a25286ca82a15415b64e3d55507adbb32f203b16fd  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
## What Problem This Solves

Restores the Plugin SDK API baseline check on current `main`.

## Why This Change Was Made

Commit `cae29a07920` moved synchronous storage-lock retry helpers out of `FileAuthStorageBackend` and `FileSettingsStorage`. The generated `agent-sessions` declarations therefore no longer include those two private class methods, but the tracked API hashes still described the previous declarations.

This refreshes only the generated SHA-256 state file. The generated JSONL diff contains exactly the removal of those two private method declarations; no public method, parameter, return type, or runtime behavior changes.

## User Impact

No user-visible or Plugin SDK behavior change. Current-main dependency and API-baseline checks are green again.

## Evidence

- Exact current-main generated JSONL comparison: only `FileAuthStorageBackend.acquireLockSyncWithRetry` and `FileSettingsStorage.acquireLockSyncWithRetry` disappear from private class members.
- Testbox `tbx_01kxf1m31gfvqv6zexx5gnebsr`: `pnpm plugin-sdk:api:check` passed.
- Testbox `tbx_01kxf1m31gfvqv6zexx5gnebsr`: `pnpm check:changed -- docs/.generated/plugin-sdk-api-baseline.sha256` passed.
- `git diff --check` passed.
- Fresh `gpt-5.6-sol` medium autoreview: no findings, patch correct (0.93).
