### PR TITLE
refactor(browser): use Express 5 async routes

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -64,7 +64,7 @@
     "node/no-exports-assign": "error",
     "eslint-plugin-unicorn/prefer-set-size": "error",
     "oxc/no-accumulating-spread": "error",
-    "oxc/no-async-endpoint-handlers": "error",
+    "oxc/no-async-endpoint-handlers": "off",
     "oxc/no-map-spread": "error",
     "promise/no-callback-in-promise": "error",
     "promise/no-multiple-resolved": "error",

--- a/extensions/browser/src/browser/routes/agent.act.download.ts
+++ b/extensions/browser/src/browser/routes/agent.act.download.ts
@@ -18,7 +18,7 @@ import { ensureOutputRootDir, resolveWritableOutputPathOrRespond } from "./outpu
 import { DEFAULT_DOWNLOAD_DIR } from "./path-output.js";
 import { readRouteTimerTimeoutMs } from "./route-numeric.js";
 import type { BrowserRouteRegistrar } from "./types.js";
-import { asyncBrowserRoute, jsonError, toStringOrEmpty } from "./utils.js";
+import { jsonError, toStringOrEmpty } from "./utils.js";
 
 function buildDownloadRequestBase(cdpUrl: string, targetId: string, timeoutMs: number | undefined) {
   return {
@@ -33,113 +33,107 @@ export function registerBrowserAgentActDownloadRoutes(
   app: BrowserRouteRegistrar,
   ctx: BrowserRouteContext,
 ) {
-  app.post(
-    "/wait/download",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = resolveTargetIdFromBody(body);
-      const out = toStringOrEmpty(body.path) || "";
-      let timeoutMs: number | undefined;
-      try {
-        timeoutMs = readRouteTimerTimeoutMs(body.timeoutMs);
-      } catch (err) {
-        return jsonError(res, 400, formatErrorMessage(err));
-      }
+  app.post("/wait/download", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const out = toStringOrEmpty(body.path) || "";
+    let timeoutMs: number | undefined;
+    try {
+      timeoutMs = readRouteTimerTimeoutMs(body.timeoutMs);
+    } catch (err) {
+      return jsonError(res, 400, formatErrorMessage(err));
+    }
 
-      await withRouteTabContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        enforceCurrentUrlAllowed: true,
-        run: async ({ profileCtx, cdpUrl, tab }) => {
-          if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
-            return jsonError(res, 501, EXISTING_SESSION_LIMITS.download.waitUnsupported);
-          }
-          const pw = await requirePwAi(res, "wait for download");
-          if (!pw) {
-            return;
-          }
-          await ensureOutputRootDir(DEFAULT_DOWNLOAD_DIR);
-          let downloadPath: string | undefined;
-          if (out.trim()) {
-            const resolvedDownloadPath = await resolveWritableOutputPathOrRespond({
-              res,
-              rootDir: DEFAULT_DOWNLOAD_DIR,
-              requestedPath: out,
-              scopeLabel: "downloads directory",
-            });
-            if (!resolvedDownloadPath) {
-              return;
-            }
-            downloadPath = resolvedDownloadPath;
-          }
-          const requestBase = buildDownloadRequestBase(cdpUrl, tab.targetId, timeoutMs);
-          const result = await pw.waitForDownloadViaPlaywright({
-            ...requestBase,
-            path: downloadPath,
-            rootDir: DEFAULT_DOWNLOAD_DIR,
-          });
-          res.json({ ok: true, targetId: tab.targetId, download: result });
-        },
-      });
-    }),
-  );
-
-  app.post(
-    "/download",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = resolveTargetIdFromBody(body);
-      const ref = toStringOrEmpty(body.ref);
-      const out = toStringOrEmpty(body.path);
-      let timeoutMs: number | undefined;
-      try {
-        timeoutMs = readRouteTimerTimeoutMs(body.timeoutMs);
-      } catch (err) {
-        return jsonError(res, 400, formatErrorMessage(err));
-      }
-      if (!ref) {
-        return jsonError(res, 400, "ref is required");
-      }
-      if (!out) {
-        return jsonError(res, 400, "path is required");
-      }
-
-      await withRouteTabContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        enforceCurrentUrlAllowed: true,
-        run: async ({ profileCtx, cdpUrl, tab }) => {
-          if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
-            return jsonError(res, 501, EXISTING_SESSION_LIMITS.download.downloadUnsupported);
-          }
-          const pw = await requirePwAi(res, "download");
-          if (!pw) {
-            return;
-          }
-          await ensureOutputRootDir(DEFAULT_DOWNLOAD_DIR);
-          const downloadPath = await resolveWritableOutputPathOrRespond({
+    await withRouteTabContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      enforceCurrentUrlAllowed: true,
+      run: async ({ profileCtx, cdpUrl, tab }) => {
+        if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
+          return jsonError(res, 501, EXISTING_SESSION_LIMITS.download.waitUnsupported);
+        }
+        const pw = await requirePwAi(res, "wait for download");
+        if (!pw) {
+          return;
+        }
+        await ensureOutputRootDir(DEFAULT_DOWNLOAD_DIR);
+        let downloadPath: string | undefined;
+        if (out.trim()) {
+          const resolvedDownloadPath = await resolveWritableOutputPathOrRespond({
             res,
             rootDir: DEFAULT_DOWNLOAD_DIR,
             requestedPath: out,
             scopeLabel: "downloads directory",
           });
-          if (!downloadPath) {
+          if (!resolvedDownloadPath) {
             return;
           }
-          const requestBase = buildDownloadRequestBase(cdpUrl, tab.targetId, timeoutMs);
-          const result = await pw.downloadViaPlaywright({
-            ...requestBase,
-            ref,
-            path: downloadPath,
-            rootDir: DEFAULT_DOWNLOAD_DIR,
-          });
-          res.json({ ok: true, targetId: tab.targetId, download: result });
-        },
-      });
-    }),
-  );
+          downloadPath = resolvedDownloadPath;
+        }
+        const requestBase = buildDownloadRequestBase(cdpUrl, tab.targetId, timeoutMs);
+        const result = await pw.waitForDownloadViaPlaywright({
+          ...requestBase,
+          path: downloadPath,
+          rootDir: DEFAULT_DOWNLOAD_DIR,
+        });
+        res.json({ ok: true, targetId: tab.targetId, download: result });
+      },
+    });
+  });
+
+  app.post("/download", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const ref = toStringOrEmpty(body.ref);
+    const out = toStringOrEmpty(body.path);
+    let timeoutMs: number | undefined;
+    try {
+      timeoutMs = readRouteTimerTimeoutMs(body.timeoutMs);
+    } catch (err) {
+      return jsonError(res, 400, formatErrorMessage(err));
+    }
+    if (!ref) {
+      return jsonError(res, 400, "ref is required");
+    }
+    if (!out) {
+      return jsonError(res, 400, "path is required");
+    }
+
+    await withRouteTabContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      enforceCurrentUrlAllowed: true,
+      run: async ({ profileCtx, cdpUrl, tab }) => {
+        if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
+          return jsonError(res, 501, EXISTING_SESSION_LIMITS.download.downloadUnsupported);
+        }
+        const pw = await requirePwAi(res, "download");
+        if (!pw) {
+          return;
+        }
+        await ensureOutputRootDir(DEFAULT_DOWNLOAD_DIR);
+        const downloadPath = await resolveWritableOutputPathOrRespond({
+          res,
+          rootDir: DEFAULT_DOWNLOAD_DIR,
+          requestedPath: out,
+          scopeLabel: "downloads directory",
+        });
+        if (!downloadPath) {
+          return;
+        }
+        const requestBase = buildDownloadRequestBase(cdpUrl, tab.targetId, timeoutMs);
+        const result = await pw.downloadViaPlaywright({
+          ...requestBase,
+          ref,
+          path: downloadPath,
+          rootDir: DEFAULT_DOWNLOAD_DIR,
+        });
+        res.json({ ok: true, targetId: tab.targetId, download: result });
+      },
+    });
+  });
 }

--- a/extensions/browser/src/browser/routes/agent.act.hooks.ts
+++ b/extensions/browser/src/browser/routes/agent.act.hooks.ts
@@ -18,157 +18,146 @@ import {
 import { EXISTING_SESSION_LIMITS } from "./existing-session-limits.js";
 import { readRouteTimerTimeoutMs } from "./route-numeric.js";
 import type { BrowserRouteRegistrar } from "./types.js";
-import {
-  asyncBrowserRoute,
-  jsonError,
-  toBoolean,
-  toStringArray,
-  toStringOrEmpty,
-} from "./utils.js";
+import { jsonError, toBoolean, toStringArray, toStringOrEmpty } from "./utils.js";
 
 /** Register file chooser and dialog hook endpoints on the browser control server. */
 export function registerBrowserAgentActHookRoutes(
   app: BrowserRouteRegistrar,
   ctx: BrowserRouteContext,
 ) {
-  app.post(
-    "/hooks/file-chooser",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = resolveTargetIdFromBody(body);
-      const ref = toStringOrEmpty(body.ref) || undefined;
-      const inputRef = toStringOrEmpty(body.inputRef) || undefined;
-      const element = toStringOrEmpty(body.element) || undefined;
-      const paths = toStringArray(body.paths) ?? [];
-      let timeoutMs: number | undefined;
-      try {
-        timeoutMs = readRouteTimerTimeoutMs(body.timeoutMs);
-      } catch (err) {
-        return jsonError(res, 400, formatErrorMessage(err));
-      }
-      if (!paths.length) {
-        return jsonError(res, 400, "paths are required");
-      }
+  app.post("/hooks/file-chooser", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const ref = toStringOrEmpty(body.ref) || undefined;
+    const inputRef = toStringOrEmpty(body.inputRef) || undefined;
+    const element = toStringOrEmpty(body.element) || undefined;
+    const paths = toStringArray(body.paths) ?? [];
+    let timeoutMs: number | undefined;
+    try {
+      timeoutMs = readRouteTimerTimeoutMs(body.timeoutMs);
+    } catch (err) {
+      return jsonError(res, 400, formatErrorMessage(err));
+    }
+    if (!paths.length) {
+      return jsonError(res, 400, "paths are required");
+    }
 
-      await withRouteTabContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        enforceCurrentUrlAllowed: true,
-        run: async ({ profileCtx, cdpUrl, tab, signal }) => {
-          const resolvedResult = await resolveExistingUploadPaths({ requestedPaths: paths });
-          if (!resolvedResult.ok) {
-            res.status(400).json({ error: resolvedResult.error });
-            return;
+    await withRouteTabContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      enforceCurrentUrlAllowed: true,
+      run: async ({ profileCtx, cdpUrl, tab, signal }) => {
+        const resolvedResult = await resolveExistingUploadPaths({ requestedPaths: paths });
+        if (!resolvedResult.ok) {
+          res.status(400).json({ error: resolvedResult.error });
+          return;
+        }
+        const resolvedPaths = resolvedResult.paths;
+
+        if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
+          if (element) {
+            return jsonError(res, 501, EXISTING_SESSION_LIMITS.hooks.uploadElement);
           }
-          const resolvedPaths = resolvedResult.paths;
-
-          if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
-            if (element) {
-              return jsonError(res, 501, EXISTING_SESSION_LIMITS.hooks.uploadElement);
-            }
-            if (resolvedPaths.length !== 1) {
-              return jsonError(res, 501, EXISTING_SESSION_LIMITS.hooks.uploadSingleFile);
-            }
-            const uid = inputRef || ref;
-            if (!uid) {
-              return jsonError(res, 501, EXISTING_SESSION_LIMITS.hooks.uploadRefRequired);
-            }
-            await uploadChromeMcpFile({
-              profileName: profileCtx.profile.name,
-              profile: profileCtx.profile,
-              targetId: tab.targetId,
-              uid,
-              filePath: resolvedPaths[0] ?? "",
-              timeoutMs: timeoutMs ?? ctx.state().resolved.actionTimeoutMs,
-              signal,
-            });
-            return res.json({ ok: true });
+          if (resolvedPaths.length !== 1) {
+            return jsonError(res, 501, EXISTING_SESSION_LIMITS.hooks.uploadSingleFile);
           }
-
-          const pw = await requirePwAi(res, "file chooser hook");
-          if (!pw) {
-            return;
+          const uid = inputRef || ref;
+          if (!uid) {
+            return jsonError(res, 501, EXISTING_SESSION_LIMITS.hooks.uploadRefRequired);
           }
+          await uploadChromeMcpFile({
+            profileName: profileCtx.profile.name,
+            profile: profileCtx.profile,
+            targetId: tab.targetId,
+            uid,
+            filePath: resolvedPaths[0] ?? "",
+            timeoutMs: timeoutMs ?? ctx.state().resolved.actionTimeoutMs,
+            signal,
+          });
+          return res.json({ ok: true });
+        }
 
-          if (inputRef || element) {
-            if (ref) {
-              return jsonError(res, 400, "ref cannot be combined with inputRef/element");
-            }
-            await pw.setInputFilesViaPlaywright({
-              cdpUrl,
-              targetId: tab.targetId,
-              inputRef,
-              element,
-              paths: resolvedPaths,
-              ssrfPolicy: ctx.state().resolved.ssrfPolicy,
-            });
-          } else if (ref) {
-            await pw.uploadViaPlaywright({
-              cdpUrl,
-              targetId: tab.targetId,
-              paths: resolvedPaths,
-              timeoutMs: timeoutMs ?? undefined,
-              ssrfPolicy: ctx.state().resolved.ssrfPolicy,
-              ref,
-              signal,
-            });
-          } else {
-            await pw.armFileUploadViaPlaywright({
-              cdpUrl,
-              targetId: tab.targetId,
-              paths: resolvedPaths,
-              timeoutMs: timeoutMs ?? undefined,
-            });
+        const pw = await requirePwAi(res, "file chooser hook");
+        if (!pw) {
+          return;
+        }
+
+        if (inputRef || element) {
+          if (ref) {
+            return jsonError(res, 400, "ref cannot be combined with inputRef/element");
           }
-          res.json({ ok: true });
-        },
-      });
-    }),
-  );
+          await pw.setInputFilesViaPlaywright({
+            cdpUrl,
+            targetId: tab.targetId,
+            inputRef,
+            element,
+            paths: resolvedPaths,
+            ssrfPolicy: ctx.state().resolved.ssrfPolicy,
+          });
+        } else if (ref) {
+          await pw.uploadViaPlaywright({
+            cdpUrl,
+            targetId: tab.targetId,
+            paths: resolvedPaths,
+            timeoutMs: timeoutMs ?? undefined,
+            ssrfPolicy: ctx.state().resolved.ssrfPolicy,
+            ref,
+            signal,
+          });
+        } else {
+          await pw.armFileUploadViaPlaywright({
+            cdpUrl,
+            targetId: tab.targetId,
+            paths: resolvedPaths,
+            timeoutMs: timeoutMs ?? undefined,
+          });
+        }
+        res.json({ ok: true });
+      },
+    });
+  });
 
