### PR TITLE
fix(signal): reject malformed signal-cli archive lengths

### DIFF
--- a/extensions/signal/src/install-signal-cli.content-length.test.ts
+++ b/extensions/signal/src/install-signal-cli.content-length.test.ts
@@ -1,0 +1,53 @@
+// Signal installer download proof tests.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("openclaw/plugin-sdk/setup-tools", () => ({
+  CONFIG_DIR: ".openclaw",
+  extractArchive: vi.fn(),
+  resolveBrewExecutable: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/run-command", () => ({
+  runPluginCommandWithTimeout: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/temp-path", () => ({
+  withTempDownloadPath: vi.fn(),
+}));
+
+const { downloadToFile } = await import("./install-signal-cli.js");
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("downloadToFile content-length parsing", () => {
+  it("rejects malformed content-length through the real guarded fetch path", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-signal-download-"));
+    const destination = path.join(tmpDir, "signal-cli.tgz");
+    let fetchCalls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        fetchCalls += 1;
+        return new Response("archive", {
+          status: 200,
+          headers: { "content-length": "0x10" },
+        });
+      }) as unknown as typeof fetch,
+    );
+
+    try {
+      await expect(
+        downloadToFile("https://example.com/signal-cli.tgz", destination, 5, 8),
+      ).rejects.toThrow("invalid content-length header: 0x10");
+      await expect(fs.stat(destination)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(fetchCalls).toBe(1);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/signal/src/install-signal-cli.test.ts
+++ b/extensions/signal/src/install-signal-cli.test.ts
@@ -303,7 +303,7 @@ describe("downloadToFile", () => {
   });
 
   it.each(["1e3", "0x10", `1${"0".repeat(309)}`])(
-    "ignores malformed declared archive lengths: %s",
+    "rejects malformed declared archive lengths: %s",
     async (contentLength) => {
       const fetchResult = okDownloadResponse("archive", {
         headers: { "content-length": contentLength },
@@ -311,9 +311,11 @@ describe("downloadToFile", () => {
       fetchWithSsrFGuardMock.mockResolvedValue(fetchResult);
 
       await withTempFile(async (filePath) => {
-        await downloadToFile("https://example.com/signal-cli.tgz", filePath, 5, 8);
+        await expect(
+          downloadToFile("https://example.com/signal-cli.tgz", filePath, 5, 8),
+        ).rejects.toThrow(`invalid content-length header: ${contentLength}`);
 
-        await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("archive");
+        await expectPathMissing(filePath);
       });
 
       expect(fetchResult.release).toHaveBeenCalledTimes(1);

--- a/extensions/signal/src/install-signal-cli.ts
+++ b/extensions/signal/src/install-signal-cli.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { parseMediaContentLength } from "openclaw/plugin-sdk/media-runtime";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { runPluginCommandWithTimeout } from "openclaw/plugin-sdk/run-command";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -34,7 +35,6 @@ const MAX_SIGNAL_CLI_ARCHIVE_BYTES = 256 * 1024 * 1024;
 export const MAX_SIGNAL_CLI_EXTRACTED_BYTES = 384 * 1024 * 1024;
 const SIGNAL_CLI_DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
 const SIGNAL_CLI_RELEASE_INFO_TIMEOUT_MS = 30_000;
-const CONTENT_LENGTH_RE = /^\d+$/;
 
 export type SignalInstallResult = {
   ok: boolean;
@@ -153,12 +153,9 @@ export async function downloadToFile(
     }
 
     const rawLength = response.headers.get("content-length");
-    if (rawLength !== null) {
-      const trimmedLength = rawLength.trim();
-      const declaredLength = CONTENT_LENGTH_RE.test(trimmedLength)
-        ? Number(trimmedLength)
-        : Number.NaN;
-      if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    const declaredLength = parseMediaContentLength(rawLength);
+    if (declaredLength !== null) {
+      if (declaredLength > maxBytes) {
         throw new Error(
           `signal-cli archive exceeds the ${maxBytes}-byte download cap (declared ${declaredLength}).`,
         );


### PR DESCRIPTION
## What Problem This Solves

The Signal plugin installer rejected oversized `signal-cli` archives when `content-length` was a valid decimal number, but it silently ignored malformed values such as `0x10`, `1e3`, or unsafe huge integers. That left the archive download path inconsistent with the stricter media/download surfaces recently fixed elsewhere, and delayed rejection until streaming byte limits instead of failing at the response-header boundary.

## Why This Change Was Made

This replaces the installer-local ad hoc `content-length` parser with the existing shared `parseMediaContentLength()` contract. The fix is small and plugin-local: valid decimal lengths keep the same archive-cap behavior, malformed lengths now reject immediately, and failed downloads still clean up the destination file.

## User Impact

A malformed `Content-Length` response while installing `signal-cli` now fails clearly and removes the partial archive instead of accepting an invalid header.

## Evidence

Current pushed head: `f2a189f59a21a8e382d78b18bde10c42b4b342c1`.

Duplicate preflight found no existing public issue or PR occupying this exact Signal installer malformed `content-length` bug:

```text
$ gh search prs --repo openclaw/openclaw --match title,body --limit 50 --json number,title,state,url,updatedAt -- "signal-cli malformed content-length"
[]
$ gh search issues --repo openclaw/openclaw --match title,body --limit 50 --json number,title,state,url,updatedAt -- "signal-cli malformed content-length"
[]
$ gh search prs --repo openclaw/openclaw --match title,body --limit 50 --json number,title,state,url,updatedAt -- "signal cli archive content length"
[]
$ gh search issues --repo openclaw/openclaw --match title,body --limit 50 --json number,title,state,url,updatedAt -- "signal cli archive content length"
[]
```

Focused Signal installer tests, including a proof test that does not mock `fetchWithSsrFGuard`:

```text
$ node scripts/run-vitest.mjs extensions/signal/src/install-signal-cli.test.ts extensions/signal/src/install-signal-cli.content-length.test.ts
[test] starting test/vitest/vitest.extension-signal.config.ts

 RUN  v4.1.9 /home/0668000995/10288592/git-hub/codex/openclaw


 Test Files  2 passed (2)
      Tests  34 passed (34)
   Start at  09:11:20
   Duration  9.06s (transform 9.65s, setup 1.47s, import 15.10s, tests 635ms, environment 0ms)

[test] passed 1 Vitest shard in 15.63s
```

Diff sanity:

```text
$ git diff --check
```

Change size:

```text
$ git diff --numstat origin/main..HEAD
53	0	extensions/signal/src/install-signal-cli.content-length.test.ts
5	3	extensions/signal/src/install-signal-cli.test.ts
4	7	extensions/signal/src/install-signal-cli.ts
```

Autoreview attempts were blocked by local reviewer tooling, with real output:

```text
$ .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
autoreview target: branch
branch: fix/signal-cli-content-length-parse
engine: codex
model: gpt-5.6-sol
fallback_model: gpt-5.6-terra
thinking: high
tools: on
web_search: on
ref: origin/main
bundle: 10794 chars
codex engine failed (1)

$ .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine claude --no-tools --no-web-search
executable not found: claude. Install it or pass an explicit trusted path when supported.

$ .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine pi --no-web-search
executable not found: pi. Install it or pass an explicit trusted path when supported.
```
