### PR TITLE
refactor(agents): inline side-question auth type

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -689,7 +689,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/agents/fallback-skip-cache.ts: peekFallbackSkipBucketsForTest",
   "src/agents/fallback-skip-cache.ts: resetFallbackSkipCacheForTest",
   "src/agents/harness/lifecycle-hook-helpers.ts: clearAgentHarnessFinalizeRetryBudget",
-  "src/agents/harness/types.ts: AgentHarnessSideQuestionPreparedRuntimeAuth",
   "src/agents/lanes.ts: AGENT_LANE_CRON_NESTED",
   "src/agents/lanes.ts: AGENT_LANE_NESTED",
   "src/agents/live-auth-keys.ts: collectAnthropicApiKeys",

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -59,14 +59,6 @@ export type AgentHarnessAuthBindingFingerprintParams = {
   agentDir: string;
   config?: import("../../config/types.openclaw.js").OpenClawConfig;
 };
-export type AgentHarnessSideQuestionPreparedRuntimeAuth = {
-  plan: import("../runtime-plan/types.js").AgentRuntimeAuthPlan;
-  authProfileStore: import("../auth-profiles/types.js").AuthProfileStore;
-  authStorage: import("../sessions/index.js").AuthStorage;
-  modelRegistry: import("../sessions/index.js").ModelRegistry;
-  /** Resolved host credential for an immutable API-key route only. */
-  resolvedApiKey?: string;
-};
 export type AgentHarnessSideQuestionParams = {
   cfg: import("../../config/types.openclaw.js").OpenClawConfig;
   agentDir: string;
@@ -74,7 +66,14 @@ export type AgentHarnessSideQuestionParams = {
   model: string;
   runtimeModel?: import("openclaw/plugin-sdk/llm").Model<import("openclaw/plugin-sdk/llm").Api>;
   /** One atomic route/profile/store snapshot prepared before native dispatch. */
-  preparedRuntimeAuth: AgentHarnessSideQuestionPreparedRuntimeAuth;
+  preparedRuntimeAuth: {
+    plan: import("../runtime-plan/types.js").AgentRuntimeAuthPlan;
+    authProfileStore: import("../auth-profiles/types.js").AuthProfileStore;
+    authStorage: import("../sessions/index.js").AuthStorage;
+    modelRegistry: import("../sessions/index.js").ModelRegistry;
+    /** Resolved host credential for an immutable API-key route only. */
+    resolvedApiKey?: string;
+  };
   question: string;
   sessionEntry: import("../../config/sessions.js").SessionEntry;
   sessionStore?: Record<string, import("../../config/sessions.js").SessionEntry>;


### PR DESCRIPTION
## What Problem This Solves

Removes an unshipped, single-use exported type that made the agent-harness API look wider than its supported plugin SDK surface and required a dead-export baseline suppression.

## Why This Change Was Made

The prepared runtime-auth shape is used only by `AgentHarnessSideQuestionParams`, so it is inlined at that owner boundary and the standalone alias is deleted. The public plugin SDK type name and its structural contract remain unchanged.

## User Impact

No runtime or user-visible behavior changes. Plugin authors keep using `AgentHarnessSideQuestionParams`; one unsupported direct import disappears before it reaches a release tag.

## Evidence

- Exact-main graph before: 313,900 nodes / 1,303,342 edges, with one `AgentHarnessSideQuestionPreparedRuntimeAuth` declaration and no independent consumer.
- Post-change graph: 313,899 nodes; search returns no alias.
- Testbox `tbx_01kxf3tqvn08qp7wwmqx24cxzw`: exact `pnpm check:changed` for both touched paths passed.
- Testbox: `pnpm plugin-sdk:api:check` passed with the existing SDK baseline.
- `pnpm deadcode:exports` no longer reports this alias; the repo-wide command currently stops on the unrelated existing `BrowserRouteHandler` export under `extensions/browser`.
- Fresh `gpt-5.6-sol` medium autoreview: clean, 0.98 confidence.
- `git diff --check` and targeted `oxfmt --check`: passed.

AI-assisted: yes. I reviewed the owner boundary, callers, release-tag reachability, plugin SDK export list, generated API baseline, and validation output.