-  app.post(
-    "/hooks/dialog",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = resolveTargetIdFromBody(body);
-      const accept = toBoolean(body.accept);
-      const promptText = toStringOrEmpty(body.promptText) || undefined;
-      let timeoutMs: number | undefined;
-      try {
-        timeoutMs = readRouteTimerTimeoutMs(body.timeoutMs);
-      } catch (err) {
-        return jsonError(res, 400, formatErrorMessage(err));
-      }
-      const dialogId = toStringOrEmpty(body.dialogId) || undefined;
-      if (accept === undefined) {
-        return jsonError(res, 400, "accept is required");
-      }
+  app.post("/hooks/dialog", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const accept = toBoolean(body.accept);
+    const promptText = toStringOrEmpty(body.promptText) || undefined;
+    let timeoutMs: number | undefined;
+    try {
+      timeoutMs = readRouteTimerTimeoutMs(body.timeoutMs);
+    } catch (err) {
+      return jsonError(res, 400, formatErrorMessage(err));
+    }
+    const dialogId = toStringOrEmpty(body.dialogId) || undefined;
+    if (accept === undefined) {
+      return jsonError(res, 400, "accept is required");
+    }
 
-      await withRouteTabContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        enforceCurrentUrlAllowed: true,
-        run: async ({ profileCtx, cdpUrl, tab, signal }) => {
-          if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
-            if (dialogId) {
-              return jsonError(res, 501, EXISTING_SESSION_LIMITS.hooks.dialogId);
-            }
-            if (timeoutMs) {
-              return jsonError(res, 501, EXISTING_SESSION_LIMITS.hooks.dialogTimeout);
-            }
-            await evaluateChromeMcpScript({
-              profileName: profileCtx.profile.name,
-              profile: profileCtx.profile,
-              targetId: tab.targetId,
-              timeoutMs: ctx.state().resolved.actionTimeoutMs,
-              signal,
-              // Existing-session Chrome MCP has no dialog hook primitive. Patch
-              // one-shot window dialog functions in-page, then restore them.
-              fn: `() => {
+    await withRouteTabContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      enforceCurrentUrlAllowed: true,
+      run: async ({ profileCtx, cdpUrl, tab, signal }) => {
+        if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
+          if (dialogId) {
+            return jsonError(res, 501, EXISTING_SESSION_LIMITS.hooks.dialogId);
+          }
+          if (timeoutMs) {
+            return jsonError(res, 501, EXISTING_SESSION_LIMITS.hooks.dialogTimeout);
+          }
+          await evaluateChromeMcpScript({
+            profileName: profileCtx.profile.name,
+            profile: profileCtx.profile,
+            targetId: tab.targetId,
+            timeoutMs: ctx.state().resolved.actionTimeoutMs,
+            signal,
+            // Existing-session Chrome MCP has no dialog hook primitive. Patch
+            // one-shot window dialog functions in-page, then restore them.
+            fn: `() => {
               const state = (window.__openclawDialogHook ??= {});
               if (!state.originals) {
                 state.originals = {
@@ -207,24 +196,23 @@ export function registerBrowserAgentActHookRoutes(
               };
               return true;
             }`,
-            });
-            return res.json({ ok: true });
-          }
-          const pw = await requirePwAi(res, "dialog hook");
-          if (!pw) {
-            return;
-          }
-          await pw.armDialogViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            dialogId,
-            accept,
-            promptText,
-            timeoutMs: timeoutMs ?? undefined,
           });
-          res.json({ ok: true });
-        },
-      });
-    }),
-  );
+          return res.json({ ok: true });
+        }
+        const pw = await requirePwAi(res, "dialog hook");
+        if (!pw) {
+          return;
+        }
+        await pw.armDialogViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          dialogId,
+          accept,
+          promptText,
+          timeoutMs: timeoutMs ?? undefined,
+        });
+        res.json({ ok: true });
+      },
+    });
+  });
 }

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -54,7 +54,7 @@ import { resolveTargetIdAfterNavigate } from "./agent.snapshot-target.js";
 import { EXISTING_SESSION_LIMITS } from "./existing-session-limits.js";
 import { readRoutePositiveInteger, readRouteTimerTimeoutMs } from "./route-numeric.js";
 import type { BrowserRouteRegistrar } from "./types.js";
-import { asyncBrowserRoute, jsonError, toStringOrEmpty } from "./utils.js";
+import { jsonError, toStringOrEmpty } from "./utils.js";
 
 const EXISTING_SESSION_INTERACTION_NAVIGATION_RECHECK_DELAYS_MS = [0, 250, 500] as const;
 
@@ -410,436 +410,428 @@ export function registerBrowserAgentActRoutes(
   app: BrowserRouteRegistrar,
   ctx: BrowserRouteContext,
 ) {
-  app.post(
-    "/act",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const kindRaw = toStringOrEmpty(body.kind);
-      if (!isActKind(kindRaw)) {
-        return jsonActError(res, 400, ACT_ERROR_CODES.kindRequired, "kind is required");
-      }
-      const kind: ActKind = kindRaw;
-      let action: BrowserActRequest;
-      try {
-        action = normalizeActRequest(body);
-      } catch (err) {
-        return jsonActError(res, 400, ACT_ERROR_CODES.invalidRequest, formatErrorMessage(err));
-      }
-      const targetId = resolveTargetIdFromBody(body);
-      if (Object.hasOwn(body, "selector") && !SELECTOR_ALLOWED_KINDS.has(kind)) {
-        return jsonActError(
-          res,
-          400,
-          ACT_ERROR_CODES.selectorUnsupported,
-          SELECTOR_UNSUPPORTED_MESSAGE,
-        );
-      }
-      const earlyFn = action.kind === "wait" || action.kind === "evaluate" ? action.fn : "";
-      if (
-        (action.kind === "evaluate" || (action.kind === "wait" && earlyFn)) &&
-        !ctx.state().resolved.evaluateEnabled
-      ) {
-        return jsonActError(
-          res,
-          403,
-          ACT_ERROR_CODES.evaluateDisabled,
-          browserEvaluateDisabledMessage(action.kind === "evaluate" ? "evaluate" : "wait"),
-        );
-      }
-
-      await withRouteTabContext({
-        req,
+  app.post("/act", async (req, res) => {
+    const body = readBody(req);
+    const kindRaw = toStringOrEmpty(body.kind);
+    if (!isActKind(kindRaw)) {
+      return jsonActError(res, 400, ACT_ERROR_CODES.kindRequired, "kind is required");
+    }
+    const kind: ActKind = kindRaw;
+    let action: BrowserActRequest;
+    try {
+      action = normalizeActRequest(body);
+    } catch (err) {
+      return jsonActError(res, 400, ACT_ERROR_CODES.invalidRequest, formatErrorMessage(err));
+    }
+    const targetId = resolveTargetIdFromBody(body);
+    if (Object.hasOwn(body, "selector") && !SELECTOR_ALLOWED_KINDS.has(kind)) {
+      return jsonActError(
         res,
-        ctx,
-        targetId,
-        enforceCurrentUrlAllowed: shouldEnforceCurrentUrlForAct(action),
-        run: async ({ profileCtx, cdpUrl, tab, signal, resolveTabUrl }) => {
-          const evaluateEnabled = ctx.state().resolved.evaluateEnabled;
-          const navigationPolicy = browserNavigationPolicyForProfile(ctx, profileCtx);
-          const isExistingSession = getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp;
-          const requestedTimeoutMs =
-            "timeoutMs" in action && typeof action.timeoutMs === "number"
-              ? action.timeoutMs
-              : undefined;
-          const existingSessionCallOptions: ChromeMcpOperationOptions = {
-            timeoutMs: requestedTimeoutMs ?? ctx.state().resolved.actionTimeoutMs,
-            signal,
+        400,
+        ACT_ERROR_CODES.selectorUnsupported,
+        SELECTOR_UNSUPPORTED_MESSAGE,
+      );
+    }
+    const earlyFn = action.kind === "wait" || action.kind === "evaluate" ? action.fn : "";
+    if (
+      (action.kind === "evaluate" || (action.kind === "wait" && earlyFn)) &&
+      !ctx.state().resolved.evaluateEnabled
+    ) {
+      return jsonActError(
+        res,
+        403,
+        ACT_ERROR_CODES.evaluateDisabled,
+        browserEvaluateDisabledMessage(action.kind === "evaluate" ? "evaluate" : "wait"),
+      );
+    }
+
+    await withRouteTabContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      enforceCurrentUrlAllowed: shouldEnforceCurrentUrlForAct(action),
+      run: async ({ profileCtx, cdpUrl, tab, signal, resolveTabUrl }) => {
+        const evaluateEnabled = ctx.state().resolved.evaluateEnabled;
+        const navigationPolicy = browserNavigationPolicyForProfile(ctx, profileCtx);
+        const isExistingSession = getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp;
+        const requestedTimeoutMs =
+          "timeoutMs" in action && typeof action.timeoutMs === "number"
+            ? action.timeoutMs
+            : undefined;
+        const existingSessionCallOptions: ChromeMcpOperationOptions = {
+          timeoutMs: requestedTimeoutMs ?? ctx.state().resolved.actionTimeoutMs,
+          signal,
+        };
+        const hasNavigationResultPolicy = Boolean(
+          navigationPolicy.ssrfPolicy || navigationPolicy.browserProxyMode,
+        );
+        const jsonOk = async (
+          extra?: Record<string, unknown>,
+          options?: { resolveCurrentTarget?: boolean },
+        ) => {
+          const shouldResolveCurrentTarget =
+            options?.resolveCurrentTarget && (!isExistingSession || hasNavigationResultPolicy);
+          const responseTargetId = shouldResolveCurrentTarget
+            ? await resolveTargetIdAfterNavigate({
+                oldTargetId: tab.targetId,
+                navigatedUrl: tab.url,
+                listTabs: () => profileCtx.listTabs(existingSessionCallOptions),
+              })
+            : tab.targetId;
+          const url =
+            responseTargetId === tab.targetId
+              ? await resolveTabUrl(tab.url)
+              : await resolveSafeRouteTabUrl({
+                  ctx,
+                  profileCtx,
+                  targetId: responseTargetId,
+                  fallbackUrl: tab.url,
+                  ...(isExistingSession ? existingSessionCallOptions : {}),
+                });
+          return res.json({
+            ok: true,
+            targetId: responseTargetId,
+            ...(url ? { url } : {}),
+            ...extra,
+          });
+        };
+        // Nested batch aliases can differ from the request alias, so prefixes
+        // must stay unique across the full tab set before canonicalization.
+        const actionTabs =
+          action.kind === "batch" && !isExistingSession ? await profileCtx.listTabs() : [tab];
+        if (!actionTabs.some((candidate) => candidate.targetId === tab.targetId)) {
+          actionTabs.unshift(tab);
+        }
+        const targetIdError = canonicalizeActTargetIds(action, tab, actionTabs);
+        if (targetIdError) {
+          return jsonActError(res, 403, ACT_ERROR_CODES.targetIdMismatch, targetIdError);
+        }
+        const profileName = profileCtx.profile.name;
+        if (isExistingSession) {
+          const existingSessionTarget: ExistingSessionOperation = {
+            profileName,
+            profile: profileCtx.profile,
+            targetId: tab.targetId,
+            ...existingSessionCallOptions,
           };
-          const hasNavigationResultPolicy = Boolean(
-            navigationPolicy.ssrfPolicy || navigationPolicy.browserProxyMode,
-          );
-          const jsonOk = async (
-            extra?: Record<string, unknown>,
-            options?: { resolveCurrentTarget?: boolean },
-          ) => {
-            const shouldResolveCurrentTarget =
-              options?.resolveCurrentTarget && (!isExistingSession || hasNavigationResultPolicy);
-            const responseTargetId = shouldResolveCurrentTarget
-              ? await resolveTargetIdAfterNavigate({
-                  oldTargetId: tab.targetId,
-                  navigatedUrl: tab.url,
-                  listTabs: () => profileCtx.listTabs(existingSessionCallOptions),
-                })
-              : tab.targetId;
-            const url =
-              responseTargetId === tab.targetId
-                ? await resolveTabUrl(tab.url)
-                : await resolveSafeRouteTabUrl({
-                    ctx,
-                    profileCtx,
-                    targetId: responseTargetId,
-                    fallbackUrl: tab.url,
-                    ...(isExistingSession ? existingSessionCallOptions : {}),
+          const initialTabTargetIds = hasNavigationResultPolicy
+            ? new Set(
+                (await profileCtx.listTabs(existingSessionCallOptions)).map(
+                  (currentTab) => currentTab.targetId,
+                ),
+              )
+            : new Set<string>();
+          const existingSessionNavigationGuard = {
+            ...existingSessionTarget,
+            ...navigationPolicy,
+            listTabs: () => profileCtx.listTabs(existingSessionCallOptions),
+            initialTabTargetIds,
+          };
+          const unsupportedMessage = getExistingSessionUnsupportedMessage(action);
+          if (unsupportedMessage) {
+            return jsonActError(
+              res,
+              501,
+              ACT_ERROR_CODES.unsupportedForExistingSession,
+              unsupportedMessage,
+            );
+          }
+          switch (action.kind) {
+            case "click":
+              await runExistingSessionActionWithNavigationGuard({
+                execute: () =>
+                  clickChromeMcpElement({
+                    ...existingSessionTarget,
+                    uid: action.ref!,
+                    doubleClick: action.doubleClick ?? false,
+                  }),
+                guard: existingSessionNavigationGuard,
+              });
+              return await jsonOk(undefined, { resolveCurrentTarget: true });
+            case "clickCoords":
+              await runExistingSessionActionWithNavigationGuard({
+                execute: () =>
+                  clickChromeMcpCoords({
+                    ...existingSessionTarget,
+                    x: action.x,
+                    y: action.y,
+                    doubleClick: action.doubleClick ?? false,
+                    button: action.button as "left" | "right" | "middle" | undefined,
+                    delayMs: action.delayMs,
+                  }),
+                guard: existingSessionNavigationGuard,
+              });
+              return await jsonOk(undefined, { resolveCurrentTarget: true });
+            case "type":
+              await runExistingSessionActionWithNavigationGuard({
+                execute: async () => {
+                  await fillChromeMcpElement({
+                    ...existingSessionTarget,
+                    uid: action.ref!,
+                    value: action.text,
                   });
-            return res.json({
-              ok: true,
-              targetId: responseTargetId,
-              ...(url ? { url } : {}),
-              ...extra,
-            });
-          };
-          // Nested batch aliases can differ from the request alias, so prefixes
-          // must stay unique across the full tab set before canonicalization.
-          const actionTabs =
-            action.kind === "batch" && !isExistingSession ? await profileCtx.listTabs() : [tab];
-          if (!actionTabs.some((candidate) => candidate.targetId === tab.targetId)) {
-            actionTabs.unshift(tab);
-          }
-          const targetIdError = canonicalizeActTargetIds(action, tab, actionTabs);
-          if (targetIdError) {
-            return jsonActError(res, 403, ACT_ERROR_CODES.targetIdMismatch, targetIdError);
-          }
-          const profileName = profileCtx.profile.name;
-          if (isExistingSession) {
-            const existingSessionTarget: ExistingSessionOperation = {
-              profileName,
-              profile: profileCtx.profile,
-              targetId: tab.targetId,
-              ...existingSessionCallOptions,
-            };
-            const initialTabTargetIds = hasNavigationResultPolicy
-              ? new Set(
-                  (await profileCtx.listTabs(existingSessionCallOptions)).map(
-                    (currentTab) => currentTab.targetId,
-                  ),
-                )
-              : new Set<string>();
-            const existingSessionNavigationGuard = {
-              ...existingSessionTarget,
-              ...navigationPolicy,
-              listTabs: () => profileCtx.listTabs(existingSessionCallOptions),
-              initialTabTargetIds,
-            };
-            const unsupportedMessage = getExistingSessionUnsupportedMessage(action);
-            if (unsupportedMessage) {
+                  if (action.submit) {
+                    await pressChromeMcpKey({
+                      ...existingSessionTarget,
+                      key: "Enter",
+                    });
+                  }
+                },
+                guard: existingSessionNavigationGuard,
+              });
+              return await jsonOk(undefined, { resolveCurrentTarget: true });
+            case "press":
+              await runExistingSessionActionWithNavigationGuard({
+                execute: () =>
+                  pressChromeMcpKey({
+                    ...existingSessionTarget,
+                    key: action.key,
+                  }),
+                guard: existingSessionNavigationGuard,
+              });
+              return await jsonOk(undefined, { resolveCurrentTarget: true });
+            case "hover":
+              await runExistingSessionActionWithNavigationGuard({
+                execute: () =>
+                  hoverChromeMcpElement({
+                    ...existingSessionTarget,
+                    uid: action.ref!,
+                  }),
+                guard: existingSessionNavigationGuard,
+              });
+              return await jsonOk(undefined, { resolveCurrentTarget: true });
+            case "scrollIntoView":
+              await runExistingSessionActionWithNavigationGuard({
+                execute: () =>
+                  evaluateChromeMcpScript({
+                    ...existingSessionTarget,
+                    fn: `(el) => { el.scrollIntoView({ block: "center", inline: "center" }); return true; }`,
+                    args: [action.ref!],
+                  }),
+                guard: existingSessionNavigationGuard,
+              });
+              return await jsonOk(undefined, { resolveCurrentTarget: true });
+            case "drag":
+              await runExistingSessionActionWithNavigationGuard({
+                execute: () =>
+                  dragChromeMcpElement({
+                    ...existingSessionTarget,
+                    fromUid: action.startRef!,
+                    toUid: action.endRef!,
+                  }),
+                guard: existingSessionNavigationGuard,
+              });
+              return await jsonOk(undefined, { resolveCurrentTarget: true });
+            case "select":
+              await runExistingSessionActionWithNavigationGuard({
+                execute: () =>
+                  fillChromeMcpElement({
+                    ...existingSessionTarget,
+                    uid: action.ref!,
+                    value: action.values[0] ?? "",
+                  }),
+                guard: existingSessionNavigationGuard,
+              });
+              return await jsonOk(undefined, { resolveCurrentTarget: true });
+            case "fill":
+              await runExistingSessionActionWithNavigationGuard({
+                execute: () =>
+                  fillChromeMcpForm({
+                    ...existingSessionTarget,
+                    elements: action.fields.map((field) => ({
+                      uid: field.ref,
+                      value: String(field.value ?? ""),
+                    })),
+                  }),
+                guard: existingSessionNavigationGuard,
+              });
+              return await jsonOk(undefined, { resolveCurrentTarget: true });
+            case "resize":
+              await resizeChromeMcpPage({
+                ...existingSessionTarget,
+                width: action.width,
+                height: action.height,
+              });
+              return await jsonOk();
+            case "wait":
+              await runExistingSessionActionWithNavigationGuard({
+                execute: () =>
+                  waitForExistingSessionCondition({
+                    ...existingSessionTarget,
+                    timeMs: action.timeMs,
+                    text: action.text,
+                    textGone: action.textGone,
+                    selector: action.selector,
+                    url: action.url,
+                    loadState: action.loadState,
+                    fn: action.fn,
+                    ...navigationPolicy,
+                  }),
+                guard: existingSessionNavigationGuard,
+              });
+              return await jsonOk();
+            case "evaluate": {
+              const result = await runExistingSessionActionWithNavigationGuard({
+                execute: () =>
+                  evaluateChromeMcpScript({
+                    ...existingSessionTarget,
+                    fn: normalizeBrowserEvaluateFunctionSource(
+                      action.fn,
+                      action.ref ? { argumentName: "el" } : undefined,
+                    ),
+                    args: action.ref ? [action.ref] : undefined,
+                  }),
+                guard: existingSessionNavigationGuard,
+              });
+              return await jsonOk({ result }, { resolveCurrentTarget: true });
+            }
+            case "close":
+              await profileCtx.closeTab(tab.targetId, {
+                ...existingSessionCallOptions,
+                exactTargetId: true,
+              });
+              return await jsonOk();
+            case "batch":
               return jsonActError(
                 res,
                 501,
                 ACT_ERROR_CODES.unsupportedForExistingSession,
-                unsupportedMessage,
+                EXISTING_SESSION_LIMITS.act.batch,
               );
-            }
-            switch (action.kind) {
-              case "click":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    clickChromeMcpElement({
-                      ...existingSessionTarget,
-                      uid: action.ref!,
-                      doubleClick: action.doubleClick ?? false,
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
-                return await jsonOk(undefined, { resolveCurrentTarget: true });
-              case "clickCoords":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    clickChromeMcpCoords({
-                      ...existingSessionTarget,
-                      x: action.x,
-                      y: action.y,
-                      doubleClick: action.doubleClick ?? false,
-                      button: action.button as "left" | "right" | "middle" | undefined,
-                      delayMs: action.delayMs,
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
-                return await jsonOk(undefined, { resolveCurrentTarget: true });
-              case "type":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: async () => {
-                    await fillChromeMcpElement({
-                      ...existingSessionTarget,
-                      uid: action.ref!,
-                      value: action.text,
-                    });
-                    if (action.submit) {
-                      await pressChromeMcpKey({
-                        ...existingSessionTarget,
-                        key: "Enter",
-                      });
-                    }
-                  },
-                  guard: existingSessionNavigationGuard,
-                });
-                return await jsonOk(undefined, { resolveCurrentTarget: true });
-              case "press":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    pressChromeMcpKey({
-                      ...existingSessionTarget,
-                      key: action.key,
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
-                return await jsonOk(undefined, { resolveCurrentTarget: true });
-              case "hover":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    hoverChromeMcpElement({
-                      ...existingSessionTarget,
-                      uid: action.ref!,
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
-                return await jsonOk(undefined, { resolveCurrentTarget: true });
-              case "scrollIntoView":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    evaluateChromeMcpScript({
-                      ...existingSessionTarget,
-                      fn: `(el) => { el.scrollIntoView({ block: "center", inline: "center" }); return true; }`,
-                      args: [action.ref!],
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
-                return await jsonOk(undefined, { resolveCurrentTarget: true });
-              case "drag":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    dragChromeMcpElement({
-                      ...existingSessionTarget,
-                      fromUid: action.startRef!,
-                      toUid: action.endRef!,
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
-                return await jsonOk(undefined, { resolveCurrentTarget: true });
-              case "select":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    fillChromeMcpElement({
-                      ...existingSessionTarget,
-                      uid: action.ref!,
-                      value: action.values[0] ?? "",
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
-                return await jsonOk(undefined, { resolveCurrentTarget: true });
-              case "fill":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    fillChromeMcpForm({
-                      ...existingSessionTarget,
-                      elements: action.fields.map((field) => ({
-                        uid: field.ref,
-                        value: String(field.value ?? ""),
-                      })),
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
-                return await jsonOk(undefined, { resolveCurrentTarget: true });
-              case "resize":
-                await resizeChromeMcpPage({
-                  ...existingSessionTarget,
-                  width: action.width,
-                  height: action.height,
-                });
-                return await jsonOk();
-              case "wait":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    waitForExistingSessionCondition({
-                      ...existingSessionTarget,
-                      timeMs: action.timeMs,
-                      text: action.text,
-                      textGone: action.textGone,
-                      selector: action.selector,
-                      url: action.url,
-                      loadState: action.loadState,
-                      fn: action.fn,
-                      ...navigationPolicy,
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
-                return await jsonOk();
-              case "evaluate": {
-                const result = await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    evaluateChromeMcpScript({
-                      ...existingSessionTarget,
-                      fn: normalizeBrowserEvaluateFunctionSource(
-                        action.fn,
-                        action.ref ? { argumentName: "el" } : undefined,
-                      ),
-                      args: action.ref ? [action.ref] : undefined,
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
-                return await jsonOk({ result }, { resolveCurrentTarget: true });
-              }
-              case "close":
-                await profileCtx.closeTab(tab.targetId, {
-                  ...existingSessionCallOptions,
-                  exactTargetId: true,
-                });
-                return await jsonOk();
-              case "batch":
-                return jsonActError(
-                  res,
-                  501,
-                  ACT_ERROR_CODES.unsupportedForExistingSession,
-                  EXISTING_SESSION_LIMITS.act.batch,
-                );
-            }
           }
+        }
 
-          const pw = await requirePwAi(res, `act:${kind}`);
-          if (!pw) {
-            return;
-          }
-          const result = await pw.executeActViaPlaywright({
-            cdpUrl,
-            action,
-            targetId: tab.targetId,
-            evaluateEnabled,
-            ...navigationPolicy,
-            signal,
+        const pw = await requirePwAi(res, `act:${kind}`);
+        if (!pw) {
+          return;
+        }
+        const result = await pw.executeActViaPlaywright({
+          cdpUrl,
+          action,
+          targetId: tab.targetId,
+          evaluateEnabled,
+          ...navigationPolicy,
+          signal,
+        });
+        if (result.blockedByDialog) {
+          return await jsonOk({
+            blockedByDialog: true,
+            browserState: result.browserState,
           });
-          if (result.blockedByDialog) {
-            return await jsonOk({
-              blockedByDialog: true,
-              browserState: result.browserState,
+        }
+        const downloads = result.downloads;
+        switch (action.kind) {
+          case "batch":
+            return await jsonOk(
+              { results: result.results ?? [], ...(downloads ? { downloads } : {}) },
+              { resolveCurrentTarget: true },
+            );
+          case "evaluate":
+            return await jsonOk(
+              { result: result.result, ...(downloads ? { downloads } : {}) },
+              { resolveCurrentTarget: true },
+            );
+          case "click":
+          case "clickCoords":
+            return await jsonOk(downloads ? { downloads } : undefined, {
+              resolveCurrentTarget: true,
             });
-          }
-          const downloads = result.downloads;
-          switch (action.kind) {
-            case "batch":
-              return await jsonOk(
-                { results: result.results ?? [], ...(downloads ? { downloads } : {}) },
-                { resolveCurrentTarget: true },
-              );
-            case "evaluate":
-              return await jsonOk(
-                { result: result.result, ...(downloads ? { downloads } : {}) },
-                { resolveCurrentTarget: true },
-              );
-            case "click":
-            case "clickCoords":
-              return await jsonOk(downloads ? { downloads } : undefined, {
-                resolveCurrentTarget: true,
-              });
-            case "resize":
-              return await jsonOk(downloads ? { downloads } : undefined);
-            default:
-              return await jsonOk(downloads ? { downloads } : undefined, {
-                resolveCurrentTarget: true,
-              });
-          }
-        },
-      });
-    }),
-  );
+          case "resize":
+            return await jsonOk(downloads ? { downloads } : undefined);
+          default:
+            return await jsonOk(downloads ? { downloads } : undefined, {
+              resolveCurrentTarget: true,
+            });
+        }
+      },
+    });
+  });
 
   registerBrowserAgentActHookRoutes(app, ctx);
   registerBrowserAgentActDownloadRoutes(app, ctx);
 
-  app.post(
-    "/response/body",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = resolveTargetIdFromBody(body);
-      const url = toStringOrEmpty(body.url);
-      let timeoutMs: number | undefined;
-      let maxChars: number | undefined;
-      try {
-        timeoutMs = readRouteTimerTimeoutMs(body.timeoutMs);
-        maxChars = readRoutePositiveInteger(body.maxChars, "maxChars");
-      } catch (err) {
-        return jsonError(res, 400, formatErrorMessage(err));
-      }
-      if (!url) {
-        return jsonError(res, 400, "url is required");
-      }
+  app.post("/response/body", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const url = toStringOrEmpty(body.url);
+    let timeoutMs: number | undefined;
+    let maxChars: number | undefined;
+    try {
+      timeoutMs = readRouteTimerTimeoutMs(body.timeoutMs);
+      maxChars = readRoutePositiveInteger(body.maxChars, "maxChars");
+    } catch (err) {
+      return jsonError(res, 400, formatErrorMessage(err));
+    }
+    if (!url) {
+      return jsonError(res, 400, "url is required");
+    }
 
-      await withRouteTabContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        enforceCurrentUrlAllowed: true,
-        run: async ({ profileCtx, cdpUrl, tab, signal, resolveTabUrl }) => {
-          if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
-            return jsonError(res, 501, EXISTING_SESSION_LIMITS.responseBody);
-          }
-          const pw = await requirePwAi(res, "response body");
-          if (!pw) {
-            return;
-          }
-          const result = await pw.responseBodyViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            url,
-            timeoutMs: timeoutMs ?? undefined,
-            maxChars: maxChars ?? undefined,
-          });
-          signal.throwIfAborted();
+    await withRouteTabContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      enforceCurrentUrlAllowed: true,
+      run: async ({ profileCtx, cdpUrl, tab, signal, resolveTabUrl }) => {
+        if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
+          return jsonError(res, 501, EXISTING_SESSION_LIMITS.responseBody);
+        }
+        const pw = await requirePwAi(res, "response body");
+        if (!pw) {
+          return;
+        }
+        const result = await pw.responseBodyViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          url,
+          timeoutMs: timeoutMs ?? undefined,
+          maxChars: maxChars ?? undefined,
+        });
+        signal.throwIfAborted();
+        const currentUrl = await resolveTabUrl(tab.url);
+        res.json({
+          ok: true,
+          targetId: tab.targetId,
+          ...(currentUrl ? { url: currentUrl } : {}),
+          response: result,
+        });
+      },
+    });
+  });
+
+  app.post("/highlight", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const ref = toStringOrEmpty(body.ref);
+    if (!ref) {
+      return jsonError(res, 400, "ref is required");
+    }
+
+    await withRouteTabContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      enforceCurrentUrlAllowed: true,
+      run: async ({ profileCtx, cdpUrl, tab, signal, resolveTabUrl }) => {
+        const jsonOk = async () => {
           const currentUrl = await resolveTabUrl(tab.url);
-          res.json({
+          return res.json({
             ok: true,
             targetId: tab.targetId,
             ...(currentUrl ? { url: currentUrl } : {}),
-            response: result,
           });
-        },
-      });
-    }),
-  );
-
-  app.post(
-    "/highlight",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = resolveTargetIdFromBody(body);
-      const ref = toStringOrEmpty(body.ref);
-      if (!ref) {
-        return jsonError(res, 400, "ref is required");
-      }
-
-      await withRouteTabContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        enforceCurrentUrlAllowed: true,
-        run: async ({ profileCtx, cdpUrl, tab, signal, resolveTabUrl }) => {
-          const jsonOk = async () => {
-            const currentUrl = await resolveTabUrl(tab.url);
-            return res.json({
-              ok: true,
-              targetId: tab.targetId,
-              ...(currentUrl ? { url: currentUrl } : {}),
-            });
-          };
-          if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
-            await evaluateChromeMcpScript({
-              profileName: profileCtx.profile.name,
-              profile: profileCtx.profile,
-              targetId: tab.targetId,
-              args: [ref],
-              timeoutMs: ctx.state().resolved.actionTimeoutMs,
-              signal,
-              fn: `(el) => {
+        };
+        if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
+          await evaluateChromeMcpScript({
+            profileName: profileCtx.profile.name,
+            profile: profileCtx.profile,
+            targetId: tab.targetId,
+            args: [ref],
+            timeoutMs: ctx.state().resolved.actionTimeoutMs,
+            signal,
+            fn: `(el) => {
               if (!(el instanceof Element)) {
                 return false;
               }
@@ -854,23 +846,22 @@ export function registerBrowserAgentActRoutes(
               }, 2000);
               return true;
             }`,
-            });
-            return await jsonOk();
-          }
-          const pw = await requirePwAi(res, "highlight");
-          if (!pw) {
-            return;
-          }
-          await pw.highlightViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            ref,
           });
-          await jsonOk();
-        },
-      });
-    }),
-  );
+          return await jsonOk();
+        }
+        const pw = await requirePwAi(res, "highlight");
+        if (!pw) {
+          return;
+        }
+        await pw.highlightViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          ref,
+        });
+        await jsonOk();
+      },
+    });
+  });
 }
 
 function toLintErrorObject(value: unknown, fallbackMessage: string): Error {

--- a/extensions/browser/src/browser/routes/agent.debug.ts
+++ b/extensions/browser/src/browser/routes/agent.debug.ts
@@ -18,7 +18,7 @@ import {
 import { resolveWritableOutputPathOrRespond } from "./output-paths.js";
 import { DEFAULT_TRACE_DIR } from "./path-output.js";
 import type { BrowserRequest, BrowserResponse, BrowserRouteRegistrar } from "./types.js";
-import { asyncBrowserRoute, toBoolean, toStringOrEmpty } from "./utils.js";
+import { toBoolean, toStringOrEmpty } from "./utils.js";
 
 function browserDebugTargetPayload(
   targetId: string,
@@ -55,173 +55,155 @@ export function registerBrowserAgentDebugRoutes(
   app: BrowserRouteRegistrar,
   ctx: BrowserRouteContext,
 ) {
-  app.get(
-    "/console",
-    asyncBrowserRoute(async (req, res) => {
-      const targetId = resolveTargetIdFromQuery(req.query);
-      const level = typeof req.query.level === "string" ? req.query.level : "";
+  app.get("/console", async (req, res) => {
+    const targetId = resolveTargetIdFromQuery(req.query);
+    const level = typeof req.query.level === "string" ? req.query.level : "";
 
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        feature: "console messages",
-        enforceCurrentUrlAllowed: true,
-        run: async ({ cdpUrl, tab, pw, resolveTabUrl }) => {
-          const messages = await pw.getConsoleMessagesViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            level: normalizeOptionalString(level),
-          });
-          const url = await resolveTabUrl(tab.url);
-          res.json({ ...browserDebugTargetPayload(tab.targetId, url), messages });
-        },
-      });
-    }),
-  );
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "console messages",
+      enforceCurrentUrlAllowed: true,
+      run: async ({ cdpUrl, tab, pw, resolveTabUrl }) => {
+        const messages = await pw.getConsoleMessagesViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          level: normalizeOptionalString(level),
+        });
+        const url = await resolveTabUrl(tab.url);
+        res.json({ ...browserDebugTargetPayload(tab.targetId, url), messages });
+      },
+    });
+  });
 
