### PR TITLE
improve(ui): drop page subtitles from settings and hub headers

### DIFF
--- a/ui/src/pages/about/about-page.ts
+++ b/ui/src/pages/about/about-page.ts
@@ -1,7 +1,7 @@
 import { consume } from "@lit/context";
 import { html } from "lit";
 import { state } from "lit/decorators.js";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { CONTROL_UI_BUILD_INFO } from "../../build-info.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
@@ -90,7 +90,6 @@ class AboutPage extends OpenClawLightDomElement {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("about")}</div>
-          <div class="page-sub">${subtitleForRoute("about")}</div>
         </div>
       </section>
       ${renderSettingsWorkspace(body)}

--- a/ui/src/pages/activity/activity-page.ts
+++ b/ui/src/pages/activity/activity-page.ts
@@ -3,7 +3,7 @@ import { html, type PropertyValues } from "lit";
 import { state } from "lit/decorators.js";
 import type { EventLogEntry } from "../../api/event-log.ts";
 import type { GatewayEventFrame } from "../../api/gateway.ts";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import {
   applicationContext,
   type ApplicationContext,
@@ -240,7 +240,6 @@ class ActivityPage extends OpenClawLightDomElement {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("activity")}</div>
-          <div class="page-sub">${subtitleForRoute("activity")}</div>
         </div>
       </section>
       ${renderSettingsWorkspace(body, { fillHeight: true })}

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -11,7 +11,7 @@ import type {
   ToolsCatalogResult,
   ToolsEffectiveResult,
 } from "../../api/types.ts";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import {
   applicationContext,
   type ApplicationContext,
@@ -743,7 +743,6 @@ class AgentsPage extends OpenClawLightDomElement implements AgentsState {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("agents")}</div>
-          <div class="page-sub">${subtitleForRoute("agents")}</div>
         </div>
       </section>
       ${renderSettingsWorkspace(

--- a/ui/src/pages/channels/channels-page.ts
+++ b/ui/src/pages/channels/channels-page.ts
@@ -3,7 +3,7 @@ import { html } from "lit";
 import { state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { NostrProfile } from "../../api/types.ts";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { resolveControlUiAuthHeader } from "../../app/control-ui-auth.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
@@ -435,7 +435,6 @@ class ChannelsPage extends OpenClawLightDomElement {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("channels")}</div>
-          <div class="page-sub">${subtitleForRoute("channels")}</div>
         </div>
       </section>
       ${renderSettingsWorkspace(

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -146,10 +146,6 @@ function configPageTitle(pageId: ConfigPageId): string {
     : t(`tabs.${CONFIG_PAGE_I18N_KEYS[pageId]}`);
 }
 
-function configPageSubtitle(pageId: ConfigPageId): string {
-  return t(`subtitles.${CONFIG_PAGE_I18N_KEYS[pageId]}`);
-}
-
 function mcpServerCount(config: unknown): number {
   const servers = asConfigRecord(asConfigRecord(config)?.mcp)?.servers;
   return servers && typeof servers === "object" && !Array.isArray(servers)

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -998,7 +998,6 @@ export class ConfigPage extends OpenClawLightDomElement {
       <section class="content-header">
         <div>
           <div class="page-title">${configPageTitle(this.pageId)}</div>
-          <div class="page-sub">${configPageSubtitle(this.pageId)}</div>
         </div>
         ${this.renderSettingsModeToggle()}
       </section>

--- a/ui/src/pages/connection/connection-page.ts
+++ b/ui/src/pages/connection/connection-page.ts
@@ -3,7 +3,7 @@
 import { consume } from "@lit/context";
 import { html } from "lit";
 import { state } from "lit/decorators.js";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { loadGatewaySessionSelection, loadSettings, type UiSettings } from "../../app/settings.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
@@ -125,7 +125,6 @@ class ConnectionPage extends OpenClawLightDomElement {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("connection")}</div>
-          <div class="page-sub">${subtitleForRoute("connection")}</div>
         </div>
       </section>
       ${renderSettingsWorkspace(body)}

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -2,7 +2,7 @@ import { consume } from "@lit/context";
 import { html } from "lit";
 import { state } from "lit/decorators.js";
 import type { AgentsListResult, CronJob } from "../../api/types.ts";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { renderAgentScopeControl } from "../../components/agent-scope-control.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
@@ -340,7 +340,6 @@ class CronPage extends OpenClawLightDomElement {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("cron")}</div>
-          <div class="page-sub">${subtitleForRoute("cron")}</div>
         </div>
         ${renderAgentScopeControl({
           agents: this.agentsList?.agents ?? [],

--- a/ui/src/pages/debug/debug-page.ts
+++ b/ui/src/pages/debug/debug-page.ts
@@ -4,7 +4,7 @@ import { state } from "lit/decorators.js";
 import type { EventLogEntry } from "../../api/event-log.ts";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { HealthSnapshot, StatusSummary } from "../../api/types.ts";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import {
   applicationContext,
   type ApplicationContext,
@@ -224,7 +224,6 @@ class DebugPage extends OpenClawLightDomElement {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("debug")}</div>
-          <div class="page-sub">${subtitleForRoute("debug")}</div>
         </div>
       </section>
       ${renderSettingsWorkspace(body)}

--- a/ui/src/pages/logs/logs-page.ts
+++ b/ui/src/pages/logs/logs-page.ts
@@ -2,7 +2,7 @@ import { consume } from "@lit/context";
 import { html, type PropertyValues } from "lit";
 import { state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import {
   applicationContext,
   type ApplicationContext,
@@ -349,7 +349,6 @@ class LogsPage extends OpenClawLightDomElement {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("logs")}</div>
-          <div class="page-sub">${subtitleForRoute("logs")}</div>
         </div>
       </section>
       ${renderSettingsWorkspace(body, { fillHeight: true })}

--- a/ui/src/pages/memory-import/memory-import-page.ts
+++ b/ui/src/pages/memory-import/memory-import-page.ts
@@ -6,7 +6,7 @@ import type {
   MigrationsMemoryPlanResult,
 } from "../../../../packages/gateway-protocol/src/schema/migrations.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
@@ -346,7 +346,6 @@ export class MemoryImportPage extends OpenClawLightDomElement {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("memory-import")}</div>
-          <div class="page-sub">${subtitleForRoute("memory-import")}</div>
         </div>
       </section>
       ${renderSettingsWorkspace(body)}

--- a/ui/src/pages/model-providers/model-providers-page.ts
+++ b/ui/src/pages/model-providers/model-providers-page.ts
@@ -3,7 +3,7 @@ import { html, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ModelsProbeResult } from "../../api/types.ts";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
@@ -586,7 +586,6 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("model-providers")}</div>
-          <div class="page-sub">${subtitleForRoute("model-providers")}</div>
         </div>
       </section>
       ${renderSettingsWorkspace(body)}

--- a/ui/src/pages/nodes/nodes-page.ts
+++ b/ui/src/pages/nodes/nodes-page.ts
@@ -3,7 +3,7 @@ import { html, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { PresenceEntry } from "../../api/types.ts";
-import { titleForRoute, subtitleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import {
   applicationContext,
   type ApplicationContext,
@@ -353,7 +353,6 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("nodes")}</div>
-          <div class="page-sub">${subtitleForRoute("nodes")}</div>
         </div>
       </section>
       ${renderSettingsWorkspace(

--- a/ui/src/pages/plugin/workspace-view.ts
+++ b/ui/src/pages/plugin/workspace-view.ts
@@ -975,14 +975,13 @@ function renderBody(
 
 /**
  * Page-header treatment for the Workspaces view (#7): the active workspace tab as
- * the title with a subtitle line, matching the app's .page-title / .page-sub
+ * the title, matching the app's .page-title header pattern
  * idiom used by the other top-level pages.
  */
 function renderWorkspacesHeader(tab: WorkspaceTab): TemplateResult {
   return html`
     <div class="workspace-page-header" data-test-id="workspace-page-header">
       <div class="page-title">${tab.title}</div>
-      <div class="page-sub">${t("workspaces.header.subtitle")}</div>
     </div>
   `;
 }

--- a/ui/src/pages/plugins/plugins-page.ts
+++ b/ui/src/pages/plugins/plugins-page.ts
@@ -4,7 +4,7 @@ import { asNullableRecord as asRecord } from "@openclaw/normalization-core/recor
 import { html, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import { pathForRoute } from "../../app-route-paths.ts";
 import {
   applicationContext,
@@ -838,7 +838,6 @@ class PluginsPage extends OpenClawLightDomElement {
       <section class="content-header content-header--page plugins-content-header">
         <div>
           <h1 class="page-title">${titleForRoute("plugins")}</h1>
-          <div class="page-sub">${subtitleForRoute("plugins")}</div>
         </div>
       </section>
       ${renderSettingsWorkspace(html`

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -3,7 +3,7 @@ import { html, nothing, svg } from "lit";
 import { state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { CostUsageSummary, SessionsUsageResult } from "../../api/types.ts";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import {
   applicationContext,
   type ApplicationContext,
@@ -531,7 +531,6 @@ export class ProfilePage extends OpenClawLightDomElement {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("profile")}</div>
-          <div class="page-sub">${subtitleForRoute("profile")}</div>
         </div>
       </section>
       ${renderSettingsWorkspace(this.renderBody())}

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -7,7 +7,7 @@ import type {
   SessionCompactionCheckpoint,
   SessionsListResult,
 } from "../../api/types.ts";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { hasOperatorWriteAccess } from "../../app/operator-access.ts";
 import { renderAgentScopeControl } from "../../components/agent-scope-control.ts";
@@ -1104,7 +1104,6 @@ class SessionsPage extends OpenClawLightDomElement {
       <section class="content-header content-header--page">
         <div>
           <div class="page-title">${titleForRoute("sessions")}</div>
-          <div class="page-sub">${subtitleForRoute("sessions")}</div>
         </div>
         ${renderAgentScopeControl({
           agents: context.agents.state.agentsList?.agents ?? [],

--- a/ui/src/pages/skill-workshop/skill-workshop-page.ts
+++ b/ui/src/pages/skill-workshop/skill-workshop-page.ts
@@ -129,7 +129,7 @@ function renderSkillWorkshopPage(
     <section class=${pageClass}>
       <section class="content-header content-header--page plugins-content-header">
         <div>
-          <h1 class="page-title">${t("tabs.plugins")}</h1>
+          <h1 class="page-title">${t("tabs.skillWorkshop")}</h1>
         </div>
         <div class="page-meta">
           ${renderSkillWorkshopHeaderControls(state, renderContext, requestUpdate)}

--- a/ui/src/pages/skill-workshop/skill-workshop-page.ts
+++ b/ui/src/pages/skill-workshop/skill-workshop-page.ts
@@ -130,7 +130,6 @@ function renderSkillWorkshopPage(
       <section class="content-header content-header--page plugins-content-header">
         <div>
           <h1 class="page-title">${t("tabs.plugins")}</h1>
-          <div class="page-sub">${t("subtitles.skillWorkshop")}</div>
         </div>
         <div class="page-meta">
           ${renderSkillWorkshopHeaderControls(state, renderContext, requestUpdate)}

--- a/ui/src/pages/skills/skills-page.ts
+++ b/ui/src/pages/skills/skills-page.ts
@@ -352,7 +352,7 @@ class SkillsPage extends OpenClawLightDomElement {
     return html`
       <section class="content-header content-header--page plugins-content-header">
         <div>
-          <h1 class="page-title">${titleForRoute("plugins")}</h1>
+          <h1 class="page-title">${titleForRoute("skills")}</h1>
         </div>
       </section>
       ${renderSettingsWorkspace(html`

--- a/ui/src/pages/skills/skills-page.ts
+++ b/ui/src/pages/skills/skills-page.ts
@@ -3,7 +3,7 @@ import { html, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { AgentsListResult, SkillStatusReport } from "../../api/types.ts";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import {
   applicationContext,
   type ApplicationContext,
@@ -353,7 +353,6 @@ class SkillsPage extends OpenClawLightDomElement {
       <section class="content-header content-header--page plugins-content-header">
         <div>
           <h1 class="page-title">${titleForRoute("plugins")}</h1>
-          <div class="page-sub">${subtitleForRoute("skills")}</div>
         </div>
       </section>
       ${renderSettingsWorkspace(html`

--- a/ui/src/pages/tasks/tasks-page.ts
+++ b/ui/src/pages/tasks/tasks-page.ts
@@ -2,7 +2,7 @@ import { consume } from "@lit/context";
 import { html } from "lit";
 import { state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import {
   applicationContext,
   type ApplicationContext,
@@ -285,7 +285,6 @@ class TasksPage extends OpenClawLightDomElement {
       <section class="content-header content-header--page">
         <div>
           <div class="page-title">${titleForRoute("tasks")}</div>
-          <div class="page-sub">${subtitleForRoute("tasks")}</div>
         </div>
         <div class="page-header-actions">
           ${renderAgentScopeControl({

--- a/ui/src/pages/usage/usage-page.ts
+++ b/ui/src/pages/usage/usage-page.ts
@@ -7,7 +7,7 @@ import type {
   SessionsUsageResult,
   SessionUsageTimeSeries,
 } from "../../api/types.ts";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import {
   applicationContext,
   type ApplicationContext,
@@ -667,7 +667,6 @@ class UsagePage extends OpenClawLightDomElement {
       <section class="content-header content-header--page">
         <div>
           <div class="page-title">${titleForRoute("usage")}</div>
-          <div class="page-sub">${subtitleForRoute("usage")}</div>
         </div>
         ${renderAgentScopeControl({
           agents: this.context.agents.state.agentsList?.agents ?? [],

--- a/ui/src/pages/workboard/workboard-page.ts
+++ b/ui/src/pages/workboard/workboard-page.ts
@@ -1,6 +1,6 @@
 import { consume } from "@lit/context";
 import { html, nothing } from "lit";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { hasOperatorAdminAccess, hasOperatorWriteAccess } from "../../app/operator-access.ts";
 import { renderAgentScopeControl } from "../../components/agent-scope-control.ts";
@@ -200,7 +200,6 @@ class WorkboardPage extends OpenClawLightDomElement {
       <section class="content-header content-header--page">
         <div>
           <div class="page-title">${titleForRoute("workboard")}</div>
-          <div class="page-sub">${subtitleForRoute("workboard")}</div>
         </div>
         ${renderAgentScopeControl({
           agents: context.agents.state.agentsList?.agents ?? [],

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -3,7 +3,7 @@ import { html, nothing } from "lit";
 import { state } from "lit/decorators.js";
 import type { WorktreeRecord } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { titleForRoute } from "../../app-navigation.ts";
 import { pathForRoute } from "../../app-route-paths.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import {
@@ -704,7 +704,6 @@ class WorktreesPage extends OpenClawLightDomElement {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("worktrees")}</div>
-          <div class="page-sub">${subtitleForRoute("worktrees")}</div>
         </div>
       </section>
       ${renderSettingsWorkspace(body)}

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2595,14 +2595,6 @@ openclaw-session-menu[popover] {
   color: var(--accent);
 }
 
-.page-sub {
-  color: var(--muted);
-  font-size: 13px;
-  font-weight: 400;
-  margin-top: 4px;
-  letter-spacing: -0.005em;
-}
-
 .page-meta {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
## What Problem This Solves

Third polish pass on the settings design language (#106470, #106521, #106898): every settings/hub page rendered a one-line subtitle under the headline that mostly restated the nav label the user just clicked ("Channels and settings.", "Edit openclaw.json.", "Active sessions and defaults."). It pushed content down ~28px on every page while sections and rows already carry contextual descriptions next to the things they describe.

## Why This Change Was Made

Headers now read title-only across all 22 settings/hub pages, matching the design-language reference. The genuinely informative subtitles were already duplicated by the first section's description (Connection, Devices), so nothing is lost. Subtitle strings intentionally stay in `app-navigation.ts` — settings-search matching and the sidebar search blocks keep using `subtitleForRoute`, so typing "credentials" still finds Connection. The now-orphaned `.page-sub` rule is deleted.

## User Impact

Cleaner, calmer page headers; the title and header actions (Simple/Advanced switch, agent scope control) sit on one line and content starts sooner. Settings search behavior unchanged. Net −30 lines.

## Evidence

| Page | Before | After |
| --- | --- | --- |
| General | ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-settings-design-language/sub-general-before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-settings-design-language/sub-general-after.png) |
| Sessions | ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-settings-design-language/sub-sessions-before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-settings-design-language/sub-sessions-after.png) |
| Automations | ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-settings-design-language/sub-cron-before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-settings-design-language/sub-cron-after.png) |

- `node scripts/run-vitest.mjs` across all touched page dirs: 506 tests green (remaining local failures are the known Node 26 jsdom `localStorage` environment family in untouched components).
- `rg page-sub` returns zero remaining markup/CSS references; `subtitleForRoute` retained only by `app-navigation.ts` and `settings-sidebar.ts` (search).
- Codex autoreview (`gpt-5.6-sol`, xhigh) ran to convergence: it caught that Skills and Skill Workshop relied on the subtitle for page identity under the hub's "Plugins" title — both now render route-specific titles (`Skills`, `Skill Workshop`) — and a leftover unused `configPageSubtitle` helper; final pass clean.
- Visually verified on General, Sessions, and Automations against the mock gateway.
