### PR TITLE
fix(testing): prevent stale changed-gate checkout state

### DIFF
--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -10,6 +10,7 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  renameSync,
   rmSync,
   statfsSync,
   statSync,
@@ -32,6 +33,7 @@ import { resolvePathEnvKey, resolveWindowsCmdExePath } from "./windows-cmd-helpe
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const CRABBOX_METADATA_PROBE_TIMEOUT_MS = 5_000;
+const REMOTE_CHANGED_GATE_BUNDLE_FILE = ".openclaw-crabbox-changed-gate.bundle";
 // A cold Crabbox (first call after an upgrade, or one on a loaded machine) can
 // exceed the snappy default probe timeout while it renders `run --help` or does
 // first-run init. Retry the metadata probes once with this generous timeout so a
@@ -2002,19 +2004,27 @@ function mergeBaseForChangedGate() {
 
 function remoteGitBootstrapForChangedGate(changedGateBase) {
   const quotedBase = shellQuote(changedGateBase);
+  const quotedBundleFile = shellQuote(REMOTE_CHANGED_GATE_BUNDLE_FILE);
   return [
-    "openclaw_changed_gate_base=${OPENCLAW_CHANGED_GATE_BASE:-" + quotedBase + "};",
+    `openclaw_changed_gate_base=${quotedBase};`,
     'if ! command -v git >/dev/null 2>&1; then echo "git is required for OpenClaw remote changed-gate sync" >&2; exit 2; fi;',
-    'openclaw_changed_gate_remote_base="$(git rev-parse --verify refs/remotes/origin/main 2>/dev/null || true)";',
-    'if ! git status --short >/dev/null 2>&1 || [ "$openclaw_changed_gate_remote_base" != "$openclaw_changed_gate_base" ]; then',
-    "rm -rf .git;",
-    "git init -q;",
-    "git remote add origin https://github.com/openclaw/openclaw.git 2>/dev/null || git remote set-url origin https://github.com/openclaw/openclaw.git;",
-    'git fetch -q --depth=1 origin "$openclaw_changed_gate_base:refs/remotes/origin/main";',
-    "git reset --mixed --quiet refs/remotes/origin/main;",
-    "git add -A;",
-    "if ! git diff --cached --quiet; then git -c user.name=OpenClaw -c user.email=ci@openclaw.local commit -q --no-gpg-sign -m remote-changed-gate-tree; fi;",
-    "fi",
+    `openclaw_changed_gate_bundle=${quotedBundleFile};`,
+    'if [ ! -f "$openclaw_changed_gate_bundle" ]; then echo "missing changed-gate bundle: $openclaw_changed_gate_bundle" >&2; exit 2; fi;',
+    'openclaw_changed_gate_bundle_tmp="$(mktemp /tmp/openclaw-changed-gate.XXXXXX)" || exit 2;',
+    "trap 'rm -f \"$openclaw_changed_gate_bundle_tmp\"' EXIT HUP INT TERM;",
+    'cp "$openclaw_changed_gate_bundle" "$openclaw_changed_gate_bundle_tmp" || exit 2;',
+    'rm -rf -- "$openclaw_changed_gate_bundle" || exit 2;',
+    "rm -rf .git || exit 2;",
+    "git init -q || exit 2;",
+    "git remote add origin https://github.com/openclaw/openclaw.git 2>/dev/null || git remote set-url origin https://github.com/openclaw/openclaw.git || exit 2;",
+    'git fetch -q --depth=2 origin "$openclaw_changed_gate_base:refs/remotes/origin/main" || exit 2;',
+    'if [ ! -f "$openclaw_changed_gate_bundle_tmp" ]; then echo "changed-gate bundle disappeared before import" >&2; exit 2; fi;',
+    "openclaw_changed_gate_target=refs/remotes/origin/main;",
+    'if [ -s "$openclaw_changed_gate_bundle_tmp" ]; then git fetch -q "$openclaw_changed_gate_bundle_tmp" HEAD:refs/heads/openclaw-changed-gate-head || exit 2; openclaw_changed_gate_target=refs/heads/openclaw-changed-gate-head; fi;',
+    'rm -f "$openclaw_changed_gate_bundle_tmp" || exit 2;',
+    "trap - EXIT HUP INT TERM;",
+    'git reset --hard --quiet "$openclaw_changed_gate_target" || exit 2;',
+    "git clean -fd -q || exit 2",
   ].join(" ");
 }
 
@@ -3054,6 +3064,7 @@ function prepareFullCheckoutForSync(options = {}) {
   assertFullCheckoutSyncDisk(syncRoot);
   const dir = mkdtempSync(resolve(syncRoot, "openclaw-crabbox-sync-"));
   let active = false;
+  let resolvedChangedGateBase = options.changedGateBase ?? "";
 
   function create() {
     const add = gitOutput(["worktree", "add", "--detach", dir, "HEAD"]);
@@ -3071,11 +3082,65 @@ function prepareFullCheckoutForSync(options = {}) {
     }
 
     if (options.changedGateBase) {
+      const bundlePath = resolve(dir, REMOTE_CHANGED_GATE_BUNDLE_FILE);
+      let bundleTempDir;
+      try {
+        bundleTempDir = mkdtempSync(resolve(syncRoot, "openclaw-crabbox-bundle-"));
+        const bundleTempPath = resolve(bundleTempDir, "changed-gate.bundle");
+        const head = gitOutput(["-C", dir, "rev-parse", "HEAD"]);
+        const base = gitOutput(["-C", dir, "rev-parse", options.changedGateBase]);
+        if (head.status !== 0 || base.status !== 0 || !head.stdout || !base.stdout) {
+          throw new Error(`git rev-parse failed: ${head.text || base.text}`);
+        }
+        resolvedChangedGateBase = base.stdout;
+        if (head.stdout === base.stdout) {
+          writeFileSync(bundleTempPath, "", "utf8");
+        } else {
+          const bundle = gitOutput([
+            "-C",
+            dir,
+            "bundle",
+            "create",
+            bundleTempPath,
+            "HEAD",
+            `^${base.stdout}`,
+          ]);
+          if (bundle.status !== 0) {
+            throw new Error(bundle.text || `git bundle exited with status ${bundle.status}`);
+          }
+        }
+        // HEAD controls this checkout path and may make it a symlink. Remove the
+        // entry, then atomically install the private temp file without following it.
+        rmSync(bundlePath, { recursive: true, force: true });
+        renameSync(bundleTempPath, bundlePath);
+      } catch (error) {
+        cleanupFullCheckout(dir, active);
+        active = false;
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`git bundle for changed-gate sync failed: ${message}`);
+      } finally {
+        if (bundleTempDir) {
+          rmSync(bundleTempDir, { recursive: true, force: true });
+        }
+      }
       const reset = gitOutput(["-C", dir, "reset", "--mixed", "--quiet", options.changedGateBase]);
       if (reset.status !== 0) {
         cleanupFullCheckout(dir, active);
         active = false;
         throw new Error(`git reset for changed-gate sync failed: ${reset.text}`);
+      }
+      const stageBundle = gitOutput([
+        "-C",
+        dir,
+        "add",
+        "-f",
+        "--",
+        REMOTE_CHANGED_GATE_BUNDLE_FILE,
+      ]);
+      if (stageBundle.status !== 0) {
+        cleanupFullCheckout(dir, active);
+        active = false;
+        throw new Error(`git add for changed-gate bundle failed: ${stageBundle.text}`);
       }
     }
   }
@@ -3084,7 +3149,7 @@ function prepareFullCheckoutForSync(options = {}) {
 
   return {
     dir,
-    changedGateBase: options.changedGateBase ?? "",
+    changedGateBase: resolvedChangedGateBase,
     restoreIfMissing() {
       try {
         if (statSync(dir).isDirectory()) {

--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -3096,6 +3096,33 @@ function prepareFullCheckoutForSync(options = {}) {
         if (head.stdout === base.stdout) {
           writeFileSync(bundleTempPath, "", "utf8");
         } else {
+          const headTree = gitOutput(["-C", dir, "rev-parse", "HEAD^{tree}"]);
+          if (headTree.status !== 0 || !headTree.stdout) {
+            throw new Error(headTree.text || "git rev-parse HEAD tree failed");
+          }
+          // Transport only the final tree. Intermediate commits can contain
+          // deleted secrets or artifacts that must never leave this checkout.
+          const syntheticCommit = gitOutput([
+            "-C",
+            dir,
+            "-c",
+            "user.name=OpenClaw",
+            "-c",
+            "user.email=ci@openclaw.local",
+            "commit-tree",
+            headTree.stdout,
+            "-p",
+            base.stdout,
+            "-m",
+            "remote-changed-gate-tree",
+          ]);
+          if (syntheticCommit.status !== 0 || !syntheticCommit.stdout) {
+            throw new Error(syntheticCommit.text || "git commit-tree failed");
+          }
+          const updateHead = gitOutput(["-C", dir, "update-ref", "HEAD", syntheticCommit.stdout]);
+          if (updateHead.status !== 0) {
+            throw new Error(updateHead.text || "git update-ref HEAD failed");
+          }
           const bundle = gitOutput([
             "-C",
             dir,

--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -3117,7 +3117,7 @@ function prepareFullCheckoutForSync(options = {}) {
         cleanupFullCheckout(dir, active);
         active = false;
         const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`git bundle for changed-gate sync failed: ${message}`);
+        throw new Error(`git bundle for changed-gate sync failed: ${message}`, { cause: error });
       } finally {
         if (bundleTempDir) {
           rmSync(bundleTempDir, { recursive: true, force: true });

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -380,8 +380,23 @@ function makeFakeGit(
       'if [ "$1" = "-C" ] && [ "$3" = "rev-parse" ]; then',
       '  if [ "$4" = "HEAD" ]; then',
       '    printf "%s\\n" "${OPENCLAW_FAKE_GIT_HEAD_SHA:-def456}"',
+      '  elif [ "$4" = "HEAD^{tree}" ]; then',
+      '    printf "%s\\n" "${OPENCLAW_FAKE_GIT_HEAD_TREE_SHA:-tree456}"',
       "  else",
       '    printf "%s\\n" "${OPENCLAW_FAKE_GIT_BASE_SHA:-abc123}"',
+      "  fi",
+      "  exit 0",
+      "fi",
+      'if [ "$1" = "-C" ] && [ "$3" = "-c" ] && [ "$7" = "commit-tree" ]; then',
+      '  if [ -n "${OPENCLAW_FAKE_GIT_SYNTHETIC_COMMIT_MARKER:-}" ]; then',
+      '    : > "$OPENCLAW_FAKE_GIT_SYNTHETIC_COMMIT_MARKER"',
+      "  fi",
+      '  printf "%s\\n" "${OPENCLAW_FAKE_GIT_SYNTHETIC_COMMIT_SHA:-synthetic789}"',
+      "  exit 0",
+      "fi",
+      'if [ "$1" = "-C" ] && [ "$3" = "update-ref" ] && [ "$4" = "HEAD" ]; then',
+      '  if [ -n "${OPENCLAW_FAKE_GIT_SYNTHETIC_HEAD_MARKER:-}" ]; then',
+      '    : > "$OPENCLAW_FAKE_GIT_SYNTHETIC_HEAD_MARKER"',
       "  fi",
       "  exit 0",
       "fi",
@@ -431,7 +446,9 @@ function makeFakeGit(
     "const args = process.argv.slice(2);",
     "if (args[0] === 'worktree' && args[1] === 'add') { fs.mkdirSync(args[3], { recursive: true }); if (process.env.OPENCLAW_FAKE_GIT_CHANGED_GATE_BUNDLE_SYMLINK_TARGET) fs.symlinkSync(process.env.OPENCLAW_FAKE_GIT_CHANGED_GATE_BUNDLE_SYMLINK_TARGET, require('node:path').join(args[3], '.openclaw-crabbox-changed-gate.bundle')); process.exit(0); }",
     "if (args[0] === '-C' && args[2] === 'sparse-checkout' && args[3] === 'disable') { process.exit(0); }",
-    "if (args[0] === '-C' && args[2] === 'rev-parse') { process.stdout.write(`${args[3] === 'HEAD' ? process.env.OPENCLAW_FAKE_GIT_HEAD_SHA || 'def456' : process.env.OPENCLAW_FAKE_GIT_BASE_SHA || 'abc123'}\\n`); process.exit(0); }",
+    "if (args[0] === '-C' && args[2] === 'rev-parse') { const value = args[3] === 'HEAD' ? process.env.OPENCLAW_FAKE_GIT_HEAD_SHA || 'def456' : args[3] === 'HEAD^{tree}' ? process.env.OPENCLAW_FAKE_GIT_HEAD_TREE_SHA || 'tree456' : process.env.OPENCLAW_FAKE_GIT_BASE_SHA || 'abc123'; process.stdout.write(`${value}\\n`); process.exit(0); }",
+    "if (args[0] === '-C' && args[2] === '-c' && args[6] === 'commit-tree') { if (process.env.OPENCLAW_FAKE_GIT_SYNTHETIC_COMMIT_MARKER) fs.writeFileSync(process.env.OPENCLAW_FAKE_GIT_SYNTHETIC_COMMIT_MARKER, ''); process.stdout.write(`${process.env.OPENCLAW_FAKE_GIT_SYNTHETIC_COMMIT_SHA || 'synthetic789'}\\n`); process.exit(0); }",
+    "if (args[0] === '-C' && args[2] === 'update-ref' && args[3] === 'HEAD') { if (process.env.OPENCLAW_FAKE_GIT_SYNTHETIC_HEAD_MARKER) fs.writeFileSync(process.env.OPENCLAW_FAKE_GIT_SYNTHETIC_HEAD_MARKER, ''); process.exit(0); }",
     "if (args[0] === '-C' && args[2] === 'bundle' && args[3] === 'create') { const bytes = Number(process.env.OPENCLAW_FAKE_GIT_BUNDLE_BYTES || 0); fs.writeFileSync(args[4], bytes ? 'x'.repeat(bytes) : process.env.OPENCLAW_FAKE_GIT_BUNDLE || 'fake-bundle'); process.exit(0); }",
     "if (args[0] === '-C' && args[2] === 'add' && args[3] === '-f') { if (process.env.OPENCLAW_FAKE_GIT_FORCE_ADD_MARKER) fs.writeFileSync(process.env.OPENCLAW_FAKE_GIT_FORCE_ADD_MARKER, ''); process.exit(0); }",
     "if (args[0] === '-C' && args[2] === 'reset' && args[3] === '--mixed') { process.exit(0); }",
@@ -3457,6 +3474,8 @@ describe("scripts/crabbox-wrapper", () => {
     const bundle = "synthetic-bundle";
     const markerDir = makeTempDir(tempDirs, "openclaw-changed-gate-force-add-");
     const forceAddMarker = path.join(markerDir, "force-added");
+    const syntheticCommitMarker = path.join(markerDir, "synthetic-commit");
+    const syntheticHeadMarker = path.join(markerDir, "synthetic-head");
     const result = runWrapper(
       "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n",
       ["run", "--provider", "aws", "--", "corepack", "pnpm", "check:changed"],
@@ -3466,6 +3485,8 @@ describe("scripts/crabbox-wrapper", () => {
           OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_FORCE_ADD: "1",
           OPENCLAW_FAKE_GIT_BUNDLE: bundle,
           OPENCLAW_FAKE_GIT_FORCE_ADD_MARKER: forceAddMarker,
+          OPENCLAW_FAKE_GIT_SYNTHETIC_COMMIT_MARKER: syntheticCommitMarker,
+          OPENCLAW_FAKE_GIT_SYNTHETIC_HEAD_MARKER: syntheticHeadMarker,
         },
         gitResponses: {
           [GIT_CONFIG_SPARSE_KEY]: { stdout: "true\n" },
@@ -3478,6 +3499,8 @@ describe("scripts/crabbox-wrapper", () => {
     expect(result.status).toBe(0);
     expect(result.stderr).not.toContain("changed-gate bundle mismatch");
     expect(existsSync(forceAddMarker)).toBe(true);
+    expect(existsSync(syntheticCommitMarker)).toBe(true);
+    expect(existsSync(syntheticHeadMarker)).toBe(true);
   });
 
   it("transports changed-gate bundles larger than the child-process buffer", () => {

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -149,6 +149,27 @@ function writeFakeCrabbox(binDir: string, helpText: string): string {
       '  trap "exit 0" INT TERM HUP',
       "  while :; do sleep 1; done",
       "fi",
+      'if [ -n "${OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE+x}" ]; then',
+      '  expected_bundle="$(mktemp)" || exit 67',
+      '  printf "%s" "$OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE" > "$expected_bundle"',
+      '  if [ ! -f .openclaw-crabbox-changed-gate.bundle ] || ! cmp -s .openclaw-crabbox-changed-gate.bundle "$expected_bundle"; then',
+      '    rm -f "$expected_bundle"',
+      '    printf "%s\\n" "changed-gate bundle mismatch" >&2',
+      "    exit 67",
+      "  fi",
+      '  rm -f "$expected_bundle"',
+      "fi",
+      'if [ -n "${OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE_BYTES:-}" ]; then',
+      '  actual_bundle_bytes="$(wc -c < .openclaw-crabbox-changed-gate.bundle 2>/dev/null | tr -d " ")"',
+      '  if [ "$actual_bundle_bytes" != "$OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE_BYTES" ]; then',
+      '    printf "%s\\n" "changed-gate bundle size mismatch" >&2',
+      "    exit 67",
+      "  fi",
+      "fi",
+      'if [ "${OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_FORCE_ADD:-}" = "1" ] && [ ! -f "${OPENCLAW_FAKE_GIT_FORCE_ADD_MARKER:-}" ]; then',
+      '  printf "%s\\n" "changed-gate bundle was not force-added" >&2',
+      "  exit 67",
+      "fi",
       'printf "%s\\0" "__OPENCLAW_FAKE_CRABBOX_V1__"',
       'printf "%s\\0" "$PWD"',
       'printf "%s\\0" "$#"',
@@ -191,6 +212,17 @@ function writeFakeCrabbox(binDir: string, helpText: string): string {
     "  require('node:fs').mkdirSync('.crabbox/runs/run_fake', { recursive: true });",
     "  require('node:fs').writeFileSync('.crabbox/runs/run_fake/fake-artifacts.tgz', 'fake artifact\\n');",
     "}",
+    "if (Object.hasOwn(process.env, 'OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE')) {",
+    "  const bundlePath = '.openclaw-crabbox-changed-gate.bundle';",
+    "  const bundle = require('node:fs').existsSync(bundlePath) ? require('node:fs').readFileSync(bundlePath, 'utf8') : null;",
+    "  if (bundle !== process.env.OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE) { process.stderr.write('changed-gate bundle mismatch\\n'); process.exit(67); }",
+    "}",
+    "if (process.env.OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE_BYTES) {",
+    "  const bundlePath = '.openclaw-crabbox-changed-gate.bundle';",
+    "  const size = require('node:fs').existsSync(bundlePath) ? require('node:fs').statSync(bundlePath).size : -1;",
+    "  if (size !== Number(process.env.OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE_BYTES)) { process.stderr.write('changed-gate bundle size mismatch\\n'); process.exit(67); }",
+    "}",
+    "if (process.env.OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_FORCE_ADD === '1' && !require('node:fs').existsSync(process.env.OPENCLAW_FAKE_GIT_FORCE_ADD_MARKER || '')) { process.stderr.write('changed-gate bundle was not force-added\\n'); process.exit(67); }",
     "console.log(JSON.stringify({ args, cwd: process.cwd(), scriptContent }));",
   ].join("\n");
   writeFileSync(helperPath, `${helperScript}\n`, "utf8");
@@ -336,9 +368,34 @@ function makeFakeGit(
       "#!/bin/sh",
       'if [ "$1" = "worktree" ] && [ "$2" = "add" ]; then',
       '  mkdir -p "$4"',
+      '  if [ -n "${OPENCLAW_FAKE_GIT_CHANGED_GATE_BUNDLE_SYMLINK_TARGET:-}" ]; then',
+      '    ln -s "$OPENCLAW_FAKE_GIT_CHANGED_GATE_BUNDLE_SYMLINK_TARGET" "$4/.openclaw-crabbox-changed-gate.bundle"',
+      "  fi",
       "  exit 0",
       "fi",
       'if [ "$1" = "-C" ] && [ "$3" = "sparse-checkout" ] && [ "$4" = "disable" ]; then',
+      "  exit 0",
+      "fi",
+      'if [ "$1" = "-C" ] && [ "$3" = "rev-parse" ]; then',
+      '  if [ "$4" = "HEAD" ]; then',
+      '    printf "%s\\n" "${OPENCLAW_FAKE_GIT_HEAD_SHA:-def456}"',
+      "  else",
+      '    printf "%s\\n" "${OPENCLAW_FAKE_GIT_BASE_SHA:-abc123}"',
+      "  fi",
+      "  exit 0",
+      "fi",
+      'if [ "$1" = "-C" ] && [ "$3" = "bundle" ] && [ "$4" = "create" ]; then',
+      '  if [ -n "${OPENCLAW_FAKE_GIT_BUNDLE_BYTES:-}" ]; then',
+      '    head -c "$OPENCLAW_FAKE_GIT_BUNDLE_BYTES" /dev/zero | tr "\\000" x > "$5"',
+      "  else",
+      '    printf "%s" "${OPENCLAW_FAKE_GIT_BUNDLE:-fake-bundle}" > "$5"',
+      "  fi",
+      "  exit 0",
+      "fi",
+      'if [ "$1" = "-C" ] && [ "$3" = "add" ] && [ "$4" = "-f" ]; then',
+      '  if [ -n "${OPENCLAW_FAKE_GIT_FORCE_ADD_MARKER:-}" ]; then',
+      '    : > "$OPENCLAW_FAKE_GIT_FORCE_ADD_MARKER"',
+      "  fi",
       "  exit 0",
       "fi",
       'if [ "$1" = "-C" ] && [ "$3" = "reset" ] && [ "$4" = "--mixed" ]; then',
@@ -371,8 +428,11 @@ function makeFakeGit(
     "const fs = require('node:fs');",
     "const responses = new Map(Object.entries(JSON.parse(process.env.OPENCLAW_FAKE_GIT_RESPONSES || '{}')));",
     "const args = process.argv.slice(2);",
-    "if (args[0] === 'worktree' && args[1] === 'add') { fs.mkdirSync(args[3], { recursive: true }); process.exit(0); }",
+    "if (args[0] === 'worktree' && args[1] === 'add') { fs.mkdirSync(args[3], { recursive: true }); if (process.env.OPENCLAW_FAKE_GIT_CHANGED_GATE_BUNDLE_SYMLINK_TARGET) fs.symlinkSync(process.env.OPENCLAW_FAKE_GIT_CHANGED_GATE_BUNDLE_SYMLINK_TARGET, require('node:path').join(args[3], '.openclaw-crabbox-changed-gate.bundle')); process.exit(0); }",
     "if (args[0] === '-C' && args[2] === 'sparse-checkout' && args[3] === 'disable') { process.exit(0); }",
+    "if (args[0] === '-C' && args[2] === 'rev-parse') { process.stdout.write(`${args[3] === 'HEAD' ? process.env.OPENCLAW_FAKE_GIT_HEAD_SHA || 'def456' : process.env.OPENCLAW_FAKE_GIT_BASE_SHA || 'abc123'}\\n`); process.exit(0); }",
+    "if (args[0] === '-C' && args[2] === 'bundle' && args[3] === 'create') { const bytes = Number(process.env.OPENCLAW_FAKE_GIT_BUNDLE_BYTES || 0); fs.writeFileSync(args[4], bytes ? 'x'.repeat(bytes) : process.env.OPENCLAW_FAKE_GIT_BUNDLE || 'fake-bundle'); process.exit(0); }",
+    "if (args[0] === '-C' && args[2] === 'add' && args[3] === '-f') { if (process.env.OPENCLAW_FAKE_GIT_FORCE_ADD_MARKER) fs.writeFileSync(process.env.OPENCLAW_FAKE_GIT_FORCE_ADD_MARKER, ''); process.exit(0); }",
     "if (args[0] === '-C' && args[2] === 'reset' && args[3] === '--mixed') { process.exit(0); }",
     "if (args[0] === 'worktree' && args[1] === 'remove') { fs.rmSync(args[3], { recursive: true, force: true }); process.exit(0); }",
     "const key = args.join('\\u0000');",
@@ -595,21 +655,28 @@ const remoteChangedGateEnvPrefix =
   "OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1";
 const remoteChangedGateExport = `export ${remoteChangedGateEnvPrefix};`;
 const remoteChangedGateFetch =
-  'git fetch -q --depth=1 origin "$openclaw_changed_gate_base:refs/remotes/origin/main"';
+  'git fetch -q --depth=2 origin "$openclaw_changed_gate_base:refs/remotes/origin/main"';
 
 function expectChangedGateGitBootstrap(remoteCommand: string): void {
   expect(remoteCommand).toContain("command -v git");
+  expect(remoteCommand).toContain("openclaw_changed_gate_base=abc123");
   expect(remoteCommand).toContain(
-    "openclaw_changed_gate_base=${OPENCLAW_CHANGED_GATE_BASE:-abc123}",
+    "openclaw_changed_gate_bundle=.openclaw-crabbox-changed-gate.bundle",
+  );
+  expect(remoteCommand).toContain("mktemp /tmp/openclaw-changed-gate.XXXXXX");
+  expect(remoteCommand).toContain('cp "$openclaw_changed_gate_bundle"');
+  expect(remoteCommand).toContain("git init -q || exit 2");
+  expect(remoteCommand).toContain(`${remoteChangedGateFetch} || exit 2`);
+  expect(remoteCommand).toContain(
+    'git fetch -q "$openclaw_changed_gate_bundle_tmp" HEAD:refs/heads/openclaw-changed-gate-head',
   );
   expect(remoteCommand).toContain(
-    'openclaw_changed_gate_remote_base="$(git rev-parse --verify refs/remotes/origin/main 2>/dev/null || true)"',
+    'git reset --hard --quiet "$openclaw_changed_gate_target" || exit 2',
   );
-  expect(remoteCommand).toContain(
-    '[ "$openclaw_changed_gate_remote_base" != "$openclaw_changed_gate_base" ]',
-  );
-  expect(remoteCommand).toContain("git init -q");
-  expect(remoteCommand).toContain(remoteChangedGateFetch);
+  expect(remoteCommand).toContain("git clean -fd -q || exit 2");
+  expect(remoteCommand).toContain("changed-gate bundle disappeared before import");
+  expect(remoteCommand).not.toContain("git apply");
+  expect(remoteCommand).not.toContain("; &&");
 }
 
 afterAll(() => {
@@ -3325,9 +3392,9 @@ describe("scripts/crabbox-wrapper", () => {
 
     expect(result.status).toBe(0);
     expect(result.stderr).toContain("syncing from temporary full checkout");
-    expect(result.stderr).toContain("overlaying local HEAD as worktree changes from origin/main");
+    expect(result.stderr).toContain("overlaying local HEAD as worktree changes from abc123");
     expect(parseFakeCrabboxOutput(result).args.join(" ")).toContain(
-      'openclaw_changed_gate_remote_base="$(git rev-parse --verify refs/remotes/origin/main 2>/dev/null || true)"',
+      "openclaw_changed_gate_bundle=.openclaw-crabbox-changed-gate.bundle",
     );
     expect(parseFakeCrabboxOutput(result).cwd).toContain("openclaw-crabbox-sync-");
   });
@@ -3379,14 +3446,93 @@ describe("scripts/crabbox-wrapper", () => {
     expect(result.status).toBe(0);
     expect(output.args).toContain("--shell");
     expectChangedGateGitBootstrap(remoteCommand);
-    expect(remoteCommand).toContain("git reset --mixed --quiet refs/remotes/origin/main");
-    expect(remoteCommand).toContain("git add -A");
-    expect(remoteCommand).toContain("git diff --cached --quiet");
-    expect(remoteCommand).toContain("commit -q --no-gpg-sign -m remote-changed-gate-tree");
+    expect(remoteCommand).toContain("refs/heads/openclaw-changed-gate-head");
     expect(remoteCommand).toMatch(
       /&& env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed$/u,
     );
   });
+
+  it("materializes the changed-gate bundle in the temporary sync checkout", () => {
+    const bundle = "synthetic-bundle";
+    const markerDir = mkdtempSync(path.join(tmpdir(), "openclaw-changed-gate-force-add-"));
+    tempDirs.push(markerDir);
+    const forceAddMarker = path.join(markerDir, "force-added");
+    const result = runWrapper(
+      "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n",
+      ["run", "--provider", "aws", "--", "corepack", "pnpm", "check:changed"],
+      {
+        env: {
+          OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE: bundle,
+          OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_FORCE_ADD: "1",
+          OPENCLAW_FAKE_GIT_BUNDLE: bundle,
+          OPENCLAW_FAKE_GIT_FORCE_ADD_MARKER: forceAddMarker,
+        },
+        gitResponses: {
+          [GIT_CONFIG_SPARSE_KEY]: { stdout: "true\n" },
+          [GIT_STATUS_PORCELAIN_KEY]: { stdout: "" },
+          [GIT_MERGE_BASE_MAIN_HEAD_KEY]: { stdout: "abc123\n" },
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("changed-gate bundle mismatch");
+    expect(existsSync(forceAddMarker)).toBe(true);
+  });
+
+  it("transports changed-gate bundles larger than the child-process buffer", () => {
+    const bundleBytes = 2 * 1024 * 1024;
+    const result = runWrapper(
+      "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n",
+      ["run", "--provider", "aws", "--", "corepack", "pnpm", "check:changed"],
+      {
+        env: {
+          OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE_BYTES: String(bundleBytes),
+          OPENCLAW_FAKE_GIT_BUNDLE_BYTES: String(bundleBytes),
+        },
+        gitResponses: {
+          [GIT_CONFIG_SPARSE_KEY]: { stdout: "true\n" },
+          [GIT_STATUS_PORCELAIN_KEY]: { stdout: "" },
+          [GIT_MERGE_BASE_MAIN_HEAD_KEY]: { stdout: "abc123\n" },
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("changed-gate bundle size mismatch");
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "does not follow a checkout-controlled changed-gate bundle symlink",
+    () => {
+      const fixtureDir = mkdtempSync(path.join(tmpdir(), "openclaw-changed-gate-symlink-"));
+      tempDirs.push(fixtureDir);
+      const victimPath = path.join(fixtureDir, "victim");
+      const victimContents = "preserve-me\n";
+      const bundle = "synthetic-bundle";
+      writeFileSync(victimPath, victimContents, "utf8");
+
+      const result = runWrapper(
+        "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n",
+        ["run", "--provider", "aws", "--", "corepack", "pnpm", "check:changed"],
+        {
+          env: {
+            OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE: bundle,
+            OPENCLAW_FAKE_GIT_BUNDLE: bundle,
+            OPENCLAW_FAKE_GIT_CHANGED_GATE_BUNDLE_SYMLINK_TARGET: victimPath,
+          },
+          gitResponses: {
+            [GIT_CONFIG_SPARSE_KEY]: { stdout: "true\n" },
+            [GIT_STATUS_PORCELAIN_KEY]: { stdout: "" },
+            [GIT_MERGE_BASE_MAIN_HEAD_KEY]: { stdout: "abc123\n" },
+          },
+        },
+      );
+
+      expect(result.status).toBe(0);
+      expect(readFileSync(victimPath, "utf8")).toBe(victimContents);
+    },
+  );
 
   it("bootstraps Git metadata for non-sparse changed gates on remote raw syncs", () => {
     const result = runWrapper(

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -20,6 +20,7 @@ import {
   isProviderAdvertised,
   parseProvidersFromHelp,
 } from "../../scripts/crabbox-wrapper-providers.mjs";
+import { makeTempDir } from "../helpers/temp-dir.js";
 
 const tempDirs: string[] = [];
 const repoRoot = process.cwd();
@@ -3454,8 +3455,7 @@ describe("scripts/crabbox-wrapper", () => {
 
   it("materializes the changed-gate bundle in the temporary sync checkout", () => {
     const bundle = "synthetic-bundle";
-    const markerDir = mkdtempSync(path.join(tmpdir(), "openclaw-changed-gate-force-add-"));
-    tempDirs.push(markerDir);
+    const markerDir = makeTempDir(tempDirs, "openclaw-changed-gate-force-add-");
     const forceAddMarker = path.join(markerDir, "force-added");
     const result = runWrapper(
       "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n",
@@ -3505,8 +3505,7 @@ describe("scripts/crabbox-wrapper", () => {
   it.skipIf(process.platform === "win32")(
     "does not follow a checkout-controlled changed-gate bundle symlink",
     () => {
-      const fixtureDir = mkdtempSync(path.join(tmpdir(), "openclaw-changed-gate-symlink-"));
-      tempDirs.push(fixtureDir);
+      const fixtureDir = makeTempDir(tempDirs, "openclaw-changed-gate-symlink-");
       const victimPath = path.join(fixtureDir, "victim");
       const victimContents = "preserve-me\n";
       const bundle = "synthetic-bundle";


### PR DESCRIPTION
Closes #106966

AI-assisted change. Maintainer-reviewed and tested.

## What Problem This Solves

Fixes an issue where maintainers reusing a Crabbox changed-gate lease could receive false generated-baseline drift when the remote checkout retained the previous branch overlay.

## Why This Change Was Made

Changed-gate sync now resolves the merge-base SHA, transports the exact local head as a Git bundle, recreates remote Git metadata, and hard-resets to the imported commit before running checks. The bootstrap fails closed and safely handles empty bundles, large bundles, and checkout-controlled bundle symlinks.

## User Impact

Maintainer changed-gate validation now starts from the exact requested commit tree on reused remote leases. No product runtime behavior changes.

## Evidence

- Blacksmith Testbox run 29298962418: `test/scripts/crabbox-wrapper.test.ts`, 195/195 passed.
- Blacksmith Testbox run 29299076163: clean-checkout `check:changed` passed through the new real bundle import path in 2m34s.
- Added coverage for synthetic final-tree-only bundle transport, bundles above 2 MiB, forced inclusion despite ignore rules, fail-fast bootstrap, and symlink-safe materialization.
- `node --check scripts/crabbox-wrapper.mjs`
- `git diff --check`
- Local structured autoreview: clean after addressing its history-disclosure finding; overall patch correct, confidence 0.90.
