### PR TITLE
test(tooling): track scoped oxlint override

### DIFF
--- a/test/scripts/oxlint-config.test.ts
+++ b/test/scripts/oxlint-config.test.ts
@@ -160,10 +160,16 @@ describe("oxlint config", () => {
     ]);
   });
 
-  it("keeps lint overrides limited to the indexed-access and test-file policies", () => {
+  it("keeps lint overrides limited to approved scoped policies", () => {
     const config = readJson(".oxlintrc.json") as OxlintConfig;
 
     expect(config.overrides).toEqual([
+      {
+        files: ["extensions/browser/src/browser/routes/*.ts"],
+        rules: {
+          "oxc/no-async-endpoint-handlers": "off",
+        },
+      },
       {
         files: [
           "packages/markdown-core/**/*.ts",


### PR DESCRIPTION
## What Problem This Solves

Current `main` and unrelated PRs fail the compact node shard because the exact oxlint override contract test was not updated when the browser route exception became scoped.

## Why This Change Was Made

The contract now includes the approved browser-route override and names the broader invariant it enforces. Exact equality remains in place, so any unreviewed override still fails the test.

## User Impact

No runtime or user-visible behavior changes. Main CI can validate the deliberately scoped lint exception without weakening the repository's override guard.

## Evidence

- Exact failing job: https://github.com/openclaw/openclaw/actions/runs/29299326530/job/86979677050
- Blacksmith Testbox `tbx_01kxf52yvbt3bbfwh7z79fmh2f`, Actions run `29299565581`: focused oxlint config suite passed 10/10 in 169ms.
- The same Testbox run passed path-scoped `check:changed`, including root test types, script lint, format, and repository guards.
- Fresh autoreview: clean, 0.95 confidence.
- `git diff --check` passed.
