### PR TITLE
chore: speed auth planner tests

### DIFF
--- a/src/agents/runtime-plan/prepare-auth.test.ts
+++ b/src/agents/runtime-plan/prepare-auth.test.ts
@@ -1445,6 +1445,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
       cfg: config,
       profileId: profileAttempt?.profileId,
       allowAuthProfileFallback: profileAttempt?.allowAuthProfileFallback,
+      lockedProfile: true,
       store,
     });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the auth planner unit suite spent roughly one minute discovering unrelated plugin synthetic-auth metadata while checking a literal stored profile.

## Why This Change Was Made

The profile materialization assertion now marks its explicitly selected fixture profile as locked. That preserves the planner and credential-resolution coverage while keeping plugin synthetic-profile fallback outside this test's scope.

## User Impact

No user-visible behavior change. The affected CI suite finishes substantially faster.

## Evidence

- Blacksmith Testbox baseline: 58/58 tests, 69.71s Vitest duration; the profile lookup case consumed 64.52s.
- Blacksmith Testbox post-change: 58/58 tests, 5.01s Vitest duration; the same case completed in 33ms.
- Path-scoped changed gate passed: formatting, core test types, lint, and repository guards.
- Autoreview clean: no accepted/actionable findings.
