### PR TITLE
fix(ci): pin corrected Kova scenario calibration

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -50,7 +50,7 @@ on:
       kova_ref:
         description: openclaw/Kova Git ref to install
         required: false
-        default: fce10ba3e06b32c783d9c99055f5422e03c88aa1
+        default: 678ff0b764b8786c2e436efbe4efac7d9aac10f8
         type: string
       dispatch_id:
         description: Optional parent workflow dispatch identifier
@@ -153,7 +153,7 @@ jobs:
             include_filters: "scenario:agent-cold-warm-message"
             expected_release_entries: "agent-cold-warm-message:mock-openai-provider"
     env:
-      KOVA_REF: ${{ inputs.kova_ref || 'fce10ba3e06b32c783d9c99055f5422e03c88aa1' }}
+      KOVA_REF: ${{ inputs.kova_ref || '678ff0b764b8786c2e436efbe4efac7d9aac10f8' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
       PERFORMANCE_HELPER_DIR: ${{ github.workspace }}/.artifacts/performance-workflow
       REPORT_DIR: ${{ github.workspace }}/.artifacts/kova/reports/${{ matrix.lane }}

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -83,7 +83,7 @@ describe("OpenClaw performance workflow", () => {
 
   it("pins the Kova evaluator with release validation contracts", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const kovaRef = "fce10ba3e06b32c783d9c99055f5422e03c88aa1";
+    const kovaRef = "678ff0b764b8786c2e436efbe4efac7d9aac10f8";
     const install = findStep("Install OCM and Kova");
     const installRun = install.run ?? "";
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where full release validation would reject healthy agent CLI cold/warm runs because OpenClaw pinned a Kova revision whose scenario-specific 900 MB RSS override superseded the approved 1000 MB calibration.

## Why This Change Was Made

Pin the corrected Kova merge from openclaw/Kova#74 in both workflow default paths and keep the workflow contract test locked to the same immutable SHA.

## User Impact

Release operators retain the intended bounded RSS gate without false failures from the stale scenario override. Runtime product behavior is unchanged.

## Evidence

- Kova PR https://github.com/openclaw/Kova/pull/74 merged at `678ff0b764b8786c2e436efbe4efac7d9aac10f8`.
- Kova CI run 29299809876 passed on Ubuntu and macOS.
- Testbox run 29300045017: 29/29 `test/scripts/openclaw-performance-workflow.test.ts` tests passed.
- Fresh autoreview: no accepted/actionable findings.
- `git diff --check` passed.