### PR TITLE
fix(google): reject malformed provider media base64

### DIFF
--- a/extensions/google/base64.ts
+++ b/extensions/google/base64.ts
@@ -1,0 +1,24 @@
+// Google provider module implements strict base64 decoding helpers.
+import { canonicalizeBase64, estimateBase64DecodedBytes } from "openclaw/plugin-sdk/media-runtime";
+
+export function decodeGoogleProviderBase64(
+  value: string,
+  params: {
+    malformedMessage: string;
+    maxBytes?: number;
+    overflowMessage?: (maxBytes: number) => string;
+  },
+): Buffer {
+  if (params.maxBytes !== undefined && estimateBase64DecodedBytes(value) > params.maxBytes) {
+    throw new Error(params.overflowMessage?.(params.maxBytes) ?? "Google base64 payload too large");
+  }
+  const canonical = canonicalizeBase64(value);
+  if (!canonical) {
+    throw new Error(params.malformedMessage);
+  }
+  const buffer = Buffer.from(canonical, "base64");
+  if (params.maxBytes !== undefined && buffer.length > params.maxBytes) {
+    throw new Error(params.overflowMessage?.(params.maxBytes) ?? "Google base64 payload too large");
+  }
+  return buffer;
+}

--- a/extensions/google/base64.ts
+++ b/extensions/google/base64.ts
@@ -1,6 +1,18 @@
 // Google provider module implements strict base64 decoding helpers.
 import { canonicalizeBase64, estimateBase64DecodedBytes } from "openclaw/plugin-sdk/media-runtime";
 
