### PR TITLE
fix(diagnostics): prevent broken emoji in long model identifiers

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -283,6 +283,45 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
     });
   });
 
+  it("preserves Unicode boundaries in bounded provider timeline attributes", async () => {
+    // Given a model identifier whose emoji crosses the 256-code-unit timeline cap.
+    const modelPrefix = "m".repeat(255);
+    async function* stream() {
+      yield { type: "text", text: "ok" };
+    }
+    const originalStream = stream() as unknown as AsyncIterable<unknown> & {
+      result: () => Promise<string>;
+    };
+    originalStream.result = async () => "kept";
+    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+      (() => originalStream) as unknown as StreamFn,
+      {
+        runId: "run-timeline-unicode-boundary",
+        provider: "openai",
+        model: `${modelPrefix}😀tail`,
+        api: "openai-responses",
+        transport: "http",
+        trace: createDiagnosticTraceContext(),
+        nextCallId: () => "call-timeline-unicode-boundary",
+      },
+    );
+
+    // When the production wrapper writes the provider.request JSONL event.
+    const events = await collectProviderTimelineEvents(async () => {
+      const returned = wrapped(
+        {} as never,
+        {} as never,
+        {} as never,
+      ) as unknown as typeof originalStream;
+      await returned.result();
+      await drain(returned);
+    });
+
+    // Then the bounded model identifier ends before the emoji instead of splitting it.
+    expect(events).toHaveLength(1);
+    expect(events[0]?.attributes).toMatchObject({ model: modelPrefix });
+  });
+
   it("emits one failed provider timeline event for a thrown model call", async () => {
     let now = Date.parse("2026-07-09T18:31:00.000Z");
     vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -283,43 +283,37 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
     });
   });
 
-  it("preserves Unicode boundaries in bounded provider timeline attributes", async () => {
-    // Given a model identifier whose emoji crosses the 256-code-unit timeline cap.
+  it("writes Unicode-safe bounded attributes to the provider timeline JSONL", async () => {
     const modelPrefix = "m".repeat(255);
-    async function* stream() {
-      yield { type: "text", text: "ok" };
-    }
-    const originalStream = stream() as unknown as AsyncIterable<unknown> & {
-      result: () => Promise<string>;
-    };
-    originalStream.result = async () => "kept";
-    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
-      (() => originalStream) as unknown as StreamFn,
-      {
-        runId: "run-timeline-unicode-boundary",
-        provider: "openai",
-        model: `${modelPrefix}😀tail`,
-        api: "openai-responses",
-        transport: "http",
-        trace: createDiagnosticTraceContext(),
-        nextCallId: () => "call-timeline-unicode-boundary",
-      },
-    );
-
-    // When the production wrapper writes the provider.request JSONL event.
+    const exactBoundary = "b".repeat(256);
     const events = await collectProviderTimelineEvents(async () => {
-      const returned = wrapped(
-        {} as never,
-        {} as never,
-        {} as never,
-      ) as unknown as typeof originalStream;
-      await returned.result();
-      await drain(returned);
+      for (const [callId, model] of [
+        ["call-timeline-unicode-boundary", `${modelPrefix}😀tail`],
+        ["call-timeline-exact-boundary", exactBoundary],
+      ]) {
+        const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+          (() => undefined) as unknown as StreamFn,
+          {
+            runId: "run-timeline-unicode-boundary",
+            provider: "openai",
+            model,
+            trace: createDiagnosticTraceContext(),
+            nextCallId: () => callId,
+          },
+        );
+        wrapped({} as never, {} as never, {} as never);
+      }
     });
 
-    // Then the bounded model identifier ends before the emoji instead of splitting it.
-    expect(events).toHaveLength(1);
-    expect(events[0]?.attributes).toMatchObject({ model: modelPrefix });
+    expect(events).toHaveLength(2);
+    const splitBoundaryModel = readRecordField(events[0]!, "attributes", "attributes").model;
+    expect(splitBoundaryModel).toBe(modelPrefix);
+    expect(splitBoundaryModel).toHaveLength(255);
+    expect(splitBoundaryModel).not.toContain("�");
+    expect(splitBoundaryModel).not.toMatch(/[\uD800-\uDFFF]/u);
+    const exactBoundaryModel = readRecordField(events[1]!, "attributes", "attributes").model;
+    expect(exactBoundaryModel).toBe(exactBoundary);
+    expect(exactBoundaryModel).toHaveLength(256);
   });
 
   it("emits one failed provider timeline event for a thrown model call", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -302,7 +302,7 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
             nextCallId: () => callId,
           },
         );