-  app.get(
-    "/errors",
-    asyncBrowserRoute(async (req, res) => {
-      const targetId = resolveTargetIdFromQuery(req.query);
-      const clear = toBoolean(req.query.clear) ?? false;
+  app.get("/errors", async (req, res) => {
+    const targetId = resolveTargetIdFromQuery(req.query);
+    const clear = toBoolean(req.query.clear) ?? false;
 
-      await sendPlaywrightDebugCollection({
-        req,
-        res,
-        ctx,
-        targetId,
-        feature: "page errors",
-        collect: async ({ cdpUrl, targetId: targetIdValue, pw }) =>
-          await pw.getPageErrorsViaPlaywright({
-            cdpUrl,
-            targetId: targetIdValue,
-            clear,
-          }),
-      });
-    }),
-  );
+    await sendPlaywrightDebugCollection({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "page errors",
+      collect: async ({ cdpUrl, targetId: targetIdValue, pw }) =>
+        await pw.getPageErrorsViaPlaywright({
+          cdpUrl,
+          targetId: targetIdValue,
+          clear,
+        }),
+    });
+  });
 
-  app.get(
-    "/requests",
-    asyncBrowserRoute(async (req, res) => {
-      const targetId = resolveTargetIdFromQuery(req.query);
-      const filter = typeof req.query.filter === "string" ? req.query.filter : "";
-      const clear = toBoolean(req.query.clear) ?? false;
+  app.get("/requests", async (req, res) => {
+    const targetId = resolveTargetIdFromQuery(req.query);
+    const filter = typeof req.query.filter === "string" ? req.query.filter : "";
+    const clear = toBoolean(req.query.clear) ?? false;
 
-      await sendPlaywrightDebugCollection({
-        req,
-        res,
-        ctx,
-        targetId,
-        feature: "network requests",
-        collect: async ({ cdpUrl, targetId: targetIdLocal, pw }) =>
-          await pw.getNetworkRequestsViaPlaywright({
-            cdpUrl,
-            targetId: targetIdLocal,
-            filter: normalizeOptionalString(filter),
-            clear,
-          }),
-      });
-    }),
-  );
+    await sendPlaywrightDebugCollection({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "network requests",
+      collect: async ({ cdpUrl, targetId: targetIdLocal, pw }) =>
+        await pw.getNetworkRequestsViaPlaywright({
+          cdpUrl,
+          targetId: targetIdLocal,
+          filter: normalizeOptionalString(filter),
+          clear,
+        }),
+    });
+  });
 
-  app.get(
-    "/dialogs",
-    asyncBrowserRoute(async (req, res) => {
-      const targetId = resolveTargetIdFromQuery(req.query);
+  app.get("/dialogs", async (req, res) => {
+    const targetId = resolveTargetIdFromQuery(req.query);
 
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        feature: "dialog state",
-        enforceCurrentUrlAllowed: true,
-        run: async ({ cdpUrl, tab, pw, resolveTabUrl }) => {
-          const browserState = await pw.getObservedBrowserStateViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            ssrfPolicy: ctx.state().resolved.ssrfPolicy,
-          });
-          const url = await resolveTabUrl(tab.url);
-          res.json({ ...browserDebugTargetPayload(tab.targetId, url), browserState });
-        },
-      });
-    }),
-  );
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "dialog state",
+      enforceCurrentUrlAllowed: true,
+      run: async ({ cdpUrl, tab, pw, resolveTabUrl }) => {
+        const browserState = await pw.getObservedBrowserStateViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          ssrfPolicy: ctx.state().resolved.ssrfPolicy,
+        });
+        const url = await resolveTabUrl(tab.url);
+        res.json({ ...browserDebugTargetPayload(tab.targetId, url), browserState });
+      },
+    });
+  });
 
-  app.post(
-    "/trace/start",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = resolveTargetIdFromBody(body);
-      const screenshots = toBoolean(body.screenshots) ?? undefined;
-      const snapshots = toBoolean(body.snapshots) ?? undefined;
-      const sources = toBoolean(body.sources) ?? undefined;
+  app.post("/trace/start", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const screenshots = toBoolean(body.screenshots) ?? undefined;
+    const snapshots = toBoolean(body.snapshots) ?? undefined;
+    const sources = toBoolean(body.sources) ?? undefined;
 
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        feature: "trace start",
-        enforceCurrentUrlAllowed: true,
-        run: async ({ cdpUrl, tab, pw, resolveTabUrl }) => {
-          await pw.traceStartViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            screenshots,
-            snapshots,
-            sources,
-          });
-          const url = await resolveTabUrl(tab.url);
-          res.json(browserDebugTargetPayload(tab.targetId, url));
-        },
-      });
-    }),
-  );
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "trace start",
+      enforceCurrentUrlAllowed: true,
+      run: async ({ cdpUrl, tab, pw, resolveTabUrl }) => {
+        await pw.traceStartViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          screenshots,
+          snapshots,
+          sources,
+        });
+        const url = await resolveTabUrl(tab.url);
+        res.json(browserDebugTargetPayload(tab.targetId, url));
+      },
+    });
+  });
 
