### PR TITLE
fix(infra): accurate SQLite linkage wording for shared Node builds

### DIFF
--- a/src/infra/node-sqlite.test.ts
+++ b/src/infra/node-sqlite.test.ts
@@ -76,6 +76,17 @@ describe("node SQLite safety", () => {
       expected: "Node 24.18.0 embeds SQLite 3.46.1",
       forbid: ["shared SQLite"],
     },
+    {
+      shared: "true" as NodeSharedSqliteFlag,
+      expected:
+        "Node 24.18.0 is using shared SQLite 3.46.1 (loaded library; process.versions.sqlite may differ)",
+      forbid: ["embeds SQLite"],
+    },
+    {
+      shared: "false" as NodeSharedSqliteFlag,
+      expected: "Node 24.18.0 embeds SQLite 3.46.1",
+      forbid: ["shared SQLite"],
+    },
   ])("describeLoadedSqliteRuntime for sharedFlag=$shared", async ({ shared, expected, forbid }) => {
     const { describeLoadedSqliteRuntime } = await import("./node-sqlite.js");
     const text = describeLoadedSqliteRuntime("3.46.1", "24.18.0", shared);
@@ -86,7 +97,7 @@ describe("node SQLite safety", () => {
   });
 
   it("rejects using host linkage wording without claiming embeds on shared builds", async () => {
-    const { requireNodeSqlite, readNodeSharedSqliteFlag } =
+    const { requireNodeSqlite, readNodeSharedSqliteFlag, normalizeNodeSharedSqliteFlag } =
       await loadNodeSqliteWithVersion("3.46.1");
     let message = "";
     try {
@@ -95,11 +106,11 @@ describe("node SQLite safety", () => {
       message = err instanceof Error ? err.message : String(err);
     }
     expect(message).toMatch(/SQLite 3\.46\.1[\s\S]*which is affected/);
-    const shared = readNodeSharedSqliteFlag();
-    if (shared === true || shared === 1) {
+    const shared = normalizeNodeSharedSqliteFlag(readNodeSharedSqliteFlag());
+    if (shared === true) {
       expect(message).toContain("shared SQLite 3.46.1");
       expect(message).not.toContain("embeds SQLite");
-    } else if (shared === false || shared === 0) {
+    } else if (shared === false) {
       expect(message).toContain("embeds SQLite 3.46.1");
     } else {
       expect(message).toContain("is using SQLite 3.46.1");

--- a/src/infra/node-sqlite.test.ts
+++ b/src/infra/node-sqlite.test.ts
@@ -1,6 +1,7 @@
-// Covers the SQLite WAL-reset corruption safety floor.
+// Covers the SQLite WAL-reset corruption safety floor and diagnostic wording.
 import { DatabaseSync, type StatementSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NodeSharedSqliteFlag } from "./node-sqlite.js";
 
 const originalPrepare = Reflect.get(DatabaseSync.prototype, "prepare") as DatabaseSync["prepare"];
 
@@ -39,11 +40,74 @@ describe("node SQLite safety", () => {
     "rejects vulnerable or unknown SQLite %s",
     async (version) => {
       const { requireNodeSqlite } = await loadNodeSqliteWithVersion(version);
-      expect(() => requireNodeSqlite()).toThrow(`embeds SQLite ${version}, which is affected`);
+      // Shared builds insert a parenthetical after the version; match the loaded
+      // library version and the WAL-safety clause without requiring "embeds".
+      expect(() => requireNodeSqlite()).toThrow(
+        new RegExp(`SQLite ${version.replaceAll(".", "\\.")}[\\s\\S]*which is affected`),
+      );
     },
   );
 
-  it("accepts the SQLite build embedded in the supported test runtime", () => {
+  it.each([
+    {
+      shared: false as NodeSharedSqliteFlag,
+      expected: "Node 24.18.0 embeds SQLite 3.46.1",
+      forbid: ["shared SQLite"],
+    },
+    {
+      shared: true as NodeSharedSqliteFlag,
+      expected:
+        "Node 24.18.0 is using shared SQLite 3.46.1 (loaded library; process.versions.sqlite may differ)",
+      forbid: ["embeds SQLite"],
+    },
+    {
+      shared: undefined as NodeSharedSqliteFlag,
+      expected: "Node 24.18.0 is using SQLite 3.46.1",
+      forbid: ["embeds SQLite", "shared SQLite"],
+    },
+    {
+      shared: 1 as NodeSharedSqliteFlag,
+      expected:
+        "Node 24.18.0 is using shared SQLite 3.46.1 (loaded library; process.versions.sqlite may differ)",
+      forbid: ["embeds SQLite"],
+    },
+    {
+      shared: 0 as NodeSharedSqliteFlag,
+      expected: "Node 24.18.0 embeds SQLite 3.46.1",
+      forbid: ["shared SQLite"],
+    },
+  ])("describeLoadedSqliteRuntime for sharedFlag=$shared", async ({ shared, expected, forbid }) => {
+    const { describeLoadedSqliteRuntime } = await import("./node-sqlite.js");
+    const text = describeLoadedSqliteRuntime("3.46.1", "24.18.0", shared);
+    expect(text).toBe(expected);
+    for (const fragment of forbid) {
+      expect(text).not.toContain(fragment);
+    }
+  });
+
+  it("rejects using host linkage wording without claiming embeds on shared builds", async () => {
+    const { requireNodeSqlite, readNodeSharedSqliteFlag } =
+      await loadNodeSqliteWithVersion("3.46.1");
+    let message = "";
+    try {
+      requireNodeSqlite();
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).toMatch(/SQLite 3\.46\.1[\s\S]*which is affected/);
+    const shared = readNodeSharedSqliteFlag();
+    if (shared === true || shared === 1) {
+      expect(message).toContain("shared SQLite 3.46.1");
+      expect(message).not.toContain("embeds SQLite");
+    } else if (shared === false || shared === 0) {
+      expect(message).toContain("embeds SQLite 3.46.1");
+    } else {
+      expect(message).toContain("is using SQLite 3.46.1");
+      expect(message).not.toContain("embeds SQLite");
+    }
+  });
+
+  it("accepts the SQLite build in the supported test runtime", () => {
     return import("./node-sqlite.js").then(({ requireNodeSqlite }) => {
       expect(() => requireNodeSqlite()).not.toThrow();
     });

--- a/src/infra/node-sqlite.ts
+++ b/src/infra/node-sqlite.ts
@@ -7,12 +7,30 @@ import { installProcessWarningFilter } from "./warning-filter.js";
 const require = createRequire(import.meta.url);
 let validatedSqliteModule: typeof import("node:sqlite") | undefined;
 
-export type NodeSharedSqliteFlag = boolean | number | undefined;
+// Node may expose process.config.variables flags as boolean, number, or
+// string ("true"/"false"); keep the raw union so callers can pass host metadata
+// without pre-coercion.
+export type NodeSharedSqliteFlag = boolean | number | string | undefined;
+
+/** Normalize Node shared-SQLite build metadata to a closed tri-state. */
+export function normalizeNodeSharedSqliteFlag(
+  sharedFlag: NodeSharedSqliteFlag,
+): boolean | undefined {
+  if (sharedFlag === true || sharedFlag === 1 || sharedFlag === "true") {
+    return true;
+  }
+  if (sharedFlag === false || sharedFlag === 0 || sharedFlag === "false") {
+    return false;
+  }
+  // Absent or unrecognized metadata: caller keeps neutral diagnostic wording.
+  return undefined;
+}
 
 /** Read Node's compile-time shared-SQLite flag when present. */
 export function readNodeSharedSqliteFlag(): NodeSharedSqliteFlag {
-  return (process.config?.variables as { node_shared_sqlite?: boolean | number } | undefined)
-    ?.node_shared_sqlite;
+  return (
+    process.config?.variables as { node_shared_sqlite?: boolean | number | string } | undefined
+  )?.node_shared_sqlite;
 }
 
 /**
@@ -27,16 +45,17 @@ export function describeLoadedSqliteRuntime(
   // means "flag unavailable", not "read process.config again".
   sharedFlag: NodeSharedSqliteFlag,
 ): string {
-  if (sharedFlag === true || sharedFlag === 1) {
+  const shared = normalizeNodeSharedSqliteFlag(sharedFlag);
+  if (shared === true) {
     return (
       `Node ${nodeVersion} is using shared SQLite ${version} ` +
       `(loaded library; process.versions.sqlite may differ)`
     );
   }
-  if (sharedFlag === false || sharedFlag === 0) {
+  if (shared === false) {
     return `Node ${nodeVersion} embeds SQLite ${version}`;
   }
-  // Build metadata unavailable: neutral wording from the observed loaded library.
+  // Build metadata unavailable/unrecognized: neutral wording from the loaded library.
   return `Node ${nodeVersion} is using SQLite ${version}`;
 }
 

--- a/src/infra/node-sqlite.ts
+++ b/src/infra/node-sqlite.ts
@@ -7,13 +7,46 @@ import { installProcessWarningFilter } from "./warning-filter.js";
 const require = createRequire(import.meta.url);
 let validatedSqliteModule: typeof import("node:sqlite") | undefined;
 
+export type NodeSharedSqliteFlag = boolean | number | undefined;
+
+/** Read Node's compile-time shared-SQLite flag when present. */
+export function readNodeSharedSqliteFlag(): NodeSharedSqliteFlag {
+  return (process.config?.variables as { node_shared_sqlite?: boolean | number } | undefined)
+    ?.node_shared_sqlite;
+}
+
+/**
+ * Describe how Node is linked to the *loaded* SQLite library for diagnostics.
+ * Shared builds can report a different process.versions.sqlite than sqlite_version();
+ * only claim "embeds" when build metadata confirms a non-shared Node SQLite.
+ */
+export function describeLoadedSqliteRuntime(
+  version: string,
+  nodeVersion: string,
+  // Required (no default): callers must pass explicit metadata so `undefined`
+  // means "flag unavailable", not "read process.config again".
+  sharedFlag: NodeSharedSqliteFlag,
+): string {
+  if (sharedFlag === true || sharedFlag === 1) {
+    return (
+      `Node ${nodeVersion} is using shared SQLite ${version} ` +
+      `(loaded library; process.versions.sqlite may differ)`
+    );
+  }
+  if (sharedFlag === false || sharedFlag === 0) {
+    return `Node ${nodeVersion} embeds SQLite ${version}`;
+  }
+  // Build metadata unavailable: neutral wording from the observed loaded library.
+  return `Node ${nodeVersion} is using SQLite ${version}`;
+}
+
 function assertSqliteWalResetSafeVersion(version: string, nodeVersion: string): void {
   if (isSqliteWalResetSafeVersion(version)) {
     return;
   }
   throw new Error(
     `OpenClaw requires SQLite 3.51.3+ (or patched 3.50.7+/3.44.6+) for WAL safety; ` +
-      `Node ${nodeVersion} embeds SQLite ${version}, which is affected by the upstream WAL-reset ` +
+      `${describeLoadedSqliteRuntime(version, nodeVersion, readNodeSharedSqliteFlag())}, which is affected by the upstream WAL-reset ` +
       "database corruption bug. Upgrade to Node 22.22.3+, 24.15.0+, or 25.9.0+ before retrying.",
   );
 }


### PR DESCRIPTION
Fixes #106933

## What Problem This Solves

Fixes an issue where users running OpenClaw on a Node build with shared system SQLite would see a startup/safety diagnostic claiming that Node **embeds** a SQLite version that actually came from the loaded shared library. That wording conflicts with `process.versions.sqlite` and steers remediation toward the wrong component.

## Why This Change Was Made

Keep the existing WAL-safety decision (loaded `sqlite_version()` remains authoritative). Only correct the diagnostic text: claim “embeds” when build metadata says Node is not shared-SQLite; say “shared SQLite … (loaded library; process.versions.sqlite may differ)” when `node_shared_sqlite` is true; use neutral “is using SQLite …” when the flag is unavailable.

Compatibility: diagnostic-only; no config/API/safety-floor change. Performance: reject path only. Usability: points operators at the real loaded library. Security: still rejects unsafe loaded versions.

## User Impact

On shared-SQLite Node builds, unsafe-SQLite errors now describe the loaded library accurately instead of saying Node embeds it. Embedded Node builds keep the previous “embeds” wording.

## Evidence

Verification host: local macOS (Crabbox bypass)

Commands:
- `pnpm exec oxfmt --check src/infra/node-sqlite.ts src/infra/node-sqlite.test.ts` → pass
- `node_modules/.bin/oxlint src/infra/node-sqlite.ts src/infra/node-sqlite.test.ts` → 0 warnings / 0 errors
- `node scripts/run-vitest.mjs src/infra/node-sqlite.test.ts` → **21/21 passed**
- Closeout note: full `pnpm check:changed` was stopped after ~30m on heavy `tsgo:core:test` expansion; path-scoped static + focused Vitest used as quality-preserving substitute

Host metadata (this machine):
```text
node: 24.17.0
process.versions.sqlite: 3.53.2
process.config.variables.node_shared_sqlite: true
```

## Real behavior proof

- Behavior addressed: SQLite WAL-safety rejection diagnostics no longer claim Node embeds the loaded library when Node was built with shared SQLite.
- Environment: local macOS, OpenClaw checkout, Node v24.17.0 with `node_shared_sqlite=true` and `process.versions.sqlite=3.53.2`.
- Current-main contrast: `assertSqliteWalResetSafeVersion` always said `Node ${nodeVersion} embeds SQLite ${version}` even when the version came from a shared system library via `SELECT sqlite_version()`.
- Exact steps or command run after this patch:
  1. `node --import tsx -e 'import { describeLoadedSqliteRuntime, readNodeSharedSqliteFlag } from "./src/infra/node-sqlite.ts"; console.log(describeLoadedSqliteRuntime("3.46.1", process.versions.node, readNodeSharedSqliteFlag()));'`
  2. `node scripts/run-vitest.mjs src/infra/node-sqlite.test.ts -t "rejects using host linkage"`
- Evidence after fix:
  ```text
  HOST_FLAG true
  DIAGNOSTIC_FOR_UNSAFE_LOADED_3_46_1:
  Node 24.17.0 is using shared SQLite 3.46.1 (loaded library; process.versions.sqlite may differ)
  CLAIMS_EMBEDS false
  ```
  Focused host-linkage test passed (1 passed / 20 skipped). Full suite: 21/21 passed.
- Control check: pure `describeLoadedSqliteRuntime` cases cover shared=`true`/`false`/`undefined`/`0`/`1`; safety still rejects unpatched loaded versions; “embeds” only when shared flag is false/0.
- Observed result after fix: shared host diagnostic names **shared SQLite** and the loaded version, and does not say “embeds SQLite”.
- What was not tested: full `pnpm check:changed` / full-repo `tsgo:core:test` (heavy expansion; path-scoped oxfmt/oxlint + focused Vitest substituted); live `openclaw` startup on a Node whose loaded SQLite is actually below the WAL floor (this host’s real loaded library is safe; unsafe path was forced via the existing `SELECT sqlite_version()` test mock).

## AI disclosure

This change was authored with AI assistance (Grok). Proof commands and outcomes above were executed on the contributor machine.

