### PR TITLE
refactor(browser): scope async route lint exception

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -64,7 +64,7 @@
     "node/no-exports-assign": "error",
     "eslint-plugin-unicorn/prefer-set-size": "error",
     "oxc/no-accumulating-spread": "error",
-    "oxc/no-async-endpoint-handlers": "off",
+    "oxc/no-async-endpoint-handlers": "error",
     "oxc/no-map-spread": "error",
     "promise/no-callback-in-promise": "error",
     "promise/no-multiple-resolved": "error",
@@ -228,6 +228,12 @@
     "**/node_modules/**"
   ],
   "overrides": [
+    {
+      "files": ["extensions/browser/src/browser/routes/*.ts"],
+      "rules": {
+        "oxc/no-async-endpoint-handlers": "off"
+      }
+    },
     {
       "files": [
         "packages/markdown-core/**/*.ts",

--- a/extensions/browser/src/browser/routes/dispatcher.abort.test.ts
+++ b/extensions/browser/src/browser/routes/dispatcher.abort.test.ts
@@ -7,55 +7,40 @@ let createBrowserRouteDispatcher: typeof import("./dispatcher.js").createBrowser
 describe("browser route dispatcher (abort)", () => {
   beforeAll(async () => {
     vi.doMock("./index.js", () => {
-      const asyncRoute = <Req, Res>(
-        handler: (req: Req, res: Res) => void | Promise<void>,
-      ): ((req: Req, res: Res) => void | Promise<void>) => {
-        return (req, res) => handler(req, res);
-      };
       return {
         registerBrowserRoutes(app: { get: (path: string, handler: unknown) => void }) {
           app.get(
             "/slow",
-            asyncRoute(
-              async (req: { signal?: AbortSignal }, res: { json: (body: unknown) => void }) => {
-                const signal = req.signal;
-                await new Promise<void>((resolve, reject) => {
-                  if (signal?.aborted) {
-                    reject(
-                      toLintErrorObject(
-                        signal.reason ?? new Error("aborted"),
-                        "Non-Error rejection",
-                      ),
-                    );
-                    return;
-                  }
-                  const onAbort = () =>
-                    reject(
-                      toLintErrorObject(
-                        signal?.reason ?? new Error("aborted"),
-                        "Non-Error rejection",
-                      ),
-                    );
-                  signal?.addEventListener("abort", onAbort, { once: true });
-                  queueMicrotask(() => {
-                    signal?.removeEventListener("abort", onAbort);
-                    resolve();
-                  });
+            async (req: { signal?: AbortSignal }, res: { json: (body: unknown) => void }) => {
+              const signal = req.signal;
+              await new Promise<void>((resolve, reject) => {
+                if (signal?.aborted) {
+                  reject(
+                    toLintErrorObject(signal.reason ?? new Error("aborted"), "Non-Error rejection"),
+                  );
+                  return;
+                }
+                const onAbort = () =>
+                  reject(
+                    toLintErrorObject(
+                      signal?.reason ?? new Error("aborted"),
+                      "Non-Error rejection",
+                    ),
+                  );
+                signal?.addEventListener("abort", onAbort, { once: true });
+                queueMicrotask(() => {
+                  signal?.removeEventListener("abort", onAbort);
+                  resolve();
                 });
-                res.json({ ok: true });
-              },
-            ),
+              });
+              res.json({ ok: true });
+            },
           );
           app.get(
             "/echo/:id",
-            asyncRoute(
-              (
-                req: { params?: Record<string, string> },
-                res: { json: (body: unknown) => void },
-              ) => {
-                res.json({ id: req.params?.id ?? null });
-              },
-            ),
+            (req: { params?: Record<string, string> }, res: { json: (body: unknown) => void }) => {
+              res.json({ id: req.params?.id ?? null });
+            },
           );
         },
       };


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #106964. Native async browser routes need an Oxlint exception, but the original change disabled `no-async-endpoint-handlers` across the entire repository.

## Why This Change Was Made

Restore the global guard and scope the exception to direct browser route modules. Those handlers run through Express 5, which forwards rejected promises, or through the in-process dispatcher, which awaits and catches them.

The dispatcher abort test now registers its handlers directly instead of retaining the deleted no-op wrapper.

## User Impact

No runtime behavior change. Async endpoint mistakes remain lint errors outside the browser route owner boundary.

## Evidence

- Blacksmith Testbox run 29298786180: focused dispatcher test, 2/2 passed.
- Scoped ordinary Oxlint: browser route implementation and dispatcher test passed.
- Fresh autoreview: clean, no actionable findings.
- `git diff --check`: clean.
