### PR TITLE
fix: validate ElevenLabs baseUrl before realtime or speech requests

### DIFF
--- a/extensions/elevenlabs/realtime-transcription-provider.test.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.test.ts
@@ -110,4 +110,35 @@ describe("buildElevenLabsRealtimeTranscriptionProvider", () => {
     expect(url).toContain("commit_strategy=vad");
     expect(url).toContain("language_code=en");
   });
+
+  it.each(["not a url", "ftp://files.example.com"])(
+    "rejects invalid realtime endpoint %s",
+    (baseUrl) => {
+      expect(() =>
+        testing.toElevenLabsRealtimeWsUrl({
+          apiKey: "eleven-key",
+          baseUrl,
+          providerConfig: {},
+          modelId: "scribe_v2_realtime",
+          audioFormat: "ulaw_8000",
+          sampleRate: 8000,
+          commitStrategy: "vad",
+        }),
+      ).toThrow(/^Invalid ElevenLabs baseUrl:/);
+    },
+  );
+
+  it("accepts explicit ws endpoints for realtime", () => {
+    const url = testing.toElevenLabsRealtimeWsUrl({
+      apiKey: "eleven-key",
+      baseUrl: "ws://localhost:9000/api",
+      providerConfig: {},
+      modelId: "scribe_v2_realtime",
+      audioFormat: "ulaw_8000",
+      sampleRate: 8000,
+      commitStrategy: "vad",
+    });
+
+    expect(url).toContain("ws://localhost:9000/api/v1/speech-to-text/realtime?");
+  });
 });

--- a/extensions/elevenlabs/realtime-transcription-provider.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.ts
@@ -131,8 +131,12 @@ function normalizeProviderConfig(
 }
 
 function normalizeElevenLabsRealtimeBaseUrl(value?: string): string {
-  const url = new URL(normalizeElevenLabsBaseUrl(value));
-  url.protocol = url.protocol === "http:" ? "ws:" : "wss:";
+  const url = new URL(normalizeElevenLabsBaseUrl(value, { allowWebSocket: true }));
+  if (url.protocol === "http:") {
+    url.protocol = "ws:";
+  } else if (url.protocol === "https:") {
+    url.protocol = "wss:";
+  }
   return url.toString().replace(/\/+$/, "");
 }
 

--- a/extensions/elevenlabs/shared.ts
+++ b/extensions/elevenlabs/shared.ts
@@ -5,7 +5,27 @@ export function isValidElevenLabsVoiceId(voiceId: string): boolean {
   return /^[a-zA-Z0-9]{10,40}$/.test(voiceId);
 }
 
-export function normalizeElevenLabsBaseUrl(baseUrl?: string): string {
+export function normalizeElevenLabsBaseUrl(
+  baseUrl?: string,
+  options?: { allowWebSocket?: boolean },
+): string {
   const trimmed = baseUrl?.trim();
-  return trimmed?.replace(/\/+$/, "") || DEFAULT_ELEVENLABS_BASE_URL;
+  if (!trimmed) {
+    return DEFAULT_ELEVENLABS_BASE_URL;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error("Invalid ElevenLabs baseUrl: value is not a valid URL");
+  }
+  const allowedSchemes = options?.allowWebSocket
+    ? new Set(["http:", "https:", "ws:", "wss:"])
+    : new Set(["http:", "https:"]);
+  if (!allowedSchemes.has(parsed.protocol)) {
+    throw new Error(
+      `Invalid ElevenLabs baseUrl: unsupported scheme "${parsed.protocol}" (expected ${options?.allowWebSocket ? "http, https, ws, or wss" : "http or https"})`,
+    );
+  }
+  return trimmed.replace(/\/+$/, "");
 }

--- a/extensions/elevenlabs/speech-provider.test.ts
+++ b/extensions/elevenlabs/speech-provider.test.ts
@@ -72,6 +72,20 @@ describe("elevenlabs speech provider", () => {
     );
   });
 
+  it.each(["not a url", "ws://localhost:9000/api", "ftp://files.example.com"])(
+    "rejects invalid speech baseUrl %s",
+    async (baseUrl) => {
+      const provider = buildElevenLabsSpeechProvider();
+
+      await expect(
+        provider.listVoices?.({
+          providerConfig: { apiKey: "xi-test", baseUrl },
+          timeoutMs: 30_000,
+        }),
+      ).rejects.toThrow(/^Invalid ElevenLabs baseUrl:/);
+    },
+  );
+
   it("keeps non-equivalent deprecated ElevenLabs TTS model IDs", async () => {
     const provider = buildElevenLabsSpeechProvider();
     const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {


### PR DESCRIPTION
Closes #106943

## Summary
- validate ElevenLabs base URLs up front with user-friendly invalid-URL and unsupported-scheme errors
- keep speech endpoints restricted to http/https while still allowing explicit ws/wss endpoints for realtime transcription
- add regression coverage for invalid speech and realtime endpoints

## Testing
- pnpm vitest run extensions/elevenlabs/realtime-transcription-provider.test.ts extensions/elevenlabs/speech-provider.test.ts

## Notes
- local `pnpm check:changed -- extensions/elevenlabs/shared.ts extensions/elevenlabs/realtime-transcription-provider.ts extensions/elevenlabs/realtime-transcription-provider.test.ts extensions/elevenlabs/speech-provider.test.ts` could not complete because the crabbox wrapper failed its local sanity check before remote execution (`selected binary failed basic --version/--help sanity checks`)