### PR TITLE
fix: avoid unhandled rejection when inbound session error hook throws

### DIFF
--- a/src/channels/session.test.ts
+++ b/src/channels/session.test.ts
@@ -189,4 +189,29 @@ describe("recordInboundSession", () => {
     expect(route.sessionKey).toBe("agent:main:main");
     expect(route.createIfMissing).toBe(false);
   });
+
+  it("swallows throwing onRecordError handlers for detached meta writes", async () => {
+    const recordError = new Error("persist failed");
+    const onRecordError = vi.fn(() => {
+      throw new Error("handler failed");
+    });
+    recordSessionMetaFromInboundMock.mockRejectedValueOnce(recordError);
+    const unhandledRejection = vi.fn();
+    process.once("unhandledRejection", unhandledRejection);
+
+    try {
+      await recordInboundSession({
+        storePath: "/tmp/openclaw-session-store.json",
+        sessionKey: "agent:main:demo-channel:1234:thread:42",
+        ctx,
+        onRecordError,
+      });
+      await Promise.resolve();
+
+      expect(onRecordError).toHaveBeenCalledWith(recordError);
+      expect(unhandledRejection).not.toHaveBeenCalled();
+    } finally {
+      process.removeListener("unhandledRejection", unhandledRejection);
+    }
+  });
 });

--- a/src/channels/session.ts
+++ b/src/channels/session.ts
@@ -48,7 +48,14 @@ export async function recordInboundSession(params: {
       groupResolution,
       createIfMissing,
     })
-    .catch(params.onRecordError);
+    .catch((error) => {
+      try {
+        params.onRecordError(error);
+      } catch {
+        // Swallow error-reporter failures so the detached meta task never
+        // becomes an unhandled rejection.
+      }
+    });
   params.trackSessionMetaTask?.(metaTask);
   void metaTask;
 


### PR DESCRIPTION
Closes #106948

## Summary
- wrap detached inbound session meta error callbacks so a throwing onRecordError handler cannot leave an unhandled rejection behind
- add regression coverage for detached meta writes with a failing error hook

## Testing
- pnpm vitest run src/channels/session.test.ts

## Notes
- local `pnpm check:changed -- src/channels/session.ts src/channels/session.test.ts` could not complete because the crabbox wrapper failed its local sanity check before remote execution (`selected binary failed basic --version/--help sanity checks`)