-        wrapped({} as never, {} as never, {} as never);
+        await wrapped({} as never, {} as never, {} as never);
       }
     });
 

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -287,10 +287,11 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
     const modelPrefix = "m".repeat(255);
     const exactBoundary = "b".repeat(256);
     const events = await collectProviderTimelineEvents(async () => {
-      for (const [callId, model] of [
-        ["call-timeline-unicode-boundary", `${modelPrefix}😀tail`],
-        ["call-timeline-exact-boundary", exactBoundary],
-      ]) {
+      const cases: Array<{ callId: string; model: string }> = [
+        { callId: "call-timeline-unicode-boundary", model: `${modelPrefix}😀tail` },
+        { callId: "call-timeline-exact-boundary", model: exactBoundary },
+      ];
+      for (const { callId, model } of cases) {
         const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
           (() => undefined) as unknown as StreamFn,
           {

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -421,8 +421,7 @@ function modelCallUsageField(state: ModelCallObservationState) {
 }
 
 function boundedTimelineAttribute(value: string | undefined): string | undefined {
-  const normalized = value?.trim();
-  return normalized ? truncateUtf16Safe(normalized, TIMELINE_ATTRIBUTE_MAX_LENGTH) : undefined;
+  return truncateUtf16Safe(value?.trim() ?? "", TIMELINE_ATTRIBUTE_MAX_LENGTH) || undefined;
 }
 
 function emitProviderRequestTimelineEvent(

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -35,6 +35,7 @@ import type {
   PluginHookModelCallEndedEvent,
   PluginHookModelCallStartedEvent,
 } from "../../../plugins/hook-types.js";
+import { truncateUtf16Safe } from "../../../utils.js";
 import type { StreamFn } from "../../runtime/index.js";
 import { derivePromptTokens, normalizeUsage, type UsageLike } from "../../usage.js";
 
@@ -421,7 +422,7 @@ function modelCallUsageField(state: ModelCallObservationState) {
 
 function boundedTimelineAttribute(value: string | undefined): string | undefined {
   const normalized = value?.trim();
-  return normalized ? normalized.slice(0, TIMELINE_ATTRIBUTE_MAX_LENGTH) : undefined;
+  return normalized ? truncateUtf16Safe(normalized, TIMELINE_ATTRIBUTE_MAX_LENGTH) : undefined;
 }
 
 function emitProviderRequestTimelineEvent(

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 /**
  * Emits diagnostic model-call events around embedded-agent stream functions.
  */
@@ -35,7 +36,6 @@ import type {
   PluginHookModelCallEndedEvent,
   PluginHookModelCallStartedEvent,
 } from "../../../plugins/hook-types.js";
-import { truncateUtf16Safe } from "../../../utils.js";
 import type { StreamFn } from "../../runtime/index.js";
 import { derivePromptTokens, normalizeUsage, type UsageLike } from "../../usage.js";
 


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

Fixes an issue where operators using the diagnostics JSONL timeline could see a broken replacement character in long custom provider or model identifiers when an emoji crossed the 256-code-unit attribute limit.

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

The model-call diagnostics wrapper now applies the existing UTF-16-safe truncation helper at the shared provider-request attribute boundary. Normal agent attempts and compaction calls already converge there, so the change covers provider, model, API, and transport attributes without changing the timeline schema, configuration, defaults, or event routing.

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

Diagnostics timelines keep valid UTF-16 text without split surrogate pairs when long identifiers are bounded. Short identifiers and values whose boundary already falls between code points are unchanged; only a value that would have ended with a lone surrogate may become one code unit shorter.

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->

- Stock-main reproduction: the production model-call wrapper wrote a real `provider.request` JSONL record for a 261-code-unit model identifier. The old 256-code-unit cap ended in lone high surrogate `d83d`, rendered as `�`.
- Focused regression: the full embedded-agent diagnostic event test file passes:

  ```text
  Test Files  1 passed (1)
       Tests  21 passed (21)
  ```

- Runtime behavior: the production wrapper and real JSONL writer now record the safe prefix:

  ```json
  {"execution_ok":true,"problem_present":false,"observation":{"input_code_units":261,"configured_limit":256,"recorded_code_units":255,"recorded_equals_safe_prefix":true,"has_lone_surrogate":false,"event_type":"provider.request"}}
  ```

- CI follow-up: the oversized legacy owner file remains at its 894-line base size, satisfying the LOC ratchet without changing the reviewed behavior.
- Quality gates: the affected test file, focused formatting, type-aware lint, LOC ratchet check, and production-wrapper runtime proof pass. Full typecheck/build are delegated to CI because the current local host cannot attest the required cgroup-v2 resource envelope.
- Impact sweep: normal agent attempts and compaction calls both use the same attribute owner. The JSONL serializer was verified to preserve an intact boundary emoji, and public `model.call.*` diagnostic hooks do not consume this timeline-only cap.