-  app.post(
-    "/trace/stop",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = resolveTargetIdFromBody(body);
-      const out = toStringOrEmpty(body.path) || "";
+  app.post("/trace/stop", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const out = toStringOrEmpty(body.path) || "";
 
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        feature: "trace stop",
-        enforceCurrentUrlAllowed: true,
-        run: async ({ cdpUrl, tab, pw, resolveTabUrl }) => {
-          const id = crypto.randomUUID();
-          const tracePath = await resolveWritableOutputPathOrRespond({
-            res,
-            rootDir: DEFAULT_TRACE_DIR,
-            requestedPath: out,
-            scopeLabel: "trace directory",
-            defaultFileName: `browser-trace-${id}.zip`,
-            ensureRootDir: true,
-          });
-          if (!tracePath) {
-            return;
-          }
-          await pw.traceStopViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            path: tracePath,
-          });
-          const url = await resolveTabUrl(tab.url);
-          res.json({
-            ...browserDebugTargetPayload(tab.targetId, url),
-            path: path.resolve(tracePath),
-          });
-        },
-      });
-    }),
-  );
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "trace stop",
+      enforceCurrentUrlAllowed: true,
+      run: async ({ cdpUrl, tab, pw, resolveTabUrl }) => {
+        const id = crypto.randomUUID();
+        const tracePath = await resolveWritableOutputPathOrRespond({
+          res,
+          rootDir: DEFAULT_TRACE_DIR,
+          requestedPath: out,
+          scopeLabel: "trace directory",
+          defaultFileName: `browser-trace-${id}.zip`,
+          ensureRootDir: true,
+        });
+        if (!tracePath) {
+          return;
+        }
+        await pw.traceStopViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          path: tracePath,
+        });
+        const url = await resolveTabUrl(tab.url);
+        res.json({
+          ...browserDebugTargetPayload(tab.targetId, url),
+          path: path.resolve(tracePath),
+        });
+      },
+    });
+  });
 }

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -57,13 +57,7 @@ import {
 import { EXISTING_SESSION_LIMITS } from "./existing-session-limits.js";
 import { readRoutePositiveInteger } from "./route-numeric.js";
 import type { BrowserResponse, BrowserRouteRegistrar } from "./types.js";
-import {
-  asyncBrowserRoute,
-  jsonError,
-  runProfileRouteOperation,
-  toBoolean,
-  toStringOrEmpty,
-} from "./utils.js";
+import { jsonError, runProfileRouteOperation, toBoolean, toStringOrEmpty } from "./utils.js";
 
 const CHROME_MCP_OVERLAY_ATTR = "data-openclaw-mcp-overlay";
 
@@ -318,250 +312,169 @@ export function registerBrowserAgentSnapshotRoutes(
   app: BrowserRouteRegistrar,
   ctx: BrowserRouteContext,
 ) {
-  app.post(
-    "/navigate",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const url = toStringOrEmpty(body.url);
-      const targetId = toStringOrEmpty(body.targetId) || undefined;
-      if (!url) {
-        return jsonError(res, 400, "url is required");
-      }
-      await withRouteTabContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        run: async ({ profileCtx, tab, cdpUrl, signal }) => {
-          if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
-            const ssrfPolicyOpts = browserNavigationPolicyForProfile(ctx, profileCtx);
-            await assertBrowserNavigationAllowed({ url, ...ssrfPolicyOpts });
-            const result = await navigateChromeMcpPage({
-              profileName: profileCtx.profile.name,
-              profile: profileCtx.profile,
-              targetId: tab.targetId,
-              url,
-              signal,
-            });
-            await assertBrowserNavigationResultAllowed({ url: result.url, ...ssrfPolicyOpts });
-            return res.json({ ok: true, targetId: tab.targetId, ...result });
-          }
-          const pw = await requirePwAi(res, "navigate");
-          if (!pw) {
-            return;
-          }
-          const result = await pw.navigateViaPlaywright({
-            cdpUrl,
+  app.post("/navigate", async (req, res) => {
+    const body = readBody(req);
+    const url = toStringOrEmpty(body.url);
+    const targetId = toStringOrEmpty(body.targetId) || undefined;
+    if (!url) {
+      return jsonError(res, 400, "url is required");
+    }
+    await withRouteTabContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      run: async ({ profileCtx, tab, cdpUrl, signal }) => {
+        if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
+          const ssrfPolicyOpts = browserNavigationPolicyForProfile(ctx, profileCtx);
+          await assertBrowserNavigationAllowed({ url, ...ssrfPolicyOpts });
+          const result = await navigateChromeMcpPage({
+            profileName: profileCtx.profile.name,
+            profile: profileCtx.profile,
             targetId: tab.targetId,
             url,
-            ...browserNavigationPolicyForProfile(ctx, profileCtx),
+            signal,
           });
-          const currentTargetId = await resolveTargetIdAfterNavigate({
-            oldTargetId: tab.targetId,
-            navigatedUrl: result.url,
-            listTabs: () => profileCtx.listTabs(),
-          });
-          res.json({ ok: true, targetId: currentTargetId, ...result });
-        },
-      });
-    }),
-  );
+          await assertBrowserNavigationResultAllowed({ url: result.url, ...ssrfPolicyOpts });
+          return res.json({ ok: true, targetId: tab.targetId, ...result });
+        }
+        const pw = await requirePwAi(res, "navigate");
+        if (!pw) {
+          return;
+        }
+        const result = await pw.navigateViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          url,
+          ...browserNavigationPolicyForProfile(ctx, profileCtx),
+        });
+        const currentTargetId = await resolveTargetIdAfterNavigate({
+          oldTargetId: tab.targetId,
+          navigatedUrl: result.url,
+          listTabs: () => profileCtx.listTabs(),
+        });
+        res.json({ ok: true, targetId: currentTargetId, ...result });
+      },
+    });
+  });
 
