### PR TITLE
fix(ui): restore reload history and bundled icons

### DIFF
--- a/src/gateway/control-ui-csp.test.ts
+++ b/src/gateway/control-ui-csp.test.ts
@@ -28,6 +28,7 @@ describe("buildControlUiCspHeader", () => {
       "'self'",
       "ws:",
       "wss:",
+      "data:",
       "https://api.openai.com",
       "https://tweakcn.com",
     ]);
@@ -67,10 +68,10 @@ describe("buildControlUiCspHeader", () => {
     expect(csp).toMatch(/script-src 'self'(?:;|$)/);
   });
 
-  it("does not relax the policy for the terminal unless allowWasm is set", () => {
+  it("does not relax script execution for the terminal unless allowWasm is set", () => {
     const csp = buildControlUiCspHeader();
     expect(csp).not.toContain("wasm-unsafe-eval");
-    expect(csp).not.toMatch(/connect-src[^;]*data:/);
+    expect(csp).toMatch(/connect-src[^;]*data:/);
   });
 
   it("relaxes script-src and connect-src for the terminal's ghostty-web WASM engine", () => {
@@ -78,7 +79,7 @@ describe("buildControlUiCspHeader", () => {
     // Narrow WASM compilation permission — never full unsafe-eval.
     expect(csp).toMatch(/script-src[^;]*'wasm-unsafe-eval'/);
     expect(csp).not.toMatch(/script-src[^;]*'unsafe-eval'(?!-)/);
-    // ghostty-web fetches its inlined WASM from a data: URL.
+    // Web Awesome icons and ghostty-web both fetch inlined data: assets.
     expect(csp).toMatch(/connect-src[^;]*\bdata:/);
   });
 

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -38,9 +38,8 @@ function hasScriptSrcAttribute(openTag: string): boolean {
 export function buildControlUiCspHeader(opts?: {
   inlineScriptHashes?: string[];
   /**
-   * Relax the policy just enough for the embedded terminal's ghostty-web engine:
-   * `'wasm-unsafe-eval'` permits WebAssembly compilation and `data:` in
-   * connect-src lets it fetch its inlined WASM binary. Gated on the terminal
+   * Relax the policy just enough for the embedded terminal's ghostty-web engine.
+   * `'wasm-unsafe-eval'` permits WebAssembly compilation. Gated on the terminal
    * being enabled so the baseline Control UI CSP stays tight otherwise.
    */
   allowWasm?: boolean;
@@ -53,10 +52,16 @@ export function buildControlUiCspHeader(opts?: {
   if (opts?.allowWasm) {
     scriptTokens.push("'wasm-unsafe-eval'");
   }
-  const connectTokens = ["'self'", "ws:", "wss:", "https://api.openai.com", "https://tweakcn.com"];
-  if (opts?.allowWasm) {
-    connectTokens.push("data:");
-  }
+  // Web Awesome resolves its bundled system icons to data: SVGs, then fetches
+  // them before rendering. This allows local bytes only, not another origin.
+  const connectTokens = [
+    "'self'",
+    "ws:",
+    "wss:",
+    "data:",
+    "https://api.openai.com",
+    "https://tweakcn.com",
+  ];
   return [
     "default-src 'self'",
     "base-uri 'none'",

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -404,7 +404,7 @@ describe("handleControlUiHttpRequest", () => {
         expect(String(csp)).toContain("frame-src 'self'");
         expect(String(csp)).toContain("script-src 'self'");
         expect(String(csp)).toContain(
-          "connect-src 'self' ws: wss: https://api.openai.com https://tweakcn.com",
+          "connect-src 'self' ws: wss: data: https://api.openai.com https://tweakcn.com",
         );
         expect(String(csp)).not.toContain("https://*.tweakcn.com");
         expect(String(csp)).not.toContain("script-src 'self' 'unsafe-inline'");

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -427,6 +427,39 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
+  it("restores the selected session transcript after a hard reload", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const historyText = "Transcript survives a hard reload.";
+    const gateway = await installMockGateway(page, {
+      historyMessages: [
+        {
+          content: [{ text: historyText, type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+      ],
+      sessionKey: "agent:main:main",
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat?session=main`);
+      await page.getByText(historyText).waitFor({ timeout: 10_000 });
+      await gateway.waitForRequest("chat.startup");
+
+      await page.reload();
+
+      await page.getByText(historyText).waitFor({ timeout: 10_000 });
+      await expect.poll(async () => (await gateway.getRequests("chat.startup")).length).toBe(1);
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
   it("sends idle stop aliases as ordinary chat messages", async () => {
     const context = await newBrowserContext({
       locale: "en-US",

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -211,8 +211,9 @@ describe("chat pane initialization", () => {
   });
 
   it("starts the connected client when a route alias is already selected canonically", () => {
+    const request = vi.fn(() => new Promise<never>(() => {}));
     const client = {
-      request: vi.fn(() => new Promise<never>(() => {})),
+      request,
     } as unknown as GatewayBrowserClient;
     const sessions = {} as SessionCapability;
     const { pane, state } = createTestChatPane({ client, sessions });
@@ -263,7 +264,7 @@ describe("chat pane initialization", () => {
 
     expect(navigate).toHaveBeenCalledWith("single", canonicalSessionKey, { replace: true });
     expect(pane.connectedClient).toBe(client);
-    expect(client.request).toHaveBeenCalledWith(
+    expect(request).toHaveBeenCalledWith(
       "chat.startup",
       expect.objectContaining({ sessionKey: canonicalSessionKey }),
     );

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -27,6 +27,7 @@ type TestChatPane = HTMLElement & {
   context: ApplicationContext;
   state: ChatPageHost;
   connectedClient: GatewayBrowserClient | null;
+  applyGatewaySnapshot: (snapshot: ApplicationContext["gateway"]["snapshot"]) => void;
   connectedCallback: () => void;
   connectionGeneration: number;
   createSession: () => Promise<boolean>;
@@ -207,6 +208,65 @@ describe("chat pane initialization", () => {
     } finally {
       pane.disconnectedCallback();
     }
+  });
+
+  it("starts the connected client when a route alias is already selected canonically", () => {
+    const client = {
+      request: vi.fn(() => new Promise<never>(() => {})),
+    } as unknown as GatewayBrowserClient;
+    const sessions = {} as SessionCapability;
+    const { pane, state } = createTestChatPane({ client, sessions });
+    const canonicalSessionKey = "agent:main:main";
+    const hello = {
+      features: { methods: ["chat.startup"] },
+      snapshot: {
+        sessionDefaults: {
+          defaultAgentId: "main",
+          mainKey: "main",
+          mainSessionKey: canonicalSessionKey,
+        },
+      },
+    } as unknown as NonNullable<ApplicationContext["gateway"]["snapshot"]["hello"]>;
+    const snapshot = {
+      ...pane.context.gateway.snapshot,
+      client,
+      connected: true,
+      hello,
+      sessionKey: canonicalSessionKey,
+    };
+    const navigate = vi.fn();
+    pane.context = {
+      ...pane.context,
+      gateway: { ...pane.context.gateway, snapshot },
+      config: {
+        current: {
+          assistantIdentity: {
+            agentId: "main",
+            avatar: null,
+            avatarReason: null,
+            avatarSource: null,
+            avatarStatus: null,
+            name: "Assistant",
+          },
+          terminalEnabled: false,
+        },
+      },
+    } as unknown as ApplicationContext;
+    pane.sessionKey = "main";
+    state.sessionKey = canonicalSessionKey;
+    state.hello = hello;
+    state.loadAssistantIdentity = vi.fn(async () => {});
+    pane.connectedClient = null;
+    pane.onPaneSessionChange = navigate;
+
+    pane.applyGatewaySnapshot(snapshot);
+
+    expect(navigate).toHaveBeenCalledWith("single", canonicalSessionKey, { replace: true });
+    expect(pane.connectedClient).toBe(client);
+    expect(client.request).toHaveBeenCalledWith(
+      "chat.startup",
+      expect.objectContaining({ sessionKey: canonicalSessionKey }),
+    );
   });
 });
 

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -1649,7 +1649,12 @@ class ChatPane extends OpenClawLightDomElement {
     ) {
       this.onPaneSessionChange?.(this.paneId, canonicalRouteSessionKey, { replace: true });
       state.requestUpdate?.();
-      return;
+      // A fast reconnect can canonicalize persisted settings before this lazy
+      // pane mounts. Continue startup when the page state already owns the
+      // canonical key; no later route update will switch sessions and load it.
+      if (state.sessionKey !== canonicalRouteSessionKey) {
+        return;
+      }
     }
     state.assistantName = this.context.config.current.assistantIdentity.name;
     if (!snapshot.connected) {

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -149,7 +149,6 @@ type ChatHistoryAnchor = {
   scrollHeight: number;
   scrollTop: number;
 };
-
 const CATALOG_TOOL_RESULT_PREVIEW_MAX_CHARS = 500;
 
 function catalogRawString(raw: unknown, keys: readonly string[]): string | null {
@@ -165,7 +164,6 @@ function catalogRawString(raw: unknown, keys: readonly string[]): string | null 
   }
   return null;
 }
-
 function catalogRawResult(raw: unknown): string | null {
   const result = catalogRawRecord(raw)?.result;
   if (result === undefined) {
@@ -178,7 +176,6 @@ function catalogRawResult(raw: unknown): string | null {
     return null;
   }
 }
-
 function nativeHistoryMessageIdentity(message: unknown): string | null {
   const record = catalogRawRecord(message);
   const metadata = catalogRawRecord(record?.["__openclaw"]);
@@ -213,7 +210,6 @@ type ChatPaneConnectionScope = {
   generation: number;
   sessions: ChatPageContext["sessions"];
 };
-
 const CHAT_OPEN_DETAILS_SELECTOR =
   ".chat-controls__inline-select[open], .context-usage details[open], .agent-chat__attach-menu[open], .chat-pr__checks[open]";
 const CHAT_COMPOSER_TEXTAREA_SELECTOR = ".agent-chat__composer-combobox > textarea";
@@ -1649,9 +1645,8 @@ class ChatPane extends OpenClawLightDomElement {
     ) {
       this.onPaneSessionChange?.(this.paneId, canonicalRouteSessionKey, { replace: true });
       state.requestUpdate?.();
-      // A fast reconnect can canonicalize persisted settings before this lazy
-      // pane mounts. Continue startup when the page state already owns the
-      // canonical key; no later route update will switch sessions and load it.
+      // Persisted state may already own the canonical key; continue startup
+      // because no later route update would load its history.
       if (state.sessionKey !== canonicalRouteSessionKey) {
         return;
       }


### PR DESCRIPTION
## What Problem This Solves

The Control UI had two live browser regressions:

- A hard reload could show an empty welcome screen even though the selected session had history. This happened when route alias canonicalization completed before the lazy chat pane mounted.
- Web Awesome system icons resolve to inline data SVGs and fetch those URLs before rendering, but the Control UI CSP blocked data URLs in connect-src. This produced repeated console errors and could leave system icons missing.

## Why This Change Was Made

Chat startup now continues when the page state already owns the canonical route key; it still returns early for a real session transition. The CSP now permits data URL fetches for bundled local assets without allowing another network origin. Unit and browser regressions cover both contracts.

## User Impact

Chat transcripts survive hard reloads. Bundled Web Awesome icons render without CSP errors.

Release note: Fixed Control UI transcript restoration after reload and bundled icon rendering under CSP.

## Evidence

- Live OpenAI Crabbox run run_bfbc53de902e: GPT-5.4 desktop turns, active-run queued turns, hard reload persistence, mobile turn, navigation, and browser error audit all passed; zero console errors and zero page errors.
- Crabbox run run_a02f94330d0e: focused hard-reload browser E2E passed.
- Crabbox run run_dcbb3a06ffcb: 43 chat tests and 115 Gateway CSP/HTTP tests passed.
- Crabbox changed gate run run_3e3dab50a50b passed LOC, format, API baseline, typecheck, lint, and static guards before an unrelated-main rebase.
- Fresh autoreview reported no accepted or actionable findings.
- Visual review: desktop and mobile screenshots clean; Web Awesome icons visible.
