### PR TITLE
fix: retry built-in provider-wrapped transient 5xx errors

### DIFF
--- a/src/llm/utils/retry.test.ts
+++ b/src/llm/utils/retry.test.ts
@@ -35,6 +35,9 @@ describe("isRetryableAssistantError", () => {
   it("keeps concrete quota failures non-retryable", () => {
     expect(isRetryableAssistantError(errorMessage("429 insufficient_quota"))).toBe(false);
     expect(isRetryableAssistantError(errorMessage("Monthly usage limit reached"))).toBe(false);
+    expect(
+      isRetryableAssistantError(errorMessage("OpenAI API error (429): insufficient_quota")),
+    ).toBe(false);
   });
 
   it.each([
@@ -43,6 +46,7 @@ describe("isRetryableAssistantError", () => {
     "Image dimensions 1504x1504 exceed the maximum allowed size",
     "Image width 500 exceeds the maximum allowed size",
     "invalid api key sk-example502value",
+    "OpenAI API error (400): 400 Model Id [gpt-5.4-nano] not found",
   ])("does not retry permanent errors with status-code substrings: %s", (text) => {
     expect(isRetryableAssistantError(errorMessage(text))).toBe(false);
   });
@@ -51,6 +55,9 @@ describe("isRetryableAssistantError", () => {
     "429 temporary provider response",
     "HTTP 500 temporary provider response",
     "503: temporary provider response",
+    "OpenAI API error (500): 500 The server had an error while processing your request.",
+    "Azure OpenAI API error (503): 503 temporary provider response",
+    "Mistral API error (504): upstream timeout",
   ])("retries explicit transient HTTP statuses: %s", (text) => {
     expect(isRetryableAssistantError(errorMessage(text))).toBe(true);
   });

--- a/src/llm/utils/retry.ts
+++ b/src/llm/utils/retry.ts
@@ -58,6 +58,17 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "please retry your request",
 ]);
 
+const WRAPPED_PROVIDER_STATUS_RE = /^(?:OpenAI|Azure OpenAI|Mistral) API error \((\d{3})\):\s*/i;
+
+function extractWrappedProviderStatus(raw: string): number | undefined {
+  const match = raw.match(WRAPPED_PROVIDER_STATUS_RE);
+  if (!match) {
+    return undefined;
+  }
+  const status = Number(match[1]);
+  return Number.isInteger(status) ? status : undefined;
+}
+
 /** Classify transient provider/transport failures for outer retry policy. */
 export function isRetryableAssistantError(message: AssistantMessage): boolean {
   if (message.stopReason !== "error" || !message.errorMessage) {
@@ -67,7 +78,8 @@ export function isRetryableAssistantError(message: AssistantMessage): boolean {
   if (NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN.test(errorMessage)) {
     return false;
   }
-  const status = extractLeadingHttpStatus(errorMessage)?.code;
+  const status =
+    extractLeadingHttpStatus(errorMessage)?.code ?? extractWrappedProviderStatus(errorMessage);
   if (status && status !== 429 && RETRYABLE_HTTP_STATUS_CODES.has(status)) {
     return true;
   }


### PR DESCRIPTION
Closes #106824

## Summary
- recognize the repository's own OpenAI, Azure OpenAI, and Mistral `... API error (<status>): ...` wrapper when classifying retryable assistant failures
- preserve the stricter permanent-error behavior by only accepting the anchored built-in wrapper format
- add regression coverage for wrapped transient and permanent statuses

## Testing
- pnpm vitest run src/llm/utils/retry.test.ts

## Notes
- local `pnpm check:changed -- src/llm/utils/retry.ts src/llm/utils/retry.test.ts` could not complete because the crabbox wrapper failed its local sanity check before remote execution (`selected binary failed basic --version/--help sanity checks`)