### PR TITLE
chore: stabilize release validation checks

### DIFF
--- a/src/cron/command-runner.test.ts
+++ b/src/cron/command-runner.test.ts
@@ -151,7 +151,7 @@ describe("runCronCommandJob", () => {
       job: makeCommandJob({
         kind: "command",
         argv: ["sh", "-lc", shellCommand],
-        timeoutSeconds: 0.2,
+        timeoutSeconds: 1,
       }),
     });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes three blocking failures in Full Release Validation for release/2026.7.2: one oxlint error, one test typecheck error, and one timing-sensitive cron process-group test.

## Why This Change Was Made

Keeps release behavior unchanged. Removes a redundant inferred type annotation, gives the Jiti test double its real argument shape, and allows the shell child enough startup time to write its PID before the timeout assertion.

## User Impact

No user-visible behavior change. Release validation can complete reliably.

## Evidence

- Failing release child: https://github.com/openclaw/openclaw/actions/runs/29297525741
- Exact-head CI required before landing.