-  app.post(
-    "/pdf",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = toStringOrEmpty(body.targetId) || undefined;
-      const profileCtx = resolveProfileContext(req, res, ctx);
-      if (!profileCtx) {
-        return;
-      }
-      if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
-        return jsonError(res, 501, EXISTING_SESSION_LIMITS.snapshot.pdfUnsupported);
-      }
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        profileCtx,
-        targetId,
-        feature: "pdf",
-        enforceCurrentUrlAllowed: true,
-        run: async ({ cdpUrl, tab, pw }) => {
-          const pdf = await pw.pdfViaPlaywright({
-            cdpUrl,
+  app.post("/pdf", async (req, res) => {
+    const body = readBody(req);
+    const targetId = toStringOrEmpty(body.targetId) || undefined;
+    const profileCtx = resolveProfileContext(req, res, ctx);
+    if (!profileCtx) {
+      return;
+    }
+    if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
+      return jsonError(res, 501, EXISTING_SESSION_LIMITS.snapshot.pdfUnsupported);
+    }
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      profileCtx,
+      targetId,
+      feature: "pdf",
+      enforceCurrentUrlAllowed: true,
+      run: async ({ cdpUrl, tab, pw }) => {
+        const pdf = await pw.pdfViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+        });
+        await saveBrowserMediaResponse({
+          res,
+          buffer: pdf.buffer,
+          contentType: "application/pdf",
+          maxBytes: pdf.buffer.byteLength,
+          targetId: tab.targetId,
+          url: tab.url,
+        });
+      },
+    });
+  });
+
+  app.post("/screenshot", async (req, res) => {
+    const body = readBody(req);
+    const targetId = toStringOrEmpty(body.targetId) || undefined;
+    const fullPage = toBoolean(body.fullPage) ?? false;
+    const ref = toStringOrEmpty(body.ref) || undefined;
+    const element = toStringOrEmpty(body.element) || undefined;
+    const labels = toBoolean(body.labels) ?? false;
+    const type = body.type === "jpeg" ? "jpeg" : "png";
+    let timeoutMs: number;
+    try {
+      const timeoutMsRaw = readRoutePositiveInteger(body.timeoutMs, "timeoutMs");
+      timeoutMs =
+        timeoutMsRaw !== undefined
+          ? normalizeBrowserTimerDelayMs(timeoutMsRaw)
+          : DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS;
+    } catch (err) {
+      return jsonError(res, 400, String(err instanceof Error ? err.message : err));
+    }
+
+    if (fullPage && (ref || element)) {
+      return jsonError(res, 400, "fullPage is not supported for element screenshots");
+    }
+
+    await withRouteTabContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      enforceCurrentUrlAllowed: true,
+      run: async ({ profileCtx, tab, cdpUrl, signal }) => {
+        if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
+          const operation: ChromeMcpSnapshotOperation = {
+            profileName: profileCtx.profile.name,
+            profile: profileCtx.profile,
             targetId: tab.targetId,
-          });
-          await saveBrowserMediaResponse({
-            res,
-            buffer: pdf.buffer,
-            contentType: "application/pdf",
-            maxBytes: pdf.buffer.byteLength,
-            targetId: tab.targetId,
-            url: tab.url,
-          });
-        },
-      });
-    }),
-  );
-
-  app.post(
-    "/screenshot",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = toStringOrEmpty(body.targetId) || undefined;
-      const fullPage = toBoolean(body.fullPage) ?? false;
-      const ref = toStringOrEmpty(body.ref) || undefined;
-      const element = toStringOrEmpty(body.element) || undefined;
-      const labels = toBoolean(body.labels) ?? false;
-      const type = body.type === "jpeg" ? "jpeg" : "png";
-      let timeoutMs: number;
-      try {
-        const timeoutMsRaw = readRoutePositiveInteger(body.timeoutMs, "timeoutMs");
-        timeoutMs =
-          timeoutMsRaw !== undefined
-            ? normalizeBrowserTimerDelayMs(timeoutMsRaw)
-            : DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS;
-      } catch (err) {
-        return jsonError(res, 400, String(err instanceof Error ? err.message : err));
-      }
-
-      if (fullPage && (ref || element)) {
-        return jsonError(res, 400, "fullPage is not supported for element screenshots");
-      }
-
-      await withRouteTabContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        enforceCurrentUrlAllowed: true,
-        run: async ({ profileCtx, tab, cdpUrl, signal }) => {
-          if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
-            const operation: ChromeMcpSnapshotOperation = {
-              profileName: profileCtx.profile.name,
-              profile: profileCtx.profile,
-              targetId: tab.targetId,
-              timeoutMs,
-              signal,
-            };
-            const ssrfPolicyOpts = browserNavigationPolicyForProfile(ctx, profileCtx);
-            if (ssrfPolicyOpts.ssrfPolicy) {
-              await assertBrowserNavigationResultAllowed({
-                url: tab.url,
-                ...ssrfPolicyOpts,
-              });
-            }
-            if (element) {
-              return jsonError(res, 400, EXISTING_SESSION_LIMITS.snapshot.screenshotElement);
-            }
-            if (labels) {
-              const snapshot = await takeChromeMcpSnapshot(operation);
-              const built = buildAiSnapshotFromChromeMcpSnapshot({ root: snapshot });
-              const labelResult = await renderChromeMcpLabels({
-                ...operation,
-                refs: Object.keys(built.refs),
-              });
-              try {
-                const buffer = await takeChromeMcpScreenshot({
-                  ...operation,
-                  fullPage,
-                  format: type,
-                });
-                await saveNormalizedScreenshotResponse({
-                  res,
-                  buffer,
-                  type,
-                  targetId: tab.targetId,
-                  url: tab.url,
-                  labels: true,
-                  labelsCount: labelResult.labels,
-                  labelsSkipped: labelResult.skipped,
-                });
-              } finally {
-                await clearChromeMcpOverlay(operation);
-              }
-              return;
-            }
-            const buffer = await takeChromeMcpScreenshot({
-              ...operation,
-              uid: ref,
-              fullPage,
-              format: type,
-            });
-            await saveNormalizedScreenshotResponse({
-              res,
-              buffer,
-              type,
-              targetId: tab.targetId,
+            timeoutMs,
+            signal,
+          };
+          const ssrfPolicyOpts = browserNavigationPolicyForProfile(ctx, profileCtx);
+          if (ssrfPolicyOpts.ssrfPolicy) {
+            await assertBrowserNavigationResultAllowed({
               url: tab.url,
+              ...ssrfPolicyOpts,
             });
-            return;
           }
-
-          let buffer: Buffer;
-          const shouldUsePlaywright =
-            labels ||
-            shouldUsePlaywrightForScreenshot({
-              profile: profileCtx.profile,
-              wsUrl: tab.wsUrl,
-              ref,
-              element,
+          if (element) {
+            return jsonError(res, 400, EXISTING_SESSION_LIMITS.snapshot.screenshotElement);
+          }
+          if (labels) {
+            const snapshot = await takeChromeMcpSnapshot(operation);
+            const built = buildAiSnapshotFromChromeMcpSnapshot({ root: snapshot });
+            const labelResult = await renderChromeMcpLabels({
+              ...operation,
+              refs: Object.keys(built.refs),
             });
-          if (shouldUsePlaywright) {
-            const pw = await requirePwAi(res, "screenshot");
-            if (!pw) {
-              return;
-            }
-            if (labels) {
-              const snap = await pw.snapshotRoleViaPlaywright({
-                cdpUrl,
-                targetId: tab.targetId,
-                ssrfPolicy: ctx.state().resolved.ssrfPolicy,
-              });
-              const labeled = await pw.screenshotWithLabelsViaPlaywright({
-                cdpUrl,
-                targetId: tab.targetId,
-                refs: snap.refs,
-                type,
-                timeoutMs,
+            try {
+              const buffer = await takeChromeMcpScreenshot({
+                ...operation,
                 fullPage,
-                ref,
-                element,
+                format: type,
               });
               await saveNormalizedScreenshotResponse({
                 res,
-                buffer: labeled.buffer,
+                buffer,
                 type,
                 targetId: tab.targetId,
                 url: tab.url,
                 labels: true,
-                labelsCount: labeled.labels,
-                labelsSkipped: labeled.skipped,
-                annotations: labeled.annotations,
+                labelsCount: labelResult.labels,
+                labelsSkipped: labelResult.skipped,
               });
-              return;
+            } finally {
+              await clearChromeMcpOverlay(operation);
             }
-            const snap = await pw.takeScreenshotViaPlaywright({
-              cdpUrl,
-              targetId: tab.targetId,
-              ref,
-              element,
-              fullPage,
-              type,
-              timeoutMs,
-            });
-            buffer = snap.buffer;
-          } else {
-            buffer = await captureScreenshot({
-              wsUrl: tab.wsUrl ?? "",
-              fullPage,
-              format: type,
-              quality: type === "jpeg" ? 85 : undefined,
-              timeoutMs,
-            });
+            return;
           }
-
+          const buffer = await takeChromeMcpScreenshot({
+            ...operation,
+            uid: ref,
+            fullPage,
+            format: type,
+          });
           await saveNormalizedScreenshotResponse({
             res,
             buffer,
@@ -569,246 +482,184 @@ export function registerBrowserAgentSnapshotRoutes(
             targetId: tab.targetId,
             url: tab.url,
           });
-        },
-      });
-    }),
-  );
+          return;
+        }
 
-  app.get(
-    "/snapshot",
-    asyncBrowserRoute(async (req, res) => {
-      const profileCtx = resolveProfileContext(req, res, ctx);
-      if (!profileCtx) {
-        return;
-      }
-      const targetId = typeof req.query.targetId === "string" ? req.query.targetId.trim() : "";
-      const pwModule = await getPwAiModule();
-      const hasPlaywright = Boolean(pwModule);
-      const plan = resolveSnapshotPlan({
-        profile: profileCtx.profile,
-        query: req.query,
-        hasPlaywright,
-      });
-      const usesChromeMcp = getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp;
-      if ((plan.labels || plan.mode === "efficient") && plan.format === "aria") {
-        return jsonError(res, 400, "labels/mode=efficient require format=ai");
-      }
-      if (usesChromeMcp && (plan.selectorValue || plan.frameSelectorValue)) {
-        return jsonError(res, 400, EXISTING_SESSION_LIMITS.snapshot.snapshotSelector);
-      }
-
-      try {
-        await runProfileRouteOperation({
-          profileCtx,
-          signal: req.signal,
-          run: async (signal) => {
-            const tab = await profileCtx.ensureTabAvailable(targetId || undefined, {
-              allowPlaywrightFallback: hasPlaywright,
-              signal,
-              timeoutMs: plan.timeoutMs,
+        let buffer: Buffer;
+        const shouldUsePlaywright =
+          labels ||
+          shouldUsePlaywrightForScreenshot({
+            profile: profileCtx.profile,
+            wsUrl: tab.wsUrl,
+            ref,
+            element,
+          });
+        if (shouldUsePlaywright) {
+          const pw = await requirePwAi(res, "screenshot");
+          if (!pw) {
+            return;
+          }
+          if (labels) {
+            const snap = await pw.snapshotRoleViaPlaywright({
+              cdpUrl,
+              targetId: tab.targetId,
+              ssrfPolicy: ctx.state().resolved.ssrfPolicy,
             });
-            const ssrfPolicyOpts = browserNavigationPolicyForProfile(ctx, profileCtx);
-            if (ssrfPolicyOpts.ssrfPolicy) {
-              await assertBrowserNavigationResultAllowed({
-                url: tab.url,
-                ...ssrfPolicyOpts,
-              });
-            }
-            let observedBrowserState: unknown;
-            if (!usesChromeMcp && pwModule) {
-              observedBrowserState = await pwModule
-                .getObservedBrowserStateViaPlaywright({
-                  cdpUrl: profileCtx.profile.cdpUrl,
-                  targetId: tab.targetId,
-                  ssrfPolicy: ctx.state().resolved.ssrfPolicy,
-                })
-                .catch(() => undefined);
-            }
-            if (usesChromeMcp) {
-              const operation: ChromeMcpSnapshotOperation = {
-                profileName: profileCtx.profile.name,
-                profile: profileCtx.profile,
-                targetId: tab.targetId,
-                timeoutMs: plan.timeoutMs,
-                signal,
-              };
-              const snapshot = await takeChromeMcpSnapshot(operation);
-              if (plan.format === "aria") {
-                return res.json({
-                  ok: true,
-                  format: "aria",
-                  targetId: tab.targetId,
-                  url: tab.url,
-                  nodes: flattenChromeMcpSnapshotToAriaNodes(snapshot, plan.limit),
-                });
-              }
-              const built = buildAiSnapshotFromChromeMcpSnapshot({
-                root: snapshot,
-                options: {
-                  interactive: plan.interactive ?? undefined,
-                  compact: plan.compact ?? undefined,
-                  maxDepth: plan.depth ?? undefined,
-                },
-              });
-              const builtWithUrls = plan.urls
-                ? {
-                    ...built,
-                    snapshot: appendSnapshotUrls(
-                      built.snapshot,
-                      await collectChromeMcpSnapshotUrls(operation),
-                    ),
-                  }
-                : built;
-              const finalized = finalizeRoleSnapshot({
-                ...builtWithUrls,
-                maxChars: plan.resolvedMaxChars,
-              });
-              if (plan.labels) {
-                const refs = Object.keys(finalized.refs);
-                const labelResult = await renderChromeMcpLabels({
-                  ...operation,
-                  refs,
-                });
-                try {
-                  const labeled = await takeChromeMcpScreenshot({
-                    ...operation,
-                    format: "png",
-                  });
-                  const normalized = await normalizeBrowserScreenshot(labeled, {
-                    maxSide: DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE,
-                    maxBytes: DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES,
-                  });
-                  await ensureMediaDir();
-                  const saved = await saveMediaBuffer(
-                    normalized.buffer,
-                    normalized.contentType ?? "image/png",
-                    "browser",
-                    DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES,
-                  );
-                  return res.json({
-                    ok: true,
-                    format: "ai",
-                    targetId: tab.targetId,
-                    url: tab.url,
-                    labels: true,
-                    labelsCount: labelResult.labels,
-                    labelsSkipped: labelResult.skipped,
-                    imagePath: path.resolve(saved.path),
-                    imageType: normalized.contentType?.includes("jpeg") ? "jpeg" : "png",
-                    ...finalized,
-                  });
-                } finally {
-                  await clearChromeMcpOverlay(operation);
-                }
-              }
-              return res.json({
-                ok: true,
-                format: "ai",
-                targetId: tab.targetId,
-                url: tab.url,
-                ...finalized,
-              });
-            }
-            if (hasPendingDialogs(observedBrowserState)) {
-              return res.json({
-                ok: true,
-                format: plan.format,
-                targetId: tab.targetId,
-                url: tab.url,
-                blockedByDialog: true,
-                ...browserStateResponseFields(observedBrowserState),
-                ...(plan.format === "aria" ? { nodes: [] } : { snapshot: "", refs: {} }),
-              });
-            }
-            if (plan.format === "ai") {
-              const roleSnapshotArgs = {
+            const labeled = await pw.screenshotWithLabelsViaPlaywright({
+              cdpUrl,
+              targetId: tab.targetId,
+              refs: snap.refs,
+              type,
+              timeoutMs,
+              fullPage,
+              ref,
+              element,
+            });
+            await saveNormalizedScreenshotResponse({
+              res,
+              buffer: labeled.buffer,
+              type,
+              targetId: tab.targetId,
+              url: tab.url,
+              labels: true,
+              labelsCount: labeled.labels,
+              labelsSkipped: labeled.skipped,
+              annotations: labeled.annotations,
+            });
+            return;
+          }
+          const snap = await pw.takeScreenshotViaPlaywright({
+            cdpUrl,
+            targetId: tab.targetId,
+            ref,
+            element,
+            fullPage,
+            type,
+            timeoutMs,
+          });
+          buffer = snap.buffer;
+        } else {
+          buffer = await captureScreenshot({
+            wsUrl: tab.wsUrl ?? "",
+            fullPage,
+            format: type,
+            quality: type === "jpeg" ? 85 : undefined,
+            timeoutMs,
+          });
+        }
+
+        await saveNormalizedScreenshotResponse({
+          res,
+          buffer,
+          type,
+          targetId: tab.targetId,
+          url: tab.url,
+        });
+      },
+    });
+  });
+
+  app.get("/snapshot", async (req, res) => {
+    const profileCtx = resolveProfileContext(req, res, ctx);
+    if (!profileCtx) {
+      return;
+    }
+    const targetId = typeof req.query.targetId === "string" ? req.query.targetId.trim() : "";
+    const pwModule = await getPwAiModule();
+    const hasPlaywright = Boolean(pwModule);
+    const plan = resolveSnapshotPlan({
+      profile: profileCtx.profile,
+      query: req.query,
+      hasPlaywright,
+    });
+    const usesChromeMcp = getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp;
+    if ((plan.labels || plan.mode === "efficient") && plan.format === "aria") {
+      return jsonError(res, 400, "labels/mode=efficient require format=ai");
+    }
+    if (usesChromeMcp && (plan.selectorValue || plan.frameSelectorValue)) {
+      return jsonError(res, 400, EXISTING_SESSION_LIMITS.snapshot.snapshotSelector);
+    }
+
+    try {
+      await runProfileRouteOperation({
+        profileCtx,
+        signal: req.signal,
+        run: async (signal) => {
+          const tab = await profileCtx.ensureTabAvailable(targetId || undefined, {
+            allowPlaywrightFallback: hasPlaywright,
+            signal,
+            timeoutMs: plan.timeoutMs,
+          });
+          const ssrfPolicyOpts = browserNavigationPolicyForProfile(ctx, profileCtx);
+          if (ssrfPolicyOpts.ssrfPolicy) {
+            await assertBrowserNavigationResultAllowed({
+              url: tab.url,
+              ...ssrfPolicyOpts,
+            });
+          }
+          let observedBrowserState: unknown;
+          if (!usesChromeMcp && pwModule) {
+            observedBrowserState = await pwModule
+              .getObservedBrowserStateViaPlaywright({
                 cdpUrl: profileCtx.profile.cdpUrl,
                 targetId: tab.targetId,
-                selector: plan.selectorValue,
-                frameSelector: plan.frameSelectorValue,
-                refsMode: plan.refsMode,
                 ssrfPolicy: ctx.state().resolved.ssrfPolicy,
-                urls: plan.urls,
-                timeoutMs: plan.timeoutMs,
-                maxChars: plan.resolvedMaxChars,
-                options: {
-                  interactive: plan.interactive ?? undefined,
-                  compact: plan.compact ?? undefined,
-                  maxDepth: plan.depth ?? undefined,
-                },
-              };
-
-              const cdpRoleSnapshot = async () => {
-                if (!tab.wsUrl) {
-                  return null;
+              })
+              .catch(() => undefined);
+          }
+          if (usesChromeMcp) {
+            const operation: ChromeMcpSnapshotOperation = {
+              profileName: profileCtx.profile.name,
+              profile: profileCtx.profile,
+              targetId: tab.targetId,
+              timeoutMs: plan.timeoutMs,
+              signal,
+            };
+            const snapshot = await takeChromeMcpSnapshot(operation);
+            if (plan.format === "aria") {
+              return res.json({
+                ok: true,
+                format: "aria",
+                targetId: tab.targetId,
+                url: tab.url,
+                nodes: flattenChromeMcpSnapshotToAriaNodes(snapshot, plan.limit),
+              });
+            }
+            const built = buildAiSnapshotFromChromeMcpSnapshot({
+              root: snapshot,
+              options: {
+                interactive: plan.interactive ?? undefined,
+                compact: plan.compact ?? undefined,
+                maxDepth: plan.depth ?? undefined,
+              },
+            });
+            const builtWithUrls = plan.urls
+              ? {
+                  ...built,
+                  snapshot: appendSnapshotUrls(
+                    built.snapshot,
+                    await collectChromeMcpSnapshotUrls(operation),
+                  ),
                 }
-                if (plan.selectorValue || plan.frameSelectorValue) {
-                  return null;
-                }
-                return await snapshotRoleViaCdp({
-                  wsUrl: tab.wsUrl,
-                  urls: plan.urls,
-                  timeoutMs: plan.timeoutMs,
-                  maxChars: plan.resolvedMaxChars,
-                  options: {
-                    interactive: plan.interactive ?? undefined,
-                    compact: plan.compact ?? undefined,
-                    maxDepth: plan.depth ?? undefined,
-                  },
+              : built;
+            const finalized = finalizeRoleSnapshot({
+              ...builtWithUrls,
+              maxChars: plan.resolvedMaxChars,
+            });
+            if (plan.labels) {
+              const refs = Object.keys(finalized.refs);
+              const labelResult = await renderChromeMcpLabels({
+                ...operation,
+                refs,
+              });
+              try {
+                const labeled = await takeChromeMcpScreenshot({
+                  ...operation,
+                  format: "png",
                 });
-              };
-
-              const pw = await getPwAiModule();
-              const snap = plan.wantsRoleSnapshot
-                ? pw
-                  ? await pw
-                      .snapshotRoleViaPlaywright(roleSnapshotArgs)
-                      .catch(async (err: unknown) => {
-                        const fallback = await cdpRoleSnapshot();
-                        if (fallback) {
-                          return fallback;
-                        }
-                        throw err;
-                      })
-                  : await cdpRoleSnapshot()
-                : pw
-                  ? await pw.snapshotAiViaPlaywright({
-                      cdpUrl: profileCtx.profile.cdpUrl,
-                      targetId: tab.targetId,
-                      ssrfPolicy: ctx.state().resolved.ssrfPolicy,
-                      urls: plan.urls,
-                      timeoutMs: plan.timeoutMs,
-                      ...(typeof plan.resolvedMaxChars === "number"
-                        ? { maxChars: plan.resolvedMaxChars }
-                        : {}),
-                    })
-                  : await cdpRoleSnapshot();
-              if (!snap) {
-                await requirePwAi(res, "ai snapshot");
-                return;
-              }
-              if (plan.labels) {
-                if (!pw) {
-                  return jsonError(res, 501, "Snapshot labels require Playwright.");
-                }
-                const labeled = await pw.screenshotWithLabelsViaPlaywright({
-                  cdpUrl: profileCtx.profile.cdpUrl,
-                  targetId: tab.targetId,
-                  refs: "refs" in snap ? snap.refs : {},
-                  type: "png",
-                  timeoutMs: plan.timeoutMs,
-                });
-                const originalMeta = labeled.annotations.length
-                  ? ((await getImageMetadata(labeled.buffer)) ?? undefined)
-                  : undefined;
-                const normalized = await normalizeBrowserScreenshot(labeled.buffer, {
+                const normalized = await normalizeBrowserScreenshot(labeled, {
                   maxSide: DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE,
                   maxBytes: DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES,
-                });
-                const scaledAnnotations = await rescaleAnnotationsForNormalization({
-                  annotations: labeled.annotations,
-                  originalMeta,
-                  normalizedBuffer: normalized.buffer,
                 });
                 await ensureMediaDir();
                 const saved = await saveMediaBuffer(
@@ -817,86 +668,217 @@ export function registerBrowserAgentSnapshotRoutes(
                   "browser",
                   DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES,
                 );
-                const imageType = normalized.contentType?.includes("jpeg") ? "jpeg" : "png";
                 return res.json({
                   ok: true,
-                  format: plan.format,
+                  format: "ai",
                   targetId: tab.targetId,
                   url: tab.url,
-                  ...browserStateResponseFields(observedBrowserState),
                   labels: true,
-                  labelsCount: labeled.labels,
-                  labelsSkipped: labeled.skipped,
-                  ...(scaledAnnotations && scaledAnnotations.length > 0
-                    ? { annotations: scaledAnnotations }
-                    : {}),
+                  labelsCount: labelResult.labels,
+                  labelsSkipped: labelResult.skipped,
                   imagePath: path.resolve(saved.path),
-                  imageType,
-                  ...snap,
+                  imageType: normalized.contentType?.includes("jpeg") ? "jpeg" : "png",
+                  ...finalized,
                 });
+              } finally {
+                await clearChromeMcpOverlay(operation);
               }
+            }
+            return res.json({
+              ok: true,
+              format: "ai",
+              targetId: tab.targetId,
+              url: tab.url,
+              ...finalized,
+            });
+          }
+          if (hasPendingDialogs(observedBrowserState)) {
+            return res.json({
+              ok: true,
+              format: plan.format,
+              targetId: tab.targetId,
+              url: tab.url,
+              blockedByDialog: true,
+              ...browserStateResponseFields(observedBrowserState),
+              ...(plan.format === "aria" ? { nodes: [] } : { snapshot: "", refs: {} }),
+            });
+          }
+          if (plan.format === "ai") {
+            const roleSnapshotArgs = {
+              cdpUrl: profileCtx.profile.cdpUrl,
+              targetId: tab.targetId,
+              selector: plan.selectorValue,
+              frameSelector: plan.frameSelectorValue,
+              refsMode: plan.refsMode,
+              ssrfPolicy: ctx.state().resolved.ssrfPolicy,
+              urls: plan.urls,
+              timeoutMs: plan.timeoutMs,
+              maxChars: plan.resolvedMaxChars,
+              options: {
+                interactive: plan.interactive ?? undefined,
+                compact: plan.compact ?? undefined,
+                maxDepth: plan.depth ?? undefined,
+              },
+            };
 
+            const cdpRoleSnapshot = async () => {
+              if (!tab.wsUrl) {
+                return null;
+              }
+              if (plan.selectorValue || plan.frameSelectorValue) {
+                return null;
+              }
+              return await snapshotRoleViaCdp({
+                wsUrl: tab.wsUrl,
+                urls: plan.urls,
+                timeoutMs: plan.timeoutMs,
+                maxChars: plan.resolvedMaxChars,
+                options: {
+                  interactive: plan.interactive ?? undefined,
+                  compact: plan.compact ?? undefined,
+                  maxDepth: plan.depth ?? undefined,
+                },
+              });
+            };
+
+            const pw = await getPwAiModule();
+            const snap = plan.wantsRoleSnapshot
+              ? pw
+                ? await pw
+                    .snapshotRoleViaPlaywright(roleSnapshotArgs)
+                    .catch(async (err: unknown) => {
+                      const fallback = await cdpRoleSnapshot();
+                      if (fallback) {
+                        return fallback;
+                      }
+                      throw err;
+                    })
+                : await cdpRoleSnapshot()
+              : pw
+                ? await pw.snapshotAiViaPlaywright({
+                    cdpUrl: profileCtx.profile.cdpUrl,
+                    targetId: tab.targetId,
+                    ssrfPolicy: ctx.state().resolved.ssrfPolicy,
+                    urls: plan.urls,
+                    timeoutMs: plan.timeoutMs,
+                    ...(typeof plan.resolvedMaxChars === "number"
+                      ? { maxChars: plan.resolvedMaxChars }
+                      : {}),
+                  })
+                : await cdpRoleSnapshot();
+            if (!snap) {
+              await requirePwAi(res, "ai snapshot");
+              return;
+            }
+            if (plan.labels) {
+              if (!pw) {
+                return jsonError(res, 501, "Snapshot labels require Playwright.");
+              }
+              const labeled = await pw.screenshotWithLabelsViaPlaywright({
+                cdpUrl: profileCtx.profile.cdpUrl,
+                targetId: tab.targetId,
+                refs: "refs" in snap ? snap.refs : {},
+                type: "png",
+                timeoutMs: plan.timeoutMs,
+              });
+              const originalMeta = labeled.annotations.length
+                ? ((await getImageMetadata(labeled.buffer)) ?? undefined)
+                : undefined;
+              const normalized = await normalizeBrowserScreenshot(labeled.buffer, {
+                maxSide: DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE,
+                maxBytes: DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES,
+              });
+              const scaledAnnotations = await rescaleAnnotationsForNormalization({
+                annotations: labeled.annotations,
+                originalMeta,
+                normalizedBuffer: normalized.buffer,
+              });
+              await ensureMediaDir();
+              const saved = await saveMediaBuffer(
+                normalized.buffer,
+                normalized.contentType ?? "image/png",
+                "browser",
+                DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES,
+              );
+              const imageType = normalized.contentType?.includes("jpeg") ? "jpeg" : "png";
               return res.json({
                 ok: true,
                 format: plan.format,
                 targetId: tab.targetId,
                 url: tab.url,
                 ...browserStateResponseFields(observedBrowserState),
+                labels: true,
+                labelsCount: labeled.labels,
+                labelsSkipped: labeled.skipped,
+                ...(scaledAnnotations && scaledAnnotations.length > 0
+                  ? { annotations: scaledAnnotations }
+                  : {}),
+                imagePath: path.resolve(saved.path),
+                imageType,
                 ...snap,
               });
             }
 
-            const usePlaywrightAriaSnapshot = shouldUsePlaywrightForAriaSnapshot({
-              profile: profileCtx.profile,
-              wsUrl: tab.wsUrl,
-            });
-            const snap = usePlaywrightAriaSnapshot
-              ? (() => {
-                  // Extension relay doesn't expose per-page WS URLs; run AX snapshot via Playwright CDP session.
-                  // Also covers cases where wsUrl is missing/unusable.
-                  return requirePwAi(res, "aria snapshot").then(async (pw) => {
-                    if (!pw) {
-                      return null;
-                    }
-                    return await pw.snapshotAriaViaPlaywright({
-                      cdpUrl: profileCtx.profile.cdpUrl,
-                      targetId: tab.targetId,
-                      limit: plan.limit,
-                      timeoutMs: plan.timeoutMs,
-                      ssrfPolicy: ctx.state().resolved.ssrfPolicy,
-                    });
-                  });
-                })()
-              : snapshotAria({
-                  wsUrl: tab.wsUrl ?? "",
-                  limit: plan.limit,
-                  timeoutMs: plan.timeoutMs,
-                });
-
-            const resolved = await Promise.resolve(snap);
-            if (!resolved) {
-              return;
-            }
-            if (!usePlaywrightAriaSnapshot) {
-              await pwModule?.storeAriaSnapshotRefsViaPlaywright?.({
-                cdpUrl: profileCtx.profile.cdpUrl,
-                targetId: tab.targetId,
-                nodes: resolved.nodes,
-              });
-            }
             return res.json({
               ok: true,
               format: plan.format,
               targetId: tab.targetId,
               url: tab.url,
               ...browserStateResponseFields(observedBrowserState),
-              ...resolved,
+              ...snap,
             });
-          },
-        });
-      } catch (err) {
-        handleRouteError(ctx, res, err);
-      }
-    }),
-  );
+          }
+
+          const usePlaywrightAriaSnapshot = shouldUsePlaywrightForAriaSnapshot({
+            profile: profileCtx.profile,
+            wsUrl: tab.wsUrl,
+          });
+          const snap = usePlaywrightAriaSnapshot
+            ? (() => {
+                // Extension relay doesn't expose per-page WS URLs; run AX snapshot via Playwright CDP session.
+                // Also covers cases where wsUrl is missing/unusable.
+                return requirePwAi(res, "aria snapshot").then(async (pw) => {
+                  if (!pw) {
+                    return null;
+                  }
+                  return await pw.snapshotAriaViaPlaywright({
+                    cdpUrl: profileCtx.profile.cdpUrl,
+                    targetId: tab.targetId,
+                    limit: plan.limit,
+                    timeoutMs: plan.timeoutMs,
+                    ssrfPolicy: ctx.state().resolved.ssrfPolicy,
+                  });
+                });
+              })()
+            : snapshotAria({
+                wsUrl: tab.wsUrl ?? "",
+                limit: plan.limit,
+                timeoutMs: plan.timeoutMs,
+              });
+
+          const resolved = await Promise.resolve(snap);
+          if (!resolved) {
+            return;
+          }
+          if (!usePlaywrightAriaSnapshot) {
+            await pwModule?.storeAriaSnapshotRefsViaPlaywright?.({
+              cdpUrl: profileCtx.profile.cdpUrl,
+              targetId: tab.targetId,
+              nodes: resolved.nodes,
+            });
+          }
+          return res.json({
+            ok: true,
+            format: plan.format,
+            targetId: tab.targetId,
+            url: tab.url,
+            ...browserStateResponseFields(observedBrowserState),
+            ...resolved,
+          });
+        },
+      });
+    } catch (err) {
+      handleRouteError(ctx, res, err);
+    }
+  });
 }

--- a/extensions/browser/src/browser/routes/agent.storage.ts
+++ b/extensions/browser/src/browser/routes/agent.storage.ts
@@ -18,13 +18,7 @@ import {
 } from "./agent.shared.js";
 import { readOptionalRouteFiniteNumber, readRouteFiniteNumber } from "./route-numeric.js";
 import type { BrowserRequest, BrowserResponse, BrowserRouteRegistrar } from "./types.js";
-import {
-  asyncBrowserRoute,
-  jsonError,
-  readHttpOrigin,
-  toBoolean,
-  toStringOrEmpty,
-} from "./utils.js";
+import { jsonError, readHttpOrigin, toBoolean, toStringOrEmpty } from "./utils.js";
 
 type StorageKind = "local" | "session";
 
@@ -183,437 +177,395 @@ export function registerBrowserAgentStorageRoutes(
   app: BrowserRouteRegistrar,
   ctx: BrowserRouteContext,
 ) {
-  app.get(
-    "/cookies",
-    asyncBrowserRoute(async (req, res) => {
-      const targetId = resolveTargetIdFromQuery(req.query);
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        feature: "cookies",
-        enforceCurrentUrlAllowed: true,
-        run: async ({ cdpUrl, tab, pw, signal }) => {
-          const result = await pw.cookiesGetViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-          });
-          signal.throwIfAborted();
-          res.json({ ok: true, targetId: tab.targetId, ...result });
-        },
-      });
-    }),
-  );
+  app.get("/cookies", async (req, res) => {
+    const targetId = resolveTargetIdFromQuery(req.query);
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "cookies",
+      enforceCurrentUrlAllowed: true,
+      run: async ({ cdpUrl, tab, pw, signal }) => {
+        const result = await pw.cookiesGetViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+        });
+        signal.throwIfAborted();
+        res.json({ ok: true, targetId: tab.targetId, ...result });
+      },
+    });
+  });
 
