### PR TITLE
fix(ci): restore browser lint contracts

### DIFF
--- a/extensions/browser/src/browser/routes/test-helpers.ts
+++ b/extensions/browser/src/browser/routes/test-helpers.ts
@@ -4,7 +4,9 @@
  * Provides an in-memory route registrar and response object for focused route
  * unit tests without standing up the HTTP server.
  */
-import type { BrowserResponse, BrowserRouteHandler, BrowserRouteRegistrar } from "./types.js";
+import type { BrowserResponse, BrowserRouteRegistrar } from "./types.js";
+
+type BrowserRouteHandler = Parameters<BrowserRouteRegistrar["get"]>[1];
 
 /** Create an in-memory route app that records handlers by method and path. */
 export function createBrowserRouteApp() {

--- a/extensions/browser/src/browser/routes/types.ts
+++ b/extensions/browser/src/browser/routes/types.ts
@@ -23,10 +23,7 @@ export type BrowserResponse = {
 };
 
 /** Async route handler signature shared by HTTP and in-process dispatch. */
-export type BrowserRouteHandler = (
-  req: BrowserRequest,
-  res: BrowserResponse,
-) => void | Promise<void>;
+type BrowserRouteHandler = (req: BrowserRequest, res: BrowserResponse) => void | Promise<void>;
 
 /** Minimal registrar interface implemented by HTTP and test dispatchers. */
 export type BrowserRouteRegistrar = {


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails two CI shards after related browser lint cleanup: `BrowserRouteHandler` remains an unsupported dead export, and the exact oxlint override contract omits the newly scoped browser-route policy.

## Why This Change Was Made

The handler alias becomes private to the route registrar, while the test helper derives the identical type from `BrowserRouteRegistrar`. The oxlint contract test now records the approved browser-route override while retaining exact full-array equality. No lint rule or gate is weakened.

## User Impact

No runtime or user-visible behavior changes. Main's dependency and compact node gates can pass again, and the browser plugin's supported runtime surface remains unchanged.

## Evidence

- Dependency failure: https://github.com/openclaw/openclaw/actions/runs/29298584286/job/86977632965
- Config-contract failure: https://github.com/openclaw/openclaw/actions/runs/29299326530/job/86979677050
- Blacksmith Testbox `tbx_01kxf5pdhvpcjrezbvvwwdqxxz`, Actions run `29300012572`: `pnpm deadcode:exports` passed with the 1,163-entry baseline matching exactly.
- The same Testbox run passed the oxlint config suite 10/10 in 163ms and passed path-scoped `check:changed` for all three touched files, including production/test types, lint, format, Plugin SDK API baseline, import cycles, and repository guards.
- Fresh combined autoreview: clean, 0.98 confidence.
- `git diff --check` passed.
