### PR TITLE
refactor(cron): privatize task history helpers

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -984,8 +984,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/cron/stagger.ts: isRecurringTopOfHourCronExpr",
   "src/cron/store/row-codec.ts: bindScheduleColumns",
   "src/cron/store/row-codec.ts: scheduleFromRow",
-  "src/cron/task-run-event-codec.ts: resolveCronRunEndedAt",
-  "src/cron/task-run-history.ts: CronTaskRunHistoryPage",
   "src/cron/task-run-history.ts: ReadCronTaskRunHistoryPageOptions",
   "src/daemon/constants.ts: formatGatewayServiceDescription",
   "src/daemon/constants.ts: GATEWAY_SYSTEMD_SERVICE_NAME",

--- a/src/cron/task-run-event-codec.ts
+++ b/src/cron/task-run-event-codec.ts
@@ -8,7 +8,7 @@ import type { CronEvent } from "./service/state.js";
 type CronFinishedEvent = CronEvent & { action: "finished" };
 
 /** Uses execution timing for one timestamp shared by ledger and legacy dual-write paths. */
-export function resolveCronRunEndedAt(event: CronFinishedEvent, fallbackTs: number): number {
+function resolveCronRunEndedAt(event: CronFinishedEvent, fallbackTs: number): number {
   if (
     typeof event.runAtMs === "number" &&
     Number.isFinite(event.runAtMs) &&

--- a/src/cron/task-run-history.ts
+++ b/src/cron/task-run-history.ts
@@ -30,7 +30,7 @@ export type ReadCronTaskRunHistoryPageOptions = {
   jobNameById?: Record<string, string>;
 };
 
-export type CronTaskRunHistoryPage = {
+type CronTaskRunHistoryPage = {
   entries: CronRunLogEntry[];
   total: number;
   offset: number;


### PR DESCRIPTION
## What Problem This Solves

Removes two internal cron task-history declarations from the repository's unused-export baseline. They were exported despite having no consumers outside their owning modules, which made the apparent module surface broader than the runtime contract.

## Why This Change Was Made

Keep both helpers named and owner-local, but stop exporting them. Their existing callers remain unchanged, and the dead-export baseline drops by two entries.

## User Impact

No user-visible behavior changes. This narrows internal API surface and makes future dead-code checks more accurate.

## Evidence

- Exhaustive symbol search found only each declaration and its existing owner-local use; no imports, barrels, docs, or reflective consumers.
- `pnpm test:serial src/cron/task-run-history.test.ts`: 7/7 passed.
- `pnpm deadcode:exports`: baseline matched 1,189 entries.
- `pnpm plugin-sdk:api:check`: generated SDK baseline unchanged.
- `pnpm check:changed -- scripts/deadcode-exports.baseline.mjs src/cron/task-run-event-codec.ts src/cron/task-run-history.ts`: passed.
- Blacksmith Testbox: `tbx_01kxf1yah8vdzm20qwj935sg1t`.
- Fresh `gpt-5.6-sol` medium branch review: 0.98, no findings.

AI-assisted: yes. No transcript attached.
