### PR TITLE
chore(release): update appcast for 2026.7.1

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -3,6 +3,1756 @@
     <channel>
         <title>OpenClaw</title>
         <item>
+            <title>2026.7.1</title>
+            <pubDate>Tue, 14 Jul 2026 01:57:48 +0000</pubDate>
+            <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
+            <sparkle:version>2607000190</sparkle:version>
+            <sparkle:shortVersionString>2026.7.1</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+            <description><![CDATA[<h2>OpenClaw 2026.7.1</h2>
+<h3>Highlights</h3>
+<ul>
+<li><strong>New models and providers:</strong> add Featherless, Claude Sonnet 5 and Mythos 5, Meta Muse Spark 1.1, and ClawRouter; make GPT-5.6 the new-setup default with <code>/think ultra</code> for Sol and Terra plus <code>max</code> for Luna, honor Z.AI <code>max</code>, and refresh model availability after OAuth renewal. (#101092, #98254, #101238, #102873, #103070, #103163, #99658, #99759, #98333, #103581, #98021, #104778, #102289) Thanks @vincentkoc, @vortexopenclaw, @HamidShojanazeri, @davemorin, @Solvely-Colin, @jalehman, @steipete-oai, @bdjben, @obviyus, @sallyom, @anyech, @100yenadmin, and @fuller-stack-dev.</li>
+<li><strong>Control UI and native macOS chat:</strong> make sessions primary with a minimal searchable sidebar, compact context ring, reasoning-effort slider, cleaner dashboard chrome, and a native macOS session browser with model and thinking pickers, slash commands, transcript export, and context usage. (#99289, #99838, #100386, #101103, #101497)</li>
+<li><strong>Conversational onboarding:</strong> Crestodian now runs a real agent-loop setup across the CLI, web install, and macOS app, with AI-guided provider setup, model-judged approvals bound to exact operations, masked credential prompts, and deterministic fallback when no model is available. (#99935, #100029, #100656, #101887) Thanks @fuller-stack-dev.</li>
+<li><strong>Offline and spoken mobile chat:</strong> iOS and Android now pre-paint bounded per-gateway session and transcript caches offline; Apple Watch gains full voice turns, and iOS can speak replies through configured Gateway TTS with on-device fallback. (#100219, #100227, #100283, #100770, #100771)</li>
+<li><strong>Session organization and generated titles:</strong> generate concise session titles through utility-model routing and add Gateway-backed groups, unread state, rename, fork, archive, and delete controls, plus group management across web, iOS, and Android. (#87643, #100814, #101117, #101234) Thanks @zhangguiping-xydt and @Juliangsm.</li>
+<li><strong>Telegram and Codex continuity:</strong> pair Codex through private <code>/login</code>, steer active runs with <code>/steer</code> and <code>/tell</code>, preserve messages when transcript acknowledgement is missing, adopt durable turns safely, and recover final sends across Telegram formatting and flood-wait failures. (#98006, #98126, #98786, #103664, #103916) Thanks @100yenadmin, @Kyzcreig, @obviyus, and @jalehman.</li>
+<li><strong>Startup and upgrade recovery:</strong> run container migrations before Gateway readiness, stop recoverable legacy state from blocking startup, and enter control-plane-safe mode after repeated unclean boots instead of restart flapping. (#101881, #104529) Fixes #98565 Thanks @sallyom, @jacobtomlinson, @bdjben, @obviyus, and @shakkernerd.</li>
+</ul>
+<h3>Changes</h3>
+<ul>
+<li><strong>Meta provider:</strong> add bundled <code>muse-spark-1.1</code> Responses API support with streaming, tool calls, encrypted reasoning replay, onboarding, exact-model live validation, and standalone npm/ClawHub distribution as <code>@openclaw/meta-provider</code>. (#102873, #103070, #103163) Thanks @HamidShojanazeri, @davemorin, @Solvely-Colin, @jalehman, and @vincentkoc.</li>
+<li><strong>Android chat agent selector:</strong> switch the active agent directly from the live chat screen while keeping chat, Talk mode, and home canvas on the same canonical session. (#80422) Thanks @bcperry and @joshavant.</li>
+<li><strong>Gateway host status:</strong> show the connected Gateway's host, network address, OS, runtime, uptime, CPU, memory, and disk details in Control UI Settings. (#100478)</li>
+<li><strong>Gateway crash-loop recovery:</strong> persist boot outcomes, enter control-plane-safe mode after repeated unclean starts, hold transport and provider activation until recovery, and exit with <code>EX_CONFIG</code> for fatal configuration errors so systemd and launchd stop restart flapping. Thanks @obviyus.</li>
+<li><strong>iOS offline chat:</strong> pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100219)</li>
+<li><strong>Slack progress indicators:</strong> use Slack's native assistant thread status and rotating loading messages by default while keeping acknowledgement reactions static; lifecycle reaction updates now require <code>messages.statusReactions.enabled: true</code>.</li>
+<li><strong>Control UI Talk controls:</strong> keep voice, model, sensitivity, and other realtime defaults in Settings → Communications → Talk, and use the composer microphone caret to select any browser audio input. (#101046)</li>
+<li><strong>Cron model selection:</strong> choose an agent-turn model in Control UI Quick Create and show configured or default models in cron job rows and details. (#95341) Thanks @ly85206559.</li>
+<li><strong>Control UI GitHub previews:</strong> show issue and pull request state, title, author, activity, comments, and change statistics in hover and keyboard-focus cards. (#100434)</li>
+<li><strong>Logbook work journal:</strong> add a disabled-by-default bundled plugin that turns paired-node screen snapshots into a private timeline, daily standup, and timeline-grounded Q&A in a plugin-contributed Control UI tab. (#99930)</li>
+<li><strong>Control UI message context:</strong> reveal per-message token, context, and model details from the timestamp on hover or activation instead of showing a separate Context button.</li>
+<li><strong>Control UI session titles:</strong> reveal truncated recent-session names with a reduced-motion-safe hover animation.</li>
+<li><strong>Control UI sidebar navigation:</strong> show a small customizable pinned destination set, keep the remaining pages under More, move Settings to the footer, and persist sidebar customization in the browser. (#100296) Thanks @vincentkoc.</li>
+<li><strong>Control UI sidebar usage:</strong> remove the provider usage quota row from the expanded sidebar while keeping usage details available in the chat composer and Usage page. Thanks @shakkernerd.</li>
+<li><strong>Android chat code highlighting:</strong> render fenced Kotlin, Swift, TypeScript, JavaScript, Python, Bash, and JSON blocks with bounded, theme-aware syntax colors while preserving plain rendering for unknown, partial, or oversized blocks. (#100217)</li>
+<li><strong>Gateway TTS playback:</strong> add an operator-scoped <code>tts.speak</code> RPC that returns configured-provider speech as inline whole-clip audio for remote clients. (#100770)</li>
+</ul>
+<ul>
+<li><strong>Control UI context usage:</strong> show context-window progress, latest-run input/output tokens, and the active model when the chat context ring is opened.</li>
+<li><strong>Apple Watch voice turns:</strong> dictate a message from the Watch chat and hear the new OpenClaw reply spoken on the Watch, with explicit silent-message and stop-speaking controls. (#100224) Thanks @vincentkoc.</li>
+<li><strong>Conversational onboarding:</strong> add a real agent-loop Crestodian setup flow across the CLI, Gateway, web install, and macOS app, with typed operations, exact approval binding, masked credential prompts, isolated session transcripts, and safe handoff to the normal agent. Thanks @vincentkoc.</li>
+<li><strong>Generated session titles:</strong> name new Control UI sessions from their first message, and add default/per-agent <code>utilityModel</code> routing for lower-cost session, topic, and thread title generation. Thanks @Juliangsm, @zhangguiping-xydt, and @vincentkoc.</li>
+<li><strong>ClawRouter routing and quotas:</strong> add the bundled ClawRouter provider plugin with credential-scoped dynamic model discovery, OpenAI-compatible and native Anthropic/Gemini transports, and managed budget reporting across OpenClaw usage surfaces. (#99658)</li>
+<li><strong>Model and provider coverage:</strong> add GPT-5.6 support, use Nemotron Super's 1M context window, and preserve explicit OpenRouter authentication headers. (#98333, #98726, #98187) Thanks @steipete-oai, @eleqtrizit, @sunlit-deng, @laurencebrown, and @shakkernerd.</li>
+<li><strong>CLI and node workflows:</strong> add <code>openclaw attach</code>, node context-path support, actionable device-approval recovery guidance, soft-resume CLI sessions when prompt metadata changes, and clearer plugin install exit diagnostics. (#96454, #97679, #98115, #98146, #98497, #99822) Thanks @anagnorisis2peripeteia, @obviyus, @wm0018, @welfo-beo, @RomneyDa, @Sanjays2402, and @vincentkoc.</li>
+<li><strong>Cron and usage:</strong> add exit-triggered schedules, detached session-targeted runs, and an in-flight job doctor warning, while making the existing usage footer easier to wrap on Telegram. (#92037, #98755, #98620, #92877) Thanks @anagnorisis2peripeteia, @obviyus, @EthanSK, @masatohoshino, @Marvinthebored, and @vincentkoc.</li>
+<li><strong>Native apps and localization:</strong> modernize iOS presentation, Chat, Talk, onboarding, and reconnect flows; add Gateway speech providers; improve QR onboarding and protocol recovery; install the local Gateway from macOS; localize core Apple and Android surfaces; and add Swedish mobile localization. (#98452, #98736, #99243, #98376, #98302, #98385, #99767, #97110, #97111, #97112, #97113, #98043) Thanks @jcooley8, @Tony-ooo, @joelnishanth, @cursoragent, @joshavant, @vincentkoc, and @yeager.</li>
+<li><strong>Messaging capabilities:</strong> add native iMessage polls, Telegram Codex pairing and steering, Telegram multi-lane progress summaries, and Signal target aliases. (#98421, #98006, #98126, #98907, #95738) Thanks @omarshahine, @lobster, @100yenadmin, @Kyzcreig, @Marvinthebored, and @jesse-merhi.</li>
+<li><strong>Local inference and chat controls:</strong> auto-discover Ollama inference nodes, add Control UI session-first navigation, reasoning controls, and command picking, and keep OpenClaw control tools available when deferred tool search selects the wrong tool family. (#99234, #99289, #99426, #99838, #99561) Thanks @100yenadmin, @joshavant, @VicZhang6, @Solvely-Colin, and @vincentkoc.</li>
+<li><strong>Doctor and diagnostics:</strong> expose auth-profile, workspace, device-pairing, channel-plugin, memory-provider, systemd exhaustion, and Windows LAN firewall findings. (#97125, #97358, #97366, #97496, #97968, #98291, #98666) Thanks @giodl73-repo, @masatohoshino, and @joshavant.</li>
+<li><strong>Policy repair previews:</strong> show review-required Gateway bind and denied node-command changes during <code>doctor --fix</code> without applying them or counting the findings as repaired. (#99776) Thanks @giodl73-repo.</li>
+<li><strong>Conversation and review controls:</strong> prepare scoped conversation capability profiles and add Cursor Agent as an autoreview engine. (#98536, #97348) Thanks @hxy91819.</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li><strong>Codex runtime switching:</strong> accept the bundled Codex runtime for both <code>codex/*</code> and <code>openai/*</code> model routes while keeping unsupported provider/runtime pairs rejected. (#103762)</li>
+<li><strong>LM Studio and xAI repaired tool calls:</strong> emit the terminal tool-call event before completion when promoting serialized plain-text tool calls, preserving the complete streaming lifecycle for consumers.</li>
+<li><strong>Browser actions on Node 24:</strong> keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.</li>
+<li><strong>SecretRef model credentials:</strong> keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)</li>
+<li><strong>Telegram token redaction:</strong> redact bot tokens even when log transports split them across chunks, preventing fragmented credentials from escaping structured and streamed logs. (#103861) Thanks @vincentkoc.</li>
+<li><strong>Telegram durable turn adoption:</strong> complete spooled updates only after durable agent adoption, detach adopted turns from the ingress reply fence, and suppress superseded replies so recovery cannot leak stale or duplicate responses. (#103664, #103952, #103965) Thanks @obviyus and @vincentkoc.</li>
+<li><strong>Task delivery recovery:</strong> normalize legacy delivery statuses while restoring task records so older queued work becomes runnable instead of aborting registry recovery. (#103946) Fixes #103168 Thanks @bek91, @theo674, and @obviyus.</li>
+<li><strong>Diagnostics provider evidence:</strong> emit one deduplicated <code>provider.request</code> timeline event for every completed or failed model call, so opt-in timelines can prove real provider traffic without double-counting terminal paths. Fixes #103063 Thanks @vincentkoc.</li>
+<li><strong>Lean local model shell access:</strong> keep <code>exec</code> directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#101607) Thanks @vincentkoc and @maweibin.</li>
+<li><strong>OAuth refresh contention diagnostics:</strong> keep local lock paths out of user-facing refresh failures and avoid duplicate failure prefixes while preserving structured provider and profile classification. (#101573) Thanks @vincentkoc.</li>
+<li><strong>Exec approval prompts:</strong> keep background-disabled fallback warnings out of pending gateway/node approvals and show them only after a command actually runs in the foreground. (#101561) Thanks @vincentkoc.</li>
+<li><strong>Direct poll delivery:</strong> route direct and hybrid channel polls through the owning outbound adapter while preserving gateway-mode routing and channel option checks. (#99950) Thanks @NianJiuZst and @shakkernerd.</li>
+<li><strong>Agent wait hard-timeout snapshots:</strong> preserve canonical hard-timeout phase and timestamps when the outer <code>agent.wait</code> timer wins the retry-grace race, while leaving queue, draining, and restart-cancelled waits correctable. (#89367) Thanks @Pick-cat and @sunnydongbo.</li>
+<li><strong>Control UI typed approvals:</strong> send <code>/approve</code> commands immediately through the authorized Gateway command path while an agent run is blocked instead of queueing the command behind that run. (#101532) Thanks @vincentkoc.</li>
+<li><strong>Microsoft Teams Graph response bounds:</strong> cap successful file-upload and chat JSON reads so oversized Microsoft Graph responses cannot be buffered without limit. (#97784) Thanks @Alix-007.</li>
+<li><strong>Packaged speech runtime:</strong> stop treating package-backed <code>speech-core</code> as a bundled plugin sidecar, restoring TTS startup in npm installs while release checks keep true activation-bypassing facades package-complete. (#89899, #89425) Thanks @zhangguiping-xydt, @ant1b0t, and @vincentkoc.</li>
+<li><strong>Container image upgrades:</strong> run versioned state migrations and plugin convergence before Gateway readiness when reusing mounted state, failing closed with <code>doctor --fix</code> recovery guidance instead of serving half-upgraded state. (#101881) Fixes #98565 Thanks @sallyom, @jacobtomlinson, and @shakkernerd.</li>
+<li><strong>Plugin update reliability:</strong> preserve plugins successfully switched through ClawHub during core updates instead of processing them a second time and disabling them after a redundant transient failure. (#105405) Thanks @vincentkoc.</li>
+<li><strong>Codex app-server protocol:</strong> require app-server 0.143 or newer, remove pre-0.142 wire-shape compatibility, migrate retired <code>on-failure</code> approval settings to <code>on-request</code> in Codex configuration and saved bindings, teach Codex to retrieve deferred native <code>spawn_agent</code> through <code>tool_search</code> so native subagent task mirroring works on search-capable models, and update the managed runtime to 0.144.1 for code-mode host installation and missing-host fallback reliability. Thanks @vincentkoc.</li>
+<li><strong>Android hardware keyboard chat:</strong> send with unmodified Enter on physical keyboards while preserving Shift+Enter and other modified Enter combinations for multiline input. (#101239) Thanks @3ninyt3nin-creator and @vincentkoc.</li>
+<li><strong>CJK Markdown emphasis:</strong> render adjacent Chinese, Japanese, and Korean emphasis punctuation through the shared Markdown pipeline instead of leaking literal markers across channels. (#101230, #101120) Thanks @nicknmorty and @j08577600-jpg.</li>
+<li><strong>Backup retry cleanup:</strong> close partial archive output handles and isolate each retry path after live-write failures, preventing Windows <code>EBUSY</code> locks from cascading across attempts or leaving stale temp archives. (#101449, #101464) Thanks @ZOOWH, @LiLan0125, @vincentkoc, @aniruddhaadak80, @shakkernerd, and @obviyus.</li>
+<li><strong>Codex yielded native subagents:</strong> keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup. Thanks @vincentkoc.</li>
+<li><strong>Delivery recovery pacing:</strong> pace eligible outbound and restart-continuation replays after gateway startup so outage backlogs do not burst into channel rate limits, while preserving the wall-clock recovery budget. (#101118, #101058) Thanks @ZengWen-DT, @aniruddhaadak80, and @vincentkoc.</li>
+<li><strong>Outbound pre-connect recovery:</strong> clear stale platform-send evidence atomically when a connect or DNS failure proves no request was sent, allowing queued Discord and other channel messages to replay after connectivity returns without weakening the unknown-send duplicate guard. (#101024, #100979) Thanks @SunnyShu0925 and @tiffanychum.</li>
+<li><strong>Discord streamed finals:</strong> send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating <code>@everyone</code> or <code>@here</code>. (#99711, #99662) Thanks @davelutztx and @xena68.</li>
+<li><strong>OpenAI-compatible SSE parsing:</strong> recognize event streams mislabeled as JSON without prepending a second <code>data:</code> prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT and @54meteor.</li>
+<li><strong>Meta Model API contract:</strong> use the current Meta endpoint and output-token field so <code>muse-spark-1.1</code> validation and live requests match the provider contract. (#103680) Fixes #103667 Thanks @vincentkoc, @HamidShojanazeri, @davemorin, @Solvely-Colin, and @jalehman.</li>
+<li><strong>LM Studio embedding preload:</strong> honor model- and provider-level context-window limits when preloading embedding models, preventing avoidable GPU out-of-memory failures. (#100750) Thanks @zak-li, @ZOOWH, and @hxz398.</li>
+<li><strong>Provider overload messaging:</strong> keep rate-limited responses classified for retry and fallback behavior while using overload wording when the provider supplies no explicit retry detail. (#98165) Thanks @SunnyShu0925.</li>
+<li><strong>Microsoft Teams attachment metadata:</strong> bound Bot Framework <code>attachmentInfo</code> JSON reads and cancel oversized streams before they can exhaust Gateway memory. (#99125) Thanks @ly85206559.</li>
+<li><strong>Agent auth copy order:</strong> preserve the source agent's portable auth-profile precedence when copying credentials to a new agent while excluding skipped profiles and transient auth state. (#100833) Thanks @machine3at.</li>
+<li><strong>Memory session repair:</strong> keep daily dreaming ingestion bookkeeping outside session-corpus audit and repair so <code>memory status --fix</code> preserves healthy daily state. (#93389) Thanks @Alix-007 and @vincentkoc.</li>
+<li><strong>Remote browser CDP policy:</strong> allow the configured CDP control host through an existing hostname allowlist without widening page navigation policy, while keeping strict-policy discovery bound to the configured control authority. (#100986, #100819) Thanks @NianJiuZst, @SarinV, and @vincentkoc.</li>
+<li><strong>Config unset diagnostics:</strong> explain when an inherited or default configuration value cannot be unset instead of reporting a misleading successful deletion. (#96557) Thanks @moeghashim.</li>
+<li><strong>Crestodian command probes:</strong> contain stdout and stderr stream failures while keeping child-process close and spawn errors authoritative, preventing unhandled probe crashes. (#100741) Thanks @lsr911.</li>
+<li><strong>Feishu mention forwarding:</strong> fail closed when the bot Open ID is unavailable so group messages cannot be misclassified as explicit bot mentions. (#100891) Thanks @zhangguiping-xydt.</li>
+<li><strong>Cron edit delivery:</strong> preserve each job's implicit delivery mode when applying partial delivery updates, so disabling best-effort delivery no longer turns detached job announcements off. (#100846) Thanks @machine3at and @vincentkoc.</li>
+<li><strong>Control UI session creation:</strong> keep newly created sessions at the front of the stable sidebar order after selecting another session. Thanks @shakkernerd.</li>
+<li><strong>Control UI file previews:</strong> keep large Skill Workshop files responsive with cached, offscreen-contained text chunks while preserving wrapped content, stable file switching, full-file copy, and clean focus behavior. (#101319) Thanks @xianshishan, @shakkernerd, and @vincentkoc.</li>
+<li><strong>FTS-only memory startup:</strong> skip plugin capability discovery when <code>memorySearch.provider</code> is explicitly <code>none</code>, avoiding an unnecessary cold-start scan.</li>
+<li><strong>Control UI agent model labels:</strong> show each selected agent's effective model in the Default picker option instead of the global model. (#100719, #77440) Thanks @hyspacex and @jwong-art.</li>
+<li><strong>Control UI inbound image previews:</strong> render canonical inbound media references through the authenticated ticket route after chat-history reloads. (#100725, #89591) Thanks @sweetcornna, @vergissberlin, and @shakkernerd.</li>
+<li><strong>Small-context compaction:</strong> cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.</li>
+<li><strong>Detail-less provider failures:</strong> keep opaque upstream failures from cooling API-key auth profiles while preserving WHAM-backed OpenAI OAuth health checks and configured model fallback. (#100617) Thanks @fabasi, @fengjikui, and @vincentkoc.</li>
+<li><strong>Plugin install diagnostics:</strong> suppress the misleading hook-pack fallback after plugin install failures only when the hook manifest is absent, while preserving actionable malformed hook-pack errors. (#100554) Thanks @vincentkoc and @obviyus.</li>
+<li><strong>Config validation diagnostics:</strong> emit each unchanged sanitized validation-warning payload once per config path, reset deduplication after a clean validation, and preserve the warning fingerprint across transient invalid reads and failed refreshes. (#100569, #25574) Thanks @vincentkoc and @mcaxtr.</li>
+<li><strong>Config size-drop guard:</strong> compare writes against canonical bytes for parseable object configs instead of raw BOM and indentation overhead, while preserving raw audit telemetry and the conservative malformed-input fallback. (#100591, #71865) Thanks @vincentkoc and @balric-seo.</li>
+<li><strong>Control UI coalesced updates:</strong> show a clear queued-restart completion banner when an update joins an already-running Gateway restart. (#93082) Thanks @goutamadwant and @motacola.</li>
+<li><strong>Control UI connection errors:</strong> preserve structured pairing and authentication failures for pending RPC callers while keeping generic disconnect behavior unchanged. (#54758) Thanks @ruanrrn.</li>
+<li><strong>iOS embedded terminal:</strong> open the terminal-only Control surface directly while native Gateway authentication connects instead of exposing the Web UI login screen.</li>
+<li><strong>TUI startup status:</strong> show <code>starting up</code> during post-connect initialization without overwriting active-run or reconnect state. (#93999) Thanks @ml12580 and @sanjarcode.</li>
+<li><strong>Control UI restart recovery:</strong> recover stale bundle pages through a bounded whole-document refresh after Gateway updates or restarts. (#99111) Thanks @ZengWen-DT and @ITOrity.</li>
+<li><strong>TUI active Gateway ports:</strong> follow the verified active local Gateway port when no explicit URL, port, or remote target is configured. (#73338, #42461) Thanks @haishmg, @vincentkoc, and @jackm1688.</li>
+<li><strong>Apple chat run recovery:</strong> restore active responses from canonical Gateway history after reconnects, foreground resumes, and event gaps, while preserving gateway user-turn identity across Codex and Copilot transcript mirrors to prevent duplicate rows. (#100277)</li>
+<li><strong>Claude CLI streamed replies:</strong> preserve assistant text already received from Claude CLI when its terminal result envelope is empty, preventing false empty-response failover after a complete streamed answer. (#90450) Thanks @totobusnello.</li>
+<li><strong>Phone identity normalization:</strong> canonicalize stray plus signs, preserve non-phone iMessage handles, and reject digit-free Signal identities across shared channel routing. (#100467) Thanks @morluto.</li>
+<li><strong>Tlon scry response bounds:</strong> cap successful Urbit scry JSON reads and cancel oversized streams instead of buffering unbounded peer responses. (#100376) Thanks @hugenshen.</li>
+<li><strong>Source build portability:</strong> keep tsdown configuration self-contained so builds do not depend on resolving the tsdown package from unrun's temporary module directory. Thanks @vincentkoc.</li>
+<li><strong>Agent tool-call decoding:</strong> preserve surrogate-range numeric HTML entities as literal text while still decoding valid supplementary-plane values, preventing malformed model output from injecting lone UTF-16 surrogates into tool arguments. (#99564) Thanks @mikasa0818, @vincentkoc, @shakkernerd, and @maweibin.</li>
+<li><strong>Gateway event dispatch:</strong> catch and log lazy subscriber setup and handler failures instead of leaking unhandled promise rejections. (#100401) Thanks @cxbAsDev.</li>
+<li><strong>Ollama fallback routing:</strong> classify incomplete native streams through the Ollama provider hook so configured model fallbacks can advance. (#100482) Thanks @TurboTheTurtle, @8kfcf95jvp-oss, and @vincentkoc.</li>
+<li><strong>Diffs rendering:</strong> render viewer and image output from one SSR preload, preserve language-pack highlighting through hydration, normalize language hints case-insensitively, skip identical before/after inputs with an explicit <code>changed</code> result, report truthful file-render and input errors, cache hash-pinned viewer runtimes, and prefer canonical file settings over stale aliases. (#100487) Thanks @vincentkoc.</li>
+<li><strong>Remote browser reliability:</strong> bound persistent Playwright tab enumeration by the existing remote CDP timeout budget and retire timed-out connection attempts so late completions cannot restore a stuck connection. (#80147, #58968) Thanks @HemantSudarshan and @KeaneYan.</li>
+<li><strong>Browser attachment downloads:</strong> return managed URL, filename, and path metadata when direct Playwright navigation starts an attachment download, while validating final URLs before saving bytes and preserving single-owner explicit downloads. (#48045, #89416) Thanks @zhangguiping-xydt and @roinou532.</li>
+<li><strong>Browser action downloads:</strong> return managed URL, filename, and path metadata when agent actions trigger downloads, while preserving explicit ownership, validating final URLs before saving bytes, and quarantining policy-denied tabs without closing them. (#93250, #93307) Thanks @sunlit-deng and @scorpiord.</li>
+<li><strong>Managed browser cookie persistence:</strong> initialize new isolated macOS headless profiles with a non-interactive encryption key while preserving existing profile keys, and close Chromium through CDP before bounded signal fallback so persistent logins survive graceful browser and Gateway restarts. (#96704, #98284) Thanks @TurboTheTurtle and @shakkernerd.</li>
+<li><strong>MCP OAuth response bounds:</strong> reject body-less foreign error bodies without calling their inherently unbounded <code>text()</code> fallback, while preserving HTTP status and headers for safe SDK diagnostics. (#98143) Thanks @Pick-cat, @wangmiao0668000666, and @vincentkoc.</li>
+<li><strong>Tlon image upload bounds:</strong> cap remote image fetches before upload and fail closed on oversized or stalled responses instead of buffering them without a limit. (#100374) Thanks @hugenshen.</li>
+<li><strong>Control UI approval prompts:</strong> keep stale resolve failures and busy-state cleanup from leaking across newer approvals or Gateway reconnects. (#98394) Thanks @haruaiclone-droid.</li>
+<li><strong>macOS service SecretRefs:</strong> preserve generated env-file values for SecretRefs that remain in config when stale Gateway LaunchAgents are repaired or reinstalled without those variables in the invoking shell. (#99124) Thanks @mushuiyu886 and @1Wanker.</li>
+<li><strong>Anthropic OAuth callbacks:</strong> keep the provider-required <code>localhost</code> redirect URI stable while allowing the local callback listener to bind an explicit loopback host. (#96917) Thanks @xialonglee, @riazrahaman, and @vincentkoc.</li>
+<li><strong>Prompt-release media delivery:</strong> accept active-leaf-preserving side appends while an embedded run temporarily releases its session lock, so successive message-tool media replies merge without a false session-takeover failure. (#100490) Thanks @scotthuang and @vincentkoc.</li>
+<li><strong>Control UI Skills filters:</strong> align agent and search controls, use translated labels, and preserve native checkbox and radio sizing. (#100526) Thanks @evan-YM and @vincentkoc.</li>
+<li><strong>Control UI completed-run state:</strong> bind active and completed updates to run identities so stale completions keep Send available while newer runs remain active. (#100527) Thanks @tiffanychum, @davidstoll, and @shakkernerd.</li>
+<li><strong>Control UI context usage:</strong> keep stale cached totals visible as approximate without triggering warning styling or Compact actions. (#89772) Thanks @bladin and @snsczssl.</li>
+<li><strong>Control UI file previews:</strong> remove the duplicate Escape header hint while retaining the Close-button shortcut hint and Escape behavior. (#100528) Thanks @xianshishan and @vincentkoc.</li>
+<li><strong>Control UI autonomous tool failures:</strong> preserve an earlier Tool error outcome across later autonomous recovery turns. (#100514) Thanks @qingminglong and @yetval.</li>
+<li><strong>Agent empty replies:</strong> surface a visible failure when a completed interactive turn has no deliverable reply, including queued follow-ups, while preserving explicit silence, pending continuations, and committed side effects, honoring queued send policies, and treating compaction notices as progress. (#100456) Thanks @mushuiyu886 and @grox2012.</li>
+<li><strong>Subprocess, maintenance, and output hardening:</strong> keep child output failures from crashing exec and TUI sessions, isolate remote skill refresh and subagent sweeps, surface skill-scan and approval diagnostics, sanitize ANSI and stray parameter markup without losing visible text, and stop Android audio capture cleanly on device loss. (#100440) Thanks @cxbAsDev, @wendy-chsy, @tzy-17, @nankingjing, @NianJiuZst, @LavyaTandel, and @maweibin.</li>
+<li><strong>Docker sandbox command output:</strong> fail and terminate Docker sandbox operations when stdout/stderr capture breaks instead of returning success with incomplete output. (#100523) Thanks @cxbAsDev and @vincentkoc.</li>
+<li><strong>Android push-to-talk lifecycle:</strong> serialize gateway PTT preparation with app foreground and Manual Mic ownership so delayed work cannot restart, replace, or tear down a newer capture. (#100552) Thanks @xialonglee.</li>
+<li><strong>Lean local-model tools:</strong> trim media generation, TTS, and PDF tools from lean agent surfaces while preserving explicit config and runtime opt-ins. (#88881) Thanks @vincentkoc.</li>
+<li><strong>iOS development app identity:</strong> keep the development app labeled OpenClaw while using its distinct debug icon to differentiate it from release builds.</li>
+<li><strong>Android chat recovery:</strong> preserve optimistic user messages and locally owned runs while reconnect and sequence-gap history snapshots catch up, preventing sent messages from disappearing or stale runs from taking ownership. (#100197)</li>
+<li><strong>iOS QR gateway handoff:</strong> stop VisionKit before delivering scanned setup codes, and keep deferred auth, approval, Watch, and foreground-node work bound to its originating gateway across reconnects. (#99572) Thanks @PollyBot13.</li>
+<li><strong>Agent terminal failures:</strong> surface a safe interactive reply when an agent run ends without visible output, while preserving completed message-tool delivery and heartbeat-specific guidance. (#99304) Thanks @moeedahmed and @maweibin.</li>
+<li><strong>MCP loopback tool results:</strong> preserve schema-valid text, image, and embedded-resource content through HTTP tool calls while rendering malformed or protocol-incompatible blocks as safe text. (#100336) Thanks @tzy-17, @OpenClawKobian99, @vincentkoc, @shakkernerd, and @maweibin.</li>
+<li><strong>Control UI tool-result images:</strong> render direct image content blocks from Gateway history and make the delayed-send scroll E2E setup deterministic. (#100295) Thanks @lzyyzznl, @Pandah97, @rquinones84, and @maweibin.</li>
+<li><strong>Control UI live tool ordering:</strong> keep assistant stream text before its matching tool card when browser and Gateway timestamps disagree. (#93184) Thanks @Pick-cat and @lileilei-camera.</li>
+<li><strong>IRC Unicode messages:</strong> split outbound PRIVMSG payloads on UTF-16 code-point boundaries so emoji cannot be cut into lone surrogates. (#96572) Thanks @WeeLi-009, @vincentkoc, @mushuiyu886, and @cursoragent.</li>
+<li><strong>OpenAI realtime voice greetings:</strong> prevent server VAD from creating a second outbound greeting while an explicit greeting response owns the turn, without disabling caller interruption. (#86285) Thanks @giodl73-repo and @jnikolaidis.</li>
+<li><strong>Realtime voice tools:</strong> filter malformed tool names at each OpenAI, Azure, and Google realtime payload boundary while preserving provider-specific valid names. (#89175) Thanks @vincentkoc.</li>
+<li><strong>Discord voice status:</strong> treat Discord error 10065 as a normal disconnected state while preserving unrelated REST failures. (#90969) Thanks @asock.</li>
+<li><strong>Discord voice accounts:</strong> isolate <code>@discordjs/voice</code> connections by Discord account and recover auto-join when gateway readiness predates listener registration. (#87530) Thanks @geekhuashan.</li>
+<li><strong>iOS Voice Wake cleanup:</strong> avoid initializing the microphone audio pipeline while disabling inactive Voice Wake, preventing simulator launch aborts and unnecessary audio setup.</li>
+<li><strong>Reliability edge cases:</strong> reject sub-millisecond cron durations, preserve generated proposal newlines, normalize blank integer inputs and fail embedded LSP startup promptly, surface persistence and memory-close failures, keep UTF-16 and plugin package verification correct, propagate Android cancellation, and defer Codex relay registry writes until listening. (#100399) Thanks @cxbAsDev, @snotty, @lin-hongkuan, @849261680, @qingminglong, @anyech, @masatohoshino, @Simon-XYDT, @xialonglee, @nankingjing, @609NFT, and @vincentkoc.</li>
+<li><strong>Voice Call completed status:</strong> resolve finalized calls from the full retained event store across Gateway, tool, and CLI status paths while preserving active-call lookup performance. (#99797) Thanks @Darren2030, @NiTeCoMM-code, and @maweibin.</li>
+<li><strong>Agent stop recovery:</strong> prevent late-aborting prompts from reacquiring orphaned session locks after teardown, so <code>/stop</code> leaves the conversation ready for the next turn.</li>
+<li><strong>Message delivery status:</strong> report failed and partially failed best-effort channel delivery instead of returning a success-shaped message-tool result. (#99928) Thanks @masatohoshino.</li>
+<li><strong>WhatsApp credential recovery:</strong> restore malformed primary auth state from a valid backup during startup. (#99070) Thanks @LeonidasLux.</li>
+<li><strong>WhatsApp quoted replies:</strong> preserve bot-authored outbound quote metadata so replies to those messages keep their reply bubble in WhatsApp Desktop. (#94879) Thanks @Bartok9, @seikosantana, and @vincentkoc.</li>
+<li><strong>WhatsApp reconnect catch-up:</strong> admit recently missed Baileys <code>append</code> messages during a bounded reconnect window while preserving startup stale-history guards. (#80642) Thanks @VishalJ99.</li>
+<li><strong>WhatsApp restart recovery:</strong> stop automatic restart loops after logged-out or connection-replaced disconnects until the account reconnects. (#78511) Thanks @openperf and @rutherlesdev.</li>
+<li><strong>Local Gateway CLI auth:</strong> keep loopback CLI token/password calls off durable device scopes so read probes cannot block later write/admin commands behind a stale pairing baseline. (#95997) Thanks @vincentkoc.</li>
+<li><strong>Plugin module identity:</strong> keep OpenClaw package chunks on Node's native module graph when jiti transforms plugin entries, preventing duplicate evaluation and class identity drift. (#88384) Thanks @vincentkoc and @ScientificProgrammer.</li>
+<li><strong>Shell completion repair:</strong> generate core-only caches during doctor and update repair while preserving full plugin command completion for onboarding and explicit user rebuilds. (#76235) Thanks @joshavant.</li>
+<li><strong>MCP schema diagnostics:</strong> attribute draft-2020-12 compiler failures to the external MCP schema so malformed patterns produce actionable setup errors. Thanks @vincentkoc.</li>
+<li><strong>Windows Scheduled Task recovery:</strong> keep clean early exits inside the existing bounded launch poll, falling back only when neither the task process nor Gateway listener becomes observable.</li>
+<li><strong>iMessage group warnings:</strong> suppress the false drop-all startup warning when an effective group sender allowlist can admit groups, and point true empty-allowlist configurations at the correct remedy. (#100046)</li>
+<li><strong>Control UI mobile login:</strong> keep Gateway recovery guidance visible after connection failures, make the disconnected gate scroll safely on constrained screens, and improve mobile keyboard and tap-target behavior. (#100208)</li>
+<li><strong>TUI streaming:</strong> render delta-only assistant events in live Gateway and embedded TUI sessions instead of waiting for the final response. (#83000) Thanks @flashosophy.</li>
+<li><strong>Model aliases:</strong> resolve provider-qualified aliases during session and chat-command model switches without collisions when providers share a display alias. (#100209) Thanks @sahilsatralkar, @david-r-jones, @shakkernerd, and @vincentkoc.</li>
+<li><strong>TUI new-session hooks:</strong> create <code>/new</code> sessions through the shared Gateway lifecycle so command and session hooks receive the completed parent transcript in both Gateway and embedded modes, while preventing rollover during an active turn. (#100241, #49918) Thanks @BingqingLyu, @caopulan, @LonExplorer-coder, and @vincentkoc.</li>
+<li><strong>TUI abort diagnostics:</strong> show sanitized tool argument-validation summaries for aborted runs in both Gateway and local TUI modes without exposing raw model arguments. (#91002) Thanks @wsyjh8 and @taerlandsen.</li>
+<li><strong>iOS Watch replies:</strong> persist queued quick replies in the gateway-scoped chat outbox and submit them through idempotent chat delivery, preventing losses, duplicates, and cross-gateway sends after reconnects. (#100372) Thanks @NianJiuZst.</li>
+<li><strong>iOS Gateway auth retry:</strong> restrict stored device-token retry to parsed loopback hosts and reject wildcard bind addresses, preventing remote lookalike hostnames from receiving trusted retry credentials. (#99859) Thanks @ly85206559 and @vincentkoc.</li>
+<li><strong>Bedrock Mantle discovery:</strong> bound model-catalog fetch time and response size, and release rejected response bodies so stalled, oversized, or failed provider responses fall back safely. (#99961) Thanks @zhangguiping-xydt and @shakkernerd.</li>
+<li><strong>Discord thread-title prompts:</strong> truncate generated-title message and channel context on UTF-16 boundaries so emoji cannot leave malformed model prompt text. (#101551) Thanks @Alix-007, @vincentkoc, @mushuiyu886, and @cursoragent.</li>
+</ul>
+<ul>
+<li><strong>Mobile pairing routes:</strong> advertise verified persistent Tailscale Serve fallbacks alongside <code>gateway.bind=lan</code> setup URLs, show every route in the Control UI and CLI, and let iOS save the first reachable endpoint. (#100280) Thanks @shakkernerd.</li>
+<li><strong>Control UI terminal tabs:</strong> vertically center the new-session button in the terminal tab strip.</li>
+<li><strong>Control UI composer scrollbar:</strong> show the message-field scrollbar only when the draft actually overflows its autosized height.</li>
+<li><strong>Control UI terminal cursor:</strong> hide the browser-native contenteditable caret so the integrated terminal shows only its canvas-rendered cursor.</li>
+<li><strong>macOS SSH tunnels:</strong> resolve user-installed SSH <code>ProxyCommand</code> helpers through the app's managed PATH while preserving inherited connection environment, so remote aliases work after Finder and sanitized-script launches.</li>
+<li><strong>Control UI OpenAI speed picker:</strong> show only Standard and Fast choices for OpenAI models.</li>
+<li><strong>Control UI terminal rendering:</strong> adopt the shared <code>@openclaw/libterminal</code> browser lifecycle and add Nerd Font fallbacks so icon-enabled shell listings render their glyphs when a compatible local font is installed.</li>
+<li><strong>Slack transcript history:</strong> let Codex app-server own its persisted assistant replies so Slack does not append redundant delivery-mirror rows, while the Control UI keeps legacy duplicate mirrors hidden. Thanks @bek91.</li>
+<li><strong>Control UI chat history:</strong> hide redundant channel-final delivery mirrors when the preceding app-server assistant reply already shows the same text.</li>
+<li><strong>Control UI chat spacing:</strong> keep the first message comfortably clear of the topbar with a responsive minimum transcript inset.</li>
+<li><strong>ClawRouter auth profiles:</strong> resolve credential-scoped catalog models during agent runs when the proxy key is stored in an auth profile, and document plugin and model allowlists.</li>
+<li><strong>Telegram durability:</strong> retry restart-dropped media, survive transient polling errors, dead-letter poison updates, preserve forwarded rich text, route plugin callbacks correctly, keep progress updates in one stable multi-line window, map self-hosted Bot API container paths through trusted host roots, and fall back safely when Telegram rejects rich final replies. (#98102, #98735, #98775, #98776, #97174, #98907, #91984, #98786) Thanks @luoyanglang, @DaveArcher18, @obviyus, @goldmar, @Marvinthebored, @Dizesales, @shakkernerd, @AiLucasdz, and @RomneyDa.</li>
+<li><strong>Cross-channel inbound media:</strong> preserve captions and expose unavailable-attachment notices when WhatsApp, LINE, Signal, iMessage, Microsoft Teams, Feishu, Mattermost, or Zalo cannot materialize inbound media, instead of dispatching phantom placeholders or dropping media-only turns. (#100092)</li>
+<li><strong>Agent and context reliability:</strong> preserve runtime overrides, steered subagent tasks, fallback tool-call hints, and legacy reseed attachments; soft-resume CLI sessions across prompt-only drift; improve harness-aware context estimation; time out silent local streams; recover mid-stream failures; and cap Gateway run-cache growth. (#92237, #77539, #99851, #99839, #99822, #97928, #98525, #95430, #77973) Thanks @sercada, @amittell, @obviyus, @liuhao1024, @yetval, @osolmaz, @lzyyzznl, @vincentkoc, @alexelgier, and @fede-kamel.</li>
+<li><strong>Provider and network safety:</strong> bound oversized or malformed responses across Moonshot, MiniMax, Anthropic OAuth, Discord, Matrix, SMS, browser, update, embeddings, Tlön, and Inworld paths. (#96502, #96322, #96644, #97693, #97662, #97999, #98455, #98508, #98554, #98496, #98660) Thanks @hugenshen, @cursoragent, @lsr911, @solodmd, @Alix-007, @wings1029, @lzyyzznl, @sunlit-deng, @vincentkoc, and @Pandah97.</li>
+<li><strong>Channel delivery and routing:</strong> keep Slack replies in active thread sessions, preserve account-bound delivery routes, apply response prefixes, and suppress internal traces and unwanted fallback replies. (#97168, #98240, #93639, #97989, #80928) Thanks @LiuwqGit, @gorkem2020, @yetval, @ZengWen-DT, @alexuser, @UnClouded77, and @vincentkoc.</li>
+<li><strong>Cron correctness:</strong> preserve provider and model selections on timeouts, retain startup catch-up deferrals across maintenance reads, keep action-required output, clear blank thinking overrides, and preserve provider-owned daily-reset sessions. (#95943, #94022, #96393, #96293, #98356) Thanks @ZengWen-DT, @cursoragent, @luke-renjoy, @RichChen01, @vincentkoc, @yetval, @snowzlmbot, @nz365guy, @takamasa-aiso, and @shakkernerd.</li>
+<li><strong>Memory and session recovery:</strong> detect unindexed transcripts, preserve notes through transient reads, avoid cross-directory resumes, disambiguate reserved wiki index pages, and skip empty QMD sync work. (#97857, #98360, #97785, #94326, #90030) Thanks @zw-xysk, @CHE10X, @qingminglong, @yetval, @vincentkoc, @sahibzada-allahyar, and @ruben2000de.</li>
+<li><strong>Windows and execution:</strong> bind allowlisted execution to the validated Windows path, propagate <code>PATHEXT</code>, normalize inbound paths case-insensitively, and prevent cleanup crashes on Windows. (#98260, #98093, #97630, #97901) Thanks @eleqtrizit, @wendy-chsy, @VectorPeak, @paulcam206, and @shakkernerd.</li>
+<li><strong>Mobile and UI stability:</strong> preserve iOS chat line breaks and final replies, improve Android pairing and TLS recovery, hide expired pairing cards, keep workspace file rails scrollable, restore copy-path over plain HTTP, and stop rubber-band scrolling in the Mac app Control UI. (#98304, #98117, #98366, #98439, #98483, #98049, #98646, #98611, #98764, #99830) Thanks @joshavant, @Jabato01, @ooiuuii, @wuqxuan, @645648406-max, @zw-xysk, @ZengWen-DT, and @adinballew.</li>
+<li><strong>Codex and approval flows:</strong> report ChatGPT authentication correctly, rename destructive approval mode to <code>ask</code>, classify <code>get_goal</code> read statuses accurately, and derive terminal-idle timeouts from the explicit run deadline. (#91240, #98501, #98659, #85296) Thanks @849261680, @ukstem, @kevinslin, @yetval, @alkor200, @vincentkoc, and @alkor2000.</li>
+<li><strong>Configuration and plugin health:</strong> restrict config traversal to owned properties, preserve config-health recovery state, surface unloadable channel plugins, preserve defaulted provider base URLs during patches, validate bundled plugin updates by manifest contract, resolve public artifacts from installed plugin roots, and retain legacy ClawHub families where required. (#99846, #99728, #96397, #98396, #98010, #98819, #98249) Thanks @vincentkoc, @zenglingbiao, @joshavant, @jalehman, @ccbridle, @849261680, @momothemage, @weltmaister, @LiLan0125, @herove, @amknight, @KelTech-Services, and @Patrick-Erichsen.</li>
+<li><strong>Runtime process safety:</strong> prevent unhandled child-stream errors in SSH tunnels, supervisors, and MCP stdio transports; keep auto-replies from waiting on transcript mirroring; and avoid splitting Unicode characters in approval previews and LINE outbound fields. (#99800, #99802, #99803, #99549, #99566, #98994) Thanks @cxbAsDev, @vincentkoc, @Shagrat2, @mikasa0818, and @LEXES7.</li>
+<li><strong>Node runtime compatibility:</strong> installers, the CLI launcher, doctor, and the macOS app now reject incompatible Node 23 runtimes and guide users toward supported Node 22 or 24 releases. (#99832) Thanks @vincentkoc and @fuller-stack-dev.</li>
+<li><strong>SQLite WAL safety:</strong> require Node releases with a patched SQLite runtime, verify the loaded library before opening state databases, and make installers upgrade and validate unsafe runtimes across supported platforms. (#106065) Thanks @vincentkoc.</li>
+<li><strong>Installer temporary-file cleanup:</strong> remove Node staging directories and pnpm workspace rewrite files when downloads or rewrites fail. (#103725) Thanks @SebTardif.</li>
+<li><strong>QQBot media delivery:</strong> scope sandbox-generated media sends to the active session's workspace so <code>/workspace/...</code> and relative generated-file paths resolve safely across QQBot media tags, structured payloads, and streaming delivery. (#92872) Thanks @zhangguiping-xydt and @sliverp.</li>
+</ul>
+<h3>Complete contribution record</h3>
+This audited record covers the complete 66e676d29b92d040716376a75aca32bad655cfac..e0ce12504d428779bb5023d4f1442f4b92261f49 history: 1536 merged PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
+Shipped baseline exclusions: v2026.6.11 (10 PRs: #87298, #89949, #90811, #92020, #92657, #93466, #93650, #93767, #93810, #97118).
+<h4>Pull requests</h4>
+<ul>
+<li><strong>PR #96502</strong> fix(moonshot): bound video description JSON response reads. Thanks @hugenshen and @cursoragent.</li>
+<li><strong>PR #98249</strong> Preserve legacy ClawHub family for selected plugins. Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #93820</strong> fix(imessage): recognize MiniMax mm: reasoning tags in reflection guard (completes #93767). Thanks @Alix-007.</li>
+<li><strong>PR #94096</strong> fix(usage): reject inverted startDate-endDate range in usage.cost and sessions.usage. Thanks @Alix-007.</li>
+<li><strong>PR #97125</strong> Doctor: expose auth profile findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #98256</strong> fix(mcp): require owner for Claude permission replies. Thanks @eleqtrizit.</li>
+<li><strong>PR #98142</strong> fix(cli): stop <code>pairing list</code> crashing with empty channel enum. Thanks @RomneyDa.</li>
+<li><strong>PR #98260</strong> fix(exec): bind Windows allowlist execution path. Thanks @eleqtrizit.</li>
+<li><strong>PR #97168</strong> fix(slack): prefer current thread session for inherited outbound replies. Related #96535. Thanks @LiuwqGit and @gorkem2020.</li>
+<li><strong>PR #97769</strong> fix(plugins): apply output text transforms to toolcall_delta and toolcall_end events. Related #97761. Thanks @ZOOWH and @get-viti.</li>
+<li><strong>PR #96544</strong> fix(doctor): merge colliding model-ref map keys instead of dropping. Thanks @yetval and @vincentkoc.</li>
+<li><strong>PR #97177</strong> fix(memory-wiki): gracefully handle unparsable YAML frontmatter in vault scans (#96125). Thanks @SunnyShu0925 and @cow11023.</li>
+<li><strong>PR #97167</strong> fix #96840: [Bug]: Targetless message.send fails with 'Action send requires a target' in WebChat despite docs stating source-reply sink should handle it. Thanks @zhangguiping-xydt and @MantisCartography.</li>
+<li><strong>PR #98302</strong> fix(ios): advance onboarding step after QR scan. Related #98297. Thanks @joelnishanth and @cursoragent.</li>
+<li><strong>PR #96644</strong> fix(anthropic-oauth): bound OAuth token endpoint response reads. Thanks @solodmd.</li>
+<li><strong>PR #96397</strong> fix: warn when configured channel plugins cannot load. Thanks @849261680.</li>
+<li><strong>PR #96359</strong> test: migrate src/commands tests to shared temp dir helpers. Thanks @xialonglee.</li>
+<li><strong>PR #96293</strong> fix(cron): clear agentTurn thinking override by blanking the field. Related #96287. Thanks @ZengWen-DT and @takamasa-aiso.</li>
+<li><strong>PR #96058</strong> test: prefer shared temp dir helpers in auto-reply and install-fallback tests. Thanks @xialonglee.</li>
+<li><strong>PR #97785</strong> fix(sessions): avoid cross-cwd recent resumes. Related #96542. Thanks @qingminglong and @yetval.</li>
+<li><strong>PR #97698</strong> fix(pdf): reject empty parsed page ranges before native analysis. Thanks @zhangguiping-xydt.</li>
+<li><strong>PR #97693</strong> fix(discord): bound requestDiscord happy-path response reads to prevent OOM. Thanks @Alix-007.</li>
+<li><strong>PR #97683</strong> fix(irc): guard surrogate-range codepoints in \u literal-escape decoder. Thanks @WeeLi-009.</li>
+<li><strong>PR #96938</strong> fix(utils): keep reply directive ids unicode-safe. Thanks @ly-wang19.</li>
+<li><strong>PR #97857</strong> fix(memory): detect unindexed session transcripts in status mode (fixes #97814). Thanks @zw-xysk and @CHE10X.</li>
+<li><strong>PR #98094</strong> fix(android): clarify gateway auth recovery states. Thanks @qingminglong.</li>
+<li><strong>PR #98205</strong> test(gateway): add unit tests for node wake state tracking and testing seam. Thanks @zenglingbiao.</li>
+<li><strong>PR #98115</strong> fix: surface node approval guidance from devices CLI. Thanks @welfo-beo.</li>
+<li><strong>PR #97898</strong> docs: clarify source checkout Node floor. Related #97792. Thanks @lin-hongkuan and @aniruddhaadak80.</li>
+<li><strong>PR #94526</strong> test(telegram): add regression test for forum topic message_thread_id with streamed reasoning. Related #89352. Thanks @xialonglee and @pmika.</li>
+<li><strong>PR #98145</strong> fix(device-pairing): don't churn requestId on subset re-requests. Thanks @RomneyDa.</li>
+<li><strong>PR #98267</strong> fix(system-prompt): move exec-approval + Authorized Senders below cache boundary. Related #98261. Thanks @headbouyJB.</li>
+<li><strong>PR #98304</strong> fix: preserve iOS chat line breaks. Related #98028. Thanks @joshavant and @Jabato01.</li>
+<li><strong>PR #98187</strong> fix(openrouter): send explicit auth headers. Related #97934. Thanks @sunlit-deng and @laurencebrown.</li>
+<li><strong>PR #95708</strong> fix: show WebChat preamble progress during tool activity. Thanks @ragesaq.</li>
+<li><strong>PR #98210</strong> fix(gateway): iOS Talk treats SecretRef-backed API keys as missing. Related #98209. Thanks @ooiuuii.</li>
+<li><strong>PR #98009</strong> test(infra): add unit tests for SQLite number normalization. Thanks @dwc1997.</li>
+<li><strong>PR #98087</strong> test(config): add unit tests for resolveExecCommandHighlighting. Thanks @solodmd.</li>
+<li><strong>PR #98219</strong> test(utils): add unit tests for chunkItems. Thanks @zenglingbiao.</li>
+<li><strong>PR #98093</strong> fix(core): propagate caller env PATHEXT through isExecutableFile on Windows. Thanks @wendy-chsy.</li>
+<li><strong>PR #97973</strong> fix(matrix): guard JSON.parse against malformed homeserver response bodies. Thanks @lsr911.</li>
+<li><strong>PR #97999</strong> fix(sms): guard Twilio JSON.parse against malformed API response bodies. Thanks @lsr911.</li>
+<li><strong>PR #98043</strong> Add Swedish mobile app localization. Thanks @yeager.</li>
+<li><strong>PR #98144</strong> fix(tui): correct disconnect copy for device scope upgrades. Thanks @RomneyDa.</li>
+<li><strong>PR #98240</strong> fix(agents): keep merged delivery routes account-bound. Thanks @yetval.</li>
+<li><strong>PR #98226</strong> Redact bare Fireworks API keys. Related #98225. Thanks @ooiuuii.</li>
+<li><strong>PR #98319</strong> docs: publish release notes for v2026.6.11. Thanks @hannesrudolph.</li>
+<li><strong>PR #98257</strong> fix: show in-progress status for channel runs. Thanks @scotthuang.</li>
+<li><strong>PR #97931</strong> fix(gateway): keep provider-owned CLI sessions across the daily default reset. Thanks @yetval.</li>
+<li><strong>PR #98325</strong> docs: refresh docs map for v2026.6.11. Thanks @hannesrudolph.</li>
+<li><strong>PR #97929</strong> fix(auto-reply): stop level directives from eating the next message word. Thanks @yetval.</li>
+<li><strong>PR #97928</strong> fix(agents): estimate harness role sizes in context guard char estimator (fixes #97927). Thanks @liuhao1024 and @yetval.</li>
+<li><strong>PR #97861</strong> fix(compaction): count bashExecution and summary turns in pre-prompt overflow precheck. Thanks @yetval.</li>
+<li><strong>PR #97137</strong> doctor: add memory search lint findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #97358</strong> Doctor: expose workspace status findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #95622</strong> test(qa-lab): harden whatsapp qa scenarios. Thanks @mcaxtr.</li>
+<li><strong>PR #98346</strong> fix: prevent skill-creator from bypassing workshop proposals. Related #96054. Thanks @momothemage and @xianshishan.</li>
+<li><strong>PR #98169</strong> fix(heartbeat): scope commitment fan-out prompts. Thanks @bdjben.</li>
+<li><strong>PR #97366</strong> Doctor: expose device pairing findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #98366</strong> fix: Android TLS fingerprint verification times out on slow handshakes. Related #98365. Thanks @joshavant.</li>
+<li><strong>PR #98353</strong> fix(ios): open app on Chat by default. Thanks @BsnizND.</li>
+<li><strong>PR #98352</strong> fix(security): warn on agent skill MCP boundary drift. Thanks @momothemage.</li>
+<li><strong>PR #98347</strong> fix: retry image describe fallback models. Thanks @momothemage.</li>
+<li><strong>PR #98117</strong> fix(ios): avoid transient duplicate final replies. Related #98116. Thanks @ooiuuii and @joshavant.</li>
+<li><strong>PR #98293</strong> fix(gateway): emit stale exec approval followup diagnostics. Thanks @BsnizND.</li>
+<li><strong>PR #98376</strong> fix(ios): use Gateway speech providers in Talk. Related #98153. Thanks @Tony-ooo.</li>
+<li><strong>PR #66685</strong> Suppress expired exec approval followup warnings. Thanks @pfrederiksen.</li>
+<li><strong>PR #98385</strong> fix: show actionable mobile protocol mismatch recovery. Related #98384. Thanks @joshavant.</li>
+<li><strong>PR #98146</strong> fix(cli): explain how to recover from device approve deadlock. Thanks @RomneyDa.</li>
+<li><strong>PR #98423</strong> improve(ios): clarify Control and Talk visual hierarchy. Related #98397.</li>
+<li><strong>PR #98217</strong> fix(doctor): recover legacy cron archive across devices. Thanks @masatohoshino.</li>
+<li><strong>PR #98333</strong> feat(openai): add GPT-5.6 series support. Related #98296. Thanks @steipete-oai.</li>
+<li><strong>PR #96393</strong> fix(cron): preserve action-required command output. Related #96346. Thanks @snowzlmbot and @nz365guy.</li>
+<li><strong>PR #98429</strong> fix(ios): classify TLS fingerprint timeouts. Thanks @joshavant.</li>
+<li><strong>PR #98439</strong> fix: Android setup codes accept local mDNS gateway hosts. Thanks @joshavant.</li>
+<li><strong>PR #98443</strong> fix(ios): improve light and dark appearance contrast. Related #98440.</li>
+<li><strong>PR #97742</strong> fix(llm): preserve structured tool result text across providers. Thanks @snowzlmbot.</li>
+<li><strong>PR #97968</strong> fix(status): surface unregistered memory embedding providers. Thanks @masatohoshino.</li>
+<li><strong>PR #92237</strong> fix(agents): preserve runtime settings overrides [AI-assisted]. Thanks @sercada.</li>
+<li><strong>PR #95888</strong> fix(active-memory): caveat mutable ops facts; mark truncated recall as incomplete. Thanks @spencer2211.</li>
+<li><strong>PR #98291</strong> fix(gateway): surface systemd start-limit exhaustion. Thanks @masatohoshino.</li>
+<li><strong>PR #90517</strong> fix(gateway): hint missing external plugin for web login. Related #83277. Thanks @TUARAN and @carol-iung.</li>
+<li><strong>PR #98369</strong> test(infra): add unit tests for SQLite user_version pragma helper. Thanks @dwc1997.</li>
+<li><strong>PR #98340</strong> fix: extension api.exec leaves child processes after timeout. Related #98335. Thanks @ooiuuii.</li>
+<li><strong>PR #92063</strong> fix(ui): collapse duplicate assistant groups during segmented streaming. Related #63956. Thanks @harjothkhara and @contentfree.</li>
+<li><strong>PR #98354</strong> fix(infra): guard delivery queue inflate against corrupted entry_json. Thanks @Pick-cat.</li>
+<li><strong>PR #90566</strong> fix(agents): warn on cron announce skip. Related #68561. Thanks @sahibzada-allahyar and @Mibslee.</li>
+<li><strong>PR #98371</strong> fix(ports): validate lsof PID parsing before assignment. Thanks @lzyyzznl.</li>
+<li><strong>PR #98356</strong> fix(cron): keep provider-owned CLI sessions across the daily default reset. Thanks @yetval.</li>
+<li><strong>PR #98395</strong> test(shared): add unit tests for account enabled guard. Thanks @dwc1997.</li>
+<li><strong>PR #98411</strong> fix(agents): recover thinking errors from provider body. Related #98308. Thanks @sunlit-deng and @clearhorizoninvestments.</li>
+<li><strong>PR #98494</strong> docs(skills): support variable landable sweep batches. Thanks @vincentkoc.</li>
+<li><strong>PR #91240</strong> fix: report Codex ChatGPT status auth. Related #91099. Thanks @849261680 and @ukstem.</li>
+<li><strong>PR #98370</strong> test(agents): add unit tests for thinking block detection. Thanks @dwc1997.</li>
+<li><strong>PR #96711</strong> test: prefer shared temp dir helpers in config, gateway, cron, crestodian, and state tests. Thanks @xialonglee.</li>
+<li><strong>PR #98483</strong> fix: Android QR scan starts gateway pairing. Thanks @joshavant.</li>
+<li><strong>PR #95230</strong> fix docs-list-mdx-pages. Thanks @hugenshen.</li>
+<li><strong>PR #96322</strong> fix(minimax): bound JSON response reads to prevent OOM. Thanks @lsr911.</li>
+<li><strong>PR #95348</strong> fix config-chmod-warning. Thanks @hugenshen and @cursoragent.</li>
+<li><strong>PR #95229</strong> fix(copilot): guard against undefined runtime.state during cli-metadata registration. Related #94516. Thanks @sunlit-deng and @cuihaijun.</li>
+<li><strong>PR #94636</strong> fix(memory): skip raw snippets during promotion. Thanks @tayoun.</li>
+<li><strong>PR #94013</strong> [AI] fix(feishu): guard partial channelRuntime in monitor startup. Thanks @xydt-tanshanshan.</li>
+<li><strong>PR #98049</strong> fix: hide expired pairing QR cards in Control UI. Related #98039. Thanks @ooiuuii.</li>
+<li><strong>PR #96094</strong> fix(memory): prove live manager recovery after CLI reindex. Related #91167. Thanks @849261680 and @kiagentkronos-cell.</li>
+<li><strong>PR #98482</strong> fix: advertise route-aware LAN Control UI links. Thanks @joshavant.</li>
+<li><strong>PR #71537</strong> Recover archived (.reset) session transcripts in memory hook + session-logs skill. Thanks @injinj.</li>
+<li><strong>PR #96375</strong> docs(config-agents): correct built-in alias table for opus and gpt. Thanks @niks999.</li>
+<li><strong>PR #98453</strong> docs(gateway): fix Telegram streaming default in config-channels.md. Thanks @solodmd.</li>
+<li><strong>PR #98533</strong> fix: repair hosted CI baseline assertions.</li>
+<li><strong>PR #98421</strong> feat(imessage): native poll support — create, read, vote. Thanks @omarshahine and @lobster.</li>
+<li><strong>PR #98318</strong> docs(matrix): document missing streaming.progress mode, progress sub-fields, and mentionPatterns config. Thanks @wm0018 and @vincentkoc.</li>
+<li><strong>PR #97753</strong> docs(onboard): document 11 missing non-interactive CLI flags. Thanks @wm0018 and @vincentkoc.</li>
+<li><strong>PR #97851</strong> fix(mattermost): bound null-body error response reads. Thanks @Pick-cat.</li>
+<li><strong>PR #98360</strong> fix(memory-wiki): preserve notes after transient page reads. Related #98345. Thanks @qingminglong and @vincentkoc and @yetval.</li>
+<li><strong>PR #98551</strong> test: fix stale core test type failures. Thanks @RomneyDa.</li>
+<li><strong>PR #98455</strong> fix(browser): bound error body read in fetchHttpJson to prevent OOM. Thanks @wings1029.</li>
+<li><strong>PR #95906</strong> fix(code-mode): surface QuickJS error name and message to the model. Thanks @ZengWen-DT and @vincentkoc.</li>
+<li><strong>PR #97901</strong> fix(agents): stop copilot autoreview cleanup crash on Windows. Thanks @paulcam206.</li>
+<li><strong>PR #97923</strong> fix(slack): truncate served arg-menu option labels on a surrogate boundary. Thanks @LEXES7.</li>
+<li><strong>PR #98010</strong> fix(update): validate bundle plugin payloads by manifest contract. Related #97985. Thanks @LiLan0125 and @herove.</li>
+<li><strong>PR #85296</strong> fix(codex): derive terminal-idle watchdog from explicit run timeout. Thanks @alkor2000 and @vincentkoc.</li>
+<li><strong>PR #97110</strong> feat(i18n): add native app locale inventory. Thanks @vincentkoc.</li>
+<li><strong>PR #98396</strong> fix: allow config.patch with defaulted provider baseUrl. Related #98270. Thanks @momothemage and @weltmaister.</li>
+<li><strong>PR #98503</strong> fix(usage-bar): use Object.hasOwn instead of in operator to avoid prototype chain pollution. Related #98466. Thanks @chenyangjun-xy and @zhangLei99586.</li>
+<li><strong>PR #97111</strong> feat(android): localize core gateway surfaces. Thanks @vincentkoc.</li>
+<li><strong>PR #97630</strong> fix(media): normalize Windows inbound paths case-insensitively. Thanks @VectorPeak.</li>
+<li><strong>PR #82638</strong> fix(agents): skip implicit provider discovery when models.mode is 'replace' [AI-assisted]. Related #66957. Thanks @eldar702 and @wangzhengshu.</li>
+<li><strong>PR #87917</strong> fix sessions json lineage metadata. Related #80286. Thanks @zhangguiping-xydt and @islandpreneur007.</li>
+<li><strong>PR #93639</strong> fix(message-tool): apply messages.responsePrefix to outbound sends. Thanks @ZengWen-DT.</li>
+<li><strong>PR #94440</strong> fix: #94432 classify Cloudflare challenge 403 as upstream_html instead of auth_html. Thanks @lzyyzznl and @pbm9z95m6z-hue.</li>
+<li><strong>PR #98119</strong> fix: reduce Docker build memory pressure. Related #98118. Thanks @zyzo.</li>
+<li><strong>PR #97679</strong> feat(node): add --context-path flag to node run/install for reverse-p…. Related #97678. Thanks @wm0018.</li>
+<li><strong>PR #98339</strong> fix(irc): classify host-less nick!user allowlist entries as mutable. Thanks @yetval.</li>
+<li><strong>PR #97662</strong> fix(matrix): bound raw transport response reads to prevent OOM. Thanks @Alix-007.</li>
+<li><strong>PR #98137</strong> fix: hoist timer declaration to avoid TDZ ReferenceError in abortable delay. Thanks @zhangLei99586.</li>
+<li><strong>PR #98134</strong> fix: clear timeout timer in Tailscale binary probe Promise.race. Thanks @zhangLei99586.</li>
+<li><strong>PR #97989</strong> fix(sms): stop internal tool-trace banners from reaching SMS replies. Thanks @ZengWen-DT.</li>
+<li><strong>PR #97972</strong> fix(browser): CDP auth fails with percent-encoded credentials. Thanks @VectorPeak.</li>
+<li><strong>PR #98063</strong> fix(reply): suppress tool-error progress delivery when messages.suppressToolErrors is set. Thanks @moeedahmed.</li>
+<li><strong>PR #94964</strong> fix(reload): cancel deferred channel reload on in-process restart. Related #79487. Thanks @lzyyzznl and @tseller.</li>
+<li><strong>PR #98598</strong> fix: restore main lint after timer repairs. Related #98462, #98464. Thanks @zhangLei99586.</li>
+<li><strong>PR #98587</strong> fix(slack): guard relay WebSocket frame JSON.parse against malformed input. Thanks @lsr911 and @vincentkoc.</li>
+<li><strong>PR #90030</strong> fix(memory-core): skip qmd zero-hit search sync. Related #90023. Thanks @sahibzada-allahyar and @ruben2000de.</li>
+<li><strong>PR #98493</strong> fix(transcripts): close readline interface and destroy read stream on error exit. Related #98467. Thanks @wangmiao0668000666 and @zhangLei99586.</li>
+<li><strong>PR #98497</strong> fix(cli): show exit code when plugin npm install returns empty output. Thanks @Sanjays2402 and @vincentkoc.</li>
+<li><strong>PR #97112</strong> feat(apple): localize core native app surfaces. Thanks @vincentkoc.</li>
+<li><strong>PR #98610</strong> fix: restore tooling CI after transcript test addition.</li>
+<li><strong>PR #77539</strong> fix(subagent): preserve steered task text on restart redispatch. Thanks @amittell.</li>
+<li><strong>PR #97113</strong> feat(i18n): refresh all native locale artifacts. Thanks @vincentkoc.</li>
+<li><strong>PR #98620</strong> feat(doctor): warn about in-flight cron jobs. Thanks @masatohoshino.</li>
+<li><strong>PR #98605</strong> test(shared): add unit tests for human-readable list formatting. Thanks @dwc1997.</li>
+<li><strong>PR #97348</strong> feat(autoreview): support cursor-agent engine. Thanks @hxy91819.</li>
+<li><strong>PR #95943</strong> fix(cron): preserve provider/model on isolated-run timeout row. Related #95873. Thanks @ZengWen-DT and @cursoragent and @luke-renjoy.</li>
+<li><strong>PR #94149</strong> fix(status): bound systemd service probes so status cannot hang on a wedged systemctl (#84698). Thanks @ZengWen-DT and @cursoragent and @zus-assistant.</li>
+<li><strong>PR #88159</strong> fix(cli): retry logs.tail after journal fallback in logs follow. Thanks @anyech and @vincentkoc.</li>
+<li><strong>PR #98508</strong> fix(update-check): bound npm registry JSON response read to prevent OOM. Thanks @lzyyzznl.</li>
+<li><strong>PR #98496</strong> fix(tlon): bound error response body reads to prevent OOM. Thanks @Pandah97.</li>
+<li><strong>PR #98554</strong> fix(openai): bound embedding batch file downloads. Thanks @sunlit-deng and @vincentkoc.</li>
+<li><strong>PR #98652</strong> fix: stop invalid message timeouts from stalling.</li>
+<li><strong>PR #77973</strong> fix(gateway): cap agentRunCache to prevent unbounded growth under run fan-out. Related #77976. Thanks @fede-kamel and @vincentkoc.</li>
+<li><strong>PR #98525</strong> fix(agents): time out local streams without first event. Thanks @osolmaz.</li>
+<li><strong>PR #94022</strong> fix(cron): persist startup catch-up deferral ids in service state to prevent read-RPC clobber. Related #93935. Thanks @RichChen01 and @vincentkoc and @yetval.</li>
+<li><strong>PR #98623</strong> fix: media tools skip env-key provider plugins when auto-selecting models. Thanks @medns.</li>
+<li><strong>PR #98665</strong> fix(claude-cli): return updatedInput in can_use_tool allow response for Claude Code 2.1. Related #95171. Thanks @yetval and @carterdawson.</li>
+<li><strong>PR #94250</strong> fix(feishu): send blocks as independent messages when blockStreaming is enabled. Related #55027. Thanks @xialonglee and @vincentkoc and @ZichaoLong.</li>
+<li><strong>PR #93379</strong> fix(whatsapp): thread authDir through command authorization and owner bypass for LID JID resolution. Related #77755. Thanks @xialonglee and @jiveshkalra.</li>
+<li><strong>PR #98646</strong> fix: keep workspace rail file sections scrollable. Related #98566. Thanks @wuqxuan and @645648406-max.</li>
+<li><strong>PR #98602</strong> fix: iOS Talk fallback settings opens Voice & Talk. Related #98593. Thanks @PollyBot13.</li>
+<li><strong>PR #98611</strong> fix(ui): add overflow-y:auto to workspace rail sections to prevent file list overflow (fixes #98566). Thanks @zw-xysk and @645648406-max.</li>
+<li><strong>PR #98619</strong> fix(qa-lab): credential lease requests fail on oversized Convex broker responses. Thanks @ZengWen-DT.</li>
+<li><strong>PR #94326</strong> fix(memory-wiki): disambiguate the reserved index page stem for synthesis and ingest. Thanks @yetval and @vincentkoc.</li>
+<li><strong>PR #98659</strong> fix(codex): classify get_goal read statuses as successful dynamic tool calls. Thanks @yetval.</li>
+<li><strong>PR #96856</strong> fix(codex): successful sessions_spawn and goal tool results recorded as failures. Thanks @nxmxbbd.</li>
+<li><strong>PR #98660</strong> fix(inworld): guard voices JSON.parse against malformed API response bodies. Thanks @solodmd.</li>
+<li><strong>PR #95430</strong> fix(embedded-agent-runner): pump async streamFn through pumpStreamWithRecovery for mid-stream error recovery. Related #95429. Thanks @lzyyzznl and @vincentkoc and @alexelgier.</li>
+<li><strong>PR #98644</strong> fix: tool summaries preserve emoji truncation boundaries. Thanks @ZengWen-DT.</li>
+<li><strong>PR #80928</strong> fix(telegram): suppress fallback reply when plugin command returns suppressReply: true. Related #80756. Thanks @alexuser and @UnClouded77.</li>
+<li><strong>PR #98701</strong> fix: prevent agents-tools message test timeouts.</li>
+<li><strong>PR #92877</strong> fix(usage): make built-in footer easier to wrap on Telegram. Thanks @Marvinthebored.</li>
+<li><strong>PR #98126</strong> Restore Telegram /steer for active Codex runs. Related #81594. Thanks @100yenadmin and @Kyzcreig.</li>
+<li><strong>PR #92037</strong> feat(cron): on-exit schedule — wake on a watched command's exit. Thanks @anagnorisis2peripeteia.</li>
+<li><strong>PR #98452</strong> feat(ios): modernize the app with iOS 26 Liquid Glass.</li>
+<li><strong>PR #98006</strong> Add Telegram /login Codex pairing flow. Thanks @100yenadmin.</li>
+<li><strong>PR #98735</strong> fix(telegram): preserve rich forwarded message text. Thanks @obviyus.</li>
+<li><strong>PR #97962</strong> refactor(qa): use transport-native actions in flow scenarios. Thanks @RomneyDa.</li>
+<li><strong>PR #98726</strong> fix(nvidia): use Nemotron Super 1M context. Thanks @eleqtrizit.</li>
+<li><strong>PR #98691</strong> fix(imessage): shed emoji anywhere in poll-vote echo match. Thanks @omarshahine.</li>
+<li><strong>PR #97174</strong> Fix Telegram plugin callback routing. Thanks @goldmar.</li>
+<li><strong>PR #89597</strong> fix: migrate QQBot credential backups to SQLite KV.</li>
+<li><strong>PR #98536</strong> feat: prepare scoped conversation capability profiles.</li>
+<li><strong>PR #92274</strong> fix(agents): classify embedded prompt lock error as permanent announce failure. Related #91527. Thanks @fsdwen and @zackchiutw.</li>
+<li><strong>PR #98102</strong> fix(telegram): durably retry inbound media dropped during restart (#98076). Thanks @luoyanglang and @DaveArcher18.</li>
+<li><strong>PR #98755</strong> fix(cron): detach session-targeted runs. Related #98121. Thanks @obviyus and @EthanSK.</li>
+<li><strong>PR #96065</strong> fix(install): manage config-secretref env refs via OPENCLAW_SERVICE_MANAGED_ENV_KEYS. Thanks @Darren2030 and @obviyus.</li>
+<li><strong>PR #98666</strong> fix: diagnose Windows LAN Gateway firewall blocks. Thanks @joshavant.</li>
+<li><strong>PR #98501</strong> fix(codex): rename destructive approval mode to ask. Related #98499. Thanks @kevinslin.</li>
+<li><strong>PR #98775</strong> fix(telegram): survive transient getUpdates errors and stop per-send cache rewrites. Related #98772, #98773. Thanks @obviyus.</li>
+<li><strong>PR #98776</strong> fix(telegram): back off, dead-letter, and tombstone spooled updates so poison messages cannot block or duplicate. Related #98774. Thanks @obviyus.</li>
+<li><strong>PR #96454</strong> feat(cli): openclaw attach — launch an external harness bound to a gateway session. Thanks @anagnorisis2peripeteia and @obviyus.</li>
+<li><strong>PR #98786</strong> fix(telegram): final replies no longer drop on rejected rich entities, captions, quotes, or long flood waits. Related #98778. Thanks @obviyus.</li>
+<li><strong>PR #97496</strong> Doctor: expose channel plugin blocker findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #98792</strong> fix(ci): restore docs and test type checks.</li>
+<li><strong>PR #98736</strong> improve(ios): simplify Talk controls and composer alignment.</li>
+<li><strong>PR #98183</strong> fix(gateway): distinguish reachable gateway from failed status probe. Thanks @masatohoshino.</li>
+<li><strong>PR #98808</strong> docs(telegram): move maintainer decisions into scoped AGENTS.md with reliability invariants. Thanks @obviyus.</li>
+<li><strong>PR #98138</strong> fix: guard setDeep against empty keys array in Chrome profile decoration. Thanks @zhangLei99586.</li>
+<li><strong>PR #92283</strong> fix(agents): don't inject A2A turns into isolated-cron sessions_send (#92257). Thanks @harjothkhara and @vincentkoc and @nailujac.</li>
+<li><strong>PR #98812</strong> fix(codex): preserve plugin app approvals in side conversations.</li>
+<li><strong>PR #97889</strong> fix(discord): guard JSON.parse against malformed API response bodies. Thanks @lsr911.</li>
+<li><strong>PR #98689</strong> fix(wizard): reject loose gateway port input. Related #98681. Thanks @qingminglong.</li>
+<li><strong>PR #98720</strong> fix(nostr): clear per-relay publish timeout timer to prevent dangling handles. Related #98463. Thanks @wangmiao0668000666 and @zhangLei99586.</li>
+<li><strong>PR #98787</strong> fix(memory-wiki): retry transient existing-page reads in wiki_apply and chatgpt import. Thanks @yetval and @vincentkoc.</li>
+<li><strong>PR #98818</strong> fix(ci): recover incomplete Swift build caches.</li>
+<li><strong>PR #98811</strong> feat(ios): modernize navigation and settings. Related #98803.</li>
+<li><strong>PR #98843</strong> docs: update mobile app release messaging. Thanks @joshavant.</li>
+<li><strong>PR #93209</strong> test: prefer auto-cleaning temp dir helper. Thanks @hxy91819.</li>
+<li><strong>PR #98789</strong> fix(telegram): sends and actions without an account id ignore the configured defaultAccount. Thanks @yetval.</li>
+<li><strong>PR #98806</strong> fix(telegram): webhook updates survive crashes and restarts via durable spooling. Related #98777. Thanks @obviyus.</li>
+<li><strong>PR #98688</strong> fix(fal): route grok-imagine and nano-banana-2-lite edits to correct endpoints. Thanks @davenicoll and @vincentkoc.</li>
+<li><strong>PR #98891</strong> fix(agents): normalize non-array tool-result content at transcript ingest. Related #98825. Thanks @obviyus and @snowzlmbot.</li>
+<li><strong>PR #98781</strong> fix(imessage): poll render vote-cue, cross-run echo suppression, and comment fold. Thanks @omarshahine.</li>
+<li><strong>PR #97500</strong> Doctor: expose tool result cap findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #98769</strong> fix: Telegram replies duplicate recent context after sent replies. Related #98767. Thanks @rabsef-bicrym.</li>
+<li><strong>PR #98933</strong> fix(agents): stop gateway crash from wedged claude-cli turns and persist heartbeat session bindings. Related #98894, #98895. Thanks @obviyus.</li>
+<li><strong>PR #98934</strong> fix(agents): recover claude-cli context-overflow sessions and keep retry artifacts alive. Related #98897. Thanks @obviyus.</li>
+<li><strong>PR #98908</strong> refactor(agents): fold assistant string normalization into transcript ingest. Thanks @obviyus.</li>
+<li><strong>PR #98738</strong> fix(agents): fail fast with attributable reason after MCP stdio session dies mid-run. Thanks @masatohoshino and @vincentkoc.</li>
+<li><strong>PR #98879</strong> fix: backup skips volatile cache paths. Related #98865. Thanks @ZengWen-DT and @vincentkoc and @carterstebbins23-spec.</li>
+<li><strong>PR #98942</strong> fix(agents): unify claude-cli output classification across live and one-shot paths. Related #98896. Thanks @obviyus.</li>
+<li><strong>PR #98932</strong> fix(anthropic): restore Fable 5 Vertex simple completions.</li>
+<li><strong>PR #98947</strong> fix(cron): restore persistent session targets.</li>
+<li><strong>PR #96523</strong> fix(agents): preserve embedded OpenAI completions usage. Thanks @ly85206559 and @vincentkoc.</li>
+<li><strong>PR #98758</strong> perf(build): reduce plugin SDK declaration package size. Related #98757. Thanks @RomneyDa.</li>
+<li><strong>PR #98877</strong> fix(mattermost): include later team members in peer directory. Related #98871. Thanks @qingminglong.</li>
+<li><strong>PR #98953</strong> feat(ios): refine the chat experience. Related #98929.</li>
+<li><strong>PR #98876</strong> fix(terminal): preserve sibling home-prefix paths. Related #98872. Thanks @qingminglong.</li>
+<li><strong>PR #98930</strong> feat(ios): PR1 brand color palette overhaul. Thanks @joelnishanth.</li>
+<li><strong>PR #94566</strong> fix(android): make offline chat actionable. Thanks @Tosko4.</li>
+<li><strong>PR #98955</strong> fix(agents): preserve fresh tool result text under aggregate cap. Related #98874. Thanks @momothemage and @lamkan0210.</li>
+<li><strong>PR #98059</strong> [codex] Support Android selected photo access. Thanks @NianJiuZst.</li>
+<li><strong>PR #98914</strong> fix(android): return settings details to their originating tab on Back. Thanks @Lokimorty.</li>
+<li><strong>PR #98898</strong> fix(ios): back from settings details returns to the originating screen. Thanks @Lokimorty.</li>
+<li><strong>PR #98235</strong> fix(feishu): include video upload duration. Thanks @areslp.</li>
+<li><strong>PR #98966</strong> fix(discord): gate guild metadata reads [AI]. Thanks @pgondhi987.</li>
+<li><strong>PR #98985</strong> fix: clean up iOS About page copy. Related #98943. Thanks @sahilsatralkar.</li>
+<li><strong>PR #98856</strong> fix(ios): gateway error shows twice on the Settings Gateway page. Thanks @Lokimorty.</li>
+<li><strong>PR #98936</strong> fix: Control row icons use inconsistent row styling (iOS). Related #98916. Thanks @sahilsatralkar.</li>
+<li><strong>PR #98040</strong> [codex] Fix Android camera snap cleanup. Thanks @NianJiuZst.</li>
+<li><strong>PR #99039</strong> fix(macos): stop runtime config-health sidecar access. Related #98917. Thanks @momothemage and @P51moustache.</li>
+<li><strong>PR #92667</strong> ci: add process exec CodeQL security shard. Thanks @hxy91819.</li>
+<li><strong>PR #98055</strong> [codex] Gate Android Talk capture starts in background. Thanks @NianJiuZst.</li>
+<li><strong>PR #98067</strong> [codex] Cancel Android gateway pending RPCs on close. Thanks @NianJiuZst.</li>
+<li><strong>PR #98698</strong> fix(android): show specific gateway auth-recovery reason instead of generic label. Related #98046. Thanks @masatohoshino and @ccaprani.</li>
+<li><strong>PR #83826</strong> test(android): poll for stale TLS probe cleanup in auth test. Thanks @NeatGuyCoding.</li>
+<li><strong>PR #98983</strong> fix(agents): handle variadic claude --mcp-config and serialize gemini credential staging. Related #98944, #98945. Thanks @obviyus.</li>
+<li><strong>PR #99145</strong> fix(auto-reply): suppress room-event notice leaks. Thanks @obviyus.</li>
+<li><strong>PR #99144</strong> fix(auto-reply): default room events to silence. Thanks @obviyus.</li>
+<li><strong>PR #98608</strong> fix: Mattermost fails to load after configured plugin repair. Related #98564. Thanks @jacobtomlinson.</li>
+<li><strong>PR #99143</strong> fix(telegram): keep group history always on. Related #99142. Thanks @obviyus.</li>
+<li><strong>PR #99159</strong> fix(agents): claude-cli lifecycle cleanup — loopback fail-loud, exit-0 failover, bounded reseed, image sweep, one prepare cleanup owner. Related #98946. Thanks @obviyus.</li>
+<li><strong>PR #98391</strong> Expose disk space doctor lint findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #98835</strong> fix(config/sessions): narrow reply-session initialization revision to identity fields. Related #98672. Thanks @moguangyu5-design and @jalehman and @AaronFaby.</li>
+<li><strong>PR #99123</strong> fix(android): ignore chat events with missing assistant role in voice text extraction. Thanks @ly85206559 and @cursoragent.</li>
+<li><strong>PR #99147</strong> fix(android): preserve split SMS permission grants. Thanks @NianJiuZst.</li>
+<li><strong>PR #99107</strong> fix(android): bracket IPv6 hosts in manual gateway URL composition. Thanks @ly85206559 and @cursoragent.</li>
+<li><strong>PR #99158</strong> fix: require Android contact and calendar write permissions in onboarding. Thanks @NianJiuZst.</li>
+<li><strong>PR #99110</strong> fix(android): strip ws scheme prefix from manual gateway host input. Related #87216. Thanks @ly85206559 and @cursoragent and @ruben2000de.</li>
+<li><strong>PR #99212</strong> fix(ci): session concurrency test flakes during child handshake.</li>
+<li><strong>PR #94385</strong> fix(feishu): preserve button command values in fallback text and add Feishu comment guidance with callback privacy. Related #69754. Thanks @xialonglee and @1yihui.</li>
+<li><strong>PR #98563</strong> fix: route iOS OpenAI realtime Talk through WebRTC. Thanks @PollyBot13.</li>
+<li><strong>PR #99204</strong> fix: require Android contact and calendar write permissions. Thanks @NianJiuZst.</li>
+<li><strong>PR #99134</strong> fix: OAuth refresh failures report reauth instead of stale success. Related #99120. Thanks @100yenadmin.</li>
+<li><strong>PR #99153</strong> fix: clean up Android camera clips on cancellation. Thanks @NianJiuZst.</li>
+<li><strong>PR #99118</strong> [codex] fix(memory-lancedb): align apache arrow peer dependency. Related #90295. Thanks @allenhurff and @joshavant.</li>
+<li><strong>PR #98066</strong> fix: keep iOS LAN QR pairing authenticated after bootstrap. Related #98064. Thanks @ooiuuii.</li>
+<li><strong>PR #99155</strong> fix: stop iOS screen recording after cancellation. Thanks @NianJiuZst.</li>
+<li><strong>PR #95973</strong> fix(telegram): explain disabled plugin approval failures. Related #95800. Thanks @MonkeyLeeT and @ChrisBot2026.</li>
+<li><strong>PR #99233</strong> fix: ignore test-only network CI guard lines. Thanks @joshavant.</li>
+<li><strong>PR #98951</strong> fix: strict guarded fetch fails before managed proxy DNS. Related #98925. Thanks @momothemage and @sandl99.</li>
+<li><strong>PR #99137</strong> fix: prevent Voice Wake crash after Talk audio capture. Thanks @PollyBot13.</li>
+<li><strong>PR #99052</strong> fix: Update Dark/Light mode UI control appearance. Related #98995. Thanks @sahilsatralkar.</li>
+<li><strong>PR #99245</strong> fix(ios): return chat to originating control detail. Thanks @Solvely-Colin.</li>
+<li><strong>PR #92602</strong> fix(android): queue node events until gateway connect. Related #79552. Thanks @ashishpatel26 and @hectorrp13.</li>
+<li><strong>PR #98277</strong> fix: keep Android gateway settings save idempotent. Thanks @Solvely-Colin.</li>
+<li><strong>PR #99256</strong> fix(auto-reply): single canonical group history and deduped turn metadata. Related #99218. Thanks @obviyus.</li>
+<li><strong>PR #99259</strong> fix(android): use Bluetooth microphones for voice capture. Related #96241. Thanks @gwtaylor.</li>
+<li><strong>PR #98751</strong> test(qa): prove native command targeting across QA transports. Thanks @RomneyDa.</li>
+<li><strong>PR #98779</strong> test(qa): cover expanded Crabline bindings. Thanks @RomneyDa.</li>
+<li><strong>PR #99262</strong> test(qa): cover Crabline Signal sends. Thanks @RomneyDa.</li>
+<li><strong>PR #99261</strong> refactor(shared): establish lazy runtime loader foundation. Thanks @RomneyDa.</li>
+<li><strong>PR #99264</strong> test(qa): cover Crabline Mattermost sends. Thanks @RomneyDa.</li>
+<li><strong>PR #99265</strong> test(qa): cover Crabline Matrix sends. Thanks @RomneyDa.</li>
+<li><strong>PR #98400</strong> Expose heartbeat template doctor lint findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #98695</strong> Expose legacy plugin manifest doctor lint findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #99278</strong> refactor(shared): consolidate core leaf lazy loaders. Thanks @RomneyDa.</li>
+<li><strong>PR #99274</strong> fix(zalo): match native bot identity fields. Thanks @RomneyDa.</li>
+<li><strong>PR #99126</strong> test(discord): clarify and guardrail gateway proxy selection. Related #98266. Thanks @svuppala2006 and @joshavant and @sallyom.</li>
+<li><strong>PR #99290</strong> feat(ios): add licenses settings screen. Thanks @joshavant.</li>
+<li><strong>PR #98907</strong> fix(telegram): distinguish and render streamed reasoning/commentary progress lanes. Thanks @Marvinthebored.</li>
+<li><strong>PR #99294</strong> fix(qa): stagger isolated worker startup. Thanks @RomneyDa.</li>
+<li><strong>PR #99276</strong> fix(memory-wiki): source imports crash on unreadable pages. Thanks @obviyus.</li>
+<li><strong>PR #99296</strong> refactor(shared): consolidate gateway and stateful runtime lazy loaders. Thanks @RomneyDa.</li>
+<li><strong>PR #98768</strong> Allow alternate Zalo Bot API roots. Thanks @RomneyDa.</li>
+<li><strong>PR #99298</strong> refactor(shared): consolidate Discord Slack and Telegram lazy loaders. Thanks @RomneyDa.</li>
+<li><strong>PR #99307</strong> fix(memory-wiki): avoid implicit error coercion. Thanks @RomneyDa.</li>
+<li><strong>PR #99306</strong> feat(auto-reply): persist ambient room events as transcript rows. Related #99257. Thanks @obviyus.</li>
+<li><strong>PR #99302</strong> refactor(shared): consolidate remaining channel lazy loaders. Thanks @RomneyDa.</li>
+<li><strong>PR #99303</strong> test(qa): cover Crabline Zalo transport. Thanks @RomneyDa.</li>
+<li><strong>PR #99299</strong> feat(android): add licenses settings screen. Thanks @joshavant.</li>
+<li><strong>PR #99220</strong> fix(ios): onboarding Retry Connection does nothing after editing gateway details. Related #99219. Thanks @abdullahtas0.</li>
+<li><strong>PR #98749</strong> refactor(shared): consolidate provider and utility lazy loaders. Thanks @RomneyDa.</li>
+<li><strong>PR #99355</strong> fix(ci): restore Telegram and plugin SDK guard checks. Thanks @RomneyDa.</li>
+<li><strong>PR #88899</strong> fix(android): render chat content through Markdown. Related #88014. Thanks @Pluviobyte and @Iman-Sharif.</li>
+<li><strong>PR #99310</strong> test(qa): migrate channel streaming evidence to transport flow. Thanks @RomneyDa.</li>
+<li><strong>PR #99350</strong> fix(ios): add Photos permission controls. Related #99046. Thanks @Tony-ooo.</li>
+<li><strong>PR #99361</strong> refactor(plugins): consolidate record guards. Thanks @RomneyDa.</li>
+<li><strong>PR #99359</strong> refactor(shared): consolidate core record guards. Thanks @RomneyDa.</li>
+<li><strong>PR #97208</strong> fix: avoid DeepSeek-native thinking on OpenRouter V4. Related #97196. Thanks @NianJiuZst and @patelmm79.</li>
+<li><strong>PR #99385</strong> fix(sessions): scope ambient transcript watermark to session id. Related #99373. Thanks @obviyus.</li>
+<li><strong>PR #99389</strong> fix(auto-reply): restore per-turn message-tool delivery contract. Related #99371. Thanks @obviyus.</li>
+<li><strong>PR #98269</strong> fix(android): derive Voice readiness from Gateway catalog. Related #98268. Thanks @Solvely-Colin.</li>
+<li><strong>PR #92872</strong> fix(qqbot): allow scoped sandbox media sends. Thanks @zhangguiping-xydt and @sliverp.</li>
+<li><strong>PR #99414</strong> fix(android): expose exact gateway recovery actions. Related #98045, #98046. Thanks @ccaprani.</li>
+<li><strong>PR #99289</strong> feat: session-first sidebar, compact context ring, and warm light theme for the Control UI. Related #99288.</li>
+<li><strong>PR #99234</strong> feat(nodes): add auto-discovered Ollama inference. Related #99228.</li>
+<li><strong>PR #97095</strong> fix: memory_search honors generic embedding providers. Thanks @849261680.</li>
+<li><strong>PR #98841</strong> fix(gateway): include session label in deriveSessionTitle fallback chain. Related #98742. Thanks @SunnyShu0925 and @BSG2000.</li>
+<li><strong>PR #99301</strong> fix(feishu): catch unhandled promise rejection in streaming card flush timer. Thanks @lwy-2.</li>
+<li><strong>PR #99391</strong> fix(compaction): count nested tool result content. Related #99375. Thanks @LZY3538 and @imchloe92.</li>
+<li><strong>PR #99407</strong> fix(daemon): avoid loading full gateway logs during diagnostics. Thanks @sunlit-deng.</li>
+<li><strong>PR #99291</strong> Fix/issue 98958 gateway lock fd leak. Related #98958. Thanks @chenyangjun-xy and @zhangLei99586.</li>
+<li><strong>PR #99475</strong> fix(ios): contacts.add crashes the app via unfetched CNContactFormatter keys. Thanks @abdullahtas0.</li>
+<li><strong>PR #98003</strong> fix(anthropic): wire buildGuardedModelFetch into the Cloudflare createClient branch. Thanks @wangmiao0668000666.</li>
+<li><strong>PR #99425</strong> fix: strip conda env marker from host tool runs. Related #99424. Thanks @ooiuuii and @krissding.</li>
+<li><strong>PR #99398</strong> fix(cli): reject unsafe sessions tail counts. Thanks @qingminglong.</li>
+<li><strong>PR #98855</strong> fix: chat.send no reply when thinking metadata is set. Thanks @jesse-merhi.</li>
+<li><strong>PR #98752</strong> Rework Android gateway onboarding setup. Thanks @jesse-merhi.</li>
+<li><strong>PR #99446</strong> fix(agents): preserve fd find failures. Thanks @zhangguiping-xydt.</li>
+<li><strong>PR #99152</strong> fix(config): use Object.hasOwn instead of in operator in restoreOriginalValueOrThrow. Thanks @zenglingbiao.</li>
+<li><strong>PR #99460</strong> fix: redact dotted API key activity previews. Related #99459. Thanks @ooiuuii.</li>
+<li><strong>PR #99455</strong> fix: long mobile media recordings time out. Thanks @NianJiuZst.</li>
+<li><strong>PR #99410</strong> fix(subagents): match requesterSessionKey when controllerSessionKey differs in list filter. Related #75593. Thanks @sheyanmin and @aaajiao.</li>
+<li><strong>PR #98791</strong> feat(signal): show status reactions during inbound replies. Thanks @jesse-merhi.</li>
+<li><strong>PR #98683</strong> fix(ui): keep landscape composer compact. Related #98615. Thanks @qingminglong and @jin-li.</li>
+<li><strong>PR #99428</strong> fix(logging): redact Telegram bot tokens from timeout URLs. Related #96982. Thanks @xialonglee and @liuhaiyang14.</li>
+<li><strong>PR #99217</strong> Preserve Codex output after missing turn completion. Thanks @100yenadmin and @Sedrak-Hovhannisyan and @fuller-stack-dev.</li>
+<li><strong>PR #99520</strong> fix(gateway): declare the dev agent required by the gateway e2e session key. Related #99513. Thanks @masatohoshino.</li>
+<li><strong>PR #95738</strong> feat(signal): add target aliases. Thanks @jesse-merhi.</li>
+<li><strong>PR #98258</strong> improve: make native chat scrolling reader-managed. Related #98255. Thanks @christopheraaronhogg.</li>
+<li><strong>PR #99506</strong> fix: keep always-on group fallback messages in dispatch. Related #99457. Thanks @LZY3538 and @zqchris.</li>
+<li><strong>PR #89671</strong> fix(google-meet): force English Meet UI via hl=en so automation works on any locale. Thanks @Unayung.</li>
+<li><strong>PR #98130</strong> fix(infra): bound jsonl-socket response buffer to prevent OOM. Thanks @Pick-cat.</li>
+<li><strong>PR #99526</strong> fix(agents): preserve primitive tool result output. Related #99523. Thanks @snowzlm.</li>
+<li><strong>PR #99525</strong> fix(imessage): recognize bare hex group chat identifiers as chat targets. Related #89235. Thanks @MatthewDelprado.</li>
+<li><strong>PR #99098</strong> fix: harden native i18n identifier filtering. Thanks @hxy91819.</li>
+<li><strong>PR #99099</strong> fix: harden docs map heading rendering. Thanks @hxy91819.</li>
+<li><strong>PR #98725</strong> Expose legacy plugin dependency doctor lint findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #99595</strong> fix(agents): keep cli session binding facts session-stable. Related #99372. Thanks @obviyus.</li>
+<li><strong>PR #90152</strong> fix(telegram): stop duplicate fallback when dispatch fails after final reply. Thanks @zhangguiping-xydt.</li>
+<li><strong>PR #98729</strong> Expose stale plugin runtime symlink doctor lint findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #99591</strong> fix(android): preserve numeric invoke error codes. Thanks @ly85206559.</li>
+<li><strong>PR #98406</strong> Expose WhatsApp responsiveness doctor lint findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #99570</strong> fix(android): reject IPv6 zone IDs in gateway endpoint URLs. Thanks @ly85206559 and @cursoragent.</li>
+<li><strong>PR #99557</strong> fix(android): filter device and internal sessions from thread picker. Thanks @ly85206559 and @cursoragent.</li>
+<li><strong>PR #99568</strong> fix(android): block self-package notification forwarding in allowlist mode. Thanks @ly85206559 and @cursoragent.</li>
+<li><strong>PR #99592</strong> fix(android): parse talk directive aliases case-insensitively. Thanks @ly85206559.</li>
+<li><strong>PR #99477</strong> fix: avoid iOS node permission prompts. Thanks @NianJiuZst.</li>
+<li><strong>PR #99374</strong> improve(qa): standardize script evidence output. Thanks @RomneyDa.</li>
+<li><strong>PR #99468</strong> improve: tighten iOS Control row density. Related #99439. Thanks @sahilsatralkar.</li>
+<li><strong>PR #99642</strong> test: avoid cross-OS socket close event race. Thanks @RomneyDa.</li>
+<li><strong>PR #89967</strong> fix(macos): LaunchAgent starts gateway on external home volumes. Related #87199. Thanks @zhangguiping-xydt and @joshdaynard.</li>
+<li><strong>PR #98613</strong> fix(media): guard ffprobe JSON parse against malformed output. Thanks @Pick-cat.</li>
+<li><strong>PR #97839</strong> fix: log terminal session persistence failures. Related #97795. Thanks @LZY3538 and @cxbAsDev and @snotty and @lin-hongkuan and @849261680 and @qingminglong and @anyech and @masatohoshino and @Simon-XYDT and @xialonglee and @nankingjing and @aniruddhaadak80.</li>
+<li><strong>PR #99247</strong> feat: clarify iOS Location Always permission flow. Thanks @PollyBot13.</li>
+<li><strong>PR #98224</strong> fix(auto-reply): strip stray punctuation before silent-reply token detection. Thanks @SunnyShu0925.</li>
+<li><strong>PR #97328</strong> fix(google): rotate Gemini API keys for LLM requests. Thanks @MonkeyLeeT.</li>
+<li><strong>PR #99661</strong> fix(macos): remote mode fails with managed SSH aliases.</li>
+<li><strong>PR #99649</strong> fix(qa): defer partial Crabline recorder rows. Related #99648. Thanks @RomneyDa.</li>
+<li><strong>PR #99211</strong> Expose legacy cron store doctor lint findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #99629</strong> test(qa): redact script evidence diagnostics. Thanks @RomneyDa.</li>
+<li><strong>PR #99647</strong> Fix Slack retry for session init conflicts. Thanks @steipete-oai.</li>
+<li><strong>PR #99628</strong> improve: enforce canonical QA scenario ownership. Related #99627. Thanks @RomneyDa.</li>
+<li><strong>PR #99632</strong> refactor(qa): simplify transport adapter contracts. Related #99622. Thanks @RomneyDa.</li>
+<li><strong>PR #99656</strong> test(qa): use full-turn budget for native stop recovery. Related #99655. Thanks @RomneyDa.</li>
+<li><strong>PR #99605</strong> fix(google): bound OAuth token error response reads. Thanks @mushuiyu886.</li>
+<li><strong>PR #99679</strong> fix(qa): consume Crabline events without recorder polling. Related #99664. Thanks @RomneyDa.</li>
+<li><strong>PR #99687</strong> refactor(infra): consolidate SHA-256 digest helpers. Related #99675. Thanks @RomneyDa.</li>
+<li><strong>PR #98796</strong> [AI-assisted] feat(android): add chat command controls. Thanks @IWhatsskill.</li>
+<li><strong>PR #99671</strong> refactor: consolidate number coercion callers. Related #99667. Thanks @RomneyDa.</li>
+<li><strong>PR #99640</strong> fix: CLI agent session resume churns when owner and non-owner alternate in a group. Related #99633. Thanks @obviyus.</li>
+<li><strong>PR #99682</strong> refactor(models): consolidate catalog ref parsing. Related #99674. Thanks @RomneyDa.</li>
+<li><strong>PR #99566</strong> fix(exec): avoid splitting surrogate pairs in approval display. Thanks @mikasa0818.</li>
+<li><strong>PR #99702</strong> refactor: remove redundant unique-list aliases. Related #99697. Thanks @RomneyDa.</li>
+<li><strong>PR #99246</strong> feat(ios): implement branded typography design system. Thanks @joelnishanth and @cursoragent.</li>
+<li><strong>PR #99710</strong> fix(build): Docker package preparation misses plugin SDK declarations. Thanks @RomneyDa.</li>
+<li><strong>PR #99715</strong> refactor: consolidate image data URL formatting. Thanks @RomneyDa.</li>
+<li><strong>PR #98764</strong> fix(ui): copy workspace file paths over plain HTTP. Related #98759. Thanks @ZengWen-DT and @adinballew.</li>
+<li><strong>PR #99678</strong> fix(build): forward default exports through stable runtime aliases. Related #99677. Thanks @headbouyJB and @vincentkoc.</li>
+<li><strong>PR #99370</strong> fix(file-transfer): don't inline zero-byte files as image content blocks. Thanks @2loch-ness6 and @vincentkoc.</li>
+<li><strong>PR #99540</strong> fix(doctor): shell completion install fails doctor when profile is read-only. Related #99237. Thanks @rballiance and @hunglp6d.</li>
+<li><strong>PR #99718</strong> refactor(text): consolidate cleanup owners. Thanks @RomneyDa.</li>
+<li><strong>PR #98819</strong> fix(plugins): resolve public artifacts from installed plugin roots. Related #98740. Thanks @amknight and @KelTech-Services.</li>
+<li><strong>PR #99721</strong> refactor: consolidate async timing helpers. Thanks @RomneyDa.</li>
+<li><strong>PR #99722</strong> fix: group agent session resume churns when messages toggle between @-mention and plain. Related #99696. Thanks @obviyus.</li>
+<li><strong>PR #99676</strong> refactor: consolidate string reader mechanics. Related #99663. Thanks @RomneyDa.</li>
+<li><strong>PR #99705</strong> improve(qa): execute runtime scenarios through Docker. Thanks @RomneyDa.</li>
+<li><strong>PR #99231</strong> improve: native iOS look with stock SwiftUI navigation, forms, chat, and talk visualizer. Related #99195. Thanks @marvkr.</li>
+<li><strong>PR #99549</strong> fix(auto-reply): don't block reply completion on transcript mirror. Thanks @Shagrat2.</li>
+<li><strong>PR #99736</strong> fix(qa): prevent smoke gateways from losing built files. Related #99734. Thanks @RomneyDa.</li>
+<li><strong>PR #99658</strong> feat(providers): add ClawRouter routing and quotas. Related #99657.</li>
+<li><strong>PR #99238</strong> Expose channel preview warning doctor findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #99759</strong> fix(providers): resolve ClawRouter auth-profile models.</li>
+<li><strong>PR #99561</strong> fix: keep OpenClaw control tools available when tool_search misroutes. Related #99464. Thanks @100yenadmin and @joshavant.</li>
+<li><strong>PR #99750</strong> refactor: consolidate exact boolean coercion. Thanks @RomneyDa.</li>
+<li><strong>PR #99753</strong> refactor: consolidate abort primitives. Thanks @RomneyDa.</li>
+<li><strong>PR #99426</strong> feat: add slash command picker in chat composer. Thanks @VicZhang6 and @Solvely-Colin.</li>
+<li><strong>PR #99771</strong> refactor: consolidate free-port test helpers. Thanks @RomneyDa.</li>
+<li><strong>PR #99755</strong> refactor: consolidate policy-free deferred promises. Thanks @RomneyDa.</li>
+<li><strong>PR #99719</strong> refactor(net): consolidate URL protocol predicates. Thanks @RomneyDa.</li>
+<li><strong>PR #99743</strong> fix: avoid native command QA timeout under CI contention. Thanks @RomneyDa.</li>
+<li><strong>PR #99368</strong> fix(qa): prevent qa smoke ci timeouts under gateway concurrency. Thanks @RomneyDa.</li>
+<li><strong>PR #99778</strong> refactor(scripts): share regexp literal escaping. Thanks @RomneyDa.</li>
+<li><strong>PR #99737</strong> test: add executable runtime fixture canaries. Thanks @RomneyDa.</li>
+<li><strong>PR #99735</strong> test(qa): exercise Gateway and MCP scenarios over real transports. Thanks @RomneyDa.</li>
+<li><strong>PR #99784</strong> fix(qa): stabilize primary smoke runtime evidence. Thanks @RomneyDa.</li>
+<li><strong>PR #99726</strong> fix(onboard): skip unavailable skill installers via lifecycle readiness preflight. Thanks @fuller-stack-dev and @Sedrak-Hovhannisyan.</li>
+<li><strong>PR #99793</strong> ci: reuse one package in QA smoke.</li>
+<li><strong>PR #99767</strong> feat(macos): install and run the local Gateway automatically. Related #99764.</li>
+<li><strong>PR #99820</strong> ci: increase artifact Testbox memory.</li>
+<li><strong>PR #99822</strong> feat: soft-resume CLI sessions on prompt drift instead of hard invalidation. Related #99729. Thanks @obviyus.</li>
+<li><strong>PR #99129</strong> fix(markdown-core): use Object.hasOwn instead of in operator in parseFrontmatterBlock. Thanks @zenglingbiao and @vincentkoc.</li>
+<li><strong>PR #99803</strong> fix(mcp): suppress unhandled error on stderr pipe in stdio transport. Thanks @cxbAsDev and @vincentkoc.</li>
+<li><strong>PR #99802</strong> fix(supervisor): suppress unhandled stream errors on child stdout/stderr. Thanks @cxbAsDev and @vincentkoc.</li>
+<li><strong>PR #99800</strong> fix(ssh-tunnel): handle spawn error to prevent unhandled rejection crash. Thanks @cxbAsDev and @vincentkoc.</li>
+<li><strong>PR #99653</strong> fix(cli): hide synthetic Claude reseed prompts. Related #99646. Thanks @ZOOWH and @vincentkoc and @Jeehut.</li>
+<li><strong>PR #99728</strong> fix(config): preserve recovery state during config-health migration. Related #99280. Thanks @joshavant and @jalehman and @ccbridle.</li>
+<li><strong>PR #99839</strong> fix(gateway): preserve legacy reseed attachments. Thanks @vincentkoc.</li>
+<li><strong>PR #99830</strong> fix: stop rubber-band bounce of the Control UI shell in the Mac app web view.</li>
+<li><strong>PR #99851</strong> fix(agents): preserve fallback tool-call hints. Thanks @vincentkoc.</li>
+<li><strong>PR #98994</strong> fix(line): truncate outbound altText, location, menu, and code fields on code point boundaries. Thanks @LEXES7 and @vincentkoc.</li>
+<li><strong>PR #99846</strong> fix(config): restrict config paths to own properties. Thanks @vincentkoc and @zenglingbiao.</li>
+<li><strong>PR #99861</strong> fix(telegram): one outbound rich-HTML normalizer and one rich-to-plain fallback policy. Related #99833. Thanks @obviyus.</li>
+<li><strong>PR #99866</strong> fix(telegram): classify inbound events from the canonical mention decision so direct mentions stop lurking. Related #99854. Thanks @obviyus.</li>
+<li><strong>PR #99832</strong> fix: reject incompatible Node 23 runtimes. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #99243</strong> Polish iOS onboarding and chat critique fixes. Thanks @jcooley8.</li>
+<li><strong>PR #99714</strong> perf(usage): shrink durable usage cache entries. Related #99511. Thanks @dexhunter and @wayne524.</li>
+<li><strong>PR #99838</strong> feat: declutter the Control UI shell — reasoning effort slider, borderless composer controls, version out of the sidebar. Related #99837.</li>
+<li><strong>PR #99600</strong> fix: outbound recovery can replay already sent replies. Thanks @zhangguiping-xydt.</li>
+<li><strong>PR #99891</strong> fix(agents): preserve images on CLI fallback. Thanks @vincentkoc.</li>
+<li><strong>PR #99821</strong> feat(codex): share native threads across Codex clients. Related #99781.</li>
+<li><strong>PR #99893</strong> fix(discord): hide internal Code Mode wait progress.</li>
+<li><strong>PR #99850</strong> refactor: consolidate duplicated plugin state and doctor migration plumbing onto SDK seams. Related #99841.</li>
+<li><strong>PR #99901</strong> refactor: consolidate core stream cleanup, watchdog locality, and approval text duplication.</li>
+<li><strong>PR #99635</strong> feat(whatsapp): add requester-bound MeowCaller calls. Related #99634.</li>
+<li><strong>PR #99527</strong> fix(edit): keep mismatch hint truncation unicode-safe. Thanks @mikasa0818.</li>
+<li><strong>PR #99902</strong> fix(agents): preserve mixed image attachment order. Thanks @vincentkoc.</li>
+<li><strong>PR #99816</strong> fix(agents): derive conversation scope from trusted group facts.</li>
+<li><strong>PR #99817</strong> refactor(agents): require one resolved capability profile per run.</li>
+<li><strong>PR #99877</strong> fix(slack): preserve time colons in interactive labels. Related #99823. Thanks @qingminglong and @rodja.</li>
+<li><strong>PR #99915</strong> feat: allow custom sandbox image tags.</li>
+<li><strong>PR #99909</strong> improve: speed up QA report source errors.</li>
+<li><strong>PR #99855</strong> fix(transcripts): mark delivery mirrors as artifacts. Thanks @vincentkoc.</li>
+<li><strong>PR #99900</strong> refactor(ui): dedupe chat styles and make the styles.css import order real. Related #99899.</li>
+<li><strong>PR #99931</strong> fix(slack): warn when bot token authenticates as user. Related #98357. Thanks @ooiuuii.</li>
+<li><strong>PR #99879</strong> fix(tui): coalesce busy submit notices. Thanks @vincentkoc.</li>
+<li><strong>PR #99940</strong> improve: speed up plugin SDK surface checks.</li>
+<li><strong>PR #99944</strong> fix(slack): remove unused unsafe auth fetch helper. Thanks @miorbnli.</li>
+<li><strong>PR #99932</strong> refactor: consolidate markdown code fences, error coercion, and byte-identical helper pairs.</li>
+<li><strong>PR #99906</strong> fix(anthropic): fall back to Claude Opus 4.8 when Fable 5 safety classifiers decline a request.</li>
+<li><strong>PR #99945</strong> test: skip real restart waits in update CLI tests.</li>
+<li><strong>PR #99949</strong> fix: improve agent runtime correctness from upstream Pi. Related #99924.</li>
+<li><strong>PR #99962</strong> docs: clarify plugin package live proof. Thanks @hxy91819.</li>
+<li><strong>PR #99955</strong> [codex] fix(copilot): preserve BYOK bearer auth through proxy. Thanks @hxy91819.</li>
+<li><strong>PR #99973</strong> docs: sync plugin package snippets.</li>
+<li><strong>PR #99969</strong> test: speed up Crabbox wrapper coverage.</li>
+<li><strong>PR #99988</strong> test: speed up Docker scheduler coverage.</li>
+<li><strong>PR #95463</strong> fix(slack): bridge presentation capabilities and renderPresentation through channel outbound facade. Related #95440. Thanks @ZOOWH and @kayla-waves.</li>
+<li><strong>PR #99249</strong> Keep workspace suggestions opt-in for doctor lint. Thanks @giodl73-repo.</li>
+<li><strong>PR #99352</strong> feat(release): add monthly npm extended-stable publication. Thanks @kevinslin.</li>
+<li><strong>PR #100002</strong> perf: defer realtime smoke live imports.</li>
+<li><strong>PR #95313</strong> fix(slack): allow channel-id reads for name-allowlisted channels. Thanks @jontsai.</li>
+<li><strong>PR #100008</strong> improve: speed up package candidate safety tests.</li>
+<li><strong>PR #94672</strong> feat: pair mobile devices from the Control UI. Thanks @bkudiess and @douhualili.</li>
+<li><strong>PR #85507</strong> fix(slack): include assistant loading messages. Thanks @emergentash.</li>
+<li><strong>PR #96312</strong> fix(slack): stop logging inbound message previews. Thanks @steipete-oai.</li>
+<li><strong>PR #99717</strong> test(qa): run the real CLI channel picker. Thanks @RomneyDa.</li>
+<li><strong>PR #100035</strong> fix(agents): replay images across cli fallback. Thanks @vincentkoc.</li>
+<li><strong>PR #99766</strong> refactor(voice-call): reuse shared webhook path normalization. Thanks @RomneyDa.</li>
+<li><strong>PR #99786</strong> refactor: reuse shared number clamp. Thanks @RomneyDa.</li>
+<li><strong>PR #99852</strong> fix(acpx): handle MCP proxy stdio pipe errors. Thanks @sunlit-deng and @vincentkoc.</li>
+<li><strong>PR #98510</strong> feat: add session thread management. Related #88568. Thanks @Maziyang2.</li>
+<li><strong>PR #99777</strong> refactor(providers): table-drive paired catalogs. Thanks @RomneyDa.</li>
+<li><strong>PR #100053</strong> fix: tests in nested git worktrees load bundled plugins from the enclosing checkout. Related #100052.</li>
+<li><strong>PR #100039</strong> improve(matrix): generate executable QA route and state evidence. Related #100038. Thanks @RomneyDa.</li>
+<li><strong>PR #97727</strong> fix(slack): include attachment text in thread context. Thanks @chthtlo.</li>
+<li><strong>PR #100051</strong> fix(telegram): report inbound media download failures. Related #100000. Thanks @batyaro777.</li>
+<li><strong>PR #100027</strong> chore: update dependencies. Related #99952.</li>
+<li><strong>PR #99788</strong> refactor(infra): consolidate identifier digest mechanics. Thanks @RomneyDa.</li>
+<li><strong>PR #99790</strong> refactor(models): share strict model ref parsing. Thanks @RomneyDa.</li>
+<li><strong>PR #99744</strong> refactor(infra): consolidate bounded HTTP body reads. Thanks @RomneyDa.</li>
+<li><strong>PR #100040</strong> fix(ui): localize mobile pairing in Hindi and Russian.</li>
+<li><strong>PR #99960</strong> fix(cron): roll back live scheduler state when persisting add/update/remove fails. Thanks @masatohoshino and @vincentkoc.</li>
+<li><strong>PR #99811</strong> feat(update): support extended-stable package updates. Related #99808. Thanks @kevinslin.</li>
+<li><strong>PR #99785</strong> refactor: consolidate unique string list helpers. Thanks @RomneyDa.</li>
+<li><strong>PR #98559</strong> improve(web-fetch): speed up provider fallback loading. Thanks @vincentkoc.</li>
+<li><strong>PR #99250</strong> Keep legacy WhatsApp crontab lint opt-in. Thanks @giodl73-repo.</li>
+<li><strong>PR #83718</strong> fix(memory-core): treat dreaming fence marker lines as inside-fence in promotion guard (#80613). Thanks @grifjef and @p0pfan.</li>
+<li><strong>PR #100081</strong> fix(gateway): harden embedded terminal policy. Related #77362. Thanks @rayncc.</li>
+<li><strong>PR #100006</strong> fix: roll rounded durations into seconds. Related #99978. Thanks @qingminglong.</li>
+<li><strong>PR #100083</strong> chore: update oxlint tsgolint.</li>
+<li><strong>PR #100087</strong> fix(tooling): accept pnpm separator in web fetch benchmark. Thanks @vincentkoc.</li>
+<li><strong>PR #91984</strong> fix(telegram): resolve local Bot API container file paths against trustedLocalFileRoots [AI-assisted]. Thanks @Dizesales and @AiLucasdz.</li>
+<li><strong>PR #100015</strong> fix(release): block stale Codex runtime pins. Related #99951. Thanks @fuller-stack-dev and @100yenadmin.</li>
+<li><strong>PR #100069</strong> test: make the local pnpm test gate green on macOS hosts. Related #100025.</li>
+<li><strong>PR #87643</strong> feat: add utility models and generated session titles. Related #77165. Thanks @zhangguiping-xydt and @Juliangsm.</li>
+<li><strong>PR #99121</strong> policy: cover gateway node commands. Thanks @giodl73-repo.</li>
+<li><strong>PR #100024</strong> feat: refactor the Control UI architecture. Thanks @shakkernerd.</li>
+<li><strong>PR #100054</strong> fix(gateway): read usage-cost cache once per agent in sessions.usage. Related #100041. Thanks @NianJiuZst and @justronin.</li>
+<li><strong>PR #82895</strong> fix(slack): preserve interaction thread status. Related #82886. Thanks @WuKongAI-CMU and @tianxiaochannel-oss88.</li>
+<li><strong>PR #100084</strong> fix(slack): preserve custom identity while streaming. Related #58737. Thanks @MoerAI and @FergusClare.</li>
+<li><strong>PR #100089</strong> feat(gateway): terminal detach/reattach with output replay, terminal.list, terminal.text. Related #100085.</li>
+<li><strong>PR #100106</strong> fix(ui): repair router refactor regressions.</li>
+<li><strong>PR #99401</strong> feat(cli): render claude CLI native thinking with /reasoning gating. Thanks @Marvinthebored.</li>
+<li><strong>PR #100077</strong> fix(agents): scale aggregate tool-result budget with context window and compact on pressure. Related #100042. Thanks @obviyus.</li>
+<li><strong>PR #99688</strong> refactor: consolidate safe JSON parsing. Related #99665. Thanks @RomneyDa.</li>
+<li><strong>PR #100061</strong> refactor(types): remove redundant local aliases. Thanks @RomneyDa.</li>
+<li><strong>PR #100012</strong> fix: detect localized Windows netstat listeners. Related #99984. Thanks @qingminglong and @vincentkoc.</li>
+<li><strong>PR #99746</strong> refactor(security): consolidate secret primitives. Thanks @RomneyDa.</li>
+<li><strong>PR #100108</strong> test(ui): stabilize Control UI suite routing. Thanks @vincentkoc.</li>
+<li><strong>PR #99763</strong> improve(ui): flatten chat tool-call rows into a scannable list. Related #99760.</li>
+<li><strong>PR #99691</strong> refactor: consolidate exact keyed async queues. Related #99683. Thanks @RomneyDa.</li>
+<li><strong>PR #99740</strong> refactor(plugin-sdk): consolidate tool result helpers. Thanks @RomneyDa.</li>
+<li><strong>PR #94990</strong> fix(feishu): emit non-empty value schema for bitable write tools (#94547). Thanks @TwinsLee.</li>
+<li><strong>PR #84335</strong> fix(slack): forward per-agent identity overlay on heartbeat and runtimeSend (#84297). Thanks @Rohang2005 and @aw-stevens.</li>
+<li><strong>PR #53467</strong> feat(slack): add ignoreOtherMentions channel config. Related #89625. Thanks @hanamizuki and @SaebAmini.</li>
+<li><strong>PR #100114</strong> fix(qa-channel): handle metadata-free final replies. Thanks @vincentkoc.</li>
+<li><strong>PR #100047</strong> fix(gateway): truncateCloseReason drops partial UTF-8 code point instead of emitting mojibake. Related #99976. Thanks @NarahariRaghava.</li>
+<li><strong>PR #100119</strong> fix(channels): expose inbound media download failures [AI-assisted]. Related #100092.</li>
+<li><strong>PR #97514</strong> Doctor: expose systemd linger findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #100128</strong> feat(ui): adopt shared libterminal runtime. Related #100126.</li>
+<li><strong>PR #95447</strong> fix(agents): use CJK-aware token estimation for tool results. Thanks @moguangyu5-design and @vincentkoc.</li>
+<li><strong>PR #100123</strong> fix(tui): queue prompts while the agent is busy. Related #89059, #90012. Thanks @SebTardif and @kevinlp.</li>
+<li><strong>PR #91584</strong> Fail closed when Slack mention detection is unavailable. Thanks @hiragram and @openclaw-agent.</li>
+<li><strong>PR #100059</strong> [AI-assisted] fix(android): polish home overview layout. Thanks @IWhatsskill.</li>
+<li><strong>PR #100013</strong> fix: keep subagent truncation within max length. Related #99979. Thanks @qingminglong.</li>
+<li><strong>PR #100122</strong> chore: enable array fill lint rule.</li>
+<li><strong>PR #100136</strong> fix(chat): hide duplicate channel delivery mirrors.</li>
+<li><strong>PR #100096</strong> fix(infra): roll session warning durations across unit boundaries. Related #99978. Thanks @NarahariRaghava and @vincentkoc.</li>
+<li><strong>PR #99165</strong> fix(qa-lab): bound suite runtime gateway JSON response reads. Thanks @hugenshen.</li>
+<li><strong>PR #100144</strong> fix(ui): add chat transcript top spacing. Thanks @steipete-oai.</li>
+<li><strong>PR #100135</strong> fix(agents): preserve spill-file pointers through elision and spill truncated web_fetch output. Related #100112. Thanks @obviyus.</li>
+<li><strong>PR #99419</strong> fix(cli): include aliases in shell completion. Related #99406. Thanks @AmirF194 and @vincentkoc and @Jack-dev-ops.</li>
+<li><strong>PR #99686</strong> policy: classify doctor fix recommendations. Thanks @giodl73-repo.</li>
+<li><strong>PR #100117</strong> fix(tui): isolate embedded event listener failures. Thanks @cxbAsDev.</li>
+<li><strong>PR #79938</strong> Warn on shared Slack Socket Mode connections. Thanks @jeffvsutherland.</li>
+<li><strong>PR #100148</strong> fix(agents): queued CLI reasoning bridge + thinking token progress for claude-cli's withheld-text wire. Thanks @obviyus.</li>
+<li><strong>PR #100088</strong> fix(ui): chat workspace panel leaves an empty gap when collapsed.</li>
+<li><strong>PR #100143</strong> fix(status): hide healthy plugin summary.</li>
+<li><strong>PR #100151</strong> fix(auto-reply): deliver model directive acknowledgements.</li>
+<li><strong>PR #100060</strong> [AI-assisted] fix(android): polish Voice text truncation. Thanks @IWhatsskill.</li>
+<li><strong>PR #100160</strong> fix: preserve Codex transcript ownership. Thanks @steipete-oai.</li>
+<li><strong>PR #100163</strong> fix(ui): align activity error badges. Thanks @steipete-oai.</li>
+<li><strong>PR #100090</strong> [AI-assisted] fix(android): prevent gateway setup button clipping. Thanks @IWhatsskill.</li>
+<li><strong>PR #82253</strong> feat(slack): support per-channel replyToMode. Thanks @truiem-bot.</li>
+<li><strong>PR #100159</strong> fix(whatsapp): replace expired terminal QR on refresh.</li>
+<li><strong>PR #100164</strong> fix(agent): hide code mode wait progress.</li>
+<li><strong>PR #100142</strong> docs: rewrite published docs grounded in current source. Related #100141.</li>
+<li><strong>PR #99896</strong> fix(plugins): stage git plugin clone on target filesystem to avoid EXDEV. Related #99885. Thanks @Bartok9 and @vincentkoc and @CarelvanHeerden.</li>
+<li><strong>PR #100157</strong> feat(ui): make mobile pairing easy to find. Related #100154.</li>
+<li><strong>PR #100183</strong> test(docs): align rewrite guards with current wording. Thanks @vincentkoc.</li>
+<li><strong>PR #100182</strong> docs: restore source-backed contract details.</li>
+<li><strong>PR #100186</strong> docs: align source contract wording.</li>
+<li><strong>PR #99059</strong> refactor: extract reusable AI runtime package. Related #99040.</li>
+<li><strong>PR #100188</strong> fix(tui): keep local commands out of model prompts. Related #71592. Thanks @goslingmanagment.</li>
+<li><strong>PR #100147</strong> fix(control-ui): declutter Settings and make Simple/Advanced switch persistent. Related #100145.</li>
+<li><strong>PR #99050</strong> fix(whatsapp): serialize overlapping Web sends. Related #99049. Thanks @ooiuuii.</li>
+<li><strong>PR #98850</strong> fix(google-meet): bound JSON response body reads to prevent OOM. Thanks @Pandah97.</li>
+<li><strong>PR #95211</strong> test(tui): lock dunder markdown rendering. Related #90769. Thanks @zhangguiping-xydt and @wscurran.</li>
+<li><strong>PR #100191</strong> fix(acp-core): keep fallback error redaction. Thanks @lin-hongkuan.</li>
+<li><strong>PR #97746</strong> fix(discord): reuse stored sessionId across voice (stt-tts) turns. Related #97688. Thanks @Sanjays2402 and @karabaralex.</li>
+<li><strong>PR #100199</strong> fix(ui): make tool activity rows selectable and less repetitive. Thanks @steipete-oai.</li>
+<li><strong>PR #100203</strong> fix(cron): job edits no longer break CLI-backend runs by stripping the default toolsAllow marker. Thanks @obviyus.</li>
+<li><strong>PR #89962</strong> fix(discord): fall back to text when voice delivery fails. Thanks @danhayman.</li>
+<li><strong>PR #100214</strong> fix(macos): preserve PATH for SSH helpers.</li>
+<li><strong>PR #99935</strong> feat(crestodian): conversational agent-loop onboarding across CLI, web install, and macOS app. Related #99934.</li>
+<li><strong>PR #100223</strong> fix(crestodian): repair post-merge checks.</li>
+<li><strong>PR #100204</strong> fix: land nine small correctness fixes. Thanks @LiLan0125 and @cxbAsDev and @lin-hongkuan and @ZOOWH and @liuhao1024 and @mikasa0818 and @Pandah97 and @harjothkhara and @sunlit-deng.</li>
+<li><strong>PR #100190</strong> fix(ui): show only Standard and Fast for OpenAI speed.</li>
+<li><strong>PR #100240</strong> fix(ui): hide duplicate terminal caret.</li>
+<li><strong>PR #97480</strong> fix(slack): reconcile ambiguous sends before replay. Thanks @joeyfrasier.</li>
+<li><strong>PR #95349</strong> fix(agents): strip system-event prefix from modelPrompt when before_prompt_build hooks add context. Related #95323. Thanks @openperf and @vincentkoc and @gorkem2020.</li>
+<li><strong>PR #100179</strong> fix(ui): publish mobile setup independently.</li>
+<li><strong>PR #100205</strong> fix(reply): prevent foreground delivery deadlock. Related #99061. Thanks @nathan-nazareth.</li>
+<li><strong>PR #100239</strong> docs(release): carry approval through publish. Thanks @vincentkoc.</li>
+<li><strong>PR #100029</strong> feat(crestodian): run CLI harnesses on the agent loop via a ring-zero MCP server.</li>
+<li><strong>PR #100222</strong> feat(ios): distinguish debug app builds.</li>
+<li><strong>PR #100220</strong> docs: default agent validation to remote runners.</li>
+<li><strong>PR #100243</strong> fix: stabilize OpenClawKit contract and chat tests.</li>
+<li><strong>PR #99806</strong> fix(subagents): killed subagent runs stay running in the task list. Thanks @masatohoshino.</li>
+<li><strong>PR #100249</strong> fix(build): restore package artifact declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #100252</strong> fix(ui): hide idle composer scrollbar.</li>
+<li><strong>PR #99864</strong> fix(compaction): avoid cached usage overcount. Related #99843. Thanks @LZY3538 and @jrex-jooni.</li>
+<li><strong>PR #100256</strong> fix(ui): center terminal new-session button.</li>
+<li><strong>PR #100259</strong> fix(ios): remove debug icon outer rim.</li>
+<li><strong>PR #100125</strong> fix: DashScope and Moonshot endpoints misclassified as custom when the provider plugin is not installed.</li>
+<li><strong>PR #100253</strong> docs(maint): raise PR close batch limit.</li>
+<li><strong>PR #100251</strong> fix(tui): keep skill approvals in the terminal. Related #100250. Thanks @vincentkoc.</li>
+<li><strong>PR #100206</strong> chore(ci): fail CI when gateway events go unhandled by the mobile apps. Related #100198.</li>
+<li><strong>PR #100200</strong> chore(android): add deterministic chat streaming replay test harness.</li>
+<li><strong>PR #99865</strong> fix(android): default manual TLS port to 18789 except Tailscale hosts. Thanks @ly85206559 and @cursoragent.</li>
+<li><strong>PR #100127</strong> fix(qqbot): channel status keeps reporting connected after the gateway websocket dies. Thanks @masatohoshino and @vincentkoc.</li>
+<li><strong>PR #100046</strong> fix(imessage): false group drop-all startup warning when groupAllowFrom is set without groups.</li>
+<li><strong>PR #100242</strong> feat(scripts): serialize pr prepare gates and add remote Testbox test gate. Related #100226.</li>
+<li><strong>PR #100210</strong> chore: sync canonical autoreview skill.</li>
+<li><strong>PR #100263</strong> fix(voice-call): share webhook replay tracking. Thanks @xialonglee.</li>
+<li><strong>PR #100258</strong> fix: harden small runtime and installer edge cases. Thanks @UditDewan and @cxbAsDev and @Simon-XYDT and @sunlit-deng and @mushuiyu886 and @connermo and @Gfaerny and @ly85206559 and @harjothkhara.</li>
+<li><strong>PR #100244</strong> fix(core): keep backend truncation UTF-16 safe. Thanks @xialonglee and @vincentkoc and @ZengWen-DT.</li>
+<li><strong>PR #78511</strong> fix(gateway): stop terminal WhatsApp restart loops. Related #78419. Thanks @openperf and @rutherlesdev.</li>
+<li><strong>PR #89585</strong> docs: document replay history normalization contract.</li>
+<li><strong>PR #87695</strong> fix(types): unblock changed gate checks. Thanks @vincentkoc.</li>
+<li><strong>PR #89558</strong> docs: document embedded compaction context contracts.</li>
+<li><strong>PR #100328</strong> fix(ios): own gateway setup deep-link delivery.</li>
+<li><strong>PR #100208</strong> fix(ui): mobile-optimize gateway dashboard login gate.</li>
+<li><strong>PR #100260</strong> fix(google): normalize Live function declarations.</li>
+<li><strong>PR #100261</strong> fix(voice-call): normalize mapped proxy addresses. Related #86525. Thanks @rohitjavvadi.</li>
+<li><strong>PR #100255</strong> fix(voice-call): auto-respond to webhook transcripts. Related #79118. Thanks @dvy.</li>
+<li><strong>PR #100264</strong> feat(ui): show context usage details.</li>
+<li><strong>PR #80642</strong> fix(whatsapp): bound reconnect catch-up replies. Thanks @VishalJ99.</li>
+<li><strong>PR #100283</strong> feat(ios): add Apple Watch voice turns. Related #100224.</li>
+<li><strong>PR #100209</strong> fix(models): resolve provider-qualified aliases. Related #75163. Thanks @sahilsatralkar and @david-r-jones.</li>
+<li><strong>PR #94879</strong> fix(whatsapp): preserve bot-authored quote replies. Related #91445. Thanks @Bartok9 and @seikosantana.</li>
+<li><strong>PR #100241</strong> fix(tui): run new sessions through lifecycle hooks. Related #49918. Thanks @caopulan and @LonExplorer-coder.</li>
+<li><strong>PR #99070</strong> fix(whatsapp): restore malformed credentials from backup. Thanks @LeonidasLux.</li>
+<li><strong>PR #91276</strong> fix(pre-commit): quote Python dependency range. Thanks @deepujain.</li>
+<li><strong>PR #96002</strong> fix(gateway): keep local CLI shared auth off device scopes. Related #95997. Thanks @vincentkoc.</li>
+<li><strong>PR #100318</strong> fix(ui): simplify grouped tool activity.</li>
+<li><strong>PR #100288</strong> feat: verify AI access during macOS onboarding before the first chat. Related #100286.</li>
+<li><strong>PR #83000</strong> fix(tui): render delta-only assistant streams. Related #82988. Thanks @flashosophy.</li>
+<li><strong>PR #88384</strong> fix(plugins): keep openclaw chunks native in jiti. Related #85057. Thanks @vincentkoc and @ScientificProgrammer.</li>
+<li><strong>PR #99928</strong> fix(outbound): report honest message delivery status. Thanks @masatohoshino.</li>
+<li><strong>PR #100346</strong> docs(changelog): record WhatsApp delivery fixes.</li>
+<li><strong>PR #100344</strong> fix(plugins): preserve jiti native module config.</li>
+<li><strong>PR #76235</strong> [codex] Fix doctor completion cache plugin loading.</li>
+<li><strong>PR #100317</strong> fix(pairing): advertise reachable Tailnet routes. Related #100280.</li>
+<li><strong>PR #100266</strong> fix(ui): clear session labels across subscribed clients.</li>
+<li><strong>PR #89619</strong> fix(agents): wrap bundle MCP schema setup errors. Thanks @vincentkoc.</li>
+<li><strong>PR #100356</strong> fix: remove sidebar usage quota. Thanks @shakkernerd.</li>
+<li><strong>PR #99690</strong> policy: repair automatic narrowing findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #76245</strong> [codex] Fallback when Windows gateway task exits early.</li>
+<li><strong>PR #91002</strong> fix(tui): surface safe tool-validation abort diagnostics. Related #90982. Thanks @wsyjh8 and @taerlandsen.</li>
+<li><strong>PR #100355</strong> test(ios): import pairing protocol model.</li>
+<li><strong>PR #100332</strong> fix(ci): bound hosted gate workflow pagination.</li>
+<li><strong>PR #100262</strong> feat(control-ui): session grouping with drag & drop and channel categorization.</li>
+<li><strong>PR #100372</strong> fix(ios): persist queued Watch replies. Thanks @NianJiuZst.</li>
+<li><strong>PR #100093</strong> Doctor: expose write-config blocker findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #100278</strong> fix(ci): catch native-only mobile protocol drift. Related #100198.</li>
+<li><strong>PR #99954</strong> feat(clickclack): publish durable agent activity rows (commentary + tool). Thanks @ragesaq.</li>
+<li><strong>PR #100370</strong> fix(ios): avoid inactive Voice Wake audio startup.</li>
+<li><strong>PR #100221</strong> fix(test): unit-fast tests inherit live host config.</li>
+<li><strong>PR #100340</strong> fix(tui): suppress unhandled rejection from editor submit handlers. Thanks @cxbAsDev.</li>
+<li><strong>PR #100105</strong> docs: tailor imsg skill for OpenClaw agents. Thanks @omarshahine.</li>
+<li><strong>PR #155</strong> docs: clarify personal vs private in README. Related #125. Thanks @mbelinky and @omarshahine and @olinorwell.</li>
+<li><strong>PR #100276</strong> feat(ui): scroll truncated sidebar session names on hover.</li>
+<li><strong>PR #100391</strong> fix(ui): reveal message context on timestamp hover. Thanks @steipete-oai.</li>
+<li><strong>PR #100379</strong> feat(ui): show provider costs in context popover.</li>
+<li><strong>PR #100398</strong> docs: explain remote Android screen mirroring. Related #100396.</li>
+<li><strong>PR #100019</strong> improve: keep isolated tests under one second. Related #100018.</li>
+<li><strong>PR #100399</strong> fix: land ten small reliability fixes. Related #98650. Thanks @cxbAsDev and @snotty and @lin-hongkuan and @849261680 and @qingminglong and @anyech and @masatohoshino and @Simon-XYDT and @xialonglee and @nankingjing and @609NFT.</li>
+<li><strong>PR #100207</strong> feat(chat-ui): syntax-highlighted code blocks and native tables in chat markdown.</li>
+<li><strong>PR #99930</strong> feat(logbook): automatic work journal plugin with Control UI timeline tab. Related #99867.</li>
+<li><strong>PR #99797</strong> fix(voice-call): resolve completed calls from the persisted store on status misses. Related #96586. Thanks @Darren2030 and @NiTeCoMM-code.</li>
+<li><strong>PR #100418</strong> fix(gateway): clarify URL override auth recovery. Thanks @gmays.</li>
+<li><strong>PR #93636</strong> fix(infra): tolerate deleted cwd across startup, PATH, home-dir, and TUI [AI-assisted]. Related #73676. Thanks @ml12580 and @oldsix-cell.</li>
+<li><strong>PR #100336</strong> fix(gateway): preserve non-text MCP content blocks through loopback normalizer. Related #100329. Thanks @tzy-17 and @OpenClawKobian99.</li>
+<li><strong>PR #96572</strong> fix(irc): chunk PRIVMSG on UTF-16 boundary to avoid lone surrogates. Thanks @WeeLi-009.</li>
+<li><strong>PR #100437</strong> fix(test): bound local full-suite RAM. Related #100429.</li>
+<li><strong>PR #100201</strong> chore(ios): add deterministic streaming replay test harness for the shared chat pipeline.</li>
+<li><strong>PR #100384</strong> feat(android): restore in-flight runs after reconnect.</li>
+<li><strong>PR #100277</strong> fix(ios): restore in-flight runs after reconnect.</li>
+<li><strong>PR #100337</strong> fix(agents): surface real plugin approval rejection reason to agent. Related #100212. Thanks @tzy-17 and @pallaoro.</li>
+<li><strong>PR #99572</strong> fix(ios): defer QR pairing after scanner dismissal. Related #99571. Thanks @PollyBot13.</li>
+<li><strong>PR #99304</strong> fix: surface terminal agent run failures. Thanks @moeedahmed.</li>
+<li><strong>PR #100295</strong> fix(ui): render direct tool-result image blocks inline in chat (#50779). Thanks @lzyyzznl and @Pandah97 and @rquinones84.</li>
+<li><strong>PR #100441</strong> docs(changelog): record five landed fixes.</li>
+<li><strong>PR #98699</strong> fix(cron): preserve delivery thread id type across SQLite round-trip. Thanks @yetval.</li>
+<li><strong>PR #100420</strong> test: stabilize load-sensitive test families that break gates under parallel load.</li>
+<li><strong>PR #96178</strong> fix(browser): resolve act targetId aliases before mismatch check. Related #96176. Thanks @ZengWen-DT and @don068589.</li>
+<li><strong>PR #86285</strong> fix(voice-call): avoid OpenAI realtime double greeting. Related #85846. Thanks @giodl73-repo and @jnikolaidis.</li>
+<li><strong>PR #100227</strong> feat(android): read-only offline cache for chat sessions and transcripts.</li>
+<li><strong>PR #100453</strong> Simplify Talk controls and move advanced defaults to Settings. Thanks @steipete-oai.</li>
+<li><strong>PR #100416</strong> feat(ios): haptic feedback for chat send, completion, and failure.</li>
+<li><strong>PR #100290</strong> feat(android): durable offline command outbox for chat sends.</li>
+<li><strong>PR #100107</strong> Preserve provider settings during onboarding updates. Thanks @frank-beans.</li>
+<li><strong>PR #100296</strong> feat(ui): declutter the Control UI sidebar with customizable pinned nav and a More section. Related #100287.</li>
+<li><strong>PR #100389</strong> fix: heartbeat survives transient filesystem read races. Related #99994. Thanks @ogarciarevett and @markr9805.</li>
+<li><strong>PR #100330</strong> fix(agents): prevent ReDoS in MCP glob-to-regex wildcard matching. Thanks @lsr911.</li>
+<li><strong>PR #90969</strong> [codex] fix discord missing voice state handling. Thanks @asock.</li>
+<li><strong>PR #99138</strong> fix(irc): long non-ASCII messages are silently truncated at the 512-byte line limit. Thanks @yetval.</li>
+<li><strong>PR #100417</strong> feat(ios): export chat transcripts as Markdown via the share sheet.</li>
+<li><strong>PR #100440</strong> fix: harden subprocess, maintenance, and output paths. Thanks @cxbAsDev and @wendy-chsy and @tzy-17 and @nankingjing and @NianJiuZst.</li>
+<li><strong>PR #100456</strong> fix(auto-reply): surface empty interactive completions. Related #99712. Thanks @mushuiyu886 and @grox2012.</li>
+<li><strong>PR #100464</strong> docs: credit empty-reply fix contributor.</li>
+<li><strong>PR #89175</strong> fix(realtime): filter malformed provider tool names. Thanks @vincentkoc.</li>
+<li><strong>PR #100459</strong> fix(ci): install release packaging dependencies. Thanks @vincentkoc.</li>
+<li><strong>PR #91519</strong> feat(qa-lab): add Codex Slack approval scenarios. Thanks @kevinslin.</li>
+<li><strong>PR #100446</strong> fix(imessage): plain-send fallback for threaded replies + db-scoped recovery cursor (#99638). Thanks @omarshahine and @brianbeals.</li>
+<li><strong>PR #100382</strong> fix(android): stabilize shell navigation layout. Thanks @IWhatsskill.</li>
+<li><strong>PR #98394</strong> fix: ignore stale approval resolve errors. Related #98392. Thanks @haruaiclone-droid.</li>
+<li><strong>PR #87530</strong> fix(discord): isolate voice connections and close auto-join race. Thanks @geekhuashan.</li>
+<li><strong>PR #100462</strong> fix(slack): prefer native status by default. Thanks @steipete-oai.</li>
+<li><strong>PR #100473</strong> docs(changelog): credit voice fixes.</li>
+<li><strong>PR #100469</strong> fix(release): package legacy candidates without AI workspace. Thanks @vincentkoc.</li>
+<li><strong>PR #100445</strong> feat(chat-ui): redesign composer bottom bar with split Talk control and reasoning-effort chip.</li>
+<li><strong>PR #100463</strong> fix(macos): reduce idle CPU wakeups. Related #100451.</li>
+<li><strong>PR #100432</strong> feat(ui): add comparative cost analysis. Related #100405.</li>
+<li><strong>PR #100484</strong> fix(codex): ignore missing mirrored session history. Thanks @vincentkoc and @litang9.</li>
+<li><strong>PR #88881</strong> fix(agents): trim media tools in lean mode. Thanks @vincentkoc.</li>
+<li><strong>PR #100488</strong> fix(macos): dashboard window keeps a dead SSH tunnel port after tunnel restart. Related #100476.</li>
+<li><strong>PR #100483</strong> fix: land ten small reliability fixes. Related #100423. Thanks @aniruddhaadak80 and @NianJiuZst and @morluto and @ZengWen-DT and @cxbAsDev and @zenglingbiao and @xialonglee and @jincheng-xydt and @Pandah97 and @versatagent.</li>
+<li><strong>PR #99450</strong> fix(openai): bound realtime voice websocket payload at 16 MiB. Thanks @sunlit-deng.</li>
+<li><strong>PR #100375</strong> fix(slack): react action rejects emoji glyphs; member-info userId affordance unclear. Thanks @gorkem2020.</li>
+<li><strong>PR #100448</strong> feat: publish plugins with extended-stable releases. Thanks @kevinslin.</li>
+<li><strong>PR #100466</strong> fix(ios): simplify development app name.</li>
+<li><strong>PR #100217</strong> feat(android): syntax-highlighted code blocks in chat.</li>
+<li><strong>PR #100495</strong> docs(changelog): stage remote browser reliability fix.</li>
+<li><strong>PR #100487</strong> fix(diffs): share SSR preloads and repair language-pack hydration.</li>
+<li><strong>PR #100497</strong> test(macos): remove stale Crestodian onboarding test. Thanks @steipete-oai.</li>
+<li><strong>PR #98143</strong> fix(agents): bound body-less MCP HTTP text responses. Related #97521. Thanks @Pick-cat and @wangmiao0668000666.</li>
+<li><strong>PR #100049</strong> fix(android): synchronize realtime tool completions. Thanks @qingminglong.</li>
+<li><strong>PR #80147</strong> fix(browser): time out remote tab enumeration. Related #58968. Thanks @HemantSudarshan and @KeaneYan.</li>
+<li><strong>PR #99555</strong> fix(gateway-protocol): trim connect error detail codes in readConnectErrorDetailCode. Thanks @ly85206559 and @cursoragent.</li>
+<li><strong>PR #100219</strong> feat(ios): read-only offline cache for chat sessions and transcripts.</li>
+<li><strong>PR #100499</strong> fix(build): make tsdown configs self-contained. Thanks @steipete-oai.</li>
+<li><strong>PR #100474</strong> refactor(auto-reply): harden empty reply delivery.</li>
+<li><strong>PR #87433</strong> [codex] Honor all ack scope for room events. Related #87368. Thanks @scoootscooob and @paul-phan.</li>
+<li><strong>PR #98284</strong> fix(browser): persist managed Chrome cookies across restarts. Related #96704. Thanks @TurboTheTurtle.</li>
+<li><strong>PR #99023</strong> fix: avoid English audio prompt for non-English STT hints. Related #98970. Thanks @NianJiuZst and @FlyVeryHigh.</li>
+<li><strong>PR #100507</strong> docs(changelog): note browser cookie persistence.</li>
+<li><strong>PR #100401</strong> fix(gateway): catch lazy import rejections in runtime event subscriptions. Thanks @cxbAsDev.</li>
+<li><strong>PR #80293</strong> fix: apply thread routing to plugin actions. Thanks @artdaal.</li>
+<li><strong>PR #99859</strong> fix(ios): reject loopback-prefix hosts for auth retry. Thanks @ly85206559.</li>
+<li><strong>PR #100386</strong> feat(ui): make the sidebar session-first and minimal.</li>
+<li><strong>PR #99593</strong> fix(skills): apply command description limits per channel. Thanks @Pick-cat.</li>
+<li><strong>PR #100517</strong> test(macos): deflake browser proxy gate tests via injectable browser control.</li>
+<li><strong>PR #100516</strong> fix(slack): avoid repeated thread root media. Related #99886. Thanks @redasadki.</li>
+<li><strong>PR #90450</strong> fix(agents): preserve streamed assistant text when Claude CLI result event is empty. Thanks @totobusnello.</li>
+<li><strong>PR #100467</strong> fix(channels): normalize phone identities with stray plus signs. Thanks @morluto.</li>
+<li><strong>PR #99961</strong> fix(bedrock): bound Mantle model discovery fetches. Thanks @zhangguiping-xydt.</li>
+<li><strong>PR #100454</strong> fix(android): harden offline cache lifecycle.</li>
+<li><strong>PR #100514</strong> fix(ui): preserve autonomous tool failures. Related #97849. Thanks @qingminglong and @yetval.</li>
+<li><strong>PR #100526</strong> fix(ui): align Skills filters. Related #99990. Thanks @evan-YM.</li>
+<li><strong>PR #99124</strong> fix #98107: Gateway regenerates service-env file on every restart, wiping Telegram bot tokens. Thanks @mushuiyu886 and @1Wanker.</li>
+<li><strong>PR #100528</strong> fix(ui): remove redundant file-preview Escape hint. Related #99027. Thanks @xianshishan.</li>
+<li><strong>PR #89416</strong> fix(browser): downloads complete over CDP connections. Related #48045. Thanks @zhangguiping-xydt and @roinou532.</li>
+<li><strong>PR #100532</strong> docs(changelog): note browser attachment downloads. Related #48045. Thanks @roinou532.</li>
+<li><strong>PR #100527</strong> fix(ui): bind stale run state to run identity. Related #88033. Thanks @tiffanychum and @davidstoll.</li>
+<li><strong>PR #94015</strong> fix(voice-call): deliver early TTS via onEarlyText before compaction wait. Related #79521. Thanks @xialonglee and @donkeykong91.</li>
+<li><strong>PR #99965</strong> fix(telegram): show typing for accepted topic messages. Thanks @moeedahmed.</li>
+<li><strong>PR #100533</strong> docs(changelog): credit Control UI fixes.</li>
+<li><strong>PR #100490</strong> fix(agents): preserve media side merges during prompt release.</li>
+<li><strong>PR #98868</strong> feat(ios): refresh onboarding setup flow. Thanks @thats2easyyy.</li>
+<li><strong>PR #96917</strong> fix(anthropic): keep OAuth callback on loopback. Related #96485. Thanks @xialonglee and @riazrahaman.</li>
+<li><strong>PR #100489</strong> fix(macos): orphaned SSH tunnels from crashed app instances keep running and squat the preferred local port. Related #100477.</li>
+<li><strong>PR #100479</strong> fix(control-ui): keep the dashboard mounted with a reconnect banner on gateway drops. Related #100475.</li>
+<li><strong>PR #98262</strong> [codex] Fail closed pair slash command routing. Related #98239. Thanks @brokemac79.</li>
+<li><strong>PR #99564</strong> fix(agents): prevent malformed HTML entities from breaking tool calls. Thanks @mikasa0818.</li>
+<li><strong>PR #100536</strong> fix(agents): skip tool prep for toolless models. Thanks @vincentkoc.</li>
+<li><strong>PR #100545</strong> docs(changelog): credit landed reliability fixes.</li>
+<li><strong>PR #100505</strong> fix(gateway): advertise exec approval node commands. Related #57775. Thanks @vincentkoc and @RTKOP.</li>
+<li><strong>PR #100512</strong> fix(ios): keep While Using selected after approval.</li>
+<li><strong>PR #100434</strong> feat(ui): preview GitHub issues and pull requests on hover. Related #100412.</li>
+<li><strong>PR #97733</strong> feat: add channel pairing request hook. Thanks @clawSean and @omarshahine.</li>
+<li><strong>PR #100482</strong> fix(ollama): fall back when native streams end early. Related #100460. Thanks @TurboTheTurtle and @8kfcf95jvp-oss.</li>
+<li><strong>PR #100555</strong> docs(changelog): add GitHub preview entry.</li>
+<li><strong>PR #100376</strong> fix(tlon): bound urbit scry JSON response reads. Thanks @hugenshen.</li>
+<li><strong>PR #100561</strong> docs(changelog): note Apple chat run recovery.</li>
+<li><strong>PR #100363</strong> fix(android): polish gateway settings layout. Thanks @IWhatsskill.</li>
+<li><strong>PR #100562</strong> docs(changelog): credit recent contributor fixes.</li>
+<li><strong>PR #100480</strong> feat(cron): declarative jobs with owner attribution and richer status.</li>
+<li><strong>PR #100551</strong> fix(android): preserve chat sends across reconnect recovery. Related #100197.</li>
+<li><strong>PR #100366</strong> improve(auto-reply): render chat history since last reply as per-message prose. Thanks @gorkem2020.</li>
+<li><strong>PR #93307</strong> fix(browser): notify agent when click triggers download. Related #93250. Thanks @sunlit-deng and @scorpiord.</li>
+<li><strong>PR #100560</strong> fix(agents): run bootstrap ritual on Claude CLI. Thanks @bill-starfoundry and @kruegerb and @vincentkoc.</li>
+<li><strong>PR #100575</strong> docs(changelog): note browser action downloads.</li>
+<li><strong>PR #100478</strong> feat(gateway): add system.info RPC and Gateway Host card in Settings. Related #100465.</li>
+<li><strong>PR #100374</strong> fix(tlon): bound external image upload reads. Thanks @hugenshen.</li>
+<li><strong>PR #100520</strong> feat: show auto-detected provider plans and billing. Related #100494.</li>
+<li><strong>PR #100442</strong> feat(commands): add /learn to draft skills from recent work. Related #100408.</li>
+<li><strong>PR #100481</strong> perf(agents): slim Skill Workshop prompt section to its routing contract. Related #100449.</li>
+<li><strong>PR #100498</strong> fix(skills): make Skill Workshop lifecycle approvals decidable and non-wedging. Related #91266, #93173, #94249. Thanks @EmpireCreator and @mmhzlrj and @mdpoirier-abbey.</li>
+<li><strong>PR #100586</strong> fix(gateway): commit runtime snapshot on noop config reloads. Thanks @obviyus.</li>
+<li><strong>PR #100468</strong> feat(goals): keep active session goals in per-turn context + continuance QA scenarios. Related #100409.</li>
+<li><strong>PR #99992</strong> fix(signal): bound receive websocket payloads. Thanks @sunlit-deng.</li>
+<li><strong>PR #100567</strong> fix(gateway): format usage dates in range timezone. Thanks @NianJiuZst and @vincentkoc.</li>
+<li><strong>PR #100593</strong> chore(maint): make the PR merge drift guard advisory by default.</li>
+<li><strong>PR #100531</strong> feat(ios): richer Settings About screen with mascot hero and project links.</li>
+<li><strong>PR #100331</strong> feat(ios): durable offline command outbox for chat sends.</li>
+<li><strong>PR #100535</strong> feat: automatic managed git worktrees for agent tasks (create, snapshot, restore, GC). Related #100534.</li>
+<li><strong>PR #93082</strong> fix(ui): show coalesced update restarts. Related #78481. Thanks @goutamadwant and @motacola.</li>
+<li><strong>PR #54758</strong> fix(ui): propagate connect errors to pending requests. Thanks @ruanrrn.</li>
+<li><strong>PR #100554</strong> fix(cli): reduce plugin hook fallback noise. Thanks @vincentkoc.</li>
+<li><strong>PR #99111</strong> fix: recover Control UI bundle loading after gateway restart. Related #99092. Thanks @ZengWen-DT and @ITOrity.</li>
+<li><strong>PR #93999</strong> fix(tui): show busy startup loader during post-connect initialization [AI-assisted]. Related #74385. Thanks @ml12580 and @sanjarcode.</li>
+<li><strong>PR #73338</strong> fix(tui): follow active gateway port. Related #42461. Thanks @haishmg and @vincentkoc and @jackm1688.</li>
+<li><strong>PR #99076</strong> feat(tencent): add Tencent Hy3 provider (TokenHub and TokenPlan). Related #99069. Thanks @MonCac and @hxy91819.</li>
+<li><strong>PR #100569</strong> fix(config): dedupe repeated validation warnings. Related #25574. Thanks @vincentkoc and @mcaxtr.</li>
+<li><strong>PR #100599</strong> docs(changelog): credit five Control UI and TUI fixes. Related #78481. Thanks @motacola.</li>
+<li><strong>PR #90552</strong> fix(sessions): persist sender metadata in user turn transcript JSONL. Related #90531. Thanks @Pick-cat and @Haderach-Ram.</li>
+<li><strong>PR #100591</strong> fix(config): compare size guard against canonical input. Related #71865. Thanks @vincentkoc and @balric-seo.</li>
+<li><strong>PR #100603</strong> docs: refresh generated docs map.</li>
+<li><strong>PR #100609</strong> docs(changelog): credit Vincent replay fixes.</li>
+<li><strong>PR #100275</strong> feat(macos): adopt the shared read-only chat transcript cache.</li>
+<li><strong>PR #100611</strong> test(plugins): register Workboard typed hook contract.</li>
+<li><strong>PR #95107</strong> feat(android): show cron job details. Thanks @Tosko4.</li>
+<li><strong>PR #100582</strong> fix(clickclack): reply to a top-level message in-channel, not as a new thread. Thanks @Marvinthebored and @vincentkoc.</li>
+<li><strong>PR #100492</strong> fix(anthropic): normalize tuple tool schemas for Opus 4.8. Related #98588. Thanks @lin-hongkuan and @vincentkoc and @brandencho.</li>
+<li><strong>PR #100612</strong> refactor(ui): consolidate sidebar navigation contract.</li>
+<li><strong>PR #100342</strong> fix(gmail-watcher): catch renewal interval errors. Thanks @cxbAsDev and @vincentkoc.</li>
+<li><strong>PR #100522</strong> fix(agents): suppress unhandled stdout/stderr stream errors in waitForChildProcess. Thanks @cxbAsDev and @vincentkoc.</li>
+<li><strong>PR #98669</strong> fix(sessions): log warning when parseJsonlEntries skips malformed JSONL lines. Thanks @cxbAsDev.</li>
+<li><strong>PR #99539</strong> fix(discord): prevent approval command previews from splitting emoji when truncated. Thanks @zhangguiping-xydt.</li>
+<li><strong>PR #99340</strong> fix(infra): enforce maxBytes in body-less HTTP error snippet path. Thanks @Pick-cat.</li>
+<li><strong>PR #99606</strong> improve(doctor): warn when cron jobs keep failing consecutive runs. Thanks @masatohoshino.</li>
+<li><strong>PR #99067</strong> fix: strengthen macOS SQLite WAL checkpoint durability. Related #99066. Thanks @ooiuuii.</li>
+<li><strong>PR #99420</strong> fix(infra): add NaN guard for unparseable timestamp in cost usage. Related #99413. Thanks @krissding and @sheyanmin.</li>
+<li><strong>PR #100618</strong> fix: replies fail when memory flush is exhausted. Related #85645. Thanks @Jerry-Xin and @rhclaw.</li>
+<li><strong>PR #99379</strong> fix: keep heredoc bodies out of exec summaries. Related #99367. Thanks @ZengWen-DT and @JoeArmani.</li>
+<li><strong>PR #100491</strong> fix(android): tighten Voice tab box sizing. Thanks @IWhatsskill.</li>
+<li><strong>PR #93184</strong> fix(ui): preserve live tool stream order. Related #92122. Thanks @Pick-cat and @lileilei-camera.</li>
+<li><strong>PR #100338</strong> fix(update-check): wrap malformed npm view JSON parse in try/catch. Thanks @cxbAsDev.</li>
+<li><strong>PR #95341</strong> fix(ui): show cron job model selection. Thanks @ly85206559.</li>
+<li><strong>PR #89772</strong> fix(webchat): keep context indicator visible with stale token data. Related #89662. Thanks @bladin and @snsczssl.</li>
+<li><strong>PR #99399</strong> fix(pdf): reject fractional page selections. Related #99393. Thanks @qingminglong.</li>
+<li><strong>PR #100621</strong> fix(agents): cap effective compaction reserve. Thanks @vincentkoc.</li>
+<li><strong>PR #100552</strong> fix(android): keep stale PTT from restarting capture. Thanks @xialonglee.</li>
+<li><strong>PR #100606</strong> fix(ui): stop repeating tool names in expanded activity.</li>
+<li><strong>PR #76386</strong> fix(install): trap SIGINT so Ctrl+C exits cleanly during upgrade doctor. Related #82304, #90011. Thanks @SebTardif.</li>
+<li><strong>PR #100347</strong> feat(android): reconnect gateway when validated network returns. Thanks @ly85206559 and @cursoragent.</li>
+<li><strong>PR #100654</strong> feat(skills): diagnose skill_workshop hidden by tool policy. Related #87570. Thanks @wangwllu.</li>
+<li><strong>PR #100120</strong> fix(agents): detect bundled and legacy providers in model-not-found hint. Related #100066. Thanks @SunnyShu0925 and @vincentkoc and @Jason-Vaughan.</li>
+<li><strong>PR #99484</strong> fix: remove Android camera clip release logs. Thanks @NianJiuZst.</li>
+<li><strong>PR #100646</strong> improve(ui): declutter the Cron Jobs page into compact scannable rows. Related #100633.</li>
+<li><strong>PR #100670</strong> fix(cli): align root command descriptions. Related #98978. Thanks @vincentkoc and @AmirF194.</li>
+<li><strong>PR #100667</strong> fix(gateway): avoid default provider auth startup prewarm. Related #86512, #86752. Thanks @vincentkoc and @mmhzlrj and @balaji1968-kingler.</li>
+<li><strong>PR #98840</strong> fix(voyage): close response body stream when batch output JSONL parsing throws. Thanks @solodmd.</li>
+<li><strong>PR #99089</strong> fix(message): thread --limit through to CLI formatter and surface provider pagination hints. Thanks @wm0018.</li>
+<li><strong>PR #98705</strong> fix(feishu): strip internal tool-trace banners from outbound text. Thanks @ZengWen-DT and @cursoragent.</li>
+<li><strong>PR #99136</strong> fix #97625: Qwen3:14b compaction fails with Already compacted. Thanks @mushuiyu886 and @pkoserowski.</li>
+<li><strong>PR #100502</strong> fix(ios): chat snaps back to bottom when scrolling to top via status-bar tap.</li>
+<li><strong>PR #100590</strong> fix(browser): diagnose empty WSL2 Chrome replies. Related #54669. Thanks @ZengWen-DT and @Owlock.</li>
+<li><strong>PR #100665</strong> fix(ui): reopen closed web terminals with a fresh screen.</li>
+<li><strong>PR #100663</strong> fix(maint): reuse recent hosted gates after rebase.</li>
+<li><strong>PR #98414</strong> fix: stop reconnecting on protocol mismatch. Related #98413. Thanks @haruaiclone-droid.</li>
+<li><strong>PR #100601</strong> refactor(macos): lock and unify PortGuardian tunnel record persistence so concurrent app instances cannot lose orphan records.</li>
+<li><strong>PR #100515</strong> fix(ios): unify Talk and Settings row typography on one branded detail row.</li>
+<li><strong>PR #100540</strong> feat(telegram): offer BotFather web app flow next to the chat flow in onboarding. Related #100538.</li>
+<li><strong>PR #100692</strong> feat(skills): suggest saving detected reusable workflows by default. Related #95477. Thanks @WangXuexin24.</li>
+<li><strong>PR #91262</strong> fix(build): fall back to tsx for build TypeScript scripts. Thanks @smoe-bot and @vincentkoc and @smoe.</li>
+<li><strong>PR #98381</strong> fix(memory-core): guard qmd mcporter JSON.parse against non-JSON stdout. Thanks @miorbnli.</li>
+<li><strong>PR #98073</strong> fix(signal): guard containerRestRequest JSON.parse against malformed responses. Thanks @lsr911.</li>
+<li><strong>PR #100519</strong> fix(hooks): suppress unhandled stdout/stderr stream errors in gmail watcher. Thanks @cxbAsDev.</li>
+<li><strong>PR #99874</strong> fix(android): block loopback canvas navigation. Thanks @ly85206559.</li>
+<li><strong>PR #100702</strong> docs(android): credit landed app improvements.</li>
+<li><strong>PR #100671</strong> Reuse Codex OAuth for OpenAI Realtime voice. Thanks @steipete-oai.</li>
+<li><strong>PR #100703</strong> fix(ci): restore gateway architecture and lint gates.</li>
+<li><strong>PR #97170</strong> Fix voice-call streaming provider resolution. Related #97738. Thanks @solavrc.</li>
+<li><strong>PR #100715</strong> fix(openai): route MP3 TTS through voice delivery. Related #80317. Thanks @HemantSudarshan and @vokasug.</li>
+<li><strong>PR #98721</strong> fix(agents): keep bounded exec output UTF-16 safe. Thanks @ZengWen-DT and @cursoragent.</li>
+<li><strong>PR #100655</strong> fix(agents): preserve completed post-tool replies. Related #80918. Thanks @LiuwqGit and @erkanisotec.</li>
+<li><strong>PR #100687</strong> refactor(infra): canonicalize session usage timestamps. Thanks @sheyanmin.</li>
+<li><strong>PR #99695</strong> fix(infra): include update timeout in managed-service handoff parent exit wait. Related #99666. Thanks @ZOOWH and @damienviaud14-sketch.</li>
+<li><strong>PR #98988</strong> fix(tools-manager): replace spawnSync extraction with safe extractArchive API. Thanks @LeonidasLux and @vincentkoc.</li>
+<li><strong>PR #100543</strong> fix(telegram): add missing "edit" retry context for editMessageTelegram. Thanks @lzw112.</li>
+<li><strong>PR #100697</strong> fix(tui): preserve balanced parentheses in markdown link URL extraction (#100661). Thanks @ZOOWH and @aniruddhaadak80.</li>
+<li><strong>PR #100521</strong> fix(secrets): suppress unhandled stdout/stderr stream errors in exec resolver. Thanks @cxbAsDev.</li>
+<li><strong>PR #100723</strong> test(release): match pinned Claude CLI setup. Thanks @vincentkoc.</li>
+<li><strong>PR #100579</strong> fix(openai): show current default model in missing-auth hint. Thanks @zhangguiping-xydt.</li>
+<li><strong>PR #100688</strong> fix(mistral): correct model id typo in usesReasoningEffort helper. Related #100664. Thanks @wm0018 and @aniruddhaadak80.</li>
+<li><strong>PR #99907</strong> fix: notify requester when sessions_send delivery later fails. Related #98415. Thanks @849261680 and @Alex-HeYuQing.</li>
+<li><strong>PR #98098</strong> fix(providers): bound successful OAuth and webhook responses. Thanks @lwy-2.</li>
+<li><strong>PR #100713</strong> fix(codex): return JSON-RPC codes for handler errors. Related #100693. Thanks @lin-hongkuan and @Encash7.</li>
+<li><strong>PR #99151</strong> fix(qa-lab): bound Telegram live transport JSON response reads. Thanks @hugenshen.</li>
+<li><strong>PR #99917</strong> fix(commands): guard shortenText against non-positive maxLen. Thanks @Super-Cabbage.</li>
+<li><strong>PR #100728</strong> fix(control-ui): preserve assistant download filenames. Related #96545. Thanks @umasik75-source.</li>
+<li><strong>PR #100737</strong> fix(channels): resolve source-only bundled entries. Thanks @steipete-oai.</li>
+<li><strong>PR #97782</strong> fix(feishu): bound Feishu API JSON response reads to prevent OOM. Thanks @Alix-007.</li>
+<li><strong>PR #100524</strong> fix(transcripts): handle read stream errors gracefully in TranscriptsStore. Thanks @cxbAsDev.</li>
+<li><strong>PR #98336</strong> fix(agents): include sender in duplicate-user-message dedup key. Related #98310. Thanks @SunnyShu0925 and @yetval.</li>
+<li><strong>PR #100573</strong> fix(telegram): dedupe visible assistant prompt context. Related #99117. Thanks @momothemage and @mooresoftware.</li>
+<li><strong>PR #84792</strong> Run memory flush before preflight compaction. Related #84695. Thanks @TurboTheTurtle and @bizzle12368239.</li>
+<li><strong>PR #100605</strong> fix(google): resolve thought_signature gate for Gemini latest aliases. Related #100566. Thanks @chenxiaoyu209 and @guarismo.</li>
+<li><strong>PR #100732</strong> fix(ios): harden Apple Watch pairing activation.</li>
+<li><strong>PR #98990</strong> fix(usage-bar): bound template file cache to prevent unbounded watche…. Related #98960. Thanks @chenyangjun-xy and @vincentkoc and @zhangLei99586.</li>
+<li><strong>PR #99842</strong> improve(health): surface dead-lettered delivery queue entries. Thanks @masatohoshino.</li>
+<li><strong>PR #99845</strong> fix: reject Telegram topic sessions_send targets before dispatch. Related #99835. Thanks @NianJiuZst and @qingminglong.</li>
+<li><strong>PR #99598</strong> improve(status): show why plugins are disabled in /status plugins. Thanks @masatohoshino.</li>
+<li><strong>PR #99577</strong> fix(discord): preserve text after oversized uploads. Related #99021. Thanks @lin-hongkuan and @NOVA-Openclaw.</li>
+<li><strong>PR #100731</strong> fix(link-understanding): honor global or largest model timeout for link fetches. Related #100660. Thanks @cxbAsDev and @aniruddhaadak80.</li>
+<li><strong>PR #99456</strong> fix(hooks): flag hook event names that no core trigger emits. Thanks @masatohoshino.</li>
+<li><strong>PR #99986</strong> fix(android): serialize PTT microphone ownership. Thanks @NianJiuZst.</li>
+<li><strong>PR #100758</strong> fix(channels): canonicalize bundled module boundaries. Thanks @steipete-oai.</li>
+<li><strong>PR #99488</strong> fix(mcp-grant): guard sessionKey.trim() against undefined input. Thanks @zhangLei99586.</li>
+<li><strong>PR #99873</strong> fix(android): accept boolean flag aliases in node invoke params. Thanks @ly85206559 and @cursoragent.</li>
+<li><strong>PR #100719</strong> fix(ui): show selected agent default model. Related #77440. Thanks @hyspacex and @jwong-art.</li>
+<li><strong>PR #100341</strong> fix(crestodian): catch rejection from async respond in sendChat. Thanks @cxbAsDev and @vincentkoc.</li>
+<li><strong>PR #100736</strong> feat(ui): redesign session goal into interactive composer pill with elapsed time and /goal edit. Related #100714.</li>
+<li><strong>PR #99602</strong> improve(cron): show consecutive failure count and last error in cron CLI output. Thanks @masatohoshino.</li>
+<li><strong>PR #99213</strong> fix #99163: harden large chat attachment parsing. Thanks @jincheng-xydt and @vincentkoc and @Taurus52.</li>
+<li><strong>PR #99267</strong> Surface config hot-reload watcher status in health. Thanks @masatohoshino and @vincentkoc.</li>
+<li><strong>PR #100576</strong> improve: skill auto-capture catches reactive corrections and routes them to existing skills. Thanks @vincentkoc.</li>
+<li><strong>PR #100725</strong> fix(ui): proxy canonical inbound media previews. Related #89591. Thanks @sweetcornna and @vergissberlin.</li>
+<li><strong>PR #98095</strong> fix(memory-wiki): strip fenced code and inline code before wikilink extraction. Related #97945. Thanks @zhangqueping and @vincentkoc and @Durambar.</li>
+<li><strong>PR #100727</strong> fix(ui): open embedded terminal before login gate.</li>
+<li><strong>PR #99196</strong> fix(plugins): discover config load.paths plugins when index has entries. Related #99185. Thanks @LeonidasLux and @vincentkoc and @OrcasClaw.</li>
+<li><strong>PR #100523</strong> fix(agents): suppress unhandled stdout/stderr stream errors in execDockerRaw. Thanks @cxbAsDev and @vincentkoc.</li>
+<li><strong>PR #100572</strong> fix(anthropic): Fable 5 skips context1m setup when enabled. Thanks @zhangguiping-xydt.</li>
+<li><strong>PR #100743</strong> fix(control-ui): restore staged media filenames.</li>
+<li><strong>PR #100619</strong> feat(browser): restore driver "extension" via a loopback Chrome extension relay (no remote-debugging prompt).</li>
+<li><strong>PR #100742</strong> improve(ui): pin sidebar nav above a scrollable session list.</li>
+<li><strong>PR #100740</strong> docs(changelog): credit Control UI fixes.</li>
+<li><strong>PR #100617</strong> fix(agents): keep missing error details out of auth health. Thanks @fengjikui.</li>
+<li><strong>PR #100755</strong> fix(errors): classify rate-limit errors before timeout in detectErrorKind. Thanks @Pick-cat.</li>
+<li><strong>PR #100570</strong> fix(telegram): extract canonical rich block text. Thanks @wangwllu.</li>
+<li><strong>PR #100781</strong> docs(changelog): add landed PR closeout entries.</li>
+<li><strong>PR #100607</strong> Record stale foreground final suppression in transcripts. Related #95490. Thanks @bek91.</li>
+<li><strong>PR #100788</strong> feat: start a new chat session in a managed worktree (web, iOS, Android).</li>
+<li><strong>PR #100650</strong> refactor: remove dead code and consolidate repeated paths. Thanks @vincentkoc.</li>
+<li><strong>PR #100684</strong> fix(compaction): annotate partial summaries with chunk order and source time range. Related #100636. Thanks @zw-xysk and @vincentkoc and @aniruddhaadak80.</li>
+<li><strong>PR #100780</strong> fix(tui): harden OSC8 URL boundaries.</li>
+<li><strong>PR #100757</strong> fix(update): guard Windows task autostart during package updates. Related #87993. Thanks @vincentkoc and @Ccccc-del.</li>
+<li><strong>PR #100762</strong> fix(telegram): add missing 'action' retry context for sendChatAction. Thanks @lzw112 and @vincentkoc.</li>
+<li><strong>PR #90063</strong> fix(channels): clarify message receipt delivery evidence. Thanks @pdurlej.</li>
+<li><strong>PR #99045</strong> fix(config): return empty string for undefined in safeStringify. Thanks @lzyyzznl.</li>
+<li><strong>PR #100779</strong> fix(google): image generation unavailable when google provider set via config apiKey + custom baseUrl. Thanks @amknight.</li>
+<li><strong>PR #100745</strong> fix(openai): image generation unavailable when openai provider set via config apiKey + custom baseUrl. Thanks @amknight.</li>
+<li><strong>PR #100805</strong> fix(android): add missing new_chat_in_worktree locale strings. Thanks @amknight.</li>
+<li><strong>PR #94732</strong> fix(memory): add batch completed log after embedding batch finishes. Thanks @xydt-tanshanshan and @vincentkoc.</li>
+<li><strong>PR #100793</strong> fix(ci): repair managed worktree follow-up gates.</li>
+<li><strong>PR #100804</strong> fix(protocol): export managed worktree session result types.</li>
+<li><strong>PR #100823</strong> refactor: remove proven dead code across runtime surfaces. Thanks @vincentkoc.</li>
+<li><strong>PR #100774</strong> feat(ios): model picker favorites and recents with working iOS model switching.</li>
+<li><strong>PR #100735</strong> fix: silence heartbeat notify=false fallback replies. Related #80569. Thanks @Hackerismydream and @vincentkoc and @BrianInAz.</li>
+<li><strong>PR #100792</strong> fix(browser): close peer-owned tabs on session reset. Thanks @FMLS.</li>
+<li><strong>PR #99091</strong> fix: unblock replies after multi-agent room reset. Related #99082. Thanks @ZengWen-DT and @gorkem2020.</li>
+<li><strong>PR #100686</strong> fix(agents): Anthropic-compatible streams hang on oversized partial responses. Thanks @zhangguiping-xydt.</li>
+<li><strong>PR #100017</strong> fix: normalise wiki lint targets. Related #73574. Thanks @ishangodawatta and @K-Kerrigan.</li>
+<li><strong>PR #100694</strong> fix(agents): MiniMax VLM can consume oversized success responses. Thanks @zhangguiping-xydt.</li>
+<li><strong>PR #100672</strong> feat: add Anthropic and OpenAI cost history. Related #100608.</li>
+<li><strong>PR #100829</strong> feat(ios): render LaTeX display math in chat via SwiftMath.</li>
+<li><strong>PR #100786</strong> fix(android): finish PTT relay handoff safely.</li>
+<li><strong>PR #98704</strong> feat: correlate native search outcomes in audit history. Related #98521.</li>
+<li><strong>PR #100810</strong> feat(ui): add configurable chat send shortcut. Related #8147. Thanks @vincentkoc and @moomx.</li>
+<li><strong>PR #100826</strong> fix(android): hide internal chat history rows. Related #87918. Thanks @Iman-Sharif.</li>
+<li><strong>PR #100856</strong> refactor(core): remove stale internal exports. Related #100854. Thanks @vincentkoc.</li>
+<li><strong>PR #100857</strong> fix(browser): foreground tabs before screenshots. Thanks @spencer2211.</li>
+<li><strong>PR #100867</strong> fix(macos): preserve launchd Node gateway in PortGuardian. Related #94476. Thanks @vincentkoc and @lsr911 and @alexph-dev.</li>
+<li><strong>PR #100842</strong> fix(macos): keep node invokes responsive during system.run. Related #89423. Thanks @vincentkoc and @Lvan185.</li>
+<li><strong>PR #99335</strong> improve: reduce repeated session startup scans. Thanks @momothemage.</li>
+<li><strong>PR #100834</strong> fix(heartbeat): catch delivery errors in maybeSendHeartbeatOk to prevent side-effect replays. Thanks @machine3at and @vincentkoc.</li>
+<li><strong>PR #90867</strong> fix(auto-reply): warn when /export-session only contains user messages (backend-delegated). Related #90844. Thanks @xydigit-sj and @vincentkoc and @Tank-x3.</li>
+<li><strong>PR #100879</strong> feat(android): add chat message actions. Related #57754. Thanks @bdhwan.</li>
+<li><strong>PR #100616</strong> fix(diagnostics-otel): route OTLP exports through env proxy. Thanks @jesse-merhi.</li>
+<li><strong>PR #100882</strong> refactor: remove unused internal exports. Related #100880. Thanks @vincentkoc.</li>
+<li><strong>PR #100799</strong> fix(irc): monitor stays disconnected after IRC socket closes. Thanks @zhangguiping-xydt.</li>
+<li><strong>PR #100888</strong> fix(android): open system notifications on tap. Related #96350. Thanks @edwardrmiller.</li>
+<li><strong>PR #77904</strong> fix(cli): exit after model inspection output. Thanks @dorukardahan and @vincentkoc.</li>
+<li><strong>PR #100828</strong> fix(reply): dedupe duplicate non-streaming final replies. Related #84623. Thanks @vincentkoc and @zhangxiaojiujiayi.</li>
+<li><strong>PR #100883</strong> fix(feishu): send card JSON message params as cards. Related #53486. Thanks @vincentkoc and @martingarramon and @ZenoRewn.</li>
+<li><strong>PR #100887</strong> chore(cli): cover HF local app flow. Thanks @osolmaz.</li>
+<li><strong>PR #100814</strong> feat(sessions): grouping, unread state, and full session controls on web, iOS, and Android. Related #100739.</li>
+<li><strong>PR #100789</strong> feat(ui): show background tasks live in the web Control UI. Related #100706.</li>
+<li><strong>PR #100832</strong> fix(agents): preserve blank lines in multi-question user input fallback parsing. Thanks @machine3at.</li>
+<li><strong>PR #100909</strong> refactor(agents): localize internal-only symbols. Thanks @vincentkoc.</li>
+<li><strong>PR #100801</strong> fix(cron): accept null fallbacks in update patch payload (#100707). Thanks @SunnyShu0925 and @yoyo837.</li>
+<li><strong>PR #100903</strong> fix(tests): restore shared-kit test module compilation after NSNull coalesce.</li>
+<li><strong>PR #100836</strong> fix(cron): use direct lookup instead of paginated search in cron edit. Thanks @machine3at and @vincentkoc.</li>
+<li><strong>PR #100898</strong> feat(android): tap-to-expand link previews in chat transcript.</li>
+<li><strong>PR #100904</strong> fix(memory): fall back to wiki for missing all-corpus reads. Thanks @mushuiyu886 and @vincentkoc.</li>
+<li><strong>PR #100897</strong> test: align shifted main assertions. Thanks @vincentkoc.</li>
+<li><strong>PR #100931</strong> refactor(ui): localize internal-only symbols. Related #100930. Thanks @vincentkoc.</li>
+<li><strong>PR #100950</strong> fix(test): preflight targeted UI e2e. Thanks @vincentkoc.</li>
+<li><strong>PR #62682</strong> fix(agents): distinguish terminal aborts from retryable failures (#60388). Thanks @simonusa and @altaywtf and @cinapbot.</li>
+<li><strong>PR #87085</strong> fix(gateway): stop chat timeout fallback cascade. Related #83962. Thanks @BunsDev and @altaywtf and @castorle7-rgb.</li>
+<li><strong>PR #100884</strong> feat(ios): word-paced fade-in for streaming assistant prose.</li>
+<li><strong>PR #100798</strong> feat(android): in-chat model picker with favorites and recents.</li>
+<li><strong>PR #89086</strong> fix(browser): preserve HTTP status in node-proxied browser errors. Thanks @rhclaw.</li>
+<li><strong>PR #100961</strong> chore(swabble): stop tracking Package.resolved clobbered by Xcode resolution.</li>
+<li><strong>PR #100875</strong> feat(ios): hide the thinking-level control for models without reasoning support.</li>
+<li><strong>PR #100744</strong> fix(agents): avoid shell snapshot stdout pipe failures. Thanks @lsr911 and @vincentkoc.</li>
+<li><strong>PR #100754</strong> feat(control-ui): multi-pane split view for chat. Related #100690.</li>
+<li><strong>PR #100952</strong> refactor(ui): trim unused type surface. Related #100951. Thanks @vincentkoc.</li>
+<li><strong>PR #100927</strong> fix(ui): keep sidebar session order stable. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #100959</strong> fix(android): finish onboarding after permission reapproval. Related #100949.</li>
+<li><strong>PR #99607</strong> fix: keep Bedrock live smoke on Bedrock runtime. Related #87876. Thanks @brian-bell and @Haderach-Ram.</li>
+<li><strong>PR #76922</strong> fix(cli): exit after hooks inspection output. Thanks @dorukardahan.</li>
+<li><strong>PR #90038</strong> fix(discord): surface failed bulk reaction removals instead of false success. Thanks @masatohoshino.</li>
+<li><strong>PR #100850</strong> fix(cli): handle stdout/stderr stream errors in execFileUtf8Tail. Thanks @cxbAsDev and @vincentkoc.</li>
+<li><strong>PR #98821</strong> fix(gateway): dedupe MCP schema conflict warnings. Thanks @harjothkhara.</li>
+<li><strong>PR #100967</strong> feat(android): support opt-in background location. Related #68581. Thanks @ioridev and @jkobject.</li>
+<li><strong>PR #100975</strong> refactor(telegram): localize private implementation types. Thanks @vincentkoc.</li>
+<li><strong>PR #100648</strong> feat(ui): stable session order, palette-only search, and macOS titlebar brand for the sidebar.</li>
+<li><strong>PR #100738</strong> feat(gateway): read-only agents.workspace list/get browsing RPCs.</li>
+<li><strong>PR #93827</strong> fix(gateway): hot-reload browser profile config. Related #43803. Thanks @goutamadwant and @piston4711.</li>
+<li><strong>PR #100558</strong> fix(acp): catch unhandled rejection from handleGatewayEvent in event callback. Thanks @ajwan8998.</li>
+<li><strong>PR #100981</strong> fix: keep newly created sidebar sessions visible after switching chats. Thanks @shakkernerd.</li>
+<li><strong>PR #100803</strong> fix: keep /steer working for active runs. Related #100796. Thanks @Hackerismydream and @najef1979-code.</li>
+<li><strong>PR #96401</strong> fix(discord): keep default account online when adding named accounts. Related #92985. Thanks @849261680 and @tinny-w.</li>
+<li><strong>PR #100753</strong> feat(diffs): changed-files summary nav for multi-file patch diffs. Related #100673.</li>
+<li><strong>PR #100989</strong> refactor(workboard): localize private store types. Thanks @vincentkoc.</li>
+<li><strong>PR #100656</strong> feat(crestodian): AI-only conversation with model-judged approvals. Related #100604.</li>
+<li><strong>PR #100855</strong> fix(ssh-tunnel): ignore stderr stream errors during teardown. Thanks @cxbAsDev and @vincentkoc.</li>
+<li><strong>PR #100846</strong> fix(cron): do not set delivery mode to announce when disabling best-effort on payload edits. Thanks @machine3at.</li>
+<li><strong>PR #100849</strong> fix(node-host): handle stdout/stderr stream errors in runCommand. Thanks @cxbAsDev.</li>
+<li><strong>PR #100985</strong> fix(android): keep chat model selection synchronized.</li>
+<li><strong>PR #100868</strong> fix(telegram): pass proxy and apiRoot config when resolving runtime target usernames. Thanks @machine3at.</li>
+<li><strong>PR #97803</strong> fix(runtime): throw typed ExitError instead of generic Error for simulated exit (#97796). Thanks @maweibin and @aniruddhaadak80.</li>
+<li><strong>PR #100831</strong> fix(openai): strip status from replayed input items for custom openai-responses endpoints. Related #100657. Thanks @chenxiaoyu209 and @zpvel.</li>
+<li><strong>PR #100861</strong> fix(auto-reply): handle stderr stream errors in sandbox media scpFile. Thanks @cxbAsDev.</li>
+<li><strong>PR #100863</strong> fix(telegram): stop local listener and bot on retry loop non-recoverable error. Thanks @machine3at.</li>
+<li><strong>PR #99998</strong> fix(discord): bound gateway websocket payloads. Thanks @sunlit-deng.</li>
+<li><strong>PR #99985</strong> fix(sessions): exclude done sessions from transcript freshness rollover guard. Related #99964. Thanks @SunnyShu0925 and @5R7W9.</li>
+<li><strong>PR #100910</strong> fix(agents): retry transient filesystem races when reading workspace bootstrap files. Thanks @masatohoshino and @vincentkoc.</li>
+<li><strong>PR #100900</strong> fix(memory-wiki): bridge status crashes on malformed memory-plugin artifacts and ignores readMemoryArtifacts=false. Related #100899. Thanks @huveewomg.</li>
+<li><strong>PR #100776</strong> feat(android): read-only workspace Files browser with preview and share.</li>
+<li><strong>PR #100995</strong> fix(ui): move Worktrees page from the sidebar into Settings navigation.</li>
+<li><strong>PR #100768</strong> feat(ios): per-gateway custom headers for gateways behind authenticating proxies.</li>
+<li><strong>PR #90503</strong> fix(sessions): sweep orphan store temp files. Related #89520. Thanks @sahibzada-allahyar and @gideonblaauw-creator.</li>
+<li><strong>PR #100976</strong> fix: device pairing floods stacked approval alerts for a retrying device and stale approvals no-op. Related #100974.</li>
+<li><strong>PR #100902</strong> fix(memory-wiki): shared search crashes with "search is not a function" when the memory plugin lacks a full search manager. Related #100901. Thanks @huveewomg.</li>
+<li><strong>PR #99707</strong> refactor(qa): add canonical live channel adapters. Related #99699. Thanks @RomneyDa.</li>
+<li><strong>PR #99768</strong> refactor: consolidate byte-size formatting. Thanks @RomneyDa.</li>
+<li><strong>PR #98184</strong> feat(doctor): warn when cron delivery targets inactive channel. Thanks @masatohoshino and @vincentkoc.</li>
+<li><strong>PR #100679</strong> feat(ui): clickable file links in chat with a workspace file viewer sidebar. Related #100615.</li>
+<li><strong>PR #100767</strong> feat(ios): read-only workspace Files browser on the Agents surface.</li>
+<li><strong>PR #92167</strong> fix(media): recognize .m2a files as audio. Related #23014. Thanks @llljjjwww333 and @mayonaissse.</li>
+<li><strong>PR #100765</strong> feat(android): per-gateway custom headers for gateways behind authenticating proxies.</li>
+<li><strong>PR #101013</strong> refactor(ui): localize view prop types. Related #101011. Thanks @vincentkoc.</li>
+<li><strong>PR #87937</strong> fix(browser): read Windows Chrome version from build dir in doctor. Related #87312. Thanks @MukundaKatta and @gaodaabao.</li>
+<li><strong>PR #97665</strong> fix(control-ui): WebSocket connects to wrong gateway when two share an origin. Related #97636. Thanks @Alix-007 and @fernandol-nvidia.</li>
+<li><strong>PR #100722</strong> fix(codex): honor timeoutSeconds for dynamic tool calls when timeoutMs is absent. Related #98864. Thanks @cxbAsDev and @carterstebbins23-spec.</li>
+<li><strong>PR #100942</strong> fix(ios): keep offline chat sends on their original route.</li>
+<li><strong>PR #100784</strong> fix(discord): limit implicit reply fanout. Related #99068. Thanks @qingminglong and @revision-co-ltd.</li>
+<li><strong>PR #99700</strong> policy: repair required deny tool findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #100691</strong> fix(acp): close shared state database on gateway shutdown (#100637). Thanks @LZY3538 and @amknight and @aniruddhaadak80.</li>
+<li><strong>PR #97587</strong> fix(google): bound OAuth project and token JSON response reads. Thanks @hugenshen.</li>
+<li><strong>PR #99169</strong> fix(qa-channel): bound QA bus JSON response reads. Thanks @hugenshen.</li>
+<li><strong>PR #100501</strong> feat(providers): add LongCat API support. Related #100485. Thanks @vincentkoc.</li>
+<li><strong>PR #97579</strong> fix(plugin-sdk): bound Copilot token exchange JSON response reads. Thanks @hugenshen.</li>
+<li><strong>PR #100994</strong> feat(android): richer Settings About screen with mascot hero and project links.</li>
+<li><strong>PR #101027</strong> fix(cron): keep implicit announcements when disabling best-effort.</li>
+<li><strong>PR #101043</strong> fix: carry 2026.7.1 stability repairs into main. Thanks @vincentkoc.</li>
+<li><strong>PR #100770</strong> feat(gateway): add tts.speak method returning synthesized audio inline.</li>
+<li><strong>PR #100990</strong> refactor(plugins): require initialized registry collections. Thanks @RomneyDa.</li>
+<li><strong>PR #100304</strong> style(android): apply ktlint to landed changes.</li>
+<li><strong>PR #100992</strong> refactor(test): consolidate script declaration contracts. Thanks @RomneyDa.</li>
+<li><strong>PR #100750</strong> fix(lmstudio): respect embedding preload context limits. Related #97016. Thanks @zak-li and @ZOOWH and @hxz398.</li>
+<li><strong>PR #101041</strong> refactor(packages): localize internal helper types. Related #101040. Thanks @vincentkoc.</li>
+<li><strong>PR #100966</strong> fix(android): stabilize chat refresh loading. Thanks @Solvely-Colin.</li>
+<li><strong>PR #100943</strong> improve(ui): sessions page fits on one screen with per-session overrides in a row drawer.</li>
+<li><strong>PR #100993</strong> fix(android): clarify SMS command authorization. Related #91781. Thanks @narcissus0702.</li>
+<li><strong>PR #101038</strong> fix(ui): move sidebar collapse toggle from the topbar into the sidebar footer.</li>
+<li><strong>PR #100741</strong> fix(crestodian): suppress unhandled stdout/stderr stream errors in probeLocalCommand. Thanks @lsr911.</li>
+<li><strong>PR #96503</strong> fix(openai): stop double-prefixing SSE bodies mislabeled as JSON. Related #96497. Thanks @ZengWen-DT and @54meteor.</li>
+<li><strong>PR #100833</strong> fix(auth): preserve copied auth profile order. Thanks @machine3at.</li>
+<li><strong>PR #100891</strong> fix(feishu): avoid mention forwarding when bot open id is unavailable. Thanks @zhangguiping-xydt.</li>
+<li><strong>PR #98165</strong> fix(agents): preserve overload wording for rate-limited responses. Thanks @SunnyShu0925.</li>
+<li><strong>PR #91907</strong> fix(test): skip live auth browser caches. Related #91893. Thanks @BryanTegomoh and @pikaqqqqqq.</li>
+<li><strong>PR #99125</strong> fix(msteams): bound Bot Framework attachmentInfo JSON response reads. Thanks @ly85206559.</li>
+<li><strong>PR #99711</strong> fix(discord): send fresh final messages after previews. Related #99662. Thanks @davelutztx and @xena68.</li>
+<li><strong>PR #96557</strong> fix(cli): explain inherited config defaults cannot be unset. Thanks @moeghashim.</li>
+<li><strong>PR #93389</strong> fix(memory-core): keep daily ingestion outside session repair. Thanks @Alix-007 and @vincentkoc.</li>
+<li><strong>PR #100996</strong> fix(line): surface partial delivery when rich or media send fails alongside text. Thanks @masatohoshino.</li>
+<li><strong>PR #100771</strong> feat(ios): add Listen action speaking assistant messages via gateway TTS.</li>
+<li><strong>PR #101007</strong> fix(agents): bound tool_search_code stderr accumulation. Thanks @hugenshen and @vincentkoc.</li>
+<li><strong>PR #101100</strong> feat(ui): select microphones from the Talk control. Related #101046.</li>
+<li><strong>PR #101088</strong> fix(discord): handle ffmpeg stderr stream errors in voice playback. Thanks @masatohoshino.</li>
+<li><strong>PR #101029</strong> fix(cli): keep UTF-8 log tails valid. Thanks @ly85206559.</li>
+<li><strong>PR #101063</strong> refactor(qa): move restart and policy scenarios to YAML. Thanks @RomneyDa.</li>
+<li><strong>PR #101081</strong> fix(android): restore lint validation. Thanks @vincentkoc.</li>
+<li><strong>PR #101109</strong> fix(gateway): keep N-1 nodes manageable during upgrades. Related #83736. Thanks @jtczville.</li>
+<li><strong>PR #101085</strong> fix(infra): wrap sha256File stream errors with context instead of leaking raw rejects. Thanks @cxbAsDev and @vincentkoc.</li>
+<li><strong>PR #100986</strong> fix(browser): navigate works with CDP hostname allowlist. Related #100819. Thanks @NianJiuZst and @SarinV.</li>
+<li><strong>PR #98922</strong> [codex] Allow reply_payload_sending to add portable buttons. Thanks @goldmar.</li>
+<li><strong>PR #101080</strong> refactor(qa): canonicalize channel command scenarios. Related #101015. Thanks @RomneyDa.</li>
+<li><strong>PR #94736</strong> fix(discord): use configured statusReactions.timing instead of DEFAULT_TIMING. Related #78431. Thanks @LiuwqGit and @cedricjanssens.</li>
+<li><strong>PR #101128</strong> docs(changelog): credit small bugfix batch.</li>
+<li><strong>PR #100948</strong> feat(ios): pair multiple gateways and switch between them without re-pairing.</li>
+<li><strong>PR #100772</strong> feat(android): add Listen action speaking assistant messages via gateway TTS.</li>
+<li><strong>PR #100973</strong> Let owner-operated Codex agents use connected account apps. Thanks @pash-openai.</li>
+<li><strong>PR #101123</strong> improve(ui): sidebar rail polish; hide Workboard nav while the plugin is disabled.</li>
+<li><strong>PR #99791</strong> fix(media-understanding): video auto-selection runs without a model. Thanks @zhangguiping-xydt and @vincentkoc.</li>
+<li><strong>PR #101135</strong> refactor(ui): localize internal type exports. Thanks @vincentkoc.</li>
+<li><strong>PR #100889</strong> fix(browser): bound client fetch success JSON reads. Thanks @mushuiyu886.</li>
+<li><strong>PR #90365</strong> test(browser): replace broad win32 skip with dynamic directory symlink check. Thanks @aniruddhaadak80.</li>
+<li><strong>PR #101158</strong> fix(agents): handle find subprocess stream failures. Thanks @cxbAsDev.</li>
+<li><strong>PR #101132</strong> feat(macos): load provider catalog during AI onboarding. Related #101019.</li>
+<li><strong>PR #101051</strong> chore: add provider and scheduler runtime evidence. Related #101010. Thanks @RomneyDa.</li>
+<li><strong>PR #101045</strong> chore(docker): execute Compose and package artifact proofs. Related #101039. Thanks @RomneyDa.</li>
+<li><strong>PR #100964</strong> feat(gateway): let write-scope operators manage chat session organization.</li>
+<li><strong>PR #101170</strong> fix(android): prevent native notification cross-session replies. Related #48516. Thanks @dyoung522.</li>
+<li><strong>PR #101184</strong> Revert "fix(qa): keep smoke profile on one channel". Thanks @RomneyDa.</li>
+<li><strong>PR #101185</strong> ci: temporarily disable QA smoke. Thanks @RomneyDa.</li>
+<li><strong>PR #101178</strong> chore(scripts): add debt ratchet to the session-accessor boundary guard. Thanks @jalehman.</li>
+<li><strong>PR #101008</strong> fix(device-pair): mobile pairing rejects local IPv6 cleartext URLs. Thanks @zhangguiping-xydt.</li>
+<li><strong>PR #101160</strong> fix(infra): contain SSH config probe stream failures. Thanks @cxbAsDev.</li>
+<li><strong>PR #101124</strong> fix(discord): terminate ffmpeg on stream errors.</li>
+<li><strong>PR #101032</strong> fix(agents): handle stdin stream errors in docker sandbox execution. Thanks @cxbAsDev.</li>
+<li><strong>PR #101014</strong> fix(agents): handle ripgrep stdout/stderr stream errors in grep tool. Thanks @cxbAsDev.</li>
+<li><strong>PR #101044</strong> fix(acp): preserve runtime option clears. Thanks @mushuiyu886.</li>
+<li><strong>PR #98861</strong> fix(browser): guard readFields JSON.parse against malformed CLI input. Thanks @lsr911.</li>
+<li><strong>PR #101196</strong> ci: keep native landing validation off queued Blacksmith capacity.</li>
+<li><strong>PR #101171</strong> fix(browser): keep CDP discovery on the configured host.</li>
+<li><strong>PR #100461</strong> feat(ui): redesign chat composer controls. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #97038</strong> fix(edit): show candidate lines with similarity scores on oldText match failure. Related #97032. Thanks @ZOOWH and @vincentkoc and @aocogoal-gethub.</li>
+<li><strong>PR #98617</strong> fix(device-pair): remove INADDR_ANY and IPv6 unspecified from isLoopbackHost. Thanks @crh-code.</li>
+<li><strong>PR #101192</strong> fix: prevent context-engine wedges after session rotation.</li>
+<li><strong>PR #101115</strong> fix(tlon): bound Memex upload JSON response read. Thanks @cxbAsDev.</li>
+<li><strong>PR #101079</strong> fix(extensions/huggingface): bound model discovery JSON response read to prevent OOM. Thanks @cxbAsDev.</li>
+<li><strong>PR #101176</strong> fix(clawhub): bound archive download bodies.</li>
+<li><strong>PR #90749</strong> Fix realtime voice-call barge-in cancellation. Thanks @moellenbeck.</li>
+<li><strong>PR #100947</strong> feat(android): pair multiple gateways and switch between them without re-pairing.</li>
+<li><strong>PR #98682</strong> fix(discord): bound gateway metadata response body reads to prevent OOM. Thanks @wings1029.</li>
+<li><strong>PR #101036</strong> fix: sanitize streamed assistant payload text. Thanks @velanir-ai-manager.</li>
+<li><strong>PR #101183</strong> feat(ios): context-window usage indicator in the chat composer.</li>
+<li><strong>PR #96183</strong> fix(discord): download attachments at receipt time, not after the run queue. Related #96165. Thanks @ZacharyYW and @judsonnudson.</li>
+<li><strong>PR #101198</strong> feat(ios): tap-to-expand link previews in chat transcript.</li>
+<li><strong>PR #101193</strong> feat(android): record and send voice notes from the chat composer.</li>
+<li><strong>PR #100896</strong> fix(discord): messages sent during gateway reconnect are silently dropped. Related #56610. Thanks @tiffanychum and @Godecule.</li>
+<li><strong>PR #101181</strong> fix(agents): preserve preflight overflow token counts into recovery budgeting. Thanks @jalehman.</li>
+<li><strong>PR #101102</strong> feat(android): server-backed session search with offline fallback.</li>
+<li><strong>PR #98254</strong> feat(models): add Claude Sonnet 5 support. Thanks @vortexopenclaw.</li>
+<li><strong>PR #101206</strong> fix: npm upgrade install fails with InstalledDistScanLimitError as packaged dist grows.</li>
+<li><strong>PR #101213</strong> fix(windows): repair legacy gateway fallback updates. Related #87156. Thanks @vincentkoc and @igormf.</li>
+<li><strong>PR #100946</strong> feat(ios): record and send voice notes from the chat composer.</li>
+<li><strong>PR #101092</strong> feat(provider): add Featherless AI integration. Related #101065. Thanks @vincentkoc.</li>
+<li><strong>PR #99479</strong> fix(openai): bound Codex OAuth token response body reads with readResponseWithLimit. Thanks @Pandah97.</li>
+<li><strong>PR #99884</strong> fix(web-shared): bound response.text() fallback to honor maxBytes. Thanks @zenglingbiao.</li>
+<li><strong>PR #101091</strong> test: execute media and Talk runtime boundaries. Related #101074. Thanks @RomneyDa.</li>
+<li><strong>PR #101169</strong> fix(control-ui): make long /btw side results scrollable. Thanks @SnoutFirst.</li>
+<li><strong>PR #101053</strong> feat(apple): session search, archived browsing, and sheet management actions.</li>
+<li><strong>PR #101218</strong> fix(macos): keep onboarding green across gateway plugin restart.</li>
+<li><strong>PR #101223</strong> fix(ci): stabilize Windows startup fallback tests.</li>
+<li><strong>PR #101212</strong> feat(android): publish signed APKs with stable releases. Related #9443. Thanks @AstridQing-AI.</li>
+<li><strong>PR #101219</strong> fix(gateway): don't over-claim a crash on a 1006 abnormal close. Thanks @Darren2030 and @vincentkoc.</li>
+<li><strong>PR #96157</strong> fix(memory-core): clamp widen-fallback kNN k to sqlite-vec 4096 limit. Thanks @itsuzef and @vincentkoc.</li>
+<li><strong>PR #101117</strong> feat(ui): rename, delete, and toggle sidebar session groups. Related #101116.</li>
+<li><strong>PR #101232</strong> chore(i18n): refresh native source inventory.</li>
+<li><strong>PR #101233</strong> chore(i18n): refresh native inventory line anchors. Thanks @vincentkoc.</li>
+<li><strong>PR #101186</strong> fix(qa): restore automatic smoke coverage across channels. Thanks @vincentkoc and @RomneyDa.</li>
+<li><strong>PR #101234</strong> feat(mobile): rename, delete, and create session groups on iOS and Android. Related #101231.</li>
+<li><strong>PR #101072</strong> improve(android): align command palette row affordances. Thanks @IWhatsskill.</li>
+<li><strong>PR #101082</strong> fix(msteams): bound Graph attachment JSON responses. Thanks @cxbAsDev.</li>
+<li><strong>PR #101238</strong> feat(models): add Claude Mythos 5 support. Related #101215. Thanks @vincentkoc.</li>
+<li><strong>PR #101236</strong> fix(ios): persist voice notes through offline delivery.</li>
+<li><strong>PR #98940</strong> fix(browser): bound response text decoding. Thanks @Pandah97.</li>
+<li><strong>PR #101165</strong> refactor(ui): localize internal type exports. Thanks @vincentkoc.</li>
+<li><strong>PR #101242</strong> docs: refresh generated map for Mythos heading.</li>
+<li><strong>PR #101112</strong> test(qa): migrate channel thread and DM isolation scenarios. Related #101111. Thanks @RomneyDa.</li>
+<li><strong>PR #89997</strong> fix(cli): protect protocol stdout during startup. Thanks @kenners22 and @vincentkoc.</li>
+<li><strong>PR #101243</strong> refactor(deadcode): localize internal type aliases. Thanks @vincentkoc.</li>
+<li><strong>PR #100895</strong> fix(android): tune screenshot mode visual sizing. Thanks @IWhatsskill.</li>
+<li><strong>PR #99720</strong> policy: repair channel ingress findings. Thanks @giodl73-repo.</li>
+<li><strong>PR #101179</strong> refactor(sessions): route new session store bypasses through the accessor. Thanks @jalehman.</li>
+<li><strong>PR #101103</strong> feat(macos): redesign chat window as native shell with sessions sidebar, toolbar pickers, slash commands, and context usage. Related #101086.</li>
+<li><strong>PR #101180</strong> refactor(sessions): move inbound meta, goals, and delivery reads behind the session accessor. Thanks @jalehman.</li>
+<li><strong>PR #101161</strong> fix(android): stabilize recent sessions overview. Thanks @Solvely-Colin.</li>
+<li><strong>PR #97732</strong> fix(security): align browser audit with plugin policy. Thanks @amtellezfernandez.</li>
+<li><strong>PR #101076</strong> test(qa): use qa flow for channel routing scenarios. Related #101073. Thanks @RomneyDa.</li>
+<li><strong>PR #101106</strong> [codex] retry whatsapp session init conflicts. Thanks @andersonjeccel.</li>
+<li><strong>PR #98639</strong> fix(auto-reply): stop treating wait as abort trigger. Thanks @ianchen08.</li>
+<li><strong>PR #101210</strong> refactor(codex): store app-server thread bindings in SQLite plugin state.</li>
+<li><strong>PR #101222</strong> fix(chat.abort): pass stored sessionId to match active embedded runs. Thanks @ZOOWH.</li>
+<li><strong>PR #101009</strong> fix(agents): normalize surrogate cache fingerprints. Related #100957. Thanks @qingminglong and @aniruddhaadak80.</li>
+<li><strong>PR #98312</strong> fix(agent-model): omit synthesized maxTokens fallback when nothing was configured. Related #98295. Thanks @Sanjays2402 and @Peole.</li>
+<li><strong>PR #101084</strong> fix(imessage): handle stdout/stderr stream errors in the RPC client child. Thanks @masatohoshino.</li>
+<li><strong>PR #100807</strong> fix: code-block copy jumps chat to message top. Thanks @Jvlegod.</li>
+<li><strong>PR #101002</strong> feat(android): hide thinking control and gate sends for models without reasoning support.</li>
+<li><strong>PR #101214</strong> feat(skills): background lifecycle curator for workshop-created skills.</li>
+<li><strong>PR #101191</strong> feat(control-ui): drag sessions into split view with animated drop preview. Related #101034.</li>
+<li><strong>PR #101245</strong> fix(acp): record cancelled background turns as cancelled, not succeeded. Thanks @masatohoshino and @vincentkoc.</li>
+<li><strong>PR #101220</strong> fix(codex): project guardianWarning circuit-breaker notification. Related #101207. Thanks @Darren2030 and @vincentkoc and @kevinlin-openai.</li>
+<li><strong>PR #101235</strong> fix ios qr scanner lifecycle. Thanks @Solvely-Colin and @joshavant.</li>
+<li><strong>PR #100438</strong> feat(update): notify extended-stable availability. Thanks @kevinslin.</li>
+<li><strong>PR #101292</strong> fix(discord): prioritize eligible default account. Related #77429. Thanks @TurboTheTurtle and @ramitrkar-hash.</li>
+<li><strong>PR #100632</strong> fix(onboard): keep the wizard alive through provider auth failures and polish standalone install UX.</li>
+<li><strong>PR #80422</strong> feat(android): add chat agent selector. Thanks @bcperry.</li>
+<li><strong>PR #101262</strong> refactor(ui): remove unused module exports. Thanks @vincentkoc.</li>
+<li><strong>PR #101031</strong> fix(agents): handle stdout/stderr stream errors in ssh sandbox commands. Thanks @cxbAsDev.</li>
+<li><strong>PR #101315</strong> fix(proxy): handle aborted upstream responses. Thanks @SebTardif.</li>
+<li><strong>PR #101295</strong> fix(agents): harden tool search child streams. Thanks @cxbAsDev.</li>
+<li><strong>PR #101244</strong> fix(diagnostics-otel): surface error message on run/harness error spans. Thanks @amknight.</li>
+<li><strong>PR #101127</strong> feat(browser): pair the Chrome extension directly to a remote gateway.</li>
+<li><strong>PR #100233</strong> fix(agents): send session_id affinity header to ChatGPT Responses backend. Related #100232. Thanks @Marvinthebored.</li>
+<li><strong>PR #100272</strong> fix(agents): carry current-turn inbound metadata in a tail runtime-context message for byte-stable prompt caching. Related #100271. Thanks @Marvinthebored.</li>
+<li><strong>PR #101321</strong> fix(android): send chat with hardware Enter. Related #101239. Thanks @3ninyt3nin-creator.</li>
+<li><strong>PR #95718</strong> Add native Signal reply quotes. Thanks @jesse-merhi.</li>
+<li><strong>PR #101105</strong> fix(macos): preserve device identity storage. Related #99283. Thanks @yetval and @iamyhzhao.</li>
+<li><strong>PR #101322</strong> fix(memory): preserve archived sessions with cron-shaped user text. Related #98241. Thanks @ly-wang19 and @yetval.</li>
+<li><strong>PR #101331</strong> test(gateway): isolate reload handler plugin records. Thanks @obviyus.</li>
+<li><strong>PR #101264</strong> fix: block WhatsApp direct sends during reachout timelock. Thanks @mcaxtr.</li>
+<li><strong>PR #101131</strong> QA-lab credentials-admin response bound. Thanks @cxbAsDev.</li>
+<li><strong>PR #101275</strong> ci: fail Android PRs on ktlint formatting drift.</li>
+<li><strong>PR #101281</strong> fix(codex): crestodian ring-zero tool hidden behind tool search when the dead per-run plugin config override is ignored.</li>
+<li><strong>PR #95596</strong> fix: preserve steered audio for inbound TTS. Related #76831. Thanks @mcaxtr and @aleps001.</li>
+<li><strong>PR #101339</strong> refactor(ui): localize unused module exports. Thanks @vincentkoc.</li>
+<li><strong>PR #101256</strong> fix(models): refresh provider auth after CLI login. Related #101254. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #101228</strong> fix(update): keep self-updates on the running install's global root. Thanks @buddyh.</li>
+<li><strong>PR #101062</strong> fix(infra): swallow mid-stream read errors in session-cost readJsonlRecords. Thanks @cxbAsDev and @vincentkoc.</li>
+<li><strong>PR #101258</strong> fix(telegram): add UND_ERR_CONNECT_TIMEOUT to PRE_CONNECT_ERROR_CODES. Thanks @lzw112.</li>
+<li><strong>PR #101355</strong> fix(text): keep bounded outputs UTF-16 safe. Thanks @vincentkoc and @Alix-007.</li>
+<li><strong>PR #101230</strong> fix(markdown-core): CJK-friendly emphasis flanking so <strong>标签：</strong>正文 renders bold (#101120). Thanks @nicknmorty and @j08577600-jpg.</li>
+<li><strong>PR #101357</strong> fix: route Anthropic SDK clients through guarded transport. Thanks @wangmiao0668000666.</li>
+<li><strong>PR #98693</strong> fix(mattermost): strip internal tool-trace banners from outbound text. Thanks @ZengWen-DT and @cursoragent.</li>
+<li><strong>PR #101221</strong> refactor(codex): raise app-server floor to 0.142, drop range compat, fix deferred spawn_agent steering.</li>
+<li><strong>PR #86526</strong> fix(openai): allow RFC 2544 fake-IP range for Realtime session requests. Thanks @shushushv.</li>
+<li><strong>PR #101359</strong> fix(minimax): clarify TTS volume boundary. Thanks @Quratulain-bilal.</li>
+<li><strong>PR #101362</strong> refactor(memory): remove unused host SDK exports. Thanks @vincentkoc.</li>
+<li><strong>PR #101364</strong> fix(feishu): keep operator logs UTF-16 safe. Thanks @ZengWen-DT.</li>
+<li><strong>PR #101118</strong> fix: pace delivery recovery after startup outages. Related #101058. Thanks @ZengWen-DT and @aniruddhaadak80.</li>
+<li><strong>PR #101174</strong> improve(ci): raise Node shard parallelism to 28. Thanks @vincentkoc.</li>
+<li><strong>PR #95832</strong> feat(voice-call): support Twilio calls in IE1 and AU1. Related #95828. Thanks @jodok.</li>
+<li><strong>PR #96980</strong> fix(tui): deduplicate assistant messages across sessions.changed reload. Related #96967. Thanks @xialonglee and @daemonegpt.</li>
+<li><strong>PR #101182</strong> feat(context-engine): report compaction successors as typed session targets. Thanks @jalehman.</li>
+<li><strong>PR #101373</strong> fix: prevent Copilot Claude sessions failing after empty tool errors. Related #97292. Thanks @galiniliev.</li>
+<li><strong>PR #101369</strong> feat(browser): expose agent download actions. Thanks @GRD-Chang.</li>
+<li><strong>PR #95902</strong> fix(gateway): show last error when status probe fails. Thanks @wAngByg and @vincentkoc.</li>
+<li><strong>PR #101177</strong> fix(usage): preserve provider-billed zero totals. Thanks @snowzlmbot.</li>
+<li><strong>PR #101372</strong> fix(tests): reorder initializer arguments so the shared-kit test module compiles.</li>
+<li><strong>PR #101360</strong> fix(android): handle hardware Enter without breaking IME input. Related #101239. Thanks @joshavant and @3ninyt3nin-creator.</li>
+<li><strong>PR #101246</strong> fix(security): route temp workspaces through private OpenClaw temp root (#101224). Thanks @yangxiansheng and @ch3ch2cho2021.</li>
+<li><strong>PR #99888</strong> fix(ios): full-row Settings toggles on iOS 26. Thanks @ly85206559 and @cursoragent.</li>
+<li><strong>PR #101366</strong> fix(windows): remove findstr from restart probe. Related #84600. Thanks @deepujain and @13884379776l.</li>
+<li><strong>PR #93862</strong> fix: avoid reminder-guard false positives for plain memory promises (#47586). Thanks @arkyu2077 and @moltpill.</li>
+<li><strong>PR #101379</strong> refactor(copilot): localize internal runtime types. Thanks @vincentkoc.</li>
+<li><strong>PR #85238</strong> fix: include pnpm 11 bins in gateway PATH. Related #80206. Thanks @shbernal and @vincentkoc and @AdoShan.</li>
+<li><strong>PR #83630</strong> fix(doctor): preview missing transcript cleanup. Related #54877. Thanks @YuanHanzhong and @Suidge.</li>
+<li><strong>PR #93335</strong> fix(thinking): clamp below-range requests down to the cheapest level,…. Thanks @obuchowski.</li>
+<li><strong>PR #101378</strong> fix: Windows CLI backends fail through npm shims. Related #91489, #92054, #98573. Thanks @wendy-chsy and @Vilard7 and @arturomagdiel and @studiodevlabs.</li>
+<li><strong>PR #101393</strong> refactor(github-copilot): localize internal helpers. Thanks @vincentkoc.</li>
+<li><strong>PR #101055</strong> refactor(qa): drive Matrix lifecycle through channel drivers. Related #101054. Thanks @RomneyDa.</li>
+<li><strong>PR #101390</strong> feat(openai): support gpt-realtime-2.1. Thanks @vincentkoc.</li>
+<li><strong>PR #101024</strong> fix(outbound): retry proven pre-connect failures. Related #100979. Thanks @SunnyShu0925 and @tiffanychum.</li>
+<li><strong>PR #101376</strong> refactor(codex): keyed turn routing, client-scoped rate limits, and resume subscription safety. Related #101338.</li>
+<li><strong>PR #101406</strong> refactor(plugins): localize private declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #101042</strong> fix(agents): avoid repeated item progress snapshots. Thanks @mushuiyu886.</li>
+<li><strong>PR #101311</strong> fix(agents): keep structured prompt summaries UTF-16 safe. Thanks @Alix-007.</li>
+<li><strong>PR #101370</strong> fix(agent-core): handle stdout/stderr stream errors in harness exec. Thanks @wings1029.</li>
+<li><strong>PR #72092</strong> fix(media): allow Bedrock SDK auth for image and PDF tools. Related #72031. Thanks @truffle-dev and @GunnarHelliesen.</li>
+<li><strong>PR #89899</strong> fix(plugin-sdk): align speech runtime packaging. Related #89425. Thanks @zhangguiping-xydt and @ant1b0t.</li>
+<li><strong>PR #98505</strong> fix(ports): ignore malformed lsof listener pids. Thanks @QiuYuang and @vincentkoc.</li>
+<li><strong>PR #101425</strong> refactor(plugins): localize provider internals. Thanks @vincentkoc.</li>
+<li><strong>PR #101352</strong> fix(ui): preserve login across same-origin gateways. Related #101351. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #101271</strong> fix: keep owner tools available in WebChat. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #101356</strong> chore(android): update dependencies and compile with API 37.</li>
+<li><strong>PR #101293</strong> fix(ui): clear stale sidebar run state after chat final. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #101392</strong> fix(process): fall back when Windows taskkill cannot spawn. Related #101381. Thanks @ZengWen-DT and @aniruddhaadak80.</li>
+<li><strong>PR #101377</strong> fix(ui): keep microphone input settings usable on narrow screens. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #100236</strong> feat(cli): add openclaw promos to discover and claim ClawHub promotional model offers. Related #100234. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #101443</strong> fix(llm): preserve schema tools across OpenAI failover. Related #97020. Thanks @chrisbaker2000.</li>
+<li><strong>PR #101371</strong> fix: show exported tool results in trace viewers. Thanks @amknight.</li>
+<li><strong>PR #101440</strong> refactor(opencode-go): localize stream internals. Thanks @vincentkoc.</li>
+<li><strong>PR #101401</strong> fix(imessage): handle CLI child stdout/stderr stream errors. Thanks @cxbAsDev.</li>
+<li><strong>PR #101421</strong> fix(qqbot): use UTF-16-safe truncation for messaging reply and approval previews. Thanks @wangmiao0668000666.</li>
+<li><strong>PR #96147</strong> fix(doctor): surface multi-account default routing warnings in preview and lint. Thanks @Pick-cat and @vincentkoc.</li>
+<li><strong>PR #101394</strong> fix(voice-call): handle tunnel child stream errors and stop-after-exit hang. Thanks @cxbAsDev.</li>
+<li><strong>PR #101452</strong> refactor(plugins): localize private config types. Thanks @vincentkoc.</li>
+<li><strong>PR #101402</strong> fix(memory-host-sdk): handle stdout/stderr stream errors in runCliCommand. Thanks @wings1029.</li>
+<li><strong>PR #101415</strong> fix(anthropic): resolve thinking as disabled when legacy budget is below 1024. Thanks @Pick-cat.</li>
+<li><strong>PR #101388</strong> feat(ios): render inline LaTeX math in completed chat prose.</li>
+<li><strong>PR #86936</strong> fix(gateway): persist media metadata in agent.request transcripts. Related #60339. Thanks @peterdsp and @Syysean.</li>
+<li><strong>PR #101391</strong> fix(signal): bound outbound container attachment file reads. Thanks @cxbAsDev.</li>
+<li><strong>PR #101337</strong> fix(status): surface auto-fallback model in status and session_status (#96126). Thanks @LZY3538 and @nblue1-ui.</li>
+<li><strong>PR #101470</strong> refactor(android): remove obsolete global cache cleanup. Thanks @vincentkoc.</li>
+<li><strong>PR #101449</strong> fix(backup): isolate retry temp archives. Related #101382. Thanks @LiLan0125 and @vincentkoc and @aniruddhaadak80.</li>
+<li><strong>PR #101481</strong> fix(ios): skip onboarding for configured gateways. Related #98570. Thanks @siebej.</li>
+<li><strong>PR #99366</strong> fix(mattermost): reject oversized websocket events. Thanks @sunlit-deng.</li>
+<li><strong>PR #99745</strong> fix(telegram): harden rich send fallback and typing breaker. Related #99471. Thanks @snowzlmbot and @Veda-openclaw.</li>
+<li><strong>PR #94431</strong> fix(cli): accept parent options placed after lazy subcommands (#55563 regression 1) [AI-assisted]. Thanks @ml12580 and @Owlock.</li>
+<li><strong>PR #101508</strong> refactor(memory): localize unused host SDK exports. Thanks @vincentkoc.</li>
+<li><strong>PR #101464</strong> fix(backup): close archive stream before retry cleanup. Related #101382. Thanks @ZOOWH and @aniruddhaadak80.</li>
+<li><strong>PR #101507</strong> fix(agent): preserve explicit recipient sessions. Related #41483. Thanks @vincentkoc and @pingfanfan and @limpicompany-maker.</li>
+<li><strong>PR #101413</strong> fix(gateway): reset channel restart counter after a stable run. Thanks @clintoncodewell.</li>
+<li><strong>PR #101516</strong> fix(qqbot): keep bounded previews UTF-16 safe. Thanks @vincentkoc and @wangmiao0668000666.</li>
+<li><strong>PR #101273</strong> fix(android): auto-detect the Android SDK when fresh worktrees lack local.properties.</li>
+<li><strong>PR #101387</strong> feat(ios): og:image thumbnails on link preview cards.</li>
+<li><strong>PR #101523</strong> refactor(agent-core): localize exec timeout helper. Thanks @vincentkoc.</li>
+<li><strong>PR #101519</strong> fix(android): stop saved gateway reconnect CI flake.</li>
+<li><strong>PR #97784</strong> fix(msteams): bound Microsoft Graph API response reads in graph-upload to prevent OOM. Thanks @Alix-007.</li>
+<li><strong>PR #101396</strong> feat(android): og:image thumbnails on link preview cards.</li>
+<li><strong>PR #101298</strong> fix(media): keep audit context truncation UTF-16 safe. Thanks @Alix-007.</li>
+<li><strong>PR #101303</strong> fix(agents): keep prompt data truncation UTF-16 safe. Thanks @Alix-007.</li>
+<li><strong>PR #101549</strong> refactor(ui): remove stale helper exports. Thanks @vincentkoc.</li>
+<li><strong>PR #101350</strong> fix: block mixed-case cron shell jobs from agent tool [AI]. Thanks @pgondhi987.</li>
+<li><strong>PR #101522</strong> feat(gateway): archive-gated session deletes give Android delete parity.</li>
+<li><strong>PR #100472</strong> ci(mantis): add web UI chat proof lane. Thanks @brokemac79.</li>
+<li><strong>PR #101312</strong> fix(web-fetch): keep spill content truncation UTF-16 safe. Thanks @Alix-007.</li>
+<li><strong>PR #101497</strong> feat(ui): redesign dashboard chrome with tiny top bar and sidebar search.</li>
+<li><strong>PR #101548</strong> fix(zalo): accept opaque string chat IDs. Related #57594. Thanks @goutamadwant and @malayvuong.</li>
+<li><strong>PR #101532</strong> fix(ui): send approvals past busy chat queue. Thanks @vincentkoc.</li>
+<li><strong>PR #101304</strong> fix(voice-call): keep realtime context truncation UTF-16 safe. Thanks @Alix-007.</li>
+<li><strong>PR #100835</strong> fix(ssrf): block loopback addresses for trusted hostname origins. Thanks @machine3at.</li>
+<li><strong>PR #89367</strong> fix: forward pending timeout snapshot in waitForAgentJob fallback timer. Related #89095. Thanks @Pick-cat and @sunnydongbo.</li>
+<li><strong>PR #101550</strong> fix(ios): serialize screen recording finalization. Related #99056. Thanks @Tony-ooo.</li>
+<li><strong>PR #101484</strong> fix(codex): Pro model first turns fail when reasoning defaults to minimal. Thanks @zhangguiping-xydt and @vincentkoc.</li>
+<li><strong>PR #101551</strong> fix(discord): keep thread title prompts UTF-16 safe. Thanks @Alix-007.</li>
+<li><strong>PR #101560</strong> fix(android): bound link preview image cache.</li>
+<li><strong>PR #101566</strong> docs(changelog): credit Discord thread title fix.</li>
+<li><strong>PR #99180</strong> fix(mcp): reject tools/call requests with non-object arguments. Thanks @VectorPeak.</li>
+<li><strong>PR #101568</strong> refactor(memory): localize host SDK helpers. Thanks @vincentkoc.</li>
+<li><strong>PR #101561</strong> fix(exec): keep pending approval warnings truthful. Thanks @vincentkoc.</li>
+<li><strong>PR #101505</strong> fix(codex): handle app-server stdio stream errors. Thanks @mushuiyu886 and @vincentkoc.</li>
+<li><strong>PR #101503</strong> fix(status): keep issue message truncation UTF-16 safe. Thanks @wm0018.</li>
+<li><strong>PR #99950</strong> fix: route direct outbound polls through channel adapters. Thanks @NianJiuZst.</li>
+<li><strong>PR #100177</strong> fix(codex): use UTF-16-safe truncation for approval display paths. Thanks @xialonglee.</li>
+<li><strong>PR #101572</strong> fix(feishu): support drive folder pagination. Thanks @zhangguiping-xydt.</li>
+<li><strong>PR #101489</strong> fix(infra): handle detached respawn child errors. Related #101458. Thanks @momothemage and @aniruddhaadak80.</li>
+<li><strong>PR #101434</strong> fix(browser): keep screenshots private by default. Related #44759. Thanks @sunshineo.</li>
+<li><strong>PR #101435</strong> feat(android): render LaTeX display math in chat via bundled KaTeX.</li>
+<li><strong>PR #101583</strong> refactor(memory): remove unused runtime facade exports. Thanks @vincentkoc.</li>
+<li><strong>PR #101534</strong> fix(codex): use truncateUtf16Safe for attempt notification text truncation. Thanks @lsr911.</li>
+<li><strong>PR #101574</strong> fix(memory): preserve UTF-16 chunk boundaries. Related #65782. Thanks @jensenwang560-blip.</li>
+<li><strong>PR #101527</strong> fix(channels): use truncateUtf16Safe for thread binding name truncation. Thanks @lsr911.</li>
+<li><strong>PR #101513</strong> fix(agents): keep exec auto-reviewer rationale truncation UTF-16 safe. Thanks @wm0018.</li>
+<li><strong>PR #101517</strong> fix(session-cost-usage): keep emoji / surrogate pairs intact during content truncation. Thanks @maweibin.</li>
+<li><strong>PR #101580</strong> fix(gateway): preserve UTF-16 plugin approval fields. Thanks @wm0018.</li>
+<li><strong>PR #101576</strong> fix: preserve session labels across rollover. Related #101451. Thanks @ZengWen-DT and @Merlin-zhou.</li>
+<li><strong>PR #101577</strong> fix(session-memory): preserve sibling paths in logs. Thanks @cxbAsDev.</li>
+<li><strong>PR #101573</strong> fix(auth): clean OAuth contention diagnostics. Thanks @vincentkoc.</li>
+<li><strong>PR #101579</strong> fix(gateway): keep plugin approval text UTF-16 safe. Thanks @wm0018.</li>
+<li><strong>PR #101535</strong> fix(acp): use truncateUtf16Safe for event mapper error text truncation. Thanks @lsr911.</li>
+<li><strong>PR #101588</strong> fix(agents): clean up ls cancellation listeners. Thanks @lzw112.</li>
+<li><strong>PR #101594</strong> refactor(memory): trim unused Windows spawn exports. Thanks @vincentkoc.</li>
+<li><strong>PR #101454</strong> fix(browser): cancel Chrome MCP requests on crash. Related #101070. Thanks @aniruddhaadak80.</li>
+<li><strong>PR #101575</strong> fix(auto-reply): keep suppressed reply text preview truncation UTF-16 safe. Thanks @wm0018.</li>
+<li><strong>PR #101590</strong> fix(file-transfer): handle child output stream errors. Thanks @sunlit-deng.</li>
+<li><strong>PR #101591</strong> fix(control-ui-assets): keep emoji / surrogate pairs intact during last-line truncation. Thanks @maweibin.</li>
+<li><strong>PR #101604</strong> refactor(memory): trim unused host SDK exports. Thanks @vincentkoc.</li>
+<li><strong>PR #101465</strong> fix(browser): keep upload errors specific. Related #38844. Thanks @tigicion.</li>
+<li><strong>PR #101607</strong> fix(agents): keep exec visible for lean local models. Thanks @vincentkoc.</li>
+<li><strong>PR #101571</strong> fix: prevent session history stream errors from crashing gateway. Related #101539. Thanks @ZengWen-DT and @aniruddhaadak80.</li>
+<li><strong>PR #101600</strong> fix(tasks): keep emoji / surrogate pairs intact during terminal output truncation. Thanks @maweibin.</li>
+<li><strong>PR #101632</strong> refactor(ui): trim unused control UI helpers. Thanks @vincentkoc.</li>
+<li><strong>PR #101647</strong> refactor(ui): remove duplicate helper paths. Thanks @vincentkoc.</li>
+<li><strong>PR #101654</strong> fix: keep bounded text truncation UTF-16 safe. Thanks @wm0018 and @lsr911 and @maweibin.</li>
+<li><strong>PR #101666</strong> refactor: localize internal reply and plugin types. Thanks @vincentkoc.</li>
+<li><strong>PR #101562</strong> fix(slack): conversation lookups no longer grow cache without bound. Thanks @zhangguiping-xydt.</li>
+<li><strong>PR #101680</strong> refactor(android): remove superseded app surfaces. Thanks @vincentkoc.</li>
+<li><strong>PR #101682</strong> refactor: remove obsolete chat display mocks. Thanks @shakkernerd.</li>
+<li><strong>PR #84161</strong> fix(voice-call): persist complete Google Live transcripts. Thanks @happydog-bot.</li>
+<li><strong>PR #101689</strong> test: remove stale native i18n sentinel.</li>
+<li><strong>PR #101650</strong> fix(channels): prevent metadata caches from growing without bound. Thanks @Alix-007 and @vincentkoc.</li>
+<li><strong>PR #101685</strong> fix: prevent garbled emoji at remaining text limits. Thanks @maweibin and @ly85206559 and @lsr911 and @wings1029.</li>
+<li><strong>PR #101669</strong> fix(gateway): support native Windows exec approvals. Thanks @vincentkoc.</li>
+<li><strong>PR #101701</strong> refactor: localize file-private exports. Thanks @vincentkoc.</li>
+<li><strong>PR #101731</strong> refactor: localize internal implementation types. Thanks @vincentkoc.</li>
+<li><strong>PR #101466</strong> fix(release): allow SHA-only extended-stable preflight. Thanks @kevinslin.</li>
+<li><strong>PR #101726</strong> fix(codex): keep app-server requests aligned with pinned protocol. Thanks @vincentkoc.</li>
+<li><strong>PR #101711</strong> fix: preserve emoji at remaining bounded-text edges. Thanks @ly85206559 and @lzw112 and @Alix-007.</li>
+<li><strong>PR #101728</strong> fix(http-error-body): keep emoji / surrogate pairs intact during error body truncation. Thanks @wings1029.</li>
+<li><strong>PR #101758</strong> refactor: localize internal implementation constants. Thanks @vincentkoc.</li>
+<li><strong>PR #100928</strong> improve(ui): nest Settings pages under /settings routes. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #101688</strong> refactor(gateway): route chat transcript injection through the session accessor. Thanks @jalehman.</li>
+<li><strong>PR #101450</strong> fix(sessions): bound trajectory snapshot and pointer reads. Thanks @cxbAsDev and @vincentkoc.</li>
+<li><strong>PR #97669</strong> fix(claude-cli): surface re-auth hint when subprocess OAuth token expires. Related #97553. Thanks @Alix-007 and @riazrahaman.</li>
+<li><strong>PR #101831</strong> refactor: localize internal implementation symbols. Thanks @vincentkoc.</li>
+<li><strong>PR #101319</strong> perf(ui): add virtual scrolling to file preview modal code viewer. Related #99062. Thanks @xianshishan.</li>
+<li><strong>PR #101699</strong> refactor(sessions): move parent-session forking behind the accessor boundary. Thanks @jalehman.</li>
+<li><strong>PR #101589</strong> fix(gateway): bound all-agent usage cache concurrency. Related #101552. Thanks @zw-xysk and @vincentkoc and @aniruddhaadak80.</li>
+<li><strong>PR #101779</strong> fix(shared): skip app-group identity migration when OPENCLAW_STATE_DIR is overridden.</li>
+<li><strong>PR #101799</strong> fix(android): keep cold-start gateway auto-connect from overriding explicit intents.</li>
+<li><strong>PR #101812</strong> feat(ui): redesign gateway connection-lost banner as floating pill.</li>
+<li><strong>PR #101195</strong> feat(cron): event triggers — polled condition-watcher scripts via code mode. Related #101194.</li>
+<li><strong>PR #101843</strong> improve: soften the idle voice button ring in the chat composer.</li>
+<li><strong>PR #101844</strong> improve(ui): restyle connection-lost pill as neutral status surface.</li>
+<li><strong>PR #99731</strong> policy: repair denied gateway http endpoints. Thanks @giodl73-repo.</li>
+<li><strong>PR #101849</strong> fix(ui): stop flashing the login gate on dashboard load when credentials are stored. Related #101847.</li>
+<li><strong>PR #101795</strong> fix: require full frontmatter delimiter lines. Related #101769. Thanks @NianJiuZst and @qingminglong.</li>
+<li><strong>PR #101858</strong> refactor(deadcode): localize UI and script symbols. Thanks @vincentkoc.</li>
+<li><strong>PR #101860</strong> refactor(deadcode): localize extension helpers. Thanks @vincentkoc.</li>
+<li><strong>PR #101325</strong> fix(mobile): clarify gateway connection security setup. Thanks @joshavant.</li>
+<li><strong>PR #101869</strong> refactor(deadcode): localize core helpers. Thanks @vincentkoc.</li>
+<li><strong>PR #101875</strong> refactor(deadcode): localize test and tooling helpers. Thanks @vincentkoc.</li>
+<li><strong>PR #101407</strong> improve(imessage): manage imsg setup and plugin skill ownership. Thanks @omarshahine.</li>
+<li><strong>PR #101886</strong> refactor(deadcode): trim private helper exports. Thanks @vincentkoc.</li>
+<li><strong>PR #101807</strong> fix(agents): avoid false unscheduled note after shell cron add. Related #52972. Thanks @BryanTegomoh and @vincentkoc and @vitobotta.</li>
+<li><strong>PR #101889</strong> refactor(deadcode): localize Parallels helpers. Thanks @vincentkoc.</li>
+<li><strong>PR #101834</strong> improve(google): identify OpenClaw Gemini API traffic. Thanks @vishal-dharm.</li>
+<li><strong>PR #101888</strong> fix(slack): unbounded thread pagination, process-wide write serialization, serialized inbound lookups. Thanks @obviyus.</li>
+<li><strong>PR #101892</strong> refactor(deadcode): localize script constants. Thanks @vincentkoc.</li>
+<li><strong>PR #101894</strong> refactor(deadcode): localize control ui declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #101898</strong> refactor(deadcode): localize browser plugin declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #101896</strong> fix: plugin tests fail on hosts with a usable /tmp/openclaw or a source checkout. Related #101876.</li>
+<li><strong>PR #101903</strong> refactor(deadcode): localize msteams declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #101904</strong> refactor(deadcode): localize release tooling declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #101907</strong> refactor(deadcode): localize AI provider declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #101703</strong> fix: lower successful agent stop completion logs. Related #101678. Thanks @ZengWen-DT and @tford-ui.</li>
+<li><strong>PR #101915</strong> refactor(deadcode): localize canvas declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #101917</strong> refactor(deadcode): localize script helper types. Thanks @vincentkoc.</li>
+<li><strong>PR #101922</strong> refactor(plugins): localize internal helper types. Thanks @vincentkoc.</li>
+<li><strong>PR #101925</strong> refactor(oc-path): localize internal result types. Thanks @vincentkoc.</li>
+<li><strong>PR #101901</strong> fix(installer): complete first-run onboarding. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #101902</strong> fix(memory-core): guard supplement lookup in resolveMemoryReadFailureResult with try-catch (fixes #101809). Thanks @zw-xysk and @vincentkoc and @aniruddhaadak80.</li>
+<li><strong>PR #101931</strong> refactor(memory-wiki): localize internal helper types. Thanks @vincentkoc.</li>
+<li><strong>PR #101936</strong> refactor(imessage): localize internal helper symbols. Thanks @vincentkoc.</li>
+<li><strong>PR #101941</strong> refactor(gateway): localize terminal helper types. Thanks @vincentkoc.</li>
+<li><strong>PR #101887</strong> feat(crestodian): guide providerless model setup. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #101945</strong> refactor(discord): localize internal declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #101596</strong> fix(google-meet): handle stdout/stderr stream errors in local audio bridge. Thanks @Alix-007.</li>
+<li><strong>PR #101949</strong> refactor(feishu): localize internal declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #101954</strong> refactor(matrix): localize internal types. Thanks @vincentkoc.</li>
+<li><strong>PR #101926</strong> fix(channels): keep native /think menus responsive. Thanks @vincentkoc.</li>
+<li><strong>PR #101959</strong> refactor(whatsapp): localize internal types. Thanks @vincentkoc.</li>
+<li><strong>PR #96592</strong> improve(diagnostics-otel): make agent-duration histograms usable beyond 10s. Thanks @hcnode and @vincentkoc and @zhiling-chen-20230331.</li>
+<li><strong>PR #101963</strong> refactor(policy): localize internal declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #101658</strong> fix(ui): keep Workboard detail drawer actions in parity. Related #99957. Thanks @momothemage and @princebansal.</li>
+<li><strong>PR #101969</strong> refactor(memory-core): localize internal declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #101974</strong> refactor(qa-matrix): localize internal declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #101980</strong> refactor(qa-lab): localize confidence report types. Thanks @vincentkoc.</li>
+<li><strong>PR #101761</strong> fix(browser): keep Playwright truncation UTF-16 safe. Thanks @mushuiyu886.</li>
+<li><strong>PR #101987</strong> refactor(qa-lab): localize evidence summary schemas. Thanks @vincentkoc.</li>
+<li><strong>PR #101990</strong> refactor(qa-lab): localize utility types. Thanks @vincentkoc.</li>
+<li><strong>PR #93402</strong> fix(gateway): log websocket handshake phase. Related #79603. Thanks @849261680 and @bzelones.</li>
+<li><strong>PR #102005</strong> refactor(qa-lab): localize orchestration declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #102010</strong> refactor(google-meet): localize internal declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #84424</strong> fix(doctor): honor per-agent bootstrap profile in size check. Thanks @kasangyong and @vincentkoc.</li>
+<li><strong>PR #102021</strong> refactor(plugins): localize internal declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #102029</strong> refactor(googlechat): localize internal declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #101597</strong> fix(matrix): handle stdout/stderr stream errors in dependency commands. Thanks @Alix-007.</li>
+<li><strong>PR #102037</strong> refactor(line): localize internal declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #102040</strong> refactor(mattermost): localize internal declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #102042</strong> refactor(signal): localize internal declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #102044</strong> refactor(slack): localize internal declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #101771</strong> fix(ui): sync native approvals i18n baseline.</li>
+<li><strong>PR #102048</strong> refactor(qqbot): localize internal declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #102036</strong> fix(lobster): keep ordinary run/resume on default flow fields. Related #102011. Thanks @LiLan0125 and @vincentkoc and @ArthurNie.</li>
+<li><strong>PR #77763</strong> fix(voice-call): preserve per-call agent routing. Related #77753. Thanks @quangtran88.</li>
+<li><strong>PR #102059</strong> refactor(voice-call): localize internal declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #102065</strong> refactor(zalo): localize internal declarations. Thanks @vincentkoc.</li>
+<li><strong>PR #102032</strong> Harden jq safe-bin semantics. Thanks @pgondhi987.</li>
+<li><strong>PR #101353</strong> fix: detect joined inline eval flags [AI]. Thanks @pgondhi987.</li>
+<li><strong>PR #100827</strong> fix(state): close agent-db and proxy-capture SQLite handles on exit; rebind stale proxy stores after shared-state close. Thanks @amknight.</li>
+<li><strong>PR #102159</strong> fix(crabbox): retry cold metadata probes so a slow run --help does not block validation.</li>
+<li><strong>PR #102009</strong> feat(secrets): egress-time credential injection with process-local sentinels. Related #102008.</li>
+<li><strong>PR #102030</strong> fix: restrict non-owner gateway tool inventory [AI]. Thanks @pgondhi987.</li>
+<li><strong>PR #102031</strong> fix: gate Gateway message action requester provenance [AI]. Thanks @pgondhi987.</li>
+<li><strong>PR #102033</strong> fix: harden web fetch HTML conversion [AI]. Thanks @pgondhi987.</li>
+<li><strong>PR #101017</strong> improve(ui): bring back openclaw brand, remove desktop topbar + breadcrumbs. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #102210</strong> fix: focus chat composer when typing. Thanks @shakkernerd.</li>
+<li><strong>PR #101757</strong> feat(release): preflight all extended-stable npm packages. Thanks @kevinslin.</li>
+<li><strong>PR #102158</strong> fix(skills): correct invalid install kinds in xurl and github [AI]. Thanks @not-stbenjam.</li>
+<li><strong>PR #102035</strong> fix: bind package-manager exec approvals to inner commands [AI]. Thanks @pgondhi987.</li>
+<li><strong>PR #101012</strong> refactor(gateway): consolidate client contracts. Thanks @RomneyDa.</li>
+<li><strong>PR #102256</strong> ci: temporarily disable QA smoke again. Thanks @RomneyDa.</li>
+<li><strong>PR #99776</strong> policy: preview review-required gateway repairs. Thanks @giodl73-repo.</li>
+<li><strong>PR #101881</strong> Fix container image upgrade migrations before gateway readiness. Related #98565. Thanks @sallyom and @jacobtomlinson.</li>
+<li><strong>PR #102444</strong> fix(codex): support app-server 0.143.0. Thanks @vincentkoc.</li>
+<li><strong>PR #102600</strong> fix(release): accept tool-only completion signal.</li>
+<li><strong>PR #102732</strong> test(qa): assert Telegram command denial.</li>
+<li><strong>PR #103244</strong> ci: pin docs i18n Go toolchain. Related #103240.</li>
+<li><strong>PR #102873</strong> feat(providers): add Meta Model API - muse-spark-1.1. Thanks @HamidShojanazeri and @davemorin and @Solvely-Colin and @jalehman.</li>
+<li><strong>PR #103070</strong> fix(providers): publish Meta under canonical package name. Thanks @vincentkoc.</li>
+<li><strong>PR #103163</strong> fix(meta): live validation targets deployed Muse Spark 1.1.</li>
+<li><strong>PR #102858</strong> ci: make release child dispatch idempotent.</li>
+<li><strong>PR #102896</strong> ci: retry transient release workflow reads.</li>
+<li><strong>PR #103564</strong> fix(release): restore bundled AI runtime in update smoke.</li>
+<li><strong>PR #103467</strong> fix(ci): read Codex bindings from SQLite in live harness. Related #103451. Thanks @vincentkoc.</li>
+<li><strong>PR #103556</strong> fix(release): bundle AI runtime in installer smoke. Related #103552. Thanks @vincentkoc.</li>
+<li><strong>PR #103635</strong> fix(qa): keep retry passes terminally successful. Related #103631.</li>
+<li><strong>PR #103650</strong> fix(qa): keep non-assistant fixtures out of token usage gate. Related #103641.</li>
+<li><strong>PR #103654</strong> fix(ci): run live suites from manual dispatches. Related #103652.</li>
+<li><strong>PR #103608</strong> fix(release): contain installer artifact restores.</li>
+<li><strong>PR #103681</strong> fix(qa): accept structured gateway restart outcomes. Related #103676.</li>
+<li><strong>PR #103685</strong> fix(qa): require web fetch after tool discovery. Related #103678.</li>
+<li><strong>PR #103718</strong> test(qa): wait for durable webchat transcript. Related #103701.</li>
+<li><strong>PR #103906</strong> fix(release): keep validation evidence immutable across reruns.</li>
+<li><strong>PR #103923</strong> fix(i18n): recognize Meta docs glossary terms.</li>
+<li><strong>PR #103095</strong> fix(ci): isolate OpenWebUI release smoke.</li>
+<li><strong>PR #103549</strong> fix(telegram): complete spooled updates at turn adoption instead of turn settle. Related #102468. Thanks @obviyus.</li>
+<li><strong>PR #103695</strong> fix(telegram): harden spooled turn adoption. Thanks @vincentkoc.</li>
+<li><strong>PR #103664</strong> fix(telegram): scope reply-fence abort authority to pre-adoption dispatch. Thanks @obviyus.</li>
+<li><strong>PR #103680</strong> fix(providers): align Meta Model API contract. Related #103667. Thanks @vincentkoc.</li>
+<li><strong>PR #104032</strong> fix(release): harden and accelerate 2026.7.1 handoff. Thanks @vincentkoc.</li>
+<li><strong>PR #103861</strong> fix(logging): redact Telegram tokens across chunk boundaries. Thanks @vincentkoc.</li>
+<li><strong>PR #104000</strong> improve(release): make preparation atomic and bounded. Thanks @vincentkoc.</li>
+<li><strong>PR #103952</strong> fix(telegram): detach adopted turns from reply fence. Thanks @vincentkoc.</li>
+<li><strong>PR #103965</strong> fix(telegram): suppress replies superseded during adoption.</li>
+<li><strong>PR #103946</strong> fix(tasks): repair legacy delivery statuses. Related #103168. Thanks @bek91 and @theo674.</li>
+<li><strong>PR #104162</strong> improve(release): reuse exact-SHA validation evidence. Related #104161. Thanks @vincentkoc.</li>
+<li><strong>PR #103222</strong> fix(release): validate GitHub notes before publish.</li>
+<li><strong>PR #104186</strong> fix: current-tree package checks support unreleased versions.</li>
+<li><strong>PR #103581</strong> feat(openai): default new setups to GPT-5.6. Related #103234. Thanks @bdjben and @obviyus and @sallyom.</li>
+<li><strong>PR #103281</strong> fix(codex): prevent startup hangs after binding migration. Thanks @bdjben and @obviyus and @sallyom.</li>
+<li><strong>PR #104529</strong> fix: startup migrations block on recoverable legacy state. Thanks @sallyom and @bdjben and @obviyus.</li>
+<li><strong>PR #103760</strong> fix(ci): align OpenAI auth contract with provider default. Related #103750. Thanks @bdjben and @obviyus and @sallyom.</li>
+<li><strong>PR #104555</strong> fix: clear remaining release validation blockers. Thanks @bdjben and @obviyus and @sallyom.</li>
+<li><strong>PR #102780</strong> fix(infra): converge legacy state migrations on archive collisions. Related #102749. Thanks @obviyus and @bdjben and @sallyom.</li>
+<li><strong>PR #104491</strong> fix(node-pairing): require operator.admin to approve browser.proxy nodes. Thanks @yetval.</li>
+<li><strong>PR #104441</strong> fix(agents): preserve UTF-16 boundaries in block chunks. Thanks @mushuiyu886.</li>
+<li><strong>PR #102948</strong> fix(feishu): add 30 s request timeout to streaming-card API calls. Thanks @hugenshen and @sallyom.</li>
+<li><strong>PR #104433</strong> fix(openrouter): Fusion prompt corrupts boundary emoji in model IDs. Thanks @zhangguiping-xydt and @vincentkoc.</li>
+<li><strong>PR #104230</strong> fix(discord): keep voice diagnostics bounded when ffmpeg errors are multibyte. Thanks @qingminglong.</li>
+<li><strong>PR #102087</strong> fix(agents): keep tool-result truncation UTF-16 safe. Thanks @chengzhichao-xydt.</li>
+<li><strong>PR #102610</strong> fix(agents): keep prompt history append-only mid-session for prompt-cache stability. Related #99495. Thanks @ugiezzz.</li>
+<li><strong>PR #99756</strong> fix: preserve tool-result text across media fallback and context pressure. Thanks @AcosX and @Solvely-Colin.</li>
+<li><strong>PR #104714</strong> fix(providers): complete repaired tool call streams.</li>
+<li><strong>PR #103916</strong> fix: preserve messages when Codex steering lacks transcript acknowledgement. Thanks @jalehman.</li>
+<li><strong>PR #104722</strong> test(qa): follow canonical frontier defaults.</li>
+<li><strong>PR #102289</strong> fix(gateway): refresh model availability after OAuth renewal. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #104750</strong> test(live): align July GPT-5.6 defaults.</li>
+<li><strong>PR #102344</strong> fix: surface OpenAI chat-completions refusal as assistant text. Related #102321. Thanks @wuqxuan and @yetval.</li>
+<li><strong>PR #103132</strong> fix(cli): reduce plugins list startup memory. Related #103131.</li>
+<li><strong>PR #103157</strong> fix: release startup migration lease before exit. Related #103145.</li>
+<li><strong>PR #103596</strong> fix(discord): recover from failed gateway resumes. Related #99681. Thanks @meepbot-oss.</li>
+<li><strong>PR #104706</strong> fix(telegram): preserve Codex login profile identity. Related #104704. Thanks @100yenadmin.</li>
+<li><strong>PR #104504</strong> fix(codex): bound app-server binding fingerprints. Related #104503. Thanks @100yenadmin.</li>
+<li><strong>PR #104778</strong> fix(zai): honor max thinking through gateway. Related #104716. Thanks @vincentkoc and @100yenadmin.</li>
+<li><strong>PR #104848</strong> fix(codex): preserve MCP bindings after beta5 upgrades. Thanks @vincentkoc.</li>
+<li><strong>PR #98021</strong> feat: support GPT-5.6 Ultra across OpenClaw and Codex runtimes. Thanks @anyech.</li>
+<li><strong>PR #102980</strong> fix(ci): retry known live tool nonce misses.</li>
+<li><strong>PR #104905</strong> test(live): retry GPT-5.6 nonce mismatches.</li>
+<li><strong>PR #104956</strong> ci: harden current and frozen release checks.</li>
+<li><strong>PR #104892</strong> fix(release): preserve original PRs for named backports. Thanks @vincentkoc.</li>
+<li><strong>PR #104975</strong> fix(release): restore pnpm package artifacts.</li>
+<li><strong>PR #104957</strong> fix(release): verify named backport provenance. Thanks @vincentkoc.</li>
+<li><strong>PR #103775</strong> fix: Codex runtime rejected for Codex provider. Related #103762.</li>
+<li><strong>PR #105133</strong> test(ui): bound chat hover browser wait.</li>
+<li><strong>PR #105055</strong> fix(release): support explicit provenance overrides. Thanks @vincentkoc.</li>
+<li><strong>PR #105405</strong> fix(update): preserve ClawHub plugins after cutover. Thanks @vincentkoc.</li>
+<li><strong>PR #105401</strong> fix(qa): align mock catalog with selected models.</li>
+<li><strong>PR #105444</strong> fix(qa): preserve Codex mock routing.</li>
+<li><strong>PR #105518</strong> fix(openai): preserve image routing before catalog load. Thanks @vincentkoc.</li>
+<li><strong>PR #105488</strong> fix(qa): keep mock memory embeddings offline.</li>
+<li><strong>PR #105493</strong> test(qa): model Codex compaction in parity mock.</li>
+<li><strong>PR #105500</strong> fix(qa): repair agentic runtime parity mocks.</li>
+<li><strong>PR #106065</strong> fix(sqlite): reject runtimes vulnerable to WAL corruption. Thanks @vincentkoc.</li>
+<li><strong>PR #103725</strong> fix(install-cli): track mktemp paths and clean up on EXIT. Thanks @SebTardif.</li>
+</ul>
+<p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
+]]></description>
+            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.7.1/OpenClaw-2026.7.1.zip" length="59038286" type="application/octet-stream" sparkle:edSignature="smUCPNQSjvwkBN8kKC0c4Oq8ygySakUmjD9m/1L3j06UQ7QXWBZKnVtCfFMfAUb8cDv5wiPPm2mUNioWfZQcBQ=="/>
+        </item>
+        <item>
             <title>2026.6.11</title>
             <pubDate>Tue, 30 Jun 2026 17:39:25 +0000</pubDate>
             <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
@@ -396,48 +2146,6 @@ This audited record covers the complete v2026.6.9..HEAD history: 12 merged PRs. 
 <p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
 ]]></description>
             <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.6.10/OpenClaw-2026.6.10.zip" length="56115790" type="application/octet-stream" sparkle:edSignature="MEeGG8+WePhUg9uDShznmdhhAgy/WWe7bAwr4XRTauNdrM441iziQYIlwhfNrtHDHX+uE1/tkRtIMcELfuekAg=="/>
-        </item>
-        <item>
-            <title>2026.6.8</title>
-            <pubDate>Tue, 16 Jun 2026 17:17:20 +0000</pubDate>
-            <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
-            <sparkle:version>2606000890</sparkle:version>
-            <sparkle:shortVersionString>2026.6.8</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
-            <description><![CDATA[<h2>OpenClaw 2026.6.8</h2>
-<h3>Highlights</h3>
-<ul>
-<li>Telegram and WhatsApp channel delivery are richer and less brittle: Telegram can send structured rich text with tables, lists, expandable blockquotes, preserved intentional line breaks, prompt-preserving CLI backend delivery, retired native draft migration, and safer rich-media boundaries, while WhatsApp now honors configured ACP bindings. (#92679, #93164, #84082, #89421, #92513) Thanks @obviyus, @jzakirov, @spacegeologist, and @TurboTheTurtle.</li>
-<li>Agent and Gateway recovery is sharper across account-scoped DM sends, generated media completions, auto-reply message-tool final replies, reset archive fallback reads, restart shutdown aborts, yielded subagent pauses, trusted subagent thinking override fallback, yielded cron media, heartbeat dedupe, session identity prompts, and unknown OpenAI agent selector rejection. (#92788, #91246, #92879, #91357, #92631, #92412, #92146, #91287, #92468, #92510) Thanks @yetval, @TurboTheTurtle, @masatohoshino, @CadanHu, @ooiuuii, @openperf, @IWhatsskill, @ZengWen-DT, and @zhangguiping-xydt.</li>
-<li>Provider/model handling expands and tightens with GLM-5.2, Claude Haiku 4.5 catalog rows, OpenRouter and Google Vertex provider-prefix normalization, managed SecretRef auth, OAuth image-default routing through Codex, bounded model browse discovery, LM Studio binary thinking-off delivery, storeless OpenAI Responses replay gating, invalid OpenAI reasoning-signature and genericized Anthropic thinking-signature recovery, Claude 4.5 Copilot tool-streaming safety, and OpenAI/Anthropic-family payload quarantine for unreadable or post-hook tool schemas. (#92796, #90116, #92627, #91218, #90686, #92824, #92247, #92002, #90706, #92941, #92201, #92916, #75393, #92908, #92921, #92928) Thanks @arkyu2077, @liuhao1024, @bymle, @rohitjavvadi, @nxmxbbd, @bek91, @samson910022, @mmyzwl, @CarlCapital, @snowzlm, @Kailigithub, and @vincentkoc.</li>
-<li><code>/usage</code> and reply payload hooks now have a native full footer renderer, default template, fixed-decimal formatting, credential-aware limits, better partial-count handling, and warnings for broken templates instead of silent bad output. (#92657, #89835, #89629) Thanks @Marvinthebored.</li>
-<li>UI and mobile flows are steadier: workspace files can collapse and start collapsed, WebChat backscroll survives streaming, the sidebar session picker remains interactive above the desktop workbench, reset soft args survive UI dispatch, stale dashboard session parent lineage is preserved, and iOS reconnects stale foreground gateways. (#92779, #92622, #92705, #91353, #90658, #92552) Thanks @shakkernerd, @TurboTheTurtle, @NianJiuZst, @zhouhe-xydt, @luoyanglang, and @Solvely-Colin.</li>
-<li>Memory, state, and diagnostics recover cleaner: oversized OpenAI embedding batches split before 431s, QMD memory search stays available in transient mode, SQLite avoids WAL on NFS state volumes, stuck-session recovery scheduling no longer resets warning backoff, full memory reindexes preserve rollback/cache recovery, raw Memory Wiki source pages stop looking malformed, and Infinity chunk limits stay genuinely unbounded. (#92650, #92618, #92639, #91247, #92752, #92881, #59137, #92876, #69700, #92735) Thanks @mushuiyu886, @TurboTheTurtle, @849261680, @gnanam1990, @TSHOGX, @arlen8411, and @yhterrance.</li>
-</ul>
-<h3>Changes</h3>
-<ul>
-<li>Providers/models: add GLM-5.2 support and Claude Haiku 4.5 catalog entries while keeping provider-qualified model IDs normalized across OpenRouter and Google Vertex paths. (#92796, #90116, #92627, #91218) Thanks @arkyu2077, @liuhao1024, and @bymle.</li>
-<li>Web search: keep key-free providers such as Parallel Free, DuckDuckGo, Ollama, and Codex Hosted Search as explicit opt-ins instead of selecting them automatically when no API-backed provider is configured. (#93616) Thanks @davemorin and @vincentkoc.</li>
-<li>Channel plugins: ship Telegram rich-message delivery and WhatsApp ACP binding support, including preserved intentional line breaks, rich prompt handoff to CLI backends, and transport fixtures for richer drafts. (#92679, #93164, #92513) Thanks @obviyus and @TurboTheTurtle.</li>
-<li>Agent commands: support <code>/btw</code> in CLI-backed sessions and keep CLI usage-error exits classified as usage failures instead of successful runs. (#92669, #92162) Thanks @joshavant and @Pandah97.</li>
-<li>Usage hooks: add built-in full footer rendering, default footer templates, per-turn usage state, credential-aware limits, and fixed-decimal formatting for usage-bar templates. (#92657, #89835, #89629) Thanks @Marvinthebored.</li>
-<li>Docs and operator guidance: document node config examples, clarify before-install hook scope, correct agent default concurrency comments, refresh ZAI provider docs, and update channel/group docs for current Telegram and WhatsApp behavior. (#92677, #92766, #92695) Thanks @liuhao1024, @sallyom, and @ArielSmoliar.</li>
-</ul>
-<h3>Fixes</h3>
-<ul>
-<li>Channels and delivery: preserve account-scoped DM channel send policy, intentional rich-message line breaks in Telegram and status output, rich Telegram final replies, rich Telegram tables and lists, Telegram thread-create CLI remapping, Feishu dynamic-agent routes after persisted binding reuse, Slack outbound <code>message_sent</code> hooks, contributed message-tool schema optionality, same-channel generated media completions, and channel chunking around surrogate pairs and Infinity limits. (#92788, #93164, #92679, #89421, #89943, #42837, #92814, #91137, #91246, #92735) Thanks @yetval, @obviyus, @spacegeologist, @rishitamrakar, @liuhao1024, @lundog, @TurboTheTurtle, and @yhterrance.</li>
-<li>Discord: give generated auto-thread titles a 60-second timeout and 4,096-token reasoning-model output budget, clamped to the selected model output cap. (#64734) Thanks @hanamizuki.</li>
-<li>Agent, cron, and Gateway runtime: mark active main sessions before restart shutdown aborts, pause yielded subagent runs whose terminal also signals abort, clamp trusted subagent thinking overrides through provider/model fallback, preserve yielded media completions, deliver channel message-tool final replies through auto-reply while hiding internal delivery hints, restore reset archive fallback reads when active async transcripts are missing, de-duplicate main-session heartbeat events, expose session identity in runtime prompts, reject unknown OpenAI agent selectors, keep generated media completions, slash-command block replies, and trajectory export commands in WebChat, and require admin privileges for HTTP session/model override surfaces. (#91357, #92631, #92412, #92146, #92879, #91287, #92468, #92510, #91246, #92651, #92646) Thanks @ooiuuii, @openperf, @IWhatsskill, @masatohoshino, @CadanHu, @ZengWen-DT, @zhangguiping-xydt, and @TurboTheTurtle.</li>
-<li>Providers and model replay: preserve storeless OpenAI Responses replay compatibility, recover invalid OpenAI reasoning signatures and genericized Anthropic thinking-signature replay errors, route OAuth image defaults through Codex for eligible OpenAI profiles, avoid eager tool streaming for Claude 4.5 in Copilot, quarantine unreadable and post-hook OpenAI/Anthropic-family tool schemas without broadening allowed tool choices, deliver explicit thinking-off requests to LM Studio binary-thinking models, honor profile auth for SecretRef model entries, bound model browsing, strip provider prefixes where runtimes need bare IDs, and surface nested embedding fetch failures. (#90706, #92941, #92201, #92916, #92824, #75393, #92908, #92921, #92928, #92002, #90686, #92247, #92627, #91218, #92628) Thanks @snowzlm, @mmyzwl, @CarlCapital, @bek91, @Kailigithub, @vincentkoc, @rohitjavvadi, @samson910022, @nxmxbbd, @liuhao1024, @bymle, and @mushuiyu886.</li>
-<li>Memory, state, diagnostics, and config: split header-too-large embedding batches, keep QMD memory search enabled in transient mode, avoid SQLite WAL on NFS volumes, preserve recovery scheduling outside stuck-session warning backoff, preserve full-reindex rollback/cache recovery, treat raw Memory Wiki source pages as source evidence, and keep shell environment fallbacks contained in config write tests. (#92650, #92618, #92639, #91247, #92752, #92881, #59137, #92876, #69700) Thanks @mushuiyu886, @TurboTheTurtle, @849261680, @gnanam1990, @TSHOGX, and @arlen8411.</li>
-<li>UI/mobile/TUI: preserve dashboard session parent lineage, WebChat backscroll, reset soft command args, sidebar session picker interactivity, collapsed workspace files, resolved <code>/model</code> confirmation refs, stale foreground iOS Gateway reconnects, and paused setup-parent stdin after inherited-stdio child exit. (#90658, #92622, #91353, #92705, #92779, #92773, #92552, #93159) Thanks @luoyanglang, @TurboTheTurtle, @zhouhe-xydt, @NianJiuZst, @shakkernerd, @NarahariRaghava, @Solvely-Colin, and @fuller-stack-dev.</li>
-<li>Plugins and updates: repair missing required platform packages during managed plugin installs and updates, including omitted Codex platform binaries.</li>
-<li>Dependencies: update Hono to 4.12.25 so published OpenClaw and ACPX packages use the patched runtime.</li>
-<li>Release and test reliability: extend slow Gateway/full-suite watchdogs, split local full-suite shards when throttled, stabilize plugin auth marker fixtures, avoid brittle provider-ref error text, fold Telegram RTT sampling into live QA evidence, simplify QA scorecard mappings around canonical coverage IDs, keep QA Lab bootstrap selection assertions aligned with flow-only scenarios, skip QA coverage artifact consumers when runtime parity producer status is not green, keep Feishu lifecycle release checks pointed at the active fixture config, isolate trajectory-export live seed turns from Codex-native shell approvals, preserve release-check child refs while pinning expected SHAs, widen live OpenAI TTS budgets for slower provider responses, and avoid false downgrade prompts for unresolved latest-tag updates. (#92652, #92550, #92558, #92911) Thanks @RomneyDa and @Andy312432.</li>
-</ul>
-<p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
-]]></description>
-            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.6.8/OpenClaw-2026.6.8.zip" length="55815364" type="application/octet-stream" sparkle:edSignature="hLJ14xg6+DMFrXViIW3Njs++OPIGO+RWH9h+mPCSzXPAkKyYUGvtOLu1qEKvvfC8rs5FGgW/w4zDLfD2azqiBA=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
Updates the stable Sparkle appcast generated by macOS publish for v2026.7.1.