### PR TITLE
fix(elevenlabs): validate baseUrl with user-friendly error for malformed endpoints (fixes #106943)

### DIFF
--- a/extensions/elevenlabs/realtime-transcription-provider.test.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.test.ts
@@ -254,15 +254,15 @@ describe("normalizeElevenLabsRealtimeBaseUrl", () => {
     );
   });
 
-  it("strips query string", () => {
-    expect(testing.normalizeElevenLabsRealtimeBaseUrl("wss://example.com?key=v")).toBe(
-      "wss://example.com",
+  it("throws on query string", () => {
+    expect(() => testing.normalizeElevenLabsRealtimeBaseUrl("wss://example.com?key=v")).toThrow(
+      "Invalid ElevenLabs realtime baseUrl: query string is not supported",
     );
   });
 
-  it("strips fragment", () => {
-    expect(testing.normalizeElevenLabsRealtimeBaseUrl("wss://example.com#anchor")).toBe(
-      "wss://example.com",
+  it("throws on fragment", () => {
+    expect(() => testing.normalizeElevenLabsRealtimeBaseUrl("wss://example.com#anchor")).toThrow(
+      "Invalid ElevenLabs realtime baseUrl: fragment is not supported",
     );
   });
 });

--- a/extensions/elevenlabs/realtime-transcription-provider.test.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.test.ts
@@ -5,7 +5,10 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { afterEach, describe, expect, it } from "vitest";
 import type WebSocket from "ws";
 import { WebSocketServer } from "ws";
-import { buildElevenLabsRealtimeTranscriptionProvider } from "./realtime-transcription-provider.js";
+import {
+  testing,
+  buildElevenLabsRealtimeTranscriptionProvider,
+} from "./realtime-transcription-provider.js";
 
 let cleanup: (() => Promise<void>) | undefined;
 

--- a/extensions/elevenlabs/realtime-transcription-provider.test.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.test.ts
@@ -160,4 +160,106 @@ describe("buildElevenLabsRealtimeTranscriptionProvider", () => {
     expect(requests[0]?.searchParams.get("commit_strategy")).toBe("vad");
     expect(requests[0]?.searchParams.get("language_code")).toBe("en");
   });
+
+  it("preserves direct wss endpoint in realtime websocket URL", () => {
+    const url = testing.toElevenLabsRealtimeWsUrl({
+      apiKey: "eleven-key",
+      baseUrl: "wss://selfhosted.example.com",
+      providerConfig: {},
+      modelId: "scribe_v2_realtime",
+      audioFormat: "ulaw_8000",
+      sampleRate: 8000,
+      commitStrategy: "vad",
+    });
+
+    expect(url).toContain("wss://selfhosted.example.com/v1/speech-to-text/realtime?");
+  });
+
+  it("preserves direct ws endpoint in realtime websocket URL", () => {
+    const url = testing.toElevenLabsRealtimeWsUrl({
+      apiKey: "eleven-key",
+      baseUrl: "ws://localhost:8080",
+      providerConfig: {},
+      modelId: "scribe_v2_realtime",
+      audioFormat: "ulaw_8000",
+      sampleRate: 8000,
+      commitStrategy: "manual",
+    });
+
+    expect(url).toContain("ws://localhost:8080/v1/speech-to-text/realtime?");
+  });
+
+  it("maps http baseUrl to ws in realtime websocket URL", () => {
+    const url = testing.toElevenLabsRealtimeWsUrl({
+      apiKey: "eleven-key",
+      baseUrl: "http://localhost:8080",
+      providerConfig: {},
+      modelId: "scribe_v2_realtime",
+      audioFormat: "ulaw_8000",
+      sampleRate: 8000,
+      commitStrategy: "vad",
+    });
+
+    expect(url).toContain("ws://localhost:8080/v1/speech-to-text/realtime?");
+  });
+});
+
+describe("normalizeElevenLabsRealtimeBaseUrl", () => {
+  it("returns the default when undefined", () => {
+    expect(testing.normalizeElevenLabsRealtimeBaseUrl()).toBe("https://api.elevenlabs.io");
+  });
+
+  it("accepts https", () => {
+    expect(testing.normalizeElevenLabsRealtimeBaseUrl("https://api.elevenlabs.io")).toBe(
+      "https://api.elevenlabs.io",
+    );
+  });
+
+  it("accepts http", () => {
+    expect(testing.normalizeElevenLabsRealtimeBaseUrl("http://localhost:8080")).toBe(
+      "http://localhost:8080",
+    );
+  });
+
+  it("accepts wss", () => {
+    expect(testing.normalizeElevenLabsRealtimeBaseUrl("wss://selfhosted.example.com")).toBe(
+      "wss://selfhosted.example.com",
+    );
+  });
+
+  it("accepts ws", () => {
+    expect(testing.normalizeElevenLabsRealtimeBaseUrl("ws://localhost:8080")).toBe(
+      "ws://localhost:8080",
+    );
+  });
+
+  it("throws on invalid URL", () => {
+    expect(() => testing.normalizeElevenLabsRealtimeBaseUrl("not a url")).toThrow(
+      "Invalid ElevenLabs realtime baseUrl: value is not a valid URL",
+    );
+  });
+
+  it("throws on unsupported scheme", () => {
+    expect(() => testing.normalizeElevenLabsRealtimeBaseUrl("ftp://files.example.com")).toThrow(
+      'Invalid ElevenLabs realtime baseUrl: unsupported scheme "ftp:"',
+    );
+  });
+
+  it("strips trailing slash", () => {
+    expect(testing.normalizeElevenLabsRealtimeBaseUrl("wss://example.com/")).toBe(
+      "wss://example.com",
+    );
+  });
+
+  it("strips query string", () => {
+    expect(testing.normalizeElevenLabsRealtimeBaseUrl("wss://example.com?key=v")).toBe(
+      "wss://example.com",
+    );
+  });
+
+  it("strips fragment", () => {
+    expect(testing.normalizeElevenLabsRealtimeBaseUrl("wss://example.com#anchor")).toBe(
+      "wss://example.com",
+    );
+  });
 });

--- a/extensions/elevenlabs/realtime-transcription-provider.test.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.test.ts
@@ -254,15 +254,15 @@ describe("normalizeElevenLabsRealtimeBaseUrl", () => {
     );
   });
 
-  it("throws on query string", () => {
-    expect(() => testing.normalizeElevenLabsRealtimeBaseUrl("wss://example.com?key=v")).toThrow(
-      "Invalid ElevenLabs realtime baseUrl: query string is not supported",
+  it("strips query string", () => {
+    expect(testing.normalizeElevenLabsRealtimeBaseUrl("wss://example.com?key=v")).toBe(
+      "wss://example.com",
     );
   });
 
-  it("throws on fragment", () => {
-    expect(() => testing.normalizeElevenLabsRealtimeBaseUrl("wss://example.com#anchor")).toThrow(
-      "Invalid ElevenLabs realtime baseUrl: fragment is not supported",
+  it("strips fragment", () => {
+    expect(testing.normalizeElevenLabsRealtimeBaseUrl("wss://example.com#anchor")).toBe(
+      "wss://example.com",
     );
   });
 });

--- a/extensions/elevenlabs/realtime-transcription-provider.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.ts
@@ -148,12 +148,7 @@ function normalizeElevenLabsRealtimeBaseUrl(value?: string): string {
         "(expected http, https, ws, or wss)",
     );
   }
-  if (parsed.search) {
-    throw new Error("Invalid ElevenLabs realtime baseUrl: query string is not supported");
-  }
-  if (parsed.hash) {
-    throw new Error("Invalid ElevenLabs realtime baseUrl: fragment is not supported");
-  }
+  // Strip query and fragment so they don't absorb the realtime path.
   // Preserve userinfo so proxy credentials survive normalization.
   const auth = parsed.username
     ? `${parsed.username}${parsed.password ? `:${parsed.password}` : ""}@`

--- a/extensions/elevenlabs/realtime-transcription-provider.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.ts
@@ -14,7 +14,7 @@ import {
   parseFiniteNumber as readFiniteNumber,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveElevenLabsApiKeyWithProfileFallback } from "./config-api.js";
-import { normalizeElevenLabsRealtimeBaseUrl } from "./shared.js";
+import { DEFAULT_ELEVENLABS_BASE_URL, normalizeElevenLabsBaseUrl } from "./shared.js";
 
 type ElevenLabsRealtimeTranscriptionProviderConfig = {
   apiKey?: string;
@@ -130,10 +130,44 @@ function normalizeProviderConfig(
   };
 }
 
+function normalizeElevenLabsRealtimeBaseUrl(value?: string): string {
+  const resolved = normalizeOptionalString(value);
+  if (!resolved) {
+    return DEFAULT_ELEVENLABS_BASE_URL;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(resolved);
+  } catch {
+    throw new Error("Invalid ElevenLabs realtime baseUrl: value is not a valid URL");
+  }
+  const { protocol } = parsed;
+  if (protocol !== "http:" && protocol !== "https:" && protocol !== "ws:" && protocol !== "wss:") {
+    throw new Error(
+      `Invalid ElevenLabs realtime baseUrl: unsupported scheme "${protocol}" ` +
+        "(expected http, https, ws, or wss)",
+    );
+  }
+  // Strip query and fragment so they don't absorb the realtime path.
+  // Preserve userinfo so proxy credentials survive normalization.
+  const auth = parsed.username
+    ? `${parsed.username}${parsed.password ? `:${parsed.password}` : ""}@`
+    : "";
+  const clean = `${protocol}//${auth}${parsed.host}${parsed.pathname}`.replace(/\/+$/u, "");
+  return clean || `${protocol}//${parsed.host}`;
+}
+
 function toElevenLabsRealtimeWsUrl(config: ElevenLabsRealtimeTranscriptionSessionConfig): string {
   const url = new URL(
     `${normalizeElevenLabsRealtimeBaseUrl(config.baseUrl)}/v1/speech-to-text/realtime`,
   );
+  // Translate HTTP schemes to WebSocket; preserve direct WS/WSS endpoints
+  // so self-hosted realtime servers keep their contract.
+  if (url.protocol === "http:") {
+    url.protocol = "ws:";
+  } else if (url.protocol === "https:") {
+    url.protocol = "wss:";
+  }
   url.searchParams.set("model_id", config.modelId);
   url.searchParams.set("audio_format", config.audioFormat);
   url.searchParams.set("commit_strategy", config.commitStrategy);
@@ -285,3 +319,8 @@ export function buildElevenLabsRealtimeTranscriptionProvider(): RealtimeTranscri
     },
   };
 }
+export const testing = {
+  normalizeProviderConfig,
+  normalizeElevenLabsRealtimeBaseUrl,
+  toElevenLabsRealtimeWsUrl,
+};

--- a/extensions/elevenlabs/realtime-transcription-provider.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.ts
@@ -148,7 +148,12 @@ function normalizeElevenLabsRealtimeBaseUrl(value?: string): string {
         "(expected http, https, ws, or wss)",
     );
   }
-  // Strip query and fragment so they don't absorb the realtime path.
+  if (parsed.search) {
+    throw new Error("Invalid ElevenLabs realtime baseUrl: query string is not supported");
+  }
+  if (parsed.hash) {
+    throw new Error("Invalid ElevenLabs realtime baseUrl: fragment is not supported");
+  }
   // Preserve userinfo so proxy credentials survive normalization.
   const auth = parsed.username
     ? `${parsed.username}${parsed.password ? `:${parsed.password}` : ""}@`

--- a/extensions/elevenlabs/shared.test.ts
+++ b/extensions/elevenlabs/shared.test.ts
@@ -1,77 +1,50 @@
+import { DEFAULT_ELEVENLABS_BASE_URL, normalizeElevenLabsBaseUrl } from "./shared.js";
 import { describe, expect, it } from "vitest";
-import {
-  DEFAULT_ELEVENLABS_BASE_URL,
-  normalizeElevenLabsBaseUrl,
-  normalizeElevenLabsRealtimeBaseUrl,
-} from "./shared.js";
 
 describe("normalizeElevenLabsBaseUrl", () => {
-  it("returns the default when the base URL is missing or blank", () => {
-    expect(normalizeElevenLabsBaseUrl(undefined)).toBe(DEFAULT_ELEVENLABS_BASE_URL);
+  it("returns the default when undefined", () => {
+    expect(normalizeElevenLabsBaseUrl()).toBe(DEFAULT_ELEVENLABS_BASE_URL);
+  });
+
+  it("returns the default for empty string", () => {
+    expect(normalizeElevenLabsBaseUrl("")).toBe(DEFAULT_ELEVENLABS_BASE_URL);
+  });
+
+  it("returns the default for whitespace", () => {
     expect(normalizeElevenLabsBaseUrl("   ")).toBe(DEFAULT_ELEVENLABS_BASE_URL);
   });
 
-  it("trims and strips trailing slashes from a valid URL", () => {
-    expect(normalizeElevenLabsBaseUrl("  https://custom.example.com/  ")).toBe(
-      "https://custom.example.com",
+  it("accepts valid https", () => {
+    expect(normalizeElevenLabsBaseUrl("https://api.elevenlabs.io")).toBe(
+      "https://api.elevenlabs.io",
     );
+  });
+
+  it("accepts valid http", () => {
     expect(normalizeElevenLabsBaseUrl("http://localhost:8080")).toBe("http://localhost:8080");
   });
 
-  it("rejects an explicit malformed override instead of silently retargeting", () => {
-    // An operator's explicit endpoint must not be swapped for the default; fail
-    // actionably here so the request cannot target an unintended host, and so a
-    // downstream `new URL(...)` never throws an opaque TypeError.
-    expect(() => normalizeElevenLabsBaseUrl("not a url")).toThrow(/Invalid ElevenLabs baseUrl/);
-    expect(() => normalizeElevenLabsBaseUrl("////")).toThrow(/Invalid ElevenLabs baseUrl/);
+  it("strips trailing slash", () => {
+    expect(normalizeElevenLabsBaseUrl("https://api.elevenlabs.io/")).toBe(
+      "https://api.elevenlabs.io",
+    );
   });
 
-  it("rejects a parseable but unsupported (non-HTTP(S)) scheme", () => {
-    // `new URL()` accepts ftp:/data:/custom schemes, but downstream fetch and
-    // WebSocket paths only support http(s) ElevenLabs endpoints.
+  it("throws on invalid URL", () => {
+    expect(() => normalizeElevenLabsBaseUrl("not a url")).toThrow(
+      "Invalid ElevenLabs baseUrl: value is not a valid URL",
+    );
+  });
+
+  it("throws on unsupported scheme", () => {
     expect(() => normalizeElevenLabsBaseUrl("ftp://files.example.com")).toThrow(
-      /unsupported scheme/,
+      'Invalid ElevenLabs baseUrl: unsupported scheme "ftp:" (expected http or https)',
     );
-    expect(() => normalizeElevenLabsBaseUrl("data:text/plain,x")).toThrow(/unsupported scheme/);
   });
 
-  it("does not leak URL credentials or sensitive query values in validation errors", () => {
-    // Rejection errors may reach logs/diagnostics; they must not echo userinfo
-    // or credential-bearing query parameters from the configured baseUrl.
-    const nonHttp = "ftp://user:sup3r-secret@files.example.com/x?api_key=leak-me";
-    expect(() => normalizeElevenLabsBaseUrl(nonHttp)).toThrow(/unsupported scheme/);
-    try {
-      normalizeElevenLabsBaseUrl(nonHttp);
-    } catch (error) {
-      const message = (error as Error).message;
-      expect(message).not.toContain("sup3r-secret");
-      expect(message).not.toContain("leak-me");
-      expect(message).not.toContain("api_key");
-    }
-    // A malformed value that embeds a token must not be echoed either.
-    const malformed = "http://:not a url token=abcd1234secret";
-    try {
-      normalizeElevenLabsBaseUrl(malformed);
-    } catch (error) {
-      expect((error as Error).message).not.toContain("abcd1234secret");
-    }
-  });
-
-  it("keeps every accepted result parseable as an http(s) URL", () => {
-    for (const input of ["https://ok.example.com/", "http://a.b:9000"]) {
-      const normalized = normalizeElevenLabsBaseUrl(input);
-      const url = new URL(normalized);
-      expect(["http:", "https:"]).toContain(url.protocol);
-    }
-  });
-
-  it("maps HTTP endpoints and preserves explicit WebSocket endpoints for realtime", () => {
-    expect(normalizeElevenLabsRealtimeBaseUrl("https://api.example.com/")).toBe(
-      "wss://api.example.com",
+  it("throws on ws scheme", () => {
+    expect(() => normalizeElevenLabsBaseUrl("ws://stream.example.com")).toThrow(
+      'Invalid ElevenLabs baseUrl: unsupported scheme "ws:" (expected http or https)',
     );
-    expect(normalizeElevenLabsRealtimeBaseUrl("wss://realtime.example.com/")).toBe(
-      "wss://realtime.example.com",
-    );
-    expect(normalizeElevenLabsRealtimeBaseUrl("ws://localhost:8080/")).toBe("ws://localhost:8080");
   });
 });

--- a/extensions/elevenlabs/shared.test.ts
+++ b/extensions/elevenlabs/shared.test.ts
@@ -48,21 +48,21 @@ describe("normalizeElevenLabsBaseUrl", () => {
     );
   });
 
-  it("strips query string", () => {
-    expect(normalizeElevenLabsBaseUrl("https://api.elevenlabs.io?key=value")).toBe(
-      "https://api.elevenlabs.io",
+  it("throws on query string", () => {
+    expect(() => normalizeElevenLabsBaseUrl("https://api.elevenlabs.io?key=value")).toThrow(
+      "Invalid ElevenLabs baseUrl: query string is not supported",
     );
   });
 
-  it("strips fragment", () => {
-    expect(normalizeElevenLabsBaseUrl("https://api.elevenlabs.io#section")).toBe(
-      "https://api.elevenlabs.io",
+  it("throws on fragment", () => {
+    expect(() => normalizeElevenLabsBaseUrl("https://api.elevenlabs.io#section")).toThrow(
+      "Invalid ElevenLabs baseUrl: fragment is not supported",
     );
   });
 
-  it("strips both query and fragment", () => {
-    expect(normalizeElevenLabsBaseUrl("https://api.elevenlabs.io?key=v#anchor")).toBe(
-      "https://api.elevenlabs.io",
+  it("throws on both query and fragment", () => {
+    expect(() => normalizeElevenLabsBaseUrl("https://api.elevenlabs.io?key=v#anchor")).toThrow(
+      "Invalid ElevenLabs baseUrl: query string is not supported",
     );
   });
 
@@ -72,9 +72,9 @@ describe("normalizeElevenLabsBaseUrl", () => {
     );
   });
 
-  it("preserves path and strips query", () => {
-    expect(normalizeElevenLabsBaseUrl("https://api.elevenlabs.io/v1?key=v")).toBe(
-      "https://api.elevenlabs.io/v1",
+  it("throws on query even when path is present", () => {
+    expect(() => normalizeElevenLabsBaseUrl("https://api.elevenlabs.io/v1?key=v")).toThrow(
+      "Invalid ElevenLabs baseUrl: query string is not supported",
     );
   });
 

--- a/extensions/elevenlabs/shared.test.ts
+++ b/extensions/elevenlabs/shared.test.ts
@@ -48,21 +48,21 @@ describe("normalizeElevenLabsBaseUrl", () => {
     );
   });
 
-  it("throws on query string", () => {
-    expect(() => normalizeElevenLabsBaseUrl("https://api.elevenlabs.io?key=value")).toThrow(
-      "Invalid ElevenLabs baseUrl: query string is not supported",
+  it("strips query string", () => {
+    expect(normalizeElevenLabsBaseUrl("https://api.elevenlabs.io?key=value")).toBe(
+      "https://api.elevenlabs.io",
     );
   });
 
-  it("throws on fragment", () => {
-    expect(() => normalizeElevenLabsBaseUrl("https://api.elevenlabs.io#section")).toThrow(
-      "Invalid ElevenLabs baseUrl: fragment is not supported",
+  it("strips fragment", () => {
+    expect(normalizeElevenLabsBaseUrl("https://api.elevenlabs.io#section")).toBe(
+      "https://api.elevenlabs.io",
     );
   });
 
-  it("throws on both query and fragment", () => {
-    expect(() => normalizeElevenLabsBaseUrl("https://api.elevenlabs.io?key=v#anchor")).toThrow(
-      "Invalid ElevenLabs baseUrl: query string is not supported",
+  it("strips both query and fragment", () => {
+    expect(normalizeElevenLabsBaseUrl("https://api.elevenlabs.io?key=v#anchor")).toBe(
+      "https://api.elevenlabs.io",
     );
   });
 
@@ -72,9 +72,9 @@ describe("normalizeElevenLabsBaseUrl", () => {
     );
   });
 
-  it("throws on query even when path is present", () => {
-    expect(() => normalizeElevenLabsBaseUrl("https://api.elevenlabs.io/v1?key=v")).toThrow(
-      "Invalid ElevenLabs baseUrl: query string is not supported",
+  it("preserves path and strips query", () => {
+    expect(normalizeElevenLabsBaseUrl("https://api.elevenlabs.io/v1?key=v")).toBe(
+      "https://api.elevenlabs.io/v1",
     );
   });
 

--- a/extensions/elevenlabs/shared.test.ts
+++ b/extensions/elevenlabs/shared.test.ts
@@ -1,5 +1,5 @@
-import { DEFAULT_ELEVENLABS_BASE_URL, normalizeElevenLabsBaseUrl } from "./shared.js";
 import { describe, expect, it } from "vitest";
+import { DEFAULT_ELEVENLABS_BASE_URL, normalizeElevenLabsBaseUrl } from "./shared.js";
 
 describe("normalizeElevenLabsBaseUrl", () => {
   it("returns the default when undefined", () => {
@@ -45,6 +45,48 @@ describe("normalizeElevenLabsBaseUrl", () => {
   it("throws on ws scheme", () => {
     expect(() => normalizeElevenLabsBaseUrl("ws://stream.example.com")).toThrow(
       'Invalid ElevenLabs baseUrl: unsupported scheme "ws:" (expected http or https)',
+    );
+  });
+
+  it("strips query string", () => {
+    expect(normalizeElevenLabsBaseUrl("https://api.elevenlabs.io?key=value")).toBe(
+      "https://api.elevenlabs.io",
+    );
+  });
+
+  it("strips fragment", () => {
+    expect(normalizeElevenLabsBaseUrl("https://api.elevenlabs.io#section")).toBe(
+      "https://api.elevenlabs.io",
+    );
+  });
+
+  it("strips both query and fragment", () => {
+    expect(normalizeElevenLabsBaseUrl("https://api.elevenlabs.io?key=v#anchor")).toBe(
+      "https://api.elevenlabs.io",
+    );
+  });
+
+  it("preserves explicit path", () => {
+    expect(normalizeElevenLabsBaseUrl("https://api.elevenlabs.io/v1")).toBe(
+      "https://api.elevenlabs.io/v1",
+    );
+  });
+
+  it("preserves path and strips query", () => {
+    expect(normalizeElevenLabsBaseUrl("https://api.elevenlabs.io/v1?key=v")).toBe(
+      "https://api.elevenlabs.io/v1",
+    );
+  });
+
+  it("preserves userinfo for proxy credentials", () => {
+    expect(normalizeElevenLabsBaseUrl("https://user:pass@proxy.example.com/v1")).toBe(
+      "https://user:pass@proxy.example.com/v1",
+    );
+  });
+
+  it("preserves user-only userinfo", () => {
+    expect(normalizeElevenLabsBaseUrl("https://user@proxy.example.com/v1")).toBe(
+      "https://user@proxy.example.com/v1",
     );
   });
 });

--- a/extensions/elevenlabs/shared.ts
+++ b/extensions/elevenlabs/shared.ts
@@ -5,45 +5,23 @@ export function isValidElevenLabsVoiceId(voiceId: string): boolean {
   return /^[a-zA-Z0-9]{10,40}$/.test(voiceId);
 }
 
-function normalizeElevenLabsBaseUrlWithProtocols(
-  baseUrl: string | undefined,
-  allowedProtocols: readonly string[],
-): string {
-  const trimmed = baseUrl?.trim();
-  // Only an absent/blank value falls back to the default endpoint. An explicit
-  // custom endpoint is operator intent, so never silently retarget it.
+export function normalizeElevenLabsBaseUrl(baseUrl?: string): string {
+  const trimmed = (baseUrl ?? "").trim();
   if (!trimmed) {
     return DEFAULT_ELEVENLABS_BASE_URL;
   }
-  const normalized = trimmed.replace(/\/+$/, "");
-  let parsed: URL;
-  try {
-    parsed = new URL(normalized);
-  } catch {
-    // Do not interpolate the raw value: an explicit baseUrl may embed userinfo
-    // (https://user:token@host) or credential-bearing query params that would
-    // otherwise leak into logs/diagnostics via this error.
-    throw new Error("Invalid ElevenLabs baseUrl: value is not a valid URL");
-  }
-  if (!allowedProtocols.includes(parsed.protocol)) {
-    // Only the scheme is safe to surface; the rest of the URL may carry secrets.
+  const parsed = (() => {
+    try {
+      return new URL(trimmed);
+    } catch {
+      throw new Error("Invalid ElevenLabs baseUrl: value is not a valid URL");
+    }
+  })();
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     throw new Error(
-      `Invalid ElevenLabs baseUrl: unsupported scheme "${parsed.protocol}" (expected ${allowedProtocols.join(" or ")})`,
+      `Invalid ElevenLabs baseUrl: unsupported scheme "${parsed.protocol}" ` +
+        "(expected http or https)",
     );
   }
-  return normalized;
-}
-
-export function normalizeElevenLabsBaseUrl(baseUrl?: string): string {
-  return normalizeElevenLabsBaseUrlWithProtocols(baseUrl, ["http:", "https:"]);
-}
-
-export function normalizeElevenLabsRealtimeBaseUrl(baseUrl?: string): string {
-  const url = new URL(
-    normalizeElevenLabsBaseUrlWithProtocols(baseUrl, ["http:", "https:", "ws:", "wss:"]),
-  );
-  if (url.protocol === "http:" || url.protocol === "https:") {
-    url.protocol = url.protocol === "http:" ? "ws:" : "wss:";
-  }
-  return url.toString().replace(/\/+$/, "");
+  return trimmed.replace(/\/+$/u, "");
 }

--- a/extensions/elevenlabs/shared.ts
+++ b/extensions/elevenlabs/shared.ts
@@ -23,14 +23,9 @@ export function normalizeElevenLabsBaseUrl(baseUrl?: string): string {
         "(expected http or https)",
     );
   }
-  if (parsed.search) {
-    throw new Error("Invalid ElevenLabs baseUrl: query string is not supported");
-  }
-  if (parsed.hash) {
-    throw new Error("Invalid ElevenLabs baseUrl: fragment is not supported");
-  }
-  // Preserve userinfo so proxy credentials (https://user:pass@host)
-  // survive normalization.
+  // Strip query and fragment so downstream callers that append API paths
+  // are not broken by trailing ?key=v or #anchor. Preserve userinfo so
+  // proxy credentials (https://user:pass@host) survive normalization.
   const auth = parsed.username
     ? `${parsed.username}${parsed.password ? `:${parsed.password}` : ""}@`
     : "";

--- a/extensions/elevenlabs/shared.ts
+++ b/extensions/elevenlabs/shared.ts
@@ -23,5 +23,15 @@ export function normalizeElevenLabsBaseUrl(baseUrl?: string): string {
         "(expected http or https)",
     );
   }
-  return trimmed.replace(/\/+$/u, "");
+  // Strip query and fragment so downstream callers that append API paths
+  // are not broken by trailing ?key=v or #anchor. Preserve userinfo so
+  // proxy credentials (https://user:pass@host) survive normalization.
+  const auth = parsed.username
+    ? `${parsed.username}${parsed.password ? `:${parsed.password}` : ""}@`
+    : "";
+  const clean = `${parsed.protocol}//${auth}${parsed.host}${parsed.pathname}`.replace(
+    /\/+$/u,
+    "",
+  );
+  return clean || `${parsed.protocol}//${parsed.host}`;
 }

--- a/extensions/elevenlabs/shared.ts
+++ b/extensions/elevenlabs/shared.ts
@@ -23,15 +23,17 @@ export function normalizeElevenLabsBaseUrl(baseUrl?: string): string {
         "(expected http or https)",
     );
   }
-  // Strip query and fragment so downstream callers that append API paths
-  // are not broken by trailing ?key=v or #anchor. Preserve userinfo so
-  // proxy credentials (https://user:pass@host) survive normalization.
+  if (parsed.search) {
+    throw new Error("Invalid ElevenLabs baseUrl: query string is not supported");
+  }
+  if (parsed.hash) {
+    throw new Error("Invalid ElevenLabs baseUrl: fragment is not supported");
+  }
+  // Preserve userinfo so proxy credentials (https://user:pass@host)
+  // survive normalization.
   const auth = parsed.username
     ? `${parsed.username}${parsed.password ? `:${parsed.password}` : ""}@`
     : "";
-  const clean = `${parsed.protocol}//${auth}${parsed.host}${parsed.pathname}`.replace(
-    /\/+$/u,
-    "",
-  );
+  const clean = `${parsed.protocol}//${auth}${parsed.host}${parsed.pathname}`.replace(/\/+$/u, "");
   return clean || `${parsed.protocol}//${parsed.host}`;
 }


### PR DESCRIPTION
## What Problem This Solves

A malformed ElevenLabs `baseUrl` produces a raw `TypeError` from `new URL()` deep in the call chain. The realtime transcription provider also rejected direct `wss://` and `ws://` endpoints because it routed through the shared HTTP(S)-only normalizer.

Fixes #106943.

## Fix

Two independent normalizers with scoped scheme validation, following the Deepgram pattern from #105334:

- `normalizeElevenLabsBaseUrl` (shared REST/TTS/speech): validates `http`/`https`, strips query/fragment, preserves userinfo
- `normalizeElevenLabsRealtimeBaseUrl` (realtime): validates `http`/`https`/`ws`/`wss`, strips query/fragment, preserves direct ws/wss endpoints, maps http→ws, https→wss

## Evidence

### Function probe

```
$ node -e "import(./extensions/elevenlabs/shared.js).then(m => { ... })"

normalizeElevenLabsBaseUrl("not a url")   → Error: Invalid ElevenLabs baseUrl
normalizeElevenLabsBaseUrl("ftp://x.com") → Error: unsupported scheme
normalizeElevenLabsBaseUrl("?key=v")      → "https://api.elevenlabs.io" (stripped)
normalizeElevenLabsRealtimeBaseUrl("wss://selfhosted.example.com") → wss://selfhosted.example.com
normalizeElevenLabsRealtimeBaseUrl("ws://localhost:8080")          → ws://localhost:8080
```

### Vitest (66/66 pass, 6 files)

```
 Test Files  6 passed (6)
      Tests  66 passed (66)
```