### PR TITLE
refactor: consolidate ws raw data handling

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -22,7 +22,7 @@ import {
   type NodePairingCleanupClaim,
   type RequestNodePairingResult,
 } from "../../../infra/node-pairing.js";
-import { rawDataToString } from "../../../infra/ws.js";
+import { rawDataByteLength, rawDataToString } from "../../../infra/ws.js";
 import { logRejectedLargePayload } from "../../../logging/diagnostic-payload.js";
 import {
   getGatewaySuspendAdmissionPhase,
@@ -186,7 +186,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
       return;
     }
 
-    const preauthPayloadBytes = !getClient() ? getRawDataByteLength(data) : undefined;
+    const preauthPayloadBytes = !getClient() ? rawDataByteLength(data) : undefined;
     if (preauthPayloadBytes !== undefined && preauthPayloadBytes > MAX_PREAUTH_PAYLOAD_BYTES) {
       logRejectedLargePayload({
         surface: "gateway.ws.preauth",
@@ -403,7 +403,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
   };
 
   const rejectConnectForClosedAdmission = async (data: RawData): Promise<boolean> => {
-    if (isClosed() || getRawDataByteLength(data) > MAX_PREAUTH_PAYLOAD_BYTES) {
+    if (isClosed() || rawDataByteLength(data) > MAX_PREAUTH_PAYLOAD_BYTES) {
       return false;
     }
     let parsed: unknown;
@@ -477,19 +477,6 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
       handleIncomingMessage(data),
     );
   });
-}
-
-function getRawDataByteLength(data: unknown): number {
-  if (Buffer.isBuffer(data)) {
-    return data.byteLength;
-  }
-  if (Array.isArray(data)) {
-    return data.reduce((total, chunk) => total + chunk.byteLength, 0);
-  }
-  if (data instanceof ArrayBuffer) {
-    return data.byteLength;
-  }
-  return Buffer.byteLength(String(data));
 }
 
 export const testing = {

--- a/src/gateway/server/ws-connection/worker-connection.ts
+++ b/src/gateway/server/ws-connection/worker-connection.ts
@@ -45,7 +45,7 @@ import {
   validateWorkerInferenceStartParams,
 } from "../../../../packages/gateway-protocol/src/schema/worker-inference.js";
 import { GATEWAY_STARTUP_RETRY_AFTER_MS } from "../../../../packages/gateway-protocol/src/startup-unavailable.js";
-import { rawDataToString } from "../../../infra/ws.js";
+import { rawDataByteLength, rawDataToString } from "../../../infra/ws.js";
 import { tryBeginGatewayRootWorkAdmission } from "../../../process/gateway-work-admission.js";
 import type { WorkerConnectionIdentity } from "../../worker-environments/connection-identity.js";
 import type { GatewayWsClient, WsHandshakePhase } from "../ws-types.js";
@@ -346,13 +346,6 @@ async function dispatchWorkerRequest(params: {
     ownerEpoch: params.identity.ownerEpoch,
   };
   params.respond(true, result);
-}
-
-function rawDataByteLength(data: RawData): number {
-  if (Array.isArray(data)) {
-    return data.reduce((total, chunk) => total + chunk.byteLength, 0);
-  }
-  return data.byteLength;
 }
 
 /** Dedicated ingress handler: worker frames never enter the generic message handler. */

--- a/src/infra/ws.test.ts
+++ b/src/infra/ws.test.ts
@@ -1,22 +1,15 @@
 // Covers WebSocket raw payload decoding.
 import { Buffer } from "node:buffer";
 import { describe, expect, it } from "vitest";
-import { rawDataToString } from "./ws.js";
+import { rawDataByteLength, rawDataToString } from "./ws.js";
 
-describe("rawDataToString", () => {
-  it("returns string input unchanged", () => {
-    expect(rawDataToString("hello" as unknown as Parameters<typeof rawDataToString>[0])).toBe(
-      "hello",
-    );
-  });
-
-  it("decodes Buffer, Buffer[] and ArrayBuffer inputs", () => {
-    expect(rawDataToString(Buffer.from("hello"))).toBe("hello");
-    expect(rawDataToString([Buffer.from("he"), Buffer.from("llo")])).toBe("hello");
-    expect(rawDataToString(Uint8Array.from([104, 101, 108, 108, 111]).buffer)).toBe("hello");
-  });
-
-  it("falls back to string coercion for other raw data shapes", () => {
-    expect(rawDataToString(Uint8Array.from([1, 2, 3]) as never)).toBe("1,2,3");
+describe("WebSocket raw data", () => {
+  it.each([
+    ["Buffer", Buffer.from("hello")],
+    ["Buffer[]", [Buffer.from("he"), Buffer.from("llo")]],
+    ["ArrayBuffer", Uint8Array.from([104, 101, 108, 108, 111]).buffer],
+  ])("handles %s", (_name, data) => {
+    expect(rawDataToString(data)).toBe("hello");
+    expect(rawDataByteLength(data)).toBe(5);
   });
 });

--- a/src/infra/ws.ts
+++ b/src/infra/ws.ts
@@ -2,23 +2,21 @@
 import { Buffer } from "node:buffer";
 import type WebSocket from "ws";
 
-// WebSocket.RawData can arrive as strings, buffers, ArrayBuffers, or buffer
-// fragments depending on ws internals and caller options.
+// ws emits raw payloads as buffers, ArrayBuffers, or buffer fragments.
 export function rawDataToString(
   data: WebSocket.RawData,
   encoding: BufferEncoding = "utf8",
 ): string {
-  if (typeof data === "string") {
-    return data;
-  }
-  if (Buffer.isBuffer(data)) {
-    return data.toString(encoding);
-  }
   if (Array.isArray(data)) {
     return Buffer.concat(data).toString(encoding);
   }
-  if (data instanceof ArrayBuffer) {
-    return Buffer.from(data).toString(encoding);
-  }
-  return Buffer.from(String(data)).toString(encoding);
+  return data instanceof ArrayBuffer
+    ? Buffer.from(data).toString(encoding)
+    : data.toString(encoding);
+}
+
+export function rawDataByteLength(data: WebSocket.RawData): number {
+  return Array.isArray(data)
+    ? data.reduce((total, chunk) => total + chunk.byteLength, 0)
+    : data.byteLength;
 }


### PR DESCRIPTION
## What Problem This Solves

Gateway WebSocket handling maintained three payload-size implementations, while the shared decoder also accepted shapes outside the declared `ws` `RawData` contract.

## Why This Change Was Made

Centralize string decoding and byte sizing around the exact `ws@8.21.0` union: `Buffer`, `Buffer[]`, and `ArrayBuffer`. Both gateway ingress paths now use the same helper.

## User Impact

No user-visible behavior change. Valid WebSocket frames keep identical decoding and size-limit behavior. Production code shrinks by consolidating dependency-backed logic.

## Evidence

- Blacksmith Testbox `tbx_01kxf1d16khy1fn1vy7vrjgby5`
- `pnpm test src/infra/ws.test.ts src/gateway/server.preauth-hardening.test.ts src/gateway/server/ws-connection/message-handler.worker.test.ts` — 29 tests passed
- `pnpm tsgo:core`
- `pnpm tsgo:test:src`
- Fresh autoreview: no accepted or actionable findings
- Net change: 23 additions, 52 deletions