-  app.post(
-    "/cookies/set",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = resolveTargetIdFromBody(body);
-      const cookie =
-        body.cookie && typeof body.cookie === "object" && !Array.isArray(body.cookie)
-          ? (body.cookie as Record<string, unknown>)
-          : null;
-      if (!cookie) {
-        return jsonError(res, 400, "cookie is required");
+  app.post("/cookies/set", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const cookie =
+      body.cookie && typeof body.cookie === "object" && !Array.isArray(body.cookie)
+        ? (body.cookie as Record<string, unknown>)
+        : null;
+    if (!cookie) {
+      return jsonError(res, 400, "cookie is required");
+    }
+    let parsedCookie: CookieSetOptions;
+    try {
+      parsedCookie = parseCookieSetOptions(cookie);
+    } catch (err) {
+      return jsonError(res, 400, formatErrorMessage(err));
+    }
+
+    // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "cookies set",
+      run: async ({ cdpUrl, tab, pw, signal }) => {
+        await pw.cookiesSetViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          cookie: parsedCookie,
+        });
+        signal.throwIfAborted();
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
+  });
+
+  app.post("/cookies/clear", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+
+    // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "cookies clear",
+      run: async ({ cdpUrl, tab, pw, signal }) => {
+        await pw.cookiesClearViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+        });
+        signal.throwIfAborted();
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
+  });
+
+  app.get("/storage/:kind", async (req, res) => {
+    const kind = parseStorageKind(toStringOrEmpty(req.params.kind));
+    if (!kind) {
+      return jsonError(res, 400, "kind must be local|session");
+    }
+    const targetId = resolveTargetIdFromQuery(req.query);
+    const key = toStringOrEmpty(req.query.key);
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "storage get",
+      enforceCurrentUrlAllowed: true,
+      run: async ({ cdpUrl, tab, pw, signal }) => {
+        const result = await pw.storageGetViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          kind,
+          key: normalizeOptionalString(key),
+        });
+        signal.throwIfAborted();
+        res.json({ ok: true, targetId: tab.targetId, ...result });
+      },
+    });
+  });
+
+  app.post("/storage/:kind/set", async (req, res) => {
+    const mutation = parseStorageMutationFromRequest(req, res);
+    if (!mutation) {
+      return;
+    }
+    const key = toStringOrEmpty(mutation.body.key);
+    if (!key) {
+      return jsonError(res, 400, "key is required");
+    }
+    const value = typeof mutation.body.value === "string" ? mutation.body.value : "";
+
+    // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId: mutation.parsed.targetId,
+      feature: "storage set",
+      run: async ({ cdpUrl, tab, pw, signal }) => {
+        await pw.storageSetViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          kind: mutation.parsed.kind,
+          key,
+          value,
+        });
+        signal.throwIfAborted();
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
+  });
+
+  app.post("/storage/:kind/clear", async (req, res) => {
+    const mutation = parseStorageMutationFromRequest(req, res);
+    if (!mutation) {
+      return;
+    }
+
+    // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId: mutation.parsed.targetId,
+      feature: "storage clear",
+      run: async ({ cdpUrl, tab, pw, signal }) => {
+        await pw.storageClearViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          kind: mutation.parsed.kind,
+        });
+        signal.throwIfAborted();
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
+  });
+
+  app.post("/set/offline", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const offline = toBoolean(body.offline);
+    if (offline === undefined) {
+      return jsonError(res, 400, "offline is required");
+    }
+
+    // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "offline",
+      run: async ({ cdpUrl, tab, pw, signal }) => {
+        await pw.setOfflineViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          offline,
+        });
+        signal.throwIfAborted();
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
+  });
+
+  app.post("/set/headers", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const headers =
+      body.headers && typeof body.headers === "object" && !Array.isArray(body.headers)
+        ? (body.headers as Record<string, unknown>)
+        : null;
+    if (!headers) {
+      return jsonError(res, 400, "headers is required");
+    }
+
+    const parsed: Record<string, string> = {};
+    for (const [k, v] of Object.entries(headers)) {
+      if (typeof v === "string") {
+        parsed[k] = v;
       }
-      let parsedCookie: CookieSetOptions;
-      try {
-        parsedCookie = parseCookieSetOptions(cookie);
-      } catch (err) {
-        return jsonError(res, 400, formatErrorMessage(err));
-      }
+    }
 
-      // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        feature: "cookies set",
-        run: async ({ cdpUrl, tab, pw, signal }) => {
-          await pw.cookiesSetViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            cookie: parsedCookie,
-          });
-          signal.throwIfAborted();
-          res.json({ ok: true, targetId: tab.targetId });
-        },
-      });
-    }),
-  );
+    // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "headers",
+      run: async ({ cdpUrl, tab, pw, signal }) => {
+        await pw.setExtraHTTPHeadersViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          headers: parsed,
+        });
+        signal.throwIfAborted();
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
+  });
 
-  app.post(
-    "/cookies/clear",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = resolveTargetIdFromBody(body);
+  app.post("/set/credentials", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const clear = toBoolean(body.clear) ?? false;
+    const username = toStringOrEmpty(body.username) || undefined;
+    const password = readStringValue(body.password);
 
-      // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        feature: "cookies clear",
-        run: async ({ cdpUrl, tab, pw, signal }) => {
-          await pw.cookiesClearViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-          });
-          signal.throwIfAborted();
-          res.json({ ok: true, targetId: tab.targetId });
-        },
-      });
-    }),
-  );
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "http credentials",
+      run: async ({ cdpUrl, tab, pw, signal }) => {
+        await pw.setHttpCredentialsViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          username,
+          password,
+          clear,
+        });
+        signal.throwIfAborted();
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
+  });
 
-  app.get(
-    "/storage/:kind",
-    asyncBrowserRoute(async (req, res) => {
-      const kind = parseStorageKind(toStringOrEmpty(req.params.kind));
-      if (!kind) {
-        return jsonError(res, 400, "kind must be local|session");
-      }
-      const targetId = resolveTargetIdFromQuery(req.query);
-      const key = toStringOrEmpty(req.query.key);
+  app.post("/set/geolocation", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    let geolocation: GeolocationOptions;
+    try {
+      geolocation = parseGeolocationOptions(body);
+    } catch (err) {
+      return jsonError(res, 400, formatErrorMessage(err));
+    }
 
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        feature: "storage get",
-        enforceCurrentUrlAllowed: true,
-        run: async ({ cdpUrl, tab, pw, signal }) => {
-          const result = await pw.storageGetViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            kind,
-            key: normalizeOptionalString(key),
-          });
-          signal.throwIfAborted();
-          res.json({ ok: true, targetId: tab.targetId, ...result });
-        },
-      });
-    }),
-  );
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "geolocation",
+      run: async ({ cdpUrl, tab, pw, signal }) => {
+        await pw.setGeolocationViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          ...geolocation,
+        });
+        signal.throwIfAborted();
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
+  });
 
-  app.post(
-    "/storage/:kind/set",
-    asyncBrowserRoute(async (req, res) => {
-      const mutation = parseStorageMutationFromRequest(req, res);
-      if (!mutation) {
-        return;
-      }
-      const key = toStringOrEmpty(mutation.body.key);
-      if (!key) {
-        return jsonError(res, 400, "key is required");
-      }
-      const value = typeof mutation.body.value === "string" ? mutation.body.value : "";
+  app.post("/set/media", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const schemeRaw = toStringOrEmpty(body.colorScheme);
+    const colorScheme =
+      schemeRaw === "dark" || schemeRaw === "light" || schemeRaw === "no-preference"
+        ? schemeRaw
+        : schemeRaw === "none"
+          ? null
+          : undefined;
+    if (colorScheme === undefined) {
+      return jsonError(res, 400, "colorScheme must be dark|light|no-preference|none");
+    }
 
-      // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        targetId: mutation.parsed.targetId,
-        feature: "storage set",
-        run: async ({ cdpUrl, tab, pw, signal }) => {
-          await pw.storageSetViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            kind: mutation.parsed.kind,
-            key,
-            value,
-          });
-          signal.throwIfAborted();
-          res.json({ ok: true, targetId: tab.targetId });
-        },
-      });
-    }),
-  );
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "media emulation",
+      run: async ({ cdpUrl, tab, pw, signal }) => {
+        await pw.emulateMediaViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          colorScheme,
+        });
+        signal.throwIfAborted();
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
+  });
 
-  app.post(
-    "/storage/:kind/clear",
-    asyncBrowserRoute(async (req, res) => {
-      const mutation = parseStorageMutationFromRequest(req, res);
-      if (!mutation) {
-        return;
-      }
+  app.post("/set/timezone", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const timezoneId = toStringOrEmpty(body.timezoneId);
+    if (!timezoneId) {
+      return jsonError(res, 400, "timezoneId is required");
+    }
 
-      // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        targetId: mutation.parsed.targetId,
-        feature: "storage clear",
-        run: async ({ cdpUrl, tab, pw, signal }) => {
-          await pw.storageClearViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            kind: mutation.parsed.kind,
-          });
-          signal.throwIfAborted();
-          res.json({ ok: true, targetId: tab.targetId });
-        },
-      });
-    }),
-  );
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "timezone",
+      run: async ({ cdpUrl, tab, pw, signal }) => {
+        await pw.setTimezoneViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          timezoneId,
+        });
+        signal.throwIfAborted();
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
+  });
 
-  app.post(
-    "/set/offline",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = resolveTargetIdFromBody(body);
-      const offline = toBoolean(body.offline);
-      if (offline === undefined) {
-        return jsonError(res, 400, "offline is required");
-      }
+  app.post("/set/locale", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const locale = toStringOrEmpty(body.locale);
+    if (!locale) {
+      return jsonError(res, 400, "locale is required");
+    }
 
-      // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        feature: "offline",
-        run: async ({ cdpUrl, tab, pw, signal }) => {
-          await pw.setOfflineViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            offline,
-          });
-          signal.throwIfAborted();
-          res.json({ ok: true, targetId: tab.targetId });
-        },
-      });
-    }),
-  );
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "locale",
+      run: async ({ cdpUrl, tab, pw, signal }) => {
+        await pw.setLocaleViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          locale,
+        });
+        signal.throwIfAborted();
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
+  });
 
-  app.post(
-    "/set/headers",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = resolveTargetIdFromBody(body);
-      const headers =
-        body.headers && typeof body.headers === "object" && !Array.isArray(body.headers)
-          ? (body.headers as Record<string, unknown>)
-          : null;
-      if (!headers) {
-        return jsonError(res, 400, "headers is required");
-      }
+  app.post("/set/device", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const name = toStringOrEmpty(body.name);
+    if (!name) {
+      return jsonError(res, 400, "name is required");
+    }
 
-      const parsed: Record<string, string> = {};
-      for (const [k, v] of Object.entries(headers)) {
-        if (typeof v === "string") {
-          parsed[k] = v;
-        }
-      }
-
-      // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        feature: "headers",
-        run: async ({ cdpUrl, tab, pw, signal }) => {
-          await pw.setExtraHTTPHeadersViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            headers: parsed,
-          });
-          signal.throwIfAborted();
-          res.json({ ok: true, targetId: tab.targetId });
-        },
-      });
-    }),
-  );
-
-  app.post(
-    "/set/credentials",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = resolveTargetIdFromBody(body);
-      const clear = toBoolean(body.clear) ?? false;
-      const username = toStringOrEmpty(body.username) || undefined;
-      const password = readStringValue(body.password);
-
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        feature: "http credentials",
-        run: async ({ cdpUrl, tab, pw, signal }) => {
-          await pw.setHttpCredentialsViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            username,
-            password,
-            clear,
-          });
-          signal.throwIfAborted();
-          res.json({ ok: true, targetId: tab.targetId });
-        },
-      });
-    }),
-  );
-
-  app.post(
-    "/set/geolocation",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = resolveTargetIdFromBody(body);
-      let geolocation: GeolocationOptions;
-      try {
-        geolocation = parseGeolocationOptions(body);
-      } catch (err) {
-        return jsonError(res, 400, formatErrorMessage(err));
-      }
-
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        feature: "geolocation",
-        run: async ({ cdpUrl, tab, pw, signal }) => {
-          await pw.setGeolocationViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            ...geolocation,
-          });
-          signal.throwIfAborted();
-          res.json({ ok: true, targetId: tab.targetId });
-        },
-      });
-    }),
-  );
-
-  app.post(
-    "/set/media",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = resolveTargetIdFromBody(body);
-      const schemeRaw = toStringOrEmpty(body.colorScheme);
-      const colorScheme =
-        schemeRaw === "dark" || schemeRaw === "light" || schemeRaw === "no-preference"
-          ? schemeRaw
-          : schemeRaw === "none"
-            ? null
-            : undefined;
-      if (colorScheme === undefined) {
-        return jsonError(res, 400, "colorScheme must be dark|light|no-preference|none");
-      }
-
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        feature: "media emulation",
-        run: async ({ cdpUrl, tab, pw, signal }) => {
-          await pw.emulateMediaViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            colorScheme,
-          });
-          signal.throwIfAborted();
-          res.json({ ok: true, targetId: tab.targetId });
-        },
-      });
-    }),
-  );
-
-  app.post(
-    "/set/timezone",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = resolveTargetIdFromBody(body);
-      const timezoneId = toStringOrEmpty(body.timezoneId);
-      if (!timezoneId) {
-        return jsonError(res, 400, "timezoneId is required");
-      }
-
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        feature: "timezone",
-        run: async ({ cdpUrl, tab, pw, signal }) => {
-          await pw.setTimezoneViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            timezoneId,
-          });
-          signal.throwIfAborted();
-          res.json({ ok: true, targetId: tab.targetId });
-        },
-      });
-    }),
-  );
-
-  app.post(
-    "/set/locale",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = resolveTargetIdFromBody(body);
-      const locale = toStringOrEmpty(body.locale);
-      if (!locale) {
-        return jsonError(res, 400, "locale is required");
-      }
-
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        feature: "locale",
-        run: async ({ cdpUrl, tab, pw, signal }) => {
-          await pw.setLocaleViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            locale,
-          });
-          signal.throwIfAborted();
-          res.json({ ok: true, targetId: tab.targetId });
-        },
-      });
-    }),
-  );
-
-  app.post(
-    "/set/device",
-    asyncBrowserRoute(async (req, res) => {
-      const body = readBody(req);
-      const targetId = resolveTargetIdFromBody(body);
-      const name = toStringOrEmpty(body.name);
-      if (!name) {
-        return jsonError(res, 400, "name is required");
-      }
-
-      await withPlaywrightRouteContext({
-        req,
-        res,
-        ctx,
-        targetId,
-        feature: "device emulation",
-        run: async ({ cdpUrl, tab, pw, signal }) => {
-          await pw.setDeviceViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            name,
-          });
-          signal.throwIfAborted();
-          res.json({ ok: true, targetId: tab.targetId });
-        },
-      });
-    }),
-  );
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "device emulation",
+      run: async ({ cdpUrl, tab, pw, signal }) => {
+        await pw.setDeviceViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          name,
+        });
+        signal.throwIfAborted();
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
+  });
 }

