### PR TITLE
refactor(agents): privatize provider request helpers

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -740,8 +740,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/agents/provider-attribution.ts: listProviderAttributionPolicies",
   "src/agents/provider-attribution.ts: resolveProviderAttributionIdentity",
   "src/agents/provider-attribution.ts: resolveProviderAttributionPolicy",
-  "src/agents/provider-request-config.ts: mergeProviderRequestOverrides",
-  "src/agents/provider-request-config.ts: sanitizeRuntimeProviderRequestOverrides",
   "src/agents/provider-transport-stream.ts: isTransportAwareApiSupported",
   "src/agents/run-wait.ts: testing",
   "src/agents/session-suspension.ts: testing",

--- a/src/agents/provider-request-config.test.ts
+++ b/src/agents/provider-request-config.test.ts
@@ -6,13 +6,11 @@ import {
   applyPreparedRuntimeAuthToModel,
   buildProviderRequestDispatcherPolicy,
   mergeModelProviderRequestOverrides,
-  mergeProviderRequestOverrides,
   resolveProviderRequestPolicyConfig,
   resolveProviderRequestConfig,
   resolveProviderRequestHeaders,
   sanitizeConfiguredModelProviderRequest,
   sanitizeConfiguredProviderRequest,
-  sanitizeRuntimeProviderRequestOverrides,
 } from "./provider-request-config.js";
 
 describe("provider request config", () => {
@@ -269,15 +267,17 @@ describe("provider request config", () => {
 
   it("rejects proxy and tls runtime auth overrides", () => {
     expect(() =>
-      sanitizeRuntimeProviderRequestOverrides({
-        headers: {
-          "X-Tenant": "acme",
+      applyPreparedRuntimeAuthToModel(
+        { provider: "custom-openai" },
+        {
+          request: {
+            proxy: {
+              mode: "explicit-proxy",
+              url: "http://proxy.internal:8443",
+            },
+          },
         },
-        proxy: {
-          mode: "explicit-proxy",
-          url: "http://proxy.internal:8443",
-        },
-      }),
+      ),
     ).toThrow(/runtime auth request overrides do not allow proxy or tls/i);
   });
 
@@ -412,7 +412,7 @@ describe("provider request config", () => {
 
   it("merges configured request overrides with later entries winning", () => {
     expect(
-      mergeProviderRequestOverrides(
+      mergeModelProviderRequestOverrides(
         {
           headers: {
             "X-Provider": "1",

--- a/src/agents/provider-request-config.ts
+++ b/src/agents/provider-request-config.ts
@@ -358,7 +358,7 @@ export function sanitizeConfiguredModelProviderRequest(
 }
 
 /** Merges provider request overrides with later entries taking precedence. */
-export function mergeProviderRequestOverrides(
+function mergeProviderRequestOverrides(
   ...overrides: Array<ProviderRequestTransportOverrides | undefined>
 ): ProviderRequestTransportOverrides | undefined {
   const merged: ProviderRequestTransportOverrides = {};
@@ -531,7 +531,7 @@ function resolveAuthOverride(params: {
 }
 
 /** Sanitizes runtime-only provider request overrides for auth request paths. */
-export function sanitizeRuntimeProviderRequestOverrides(
+function sanitizeRuntimeProviderRequestOverrides(
   request: ProviderRequestTransportOverrides | undefined,
 ): ProviderRequestTransportOverrides | undefined {
   if (!request) {


### PR DESCRIPTION
## What Problem This Solves

Removes two internal provider-request helpers from the repository's unused-export baseline. They were exported even though production only calls them from public composition functions in the same module, encouraging tests and future callers to couple to implementation details.

## Why This Change Was Made

Make `mergeProviderRequestOverrides` and `sanitizeRuntimeProviderRequestOverrides` module-private. Their tests now exercise the same branches through `mergeModelProviderRequestOverrides` and `applyPreparedRuntimeAuthToModel`, preserving owner-boundary coverage without exposing internals.

## User Impact

No user-visible behavior changes. The provider request contract is unchanged while the internal API surface and dead-export baseline are smaller.

## Evidence

- Exact source search and a fresh codebase-memory graph resolve one production caller for each helper, both in `src/agents/provider-request-config.ts`.
- Codebase-memory index: 313,820 nodes / 1,302,272 edges.
- `pnpm test:serial src/agents/provider-request-config.test.ts`: 30/30 passed.
- `pnpm deadcode:exports`: baseline matched 1,187 entries.
- `pnpm plugin-sdk:api:check`: generated SDK baseline unchanged.
- `pnpm check:changed -- scripts/deadcode-exports.baseline.mjs src/agents/provider-request-config.ts src/agents/provider-request-config.test.ts`: passed.
- Blacksmith Testbox: `tbx_01kxf2ja6gm698eck9te1j8c1r`.
- Fresh `gpt-5.6-sol` medium branch review: 0.96, no findings.

AI-assisted: yes. No transcript attached.
