### PR TITLE
test(exec): retry transient security-floor cleanup

### DIFF
--- a/src/agents/bash-tools.exec.security-floor.test.ts
+++ b/src/agents/bash-tools.exec.security-floor.test.ts
@@ -89,7 +89,7 @@ describe("exec security floor", () => {
     tempRoot = undefined;
     envSnapshot.restore();
     if (dir) {
-      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where main CI intermittently fails the agent core-tools shard because temporary-directory teardown can observe a transient Linux `ENOTEMPTY` while files are still settling.

## Why This Change Was Made

The test now uses Node's native recursive-remove retry controls, matching existing OpenClaw temporary-directory cleanup helpers. Runtime behavior and security assertions are unchanged.

AI-assisted: yes. The patch received a clean structured Codex autoreview.

## User Impact

No user-visible behavior change. Main CI no longer fails this security-floor test on a transient filesystem cleanup race.

## Evidence

- Before: https://github.com/openclaw/openclaw/actions/runs/29296860920/job/86972497549 failed with `ENOTEMPTY` at `src/agents/bash-tools.exec.security-floor.test.ts:92` after 1,376 passing assertions in the shard.
- Testbox-through-Crabbox `tbx_01kxf1s35ag8431sxqeyecpw06`, Actions run https://github.com/openclaw/openclaw/actions/runs/29297101774.
- Focused file passed 10 consecutive iterations: 150/150 assertions.
- `pnpm check:changed -- src/agents/bash-tools.exec.security-floor.test.ts` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local`: clean; no accepted/actionable findings.