--- a/extensions/browser/src/browser/routes/basic.ts
+++ b/extensions/browser/src/browser/routes/basic.ts
@@ -24,7 +24,6 @@ import { dismissSystemProfileImportPrompt } from "../system-profile-import-state
 import { resolveProfileContext } from "./agent.shared.js";
 import type { BrowserRequest, BrowserResponse, BrowserRouteRegistrar } from "./types.js";
 import {
-  asyncBrowserRoute,
   jsonBrowserError,
   jsonError,
   runProfileRouteOperation,
@@ -108,17 +107,14 @@ function registerBasicProfilePost(
     profileCtx: ProfileContext;
   }) => Promise<void>,
 ) {
-  app.post(
-    path,
-    asyncBrowserRoute(async (req, res) => {
-      await withBasicProfileRoute({
-        req,
-        res,
-        ctx,
-        run: async (profileCtx) => await run({ req, res, profileCtx }),
-      });
-    }),
-  );
+  app.post(path, async (req, res) => {
+    await withBasicProfileRoute({
+      req,
+      res,
+      ctx,
+      run: async (profileCtx) => await run({ req, res, profileCtx }),
+    });
+  });
 }
 
 async function withProfilesServiceMutation(params: {
@@ -347,108 +343,90 @@ function parseHeadlessStartOverride(params: {
 
 /** Register basic browser lifecycle, status, doctor, and profile endpoints. */
 export function registerBrowserBasicRoutes(app: BrowserRouteRegistrar, ctx: BrowserRouteContext) {
-  app.get(
-    "/system-profiles",
-    asyncBrowserRoute(async (req, res) => {
-      await sendBasicJsonResponse({
-        res,
-        run: async () => {
-          const service = createBrowserProfilesService(ctx);
-          return {
-            systemProfiles: await service.listSystemProfiles(
-              toStringOrEmpty(req.query.browser) || undefined,
-            ),
-          };
-        },
-      });
-    }),
-  );
+  app.get("/system-profiles", async (req, res) => {
+    await sendBasicJsonResponse({
+      res,
+      run: async () => {
+        const service = createBrowserProfilesService(ctx);
+        return {
+          systemProfiles: await service.listSystemProfiles(
+            toStringOrEmpty(req.query.browser) || undefined,
+          ),
+        };
+      },
+    });
+  });
 
-  app.get(
-    "/system-profile-import/status",
-    asyncBrowserRoute(async (_req, res) => {
-      await sendBasicJsonResponse({
-        res,
-        run: async () => await createBrowserProfilesService(ctx).getSystemProfileImportStatus(),
-      });
-    }),
-  );
+  app.get("/system-profile-import/status", async (_req, res) => {
+    await sendBasicJsonResponse({
+      res,
+      run: async () => await createBrowserProfilesService(ctx).getSystemProfileImportStatus(),
+    });
+  });
 
-  app.post(
-    "/system-profile-import/dismiss",
-    asyncBrowserRoute(async (_req, res) => {
-      await sendBasicJsonResponse({
-        res,
-        run: async () => {
-          await dismissSystemProfileImportPrompt();
-          return { ok: true };
-        },
-      });
-    }),
-  );
+  app.post("/system-profile-import/dismiss", async (_req, res) => {
+    await sendBasicJsonResponse({
+      res,
+      run: async () => {
+        await dismissSystemProfileImportPrompt();
+        return { ok: true };
+      },
+    });
+  });
 
   // List all profiles with their status
-  app.get(
-    "/profiles",
-    asyncBrowserRoute(async (_req, res) => {
-      try {
-        const service = createBrowserProfilesService(ctx);
-        const profiles = await service.listProfiles();
-        res.json({ profiles });
-      } catch (err) {
-        return handleBrowserRouteError(res, err);
-      }
-    }),
-  );
+  app.get("/profiles", async (_req, res) => {
+    try {
+      const service = createBrowserProfilesService(ctx);
+      const profiles = await service.listProfiles();
+      res.json({ profiles });
+    } catch (err) {
+      return handleBrowserRouteError(res, err);
+    }
+  });
 
   // Get status (profile-aware)
-  app.get(
-    "/",
-    asyncBrowserRoute(async (req, res) => {
-      const profileCtx = resolveProfileContext(req, res, ctx);
-      if (!profileCtx) {
-        return;
-      }
-      try {
-        const status = await runProfileRouteOperation({
-          profileCtx,
-          signal: req.signal,
-          run: async (signal) => await buildBrowserStatus(ctx, profileCtx, signal),
-        });
-        res.json(status);
-      } catch (err) {
-        return handleBrowserRouteError(res, err);
-      }
-    }),
-  );
+  app.get("/", async (req, res) => {
+    const profileCtx = resolveProfileContext(req, res, ctx);
+    if (!profileCtx) {
+      return;
+    }
+    try {
+      const status = await runProfileRouteOperation({
+        profileCtx,
+        signal: req.signal,
+        run: async (signal) => await buildBrowserStatus(ctx, profileCtx, signal),
+      });
+      res.json(status);
+    } catch (err) {
+      return handleBrowserRouteError(res, err);
+    }
+  });
 
-  app.get(
-    "/doctor",
-    asyncBrowserRoute(async (req, res) => {
-      const profileCtx = resolveProfileContext(req, res, ctx);
-      if (!profileCtx) {
-        return;
-      }
-      try {
-        const report = await runProfileRouteOperation({
-          profileCtx,
-          signal: req.signal,
-          run: async (signal) => {
-            const status = await buildBrowserStatus(ctx, profileCtx, signal);
-            const doctorReport = buildBrowserDoctorReport({ status });
-            if (toBoolean(req.query.deep) === true || toBoolean(req.query.live) === true) {
-              doctorReport.checks.push(await runBrowserLiveProbe(profileCtx, signal));
-              doctorReport.ok = doctorReport.checks.every((check) => check.status !== "fail");
-            }
-            return doctorReport;
-          },
-        });
-        res.json(report);
-      } catch (err) {
-        return handleBrowserRouteError(res, err);
-      }
-    }),
-  );
+  app.get("/doctor", async (req, res) => {
+    const profileCtx = resolveProfileContext(req, res, ctx);
+    if (!profileCtx) {
+      return;
+    }
+    try {
+      const report = await runProfileRouteOperation({
+        profileCtx,
+        signal: req.signal,
+        run: async (signal) => {
+          const status = await buildBrowserStatus(ctx, profileCtx, signal);
+          const doctorReport = buildBrowserDoctorReport({ status });
+          if (toBoolean(req.query.deep) === true || toBoolean(req.query.live) === true) {
+            doctorReport.checks.push(await runBrowserLiveProbe(profileCtx, signal));
+            doctorReport.ok = doctorReport.checks.every((check) => check.status !== "fail");
+          }
+          return doctorReport;
+        },
+      });
+      res.json(report);
+    } catch (err) {
+      return handleBrowserRouteError(res, err);
+    }
+  });
 
   // Start browser (profile-aware)
   registerBasicProfilePost(app, ctx, "/start", async ({ req, res, profileCtx }) => {
@@ -480,91 +458,82 @@ export function registerBrowserBasicRoutes(app: BrowserRouteRegistrar, ctx: Brow
   });
 
   // Create a new profile
-  app.post(
-    "/profiles/create",
-    asyncBrowserRoute(async (req, res) => {
-      const name = toStringOrEmpty((req.body as { name?: unknown })?.name);
-      const color = toStringOrEmpty((req.body as { color?: unknown })?.color);
-      const cdpUrl = toStringOrEmpty((req.body as { cdpUrl?: unknown })?.cdpUrl);
-      const userDataDir = toStringOrEmpty((req.body as { userDataDir?: unknown })?.userDataDir);
-      const driver = toStringOrEmpty((req.body as { driver?: unknown })?.driver);
+  app.post("/profiles/create", async (req, res) => {
+    const name = toStringOrEmpty((req.body as { name?: unknown })?.name);
+    const color = toStringOrEmpty((req.body as { color?: unknown })?.color);
+    const cdpUrl = toStringOrEmpty((req.body as { cdpUrl?: unknown })?.cdpUrl);
+    const userDataDir = toStringOrEmpty((req.body as { userDataDir?: unknown })?.userDataDir);
+    const driver = toStringOrEmpty((req.body as { driver?: unknown })?.driver);
 
-      if (!name) {
-        return jsonError(res, 400, "name is required");
-      }
-      if (driver && driver !== "openclaw" && driver !== "clawd" && driver !== "existing-session") {
-        return jsonError(
-          res,
-          400,
-          `unsupported profile driver "${driver}"; use "openclaw", "clawd", or "existing-session"`,
-        );
-      }
-
-      await withProfilesServiceMutation({
+    if (!name) {
+      return jsonError(res, 400, "name is required");
+    }
+    if (driver && driver !== "openclaw" && driver !== "clawd" && driver !== "existing-session") {
+      return jsonError(
         res,
-        ctx,
-        run: async (service) =>
-          await service.createProfile({
-            name,
-            color: color || undefined,
-            cdpUrl: cdpUrl || undefined,
-            userDataDir: userDataDir || undefined,
-            driver:
-              driver === "existing-session"
-                ? "existing-session"
-                : driver === "openclaw" || driver === "clawd"
-                  ? "openclaw"
-                  : undefined,
-          }),
-      });
-    }),
-  );
+        400,
+        `unsupported profile driver "${driver}"; use "openclaw", "clawd", or "existing-session"`,
+      );
+    }
 
-  app.post(
-    "/profiles/import",
-    asyncBrowserRoute(async (req, res) => {
-      const body = (req.body ?? {}) as Record<string, unknown>;
-      // Fail closed on a malformed domain filter: a caller that meant to scope
-      // the import must never silently import every cookie instead.
-      let domains: string[] | undefined;
-      try {
-        domains = parseSystemProfileDomains(body.domains);
-      } catch (err) {
-        return jsonError(res, 400, err instanceof Error ? err.message : "invalid domains");
-      }
-      try {
-        const service = createBrowserProfilesService(ctx);
-        const result = await service.importSystemProfile(
-          {
-            browser: toStringOrEmpty(body.browser) || undefined,
-            systemProfile: toStringOrEmpty(body.systemProfile) || undefined,
-            into: toStringOrEmpty(body.into) || undefined,
-            domains,
-            makeDefault: toBoolean(body.makeDefault) ?? false,
-          },
-          { signal: req.signal },
-        );
-        res.json(result);
-      } catch (err) {
-        return handleBrowserRouteError(res, err);
-      }
-    }),
-  );
+    await withProfilesServiceMutation({
+      res,
+      ctx,
+      run: async (service) =>
+        await service.createProfile({
+          name,
+          color: color || undefined,
+          cdpUrl: cdpUrl || undefined,
+          userDataDir: userDataDir || undefined,
+          driver:
+            driver === "existing-session"
+              ? "existing-session"
+              : driver === "openclaw" || driver === "clawd"
+                ? "openclaw"
+                : undefined,
+        }),
+    });
+  });
+
+  app.post("/profiles/import", async (req, res) => {
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    // Fail closed on a malformed domain filter: a caller that meant to scope
+    // the import must never silently import every cookie instead.
+    let domains: string[] | undefined;
+    try {
+      domains = parseSystemProfileDomains(body.domains);
+    } catch (err) {
+      return jsonError(res, 400, err instanceof Error ? err.message : "invalid domains");
+    }
+    try {
+      const service = createBrowserProfilesService(ctx);
+      const result = await service.importSystemProfile(
+        {
+          browser: toStringOrEmpty(body.browser) || undefined,
+          systemProfile: toStringOrEmpty(body.systemProfile) || undefined,
+          into: toStringOrEmpty(body.into) || undefined,
+          domains,
+          makeDefault: toBoolean(body.makeDefault) ?? false,
+        },
+        { signal: req.signal },
+      );
+      res.json(result);
+    } catch (err) {
+      return handleBrowserRouteError(res, err);
+    }
+  });
 
   // Delete a profile
-  app.delete(
-    "/profiles/:name",
-    asyncBrowserRoute(async (req, res) => {
-      const name = toStringOrEmpty(req.params.name);
-      if (!name) {
-        return jsonError(res, 400, "profile name is required");
-      }
+  app.delete("/profiles/:name", async (req, res) => {
+    const name = toStringOrEmpty(req.params.name);
+    if (!name) {
+      return jsonError(res, 400, "profile name is required");
+    }
 
-      await withProfilesServiceMutation({
-        res,
-        ctx,
-        run: async (service) => await service.deleteProfile(name),
-      });
-    }),
-  );
+    await withProfilesServiceMutation({
+      res,
+      ctx,
+      run: async (service) => await service.deleteProfile(name),
+    });
+  });
 }

--- a/extensions/browser/src/browser/routes/permissions.ts
+++ b/extensions/browser/src/browser/routes/permissions.ts
@@ -18,7 +18,6 @@ import { isProfileRestartRequiredError } from "../server-context.lifecycle.js";
 import { readRouteTimerTimeoutMs } from "./route-numeric.js";
 import type { BrowserRouteRegistrar } from "./types.js";
 import {
-  asyncBrowserRoute,
   getProfileContext,
   jsonBrowserError,
   jsonError,
@@ -139,75 +138,72 @@ export function registerBrowserPermissionRoutes(
   app: BrowserRouteRegistrar,
   ctx: BrowserRouteContext,
 ) {
-  app.post(
-    "/permissions/grant",
-    asyncBrowserRoute(async (req, res) => {
-      const body = (req.body ?? {}) as GrantPermissionsBody;
-      const origin = readHttpOrigin(body.origin);
-      if (!origin) {
-        return jsonError(res, 400, "origin must be an http(s) origin");
-      }
-      const requiredPermissions = readPermissions(body.permissions);
-      if (!requiredPermissions || requiredPermissions.length === 0) {
-        return jsonError(res, 400, "permissions must be a non-empty string array");
-      }
-      const optionalPermissions = readPermissions(body.optionalPermissions ?? []) ?? [];
-      const targetId = toStringOrEmpty(body.targetId) || undefined;
-      let timeoutMs: number;
-      try {
-        timeoutMs = readRouteTimerTimeoutMs(body.timeoutMs, "timeoutMs", { minMs: 1_000 }) ?? 5_000;
-      } catch (err) {
-        return jsonError(res, 400, formatErrorMessage(err));
-      }
+  app.post("/permissions/grant", async (req, res) => {
+    const body = (req.body ?? {}) as GrantPermissionsBody;
+    const origin = readHttpOrigin(body.origin);
+    if (!origin) {
+      return jsonError(res, 400, "origin must be an http(s) origin");
+    }
+    const requiredPermissions = readPermissions(body.permissions);
+    if (!requiredPermissions || requiredPermissions.length === 0) {
+      return jsonError(res, 400, "permissions must be a non-empty string array");
+    }
+    const optionalPermissions = readPermissions(body.optionalPermissions ?? []) ?? [];
+    const targetId = toStringOrEmpty(body.targetId) || undefined;
+    let timeoutMs: number;
+    try {
+      timeoutMs = readRouteTimerTimeoutMs(body.timeoutMs, "timeoutMs", { minMs: 1_000 }) ?? 5_000;
+    } catch (err) {
+      return jsonError(res, 400, formatErrorMessage(err));
+    }
 
-      const profileCtx = getProfileContext(req, ctx);
-      if ("error" in profileCtx) {
-        return jsonError(res, profileCtx.status, profileCtx.error);
-      }
+    const profileCtx = getProfileContext(req, ctx);
+    if ("error" in profileCtx) {
+      return jsonError(res, profileCtx.status, profileCtx.error);
+    }
 
-      try {
-        const granted = await runProfileRouteOperation({
-          profileCtx,
-          signal: req.signal,
-          run: async (signal) => {
-            await profileCtx.ensureBrowserAvailable({ signal });
-            const cdpPolicy = resolveCdpControlPolicy(
-              profileCtx.profile,
-              ctx.state().resolved.ssrfPolicy,
-            );
-            const wsUrl = await getChromeWebSocketUrl(
-              profileCtx.profile.cdpUrl,
-              timeoutMs,
-              cdpPolicy,
-            );
-            signal.throwIfAborted();
-            if (!wsUrl) {
-              throw new BrowserProfileUnavailableError("browser CDP WebSocket unavailable");
-            }
-            return await grantPermissions({
-              profileCtx,
-              targetId,
-              wsUrl,
-              origin,
-              requiredPermissions,
-              optionalPermissions,
-              timeoutMs,
-              ssrfPolicy: cdpPolicy,
-              signal,
-            });
-          },
-        });
-        return res.json({ ok: true, origin, ...granted });
-      } catch (error) {
-        if (isProfileRestartRequiredError(error)) {
-          throw error;
-        }
-        const mapped = toBrowserErrorResponse(error);
-        if (mapped) {
-          return jsonBrowserError(res, mapped);
-        }
-        return jsonError(res, 500, error instanceof Error ? error.message : String(error));
+    try {
+      const granted = await runProfileRouteOperation({
+        profileCtx,
+        signal: req.signal,
+        run: async (signal) => {
+          await profileCtx.ensureBrowserAvailable({ signal });
+          const cdpPolicy = resolveCdpControlPolicy(
+            profileCtx.profile,
+            ctx.state().resolved.ssrfPolicy,
+          );
+          const wsUrl = await getChromeWebSocketUrl(
+            profileCtx.profile.cdpUrl,
+            timeoutMs,
+            cdpPolicy,
+          );
+          signal.throwIfAborted();
+          if (!wsUrl) {
+            throw new BrowserProfileUnavailableError("browser CDP WebSocket unavailable");
+          }
+          return await grantPermissions({
+            profileCtx,
+            targetId,
+            wsUrl,
+            origin,
+            requiredPermissions,
+            optionalPermissions,
+            timeoutMs,
+            ssrfPolicy: cdpPolicy,
+            signal,
+          });
+        },
+      });
+      return res.json({ ok: true, origin, ...granted });
+    } catch (error) {
+      if (isProfileRestartRequiredError(error)) {
+        throw error;
       }
-    }),
-  );
+      const mapped = toBrowserErrorResponse(error);
+      if (mapped) {
+        return jsonBrowserError(res, mapped);
+      }
+      return jsonError(res, 500, error instanceof Error ? error.message : String(error));
+    }
+  });
 }

--- a/extensions/browser/src/browser/routes/tabs.ts
+++ b/extensions/browser/src/browser/routes/tabs.ts
@@ -21,13 +21,7 @@ import { resolveTargetIdFromTabs } from "../target-id.js";
 import { browserNavigationPolicyForProfile, resolveProfileContext } from "./agent.shared.js";
 import { readRouteNonNegativeInteger } from "./route-numeric.js";
 import type { BrowserRequest, BrowserResponse, BrowserRouteRegistrar } from "./types.js";
-import {
-  asyncBrowserRoute,
-  jsonBrowserError,
-  jsonError,
-  runProfileRouteOperation,
-  toStringOrEmpty,
-} from "./utils.js";
+import { jsonBrowserError, jsonError, runProfileRouteOperation, toStringOrEmpty } from "./utils.js";
 
 const DEFAULT_TAB_REACHABILITY_TIMEOUT_MS = 300;
 const TAB_REACHABILITY_RETRY_DELAY_MS = 250;
@@ -218,222 +212,204 @@ async function runTabTargetMutation(params: {
 
 /** Register tab listing and mutation endpoints on the browser control server. */
 export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: BrowserRouteContext) {
-  app.get(
-    "/tabs",
-    asyncBrowserRoute(async (req, res) => {
-      const result = await runTabsProfileRoute({
-        req,
-        res,
-        ctx,
-        run: async (profileCtx, signal) => {
+  app.get("/tabs", async (req, res) => {
+    const result = await runTabsProfileRoute({
+      req,
+      res,
+      ctx,
+      run: async (profileCtx, signal) => {
+        const reachable = await checkTabReachability(ctx, profileCtx, signal);
+        if (!reachable) {
+          return { running: false, tabs: [] as unknown[] };
+        }
+        const tabs = await redactBlockedTabUrls({
+          tabs: await profileCtx.listTabs(),
+          navigationPolicy: browserNavigationPolicyForProfile(ctx, profileCtx),
+        });
+        signal.throwIfAborted();
+        return { running: true, tabs };
+      },
+    });
+    if (result) {
+      res.json(result);
+    }
+  });
+
+  app.post("/tabs/open", async (req, res) => {
+    const url = toStringOrEmpty((req.body as { url?: unknown })?.url);
+    const label = readOptionalTabLabel(req.body);
+    if (!url) {
+      return jsonError(res, 400, "url is required");
+    }
+
+    const result = await runTabsProfileRoute({
+      req,
+      res,
+      ctx,
+      mapTabError: true,
+      run: async (profileCtx, signal) => {
+        await assertBrowserNavigationAllowed({
+          url,
+          ...browserNavigationPolicyForProfile(ctx, profileCtx),
+        });
+        await profileCtx.ensureBrowserAvailable({ signal });
+        return await profileCtx.openTab(url, { label });
+      },
+    });
+    if (result) {
+      res.json(result);
+    }
+  });
+
+  app.post("/tabs/focus", async (req, res) => {
+    const targetId = parseRequiredTargetId(res, (req.body as { targetId?: unknown })?.targetId);
+    if (!targetId) {
+      return;
+    }
+    await runTabTargetMutation({
+      req,
+      res,
+      ctx,
+      targetId,
+      mutate: async (profileCtx, id) => {
+        const tabs = await profileCtx.listTabs();
+        const resolved = resolveTargetIdFromTabs(id, tabs);
+        if (!resolved.ok) {
+          if (resolved.reason === "ambiguous") {
+            throw new BrowserTargetAmbiguousError();
+          }
+          throw new BrowserTabNotFoundError({ input: id });
+        }
+        const tab = tabs.find((currentTab) => currentTab.targetId === resolved.targetId);
+        if (!tab) {
+          throw new BrowserTabNotFoundError({ input: id });
+        }
+        const ssrfPolicyOpts = browserNavigationPolicyForProfile(ctx, profileCtx);
+        if (ssrfPolicyOpts.ssrfPolicy) {
+          await assertBrowserNavigationResultAllowed({
+            url: tab.url,
+            ...ssrfPolicyOpts,
+          });
+        }
+        await profileCtx.focusTab(resolved.targetId, { exactTargetId: true });
+      },
+    });
+  });
+
+  app.delete("/tabs/:targetId", async (req, res) => {
+    const targetId = parseRequiredTargetId(res, req.params.targetId);
+    if (!targetId) {
+      return;
+    }
+    const targetIdMode = toStringOrEmpty(req.query.targetIdMode);
+    if (targetIdMode && targetIdMode !== "raw") {
+      return jsonError(res, 400, 'targetIdMode must be "raw"');
+    }
+    await runTabTargetMutation({
+      req,
+      res,
+      ctx,
+      targetId,
+      mutate: async (profileCtx, id) => {
+        await profileCtx.closeTab(id, targetIdMode === "raw" ? { exactTargetId: true } : undefined);
+      },
+    });
+  });
+
+  app.post("/tabs/action", async (req, res) => {
+    const action = toStringOrEmpty((req.body as { action?: unknown })?.action);
+    if (
+      action !== "list" &&
+      action !== "new" &&
+      action !== "label" &&
+      action !== "close" &&
+      action !== "select"
+    ) {
+      return jsonError(res, 400, "unknown tab action");
+    }
+    const targetId =
+      action === "label"
+        ? parseRequiredTargetId(res, (req.body as { targetId?: unknown })?.targetId)
+        : undefined;
+    if (action === "label" && !targetId) {
+      return;
+    }
+    const label =
+      action === "label" || action === "new" ? readOptionalTabLabel(req.body) : undefined;
+    if (action === "label" && !label) {
+      return jsonError(res, 400, "label is required");
+    }
+    const index =
+      action === "close"
+        ? readTabIndex(res, req.body)
+        : action === "select"
+          ? readTabIndex(res, req.body, { required: true })
+          : undefined;
+    if ((action === "close" && index === null) || (action === "select" && index == null)) {
+      return;
+    }
+
+    const result = await runTabsProfileRoute({
+      req,
+      res,
+      ctx,
+      mapTabError: true,
+      run: async (profileCtx, signal) => {
+        if (action === "list") {
           const reachable = await checkTabReachability(ctx, profileCtx, signal);
           if (!reachable) {
-            return { running: false, tabs: [] as unknown[] };
+            return { ok: true, tabs: [] as unknown[] };
           }
           const tabs = await redactBlockedTabUrls({
             tabs: await profileCtx.listTabs(),
             navigationPolicy: browserNavigationPolicyForProfile(ctx, profileCtx),
           });
           signal.throwIfAborted();
-          return { running: true, tabs };
-        },
-      });
-      if (result) {
-        res.json(result);
-      }
-    }),
-  );
+          return { ok: true, tabs };
+        }
 
-  app.post(
-    "/tabs/open",
-    asyncBrowserRoute(async (req, res) => {
-      const url = toStringOrEmpty((req.body as { url?: unknown })?.url);
-      const label = readOptionalTabLabel(req.body);
-      if (!url) {
-        return jsonError(res, 400, "url is required");
-      }
-
-      const result = await runTabsProfileRoute({
-        req,
-        res,
-        ctx,
-        mapTabError: true,
-        run: async (profileCtx, signal) => {
-          await assertBrowserNavigationAllowed({
-            url,
-            ...browserNavigationPolicyForProfile(ctx, profileCtx),
-          });
+        if (action === "new") {
           await profileCtx.ensureBrowserAvailable({ signal });
-          return await profileCtx.openTab(url, { label });
-        },
-      });
-      if (result) {
-        res.json(result);
-      }
-    }),
-  );
+          const tab = await profileCtx.openTab("about:blank", { label });
+          return { ok: true, tab };
+        }
 
-  app.post(
-    "/tabs/focus",
-    asyncBrowserRoute(async (req, res) => {
-      const targetId = parseRequiredTargetId(res, (req.body as { targetId?: unknown })?.targetId);
-      if (!targetId) {
-        return;
-      }
-      await runTabTargetMutation({
-        req,
-        res,
-        ctx,
-        targetId,
-        mutate: async (profileCtx, id) => {
-          const tabs = await profileCtx.listTabs();
-          const resolved = resolveTargetIdFromTabs(id, tabs);
-          if (!resolved.ok) {
-            if (resolved.reason === "ambiguous") {
-              throw new BrowserTargetAmbiguousError();
-            }
-            throw new BrowserTabNotFoundError({ input: id });
-          }
-          const tab = tabs.find((currentTab) => currentTab.targetId === resolved.targetId);
-          if (!tab) {
-            throw new BrowserTabNotFoundError({ input: id });
-          }
-          const ssrfPolicyOpts = browserNavigationPolicyForProfile(ctx, profileCtx);
-          if (ssrfPolicyOpts.ssrfPolicy) {
-            await assertBrowserNavigationResultAllowed({
-              url: tab.url,
-              ...ssrfPolicyOpts,
-            });
-          }
-          await profileCtx.focusTab(resolved.targetId, { exactTargetId: true });
-        },
-      });
-    }),
-  );
+        if (action === "label") {
+          await ensureBrowserRunning(ctx, profileCtx, signal);
+          const tab = await profileCtx.labelTab(targetId!, label!);
+          return { ok: true, tab };
+        }
 
-  app.delete(
-    "/tabs/:targetId",
-    asyncBrowserRoute(async (req, res) => {
-      const targetId = parseRequiredTargetId(res, req.params.targetId);
-      if (!targetId) {
-        return;
-      }
-      const targetIdMode = toStringOrEmpty(req.query.targetIdMode);
-      if (targetIdMode && targetIdMode !== "raw") {
-        return jsonError(res, 400, 'targetIdMode must be "raw"');
-      }
-      await runTabTargetMutation({
-        req,
-        res,
-        ctx,
-        targetId,
-        mutate: async (profileCtx, id) => {
-          await profileCtx.closeTab(
-            id,
-            targetIdMode === "raw" ? { exactTargetId: true } : undefined,
-          );
-        },
-      });
-    }),
-  );
-
-  app.post(
-    "/tabs/action",
-    asyncBrowserRoute(async (req, res) => {
-      const action = toStringOrEmpty((req.body as { action?: unknown })?.action);
-      if (
-        action !== "list" &&
-        action !== "new" &&
-        action !== "label" &&
-        action !== "close" &&
-        action !== "select"
-      ) {
-        return jsonError(res, 400, "unknown tab action");
-      }
-      const targetId =
-        action === "label"
-          ? parseRequiredTargetId(res, (req.body as { targetId?: unknown })?.targetId)
-          : undefined;
-      if (action === "label" && !targetId) {
-        return;
-      }
-      const label =
-        action === "label" || action === "new" ? readOptionalTabLabel(req.body) : undefined;
-      if (action === "label" && !label) {
-        return jsonError(res, 400, "label is required");
-      }
-      const index =
-        action === "close"
-          ? readTabIndex(res, req.body)
-          : action === "select"
-            ? readTabIndex(res, req.body, { required: true })
-            : undefined;
-      if ((action === "close" && index === null) || (action === "select" && index == null)) {
-        return;
-      }
-
-      const result = await runTabsProfileRoute({
-        req,
-        res,
-        ctx,
-        mapTabError: true,
-        run: async (profileCtx, signal) => {
-          if (action === "list") {
-            const reachable = await checkTabReachability(ctx, profileCtx, signal);
-            if (!reachable) {
-              return { ok: true, tabs: [] as unknown[] };
-            }
-            const tabs = await redactBlockedTabUrls({
-              tabs: await profileCtx.listTabs(),
-              navigationPolicy: browserNavigationPolicyForProfile(ctx, profileCtx),
-            });
-            signal.throwIfAborted();
-            return { ok: true, tabs };
-          }
-
-          if (action === "new") {
-            await profileCtx.ensureBrowserAvailable({ signal });
-            const tab = await profileCtx.openTab("about:blank", { label });
-            return { ok: true, tab };
-          }
-
-          if (action === "label") {
-            await ensureBrowserRunning(ctx, profileCtx, signal);
-            const tab = await profileCtx.labelTab(targetId!, label!);
-            return { ok: true, tab };
-          }
-
-          if (action === "close") {
-            await ensureBrowserRunning(ctx, profileCtx, signal);
-            const tabs = await profileCtx.listTabs();
-            const target = resolveIndexedTab(tabs, index);
-            if (!target) {
-              throw new BrowserTabNotFoundError();
-            }
-            await profileCtx.closeTab(target.targetId, { exactTargetId: true });
-            return { ok: true, targetId: target.targetId };
-          }
-
+        if (action === "close") {
           await ensureBrowserRunning(ctx, profileCtx, signal);
           const tabs = await profileCtx.listTabs();
-          const target = tabs[index!];
+          const target = resolveIndexedTab(tabs, index);
           if (!target) {
             throw new BrowserTabNotFoundError();
           }
-          const ssrfPolicyOpts = browserNavigationPolicyForProfile(ctx, profileCtx);
-          if (ssrfPolicyOpts.ssrfPolicy) {
-            await assertBrowserNavigationResultAllowed({
-              url: target.url,
-              ...ssrfPolicyOpts,
-            });
-          }
-          await profileCtx.focusTab(target.targetId, { exactTargetId: true });
+          await profileCtx.closeTab(target.targetId, { exactTargetId: true });
           return { ok: true, targetId: target.targetId };
-        },
-      });
-      if (result) {
-        res.json(result);
-      }
-    }),
-  );
+        }
+
+        await ensureBrowserRunning(ctx, profileCtx, signal);
+        const tabs = await profileCtx.listTabs();
+        const target = tabs[index!];
+        if (!target) {
+          throw new BrowserTabNotFoundError();
+        }
+        const ssrfPolicyOpts = browserNavigationPolicyForProfile(ctx, profileCtx);
+        if (ssrfPolicyOpts.ssrfPolicy) {
+          await assertBrowserNavigationResultAllowed({
+            url: target.url,
+            ...ssrfPolicyOpts,
+          });
+        }
+        await profileCtx.focusTab(target.targetId, { exactTargetId: true });
+        return { ok: true, targetId: target.targetId };
+      },
+    });
+    if (result) {
+      res.json(result);
+    }
+  });
 }

--- a/extensions/browser/src/browser/routes/utils.ts
+++ b/extensions/browser/src/browser/routes/utils.ts
@@ -1,8 +1,8 @@
 /**
  * Browser route utility functions.
  *
- * Wraps async handlers, profile lookup, JSON errors, and route value coercion
- * shared across browser control endpoints.
+ * Profile lookup, JSON errors, and route value coercion shared across browser
+ * control endpoints.
  */
 import { BrowserProfileUnavailableError, type BrowserErrorResponse } from "../errors.js";
 import {
@@ -11,15 +11,10 @@ import {
   withProfileContextOperation,
 } from "../server-context.js";
 import { isProfileRestartRequiredError } from "../server-context.lifecycle.js";
-import type { BrowserRequest, BrowserResponse, BrowserRouteHandler } from "./types.js";
+import type { BrowserRequest, BrowserResponse } from "./types.js";
 
 function normalizeOptionalString(value: string): string | undefined {
   return value.trim() || undefined;
-}
-
-/** Convert thrown async route errors into next(error) calls for the HTTP layer. */
-export function asyncBrowserRoute(handler: BrowserRouteHandler): BrowserRouteHandler {
-  return (req, res) => handler(req, res);
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Browser routes carried a no-op async-handler wrapper that added nesting across every endpoint even though the supported Express runtime already handles rejected promises natively.

## Why This Change Was Made

Register all 47 async Browser handlers directly, delete the redundant wrapper, and disable the lint rule whose own contract targets Express versions before v5. The Express pin remains exact at 5.2.1, and the in-process dispatcher continues to await the same returned promises.

## User Impact

No user-visible behavior change. Browser route behavior, error propagation, methods, paths, and response bodies stay the same while 175 lines of adapter boilerplate disappear.

## Evidence

- Exact installed contract inspected: Express 5.2.1, router 2.2.0 promise rejection forwarding, Express request-handler types, Browser registrar, and in-process dispatcher.
- AST equivalence probe: all 47 wrapper calls transformed; all 10 TypeScript files structurally identical after accounting for wrapper, import, and helper deletion.
- Blacksmith Testbox `tbx_01kxf29krg5r5qjza3rgexz4w8`: 188 Browser route/server tests passed; exact-file `check:changed` passed formatting, extension/test type lanes, extension/script lint, boundary guards, and import-cycle checks; full `pnpm build` passed.
- Rebased exact-head Blacksmith Testbox `tbx_01kxf32ytqte6nnjyxs0h495qf`: 188/188 focused tests passed again.
- Stable patch-id preserved across the final clean rebase over unrelated main changes.
- `git diff --check` passed. Two fresh autoreview runs reported no accepted/actionable findings.