+function normalizeGoogleProviderBase64Alphabet(value: string): string | undefined {
+  const hasStandardOnlyChars = value.includes("+") || value.includes("/");
+  const hasUrlSafeOnlyChars = value.includes("-") || value.includes("_");
+  if (hasStandardOnlyChars && hasUrlSafeOnlyChars) {
+    return undefined;
+  }
+  if (!hasUrlSafeOnlyChars) {
+    return value;
+  }
+  return value.replaceAll("-", "+").replaceAll("_", "/");
+}
+
 export function decodeGoogleProviderBase64(
   value: string,
   params: {
@@ -12,7 +24,8 @@ export function decodeGoogleProviderBase64(
   if (params.maxBytes !== undefined && estimateBase64DecodedBytes(value) > params.maxBytes) {
     throw new Error(params.overflowMessage?.(params.maxBytes) ?? "Google base64 payload too large");
   }
-  const canonical = canonicalizeBase64(value);
+  const normalized = normalizeGoogleProviderBase64Alphabet(value);
+  const canonical = normalized ? canonicalizeBase64(normalized) : undefined;
   if (!canonical) {
     throw new Error(params.malformedMessage);
   }

--- a/extensions/google/music-generation-provider.test.ts
+++ b/extensions/google/music-generation-provider.test.ts
@@ -175,6 +175,36 @@ describe("google music generation provider", () => {
     expect(generateContentMock).toHaveBeenCalledTimes(1);
   });
 
+  it("accepts valid base64url inline audio", async () => {
+    mockGoogleAuth();
+    const audioBytes = Buffer.from([251, 255, 254, 250]);
+    generateContentMock.mockResolvedValue({
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                inlineData: {
+                  data: audioBytes.toString("base64url"),
+                  mimeType: "audio/mpeg",
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = await buildGoogleMusicGenerationProvider().generateMusic({
+      provider: "google",
+      model: "lyria-3-clip-preview",
+      prompt: "upbeat synthpop anthem",
+      cfg: {},
+    });
+
+    expect(result.tracks[0]?.buffer).toEqual(audioBytes);
+  });
+
   it("retries once when Lyria returns an unblocked text-only response", async () => {
     mockGoogleAuth();
     generateContentMock

--- a/extensions/google/music-generation-provider.test.ts
+++ b/extensions/google/music-generation-provider.test.ts
@@ -170,7 +170,7 @@ describe("google music generation provider", () => {
         prompt: "upbeat synthpop anthem",
         cfg: {},
       }),
-    ).rejects.toThrow("Generated music asset contains malformed base64 audio data");
+    ).rejects.toThrow("Google music generation response returned malformed audio base64");
 
     expect(generateContentMock).toHaveBeenCalledTimes(1);
   });

--- a/extensions/google/music-generation-provider.ts
+++ b/extensions/google/music-generation-provider.ts
@@ -1,6 +1,5 @@
 // Google provider module implements model/runtime integration.
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
-import { generatedMusicAssetFromBase64 } from "openclaw/plugin-sdk/music-generation";
 import type {
   GeneratedMusicAsset,
   MusicGenerationProvider,
@@ -13,6 +12,7 @@ import {
 } from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveGoogleGenerativeAiApiOrigin } from "./api.js";
+import { decodeGoogleProviderBase64 } from "./base64.js";
 import {
   createGoogleMusicGenerationProviderMetadata,
   DEFAULT_GOOGLE_MUSIC_MODEL,
@@ -95,17 +95,17 @@ function extractTracks(params: { payload: GoogleGenerateMusicResponse; model: st
         normalizeOptionalString(inline?.mimeType) ||
         normalizeOptionalString(inline?.mime_type) ||
         "audio/mpeg";
-      tracks.push(
-        generatedMusicAssetFromBase64({
-          base64: data,
-          mimeType,
-          fileName: resolveTrackFileName({
-            index: tracks.length,
-            mimeType,
-            model: params.model,
-          }),
+      tracks.push({
+        buffer: decodeGoogleProviderBase64(data, {
+          malformedMessage: "Google music generation response returned malformed audio base64",
         }),
-      );
+        mimeType,
+        fileName: resolveTrackFileName({
+          index: tracks.length,
+          mimeType,
+          model: params.model,
+        }),
+      });
     }
   }
   return { tracks, lyrics };

--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -1122,6 +1122,38 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     expect(requireFirstAudio(onAudio)).toEqual(pcm24k);
   });
 
+  it("accepts valid base64url Google Live audio", async () => {
+    const provider = buildGoogleRealtimeVoiceProvider();
+    const onAudio = vi.fn();
+    const pcm24k = Buffer.from([251, 255, 254, 250]);
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "gemini-key" },
+      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+      onAudio,
+      onClearAudio: vi.fn(),
+    });
+
+    await bridge.connect();
+    lastConnectParams().callbacks.onmessage({
+      setupComplete: {},
+      serverContent: {
+        modelTurn: {
+          parts: [
+            {
+              inlineData: {
+                mimeType: "audio/L16;codec=pcm;rate=24000",
+                data: pcm24k.toString("base64url"),
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(onAudio).toHaveBeenCalledTimes(1);
+    expect(requireFirstAudio(onAudio)).toEqual(pcm24k);
+  });
+
   it.each([
     ["invalid alphabet", "not-base64!"],
     ["non-canonical pad bits", "ZE=="],

--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -18,7 +18,6 @@ import {
   type ThinkingConfig,
   TurnCoverage,
 } from "@google/genai";
-import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import {
   resolveExpiresAtMsFromDurationMs,
   timestampMsToIsoString,
@@ -51,6 +50,7 @@ import {
   asFiniteNumber,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { decodeGoogleProviderBase64 } from "./base64.js";
 import { createGoogleGenAI } from "./google-genai-runtime.js";
 import { resolveGoogleGemini3ThinkingLevel } from "./thinking.js";
 
@@ -261,8 +261,6 @@ function resolveEnvApiKey(): string | undefined {
   return trimToUndefined(process.env.GEMINI_API_KEY) ?? trimToUndefined(process.env.GOOGLE_API_KEY);
 }
 
-// Gemini 3.1 Live replaces client-content text and async tools with realtime text
-// and sequential function responses; explicit older models keep their prior contract.
 function isGemini31LiveModel(model: string): boolean {
   const modelId = model.startsWith("models/") ? model.slice("models/".length) : model;
   return modelId.startsWith("gemini-3.1-") && modelId.includes("-live");
@@ -337,8 +335,6 @@ function buildFunctionDeclarations(
         omitted += 1;
         continue;
       }
-      // Live preview models honor the OpenAPI `parameters` field; the SDK normalizes
-      // our lowercase JSON Schema types before sending the mutually exclusive field.
       const declaration: FunctionDeclaration = {
         name,
         description: tool.description,
@@ -489,8 +485,6 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
     const canResumeSession =
       this.config.sessionResumption !== false && Boolean(this.resumptionHandle);
     if (this.hasConnectedSession && !canResumeSession) {
-      // An unfinished recognition hypothesis cannot cross into a fresh server session.
-      // Dropping it avoids treating a transport break as a completed user utterance.
       this.resetPendingTranscripts();
     }
     this.intentionallyClosed = false;
@@ -552,8 +546,6 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
           if (this.scheduleReconnect(closeDetails)) {
             return;
           }
-          // Transport failure is not an utterance boundary. Preserve transcript
-          // fragments across reconnects and finalize only when recovery is exhausted.
           this.flushPendingTranscripts();
           this.config.onError?.(
             new Error(`Google Live session closed after reconnect attempts: ${closeDetails}`),
@@ -791,19 +783,24 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
     }
 
     if (content.outputTranscription) {
-      // outputAudioTranscription is requested in the session config. Keep that
-      // official stream canonical; modelTurn text has no transcript turn identity.
       this.appendTranscript("assistant", content.outputTranscription);
     }
 
     for (const part of content.modelTurn?.parts ?? []) {
       if (part.inlineData?.data) {
-        const canonicalAudio = canonicalizeBase64(part.inlineData.data);
-        if (!canonicalAudio) {
-          this.failConnection(new Error("Google Live stream returned malformed base64 audio data"));
+        let pcm: Buffer;
+        try {
+          pcm = decodeGoogleProviderBase64(part.inlineData.data, {
+            malformedMessage: "Google Live stream returned malformed base64 audio data",
+          });
+        } catch (error) {
+          this.failConnection(
+            error instanceof Error
+              ? error
+              : new Error("Google Live stream returned malformed base64 audio data"),
+          );
           return;
         }
-        const pcm = Buffer.from(canonicalAudio, "base64");
         const sampleRate = parsePcmSampleRate(part.inlineData.mimeType);
         const audio = this.toOutputAudio(pcm, sampleRate);
         if (audio.length > 0) {
@@ -821,8 +818,6 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
       this.pendingTranscripts[role] += text;
       this.emitTranscript(role, text, false);
     }
-    // turnComplete belongs to model generation and is unordered with transcription.
-    // Finalize only on the protocol terminal or when the bridge permanently closes.
     if (transcript.finished) {
       this.flushPendingTranscript(role);
     }
@@ -844,9 +839,7 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
         this.config.onError?.(
           error instanceof Error ? error : new Error("Google Live transcript callback failed"),
         );
-      } catch {
-        // Consumer callback failures must not abort provider cleanup.
-      }
+      } catch {}
     }
   }
 

--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -261,6 +261,8 @@ function resolveEnvApiKey(): string | undefined {
   return trimToUndefined(process.env.GEMINI_API_KEY) ?? trimToUndefined(process.env.GOOGLE_API_KEY);
 }
 
+// Gemini 3.1 Live replaces client-content text and async tools with realtime text
+// and sequential function responses; explicit older models keep their prior contract.
 function isGemini31LiveModel(model: string): boolean {
   const modelId = model.startsWith("models/") ? model.slice("models/".length) : model;
   return modelId.startsWith("gemini-3.1-") && modelId.includes("-live");
@@ -335,6 +337,8 @@ function buildFunctionDeclarations(
         omitted += 1;
         continue;
       }
+      // Live preview models honor the OpenAPI `parameters` field; the SDK normalizes
+      // our lowercase JSON Schema types before sending the mutually exclusive field.
       const declaration: FunctionDeclaration = {
         name,
         description: tool.description,
@@ -485,6 +489,8 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
     const canResumeSession =
       this.config.sessionResumption !== false && Boolean(this.resumptionHandle);
     if (this.hasConnectedSession && !canResumeSession) {
+      // An unfinished recognition hypothesis cannot cross into a fresh server session.
+      // Dropping it avoids treating a transport break as a completed user utterance.
       this.resetPendingTranscripts();
     }
     this.intentionallyClosed = false;

--- a/extensions/google/speech-provider.test.ts
+++ b/extensions/google/speech-provider.test.ts
@@ -214,6 +214,47 @@ describe("Google speech provider", () => {
     expect(release).toHaveBeenCalledTimes(2);
   });
 
+  it("accepts valid base64url Gemini TTS audio", async () => {
+    const pcm = Buffer.from([251, 255, 254, 250]);
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: {
+        ok: true,
+        json: async () => ({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    inlineData: {
+                      mimeType: "audio/L16;codec=pcm;rate=24000",
+                      data: pcm.toString("base64url"),
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      },
+      release,
+    });
+    const provider = buildGoogleSpeechProvider();
+
+    const result = await provider.synthesize({
+      text: "Say this.",
+      cfg: {},
+      providerConfig: {
+        apiKey: "google-test-key",
+      },
+      target: "audio-file",
+      timeoutMs: 12_000,
+    });
+
+    expect(result.audioBuffer.subarray(44)).toEqual(pcm);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
   it("bounds oversized Gemini TTS success JSON responses and cancels the stream", async () => {
     let cancelCount = 0;
     const release = vi.fn(async () => {});

--- a/extensions/google/speech-provider.test.ts
+++ b/extensions/google/speech-provider.test.ts
@@ -7,10 +7,10 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 
 const transcodeAudioBufferToOpusMock = vi.hoisted(() => vi.fn());
 
-vi.mock("openclaw/plugin-sdk/media-runtime", async () => {
-  const { canonicalizeBase64 } = await import("@openclaw/media-core/base64");
+vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/media-runtime")>();
   return {
-    canonicalizeBase64,
+    ...actual,
     transcodeAudioBufferToOpus: transcodeAudioBufferToOpusMock,
   };
 });
@@ -172,6 +172,46 @@ describe("Google speech provider", () => {
     expect(result.audioBuffer.readUInt32LE(24)).toBe(24_000);
     expect(result.audioBuffer.subarray(44)).toEqual(Buffer.from([1, 0, 2, 0]));
     expect(transcodeAudioBufferToOpusMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed Gemini TTS audio base64", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: {
+        ok: true,
+        json: async () => ({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    inlineData: {
+                      mimeType: "audio/L16;codec=pcm;rate=24000",
+                      data: "not valid base64!",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      },
+      release,
+    });
+    const provider = buildGoogleSpeechProvider();
+
+    await expect(
+      provider.synthesize({
+        text: "Say this.",
+        cfg: {},
+        providerConfig: {
+          apiKey: "google-test-key",
+        },
+        target: "audio-file",
+        timeoutMs: 12_000,
+      }),
+    ).rejects.toThrow("Google TTS response returned malformed audio base64");
+    expect(release).toHaveBeenCalledTimes(2);
   });
 
   it("bounds oversized Gemini TTS success JSON responses and cancels the stream", async () => {

--- a/extensions/google/speech-provider.test.ts
+++ b/extensions/google/speech-provider.test.ts
@@ -451,7 +451,7 @@ describe("Google speech provider", () => {
         target: "audio-file",
         timeoutMs: 5_000,
       }),
-    ).rejects.toThrow("Google TTS response returned malformed base64 audio data");
+    ).rejects.toThrow("Google TTS response returned malformed audio base64");
     expect(requestSequence).toHaveBeenCalledTimes(2);
   });
 

--- a/extensions/google/speech-provider.ts
+++ b/extensions/google/speech-provider.ts
@@ -1,5 +1,5 @@
 // Google provider module implements model/runtime integration.
-import { canonicalizeBase64, transcodeAudioBufferToOpus } from "openclaw/plugin-sdk/media-runtime";
+import { transcodeAudioBufferToOpus } from "openclaw/plugin-sdk/media-runtime";
 import {
   assertOkOrThrowProviderError,
   postJsonRequest,
@@ -18,6 +18,7 @@ import type {
 import { asObject, trimToUndefined } from "openclaw/plugin-sdk/speech-core";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveGoogleGenerativeAiHttpRequestConfig } from "./api.js";
+import { decodeGoogleProviderBase64 } from "./base64.js";
 
 const DEFAULT_GOOGLE_TTS_MODEL = "gemini-3.1-flash-tts-preview";
 const DEFAULT_GOOGLE_TTS_VOICE = "Kore";
@@ -290,18 +291,13 @@ function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext): {
 }
 
 function extractGoogleSpeechPcm(payload: GoogleGenerateSpeechResponse): Buffer {
-  for (const candidate of payload.candidates ?? []) {
-    for (const part of candidate.content?.parts ?? []) {
-      const inline = part.inlineData ?? part.inline_data;
-      const data = normalizeOptionalString(inline?.data);
-      if (!data) {
-        continue;
-      }
-      const canonicalAudio = canonicalizeBase64(data);
-      if (!canonicalAudio) {
-        throw new Error("Google TTS response returned malformed base64 audio data");
-      }
-      return Buffer.from(canonicalAudio, "base64");
+  const parts = (payload.candidates ?? []).flatMap((c) => c.content?.parts ?? []);
+  for (const part of parts) {
+    const data = normalizeOptionalString((part.inlineData ?? part.inline_data)?.data);
+    if (data) {
+      return decodeGoogleProviderBase64(data, {
+        malformedMessage: "Google TTS response returned malformed audio base64",
+      });
     }
   }
   throw new Error("Google TTS response missing audio data");

--- a/extensions/google/video-generation-provider.test.ts
+++ b/extensions/google/video-generation-provider.test.ts
@@ -235,7 +235,7 @@ describe("google video generation provider", () => {
         cfg: {},
         durationSeconds: 3,
       }),
-    ).rejects.toThrow("Google video generation returned malformed base64 video data");
+    ).rejects.toThrow("Google generated video response returned malformed video base64");
   });
 
   it("rejects inline video bytes that exceed the configured media cap", async () => {
@@ -268,6 +268,38 @@ describe("google video generation provider", () => {
         durationSeconds: 3,
       }),
     ).rejects.toThrow("Google generated video download exceeds 1 bytes");
+  });
+
+  it("rejects malformed inline video base64", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateVideosMock.mockResolvedValue({
+      done: true,
+      response: {
+        generatedVideos: [
+          {
+            video: {
+              videoBytes: "not valid base64!",
+              mimeType: "video/mp4",
+            },
+          },
+        ],
+      },
+    });
+
+    const provider = buildGoogleVideoGenerationProvider();
+    await expect(
+      provider.generateVideo({
+        provider: "google",
+        model: "veo-3.1-fast-generate-preview",
+        prompt: "A tiny robot watering a windowsill garden",
+        cfg: {},
+        durationSeconds: 3,
+      }),
+    ).rejects.toThrow("Google generated video response returned malformed video base64");
   });
 
   it("strips /v1beta suffix from configured baseUrl before passing to GoogleGenAI SDK", async () => {

--- a/extensions/google/video-generation-provider.test.ts
+++ b/extensions/google/video-generation-provider.test.ts
@@ -302,6 +302,38 @@ describe("google video generation provider", () => {
     ).rejects.toThrow("Google generated video response returned malformed video base64");
   });
 
+  it("accepts valid base64url inline video bytes", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    const videoBytes = Buffer.from([251, 255, 254, 250]);
+    generateVideosMock.mockResolvedValue({
+      done: true,
+      response: {
+        generatedVideos: [
+          {
+            video: {
+              videoBytes: videoBytes.toString("base64url"),
+              mimeType: "video/mp4",
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await buildGoogleVideoGenerationProvider().generateVideo({
+      provider: "google",
+      model: "veo-3.1-fast-generate-preview",
+      prompt: "A tiny robot watering a windowsill garden",
+      cfg: {},
+      durationSeconds: 3,
+    });
+
+    expect(result.videos[0]?.buffer).toEqual(videoBytes);
+  });
+
   it("strips /v1beta suffix from configured baseUrl before passing to GoogleGenAI SDK", async () => {
     vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
       apiKey: "google-key",

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -1,6 +1,5 @@
 // Google provider module implements model/runtime integration.
 import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
-import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   createProviderOperationDeadline,
@@ -17,6 +16,7 @@ import type {
   VideoGenerationRequest,
 } from "openclaw/plugin-sdk/video-generation";
 import { parseGeminiAuth, resolveGoogleGenerativeAiApiOrigin } from "./api.js";
+import { decodeGoogleProviderBase64 } from "./base64.js";
 import {
   createGoogleVideoGenerationProviderMetadata,
   DEFAULT_GOOGLE_VIDEO_MODEL,
@@ -37,12 +37,6 @@ const GOOGLE_VIDEO_EMPTY_RESULT_MESSAGE =
 function resolveConfiguredGoogleVideoBaseUrl(req: VideoGenerationRequest): string | undefined {
   const configured = normalizeOptionalString(req.cfg?.models?.providers?.google?.baseUrl);
   return configured ? resolveGoogleGenerativeAiApiOrigin(configured) : undefined;
-}
-
-function assertGeneratedVideoBufferWithinLimit(buffer: Buffer, maxBytes: number): void {
-  if (buffer.length > maxBytes) {
-    throw new Error(`Google generated video download exceeds ${maxBytes} bytes`);
-  }
 }
 
 function resolveGoogleVideoRestBaseUrl(configuredBaseUrl?: string): string {
@@ -565,12 +559,12 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
             | { videoBytes?: string; uri?: string; mimeType?: string }
             | undefined;
           if (inline?.videoBytes) {
-            const canonicalVideo = canonicalizeBase64(inline.videoBytes);
-            if (!canonicalVideo) {
-              throw new Error("Google video generation returned malformed base64 video data");
-            }
-            const buffer = Buffer.from(canonicalVideo, "base64");
-            assertGeneratedVideoBufferWithinLimit(buffer, maxVideoBytes);
+            const buffer = decodeGoogleProviderBase64(inline.videoBytes, {
+              malformedMessage: "Google generated video response returned malformed video base64",
+              maxBytes: maxVideoBytes,
+              overflowMessage: (maxBytes) =>
+                `Google generated video download exceeds ${maxBytes} bytes`,
+            });
             return {
               buffer,
               mimeType: normalizeOptionalString(inline.mimeType) || "video/mp4",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Google provider responses could include malformed inline audio or video base64 that Node would decode permissively instead of rejecting.

## Why This Change Was Made

Google music, speech, video generation, and Realtime Live audio now share a strict base64 decoder before materializing provider-returned media. The Google-specific decoder accepts both standard base64 and Google ProtoJSON-valid base64url payloads before canonical validation, while inline video bytes reuse the existing generated-video byte cap before decode so oversized payloads fail before allocating the full buffer.

## User Impact

Users get a clear provider error for malformed Google media responses without rejecting valid base64url media that Google may return. Realtime Live malformed inline audio is routed through `onError` without emitting corrupt audio, and operators keep the existing video media cap behavior without permissive base64 decoding.

## Evidence

Live Google TTS run through the production `buildGoogleSpeechProvider().synthesize()` entrypoint; this was captured on the earlier PR head `f36b9f96544a6416e51712ee3881e682409df825` before the base64url compatibility follow-up, and the same entrypoint remains covered by focused regression tests on current head `4f77e023235`:

```text
$ GEMINI_API_KEY=<redacted> node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-providers.config.ts extensions/google/live-google-tts-proof.test.ts --reporter verbose

=== LIVE GOOGLE TTS PROOF ===
entrypoint=buildGoogleSpeechProvider().synthesize
started_at=2026-07-14T12:47:34.918Z
model=gemini-3.1-flash-tts-preview
voice=Kore
proxy=explicit-redacted
api_key=redacted
ok=true
output_format=wav
file_extension=.wav
audio_bytes=109484
pcm_payload_bytes=109440
wav_header=RIFF/WAVE
```

The focused tests drive the real exported provider entrypoints — `buildGoogleSpeechProvider().synthesize()`, `buildGoogleMusicGenerationProvider().generateMusic()`, `buildGoogleVideoGenerationProvider().generateVideo()`, and `buildGoogleRealtimeVoiceProvider().createBridge()` — with crafted valid, malformed, and oversized provider responses; the `decodeGoogleProviderBase64` guard runs as real production code on those response paths:

- **Valid path preserved:** legitimate standard base64 and base64url audio/video still materialize; the video byte cap reuses the existing generated-video limit rather than a new arbitrary value, so valid traffic is not truncated.
- **Malformed rejected:** music, speech, video, and Google Live malformed inline base64 each raise a provider-specific error instead of decoding corrupt bytes; the Live path does not call `onAudio`.
- **Oversized rejected before buffering:** inline video bytes, direct URI downloads, and SDK file-handle downloads exceeding the media cap fail before unbounded allocation.

Real-trigger-chain run of the production `buildGoogleSpeechProvider().synthesize()` entrypoint with a crafted TTS response:

```text
=== GOOGLE SPEECH (real buildGoogleSpeechProvider().synthesize) ===
[valid PCM 2048B] synthesize ok=true  decoded audio bytes=2092
[malformed] rejected: Google TTS response returned malformed audio base64
[base64url] synthesize ok=true  decoded pcm payload bytes=4
```

```text
$ node scripts/run-vitest.mjs extensions/google/realtime-voice-provider.test.ts extensions/google/music-generation-provider.test.ts extensions/google/speech-provider.test.ts extensions/google/video-generation-provider.test.ts
[test] starting test/vitest/vitest.extension-providers.config.ts

 RUN  v4.1.9 <repo root>

 Test Files  4 passed (4)
      Tests  98 passed (98)

[test] passed 1 Vitest shard
```

CI notes:

- Rebased onto latest `origin/main`. The earlier `check-dependencies` failure flagged an unused export (`CurrentUserTimestampOverride`) in `src/agents/embedded-agent-runner/run/attempt-session-boundary.ts`, a file this PR never touches; it was a stale-base artifact and clears after the rebase.
- Fixed the `check-lint` `oxlint(curly)` error by adding braces to the guard in `extensions/google/speech-provider.ts`.

<details>
<summary>Focused reproduction commands</summary>

```bash
PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false \
  node scripts/run-vitest.mjs \
  extensions/google/realtime-voice-provider.test.ts \
  extensions/google/music-generation-provider.test.ts \
  extensions/google/speech-provider.test.ts \
  extensions/google/video-generation-provider.test.ts

PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false \
  OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 \
  node scripts/check-changed.mjs -- \
  extensions/google/base64.ts \
  extensions/google/realtime-voice-provider.ts \
  extensions/google/realtime-voice-provider.test.ts \
  extensions/google/music-generation-provider.ts \
  extensions/google/music-generation-provider.test.ts \
  extensions/google/speech-provider.ts \
  extensions/google/speech-provider.test.ts \
  extensions/google/video-generation-provider.ts \
  extensions/google/video-generation-provider.test.ts
```

</details>

AI-assisted: built with Codex
